### PR TITLE
fix(context-reviewer): require structured PR reviews

### DIFF
--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -129,9 +129,12 @@ describe("Context Reviewer PR prompt", () => {
     expect(prompt).toContain("clear, accurate");
     expect(prompt).toContain("missing background");
     expect(prompt).toContain("excessive detail");
-    expect(prompt).toContain("gh pr review 123 --repo owner/context-tree --comment --body");
-    expect(prompt).toContain("gh pr review 123 --repo owner/context-tree --approve --body");
-    expect(prompt).toContain("review action was submitted: `approved`, `commented`, or `failed`");
+    expect(prompt).toContain("gh pr review 123 --repo owner/context-tree --request-changes --body-file");
+    expect(prompt).toContain("gh pr review 123 --repo owner/context-tree --comment --body-file");
+    expect(prompt).toContain("gh pr review 123 --repo owner/context-tree --approve --body-file");
+    expect(prompt).toContain("Context changes requested");
+    expect(prompt).toContain("Still unclear or needs more detail");
+    expect(prompt).toContain("review action was submitted: `approved`, `commented`, `changes_requested`, or `failed`");
   });
 
   it("renders when optional refs are missing", async () => {
@@ -152,8 +155,9 @@ describe("Context Reviewer PR prompt", () => {
     expect(prompt).toContain("Base ref: unknown");
     expect(prompt).toContain("Head ref: unknown");
     expect(prompt).toContain("Trigger event: pull_request.synchronize");
-    expect(prompt).toContain("gh pr review 124 --repo owner/context-tree --comment --body");
-    expect(prompt).toContain("gh pr review 124 --repo owner/context-tree --approve --body");
+    expect(prompt).toContain("gh pr review 124 --repo owner/context-tree --request-changes --body-file");
+    expect(prompt).toContain("gh pr review 124 --repo owner/context-tree --comment --body-file");
+    expect(prompt).toContain("gh pr review 124 --repo owner/context-tree --approve --body-file");
   });
 
   it("renders comment trigger context when present", async () => {
@@ -304,8 +308,11 @@ describe("handleContextReviewerPrEvent", () => {
     );
 
     const [message] = await app.db.select().from(messages).where(eq(messages.id, result.messageId)).limit(1);
-    expect(message?.content).toContain("gh pr review 123 --repo owner/context-tree --comment --body");
-    expect(message?.content).toContain("gh pr review 123 --repo owner/context-tree --approve --body");
+    expect(message?.content).toContain("gh pr review 123 --repo owner/context-tree --request-changes --body-file");
+    expect(message?.content).toContain("gh pr review 123 --repo owner/context-tree --comment --body-file");
+    expect(message?.content).toContain("gh pr review 123 --repo owner/context-tree --approve --body-file");
+    expect(message?.content).toContain("Context changes requested");
+    expect(message?.content).toContain("Still unclear or needs more detail");
     expect(message?.content).toContain("Trigger event: pull_request.opened");
     expect(message?.metadata).toMatchObject({
       contextTreeReviewer: true,

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -1289,8 +1289,11 @@ describe("POST /webhooks/github-app", () => {
       .from(messages)
       .where(eq(messages.chatId, chat?.id ?? ""))
       .limit(1);
-    expect(message?.content).toContain("gh pr review 42 --repo owner/context-tree --comment --body");
-    expect(message?.content).toContain("gh pr review 42 --repo owner/context-tree --approve --body");
+    expect(message?.content).toContain("gh pr review 42 --repo owner/context-tree --request-changes --body-file");
+    expect(message?.content).toContain("gh pr review 42 --repo owner/context-tree --comment --body-file");
+    expect(message?.content).toContain("gh pr review 42 --repo owner/context-tree --approve --body-file");
+    expect(message?.content).toContain("Context changes requested");
+    expect(message?.content).toContain("Still unclear or needs more detail");
     expect(message?.metadata).toMatchObject({
       source: "github",
       event: "pull_request",

--- a/packages/server/src/prompts/context-reviewer-pr.ejs
+++ b/packages/server/src/prompts/context-reviewer-pr.ejs
@@ -29,20 +29,44 @@ Review goals:
 Required workflow:
 
 1. Inspect this pull request with `gh` commands before deciding on the review outcome.
-2. Submit exactly one GitHub PR review using one of these outcomes:
+2. Write the review body to a temporary Markdown file and pass it with `--body-file <file>`. Do not inline multiline Markdown with `--body`; avoiding shell quoting issues is part of the required workflow.
+3. Submit exactly one GitHub PR review using one of these outcomes:
 
-- If changes are needed, or if feedback should be recorded without approval, run:
-
-```bash
-gh pr review <%= prNumber %> --repo <%= repoFullName %> --comment --body "..."
-```
-
-- If inspection is complete, the PR needs no changes, satisfies merge requirements, and is safe to merge as durable Context Tree material, run:
+- If Context is incorrect, misleading, contradictory, missing required durable rationale, or otherwise should block merge, run:
 
 ```bash
-gh pr review <%= prNumber %> --repo <%= repoFullName %> --approve --body "..."
+gh pr review <%= prNumber %> --repo <%= repoFullName %> --request-changes --body-file <file>
 ```
 
-3. Approve only after inspection is complete and only when the PR is safe to merge as Context Tree material.
-4. Do not also post a top-level `gh pr comment` for the same outcome.
-5. After submitting the PR review, reply in this chat with a short summary and report which review action was submitted: `approved`, `commented`, or `failed`.
+- If feedback is useful but not blocking, run:
+
+```bash
+gh pr review <%= prNumber %> --repo <%= repoFullName %> --comment --body-file <file>
+```
+
+- If inspection is complete, no blocking gaps remain, and the PR is safe to merge as durable Context Tree material, run:
+
+```bash
+gh pr review <%= prNumber %> --repo <%= repoFullName %> --approve --body-file <file>
+```
+
+4. When changes or clarification are needed, structure the review body like this, separating incorrect or change-needed Context from Context that is still unclear or missing detail:
+
+```md
+## Context changes requested
+
+- Context: `<path or node title>`
+  Problem: ...
+  Suggested change: ...
+
+## Still unclear or needs more detail
+
+- Context: `<path or node title>`
+  Needed detail: ...
+  Why it matters: ...
+```
+
+If one of those sections has no items, write `None.` under that heading.
+5. Approve only after inspection is complete and only when the PR is safe to merge as Context Tree material.
+6. Do not also post a top-level `gh pr comment` for the same outcome.
+7. After submitting the PR review, reply in this chat with a short summary and report which review action was submitted: `approved`, `commented`, `changes_requested`, or `failed`.


### PR DESCRIPTION
## Summary
- Require Context Reviewer tasks to submit exactly one GitHub PR review using request-changes, comment, or approve.
- Require multiline review bodies via --body-file and structured sections for context changes vs unclear/missing detail.
- Update prompt-render and webhook task-message assertions for the new review contract.

## Verification
- pnpm --filter @first-tree/server test -- context-reviewer-pr github-app-webhook-route
- pnpm check && pnpm typecheck
- pnpm --filter @first-tree/skill-evals test

## Notes
- pnpm test was attempted twice and failed in @first-tree/skill-evals under concurrent turbo execution due a 5s timeout in first-tree-seed periodic fixture validation; the same package passed when run directly.