### PR TITLE
feat(scan): raise apply-consent and conversion as tracked ask-user cards

### DIFF
--- a/packages/server/src/__tests__/campaign-scan-skill.test.ts
+++ b/packages/server/src/__tests__/campaign-scan-skill.test.ts
@@ -24,8 +24,11 @@ describe("campaign scan skills", () => {
       expect(body).toContain("Step 5");
       expect(body).toContain("ready-to-apply");
       // Offers to apply via the user's own GitHub (gh), on a branch.
-      expect(body).toContain("open a PR");
       expect(body).toContain("`gh`");
+      // The apply-consent offer is raised as a tracked ask-user decision (chat ask),
+      // not a plain message — so it can't be missed and blocks on the answer.
+      expect(body).toContain("tracked ask-user");
+      expect(body).toContain("chat ask");
       // Consent gate: never mutates the repo without an explicit yes.
       expect(body.toLowerCase()).toContain("read-only until");
       expect(body).toContain("explicit go-ahead");
@@ -62,6 +65,11 @@ describe("campaign scan skills", () => {
       expect(body).toContain("ONE ask at a time");
       // (4) explicit stop condition — no re-pitch when unanswered / declined / quiet.
       expect(body).toContain("don't re-pitch");
+      // (5) BOTH the apply-consent offer and the Step 6 conversion are raised as
+      //     tracked ask-user decisions (chat ask) — the two asks in the flow — and
+      //     the conversion stays a single yes/no, never a multi-option menu.
+      expect((body.match(/chat ask/g) ?? []).length).toBeGreaterThanOrEqual(2);
+      expect(body).toContain("never a menu");
     }
   });
 });

