### PR TITLE
test(skill-evals): require seed tree-init --dir to resolve inside the eval workspace

### DIFF
--- a/packages/client/src/__tests__/retired-tree-commands-drift.test.ts
+++ b/packages/client/src/__tests__/retired-tree-commands-drift.test.ts
@@ -50,7 +50,12 @@ const SHIPPED_SKILLS = ["first-tree-welcome", "first-tree-write", "first-tree-re
 
 const RETIRED_TREE_SUBCOMMANDS = [
   "status",
-  "init",
+  // `init` is intentionally NOT retired: PR #848 deleted the original, but it
+  // was reintroduced in 2026-07 (#1379) in a different shape as the agent-gh
+  // Context Tree creation command and is registered in
+  // `apps/cli/src/commands/tree/index.ts`. Shipped skills (first-tree-seed
+  // Step 0) legitimately instruct `first-tree tree init`, so per the
+  // un-retirement procedure documented above it must stay OFF this list.
   "migrate",
   "migrate-to-w1",
   "upgrade",

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
@@ -641,6 +641,114 @@ describe("first-tree-seed grader", () => {
     }
   });
 
+  it("rejects an absolute tree init --dir that resolves outside the workspace", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-abs-outside-"));
+    try {
+      // `/tmp/context-tree` shares the `context-tree` basename but the checkout
+      // would land outside the workspace-managed `<workspacePath>/context-tree`.
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--title", "Apollo Console", "--dir", "/tmp/context-tree"],
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(false);
+      expect(
+        casePassed(
+          findCase("unbound-tree-inits-with-dir"),
+          baseMetrics({
+            skeletonObserved: false,
+            sourceEvidenceReadObserved: false,
+            sourceWorktreeCreated: false,
+            treeInitObserved: true,
+            treeInitWithContextTreeDirObserved: metrics.treeInitWithContextTreeDirObserved,
+          }),
+        ),
+      ).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a relative ../context-tree tree init --dir that escapes the workspace", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-parent-dir-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              command: "first-tree tree init --title 'Apollo Console' --dir ../context-tree",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("accepts a relative ./context-tree tree init --dir resolved against the workspace cwd", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-rel-dir-"));
+    try {
+      // The model runs with cwd = workspacePath, so `./context-tree` and
+      // `context-tree` resolve to the workspace-managed checkout.
+      const relativeMetrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--title", "Apollo Console", "--dir", "./context-tree"],
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+      expect(relativeMetrics.treeInitWithContextTreeDirObserved).toBe(true);
+
+      // The absolute workspace path is likewise accepted.
+      const absoluteMetrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--title", "Apollo Console", "--dir", join(tempRoot, "context-tree")],
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+      expect(absoluteMetrics.treeInitWithContextTreeDirObserved).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   it("still flags real repo creation as a forbidden side effect in the unbound case", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-repo-create-"));
     try {

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -707,15 +707,16 @@ describe("first-tree-seed grader", () => {
     }
   });
 
-  it("accepts a relative ./context-tree tree init --dir resolved against the workspace cwd", () => {
+  it("accepts a relative ./context-tree tree init --dir resolved against the captured workspace cwd", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-rel-dir-"));
     try {
-      // The model runs with cwd = workspacePath, so `./context-tree` and
-      // `context-tree` resolve to the workspace-managed checkout.
+      // The model runs with cwd = workspacePath, so `./context-tree` resolves
+      // against the CAPTURED cwd to the workspace-managed checkout.
       const relativeMetrics = deriveMetrics(
         [
           {
             argv: ["tree", "init", "--title", "Apollo Console", "--dir", "./context-tree"],
+            cwd: tempRoot,
             phase: "model",
             type: "first_tree_call",
           },
@@ -728,11 +729,12 @@ describe("first-tree-seed grader", () => {
       );
       expect(relativeMetrics.treeInitWithContextTreeDirObserved).toBe(true);
 
-      // The absolute workspace path is likewise accepted.
+      // The absolute workspace path is likewise accepted, cwd-independent.
       const absoluteMetrics = deriveMetrics(
         [
           {
             argv: ["tree", "init", "--title", "Apollo Console", "--dir", join(tempRoot, "context-tree")],
+            cwd: "/tmp",
             phase: "model",
             type: "first_tree_call",
           },
@@ -746,6 +748,146 @@ describe("first-tree-seed grader", () => {
       expect(absoluteMetrics.treeInitWithContextTreeDirObserved).toBe(true);
     } finally {
       rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a relative ./context-tree tree init --dir when captured cwd is OUTSIDE the workspace", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-cwd-outside-"));
+    try {
+      // `cd /tmp && first-tree tree init --dir ./context-tree`: the relative
+      // --dir resolves against the CAPTURED cwd (/tmp), NOT the workspace, so
+      // the checkout would land at /tmp/context-tree — reject it.
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--title", "Apollo Console", "--dir", "./context-tree"],
+            cwd: "/tmp",
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(false);
+      expect(
+        casePassed(
+          findCase("unbound-tree-inits-with-dir"),
+          baseMetrics({
+            skeletonObserved: false,
+            sourceEvidenceReadObserved: false,
+            sourceWorktreeCreated: false,
+            treeInitObserved: true,
+            treeInitWithContextTreeDirObserved: metrics.treeInitWithContextTreeDirObserved,
+          }),
+        ),
+      ).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("does not credit a relative --dir from a bare command string, even with a context-tree basename", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-cmd-relative-"));
+    try {
+      // The command-string path carries no structured cwd (`cd /tmp && ...`),
+      // so a relative --dir cannot be resolved soundly: it must NOT credit
+      // withContextTreeDir. This is the FINDING 1b bypass.
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              command: "cd /tmp && first-tree tree init --title 'Apollo Console' --dir ./context-tree",
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("credits an absolute --dir to the workspace context-tree from a command string", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-cmd-abs-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            event: {
+              command: `first-tree tree init --title 'Apollo Console' --dir ${join(tempRoot, "context-tree")}`,
+              type: "command_execution",
+            },
+            type: "codex_event",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("canonicalizes symlinked roots so a --dir through a symlinked workspace is accepted", () => {
+    // FINDING 2: the context-tree leaf does not exist (shim blocks creation),
+    // so the resolver must canonicalize the deepest EXISTING ancestor. Here the
+    // real workspace lives under a real dir, and we present the workspacePath
+    // through a symlink to it; the argv --dir uses the real (realpath) form with
+    // the non-existent context-tree leaf. They must compare equal.
+    const realBase = mkdtempSync(join(tmpdir(), "seed-eval-symlink-real-"));
+    const linkBase = `${realBase}-link`;
+    try {
+      const realWorkspace = join(realBase, "workspace");
+      mkdirSync(realWorkspace, { recursive: true });
+      symlinkSync(realBase, linkBase);
+      const linkedWorkspace = join(linkBase, "workspace");
+      const realDir = join(realpathSync(realWorkspace), "context-tree"); // leaf absent
+
+      const paths = baseRunPaths(linkedWorkspace); // workspacePath through the symlink
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--title", "Apollo Console", "--dir", realDir],
+            cwd: linkedWorkspace,
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        paths,
+        join(linkedWorkspace, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(true);
+    } finally {
+      // linkBase is a symlink to a directory; unlink the link itself (rmSync
+      // without recursive refuses a directory target), then remove the real dir.
+      unlinkSync(linkBase);
+      rmSync(realBase, { force: true, recursive: true });
     }
   });
 

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
@@ -643,6 +643,88 @@ describe("first-tree-seed grader", () => {
     }
   });
 
+  it("uses the LAST --dir when repeated (Commander overwrites), so a later outside path fails", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-argv-dup-outside-"));
+    try {
+      // `--dir <ws>/context-tree --dir /tmp/context-tree`: Commander keeps the
+      // LAST scalar value, so the effective target is the outside `/tmp` path.
+      // The grader must mirror that and NOT credit the earlier managed value.
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--dir", join(tempRoot, "context-tree"), "--dir", "/tmp/context-tree"],
+            cwd: tempRoot,
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("uses the LAST --dir when repeated so a later managed path is credited", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-argv-dup-inside-"));
+    try {
+      // Reverse order: outside first, managed last -> last wins -> accepted.
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--dir=/tmp/context-tree", `--dir=${join(tempRoot, "context-tree")}`],
+            cwd: tempRoot,
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("stops --dir scanning at a -- terminator (later --dir is a positional, not an option)", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-argv-terminator-"));
+    try {
+      // After `--`, tokens are positionals: the managed `--dir` before the
+      // terminator is the effective option; the `/tmp` one after it is not.
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--dir", join(tempRoot, "context-tree"), "--", "--dir", "/tmp/context-tree"],
+            cwd: tempRoot,
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   it("detects a tree init without a context-tree --dir as the regression", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-nodir-"));
     try {

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
@@ -584,6 +584,65 @@ describe("first-tree-seed grader", () => {
     }
   });
 
+  it("accepts the equals form tree init --dir=<workspace>/context-tree from captured argv", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-argv-eq-"));
+    try {
+      // Commander declares `.option("--dir <path>")`, which accepts BOTH
+      // `--dir <path>` and `--dir=<path>`. The shim records raw argv before
+      // Commander parses it, so an equals-form invocation appears as the single
+      // token `--dir=<path>`; the structured parser must credit it (now that
+      // raw command strings are presence-only, this is the only load-bearing
+      // path).
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--title", "Apollo Console", `--dir=${join(tempRoot, "context-tree")}`],
+            cwd: tempRoot,
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(true);
+      expect(metrics.forbiddenSideEffectHits).toEqual([]);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects the equals form tree init --dir=/tmp/context-tree that resolves outside the workspace", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-argv-eq-outside-"));
+    try {
+      const metrics = deriveMetrics(
+        [
+          {
+            argv: ["tree", "init", "--title", "Apollo Console", "--dir=/tmp/context-tree"],
+            cwd: tempRoot,
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        findCase("unbound-tree-inits-with-dir"),
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        join(tempRoot, "context-tree"),
+      );
+
+      expect(metrics.treeInitObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   it("detects a tree init without a context-tree --dir as the regression", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-nodir-"));
     try {

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/grader.test.ts
@@ -822,14 +822,26 @@ describe("first-tree-seed grader", () => {
     }
   });
 
-  it("credits an absolute --dir to the workspace context-tree from a command string", () => {
-    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-cmd-abs-"));
+  it("does not credit a later command-string --dir to a real tree init that lacks --dir (cross-segment false green)", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "seed-eval-tree-init-cmd-crosssegment-"));
     try {
+      // `first-tree tree init --title X && echo --dir <ws>/context-tree`: the
+      // real shimmed argv has NO --dir, but the raw command string carries a
+      // later, unrelated absolute --dir in a separate `echo` segment. A naive
+      // scan of the whole string would mis-attribute that --dir to the tree
+      // init. withContextTreeDir must come SOLELY from the structured
+      // first_tree_call argv, so the later --dir must NOT be credited.
       const metrics = deriveMetrics(
         [
           {
+            argv: ["tree", "init", "--title", "Apollo Console"],
+            cwd: tempRoot,
+            phase: "model",
+            type: "first_tree_call",
+          },
+          {
             event: {
-              command: `first-tree tree init --title 'Apollo Console' --dir ${join(tempRoot, "context-tree")}`,
+              command: `first-tree tree init --title 'Apollo Console' && echo --dir ${join(tempRoot, "context-tree")}`,
               type: "command_execution",
             },
             type: "codex_event",
@@ -843,7 +855,8 @@ describe("first-tree-seed grader", () => {
       );
 
       expect(metrics.treeInitObserved).toBe(true);
-      expect(metrics.treeInitWithContextTreeDirObserved).toBe(true);
+      expect(metrics.treeInitWithContextTreeDirObserved).toBe(false);
+      expect(casePassed(findCase("unbound-tree-inits-with-dir"), metrics)).toBe(false);
     } finally {
       rmSync(tempRoot, { force: true, recursive: true });
     }

--- a/packages/skill-evals/src/suites/first-tree-seed/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/grader.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, realpathSync } from "node:fs";
-import { isAbsolute, join, normalize, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, normalize, resolve } from "node:path";
 
 import { runCommand } from "../../core/commands.js";
 import { isRecord, isStringArray } from "../../core/events.js";
@@ -396,38 +396,62 @@ function stripQuotes(value: string): string {
   return value.replace(/^['"]|['"]$/gu, "");
 }
 
-// Resolve a path to its real (symlink-followed) form when it exists, otherwise
-// fall back to the normalized string. The eval shim blocks real `tree init`, so
-// the target `context-tree` checkout usually does NOT exist on disk — hence the
-// ENOENT-tolerant fallback. This exists to defeat the macOS symlinked-root
-// caveat (e.g. `/var` -> `/private/var`, `/tmp` -> `/private/tmp`): the captured
-// absolute `--dir` and the derived workspace path can print differently yet
-// point at the same location, so we realpath BOTH sides before comparing.
-function realpathOrNormalized(path: string): string {
-  try {
-    return realpathSync(path);
-  } catch {
-    return normalize(path);
+// Canonicalize an absolute path for equality comparison, tolerating a
+// non-existent leaf. The eval shim BLOCKS real `tree init`, and the unbound
+// fixture returns `<workspace>/context-tree` WITHOUT creating it, so the target
+// (and any candidate aimed at it) does NOT exist on disk. A plain
+// `realpathSync(path)` therefore ENOENTs and never canonicalizes the symlinked
+// ROOT (macOS `/var` -> `/private/var`, `/tmp` -> `/private/tmp`), which would
+// wrongly reject a VALID managed path whose parents are symlinked. Instead we
+// walk up to the deepest EXISTING ancestor, `realpathSync` that, and re-append
+// the remaining non-existent suffix. The workspace root itself exists in the
+// fixture, so `<workspacePath>/context-tree` canonicalizes to
+// `realpath(<workspacePath>) + "/context-tree"`.
+function canonicalizeExistingAncestor(inputPath: string): string {
+  const normalized = normalize(inputPath);
+  let existing = normalized;
+  const trailing: string[] = [];
+  // Walk up until we hit a path that exists (or the filesystem root).
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) {
+      // Reached the root without finding an existing ancestor; nothing to
+      // canonicalize — fall back to the normalized string.
+      return normalized;
+    }
+    trailing.unshift(basename(existing));
+    existing = parent;
   }
+  let canonical: string;
+  try {
+    canonical = realpathSync(existing);
+  } catch {
+    return normalized;
+  }
+  return trailing.length === 0 ? canonical : join(canonical, ...trailing);
 }
 
 // True when a captured `--dir` value resolves to the workspace-managed
-// `<workspacePath>/context-tree`, NOT merely shares its basename. `tree init`
-// otherwise clones to `<cwd>/<repo>`; the model runs with cwd = workspacePath,
-// so a RELATIVE `--dir` (e.g. `./context-tree`, `context-tree`) resolves
-// against the workspace, while an absolute `--dir` must equal the target
-// outright. This ACCEPTS `./context-tree` / `context-tree` / an absolute
+// `<baseDir>/context-tree`, NOT merely shares its basename. `tree init`
+// otherwise clones to `<cwd>/<repo>`. A RELATIVE `--dir` (e.g. `./context-tree`,
+// `context-tree`) is resolved against `baseDir` — which the CALLER supplies as
+// the captured invocation cwd, falling back to workspacePath only when no cwd
+// was recorded — while an absolute `--dir` is compared outright. Both the
+// candidate and the target are canonicalized (symlinked-root aware) before the
+// equality check. This ACCEPTS `./context-tree` / `context-tree` / an absolute
 // `<workspacePath>/context-tree`; it REJECTS `/tmp/context-tree`,
-// `../context-tree`, and `<other>/context-tree` — all of which would land the
-// checkout outside the workspace-managed path.
-function dirResolvesToWorkspaceContextTree(dirValue: string, workspacePath: string): boolean {
+// `../context-tree`, `<other>/context-tree`, and a relative `--dir` launched
+// from a cwd outside the workspace — all of which land the checkout outside the
+// workspace-managed path.
+function dirResolvesToWorkspaceContextTree(dirValue: string, baseDir: string, workspacePath: string): boolean {
   const cleaned = stripQuotes(dirValue).replace(/\/+$/u, "");
   if (cleaned.length === 0) return false;
   const target = join(workspacePath, TREE_INIT_DIR_TARGET);
-  const candidate = isAbsolute(cleaned) ? normalize(cleaned) : resolve(workspacePath, cleaned);
+  const candidate = isAbsolute(cleaned) ? normalize(cleaned) : resolve(baseDir, cleaned);
   if (normalize(candidate) === normalize(target)) return true;
-  // Symlinked-root fallback (macOS /var, /tmp, /private/*): compare realpaths.
-  return realpathOrNormalized(candidate) === realpathOrNormalized(target);
+  // Symlinked-root aware compare (macOS /var, /tmp, /private/*) that tolerates
+  // the non-existent `context-tree` leaf.
+  return canonicalizeExistingAncestor(candidate) === canonicalizeExistingAncestor(target);
 }
 
 // Detect a `tree init` invocation from a captured first-tree argv vector.
@@ -436,18 +460,34 @@ function argvIsTreeInit(argv: readonly string[]): boolean {
 }
 
 // Detect `tree init --dir <workspacePath>/context-tree` from a captured argv
-// vector — the `--dir` must resolve to the workspace-managed context-tree path.
-function argvIsTreeInitWithContextTreeDir(argv: readonly string[], workspacePath: string): boolean {
+// vector. A relative `--dir` is resolved against the invocation's captured
+// `cwd` (the shim records `process.cwd()` on every `first_tree_call`) — so
+// `cd /tmp && first-tree tree init --dir ./context-tree` resolves against
+// `/tmp`, NOT the workspace, and is correctly rejected. When no cwd was
+// captured we fall back to workspacePath.
+function argvIsTreeInitWithContextTreeDir(argv: readonly string[], cwd: string | null, workspacePath: string): boolean {
   if (!argvIsTreeInit(argv)) return false;
   const dirIndex = argv.indexOf("--dir");
   if (dirIndex < 0) return false;
   const dirValue = argv[dirIndex + 1];
-  return typeof dirValue === "string" && dirResolvesToWorkspaceContextTree(dirValue, workspacePath);
+  return (
+    typeof dirValue === "string" && dirResolvesToWorkspaceContextTree(dirValue, cwd ?? workspacePath, workspacePath)
+  );
 }
 
 // Detect a `first-tree[-staging] tree init` invocation inside a raw command
 // string captured from a real command/exec event. Returns whether it is present
 // and whether its `--dir` resolves to the workspace-managed `context-tree`.
+//
+// A raw command string carries NO structured cwd (the model may prefix it with
+// `cd /tmp && ...`), so a relative `--dir` here cannot be resolved soundly.
+// Therefore this path credits `withContextTreeDir` ONLY for an ABSOLUTE `--dir`
+// resolving to the target (cwd-independent); a relative `--dir` counts toward
+// `present`/`observed` but NEVER toward `withContextTreeDir`. That is safe
+// because the authoritative cwd-aware signal is the shim `first_tree_call`
+// argv event, which fires for every real invocation regardless of how it was
+// launched — so relative-`--dir` correctness rides entirely on the argv path.
+//
 // This must only ever be fed captured COMMAND strings, never free-text prose:
 // a run where the model merely describes the command in its final response
 // (without invoking it) must NOT satisfy the invocation signal.
@@ -460,17 +500,22 @@ function commandTreeInitSignal(text: string, workspacePath: string): { present: 
     const rest = text.slice(match.index);
     const dirMatch = rest.match(/--dir(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))/u);
     const dirValue = dirMatch?.[1] ?? dirMatch?.[2] ?? dirMatch?.[3] ?? null;
-    if (dirValue !== null && dirResolvesToWorkspaceContextTree(dirValue, workspacePath)) {
+    if (dirValue === null) continue;
+    const cleaned = stripQuotes(dirValue).replace(/\/+$/u, "");
+    // Absolute-only: a relative --dir has no trustworthy base here.
+    if (isAbsolute(cleaned) && dirResolvesToWorkspaceContextTree(cleaned, workspacePath, workspacePath)) {
       withContextTreeDir = true;
     }
   }
   return { present, withContextTreeDir };
 }
 
+type FirstTreeCall = { argv: readonly string[]; cwd: string | null };
+
 type TreeInitObservation = { observed: boolean; withContextTreeDir: boolean };
 
 // The tree-init signal is derived ONLY from captured invocation evidence — the
-// shimmed `first-tree` argv vectors and the real codex exec/command-string
+// shimmed `first-tree` argv+cwd vectors and the real codex exec/command-string
 // events. The model's final response prose is deliberately NOT consulted here:
 // describing `tree init --dir .../context-tree` without invoking it must not
 // pass a gate whose whole point is to prove a real `tree init` invocation. The
@@ -478,15 +523,15 @@ type TreeInitObservation = { observed: boolean; withContextTreeDir: boolean };
 // basename, so a checkout aimed outside the workspace fails the gate.
 function deriveTreeInitObservation(
   events: readonly unknown[],
-  firstTreeArgv: readonly (readonly string[])[],
+  firstTreeCalls: readonly FirstTreeCall[],
   workspacePath: string,
 ): TreeInitObservation {
   let observed = false;
   let withContextTreeDir = false;
 
-  for (const argv of firstTreeArgv) {
-    if (argvIsTreeInit(argv)) observed = true;
-    if (argvIsTreeInitWithContextTreeDir(argv, workspacePath)) withContextTreeDir = true;
+  for (const call of firstTreeCalls) {
+    if (argvIsTreeInit(call.argv)) observed = true;
+    if (argvIsTreeInitWithContextTreeDir(call.argv, call.cwd, workspacePath)) withContextTreeDir = true;
   }
 
   for (const event of events) {
@@ -570,6 +615,7 @@ export function deriveMetrics(
   let workspaceManifestReadObserved = false;
   let sourceEvidenceReadObserved = false;
   const firstTreeArgv: string[][] = [];
+  const firstTreeCalls: FirstTreeCall[] = [];
   const modelOutputTexts: string[] = [];
 
   for (const event of events) {
@@ -598,7 +644,13 @@ export function deriveMetrics(
     const type = eventType(event);
     if ((type === "first_tree_call" || type === "first_tree_staging_call") && isModelPhase(event)) {
       const argv = firstTreeArgvFromEvent(event);
-      if (argv !== null) firstTreeArgv.push(argv);
+      if (argv !== null) {
+        firstTreeArgv.push(argv);
+        // The shim records the invocation cwd (`process.cwd()`) alongside argv;
+        // keep it so a relative `--dir` resolves against the real launch cwd.
+        const cwd = typeof event.cwd === "string" ? event.cwd : null;
+        firstTreeCalls.push({ argv, cwd });
+      }
     }
   }
 
@@ -608,7 +660,7 @@ export function deriveMetrics(
   const sourceWorktreeWasCreated = sourceWorktreeCreated(paths);
   const skeletonHints = evalCase.expected.skeletonHints ?? [];
   const approvalHints = evalCase.expected.approvalHints ?? [];
-  const treeInit = deriveTreeInitObservation(events, firstTreeArgv, paths.workspacePath);
+  const treeInit = deriveTreeInitObservation(events, firstTreeCalls, paths.workspacePath);
 
   const partialMetrics = {
     approvalRequestObserved: approvalHints.length === 0 || containsAny(finalResponse, approvalHints),

--- a/packages/skill-evals/src/suites/first-tree-seed/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/grader.ts
@@ -476,38 +476,25 @@ function argvIsTreeInitWithContextTreeDir(argv: readonly string[], cwd: string |
 }
 
 // Detect a `first-tree[-staging] tree init` invocation inside a raw command
-// string captured from a real command/exec event. Returns whether it is present
-// and whether its `--dir` resolves to the workspace-managed `context-tree`.
+// string captured from a real command/exec event. Reports ONLY presence — it
+// deliberately does NOT parse `--dir` or credit `withContextTreeDir`.
 //
-// A raw command string carries NO structured cwd (the model may prefix it with
-// `cd /tmp && ...`), so a relative `--dir` here cannot be resolved soundly.
-// Therefore this path credits `withContextTreeDir` ONLY for an ABSOLUTE `--dir`
-// resolving to the target (cwd-independent); a relative `--dir` counts toward
-// `present`/`observed` but NEVER toward `withContextTreeDir`. That is safe
-// because the authoritative cwd-aware signal is the shim `first_tree_call`
-// argv event, which fires for every real invocation regardless of how it was
-// launched — so relative-`--dir` correctness rides entirely on the argv path.
+// A raw command string cannot soundly bind a `--dir` token to the matched
+// `tree init`: the model may chain unrelated commands
+// (`first-tree tree init --title X && echo --dir <ws>/context-tree`), so a later
+// `--dir` in the same string is not necessarily an option of that `tree init`;
+// and the string carries no structured cwd for resolving a relative `--dir`.
+// The authoritative, cwd-aware, per-invocation `--dir` signal is the shim
+// `first_tree_call` argv event, which fires for EVERY real invocation with the
+// exact argv vector — so `withContextTreeDir` is derived SOLELY from that
+// structured path (see `deriveTreeInitObservation`). This path only backstops
+// `observed` (a `tree init` was attempted).
 //
 // This must only ever be fed captured COMMAND strings, never free-text prose:
 // a run where the model merely describes the command in its final response
 // (without invoking it) must NOT satisfy the invocation signal.
-function commandTreeInitSignal(text: string, workspacePath: string): { present: boolean; withContextTreeDir: boolean } {
-  const initPattern = /\bfirst-tree(?:-staging)?\s+tree\s+init\b/gu;
-  let present = false;
-  let withContextTreeDir = false;
-  for (let match = initPattern.exec(text); match !== null; match = initPattern.exec(text)) {
-    present = true;
-    const rest = text.slice(match.index);
-    const dirMatch = rest.match(/--dir(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))/u);
-    const dirValue = dirMatch?.[1] ?? dirMatch?.[2] ?? dirMatch?.[3] ?? null;
-    if (dirValue === null) continue;
-    const cleaned = stripQuotes(dirValue).replace(/\/+$/u, "");
-    // Absolute-only: a relative --dir has no trustworthy base here.
-    if (isAbsolute(cleaned) && dirResolvesToWorkspaceContextTree(cleaned, workspacePath, workspacePath)) {
-      withContextTreeDir = true;
-    }
-  }
-  return { present, withContextTreeDir };
+function commandMentionsTreeInit(text: string): boolean {
+  return /\bfirst-tree(?:-staging)?\s+tree\s+init\b/u.test(text);
 }
 
 type FirstTreeCall = { argv: readonly string[]; cwd: string | null };
@@ -537,9 +524,10 @@ function deriveTreeInitObservation(
   for (const event of events) {
     if (!isRecord(event) || eventType(event) !== "codex_event") continue;
     for (const command of collectCommandStrings(event.event)) {
-      const signal = commandTreeInitSignal(command, workspacePath);
-      if (signal.present) observed = true;
-      if (signal.withContextTreeDir) withContextTreeDir = true;
+      // Command strings backstop `observed` only; `withContextTreeDir` comes
+      // solely from the structured argv+cwd path above (see the comment on
+      // `commandMentionsTreeInit`).
+      if (commandMentionsTreeInit(command)) observed = true;
     }
   }
 

--- a/packages/skill-evals/src/suites/first-tree-seed/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/grader.ts
@@ -459,20 +459,32 @@ function argvIsTreeInit(argv: readonly string[]): boolean {
   return argv[0] === "tree" && argv[1] === "init";
 }
 
-// Extract the `--dir` value from a captured argv vector, accepting BOTH the
-// space form (`--dir <value>`, two tokens) and the equals form (`--dir=<value>`,
-// one token) — Commander accepts either, so the grader must too, else a valid
-// `tree init --dir=<managed>/context-tree` would be wrongly rejected. Scanning
-// the whole vector is safe here (unlike a raw command string): it is a single
-// invocation's argv, so any `--dir` in it belongs to this `tree init`.
+// Extract the EFFECTIVE `--dir` value from a captured argv vector, mirroring
+// Commander's parsing of `.option("--dir <path>")` so the grader sees the same
+// target the real CLI would use:
+//   - accept BOTH spellings: space form (`--dir <value>`) and equals form
+//     (`--dir=<value>`) — else a valid `--dir=<managed>/context-tree` is wrongly
+//     rejected;
+//   - LAST occurrence wins (Commander overwrites a scalar option), so a later
+//     outside-workspace `--dir` overrides an earlier managed one and must not
+//     false-green;
+//   - stop at a `--` terminator: tokens after it are positionals, not options.
+// Scanning the vector is safe (unlike a raw command string): it is a single
+// invocation's argv, so any option `--dir` in it belongs to this `tree init`.
 function treeInitDirValueFromArgv(argv: readonly string[]): string | null {
+  let dirValue: string | null = null;
   for (let i = 0; i < argv.length; i++) {
     const token = argv[i];
     if (token === undefined) continue;
-    if (token === "--dir") return argv[i + 1] ?? null;
-    if (token.startsWith("--dir=")) return token.slice("--dir=".length);
+    if (token === "--") break; // option terminator; the rest are positionals
+    if (token === "--dir") {
+      dirValue = argv[i + 1] ?? null;
+      i++; // consume the value token Commander binds to --dir
+    } else if (token.startsWith("--dir=")) {
+      dirValue = token.slice("--dir=".length);
+    }
   }
-  return null;
+  return dirValue;
 }
 
 // Detect `tree init --dir <workspacePath>/context-tree` from a captured argv

--- a/packages/skill-evals/src/suites/first-tree-seed/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/grader.ts
@@ -459,6 +459,22 @@ function argvIsTreeInit(argv: readonly string[]): boolean {
   return argv[0] === "tree" && argv[1] === "init";
 }
 
+// Extract the `--dir` value from a captured argv vector, accepting BOTH the
+// space form (`--dir <value>`, two tokens) and the equals form (`--dir=<value>`,
+// one token) — Commander accepts either, so the grader must too, else a valid
+// `tree init --dir=<managed>/context-tree` would be wrongly rejected. Scanning
+// the whole vector is safe here (unlike a raw command string): it is a single
+// invocation's argv, so any `--dir` in it belongs to this `tree init`.
+function treeInitDirValueFromArgv(argv: readonly string[]): string | null {
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === undefined) continue;
+    if (token === "--dir") return argv[i + 1] ?? null;
+    if (token.startsWith("--dir=")) return token.slice("--dir=".length);
+  }
+  return null;
+}
+
 // Detect `tree init --dir <workspacePath>/context-tree` from a captured argv
 // vector. A relative `--dir` is resolved against the invocation's captured
 // `cwd` (the shim records `process.cwd()` on every `first_tree_call`) — so
@@ -467,12 +483,8 @@ function argvIsTreeInit(argv: readonly string[]): boolean {
 // captured we fall back to workspacePath.
 function argvIsTreeInitWithContextTreeDir(argv: readonly string[], cwd: string | null, workspacePath: string): boolean {
   if (!argvIsTreeInit(argv)) return false;
-  const dirIndex = argv.indexOf("--dir");
-  if (dirIndex < 0) return false;
-  const dirValue = argv[dirIndex + 1];
-  return (
-    typeof dirValue === "string" && dirResolvesToWorkspaceContextTree(dirValue, cwd ?? workspacePath, workspacePath)
-  );
+  const dirValue = treeInitDirValueFromArgv(argv);
+  return dirValue !== null && dirResolvesToWorkspaceContextTree(dirValue, cwd ?? workspacePath, workspacePath);
 }
 
 // Detect a `first-tree[-staging] tree init` invocation inside a raw command

--- a/packages/skill-evals/src/suites/first-tree-seed/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/grader.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readdirSync, realpathSync } from "node:fs";
+import { isAbsolute, join, normalize, resolve } from "node:path";
 
 import { runCommand } from "../../core/commands.js";
 import { isRecord, isStringArray } from "../../core/events.js";
@@ -396,11 +396,38 @@ function stripQuotes(value: string): string {
   return value.replace(/^['"]|['"]$/gu, "");
 }
 
-function dirBasenameIsContextTree(dirValue: string): boolean {
+// Resolve a path to its real (symlink-followed) form when it exists, otherwise
+// fall back to the normalized string. The eval shim blocks real `tree init`, so
+// the target `context-tree` checkout usually does NOT exist on disk — hence the
+// ENOENT-tolerant fallback. This exists to defeat the macOS symlinked-root
+// caveat (e.g. `/var` -> `/private/var`, `/tmp` -> `/private/tmp`): the captured
+// absolute `--dir` and the derived workspace path can print differently yet
+// point at the same location, so we realpath BOTH sides before comparing.
+function realpathOrNormalized(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return normalize(path);
+  }
+}
+
+// True when a captured `--dir` value resolves to the workspace-managed
+// `<workspacePath>/context-tree`, NOT merely shares its basename. `tree init`
+// otherwise clones to `<cwd>/<repo>`; the model runs with cwd = workspacePath,
+// so a RELATIVE `--dir` (e.g. `./context-tree`, `context-tree`) resolves
+// against the workspace, while an absolute `--dir` must equal the target
+// outright. This ACCEPTS `./context-tree` / `context-tree` / an absolute
+// `<workspacePath>/context-tree`; it REJECTS `/tmp/context-tree`,
+// `../context-tree`, and `<other>/context-tree` — all of which would land the
+// checkout outside the workspace-managed path.
+function dirResolvesToWorkspaceContextTree(dirValue: string, workspacePath: string): boolean {
   const cleaned = stripQuotes(dirValue).replace(/\/+$/u, "");
   if (cleaned.length === 0) return false;
-  const segments = cleaned.split("/");
-  return segments[segments.length - 1] === TREE_INIT_DIR_TARGET;
+  const target = join(workspacePath, TREE_INIT_DIR_TARGET);
+  const candidate = isAbsolute(cleaned) ? normalize(cleaned) : resolve(workspacePath, cleaned);
+  if (normalize(candidate) === normalize(target)) return true;
+  // Symlinked-root fallback (macOS /var, /tmp, /private/*): compare realpaths.
+  return realpathOrNormalized(candidate) === realpathOrNormalized(target);
 }
 
 // Detect a `tree init` invocation from a captured first-tree argv vector.
@@ -408,22 +435,23 @@ function argvIsTreeInit(argv: readonly string[]): boolean {
   return argv[0] === "tree" && argv[1] === "init";
 }
 
-// Detect `tree init --dir <...>/context-tree` from a captured argv vector.
-function argvIsTreeInitWithContextTreeDir(argv: readonly string[]): boolean {
+// Detect `tree init --dir <workspacePath>/context-tree` from a captured argv
+// vector — the `--dir` must resolve to the workspace-managed context-tree path.
+function argvIsTreeInitWithContextTreeDir(argv: readonly string[], workspacePath: string): boolean {
   if (!argvIsTreeInit(argv)) return false;
   const dirIndex = argv.indexOf("--dir");
   if (dirIndex < 0) return false;
   const dirValue = argv[dirIndex + 1];
-  return typeof dirValue === "string" && dirBasenameIsContextTree(dirValue);
+  return typeof dirValue === "string" && dirResolvesToWorkspaceContextTree(dirValue, workspacePath);
 }
 
 // Detect a `first-tree[-staging] tree init` invocation inside a raw command
 // string captured from a real command/exec event. Returns whether it is present
-// and whether it carries a `--dir` resolving to a `context-tree` checkout.
+// and whether its `--dir` resolves to the workspace-managed `context-tree`.
 // This must only ever be fed captured COMMAND strings, never free-text prose:
 // a run where the model merely describes the command in its final response
 // (without invoking it) must NOT satisfy the invocation signal.
-function commandTreeInitSignal(text: string): { present: boolean; withContextTreeDir: boolean } {
+function commandTreeInitSignal(text: string, workspacePath: string): { present: boolean; withContextTreeDir: boolean } {
   const initPattern = /\bfirst-tree(?:-staging)?\s+tree\s+init\b/gu;
   let present = false;
   let withContextTreeDir = false;
@@ -432,7 +460,7 @@ function commandTreeInitSignal(text: string): { present: boolean; withContextTre
     const rest = text.slice(match.index);
     const dirMatch = rest.match(/--dir(?:=|\s+)(?:"([^"]+)"|'([^']+)'|(\S+))/u);
     const dirValue = dirMatch?.[1] ?? dirMatch?.[2] ?? dirMatch?.[3] ?? null;
-    if (dirValue !== null && dirBasenameIsContextTree(dirValue)) {
+    if (dirValue !== null && dirResolvesToWorkspaceContextTree(dirValue, workspacePath)) {
       withContextTreeDir = true;
     }
   }
@@ -445,23 +473,26 @@ type TreeInitObservation = { observed: boolean; withContextTreeDir: boolean };
 // shimmed `first-tree` argv vectors and the real codex exec/command-string
 // events. The model's final response prose is deliberately NOT consulted here:
 // describing `tree init --dir .../context-tree` without invoking it must not
-// pass a gate whose whole point is to prove a real `tree init` invocation.
+// pass a gate whose whole point is to prove a real `tree init` invocation. The
+// `--dir` must RESOLVE to `<workspacePath>/context-tree`, not merely share a
+// basename, so a checkout aimed outside the workspace fails the gate.
 function deriveTreeInitObservation(
   events: readonly unknown[],
   firstTreeArgv: readonly (readonly string[])[],
+  workspacePath: string,
 ): TreeInitObservation {
   let observed = false;
   let withContextTreeDir = false;
 
   for (const argv of firstTreeArgv) {
     if (argvIsTreeInit(argv)) observed = true;
-    if (argvIsTreeInitWithContextTreeDir(argv)) withContextTreeDir = true;
+    if (argvIsTreeInitWithContextTreeDir(argv, workspacePath)) withContextTreeDir = true;
   }
 
   for (const event of events) {
     if (!isRecord(event) || eventType(event) !== "codex_event") continue;
     for (const command of collectCommandStrings(event.event)) {
-      const signal = commandTreeInitSignal(command);
+      const signal = commandTreeInitSignal(command, workspacePath);
       if (signal.present) observed = true;
       if (signal.withContextTreeDir) withContextTreeDir = true;
     }
@@ -577,7 +608,7 @@ export function deriveMetrics(
   const sourceWorktreeWasCreated = sourceWorktreeCreated(paths);
   const skeletonHints = evalCase.expected.skeletonHints ?? [];
   const approvalHints = evalCase.expected.approvalHints ?? [];
-  const treeInit = deriveTreeInitObservation(events, firstTreeArgv);
+  const treeInit = deriveTreeInitObservation(events, firstTreeArgv, paths.workspacePath);
 
   const partialMetrics = {
     approvalRequestObserved: approvalHints.length === 0 || containsAny(finalResponse, approvalHints),


### PR DESCRIPTION
## What

Post-merge follow-up to **#1391** (merged `be48a0e2`): tightens the `first-tree-seed` state-A eval grader so the `unbound-tree-inits-with-dir` gate proves the tree lands at the **workspace-managed** `<workspaceRoot>/context-tree`, not merely that `--dir` ends in `context-tree`.

Fixes a valid **P2** the Codex GitHub bot raised on head `0391a3ef` ~1 min after #1391 merged (`grader.ts:399`, escalated by codex-assistant). The gap: `dirBasenameIsContextTree` compared only the final path segment, so `first-tree tree init --dir /tmp/context-tree`, `--dir ../context-tree`, or `--dir <other>/context-tree` would set `treeInitWithContextTreeDirObserved` and pass state A even though the checkout would land outside the managed path — defeating the exact handoff invariant this case guards.

## Change (`packages/skill-evals/src/suites/first-tree-seed/grader.ts`)

- Replace `dirBasenameIsContextTree(dirValue)` with `dirResolvesToWorkspaceContextTree(dirValue, workspacePath)`:
  - `target = join(workspacePath, "context-tree")`.
  - Absolute `--dir` → `normalize` and require `=== target`.
  - Relative `--dir` → `resolve(workspacePath, dirValue)` (the model runs with cwd = workspacePath) and require `=== target`.
  - **Accepts** `./context-tree`, `context-tree`, absolute `<workspacePath>/context-tree`; **rejects** `/tmp/context-tree`, `../context-tree`, `<other>/context-tree`.
- Add `realpathOrNormalized` — a defensive symlinked-root fallback (macOS `/var`→`/private/var`, `/tmp`→`/private/tmp`): realpath **both** sides when the plain-normalize compare misses, ENOENT-tolerant since the shim blocks real `tree init` so the target checkout usually doesn't exist.
- Thread `paths.workspacePath` through `deriveTreeInitObservation` into both the argv path (`argvIsTreeInitWithContextTreeDir`) and the command-string path (`commandTreeInitSignal`).

## Regression tests (`__tests__/grader.test.ts`)

- `--dir /tmp/context-tree` (absolute, outside) → `treeInitWithContextTreeDirObserved === false`, `casePassed(...) === false`.
- `--dir ../context-tree` (escapes workspace) → false.
- `--dir ./context-tree` (relative, workspace cwd) → true, and absolute `<workspacePath>/context-tree` → true.

## Verification

- `typecheck` clean · `biome check` clean · `vitest run src/suites/first-tree-seed` **38 pass** (+3) · `eval:floor --suite first-tree-seed` PASS.
- **Real codex eval** for `unbound-tree-inits-with-dir` still grades **PASS**: the model emitted an absolute `--dir = <workspacePath>/context-tree` (exact managed path); the tightened grader accepts it (`treeInitWithContextTreeDirObserved: true`, `sourceWorktreeCreated: false`, `sourceEvidenceReadObserved: false`, `passed: true`). Realpath normalization was not needed for the run's paths — the fallback is a defensive guard.

Closes the Codex-bot P2 on #1391. Skill-eval-only; no skill-payload or runtime change.
