### PR TITLE
chore: draft the tree PR until the code PR merges

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -930,16 +930,17 @@ describe("buildAgentBriefing — # Context Tree", () => {
 
     // Writing discipline anchors — fresh vs persistent context framing, the
     // co-open + cross-link PR coordination rule, and the tightened merge
-    // order: the code PR merges first, then the tree PR is reconciled against
-    // the final merged code before it lands (never concurrent or ahead). The
-    // prose wraps the emphasised phrases across lines, so allow either
-    // single-line or wrapped forms.
+    // order: the tree PR opens as a draft so it can't land ahead, the code PR
+    // merges first, then the tree PR is reconciled against the final merged
+    // code and marked ready. The prose wraps the emphasised phrases across
+    // lines, so allow either single-line or wrapped forms.
     expect(briefing).toContain("fresh context");
     expect(briefing).toMatch(/\*\*persistent[\s\n]+context\*\*/);
     expect(briefing).toMatch(
       /open the tree PR and the code[\s\n]+PR[\s\n]+together and cross-link them in the PR descriptions/,
     );
     expect(briefing).toMatch(/Merge the code PR first, then[\s\n]+the tree PR/);
+    expect(briefing).toMatch(/open the tree PR as a draft/);
     expect(briefing).toContain("final merged");
     expect(briefing).not.toContain("need not merge first");
     expect(briefing).toContain("Implementation-only changes skip the tree");

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -1054,14 +1054,17 @@ together and cross-link them in the PR descriptions**, so a reviewer on
 the code PR can reach the decision and its rationale from the linked
 tree PR; when review reshapes the design, update both PRs together so
 they never describe different things. **Merge the code PR first, then
-the tree PR** — the code PR is the source of truth for what was decided,
-so let it settle before the tree records it; do not merge the tree PR
-concurrently with, or ahead of, the code PR. Before merging the tree
-PR, reconcile it against the **final merged** code PR: fold in any
-last-round review changes so the tree PR reflects the code's final
-conclusion, not an earlier draft. Then merge the tree PR promptly — a
-tree that trails the merged code for long is one other agents read
-while stale.
+the tree PR.** To hold that order, **open the tree PR as a draft**: a
+draft stays cross-linked and fully readable — a code reviewer still
+reaches the decision and rationale from it — but cannot merge, so it
+can't land ahead of the code PR or auto-merge on green. The code PR is
+the source of truth for what was decided, so let it settle first. Once
+the code PR merges, reconcile the tree PR against the **final merged**
+code PR — fold in any last-round review changes so it reflects the
+code's final conclusion, not an earlier draft — then mark the tree PR
+**ready**. Its own review and merge happen at that point, against the
+final code; keep it prompt so the tree does not trail the merged code
+for long.
 Implementation-only changes skip the tree write — not the read.
 
 Before writing, you MUST load the relevant skill first and follow its


### PR DESCRIPTION
## What

Makes the tightened "merge the code PR first, then the tree PR" rule **mechanically enforceable** in the injected agent briefing: **open the tree PR as a draft**. A draft stays cross-linked and fully readable (a code reviewer still reaches the decision + rationale from it) but cannot merge or auto-merge — so it can't land ahead of the code PR. After the code PR merges, reconcile the tree PR against the final merged code, then mark it **ready**; its own review and merge run at that point, against the final code.

## Why

The prior rule was prose-only, and nothing holds a green tree PR back: `first-tree-context` auto-merges an owner's PR the moment `validate` is green (no approval gate), so a non-draft tree PR squash-lands within seconds — ahead of the code PR. Observed directly: the previous tightening's tree PR (`first-tree-context#656`) auto-merged 33s after opening, ahead of its code PR (`first-tree#1385`).

## Where

`packages/client/src/runtime/agent-briefing.ts` (the `(First Tree Managed)` Writing-the-Tree block rendered into every agent's briefing) + a test anchor in `agent-briefing.test.ts`.

## Paired tree PR

agent-team-foundation/first-tree-context#657 (tightens `team-practice/tree-maintenance.md` to match). **That tree PR is intentionally opened as a draft** — dogfooding this very rule; it will be marked ready only after this code PR merges and is reconciled against the final wording.

## Test

- `pnpm --filter @first-tree/client test agent-briefing` — 39 passed
- `pnpm exec biome check` on changed files — clean
- `pnpm --filter @first-tree/client typecheck` — clean