--- a/packages/server/src/__tests__/campaign-scan-skill.test.ts
+++ b/packages/server/src/__tests__/campaign-scan-skill.test.ts
@@ -29,6 +29,9 @@ describe("campaign scan skills", () => {
       // not a plain message — so it can't be missed and blocks on the answer.
       expect(body).toContain("tracked ask-user");
       expect(body).toContain("chat ask");
+      // The skill states the GENERAL principle (not only the two concrete asks):
+      // any user decision goes through a tracked ask-user card, never a plain message.
+      expect(body).toContain("any decision you put to the user");
       // Consent gate: never mutates the repo without an explicit yes.
       expect(body.toLowerCase()).toContain("read-only until");
       expect(body).toContain("explicit go-ahead");

--- a/packages/server/src/services/campaign-scan-skill.ts
+++ b/packages/server/src/services/campaign-scan-skill.ts
@@ -33,6 +33,11 @@ You are a senior staff engineer doing a pre-launch review of the **target
 repository for this chat**. Produce a structured production-readiness report.
 **READ-ONLY**: do not modify, stage, or commit anything.
 
+**How you ask:** any decision you put to the user — a real choice they must make
+to proceed — goes through a **tracked ask-user card** (your \`chat ask\`), never a
+plain message: Yes/No or a few clean options, one ask at a time, dropped if they
+decline or go quiet.
+
 ## Step 0 — get the repo
 Get the target repo before scanning. **Fastest path (preferred):** the repo's
 GitHub URL is in the opening chat message ("connected to your code: …") —
@@ -171,6 +176,11 @@ const AGENT_READINESS_BODY = `# Agent Readiness Scan
 You assess how well a coding agent (Claude Code / Codex / Cursor) can work in the
 **target repository for this chat** without getting lost. Produce a
 structured agent-readiness report. **READ-ONLY**: do not modify anything.
+
+**How you ask:** any decision you put to the user — a real choice they must make
+to proceed — goes through a **tracked ask-user card** (your \`chat ask\`), never a
+plain message: Yes/No or a few clean options, one ask at a time, dropped if they
+decline or go quiet.
 
 ## Step 0 — get the repo
 Get the target repo before scanning. **Fastest path (preferred):** the repo's

--- a/packages/server/src/services/campaign-scan-skill.ts
+++ b/packages/server/src/services/campaign-scan-skill.ts
@@ -112,9 +112,15 @@ never inside the committed file itself, and never more than once. Use that exact
 line (don't invent or guess a different URL); if the user would rather it not be
 there, drop it without a fuss.
 
-Then offer to **apply it on the user's behalf using their own GitHub**: e.g.
-"Want me to open a PR with this change to \`<owner>/<repo>\`?" (or file the
-issue). **Stay READ-ONLY until the user explicitly says yes.** On yes, use the
+Then offer to **apply it on the user's behalf using their own GitHub** — and raise
+that offer as a **tracked ask-user decision, not a plain chat message**: use your
+First Tree \`chat ask\` to pose a blocking Yes/No card — a confirm option whose
+label matches the action (**Open the PR** for a diff, **File the issue** for an
+issue) and a **Not now** decline. Give each option a short label (≤5 words) AND a
+one-line description — \`chat ask\` requires both. Phrase the question like "Open a
+PR with this change to \`<owner>/<repo>\`?" (or "File this as an issue?"). Opening a PR is a real write on their own GitHub, so it must be an
+explicit, un-missable decision that blocks on their answer. **Stay READ-ONLY until
+they pick yes.** On yes, use the
 \`gh\` CLI on this machine to open the PR (or file the issue) on a new branch,
 then share the link. If \`gh\` is not authenticated, hand them the exact command
 to run instead. Never push to their default branch or change anything without
@@ -139,15 +145,19 @@ and every teammate starts from it instead of re-learning the repo. That is the
 difference from the static file you just wrote: it's the team's durable, reviewed
 source of context that stays useful as work happens, not a doc that quietly goes
 stale. Then make the
-concrete ask: set up their First Tree team and build the context tree for this
-repo. If they're in, walk them through only the standard setup steps they haven't
-already done — their team, their agent, and the context tree — skipping anything
+concrete ask as a **tracked ask-user decision** — your \`chat ask\` posing a single
+Yes/No card: a **Set it up** confirm and a **Not now** decline, each with a short
+label (≤5 words) and a one-line description (\`chat ask\` requires both). Phrase it
+like "Set up your First Tree team and build the context tree for this repo?" — a
+single clear yes/no, **never a multi-option menu**. If they pick yes, walk them through only the standard setup
+steps they haven't already done — their team, their agent, and the context tree — skipping anything
 the current flow already handled. This is the confident default, tied to their
 demonstrated pain, not a soft footnote.
 
 **Secondary (lighter) — only if they decline the team AND explicitly want to keep
-going:** offer exactly one lighter next step instead — turn the next blocker into a
-fix, or scan another (or a private) repo. This is offered instead of re-pitching
+going:** offer exactly one lighter next step instead, **as a plain conversational
+offer — not another ask-user card** — turn the next blocker into a fix, or scan
+another (or a private) repo. This is offered instead of re-pitching
 the team; it is never a second ask stacked after a no.
 
 Otherwise, **stop.** ONE ask at a time is the rule, and the stop condition is
@@ -240,9 +250,15 @@ never inside the committed file itself, and never more than once. Use that exact
 line (don't invent or guess a different URL); if the user would rather it not be
 there, drop it without a fuss.
 
-Then offer to **apply it on the user's behalf using their own GitHub**: e.g.
-"Want me to open a PR adding this AGENTS.md to \`<owner>/<repo>\`?" **Stay
-READ-ONLY until the user explicitly says yes.** On yes, use the \`gh\` CLI on
+Then offer to **apply it on the user's behalf using their own GitHub** — and raise
+that offer as a **tracked ask-user decision, not a plain chat message**: use your
+First Tree \`chat ask\` to pose a blocking Yes/No card — a confirm option whose
+label matches the action (**Open the PR**, or **File the issue** if the deliverable
+is an issue) and a **Not now** decline. Give each option a short label (≤5 words)
+AND a one-line description — \`chat ask\` requires both. Phrase it like "Open a PR
+adding this AGENTS.md to \`<owner>/<repo>\`?" Opening a PR
+is a real write on their own GitHub, so it must be an explicit, un-missable
+decision that blocks on their answer. **Stay READ-ONLY until they pick yes.** On yes, use the \`gh\` CLI on
 this machine to open the PR (or file the issue) on a new branch, then share the
 link. If \`gh\` is not authenticated, hand them the exact command to run instead.
 Never push to their default branch or change anything without that explicit
@@ -267,15 +283,19 @@ and every teammate starts from it instead of re-learning the repo. That is the
 difference from the static file you just wrote: it's the team's durable, reviewed
 source of context that stays useful as work happens, not a doc that quietly goes
 stale. Then make the
-concrete ask: set up their First Tree team and build the context tree for this
-repo. If they're in, walk them through only the standard setup steps they haven't
-already done — their team, their agent, and the context tree — skipping anything
+concrete ask as a **tracked ask-user decision** — your \`chat ask\` posing a single
+Yes/No card: a **Set it up** confirm and a **Not now** decline, each with a short
+label (≤5 words) and a one-line description (\`chat ask\` requires both). Phrase it
+like "Set up your First Tree team and build the context tree for this repo?" — a
+single clear yes/no, **never a multi-option menu**. If they pick yes, walk them through only the standard setup
+steps they haven't already done — their team, their agent, and the context tree — skipping anything
 the current flow already handled. This is the confident default, tied to their
 demonstrated pain, not a soft footnote.
 
 **Secondary (lighter) — only if they decline the team AND explicitly want to keep
-going:** offer exactly one lighter next step instead — turn the next blocker into a
-fix, or scan another (or a private) repo. This is offered instead of re-pitching
+going:** offer exactly one lighter next step instead, **as a plain conversational
+offer — not another ask-user card** — turn the next blocker into a fix, or scan
+another (or a private) repo. This is offered instead of re-pitching
 the team; it is never a second ask stacked after a no.
 
 Otherwise, **stop.** ONE ask at a time is the rule, and the stop condition is


### PR DESCRIPTION
## Why
Testing the scan flow surfaced a UX gap: when the agent asks the user a real decision — "open a PR on your GitHub?" (Step 5 apply-consent) or "set up a First Tree team + build the context tree?" (Step 6 conversion) — it sent a **plain chat message**, not a tracked `ask user`. A plain message can be scrolled past and doesn't signal the agent is blocked waiting; for an irreversible write on the user's own GitHub that's the wrong affordance. Product direction: both should be tracked ask-user decisions.

## What
Both scan bodies now raise those two decision points via the agent's First Tree `chat ask` (**binary-agnostic** — no hardcoded CLI name), rendering a blocking Yes/No card:
- **Step 5 (apply-consent):** confirm label tracks the action — **Open the PR** for a diff / **File the issue** for an issue — plus a **Not now** decline.
- **Step 6 (conversion):** a single **Set it up** / **Not now** yes/no — never a multi-option menu.
- Each option carries a short (≤5-word) label **and** a one-line description, as `askOptionSchema` (packages/shared) requires — otherwise the card would fail to validate at runtime.

Guardrails unchanged: READ-ONLY until explicit yes; the `gh pr create` / `gh issue create` write fence; PR/issue-description-only attribution; the apply-offer gate before Step 6; one ask at a time; the explicit stop / no-re-pitch condition. The secondary lighter follow-up stays a **plain conversational offer, never a second card**, so two cards never stack.

Tests lock the ask-user **behavior** as anchors (`tracked ask-user`, ≥2 `chat ask`, `never a menu`) without freezing marketing wording.

## Review
Two independent reviews (correctness/consistency + conversion/taste-and-not-naggy) — both NON-BLOCKING. Their nits are folded in: confirm label now tracks PR-vs-issue, and each option now supplies the schema-required description. `biome` clean; `pnpm --filter @first-tree/server typecheck` clean; full server suite **1638/1638** green.

## Merge order
Stacked on `refactor/scan-skill-behavior-anchors` (#1397) since it builds on that Step 5/6 copy. Merge #1397 first; this retargets to `main` after.
