### PR TITLE
fix(cli): route daemon update logs through client logger

### DIFF
--- a/apps/cli/src/__tests__/core-attention-update-extra.test.ts
+++ b/apps/cli/src/__tests__/core-attention-update-extra.test.ts
@@ -142,7 +142,8 @@ describe("core update helpers", () => {
     childRegistryMocks.classify.mockReturnValueOnce({ kind: "permanent", reasonCode: "ebadengine" });
     const failChild = new MockChild();
     installSpawn(failChild);
-    const failPromise = installGlobalSpec("latest");
+    const installOutput: string[] = [];
+    const failPromise = installGlobalSpec("latest", { output: (chunk) => installOutput.push(chunk) });
     failChild.stderr.emit("data", Buffer.from("line1\nline2\nline3\nline4\n"));
     failChild.emit("exit", 1, null);
     const failResult = await failPromise;
@@ -153,6 +154,8 @@ describe("core update helpers", () => {
     });
     if (failResult.ok) throw new Error("expected install failure");
     expect(failResult.reason).toContain("line2 | line3 | line4");
+    expect(installOutput).toEqual(["line1\nline2\nline3\nline4\n"]);
+    expect(printLineMock).not.toHaveBeenCalled();
 
     const timeoutChild = new MockChild();
     installSpawn(timeoutChild);

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -8,6 +8,7 @@ const clientMocks = vi.hoisted(() => ({
   applyClientLoggerConfig: vi.fn(),
   captureClientException: vi.fn(),
   configureClientLoggerForService: vi.fn(),
+  createLogger: vi.fn(),
   discoverClaudeCodeSkills: vi.fn(),
   flushClientSentry: vi.fn(),
   initClientSentry: vi.fn(),
@@ -112,6 +113,12 @@ beforeEach(() => {
   stderrSpy.mockClear();
 
   clientMocks.probeCapabilities.mockResolvedValue({ "claude-code": { state: "ok" } });
+  clientMocks.createLogger.mockReturnValue({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  });
   clientMocks.reprobeOnReconnect.mockResolvedValue({
     capabilities: { "claude-code": { state: "ok" } },
     mode: "revalidate",
@@ -343,7 +350,9 @@ describe("daemon start command", () => {
     await expect(runStart(["--no-interactive"])).rejects.toMatchObject({ exitCode: 1 });
 
     expect(coreMocks.promptMissingFields).toHaveBeenCalledWith(expect.objectContaining({ noInteractive: true }));
-    expect(coreMocks.createExecuteUpdate).toHaveBeenCalledWith(expect.objectContaining({ managed: true }));
+    expect(coreMocks.createExecuteUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ log: expect.any(Function), managed: true }),
+    );
     expect(clientMocks.configureClientLoggerForService).toHaveBeenCalledWith(join(home, "logs"));
     expect(coreMocks.ClientRuntime).toHaveBeenCalledWith(
       "https://first-tree.example",

--- a/apps/cli/src/__tests__/install-global-spec-prod-staging.test.ts
+++ b/apps/cli/src/__tests__/install-global-spec-prod-staging.test.ts
@@ -54,11 +54,13 @@ describe("§9 channel-mismatch guard — prod CLI", () => {
     vi.resetModules();
     vi.doMock("../core/channel.js", () => PROD_MOCK);
     const { installGlobalSpec } = await import("../core/update.js");
-    const result = await installGlobalSpec("0.5.2-staging.42.1");
+    const output = vi.fn();
+    const result = await installGlobalSpec("0.5.2-staging.42.1", { output });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toMatch(/target channel "staging" does not match my channel "prod"/i);
     }
+    expect(output).toHaveBeenCalledWith(expect.stringContaining('target channel "staging"'));
   }, 30_000);
 
   it("refuses unknown prerelease formats (fail-closed)", async () => {

--- a/apps/cli/src/__tests__/update-glue.test.ts
+++ b/apps/cli/src/__tests__/update-glue.test.ts
@@ -159,4 +159,42 @@ describe("update glue", () => {
     ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
     expect(output()).toContain("warning: 'daemon refresh-unit' exited with status 7");
   });
+
+  it("routes managed update output through the injected logger and captures refresh-unit output", async () => {
+    const { SELF_RESTART_EXIT_CODE, createExecuteUpdate } = await import("../core/update-glue.js");
+    const logs: Array<[level: string, message: string]> = [];
+    updateMocks.installGlobalSpec.mockImplementationOnce(
+      async (_target: string, options?: { output?: (chunk: string) => void }) => {
+        options?.output?.("npm stderr line\n");
+        return { ok: true, mode: "global" as const, installedVersion: "0.6.0" };
+      },
+    );
+    spawnSyncMock.mockReturnValueOnce({
+      status: 7,
+      signal: "SIGTERM",
+      stderr: "stderr line\n",
+      stdout: "stdout line\n",
+    });
+
+    await expect(
+      createExecuteUpdate({
+        managed: true,
+        log: (level, message) => logs.push([level, message]),
+      })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
+
+    expect(printLineMock).not.toHaveBeenCalled();
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      channelConfig.binName,
+      ["daemon", "refresh-unit"],
+      expect.objectContaining({ encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }),
+    );
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        ["info", "npm stderr line"],
+        ["warn", expect.stringContaining("warning: 'daemon refresh-unit' exited with status 7")],
+        ["warn", expect.stringContaining("Output: stderr line | stdout line")],
+      ]),
+    );
+  });
 });

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -5,6 +5,7 @@ import {
   ClientUserMismatchError,
   captureClientException,
   configureClientLoggerForService,
+  createLogger,
   discoverClaudeCodeSkills,
   flushClientSentry,
   initClientSentry,
@@ -229,6 +230,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
         // exit-for-restart path scoped to that case.
         const noInteractive = options.interactive === false;
         const managed = isSupervisorChild;
+        const updateLogger = createLogger("update");
         // The `executeUpdate` closure needs access to the ClientRuntime's
         // connection to emit `resilience.update.failed`, but the runtime
         // doesn't exist yet at construction time. Use a deferred reference
@@ -238,6 +240,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
         let runtimeRef: ClientRuntime | null = null;
         const executeUpdate = createExecuteUpdate({
           managed,
+          log: managed ? (level, msg) => updateLogger[level](msg) : undefined,
           onUpdateFailed: (payload) => {
             runtimeRef?.emitConnectionResilienceEvent("resilience.update.failed", payload);
           },

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import {
   AgentSlot,
   ClientConnection,
+  createLogger,
   getChildProcessRegistry,
   getHandlerFactory,
   hasHandler,
@@ -268,11 +269,12 @@ export class ClientRuntime {
     // Attach before connecting so the first welcome frame on a stale client
     // is acted on rather than missed until the next reconnect.
     if (this.options.currentVersion && this.options.update) {
+      const updateLogger = createLogger("update");
       this.updateManager = UpdateManager.attach(this.connection, {
         currentVersion: this.options.currentVersion,
         ...this.options.update,
         isTTY: Boolean(process.stdout.isTTY),
-        log: (level, msg) => print.status(`[update/${level}]`, msg),
+        log: (level, msg) => updateLogger[level](msg),
         getQuietGateSnapshot: () => this.aggregateQuietGate(),
       });
     }

--- a/apps/cli/src/core/update-glue.ts
+++ b/apps/cli/src/core/update-glue.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import type { ExecuteUpdateFn, RefreshUpdateTargetFn, UpdatePromptFn } from "@first-tree/client";
+import type { ExecuteUpdateFn, RefreshUpdateTargetFn, UpdateLogger, UpdatePromptFn } from "@first-tree/client";
 import { confirm } from "@inquirer/prompts";
 import * as semver from "semver";
 import { channelConfig } from "./channel.js";
@@ -50,6 +50,22 @@ export type UpdateFailedPayload = {
   reasonCode: string;
 };
 
+function formatUpdateLine(message: string): string {
+  return `  [update] ${message.replace(/\n$/, "")}\n`;
+}
+
+function defaultUpdateLog(_level: "info" | "warn", message: string): void {
+  print.line(formatUpdateLine(message));
+}
+
+function createInstallOutputLog(log: UpdateLogger | undefined): ((chunk: string) => void) | undefined {
+  if (!log) return undefined;
+  return (chunk) => {
+    const message = chunk.trimEnd();
+    if (message) log("info", message);
+  };
+}
+
 /**
  * Build the command-layer `executeUpdate` callback.
  *
@@ -73,21 +89,26 @@ export type UpdateFailedPayload = {
  */
 export function createExecuteUpdate({
   managed,
+  log,
   onUpdateFailed,
 }: {
   managed: boolean;
+  log?: UpdateLogger;
   onUpdateFailed?: (payload: UpdateFailedPayload) => void;
 }): ExecuteUpdateFn {
+  const emit = log ?? defaultUpdateLog;
+  const installOutput = createInstallOutputLog(log);
   return async ({ currentVersion, targetVersion }) => {
     const mode = detectInstallMode();
     if (mode === "source") {
-      print.line("  [update] Running from source checkout — self-update skipped. Use `git pull` instead.\n");
+      emit("info", "Running from source checkout — self-update skipped. Use `git pull` instead.");
       return { installed: false };
     }
     if (mode === "npx") {
       const installHint = PACKAGE_NAME ?? channelConfig.binName;
-      print.line(
-        `  [update] Cannot self-update — not launched from a global npm install.\n  Run \`npm i -g ${installHint}\` manually.\n`,
+      emit(
+        "warn",
+        `Cannot self-update — not launched from a global npm install.\n  Run \`npm i -g ${installHint}\` manually.`,
       );
       return { installed: false };
     }
@@ -114,12 +135,13 @@ export function createExecuteUpdate({
     // get stuck on $target").
     if (isLoopGuarded(targetVersion)) {
       const installHint = PACKAGE_NAME ?? channelConfig.binName;
-      print.line(
-        `  [update] Refusing to retry ${targetVersion} — a previous attempt completed without\n` +
+      emit(
+        "warn",
+        `Refusing to retry ${targetVersion} — a previous attempt completed without\n` +
           "           advancing the on-disk version. The most likely cause is npm's `latest`\n" +
           "           dist-tag resolving to the same version this client is already running.\n" +
           `           Operator action: manually run \`npm install -g ${installHint}@latest\`,\n` +
-          "           then restart the service.\n",
+          "           then restart the service.",
       );
       return { installed: true };
     }
@@ -131,10 +153,10 @@ export function createExecuteUpdate({
     // run"; channelConfig.packageName guarantees we install against this
     // binary's own package (prod / staging), never crossing channels.
     const pkgSpec = PACKAGE_NAME ?? channelConfig.binName;
-    print.line(`  [update] Running \`npm install -g ${pkgSpec}@${targetVersion}\`...\n`);
-    const result = await installGlobalSpec(targetVersion);
+    emit("info", `Running \`npm install -g ${pkgSpec}@${targetVersion}\`...`);
+    const result = await installGlobalSpec(targetVersion, installOutput ? { output: installOutput } : undefined);
     if (!result.ok) {
-      print.line(`  [update] Install failed: ${result.reason}\n`);
+      emit("warn", `Install failed: ${result.reason}`);
       recordUpdateAttempt({
         result: "failed",
         target: targetVersion,
@@ -178,8 +200,8 @@ export function createExecuteUpdate({
     const installed = result.installedVersion;
     if (installed && semver.valid(installed) && semver.valid(targetVersion) && semver.lt(installed, targetVersion)) {
       const reason = `npm reported install of ${installed}, but the server-advertised target was ${targetVersion} (running ${currentVersion})`;
-      print.line(`  [update] WARNING: ${reason}\n`);
-      print.line("  [update] Skipping restart to avoid an exit-75 → reboot loop. Loop guard armed.\n");
+      emit("warn", `WARNING: ${reason}`);
+      emit("warn", "Skipping restart to avoid an exit-75 → reboot loop. Loop guard armed.");
       recordUpdateAttempt({
         result: "blocked",
         target: targetVersion,
@@ -218,12 +240,13 @@ export function createExecuteUpdate({
       // (matches `commands/upgrade.ts`'s "warn and continue" stance — the
       // operator can recover with logout + login if the
       // unit ends up stale).
-      refreshServiceUnit();
-      print.line(`  [update] Installed ${installedLabel}. Restarting (exit ${SELF_RESTART_EXIT_CODE}).\n`);
+      refreshServiceUnit(emit);
+      emit("info", `Installed ${installedLabel}. Restarting (exit ${SELF_RESTART_EXIT_CODE}).`);
       process.exit(SELF_RESTART_EXIT_CODE);
     }
-    print.line(
-      `  [update] Installed ${installedLabel}. Restart the client manually (Ctrl+C then \`${channelConfig.binName} daemon start\`) to pick up the new version.\n`,
+    emit(
+      "info",
+      `Installed ${installedLabel}. Restart the client manually (Ctrl+C then \`${channelConfig.binName} daemon start\`) to pick up the new version.`,
     );
     return { installed: true };
   };
@@ -249,7 +272,7 @@ export function createExecuteUpdate({
  * runs `daemon-reload` + `enable --now` and on launchd runs `bootout` +
  * `bootstrap`, both of which routinely take 10-30s under load.
  */
-function refreshServiceUnit(): void {
+function refreshServiceUnit(log: (level: "info" | "warn", message: string) => void): void {
   // Spawn the channel's own bin name (prod → `first-tree`, staging →
   // `first-tree-staging`, dev → `first-tree-dev`). Crossing channels here
   // would either ENOENT (the other bin isn't installed) or, worse,
@@ -259,7 +282,8 @@ function refreshServiceUnit(): void {
   const recovery = `\`${bin} logout && ${bin} login <token>\``;
   try {
     const res = spawnSync(bin, ["daemon", "refresh-unit"], {
-      stdio: ["ignore", "inherit", "inherit"],
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
       timeout: 45_000,
       // Sanitize FIRST_TREE_SERVICE_MODE so the child doesn't think it's
       // being invoked by the supervisor and recursively delegate to
@@ -268,17 +292,20 @@ function refreshServiceUnit(): void {
       env: { ...process.env, FIRST_TREE_SERVICE_MODE: "" },
     });
     if (res.status !== 0) {
-      print.line(
-        `  [update] warning: 'daemon refresh-unit' exited with status ${res.status ?? "unknown"} ` +
+      const output = [res.stderr?.trim(), res.stdout?.trim()].filter(Boolean).join(" | ");
+      const outputSuffix = output ? ` Output: ${output}` : "";
+      log(
+        "warn",
+        `warning: 'daemon refresh-unit' exited with status ${res.status ?? "unknown"} ` +
           `(signal=${res.signal ?? "none"}). If the supervisor restart fails after exit ${SELF_RESTART_EXIT_CODE}, ` +
-          `recover with ${recovery}.\n`,
+          `recover with ${recovery}.${outputSuffix}`,
       );
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    print.line(
-      `  [update] warning: could not spawn 'daemon refresh-unit': ${msg}. If the supervisor restart fails, ` +
-        `recover with ${recovery}.\n`,
+    log(
+      "warn",
+      `warning: could not spawn 'daemon refresh-unit': ${msg}. If the supervisor restart fails, recover with ${recovery}.`,
     );
   }
 }

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -148,6 +148,14 @@ export type ExecuteUpdateResult =
       reasonCode?: string;
     };
 
+export type InstallGlobalSpecOptions = {
+  output?: (chunk: string) => void;
+};
+
+function writeInstallOutput(options: InstallGlobalSpecOptions | undefined, chunk: string): void {
+  (options?.output ?? print.line)(chunk);
+}
+
 /**
  * Validate an npm install spec (the part after `@` in `<pkg>@<spec>`). We
  * accept either a known dist-tag string (`latest`, `alpha`, …) or an exact
@@ -186,7 +194,10 @@ function looksLikeVersion(spec: string): boolean {
  * install that exact version. The explicit `upgrade --latest` escape hatch keeps the dist-tag form for
  * operators who want the freshest package directly from npm.
  */
-export async function installGlobalSpec(spec: string): Promise<ExecuteUpdateResult> {
+export async function installGlobalSpec(
+  spec: string,
+  options?: InstallGlobalSpecOptions,
+): Promise<ExecuteUpdateResult> {
   if (!isSafeInstallSpec(spec)) {
     return {
       ok: false,
@@ -218,7 +229,7 @@ export async function installGlobalSpec(spec: string): Promise<ExecuteUpdateResu
         `Refusing to install ${spec}: target channel "${targetChannel}" does not match my channel ` +
         `"${channelConfig.channel}". This usually means the First Tree server is misconfigured ` +
         `(check FIRST_TREE_CHANNEL on the server).`;
-      print.line(`  [update] ${reason}\n`);
+      writeInstallOutput(options, `  [update] ${reason}\n`);
       return { ok: false, mode: "global", reason };
     }
   }
@@ -243,7 +254,7 @@ export async function installGlobalSpec(spec: string): Promise<ExecuteUpdateResu
     child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
     child.stderr?.on("data", (chunk: Buffer) => {
       stderrChunks.push(chunk);
-      print.line(chunk.toString("utf8"));
+      writeInstallOutput(options, chunk.toString("utf8"));
     });
 
     child.on("error", (err) => {
@@ -295,8 +306,8 @@ export async function installGlobalSpec(spec: string): Promise<ExecuteUpdateResu
  * `upgrade --latest`; managed update paths prefer
  * `installGlobalSpec` with the server-advertised target version.
  */
-export async function installGlobalLatest(): Promise<ExecuteUpdateResult> {
-  return installGlobalSpec("latest");
+export async function installGlobalLatest(options?: InstallGlobalSpecOptions): Promise<ExecuteUpdateResult> {
+  return installGlobalSpec("latest", options);
 }
 
 /**

--- a/packages/client/src/__tests__/update-manager.test.ts
+++ b/packages/client/src/__tests__/update-manager.test.ts
@@ -356,6 +356,49 @@ describe("UpdateManager decision flow", () => {
     }
   });
 
+  it("throttles quiet-gate debug logs without changing the re-check interval", async () => {
+    vi.useFakeTimers();
+    try {
+      const conn = makeFakeConnection();
+      const logs: Array<{ level: string; msg: string }> = [];
+      const executeUpdate = vi.fn(async () => ({ installed: false }));
+      const getQuietGateSnapshot = vi.fn(() => ({ activeCount: 1, lastActivityMs: Date.now() }));
+
+      const mgr = UpdateManager.attach(conn, {
+        currentVersion: "0.8.4",
+        updateConfig: makeUpdateConfig({
+          policy: "auto",
+          restart_quiet_seconds: 30,
+          restart_check_interval_seconds: 10,
+        }),
+        isTTY: false,
+        log: (level, msg) => logs.push({ level, msg }),
+        getQuietGateSnapshot,
+        prompt: async () => false,
+        executeUpdate,
+      });
+
+      conn.emitWelcome(makeWelcome("0.9.2", true));
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(getQuietGateSnapshot).toHaveBeenCalledTimes(1);
+      expect(logs.filter((entry) => entry.msg.startsWith("Quiet gate:"))).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(50_000);
+      expect(getQuietGateSnapshot).toHaveBeenCalledTimes(6);
+      expect(logs.filter((entry) => entry.msg.startsWith("Quiet gate:"))).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(getQuietGateSnapshot).toHaveBeenCalledTimes(7);
+      expect(logs.filter((entry) => entry.msg.startsWith("Quiet gate:"))).toHaveLength(2);
+      expect(executeUpdate).not.toHaveBeenCalled();
+
+      mgr.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("policy=auto, reconnect coalesces the latest welcome target while the quiet gate waits", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/client/src/runtime/update-manager.ts
+++ b/packages/client/src/runtime/update-manager.ts
@@ -23,6 +23,8 @@ export type UpdateLogLevel = "debug" | "info" | "warn";
 
 export type UpdateLogger = (level: UpdateLogLevel, msg: string) => void;
 
+const QUIET_GATE_LOG_INTERVAL_MS = 60_000;
+
 /**
  * Command-layer TTY prompt. Returns `true` when the operator explicitly
  * consents to the update (pressing `y`); returns `false` on `N`, timeout, or
@@ -298,15 +300,19 @@ export class UpdateManager {
   private async waitForQuietGate(): Promise<void> {
     const quietMs = this.options.updateConfig.restart_quiet_seconds * 1000;
     const intervalMs = this.options.updateConfig.restart_check_interval_seconds * 1000;
+    let lastQuietGateLogAt = Number.NEGATIVE_INFINITY;
     while (!this.disposed) {
       const snapshot = this.options.getQuietGateSnapshot();
       const now = Date.now();
       const idleFor = snapshot.lastActivityMs === 0 ? Number.POSITIVE_INFINITY : now - snapshot.lastActivityMs;
       if (snapshot.activeCount === 0 && idleFor >= quietMs) return;
-      this.options.log(
-        "debug",
-        `Quiet gate: activeCount=${snapshot.activeCount}, idleFor=${Math.round(idleFor)}ms; re-checking in ${intervalMs}ms`,
-      );
+      if (now - lastQuietGateLogAt >= QUIET_GATE_LOG_INTERVAL_MS) {
+        lastQuietGateLogAt = now;
+        this.options.log(
+          "debug",
+          `Quiet gate: activeCount=${snapshot.activeCount}, idleFor=${Math.round(idleFor)}ms; re-checking in ${intervalMs}ms`,
+        );
+      }
       await new Promise<void>((resolve) => {
         this.quietGateTimer = setTimeout(() => {
           this.quietGateTimer = null;


### PR DESCRIPTION
## Summary
- Route daemon auto-update diagnostics through the client logger instead of CLI `print.*` in service mode
- Capture managed `daemon refresh-unit` child output and npm install output so service-mode update paths write to `client.log`, while foreground/manual output keeps the existing terminal behavior
- Keep quiet-gate re-checks at the configured 10s interval, but throttle the repeated debug log to once per minute

## Tests
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/update-glue.test.ts src/__tests__/client-runtime-context-tree.test.ts src/__tests__/daemon-start-command.test.ts src/__tests__/cli-command-matrix-extra.test.ts src/__tests__/core-attention-update-extra.test.ts src/__tests__/install-global-spec-prod-staging.test.ts --maxWorkers=2`
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/install-global-spec.test.ts src/__tests__/install-global-spec-channel.test.ts src/__tests__/install-global-spec-prod-staging.test.ts src/__tests__/update-install.test.ts src/__tests__/core-attention-update-extra.test.ts src/__tests__/update-glue.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/update-manager.test.ts --maxWorkers=2`
- `pnpm check` (passes with existing unrelated warnings)
- `pnpm typecheck`
