### PR TITLE
refactor(tree): render tree init scaffold templates from ejs

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "dev": "tsx src/cli/index.ts",
-    "build": "tsdown src/cli/index.ts src/index.ts --format esm --no-dts --external @anthropic-ai/claude-agent-sdk --external @openai/codex-sdk && node ../../scripts/copy-client-runtime-templates.mjs apps/cli",
+    "build": "tsdown src/cli/index.ts src/index.ts --format esm --no-dts --external @anthropic-ai/claude-agent-sdk --external @openai/codex-sdk && node ../../scripts/copy-client-runtime-templates.mjs apps/cli && node ../../scripts/copy-cli-tree-templates.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "coverage": "pnpm run build && vitest run --coverage --passWithNoTests",
@@ -74,6 +74,7 @@
     "@first-tree/server": "workspace:*",
     "@first-tree/shared": "workspace:*",
     "@first-tree/web": "workspace:*",
+    "@types/ejs": "^3.1.5",
     "@types/node": "^22.16.0",
     "@types/semver": "^7.5.8",
     "@vitest/coverage-v8": "3.2.4",

--- a/apps/cli/src/__tests__/tree-init.test.ts
+++ b/apps/cli/src/__tests__/tree-init.test.ts
@@ -4,6 +4,12 @@ import { dirname, join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 import { buildScaffoldFiles, defaultRepoName, resolveRepoOwner, type ScaffoldFile } from "../commands/tree/init.js";
+import {
+  memberNodeContent,
+  membersIndexContent,
+  rootNodeContent,
+  validateTreeWorkflowContent,
+} from "../commands/tree/scaffold-templates.js";
 import { renderContextTree } from "../commands/tree/tree.js";
 import { verifyTreeRoot } from "../commands/tree/verify.js";
 
@@ -116,5 +122,37 @@ describe("resolveRepoOwner", () => {
     expect(resolveRepoOwner({ optionOwner: "someone", creatorLogin: "octocat", installationAccount: null })).toBe(
       "someone",
     );
+  });
+
+  it("matches --owner case-insensitively and returns the canonical casing", () => {
+    // GitHub account names are case-insensitive, so `--owner ACME-Org` must not
+    // be rejected against a stored `acme-org`; the canonical casing is returned.
+    expect(
+      resolveRepoOwner({ optionOwner: "ACME-Org", creatorLogin: "octocat", installationAccount: "acme-org" }),
+    ).toBe("acme-org");
+  });
+});
+
+describe("scaffold-templates (ejs)", () => {
+  it("renders the root node with quoted frontmatter and the owner", () => {
+    const node = rootNodeContent("Acme", "octocat");
+    expect(node).toContain('title: "Acme Context Tree"');
+    expect(node).toContain("owners: [octocat]");
+    expect(node).toContain("# Acme's Context Tree");
+  });
+
+  it("renders the members index with a non-empty owner", () => {
+    expect(membersIndexContent("octocat")).toContain("owners: [octocat]");
+  });
+
+  it("renders a member node carrying the required member fields", () => {
+    const node = memberNodeContent("octocat");
+    expect(node).toContain('title: "octocat"');
+    expect(node).toContain("owners: [octocat]");
+    expect(node).toContain("type: human");
+  });
+
+  it("renders the validate-tree workflow", () => {
+    expect(validateTreeWorkflowContent()).toContain("first-tree tree verify");
   });
 });

--- a/apps/cli/src/commands/tree/init.ts
+++ b/apps/cli/src/commands/tree/init.ts
@@ -6,36 +6,18 @@ import type { Command } from "commander";
 import { ensureFreshAccessToken, resolveServerUrl } from "../../core/bootstrap.js";
 import { channelConfig } from "../../core/channel.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
+import {
+  memberNodeContent,
+  membersIndexContent,
+  rootNodeContent,
+  validateTreeWorkflowContent,
+} from "./scaffold-templates.js";
 import { ensureTrailingNewline, runCommand } from "./shared.js";
 import { type VerifySummary, verifyTreeRoot } from "./verify.js";
 
 const REPO_SUFFIX = "-context-tree";
 const GITHUB_REPO_NAME_MAX_LENGTH = 100;
 const DEFAULT_BRANCH = "main";
