### PR TITLE
chore: tighten tree/code PR merge order in agent briefing

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -928,16 +928,20 @@ describe("buildAgentBriefing — # Context Tree", () => {
     expect(briefing).toContain("the tree wins");
     expect(briefing).toContain("eagerly, not lazily");
 
-    // Writing discipline anchors — fresh vs persistent context framing and
-    // the co-open + cross-link PR coordination rule (the tree PR need not
-    // merge before the code PR). The prose wraps the emphasised phrases
-    // across lines, so allow either single-line or wrapped forms.
+    // Writing discipline anchors — fresh vs persistent context framing, the
+    // co-open + cross-link PR coordination rule, and the tightened merge
+    // order: the code PR merges first, then the tree PR is reconciled against
+    // the final merged code before it lands (never concurrent or ahead). The
+    // prose wraps the emphasised phrases across lines, so allow either
+    // single-line or wrapped forms.
     expect(briefing).toContain("fresh context");
     expect(briefing).toMatch(/\*\*persistent[\s\n]+context\*\*/);
     expect(briefing).toMatch(
       /open the tree PR and the code[\s\n]+PR[\s\n]+together and cross-link them in the PR descriptions/,
     );
-    expect(briefing).toMatch(/with[\s\n]+the code PR or shortly after/);
+    expect(briefing).toMatch(/Merge the code PR first, then[\s\n]+the tree PR/);
+    expect(briefing).toContain("final merged");
+    expect(briefing).not.toContain("need not merge first");
     expect(briefing).toContain("Implementation-only changes skip the tree");
 
     // Tree path interpolated under Tree Location.

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -1052,10 +1052,16 @@ open the code PR. If the task touched decisions, constraints, ownership,
 or cross-domain relationships, **open the tree PR and the code PR
 together and cross-link them in the PR descriptions**, so a reviewer on
 the code PR can reach the decision and its rationale from the linked
-tree PR; when review
-reshapes the design, update both PRs together. The tree PR lands **with
-the code PR or shortly after** — it need not merge first, but keep it
-close so the tree never trails the merged code for long.
+tree PR; when review reshapes the design, update both PRs together so
+they never describe different things. **Merge the code PR first, then
+the tree PR** — the code PR is the source of truth for what was decided,
+so let it settle before the tree records it; do not merge the tree PR
+concurrently with, or ahead of, the code PR. Before merging the tree
+PR, reconcile it against the **final merged** code PR: fold in any
+last-round review changes so the tree PR reflects the code's final
+conclusion, not an earlier draft. Then merge the tree PR promptly — a
+tree that trails the merged code for long is one other agents read
+while stale.
 Implementation-only changes skip the tree write — not the read.
 
 Before writing, you MUST load the relevant skill first and follow its


### PR DESCRIPTION
## What

Tightens the injected **Writing the Tree** rule in the agent briefing so every agent's generated `CLAUDE.md` / `AGENTS.md` states the tree/code PR merge order explicitly:

- **Merge the code PR first, then the tree PR** — do not merge the tree PR concurrently with, or ahead of, the code PR.
- **Before merging the tree PR, reconcile it against the final merged code PR** so the tree reflects the code's final conclusion, not an earlier draft.

The co-open + cross-link and keep-in-sync rules are unchanged.

## Why

The prior wording — "The tree PR lands with the code PR or shortly after — it need not merge first" — permitted a concurrent/ahead merge and had no explicit reconcile step, so a last-round change to the code PR could land while the tree PR merged off an earlier draft. The tightened rule closes that gap.

## Where

`packages/client/src/runtime/agent-briefing.ts` renders the `(First Tree Managed)` Writing-the-Tree block that every agent reads; the `agent-briefing.test.ts` anchors are updated to assert the tightened wording (and to lock out the removed "need not merge first" phrasing).

## Paired tree PR

The same rule is a durable team decision; tightened to match in **agent-team-foundation/first-tree-context#656** (`team-practice/tree-maintenance.md` § Tree PR / Code PR Coordination). Per the rule itself, merge that tree PR **after** this code PR.

## Test

- `pnpm --filter @first-tree/client test agent-briefing` — 39 passed
- `pnpm exec biome check` on changed files — clean
- `pnpm --filter @first-tree/client typecheck` — clean
