### PR TITLE
fix(web): make composer placeholder visible

### DIFF
--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -300,6 +300,11 @@ export function AskTakeover({
       />
       <textarea
         ref={taRef}
+        // Shares the composer's transparent-text overlay treatment: the class
+        // carries `::selection` + `::placeholder { opacity: 1 }`, and the
+        // utility colors the placeholder — without these the transparent text
+        // color cascades to the placeholder and it renders invisible.
+        className="mention-composer-textarea placeholder:text-muted-foreground"
         value={freeText}
         onChange={(e) => {
           setFreeText(e.target.value);

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1824,6 +1824,17 @@ body:has(#onboarding-preview-root) hearback-widget {
   color: transparent;
 }
 
+/* The textarea paints its own glyphs transparent (the mirror overlay draws
+   them); without an explicit placeholder color the placeholder would inherit
+   that transparent color and render invisible. The `placeholder:text-muted-
+   foreground` utility on the textarea sets the color (matching every other
+   composer/input placeholder in the app); this rule only forces `opacity: 1`
+   so browsers that dim `::placeholder` by default don't fade it further. Font
+   size is inherited from the textarea (`--composer-font-size`). */
+.mention-composer-textarea::placeholder {
+  opacity: 1;
+}
+
 /* ============================================================================
    Agent profile · Usage tab — Activity calendar + Recent turns
    ============================================================================

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -4053,7 +4053,7 @@ export function ChatView({
                             }
                           }}
                           disabled={sendMut.isPending || uploading}
-                          className="mention-composer-textarea w-full outline-none text-subtitle font-normal"
+                          className="mention-composer-textarea w-full outline-none text-subtitle font-normal placeholder:text-muted-foreground"
                           style={{
                             padding: "var(--sp-2_25) var(--sp-3) var(--sp-7_5)",
                             background: "transparent",


### PR DESCRIPTION
## What & why

Follow-up defect fix for #1382. The group-mention placeholder (`In a group, @mention who this is for`) — and in fact **every** composer placeholder — was rendering **invisible**.

Root cause: the composer `<textarea>` sets `color: transparent` (its glyphs are painted by the `MentionHighlightOverlay` mirror layer, only the caret shows). `::placeholder` defaults to `currentColor`, so it inherited `transparent` and never showed. There was no `::placeholder` color rule.

Fix (2 lines):
- Add the standard `placeholder:text-muted-foreground` utility to the textarea — the same placeholder color (`--fg-3`) every other input in the app uses.
- Add `.mention-composer-textarea::placeholder { opacity: 1 }` so browsers that dim `::placeholder` by default don't fade it.

Font size is inherited from the textarea (`--composer-font-size`), so the placeholder matches typed text (13px desktop / 16px mobile).

## Verification

Ran the local full stack in a real 3-speaker group chat and confirmed **live in both themes** the placeholder now renders in muted grey at the composer font size (it was blank before). `pnpm --filter @first-tree/web test` 1095/1095, typecheck + biome + lint:tokens clean.

Implementation-only; no contract/tree change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
