### PR TITLE
Add Phase 0.5 client switch safety gates

### DIFF
--- a/apps/cli/src/__tests__/client-switch-gates.test.ts
+++ b/apps/cli/src/__tests__/client-switch-gates.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   assertDaemonStartupAllowedDuringClientSwitch,
   assertSameDeviceMove,
+  authorizeDifferentUserLoginSwitch,
+  ClientSwitchAuthorizationError,
   ClientSwitchFilesystemError,
   ClientSwitchMaintenanceError,
   ClientSwitchServiceError,
@@ -85,6 +87,32 @@ describe("client switch service supervisor gate", () => {
         }),
       }),
     ).toThrow("daemon service stop failed before client switch: permission denied");
+  });
+});
+
+describe("client switch login authorization", () => {
+  it("requires --force-switch for different-user login in non-interactive contexts", () => {
+    expect(() => authorizeDifferentUserLoginSwitch({ forceSwitch: false, isInteractive: false })).toThrow(
+      ClientSwitchAuthorizationError,
+    );
+  });
+
+  it("treats --force-switch as interrupt authorization, not a safety-gate bypass", () => {
+    expect(authorizeDifferentUserLoginSwitch({ forceSwitch: true, isInteractive: false })).toEqual({
+      mode: "force-switch",
+      interruptRuntime: true,
+      createsNewClientIdForNewUser: true,
+      bypassesSafetyGates: false,
+    });
+  });
+
+  it("allows the interactive path to ask for an explicit switch confirmation", () => {
+    expect(authorizeDifferentUserLoginSwitch({ forceSwitch: false, isInteractive: true })).toEqual({
+      mode: "interactive-confirmation",
+      interruptRuntime: true,
+      createsNewClientIdForNewUser: true,
+      bypassesSafetyGates: false,
+    });
   });
 });
 

