### PR TITLE
test(context-reviewer): require approval review for clean context PRs

### DIFF
--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -129,7 +129,9 @@ describe("Context Reviewer PR prompt", () => {
     expect(prompt).toContain("clear, accurate");
     expect(prompt).toContain("missing background");
     expect(prompt).toContain("excessive detail");
-    expect(prompt).toContain("gh pr comment 123 --repo owner/context-tree --body");
+    expect(prompt).toContain("gh pr review 123 --repo owner/context-tree --comment --body");
+    expect(prompt).toContain("gh pr review 123 --repo owner/context-tree --approve --body");
+    expect(prompt).toContain("review action was submitted: `approved`, `commented`, or `failed`");
   });
 
   it("renders when optional refs are missing", async () => {
@@ -150,7 +152,8 @@ describe("Context Reviewer PR prompt", () => {
     expect(prompt).toContain("Base ref: unknown");
     expect(prompt).toContain("Head ref: unknown");
     expect(prompt).toContain("Trigger event: pull_request.synchronize");
-    expect(prompt).toContain("gh pr comment 124 --repo owner/context-tree --body");
+    expect(prompt).toContain("gh pr review 124 --repo owner/context-tree --comment --body");
+    expect(prompt).toContain("gh pr review 124 --repo owner/context-tree --approve --body");
   });
 
   it("renders comment trigger context when present", async () => {
@@ -301,7 +304,8 @@ describe("handleContextReviewerPrEvent", () => {
     );
 
     const [message] = await app.db.select().from(messages).where(eq(messages.id, result.messageId)).limit(1);
-    expect(message?.content).toContain("gh pr comment 123 --repo owner/context-tree --body");
+    expect(message?.content).toContain("gh pr review 123 --repo owner/context-tree --comment --body");
+    expect(message?.content).toContain("gh pr review 123 --repo owner/context-tree --approve --body");
     expect(message?.content).toContain("Trigger event: pull_request.opened");
     expect(message?.metadata).toMatchObject({
       contextTreeReviewer: true,
@@ -341,7 +345,7 @@ describe("handleContextReviewerPrEvent", () => {
     expect(messageRows).toHaveLength(2);
     const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
     expect(followUp?.content).toBe(FOLLOW_UP_NOTICE);
-    expect(followUp?.content).not.toContain("gh pr comment 123 --repo owner/context-tree --body");
+    expect(followUp?.content).not.toContain("gh pr review 123 --repo owner/context-tree");
     const chatRows = await app.db.select({ id: chats.id }).from(chats);
     expect(chatRows).toHaveLength(1);
   });
@@ -375,7 +379,7 @@ describe("handleContextReviewerPrEvent", () => {
     expect(followUp?.format).toBe("markdown");
     expect(followUp?.content).toBe(FOLLOW_UP_NOTICE);
     expect(followUp?.content).not.toContain("clear, accurate");
-    expect(followUp?.content).not.toContain("gh pr comment 123 --repo owner/context-tree --body");
+    expect(followUp?.content).not.toContain("gh pr review 123 --repo owner/context-tree");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
       event: "pull_request",
@@ -424,7 +428,7 @@ describe("handleContextReviewerPrEvent", () => {
         "Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-1",
       ].join("\n"),
     );
-    expect(followUp?.content).not.toContain("gh pr comment 123 --repo owner/context-tree --body");
+    expect(followUp?.content).not.toContain("gh pr review 123 --repo owner/context-tree");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
       event: "issue_comment",
@@ -475,7 +479,7 @@ describe("handleContextReviewerPrEvent", () => {
         "Comment URL: https://github.com/owner/context-tree/pull/123#discussion_r1",
       ].join("\n"),
     );
-    expect(followUp?.content).not.toContain("gh pr comment 123 --repo owner/context-tree --body");
+    expect(followUp?.content).not.toContain("gh pr review 123 --repo owner/context-tree");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
       event: "pull_request_review_comment",

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -1289,7 +1289,8 @@ describe("POST /webhooks/github-app", () => {
       .from(messages)
       .where(eq(messages.chatId, chat?.id ?? ""))
       .limit(1);
-    expect(message?.content).toContain("gh pr comment 42 --repo owner/context-tree --body");
+    expect(message?.content).toContain("gh pr review 42 --repo owner/context-tree --comment --body");
+    expect(message?.content).toContain("gh pr review 42 --repo owner/context-tree --approve --body");
     expect(message?.metadata).toMatchObject({
       source: "github",
       event: "pull_request",
@@ -1337,7 +1338,7 @@ describe("POST /webhooks/github-app", () => {
         "Comment URL: https://github.com/owner/context-tree/pull/42#issuecomment-2",
       ].join("\n"),
     );
-    expect(followUpMessage?.content).not.toContain("gh pr comment 42 --repo owner/context-tree --body");
+    expect(followUpMessage?.content).not.toContain("gh pr review 42 --repo owner/context-tree");
     expect(followUpMessage?.metadata).toMatchObject({
       source: "github",
       event: "issue_comment",

--- a/packages/server/src/prompts/context-reviewer-pr.ejs
+++ b/packages/server/src/prompts/context-reviewer-pr.ejs
@@ -28,11 +28,21 @@ Review goals:
 
 Required workflow:
 
-1. Inspect this pull request with `gh` commands.
-2. Post a top-level PR review comment using exactly this GitHub CLI shape:
+1. Inspect this pull request with `gh` commands before deciding on the review outcome.
+2. Submit exactly one GitHub PR review using one of these outcomes:
+
+- If changes are needed, or if feedback should be recorded without approval, run:
 
 ```bash
-gh pr comment <%= prNumber %> --repo <%= repoFullName %> --body "..."
+gh pr review <%= prNumber %> --repo <%= repoFullName %> --comment --body "..."
 ```
 
-3. After posting the PR comment, reply in this chat with a short summary and include whether the comment was posted successfully.
+- If inspection is complete, the PR needs no changes, satisfies merge requirements, and is safe to merge as durable Context Tree material, run:
+
+```bash
+gh pr review <%= prNumber %> --repo <%= repoFullName %> --approve --body "..."
+```
+
+3. Approve only after inspection is complete and only when the PR is safe to merge as Context Tree material.
+4. Do not also post a top-level `gh pr comment` for the same outcome.
+5. After submitting the PR review, reply in this chat with a short summary and report which review action was submitted: `approved`, `commented`, or `failed`.


### PR DESCRIPTION
## Summary
- update the Context Reviewer PR prompt to submit GitHub PR reviews instead of top-level PR comments
- require `gh pr review --comment` for feedback-only outcomes and `gh pr review --approve` when the Context Tree PR is merge-ready
- update prompt-rendering and webhook prompt assertions for both review actions

## Context Tree PR
- Paired with agent-team-foundation/first-tree-context#664.
- Merge this source PR first, then merge the Tree PR after reconciling any final source changes.

## Tests
- `pnpm --filter @first-tree/server test -- context-reviewer-pr github-app-webhook-route`
- `pnpm check && pnpm typecheck`
