### PR TITLE
fix(cli): unify daemon runtime logging

### DIFF
--- a/apps/cli/src/__tests__/cli-helper-surfaces-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-helper-surfaces-extra.test.ts
@@ -233,4 +233,52 @@ describe("client org mismatch handler", () => {
     expect(output).toContain("first-tree-dev logout --purge");
     expect(output).toContain("first-tree-dev login <token>");
   });
+
+  it("routes managed recovery text through an injected output sink", async () => {
+    const { handleClientOrgMismatch } = await import("../core/client-reidentify.js");
+    const output = {
+      blank: vi.fn(),
+      line: vi.fn(),
+    };
+
+    await expect(
+      handleClientOrgMismatch(new Error("wrong org") as never, {
+        managed: true,
+        configDir: tempDir,
+        rerunCommand: "ignored",
+        output,
+      }),
+    ).rejects.toMatchObject({ code: 1 });
+
+    expect(output.blank).toHaveBeenCalled();
+    expect(output.line).toHaveBeenCalledWith(expect.stringContaining("wrong org"));
+    expect(printMocks.blank).not.toHaveBeenCalled();
+    expect(printMocks.line).not.toHaveBeenCalled();
+  });
+
+  it("routes managed logger output through an error-level status summary", async () => {
+    const { handleClientOrgMismatch } = await import("../core/client-reidentify.js");
+    const output = {
+      blank: vi.fn(),
+      line: vi.fn(),
+      status: vi.fn(),
+    };
+
+    await expect(
+      handleClientOrgMismatch(new Error("wrong org") as never, {
+        managed: true,
+        configDir: tempDir,
+        rerunCommand: "ignored",
+        output,
+      }),
+    ).rejects.toMatchObject({ code: 1 });
+
+    expect(output.status).toHaveBeenCalledWith("✗", expect.stringContaining("wrong org"));
+    expect(output.status).toHaveBeenCalledWith("✗", expect.stringContaining("first-tree-dev logout --purge"));
+    expect(output.status).toHaveBeenCalledWith("✗", expect.stringContaining("first-tree-dev login <token>"));
+    expect(output.blank).not.toHaveBeenCalled();
+    expect(output.line).not.toHaveBeenCalled();
+    expect(printMocks.blank).not.toHaveBeenCalled();
+    expect(printMocks.line).not.toHaveBeenCalled();
+  });
 });

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -335,6 +335,32 @@ describe("ClientRuntime context-tree wiring", () => {
     await rt.stop();
   });
 