--- a/apps/cli/src/__tests__/client-switch-gates.test.ts
+++ b/apps/cli/src/__tests__/client-switch-gates.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  assertDaemonStartupAllowedDuringClientSwitch,
+  assertSameDeviceMove,
+  ClientSwitchFilesystemError,
+  ClientSwitchMaintenanceError,
+  ClientSwitchServiceError,
+  readClientSwitchMaintenanceState,
+  renameSameDeviceDirectory,
+  stopServiceForClientSwitch,
+} from "../core/client-switch-gates.js";
+
+describe("client switch maintenance gate", () => {
+  it("reports lock and journal paths without touching root config/data", () => {
+    const home = "/tmp/first-tree";
+    const exists = vi.fn((path: string) => path.endsWith("client-switch.lock"));
+
+    expect(readClientSwitchMaintenanceState(home, { exists })).toEqual({
+      home,
+      stateDir: "/tmp/first-tree/state",
+      lockPath: "/tmp/first-tree/state/client-switch.lock",
+      journalPath: "/tmp/first-tree/state/client-switch-journal.json",
+      parkedClientsDir: "/tmp/first-tree/parked-clients",
+      lockExists: true,
+      journalExists: false,
+      blocked: true,
+      reason: "lock",
+    });
+    expect(exists).toHaveBeenCalledWith("/tmp/first-tree/state/client-switch.lock");
+    expect(exists).toHaveBeenCalledWith("/tmp/first-tree/state/client-switch-journal.json");
+  });
+
+  it("blocks daemon startup while switch journal recovery is pending", () => {
+    expect(() =>
+      assertDaemonStartupAllowedDuringClientSwitch("/tmp/first-tree", {
+        exists: (path) => path.endsWith("client-switch-journal.json"),
+      }),
+    ).toThrow(ClientSwitchMaintenanceError);
+  });
+});
+
+describe("client switch service supervisor gate", () => {
+  it("accepts inactive service state after stop", () => {
+    const status = {
+      platform: "systemd" as const,
+      state: "inactive" as const,
+      label: "first-tree.service",
+      unitPath: "/unit",
+      logDir: "/logs",
+    };
+    expect(
+      stopServiceForClientSwitch({
+        stop: () => ({ ok: true }),
+        status: () => status,
+      }),
+    ).toBe(status);
+  });
+
+  it("aborts when service stop succeeds but supervisor still reports active", () => {
+    expect(() =>
+      stopServiceForClientSwitch({
+        stop: () => ({ ok: true }),
+        status: () => ({
+          platform: "launchd",
+          state: "active",
+          label: "dev.first-tree",
+          unitPath: "/plist",
+          detail: "pid 123",
+          logDir: "/logs",
+        }),
+      }),
+    ).toThrow(ClientSwitchServiceError);
+  });
+
+  it("aborts when service stop itself fails", () => {
+    expect(() =>
+      stopServiceForClientSwitch({
+        stop: () => ({ ok: false, reason: "permission denied" }),
+        status: () => ({
+          platform: "systemd",
+          state: "inactive",
+          label: "first-tree.service",
+          unitPath: "/unit",
+          logDir: "/logs",
+        }),
+      }),
+    ).toThrow("daemon service stop failed before client switch: permission denied");
+  });
+});
+
+describe("client switch filesystem gate", () => {
+  const move = { name: "park-root-data", from: "/home/ft/data", to: "/home/ft/parked-clients/client_A/data" };
+
+  it("allows same-device directory rename preflight", () => {
+    expect(() =>
+      assertSameDeviceMove(move, {
+        stat: (path) => ({ dev: path === "/home/ft/data" ? 7 : 7 }),
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects cross-device moves before rename", () => {
+    expect(() =>
+      assertSameDeviceMove(move, {
+        stat: (path) => ({ dev: path === "/home/ft/data" ? 7 : 8 }),
+      }),
+    ).toThrow(ClientSwitchFilesystemError);
+  });
+
+  it("does not convert EXDEV into an implicit copy fallback", () => {
+    const rename = vi.fn(() => {
+      throw Object.assign(new Error("cross-device link"), { code: "EXDEV" });
+    });
+
+    expect(() =>
+      renameSameDeviceDirectory(move, {
+        stat: () => ({ dev: 7 }),
+        rename,
+      }),
+    ).toThrow("crossed devices during rename; refusing implicit copy");
+    expect(rename).toHaveBeenCalledWith(move.from, move.to);
+  });
+});

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -19,6 +19,8 @@ const clientMocks = vi.hoisted(() => ({
 const coreMocks = vi.hoisted(() => ({
   CapabilityRefresher: vi.fn(),
   ClientRuntime: vi.fn(),
+  ClientSwitchMaintenanceError: class ClientSwitchMaintenanceError extends Error {},
+  assertDaemonStartupAllowedDuringClientSwitch: vi.fn(),
   createApiNameResolver: vi.fn(),
   createExecuteUpdate: vi.fn(),
   createLoggerRuntimeOutput: vi.fn(),
@@ -109,7 +111,9 @@ beforeEach(() => {
   delete process.env.FIRST_TREE_SERVICE_MODE;
 
   for (const mock of Object.values(clientMocks)) mock.mockReset();
-  for (const mock of Object.values(coreMocks)) mock.mockReset();
+  for (const mock of Object.values(coreMocks)) {
+    if (typeof mock === "function" && "mockReset" in mock) mock.mockReset();
+  }
   failMock.mockClear();
   stderrSpy.mockClear();
 
@@ -135,6 +139,7 @@ beforeEach(() => {
     logDir: join(home, "logs"),
   });
   coreMocks.startClientService.mockReturnValue({ ok: true });
+  coreMocks.assertDaemonStartupAllowedDuringClientSwitch.mockImplementation(() => undefined);
   coreMocks.ensureFreshAccessToken.mockResolvedValue("access-token");
   coreMocks.listPinnedAgents.mockResolvedValue([
     { agentId: "agent-1", clientId: "client_1234abcd", runtimeProvider: "claude-code", status: "active" },
@@ -214,6 +219,38 @@ function output(): string {
 }
 
 describe("daemon start command", () => {
+  it("blocks before credentials when a client switch maintenance file exists", async () => {
+    coreMocks.assertDaemonStartupAllowedDuringClientSwitch.mockImplementationOnce(() => {
+      throw new coreMocks.ClientSwitchMaintenanceError(
+        "client switch in progress; daemon startup is blocked before reading root client state",
+      );
+    });
+
+    await expect(runStart()).rejects.toMatchObject({ exitCode: 1 });
+    expect(coreMocks.loadCredentials).not.toHaveBeenCalled();
+    expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
+    expect(output()).toContain("client switch in progress");
+  });
+
+  it("lets supervisor restart attempts exit cleanly during client switch maintenance", async () => {
+    const daemonLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    clientMocks.createLogger.mockReturnValue(daemonLogger);
+    process.env.FIRST_TREE_SERVICE_MODE = "1";
+    coreMocks.assertDaemonStartupAllowedDuringClientSwitch.mockImplementationOnce(() => {
+      throw new coreMocks.ClientSwitchMaintenanceError(
+        "client switch in progress; daemon startup is blocked before reading root client state",
+      );
+    });
+
+    await expect(runStart(["--no-interactive"])).rejects.toMatchObject({ exitCode: 0 });
+    expect(coreMocks.loadCredentials).not.toHaveBeenCalled();
+    expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
+    expect(daemonLogger.warn).toHaveBeenCalledWith(
+      "⚠️ client switch in progress; daemon startup is blocked before reading root client state",
+    );
+    expect(output()).toBe("");
+  });
+
   it("fails closed when credentials are missing", async () => {
     coreMocks.loadCredentials.mockReturnValueOnce(null);
 

--- a/apps/cli/src/__tests__/login-command.test.ts
+++ b/apps/cli/src/__tests__/login-command.test.ts
@@ -58,6 +58,7 @@ vi.mock("../core/update-glue.js", async (importOriginal) => ({
 
 const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
 const originalServerUrl = process.env.FIRST_TREE_SERVER_URL;
+const originalStdinIsTTY = process.stdin.isTTY;
 
 let home: string;
 let runtimeInstance: {
@@ -103,11 +104,16 @@ function writeCredentials(memberId: string, serverUrl = "http://old.test", sub =
   );
 }
 
+function setStdinIsTTY(value: boolean | undefined): void {
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value });
+}
+
 beforeEach(() => {
   vi.resetModules();
   home = join(tmpdir(), `ft-login-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(join(home, "config"), { recursive: true });
   process.env.FIRST_TREE_HOME = home;
+  setStdinIsTTY(false);
   delete process.env.FIRST_TREE_SERVER_URL;
   cliFetchMock.mockReset();
   installClientServiceMock.mockReset();
@@ -148,6 +154,7 @@ afterEach(() => {
   else process.env.FIRST_TREE_HOME = originalFirstTreeHome;
   if (originalServerUrl === undefined) delete process.env.FIRST_TREE_SERVER_URL;
   else process.env.FIRST_TREE_SERVER_URL = originalServerUrl;
+  setStdinIsTTY(originalStdinIsTTY);
   process.exitCode = undefined;
 });
 
@@ -175,7 +182,7 @@ describe("login command", { timeout: 15_000 }, () => {
     expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("--no-start");
   });
 
-  it("rejects cross-account login before overwriting local credentials", async () => {
+  it("requires --force-switch for non-interactive cross-account login before overwriting local credentials", async () => {
     const yamlPath = join(home, "config", "client.yaml");
     writeFileSync(yamlPath, "client:\n  id: client_aabbccdd\n");
     writeCredentials("member-old", "http://first-tree.test", "user-old");
@@ -189,8 +196,29 @@ describe("login command", { timeout: 15_000 }, () => {
     expect(readFileSync(yamlPath, "utf8")).toContain("client_aabbccdd");
     expect(installClientServiceMock).not.toHaveBeenCalled();
     const output = stderrMock.mock.calls.map((call) => String(call[0])).join("");
-    expect(output).toContain("ACCOUNT_SWITCH_REQUIRES_PURGE");
-    expect(output).toContain("first-tree-dev logout --purge");
+    expect(output).toContain("CLIENT_SWITCH_REQUIRES_FORCE_SWITCH");
+    expect(output).toContain("first-tree-dev login <token> --force-switch");
+    expect(output).toContain("may stop the current daemon, agents, and provider turn");
+  });
+
+  it("accepts --force-switch as interrupt authorization but still refuses the unimplemented root-state switch", async () => {
+    const yamlPath = join(home, "config", "client.yaml");
+    writeFileSync(yamlPath, "client:\n  id: client_aabbccdd\n");
+    writeCredentials("member-old", "http://first-tree.test", "user-old");
+
+    await expect(
+      runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--force-switch", "--no-start"]),
+    ).rejects.toThrow("process.exit");
+
+    expect(cliFetchMock).toHaveBeenCalledTimes(1);
+    expect(readFileSync(credentialsPath(), "utf8")).toContain("old-refresh");
+    expect(readFileSync(yamlPath, "utf8")).toContain("client_aabbccdd");
+    expect(installClientServiceMock).not.toHaveBeenCalled();
+    const output = stderrMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("CLIENT_SWITCH_NOT_IMPLEMENTED");
+    expect(output).toContain("authorized by --force-switch");
+    expect(output).toContain("new First Tree user must receive a separate");
+    expect(output).toContain("Safety gates are not bypassed by --force-switch");
   });
 
   it("allows same-user reauth without rotating the client identity", async () => {
@@ -291,6 +319,8 @@ describe("login command", { timeout: 15_000 }, () => {
     exitMock.mockClear();
     writeCredentials("member-old");
     await expect(runLogin(["login", jwt({ iss: "http://hub.test" })])).rejects.toThrow("process.exit");
-    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("ACCOUNT_SWITCH_REQUIRES_PURGE");
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "CLIENT_SWITCH_REQUIRES_FORCE_SWITCH",
+    );
   });
 });

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -26,8 +26,10 @@ import { CLIENT_SENTRY_DSN, GIT_SHA } from "../../build-info.js";
 import { fail } from "../../cli/output.js";
 import { channelConfig } from "../../core/channel.js";
 import {
+  assertDaemonStartupAllowedDuringClientSwitch,
   CapabilityRefresher,
   ClientRuntime,
+  ClientSwitchMaintenanceError,
   COMMAND_VERSION,
   createApiNameResolver,
   createExecuteUpdate,
@@ -83,6 +85,15 @@ export function registerDaemonStartCommand(daemon: Command): void {
         }
         process.exit(1);
       };
+      try {
+        assertDaemonStartupAllowedDuringClientSwitch(defaultHome());
+      } catch (err) {
+        if (err instanceof ClientSwitchMaintenanceError) {
+          writeStatus("⚠️", err.message);
+          process.exit(isSupervisorChild ? 0 : 1);
+        }
+        throw err;
+      }
       // Compatibility, not management: a launchd / systemd daemon does not inherit
       // the user's login-shell environment, so load the user-owned
       // `~/.first-tree/daemon.env` (if present) into our env BEFORE the runtime

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -15,7 +15,10 @@ import type { Command } from "commander";
 import { fail } from "../cli/output.js";
 import { channelConfig } from "../core/channel.js";
 import {
+  authorizeDifferentUserLoginSwitch,
   ClientRuntime,
+  ClientSwitchAuthorizationError,
+  type ClientSwitchLoginAuthorization,
   COMMAND_VERSION,
   cliFetch,
   createApiNameResolver,
@@ -50,19 +53,42 @@ function formatServiceLine(): string {
   return "not installed";
 }
 
-function rejectAccountSwitch(opts: { reason: string; serverUrl?: string }): never {
-  const purgeCommand = `${channelConfig.binName} logout --purge`;
+function rejectAccountSwitch(opts: {
+  reason: string;
+  serverUrl?: string;
+  authorization?: ClientSwitchLoginAuthorization;
+  authorizationError?: ClientSwitchAuthorizationError;
+}): never {
+  const switchCommand = `${channelConfig.binName} login <token> --force-switch`;
   print.line("\n  This computer already has First Tree login state for another or unknown user.\n\n");
   if (opts.serverUrl) print.line(`       Existing server:    ${opts.serverUrl}\n`);
   print.line(`       Background service: ${formatServiceLine()}\n\n`);
-  print.line("  Refusing to overwrite local credentials or reuse this machine's client identity.\n");
-  print.line(`  To switch accounts, run \`${purgeCommand}\` first, then login again.\n\n`);
-  print.line("  `logout --purge` stops the current daemon, signs out the current user, and\n");
-  print.line("  removes this machine's local client identity plus local agent configs,\n");
-  print.line("  workspaces, and session state. Server-side clients, agents, chats, and\n");
-  print.line("  history are not deleted; the previous client and agents simply stop running\n");
-  print.line("  from this machine unless they are set up again.\n\n");
-  fail("ACCOUNT_SWITCH_REQUIRES_PURGE", opts.reason, 1);
+  print.line("  Refusing to overwrite local credentials or reuse this machine's client identity.\n\n");
+
+  if (opts.authorizationError) {
+    print.line("  Different-user login changes the active First Tree user on this computer.\n");
+    print.line("  In non-interactive contexts this requires explicit authorization because it\n");
+    print.line("  may stop the current daemon, agents, and provider turn.\n\n");
+    print.line(`  Re-run with \`${switchCommand}\` to authorize the switch attempt.\n\n`);
+    fail(opts.authorizationError.code, opts.authorizationError.message, 1);
+  }
+
+  if (opts.authorization) {
+    const mode = opts.authorization.mode === "force-switch" ? "authorized by --force-switch" : "approved interactively";
+    print.line(`  Account switch ${mode}: the switch may interrupt the current daemon,\n`);
+    print.line("  agents, and provider turn. A new First Tree user must receive a separate\n");
+    print.line("  local client id; the existing client id is not transferred or reused.\n\n");
+    print.line("  This Phase 0.5 build has the safety gates but not the root state\n");
+    print.line("  park/restore transaction, so it cannot complete the switch yet.\n");
+    print.line("  Safety gates are not bypassed by --force-switch.\n\n");
+    fail(
+      "CLIENT_SWITCH_NOT_IMPLEMENTED",
+      `${opts.reason} Controlled client switch is not implemented in this build.`,
+      1,
+    );
+  }
+
+  fail("CLIENT_SWITCH_NOT_IMPLEMENTED", opts.reason, 1);
 }
 
 async function exchangeToken(url: string, token: string): Promise<{ accessToken: string; refreshToken: string }> {
@@ -86,16 +112,21 @@ async function exchangeToken(url: string, token: string): Promise<{ accessToken:
  *
  * Account switches are fail-closed when credentials already exist. The stored
  * access token owner is compared with the new server-issued access token's
- * `sub` claim; a mismatch must go through `logout --purge` before logging in
- * again. Without credentials, login preserves the local client identity so a
- * normal `logout` can be followed by same-user reconnect.
+ * `sub` claim; a mismatch must go through controlled local-client switch, not
+ * credential overwrite or client-id reuse. Without credentials, login preserves
+ * the local client identity so a normal `logout` can be followed by same-user
+ * reconnect.
  */
 export function registerLoginCommand(program: Command): void {
   program
     .command("login <token>")
     .description("Sign this computer into First Tree using a token from the web console")
     .option("--no-start", "Skip background daemon install/start (writes credentials and exits)")
-    .action(async (token: string, options: { start?: boolean }) => {
+    .option(
+      "--force-switch",
+      "Authorize a different First Tree user to become active here; may interrupt the current runtime",
+    )
+    .action(async (token: string, options: { forceSwitch?: boolean; start?: boolean }) => {
       try {
         let url: string;
         try {
@@ -117,10 +148,23 @@ export function registerLoginCommand(program: Command): void {
           fail("AUTH_ERROR", "Server access token is missing the required `sub` claim.", 1);
         }
         if (existingCredentials && (!previousOwnerSub || previousOwnerSub !== newOwnerSub)) {
+          let authorization: ClientSwitchLoginAuthorization | undefined;
+          let authorizationError: ClientSwitchAuthorizationError | undefined;
+          try {
+            authorization = authorizeDifferentUserLoginSwitch({
+              forceSwitch: options.forceSwitch === true,
+              isInteractive: process.stdin.isTTY === true,
+            });
+          } catch (err) {
+            if (err instanceof ClientSwitchAuthorizationError) authorizationError = err;
+            else throw err;
+          }
           rejectAccountSwitch({
             reason:
               "This connect token belongs to a different user than the credentials already stored on this machine.",
             serverUrl: existingCredentials.serverUrl,
+            authorization,
+            authorizationError,
           });
         }
 

--- a/apps/cli/src/core/client-switch-gates.ts
+++ b/apps/cli/src/core/client-switch-gates.ts
@@ -46,6 +46,25 @@ export class ClientSwitchFilesystemError extends Error {
   }
 }
 
+export type ClientSwitchLoginAuthorizationMode = "interactive-confirmation" | "force-switch";
+
+export type ClientSwitchLoginAuthorization = {
+  mode: ClientSwitchLoginAuthorizationMode;
+  interruptRuntime: true;
+  createsNewClientIdForNewUser: true;
+  bypassesSafetyGates: false;
+};
+
+export class ClientSwitchAuthorizationError extends Error {
+  constructor(
+    readonly code: "CLIENT_SWITCH_REQUIRES_FORCE_SWITCH",
+    message: string,
+  ) {
+    super(message);
+    this.name = "ClientSwitchAuthorizationError";
+  }
+}
+
 type ExistsFn = (path: string) => boolean;
 
 export function clientSwitchPaths(home = defaultHome()): ClientSwitchPaths {
@@ -116,6 +135,32 @@ export function stopServiceForClientSwitch(deps: {
   const after = deps.status();
   assertServiceInactiveForClientSwitch(after);
   return after;
+}
+
+export function authorizeDifferentUserLoginSwitch(options: {
+  forceSwitch: boolean;
+  isInteractive: boolean;
+}): ClientSwitchLoginAuthorization {
+  if (options.forceSwitch) {
+    return {
+      mode: "force-switch",
+      interruptRuntime: true,
+      createsNewClientIdForNewUser: true,
+      bypassesSafetyGates: false,
+    };
+  }
+  if (!options.isInteractive) {
+    throw new ClientSwitchAuthorizationError(
+      "CLIENT_SWITCH_REQUIRES_FORCE_SWITCH",
+      "different-user login would switch this computer's active First Tree user; rerun with --force-switch to authorize interrupting the current runtime in a non-interactive context",
+    );
+  }
+  return {
+    mode: "interactive-confirmation",
+    interruptRuntime: true,
+    createsNewClientIdForNewUser: true,
+    bypassesSafetyGates: false,
+  };
 }
 
 export type DirectoryMovePlan = {

--- a/apps/cli/src/core/client-switch-gates.ts
+++ b/apps/cli/src/core/client-switch-gates.ts
@@ -1,0 +1,178 @@
+import { existsSync, renameSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { defaultHome } from "@first-tree/shared/config";
+import type { ServiceInfo, ServiceOpResult } from "./service-install.js";
+
+export type ClientSwitchPaths = {
+  home: string;
+  stateDir: string;
+  lockPath: string;
+  journalPath: string;
+  parkedClientsDir: string;
+};
+
+export type ClientSwitchMaintenanceState = ClientSwitchPaths & {
+  lockExists: boolean;
+  journalExists: boolean;
+  blocked: boolean;
+  reason: "lock" | "journal" | "lock-and-journal" | null;
+};
+
+export class ClientSwitchMaintenanceError extends Error {
+  constructor(readonly state: ClientSwitchMaintenanceState) {
+    super(formatMaintenanceBlockedMessage(state));
+    this.name = "ClientSwitchMaintenanceError";
+  }
+}
+
+export class ClientSwitchServiceError extends Error {
+  constructor(
+    message: string,
+    readonly service?: Pick<ServiceInfo, "platform" | "state" | "detail" | "label">,
+  ) {
+    super(message);
+    this.name = "ClientSwitchServiceError";
+  }
+}
+
+export class ClientSwitchFilesystemError extends Error {
+  constructor(
+    message: string,
+    readonly move?: DirectoryMovePlan,
+    readonly causeCode?: string,
+  ) {
+    super(message);
+    this.name = "ClientSwitchFilesystemError";
+  }
+}
+
+type ExistsFn = (path: string) => boolean;
+
+export function clientSwitchPaths(home = defaultHome()): ClientSwitchPaths {
+  const stateDir = join(home, "state");
+  return {
+    home,
+    stateDir,
+    lockPath: join(stateDir, "client-switch.lock"),
+    journalPath: join(stateDir, "client-switch-journal.json"),
+    parkedClientsDir: join(home, "parked-clients"),
+  };
+}
+
+export function readClientSwitchMaintenanceState(
+  home = defaultHome(),
+  deps: { exists?: ExistsFn } = {},
+): ClientSwitchMaintenanceState {
+  const paths = clientSwitchPaths(home);
+  const exists = deps.exists ?? existsSync;
+  const lockExists = exists(paths.lockPath);
+  const journalExists = exists(paths.journalPath);
+  const reason =
+    lockExists && journalExists ? "lock-and-journal" : lockExists ? "lock" : journalExists ? "journal" : null;
+  return {
+    ...paths,
+    lockExists,
+    journalExists,
+    blocked: reason !== null,
+    reason,
+  };
+}
+
+export function assertDaemonStartupAllowedDuringClientSwitch(
+  home = defaultHome(),
+  deps: { exists?: ExistsFn } = {},
+): void {
+  const state = readClientSwitchMaintenanceState(home, deps);
+  if (state.blocked) throw new ClientSwitchMaintenanceError(state);
+}
+
+function formatMaintenanceBlockedMessage(state: ClientSwitchMaintenanceState): string {
+  if (state.reason === "lock") {
+    return `client switch in progress (${state.lockPath}); daemon startup is blocked before reading root client state`;
+  }
+  if (state.reason === "journal") {
+    return `client switch recovery required (${state.journalPath}); daemon startup is blocked before reading root client state`;
+  }
+  return `client switch in progress (${state.lockPath}, ${state.journalPath}); daemon startup is blocked before reading root client state`;
+}
+
+export function assertServiceInactiveForClientSwitch(service: ServiceInfo): void {
+  if (service.state === "inactive" || service.state === "not-installed") return;
+  const detail = service.detail ? `: ${service.detail}` : "";
+  throw new ClientSwitchServiceError(
+    `daemon service must be inactive before client switch; observed ${service.platform} state=${service.state}${detail}`,
+    service,
+  );
+}
+
+export function stopServiceForClientSwitch(deps: {
+  stop: () => ServiceOpResult;
+  status: () => ServiceInfo;
+}): ServiceInfo {
+  const stopped = deps.stop();
+  if (!stopped.ok) {
+    throw new ClientSwitchServiceError(`daemon service stop failed before client switch: ${stopped.reason}`);
+  }
+  const after = deps.status();
+  assertServiceInactiveForClientSwitch(after);
+  return after;
+}
+
+export type DirectoryMovePlan = {
+  name: string;
+  from: string;
+  to: string;
+};
+
+type StatLike = { dev: number };
+type RenameDeps = {
+  stat?: (path: string) => StatLike;
+  rename?: (from: string, to: string) => void;
+};
+
+function statDevice(path: string, move: DirectoryMovePlan, stat: (path: string) => StatLike): number {
+  try {
+    return stat(path).dev;
+  } catch (err) {
+    throw new ClientSwitchFilesystemError(
+      `cannot stat ${path} for client switch move ${move.name}: ${err instanceof Error ? err.message : String(err)}`,
+      move,
+    );
+  }
+}
+
+export function assertSameDeviceMove(move: DirectoryMovePlan, deps: RenameDeps = {}): void {
+  const stat = deps.stat ?? statSync;
+  const fromDev = statDevice(move.from, move, stat);
+  const targetParent = dirname(move.to);
+  const toParentDev = statDevice(targetParent, move, stat);
+  if (fromDev !== toParentDev) {
+    throw new ClientSwitchFilesystemError(
+      `client switch move ${move.name} crosses devices (${move.from} dev=${fromDev}, ${targetParent} dev=${toParentDev}); refusing implicit copy`,
+      move,
+      "EXDEV",
+    );
+  }
+}
+
+export function assertSameDeviceMovePlan(moves: readonly DirectoryMovePlan[], deps: RenameDeps = {}): void {
+  for (const move of moves) assertSameDeviceMove(move, deps);
+}
+
+export function renameSameDeviceDirectory(move: DirectoryMovePlan, deps: RenameDeps = {}): void {
+  assertSameDeviceMove(move, deps);
+  const rename = deps.rename ?? renameSync;
+  try {
+    rename(move.from, move.to);
+  } catch (err) {
+    const code = typeof err === "object" && err && "code" in err ? String((err as { code?: unknown }).code) : undefined;
+    if (code === "EXDEV") {
+      throw new ClientSwitchFilesystemError(
+        `client switch move ${move.name} crossed devices during rename; refusing implicit copy`,
+        move,
+        "EXDEV",
+      );
+    }
+    throw err;
+  }
+}

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -23,12 +23,19 @@ export { handleClientOrgMismatch } from "./client-reidentify.js";
 export type { ClientRuntimeOptions, ClientRuntimeOutput } from "./client-runtime.js";
 // Client runtime
 export { ClientRuntime, createLoggerRuntimeOutput } from "./client-runtime.js";
-export type { ClientSwitchMaintenanceState, ClientSwitchPaths, DirectoryMovePlan } from "./client-switch-gates.js";
+export type {
+  ClientSwitchLoginAuthorization,
+  ClientSwitchMaintenanceState,
+  ClientSwitchPaths,
+  DirectoryMovePlan,
+} from "./client-switch-gates.js";
 export {
   assertDaemonStartupAllowedDuringClientSwitch,
   assertSameDeviceMove,
   assertSameDeviceMovePlan,
   assertServiceInactiveForClientSwitch,
+  authorizeDifferentUserLoginSwitch,
+  ClientSwitchAuthorizationError,
   ClientSwitchFilesystemError,
   ClientSwitchMaintenanceError,
   ClientSwitchServiceError,

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -23,6 +23,20 @@ export { handleClientOrgMismatch } from "./client-reidentify.js";
 export type { ClientRuntimeOptions, ClientRuntimeOutput } from "./client-runtime.js";
 // Client runtime
 export { ClientRuntime, createLoggerRuntimeOutput } from "./client-runtime.js";
+export type { ClientSwitchMaintenanceState, ClientSwitchPaths, DirectoryMovePlan } from "./client-switch-gates.js";
+export {
+  assertDaemonStartupAllowedDuringClientSwitch,
+  assertSameDeviceMove,
+  assertSameDeviceMovePlan,
+  assertServiceInactiveForClientSwitch,
+  ClientSwitchFilesystemError,
+  ClientSwitchMaintenanceError,
+  ClientSwitchServiceError,
+  clientSwitchPaths,
+  readClientSwitchMaintenanceState,
+  renameSameDeviceDirectory,
+  stopServiceForClientSwitch,
+} from "./client-switch-gates.js";
 // User-owned daemon environment (proxy etc.) — read, never written by us
 export { daemonEnvPath, loadDaemonEnv, parseDaemonEnv } from "./daemon-env.js";
 // Diagnostics (doctor)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -53,21 +53,29 @@ first-tree
 ## login
 
 ```
-first-tree login <token> [--no-start]
+first-tree login <token> [--no-start] [--force-switch]
 ```
 
 Sign this computer in using a connect token from the web console. The
 token's `iss` claim carries the server URL — no `--server` flag needed,
 and switching to a different deployment only requires a fresh token.
 If this machine already has credentials for another user, `login` refuses to
-overwrite them. If credentials are missing, `login` preserves `client.yaml` and
-local agent state so the same user can reconnect after a normal `logout`. Switch
-accounts by running `first-tree logout --purge` first, then login with the new
-token.
+overwrite them or reuse the existing client id. If credentials are missing,
+`login` preserves `client.yaml` and local agent state so the same user can
+reconnect after a normal `logout`.
+
+Switching this computer to a different First Tree user is a controlled local
+client switch: the current daemon/agents may be interrupted, the old user's
+root state is preserved, and the new user gets a separate local client id. In a
+non-interactive shell, `--force-switch` is required to authorize that switch
+attempt; it does not bypass provider-drain, service, filesystem, or recovery
+safety gates. Until the root-state park/restore transaction is available,
+different-user login fails closed rather than overwriting local credentials.
 
 | Flag | Effect |
 |---|---|
 | `--no-start` | Write credentials and exit without installing/starting the background daemon. |
+| `--force-switch` | Authorize a different First Tree user to become active on this computer in non-interactive contexts. May interrupt the current runtime; does not bypass switch safety gates. |
 
 ## logout
 
@@ -77,12 +85,12 @@ first-tree logout [--purge]
 
 Stop the daemon and clear credentials. `--purge` additionally removes
 `client.yaml`, local agent configs, agent workspaces, and session state. Use
-`--purge` before switching this machine to a different account. The purge is
-local-only: server-side clients, agents, chats, and history are not deleted,
-but the previous client and agents stop running from this machine unless they
-are set up again. If the daemon is active and cannot be stopped, `--purge`
-refuses to delete local agent state. The default keeps local client/agent state
-for the same user to reconnect later.
+`--purge` as a destructive local computer reset, not as the ordinary account
+switch path. The purge is local-only: server-side clients, agents, chats, and
+history are not deleted, but the previous client and agents stop running from
+this machine unless they are set up again. If the daemon is active and cannot
+be stopped, `--purge` refuses to delete local agent state. The default keeps
+local client/agent state for the same user to reconnect later.
 
 ## status
 

--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -428,7 +428,7 @@ describe("formatInboundContent", () => {
 });
 
 describe("buildAgentEnv", () => {
-  it("layers the four First Tree envelope vars on top of parent env (parent wins on unrelated keys)", () => {
+  it("layers the First Tree envelope vars on top of parent env (parent wins on unrelated keys)", () => {
     const parent = { PATH: "/usr/bin", FOO: "bar" } as NodeJS.ProcessEnv;
     const env = buildAgentEnv(parent, {
       sdk: { serverUrl: "http://first-tree" },
@@ -442,10 +442,12 @@ describe("buildAgentEnv", () => {
         metadata: {},
       },
       chatId: "chat-1",
+      clientId: "client-a",
     });
     expect(env.PATH).toBe("/usr/bin");
     expect(env.FOO).toBe("bar");
     expect(env.FIRST_TREE_SERVER_URL).toBe("http://first-tree");
+    expect(env.FIRST_TREE_CLIENT_ID).toBe("client-a");
     expect(env.FIRST_TREE_AGENT_ID).toBe("agent-a");
     expect(env.FIRST_TREE_INBOX_ID).toBe("inbox-a");
     expect(env.FIRST_TREE_CHAT_ID).toBe("chat-1");

--- a/packages/client/src/__tests__/process-tree-probe.test.ts
+++ b/packages/client/src/__tests__/process-tree-probe.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  assertProviderDrainClear,
   buildChildrenIndex,
   extractChatId,
+  extractEnvValue,
   findProviderPids,
   hasDescendant,
+  OsProviderDrainSource,
   PsSubprocessProbe,
   parseProcessRows,
+  providerNameForComm,
 } from "../runtime/process-tree-probe.js";
 import { silentLogger } from "./_logger-helpers.js";
 
@@ -52,6 +56,15 @@ describe("process-tree-probe pure helpers", () => {
     );
     // The value must not bleed into the next NUL-separated entry.
     expect(extractChatId(environ)).toBe("f93566d9-00c8");
+  });
+
+  it("extracts arbitrary FIRST_TREE env values and provider names", () => {
+    const environ = ["FIRST_TREE_CLIENT_ID=client_a", "FIRST_TREE_HOME=/tmp/first-tree", ""].join("\0");
+    expect(extractEnvValue(environ, "FIRST_TREE_CLIENT_ID")).toBe("client_a");
+    expect(extractEnvValue(environ, "FIRST_TREE_HOME")).toBe("/tmp/first-tree");
+    expect(providerNameForComm("/opt/homebrew/bin/codex")).toBe("codex");
+    expect(providerNameForComm("/opt/homebrew/bin/claude")).toBe("claude");
+    expect(providerNameForComm("/bin/zsh")).toBeNull();
   });
 });
 
@@ -110,5 +123,127 @@ describe("PsSubprocessProbe", () => {
     await probe.refresh();
     expect(probe.hasLiveSubprocess("chat-A")).toBe(false);
     probe.stop();
+  });
+});
+
+describe("OsProviderDrainSource", () => {
+  const snapshot = [
+    "100  1 /opt/homebrew/bin/claude",
+    "101 100 /bin/zsh",
+    "102 101 sleep",
+    "200  1 /usr/local/bin/codex",
+    "300  1 /usr/local/bin/codex",
+  ].join("\n");
+
+  const envForPid = async (pid: number): Promise<string> => {
+    if (pid === 100) {
+      return ["FIRST_TREE_CLIENT_ID=client_A", "FIRST_TREE_AGENT_ID=agent-A", "FIRST_TREE_CHAT_ID=chat-A"].join("\0");
+    }
+    if (pid === 200) {
+      return ["FIRST_TREE_CLIENT_ID=client_B", "FIRST_TREE_AGENT_ID=agent-B", "FIRST_TREE_CHAT_ID=chat-B"].join("\0");
+    }
+    return ["FIRST_TREE_HOME=/tmp/first-tree", "FIRST_TREE_AGENT_ID=agent-old"].join("\0");
+  };
+
+  it("reports scoped provider processes and descendants for switch drain", async () => {
+    const source = new OsProviderDrainSource({
+      clientId: "client_A",
+      runProcessSnapshot: async () => snapshot,
+      runEnvForPid: envForPid,
+    });
+
+    const result = await source.snapshot();
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.processes).toEqual([
+      expect.objectContaining({
+        pid: 100,
+        provider: "claude",
+        clientId: "client_A",
+        agentId: "agent-A",
+        chatId: "chat-A",
+        descendantPids: [101, 102],
+      }),
+    ]);
+  });
+
+  it("can scope older provider processes by FIRST_TREE_HOME when client id is absent", async () => {
+    const source = new OsProviderDrainSource({
+      home: "/tmp/first-tree",
+      runProcessSnapshot: async () => snapshot,
+      runEnvForPid: envForPid,
+    });
+
+    const result = await source.snapshot();
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.reason);
+    expect(result.processes.map((p) => p.pid)).toEqual([300]);
+  });
+
+  it("fails closed when process snapshot is unavailable", async () => {
+    const source = new OsProviderDrainSource({
+      clientId: "client_A",
+      runProcessSnapshot: async () => {
+        throw new Error("ps denied");
+      },
+      runEnvForPid: envForPid,
+    });
+
+    await expect(source.snapshot()).resolves.toEqual({
+      ok: false,
+      reason: "provider process snapshot failed: ps denied",
+    });
+  });
+
+  it("fails closed when a provider env cannot be read", async () => {
+    const source = new OsProviderDrainSource({
+      clientId: "client_A",
+      runProcessSnapshot: async () => snapshot,
+      runEnvForPid: async (pid) => {
+        if (pid === 100) throw new Error("permission denied");
+        return envForPid(pid);
+      },
+    });
+
+    await expect(source.snapshot()).resolves.toEqual({
+      ok: false,
+      reason: "provider process env read failed for pid 100: permission denied",
+    });
+  });
+
+  it("assertProviderDrainClear rejects live or unavailable drain snapshots", async () => {
+    await expect(
+      assertProviderDrainClear(
+        new OsProviderDrainSource({
+          clientId: "client_A",
+          runProcessSnapshot: async () => snapshot,
+          runEnvForPid: envForPid,
+        }),
+      ),
+    ).rejects.toThrow("provider processes still live: claude pid 100 chat chat-A");
+
+    await expect(
+      assertProviderDrainClear(
+        new OsProviderDrainSource({
+          clientId: "client_A",
+          runProcessSnapshot: async () => {
+            throw new Error("ps denied");
+          },
+          runEnvForPid: envForPid,
+        }),
+      ),
+    ).rejects.toThrow("provider drain source unavailable: provider process snapshot failed: ps denied");
+  });
+
+  it("assertProviderDrainClear resolves only after the scoped provider is gone", async () => {
+    await expect(
+      assertProviderDrainClear(
+        new OsProviderDrainSource({
+          clientId: "client_A",
+          runProcessSnapshot: async () => "200 1 /usr/local/bin/codex",
+          runEnvForPid: envForPid,
+        }),
+      ),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -82,6 +82,13 @@ export type {
 } from "./runtime/handler.js";
 export { getHandlerFactory, hasHandler, registerHandler } from "./runtime/handler.js";
 export { InputController } from "./runtime/input-controller.js";
+export type { ProviderDrainProcess, ProviderDrainSnapshot, ProviderProcessName } from "./runtime/process-tree-probe.js";
+export {
+  assertProviderDrainClear,
+  OsProviderDrainSource,
+  PROVIDER_DRAIN_PROCESS_NAMES,
+  ProviderDrainBlockedError,
+} from "./runtime/process-tree-probe.js";
 export type { AgentRuntimeOptions } from "./runtime/runtime.js";
 export { AgentRuntime } from "./runtime/runtime.js";
 // Runtime-auth (browser OAuth)

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -72,6 +72,7 @@ export function buildAgentEnv(
       workspacesRoot: string;
       selfSlug: string;
     };
+    clientId?: string;
     log?: (msg: string) => void;
   },
 ): NodeJS.ProcessEnv {
@@ -79,6 +80,7 @@ export function buildAgentEnv(
   return {
     ...env,
     FIRST_TREE_SERVER_URL: ctx.sdk.serverUrl,
+    ...(ctx.clientId ? { FIRST_TREE_CLIENT_ID: ctx.clientId } : {}),
     FIRST_TREE_AGENT_ID: ctx.agent.agentId,
     FIRST_TREE_INBOX_ID: ctx.agent.inboxId,
     FIRST_TREE_CHAT_ID: ctx.chatId,

--- a/packages/client/src/runtime/index.ts
+++ b/packages/client/src/runtime/index.ts
@@ -18,6 +18,13 @@ export type {
 export { getHandlerFactory, hasHandler, registerHandler } from "./handler.js";
 export { InputController } from "./input-controller.js";
 export { registerShutdownHook, runShutdown } from "./lifecycle.js";
+export type { ProviderDrainProcess, ProviderDrainSnapshot, ProviderProcessName } from "./process-tree-probe.js";
+export {
+  assertProviderDrainClear,
+  OsProviderDrainSource,
+  PROVIDER_DRAIN_PROCESS_NAMES,
+  ProviderDrainBlockedError,
+} from "./process-tree-probe.js";
 export type { AgentRuntimeOptions } from "./runtime.js";
 export { AgentRuntime } from "./runtime.js";
 export { SessionManager } from "./session-manager.js";

--- a/packages/client/src/runtime/process-tree-probe.ts
+++ b/packages/client/src/runtime/process-tree-probe.ts
@@ -27,6 +27,22 @@ export interface SubprocessProbe {
 }
 
 export type ProcessRow = { pid: number; ppid: number; comm: string };
+export type ProviderProcessName = "claude" | "codex";
+export const PROVIDER_DRAIN_PROCESS_NAMES: readonly ProviderProcessName[] = ["claude", "codex"];
+
+export type ProviderDrainProcess = {
+  pid: number;
+  ppid: number;
+  comm: string;
+  provider: ProviderProcessName;
+  clientId: string | null;
+  agentId: string | null;
+  chatId: string | null;
+  home: string | null;
+  descendantPids: number[];
+};
+
+export type ProviderDrainSnapshot = { ok: true; processes: ProviderDrainProcess[] } | { ok: false; reason: string };
 
 /** Parse `ps -axo pid=,ppid=,comm=` output into rows. Unparseable lines are skipped. */
 export function parseProcessRows(output: string): ProcessRow[] {
@@ -57,6 +73,18 @@ function isClaudeComm(comm: string): boolean {
   return comm === "claude" || comm.endsWith("/claude");
 }
 
+function basenameForComm(comm: string): string {
+  return comm.split(/[\\/]/).pop() ?? comm;
+}
+
+export function providerNameForComm(comm: string): ProviderProcessName | null {
+  const base = basenameForComm(comm);
+  for (const name of PROVIDER_DRAIN_PROCESS_NAMES) {
+    if (base === name) return name;
+  }
+  return null;
+}
+
 /** Provider pids = `claude` processes that are direct children of the daemon. */
 export function findProviderPids(rows: readonly ProcessRow[], daemonPid: number): number[] {
   return rows.filter((row) => row.ppid === daemonPid && isClaudeComm(row.comm)).map((row) => row.pid);
@@ -73,6 +101,36 @@ export function hasDescendant(pid: number, childrenByParent: ReadonlyMap<number,
   return (childrenByParent.get(pid)?.length ?? 0) > 0;
 }
 
+export function collectDescendantPids(pid: number, childrenByParent: ReadonlyMap<number, number[]>): number[] {
+  const out: number[] = [];
+  const stack = [...(childrenByParent.get(pid) ?? [])];
+  while (stack.length > 0) {
+    const child = stack.pop();
+    if (child === undefined) continue;
+    out.push(child);
+    stack.push(...(childrenByParent.get(child) ?? []));
+  }
+  out.sort((a, b) => a - b);
+  return out;
+}
+
+export function buildParentIndex(rows: readonly ProcessRow[]): Map<number, number> {
+  const byPid = new Map<number, number>();
+  for (const { pid, ppid } of rows) byPid.set(pid, ppid);
+  return byPid;
+}
+
+export function isDescendantOf(pid: number, ancestorPid: number, parentByPid: ReadonlyMap<number, number>): boolean {
+  let current = parentByPid.get(pid);
+  const seen = new Set<number>();
+  while (typeof current === "number" && current > 0 && !seen.has(current)) {
+    if (current === ancestorPid) return true;
+    seen.add(current);
+    current = parentByPid.get(current);
+  }
+  return false;
+}
+
 /**
  * Extract the `FIRST_TREE_CHAT_ID` value from a process's environment dump.
  * Handles both forms produced by {@link defaultEnvForPid}: space-separated
@@ -85,6 +143,19 @@ export function extractChatId(envText: string): string | null {
   return match ? (match[1] ?? null) : null;
 }
 
+export function extractEnvValue(envText: string, key: string): string | null {
+  if (envText.includes("\0")) {
+    const prefix = `${key}=`;
+    for (const part of envText.split("\0")) {
+      if (part.startsWith(prefix)) return part.slice(prefix.length);
+    }
+    return null;
+  }
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = envText.match(new RegExp(`(?:^|[\\s\\0])${escaped}=([^\\s\\0]+)`));
+  return match ? (match[1] ?? null) : null;
+}
+
 type PsSubprocessProbeOptions = {
   log: pino.Logger;
   /** Defaults to this daemon process. */
@@ -94,6 +165,21 @@ type PsSubprocessProbeOptions = {
   /** Injectable for tests: returns `ps -axo pid=,ppid=,comm=` stdout. */
   runProcessSnapshot?: () => Promise<string>;
   /** Injectable for tests: returns `ps -Eww -p <pid> -o command=` stdout. */
+  runEnvForPid?: (pid: number) => Promise<string>;
+};
+
+export type OsProviderDrainSourceOptions = {
+  /** Defaults to this process. Used when checking a live daemon's process tree. */
+  daemonPid?: number;
+  /** Active local client id. Preferred switch-drain scope once provider env carries it. */
+  clientId?: string;
+  /** Current FIRST_TREE_HOME. Covers older provider envs before FIRST_TREE_CLIENT_ID existed. */
+  home?: string;
+  /** Optional narrower scope for callers that already know local agent ids. */
+  agentIds?: readonly string[];
+  /** Injectable for tests: returns `ps -axo pid=,ppid=,comm=` stdout. */
+  runProcessSnapshot?: () => Promise<string>;
+  /** Injectable for tests: returns the provider process env text. */
   runEnvForPid?: (pid: number) => Promise<string>;
 };
 
@@ -112,6 +198,122 @@ async function defaultEnvForPid(pid: number): Promise<string> {
   }
   const { stdout } = await execFileAsync("ps", ["-Eww", "-p", String(pid), "-o", "command="]);
   return stdout;
+}
+
+function hasDrainScope(opts: OsProviderDrainSourceOptions): boolean {
+  return Boolean(opts.clientId || opts.home || (opts.agentIds && opts.agentIds.length > 0) || opts.daemonPid);
+}
+
+function processMatchesDrainScope(input: {
+  envText: string;
+  pid: number;
+  opts: OsProviderDrainSourceOptions;
+  parentByPid: ReadonlyMap<number, number>;
+}): boolean {
+  const { envText, pid, opts, parentByPid } = input;
+  if (opts.clientId && extractEnvValue(envText, "FIRST_TREE_CLIENT_ID") === opts.clientId) return true;
+  if (opts.home && extractEnvValue(envText, "FIRST_TREE_HOME") === opts.home) return true;
+  const agentId = extractEnvValue(envText, "FIRST_TREE_AGENT_ID");
+  if (agentId && opts.agentIds?.includes(agentId)) return true;
+  if (typeof opts.daemonPid === "number" && isDescendantOf(pid, opts.daemonPid, parentByPid)) return true;
+  return false;
+}
+
+/**
+ * Fail-closed process-tree source for client-switch drain. Unlike
+ * {@link PsSubprocessProbe}, which is an idle-suspend hint and degrades to
+ * "no live background work", this source is a safety gate: a process or env
+ * snapshot failure means the caller cannot prove the old provider is gone.
+ */
+export class OsProviderDrainSource {
+  private readonly daemonPid: number | undefined;
+  private readonly runProcessSnapshot: () => Promise<string>;
+  private readonly runEnvForPid: (pid: number) => Promise<string>;
+
+  constructor(private readonly opts: OsProviderDrainSourceOptions = {}) {
+    this.daemonPid = opts.daemonPid;
+    this.runProcessSnapshot = opts.runProcessSnapshot ?? defaultProcessSnapshot;
+    this.runEnvForPid = opts.runEnvForPid ?? defaultEnvForPid;
+  }
+
+  async snapshot(): Promise<ProviderDrainSnapshot> {
+    if (!hasDrainScope({ ...this.opts, daemonPid: this.daemonPid })) {
+      return { ok: false, reason: "provider drain source has no client/home/agent/daemon scope" };
+    }
+
+    let rows: ProcessRow[];
+    try {
+      rows = parseProcessRows(await this.runProcessSnapshot());
+    } catch (err) {
+      return {
+        ok: false,
+        reason: `provider process snapshot failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    const parentByPid = buildParentIndex(rows);
+    const childrenByParent = buildChildrenIndex(rows);
+    const processes: ProviderDrainProcess[] = [];
+    for (const row of rows) {
+      const provider = providerNameForComm(row.comm);
+      if (!provider) continue;
+      let envText: string;
+      try {
+        envText = await this.runEnvForPid(row.pid);
+      } catch (err) {
+        return {
+          ok: false,
+          reason: `provider process env read failed for pid ${row.pid}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        };
+      }
+      const scoped = processMatchesDrainScope({
+        envText,
+        pid: row.pid,
+        opts: { ...this.opts, daemonPid: this.daemonPid },
+        parentByPid,
+      });
+      if (!scoped) continue;
+      processes.push({
+        pid: row.pid,
+        ppid: row.ppid,
+        comm: row.comm,
+        provider,
+        clientId: extractEnvValue(envText, "FIRST_TREE_CLIENT_ID"),
+        agentId: extractEnvValue(envText, "FIRST_TREE_AGENT_ID"),
+        chatId: extractChatId(envText),
+        home: extractEnvValue(envText, "FIRST_TREE_HOME"),
+        descendantPids: collectDescendantPids(row.pid, childrenByParent),
+      });
+    }
+
+    processes.sort((a, b) => a.pid - b.pid);
+    return { ok: true, processes };
+  }
+}
+
+export class ProviderDrainBlockedError extends Error {
+  constructor(
+    message: string,
+    readonly snapshot: ProviderDrainSnapshot,
+  ) {
+    super(message);
+    this.name = "ProviderDrainBlockedError";
+  }
+}
+
+export async function assertProviderDrainClear(source: Pick<OsProviderDrainSource, "snapshot">): Promise<void> {
+  const snapshot = await source.snapshot();
+  if (!snapshot.ok) {
+    throw new ProviderDrainBlockedError(`provider drain source unavailable: ${snapshot.reason}`, snapshot);
+  }
+  if (snapshot.processes.length > 0) {
+    const details = snapshot.processes
+      .map((p) => `${p.provider} pid ${p.pid}${p.chatId ? ` chat ${p.chatId}` : ""}`)
+      .join(", ");
+    throw new ProviderDrainBlockedError(`provider processes still live: ${details}`, snapshot);
+  }
 }
 
 /**

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -2034,6 +2034,7 @@ export class SessionManager {
       sdk: this.config.sdk,
       agent: this.config.agentIdentity,
       chatId,
+      clientId: typeof this.config.handlerConfig.clientId === "string" ? this.config.handlerConfig.clientId : undefined,
       log,
       docContext: {
         base: docBase,


### PR DESCRIPTION
## Summary
- add a fail-closed OS process-tree provider drain source for local client switch feasibility
- propagate `FIRST_TREE_CLIENT_ID` into provider process env so Claude/Codex processes can be attributed to the active local client
- add switch maintenance and filesystem gates in CLI core, with daemon startup blocked before reading root client state when switch lock/journal files exist
- define different-user `login` switch authorization: non-interactive use requires `--force-switch`, confirmation authorizes runtime/provider interruption, and the flag does not bypass safety gates
- update CLI reference and the local design plan with new-user/new-client-id, force-switch, and recovery-boundary semantics

## Scope
This is Phase 0.5 only. It does not implement the real client switch transaction and does not move root `config/` or `data/`.

Different-user login still fails closed in this build after validating the switch intent, so it cannot overwrite credentials or reuse/transfer the active user's client id before the park/restore transaction exists.

## Validation
- `pnpm --dir packages/client exec vitest run src/__tests__/process-tree-probe.test.ts src/__tests__/agent-io.test.ts`
- `pnpm --dir apps/cli exec vitest run src/__tests__/client-switch-gates.test.ts src/__tests__/daemon-start-command.test.ts`
- `pnpm --dir apps/cli exec vitest run src/__tests__/client-switch-gates.test.ts src/__tests__/login-command.test.ts src/__tests__/daemon-start-command.test.ts`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter first-tree-dev typecheck`
- `pnpm exec biome check apps/cli/src/core/client-switch-gates.ts apps/cli/src/__tests__/client-switch-gates.test.ts apps/cli/src/__tests__/daemon-start-command.test.ts apps/cli/src/commands/daemon/start.ts apps/cli/src/core/index.ts packages/client/src/runtime/process-tree-probe.ts packages/client/src/__tests__/process-tree-probe.test.ts packages/client/src/runtime/agent-io.ts packages/client/src/__tests__/agent-io.test.ts packages/client/src/runtime/session-manager.ts packages/client/src/runtime/index.ts packages/client/src/index.ts`
- `git diff --check`

Also ran broader package tests after dependency install:
- `pnpm --filter @first-tree/client test -- src/__tests__/process-tree-probe.test.ts src/__tests__/agent-io.test.ts` (ran client package suite)
- `pnpm --filter first-tree-dev test -- src/__tests__/client-switch-gates.test.ts src/__tests__/daemon-start-command.test.ts` (ran CLI package suite)