-
-// Kept byte-for-byte in sync with the server's one-click bootstrap
-// (`packages/server/src/api/orgs/context-tree.ts`) so a tree created either way
-// runs the same CI. Only seeded when `--with-workflow` is passed, because
-// writing under `.github/workflows/` needs the interactive `workflow` gh scope
-// (`gh auth refresh -s workflow`); the default path skips it and stays
-// frictionless — the workflow is optional CI, not required for a valid tree.
-const VALIDATE_TREE_WORKFLOW = `name: Validate Context Tree
-
-on:
-  pull_request:
-  push:
-    branches: [main]
-  workflow_dispatch:
-
-jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Validate Context Tree
-        run: npx -p first-tree first-tree tree verify
-`;
 
 export type TreeInitOptions = {
   owner?: string;
@@ -50,10 +32,6 @@ export type TreeInitOptions = {
 };
 
 export type ScaffoldFile = { relPath: string; content: string };
-
-function yamlDoubleQuote(value: string): string {
-  return JSON.stringify(value.replace(/\s+/g, " ").trim());
-}
 
 // Mirror the server's `slugifyRepoBase` byte-for-byte (NFKD strip + hyphenate +
 // collapse), including the `team` fallback, so agent-created and Cloud-created
@@ -79,58 +57,11 @@ export function defaultRepoName(title: string): string {
   return `${base}${REPO_SUFFIX}`;
 }
 
-function rootNodeContent(title: string, ownerLogin: string): string {
-  const description = `Shared context, decisions, ownership, and operating knowledge for ${title}.`;
-  return `---
-title: ${yamlDoubleQuote(`${title} Context Tree`)}
-description: ${yamlDoubleQuote(description)}
-owners: [${ownerLogin}]
----
-
-# ${title}'s Context Tree
-`;
-}
-
-function membersIndexContent(ownerLogin: string): string {
-  // Non-empty owners on purpose: `tree tree` skips any directory node whose
-  // owners array is empty, so `owners: []` would pass `tree verify` yet make
-  // the members domain invisible to the hierarchy browser. Seed the creator as
-  // the initial owner; seeding refines this later.
-  return `---
-title: "Members"
-description: "Member definitions and work specifications."
-owners: [${ownerLogin}]
----
-
-# Members
-
-Member definitions, work scope, and personal node specifications. Members are
-both humans and AI agents — each has a personal node under \`members/<id>/\`.
-`;
-}
-
-function memberNodeContent(login: string): string {
-  return `---
-title: ${yamlDoubleQuote(login)}
-description: ${yamlDoubleQuote(`Member profile for ${login}.`)}
-owners: [${login}]
-type: human
-role: "Team member"
-domains:
-  - "context-tree"
----
-
-# ${login}
-
-Initial member node, created when the team Context Tree was bootstrapped.
-Replace this with a short description of what you own and decide.
-`;
-}
-
 /**
  * The minimal file set that makes a fresh tree pass `first-tree tree verify`:
  * a root `NODE.md`, the `members/` domain index, and one member node for the
- * creator (verify hard-fails on a `members/` dir with no member nodes).
+ * creator (verify hard-fails on a `members/` dir with no member nodes). The node
+ * bodies are rendered from `./templates/*.ejs` (see `scaffold-templates.ts`).
  */
 export function buildScaffoldFiles(opts: { title: string; ownerLogin: string; withWorkflow: boolean }): ScaffoldFile[] {
   const files: ScaffoldFile[] = [
@@ -139,7 +70,7 @@ export function buildScaffoldFiles(opts: { title: string; ownerLogin: string; wi
     { relPath: join("members", opts.ownerLogin, "NODE.md"), content: memberNodeContent(opts.ownerLogin) },
   ];
   if (opts.withWorkflow) {
-    files.push({ relPath: join(".github", "workflows", "validate-tree.yml"), content: VALIDATE_TREE_WORKFLOW });
+    files.push({ relPath: join(".github", "workflows", "validate-tree.yml"), content: validateTreeWorkflowContent() });
   }
   return files;
 }
@@ -290,7 +221,9 @@ export function resolveRepoOwner(args: {
 }): string {
   const explicit = args.optionOwner?.trim();
   if (args.installationAccount) {
-    if (explicit && explicit !== args.installationAccount) {
+    // GitHub account names are case-insensitive, so compare case-folded; always
+    // return the installation account's canonical casing.
+    if (explicit && explicit.toLowerCase() !== args.installationAccount.toLowerCase()) {
       throw new Error(
         `--owner ${explicit} does not match this team's GitHub App installation account (${args.installationAccount}). The tree repo must live under ${args.installationAccount} so the App can cover it — omit --owner to use it, or pass --no-bind to create it elsewhere without binding.`,
       );

--- a/apps/cli/src/commands/tree/scaffold-templates.ts
+++ b/apps/cli/src/commands/tree/scaffold-templates.ts
@@ -58,6 +58,13 @@ function yamlDoubleQuote(value: string): string {
   return JSON.stringify(value.replace(/\s+/g, " ").trim());
 }
 
+// NOTE: `validate-tree-workflow.yml.ejs` and `root-node.md.ejs` are kept
+// byte-for-byte in sync with the server one-click bootstrap's
+// `VALIDATE_TREE_WORKFLOW_CONTENT` / `initialRootNode`
+// (`packages/server/src/api/orgs/context-tree.ts`) so a tree created by either
+// path is identical. There is no cross-package test guarding this (the server
+// constants are module-private); if you touch either side, mirror the other.
+
 /** `.github/workflows/validate-tree.yml` — the optional CI workflow (`--with-workflow`). */
 export function validateTreeWorkflowContent(): string {
   return render("validate-tree-workflow.yml.ejs", {});

--- a/apps/cli/src/commands/tree/scaffold-templates.ts
+++ b/apps/cli/src/commands/tree/scaffold-templates.ts
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+import type * as ejs from "ejs";
+
+// EJS is published as CommonJS at runtime even though its types expose named
+// exports, so native ESM cannot `import { render }` directly — mirror the
+// client runtime's `agent-briefing.ts` and load it through createRequire.
+const require = createRequire(import.meta.url);
+const ejsRuntime: typeof ejs = require("ejs");
+
+const TEMPLATE_DIR = "templates";
+
+type LoadedTemplate = { filename: string; source: string };
+const templateCache = new Map<string, LoadedTemplate>();
+
+/**
+ * The `.ejs` files live next to this module at `./templates/` during source /
+ * test execution, and are copied to `dist/templates/` by
+ * `scripts/copy-cli-tree-templates.mjs` for the bundled CLI. Try both layouts —
+ * the same two-candidate resolution the client runtime uses for its briefing
+ * template.
+ */
+export function resolveScaffoldTemplatePath(name: string): string {
+  const candidates = [
+    new URL(`./${TEMPLATE_DIR}/${name}`, import.meta.url),
+    new URL(`../${TEMPLATE_DIR}/${name}`, import.meta.url),
+  ];
+  for (const url of candidates) {
+    const filename = fileURLToPath(url);
+    if (existsSync(filename)) {
+      return filename;
+    }
+  }
+  throw new Error(`Context Tree scaffold template is missing: ${TEMPLATE_DIR}/${name}`);
+}
+
+function loadTemplate(name: string): LoadedTemplate {
+  const cached = templateCache.get(name);
+  if (cached) {
+    return cached;
+  }
+  const filename = resolveScaffoldTemplatePath(name);
+  const loaded: LoadedTemplate = { filename, source: readFileSync(filename, "utf8") };
+  templateCache.set(name, loaded);
+  return loaded;
+}
+
+function render(name: string, model: Record<string, unknown>): string {
+  const template = loadTemplate(name);
+  return ejsRuntime.render(template.source, model, { filename: template.filename });
+}
+
+// YAML frontmatter values are double-quoted via JSON.stringify so embedded
+// quotes / colons stay valid; whitespace is collapsed to keep them single-line.
+function yamlDoubleQuote(value: string): string {
+  return JSON.stringify(value.replace(/\s+/g, " ").trim());
+}
+
+/** `.github/workflows/validate-tree.yml` — the optional CI workflow (`--with-workflow`). */
+export function validateTreeWorkflowContent(): string {
+  return render("validate-tree-workflow.yml.ejs", {});
+}
+
+/** Root `NODE.md` for a freshly created team Context Tree. */
+export function rootNodeContent(title: string, ownerLogin: string): string {
+  return render("root-node.md.ejs", {
+    title,
+    ownerLogin,
+    titleField: yamlDoubleQuote(`${title} Context Tree`),
+    descriptionField: yamlDoubleQuote(`Shared context, decisions, ownership, and operating knowledge for ${title}.`),
+  });
+}
+
+/** The `members/` domain index node. */
+export function membersIndexContent(ownerLogin: string): string {
+  return render("members-index.md.ejs", { ownerLogin });
+}
+
+/** The creator's `members/<login>/NODE.md` member node. */
+export function memberNodeContent(login: string): string {
+  return render("member-node.md.ejs", {
+    login,
+    titleField: yamlDoubleQuote(login),
+    descriptionField: yamlDoubleQuote(`Member profile for ${login}.`),
+  });
+}

--- a/apps/cli/src/commands/tree/templates/member-node.md.ejs
+++ b/apps/cli/src/commands/tree/templates/member-node.md.ejs
@@ -1,0 +1,14 @@
+---
+title: <%- titleField %>
+description: <%- descriptionField %>
+owners: [<%- login %>]
+type: human
+role: "Team member"
+domains:
+  - "context-tree"
+---
+
+# <%- login %>
+
+Initial member node, created when the team Context Tree was bootstrapped.
+Replace this with a short description of what you own and decide.

--- a/apps/cli/src/commands/tree/templates/members-index.md.ejs
+++ b/apps/cli/src/commands/tree/templates/members-index.md.ejs
@@ -1,0 +1,10 @@
+---
+title: "Members"
+description: "Member definitions and work specifications."
+owners: [<%- ownerLogin %>]
+---
+
+# Members
+
+Member definitions, work scope, and personal node specifications. Members are
+both humans and AI agents — each has a personal node under `members/<id>/`.

--- a/apps/cli/src/commands/tree/templates/root-node.md.ejs
+++ b/apps/cli/src/commands/tree/templates/root-node.md.ejs
@@ -1,0 +1,7 @@
+---
+title: <%- titleField %>
+description: <%- descriptionField %>
+owners: [<%- ownerLogin %>]
+---
+
+# <%- title %>'s Context Tree

--- a/apps/cli/src/commands/tree/templates/validate-tree-workflow.yml.ejs
+++ b/apps/cli/src/commands/tree/templates/validate-tree-workflow.yml.ejs
@@ -1,0 +1,16 @@
+name: Validate Context Tree
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate Context Tree
+        run: npx -p first-tree first-tree tree verify

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@first-tree/web':
         specifier: workspace:*
         version: link:../../packages/web
+      '@types/ejs':
+        specifier: ^3.1.5
+        version: 3.1.5
       '@types/node':
         specifier: ^22.16.0
         version: 22.19.15
@@ -557,8 +560,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/runtime@7.29.7':
-    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -3017,8 +3020,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  body-parser@2.3.0:
-    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
   brace-expansion@2.0.2:
@@ -3436,8 +3439,8 @@ packages:
   es-module-lexer@2.2.0:
     resolution: {integrity: sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==}
 
-  es-object-atoms@1.1.2:
-    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.18.20:
@@ -3500,8 +3503,8 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.1.0:
-    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -3698,8 +3701,8 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.4:
-    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-jsx-runtime@2.3.6:
@@ -3714,8 +3717,8 @@ packages:
   hearback-server@0.1.6:
     resolution: {integrity: sha512-IlwduoRJvUBW3dU4H0hBvLjsgZHfXeOLQMqK9ahCLb45wgotIVL+CqieJnN7cQMNGU0i0sSpgyji5ELuwB+H5g==}
 
-  hono@4.12.27:
-    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+  hono@4.12.22:
+    resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.0:
@@ -3835,9 +3838,6 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-
-  jose@5.10.0:
-    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
@@ -4719,8 +4719,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.1:
-    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -5430,7 +5430,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/runtime@7.29.7': {}
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5830,9 +5830,9 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.14(hono@4.12.27)':
+  '@hono/node-server@1.19.14(hono@4.12.22)':
     dependencies:
-      hono: 4.12.27
+      hono: 4.12.22
 
   '@inquirer/ansi@2.0.4': {}
 
@@ -5995,17 +5995,17 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.27)
+      '@hono/node-server': 1.19.14(hono@4.12.22)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.27
+      hono: 4.12.22
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -7502,7 +7502,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 22.19.19
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -7626,22 +7626,6 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
-
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -7854,10 +7838,10 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@2.3.0:
+  body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
-      content-type: 2.0.0
+      content-type: 1.0.5
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
@@ -8158,7 +8142,7 @@ snapshots:
 
   es-module-lexer@2.2.0: {}
 
-  es-object-atoms@1.1.2:
+  es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
 
@@ -8277,11 +8261,11 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.1.0: {}
+  eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.0.8
 
   expect-type@1.3.0: {}
 
@@ -8293,7 +8277,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.2.2
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -8466,12 +8450,12 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.2
+      es-object-atoms: 1.1.1
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.4
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -8481,7 +8465,7 @@ snapshots:
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.2
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -8531,7 +8515,7 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  hasown@2.0.4:
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -8567,7 +8551,7 @@ snapshots:
     dependencies:
       hearback-core: 0.1.1
 
-  hono@4.12.27: {}
+  hono@4.12.22: {}
 
   hookable@6.1.0: {}
 
@@ -8678,8 +8662,6 @@ snapshots:
 
   jiti@2.6.1: {}
 
-  jose@5.10.0: {}
-
   jose@6.2.2: {}
 
   js-tokens@10.0.0: {}
@@ -8709,7 +8691,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.29.7
+      '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
@@ -9315,13 +9297,15 @@ snapshots:
   pg-cloudflare@1.3.0:
     optional: true
 
-  pg-connection-string@2.12.0: {}
+  pg-connection-string@2.12.0:
+    optional: true
 
   pg-int8@1.0.1: {}
 
   pg-pool@3.13.0(pg@8.20.0):
     dependencies:
       pg: 8.20.0
+    optional: true
 
   pg-protocol@1.13.0: {}
 
@@ -9342,10 +9326,12 @@ snapshots:
       pgpass: 1.0.5
     optionalDependencies:
       pg-cloudflare: 1.3.0
+    optional: true
 
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -9473,7 +9459,7 @@ snapshots:
 
   qs@6.15.2:
     dependencies:
-      side-channel: 1.1.1
+      side-channel: 1.1.0
 
   quansync@1.0.0: {}
 
@@ -9804,7 +9790,7 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.1:
+  side-channel@1.1.0:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -10313,7 +10299,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -10356,7 +10342,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,8 +560,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/runtime@7.29.2':
-    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -3020,8 +3020,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   brace-expansion@2.0.2:
@@ -3439,8 +3439,8 @@ packages:
   es-module-lexer@2.2.0:
     resolution: {integrity: sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==}
 
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.18.20:
@@ -3503,8 +3503,8 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.0.8:
-    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -3701,8 +3701,8 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-jsx-runtime@2.3.6:
@@ -3717,8 +3717,8 @@ packages:
   hearback-server@0.1.6:
     resolution: {integrity: sha512-IlwduoRJvUBW3dU4H0hBvLjsgZHfXeOLQMqK9ahCLb45wgotIVL+CqieJnN7cQMNGU0i0sSpgyji5ELuwB+H5g==}
 
-  hono@4.12.22:
-    resolution: {integrity: sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==}
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.0:
@@ -3838,6 +3838,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
@@ -4719,8 +4722,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -5430,7 +5433,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/runtime@7.29.2': {}
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5830,9 +5833,9 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.14(hono@4.12.22)':
+  '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
-      hono: 4.12.22
+      hono: 4.12.27
 
   '@inquirer/ansi@2.0.4': {}
 
@@ -5995,17 +5998,17 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.22)
+      '@hono/node-server': 1.19.14(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.22
+      hono: 4.12.27
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -7502,7 +7505,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 22.19.15
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -7626,6 +7629,22 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -7838,10 +7857,10 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
@@ -8142,7 +8161,7 @@ snapshots:
 
   es-module-lexer@2.2.0: {}
 
-  es-object-atoms@1.1.1:
+  es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
 
@@ -8261,11 +8280,11 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.8: {}
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.1.0
 
   expect-type@1.3.0: {}
 
@@ -8277,7 +8296,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -8450,12 +8469,12 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
       function-bind: 1.1.2
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -8465,7 +8484,7 @@ snapshots:
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -8515,7 +8534,7 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  hasown@2.0.3:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -8551,7 +8570,7 @@ snapshots:
     dependencies:
       hearback-core: 0.1.1
 
-  hono@4.12.22: {}
+  hono@4.12.27: {}
 
   hookable@6.1.0: {}
 
@@ -8662,6 +8681,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@5.10.0: {}
+
   jose@6.2.2: {}
 
   js-tokens@10.0.0: {}
@@ -8691,7 +8712,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
@@ -9297,15 +9318,13 @@ snapshots:
   pg-cloudflare@1.3.0:
     optional: true
 
-  pg-connection-string@2.12.0:
-    optional: true
+  pg-connection-string@2.12.0: {}
 
   pg-int8@1.0.1: {}
 
   pg-pool@3.13.0(pg@8.20.0):
     dependencies:
       pg: 8.20.0
-    optional: true
 
   pg-protocol@1.13.0: {}
 
@@ -9326,12 +9345,10 @@ snapshots:
       pgpass: 1.0.5
     optionalDependencies:
       pg-cloudflare: 1.3.0
-    optional: true
 
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
-    optional: true
 
   picocolors@1.1.1: {}
 
@@ -9459,7 +9476,7 @@ snapshots:
 
   qs@6.15.2:
     dependencies:
-      side-channel: 1.1.0
+      side-channel: 1.1.1
 
   quansync@1.0.0: {}
 
@@ -9790,7 +9807,7 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -10299,7 +10316,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -10342,7 +10359,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/scripts/copy-cli-tree-templates.mjs
+++ b/scripts/copy-cli-tree-templates.mjs
@@ -1,0 +1,24 @@
+import { existsSync, statSync } from "node:fs";
+import { cp, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Copy the `first-tree tree init` scaffold `.ejs` templates into the CLI's
+// bundle so the published binary can read them at runtime. Runs AFTER
+// `copy-client-runtime-templates.mjs apps/cli` (which rm's + repopulates
+// `dist/templates/` with the client briefing template), so this only ADDS files
+// and must not remove the directory.
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const sourceDir = resolve(repoRoot, "apps/cli/src/commands/tree/templates");
+const targetDir = resolve(repoRoot, "apps/cli/dist/templates");
+
+if (!existsSync(sourceDir) || !statSync(sourceDir).isDirectory()) {
+  throw new Error(`CLI tree templates source is missing: ${sourceDir}`);
+}
+
+await mkdir(targetDir, { recursive: true });
+await cp(sourceDir, targetDir, {
+  recursive: true,
+  filter: (source) => statSync(source).isDirectory() || source.endsWith(".ejs"),
+});


### PR DESCRIPTION
## What

Follow-up to #1379 (merged), per @bestony's review: the `first-tree tree init` scaffold content lived as inline template-literal strings in `init.ts` (`VALIDATE_TREE_WORKFLOW`, `rootNodeContent`, and the members index / member node). This moves them to `.ejs` files rendered at runtime, following the established client-runtime pattern (`packages/client/src/runtime/templates/agent-briefing.ejs` + `copy-*-templates.mjs`).

## Changes

- **Templates** — `apps/cli/src/commands/tree/templates/`: `validate-tree-workflow.yml.ejs`, `root-node.md.ejs`, `members-index.md.ejs`, `member-node.md.ejs`.
- **Render helper** — `scaffold-templates.ts`: loads a template via `createRequire('ejs')` (EJS ships CJS at runtime) and resolves it from `./templates/` (source / test) or `../templates/` (bundled) — the same two-candidate resolution the client briefing uses. YAML-quoting stays in JS; templates are pure placeholders.
- **Build** — `scripts/copy-cli-tree-templates.mjs` runs after the existing client-template copy so the `.ejs` land in `apps/cli/dist/templates/` for the published binary. `@types/ejs` declared for the CLI (`ejs` is already a runtime dep).
- **Nit fold-in** (code-reviewer): `resolveRepoOwner` now compares `--owner` against the installation account **case-insensitively** (GitHub logins are case-insensitive) and returns the canonical casing.

## Behavior is unchanged

The rendered output is byte-for-byte what the inline strings produced — the existing `verify` + `tree tree` render tests still pass, and new tests assert the ejs output. Verified the build copies all four `.ejs` into `dist/templates/`.

## Tests
- New: scaffold-templates render tests (root/members-index/member/workflow) + `--owner` case-insensitive match. Full CLI suite **539 pass**.
- `pnpm check && pnpm typecheck` clean; `pnpm --filter first-tree-dev build` populates `dist/templates/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)