+  it("routes runtime status through an injected output sink", async () => {
+    const { print } = await import("../core/output.js");
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const output = {
+      blank: vi.fn(),
+      check: vi.fn(),
+      line: vi.fn(),
+      status: vi.fn(),
+    };
+    const rt = new ClientRuntime("https://hub.test", "client-test", { output });
+    rt.addAgent("alpha", {
+      agentId: "agent-alpha",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rt.addAgent>[1]);
+
+    await rt.start();
+
+    expect(output.check).toHaveBeenCalledWith(true, "client registered", "client-test");
+    expect(output.check).toHaveBeenCalledWith(true, "alpha: connected", "agent: alpha");
+    expect(output.status).toHaveBeenCalledWith("", "1 agent(s) running. Press Ctrl+C to stop.");
+    expect(print.check).not.toHaveBeenCalledWith(true, "client registered", "client-test");
+    await rt.stop();
+  });
+
   it("reports generic agent start failures and ignores already-starting entries", async () => {
     const { print } = await import("../core/output.js");
     const { ClientRuntime } = await import("../core/client-runtime.js");

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -21,6 +21,7 @@ const coreMocks = vi.hoisted(() => ({
   ClientRuntime: vi.fn(),
   createApiNameResolver: vi.fn(),
   createExecuteUpdate: vi.fn(),
+  createLoggerRuntimeOutput: vi.fn(),
   declineUpdate: vi.fn(),
   ensureFreshAccessToken: vi.fn(),
   getClientServiceStatus: vi.fn(),
@@ -141,6 +142,26 @@ beforeEach(() => {
   coreMocks.promptMissingFields.mockResolvedValue(undefined);
   coreMocks.createApiNameResolver.mockReturnValue(async () => "nova");
   coreMocks.createExecuteUpdate.mockReturnValue(async () => undefined);
+  coreMocks.createLoggerRuntimeOutput.mockImplementation(
+    (logger: {
+      error: (message: string) => void;
+      info: (message: string) => void;
+      warn: (message: string) => void;
+    }) => ({
+      blank: vi.fn(),
+      check: vi.fn((pass: boolean, label: string, detail?: string) => {
+        logger[pass ? "info" : "warn"](detail ? `${label}: ${detail}` : label);
+      }),
+      line: vi.fn((text: string) => {
+        const message = text.trim();
+        if (message) logger.info(message);
+      }),
+      status: vi.fn((symbol: string, msg: string) => {
+        const level = symbol === "⚠️" ? "warn" : symbol === "✗" ? "error" : "info";
+        logger[level](symbol ? `${symbol} ${msg}` : msg);
+      }),
+    }),
+  );
   coreMocks.migrateLocalAgentDirs.mockResolvedValue(undefined);
   coreMocks.reconcileLocalRuntimeProviders.mockResolvedValue(undefined);
   coreMocks.uploadClientCapabilities.mockResolvedValue(undefined);
@@ -230,7 +251,8 @@ describe("daemon start command", () => {
     await expect(runStart()).resolves.toBeTruthy();
     expect(coreMocks.startClientService).toHaveBeenCalled();
     expect(output()).toContain("Started systemd service");
-    expect(output()).toContain("journalctl --user -u first-tree");
+    expect(output()).toContain("Logs:  /logs/client.log");
+    expect(output()).toContain("Supervisor fallback: `journalctl --user -u first-tree`");
   });
 
   it("prints WSL repair guidance when service startup fails", async () => {
@@ -354,13 +376,91 @@ describe("daemon start command", () => {
       expect.objectContaining({ log: expect.any(Function), managed: true }),
     );
     expect(clientMocks.configureClientLoggerForService).toHaveBeenCalledWith(join(home, "logs"));
+    expect(clientMocks.applyClientLoggerConfig).toHaveBeenCalledWith({ level: "info" });
+    expect(coreMocks.createLoggerRuntimeOutput).toHaveBeenCalledWith(expect.any(Object));
     expect(coreMocks.ClientRuntime).toHaveBeenCalledWith(
       "https://first-tree.example",
       "client_1234abcd",
       expect.objectContaining({
+        output: expect.any(Object),
         update: expect.objectContaining({ prompt: coreMocks.declineUpdate }),
       }),
     );
+    expect(output()).toBe("");
+  });
+
+  it("logs early service-mode startup failures before config logLevel is applied", async () => {
+    const daemonLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    clientMocks.createLogger.mockReturnValue(daemonLogger);
+    process.env.FIRST_TREE_SERVICE_MODE = "1";
+    coreMocks.promptMissingFields.mockRejectedValueOnce(new Error("client.yaml is malformed"));
+
+    await expect(runStart(["--no-interactive"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(clientMocks.configureClientLoggerForService).toHaveBeenCalledWith(join(home, "logs"));
+    expect(clientMocks.applyClientLoggerConfig).toHaveBeenCalledWith({ level: "info" });
+    expect(daemonLogger.error).toHaveBeenCalledWith("✗ Error: client.yaml is malformed");
+    expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
+    expect(output()).toBe("");
+  });
+
+  it("logs missing credentials through the service logger instead of CLI stderr", async () => {
+    const daemonLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    clientMocks.createLogger.mockReturnValue(daemonLogger);
+    process.env.FIRST_TREE_SERVICE_MODE = "1";
+    coreMocks.loadCredentials.mockReturnValueOnce(null);
+
+    await expect(runStart(["--no-interactive"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(failMock).not.toHaveBeenCalled();
+    expect(daemonLogger.error).toHaveBeenCalledWith(
+      "✗ no credentials — run `first-tree-dev login <token>` to sign in before starting the daemon.",
+    );
+    expect(output()).toBe("");
+  });
+
+  it("logs service-mode user mismatch through error-level logger after config logLevel is applied", async () => {
+    const daemonLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    clientMocks.createLogger.mockReturnValue(daemonLogger);
+    writeFileSync(
+      join(home, "config", "client.yaml"),
+      "logLevel: error\nserver:\n  url: https://first-tree.example\nclient:\n  id: client_1234abcd\n",
+    );
+    process.env.FIRST_TREE_SERVICE_MODE = "1";
+    const client = await import("@first-tree/client");
+    runtimeInstance.start.mockRejectedValueOnce(new client.ClientUserMismatchError("wrong user"));
+
+    await expect(runStart(["--no-interactive"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(clientMocks.applyClientLoggerConfig).toHaveBeenCalledWith({ level: "error" });
+    expect(daemonLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining("client.yaml is owned by a different user"),
+    );
+    expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("first-tree-dev logout --purge"));
+    expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("first-tree-dev login <token>"));
+    expect(output()).toBe("");
+  });
+
+  it("logs service-mode org mismatch through error-level logger after config logLevel is applied", async () => {
+    const daemonLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    clientMocks.createLogger.mockReturnValue(daemonLogger);
+    writeFileSync(
+      join(home, "config", "client.yaml"),
+      "logLevel: warn\nserver:\n  url: https://first-tree.example\nclient:\n  id: client_1234abcd\n",
+    );
+    process.env.FIRST_TREE_SERVICE_MODE = "1";
+    const client = await import("@first-tree/client");
+    const actual = await vi.importActual<typeof import("../core/client-reidentify.js")>("../core/client-reidentify.js");
+    coreMocks.handleClientOrgMismatch.mockImplementation(actual.handleClientOrgMismatch);
+    runtimeInstance.start.mockRejectedValueOnce(new client.ClientOrgMismatchError("wrong org"));
+
+    await expect(runStart(["--no-interactive"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(clientMocks.applyClientLoggerConfig).toHaveBeenCalledWith({ level: "warn" });
+    expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("wrong org"));
+    expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("first-tree-dev logout --purge"));
+    expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("first-tree-dev login <token>"));
+    expect(output()).toBe("");
   });
 
   it("does not treat non-supervisor --no-interactive inline runs as managed updates", async () => {
@@ -373,6 +473,7 @@ describe("daemon start command", () => {
       "https://first-tree.example",
       "client_1234abcd",
       expect.objectContaining({
+        output: undefined,
         update: expect.objectContaining({ prompt: coreMocks.declineUpdate }),
       }),
     );

--- a/apps/cli/src/__tests__/migrate-agent-dirs-extra.test.ts
+++ b/apps/cli/src/__tests__/migrate-agent-dirs-extra.test.ts
@@ -98,6 +98,22 @@ describe("createApiNameResolver", () => {
 });
 
 describe("migrateLocalAgentDirs extra failure branches", () => {
+  it("routes migration status through an injected logger", async () => {
+    const { migrateLocalAgentDirs } = await import("../core/migrate-agent-dirs.js");
+    writeAgentYaml("old", "agent-1");
+    const log = vi.fn();
+
+    const result = await migrateLocalAgentDirs({
+      ...dirs(),
+      resolver: { resolveName: vi.fn(async () => "new") },
+      log,
+    });
+
+    expect(result).toMatchObject({ renamed: 1, errors: 0 });
+    expect(log).toHaveBeenCalledWith("", 'agent "old" renamed to "new" to match server');
+    expect(printMock.status).not.toHaveBeenCalled();
+  });
+
   it("records an enumeration error without throwing", async () => {
     const { migrateLocalAgentDirs } = await import("../core/migrate-agent-dirs.js");
     const agentsDir = join(root, "config", "agents");

--- a/apps/cli/src/__tests__/status-blocks.test.ts
+++ b/apps/cli/src/__tests__/status-blocks.test.ts
@@ -69,11 +69,12 @@ describe("status block renderers", () => {
         label: state === "active" ? "first-tree-dev.service" : "dev.first-tree",
         state,
         detail: state === "active" ? "pid 123" : "",
+        logDir: "/logs",
       });
       renderServiceBlock();
       expect(output()).toContain(expected);
     }
-    expect(output()).toContain("journalctl --user -u first-tree-dev -f");
+    expect(output()).toContain("logs: /logs/client.log");
   });
 
   it("renders server configuration states", async () => {

--- a/apps/cli/src/commands/_shared/status-blocks.ts
+++ b/apps/cli/src/commands/_shared/status-blocks.ts
@@ -26,8 +26,7 @@ export function renderServiceBlock(): void {
     return;
   }
   const svc = getClientServiceStatus();
-  const tail =
-    svc.platform === "systemd" ? `  (logs: journalctl --user -u ${svc.label.replace(/\.service$/, "")} -f)` : "";
+  const tail = `  (logs: ${join(svc.logDir, "client.log")})`;
   if (svc.state === "active") {
     print.line(`  Service:  ✓ running (${svc.platform}${svc.detail ? `, ${svc.detail}` : ""})${tail}\n`);
   } else if (svc.state === "inactive") {

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -31,6 +31,7 @@ import {
   COMMAND_VERSION,
   createApiNameResolver,
   createExecuteUpdate,
+  createLoggerRuntimeOutput,
   declineUpdate,
   ensureFreshAccessToken,
   getClientServiceStatus,
@@ -60,6 +61,28 @@ export function registerDaemonStartCommand(daemon: Command): void {
     .option("--foreground", "Run inline instead of delegating to the background service (for debugging)")
     .action(async (options: { interactive?: boolean; foreground?: boolean }) => {
       const binName = channelConfig.binName;
+      const serviceMode = process.env.FIRST_TREE_SERVICE_MODE === "1";
+      const isSupervisorChild = options.interactive === false && serviceMode;
+      if (serviceMode) {
+        configureClientLoggerForService(join(defaultHome(), "logs"));
+        // The CLI preAction defaults one-shot command logs to `warn`; the
+        // daemon service is long-running and needs startup diagnostics in
+        // client.log even before client.yaml has been parsed. This is
+        // config-driven, so explicit operator levels still win.
+        applyClientLoggerConfig({ level: "info" });
+      }
+      const daemonOutput = serviceMode ? createLoggerRuntimeOutput(createLogger("daemon")) : null;
+      const writeLine = (text: string) => (daemonOutput ? daemonOutput.line(text) : print.line(text));
+      const writeStatus = (symbol: string, msg: string) =>
+        daemonOutput ? daemonOutput.status(symbol, msg) : print.status(symbol, msg);
+      const writeErrorAndExit = (message: string): never => {
+        if (daemonOutput) {
+          daemonOutput.status("✗", message);
+        } else {
+          print.line(`  ${message}\n`);
+        }
+        process.exit(1);
+      };
       // Compatibility, not management: a launchd / systemd daemon does not inherit
       // the user's login-shell environment, so load the user-owned
       // `~/.first-tree/daemon.env` (if present) into our env BEFORE the runtime
@@ -67,19 +90,18 @@ export function registerDaemonStartCommand(daemon: Command): void {
       // whatever proxy the user configured. First Tree only reads this file.
       const appliedDaemonEnv = loadDaemonEnv();
       if (appliedDaemonEnv.length > 0) {
-        print.line(`  loaded ${appliedDaemonEnv.length} var(s) from daemon.env (${appliedDaemonEnv.join(", ")})\n`);
+        writeLine(`  loaded ${appliedDaemonEnv.length} var(s) from daemon.env (${appliedDaemonEnv.join(", ")})\n`);
       }
       // Fail closed: never spin up the runtime without persisted credentials.
       // Hooking this in BEFORE the service-delegation branch keeps the policy
       // uniform — supervisor child, foreground debug, or background daemon
       // launch all bail out the same way pointing at `login`.
-      const isSupervisorChild = options.interactive === false && process.env.FIRST_TREE_SERVICE_MODE === "1";
       if (!loadCredentials()) {
-        fail(
-          "NO_CREDENTIALS",
-          `no credentials — run \`${binName} login <token>\` to sign in before starting the daemon.`,
-          1,
-        );
+        const message = `no credentials — run \`${binName} login <token>\` to sign in before starting the daemon.`;
+        if (daemonOutput) {
+          writeErrorAndExit(message);
+        }
+        fail("NO_CREDENTIALS", message, 1);
       }
 
       try {
@@ -97,52 +119,53 @@ export function registerDaemonStartCommand(daemon: Command): void {
         if (!wantInline && isServiceSupported()) {
           const svc = getClientServiceStatus();
           if (svc.state === "active") {
-            print.line("\n");
-            print.line(`  Service is already running (${svc.platform}${svc.detail ? `, ${svc.detail}` : ""}).\n`);
-            print.line(`  Use \`${binName} daemon restart\` to restart, or \`--foreground\` to run inline.\n\n`);
+            writeLine("\n");
+            writeLine(`  Service is already running (${svc.platform}${svc.detail ? `, ${svc.detail}` : ""}).\n`);
+            writeLine(`  Use \`${binName} daemon restart\` to restart, or \`--foreground\` to run inline.\n\n`);
             return;
           }
           if (svc.state === "inactive") {
             const res = startClientService();
             if (!res.ok) {
-              print.line(`\n  Failed to start service: ${res.reason}\n`);
+              writeLine(`\n  Failed to start service: ${res.reason}\n`);
               if (isWslDbusOvermount(res.reason)) {
-                print.line("\n");
-                print.line("  WSL2 detected — WSLg has over-mounted /run/user/$UID and is hiding\n");
-                print.line("  the user dbus socket. The systemd user manager is fine; the bus\n");
-                print.line("  socket just isn't reachable from your shell.\n\n");
-                print.line("  Quick fix (one-shot, lost on reboot):\n");
-                print.line("      sudo umount -l /run/user/$(id -u)\n\n");
-                print.line("  Permanent fix — install a boot-time helper, then update wsl.conf:\n\n");
-                print.line("      sudo tee /usr/local/bin/strip-wslg-overlay.sh >/dev/null <<'EOF'\n");
-                print.line("      #!/bin/sh\n");
-                print.line("      for d in /run/user/*; do\n");
-                print.line('        uid=$(basename "$d")\n');
-                print.line('        case "$uid" in ""|*[!0-9]*) continue ;; esac\n');
-                print.line("        for i in $(seq 1 30); do\n");
-                print.line('          if mount | grep -q "tmpfs on $d .*mode=755"; then\n');
-                print.line('            umount -l "$d"; break\n');
-                print.line("          fi\n");
-                print.line("          sleep 1\n");
-                print.line("        done\n");
-                print.line("      done\n");
-                print.line("      EOF\n");
-                print.line("      sudo chmod +x /usr/local/bin/strip-wslg-overlay.sh\n\n");
-                print.line("  Then add to /etc/wsl.conf under [boot]:\n");
-                print.line("      command=/usr/local/bin/strip-wslg-overlay.sh\n\n");
-                print.line("  Then run `wsl --shutdown` in Windows PowerShell and reopen the shell.\n");
+                writeLine("\n");
+                writeLine("  WSL2 detected — WSLg has over-mounted /run/user/$UID and is hiding\n");
+                writeLine("  the user dbus socket. The systemd user manager is fine; the bus\n");
+                writeLine("  socket just isn't reachable from your shell.\n\n");
+                writeLine("  Quick fix (one-shot, lost on reboot):\n");
+                writeLine("      sudo umount -l /run/user/$(id -u)\n\n");
+                writeLine("  Permanent fix — install a boot-time helper, then update wsl.conf:\n\n");
+                writeLine("      sudo tee /usr/local/bin/strip-wslg-overlay.sh >/dev/null <<'EOF'\n");
+                writeLine("      #!/bin/sh\n");
+                writeLine("      for d in /run/user/*; do\n");
+                writeLine('        uid=$(basename "$d")\n');
+                writeLine('        case "$uid" in ""|*[!0-9]*) continue ;; esac\n');
+                writeLine("        for i in $(seq 1 30); do\n");
+                writeLine('          if mount | grep -q "tmpfs on $d .*mode=755"; then\n');
+                writeLine('            umount -l "$d"; break\n');
+                writeLine("          fi\n");
+                writeLine("          sleep 1\n");
+                writeLine("        done\n");
+                writeLine("      done\n");
+                writeLine("      EOF\n");
+                writeLine("      sudo chmod +x /usr/local/bin/strip-wslg-overlay.sh\n\n");
+                writeLine("  Then add to /etc/wsl.conf under [boot]:\n");
+                writeLine("      command=/usr/local/bin/strip-wslg-overlay.sh\n\n");
+                writeLine("  Then run `wsl --shutdown` in Windows PowerShell and reopen the shell.\n");
               }
-              print.line("  Try `--foreground` to run inline instead.\n\n");
+              writeLine("  Try `--foreground` to run inline instead.\n\n");
               process.exit(1);
             }
             const after = getClientServiceStatus();
-            print.line("\n");
-            print.line(`  Started ${after.platform} service${after.detail ? ` (${after.detail})` : ""}.\n`);
-            const journalHint =
+            writeLine("\n");
+            writeLine(`  Started ${after.platform} service${after.detail ? ` (${after.detail})` : ""}.\n`);
+            writeLine(`  Logs:  ${join(after.logDir, "client.log")}\n`);
+            const supervisorHint =
               after.platform === "systemd"
-                ? `  (or \`journalctl --user -u ${after.label.replace(/\.service$/, "")}\`)`
-                : "";
-            print.line(`  Logs:  ${after.logDir}${journalHint}\n\n`);
+                ? `  Supervisor fallback: \`journalctl --user -u ${after.label.replace(/\.service$/, "")}\`\n\n`
+                : `  Supervisor fallback: ${join(after.logDir, "client.stdout.log")} / ${join(after.logDir, "client.stderr.log")}\n\n`;
+            writeLine(supervisorHint);
             return;
           }
           if (svc.state === "unknown") {
@@ -151,10 +174,10 @@ export function registerDaemonStartCommand(daemon: Command): void {
             // race a still-supervised process for the same client.id, which
             // is exactly the failure mode this whole PR is trying to
             // eliminate. Refuse and let the operator inspect.
-            print.line(
+            writeLine(
               `\n  Service state could not be determined (${svc.platform}${svc.detail ? `: ${svc.detail}` : ""}).\n`,
             );
-            print.line(`  Inspect with \`${binName} daemon doctor\`, or pass \`--foreground\` to bypass.\n\n`);
+            writeLine(`  Inspect with \`${binName} daemon doctor\`, or pass \`--foreground\` to bypass.\n\n`);
             process.exit(1);
           }
           // state === "not-installed" → fall through to inline run.
@@ -176,12 +199,6 @@ export function registerDaemonStartCommand(daemon: Command): void {
         // `logLevel: debug` in client.yaml is parsed but never reaches pino.
         applyClientLoggerConfig({ level: config.logLevel });
 
-        // Service mode (launchd / systemd): route pino through a rotating
-        // NDJSON file instead of stderr, so the supervisor's stdout/stderr
-        // capture stays empty under normal operation.
-        if (process.env.FIRST_TREE_SERVICE_MODE === "1") {
-          configureClientLoggerForService(join(defaultHome(), "logs"));
-        }
         initClientSentry({ version: COMMAND_VERSION, gitSha: GIT_SHA, defaultDsn: CLIENT_SENTRY_DSN });
 
         // Load agents (may be empty — daemon can start without agents).
@@ -197,10 +214,11 @@ export function registerDaemonStartCommand(daemon: Command): void {
             workspacesDir: join(defaultDataDir(), "workspaces"),
             sessionsDir: join(defaultDataDir(), "sessions"),
             resolver: createApiNameResolver(config.server.url, () => ensureFreshAccessToken()),
+            log: writeStatus,
           });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          print.status("⚠️", `agent-dir migration skipped: ${msg}`);
+          writeStatus("⚠️", `agent-dir migration skipped: ${msg}`);
         }
 
         // Pre-flight runtime-provider reconciliation rewrites any local
@@ -214,15 +232,15 @@ export function registerDaemonStartCommand(daemon: Command): void {
             serverUrl: config.server.url,
             accessToken,
             agentsDir,
-            log: (level, msg) => print.status(level === "warn" ? "⚠️" : "•", msg),
+            log: (level, msg) => writeStatus(level === "warn" ? "⚠️" : "•", msg),
           });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          print.status("⚠️", `runtime-provider reconcile skipped: ${msg}`);
+          writeStatus("⚠️", `runtime-provider reconcile skipped: ${msg}`);
         }
         const agents = loadAgents({ schema: agentConfigSchema, agentsDir });
 
-        print.line(`\n  Connecting to ${config.server.url} (client id: ${config.client.id})...\n`);
+        writeLine(`\n  Connecting to ${config.server.url} (client id: ${config.client.id})...\n`);
 
         // `--no-interactive` suppresses update prompts, but it does not by
         // itself prove a supervisor will relaunch us after exit(75). Only the
@@ -247,6 +265,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
         });
         const runtime = new ClientRuntime(config.server.url, config.client.id, {
           currentVersion: COMMAND_VERSION,
+          output: daemonOutput ?? undefined,
           update: {
             updateConfig: config.update,
             prompt: noInteractive ? declineUpdate : promptUpdate,
@@ -274,7 +293,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
               capabilities,
             });
           },
-          log: (symbol, msg) => print.status(symbol, msg),
+          log: (symbol, msg) => writeStatus(symbol, msg),
         });
         runtime.onReconnect(() => capabilityRefresher.onReconnect());
 
@@ -290,7 +309,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
           // preserve the pending browser-auth entry instead of clobbering it on
           // the next re-probe.
           if (capabilityRefresher.isInteractive(command.provider)) {
-            print.status(
+            writeStatus(
               "•",
               `runtime-auth: ${command.provider} login already in progress — ignoring duplicate (ref ${command.ref})`,
             );
@@ -300,7 +319,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
           void runRuntimeAuthLogin(command, {
             currentEntry: (provider) => capabilityRefresher.currentEntry(provider),
             setProviderEntry: (provider, entry) => capabilityRefresher.setProviderEntry(provider, entry),
-            log: (symbol, msg) => print.status(symbol, msg),
+            log: (symbol, msg) => writeStatus(symbol, msg),
           }).finally(() => capabilityRefresher.endInteractive(command.provider));
         });
 
@@ -323,7 +342,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
           const claudeAgents = [...agents].filter(([, c]) => c.runtime === "claude-code");
           if (claudeAgents.length > 0) {
             const skills = await discoverClaudeCodeSkills({
-              warn: (msg) => print.status("⚠️", `skill scan: ${msg}`),
+              warn: (msg) => writeStatus("⚠️", `skill scan: ${msg}`),
             });
             const accessToken = await ensureFreshAccessToken();
             let pinnedByAgentId: Map<string, { agentId: string; clientId: string }> | null = null;
@@ -332,21 +351,21 @@ export function registerDaemonStartCommand(daemon: Command): void {
               pinnedByAgentId = new Map(pinned.map((agent) => [agent.agentId, agent]));
             } catch (err) {
               const msg = err instanceof Error ? err.message : String(err);
-              print.status("⚠️", `skills upload pin check skipped: ${msg}`);
+              writeStatus("⚠️", `skills upload pin check skipped: ${msg}`);
             }
             await Promise.all(
               claudeAgents.map(async ([name, c]) => {
                 try {
                   const pinned = pinnedByAgentId?.get(c.agentId);
                   if (pinnedByAgentId && !pinned) {
-                    print.status(
+                    writeStatus(
                       "⚠️",
                       `skills upload for ${name} skipped: local agent ${c.agentId} is not pinned to this user; run \`${binName} agent prune --dry-run\` to inspect stale aliases.`,
                     );
                     return;
                   }
                   if (pinned && pinned.clientId !== config.client.id) {
-                    print.status(
+                    writeStatus(
                       "⚠️",
                       `skills upload for ${name} skipped: local agent ${c.agentId} is pinned to another client (${pinned.clientId}); run \`${binName} agent prune --dry-run\` to inspect stale aliases.`,
                     );
@@ -360,14 +379,14 @@ export function registerDaemonStartCommand(daemon: Command): void {
                   });
                 } catch (err) {
                   const msg = err instanceof Error ? err.message : String(err);
-                  print.status("⚠️", `skills upload for ${name} skipped: ${msg}`);
+                  writeStatus("⚠️", `skills upload for ${name} skipped: ${msg}`);
                 }
               }),
             );
           }
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          print.status("⚠️", `skills upload skipped: ${msg}`);
+          writeStatus("⚠️", `skills upload skipped: ${msg}`);
         }
 
         // Watch agents config dir for hot-add
@@ -375,7 +394,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
 
         // Graceful shutdown
         const shutdown = async () => {
-          print.line("\n  Shutting down...\n");
+          writeLine("\n  Shutting down...\n");
           capabilityRefresher.stop();
           runtime.unwatchAgentsDir();
           await runtime.stop();
@@ -389,13 +408,20 @@ export function registerDaemonStartCommand(daemon: Command): void {
         await new Promise(() => {});
       } catch (error) {
         if (error instanceof ClientUserMismatchError) {
-          print.line("\n");
-          print.line("  ⚠️  This client.yaml is owned by a different user.\n");
-          print.line(`  Run \`${binName} logout --purge\` before logging in with another account.\n`);
-          print.line("  This signs out the current user and removes this machine's local client\n");
-          print.line("  identity plus local agent configs, workspaces, and session state. Server-side\n");
-          print.line("  clients, agents, chats, and history are not deleted; the previous client and\n");
-          print.line("  agents simply stop running from this machine unless they are set up again.\n\n");
+          if (daemonOutput) {
+            writeStatus(
+              "✗",
+              `client.yaml is owned by a different user; run \`${binName} logout --purge\`, then \`${binName} login <token>\` with the intended account. This signs out the current local client identity plus local agent configs, workspaces, and session state; server-side clients, agents, chats, and history are not deleted.`,
+            );
+            process.exit(1);
+          }
+          writeLine("\n");
+          writeLine("  ⚠️  This client.yaml is owned by a different user.\n");
+          writeLine(`  Run \`${binName} logout --purge\` before logging in with another account.\n`);
+          writeLine("  This signs out the current user and removes this machine's local client\n");
+          writeLine("  identity plus local agent configs, workspaces, and session state. Server-side\n");
+          writeLine("  clients, agents, chats, and history are not deleted; the previous client and\n");
+          writeLine("  agents simply stop running from this machine unless they are set up again.\n\n");
           process.exit(1);
         }
         if (error instanceof ClientOrgMismatchError) {
@@ -403,13 +429,13 @@ export function registerDaemonStartCommand(daemon: Command): void {
             managed: isSupervisorChild,
             configDir: defaultConfigDir(),
             rerunCommand: `${binName} daemon start`,
+            output: daemonOutput ?? undefined,
           });
         }
         const msg = error instanceof Error ? error.message : String(error);
         captureClientException(error, { command: "daemon start" });
         await flushClientSentry();
-        print.line(`  Error: ${msg}\n`);
-        process.exit(1);
+        writeErrorAndExit(`Error: ${msg}`);
       } finally {
         // Reset singleton so other commands can reinit
         resetConfig();

--- a/apps/cli/src/core/client-reidentify.ts
+++ b/apps/cli/src/core/client-reidentify.ts
@@ -1,6 +1,15 @@
 import type { ClientOrgMismatchError } from "@first-tree/client";
 import { channelConfig } from "./channel.js";
+import type { ClientRuntimeOutput } from "./client-runtime.js";
 import { print } from "./output.js";
+
+type ClientReidentifyOutput = Pick<ClientRuntimeOutput, "blank" | "line"> &
+  Partial<Pick<ClientRuntimeOutput, "status">>;
+
+const printClientReidentifyOutput: ClientReidentifyOutput = {
+  blank: () => print.blank(),
+  line: (text) => print.line(text),
+};
 
 /**
  * Shared handler for legacy `CLIENT_ORG_MISMATCH` rejections. Current servers
@@ -11,23 +20,32 @@ import { print } from "./output.js";
  */
 export async function handleClientOrgMismatch(
   err: ClientOrgMismatchError,
-  _opts: {
+  opts: {
     managed: boolean;
     configDir: string;
     rerunCommand: string;
+    output?: ClientReidentifyOutput;
   },
 ): Promise<never> {
+  const output = opts.output ?? printClientReidentifyOutput;
   const purgeCommand = `${channelConfig.binName} logout --purge`;
-  print.blank();
-  print.line("  ⚠️  This machine's client identity is not accepted for this account.\n");
-  print.line(`     Server message: ${err.message}\n`);
-  print.blank();
-  print.line(`  To switch accounts, run \`${purgeCommand}\` first, then login again.\n\n`);
-  print.line("  `logout --purge` stops the current daemon, signs out the current user, and\n");
-  print.line("  removes this machine's local client identity plus local agent configs,\n");
-  print.line("  workspaces, and session state. Server-side clients, agents, chats, and\n");
-  print.line("  history are not deleted; the previous client and agents simply stop running\n");
-  print.line("  from this machine unless they are set up again.\n\n");
-  print.line(`  Then run \`${channelConfig.binName} login <token>\` with the intended account's connect token.\n\n`);
+  if (opts.managed && opts.output?.status) {
+    output.status?.(
+      "✗",
+      `client identity is not accepted for this account (${err.message}); run \`${purgeCommand}\`, then \`${channelConfig.binName} login <token>\` with the intended account's connect token. Local client identity plus local agent configs, workspaces, and session state stay account-scoped; server-side clients, agents, chats, and history are not deleted.`,
+    );
+    process.exit(1);
+  }
+  output.blank();
+  output.line("  ⚠️  This machine's client identity is not accepted for this account.\n");
+  output.line(`     Server message: ${err.message}\n`);
+  output.blank();
+  output.line(`  To switch accounts, run \`${purgeCommand}\` first, then login again.\n\n`);
+  output.line("  `logout --purge` stops the current daemon, signs out the current user, and\n");
+  output.line("  removes this machine's local client identity plus local agent configs,\n");
+  output.line("  workspaces, and session state. Server-side clients, agents, chats, and\n");
+  output.line("  history are not deleted; the previous client and agents simply stop running\n");
+  output.line("  from this machine unless they are set up again.\n\n");
+  output.line(`  Then run \`${channelConfig.binName} login <token>\` with the intended account's connect token.\n\n`);
   process.exit(1);
 }

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -33,6 +33,53 @@ type AgentStartState = "idle" | "starting" | "running" | "suspended-skipped" | "
 
 const CLIENT_RUNTIME_AGENT_UNBOUND_LISTENER_COUNT = 1;
 
+export type ClientRuntimeOutput = {
+  blank: () => void;
+  check: (pass: boolean, label: string, detail?: string) => void;
+  line: (text: string) => void;
+  status: (label: string, message: string) => void;
+};
+
+type RuntimeOutputLogLevel = "info" | "warn" | "error";
+
+type RuntimeOutputLogger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+};
+
+const printRuntimeOutput: ClientRuntimeOutput = {
+  blank: () => print.blank(),
+  check: (pass, label, detail) => print.check(pass, label, detail),
+  line: (text) => print.line(text),
+  status: (label, message) => print.status(label, message),
+};
+
+function logTrimmed(logger: RuntimeOutputLogger, level: RuntimeOutputLogLevel, text: string): void {
+  const message = text.trim();
+  if (message) logger[level](message);
+}
+
+function levelForStatus(label: string): RuntimeOutputLogLevel {
+  if (label.includes("✗")) return "error";
+  if (label.includes("⚠")) return "warn";
+  return "info";
+}
+
+export function createLoggerRuntimeOutput(logger: RuntimeOutputLogger): ClientRuntimeOutput {
+  return {
+    blank: () => undefined,
+    check: (pass, label, detail) => {
+      const message = detail ? `${label}: ${detail}` : label;
+      logger[pass ? "info" : "warn"](message);
+    },
+    line: (text) => logTrimmed(logger, "info", text),
+    status: (label, message) => {
+      logger[levelForStatus(label)](label ? `${label} ${message}` : message);
+    },
+  };
+}
+
 export function isAgentSuspendedBindError(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : String(error);
   return msg.includes("agent_suspended");
@@ -58,6 +105,12 @@ export type ClientRuntimeOptions = {
    * UpdateManager attaches only when this and `currentVersion` are both set.
    */
   update?: UpdateHooks;
+  /**
+   * Human/status output sink. Defaults to the CLI Print layer for foreground
+   * runs; daemon service children inject a logger-backed sink so runtime
+   * diagnostics go through `client.log` instead of supervisor stderr.
+   */
+  output?: ClientRuntimeOutput;
 };
 
 /**
@@ -79,6 +132,7 @@ export class ClientRuntime {
   private readonly agentNames = new Set<string>();
   private readonly agentIds = new Set<string>();
   private readonly options: ClientRuntimeOptions;
+  private readonly output: ClientRuntimeOutput;
   private updateManager: UpdateManager | null = null;
   private watcher: FSWatcher | null = null;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -109,6 +163,7 @@ export class ClientRuntime {
   constructor(serverUrl: string, clientId: string, options: ClientRuntimeOptions = {}) {
     this.serverUrl = serverUrl;
     this.options = options;
+    this.output = options.output ?? printRuntimeOutput;
     this.connection = new ClientConnection({
       serverUrl,
       clientId,
@@ -125,7 +180,7 @@ export class ClientRuntime {
     registerBuiltinHandlers();
 
     this.connection.on("auth:expired", () => {
-      print.status("⚠️", "access token expired — reconnecting after refresh...");
+      this.output.status("⚠️", "access token expired — reconnecting after refresh...");
     });
 
     // Refresh token rejected by the server. Bug 2 fix: instead of
@@ -136,20 +191,20 @@ export class ClientRuntime {
     // to run the channel-aware login command. On change we call
     // `connection.clearPaused()` to resume.
     this.connection.on("auth:paused", (reason, err) => {
-      print.blank();
-      print.status("✗", "auth rejected — pausing agents until fresh credentials arrive.");
-      print.status("", authPausedDetail(err));
-      print.status("", "Recovery: get a new connect token from the First Tree web console");
-      print.status(
+      this.output.blank();
+      this.output.status("✗", "auth rejected — pausing agents until fresh credentials arrive.");
+      this.output.status("", authPausedDetail(err));
+      this.output.status("", "Recovery: get a new connect token from the First Tree web console");
+      this.output.status(
         "",
         `          (Computers → + New Connection), then re-run \`${channelConfig.binName} login <token>\`.`,
       );
-      print.status("", `Paused reason: ${reason}. Process is staying alive — no restart needed after login.`);
+      this.output.status("", `Paused reason: ${reason}. Process is staying alive — no restart needed after login.`);
       this.ensureCredentialsWatcher();
     });
 
     this.connection.on("auth:resumed", (previousReason) => {
-      print.status("✓", `credentials refreshed — resuming agents (was paused: ${previousReason})`);
+      this.output.status("✓", `credentials refreshed — resuming agents (was paused: ${previousReason})`);
     });
 
     // Back-compat: legacy auth:fatal listeners on older consumers used to
@@ -163,7 +218,7 @@ export class ClientRuntime {
     // failures) to the operator. ClientConnection's own reconnect loop handles
     // recovery; the process-wide crash guard lives in ClientConnection itself.
     this.connection.on("error", (err) => {
-      print.status("⚠️", `client connection error: ${err.message}`);
+      this.output.status("⚠️", `client connection error: ${err.message}`);
     });
 
     // Server tells us an agent has just been pinned to this client — mirror
@@ -190,7 +245,7 @@ export class ClientRuntime {
         try {
           cb();
         } catch (err) {
-          print.status("⚠️", `reconnect handler error: ${err instanceof Error ? err.message : String(err)}`);
+          this.output.status("⚠️", `reconnect handler error: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
     });
@@ -225,7 +280,7 @@ export class ClientRuntime {
     // name/id so rescans and reconnects don't re-warn; a client upgrade + restart
     // picks the agent up once its handler is registered.
     if (!hasHandler(config.runtime)) {
-      print.status(
+      this.output.status(
         "⚠️",
         `agent "${name}" uses runtime "${config.runtime}" which this client build does not support yet — skipping. Update the client to run it.`,
       );
@@ -280,16 +335,16 @@ export class ClientRuntime {
     }
 
     await this.connection.connect();
-    print.check(true, "client registered", this.connection.clientId);
+    this.output.check(true, "client registered", this.connection.clientId);
 
     if (this.agents.length === 0) {
-      print.blank();
-      print.status("", "no agents configured yet.");
-      print.status(
+      this.output.blank();
+      this.output.status("", "no agents configured yet.");
+      this.output.status(
         "",
         `add one with: ${channelConfig.binName} agent create <name> --type claude-code --client-id <id>`,
       );
-      print.blank();
+      this.output.blank();
       return;
     }
 
@@ -297,9 +352,9 @@ export class ClientRuntime {
 
     const connected = startupResults.filter((r) => r === "connected").length;
     const skipped = startupResults.filter((r) => r === "skipped").length;
-    print.blank();
+    this.output.blank();
     const skippedSuffix = skipped > 0 ? `, ${skipped} skipped` : "";
-    print.status("", `${connected} agent(s) running${skippedSuffix}. Press Ctrl+C to stop.`);
+    this.output.status("", `${connected} agent(s) running${skippedSuffix}. Press Ctrl+C to stop.`);
   }
 
   watchAgentsDir(agentsDir: string): void {
@@ -320,7 +375,7 @@ export class ClientRuntime {
     // or inotify exhaustion on Linux). An unhandled 'error' throws and would
     // take down the daemon — tear the watcher down so it degrades gracefully.
     this.watcher.on("error", (err: Error) => {
-      print.status("⚠️", `agents dir watcher error: ${err.message}`);
+      this.output.status("⚠️", `agents dir watcher error: ${err.message}`);
       this.unwatchAgentsDir();
     });
   }
@@ -376,7 +431,7 @@ export class ClientRuntime {
           if (snapshot && snapshot !== this.lastCredentialsSnapshot) {
             this.lastCredentialsSnapshot = snapshot;
             if (this.connection.isPaused()) {
-              print.status("", "credentials.json updated — clearing paused mode");
+              this.output.status("", "credentials.json updated — clearing paused mode");
               this.connection.clearPaused();
             }
           }
@@ -386,11 +441,11 @@ export class ClientRuntime {
       // still emit 'error' later; without a listener that would crash the
       // daemon. Tear it down so paused-mode recovery degrades gracefully.
       this.credentialsWatcher.on("error", (err: Error) => {
-        print.status("⚠️", `credentials watcher error: ${err.message}`);
+        this.output.status("⚠️", `credentials watcher error: ${err.message}`);
         this.stopCredentialsWatcher();
       });
     } catch (err) {
-      print.status("⚠️", `credentials watcher failed: ${err instanceof Error ? err.message : String(err)}`);
+      this.output.status("⚠️", `credentials watcher failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
@@ -454,8 +509,8 @@ export class ClientRuntime {
         if (this.agentNames.has(name)) continue;
         if (this.agentIds.has(config.agentId)) continue;
 
-        print.blank();
-        print.status("", `new agent detected: ${name}`);
+        this.output.blank();
+        this.output.status("", `new agent detected: ${name}`);
         this.addAgent(name, config);
         this.startAgent(name);
       }
@@ -474,14 +529,14 @@ export class ClientRuntime {
     const existing = this.agents.find((agent) => agent.slot.agentId === message.agentId);
     if (existing) {
       if (existing.state === "suspended-skipped") {
-        print.status("", `agent reactivated: ${existing.name}`);
+        this.output.status("", `agent reactivated: ${existing.name}`);
         this.startAgent(existing.name);
       }
       return;
     }
 
     if (!this.agentsDir) {
-      print.status("⚠️", `agent pinned (${message.agentId}) but no agents dir set — cannot auto-register.`);
+      this.output.status("⚠️", `agent pinned (${message.agentId}) but no agents dir set — cannot auto-register.`);
       return;
     }
 
@@ -491,10 +546,10 @@ export class ClientRuntime {
       mkdirSync(agentDir, { recursive: true, mode: 0o700 });
       const yaml = stringifyYaml({ agentId: message.agentId, runtime: message.runtimeProvider });
       writeFileSync(join(agentDir, "agent.yaml"), yaml, { mode: 0o600 });
-      print.check(true, `auto-added agent "${localName}"`, `${message.agentId} (from server push)`);
+      this.output.check(true, `auto-added agent "${localName}"`, `${message.agentId} (from server push)`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      print.check(false, `failed to auto-add agent "${localName}"`, msg);
+      this.output.check(false, `failed to auto-add agent "${localName}"`, msg);
       return;
     }
 
@@ -550,17 +605,17 @@ export class ClientRuntime {
     try {
       const identity = await entry.slot.start();
       entry.state = "running";
-      print.check(true, `${entry.name}: connected`, `agent: ${identity.displayName ?? identity.agentId}`);
+      this.output.check(true, `${entry.name}: connected`, `agent: ${identity.displayName ?? identity.agentId}`);
       return "connected";
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       if (isAgentSuspendedBindError(error)) {
         entry.state = "suspended-skipped";
-        print.status("•", `${entry.name}: skipped (suspended)`);
+        this.output.status("•", `${entry.name}: skipped (suspended)`);
         return "skipped";
       }
       entry.state = "failed";
-      print.check(false, `${entry.name}: connection failed`, msg);
+      this.output.check(false, `${entry.name}: connection failed`, msg);
       return "failed";
     }
   }

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -20,9 +20,9 @@ export { CapabilityRefresher, stableCapabilitiesJson } from "./capability-refres
 export { cliFetch } from "./cli-fetch.js";
 // Local client identity recovery helpers
 export { handleClientOrgMismatch } from "./client-reidentify.js";
-export type { ClientRuntimeOptions } from "./client-runtime.js";
+export type { ClientRuntimeOptions, ClientRuntimeOutput } from "./client-runtime.js";
 // Client runtime
-export { ClientRuntime } from "./client-runtime.js";
+export { ClientRuntime, createLoggerRuntimeOutput } from "./client-runtime.js";
 // User-owned daemon environment (proxy etc.) — read, never written by us
 export { daemonEnvPath, loadDaemonEnv, parseDaemonEnv } from "./daemon-env.js";
 // Diagnostics (doctor)
@@ -45,7 +45,7 @@ export type { InstallCodexResult } from "./install-codex-runtime.js";
 export { installCodexRuntime } from "./install-codex-runtime.js";
 // Phase 3 of the agent-naming refactor — renames local agent dirs whose
 // name drifted from the server-authoritative `agent.name` slug.
-export type { AgentDirMigrationResult, NameResolver } from "./migrate-agent-dirs.js";
+export type { AgentDirMigrationLog, AgentDirMigrationResult, NameResolver } from "./migrate-agent-dirs.js";
 export { createApiNameResolver, migrateLocalAgentDirs } from "./migrate-agent-dirs.js";
 // Workspace migration to W1
 export type {

--- a/apps/cli/src/core/migrate-agent-dirs.ts
+++ b/apps/cli/src/core/migrate-agent-dirs.ts
@@ -43,6 +43,10 @@ export type AgentDirMigrationResult = {
   errors: number;
 };
 
+export type AgentDirMigrationLog = (symbol: string, message: string) => void;
+
+const defaultAgentDirMigrationLog: AgentDirMigrationLog = (symbol, message) => print.status(symbol, message);
+
 /**
  * Resolve the canonical server names for every local agentId. Uses the
  * admin `/agents` listing because it's a single paginated call — much
@@ -119,7 +123,12 @@ function readAgentId(agentYamlPath: string): string | null {
   }
 }
 
-function migrateWorkspaceRuntimeDir(workspacePath: string, agentName: string, result: AgentDirMigrationResult): void {
+function migrateWorkspaceRuntimeDir(
+  workspacePath: string,
+  agentName: string,
+  result: AgentDirMigrationResult,
+  log: AgentDirMigrationLog,
+): void {
   if (!existsSync(workspacePath)) return;
   try {
     if (!statSync(workspacePath).isDirectory()) return;
@@ -131,7 +140,7 @@ function migrateWorkspaceRuntimeDir(workspacePath: string, agentName: string, re
     migrateLegacyRuntimeLayout(workspacePath);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    print.status("⚠️", `agent-dir migration: runtime-dir migration failed for "${agentName}": ${msg}`);
+    log("⚠️", `agent-dir migration: runtime-dir migration failed for "${agentName}": ${msg}`);
     result.errors += 1;
   }
 }
@@ -147,8 +156,10 @@ export async function migrateLocalAgentDirs(opts: {
   workspacesDir: string;
   sessionsDir: string;
   resolver: NameResolver;
+  log?: AgentDirMigrationLog;
 }): Promise<AgentDirMigrationResult> {
   const { agentsDir, workspacesDir, sessionsDir, resolver } = opts;
+  const log = opts.log ?? defaultAgentDirMigrationLog;
   const result: AgentDirMigrationResult = { scanned: 0, renamed: 0, skipped: 0, errors: 0 };
 
   if (!existsSync(agentsDir)) return result;
@@ -169,7 +180,7 @@ export async function migrateLocalAgentDirs(opts: {
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    print.status("⚠️", `agent-dir migration: unable to enumerate ${agentsDir}: ${msg}`);
+    log("⚠️", `agent-dir migration: unable to enumerate ${agentsDir}: ${msg}`);
     return { ...result, errors: result.errors + 1 };
   }
 
@@ -187,7 +198,7 @@ export async function migrateLocalAgentDirs(opts: {
       // exists but didn't parse — a bare dir with no agent.yaml is
       // probably unrelated (dot-files, test fixtures).
       if (existsSync(agentYamlPath)) {
-        print.status("⚠️", `agent-dir migration: unreadable ${agentYamlPath}; skipping this dir.`);
+        log("⚠️", `agent-dir migration: unreadable ${agentYamlPath}; skipping this dir.`);
         result.errors += 1;
       }
       continue;
@@ -203,7 +214,7 @@ export async function migrateLocalAgentDirs(opts: {
       // again; idempotent design means we don't leave the layout wedged.
       const msg = err instanceof Error ? err.message : String(err);
       const hint = msg.includes("403") ? " (likely a non-admin account — migration skipped)" : "";
-      print.status("⚠️", `agent-dir migration: failed to resolve "${dirName}" (${agentId}): ${msg}${hint}`);
+      log("⚠️", `agent-dir migration: failed to resolve "${dirName}" (${agentId}): ${msg}${hint}`);
       result.errors += 1;
       // One resolver failure usually means the whole fetch is broken — bail
       // out so we don't spam a warning per agent.
@@ -217,22 +228,19 @@ export async function migrateLocalAgentDirs(opts: {
       continue;
     }
     if (serverName === dirName) {
-      migrateWorkspaceRuntimeDir(oldWorkspace, dirName, result);
+      migrateWorkspaceRuntimeDir(oldWorkspace, dirName, result, log);
       continue;
     }
 
     const oldDir = join(agentsDir, dirName);
     const newDir = join(agentsDir, serverName);
     if (existsSync(newDir)) {
-      print.status(
-        "⚠️",
-        `agent-dir migration: cannot rename "${dirName}" → "${serverName}" — target already exists. Skipping.`,
-      );
+      log("⚠️", `agent-dir migration: cannot rename "${dirName}" → "${serverName}" — target already exists. Skipping.`);
       result.skipped += 1;
       continue;
     }
 
-    migrateWorkspaceRuntimeDir(oldWorkspace, dirName, result);
+    migrateWorkspaceRuntimeDir(oldWorkspace, dirName, result, log);
 
     try {
       renameSync(oldDir, newDir);
@@ -240,7 +248,7 @@ export async function migrateLocalAgentDirs(opts: {
       finalDirNames.add(serverName);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      print.status("⚠️", `agent-dir migration: config dir rename failed for "${dirName}": ${msg}`);
+      log("⚠️", `agent-dir migration: config dir rename failed for "${dirName}": ${msg}`);
       result.errors += 1;
       continue;
     }
@@ -253,7 +261,7 @@ export async function migrateLocalAgentDirs(opts: {
     if (existsSync(oldWorkspace)) {
       try {
         if (existsSync(newWorkspace)) {
-          print.status(
+          log(
             "⚠️",
             `agent-dir migration: workspace target "${serverName}" already exists; leaving old "${dirName}" in place for manual cleanup.`,
           );
@@ -262,19 +270,19 @@ export async function migrateLocalAgentDirs(opts: {
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        print.status("⚠️", `agent-dir migration: workspace rename failed for "${dirName}": ${msg}`);
+        log("⚠️", `agent-dir migration: workspace rename failed for "${dirName}": ${msg}`);
         result.errors += 1;
       }
     }
 
-    migrateWorkspaceRuntimeDir(newWorkspace, serverName, result);
+    migrateWorkspaceRuntimeDir(newWorkspace, serverName, result, log);
 
     const oldSessions = join(sessionsDir, `${dirName}.json`);
     const newSessions = join(sessionsDir, `${serverName}.json`);
     if (existsSync(oldSessions)) {
       try {
         if (existsSync(newSessions)) {
-          print.status(
+          log(
             "⚠️",
             `agent-dir migration: sessions target "${serverName}.json" already exists; leaving old "${dirName}.json" in place for manual cleanup.`,
           );
@@ -283,12 +291,12 @@ export async function migrateLocalAgentDirs(opts: {
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        print.status("⚠️", `agent-dir migration: sessions rename failed for "${dirName}": ${msg}`);
+        log("⚠️", `agent-dir migration: sessions rename failed for "${dirName}": ${msg}`);
         result.errors += 1;
       }
     }
 
-    print.status("", `agent "${dirName}" renamed to "${serverName}" to match server`);
+    log("", `agent "${dirName}" renamed to "${serverName}" to match server`);
     result.renamed += 1;
   }
 
@@ -308,7 +316,7 @@ export async function migrateLocalAgentDirs(opts: {
       const parts: string[] = [];
       if (orphanWs.length > 0) parts.push(`workspaces: ${orphanWs.join(", ")}`);
       if (orphanSessions.length > 0) parts.push(`sessions: ${orphanSessions.join(", ")}`);
-      print.status(
+      log(
         "",
         `orphaned local state detected (${parts.join("; ")}). Run \`${channelConfig.binName} agent workspace clean\` to reclaim disk.`,
       );

--- a/apps/cli/src/core/service-install.ts
+++ b/apps/cli/src/core/service-install.ts
@@ -589,9 +589,8 @@ export function renderSystemdUnit(invocation: ResolvedBinary): string {
   //     UpdateManager exits 75 after `npm i -g`, systemd sees it as a
   //     "must restart" signal and brings up the new binary.
   // StartLimit* caps a crash storm (10 failures in 5 min → systemd holds back).
-  // Logs go through journald — `journalctl --user -u <service-unit>` is
-  // the documented surface. The client itself still writes its rotating NDJSON
-  // to client.log when FIRST_TREE_SERVICE_MODE=1; journald only catches
+  // Normal client diagnostics go through the rotating NDJSON `client.log` when
+  // FIRST_TREE_SERVICE_MODE=1; journald is only the supervisor fallback for
   // bare stdout/stderr (crashes, third-party spam).
   return `[Unit]
 Description=First Tree Client

--- a/packages/client/src/__tests__/builtin-handlers.test.ts
+++ b/packages/client/src/__tests__/builtin-handlers.test.ts
@@ -1,9 +1,23 @@
+import { Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { registerBuiltinHandlers } from "../handlers/index.js";
+import { applyClientLoggerConfig } from "../observability/logger.js";
 import { getHandlerFactory } from "../runtime/handler.js";
+
+function collectLogs(): { dest: Writable; read: () => string } {
+  const chunks: string[] = [];
+  const dest = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  });
+  return { dest, read: () => chunks.join("") };
+}
 
 describe("Built-in Handlers", () => {
   afterEach(() => {
+    applyClientLoggerConfig({ level: "silent", format: "json", destination: process.stderr, explicit: false });
     vi.restoreAllMocks();
   });
 
@@ -71,19 +85,14 @@ describe("Built-in Handlers", () => {
   });
 
   it("logs the SDK bundled binary fallback when no Claude executable is resolved", () => {
-    const stderrMessages: string[] = [];
-    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation((message: string | Uint8Array) => {
-      stderrMessages.push(String(message));
-      return true;
-    });
-    try {
-      // Inject a resolver that finds nothing — hermetic against the dev machine's
-      // real PATH / well-known install dirs and any login-shell probe.
-      registerBuiltinHandlers({ resolveExecutable: () => ({ path: undefined, source: "default" }) });
-    } finally {
-      stderrWrite.mockRestore();
-    }
+    const { dest, read } = collectLogs();
+    applyClientLoggerConfig({ level: "info", format: "json", destination: dest });
 
-    expect(stderrMessages.join("")).toContain("using SDK bundled native binary");
+    // Inject a resolver that finds nothing — hermetic against the dev machine's
+    // real PATH / well-known install dirs and any login-shell probe.
+    registerBuiltinHandlers({ resolveExecutable: () => ({ path: undefined, source: "default" }) });
+
+    expect(read()).toContain('"module":"handlers"');
+    expect(read()).toContain("using SDK bundled native binary");
   });
 });

--- a/packages/client/src/__tests__/sdk-retry.test.ts
+++ b/packages/client/src/__tests__/sdk-retry.test.ts
@@ -1,4 +1,6 @@
+import { Writable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyClientLoggerConfig } from "../observability/logger.js";
 import { FirstTreeHubSDK, SdkError } from "../sdk.js";
 
 /**
@@ -81,6 +83,17 @@ function buildFetchMock(results: Array<Response | Error>): ReturnType<typeof vi.
   return fetchMock;
 }
 
+function collectLogs(): { dest: Writable; read: () => string } {
+  const chunks: string[] = [];
+  const dest = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  });
+  return { dest, read: () => chunks.join("") };
+}
+
 /**
  * Drive an async expression to completion under fake timers. Each iteration
  * flushes microtasks (so the awaited `setTimeout` registers its scheduler
@@ -121,16 +134,13 @@ function makeSdk(): FirstTreeHubSDK {
 describe("FirstTreeHubSDK doFetch retry layer", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    // Suppress the deliberate `console.warn` retry logs in the SUT so test
-    // output stays readable. We do not assert on the log text itself —
-    // those are diagnostic, not contractual.
-    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    applyClientLoggerConfig({ level: "silent", format: "json", destination: process.stderr, explicit: false });
   });
 
   it("retries through two transient fetch-failed errors and succeeds on the third attempt", async () => {
@@ -202,6 +212,8 @@ describe("FirstTreeHubSDK doFetch retry layer", () => {
   });
 
   it("retries on HTTP 500 and succeeds on the second attempt", async () => {
+    const { dest, read } = collectLogs();
+    applyClientLoggerConfig({ level: "warn", format: "json", destination: dest });
     const fetchMock = buildFetchMock([makeStatusResponse(500, "boom"), makeOkResponse()]);
     vi.stubGlobal("fetch", fetchMock);
 
@@ -210,6 +222,8 @@ describe("FirstTreeHubSDK doFetch retry layer", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(result).toMatchObject({ id: "m-1" });
+    expect(read()).toContain('"module":"sdk"');
+    expect(read()).toContain("retry attempt=1 reason=http-500 path=");
   });
 
   it("treats AbortError (timeout) as transient and retries up to three times", async () => {

--- a/packages/client/src/__tests__/sdk-surface.test.ts
+++ b/packages/client/src/__tests__/sdk-surface.test.ts
@@ -1,5 +1,7 @@
+import { Writable } from "node:stream";
 import { AGENT_SELECTOR_HEADER } from "@first-tree/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyClientLoggerConfig } from "../observability/logger.js";
 import { FirstTreeHubSDK, SdkError } from "../sdk.js";
 
 const SERVER_URL = "https://first-tree.example/";
@@ -36,6 +38,17 @@ function makeSdk(): FirstTreeHubSDK {
   });
 }
 
+function collectLogs(): { dest: Writable; read: () => string } {
+  const chunks: string[] = [];
+  const dest = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  });
+  return { dest, read: () => chunks.join("") };
+}
+
 async function flush<T>(promise: Promise<T>, maxFlushes = 50): Promise<T> {
   let settled = false;
   let result: T | undefined;
@@ -64,6 +77,7 @@ describe("FirstTreeHubSDK public surface", () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    applyClientLoggerConfig({ level: "silent", format: "json", destination: process.stderr, explicit: false });
   });
 
   it("normalizes serverUrl and exposes the scoped agent id", () => {
@@ -220,8 +234,10 @@ describe("FirstTreeHubSDK public surface", () => {
     await expect(sdk.listChats()).rejects.toBe("plain failure");
   });
 
-  it("logs retry reasons for retryable Error and non-Error shapes", async () => {
+  it("logs retry reasons through the client logger for retryable Error and non-Error shapes", async () => {
     vi.useFakeTimers();
+    const { dest, read } = collectLogs();
+    applyClientLoggerConfig({ level: "warn", format: "json", destination: dest });
     const socketError = new Error("socket reset happened");
     Object.assign(socketError, { code: "ECONNRESET" });
     const abortLike = { name: "AbortError" };
@@ -231,12 +247,12 @@ describe("FirstTreeHubSDK public surface", () => {
       .mockRejectedValueOnce(abortLike)
       .mockResolvedValueOnce(jsonResponse({ items: [], nextCursor: null }));
     vi.stubGlobal("fetch", fetchMock);
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await expect(flush(makeSdk().listChats())).resolves.toEqual({ items: [], nextCursor: null });
 
-    expect(warn).toHaveBeenCalledWith("sdk: retry attempt=1 reason=socket reset happened path=/api/v1/agent/chats");
-    expect(warn).toHaveBeenCalledWith("sdk: retry attempt=2 reason=unknown path=/api/v1/agent/chats");
+    expect(read()).toContain('"module":"sdk"');
+    expect(read()).toContain("retry attempt=1 reason=socket reset happened path=/api/v1/agent/chats");
+    expect(read()).toContain("retry attempt=2 reason=unknown path=/api/v1/agent/chats");
   });
 
   it("merges caller-provided abort signals with the SDK timeout signal", async () => {

--- a/packages/client/src/__tests__/session-registry.test.ts
+++ b/packages/client/src/__tests__/session-registry.test.ts
@@ -1,8 +1,21 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Writable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyClientLoggerConfig } from "../observability/logger.js";
 import { SessionRegistry } from "../runtime/session-registry.js";
+
+function collectLogs(): { dest: Writable; read: () => string } {
+  const chunks: string[] = [];
+  const dest = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString());
+      callback();
+    },
+  });
+  return { dest, read: () => chunks.join("") };
+}
 
 describe("SessionRegistry", () => {
   let testDir: string;
@@ -17,6 +30,7 @@ describe("SessionRegistry", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    applyClientLoggerConfig({ level: "silent", format: "json", destination: process.stderr, explicit: false });
     rmSync(testDir, { recursive: true, force: true });
   });
 
@@ -190,12 +204,9 @@ describe("SessionRegistry", () => {
   it("logs persistence failures without throwing", () => {
     const parentAsFile = join(testDir, "not-a-directory");
     writeFileSync(parentAsFile, "file blocks mkdir", "utf-8");
+    const { dest, read } = collectLogs();
+    applyClientLoggerConfig({ level: "warn", format: "json", destination: dest });
     const registry = new SessionRegistry(join(parentAsFile, "sessions.json"));
-    const stderrMessages: string[] = [];
-    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation((message: string | Uint8Array) => {
-      stderrMessages.push(String(message));
-      return true;
-    });
 
     expect(() =>
       registry.flush(
@@ -205,8 +216,8 @@ describe("SessionRegistry", () => {
       ),
     ).not.toThrow();
 
-    expect(stderrMessages.join("")).toContain("[session-registry] Failed to persist:");
-    stderrWrite.mockRestore();
+    expect(read()).toContain('"module":"session-registry"');
+    expect(read()).toContain('"msg":"Failed to persist:');
   });
 
   it("logs non-Error persistence failures", async () => {
@@ -220,13 +231,11 @@ describe("SessionRegistry", () => {
         },
       };
     });
+    const loggerMod = await import("../observability/logger.js");
+    const { dest, read } = collectLogs();
+    loggerMod.applyClientLoggerConfig({ level: "warn", format: "json", destination: dest });
     const mod = await import("../runtime/session-registry.js");
     const registry = new mod.SessionRegistry(filePath);
-    const stderrMessages: string[] = [];
-    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation((message: string | Uint8Array) => {
-      stderrMessages.push(String(message));
-      return true;
-    });
 
     registry.flush(
       makeEntries({
@@ -234,8 +243,7 @@ describe("SessionRegistry", () => {
       }),
     );
 
-    expect(stderrMessages.join("")).toContain("mkdir failed");
-    stderrWrite.mockRestore();
+    expect(read()).toContain("mkdir failed");
     vi.doUnmock("node:fs");
     vi.resetModules();
   });

--- a/packages/client/src/__tests__/update-manager.test.ts
+++ b/packages/client/src/__tests__/update-manager.test.ts
@@ -356,7 +356,7 @@ describe("UpdateManager decision flow", () => {
     }
   });
 
-  it("throttles quiet-gate debug logs without changing the re-check interval", async () => {
+  it("throttles quiet-gate info logs without changing the re-check interval", async () => {
     vi.useFakeTimers();
     try {
       const conn = makeFakeConnection();
@@ -383,6 +383,7 @@ describe("UpdateManager decision flow", () => {
 
       expect(getQuietGateSnapshot).toHaveBeenCalledTimes(1);
       expect(logs.filter((entry) => entry.msg.startsWith("Quiet gate:"))).toHaveLength(1);
+      expect(logs.filter((entry) => entry.msg.startsWith("Quiet gate:")).map((entry) => entry.level)).toEqual(["info"]);
 
       await vi.advanceTimersByTimeAsync(50_000);
       expect(getQuietGateSnapshot).toHaveBeenCalledTimes(6);
@@ -391,6 +392,10 @@ describe("UpdateManager decision flow", () => {
       await vi.advanceTimersByTimeAsync(10_000);
       expect(getQuietGateSnapshot).toHaveBeenCalledTimes(7);
       expect(logs.filter((entry) => entry.msg.startsWith("Quiet gate:"))).toHaveLength(2);
+      expect(logs.filter((entry) => entry.msg.startsWith("Quiet gate:")).map((entry) => entry.level)).toEqual([
+        "info",
+        "info",
+      ]);
       expect(executeUpdate).not.toHaveBeenCalled();
 
       mgr.dispose();

--- a/packages/client/src/handlers/index.ts
+++ b/packages/client/src/handlers/index.ts
@@ -1,3 +1,4 @@
+import { createLogger } from "../observability/logger.js";
 import { registerHandler } from "../runtime/handler.js";
 import { createClaudeCodeHandler } from "./claude-code.js";
 import { createClaudeCodeTuiHandler } from "./claude-code-tui/index.js";
@@ -19,11 +20,12 @@ export function registerBuiltinHandlers(deps: RegisterBuiltinHandlersDeps = {}):
   // (which re-resolves with the login-shell probe) and by the capability probe
   // (post-registration) — neither of which is on the pre-connect path.
   const resolution = (deps.resolveExecutable ?? (() => resolveClaudeCodeExecutable({ includeLoginShell: false })))();
+  const log = createLogger("handlers");
   if (resolution.path) {
-    process.stderr.write(`[handlers] Claude Code executable: ${resolution.path} (source=${resolution.source})\n`);
+    log.info(`Claude Code executable: ${resolution.path} (source=${resolution.source})`);
   } else {
-    process.stderr.write(
-      "[handlers] Claude Code executable: using SDK bundled native binary (set CLAUDE_CODE_EXECUTABLE or install `claude` on PATH to override)\n",
+    log.info(
+      "Claude Code executable: using SDK bundled native binary (set CLAUDE_CODE_EXECUTABLE or install `claude` on PATH to override)",
     );
   }
   registerHandler("claude-code", (config) =>

--- a/packages/client/src/runtime/session-registry.ts
+++ b/packages/client/src/runtime/session-registry.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import { createLogger } from "../observability/logger.js";
 
 const REGISTRY_VERSION = 1;
 
@@ -22,6 +23,7 @@ type RegistryData = {
  */
 export class SessionRegistry {
   private readonly filePath: string;
+  private readonly logger = createLogger("session-registry");
   private writeTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingEntries: Map<string, { claudeSessionId: string; lastActivity: number; status: string }> | null = null;
 
@@ -103,9 +105,7 @@ export class SessionRegistry {
       renameSync(tmpPath, this.filePath);
     } catch (err) {
       // Log but don't throw — registry persistence is best-effort
-      process.stderr.write(
-        `[session-registry] Failed to persist: ${err instanceof Error ? err.message : String(err)}\n`,
-      );
+      this.logger.warn(`Failed to persist: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/packages/client/src/runtime/update-manager.ts
+++ b/packages/client/src/runtime/update-manager.ts
@@ -309,7 +309,7 @@ export class UpdateManager {
       if (now - lastQuietGateLogAt >= QUIET_GATE_LOG_INTERVAL_MS) {
         lastQuietGateLogAt = now;
         this.options.log(
-          "debug",
+          "info",
           `Quiet gate: activeCount=${snapshot.activeCount}, idleFor=${Math.round(idleFor)}ms; re-checking in ${intervalMs}ms`,
         );
       }

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -22,6 +22,7 @@ import {
   type UploadAttachmentResponse,
   uploadAttachmentResponseSchema,
 } from "@first-tree/shared";
+import { createLogger } from "./observability/logger.js";
 
 /**
  * Callback that returns the current member access JWT.
@@ -208,6 +209,7 @@ export class FirstTreeHubSDK {
   private readonly getAccessToken: AccessTokenProvider;
   private readonly _agentId: string | undefined;
   private readonly _userAgent: string | undefined;
+  private readonly logger = createLogger("sdk");
 
   constructor(config: SdkConfig) {
     this._baseUrl = config.serverUrl.replace(/\/+$/, "");
@@ -554,7 +556,7 @@ export class FirstTreeHubSDK {
         const response = await this.doFetchOnce(path, init, opts);
         const isLastAttempt = attempt === delays.length - 1;
         if (response.status >= 500 && !isLastAttempt) {
-          console.warn(`sdk: retry attempt=${attempt + 1} reason=http-${response.status} path=${path}`);
+          this.logger.warn(`retry attempt=${attempt + 1} reason=http-${response.status} path=${path}`);
           lastErr = new Error(`HTTP ${response.status}`);
           continue;
         }
@@ -564,7 +566,7 @@ export class FirstTreeHubSDK {
         if (!isTransientNetworkError(err)) throw err;
         const isLastAttempt = attempt === delays.length - 1;
         if (!isLastAttempt) {
-          console.warn(`sdk: retry attempt=${attempt + 1} reason=${classifyRetryReason(err)} path=${path}`);
+          this.logger.warn(`retry attempt=${attempt + 1} reason=${classifyRetryReason(err)} path=${path}`);
         }
       }
     }


### PR DESCRIPTION
## Summary

- route daemon service-mode runtime/status output through the client logger while keeping foreground/manual CLI output on `print.*`
- move additional runtime diagnostics (`handlers`, `SessionRegistry`, SDK retry warnings, agent-dir migration, org/user mismatch handling) off direct stderr/console paths and into `client.log` when supervised
- update daemon/status log hints to make `client.log` the primary log surface, with journald/stdout-stderr only as supervisor fallback

## Review

Reviewed in First Tree by `codex-reviewer`; blocker R4 was fixed and re-reviewed with no remaining blocking issues.

## Validation

- `pnpm --filter first-tree-dev exec vitest run src/__tests__/daemon-start-command.test.ts src/__tests__/cli-helper-surfaces-extra.test.ts --maxWorkers=2`
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/daemon-start-command.test.ts src/__tests__/status-blocks.test.ts src/__tests__/cli-helper-surfaces-extra.test.ts src/__tests__/client-runtime-context-tree.test.ts src/__tests__/migrate-agent-dirs-extra.test.ts src/__tests__/migrate-agent-dirs.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/sdk-retry.test.ts src/__tests__/session-registry.test.ts src/__tests__/builtin-handlers.test.ts --maxWorkers=2`
- `pnpm check` (passes; existing repo warnings remain outside this change)
- `pnpm typecheck`
- `git diff --check`
