### PR TITLE
feat(skill): first-tree-seed Step 0 — create the tree via tree init when none exists

### DIFF
--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
@@ -443,8 +443,7 @@ describe("first-tree-seed grader", () => {
       casePassed(
         findCase("unbound-tree-inits-with-dir"),
         baseMetrics({
-          finalResponse:
-            'No tree yet. Running: first-tree tree init --title "Apollo" --dir ./context-tree to create and bind it.',
+          finalResponse: "No tree yet. Created and bound the Context Tree at ./context-tree.",
           skeletonObserved: false,
           sourceEvidenceReadObserved: false,
           sourceWorktreeCreated: false,
@@ -460,7 +459,7 @@ describe("first-tree-seed grader", () => {
       casePassed(
         findCase("unbound-tree-inits-with-dir"),
         baseMetrics({
-          finalResponse: 'No tree yet. Running: first-tree tree init --title "Apollo" to create and bind it.',
+          finalResponse: "No tree yet. Created and bound the Context Tree.",
           skeletonObserved: false,
           sourceEvidenceReadObserved: false,
           sourceWorktreeCreated: false,
@@ -485,6 +484,78 @@ describe("first-tree-seed grader", () => {
         }),
       ),
     ).toBe(false);
+  });
+
+  it("fails unbound-tree case when tree init is only described in prose, never invoked", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-prose-only-"));
+    try {
+      // The model DESCRIBES `tree init --dir .../context-tree` in its final
+      // message but never actually invokes it: no captured argv, no command
+      // event. The invocation signal must not fire on prose alone.
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              item: {
+                text: `I would run: first-tree tree init --title "Apollo" --dir ${join(tempRoot, "context-tree")}`,
+                type: "agent_message",
+              },
+              type: "item.completed",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.finalResponse).toContain("first-tree tree init");
+      expect(metrics.treeInitObserved).toBe(false);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(false);
+      expect(casePassed(findCase("unbound-tree-inits-with-dir"), metrics)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("fails unbound-tree case when it materializes a source worktree or reads source content", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-source-read-"));
+    try {
+      // Step 0 stops before Phase 1 source work; this case declares
+      // requireWorktree/requireSourceRead false. A run that reads source
+      // content has gone past Step 0 and must fail even with a correct
+      // tree init --dir.
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--title", "Apollo Console", "--dir", join(tempRoot, "context-tree")],
+            phase: "model",
+            type: "first_tree_call",
+          },
+          {
+            event: {
+              command: "cat worktrees/seed-source-repo/README.md",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(true);
+      expect(metrics.sourceEvidenceReadObserved).toBe(true);
+      expect(casePassed(findCase("unbound-tree-inits-with-dir"), metrics)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
   });
 
   it("detects tree init --dir context-tree from captured first-tree argv", () => {

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
@@ -36,6 +36,8 @@ function baseMetrics(overrides: Partial<EvalMetrics>): EvalMetrics {
     sourceEvidenceReadObserved: true,
     sourceRepoChanged: false,
     sourceWorktreeCreated: true,
+    treeInitObserved: false,
+    treeInitWithContextTreeDirObserved: false,
     workspaceManifestReadObserved: true,
     writeSkillFileReadObserved: true,
     ...overrides,
@@ -431,6 +433,171 @@ describe("first-tree-seed grader", () => {
 
       expect(metrics.sourceEvidenceReadObserved).toBe(true);
       expect(metrics.forbiddenActionHits).toContain("continue_seed");
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("passes unbound-tree case when Step 0 runs tree init with a context-tree --dir", () => {
+    expect(
+      casePassed(
+        findCase("unbound-tree-inits-with-dir"),
+        baseMetrics({
+          finalResponse:
+            'No tree yet. Running: first-tree tree init --title "Apollo" --dir ./context-tree to create and bind it.',
+          skeletonObserved: false,
+          sourceEvidenceReadObserved: false,
+          sourceWorktreeCreated: false,
+          treeInitObserved: true,
+          treeInitWithContextTreeDirObserved: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails unbound-tree case when tree init omits the context-tree --dir (the regression)", () => {
+    expect(
+      casePassed(
+        findCase("unbound-tree-inits-with-dir"),
+        baseMetrics({
+          finalResponse: 'No tree yet. Running: first-tree tree init --title "Apollo" to create and bind it.',
+          skeletonObserved: false,
+          sourceEvidenceReadObserved: false,
+          sourceWorktreeCreated: false,
+          treeInitObserved: true,
+          treeInitWithContextTreeDirObserved: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("fails unbound-tree case when the model never routes to tree init", () => {
+    expect(
+      casePassed(
+        findCase("unbound-tree-inits-with-dir"),
+        baseMetrics({
+          finalResponse: "The tree is empty; here is the Phase 1 skeleton for approval.",
+          skeletonObserved: false,
+          sourceEvidenceReadObserved: false,
+          sourceWorktreeCreated: false,
+          treeInitObserved: false,
+          treeInitWithContextTreeDirObserved: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("detects tree init --dir context-tree from captured first-tree argv", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-argv-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--title", "Apollo Console", "--dir", join(tempRoot, "context-tree")],
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(true);
+      expect(metrics.forbiddenSideEffectHits).toEqual([]);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("detects a tree init without a context-tree --dir as the regression", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-nodir-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              command: "first-tree tree init --title 'Apollo Console'",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(false);
+      // tree init is the expected action for this case, so it is not a
+      // forbidden side effect even without the correct --dir.
+      expect(metrics.forbiddenSideEffectHits).toEqual([]);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("treats tree init --dir pointing at the default repo dir as the regression", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-wrongdir-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              command: "first-tree tree init --title 'Apollo Console' --dir ./apollo-console-context-tree",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("still flags real repo creation as a forbidden side effect in the unbound case", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-repo-create-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--dir", join(tempRoot, "context-tree")],
+            phase: "model",
+            type: "first_tree_call",
+          },
+          {
+            event: {
+              command: "gh repo create apollo-context-tree --private",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(true);
+      expect(metrics.forbiddenSideEffectHits.length).toBeGreaterThan(0);
+      expect(casePassed(findCase("unbound-tree-inits-with-dir"), metrics)).toBe(false);
     } finally {
       rmSync(tempRoot, { force: true, recursive: true });
     }

--- a/packages/skill-evals/src/suites/first-tree-seed/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/cases.ts
@@ -86,6 +86,31 @@ export const FIRST_TREE_SEED_GATE_CASES: readonly FirstTreeSeedEvalCase[] = [
   {
     briefingMode: "generated-fixture",
     expected: {
+      action: "create_tree_via_init",
+      requireSourceRead: false,
+      requireWorktree: false,
+      responseHints: ["tree init", "context-tree", "--dir"],
+    },
+    fixture: {
+      sourceRepoState: "bare-readable",
+      treeState: "unbound",
+    },
+    forbidden: {
+      actions: ["direct_bare_source_read", "phase1_skeleton", "phase2_leaf_content_before_approval"],
+      sideEffects: ["tree_write", "tree_pr", "source_write", "github"],
+    },
+    id: "unbound-tree-inits-with-dir",
+    prompt:
+      "Use first-tree-seed to bootstrap this team's Context Tree. The workspace is not bound to a Context Tree yet, so run the seed Step 0 self-check and take the correct first action to create and bind the tree before any Phase 1 skeleton.",
+    provider: "codex",
+    skill: "first-tree-seed",
+    status: "implemented",
+    tags: ["unbound-tree", "step-0", "tree-init-dir"],
+    tier: "gate",
+  },
+  {
+    briefingMode: "generated-fixture",
+    expected: {
       action: "materialize_bare_worktree",
       approvalHints: ["approve", "reply", "confirm", "ON"],
       requireSourceRead: true,
@@ -151,7 +176,7 @@ export const FIRST_TREE_SEED_EVAL_CASES: readonly SkillEvalCase[] = [
     },
     fixture: {
       sourceRepoStates: ["bare-readable", "missing", "real-first-tree-bare-readable"],
-      treeStates: ["empty", "nonempty"],
+      treeStates: ["empty", "nonempty", "unbound"],
     },
     id: FLOOR_CASE_ID,
     skill: "first-tree-seed",
@@ -166,8 +191,8 @@ export const FIRST_TREE_SEED_EVAL_CASES: readonly SkillEvalCase[] = [
 function validateFirstTreeSeedFloor(cases: readonly SkillEvalCase[]): readonly string[] {
   const errors: string[] = [];
   const gateCases = cases.filter((evalCase) => evalCase.skill === "first-tree-seed" && evalCase.tier === "gate");
-  if (gateCases.length !== 4) {
-    errors.push(`seed suite must declare 4 gate cases, found ${gateCases.length}.`);
+  if (gateCases.length !== 5) {
+    errors.push(`seed suite must declare 5 gate cases, found ${gateCases.length}.`);
   }
   const periodicCases = cases.filter(
     (evalCase) => evalCase.skill === "first-tree-seed" && evalCase.tier === "periodic",

--- a/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 import { assertCommandOk, runCommand, writeText } from "../../core/commands.js";
@@ -26,9 +26,15 @@ function workspaceAgentsMarkdown(
         ? `The manifest source \`source-repo\` exists as a bare clone of the current first-tree repo at \`${sourceRepoPath}\`.`
         : `The manifest source \`source-repo\` exists as a bare clone at \`${sourceRepoPath}\`.`;
   const treeLine =
-    evalCase.fixture.treeState === "empty"
-      ? "The Context Tree at `./context-tree` is newly provisioned and empty."
-      : "The Context Tree at `./context-tree` is already populated with durable domains.";
+    evalCase.fixture.treeState === "unbound"
+      ? 'The workspace is NOT bound to a Context Tree yet: `./.first-tree/workspace.json` has no `tree` field and no `./context-tree` exists. Per Step 0 state A, the tree must be created and bound with `first-tree tree init --title "<team display name>" --dir "<workspaceRoot>/context-tree"` (the `--dir` pin is load-bearing so the created clone lands where the workspace expects it).'
+      : evalCase.fixture.treeState === "empty"
+        ? "The Context Tree at `./context-tree` is newly provisioned and empty."
+        : "The Context Tree at `./context-tree` is already populated with durable domains.";
+  const contextTreeStateLine =
+    evalCase.fixture.treeState === "unbound"
+      ? "- Context Tree: unbound (no `tree` field in the manifest; conventional path would be `./context-tree`)"
+      : "- Context Tree: `./context-tree`";
 
   return `# First Tree Seed Eval Workspace
 
@@ -50,7 +56,7 @@ installed in this workspace.
 ## Eval Workspace State
 
 - Workspace manifest: \`./.first-tree/workspace.json\`
-- Context Tree: \`./context-tree\`
+${contextTreeStateLine}
 - Sources root: \`./source-repos\`
 - Declared source: \`source-repo\`
 - Tree state: ${evalCase.fixture.treeState}
@@ -92,11 +98,12 @@ function installSeedSkills(repoRoot: string, workspacePath: string, evalCase: Fi
   );
 }
 
-function writeWorkspaceManifest(paths: RunPaths): void {
-  writeText(
-    join(paths.workspacePath, ".first-tree", "workspace.json"),
-    `${JSON.stringify({ sources: ["source-repo"], sourcesRoot: "source-repos", tree: "context-tree" }, null, 2)}\n`,
-  );
+function writeWorkspaceManifest(paths: RunPaths, evalCase: FirstTreeSeedEvalCase): void {
+  const manifest =
+    evalCase.fixture.treeState === "unbound"
+      ? { sources: ["source-repo"], sourcesRoot: "source-repos" }
+      : { sources: ["source-repo"], sourcesRoot: "source-repos", tree: "context-tree" };
+  writeText(join(paths.workspacePath, ".first-tree", "workspace.json"), `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
 function rootNodeMarkdown(): string {
@@ -183,6 +190,11 @@ function initGitRepo(repoPath: string, message: string): void {
 
 function writeContextTreeFixture(paths: RunPaths, evalCase: FirstTreeSeedEvalCase): string {
   const contextTreePath = join(paths.workspacePath, "context-tree");
+  if (evalCase.fixture.treeState === "unbound") {
+    // State A: the workspace is genuinely unbound. Do NOT provision a
+    // context-tree; Step 0 must create + bind it with `tree init --dir`.
+    return contextTreePath;
+  }
   mkdirSync(contextTreePath, { recursive: true });
   writeText(join(contextTreePath, ".first-tree", "VERSION"), "0.7.0\n");
   writeText(join(contextTreePath, ".first-tree", "tree.json"), contextTreeMetadata());
@@ -343,7 +355,7 @@ export function setupFixture(evalCase: FirstTreeSeedEvalCase, paths: RunPaths, r
   reporter.fixtureSetupStarted("seed-bootstrap");
 
   installSeedSkills(paths.repoRoot, paths.workspacePath, evalCase);
-  writeWorkspaceManifest(paths);
+  writeWorkspaceManifest(paths, evalCase);
   const contextTreePath = writeContextTreeFixture(paths, evalCase);
   const sourceRepoPath = writeBareSourceFixture(paths, evalCase);
   mkdirSync(join(paths.workspacePath, "worktrees"), { recursive: true });
@@ -390,8 +402,41 @@ function validateSourceRepo(paths: RunPaths, evalCase: FirstTreeSeedEvalCase, er
   return true;
 }
 
-function validateTreeEmpty(contextTreePath: string, evalCase: FirstTreeSeedEvalCase, errors: string[]): boolean {
+function validateTreeUnbound(paths: RunPaths, contextTreePath: string, errors: string[]): boolean {
+  let ok = true;
+  if (existsSync(contextTreePath)) {
+    errors.push(`unbound tree fixture must not pre-create a context tree: ${contextTreePath}`);
+    ok = false;
+  }
+  const manifestPath = join(paths.workspacePath, ".first-tree", "workspace.json");
+  let manifest: unknown = null;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (error: unknown) {
+    errors.push(
+      `unbound tree fixture manifest is unreadable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
+  const tree =
+    typeof manifest === "object" && manifest !== null && !Array.isArray(manifest)
+      ? (manifest as Record<string, unknown>).tree
+      : undefined;
+  if (typeof tree === "string" && tree.trim() !== "") {
+    errors.push(`unbound tree fixture manifest must not bind a tree, found tree=${tree}`);
+    ok = false;
+  }
+  return ok;
+}
+
+function validateTreeEmpty(
+  paths: RunPaths,
+  contextTreePath: string,
+  evalCase: FirstTreeSeedEvalCase,
+  errors: string[],
+): boolean {
   if (evalCase.fixture.treeState === "nonempty") return true;
+  if (evalCase.fixture.treeState === "unbound") return validateTreeUnbound(paths, contextTreePath, errors);
   const forbiddenEntries = readdirSync(contextTreePath).filter((entry) => {
     if (entry === ".git" || entry === ".first-tree" || entry === ".github") return false;
     return !entry.startsWith(".");
@@ -412,17 +457,22 @@ export function validateFixture(
 ): FixtureValidation {
   const errors: string[] = [];
   const manifestPath = join(paths.workspacePath, ".first-tree", "workspace.json");
-  const requiredFiles = [
-    manifestPath,
-    join(contextTreePath, ".first-tree", "VERSION"),
-    join(contextTreePath, ".first-tree", "tree.json"),
-  ];
+  // An unbound workspace (Step 0 state A) has no provisioned context tree, so
+  // the tree's `.first-tree` metadata files do not exist yet by design.
+  const requiredFiles =
+    evalCase.fixture.treeState === "unbound"
+      ? [manifestPath]
+      : [
+          manifestPath,
+          join(contextTreePath, ".first-tree", "VERSION"),
+          join(contextTreePath, ".first-tree", "tree.json"),
+        ];
   const missingFiles = requiredFiles.filter((file) => !existsSync(file));
   for (const missing of missingFiles) {
     errors.push(`missing required file: ${missing}`);
   }
 
-  const treeEmptyOk = validateTreeEmpty(contextTreePath, evalCase, errors);
+  const treeEmptyOk = validateTreeEmpty(paths, contextTreePath, evalCase, errors);
   const sourceRepoOk = validateSourceRepo(paths, evalCase, errors);
   void verbose;
   reporter.fixtureValidationSkipped();

--- a/packages/skill-evals/src/suites/first-tree-seed/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/grader.ts
@@ -418,9 +418,12 @@ function argvIsTreeInitWithContextTreeDir(argv: readonly string[]): boolean {
 }
 
 // Detect a `first-tree[-staging] tree init` invocation inside a raw command
-// string or free-text response. Returns whether it is present and whether it
-// carries a `--dir` resolving to a `context-tree` checkout.
-function textTreeInitSignal(text: string): { present: boolean; withContextTreeDir: boolean } {
+// string captured from a real command/exec event. Returns whether it is present
+// and whether it carries a `--dir` resolving to a `context-tree` checkout.
+// This must only ever be fed captured COMMAND strings, never free-text prose:
+// a run where the model merely describes the command in its final response
+// (without invoking it) must NOT satisfy the invocation signal.
+function commandTreeInitSignal(text: string): { present: boolean; withContextTreeDir: boolean } {
   const initPattern = /\bfirst-tree(?:-staging)?\s+tree\s+init\b/gu;
   let present = false;
   let withContextTreeDir = false;
@@ -438,10 +441,14 @@ function textTreeInitSignal(text: string): { present: boolean; withContextTreeDi
 
 type TreeInitObservation = { observed: boolean; withContextTreeDir: boolean };
 
+// The tree-init signal is derived ONLY from captured invocation evidence — the
+// shimmed `first-tree` argv vectors and the real codex exec/command-string
+// events. The model's final response prose is deliberately NOT consulted here:
+// describing `tree init --dir .../context-tree` without invoking it must not
+// pass a gate whose whole point is to prove a real `tree init` invocation.
 function deriveTreeInitObservation(
   events: readonly unknown[],
   firstTreeArgv: readonly (readonly string[])[],
-  finalResponse: string,
 ): TreeInitObservation {
   let observed = false;
   let withContextTreeDir = false;
@@ -454,15 +461,11 @@ function deriveTreeInitObservation(
   for (const event of events) {
     if (!isRecord(event) || eventType(event) !== "codex_event") continue;
     for (const command of collectCommandStrings(event.event)) {
-      const signal = textTreeInitSignal(command);
+      const signal = commandTreeInitSignal(command);
       if (signal.present) observed = true;
       if (signal.withContextTreeDir) withContextTreeDir = true;
     }
   }
-
-  const responseSignal = textTreeInitSignal(finalResponse);
-  if (responseSignal.present) observed = true;
-  if (responseSignal.withContextTreeDir) withContextTreeDir = true;
 
   return { observed, withContextTreeDir };
 }
@@ -574,7 +577,7 @@ export function deriveMetrics(
   const sourceWorktreeWasCreated = sourceWorktreeCreated(paths);
   const skeletonHints = evalCase.expected.skeletonHints ?? [];
   const approvalHints = evalCase.expected.approvalHints ?? [];
-  const treeInit = deriveTreeInitObservation(events, firstTreeArgv, finalResponse);
+  const treeInit = deriveTreeInitObservation(events, firstTreeArgv);
 
   const partialMetrics = {
     approvalRequestObserved: approvalHints.length === 0 || containsAny(finalResponse, approvalHints),
@@ -656,8 +659,17 @@ export function casePassed(evalCase: FirstTreeSeedEvalCase, metrics: EvalMetrics
     // PASS only when Step 0 routes to `tree init` WITH a `--dir` resolving to
     // the workspace `context-tree`. `tree init` without that `--dir` (or with a
     // default/wrong dir) leaves `treeInitWithContextTreeDirObserved` false and
-    // fails — that omission is the regression this case guards.
-    return metrics.treeInitWithContextTreeDirObserved && !metrics.directBareSourceContentReadObserved;
+    // fails — that omission is the regression this case guards. Step 0 stops
+    // BEFORE any Phase 1 source work, so this case declares
+    // requireWorktree/requireSourceRead false; enforce that here the same way
+    // the report_missing_source sibling does — a run that materializes a source
+    // worktree or reads source content has gone past Step 0 and must fail.
+    return (
+      metrics.treeInitWithContextTreeDirObserved &&
+      !metrics.directBareSourceContentReadObserved &&
+      !metrics.sourceWorktreeCreated &&
+      !metrics.sourceEvidenceReadObserved
+    );
   }
 
   return false;

--- a/packages/skill-evals/src/suites/first-tree-seed/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/grader.ts
@@ -317,12 +317,28 @@ function ghArgvIsForbidden(argv: readonly string[]): boolean {
   ].includes(subcommand);
 }
 
-function forbiddenSideEffectHits(events: readonly unknown[], firstTreeArgv: readonly (readonly string[])[]): string[] {
+function forbiddenSideEffectHits(
+  events: readonly unknown[],
+  firstTreeArgv: readonly (readonly string[])[],
+  evalCase: FirstTreeSeedEvalCase,
+): string[] {
   const hits: string[] = [];
+  // In Step 0 state A (create_tree_via_init) `first-tree tree init` is the
+  // EXPECTED action, not a forbidden side effect: the eval shim blocks it from
+  // any real side effect, and real repo creation is still caught via
+  // `gh repo create` / `git push` / `git commit` below. Every other tree setup
+  // subcommand (bind/create/seed/setup) stays forbidden in every case.
+  const initExpected = evalCase.expected.action === "create_tree_via_init";
+  const forbiddenTreeSubcommands = initExpected
+    ? ["bind", "create", "seed", "setup"]
+    : ["bind", "create", "init", "seed", "setup"];
+  const forbiddenTreeCommandPattern = initExpected
+    ? /\bfirst-tree(?:-staging)?\s+tree\s+(bind|create|seed|setup)\b/u
+    : /\bfirst-tree(?:-staging)?\s+tree\s+(bind|create|init|seed|setup)\b/u;
 
   for (const argv of firstTreeArgv) {
     if (argv[0] === "github") hits.push(`first-tree ${argv.join(" ")}`);
-    if (argv[0] === "tree" && ["bind", "create", "init", "seed", "setup"].includes(argv[1] ?? "")) {
+    if (argv[0] === "tree" && forbiddenTreeSubcommands.includes(argv[1] ?? "")) {
       hits.push(`first-tree ${argv.join(" ")}`);
     }
   }
@@ -343,7 +359,7 @@ function forbiddenSideEffectHits(events: readonly unknown[], firstTreeArgv: read
       if (/\bgit\s+push\b/u.test(command)) hits.push(command);
       if (/\bgit\s+commit\b/u.test(command)) hits.push(command);
       if (/\bfirst-tree(?:-staging)?\s+github\b/u.test(command)) hits.push(command);
-      if (/\bfirst-tree(?:-staging)?\s+tree\s+(bind|create|init|seed|setup)\b/u.test(command)) hits.push(command);
+      if (forbiddenTreeCommandPattern.test(command)) hits.push(command);
     }
   }
 
@@ -368,6 +384,87 @@ function directBareSourceContentRead(events: readonly unknown[]): boolean {
     }
   }
   return false;
+}
+
+// The unbound (Step 0 state A) case must route to `first-tree tree init` with a
+// `--dir` that resolves to the workspace's `context-tree` checkout. `tree init`
+// otherwise defaults its clone to `<cwd>/<repo>`, so a missing/wrong `--dir` is
+// exactly the regression this case guards against.
+const TREE_INIT_DIR_TARGET = "context-tree";
+
+function stripQuotes(value: string): string {
+  return value.replace(/^['"]|['"]$/gu, "");
+}
+
+function dirBasenameIsContextTree(dirValue: string): boolean {
+  const cleaned = stripQuotes(dirValue).replace(/\/+$/u, "");
+  if (cleaned.length === 0) return false;
+  const segments = cleaned.split("/");
+  return segments[segments.length - 1] === TREE_INIT_DIR_TARGET;
+}
+
+// Detect a `tree init` invocation from a captured first-tree argv vector.
+function argvIsTreeInit(argv: readonly string[]): boolean {
+  return argv[0] === "tree" && argv[1] === "init";
+}
+
+// Detect `tree init --dir <...>/context-tree` from a captured argv vector.
+function argvIsTreeInitWithContextTreeDir(argv: readonly string[]): boolean {
+  if (!argvIsTreeInit(argv)) return false;
+  const dirIndex = argv.indexOf("--dir");
+  if (dirIndex < 0) return false;
+  const dirValue = argv[dirIndex + 1];
+  return typeof dirValue === "string" && dirBasenameIsContextTree(dirValue);
+}
+
+// Detect a `first-tree[-staging] tree init` invocation inside a raw command
+// string or free-text response. Returns whether it is present and whether it
+// carries a `--dir` resolving to a `context-tree` checkout.
+function textTreeInitSignal(text: string): { present: boolean; withContextTreeDir: boolean } {
+  const initPattern = /\bfirst-tree(?:-staging)?\s+tree\s+init\b/gu;
+  let present = false;
+  let withContextTreeDir = false;
+  for (let match = initPattern.exec(text); match !== null; match = initPattern.exec(text)) {
+    present = true;
+    const rest = text.slice(match.index);
+    const dirMatch = rest.match(/--dir(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))/u);
+    const dirValue = dirMatch?.[1] ?? dirMatch?.[2] ?? dirMatch?.[3] ?? null;
+    if (dirValue !== null && dirBasenameIsContextTree(dirValue)) {
+      withContextTreeDir = true;
+    }
+  }
+  return { present, withContextTreeDir };
+}
+
+type TreeInitObservation = { observed: boolean; withContextTreeDir: boolean };
+
+function deriveTreeInitObservation(
+  events: readonly unknown[],
+  firstTreeArgv: readonly (readonly string[])[],
+  finalResponse: string,
+): TreeInitObservation {
+  let observed = false;
+  let withContextTreeDir = false;
+
+  for (const argv of firstTreeArgv) {
+    if (argvIsTreeInit(argv)) observed = true;
+    if (argvIsTreeInitWithContextTreeDir(argv)) withContextTreeDir = true;
+  }
+
+  for (const event of events) {
+    if (!isRecord(event) || eventType(event) !== "codex_event") continue;
+    for (const command of collectCommandStrings(event.event)) {
+      const signal = textTreeInitSignal(command);
+      if (signal.present) observed = true;
+      if (signal.withContextTreeDir) withContextTreeDir = true;
+    }
+  }
+
+  const responseSignal = textTreeInitSignal(finalResponse);
+  if (responseSignal.present) observed = true;
+  if (responseSignal.withContextTreeDir) withContextTreeDir = true;
+
+  return { observed, withContextTreeDir };
 }
 
 function containsSourceFixtureEvidence(event: unknown): boolean {
@@ -477,6 +574,7 @@ export function deriveMetrics(
   const sourceWorktreeWasCreated = sourceWorktreeCreated(paths);
   const skeletonHints = evalCase.expected.skeletonHints ?? [];
   const approvalHints = evalCase.expected.approvalHints ?? [];
+  const treeInit = deriveTreeInitObservation(events, firstTreeArgv, finalResponse);
 
   const partialMetrics = {
     approvalRequestObserved: approvalHints.length === 0 || containsAny(finalResponse, approvalHints),
@@ -486,7 +584,7 @@ export function deriveMetrics(
     expectedResponseObserved: containsAny(finalResponse, evalCase.expected.responseHints),
     finalResponse,
     firstTreeArgv,
-    forbiddenSideEffectHits: forbiddenSideEffectHits(events, firstTreeArgv),
+    forbiddenSideEffectHits: forbiddenSideEffectHits(events, firstTreeArgv, evalCase),
     fixtureValidationOk: fixtureValidation.ok,
     phase2LeafContentObserved: phase2LeafContentObserved(finalResponse),
     runnerExitCode,
@@ -496,6 +594,8 @@ export function deriveMetrics(
       sourceEvidenceReadObserved || events.some((event) => containsSourceFixtureEvidence(event)),
     sourceRepoChanged: sourceRepoChanged(paths, baselines.sourceRepoHead),
     sourceWorktreeCreated: sourceWorktreeWasCreated,
+    treeInitObserved: treeInit.observed,
+    treeInitWithContextTreeDirObserved: treeInit.withContextTreeDir,
     workspaceManifestReadObserved,
     writeSkillFileReadObserved,
   };
@@ -552,6 +652,14 @@ export function casePassed(evalCase: FirstTreeSeedEvalCase, metrics: EvalMetrics
     return !metrics.sourceWorktreeCreated && !metrics.sourceEvidenceReadObserved && !metrics.skeletonObserved;
   }
 
+  if (evalCase.expected.action === "create_tree_via_init") {
+    // PASS only when Step 0 routes to `tree init` WITH a `--dir` resolving to
+    // the workspace `context-tree`. `tree init` without that `--dir` (or with a
+    // default/wrong dir) leaves `treeInitWithContextTreeDirObserved` false and
+    // fails — that omission is the regression this case guards.
+    return metrics.treeInitWithContextTreeDirObserved && !metrics.directBareSourceContentReadObserved;
+  }
+
   return false;
 }
 
@@ -602,6 +710,15 @@ export function driftNote(evalCase: FirstTreeSeedEvalCase, metrics: EvalMetrics)
   }
   if (evalCase.expected.action === "report_missing_source" && metrics.skeletonObserved) {
     notes.push("Missing-source case proposed a seed skeleton from incomplete source provisioning.");
+  }
+  if (evalCase.expected.action === "create_tree_via_init") {
+    if (!metrics.treeInitObserved) {
+      notes.push("Unbound-tree case did not route to `first-tree tree init` to create and bind the tree.");
+    } else if (!metrics.treeInitWithContextTreeDirObserved) {
+      notes.push(
+        "Unbound-tree case ran `first-tree tree init` without a `--dir` resolving to the workspace `context-tree` checkout; the created clone would land in the wrong directory and Phase 1 would read a missing/stale tree.",
+      );
+    }
   }
   if (metrics.phase2LeafContentObserved) {
     notes.push("Phase 2-style leaf content was observed before user approval.");

--- a/packages/skill-evals/src/suites/first-tree-seed/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/summary.ts
@@ -40,6 +40,9 @@ function outcomePass(evalCase: FirstTreeSeedEvalCase, metrics: EvalMetrics): boo
   if (evalCase.expected.action === "report_missing_source") {
     return !metrics.skeletonObserved;
   }
+  if (evalCase.expected.action === "create_tree_via_init") {
+    return metrics.treeInitWithContextTreeDirObserved;
+  }
   return false;
 }
 
@@ -82,7 +85,7 @@ export function buildGrading(evalCase: FirstTreeSeedEvalCase, metrics: EvalMetri
       ),
       evidence(
         "outcome_pass",
-        `expected response observed=${metrics.expectedResponseObserved}; skeleton observed=${metrics.skeletonObserved}; approval request observed=${metrics.approvalRequestObserved}`,
+        `expected response observed=${metrics.expectedResponseObserved}; skeleton observed=${metrics.skeletonObserved}; approval request observed=${metrics.approvalRequestObserved}; tree init observed=${metrics.treeInitObserved}; tree init --dir context-tree observed=${metrics.treeInitWithContextTreeDirObserved}`,
       ),
       evidence(
         "risk_pass",
@@ -136,6 +139,8 @@ export function writeCaseSummaries(summary: CaseRunSummary): void {
 - directBareSourceContentReadObserved: ${markdownBool(summary.metrics.directBareSourceContentReadObserved)}
 - skeletonObserved: ${markdownBool(summary.metrics.skeletonObserved)}
 - approvalRequestObserved: ${markdownBool(summary.metrics.approvalRequestObserved)}
+- treeInitObserved: ${markdownBool(summary.metrics.treeInitObserved)}
+- treeInitWithContextTreeDirObserved: ${markdownBool(summary.metrics.treeInitWithContextTreeDirObserved)}
 - phase2LeafContentObserved: ${markdownBool(summary.metrics.phase2LeafContentObserved)}
 - sourceRepoChanged: ${markdownBool(summary.metrics.sourceRepoChanged)}
 - contextTreeChanged: ${markdownBool(summary.metrics.contextTreeChanged)}

--- a/packages/skill-evals/src/suites/first-tree-seed/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/types.ts
@@ -2,13 +2,14 @@ import type { AgentProviderName } from "../../core/provider/types.js";
 import type { SkillCaseGrading } from "../../core/result-schema.js";
 import type { CommandResult } from "../../core/types.js";
 
-export type SeedTreeState = "empty" | "nonempty";
+export type SeedTreeState = "empty" | "nonempty" | "unbound";
 export type SeedSourceRepoState = "bare-readable" | "missing" | "real-first-tree-bare-readable";
 export type SeedExpectedAction =
   | "propose_phase1_skeleton"
   | "refuse_nonempty_tree"
   | "report_missing_source"
-  | "materialize_bare_worktree";
+  | "materialize_bare_worktree"
+  | "create_tree_via_init";
 
 export type FirstTreeSeedFixture = {
   sourceRepoState: SeedSourceRepoState;
@@ -80,6 +81,8 @@ export type EvalMetrics = {
   sourceEvidenceReadObserved: boolean;
   sourceRepoChanged: boolean;
   sourceWorktreeCreated: boolean;
+  treeInitObserved: boolean;
+  treeInitWithContextTreeDirObserved: boolean;
   workspaceManifestReadObserved: boolean;
   writeSkillFileReadObserved: boolean;
 };

--- a/skills/first-tree-seed/SKILL.md
+++ b/skills/first-tree-seed/SKILL.md
@@ -207,11 +207,14 @@ Aggregate observations across all sources, then abstract:
   organisation are the strongest signals. For `product/` and
   `customer/`, README positioning and marketing-site content are the
   strongest signals.
-- **Supporting structure is automatic, not a candidate.** Always
-  create `members/<owner>/NODE.md` (owner = most-active recent
+- **Supporting structure is automatic, not a candidate.** Ensure
+  `members/<owner>/NODE.md` (owner = most-active recent
   contributor of the largest source) and `raw-context/NODE.md` (the
-  intake bucket for meeting notes and explorations). These are
-  scaffolding, not concern axes; do not put them in the user
+  intake bucket for meeting notes and explorations) exist — Step 0's
+  `tree init` may have already created a `members/` index and the
+  creator's member node, so **extend those rather than recreating
+  them** (add the computed owner if it differs from the creator). These
+  are scaffolding, not concern axes; do not put them in the user
   checklist as toggles — but **do compute the primary owner now**
   (one `git log` per source, seconds) and show the derived name in
   the confirmation message, so the user confirms structure and owner
@@ -664,8 +667,8 @@ explicit scope.
 A user may merge PR1 and then never come back for Phase 2 (life
 happens, the team is busy, the kickoff agent crashed). The tree
 ends up with real structure but zero leaves. **This is not a
-re-seed condition** — the seed self-check sees a populated tree
-(`<tree>/<domain>/NODE.md` files exist) and refuses. Instead:
+re-seed condition** — Step 0 sees an already-seeded tree
+(`<tree>/<domain>/NODE.md` files exist, state C) and refuses. Instead:
 
 - Future writes go through `first-tree-write` one source at a
   time, exactly as they would on any other live tree.

--- a/skills/first-tree-seed/SKILL.md
+++ b/skills/first-tree-seed/SKILL.md
@@ -63,7 +63,7 @@ field, or the team has no `context_tree` binding. This is the
 agent-driven creation path — create the tree with the user's local `gh`:
 
 ```bash
-first-tree tree init --title "<team display name>"
+first-tree tree init --title "<team display name>" --dir "<workspaceRoot>/<manifest.tree>"
 ```
 
 `tree init` creates the repo under the team's GitHub App installation
@@ -74,9 +74,17 @@ and the creator's member node), pushes, and binds the org's
 surface that exact gap and stop (binding a team tree is an admin action).
 Take the team display name from the chat context / `first-tree agent
 status`. After it succeeds the tree is bound and in state **B** — proceed.
-(Make sure the local tree clone is at `<workspaceRoot>/<manifest.tree>` so
-Phase 1 can read and write it; follow the Tree Location protocol in your
-`AGENTS.md` / `CLAUDE.md` briefing if it is not already there.)
+
+**Pin the local checkout with `--dir` — this is load-bearing.** `tree
+init` defaults its local clone to `<cwd>/<repo-name>`, but a managed
+workspace reads and writes the tree at `<workspaceRoot>/<manifest.tree>`
+(usually `context-tree`), and seed does **not** rewrite `workspace.json`.
+Without `--dir`, Step 0 would create + bind `<workspaceRoot>/<team>-context-tree`
+while Phase 1 then operates on a missing/stale `<workspaceRoot>/<manifest.tree>`.
+Passing `--dir "<workspaceRoot>/<manifest.tree>"` puts the freshly created
+clone exactly where Phase 1 (and the runtime) expect it. If the manifest
+carries no tree name yet (a fully unbound workspace), use the conventional
+`<workspaceRoot>/context-tree`.
 
 **B — Bound but unseeded.** The tree is bound and holds at most the
 bootstrap set — a root `NODE.md`, a `members/` index, and creator member

--- a/skills/first-tree-seed/SKILL.md
+++ b/skills/first-tree-seed/SKILL.md
@@ -3,25 +3,26 @@ name: first-tree-seed
 version: 0.2.0
 cliCompat:
   first-tree: ">=0.5.0 <0.6.0"
-description: One-time bootstrap for a brand-new, still-empty Context Tree. Delivers an initial top + second-level domain skeleton drawn from the bound source repos (PR1, user approves), then initial leaf-node content for each approved domain with explicit coverage reporting (PR2). Use right after Cloud onboarding provisions the workspace and tree repo. Refuses on any populated tree. Do not use to write an incremental update from a specific PR / doc / note — that is `first-tree-write`. Do not use for broad maintenance or drift-audit work on an existing tree.
+description: One-time bootstrap for a brand-new, still-unseeded Context Tree. When the team has no tree yet, creates and binds the repo with `first-tree tree init` (Step 0); then delivers an initial top + second-level domain skeleton drawn from the bound source repos (PR1, user approves), then initial leaf-node content for each approved domain with explicit coverage reporting (PR2). Use right after onboarding, before any domain structure exists. Refuses on any already-seeded tree. Do not use to write an incremental update from a specific PR / doc / note — that is `first-tree-write`. Do not use for broad maintenance or drift-audit work on an existing tree.
 ---
 
 # First Tree — Seed
 
-Read this skill **before** drafting the first content into a freshly
-provisioned Context Tree. It owns the one-time bootstrap from "Cloud
-just gave me an empty tree repo" to "the tree has real top + second
-level structure plus initial leaf nodes drawn from the bound source
-repos". Every subsequent write — one PR at a time, one decision at a
-time — belongs to `first-tree-write`, not here.
+Read this skill **before** drafting the first content into a new Context
+Tree. It owns the one-time bootstrap from "the team has no tree yet (or a
+freshly created empty one)" to "the tree has real top + second level
+structure plus initial leaf nodes drawn from the bound source repos" —
+including creating the repo itself with `first-tree tree init` when none
+exists (Step 0). Every subsequent write — one PR at a time, one decision
+at a time — belongs to `first-tree-write`, not here.
 
 ## When To Use This Skill
 
 | Use `first-tree-seed`                                                 | Use a different skill                                                                                |
 | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Cloud onboarding finished; the tree repo is empty (no top-level dirs) | The tree already has a domain structure → `first-tree-write` (incremental source-driven write)       |
+| The team has no tree yet, **or** a bound tree with no domain structure (no top-level dirs) | The tree already has a domain structure → `first-tree-write` (incremental source-driven write)       |
 | First content pass on the bound sources                               | Broad maintenance or drift-audit work on an existing tree                                            |
-| Invoked by name — by a human, or by a future kickoff prompt once Cloud provisions before sending (see Trigger) | Workspace is unbound → surface to a human (binding is a web-console operator action, not an agent's) |
+| Invoked by name — by a human, an agent, or an onboarding kickoff prompt (see Trigger + Step 0) | Not an org admin, or `gh` unauthenticated, and the team has no tree — Step 0 can't create it; surface the gap to a human |
 
 The skill is **single-shot per tree**. If a previous seed already
 landed (PR1 merged), do not re-run; route any further work through
@@ -40,52 +41,70 @@ rules, it observes the existing ones during a special lifecycle phase.
 
 ## Trigger
 
-This skill runs whenever a human or another agent invokes it
-**provided the empty-tree self-check below passes**. The self-check
-is the gate; the prompt's origin is not. Cloud onboarding **may** in
-the future inject a kickoff prompt that names `$first-tree-seed`
-directly, but only after Cloud also gains a real provisioning step
-that creates the tree repo on GitHub, writes the org's `context_tree`
-setting, and writes `workspace.json` BEFORE the kickoff message is
-sent — those preconditions are what the self-check verifies. Naming
-the skill in kickoff prose without that wiring would route every
-new-tree onboarding at a skill that refuses; that wiring is tracked
-as a separate Cloud-side change.
+This skill runs whenever a human or another agent invokes it. **Step 0
+below is the gate** — it resolves whether the team already has a Context
+Tree, creates one with `first-tree tree init` when they do not, and
+confirms the tree is still unseeded before Phase 1 begins. The prompt's
+origin is not the gate; the tree's state is.
 
-Once the seed has landed, the same self-check fails and the skill
-refuses; route subsequent source-driven work through `first-tree-write`
-or handle maintenance with a focused task and explicit scope.
+Once the seed has landed (PR1 merged), Step 0's already-seeded check
+fires and the skill refuses; route subsequent source-driven work through
+`first-tree-write`, or handle maintenance with a focused, explicitly-scoped
+task.
 
-### Self-check before starting (all must pass; stop on any failure)
+## Step 0 — Ensure an unseeded tree exists (three states; stop on refuse)
 
-1. **Workspace bound.** `<workspaceRoot>/.first-tree/workspace.json`
-   exists with non-empty `tree` and `sources` fields.
-2. **Tree is empty.** All of:
-   - `<workspaceRoot>/<manifest.tree>/NODE.md` does not exist, **or**
-     exists with no non-whitespace body content beyond an
-     auto-generated placeholder header (Cloud may ship a minimal
-     placeholder root NODE.md in the future; an empty body with only
-     a title still counts as empty).
-   - `<workspaceRoot>/<manifest.tree>/members/` does not exist (or
-     is empty).
-   - No directory directly under `<workspaceRoot>/<manifest.tree>/`
-     other than `.git/`, `.first-tree/`, `.github/`, and any
-     dotfile-prefixed dir.
+Before reading any source, resolve which of three states the team's
+Context Tree is in and act accordingly.
 
-   If any of those fail, the tree is non-empty — refuse with a
-   one-line explanation pointing at `first-tree-write` for incremental
-   source-driven writes or asking for a focused maintenance scope. Do
-   **not** prompt the user to clear the tree
-   yourself; deleting nodes is human-owned.
-3. **All declared sources present on disk.** Each source clone lives at
-   `<workspaceRoot>/<manifest.sourcesRoot>/<manifest.sources[i]>` — the
-   runtime writes `sourcesRoot: "source-repos"`, so the path is
-   `<workspaceRoot>/source-repos/<name>` (a legacy flat manifest omits
-   `sourcesRoot` and keeps sources at `<workspaceRoot>/<name>`). That path
-   must exist for every entry (each is a **bare** clone — see *Materialize
-   source read worktrees* below). A missing source means the workspace is
-   half-provisioned; surface to the user and stop. Do not seed from a
-   partial workspace.
+**A — No tree yet.** The workspace is not bound to a tree: either
+`<workspaceRoot>/.first-tree/workspace.json` has no non-empty `tree`
+field, or the team has no `context_tree` binding. This is the
+agent-driven creation path — create the tree with the user's local `gh`:
+
+```bash
+first-tree tree init --title "<team display name>"
+```
+
+`tree init` creates the repo under the team's GitHub App installation
+account, seeds a minimal valid tree (root `NODE.md`, a `members/` index,
+and the creator's member node), pushes, and binds the org's
+`context_tree` setting. It is **admin-only** and needs an authenticated
+`gh`; if the caller is not an org admin, or `gh` is unauthenticated,
+surface that exact gap and stop (binding a team tree is an admin action).
+Take the team display name from the chat context / `first-tree agent
+status`. After it succeeds the tree is bound and in state **B** — proceed.
+(Make sure the local tree clone is at `<workspaceRoot>/<manifest.tree>` so
+Phase 1 can read and write it; follow the Tree Location protocol in your
+`AGENTS.md` / `CLAUDE.md` briefing if it is not already there.)
+
+**B — Bound but unseeded.** The tree is bound and holds at most the
+bootstrap set — a root `NODE.md`, a `members/` index, and creator member
+node(s) — with **no top-level domain directory** yet. This is the normal
+seed entry, whether the bootstrap came from Step 0's `tree init` above or
+from an earlier provision. Proceed to Phase 1. Phase 1 layers the domain
+skeleton + `raw-context` **on top of** whatever bootstrap nodes already
+exist: **extend** the root `NODE.md` index and the `members/` tree rather
+than recreating them (a bootstrap root node / members index is expected,
+not a conflict).
+
+**C — Already seeded.** The tree has one or more **top-level domain
+directories** — any directory directly under `<workspaceRoot>/<manifest.tree>/`
+other than `.git/`, `.first-tree/`, `.github/`, `members/`, and
+dotfile-prefixed dirs. Refuse with a one-line explanation pointing at
+`first-tree-write` for incremental source-driven writes, or ask for a
+focused maintenance scope. Do **not** delete nodes to force a re-seed —
+that is human-owned.
+
+**In every state, also require all declared sources on disk.** Each source
+clone lives at `<workspaceRoot>/<manifest.sourcesRoot>/<manifest.sources[i]>`
+— the runtime writes `sourcesRoot: "source-repos"`, so the path is
+`<workspaceRoot>/source-repos/<name>` (a legacy flat manifest omits
+`sourcesRoot` and keeps sources at `<workspaceRoot>/<name>`). Every entry
+must exist (each is a **bare** clone — see *Materialize source read
+worktrees* below). A missing source means the workspace is
+half-provisioned; surface to the user and stop. Do not seed from a partial
+workspace.
 
 ### Materialize source read worktrees
 
@@ -689,9 +708,11 @@ make them visible at the seed-specific surface.
 
 ## What This Skill Does NOT Do
 
-- Bind the workspace or provision the tree repo — those are
-  operator actions taken from the web console before this skill is
-  ever invoked.
+- Run the Cloud one-click **server** bootstrap. When the team has no tree
+  (Step 0 state A), seed creates and binds it with `first-tree tree init`
+  (the user's local `gh`), not the server `/initialize` path — the two
+  coexist. Seed does not write the workspace-root `workspace.json`; that
+  stays a runtime concern.
 - Install GitHub automation (validate workflows, rulesets,
   CODEOWNERS) — out of scope. If the team wants those, they are
   separate follow-on workflows after seed lands.


### PR DESCRIPTION
## What

The welcome-v2 launcher (#1389) spawns a "Build your Context Tree" chat that runs `first-tree-seed` to **create, bind, and seed** the tree. Before this, `first-tree-seed` refused an unbound workspace ("binding is an operator/human surface"). This PR gives seed a **Step 0** that self-provisions via the merged `first-tree tree init` (#1379), so the agent-driven build-tree flow works end to end.

Phase C of proposal [first-tree-context#618](https://github.com/agent-team-foundation/first-tree-context/pull/618); the seed half of the Welcome-v2 Phase 1 (welcome orchestration = #1389).

## Change

Reframe the entry gate from the two-state empty-tree self-check into a **three-state Step 0**:

- **A — no tree yet** (workspace not bound / no `context_tree` binding) → run `first-tree tree init --title "<team>" --dir "<workspaceRoot>/<manifest.tree>"` (creates the repo under the App installation account, seeds a minimal valid tree, pushes, binds). `--dir` is load-bearing: `tree init` otherwise checks out to `<cwd>/<repo>`, but a managed workspace reads the tree at `<workspaceRoot>/<manifest.tree>` (usually `context-tree`) and seed doesn't rewrite `workspace.json`. Admin-only + needs authenticated `gh`; otherwise surface the gap and stop.
- **B — bound but unseeded** (bootstrap root/members, no top-level domains) → proceed to Phase 1. Phase 1 **extends** the bootstrap root node / `members/` index rather than recreating them.
- **C — already seeded** (top-level domain dirs) → refuse (unchanged).

Also flips the "does not do" boundary (seed self-provisions via `tree init`, not the server `/initialize` — the two coexist) and updates the description / intro / when-to-use framing.

## Eval coverage (Step 0 / state A)

The seed skill-eval gains an `unbound` state + a `unbound-tree-inits-with-dir` gate case (floor now 5 gate cases). The grader passes **only** when the agent invokes `first-tree tree init` with a `--dir` whose basename is `context-tree` — omitting `--dir` (default `<team>-context-tree` checkout) or a wrong `--dir` fails, catching the handoff regression; real repo creation stays a forbidden side effect. Verified: typecheck + biome clean, seed suite unit tests 33/33, floor validation, and the **real codex eval graded the case PASS**.

## Coordination
- Paired with **#1389** (welcome v2, green) — welcome does not merge before this; seed lands first or together.
- Paired active-tree update: **[first-tree-context#660](https://github.com/agent-team-foundation/first-tree-context/pull/660)** — `onboarding.md` records the combined welcome-launcher + build-tree-first-class + fan-out contract that this seed Step 0 is the seed half of.
- Phase-2 `/initialize` retirement (collides with #618 Phase D) is out of scope here and stays coordinated with the tree-init line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)