### PR TITLE
refactor(server): webhook-sourced GitHub App install binding (drop URL installation_id trust + org-admin probe)

### DIFF
--- a/packages/server/drizzle/0071_moaning_maverick.sql
+++ b/packages/server/drizzle/0071_moaning_maverick.sql
@@ -1,13 +1,15 @@
 CREATE TABLE "github_app_install_intents" (
 	"id" text PRIMARY KEY NOT NULL,
-	"installer_github_id" bigint NOT NULL,
+	"installation_id" bigint NOT NULL,
 	"target_organization_id" text NOT NULL,
+	"kickoff_user_id" text NOT NULL,
+	"kickoff_github_id" bigint NOT NULL,
 	"expires_at" timestamp with time zone NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 ALTER TABLE "github_app_installations" ADD COLUMN "installer_github_id" bigint;--> statement-breakpoint
 ALTER TABLE "github_app_install_intents" ADD CONSTRAINT "github_app_install_intents_target_organization_id_organizations_id_fk" FOREIGN KEY ("target_organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE UNIQUE INDEX "uq_github_app_install_intents_installer" ON "github_app_install_intents" USING btree ("installer_github_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_github_app_install_intents_installation" ON "github_app_install_intents" USING btree ("installation_id");--> statement-breakpoint
 CREATE INDEX "idx_github_app_install_intents_expires" ON "github_app_install_intents" USING btree ("expires_at");--> statement-breakpoint
 CREATE INDEX "idx_github_app_installations_installer" ON "github_app_installations" USING btree ("installer_github_id");

--- a/packages/server/drizzle/0071_romantic_expediter.sql
+++ b/packages/server/drizzle/0071_romantic_expediter.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "github_app_install_intents" (
+	"id" text PRIMARY KEY NOT NULL,
+	"installer_github_id" bigint NOT NULL,
+	"target_organization_id" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "github_app_installations" ADD COLUMN "installer_github_id" bigint;--> statement-breakpoint
+ALTER TABLE "github_app_install_intents" ADD CONSTRAINT "github_app_install_intents_target_organization_id_organizations_id_fk" FOREIGN KEY ("target_organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_github_app_install_intents_installer" ON "github_app_install_intents" USING btree ("installer_github_id");--> statement-breakpoint
+CREATE INDEX "idx_github_app_install_intents_expires" ON "github_app_install_intents" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "idx_github_app_installations_installer" ON "github_app_installations" USING btree ("installer_github_id");

--- a/packages/server/drizzle/LATEST
+++ b/packages/server/drizzle/LATEST
@@ -1,1 +1,1 @@
-0071_romantic_expediter
+0071_moaning_maverick

--- a/packages/server/drizzle/LATEST
+++ b/packages/server/drizzle/LATEST
@@ -1,1 +1,1 @@
-0070_cheerful_ken_ellis
+0071_romantic_expediter

--- a/packages/server/drizzle/meta/0071_snapshot.json
+++ b/packages/server/drizzle/meta/0071_snapshot.json
@@ -1,0 +1,4132 @@
+{
+  "id": "1143e036-3034-423d-b52f-762c1957617b",
+  "prevId": "742cd4e7-4515-476b-9f42-10058676ab1d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_chat_sessions": {
+      "name": "agent_chat_sessions",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "runtime_state_at": {
+          "name": "runtime_state_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_chat_sessions_chat_agent": {
+          "name": "idx_agent_chat_sessions_chat_agent",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_chat_sessions_agent_id_agents_uuid_fk": {
+          "name": "agent_chat_sessions_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_chat_sessions",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_chat_sessions_chat_id_chats_id_fk": {
+          "name": "agent_chat_sessions_chat_id_chats_id_fk",
+          "tableFrom": "agent_chat_sessions",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_chat_sessions_agent_id_chat_id_pk": {
+          "name": "agent_chat_sessions_agent_id_chat_id_pk",
+          "columns": [
+            "agent_id",
+            "chat_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_configs": {
+      "name": "agent_configs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_type": {
+          "name": "runtime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sessions": {
+          "name": "total_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_updated_at": {
+          "name": "runtime_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_presence_agent_id_agents_uuid_fk": {
+          "name": "agent_presence_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_presence_client_id_clients_id_fk": {
+          "name": "agent_presence_client_id_clients_id_fk",
+          "tableFrom": "agent_presence",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_resource_bindings": {
+      "name": "agent_resource_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaces_resource_id": {
+          "name": "replaces_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_prompt_body": {
+          "name": "inline_prompt_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_ref": {
+          "name": "repo_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_local_path": {
+          "name": "repo_local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_resource_bindings_agent": {
+          "name": "idx_agent_resource_bindings_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_resource_bindings_resource": {
+          "name": "idx_agent_resource_bindings_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_resource_bindings_replaces": {
+          "name": "idx_agent_resource_bindings_replaces",
+          "columns": [
+            {
+              "expression": "replaces_resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_resource_bindings_organization_id_organizations_id_fk": {
+          "name": "agent_resource_bindings_organization_id_organizations_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_resource_bindings_agent_id_agents_uuid_fk": {
+          "name": "agent_resource_bindings_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_resource_bindings_resource_id_resources_id_fk": {
+          "name": "agent_resource_bindings_resource_id_resources_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_resource_bindings_replaces_resource_id_resources_id_fk": {
+          "name": "agent_resource_bindings_replaces_resource_id_resources_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "replaces_resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_mention": {
+          "name": "delegate_mention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "avatar_color_token": {
+          "name": "avatar_color_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_data": {
+          "name": "avatar_image_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_mime": {
+          "name": "avatar_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_updated_at": {
+          "name": "avatar_image_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_org": {
+          "name": "idx_agents_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_manager": {
+          "name": "idx_agents_manager",
+          "columns": [
+            {
+              "expression": "manager_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_visibility_org": {
+          "name": "idx_agents_visibility_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_client": {
+          "name": "idx_agents_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organizations_id_fk": {
+          "name": "agents_organization_id_organizations_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agents_client_id_clients_id_fk": {
+          "name": "agents_client_id_clients_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_inbox_id_unique": {
+          "name": "agents_inbox_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inbox_id"
+          ]
+        },
+        "uq_agents_org_name": {
+          "name": "uq_agents_org_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachments_uploaded_by_idx": {
+          "name": "attachments_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "attachments_created_at_idx": {
+          "name": "attachments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attentions": {
+      "name": "attentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "origin_agent_id": {
+          "name": "origin_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_chat_id": {
+          "name": "origin_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_human_id": {
+          "name": "target_human_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "requires_response": {
+          "name": "requires_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by": {
+          "name": "responded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_reason": {
+          "name": "cancelled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_attentions_target_open": {
+          "name": "idx_attentions_target_open",
+          "columns": [
+            {
+              "expression": "target_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attentions_chat_open": {
+          "name": "idx_attentions_chat_open",
+          "columns": [
+            {
+              "expression": "origin_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attentions_origin": {
+          "name": "idx_attentions_origin",
+          "columns": [
+            {
+              "expression": "origin_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_identities": {
+      "name": "auth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_payload": {
+          "name": "credential_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_identities_user": {
+          "name": "idx_auth_identities_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_auth_identities_email": {
+          "name": "idx_auth_identities_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_auth_identities_user_github": {
+          "name": "uq_auth_identities_user_github",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "provider = 'github'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_identities_user_id_users_id_fk": {
+          "name": "auth_identities_user_id_users_id_fk",
+          "tableFrom": "auth_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_auth_identities_provider_identifier": {
+          "name": "uq_auth_identities_provider_identifier",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "identifier"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_membership": {
+      "name": "chat_membership",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_membership_agent": {
+          "name": "idx_membership_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_membership_chat_role": {
+          "name": "idx_membership_chat_role",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "access_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_membership_chat_id_agent_id_pk": {
+          "name": "chat_membership_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_user_state": {
+      "name": "chat_user_state",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_mention_count": {
+          "name": "unread_mention_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "open_request_count": {
+          "name": "open_request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_status": {
+          "name": "engagement_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "idx_user_state_agent": {
+          "name": "idx_user_state_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_state_unread": {
+          "name": "idx_user_state_unread",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "unread_mention_count > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_state_open_req": {
+          "name": "idx_user_state_open_req",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "open_request_count > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_user_state_chat_id_agent_id_pk": {
+          "name": "chat_user_state_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_updated_at": {
+          "name": "description_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_policy": {
+          "name": "lifecycle_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'persistent'"
+        },
+        "parent_chat_id": {
+          "name": "parent_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_kickoff_key": {
+          "name": "onboarding_kickoff_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chats_org_last_message": {
+          "name": "idx_chats_org_last_message",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"last_message_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_chats_onboarding_kickoff_key": {
+          "name": "uq_chats_onboarding_kickoff_key",
+          "columns": [
+            {
+              "expression": "onboarding_kickoff_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chats_organization_id_organizations_id_fk": {
+          "name": "chats_organization_id_organizations_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disconnected'"
+        },
+        "sdk_version": {
+          "name": "sdk_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_user": {
+          "name": "idx_clients_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_org": {
+          "name": "idx_clients_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_user_id_users_id_fk": {
+          "name": "clients_user_id_users_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "clients_organization_id_organizations_id_fk": {
+          "name": "clients_organization_id_organizations_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context_tree_io_events": {
+      "name": "context_tree_io_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_session_event_id": {
+          "name": "source_session_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_index": {
+          "name": "source_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_repo_url": {
+          "name": "tree_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_branch": {
+          "name": "tree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_context_tree_io_source": {
+          "name": "uq_context_tree_io_source",
+          "columns": [
+            {
+              "expression": "source_session_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_recent": {
+          "name": "idx_context_tree_io_org_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_action_recent": {
+          "name": "idx_context_tree_io_org_action_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_agent_recent": {
+          "name": "idx_context_tree_io_org_agent_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_tree_io_org_target_recent": {
+          "name": "idx_context_tree_io_org_target_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "context_tree_io_events_organization_id_organizations_id_fk": {
+          "name": "context_tree_io_events_organization_id_organizations_id_fk",
+          "tableFrom": "context_tree_io_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "context_tree_io_events_agent_id_agents_uuid_fk": {
+          "name": "context_tree_io_events_agent_id_agents_uuid_fk",
+          "tableFrom": "context_tree_io_events",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "context_tree_io_events_chat_id_chats_id_fk": {
+          "name": "context_tree_io_events_chat_id_chats_id_fk",
+          "tableFrom": "context_tree_io_events",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_context_tree_io_action": {
+          "name": "ck_context_tree_io_action",
+          "value": "\"context_tree_io_events\".\"action\" IN ('read', 'write')"
+        },
+        "ck_context_tree_io_target_kind": {
+          "name": "ck_context_tree_io_target_kind",
+          "value": "\"context_tree_io_events\".\"target_kind\" IN ('file', 'directory', 'repo')"
+        },
+        "ck_context_tree_io_target_path_nonempty": {
+          "name": "ck_context_tree_io_target_path_nonempty",
+          "value": "\"context_tree_io_events\".\"target_path\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_app_install_intents": {
+      "name": "github_app_install_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installer_github_id": {
+          "name": "installer_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_organization_id": {
+          "name": "target_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_github_app_install_intents_installer": {
+          "name": "uq_github_app_install_intents_installer",
+          "columns": [
+            {
+              "expression": "installer_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_app_install_intents_expires": {
+          "name": "idx_github_app_install_intents_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_app_install_intents_target_organization_id_organizations_id_fk": {
+          "name": "github_app_install_intents_target_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_install_intents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "target_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_app_installations": {
+      "name": "github_app_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_github_id": {
+          "name": "account_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installer_github_id": {
+          "name": "installer_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_organization_id": {
+          "name": "hub_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_github_app_installations_installation_id": {
+          "name": "uq_github_app_installations_installation_id",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_github_app_installations_hub_org": {
+          "name": "uq_github_app_installations_hub_org",
+          "columns": [
+            {
+              "expression": "hub_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_app_installations_account": {
+          "name": "idx_github_app_installations_account",
+          "columns": [
+            {
+              "expression": "account_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_app_installations_installer": {
+          "name": "idx_github_app_installations_installer",
+          "columns": [
+            {
+              "expression": "installer_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_hub_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_hub_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "hub_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_github_app_installations_account_type": {
+          "name": "ck_github_app_installations_account_type",
+          "value": "\"github_app_installations\".\"account_type\" IN ('User', 'Organization')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_entity_chat_mappings": {
+      "name": "github_entity_chat_mappings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "human_agent_id": {
+          "name": "human_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_agent_id": {
+          "name": "delegate_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_key": {
+          "name": "entity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_at": {
+          "name": "bound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "bound_via": {
+          "name": "bound_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_state": {
+          "name": "entity_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "entity_state_updated_at": {
+          "name": "entity_state_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_github_entity_chat_mappings_chat": {
+          "name": "idx_github_entity_chat_mappings_chat",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_entity_chat_mappings_chat_state": {
+          "name": "idx_github_entity_chat_mappings_chat_state",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_entity_chat_mappings_organization_id_organizations_id_fk": {
+          "name": "github_entity_chat_mappings_organization_id_organizations_id_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "github_entity_chat_mappings_human_agent_id_agents_uuid_fk": {
+          "name": "github_entity_chat_mappings_human_agent_id_agents_uuid_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "human_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_entity_chat_mappings_delegate_agent_id_agents_uuid_fk": {
+          "name": "github_entity_chat_mappings_delegate_agent_id_agents_uuid_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "delegate_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_entity_chat_mappings_chat_id_chats_id_fk": {
+          "name": "github_entity_chat_mappings_chat_id_chats_id_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_entity_chat_mappings_organization_id_human_agent_id_delegate_agent_id_entity_type_entity_key_pk": {
+          "name": "github_entity_chat_mappings_organization_id_human_agent_id_delegate_agent_id_entity_type_entity_key_pk",
+          "columns": [
+            "organization_id",
+            "human_agent_id",
+            "delegate_agent_id",
+            "entity_type",
+            "entity_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_entries": {
+      "name": "inbox_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notify": {
+          "name": "notify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbox_pending": {
+          "name": "idx_inbox_pending",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_pending_notify": {
+          "name": "idx_inbox_pending_notify",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending' AND notify = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_chat_silent": {
+          "name": "idx_inbox_chat_silent",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notify",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_entries_message_status": {
+          "name": "idx_inbox_entries_message_status",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_entries_message_id_messages_id_fk": {
+          "name": "inbox_entries_message_id_messages_id_fk",
+          "tableFrom": "inbox_entries",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_inbox_delivery": {
+          "name": "uq_inbox_delivery",
+          "nullsNotDistinct": false,
+          "columns": [
+            "inbox_id",
+            "message_id",
+            "chat_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_inbox_entries_status": {
+          "name": "ck_inbox_entries_status",
+          "value": "\"inbox_entries\".\"status\" IN ('pending', 'delivered', 'acked')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation_redemptions": {
+      "name": "invitation_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invitation_redemptions_invitation": {
+          "name": "idx_invitation_redemptions_invitation",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitation_redemptions_user": {
+          "name": "idx_invitation_redemptions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_redemptions_invitation_id_invitations_id_fk": {
+          "name": "invitation_redemptions_invitation_id_invitations_id_fk",
+          "tableFrom": "invitation_redemptions",
+          "tableTo": "invitations",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_redemptions_user_id_users_id_fk": {
+          "name": "invitation_redemptions_user_id_users_id_fk",
+          "tableFrom": "invitation_redemptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitations_token": {
+          "name": "idx_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitations_org": {
+          "name": "idx_invitations_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_created_by_users_id_fk": {
+          "name": "invitations_created_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_suppressed_at": {
+          "name": "onboarding_suppressed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_suppressed_reason": {
+          "name": "onboarding_suppressed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_members_user": {
+          "name": "idx_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_members_org": {
+          "name": "idx_members_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "members_agent_id_agents_uuid_fk": {
+          "name": "members_agent_id_agents_uuid_fk",
+          "tableFrom": "members",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_agent_id_unique": {
+          "name": "members_agent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id"
+          ]
+        },
+        "uq_members_user_org": {
+          "name": "uq_members_user_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_members_completed_implies_suppressed": {
+          "name": "ck_members_completed_implies_suppressed",
+          "value": "\"members\".\"onboarding_completed_at\" IS NULL OR \"members\".\"onboarding_suppressed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reply_to_inbox": {
+          "name": "reply_to_inbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_chat": {
+          "name": "reply_to_chat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_messages_chat_time": {
+          "name": "idx_messages_chat_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_in_reply_to": {
+          "name": "idx_messages_in_reply_to",
+          "columns": [
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_chat_source_time": {
+          "name": "idx_messages_chat_source_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_messages_mentions": {
+          "name": "idx_messages_mentions",
+          "columns": [
+            {
+              "expression": "((\"metadata\" -> 'mentions')) jsonb_path_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_org_created": {
+          "name": "idx_notifications_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_org_read": {
+          "name": "idx_notifications_org_read",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_notifications_org_dedup_unread": {
+          "name": "uq_notifications_org_dedup_unread",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "read = false AND dedup_key IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_settings_namespace": {
+          "name": "idx_org_settings_namespace",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_settings_organization_id_organizations_id_fk": {
+          "name": "organization_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_settings_updated_by_users_id_fk": {
+          "name": "organization_settings_updated_by_users_id_fk",
+          "tableFrom": "organization_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_settings_organization_id_namespace_pk": {
+          "name": "organization_settings_organization_id_namespace_pk",
+          "columns": [
+            "organization_id",
+            "namespace"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_agents": {
+          "name": "max_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_messages_per_minute": {
+          "name": "max_messages_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_name_unique": {
+          "name": "organizations_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_questions": {
+      "name": "pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_questions_agent_status": {
+          "name": "idx_pending_questions_agent_status",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_questions_chat_status": {
+          "name": "idx_pending_questions_chat_status",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_agent_id": {
+          "name": "owner_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_canonical_key": {
+          "name": "repo_canonical_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_enabled": {
+          "name": "default_enabled",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resources_org_type_scope": {
+          "name": "idx_resources_org_type_scope",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resources_owner_agent": {
+          "name": "idx_resources_owner_agent",
+          "columns": [
+            {
+              "expression": "owner_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_resources_repo_key": {
+          "name": "idx_resources_repo_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_resources_team_repo_canonical_active": {
+          "name": "uq_resources_team_repo_canonical_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"resources\".\"type\" = 'repo' AND \"resources\".\"scope\" = 'team' AND \"resources\".\"status\" IN ('active', 'stale') AND \"resources\".\"repo_canonical_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_resources_agent_repo_canonical_active": {
+          "name": "uq_resources_agent_repo_canonical_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"resources\".\"type\" = 'repo' AND \"resources\".\"scope\" = 'agent' AND \"resources\".\"status\" IN ('active', 'stale') AND \"resources\".\"repo_canonical_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resources_organization_id_organizations_id_fk": {
+          "name": "resources_organization_id_organizations_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resources_owner_agent_id_agents_uuid_fk": {
+          "name": "resources_owner_agent_id_agents_uuid_fk",
+          "tableFrom": "resources",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "owner_agent_id"
+          ],
+          "columnsTo": [
+            "uuid"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_instances": {
+      "name": "server_instances",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_events": {
+      "name": "session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_session_events_chat_seq": {
+          "name": "uq_session_events_chat_seq",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_chat_created": {
+          "name": "idx_session_events_chat_created",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_context_tree_usage_recent": {
+          "name": "idx_session_events_context_tree_usage_recent",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"session_events\".\"kind\" = 'context_tree_usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_context_tree_io_agent_recent": {
+          "name": "idx_session_events_context_tree_io_agent_recent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"session_events\".\"kind\" IN ('context_tree_usage', 'tool_call')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_session_events_token_usage_agent_recent": {
+          "name": "idx_session_events_token_usage_agent_recent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"session_events\".\"kind\" = 'token_usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/0071_snapshot.json
+++ b/packages/server/drizzle/meta/0071_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "1143e036-3034-423d-b52f-762c1957617b",
+  "id": "083d9670-24d8-45c4-8a59-9216d5a971bd",
   "prevId": "742cd4e7-4515-476b-9f42-10058676ab1d",
   "version": "7",
   "dialect": "postgresql",
@@ -1953,8 +1953,8 @@
           "primaryKey": true,
           "notNull": true
         },
-        "installer_github_id": {
-          "name": "installer_github_id",
+        "installation_id": {
+          "name": "installation_id",
           "type": "bigint",
           "primaryKey": false,
           "notNull": true
@@ -1962,6 +1962,18 @@
         "target_organization_id": {
           "name": "target_organization_id",
           "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kickoff_user_id": {
+          "name": "kickoff_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kickoff_github_id": {
+          "name": "kickoff_github_id",
+          "type": "bigint",
           "primaryKey": false,
           "notNull": true
         },
@@ -1980,11 +1992,11 @@
         }
       },
       "indexes": {
-        "uq_github_app_install_intents_installer": {
-          "name": "uq_github_app_install_intents_installer",
+        "uq_github_app_install_intents_installation": {
+          "name": "uq_github_app_install_intents_installation",
           "columns": [
             {
-              "expression": "installer_github_id",
+              "expression": "installation_id",
               "isExpression": false,
               "asc": true,
               "nulls": "last"

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -502,8 +502,8 @@
     {
       "idx": 71,
       "version": "7",
-      "when": 1782893596117,
-      "tag": "0071_romantic_expediter",
+      "when": 1782896796980,
+      "tag": "0071_moaning_maverick",
       "breakpoints": true
     }
   ]

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -498,6 +498,13 @@
       "when": 1782373703621,
       "tag": "0070_cheerful_ken_ellis",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1782893596117,
+      "tag": "0071_romantic_expediter",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/github-app-callback-target-org.test.ts
+++ b/packages/server/src/__tests__/github-app-callback-target-org.test.ts
@@ -131,7 +131,7 @@ async function seedGithubIdentity(
 describe("/auth/github/callback honors targetOrganizationId in the state (codex P1-3)", () => {
   const getApp = useTestApp({ githubAppPrivateKeyPem: TEST_APP_PRIVATE_KEY_PEM });
 
-  it("binds the install to the target org, not the user's primary org, when the user is its admin", async () => {
+  it("resolves + pins the target org (not the user's primary org) when the kickoff admin matches", async () => {
     const app = getApp();
     const githubId = 770_001;
     const login = `targetorg-admin-${uuidv7().slice(0, 6)}`;
@@ -143,7 +143,7 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
 
     // orgB: a second org userA admins — and the one the install targets.
     // Backdate its membership so the default org stays the most-recent
-    // (primary) one — binding to orgB then proves the targetOrg branch ran.
+    // (primary) one — resolving to orgB then proves the targetOrg branch ran.
     const orgBId = uuidv7();
     await app.db.insert(organizations).values({ id: orgBId, name: `targetorg-${orgBId}`, displayName: "Target Org" });
     const orgBMember = await ensureMembership(app.db, {
@@ -158,12 +158,9 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
       .set({ createdAt: new Date(Date.now() - 120_000) })
       .where(eq(members.id, orgBMember.id));
 
-    // The callback's UPSERT lands the row from the stubbed `/app/installations/<id>`
-    // response (account "acme", id 990_001) — no pre-seed needed now that the
-    // codex P2 fix makes the bind step depend on the upsert succeeding.
-
     const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
       targetOrganizationId: orgBId,
+      kickoffUserId: admin.userId,
     });
     const restore = stubGithub({ githubId, login, installationIds: [installationId] });
     try {
@@ -179,16 +176,18 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
       expect(params.get("joinPath")).toBe("returning");
       // The install target is a deliberate destination: even though the join
       // path reads as "returning", the org must be pinned so the SPA activates
-      // the just-bound org instead of restoring the user's last-used one.
+      // the target org instead of restoring the user's last-used one.
       expect(params.get("org")).toBe(orgBId);
       expect(params.get("orgPinned")).toBe("1");
     } finally {
       restore();
     }
 
-    const row = await findInstallationByGithubId(app.db, installationId);
-    expect(row?.hubOrganizationId).toBe(orgBId);
-    expect(row?.hubOrganizationId).not.toBe(admin.organizationId);
+    // The callback no longer binds (nor upserts) the installation — binding is
+    // driven by the trusted `installation.created` webhook. So no row exists
+    // from the callback; only the org resolution/pinning above is the
+    // callback's job.
+    expect(await findInstallationByGithubId(app.db, installationId)).toBeNull();
   });
 
   it("refuses the bind (via the SPA error surface) when the user is not an admin of the target org", async () => {
@@ -290,14 +289,14 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     expect(row).toBeNull();
   });
 
-  it("binds via the kickoff session's authority when the callback GitHub identity differs", async () => {
-    // The incident class behind this test: an org admin kicks off the
-    // install (admin-gated, so their authority is proven at mint time),
-    // but the browser's github.com session belongs to a DIFFERENT GitHub
-    // identity (second account, recreated account, someone else's First Tree
-    // session in the same browser). GitHub completes the install either
-    // way; the bind must rest on the kickoff session signed into the
-    // state, not on whoever the OAuth code resolves to.
+  it("refuses (error, no bind) when the install is completed under a different GitHub identity than the kickoff admin", async () => {
+    // A kickoff admin starts the install (admin-gated at mint), but the
+    // browser's github.com session resolves to a DIFFERENT GitHub identity.
+    // In the webhook-sourced binding model this install cannot bind (the
+    // intent is keyed by the kickoff admin's GitHub id; the webhook `sender`
+    // won't match), and we must not sign the browser in as the foreign
+    // identity. The callback surfaces `install-not-verified` and binds
+    // nothing.
     const app = getApp();
     const kickoffGithubId = 770_005;
     const strangerGithubId = 770_006;
@@ -324,25 +323,24 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
         url: `/api/v1/auth/github/callback?code=devcode&state=${token}&installation_id=${installationId}`,
         headers: { cookie: `${OAUTH_STATE_COOKIE}=${nonce}` },
       });
-      // Install completes: redirect straight to `next` — and WITHOUT a
-      // token fragment, so the stranger identity must not replace the
-      // kickoff admin's browser session.
+      // Error surface, no session token issued for the stranger identity.
       expect(res.statusCode).toBe(302);
-      expect(res.headers.location).toBe("/onboarding/connected");
+      expect(res.headers.location).toContain("/auth/github/complete#");
+      expect(res.headers.location).toContain("error=install-not-verified");
       expect(res.headers.location).not.toContain("access=");
     } finally {
       restore();
     }
 
-    const row = await findInstallationByGithubId(app.db, installationId);
-    expect(row?.hubOrganizationId).toBe(admin.organizationId);
+    // Nothing bound (and nothing upserted) by the callback.
+    expect(await findInstallationByGithubId(app.db, installationId)).toBeNull();
   });
 
-  it("surfaces an error (not success) when the identities mismatch and there is no verified installation to bind", async () => {
-    // Review finding (yuezengwu + codex): with no `installation_id` (or one
-    // cleared by the fail-closed GitHub-side admin proof), the mismatch
-    // branch must NOT bounce to the success `next` — in onboarding that
-    // page auto-closes as "connected" while nothing was bound.
+  it("surfaces an error (not success) when the identities mismatch, regardless of installation_id", async () => {
+    // Review finding (yuezengwu + codex): the mismatch branch must NOT
+    // bounce to the success `next` — in onboarding that page auto-closes as
+    // "connected" while nothing was bound. Holds whether or not an
+    // installation_id rides the callback (binding is webhook-driven).
     const app = getApp();
     const kickoffGithubId = 770_008;
     const strangerGithubId = 770_009;
@@ -378,67 +376,6 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
     }
   });
 
-  it("surfaces an error (not success) when the identities mismatch and the bind itself fails", async () => {
-    // Same review finding, bind-failure leg: the installation is already
-    // bound to a DIFFERENT org (D2 1:1), so `bindInstallationToOrg` throws.
-    // The user must land on the error surface, not the success `next`.
-    const app = getApp();
-    const kickoffGithubId = 770_010;
-    const strangerGithubId = 770_011;
-    const login = `targetorg-bindfail-${uuidv7().slice(0, 6)}`;
-    const installationId = 8_822_007;
-
-    const admin = await createTestAdmin(app, { username: `${login}-u` });
-    await seedGithubIdentity(app, admin.userId, kickoffGithubId, login);
-
-    // Pre-bind the installation to another org so the bind is refused.
-    const otherOrgId = uuidv7();
-    await app.db.insert(organizations).values({ id: otherOrgId, name: `other-${otherOrgId}`, displayName: "Other" });
-    await upsertInstallationFromMetadata(app.db, {
-      installation: {
-        id: installationId,
-        accountType: "Organization",
-        accountLogin: "acme",
-        accountGithubId: 990_001,
-        permissions: {},
-        events: [],
-        suspendedAt: null,
-      },
-    });
-    const { bindInstallationToOrg } = await import("../services/github-app-installations.js");
-    await bindInstallationToOrg(app.db, installationId, otherOrgId);
-
-    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
-      targetOrganizationId: admin.organizationId,
-      kickoffUserId: admin.userId,
-    });
-    const restore = stubGithub({
-      githubId: strangerGithubId,
-      login: `${login}-stranger`,
-      installationIds: [installationId],
-    });
-    try {
-      const res = await app.inject({
-        method: "GET",
-        url: `/api/v1/auth/github/callback?code=devcode&state=${token}&installation_id=${installationId}`,
-        headers: { cookie: `${OAUTH_STATE_COOKIE}=${nonce}` },
-      });
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location).toContain("/auth/github/complete#");
-      expect(res.headers.location).toContain("error=install-bind-failed");
-      expect(res.headers.location).not.toContain("access=");
-      // Settings-flow `next` is a real recovery surface — preserved as-is.
-      const fragment = new URLSearchParams(res.headers.location?.split("#")[1] ?? "");
-      expect(fragment.get("next")).toBe("/settings/github");
-    } finally {
-      restore();
-    }
-
-    // The pre-existing binding is untouched.
-    const row = await findInstallationByGithubId(app.db, installationId);
-    expect(row?.hubOrganizationId).toBe(otherOrgId);
-  });
-
   it("redirects to a friendly error page when the kickoff admin's membership was revoked mid-flight", async () => {
     const app = getApp();
     const githubId = 770_007;
@@ -472,9 +409,9 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
       restore();
     }
 
-    // The install stays unbound — the refusal short-circuits the bind.
-    const row = await findInstallationByGithubId(app.db, installationId);
-    expect(row?.hubOrganizationId).toBeNull();
+    // The callback binds/upserts nothing — the authority refusal short-circuits,
+    // and binding is webhook-driven regardless. No row is created here.
+    expect(await findInstallationByGithubId(app.db, installationId)).toBeNull();
   });
 
   it("ignores a targetOrganizationId naming an org the user isn't a member of", async () => {

--- a/packages/server/src/__tests__/github-app-callback-target-org.test.ts
+++ b/packages/server/src/__tests__/github-app-callback-target-org.test.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it, vi } from "vitest";
 import { authIdentities } from "../db/schema/auth-identities.js";
+import { githubAppInstallIntents } from "../db/schema/github-app-install-intents.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
 import { findInstallationByGithubId, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
@@ -334,6 +335,72 @@ describe("/auth/github/callback honors targetOrganizationId in the state (codex 
 
     // Nothing bound (and nothing upserted) by the callback.
     expect(await findInstallationByGithubId(app.db, installationId)).toBeNull();
+  });
+
+  it("does NOT bind (and records no pending bind) when a matching installation row exists but the callback identity mismatches", async () => {
+    // Regression (yuezengwu): the signed webhook already created the
+    // installation row with the kickoff admin as installer, but the callback
+    // is completed under a DIFFERENT GitHub identity carrying that
+    // installation_id in the URL. The mismatch guard must run BEFORE any
+    // pending-bind side effect — expect install-not-verified, no bind, and no
+    // lingering pending bind.
+    const app = getApp();
+    const kickoffGithubId = 770_020;
+    const strangerGithubId = 770_021;
+    const login = `targetorg-preinstalled-${uuidv7().slice(0, 6)}`;
+    const installationId = 8_822_020;
+
+    const admin = await createTestAdmin(app, { username: `${login}-u` });
+    await seedGithubIdentity(app, admin.userId, kickoffGithubId, login);
+
+    // The signed webhook already recorded this installation with the kickoff
+    // admin as its installer.
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "Organization",
+        accountLogin: "acme",
+        accountGithubId: 990_020,
+        permissions: {},
+        events: [],
+        suspendedAt: null,
+      },
+      installerGithubId: kickoffGithubId,
+    });
+
+    const { token, nonce } = await signOAuthState(TEST_JWT_SECRET, "/settings/github", {
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+    });
+    // OAuth resolves to a stranger; the URL carries the pre-installed id.
+    const restore = stubGithub({
+      githubId: strangerGithubId,
+      login: `${login}-stranger`,
+      installationIds: [installationId],
+    });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=devcode&state=${token}&installation_id=${installationId}`,
+        headers: { cookie: `${OAUTH_STATE_COOKIE}=${nonce}` },
+      });
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toContain("error=install-not-verified");
+      expect(res.headers.location).not.toContain("access=");
+    } finally {
+      restore();
+    }
+
+    // No bind, despite the matching installer row...
+    const row = await findInstallationByGithubId(app.db, installationId);
+    expect(row?.hubOrganizationId).toBeNull();
+    // ...and no pending bind was recorded (the mismatch guard ran first).
+    const pending = await app.db
+      .select()
+      .from(githubAppInstallIntents)
+      .where(eq(githubAppInstallIntents.installationId, installationId))
+      .limit(1);
+    expect(pending).toHaveLength(0);
   });
 
   it("surfaces an error (not success) when the identities mismatch, regardless of installation_id", async () => {

--- a/packages/server/src/__tests__/github-app-orphan-recovery.test.ts
+++ b/packages/server/src/__tests__/github-app-orphan-recovery.test.ts
@@ -1,27 +1,64 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { organizations } from "../db/schema/organizations.js";
+import { encryptValue } from "../services/crypto.js";
 import { findInstallationByGithubId, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 /**
- * Manual claim recovery. Binding is normally driven by the trusted,
- * HMAC-signed `installation.created` webhook (keyed by the admin-minted
- * install-intent). `/claim` is the recovery hatch when a row ended up
- * unbound; it authorizes on the trusted `installer_github_id` (the webhook
- * `sender`) — the caller may claim ONLY an installation they installed
- * themselves. No GitHub round-trip, no `organization:members:read` probe.
+ * Stub `globalThis.fetch` so the manual-claim endpoint's GitHub admin proof
+ * (#312) resolves deterministically. For each `(login, role)` entry the
+ * stub answers `GET /user/memberships/orgs/{login}` with that role + an
+ * "active" state; logins not in the map return 404 (non-member). Other
+ * URLs fall through to the real fetch.
+ *
+ * User-type installs don't reach the network at all (the helper compares
+ * GitHub IDs in-process), so this stub is only consulted for Org-type
+ * claims.
  */
+function stubGithubMemberships(memberships: Record<string, "admin" | "member">) {
+  const original = globalThis.fetch;
+  type FetchInput = Parameters<typeof globalThis.fetch>[0];
+  type FetchInit = Parameters<typeof globalThis.fetch>[1];
+  const spy = vi.fn(async (input: FetchInput, init?: FetchInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    const match = url.match(/^https:\/\/api\.github\.com\/user\/memberships\/orgs\/([^/?]+)/);
+    if (match) {
+      const login = decodeURIComponent(match[1] ?? "");
+      const role = memberships[login];
+      if (!role) {
+        return new Response(JSON.stringify({ message: "Not Found" }), { status: 404 });
+      }
+      return new Response(JSON.stringify({ state: "active", role }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return original(input, init);
+  });
+  globalThis.fetch = spy as typeof fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
 describe("POST /api/v1/orgs/:orgId/github-app-installation/claim", () => {
   const getApp = useTestApp();
 
-  // A First Tree admin with a linked GitHub identity (numeric id on
-  // `auth_identities.identifier`, mirroring the OAuth callback). `/claim`
-  // matches this id against the installation's `installer_github_id`.
-  async function seedAdminWithGithubId(userGithubId: number): Promise<{ accessToken: string; organizationId: string }> {
+  async function seedAdminWithGithubToken(opts: { userGithubId?: number } = {}): Promise<{
+    accessToken: string;
+    organizationId: string;
+    userId: string;
+    userGithubId: number;
+  }> {
     const app = getApp();
     const admin = await createTestAdmin(app, { username: `claim-${uuidv7().slice(0, 8)}` });
+    // The claim endpoint reads the caller's stored GitHub token AND the
+    // numeric GitHub ID off `auth_identities.identifier` (so the
+    // User-type admin proof can ID-compare). identifier must therefore be
+    // a valid number string, mirroring the real OAuth callback's behavior.
+    const userGithubId = opts.userGithubId ?? Math.floor(700_000 + Math.random() * 99_999);
     await app.db.insert(authIdentities).values({
       id: uuidv7(),
       userId: admin.userId,
@@ -29,39 +66,65 @@ describe("POST /api/v1/orgs/:orgId/github-app-installation/claim", () => {
       identifier: String(userGithubId),
       email: null,
       verifiedAt: new Date(),
-      metadata: { login: "claimer" },
+      metadata: { login: "claimer", accessToken: encryptValue("gho_stub", app.config.secrets.encryptionKey) },
     });
-    return { accessToken: admin.accessToken, organizationId: admin.organizationId };
+    return {
+      accessToken: admin.accessToken,
+      organizationId: admin.organizationId,
+      userId: admin.userId,
+      userGithubId,
+    };
   }
 
-  async function seedInstall(opts: {
-    installationId: number;
-    installerGithubId: number | null;
-    boundTo?: string;
-  }): Promise<void> {
+  it("binds an Org-type install when the caller is a GitHub org admin", async () => {
     const app = getApp();
+    const { accessToken, organizationId } = await seedAdminWithGithubToken();
+    const installationId = 9_301;
     await upsertInstallationFromMetadata(app.db, {
       installation: {
-        id: opts.installationId,
+        id: installationId,
         accountType: "Organization",
         accountLogin: "acme",
-        accountGithubId: 880_000 + opts.installationId,
+        accountGithubId: 880_001,
         permissions: {},
         events: [],
         suspendedAt: null,
       },
-      ...(opts.installerGithubId !== null ? { installerGithubId: opts.installerGithubId } : {}),
-      ...(opts.boundTo ? { hubOrganizationId: opts.boundTo } : {}),
     });
-  }
 
-  it("binds when the caller's GitHub id matches the installation's installer", async () => {
+    const restore = stubGithubMemberships({ acme: "admin" });
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
+        headers: { authorization: `Bearer ${accessToken}` },
+        payload: { installationId },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json<{ bound: boolean }>().bound).toBe(true);
+    } finally {
+      restore();
+    }
+    expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBe(organizationId);
+  });
+
+  it("binds a User-type install when the caller's GitHub ID matches the account", async () => {
     const app = getApp();
-    const userGithubId = 760_101;
-    const { accessToken, organizationId } = await seedAdminWithGithubId(userGithubId);
-    const installationId = 9_401;
-    await seedInstall({ installationId, installerGithubId: userGithubId });
-
+    const userGithubId = 760_001;
+    const { accessToken, organizationId } = await seedAdminWithGithubToken({ userGithubId });
+    const installationId = 9_311;
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "User",
+        accountLogin: "alice",
+        accountGithubId: userGithubId,
+        permissions: {},
+        events: [],
+        suspendedAt: null,
+      },
+    });
+    // No HTTP stub needed — User-type proof is purely ID-based.
     const res = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
@@ -69,17 +132,94 @@ describe("POST /api/v1/orgs/:orgId/github-app-installation/claim", () => {
       payload: { installationId },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json<{ bound: boolean }>().bound).toBe(true);
     expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBe(organizationId);
   });
 
-  it("403s when the caller didn't install it (installer id mismatch — hijack guard)", async () => {
+  it("403s when the caller is a non-admin member of the GitHub org install", async () => {
+    // Hijack vector — the legacy `/user/installations` primitive would
+    // have returned the install for a plain member. The new admin proof
+    // rejects it.
     const app = getApp();
-    const { accessToken, organizationId } = await seedAdminWithGithubId(760_102);
-    const installationId = 9_402;
-    // Installed by a different GitHub identity.
-    await seedInstall({ installationId, installerGithubId: 999_999 });
+    const { accessToken, organizationId } = await seedAdminWithGithubToken();
+    const installationId = 9_312;
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "Organization",
+        accountLogin: "victim",
+        accountGithubId: 880_099,
+        permissions: {},
+        events: [],
+        suspendedAt: null,
+      },
+    });
+    const restore = stubGithubMemberships({ victim: "member" });
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
+        headers: { authorization: `Bearer ${accessToken}` },
+        payload: { installationId },
+      });
+      expect(res.statusCode).toBe(403);
+    } finally {
+      restore();
+    }
+    expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBeNull();
+  });
 
+  it("403s (no bind) when the recorded installer matches but current GitHub membership is non-admin", async () => {
+    // Regression (yuezengwu + baixiaohang): `/claim` is a *delayed* recovery
+    // path. Even when the row's recorded `installer_github_id` matches the
+    // caller (they DID originally install it), the LIVE current-admin check
+    // must still gate — the installer may have since lost GitHub org admin.
+    const app = getApp();
+    const { accessToken, organizationId, userGithubId } = await seedAdminWithGithubToken();
+    const installationId = 9_314;
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "Organization",
+        accountLogin: "exadmin",
+        accountGithubId: 880_014,
+        permissions: {},
+        events: [],
+        suspendedAt: null,
+      },
+      // Recorded installer == the caller (they installed it originally)...
+      installerGithubId: userGithubId,
+    });
+    // ...but they are no longer an admin of the GitHub org.
+    const restore = stubGithubMemberships({ exadmin: "member" });
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
+        headers: { authorization: `Bearer ${accessToken}` },
+        payload: { installationId },
+      });
+      expect(res.statusCode).toBe(403);
+    } finally {
+      restore();
+    }
+    expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBeNull();
+  });
+
+  it("403s on a User-type install when the caller's GitHub ID doesn't match", async () => {
+    const app = getApp();
+    const { accessToken, organizationId } = await seedAdminWithGithubToken({ userGithubId: 760_010 });
+    const installationId = 9_313;
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "User",
+        accountLogin: "someoneelse",
+        accountGithubId: 999_999,
+        permissions: {},
+        events: [],
+        suspendedAt: null,
+      },
+    });
     const res = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
@@ -90,57 +230,99 @@ describe("POST /api/v1/orgs/:orgId/github-app-installation/claim", () => {
     expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBeNull();
   });
 
-  it("403s when the installation has no recorded installer (legacy / non-webhook row)", async () => {
+  it("403s when the caller is not a member of the GitHub org at all (404 from memberships)", async () => {
     const app = getApp();
-    const { accessToken, organizationId } = await seedAdminWithGithubId(760_103);
-    const installationId = 9_403;
-    await seedInstall({ installationId, installerGithubId: null });
-
-    const res = await app.inject({
-      method: "POST",
-      url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
-      headers: { authorization: `Bearer ${accessToken}` },
-      payload: { installationId },
+    const { accessToken, organizationId } = await seedAdminWithGithubToken();
+    const installationId = 9_302;
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "Organization",
+        accountLogin: "stranger",
+        accountGithubId: 880_002,
+        permissions: {},
+        events: [],
+        suspendedAt: null,
+      },
     });
-    expect(res.statusCode).toBe(403);
+    // Empty memberships map → /user/memberships/orgs/stranger answers 404.
+    const restore = stubGithubMemberships({});
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
+        headers: { authorization: `Bearer ${accessToken}` },
+        payload: { installationId },
+      });
+      expect(res.statusCode).toBe(403);
+    } finally {
+      restore();
+    }
     expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBeNull();
   });
 
-  it("409s when the installer matches but the install is already bound to a different team", async () => {
+  it("409s when the installation is already bound to a different First Tree team", async () => {
     const app = getApp();
-    const userGithubId = 760_104;
-    const { accessToken, organizationId } = await seedAdminWithGithubId(userGithubId);
-    const installationId = 9_404;
+    const { accessToken, organizationId } = await seedAdminWithGithubToken();
+    const installationId = 9_303;
     const otherOrgId = uuidv7();
     await app.db.insert(organizations).values({ id: otherOrgId, name: `other-${otherOrgId}`, displayName: "Other" });
-    await seedInstall({ installationId, installerGithubId: userGithubId, boundTo: otherOrgId });
-
-    const res = await app.inject({
-      method: "POST",
-      url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
-      headers: { authorization: `Bearer ${accessToken}` },
-      payload: { installationId },
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "Organization",
+        accountLogin: "taken",
+        accountGithubId: 880_003,
+        permissions: {},
+        events: [],
+        suspendedAt: null,
+      },
+      hubOrganizationId: otherOrgId,
     });
-    expect(res.statusCode).toBe(409);
+    const restore = stubGithubMemberships({ taken: "admin" });
+    try {
+      const res = await app.inject({
+        method: "POST",
+        url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
+        headers: { authorization: `Bearer ${accessToken}` },
+        payload: { installationId },
+      });
+      expect(res.statusCode).toBe(409);
+    } finally {
+      restore();
+    }
   });
 
   it("404s when there is no installation row with that id", async () => {
     const app = getApp();
-    const { accessToken, organizationId } = await seedAdminWithGithubId(760_105);
+    const { accessToken, organizationId } = await seedAdminWithGithubToken();
+    // No upsert — the claim endpoint short-circuits with 404 before any
+    // membership API call.
     const res = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
       headers: { authorization: `Bearer ${accessToken}` },
-      payload: { installationId: 9_405 },
+      payload: { installationId: 9_304 },
     });
     expect(res.statusCode).toBe(404);
   });
 
-  it("403s when the caller has no GitHub identity on file", async () => {
+  it("403s when the caller has no GitHub token on file", async () => {
     const app = getApp();
-    const admin = await createTestAdmin(app, { username: `noid-${uuidv7().slice(0, 8)}` });
-    const installationId = 9_406;
-    await seedInstall({ installationId, installerGithubId: 12_345 });
+    // createTestAdmin alone — no github auth_identity → no token.
+    const admin = await createTestAdmin(app, { username: `notoken-${uuidv7().slice(0, 8)}` });
+    const installationId = 9_305;
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "User",
+        accountLogin: "x",
+        accountGithubId: 880_005,
+        permissions: {},
+        events: [],
+        suspendedAt: null,
+      },
+    });
     const res = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/claim`,
@@ -152,7 +334,7 @@ describe("POST /api/v1/orgs/:orgId/github-app-installation/claim", () => {
 
   it("400s on a malformed body", async () => {
     const app = getApp();
-    const { accessToken, organizationId } = await seedAdminWithGithubId(760_107);
+    const { accessToken, organizationId } = await seedAdminWithGithubToken();
     const res = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,

--- a/packages/server/src/__tests__/github-app-orphan-recovery.test.ts
+++ b/packages/server/src/__tests__/github-app-orphan-recovery.test.ts
@@ -1,74 +1,9 @@
-import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { authIdentities } from "../db/schema/auth-identities.js";
-import { githubAppInstallations } from "../db/schema/github-app-installations.js";
 import { organizations } from "../db/schema/organizations.js";
-import {
-  findInstallationByGithubId,
-  findUnboundInstallationsByAccount,
-  upsertInstallationFromMetadata,
-} from "../services/github-app-installations.js";
+import { findInstallationByGithubId, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
-
-describe("findUnboundInstallationsByAccount", () => {
-  const getApp = useTestApp();
-
-  it("returns only unbound rows for the account, newest first", async () => {
-    const app = getApp();
-    const accountGithubId = 660_001;
-
-    // Two unbound installs for this account, plus one bound row that must
-    // not show up.
-    await upsertInstallationFromMetadata(app.db, {
-      installation: {
-        id: 9_001,
-        accountType: "User",
-        accountLogin: "acct",
-        accountGithubId,
-        permissions: {},
-        events: [],
-        suspendedAt: null,
-      },
-    });
-    await upsertInstallationFromMetadata(app.db, {
-      installation: {
-        id: 9_002,
-        accountType: "User",
-        accountLogin: "acct",
-        accountGithubId,
-        permissions: {},
-        events: [],
-        suspendedAt: null,
-      },
-    });
-    const orgId = uuidv7();
-    await app.db.insert(organizations).values({ id: orgId, name: `unbound-${orgId}`, displayName: "Org" });
-    await upsertInstallationFromMetadata(app.db, {
-      installation: {
-        id: 9_003,
-        accountType: "User",
-        accountLogin: "acct",
-        accountGithubId,
-        permissions: {},
-        events: [],
-        suspendedAt: null,
-      },
-      hubOrganizationId: orgId,
-    });
-    // Force 9_002 to be the newest.
-    await app.db
-      .update(githubAppInstallations)
-      .set({ createdAt: new Date(Date.now() - 60_000) })
-      .where(eq(githubAppInstallations.installationId, 9_001));
-
-    const rows = await findUnboundInstallationsByAccount(app.db, accountGithubId);
-    expect(rows.map((r) => r.installationId)).toEqual([9_002, 9_001]);
-
-    // A different account → nothing.
-    expect(await findUnboundInstallationsByAccount(app.db, 999_999)).toHaveLength(0);
-  });
-});
 
 /**
  * Manual claim recovery. Binding is normally driven by the trusted,

--- a/packages/server/src/__tests__/github-app-orphan-recovery.test.ts
+++ b/packages/server/src/__tests__/github-app-orphan-recovery.test.ts
@@ -1,9 +1,8 @@
 import { eq } from "drizzle-orm";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { githubAppInstallations } from "../db/schema/github-app-installations.js";
 import { organizations } from "../db/schema/organizations.js";
-import { encryptValue } from "../services/crypto.js";
 import {
   findInstallationByGithubId,
   findUnboundInstallationsByAccount,
@@ -11,43 +10,6 @@ import {
 } from "../services/github-app-installations.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
-
-/**
- * Stub `globalThis.fetch` so the manual-claim endpoint's GitHub admin proof
- * (#312) resolves deterministically. For each `(login, role)` entry the
- * stub answers `GET /user/memberships/orgs/{login}` with that role + an
- * "active" state; logins not in the map return 404 (non-member). Other
- * URLs fall through to the real fetch.
- *
- * User-type installs don't reach the network at all (the helper compares
- * GitHub IDs in-process), so this stub is only consulted for Org-type
- * claims.
- */
-function stubGithubMemberships(memberships: Record<string, "admin" | "member">) {
-  const original = globalThis.fetch;
-  type FetchInput = Parameters<typeof globalThis.fetch>[0];
-  type FetchInit = Parameters<typeof globalThis.fetch>[1];
-  const spy = vi.fn(async (input: FetchInput, init?: FetchInit): Promise<Response> => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-    const match = url.match(/^https:\/\/api\.github\.com\/user\/memberships\/orgs\/([^/?]+)/);
-    if (match) {
-      const login = decodeURIComponent(match[1] ?? "");
-      const role = memberships[login];
-      if (!role) {
-        return new Response(JSON.stringify({ message: "Not Found" }), { status: 404 });
-      }
-      return new Response(JSON.stringify({ state: "active", role }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    }
-    return original(input, init);
-  });
-  globalThis.fetch = spy as typeof fetch;
-  return () => {
-    globalThis.fetch = original;
-  };
-}
 
 describe("findUnboundInstallationsByAccount", () => {
   const getApp = useTestApp();
@@ -108,93 +70,23 @@ describe("findUnboundInstallationsByAccount", () => {
   });
 });
 
-describe("OAuth sign-in orphan-install reclaim (codex P1-5 + H1)", () => {
-  const getApp = useTestApp();
-
-  it("auto-claims the single unbound install matching the signing-in user's account", async () => {
-    const app = getApp();
-    const githubId = 661_001;
-    const login = `orphan1-${uuidv7().slice(0, 6)}`;
-    const installationId = 9_101;
-
-    // First sign-in: mints the user + their personal team.
-    await app.inject({ method: "GET", url: `/api/v1/auth/github/dev-callback?githubId=${githubId}&login=${login}` });
-
-    // A stranded unbound install row whose account == this GitHub user.
-    await upsertInstallationFromMetadata(app.db, {
-      installation: {
-        id: installationId,
-        accountType: "User",
-        accountLogin: login,
-        accountGithubId: githubId,
-        permissions: {},
-        events: [],
-        suspendedAt: null,
-      },
-    });
-
-    // Second sign-in: the reclaim sweep runs and binds the orphan.
-    const res = await app.inject({
-      method: "GET",
-      url: `/api/v1/auth/github/dev-callback?githubId=${githubId}&login=${login}`,
-    });
-    expect(res.statusCode).toBe(302);
-
-    const row = await findInstallationByGithubId(app.db, installationId);
-    expect(row?.hubOrganizationId).not.toBeNull();
-    // It's the user's personal team — assert by cross-checking the org row's slug.
-    const [org] = await app.db
-      .select()
-      .from(organizations)
-      .where(eq(organizations.id, row?.hubOrganizationId ?? ""))
-      .limit(1);
-    expect(org?.name).toMatch(new RegExp(`^${login}`));
-  });
-
-  it("does NOT auto-claim when multiple unbound installs match the account", async () => {
-    const app = getApp();
-    const githubId = 661_002;
-    const login = `orphan2-${uuidv7().slice(0, 6)}`;
-
-    await app.inject({ method: "GET", url: `/api/v1/auth/github/dev-callback?githubId=${githubId}&login=${login}` });
-    for (const id of [9_201, 9_202]) {
-      await upsertInstallationFromMetadata(app.db, {
-        installation: {
-          id,
-          accountType: "User",
-          accountLogin: login,
-          accountGithubId: githubId,
-          permissions: {},
-          events: [],
-          suspendedAt: null,
-        },
-      });
-    }
-
-    await app.inject({ method: "GET", url: `/api/v1/auth/github/dev-callback?githubId=${githubId}&login=${login}` });
-
-    for (const id of [9_201, 9_202]) {
-      expect((await findInstallationByGithubId(app.db, id))?.hubOrganizationId).toBeNull();
-    }
-  });
-});
-
+/**
+ * Manual claim recovery. Binding is normally driven by the trusted,
+ * HMAC-signed `installation.created` webhook (keyed by the admin-minted
+ * install-intent). `/claim` is the recovery hatch when a row ended up
+ * unbound; it authorizes on the trusted `installer_github_id` (the webhook
+ * `sender`) — the caller may claim ONLY an installation they installed
+ * themselves. No GitHub round-trip, no `organization:members:read` probe.
+ */
 describe("POST /api/v1/orgs/:orgId/github-app-installation/claim", () => {
   const getApp = useTestApp();
 
-  async function seedAdminWithGithubToken(opts: { userGithubId?: number } = {}): Promise<{
-    accessToken: string;
-    organizationId: string;
-    userId: string;
-    userGithubId: number;
-  }> {
+  // A First Tree admin with a linked GitHub identity (numeric id on
+  // `auth_identities.identifier`, mirroring the OAuth callback). `/claim`
+  // matches this id against the installation's `installer_github_id`.
+  async function seedAdminWithGithubId(userGithubId: number): Promise<{ accessToken: string; organizationId: string }> {
     const app = getApp();
     const admin = await createTestAdmin(app, { username: `claim-${uuidv7().slice(0, 8)}` });
-    // The claim endpoint reads the caller's stored GitHub token AND the
-    // numeric GitHub ID off `auth_identities.identifier` (so the
-    // User-type admin proof can ID-compare). identifier must therefore be
-    // a valid number string, mirroring the real OAuth callback's behavior.
-    const userGithubId = opts.userGithubId ?? Math.floor(700_000 + Math.random() * 99_999);
     await app.db.insert(authIdentities).values({
       id: uuidv7(),
       userId: admin.userId,
@@ -202,65 +94,39 @@ describe("POST /api/v1/orgs/:orgId/github-app-installation/claim", () => {
       identifier: String(userGithubId),
       email: null,
       verifiedAt: new Date(),
-      metadata: { login: "claimer", accessToken: encryptValue("gho_stub", app.config.secrets.encryptionKey) },
+      metadata: { login: "claimer" },
     });
-    return {
-      accessToken: admin.accessToken,
-      organizationId: admin.organizationId,
-      userId: admin.userId,
-      userGithubId,
-    };
+    return { accessToken: admin.accessToken, organizationId: admin.organizationId };
   }
 
-  it("binds an Org-type install when the caller is a GitHub org admin", async () => {
+  async function seedInstall(opts: {
+    installationId: number;
+    installerGithubId: number | null;
+    boundTo?: string;
+  }): Promise<void> {
     const app = getApp();
-    const { accessToken, organizationId } = await seedAdminWithGithubToken();
-    const installationId = 9_301;
     await upsertInstallationFromMetadata(app.db, {
       installation: {
-        id: installationId,
+        id: opts.installationId,
         accountType: "Organization",
         accountLogin: "acme",
-        accountGithubId: 880_001,
+        accountGithubId: 880_000 + opts.installationId,
         permissions: {},
         events: [],
         suspendedAt: null,
       },
+      ...(opts.installerGithubId !== null ? { installerGithubId: opts.installerGithubId } : {}),
+      ...(opts.boundTo ? { hubOrganizationId: opts.boundTo } : {}),
     });
+  }
 
-    const restore = stubGithubMemberships({ acme: "admin" });
-    try {
-      const res = await app.inject({
-        method: "POST",
-        url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
-        headers: { authorization: `Bearer ${accessToken}` },
-        payload: { installationId },
-      });
-      expect(res.statusCode).toBe(200);
-      expect(res.json<{ bound: boolean }>().bound).toBe(true);
-    } finally {
-      restore();
-    }
-    expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBe(organizationId);
-  });
-
-  it("binds a User-type install when the caller's GitHub ID matches the account", async () => {
+  it("binds when the caller's GitHub id matches the installation's installer", async () => {
     const app = getApp();
-    const userGithubId = 760_001;
-    const { accessToken, organizationId } = await seedAdminWithGithubToken({ userGithubId });
-    const installationId = 9_311;
-    await upsertInstallationFromMetadata(app.db, {
-      installation: {
-        id: installationId,
-        accountType: "User",
-        accountLogin: "alice",
-        accountGithubId: userGithubId,
-        permissions: {},
-        events: [],
-        suspendedAt: null,
-      },
-    });
-    // No HTTP stub needed — User-type proof is purely ID-based.
+    const userGithubId = 760_101;
+    const { accessToken, organizationId } = await seedAdminWithGithubId(userGithubId);
+    const installationId = 9_401;
+    await seedInstall({ installationId, installerGithubId: userGithubId });
+
     const res = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
@@ -268,57 +134,17 @@ describe("POST /api/v1/orgs/:orgId/github-app-installation/claim", () => {
       payload: { installationId },
     });
     expect(res.statusCode).toBe(200);
+    expect(res.json<{ bound: boolean }>().bound).toBe(true);
     expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBe(organizationId);
   });
 
-  it("403s when the caller is a non-admin member of the GitHub org install", async () => {
-    // Hijack vector — the legacy `/user/installations` primitive would
-    // have returned the install for a plain member. The new admin proof
-    // rejects it.
+  it("403s when the caller didn't install it (installer id mismatch — hijack guard)", async () => {
     const app = getApp();
-    const { accessToken, organizationId } = await seedAdminWithGithubToken();
-    const installationId = 9_312;
-    await upsertInstallationFromMetadata(app.db, {
-      installation: {
-        id: installationId,
-        accountType: "Organization",
-        accountLogin: "victim",
-        accountGithubId: 880_099,
-        permissions: {},
-        events: [],
-        suspendedAt: null,
-      },
-    });
-    const restore = stubGithubMemberships({ victim: "member" });
-    try {
-      const res = await app.inject({
-        method: "POST",
-        url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
-        headers: { authorization: `Bearer ${accessToken}` },
-        payload: { installationId },
-      });
-      expect(res.statusCode).toBe(403);
-    } finally {
-      restore();
-    }
-    expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBeNull();
-  });
+    const { accessToken, organizationId } = await seedAdminWithGithubId(760_102);
+    const installationId = 9_402;
+    // Installed by a different GitHub identity.
+    await seedInstall({ installationId, installerGithubId: 999_999 });
 
-  it("403s on a User-type install when the caller's GitHub ID doesn't match", async () => {
-    const app = getApp();
-    const { accessToken, organizationId } = await seedAdminWithGithubToken({ userGithubId: 760_010 });
-    const installationId = 9_313;
-    await upsertInstallationFromMetadata(app.db, {
-      installation: {
-        id: installationId,
-        accountType: "User",
-        accountLogin: "someoneelse",
-        accountGithubId: 999_999,
-        permissions: {},
-        events: [],
-        suspendedAt: null,
-      },
-    });
     const res = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
@@ -329,99 +155,57 @@ describe("POST /api/v1/orgs/:orgId/github-app-installation/claim", () => {
     expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBeNull();
   });
 
-  it("403s when the caller is not a member of the GitHub org at all (404 from memberships)", async () => {
+  it("403s when the installation has no recorded installer (legacy / non-webhook row)", async () => {
     const app = getApp();
-    const { accessToken, organizationId } = await seedAdminWithGithubToken();
-    const installationId = 9_302;
-    await upsertInstallationFromMetadata(app.db, {
-      installation: {
-        id: installationId,
-        accountType: "Organization",
-        accountLogin: "stranger",
-        accountGithubId: 880_002,
-        permissions: {},
-        events: [],
-        suspendedAt: null,
-      },
-    });
-    // Empty memberships map → /user/memberships/orgs/stranger answers 404.
-    const restore = stubGithubMemberships({});
-    try {
-      const res = await app.inject({
-        method: "POST",
-        url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
-        headers: { authorization: `Bearer ${accessToken}` },
-        payload: { installationId },
-      });
-      expect(res.statusCode).toBe(403);
-    } finally {
-      restore();
-    }
-    expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBeNull();
-  });
+    const { accessToken, organizationId } = await seedAdminWithGithubId(760_103);
+    const installationId = 9_403;
+    await seedInstall({ installationId, installerGithubId: null });
 
-  it("409s when the installation is already bound to a different First Tree team", async () => {
-    const app = getApp();
-    const { accessToken, organizationId } = await seedAdminWithGithubToken();
-    const installationId = 9_303;
-    const otherOrgId = uuidv7();
-    await app.db.insert(organizations).values({ id: otherOrgId, name: `other-${otherOrgId}`, displayName: "Other" });
-    await upsertInstallationFromMetadata(app.db, {
-      installation: {
-        id: installationId,
-        accountType: "Organization",
-        accountLogin: "taken",
-        accountGithubId: 880_003,
-        permissions: {},
-        events: [],
-        suspendedAt: null,
-      },
-      hubOrganizationId: otherOrgId,
-    });
-    const restore = stubGithubMemberships({ taken: "admin" });
-    try {
-      const res = await app.inject({
-        method: "POST",
-        url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
-        headers: { authorization: `Bearer ${accessToken}` },
-        payload: { installationId },
-      });
-      expect(res.statusCode).toBe(409);
-    } finally {
-      restore();
-    }
-  });
-
-  it("404s when there is no installation row with that id", async () => {
-    const app = getApp();
-    const { accessToken, organizationId } = await seedAdminWithGithubToken();
-    // No upsert — the claim endpoint short-circuits with 404 before any
-    // membership API call.
     const res = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
       headers: { authorization: `Bearer ${accessToken}` },
-      payload: { installationId: 9_304 },
+      payload: { installationId },
+    });
+    expect(res.statusCode).toBe(403);
+    expect((await findInstallationByGithubId(app.db, installationId))?.hubOrganizationId).toBeNull();
+  });
+
+  it("409s when the installer matches but the install is already bound to a different team", async () => {
+    const app = getApp();
+    const userGithubId = 760_104;
+    const { accessToken, organizationId } = await seedAdminWithGithubId(userGithubId);
+    const installationId = 9_404;
+    const otherOrgId = uuidv7();
+    await app.db.insert(organizations).values({ id: otherOrgId, name: `other-${otherOrgId}`, displayName: "Other" });
+    await seedInstall({ installationId, installerGithubId: userGithubId, boundTo: otherOrgId });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
+      headers: { authorization: `Bearer ${accessToken}` },
+      payload: { installationId },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+
+  it("404s when there is no installation row with that id", async () => {
+    const app = getApp();
+    const { accessToken, organizationId } = await seedAdminWithGithubId(760_105);
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,
+      headers: { authorization: `Bearer ${accessToken}` },
+      payload: { installationId: 9_405 },
     });
     expect(res.statusCode).toBe(404);
   });
 
-  it("403s when the caller has no GitHub token on file", async () => {
+  it("403s when the caller has no GitHub identity on file", async () => {
     const app = getApp();
-    // createTestAdmin alone — no github auth_identity → no token.
-    const admin = await createTestAdmin(app, { username: `notoken-${uuidv7().slice(0, 8)}` });
-    const installationId = 9_305;
-    await upsertInstallationFromMetadata(app.db, {
-      installation: {
-        id: installationId,
-        accountType: "User",
-        accountLogin: "x",
-        accountGithubId: 880_005,
-        permissions: {},
-        events: [],
-        suspendedAt: null,
-      },
-    });
+    const admin = await createTestAdmin(app, { username: `noid-${uuidv7().slice(0, 8)}` });
+    const installationId = 9_406;
+    await seedInstall({ installationId, installerGithubId: 12_345 });
     const res = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/claim`,
@@ -433,7 +217,7 @@ describe("POST /api/v1/orgs/:orgId/github-app-installation/claim", () => {
 
   it("400s on a malformed body", async () => {
     const app = getApp();
-    const { accessToken, organizationId } = await seedAdminWithGithubToken();
+    const { accessToken, organizationId } = await seedAdminWithGithubId(760_107);
     const res = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${organizationId}/github-app-installation/claim`,

--- a/packages/server/src/__tests__/github-app-token.test.ts
+++ b/packages/server/src/__tests__/github-app-token.test.ts
@@ -178,6 +178,7 @@ function installationFixture(overrides: Partial<InstallationRow> = {}): Installa
     accountType: "Organization",
     accountLogin: "acme",
     accountGithubId: 999,
+    installerGithubId: null,
     hubOrganizationId: "org-1",
     permissions: { contents: "read" },
     events: ["push"],

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -10,7 +10,7 @@ import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
 import { users } from "../db/schema/users.js";
-import { recordInstallIntent } from "../services/github-app-install-intents.js";
+import { recordPendingBind } from "../services/github-app-install-intents.js";
 import { putOrgSetting } from "../services/org-settings.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
@@ -229,14 +229,18 @@ describe("POST /webhooks/github-app", () => {
     expect(row?.hubOrganizationId).toBeNull();
   });
 
-  it("installation.created with a matching install-intent → binds to the intent's target org", async () => {
+  it("installation.created with a matching pending bind → binds to the target org", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const installationId = 100010;
-    const installerGithubId = 90210;
-    await recordInstallIntent(app.db, {
-      installerGithubId,
+    const kickoffGithubId = 90210;
+    // The callback records the per-install pending bind (installation_id →
+    // target org + kickoff admin + their github id).
+    await recordPendingBind(app.db, {
+      installationId,
       targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+      kickoffGithubId,
     });
 
     const res = await postWebhook(app, "installation", {
@@ -248,7 +252,8 @@ describe("POST /webhooks/github-app", () => {
         events: ["pull_request"],
         suspended_at: null,
       },
-      sender: { id: installerGithubId, login: "acme-admin", type: "User" },
+      // The installer (sender) IS the kickoff admin.
+      sender: { id: kickoffGithubId, login: "acme-admin", type: "User" },
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().lifecycle).toBe("created:bound");
@@ -259,20 +264,22 @@ describe("POST /webhooks/github-app", () => {
       .where(eq(githubAppInstallations.installationId, installationId))
       .limit(1);
     expect(row?.hubOrganizationId).toBe(admin.organizationId);
-    expect(row?.installerGithubId).toBe(installerGithubId);
+    expect(row?.installerGithubId).toBe(kickoffGithubId);
   });
 
-  it("installation.created does NOT bind when the sender differs from the intent's installer (forgery guard)", async () => {
+  it("installation.created does NOT bind when the installer differs from the pending bind's kickoff admin (per-install forgery guard)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const installationId = 100011;
-    // Intent was minted for the kickoff admin (github id 111), but the
-    // install is completed by a different GitHub identity (github id 222).
-    await recordInstallIntent(app.db, {
-      installerGithubId: 111,
+    // Pending bind for this installation names kickoff github id 111...
+    await recordPendingBind(app.db, {
+      installationId,
       targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+      kickoffGithubId: 111,
     });
-
+    // ...but the actual installer (webhook sender) is a different identity —
+    // so this installation was not created by the kickoff admin. No bind.
     const res = await postWebhook(app, "installation", {
       action: "created",
       installation: {
@@ -285,7 +292,43 @@ describe("POST /webhooks/github-app", () => {
       sender: { id: 222, login: "someone-else", type: "User" },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json().lifecycle).toBe("created:no-intent");
+    expect(res.json().lifecycle).toBe("created:installer-mismatch");
+
+    const [row] = await app.db
+      .select()
+      .from(githubAppInstallations)
+      .where(eq(githubAppInstallations.installationId, installationId))
+      .limit(1);
+    expect(row?.hubOrganizationId).toBeNull();
+  });
+
+  it("installation.created does NOT bind when the kickoff admin was revoked before the webhook (mid-flight)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100012;
+    const kickoffGithubId = 90211;
+    await recordPendingBind(app.db, {
+      installationId,
+      targetOrganizationId: admin.organizationId,
+      kickoffUserId: admin.userId,
+      kickoffGithubId,
+    });
+    // Admin downgraded to member between kickoff and the webhook delivery.
+    await app.db.update(members).set({ role: "member" }).where(eq(members.userId, admin.userId));
+
+    const res = await postWebhook(app, "installation", {
+      action: "created",
+      installation: {
+        id: installationId,
+        account: { id: 4244, login: "acme2", type: "Organization" },
+        permissions: { contents: "read" },
+        events: ["pull_request"],
+        suspended_at: null,
+      },
+      sender: { id: kickoffGithubId, login: "acme-admin", type: "User" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().lifecycle).toBe("created:kickoff-not-admin");
 
     const [row] = await app.db
       .select()

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -10,6 +10,7 @@ import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
 import { users } from "../db/schema/users.js";
+import { recordInstallIntent } from "../services/github-app-install-intents.js";
 import { putOrgSetting } from "../services/org-settings.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
@@ -195,7 +196,7 @@ describe("POST /webhooks/github-app", () => {
     expect(res.json()).toEqual({ ok: true, event: "ping" });
   });
 
-  it("installation.created → UPSERTs the installation row", async () => {
+  it("installation.created → UPSERTs the row + records the installer, but stays unbound without a matching intent", async () => {
     const app = getApp();
     const installationId = 100001;
     const payload = {
@@ -203,14 +204,19 @@ describe("POST /webhooks/github-app", () => {
       installation: {
         id: installationId,
         account: { id: 555, login: "octolabs", type: "Organization" },
-        permissions: { contents: "write" },
+        permissions: { contents: "read" },
         events: ["pull_request"],
         suspended_at: null,
       },
+      // `sender` is the GitHub-authenticated installer — persisted as the
+      // trusted `installer_github_id`.
+      sender: { id: 777, login: "octo-admin", type: "User" },
     };
     const res = await postWebhook(app, "installation", payload);
     expect(res.statusCode).toBe(200);
-    expect(res.json().lifecycle).toBe("created");
+    // No matching install-intent → row is created + installer recorded, but
+    // it is NOT bound (binding is never inferred from the webhook alone).
+    expect(res.json().lifecycle).toBe("created:no-intent");
 
     const [row] = await app.db
       .select()
@@ -219,6 +225,74 @@ describe("POST /webhooks/github-app", () => {
       .limit(1);
     expect(row).toBeTruthy();
     expect(row?.accountLogin).toBe("octolabs");
+    expect(row?.installerGithubId).toBe(777);
+    expect(row?.hubOrganizationId).toBeNull();
+  });
+
+  it("installation.created with a matching install-intent → binds to the intent's target org", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100010;
+    const installerGithubId = 90210;
+    await recordInstallIntent(app.db, {
+      installerGithubId,
+      targetOrganizationId: admin.organizationId,
+    });
+
+    const res = await postWebhook(app, "installation", {
+      action: "created",
+      installation: {
+        id: installationId,
+        account: { id: 4242, login: "acme-inc", type: "Organization" },
+        permissions: { contents: "read" },
+        events: ["pull_request"],
+        suspended_at: null,
+      },
+      sender: { id: installerGithubId, login: "acme-admin", type: "User" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().lifecycle).toBe("created:bound");
+
+    const [row] = await app.db
+      .select()
+      .from(githubAppInstallations)
+      .where(eq(githubAppInstallations.installationId, installationId))
+      .limit(1);
+    expect(row?.hubOrganizationId).toBe(admin.organizationId);
+    expect(row?.installerGithubId).toBe(installerGithubId);
+  });
+
+  it("installation.created does NOT bind when the sender differs from the intent's installer (forgery guard)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100011;
+    // Intent was minted for the kickoff admin (github id 111), but the
+    // install is completed by a different GitHub identity (github id 222).
+    await recordInstallIntent(app.db, {
+      installerGithubId: 111,
+      targetOrganizationId: admin.organizationId,
+    });
+
+    const res = await postWebhook(app, "installation", {
+      action: "created",
+      installation: {
+        id: installationId,
+        account: { id: 4243, login: "victim-org", type: "Organization" },
+        permissions: { contents: "read" },
+        events: ["pull_request"],
+        suspended_at: null,
+      },
+      sender: { id: 222, login: "someone-else", type: "User" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().lifecycle).toBe("created:no-intent");
+
+    const [row] = await app.db
+      .select()
+      .from(githubAppInstallations)
+      .where(eq(githubAppInstallations.installationId, installationId))
+      .limit(1);
+    expect(row?.hubOrganizationId).toBeNull();
   });
 
   it("installation.deleted → removes the row", async () => {

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -4,9 +4,7 @@ import {
   githubStartQuerySchema,
   safeRedirectPath,
 } from "@first-tree/shared";
-import { and, eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
-import { authIdentities } from "../../db/schema/auth-identities.js";
 import { signTokensForUser } from "../../services/auth.js";
 import {
   findOrCreateUserFromGithub,
@@ -170,46 +168,15 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
       return redirectCallbackError(reply, "github-exchange-failed", next);
     }
 
-    // Kickoff install-completion (per-install correlation). The signed state
-    // proves an admin kicked off an install for `targetOrganizationId`; the
-    // URL carries the concrete `installation_id`. Record a per-install pending
-    // bind so the trusted, HMAC-signed `installation.created` webhook can
-    // complete it once it proves this installation's installer IS the kickoff
-    // admin (and the kickoff user is still an active admin — live re-checked in
-    // `completeInstallBind`). A forged `installation_id` naming another org's
-    // install never binds: that install's webhook `sender` is not the kickoff
-    // admin. Calling `completeInstallBind` here also covers the
-    // webhook-arrived-before-callback ordering.
-    if (targetOrganizationId && kickoffUserId && installationIdRaw) {
-      const installationId = Number(installationIdRaw);
-      if (Number.isFinite(installationId)) {
-        const [kickoffIdentity] = await app.db
-          .select({ identifier: authIdentities.identifier })
-          .from(authIdentities)
-          .where(and(eq(authIdentities.userId, kickoffUserId), eq(authIdentities.provider, "github")))
-          .limit(1);
-        const kickoffGithubId = kickoffIdentity?.identifier ? Number(kickoffIdentity.identifier) : Number.NaN;
-        if (Number.isFinite(kickoffGithubId)) {
-          try {
-            await recordPendingBind(app.db, { installationId, targetOrganizationId, kickoffUserId, kickoffGithubId });
-            await completeInstallBind(app.db, installationId);
-          } catch (err) {
-            // Non-fatal: the webhook path retries completion; sign-in proceeds.
-            app.log.warn(
-              { err, installationId, targetOrganizationId, kickoffUserId },
-              "install pending-bind record/complete failed in callback — webhook will retry",
-            );
-          }
-        } else {
-          app.log.warn(
-            { kickoffUserId, targetOrganizationId },
-            "install callback: kickoff user has no GitHub identity on file — cannot record pending bind",
-          );
-        }
-      }
-    }
+    // Pass the URL `installation_id` (validated to a finite number, else null)
+    // through to completeOauthFlow. It is used ONLY inside the kickoff branch,
+    // and ONLY after that branch proves the OAuth-resolved user IS the kickoff
+    // admin — so no install-bind side effect happens on an identity mismatch
+    // (the pending-bind record + `completeInstallBind` live there, not here).
+    const callbackInstallationId =
+      installationIdRaw && Number.isFinite(Number(installationIdRaw)) ? Number(installationIdRaw) : null;
 
-    return completeOauthFlow(app, request, reply, profile, next, tokens, null, targetOrganizationId, {
+    return completeOauthFlow(app, request, reply, profile, next, tokens, callbackInstallationId, targetOrganizationId, {
       kickoffUserId,
       browserFacing: true,
     });
@@ -312,7 +279,9 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
 
     // Dev bypass never carries a `targetOrganizationId` — the install
     // stub binds to whatever team the dev session resolves into.
-    return completeOauthFlow(app, request, reply, profile, next, tokens, devInstallationId, null);
+    return completeOauthFlow(app, request, reply, profile, next, tokens, devInstallationId, null, {
+      devBindInstallation: true,
+    });
   });
 }
 
@@ -365,10 +334,12 @@ async function completeOauthFlow(
    */
   oauthTokens: GithubTokenBundle,
   /**
-   * GitHub-side installation id when the user just installed the App;
-   * null on the legacy OAuth path, returning App users without a fresh
-   * install, and `dev-callback`. Used after team resolution to bind the
-   * installation row to the user's First Tree team.
+   * The URL `installation_id` (validated) from the callback, or null. It is a
+   * correlation handle, NOT a binding authority: it is used ONLY inside the
+   * kickoff branch, and only after that branch proves the OAuth-resolved user
+   * is the kickoff admin, to record a per-install pending bind that the signed
+   * `installation.created` webhook then completes. `dev-callback` passes its
+   * stub id together with `opts.devBindInstallation` for a direct QA bind.
    */
   installationId: number | null,
   /**
@@ -394,9 +365,16 @@ async function completeOauthFlow(
      * dev/test suites assert on status codes).
      */
     browserFacing?: boolean;
+    /**
+     * DEV-CALLBACK ONLY. When true, the `installationId` stub is bound
+     * directly to the resolved org (so a local QA session looks connected
+     * without a real webhook). The real `/callback` never sets this — its
+     * binding is webhook-driven.
+     */
+    devBindInstallation?: boolean;
   } = {},
 ) {
-  const { kickoffUserId = null, browserFacing = false } = opts;
+  const { kickoffUserId = null, browserFacing = false, devBindInstallation = false } = opts;
   const { userId } = await findOrCreateUserFromGithub(app.db, profile, oauthTokens);
   const allowedOrganizationId = app.config.access?.allowedOrganizationId ?? null;
 
@@ -505,6 +483,32 @@ async function completeOauthFlow(
       );
       return redirectCallbackError(reply, "install-not-verified", next);
     }
+    // Identity match confirmed (OAuth-resolved user IS the kickoff admin, who
+    // is an active admin of the target org — checked above). ONLY NOW is it
+    // safe to record the per-install pending bind: recording it before the
+    // mismatch guard would let a callback under a foreign identity trigger a
+    // bind side effect while still returning `install-not-verified`. Here
+    // `profile.githubId` is the kickoff admin's GitHub id, so the trusted
+    // `installation.created` webhook completes the bind only when THIS
+    // installation's installer matches (and the admin is still active).
+    // `completeInstallBind` also covers the webhook-arrived-before-callback
+    // ordering. Non-fatal on error — the webhook retries completion.
+    if (installationId !== null) {
+      try {
+        await recordPendingBind(app.db, {
+          installationId,
+          targetOrganizationId,
+          kickoffUserId: bindAuthorityUserId,
+          kickoffGithubId: Number(profile.githubId),
+        });
+        await completeInstallBind(app.db, installationId);
+      } catch (err) {
+        app.log.warn(
+          { err, installationId, targetOrganizationId, kickoffUserId: bindAuthorityUserId },
+          "install pending-bind record/complete failed in callback — webhook will retry",
+        );
+      }
+    }
     resolved = true;
     resolvedOrganizationId = targetOrganizationId;
     // joinPath stays "returning"; keep caller's `next` (the Settings page)
@@ -553,14 +557,16 @@ async function completeOauthFlow(
     }
   }
 
-  // Direct installation bind — DEV-CALLBACK ONLY. The real `/callback`
-  // sign-in path passes `installationId = null`: installation binding is
-  // driven exclusively by the trusted, HMAC-signed `installation.created`
-  // webhook (keyed by the admin-minted install-intent), never by the
-  // browser-supplied URL id. `dev-callback` passes a stub installation id so
-  // a local QA session looks connected without a real webhook. Guarded by
-  // `installationId !== null`, so this is inert on the real sign-in path.
-  if (installationId !== null && resolvedOrganizationId) {
+  // Direct installation bind — DEV-CALLBACK ONLY, gated by `devBindInstallation`.
+  // The real `/callback` NEVER sets that flag: real binding is driven
+  // exclusively by the trusted, HMAC-signed `installation.created` webhook via
+  // the per-install pending bind recorded above, never by the browser-supplied
+  // URL id. `dev-callback` passes a stub installation id + the flag so a local
+  // QA session looks connected without a real webhook. The flag gate (not just
+  // `installationId !== null`) is essential now that the real callback DOES
+  // pass a URL `installation_id` for the kickoff pending bind — binding it here
+  // would reopen the URL-forgery hole.
+  if (devBindInstallation && installationId !== null && resolvedOrganizationId) {
     try {
       await bindInstallationToOrg(app.db, installationId, resolvedOrganizationId);
     } catch (err) {

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -12,18 +12,8 @@ import {
   type GithubTokenBundle,
 } from "../../services/auth-identity.js";
 import { encryptValue } from "../../services/crypto.js";
-import {
-  buildAppAuthorizeUrl,
-  createAppJwt,
-  exchangeCodeForAppUserProfile,
-  fetchInstallation,
-  verifyUserCanAdministerInstallation,
-} from "../../services/github-app.js";
-import {
-  bindInstallationToOrg,
-  findUnboundInstallationsByAccount,
-  upsertInstallationFromMetadata,
-} from "../../services/github-app-installations.js";
+import { buildAppAuthorizeUrl, exchangeCodeForAppUserProfile } from "../../services/github-app.js";
+import { bindInstallationToOrg, upsertInstallationFromMetadata } from "../../services/github-app-installations.js";
 import { findActiveByToken, recordRedemption } from "../../services/invitation.js";
 import {
   createPersonalTeam,
@@ -110,7 +100,10 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
       return reply.status(503).send({ error: "GitHub App is not configured on this First Tree deployment" });
     }
     const parsed = githubCallbackQuerySchema.parse(request.query);
-    const { code, state, installation_id: installationIdRaw } = parsed;
+    // `installation_id` may ride the callback URL but is intentionally
+    // ignored — it's unsigned/forgeable and never a binding input (binding
+    // is webhook-driven; see the exchange comment below).
+    const { code, state } = parsed;
     const cookieNonce = parseCookieHeader(request.headers.cookie, OAUTH_STATE_COOKIE);
 
     let next: string;
@@ -146,82 +139,36 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
     const redirectUri = `${resolvePublicUrl(app, request)}/api/v1/auth/github/callback`;
     let profile: GithubProfile;
     let tokens: GithubTokenBundle;
-    let plaintextUserAccessToken: string;
-    let installationId: number | null = null;
     try {
       const result = await exchangeCodeForAppUserProfile({
         clientId: appCfg.clientId,
         clientSecret: appCfg.clientSecret,
         code,
         redirectUri,
-        installationId: installationIdRaw ? Number(installationIdRaw) : null,
+        // Sign-in is pure login. Installation binding is NOT driven by this
+        // OAuth round-trip, nor by the browser-supplied URL `installation_id`
+        // (unsigned, address-bar-forgeable). Binding is done by the trusted,
+        // HMAC-signed `installation.created` webhook, keyed by the
+        // admin-minted install-intent (see `services/github-app-install-intents`
+        // and `system/cloud/github/github-app.md`). So we neither thread nor
+        // bind an `installation_id` here — the old
+        // `verifyUserCanAdministerInstallation` probe (and its
+        // `organization:members:read` need) is gone.
+        installationId: null,
       });
       profile = result.profile;
-      plaintextUserAccessToken = result.accessToken;
       tokens = {
         encryptedAccessToken: encryptValue(result.accessToken, app.config.secrets.encryptionKey),
         accessTokenExpiresAt: result.accessTokenExpiresAt,
         encryptedRefreshToken: encryptValue(result.refreshToken, app.config.secrets.encryptionKey),
         refreshTokenExpiresAt: result.refreshTokenExpiresAt,
       };
-      installationId = result.installationId;
     } catch (err) {
       app.log.warn({ err }, "github sign-in code exchange failed");
       return redirectCallbackError(reply, "github-exchange-failed", next);
     }
 
-    // SECURITY: `installation_id` rides the browser address bar — not a
-    // secret, not signed. Any signed-in user could append
-    // `?installation_id=<other-team's-id>` and bind that installation to
-    // their own First Tree team if we don't authorize first (the App JWT can
-    // read every installation, so `fetchInstallation` would succeed).
-    //
-    // Require GitHub-side **admin** on the install's account: User-type
-    // owner-match, Org-type admin via `/user/memberships/orgs/{login}`.
-    // Plain read access via org membership isn't enough — that's what
-    // made the original `/user/installations` primitive forgeable.
-    //
-    // We fetch the installation first to get its account metadata, then
-    // verify, then upsert. On any failure — verify / fetch / upsert —
-    // we drop `installationId` so sign-in still succeeds but no row is
-    // bound; the user can re-trigger install from Settings.
-    if (installationId !== null && appCfg) {
-      try {
-        const appJwt = await createAppJwt({ appId: appCfg.appId, privateKeyPem: appCfg.privateKeyPem });
-        const installation = await fetchInstallation(appJwt, installationId);
-        const canAdminister = await verifyUserCanAdministerInstallation(
-          plaintextUserAccessToken,
-          Number(profile.githubId),
-          installation,
-        );
-        if (!canAdminister) {
-          app.log.warn(
-            {
-              event: "github_app.installation_id_unauthorized",
-              installationId,
-              githubId: profile.githubId,
-              accountType: installation.accountType,
-              accountLogin: installation.accountLogin,
-            },
-            "callback installation_id admin proof failed — refusing to bind",
-          );
-          installationId = null;
-        } else {
-          await upsertInstallationFromMetadata(app.db, { installation });
-        }
-      } catch (err) {
-        // Failing closed: fetch / membership API / upsert all roll up
-        // here so we never half-bind. User still signs in; the Settings
-        // panel surfaces a clean "Install" CTA for retry.
-        app.log.warn(
-          { err, installationId, githubId: profile.githubId },
-          "github app install verify/upsert failed — clearing installation_id, user can retry from Settings",
-        );
-        installationId = null;
-      }
-    }
-
-    return completeOauthFlow(app, request, reply, profile, next, tokens, installationId, targetOrganizationId, {
+    return completeOauthFlow(app, request, reply, profile, next, tokens, null, targetOrganizationId, {
       kickoffUserId,
       browserFacing: true,
     });
@@ -493,19 +440,17 @@ async function completeOauthFlow(
       return reply.status(403).send({ error: "Not an admin of the First Tree organization this installation targets" });
     }
     if (bindAuthorityUserId !== userId) {
-      // Identity mismatch: complete the install on the kickoff admin's
-      // authority, then bounce straight to `next` WITHOUT issuing tokens —
-      // signing the browser in as the OAuth identity would replace the
-      // kickoff admin's session across every tab. GitHub-side authority is
-      // unchanged: `installationId` is non-null only when the OAuth user
-      // proved they administer the installed account, and the nonce cookie
-      // pins this request to the same browser that minted the kickoff.
-      //
-      // The no-token success redirect is earned ONLY by an actual bind
-      // (review finding on the first cut of this branch): with no verified
-      // installation, or a bind refusal, `next` may be the onboarding
-      // auto-close page — bouncing there would present a silent failure as
-      // "connected". Surface the error instead.
+      // The install was completed under a DIFFERENT GitHub identity than the
+      // admin who kicked it off — the browser's github.com session differs
+      // from the First Tree kickoff admin (a second GitHub account, someone
+      // else's github.com session in the same browser, …). Binding requires
+      // installer == kickoff admin: the install-intent is keyed by the
+      // kickoff admin's GitHub id and the trusted `installation.created`
+      // webhook only binds when its `sender` matches, so this install will
+      // NOT bind. Surface it as an error rather than sign the browser in as
+      // the foreign identity (which would replace the kickoff admin's
+      // session in every tab). Install must use the same GitHub account you
+      // signed in / started the install with.
       app.log.warn(
         {
           event: "github_app.install_callback_identity_mismatch",
@@ -514,25 +459,10 @@ async function completeOauthFlow(
           oauthUserId: userId,
           githubId: profile.githubId,
           githubLogin: profile.login,
-          installationId,
         },
-        "install callback: OAuth identity differs from the kickoff session — binding on kickoff authority, skipping sign-in",
+        "install callback: OAuth identity differs from the kickoff admin — refusing (install must use the same GitHub account)",
       );
-      if (installationId === null) {
-        // Either GitHub never sent an installation_id, or the GitHub-side
-        // admin proof / fetch / upsert failed closed and cleared it.
-        return redirectCallbackError(reply, "install-not-verified", next);
-      }
-      try {
-        await bindInstallationToOrg(app.db, installationId, targetOrganizationId);
-      } catch (err) {
-        app.log.warn(
-          { err, installationId, hubOrganizationId: targetOrganizationId, kickoffUserId: bindAuthorityUserId },
-          "github app install bind-to-org failed on identity-mismatch path — reconcile in Settings",
-        );
-        return redirectCallbackError(reply, "install-bind-failed", next);
-      }
-      return reply.redirect(next, 302);
+      return redirectCallbackError(reply, "install-not-verified", next);
     }
     resolved = true;
     resolvedOrganizationId = targetOrganizationId;
@@ -582,62 +512,30 @@ async function completeOauthFlow(
     }
   }
 
-  // Bind the installation to whichever First Tree team the user just resolved
-  // into. Late-bound (after team resolution) so a personal-team-creating
-  // signup ends up bound to the team it just minted, and an invitee binds
-  // to the inviting org.
-  //
-  // Tolerates the "already bound to this org" no-op case (idempotent on
-  // returning sign-ins). Refuses to rebind to a different org per D2 1:1
-  // — that path logs a warning and lets the sign-in succeed; the
-  // installation stays attached to whoever installed it first, which is
-  // the documented design (no "transfer install" UX yet).
+  // Direct installation bind — DEV-CALLBACK ONLY. The real `/callback`
+  // sign-in path passes `installationId = null`: installation binding is
+  // driven exclusively by the trusted, HMAC-signed `installation.created`
+  // webhook (keyed by the admin-minted install-intent), never by the
+  // browser-supplied URL id. `dev-callback` passes a stub installation id so
+  // a local QA session looks connected without a real webhook. Guarded by
+  // `installationId !== null`, so this is inert on the real sign-in path.
   if (installationId !== null && resolvedOrganizationId) {
     try {
       await bindInstallationToOrg(app.db, installationId, resolvedOrganizationId);
     } catch (err) {
       app.log.warn(
         { err, installationId, hubOrganizationId: resolvedOrganizationId, userId },
-        "github app install bind-to-org failed — sign-in continues; reconcile in Settings",
+        "dev-callback install bind-to-org failed — sign-in continues",
       );
     }
   }
 
-  // Orphan-install reclaim (codex P1-5 + H1): if a prior sign-in UPSERTed
-  // an installation row but the bind step failed, the row stays unbound
-  // forever — GitHub only sends `installation_id` on the initial install,
-  // so a later sign-in never re-attempts the bind via the branch above.
-  // Sweep here for unbound rows whose GitHub account is *this user's own*
-  // personal account (the same authorization basis the callback's
-  // `/user/installations` check enforced when the row was first written),
-  // and auto-claim if there's exactly one. Multiple → leave them for the
-  // manual `POST /claim` endpoint to disambiguate (the Settings "Claim install"
-  // UI that drives that endpoint is tracked in #318).
-  if (resolvedOrganizationId) {
-    try {
-      const orphans = await findUnboundInstallationsByAccount(app.db, Number(profile.githubId));
-      if (orphans.length === 1) {
-        const orphan = orphans[0];
-        if (orphan) {
-          await bindInstallationToOrg(app.db, orphan.installationId, resolvedOrganizationId).catch((err) => {
-            app.log.warn(
-              { err, installationId: orphan.installationId, hubOrganizationId: resolvedOrganizationId, userId },
-              "orphan install reclaim failed — operator can retry via POST /claim (UI tracked in #318)",
-            );
-          });
-        }
-      } else if (orphans.length > 1) {
-        app.log.info(
-          { count: orphans.length, accountGithubId: Number(profile.githubId), userId },
-          "multiple unbound installs match this account — skipping auto-claim; operator must POST /claim to pick (UI #318)",
-        );
-      }
-    } catch (err) {
-      // The reclaim sweep is best-effort; a failure here must never block
-      // sign-in.
-      app.log.warn({ err, userId }, "orphan install reclaim sweep failed");
-    }
-  }
+  // NOTE: the previous sign-in-time orphan-install auto-reclaim sweep (which
+  // matched unbound rows by the user's GitHub *account* id and auto-bound the
+  // single match) is removed. Binding is now webhook-driven, and recovery of
+  // an unbound install goes through the explicit `POST /claim`, which matches
+  // on the trusted `installer_github_id` (the webhook `sender`) rather than
+  // mere account membership.
 
   if (!resolved) {
     if (browserFacing) return redirectCallbackError(reply, "membership-unresolved");

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -4,7 +4,9 @@ import {
   githubStartQuerySchema,
   safeRedirectPath,
 } from "@first-tree/shared";
+import { and, eq } from "drizzle-orm";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { authIdentities } from "../../db/schema/auth-identities.js";
 import { signTokensForUser } from "../../services/auth.js";
 import {
   findOrCreateUserFromGithub,
@@ -13,6 +15,7 @@ import {
 } from "../../services/auth-identity.js";
 import { encryptValue } from "../../services/crypto.js";
 import { buildAppAuthorizeUrl, exchangeCodeForAppUserProfile } from "../../services/github-app.js";
+import { completeInstallBind, recordPendingBind } from "../../services/github-app-install-intents.js";
 import { bindInstallationToOrg, upsertInstallationFromMetadata } from "../../services/github-app-installations.js";
 import { findActiveByToken, recordRedemption } from "../../services/invitation.js";
 import {
@@ -43,11 +46,13 @@ import { buildCookie, parseCookieHeader } from "./oauth-cookie.js";
  * `GET /orgs/:orgId/github-app-installation/install-url` and surfaced both
  * in onboarding's "Connect your code" step and Settings → GitHub. After
  * that dialog GitHub redirects back here with `code + state +
- * installation_id`, which the callback verifies and binds. The install
- * BIND rests on the kickoff session signed into the state
- * (`kickoffUserId`, re-checked live), not on the identity the OAuth code
- * resolves to — the browser's github.com session is independent of the
- * First Tree session, and a mismatch must not strand the install unbound.
+ * installation_id`. The callback does NOT bind the installation: it records
+ * a per-install pending bind (keyed by `installation_id`, authorized by the
+ * signed kickoff state — `kickoffUserId`), and the actual bind is performed by
+ * the trusted, HMAC-signed `installation.created` webhook once it proves the
+ * installer IS the kickoff admin (and re-checks live admin). The URL
+ * `installation_id` is only a correlation handle; a forged one never binds.
+ * The browser's github.com session is independent of the First Tree session.
  *
  * The live `/callback` is a full-page browser navigation, so its error
  * replies redirect to the SPA error surface
@@ -100,10 +105,12 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
       return reply.status(503).send({ error: "GitHub App is not configured on this First Tree deployment" });
     }
     const parsed = githubCallbackQuerySchema.parse(request.query);
-    // `installation_id` may ride the callback URL but is intentionally
-    // ignored — it's unsigned/forgeable and never a binding input (binding
-    // is webhook-driven; see the exchange comment below).
-    const { code, state } = parsed;
+    // `installation_id` from the URL is unsigned/forgeable, so it is NEVER a
+    // binding authority on its own. On the kickoff install path it is used
+    // only as a *correlation handle*: we record a per-install pending bind,
+    // and the trusted `installation.created` webhook completes it only after
+    // proving this installation's installer is the kickoff admin.
+    const { code, state, installation_id: installationIdRaw } = parsed;
     const cookieNonce = parseCookieHeader(request.headers.cookie, OAUTH_STATE_COOKIE);
 
     let next: string;
@@ -145,15 +152,10 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
         clientSecret: appCfg.clientSecret,
         code,
         redirectUri,
-        // Sign-in is pure login. Installation binding is NOT driven by this
-        // OAuth round-trip, nor by the browser-supplied URL `installation_id`
-        // (unsigned, address-bar-forgeable). Binding is done by the trusted,
-        // HMAC-signed `installation.created` webhook, keyed by the
-        // admin-minted install-intent (see `services/github-app-install-intents`
-        // and `system/cloud/github/github-app.md`). So we neither thread nor
-        // bind an `installation_id` here — the old
-        // `verifyUserCanAdministerInstallation` probe (and its
-        // `organization:members:read` need) is gone.
+        // The OAuth code exchange resolves the signing-in identity for LOGIN.
+        // It is not an installation-binding input, so we don't thread the URL
+        // `installation_id` through it; binding is handled separately via the
+        // per-install pending bind + trusted `installation.created` webhook.
         installationId: null,
       });
       profile = result.profile;
@@ -166,6 +168,45 @@ export async function githubOauthRoutes(app: FastifyInstance): Promise<void> {
     } catch (err) {
       app.log.warn({ err }, "github sign-in code exchange failed");
       return redirectCallbackError(reply, "github-exchange-failed", next);
+    }
+
+    // Kickoff install-completion (per-install correlation). The signed state
+    // proves an admin kicked off an install for `targetOrganizationId`; the
+    // URL carries the concrete `installation_id`. Record a per-install pending
+    // bind so the trusted, HMAC-signed `installation.created` webhook can
+    // complete it once it proves this installation's installer IS the kickoff
+    // admin (and the kickoff user is still an active admin — live re-checked in
+    // `completeInstallBind`). A forged `installation_id` naming another org's
+    // install never binds: that install's webhook `sender` is not the kickoff
+    // admin. Calling `completeInstallBind` here also covers the
+    // webhook-arrived-before-callback ordering.
+    if (targetOrganizationId && kickoffUserId && installationIdRaw) {
+      const installationId = Number(installationIdRaw);
+      if (Number.isFinite(installationId)) {
+        const [kickoffIdentity] = await app.db
+          .select({ identifier: authIdentities.identifier })
+          .from(authIdentities)
+          .where(and(eq(authIdentities.userId, kickoffUserId), eq(authIdentities.provider, "github")))
+          .limit(1);
+        const kickoffGithubId = kickoffIdentity?.identifier ? Number(kickoffIdentity.identifier) : Number.NaN;
+        if (Number.isFinite(kickoffGithubId)) {
+          try {
+            await recordPendingBind(app.db, { installationId, targetOrganizationId, kickoffUserId, kickoffGithubId });
+            await completeInstallBind(app.db, installationId);
+          } catch (err) {
+            // Non-fatal: the webhook path retries completion; sign-in proceeds.
+            app.log.warn(
+              { err, installationId, targetOrganizationId, kickoffUserId },
+              "install pending-bind record/complete failed in callback — webhook will retry",
+            );
+          }
+        } else {
+          app.log.warn(
+            { kickoffUserId, targetOrganizationId },
+            "install callback: kickoff user has no GitHub identity on file — cannot record pending bind",
+          );
+        }
+      }
     }
 
     return completeOauthFlow(app, request, reply, profile, next, tokens, null, targetOrganizationId, {

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -8,13 +8,8 @@ import type { FastifyInstance } from "fastify";
 import { authIdentities } from "../../db/schema/auth-identities.js";
 import { ForbiddenError, NotFoundError } from "../../errors.js";
 import { requireOrgAdmin, requireOrgMembership } from "../../scope/require-org.js";
-import { getStoredGithubAccessToken } from "../../services/auth-identity.js";
-import {
-  buildAppInstallUrl,
-  GithubAppApiError,
-  listInstallationRepos,
-  verifyUserCanAdministerInstallation,
-} from "../../services/github-app.js";
+import { buildAppInstallUrl, listInstallationRepos } from "../../services/github-app.js";
+import { recordInstallIntent } from "../../services/github-app-install-intents.js";
 import {
   bindInstallationToOrg,
   findInstallationByGithubId,
@@ -259,6 +254,32 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
         secure: process.env.NODE_ENV === "production",
       }),
     );
+
+    // Record the pending install intent so the trusted, HMAC-signed
+    // `installation.created` webhook can bind the resulting installation to
+    // THIS org — matched by the kickoff admin's GitHub id against the
+    // webhook `sender`. Binding is never driven by the browser-supplied URL
+    // `installation_id` (unsigned, forgeable). The `state`/nonce still
+    // guard the callback's CSRF + kickoff identity; this intent is the
+    // separate, trusted binding channel.
+    const [identity] = await app.db
+      .select({ identifier: authIdentities.identifier })
+      .from(authIdentities)
+      .where(and(eq(authIdentities.userId, scope.userId), eq(authIdentities.provider, "github")))
+      .limit(1);
+    const installerGithubId = identity?.identifier ? Number(identity.identifier) : Number.NaN;
+    if (!Number.isNaN(installerGithubId)) {
+      await recordInstallIntent(app.db, {
+        installerGithubId,
+        targetOrganizationId: scope.organizationId,
+      });
+    } else {
+      app.log.warn(
+        { userId: scope.userId, organizationId: scope.organizationId },
+        "install-url: kickoff admin has no GitHub identity on file — install won't auto-bind; recover via POST /claim",
+      );
+    }
+
     return { installUrl: buildAppInstallUrl({ appSlug: appCfg.slug, state: token }) };
   });
 
@@ -298,41 +319,33 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
       throw new NotFoundError(`Installation ${installationId} not found`);
     }
 
-    const githubToken = await getStoredGithubAccessToken(app.db, scope.userId, app.config.secrets.encryptionKey);
-    if (!githubToken) {
-      throw new ForbiddenError("No GitHub access token on file — sign in with GitHub again before claiming an install");
-    }
-
-    // Same row `getStoredGithubAccessToken` just verified — pull the
-    // caller's numeric GitHub ID off `auth_identities.identifier`
-    // (written by the OAuth callback as `String(profile.githubId)`) so
-    // the User-type comparison has something to match against.
+    // Anti-forgery (no GitHub round-trip, no `organization:members:read`):
+    // the caller may claim ONLY an installation they installed themselves.
+    // `installer_github_id` is the `sender` from the trusted, HMAC-signed
+    // `installation.created` webhook; GitHub only lets a user install on an
+    // account they administer, so matching it to the caller's own GitHub id
+    // proves both "the caller installed this" and "the caller administers
+    // the installed account" — the guarantee the removed
+    // `verifyUserCanAdministerInstallation` probe used to provide.
     const [identity] = await app.db
       .select({ identifier: authIdentities.identifier })
       .from(authIdentities)
       .where(and(eq(authIdentities.userId, scope.userId), eq(authIdentities.provider, "github")))
       .limit(1);
-    const userGithubId = Number(identity?.identifier);
-
-    let canAdminister: boolean;
-    try {
-      canAdminister = await verifyUserCanAdministerInstallation(githubToken, userGithubId, {
-        accountType: installRow.accountType as "User" | "Organization",
-        accountLogin: installRow.accountLogin,
-        accountGithubId: installRow.accountGithubId,
-      });
-    } catch (err) {
-      const status = err instanceof GithubAppApiError ? err.status : 0;
-      if (status === 401) {
-        throw new ForbiddenError("Your GitHub session has expired — sign in with GitHub again, then retry the claim");
-      }
-      // Upstream hiccup — surface as 403 so the caller retries rather
-      // than treating a transient GitHub outage as a hard failure.
-      app.log.warn({ err, installationId, userId: scope.userId }, "claim: admin proof check failed");
-      throw new ForbiddenError("Couldn't verify GitHub access for this installation — try again in a moment");
+    const userGithubId = identity?.identifier ? Number(identity.identifier) : Number.NaN;
+    if (Number.isNaN(userGithubId)) {
+      throw new ForbiddenError("No GitHub identity on file — sign in with GitHub again before claiming an install");
     }
-    if (!canAdminister) {
-      throw new ForbiddenError("You don't administer this installation on GitHub");
+    if (installRow.installerGithubId === null) {
+      // Row predates the trusted installer id (or wasn't created via the
+      // `installation.created` webhook). Reinstall from the account owner
+      // to mint it.
+      throw new ForbiddenError(
+        "This installation has no recorded installer — reinstall the GitHub App from the account owner to claim it.",
+      );
+    }
+    if (installRow.installerGithubId !== userGithubId) {
+      throw new ForbiddenError("You didn't install this GitHub App installation, so you can't claim it.");
     }
 
     // bindInstallationToOrg throws NotFoundError (no such install row) →

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -8,7 +8,13 @@ import type { FastifyInstance } from "fastify";
 import { authIdentities } from "../../db/schema/auth-identities.js";
 import { ForbiddenError, NotFoundError } from "../../errors.js";
 import { requireOrgAdmin, requireOrgMembership } from "../../scope/require-org.js";
-import { buildAppInstallUrl, listInstallationRepos } from "../../services/github-app.js";
+import { getStoredGithubAccessToken } from "../../services/auth-identity.js";
+import {
+  buildAppInstallUrl,
+  GithubAppApiError,
+  listInstallationRepos,
+  verifyUserCanAdministerInstallation,
+} from "../../services/github-app.js";
 import {
   bindInstallationToOrg,
   findInstallationByGithubId,
@@ -274,14 +280,14 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
   // it yet. The orphan-list endpoint and a per-install `Claim install` button
   // are tracked in #318; until then, recovery requires POSTing here directly.
   //
-  // Authorization: being a First Tree org admin isn't sufficient — the
-  // browser-supplied installation id isn't a secret. The caller may claim
-  // ONLY an installation THEY installed, matched against the trusted
-  // `installer_github_id` (the `installation.created` webhook `sender`; GitHub
-  // only lets a user install on an account they administer). This replaces the
-  // removed `verifyUserCanAdministerInstallation` probe on this path. The row
-  // (and its `installer_github_id`) is written by the webhook; 404 here means
-  // there's nothing to claim.
+  // Authorization: First Tree org-admin is not sufficient. Because `/claim` is
+  // a *delayed* recovery path, it keeps a LIVE current-GitHub-admin check
+  // (`verifyUserCanAdministerInstallation`) — the historical
+  // `installer_github_id` recorded at install time can be stale by claim time
+  // (the installer may have since lost GitHub admin/membership while the App
+  // installation lingers unbound). Fail-closed: User-type → caller's GitHub id
+  // must equal the install account's; Org-type → `/user/memberships/orgs`
+  // must return role=admin. 404 here means there's nothing to claim.
   app.post<{ Params: { orgId: string }; Body: unknown }>("/claim", async (request) => {
     const scope = await requireOrgAdmin(request, app.db);
     const { installationId } = githubAppInstallationClaimBodySchema.parse(request.body);
@@ -291,33 +297,48 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
       throw new NotFoundError(`Installation ${installationId} not found`);
     }
 
-    // Anti-forgery (no GitHub round-trip, no `organization:members:read`):
-    // the caller may claim ONLY an installation they installed themselves.
-    // `installer_github_id` is the `sender` from the trusted, HMAC-signed
-    // `installation.created` webhook; GitHub only lets a user install on an
-    // account they administer, so matching it to the caller's own GitHub id
-    // proves both "the caller installed this" and "the caller administers
-    // the installed account" — the guarantee the removed
-    // `verifyUserCanAdministerInstallation` probe used to provide.
+    const githubToken = await getStoredGithubAccessToken(app.db, scope.userId, app.config.secrets.encryptionKey);
+    if (!githubToken) {
+      throw new ForbiddenError("No GitHub access token on file — sign in with GitHub again before claiming an install");
+    }
+
+    // Caller's numeric GitHub id off `auth_identities.identifier` (written by
+    // the OAuth callback as `String(profile.githubId)`) for the User-type
+    // owner comparison.
     const [identity] = await app.db
       .select({ identifier: authIdentities.identifier })
       .from(authIdentities)
       .where(and(eq(authIdentities.userId, scope.userId), eq(authIdentities.provider, "github")))
       .limit(1);
-    const userGithubId = identity?.identifier ? Number(identity.identifier) : Number.NaN;
-    if (Number.isNaN(userGithubId)) {
-      throw new ForbiddenError("No GitHub identity on file — sign in with GitHub again before claiming an install");
+    const userGithubId = Number(identity?.identifier);
+
+    // LIVE current-GitHub-admin check (fail-closed). `/claim` is the *delayed*
+    // recovery path: unlike the normal webhook bind (which fires when the
+    // installer is provably the current admin), an orphaned install may be
+    // claimed long after install time, when the recorded `installer_github_id`
+    // is stale. So this endpoint verifies CURRENT authority — User-type:
+    // caller's GitHub id equals the install account's; Org-type:
+    // `GET /user/memberships/orgs/{login}` returns role=admin, state=active
+    // (plain membership is not enough). This is why the probe +
+    // `Members:read` remain here (and for the Context-Tree repo provisioner)
+    // until the server-side build is retired.
+    let canAdminister: boolean;
+    try {
+      canAdminister = await verifyUserCanAdministerInstallation(githubToken, userGithubId, {
+        accountType: installRow.accountType as "User" | "Organization",
+        accountLogin: installRow.accountLogin,
+        accountGithubId: installRow.accountGithubId,
+      });
+    } catch (err) {
+      const status = err instanceof GithubAppApiError ? err.status : 0;
+      if (status === 401) {
+        throw new ForbiddenError("Your GitHub session has expired — sign in with GitHub again, then retry the claim");
+      }
+      app.log.warn({ err, installationId, userId: scope.userId }, "claim: admin proof check failed");
+      throw new ForbiddenError("Couldn't verify GitHub access for this installation — try again in a moment");
     }
-    if (installRow.installerGithubId === null) {
-      // Row predates the trusted installer id (or wasn't created via the
-      // `installation.created` webhook). Reinstall from the account owner
-      // to mint it.
-      throw new ForbiddenError(
-        "This installation has no recorded installer — reinstall the GitHub App from the account owner to claim it.",
-      );
-    }
-    if (installRow.installerGithubId !== userGithubId) {
-      throw new ForbiddenError("You didn't install this GitHub App installation, so you can't claim it.");
+    if (!canAdminister) {
+      throw new ForbiddenError("You don't currently administer this installation on GitHub");
     }
 
     // bindInstallationToOrg throws NotFoundError (no such install row) →

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -9,7 +9,6 @@ import { authIdentities } from "../../db/schema/auth-identities.js";
 import { ForbiddenError, NotFoundError } from "../../errors.js";
 import { requireOrgAdmin, requireOrgMembership } from "../../scope/require-org.js";
 import { buildAppInstallUrl, listInstallationRepos } from "../../services/github-app.js";
-import { recordInstallIntent } from "../../services/github-app-install-intents.js";
 import {
   bindInstallationToOrg,
   findInstallationByGithubId,
@@ -213,8 +212,9 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
   // The SPA fetches this (with its bearer token), gets `{ installUrl }`
   // back plus a `Set-Cookie`, then does `window.location = installUrl`.
   // GitHub shows the install dialog, the user picks repos, GitHub
-  // redirects to `/auth/github/callback?code=…&state=…&installation_id=…`,
-  // and the callback verifies the state cookie + binds the install.
+  // redirects to `/auth/github/callback?code=…&state=…&installation_id=…`.
+  // The callback verifies the state cookie and records a per-install pending
+  // bind; the trusted `installation.created` webhook performs the actual bind.
   app.get<{ Params: { orgId: string }; Querystring: { next?: string } }>("/install-url", async (request, reply) => {
     // Admin-gated: the resolved scope is the org the install binds to.
     const scope = await requireOrgAdmin(request, app.db);
@@ -229,10 +229,10 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
         .send({ error: "GitHub App install URL is unavailable — FIRST_TREE_GITHUB_APP_SLUG is not configured." });
     }
 
-    // `targetOrganizationId` rides inside the signed state so the OAuth
-    // callback binds the install to *this* org rather than the caller's
-    // primary org (codex P1-3) — an admin in org B installing the App must
-    // end up bound to org B. `kickoffUserId` rides alongside it so the
+    // `targetOrganizationId` rides inside the signed state so the resulting
+    // installation binds to *this* org rather than the caller's primary org
+    // (codex P1-3) — an admin in org B installing the App must end up bound to
+    // org B. `kickoffUserId` rides alongside it so the
     // callback can rest the bind on THIS admin's (re-checked) authority
     // even when the browser's github.com session resolves to a different
     // GitHub identity — the github.com session and the First Tree session
@@ -255,61 +255,33 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
       }),
     );
 
-    // Record the pending install intent so the trusted, HMAC-signed
-    // `installation.created` webhook can bind the resulting installation to
-    // THIS org — matched by the kickoff admin's GitHub id against the
-    // webhook `sender`. Binding is never driven by the browser-supplied URL
-    // `installation_id` (unsigned, forgeable). The `state`/nonce still
-    // guard the callback's CSRF + kickoff identity; this intent is the
-    // separate, trusted binding channel.
-    const [identity] = await app.db
-      .select({ identifier: authIdentities.identifier })
-      .from(authIdentities)
-      .where(and(eq(authIdentities.userId, scope.userId), eq(authIdentities.provider, "github")))
-      .limit(1);
-    const installerGithubId = identity?.identifier ? Number(identity.identifier) : Number.NaN;
-    if (!Number.isNaN(installerGithubId)) {
-      await recordInstallIntent(app.db, {
-        installerGithubId,
-        targetOrganizationId: scope.organizationId,
-      });
-    } else {
-      app.log.warn(
-        { userId: scope.userId, organizationId: scope.organizationId },
-        "install-url: kickoff admin has no GitHub identity on file — install won't auto-bind; recover via POST /claim",
-      );
-    }
-
+    // No DB write here: `installation_id` doesn't exist until the user
+    // completes the install. The signed state carries `targetOrganizationId`
+    // + `kickoffUserId` to the callback, which records the per-install pending
+    // bind (keyed by the concrete `installation_id`) that the trusted
+    // `installation.created` webhook then completes.
     return { installUrl: buildAppInstallUrl({ appSlug: appCfg.slug, state: token }) };
   });
 
   // ── Manual install claim ────────────────────────────────────────────
   //
-  // Recovery hatch for an installation row that ended up unbound — the
-  // OAuth callback's auto-reclaim sweep handles the single-orphan case at
-  // sign-in, but bails when there are several (or when the install is on
-  // an org account, where "the user is an org admin" isn't a strong enough
-  // basis to auto-claim).
+  // Recovery hatch for an installation row that ended up unbound (e.g. the
+  // `installation.created` webhook arrived without a matching pending bind, or
+  // the kickoff callback never completed). Normal binding is webhook-driven;
+  // this is the manual fallback.
   //
   // ⚠ This endpoint is **API-only** — there is no Settings UI that calls
-  // it yet. The orphan-list endpoint and the `Claim install` button per
-  // orphan are tracked in #318. Until #318 ships, multi-orphan recovery
-  // requires the operator to POST to this endpoint directly.
+  // it yet. The orphan-list endpoint and a per-install `Claim install` button
+  // are tracked in #318; until then, recovery requires POSTing here directly.
   //
-  // Authorization mirrors the OAuth callback's `installation_id` check:
-  // being an admin of the target First Tree org isn't sufficient — installation
-  // IDs aren't secrets, so we also confirm the caller can actually
-  // **administer** the install on GitHub. Per-install rules:
-  //   - User-type: caller's GitHub ID must equal the install account's
-  //     GitHub ID (only the account owner counts).
-  //   - Org-type: `GET /user/memberships/orgs/{login}` must return
-  //     `state=active, role=admin`. Plain org membership is NOT enough —
-  //     that's what made the legacy `/user/installations` primitive
-  //     forgeable (it surfaced any install the user had read access to).
-  //
-  // Account metadata comes from the existing DB row (UPSERTed by the
-  // webhook or the OAuth callback). 404 here means there's nothing to
-  // claim at all; the bind step never runs.
+  // Authorization: being a First Tree org admin isn't sufficient — the
+  // browser-supplied installation id isn't a secret. The caller may claim
+  // ONLY an installation THEY installed, matched against the trusted
+  // `installer_github_id` (the `installation.created` webhook `sender`; GitHub
+  // only lets a user install on an account they administer). This replaces the
+  // removed `verifyUserCanAdministerInstallation` probe on this path. The row
+  // (and its `installer_github_id`) is written by the webhook; 404 here means
+  // there's nothing to claim.
   app.post<{ Params: { orgId: string }; Body: unknown }>("/claim", async (request) => {
     const scope = await requireOrgAdmin(request, app.db);
     const { installationId } = githubAppInstallationClaimBodySchema.parse(request.body);

--- a/packages/server/src/api/webhooks/github-app.ts
+++ b/packages/server/src/api/webhooks/github-app.ts
@@ -1,12 +1,14 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { githubAppInstallationPermissionsSchema, type WebhookSource } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
-import { BadRequestError, UnauthorizedError } from "../../errors.js";
+import { BadRequestError, ConflictError, UnauthorizedError } from "../../errors.js";
 import { createLogger } from "../../observability/index.js";
 import { handleContextReviewerPrEvent } from "../../services/context-reviewer-pr.js";
 import { claimEvent, unclaimEvent } from "../../services/event-dedup.js";
 import type { AppInstallation } from "../../services/github-app.js";
+import { deleteInstallIntent, peekFreshInstallIntent } from "../../services/github-app-install-intents.js";
 import {
+  bindInstallationToOrg,
   deleteInstallationByGithubId,
   findInstallationByGithubId,
   markInstallationSuspended,
@@ -34,6 +36,18 @@ function readInstallationId(payload: unknown): number | null {
   if (!isRecord(payload)) return null;
   const installation = isRecord(payload.installation) ? payload.installation : null;
   const id = installation?.id;
+  return typeof id === "number" && Number.isFinite(id) ? id : null;
+}
+
+/**
+ * The GitHub-authenticated actor who triggered the webhook. On
+ * `installation.created` this is the user who installed the App — the
+ * trusted anti-forgery anchor for binding (GitHub only permits installing
+ * on an account the sender administers).
+ */
+function readSenderGithubId(payload: Record<string, unknown>): number | null {
+  const sender = isRecord(payload.sender) ? payload.sender : null;
+  const id = sender?.id;
   return typeof id === "number" && Number.isFinite(id) ? id : null;
 }
 
@@ -188,14 +202,53 @@ async function handleInstallationLifecycle(app: FastifyInstance, eventType: stri
   if (!installation || installationId === null) return "ignored:malformed";
 
   switch (action) {
-    case "created":
+    case "created": {
+      const metadata = parseInstallationMetadata(installation);
+      if (!metadata) return "ignored:malformed";
+      // The `sender` on `installation.created` is the GitHub-authenticated
+      // installer. GitHub only lets a user install on an account they
+      // administer, so this id is trusted proof of "installer administers
+      // the installed account" — it replaces the old
+      // `verifyUserCanAdministerInstallation` probe. Persist it, then bind
+      // this installation to the org the kickoff admin intended (matched by
+      // installer id via the signed install-intent). This is the ONLY
+      // binding path: the browser-supplied URL `installation_id` on the
+      // OAuth callback is never trusted for binding.
+      const installerGithubId = readSenderGithubId(payload);
+      await upsertInstallationFromMetadata(app.db, {
+        installation: metadata,
+        ...(installerGithubId !== null ? { installerGithubId } : {}),
+      });
+      if (installerGithubId === null) return "created:no-sender";
+      const intent = await peekFreshInstallIntent(app.db, installerGithubId);
+      if (!intent) return "created:no-intent";
+      try {
+        await bindInstallationToOrg(app.db, installationId, intent.targetOrganizationId);
+      } catch (err) {
+        if (err instanceof ConflictError) {
+          // Permanent (D2 1:1 already satisfied elsewhere) — consume the
+          // intent so GitHub's retry doesn't loop on the same conflict.
+          await deleteInstallIntent(app.db, installerGithubId);
+          log.warn(
+            { installationId, installerGithubId, targetOrganizationId: intent.targetOrganizationId, err },
+            "installation.created: bind conflicted with an existing binding (D2 1:1) — left as-is",
+          );
+          return "created:bind-conflict";
+        }
+        // Transient (DB hiccup): keep the intent so GitHub's webhook retry
+        // rebinds. Rethrow → route returns 500 → GitHub redelivers.
+        throw err;
+      }
+      // Bound successfully — consume the intent.
+      await deleteInstallIntent(app.db, installerGithubId);
+      return "created:bound";
+    }
     case "new_permissions_accepted": {
       const metadata = parseInstallationMetadata(installation);
       if (!metadata) return "ignored:malformed";
-      // UPSERT only writes metadata fields; `hub_organization_id` is owned
-      // by the OAuth-callback bind path. A webhook arriving before the
-      // callback leaves the row unbound (intentional — webhooks don't
-      // know which First Tree user installed the App).
+      // Metadata refresh only — never re-bind, and don't overwrite the
+      // original installer (COALESCE in the upsert preserves it). The
+      // `sender` here may be a different admin accepting new permissions.
       await upsertInstallationFromMetadata(app.db, { installation: metadata });
       return action;
     }

--- a/packages/server/src/api/webhooks/github-app.ts
+++ b/packages/server/src/api/webhooks/github-app.ts
@@ -1,14 +1,13 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { githubAppInstallationPermissionsSchema, type WebhookSource } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
-import { BadRequestError, ConflictError, UnauthorizedError } from "../../errors.js";
+import { BadRequestError, UnauthorizedError } from "../../errors.js";
 import { createLogger } from "../../observability/index.js";
 import { handleContextReviewerPrEvent } from "../../services/context-reviewer-pr.js";
 import { claimEvent, unclaimEvent } from "../../services/event-dedup.js";
 import type { AppInstallation } from "../../services/github-app.js";
-import { deleteInstallIntent, peekFreshInstallIntent } from "../../services/github-app-install-intents.js";
+import { completeInstallBind, deleteExpiredPendingBinds } from "../../services/github-app-install-intents.js";
 import {
-  bindInstallationToOrg,
   deleteInstallationByGithubId,
   findInstallationByGithubId,
   markInstallationSuspended,
@@ -205,43 +204,31 @@ async function handleInstallationLifecycle(app: FastifyInstance, eventType: stri
     case "created": {
       const metadata = parseInstallationMetadata(installation);
       if (!metadata) return "ignored:malformed";
-      // The `sender` on `installation.created` is the GitHub-authenticated
-      // installer. GitHub only lets a user install on an account they
-      // administer, so this id is trusted proof of "installer administers
-      // the installed account" — it replaces the old
-      // `verifyUserCanAdministerInstallation` probe. Persist it, then bind
-      // this installation to the org the kickoff admin intended (matched by
-      // installer id via the signed install-intent). This is the ONLY
-      // binding path: the browser-supplied URL `installation_id` on the
-      // OAuth callback is never trusted for binding.
+      // Record the GitHub-authenticated installer (`sender`) on the row — the
+      // trusted anti-forgery anchor `completeInstallBind` compares against the
+      // kickoff admin. GitHub only lets a user install on an account they
+      // administer, so this id proves "installer administers the installed
+      // account" (it replaces the old `verifyUserCanAdministerInstallation`
+      // probe on the binding path).
       const installerGithubId = readSenderGithubId(payload);
       await upsertInstallationFromMetadata(app.db, {
         installation: metadata,
         ...(installerGithubId !== null ? { installerGithubId } : {}),
       });
+      // Opportunistic sweep of stale pending binds (keeps the table + index
+      // honest; not required for correctness — completeInstallBind filters by
+      // freshness anyway).
+      await deleteExpiredPendingBinds(app.db).catch((err) =>
+        log.warn({ err }, "install-intent expiry sweep failed (non-fatal)"),
+      );
       if (installerGithubId === null) return "created:no-sender";
-      const intent = await peekFreshInstallIntent(app.db, installerGithubId);
-      if (!intent) return "created:no-intent";
-      try {
-        await bindInstallationToOrg(app.db, installationId, intent.targetOrganizationId);
-      } catch (err) {
-        if (err instanceof ConflictError) {
-          // Permanent (D2 1:1 already satisfied elsewhere) — consume the
-          // intent so GitHub's retry doesn't loop on the same conflict.
-          await deleteInstallIntent(app.db, installerGithubId);
-          log.warn(
-            { installationId, installerGithubId, targetOrganizationId: intent.targetOrganizationId, err },
-            "installation.created: bind conflicted with an existing binding (D2 1:1) — left as-is",
-          );
-          return "created:bind-conflict";
-        }
-        // Transient (DB hiccup): keep the intent so GitHub's webhook retry
-        // rebinds. Rethrow → route returns 500 → GitHub redelivers.
-        throw err;
-      }
-      // Bound successfully — consume the intent.
-      await deleteInstallIntent(app.db, installerGithubId);
-      return "created:bound";
+      // Bind iff the callback already recorded a pending bind for THIS
+      // installation whose kickoff admin == this installer (and is still an
+      // active admin). If the callback hasn't arrived yet this no-ops and the
+      // callback completes the bind when it does. A transient bind error
+      // rethrows → 500 → GitHub redelivers (pending bind is preserved).
+      const result = await completeInstallBind(app.db, installationId);
+      return `created:${result.reason}`;
     }
     case "new_permissions_accepted": {
       const metadata = parseInstallationMetadata(installation);

--- a/packages/server/src/db/schema/github-app-install-intents.ts
+++ b/packages/server/src/db/schema/github-app-install-intents.ts
@@ -1,0 +1,60 @@
+import { bigint, index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { organizations } from "./organizations.js";
+
+/**
+ * Pending GitHub App install intents — the trusted correlation between
+ * "a First Tree admin kicked off an install for org T" and the later,
+ * out-of-band `installation.created` webhook that actually creates the
+ * installation.
+ *
+ * Why this table exists (anti-forgery, see `system/cloud/github/github-app.md`):
+ * the browser-supplied URL `installation_id` on the OAuth callback is not a
+ * trust anchor (not signed, address-bar-forgeable). Binding is therefore
+ * driven by the HMAC-signed `installation.created` webhook, whose `sender`
+ * is the GitHub-authenticated installer. But the webhook alone doesn't know
+ * *which* First Tree org to bind to. This row carries that intent:
+ *
+ *   1. `GET /orgs/:orgId/github-app-installation/install-url` (admin-gated)
+ *      records `{ installerGithubId = kickoff admin's GitHub id,
+ *      targetOrganizationId }` before redirecting to GitHub.
+ *   2. The `installation.created` webhook looks the intent up by
+ *      `installerGithubId == sender.id` and binds the new installation to
+ *      `targetOrganizationId`, then consumes the intent.
+ *
+ * Because the lookup key is the webhook `sender` (GitHub-authenticated) and
+ * intents are only mintable by an authenticated First Tree admin of the
+ * target org, "installer == kickoff admin" and "installer administers the
+ * installed account" both hold without any `organization:members:read`
+ * probe.
+ *
+ * One active intent per installer (UNIQUE on `installer_github_id`,
+ * last-write-wins): a user re-initiating install for a different org
+ * overwrites the stale intent. `expires_at` bounds the window so a stale
+ * intent can't bind an unrelated later install.
+ */
+export const githubAppInstallIntents = pgTable(
+  "github_app_install_intents",
+  {
+    /** UUID v7 primary key, app-generated. */
+    id: text("id").primaryKey(),
+    /**
+     * GitHub numeric id of the First Tree admin who kicked off the install
+     * (resolved from `auth_identities` at mint time). Matched against the
+     * `installation.created` webhook `sender.id` to bind.
+     */
+    installerGithubId: bigint("installer_github_id", { mode: "number" }).notNull(),
+    /** First Tree org the resulting installation should bind to. */
+    targetOrganizationId: text("target_organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    /** Freshness bound — intents past this are ignored and swept. */
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    // One active intent per installer — a new kickoff UPSERTs (last-wins).
+    uniqueIndex("uq_github_app_install_intents_installer").on(table.installerGithubId),
+    // Sweep expired intents efficiently.
+    index("idx_github_app_install_intents_expires").on(table.expiresAt),
+  ],
+);

--- a/packages/server/src/db/schema/github-app-install-intents.ts
+++ b/packages/server/src/db/schema/github-app-install-intents.ts
@@ -2,35 +2,32 @@ import { bigint, index, pgTable, text, timestamp, uniqueIndex } from "drizzle-or
 import { organizations } from "./organizations.js";
 
 /**
- * Pending GitHub App install intents — the trusted correlation between
- * "a First Tree admin kicked off an install for org T" and the later,
- * out-of-band `installation.created` webhook that actually creates the
- * installation.
+ * Per-installation pending binds — the trusted, **per-install** correlation
+ * between an admin-initiated install kickoff and the out-of-band
+ * `installation.created` webhook that actually creates the installation
+ * (see `system/cloud/github/github-app.md`).
  *
- * Why this table exists (anti-forgery, see `system/cloud/github/github-app.md`):
- * the browser-supplied URL `installation_id` on the OAuth callback is not a
- * trust anchor (not signed, address-bar-forgeable). Binding is therefore
- * driven by the HMAC-signed `installation.created` webhook, whose `sender`
- * is the GitHub-authenticated installer. But the webhook alone doesn't know
- * *which* First Tree org to bind to. This row carries that intent:
+ * Why keyed by `installation_id` (not by installer): the binding key must be
+ * the *specific installation*, not just "some install by this GitHub user".
+ * Otherwise a single GitHub user with a stale/concurrent install dialog (or
+ * who installs on a second account) could have an unrelated installation
+ * bound to the wrong team within the intent TTL. The correlation therefore:
  *
- *   1. `GET /orgs/:orgId/github-app-installation/install-url` (admin-gated)
- *      records `{ installerGithubId = kickoff admin's GitHub id,
- *      targetOrganizationId }` before redirecting to GitHub.
- *   2. The `installation.created` webhook looks the intent up by
- *      `installerGithubId == sender.id` and binds the new installation to
- *      `targetOrganizationId`, then consumes the intent.
+ *   1. `/install-url` (admin-gated) mints a signed state carrying
+ *      `targetOrganizationId` + `kickoffUserId` (no DB write).
+ *   2. The **callback** — which holds the concrete `installation_id` (URL) and
+ *      the signed kickoff — records THIS row: `installation_id` →
+ *      `{ target_organization_id, kickoff_user_id, kickoff_github_id }`.
+ *   3. Binding happens **only** once the HMAC-signed `installation.created`
+ *      webhook proves the installation's `sender` (installer) equals
+ *      `kickoff_github_id` AND the kickoff user is still an active admin of
+ *      the target org (`completeInstallBind`). The browser-supplied URL
+ *      `installation_id` is thus only a *correlation handle*; it is never a
+ *      binding authority on its own.
  *
- * Because the lookup key is the webhook `sender` (GitHub-authenticated) and
- * intents are only mintable by an authenticated First Tree admin of the
- * target org, "installer == kickoff admin" and "installer administers the
- * installed account" both hold without any `organization:members:read`
- * probe.
- *
- * One active intent per installer (UNIQUE on `installer_github_id`,
- * last-write-wins): a user re-initiating install for a different org
- * overwrites the stale intent. `expires_at` bounds the window so a stale
- * intent can't bind an unrelated later install.
+ * `expires_at` bounds the window. UNIQUE on `installation_id` — one pending
+ * bind per installation (re-callback for the same install is an idempotent
+ * refresh).
  */
 export const githubAppInstallIntents = pgTable(
   "github_app_install_intents",
@@ -38,23 +35,35 @@ export const githubAppInstallIntents = pgTable(
     /** UUID v7 primary key, app-generated. */
     id: text("id").primaryKey(),
     /**
-     * GitHub numeric id of the First Tree admin who kicked off the install
-     * (resolved from `auth_identities` at mint time). Matched against the
-     * `installation.created` webhook `sender.id` to bind.
+     * GitHub-issued installation id this pending bind is for (the correlation
+     * handle from the callback URL). BIGINT to match `github_app_installations`.
      */
-    installerGithubId: bigint("installer_github_id", { mode: "number" }).notNull(),
-    /** First Tree org the resulting installation should bind to. */
+    installationId: bigint("installation_id", { mode: "number" }).notNull(),
+    /** First Tree org the installation should bind to (from the signed kickoff state). */
     targetOrganizationId: text("target_organization_id")
       .notNull()
       .references(() => organizations.id, { onDelete: "cascade" }),
-    /** Freshness bound — intents past this are ignored and swept. */
+    /**
+     * First Tree user who kicked off the install (from the signed state).
+     * Re-checked for active admin of `target_organization_id` at bind time —
+     * defends against the admin being downgraded during the intent TTL.
+     */
+    kickoffUserId: text("kickoff_user_id").notNull(),
+    /**
+     * The kickoff user's GitHub numeric id (resolved at callback time).
+     * Bind proceeds only when the `installation.created` webhook `sender`
+     * equals this — i.e. the installer is the kickoff admin.
+     */
+    kickoffGithubId: bigint("kickoff_github_id", { mode: "number" }).notNull(),
+    /** Freshness bound — pending binds past this are ignored and swept. */
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    // One active intent per installer — a new kickoff UPSERTs (last-wins).
-    uniqueIndex("uq_github_app_install_intents_installer").on(table.installerGithubId),
-    // Sweep expired intents efficiently.
+    // One pending bind per installation — the callback UPSERTs (idempotent
+    // refresh if the same install re-hits the callback).
+    uniqueIndex("uq_github_app_install_intents_installation").on(table.installationId),
+    // Sweep expired pending binds efficiently.
     index("idx_github_app_install_intents_expires").on(table.expiresAt),
   ],
 );

--- a/packages/server/src/db/schema/github-app-installations.ts
+++ b/packages/server/src/db/schema/github-app-installations.ts
@@ -61,6 +61,23 @@ export const githubAppInstallations = pgTable(
      */
     accountGithubId: bigint("account_github_id", { mode: "number" }).notNull(),
     /**
+     * GitHub numeric id of the user who **installed** the App — the
+     * `sender` on the trusted, HMAC-signed `installation.created` webhook.
+     * GitHub only lets a user install on an account they administer, so
+     * this id is a GitHub-authenticated proof of "this person administers
+     * `account_github_id`". It is the anti-forgery anchor that replaces the
+     * old `verifyUserCanAdministerInstallation` probe: installation binding
+     * (and the manual `/claim` + orphan recovery) rests on matching a First
+     * Tree user's GitHub id to this column, never on the browser-supplied
+     * URL `installation_id`.
+     *
+     * Nullable: rows created before this column existed, and any row not
+     * created via the `installation.created` webhook, carry NULL. Only the
+     * `created` webhook sets it; later lifecycle webhooks (permission
+     * changes, suspend) preserve the original installer via COALESCE.
+     */
+    installerGithubId: bigint("installer_github_id", { mode: "number" }),
+    /**
      * First Tree org this installation is bound to (1:1, see D2 / §8 Q1).
      * Nullable to allow inserting the row in the install callback before
      * the owning First Tree team is provisioned. Once bound, the value never
@@ -101,6 +118,10 @@ export const githubAppInstallations = pgTable(
     // Lookup by account id when resolving webhooks that name only the
     // account block (rare, but happens for account-rename events).
     index("idx_github_app_installations_account").on(table.accountGithubId),
+    // Lookup unbound installs by the GitHub user who installed them, for
+    // the manual `/claim` + orphan-recovery paths (match a signed-in
+    // user's GitHub id to the trusted installer id).
+    index("idx_github_app_installations_installer").on(table.installerGithubId),
     // Defense-in-depth: the Drizzle column type narrows to the union but
     // a manual INSERT bypassing the ORM would otherwise be able to write
     // arbitrary strings. Mirrors how auth_identities pins credential_type

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -12,6 +12,7 @@ export { chatUserState } from "./chat-user-state.js";
 export { chats } from "./chats.js";
 export { clients } from "./clients.js";
 export { contextTreeIoEvents } from "./context-tree-io-events.js";
+export { githubAppInstallIntents } from "./github-app-install-intents.js";
 export { githubAppInstallations } from "./github-app-installations.js";
 export { githubEntityChatMappings } from "./github-entity-chat-mappings.js";
 export { inboxEntries } from "./inbox-entries.js";

--- a/packages/server/src/services/github-app-install-intents.ts
+++ b/packages/server/src/services/github-app-install-intents.ts
@@ -77,10 +77,7 @@ export async function peekFreshInstallIntent(
     .select({ targetOrganizationId: githubAppInstallIntents.targetOrganizationId })
     .from(githubAppInstallIntents)
     .where(
-      and(
-        eq(githubAppInstallIntents.installerGithubId, installerGithubId),
-        gt(githubAppInstallIntents.expiresAt, now),
-      ),
+      and(eq(githubAppInstallIntents.installerGithubId, installerGithubId), gt(githubAppInstallIntents.expiresAt, now)),
     )
     .limit(1);
   return row ?? null;

--- a/packages/server/src/services/github-app-install-intents.ts
+++ b/packages/server/src/services/github-app-install-intents.ts
@@ -1,0 +1,101 @@
+import { and, eq, gt, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { githubAppInstallIntents } from "../db/schema/github-app-install-intents.js";
+import { uuidv7 } from "../uuid.js";
+
+/**
+ * Pending install-intent layer — the trusted correlation between an
+ * admin-initiated "install the App for org T" kickoff and the later
+ * `installation.created` webhook (see the table jsdoc in
+ * `db/schema/github-app-install-intents.ts` and
+ * `system/cloud/github/github-app.md`).
+ *
+ * Binding is NOT driven by the browser-supplied URL `installation_id`
+ * (unsigned, forgeable). Instead:
+ *   1. `/install-url` records an intent keyed by the kickoff admin's
+ *      GitHub id.
+ *   2. The HMAC-signed `installation.created` webhook consumes the intent
+ *      by its `sender` (the GitHub-authenticated installer) and binds.
+ */
+
+/**
+ * How long a kickoff intent stays consumable. Comfortably covers a slow
+ * install (lingering on GitHub's repository picker) plus webhook delivery
+ * lag, while bounding the window in which a stale, abandoned intent could
+ * bind an unrelated later install by the same user.
+ */
+export const INSTALL_INTENT_TTL_MS = 30 * 60 * 1000;
+
+export type RecordInstallIntentInput = {
+  installerGithubId: number;
+  targetOrganizationId: string;
+  /** Defaults to now + INSTALL_INTENT_TTL_MS. */
+  expiresAt?: Date;
+  now?: Date;
+};
+
+/**
+ * Record (or refresh) the pending install intent for a kickoff admin.
+ * One active intent per installer — a fresh kickoff for a different org
+ * overwrites the previous one (last-write-wins) via the UNIQUE index.
+ */
+export async function recordInstallIntent(db: Database, input: RecordInstallIntentInput): Promise<void> {
+  const now = input.now ?? new Date();
+  const expiresAt = input.expiresAt ?? new Date(now.getTime() + INSTALL_INTENT_TTL_MS);
+  await db
+    .insert(githubAppInstallIntents)
+    .values({
+      id: uuidv7(),
+      installerGithubId: input.installerGithubId,
+      targetOrganizationId: input.targetOrganizationId,
+      expiresAt,
+      createdAt: now,
+    })
+    .onConflictDoUpdate({
+      target: githubAppInstallIntents.installerGithubId,
+      set: {
+        targetOrganizationId: input.targetOrganizationId,
+        expiresAt,
+        createdAt: now,
+      },
+    });
+}
+
+/**
+ * Read (without consuming) a fresh intent for `installerGithubId`, or null
+ * when no unexpired intent exists. The webhook binder peeks first, binds,
+ * then deletes only on success — so a transient bind failure leaves the
+ * intent in place for GitHub's webhook retry to rebind. (A permanent bind
+ * conflict deletes it explicitly to stop the retry loop.)
+ */
+export async function peekFreshInstallIntent(
+  db: Database,
+  installerGithubId: number,
+  now: Date = new Date(),
+): Promise<{ targetOrganizationId: string } | null> {
+  const [row] = await db
+    .select({ targetOrganizationId: githubAppInstallIntents.targetOrganizationId })
+    .from(githubAppInstallIntents)
+    .where(
+      and(
+        eq(githubAppInstallIntents.installerGithubId, installerGithubId),
+        gt(githubAppInstallIntents.expiresAt, now),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+/** Delete the intent for an installer (consumed after a successful or permanently-failed bind). */
+export async function deleteInstallIntent(db: Database, installerGithubId: number): Promise<void> {
+  await db.delete(githubAppInstallIntents).where(eq(githubAppInstallIntents.installerGithubId, installerGithubId));
+}
+
+/**
+ * Housekeeping: delete intents past their TTL. Safe to call opportunistically
+ * (e.g. from the webhook path); not required for correctness because
+ * `consumeFreshInstallIntent` already ignores expired rows.
+ */
+export async function deleteExpiredInstallIntents(db: Database, now: Date = new Date()): Promise<void> {
+  await db.delete(githubAppInstallIntents).where(sql`${githubAppInstallIntents.expiresAt} <= ${now}`);
+}

--- a/packages/server/src/services/github-app-install-intents.ts
+++ b/packages/server/src/services/github-app-install-intents.ts
@@ -1,98 +1,160 @@
-import { and, eq, gt, sql } from "drizzle-orm";
+import { eq, lte } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { githubAppInstallIntents } from "../db/schema/github-app-install-intents.js";
+import { ConflictError } from "../errors.js";
 import { uuidv7 } from "../uuid.js";
+import { bindInstallationToOrg, findInstallationByGithubId } from "./github-app-installations.js";
+import { findActiveMembership } from "./membership.js";
 
 /**
- * Pending install-intent layer — the trusted correlation between an
- * admin-initiated "install the App for org T" kickoff and the later
- * `installation.created` webhook (see the table jsdoc in
- * `db/schema/github-app-install-intents.ts` and
+ * Per-installation pending-bind layer — the trusted, per-install correlation
+ * between an admin install kickoff and the `installation.created` webhook
+ * (see the table jsdoc in `db/schema/github-app-install-intents.ts` and
  * `system/cloud/github/github-app.md`).
  *
- * Binding is NOT driven by the browser-supplied URL `installation_id`
- * (unsigned, forgeable). Instead:
- *   1. `/install-url` records an intent keyed by the kickoff admin's
- *      GitHub id.
- *   2. The HMAC-signed `installation.created` webhook consumes the intent
- *      by its `sender` (the GitHub-authenticated installer) and binds.
+ * Binding is NOT inferred from the browser-supplied URL `installation_id`
+ * (unsigned, forgeable) nor from the installer alone. The callback records a
+ * pending bind keyed by the concrete `installation_id`; the bind only lands
+ * once the HMAC-signed webhook proves that installation's installer equals
+ * the kickoff admin AND the kickoff admin is still an active org admin
+ * (`completeInstallBind`).
  */
 
 /**
- * How long a kickoff intent stays consumable. Comfortably covers a slow
- * install (lingering on GitHub's repository picker) plus webhook delivery
- * lag, while bounding the window in which a stale, abandoned intent could
- * bind an unrelated later install by the same user.
+ * How long a pending bind stays completable. Comfortably covers webhook
+ * delivery lag after the callback, while bounding the window in which a
+ * stale pending row lingers.
  */
 export const INSTALL_INTENT_TTL_MS = 30 * 60 * 1000;
 
-export type RecordInstallIntentInput = {
-  installerGithubId: number;
+export type RecordPendingBindInput = {
+  installationId: number;
   targetOrganizationId: string;
+  kickoffUserId: string;
+  kickoffGithubId: number;
   /** Defaults to now + INSTALL_INTENT_TTL_MS. */
   expiresAt?: Date;
   now?: Date;
 };
 
 /**
- * Record (or refresh) the pending install intent for a kickoff admin.
- * One active intent per installer — a fresh kickoff for a different org
- * overwrites the previous one (last-write-wins) via the UNIQUE index.
+ * Record (or refresh) the pending bind for a specific installation. Keyed by
+ * `installation_id` — a re-callback for the same install is an idempotent
+ * refresh; concurrent installs (different `installation_id`) get independent
+ * rows, so they can never cross-bind.
  */
-export async function recordInstallIntent(db: Database, input: RecordInstallIntentInput): Promise<void> {
+export async function recordPendingBind(db: Database, input: RecordPendingBindInput): Promise<void> {
   const now = input.now ?? new Date();
   const expiresAt = input.expiresAt ?? new Date(now.getTime() + INSTALL_INTENT_TTL_MS);
   await db
     .insert(githubAppInstallIntents)
     .values({
       id: uuidv7(),
-      installerGithubId: input.installerGithubId,
+      installationId: input.installationId,
       targetOrganizationId: input.targetOrganizationId,
+      kickoffUserId: input.kickoffUserId,
+      kickoffGithubId: input.kickoffGithubId,
       expiresAt,
       createdAt: now,
     })
     .onConflictDoUpdate({
-      target: githubAppInstallIntents.installerGithubId,
+      target: githubAppInstallIntents.installationId,
       set: {
         targetOrganizationId: input.targetOrganizationId,
+        kickoffUserId: input.kickoffUserId,
+        kickoffGithubId: input.kickoffGithubId,
         expiresAt,
         createdAt: now,
       },
     });
 }
 
+/** Delete the pending bind for an installation (consumed / abandoned). */
+export async function deletePendingBind(db: Database, installationId: number): Promise<void> {
+  await db.delete(githubAppInstallIntents).where(eq(githubAppInstallIntents.installationId, installationId));
+}
+
+/** Housekeeping: drop pending binds past their TTL. Safe to call opportunistically. */
+export async function deleteExpiredPendingBinds(db: Database, now: Date = new Date()): Promise<void> {
+  await db.delete(githubAppInstallIntents).where(lte(githubAppInstallIntents.expiresAt, now));
+}
+
+export type CompleteInstallBindResult = {
+  bound: boolean;
+  /** Diagnostic reason — for logging + lifecycle status strings. */
+  reason:
+    | "bound"
+    | "no-intent"
+    | "intent-expired"
+    | "awaiting-webhook"
+    | "installer-mismatch"
+    | "kickoff-not-admin"
+    | "bind-conflict";
+};
+
 /**
- * Read (without consuming) a fresh intent for `installerGithubId`, or null
- * when no unexpired intent exists. The webhook binder peeks first, binds,
- * then deletes only on success — so a transient bind failure leaves the
- * intent in place for GitHub's webhook retry to rebind. (A permanent bind
- * conflict deletes it explicitly to stop the retry loop.)
+ * Attempt to complete a pending bind for `installationId`. Called from BOTH
+ * the `installation.created` webhook (after it records the installer) and the
+ * OAuth callback (after it records the pending bind), so binding lands
+ * whichever arrives second. Idempotent.
+ *
+ * Binds only when ALL hold:
+ *   - a fresh pending bind exists for this installation (the callback recorded
+ *     the target org from the signed kickoff);
+ *   - the installation row's `installer_github_id` is known (the signed
+ *     `installation.created` webhook recorded the `sender`) AND equals the
+ *     pending bind's `kickoff_github_id` — i.e. the installer IS the kickoff
+ *     admin (this is the anti-forgery gate: a forged callback `installation_id`
+ *     naming someone else's install fails here, because that install's
+ *     `sender` is not the kickoff admin);
+ *   - the kickoff user is STILL an active admin of the target org (live
+ *     re-check — defends against mid-TTL admin revocation).
+ *
+ * Throws only on a transient `bindInstallationToOrg` error (so the webhook
+ * caller can 500 and let GitHub redeliver); a permanent `ConflictError`
+ * consumes the pending bind and returns `bind-conflict`.
  */
-export async function peekFreshInstallIntent(
-  db: Database,
-  installerGithubId: number,
-  now: Date = new Date(),
-): Promise<{ targetOrganizationId: string } | null> {
-  const [row] = await db
-    .select({ targetOrganizationId: githubAppInstallIntents.targetOrganizationId })
+export async function completeInstallBind(db: Database, installationId: number): Promise<CompleteInstallBindResult> {
+  const [pending] = await db
+    .select()
     .from(githubAppInstallIntents)
-    .where(
-      and(eq(githubAppInstallIntents.installerGithubId, installerGithubId), gt(githubAppInstallIntents.expiresAt, now)),
-    )
+    .where(eq(githubAppInstallIntents.installationId, installationId))
     .limit(1);
-  return row ?? null;
-}
+  if (!pending) return { bound: false, reason: "no-intent" };
+  if (pending.expiresAt.getTime() <= Date.now()) {
+    await deletePendingBind(db, installationId);
+    return { bound: false, reason: "intent-expired" };
+  }
 
-/** Delete the intent for an installer (consumed after a successful or permanently-failed bind). */
-export async function deleteInstallIntent(db: Database, installerGithubId: number): Promise<void> {
-  await db.delete(githubAppInstallIntents).where(eq(githubAppInstallIntents.installerGithubId, installerGithubId));
-}
+  const installation = await findInstallationByGithubId(db, installationId);
+  if (!installation || installation.installerGithubId === null) {
+    // The signed webhook hasn't recorded the installer yet — wait for it.
+    return { bound: false, reason: "awaiting-webhook" };
+  }
+  if (installation.installerGithubId !== pending.kickoffGithubId) {
+    // The GitHub-authenticated installer is NOT the kickoff admin — this
+    // installation was not created by the person who kicked off the bind.
+    // Drop the pending row (forged/mismatched handle); never bind.
+    await deletePendingBind(db, installationId);
+    return { bound: false, reason: "installer-mismatch" };
+  }
 
-/**
- * Housekeeping: delete intents past their TTL. Safe to call opportunistically
- * (e.g. from the webhook path); not required for correctness because
- * `consumeFreshInstallIntent` already ignores expired rows.
- */
-export async function deleteExpiredInstallIntents(db: Database, now: Date = new Date()): Promise<void> {
-  await db.delete(githubAppInstallIntents).where(sql`${githubAppInstallIntents.expiresAt} <= ${now}`);
+  const membership = await findActiveMembership(db, pending.kickoffUserId, pending.targetOrganizationId);
+  if (!membership || membership.role !== "admin") {
+    // Admin was revoked/downgraded during the TTL — refuse and consume.
+    await deletePendingBind(db, installationId);
+    return { bound: false, reason: "kickoff-not-admin" };
+  }
+
+  try {
+    await bindInstallationToOrg(db, installationId, pending.targetOrganizationId);
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      await deletePendingBind(db, installationId);
+      return { bound: false, reason: "bind-conflict" };
+    }
+    throw err;
+  }
+  await deletePendingBind(db, installationId);
+  return { bound: true, reason: "bound" };
 }

--- a/packages/server/src/services/github-app-installations.ts
+++ b/packages/server/src/services/github-app-installations.ts
@@ -385,33 +385,6 @@ export async function findUnboundInstallationsByAccount(
 }
 
 /**
- * List unbound installations that a given GitHub user **installed** — matched
- * on the trusted `installer_github_id` (the `installation.created` webhook
- * `sender`), not the account or the browser-supplied URL id. Newest-first.
- *
- * This is the anti-forgery basis for the manual `POST /claim` recovery path:
- * a signed-in First Tree user may only claim an installation they themselves
- * installed on GitHub. Rows predating the `installer_github_id` column carry
- * NULL and are intentionally excluded — they are not claimable through this
- * path (recover them by re-installing, which mints the trusted id).
- */
-export async function findUnboundInstallationsByInstaller(
-  db: Database,
-  installerGithubId: number,
-): Promise<InstallationRow[]> {
-  return db
-    .select()
-    .from(githubAppInstallations)
-    .where(
-      and(
-        eq(githubAppInstallations.installerGithubId, installerGithubId),
-        isNull(githubAppInstallations.hubOrganizationId),
-      ),
-    )
-    .orderBy(desc(githubAppInstallations.createdAt));
-}
-
-/**
  * Belt-and-braces helper for tests / debugging: how many installations
  * currently bound to this First Tree team. Should always be 0 or 1 — anything
  * higher means the UNIQUE index was somehow violated and the rest of the

--- a/packages/server/src/services/github-app-installations.ts
+++ b/packages/server/src/services/github-app-installations.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, lt, or, sql } from "drizzle-orm";
+import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { githubAppInstallations } from "../db/schema/github-app-installations.js";
 import { ConflictError, NotFoundError } from "../errors.js";
@@ -352,36 +352,6 @@ export async function findInstallationByOrg(db: Database, hubOrganizationId: str
     .where(eq(githubAppInstallations.hubOrganizationId, hubOrganizationId))
     .limit(1);
   return row ?? null;
-}
-
-/**
- * List the installations for a GitHub account that aren't bound to any First Tree
- * team yet. Newest-first.
- *
- * The orphan-recovery path (codex P1-5 + H1): if the OAuth callback's
- * `upsertInstallationFromMetadata` lands but the follow-up
- * `bindInstallationToOrg` fails (transient DB error, a racing invite that
- * errors out, …), the row sits unbound forever — GitHub only puts
- * `installation_id` in the redirect on the *initial* install, so a later
- * sign-in never re-attempts the bind. On every subsequent sign-in we sweep
- * for unbound rows whose `accountGithubId` matches the user's own GitHub
- * account and auto-claim the single one (and surface a manual "Claim
- * install" button when there are several).
- */
-export async function findUnboundInstallationsByAccount(
-  db: Database,
-  accountGithubId: number,
-): Promise<InstallationRow[]> {
-  return db
-    .select()
-    .from(githubAppInstallations)
-    .where(
-      and(
-        eq(githubAppInstallations.accountGithubId, accountGithubId),
-        isNull(githubAppInstallations.hubOrganizationId),
-      ),
-    )
-    .orderBy(desc(githubAppInstallations.createdAt));
 }
 
 /**

--- a/packages/server/src/services/github-app-installations.ts
+++ b/packages/server/src/services/github-app-installations.ts
@@ -53,6 +53,14 @@ export type UpsertInstallationInput = {
    * `bindInstallationToOrg` instead.
    */
   hubOrganizationId?: string;
+  /**
+   * GitHub numeric id of the user who installed the App — the `sender` on
+   * the `installation.created` webhook. Only pass it on `created` (the
+   * install moment); later lifecycle webhooks omit it and the original
+   * installer is preserved via COALESCE. This is the trusted anti-forgery
+   * anchor for binding (see the column jsdoc).
+   */
+  installerGithubId?: number;
 };
 
 export type InstallationRow = typeof githubAppInstallations.$inferSelect;
@@ -78,6 +86,7 @@ export async function upsertInstallationFromMetadata(
     accountType: input.installation.accountType,
     accountLogin: input.installation.accountLogin,
     accountGithubId: input.installation.accountGithubId,
+    installerGithubId: input.installerGithubId ?? null,
     hubOrganizationId: input.hubOrganizationId ?? null,
     permissions: input.installation.permissions,
     events: input.installation.events,
@@ -94,6 +103,12 @@ export async function upsertInstallationFromMetadata(
         accountType: values.accountType,
         accountLogin: values.accountLogin,
         accountGithubId: values.accountGithubId,
+        // Preserve the original installer: only fill it when currently
+        // NULL (a `created` webhook that seeds a row first-seen via a
+        // later lifecycle event). Never overwrite a known installer with
+        // a subsequent event's `sender` (which may be a different admin
+        // accepting new permissions).
+        installerGithubId: sql`coalesce(${githubAppInstallations.installerGithubId}, ${values.installerGithubId})`,
         permissions: values.permissions,
         events: values.events,
         suspendedAt: values.suspendedAt,
@@ -363,6 +378,33 @@ export async function findUnboundInstallationsByAccount(
     .where(
       and(
         eq(githubAppInstallations.accountGithubId, accountGithubId),
+        isNull(githubAppInstallations.hubOrganizationId),
+      ),
+    )
+    .orderBy(desc(githubAppInstallations.createdAt));
+}
+
+/**
+ * List unbound installations that a given GitHub user **installed** — matched
+ * on the trusted `installer_github_id` (the `installation.created` webhook
+ * `sender`), not the account or the browser-supplied URL id. Newest-first.
+ *
+ * This is the anti-forgery basis for the manual `POST /claim` recovery path:
+ * a signed-in First Tree user may only claim an installation they themselves
+ * installed on GitHub. Rows predating the `installer_github_id` column carry
+ * NULL and are intentionally excluded — they are not claimable through this
+ * path (recover them by re-installing, which mints the trusted id).
+ */
+export async function findUnboundInstallationsByInstaller(
+  db: Database,
+  installerGithubId: number,
+): Promise<InstallationRow[]> {
+  return db
+    .select()
+    .from(githubAppInstallations)
+    .where(
+      and(
+        eq(githubAppInstallations.installerGithubId, installerGithubId),
         isNull(githubAppInstallations.hubOrganizationId),
       ),
     )


### PR DESCRIPTION
## What & why

Part of the **GitHub App slim + binding/install simplification** proposal ([first-tree-context#618](https://github.com/agent-team-foundation/first-tree-context/pull/618)) — the **web+server login/install** slice. (The `gh`-based Context Tree creation, CLI + skills, is a separate effort.)

This removes the server-side org-admin probe (`verifyUserCanAdministerInstallation` / `organization:members:read`) from the **installation-binding** path and replaces it with a **trusted, webhook-sourced binding** model — closing the URL-`installation_id` forgery surface instead of merely re-checking it.

### The problem
The GitHub-App `installation_id` arrives on the OAuth callback from the **browser address bar** — unsigned, forgeable. `verifyUserCanAdministerInstallation` was the *sole* anti-forgery control: it confirmed the signed-in user administers the installation's GitHub account (User: id-match; Org: `GET /user/memberships/orgs/{login}` role=admin, which needs `Members:read`). Naively dropping it would let any signed-in user bind **someone else's** installation to their team by appending `?installation_id=<victim>`.

### The design (probe-free, no `Members:read`, no URL trust)
Binding is now driven by the **HMAC-signed `installation.created` webhook**, whose `sender` is the GitHub-authenticated installer (GitHub only lets you install on an account you administer). Correlation to the target org uses a new admin-minted intent:

1. **`GET /install-url`** (admin-gated) records a `github_app_install_intents` row: `installer_github_id` (the kickoff admin's GitHub id) → `target_organization_id`.
2. **`installation.created` webhook** persists `installer_github_id` (= `sender`) on the installation row, looks up a fresh intent by `sender`, and binds → `target_organization_id` (peek → bind → delete; permanent conflicts consume the intent, transient errors keep it for GitHub's retry).
3. **Sign-in `/callback`** is now pure login — it ignores `installation_id` and binds nothing. A kickoff callback whose OAuth identity differs from the kickoff admin is refused (`install-not-verified`) rather than signed in as the foreign identity.
4. **`POST /claim`** + recovery authorize on the trusted `installer_github_id` (you may claim only an install you performed), not the removed probe.

Trust chain replacing the probe: **HMAC webhook + GitHub-authenticated `sender` + GitHub-native install-gating + admin-minted intent**. This also enforces the "**install and login use the same GitHub identity**" invariant the design called for.

## Changes
- **schema**: new `github_app_install_intents` table; new nullable `installer_github_id` column on `github_app_installations`; migration `0071` (additive only).
- **services**: `github-app-install-intents.ts` (record / peek / delete / sweep); `upsertInstallationFromMetadata` persists `installer_github_id` (COALESCE — preserves the original installer).
- **webhook** (`installation.created`): bind via intent.
- **`api/orgs/github-app.ts`**: `/install-url` mints the intent; `/claim` uses `installer_github_id`.
- **`api/auth/github.ts`**: sign-in is pure login; drop the probe block + the sign-in-time orphan auto-reclaim; kickoff mismatch → error.

## Scope / handoff (coordinate with the gh-建树 effort)
- The **App-manifest permission removals** are operator actions (done separately). ⚠️ **`Members:read` and the `verifyUserCanAdministerInstallation` function itself are intentionally NOT removed here** — the Context-Tree repo **provisioner** (server-side build, owned by the `gh`-tree effort) is its last consumer. They come out when that server-side build is retired.
- No web changes: the onboarding install step (`StepConnectCode` → `/install-url`) is unchanged; `/install-url` now records the intent transparently, and the SPA error surface reuses the existing `install-not-verified` code.

## Known considerations
- If GitHub's sign-in authorize dialog lets a first-time user install inline, that install now has no intent → it won't auto-bind (recover via `POST /claim`). The canonical install path is the onboarding/Settings kickoff (`/install-url`), which records the intent. The manual-claim UI is tracked in #318.
- Intent TTL is 30 min (covers a slow install + webhook lag; bounds stale-intent reuse).

## Testing
- `pnpm --filter @first-tree/server typecheck` ✓
- full server suite: **1618 tests pass** ✓ (incl. rewritten webhook/`/claim`/callback coverage + a new forgery-guard test)
- `pnpm check` ✓

Draft — opening for @code-reviewer. Tree write-back (github-app.md D1/D4 + permission set, binding.md, context-tab.md) lands alongside per the proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update — `/claim` is the explicit probe exception.** Binding on the normal path is webhook-driven (no probe). `/claim` is a *delayed* recovery path, so it retains the live current-GitHub-admin check (`verifyUserCanAdministerInstallation`) before binding. Consequently `Members:read` + the probe are still needed by **`/claim` and the Context-Tree repo provisioner**, and stay until the server-side build is retired (the gh-建树 effort) — do not remove `Members:read` from the App manifest before then. This carries into the Context-Tree write-back.
