### PR TITLE
fix(web): make group @mention reminder a placeholder + on-send tip

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -797,6 +797,53 @@
   }
 }
 
+/* Group-mention tip bubble: entrance rises toward the send button it points at;
+   exit reverses. See chat-view's `mentionTip` state machine. */
+@keyframes mention-tip-in {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@keyframes mention-tip-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+}
+.mention-tip {
+  animation: mention-tip-in 150ms ease-out;
+}
+.mention-tip.mention-tip-out {
+  animation: mention-tip-out 300ms ease-in forwards;
+}
+/* The downward caret connecting the bubble to the send button below it. */
+.mention-tip-arrow {
+  position: absolute;
+  right: 14px;
+  bottom: -5px;
+  width: 9px;
+  height: 9px;
+  background: var(--bg-raised);
+  border-right: var(--hairline) solid var(--border-strong);
+  border-bottom: var(--hairline) solid var(--border-strong);
+  transform: rotate(45deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .mention-tip,
+  .mention-tip.mention-tip-out {
+    animation: none;
+  }
+}
+
 @keyframes context-live-halo-breathe {
   0%,
   100% {

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1173,7 +1173,7 @@ describe("page SSR smoke coverage", () => {
     const { ChatView } = await import("../workspace/center/chat-view.js");
 
     expect(renderWithClient(<ChatView agentId="agent-1" chatId="chat-1" />, createClient())).toContain(
-      "@mention someone to send in this group",
+      "In a group, @mention who this is for",
     );
 
     const readOnlyClient = createClient();

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1331,11 +1331,23 @@ describe("ChatView", () => {
 
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
     if (!textarea) throw new Error("Composer textarea missing");
-    // Group chat, no @mention yet: the persistent hint row states the rule, so
-    // the placeholder stays neutral (no duplicate "@ to pick a recipient").
-    expect(textarea.placeholder).toContain("Write a message");
-    expect(textarea.placeholder).not.toContain("Type @ to pick a recipient");
-    expect(container.textContent).toContain("@mention someone to send in this group");
+    // Group chat, no @mention yet: the placeholder carries the rule, and the
+    // tip bubble is NOT shown until a blocked send is actually attempted.
+    expect(textarea.placeholder).toContain("In a group, @mention who this is for");
+    expect(container.textContent).not.toContain("or no one gets this");
+
+    // Blocked TEXT send: typing without an @mention then pressing Enter pops the
+    // tip bubble and sends nothing. The send button stays clickable (not
+    // `disabled`) so a click would trigger the same tip.
+    await setValue(textarea, "no recipient here");
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Send"]')?.disabled).toBe(false);
+    await act(async () => {
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    });
+    await flush();
+    await waitForText(container, "@mention someone, or no one gets this");
+    expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
+
     await setValue(textarea, "Please review @nova");
     await click(container.querySelector('button[aria-label="Send"]'));
     await waitForCondition(() => chatMocks.sendChatMessage.mock.calls.length > 0, "Expected text send");
@@ -1350,9 +1362,9 @@ describe("ChatView", () => {
       textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
     });
     await flush();
-    // Image-only send with no @mention is blocked too; the persistent hint row
-    // carries the reason for both text and image sends (no separate line).
-    await waitForText(container, "@mention someone to send in this group");
+    // Image-only send with no @mention is blocked too; the tip bubble pops for
+    // both text and image attempts.
+    await waitForText(container, "@mention someone, or no one gets this");
     expect(chatMocks.sendFileMessageBatch).not.toHaveBeenCalled();
 
     await setValue(textarea, "@design image attached");

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1385,6 +1385,45 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("clears the mention tip when switching to another group chat", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const { container, queryClient, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      undefined,
+      "/",
+    );
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Composer textarea missing");
+    // Trigger the tip in chat-1 (group, no @mention).
+    await setValue(textarea, "no recipient");
+    await act(async () => {
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    });
+    await flush();
+    await waitForText(container, "@mention someone, or no one gets this");
+
+    // Switch to another group chat on the SAME long-lived ChatView instance
+    // (identical provider wrappers → React updates the chatId prop rather than
+    // remounting). The tip must not leak into the new chat before any blocked
+    // send there.
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/"]}>
+          <QueryClientProvider client={queryClient}>
+            <ToastProvider>
+              <ChatView agentId="agent-1" chatId="chat-2" />
+            </ToastProvider>
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+    });
+    await flush();
+    expect(container.textContent).not.toContain("@mention someone, or no one gets this");
+
+    await act(async () => root.unmount());
+  });
+
   it("clears a stale auto-primed @ when a request dock arrives late and clean-resolves option answers", async () => {
     const { ChatView } = await import("../chat-view.js");
     const dockMessages = messages([

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1418,6 +1418,10 @@ describe("ChatView", () => {
         </MemoryRouter>,
       );
     });
+    // Pre-paint: the render gate (tip's origin chat ≠ viewed chat) keeps the
+    // stale bubble from painting even before effects flush — assert right after
+    // the commit, with no intervening flush.
+    expect(container.textContent).not.toContain("@mention someone, or no one gets this");
     await flush();
     expect(container.textContent).not.toContain("@mention someone, or no one gets this");
 

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1437,6 +1437,16 @@ export function ChatView({
     mentionTipExitTimer.current = setTimeout(() => setMentionTip("hidden"), MENTION_TIP_EXIT_MS);
   }, [clearMentionTipTimers]);
   useEffect(() => clearMentionTipTimers, [clearMentionTipTimers]);
+  // Hard-reset on chat switch. ChatView is long-lived across chats, so a tip
+  // triggered in one group chat must not linger into the next — the gate-lift
+  // effect won't fire when both chats are group/no-mention (the gate stays
+  // true). Clear the timers and hide immediately (no exit animation) so the
+  // new chat never paints a stale bubble.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: chatId is a reset trigger — the body doesn't read it, but the tip must clear whenever the viewed chat changes
+  useEffect(() => {
+    clearMentionTipTimers();
+    setMentionTip("hidden");
+  }, [chatId, clearMentionTipTimers]);
   // Right-rail visibility. The rail holds participants + GitHub bindings; the
   // running summary now lives in the pinned ChatSummary above the stream, not
   // here. Default: the user's stored preference if they have ever toggled the

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1396,6 +1396,10 @@ export function ChatView({
   mentionTipPhaseRef.current = mentionTip;
   const mentionTipHoldTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mentionTipExitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The chat that owns the current tip. The bubble only renders while this
+  // matches the viewed `chatId`, so a tip from a previous chat can never paint
+  // in the next one — a render-time guard that holds regardless of effect timing.
+  const mentionTipChatId = useRef<string | null>(null);
   // Answering a blocking ask is owned by the AskTakeover overlay, which composes
   // its own text + @mentions + image attachments. `askBusy` disables the card
   // while its resolving reply is in flight (kept true through success so the
@@ -1421,12 +1425,15 @@ export function ChatView({
   // brief exit phase.
   const flashMentionTip = useCallback(() => {
     clearMentionTipTimers();
+    // Stamp the chat that owns this tip so the render gate can refuse to paint
+    // it in any other chat, even for a single frame before effects run.
+    mentionTipChatId.current = chatId;
     setMentionTip("in");
     mentionTipHoldTimer.current = setTimeout(() => {
       setMentionTip("out");
       mentionTipExitTimer.current = setTimeout(() => setMentionTip("hidden"), MENTION_TIP_EXIT_MS);
     }, MENTION_TIP_MS);
-  }, [clearMentionTipTimers]);
+  }, [clearMentionTipTimers, chatId]);
   // Dismiss early (user started typing, addressed someone, or the gate lifted):
   // play the exit anim if currently shown, otherwise just ensure it's hidden.
   const dismissMentionTip = useCallback(() => {
@@ -1440,12 +1447,14 @@ export function ChatView({
   // Hard-reset on chat switch. ChatView is long-lived across chats, so a tip
   // triggered in one group chat must not linger into the next — the gate-lift
   // effect won't fire when both chats are group/no-mention (the gate stays
-  // true). Clear the timers and hide immediately (no exit animation) so the
-  // new chat never paints a stale bubble.
+  // true). The render gate (`mentionTipChatId.current === chatId`) already keeps
+  // a stale tip from painting in the new chat; this pre-paint `useLayoutEffect`
+  // additionally drains the timers and hard-hides so no exit animation plays.
   // biome-ignore lint/correctness/useExhaustiveDependencies: chatId is a reset trigger — the body doesn't read it, but the tip must clear whenever the viewed chat changes
-  useEffect(() => {
+  useLayoutEffect(() => {
     clearMentionTipTimers();
     setMentionTip("hidden");
+    mentionTipChatId.current = null;
   }, [chatId, clearMentionTipTimers]);
   // Right-rail visibility. The rail holds participants + GitHub bindings; the
   // running summary now lives in the pinned ChatSummary above the stream, not
@@ -3836,7 +3845,7 @@ export function ChatView({
                           screen), points at the send button, and auto-dismisses.
                           `pointer-events: none` so it never eats a click/keystroke
                           that would resolve the block. */}
-                      {mentionTip !== "hidden" && (
+                      {mentionTip !== "hidden" && mentionTipChatId.current === chatId && (
                         <div
                           role="status"
                           className={mentionTip === "out" ? "mention-tip mention-tip-out" : "mention-tip"}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1297,8 +1297,10 @@ function EntityLink({ metadata }: { metadata: Record<string, unknown> | undefine
   );
 }
 
-/** How long the group-mention hint row stays error-toned after a blocked send. */
-const MENTION_NUDGE_MS = 2200;
+/** How long the group-mention tip bubble stays up (no-interaction ceiling). */
+const MENTION_TIP_MS = 4000;
+/** Exit-animation duration before the tip bubble unmounts. */
+const MENTION_TIP_EXIT_MS = 300;
 
 export function ChatView({
   agentId,
@@ -1382,13 +1384,18 @@ export function ChatView({
   const [cursor, setCursor] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
-  // Transient emphasis for the persistent group-mention hint row (A1): a blocked
-  // Enter-press flips this true so the always-shown "mention a member" row turns
-  // an error tone for a beat, acknowledging the send attempt without printing a
-  // second, duplicate line below the composer. Cleared by the timer, the next
-  // keystroke, or the gate lifting (see effects near `sendBlockedByMentionGate`).
-  const [mentionGateNudged, setMentionGateNudged] = useState(false);
-  const mentionGateNudgeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Group-mention tip bubble: a transient popover above the send button, shown
+  // only when a group send is attempted with no @mention. `"hidden"` = not
+  // rendered; `"in"` = shown (entrance anim); `"out"` = playing the exit anim
+  // before unmount. Driven by `flashMentionTip` / `dismissMentionTip` below.
+  const [mentionTip, setMentionTip] = useState<"hidden" | "in" | "out">("hidden");
+  // Mirror of `mentionTip` for cheap reads inside callbacks (avoids re-creating
+  // them on every phase change); lets `dismissMentionTip` early-out when already
+  // hidden instead of arming a needless timer on every keystroke.
+  const mentionTipPhaseRef = useRef(mentionTip);
+  mentionTipPhaseRef.current = mentionTip;
+  const mentionTipHoldTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mentionTipExitTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Answering a blocking ask is owned by the AskTakeover overlay, which composes
   // its own text + @mentions + image attachments. `askBusy` disables the card
   // while its resolving reply is in flight (kept true through success so the
@@ -1402,20 +1409,34 @@ export function ChatView({
     // user adds or removes an image — they're already fixing it.
     onChange: () => setUploadError(null),
   });
-  // Emphasise the persistent mention-hint row on a blocked send attempt, then
-  // relax it after a beat. Re-arming clears any pending timer so rapid Enter
-  // presses keep the row lit rather than flickering.
-  const nudgeMentionGate = useCallback(() => {
-    setMentionGateNudged(true);
-    if (mentionGateNudgeTimer.current) clearTimeout(mentionGateNudgeTimer.current);
-    mentionGateNudgeTimer.current = setTimeout(() => setMentionGateNudged(false), MENTION_NUDGE_MS);
+  const clearMentionTipTimers = useCallback(() => {
+    if (mentionTipHoldTimer.current) clearTimeout(mentionTipHoldTimer.current);
+    if (mentionTipExitTimer.current) clearTimeout(mentionTipExitTimer.current);
+    mentionTipHoldTimer.current = null;
+    mentionTipExitTimer.current = null;
   }, []);
-  useEffect(
-    () => () => {
-      if (mentionGateNudgeTimer.current) clearTimeout(mentionGateNudgeTimer.current);
-    },
-    [],
-  );
+  // Show the tip on a blocked send attempt (Enter or clicking the dimmed send
+  // button). Re-arming resets the timers so a repeat attempt refreshes the
+  // bubble rather than stacking timers. Auto-hides after MENTION_TIP_MS via a
+  // brief exit phase.
+  const flashMentionTip = useCallback(() => {
+    clearMentionTipTimers();
+    setMentionTip("in");
+    mentionTipHoldTimer.current = setTimeout(() => {
+      setMentionTip("out");
+      mentionTipExitTimer.current = setTimeout(() => setMentionTip("hidden"), MENTION_TIP_EXIT_MS);
+    }, MENTION_TIP_MS);
+  }, [clearMentionTipTimers]);
+  // Dismiss early (user started typing, addressed someone, or the gate lifted):
+  // play the exit anim if currently shown, otherwise just ensure it's hidden.
+  const dismissMentionTip = useCallback(() => {
+    // Already gone — nothing to dismiss (skips per-keystroke timer churn).
+    if (mentionTipPhaseRef.current === "hidden") return;
+    clearMentionTipTimers();
+    setMentionTip((prev) => (prev === "in" ? "out" : "hidden"));
+    mentionTipExitTimer.current = setTimeout(() => setMentionTip("hidden"), MENTION_TIP_EXIT_MS);
+  }, [clearMentionTipTimers]);
+  useEffect(() => clearMentionTipTimers, [clearMentionTipTimers]);
   // Right-rail visibility. The rail holds participants + GitHub bindings; the
   // running summary now lives in the pinned ChatSummary above the stream, not
   // here. Default: the user's stored preference if they have ever toggled the
@@ -1902,19 +1923,17 @@ export function ChatView({
     // nothing and the button stays disabled, prompting the user to use
     // the `[+]` button or the autocomplete picker.
 
-    // Group-chat send guard: a multi-speaker chat has no no-recipient send
-    // path — every message must @mention at least one member. The send button
-    // is already disabled in this state (see `sendBlockedByMentionGate`), so
-    // this is the Enter-key / programmatic backstop. Applies to image-only
-    // sends too: the server's mention check runs per message regardless of
-    // format, so an un-addressed image would 400 just like un-addressed text.
-    // The persistent hint row (A1, rendered inside the composer when
-    // `sendBlockedByMentionGate`) already states the rule for both text and
-    // image sends; `nudgeMentionGate` emphasises that same row for a beat so a
-    // blocked Enter isn't a silent no-op — no separate line is printed. A live
-    // dock lifts the gate — `routedMentions` below defaults to the asker.
+    // Group-chat send guard: a multi-speaker chat has no no-recipient send path
+    // — every message must @mention at least one member. This is the send path
+    // for both Enter and clicking the dimmed-but-clickable send button (kept
+    // clickable precisely so a click here isn't a silent no-op). Applies to
+    // image-only sends too: the server's mention check runs per message
+    // regardless of format, so an un-addressed image would 400 just like
+    // un-addressed text. `flashMentionTip` pops the tip bubble above the send
+    // button for both text and image attempts. A live dock lifts the gate —
+    // `routedMentions` below defaults to the asker.
     if (sendBlockedByMentionGate) {
-      nudgeMentionGate();
+      flashMentionTip();
       return;
     }
 
@@ -3152,25 +3171,27 @@ export function ChatView({
     [draftMentions, peerAgentId],
   );
 
-  // Group-chat mention gate, shared by the send button (disabled / title /
-  // dimming) and handleSend's Enter-key backstop. A blocking question lifts the
-  // gate: the pinned question makes its asker the default recipient, so no
-  // typed @mention is required while a question blocks me.
+  // Group-chat mention gate, shared by the send button (dimming / title) and
+  // handleSend's guard. A blocking question lifts the gate: the pinned question
+  // makes its asker the default recipient, so no typed @mention is required
+  // while a question blocks me.
   const sendBlockedByMentionGate = requiresMention && draftMentions.length === 0 && !askOverlayActive;
 
   // Once the gate lifts (a member gets @mentioned, or a dock/overlay takes over)
-  // the hint row unmounts — drop any lingering emphasis so it never flashes back
-  // on the next block.
+  // the tip is moot — dismiss it so it never lingers into the next block.
   useEffect(() => {
-    if (!sendBlockedByMentionGate) setMentionGateNudged(false);
-  }, [sendBlockedByMentionGate]);
+    if (!sendBlockedByMentionGate) dismissMentionTip();
+  }, [sendBlockedByMentionGate, dismissMentionTip]);
 
   // Unified send-disabled gate for the composer. While the AskTakeover overlay
   // is active it covers the composer (answering is owned there), so the composer
-  // only ever sends ordinary messages: need text or an image, and (group chats)
-  // an addressed @mention.
-  const sendDisabled =
-    sendMut.isPending || uploading || (!draft.trim() && pendingImages.length === 0) || sendBlockedByMentionGate;
+  // only ever sends ordinary messages: need text or an image. NOTE: the mention
+  // gate is deliberately NOT part of `sendDisabled` — a truly disabled button
+  // swallows clicks, so we keep the button clickable when only the mention is
+  // missing and let handleSend pop the tip. `sendDimmed` carries the greyed-out
+  // look for that state.
+  const sendDisabled = sendMut.isPending || uploading || (!draft.trim() && pendingImages.length === 0);
+  const sendDimmed = sendDisabled || sendBlockedByMentionGate;
 
   const mention = useMentionAutocomplete({
     value: draft,
@@ -3798,26 +3819,37 @@ export function ChatView({
                         addImages(Array.from(e.dataTransfer.files));
                       }}
                     >
-                      {/* Persistent mention-required hint (A1): a group send has no
-                          no-recipient path, so while the gate blocks (group chat,
-                          no @mention yet) this row states the rule inside the card —
-                          above the textarea, sharing the composer's frame so it never
-                          collides with the agent status bar above. It collapses the
-                          moment a member is @mentioned. A blocked send attempt
-                          (`nudgeMentionGate`) tints it an error tone for a beat. */}
-                      {sendBlockedByMentionGate && (
+                      {/* Group-mention tip bubble: a transient popover anchored
+                          above the send button, shown only on a blocked send
+                          attempt (`flashMentionTip`). Opens upward (the composer
+                          hugs the screen bottom, so a hint below it would be off
+                          screen), points at the send button, and auto-dismisses.
+                          `pointer-events: none` so it never eats a click/keystroke
+                          that would resolve the block. */}
+                      {mentionTip !== "hidden" && (
                         <div
-                          className="flex items-center"
+                          role="status"
+                          className={mentionTip === "out" ? "mention-tip mention-tip-out" : "mention-tip"}
                           style={{
+                            position: "absolute",
+                            right: 8,
+                            bottom: 44,
+                            zIndex: 5,
+                            pointerEvents: "none",
+                            maxWidth: "calc(100% - var(--sp-4))",
+                            display: "flex",
+                            alignItems: "center",
                             gap: "var(--sp-1_5)",
-                            padding: "var(--sp-1_75) var(--sp-3)",
-                            borderBottom: "var(--hairline) solid var(--border-faint)",
-                            color: mentionGateNudged ? "var(--fg-error-strong)" : "var(--fg-3)",
-                            transition: "color 120ms ease",
+                            padding: "var(--sp-1_5) var(--sp-2_5)",
+                            borderRadius: "var(--radius-panel)",
+                            border: "var(--hairline) solid var(--border-strong)",
+                            background: "var(--bg-raised)",
+                            boxShadow: "var(--shadow-md)",
+                            color: "var(--fg)",
                           }}
                         >
-                          <AtSign className="h-3 w-3 shrink-0" aria-hidden="true" />
-                          <span className="text-label">@mention someone to send in this group</span>
+                          <span className="text-label">@mention someone, or no one gets this</span>
+                          <span className="mention-tip-arrow" aria-hidden="true" />
                         </div>
                       )}
                       {/* Image preview area — above textarea */}
@@ -3924,9 +3956,9 @@ export function ChatView({
                             // — React bails on identical setState so the null→null
                             // case is free.
                             setUploadError(null);
-                            // Same rationale for the mention-hint emphasis: the
-                            // user is actively editing, so relax the row.
-                            setMentionGateNudged(false);
+                            // Same rationale for the mention tip: the user is
+                            // actively editing, so dismiss it early.
+                            dismissMentionTip();
                           }}
                           onSelect={(e) => {
                             setCursor(e.currentTarget.selectionStart ?? draft.length);
@@ -3974,10 +4006,11 @@ export function ChatView({
                           }}
                           placeholder={
                             requiresMention
-                              ? // The mention-hint row (A1) above already tells the
-                                // user to @mention, so the placeholder stays neutral
-                                // rather than repeating it.
-                                "Write a message…  ·  / for commands"
+                              ? // Group chat: the placeholder carries the rule (this
+                                // is the calm, always-there teaching surface). It
+                                // shows only while empty; once the user types it's
+                                // gone, and the tip bubble covers a blocked send.
+                                "In a group, @mention who this is for"
                               : `Message @${displayName}  ·  / for commands  ·  @ to mention`
                           }
                           rows={2}
@@ -4136,16 +4169,22 @@ export function ChatView({
                           <button
                             type="button"
                             onClick={handleSend}
+                            // NOT `disabled` when only the mention is missing — a
+                            // disabled button swallows the click and the tip never
+                            // fires. `aria-disabled` still conveys the blocked
+                            // state to assistive tech while keeping it clickable.
                             disabled={sendDisabled}
+                            aria-disabled={sendBlockedByMentionGate || undefined}
                             title={
                               sendBlockedByMentionGate
-                                ? "@mention a member to send — a group message must address someone"
+                                ? "@mention someone to send — a group message must address someone"
                                 : "Send (Enter)"
                             }
                             aria-label="Send"
                             className={cn(
                               "inline-flex items-center justify-center transition-opacity",
-                              sendDisabled && "opacity-40 cursor-not-allowed",
+                              sendDimmed && "opacity-40",
+                              sendDisabled && "cursor-not-allowed",
                             )}
                             style={{
                               width: 28,


### PR DESCRIPTION
## What & why

Refine of #1376 after the product owner's design review. The v1 shipped a **persistent in-card hint row** + a row-emphasis on blocked send. In practice the row read as extra chrome (it stayed up while typing, so the composer was never "quiet"), and the blocked-send feedback wasn't prominent or well-placed. This reworks it to the simpler, approved shape.

### Changes
- **Drop the persistent hint row.** The rule now rides the **placeholder** — `In a group, @mention who this is for` — shown only while the composer is empty. Typing is quiet; no standing chrome.
- **Send button: greyed but clickable** when only the `@mention` is missing. A truly `disabled` button swallows clicks, so the tip could never fire on click. `aria-disabled` conveys the blocked state to AT; the mention gate is removed from `sendDisabled` and a new `sendDimmed` drives the greyed look.
- **On-send tip bubble.** A blocked send attempt (Enter *or* click) pops a transient bubble above the send button: `@mention someone, or no one gets this`. It opens **upward** (the composer hugs the screen bottom, so a hint *below* it would be off-screen), points at the button with a caret, auto-dismisses after 4s, and clears early on typing / addressing someone / the gate lifting. Fade+rise in (150ms), fade+drop out (300ms), `prefers-reduced-motion` aware. **No `@` icon** — the text already leads with `@mention`, so there's no duplicate `@` (a specific piece of review feedback).

Covers text and image sends uniformly, replacing the old image-only `uploadError` hint. Everything stays gated on the existing `sendBlockedByMentionGate`, in lockstep with the server's `enforceGroupMention`.

## Design
Approved via a dual-theme, animated effect image (bubble plays on its real timing). All values use existing design tokens; a code review verified the caret geometry points at the send button and clears the toolbar in both themes.

## Tests
- Web suite green: **1094/1094**; `typecheck` + `biome` + `lint:tokens` clean.
- Composer DOM test updated + extended: placeholder copy, tip **not** shown until a blocked send, blocked **text** send pops the tip and sends nothing, send button stays clickable when blocked, image-only blocked send pops the tip. SSR smoke asserts the new placeholder.

## Review
Two independent reviews (correctness + design/visual) — both **approve, zero blocking**. Adopted their two suggestions: `borderRadius` → `var(--radius-panel)`, and an early-out in `dismissMentionTip` to skip per-keystroke timer churn.

## Context Tree
The must-`@mention` contract is already documented in `system/cloud/chat/messaging.md`; this only changes how it's surfaced in the composer — **implementation-only, no tree write**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
