### PR TITLE
Implement local client user switch

### DIFF
--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -14,6 +14,7 @@ const configMocks = vi.hoisted(() => ({
   clientConfigSchema: {},
   defaultConfigDir: vi.fn(),
   defaultDataDir: vi.fn(),
+  defaultHome: vi.fn(),
   loadAgents: vi.fn(),
   resolveConfigReadonly: vi.fn(),
   setConfigValue: vi.fn(),
@@ -43,8 +44,11 @@ const coreMocks = vi.hoisted(() => ({
   installGlobalSpec: vi.fn(),
   installPortableSpec: vi.fn(),
   isServiceSupported: vi.fn(),
+  loadCredentials: vi.fn(),
   PACKAGE_NAME: "first-tree",
   promptAddAgent: vi.fn(),
+  readActiveRootClientId: vi.fn(),
+  recordActiveClientOwner: vi.fn(),
   removeLocalAgent: vi.fn(),
   resolveServerUrl: vi.fn(),
   restartClientService: vi.fn(),
@@ -82,6 +86,10 @@ function jsonResponse(body: unknown, ok = true, status = 200): Response {
   } as unknown as Response;
 }
 
+function jwt(payload: Record<string, unknown>): string {
+  return `h.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.s`;
+}
+
 async function runAgent(args: string[]): Promise<void> {
   const { registerAgentCommands } = await import("../commands/agent/index.js");
   const program = new Command();
@@ -102,6 +110,7 @@ async function runTopLevel(register: (program: Command) => void, args: string[])
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "ft-cli-agent-commands-"));
   vi.clearAllMocks();
+  configMocks.defaultHome.mockReturnValue(tempDir);
   configMocks.defaultConfigDir.mockReturnValue(tempDir);
   configMocks.defaultDataDir.mockReturnValue(join(tempDir, "data"));
   configMocks.resolveConfigReadonly.mockReturnValue({ client: { id: "client-1" } });
@@ -116,6 +125,8 @@ beforeEach(() => {
   coreMocks.installGlobalLatest.mockResolvedValue({ ok: true, mode: "global", installedVersion: "99.0.0" });
   coreMocks.installGlobalSpec.mockResolvedValue({ ok: true, mode: "global", installedVersion: "99.0.0" });
   coreMocks.installPortableSpec.mockResolvedValue({ ok: true, mode: "portable", installedVersion: "99.0.0" });
+  coreMocks.loadCredentials.mockReturnValue(null);
+  coreMocks.readActiveRootClientId.mockReturnValue(null);
   cliFetchMock.mockReset();
   coreMocks.promptAddAgent.mockResolvedValue({ name: "nova", agentId: "agent-1" });
   coreMocks.findStaleAliases.mockResolvedValue([
@@ -279,21 +290,53 @@ describe("agent lifecycle CLI commands", () => {
 });
 
 describe("logout and upgrade commands", () => {
+  it("logout remembers the active client owner before removing credentials", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(credentials, "{}");
+    coreMocks.loadCredentials.mockReturnValue({
+      accessToken: jwt({ sub: "user-old" }),
+      refreshToken: "refresh",
+      serverUrl: "https://first-tree.example",
+    });
+    coreMocks.readActiveRootClientId.mockReturnValue("client_aabbccdd");
+    coreMocks.isServiceSupported.mockReturnValue(false);
+
+    const { registerLogoutCommand } = await import("../commands/logout.js");
+    await runTopLevel(registerLogoutCommand, ["logout"]);
+
+    expect(coreMocks.recordActiveClientOwner).toHaveBeenCalledWith({
+      clientId: "client_aabbccdd",
+      userId: "user-old",
+      serverUrl: "https://first-tree.example",
+    });
+    expect(() => readFileSync(credentials, "utf8")).toThrow();
+  });
+
   it("logout stops an active service and removes credentials, client config, and agent runtime state when purging", async () => {
     const credentials = join(tempDir, "credentials.json");
     const clientYaml = join(tempDir, "client.yaml");
     const agentsDir = join(tempDir, "agents");
     const sessionsDir = join(tempDir, "data", "sessions");
     const workspacesDir = join(tempDir, "data", "workspaces");
+    const parkedClientsDir = join(tempDir, "parked-clients");
+    const switchLock = join(tempDir, "state", "client-switch.lock");
+    const switchJournal = join(tempDir, "state", "client-switch-journal.json");
     mkdirSync(tempDir, { recursive: true });
     mkdirSync(agentsDir, { recursive: true });
     mkdirSync(sessionsDir, { recursive: true });
     mkdirSync(workspacesDir, { recursive: true });
+    mkdirSync(join(parkedClientsDir, "client_old", "data", "workspaces"), { recursive: true });
+    mkdirSync(join(tempDir, "state"), { recursive: true });
     writeFileSync(credentials, "{}");
     writeFileSync(clientYaml, "client:\n  id: client-1\n");
     writeFileSync(join(agentsDir, "agent.yaml"), "agentId: agent-1\n");
     writeFileSync(join(sessionsDir, "session.json"), "{}");
     writeFileSync(join(workspacesDir, "workspace.json"), "{}");
+    writeFileSync(join(parkedClientsDir, "index.json"), "{}");
+    writeFileSync(join(parkedClientsDir, "client_old", "data", "workspaces", "marker.txt"), "old");
+    writeFileSync(switchLock, "locked");
+    writeFileSync(switchJournal, "{}");
     coreMocks.isServiceSupported.mockReturnValue(true);
     coreMocks.getClientServiceStatus.mockReturnValue({ state: "active", platform: "launchd" });
     coreMocks.stopClientService.mockReturnValue({ ok: true });
@@ -307,7 +350,52 @@ describe("logout and upgrade commands", () => {
     expect(() => readFileSync(join(agentsDir, "agent.yaml"), "utf8")).toThrow();
     expect(() => readFileSync(join(sessionsDir, "session.json"), "utf8")).toThrow();
     expect(() => readFileSync(join(workspacesDir, "workspace.json"), "utf8")).toThrow();
+    expect(existsSync(parkedClientsDir)).toBe(false);
+    expect(existsSync(switchLock)).toBe(false);
+    expect(existsSync(switchJournal)).toBe(false);
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Logged out");
+  });
+
+  it("computer reset uses the same guarded local-state removal as logout --purge", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    const clientYaml = join(tempDir, "client.yaml");
+    const agentsDir = join(tempDir, "agents");
+    const sessionsDir = join(tempDir, "data", "sessions");
+    const workspacesDir = join(tempDir, "data", "workspaces");
+    const parkedClientsDir = join(tempDir, "parked-clients");
+    const switchLock = join(tempDir, "state", "client-switch.lock");
+    const switchJournal = join(tempDir, "state", "client-switch-journal.json");
+    mkdirSync(tempDir, { recursive: true });
+    mkdirSync(agentsDir, { recursive: true });
+    mkdirSync(sessionsDir, { recursive: true });
+    mkdirSync(workspacesDir, { recursive: true });
+    mkdirSync(join(parkedClientsDir, "client_old", "data", "sessions"), { recursive: true });
+    mkdirSync(join(tempDir, "state"), { recursive: true });
+    writeFileSync(credentials, "{}");
+    writeFileSync(clientYaml, "client:\n  id: client-1\n");
+    writeFileSync(join(agentsDir, "agent.yaml"), "agentId: agent-1\n");
+    writeFileSync(join(sessionsDir, "session.json"), "{}");
+    writeFileSync(join(workspacesDir, "workspace.json"), "{}");
+    writeFileSync(join(parkedClientsDir, "index.json"), "{}");
+    writeFileSync(join(parkedClientsDir, "client_old", "data", "sessions", "marker.json"), "{}");
+    writeFileSync(switchLock, "locked");
+    writeFileSync(switchJournal, "{}");
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.getClientServiceStatus.mockReturnValue({ state: "active", platform: "launchd" });
+    coreMocks.stopClientService.mockReturnValue({ ok: true });
+
+    const { registerComputerCommands } = await import("../commands/computer/index.js");
+    await runTopLevel(registerComputerCommands, ["computer", "reset"]);
+
+    expect(coreMocks.stopClientService).toHaveBeenCalled();
+    expect(() => readFileSync(credentials, "utf8")).toThrow();
+    expect(() => readFileSync(clientYaml, "utf8")).toThrow();
+    expect(() => readFileSync(join(agentsDir, "agent.yaml"), "utf8")).toThrow();
+    expect(() => readFileSync(join(sessionsDir, "session.json"), "utf8")).toThrow();
+    expect(() => readFileSync(join(workspacesDir, "workspace.json"), "utf8")).toThrow();
+    expect(existsSync(parkedClientsDir)).toBe(false);
+    expect(existsSync(switchLock)).toBe(false);
+    expect(existsSync(switchJournal)).toBe(false);
   });
 
   it("refuses purge before deleting local state when an active service cannot be stopped", async () => {

--- a/apps/cli/src/__tests__/cli-entry-and-tree-actions-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-entry-and-tree-actions-extra.test.ts
@@ -11,6 +11,7 @@ const clientMocks = vi.hoisted(() => ({
 const registrationMocks = vi.hoisted(() => ({
   registerAgentCommands: vi.fn(),
   registerChatCommands: vi.fn(),
+  registerComputerCommands: vi.fn(),
   registerConfigCommands: vi.fn(),
   registerDaemonCommands: vi.fn(),
   registerDoctorCommand: vi.fn(),
@@ -29,6 +30,9 @@ const outputMocks = vi.hoisted(() => ({
 vi.mock("@first-tree/client", () => clientMocks);
 vi.mock("../commands/agent/index.js", () => ({ registerAgentCommands: registrationMocks.registerAgentCommands }));
 vi.mock("../commands/chat/index.js", () => ({ registerChatCommands: registrationMocks.registerChatCommands }));
+vi.mock("../commands/computer/index.js", () => ({
+  registerComputerCommands: registrationMocks.registerComputerCommands,
+}));
 vi.mock("../commands/config/index.js", () => ({ registerConfigCommands: registrationMocks.registerConfigCommands }));
 vi.mock("../commands/daemon/index.js", () => ({ registerDaemonCommands: registrationMocks.registerDaemonCommands }));
 vi.mock("../commands/doctor.js", () => ({ registerDoctorCommand: registrationMocks.registerDoctorCommand }));
@@ -93,6 +97,7 @@ describe("CLI entry and public exports", () => {
         registrationMocks.registerUpgradeCommand,
         registrationMocks.registerAgentCommands,
         registrationMocks.registerChatCommands,
+        registrationMocks.registerComputerCommands,
         registrationMocks.registerOrgCommands,
         registrationMocks.registerDaemonCommands,
         registrationMocks.registerConfigCommands,

--- a/apps/cli/src/__tests__/cli-helper-surfaces-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-helper-surfaces-extra.test.ts
@@ -193,7 +193,7 @@ describe("doctor checks and agent resolver", () => {
 });
 
 describe("client org mismatch handler", () => {
-  it("fails closed with purge-first recovery and leaves client.yaml unchanged", async () => {
+  it("fails closed with reset-first recovery and leaves client.yaml unchanged", async () => {
     const yamlPath = join(tempDir, "client.yaml");
     const before = stringifyYaml({ client: { id: "client_11111111" } });
     writeFileSync(yamlPath, before);
@@ -210,15 +210,15 @@ describe("client org mismatch handler", () => {
     expect(readFileSync(yamlPath, "utf8")).toBe(before);
     const output = printMocks.line.mock.calls.map((call) => String(call[0])).join("");
     expect(output).toContain("wrong org");
-    expect(output).toContain("first-tree-dev logout --purge");
     expect(output).toContain("first-tree-dev login <token>");
-    expect(output).toContain("local agent configs");
+    expect(output).toContain("first-tree-dev computer reset");
+    expect(output).toContain("valid server-side owner pair");
     expect(output).not.toContain("Rotate");
     expect(output).not.toContain("Rotated");
     expect(output).not.toContain("client.yaml.bak");
   });
 
-  it("uses the same purge-first recovery in managed mode", async () => {
+  it("uses the same reset-first recovery in managed mode", async () => {
     const { handleClientOrgMismatch } = await import("../core/client-reidentify.js");
 
     await expect(
@@ -230,8 +230,8 @@ describe("client org mismatch handler", () => {
     ).rejects.toMatchObject({ code: 1 });
 
     const output = printMocks.line.mock.calls.map((call) => String(call[0])).join("");
-    expect(output).toContain("first-tree-dev logout --purge");
     expect(output).toContain("first-tree-dev login <token>");
+    expect(output).toContain("first-tree-dev computer reset");
   });
 
   it("routes managed recovery text through an injected output sink", async () => {
@@ -274,8 +274,8 @@ describe("client org mismatch handler", () => {
     ).rejects.toMatchObject({ code: 1 });
 
     expect(output.status).toHaveBeenCalledWith("✗", expect.stringContaining("wrong org"));
-    expect(output.status).toHaveBeenCalledWith("✗", expect.stringContaining("first-tree-dev logout --purge"));
     expect(output.status).toHaveBeenCalledWith("✗", expect.stringContaining("first-tree-dev login <token>"));
+    expect(output.status).toHaveBeenCalledWith("✗", expect.stringContaining("first-tree-dev computer reset"));
     expect(output.blank).not.toHaveBeenCalled();
     expect(output.line).not.toHaveBeenCalled();
     expect(printMocks.blank).not.toHaveBeenCalled();

--- a/apps/cli/src/__tests__/client-switch.test.ts
+++ b/apps/cli/src/__tests__/client-switch.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectSwitchDrainProcessFromEnvText,
+  isSwitchDrainEnvRequired,
+  parseSwitchProcessEnvValue,
+} from "../core/client-switch.js";
+
+describe("client switch drain markers", () => {
+  it("preserves spaces inside NUL-delimited process environment values", () => {
+    const envText = [
+      "FIRST_TREE_PROVIDER=codex",
+      "FIRST_TREE_HOME=/Users/Alice Smith/.first-tree",
+      "FIRST_TREE_CLIENT_ID=client_aabbccdd",
+      "FIRST_TREE_SWITCH_DRAIN_VERSION=1",
+      "",
+    ].join("\0");
+
+    expect(parseSwitchProcessEnvValue(envText, "FIRST_TREE_HOME")).toBe("/Users/Alice Smith/.first-tree");
+    expect(parseSwitchProcessEnvValue(envText, "FIRST_TREE_CLIENT_ID")).toBe("client_aabbccdd");
+  });
+
+  it("keeps whitespace-delimited process text parsing for ps output", () => {
+    const envText = "FIRST_TREE_HOME=/Users/alice/.first-tree FIRST_TREE_CLIENT_ID=client_aabbccdd /usr/bin/codex";
+
+    expect(parseSwitchProcessEnvValue(envText, "FIRST_TREE_HOME")).toBe("/Users/alice/.first-tree");
+    expect(parseSwitchProcessEnvValue(envText, "FIRST_TREE_CLIENT_ID")).toBe("client_aabbccdd");
+  });
+
+  it("preserves spaces inside process text values when another env marker follows", () => {
+    const envText =
+      "FIRST_TREE_PROVIDER=codex FIRST_TREE_HOME=/Users/Alice Smith/.first-tree FIRST_TREE_CLIENT_ID=client_aabbccdd";
+
+    expect(parseSwitchProcessEnvValue(envText, "FIRST_TREE_HOME")).toBe("/Users/Alice Smith/.first-tree");
+    expect(parseSwitchProcessEnvValue(envText, "FIRST_TREE_PROVIDER")).toBe("codex");
+  });
+
+  it("treats unknown commands with trusted switch markers as live descendants", () => {
+    const providers: Array<{ pid: number; provider: string; command: string }> = [];
+    const issues: Array<{ pid: number; command: string; reason: string }> = [];
+    const envText = [
+      "FIRST_TREE_HOME=/Users/alice/.first-tree",
+      "FIRST_TREE_CLIENT_ID=client_aabbccdd",
+      "FIRST_TREE_SWITCH_DRAIN_VERSION=1",
+      "",
+    ].join("\0");
+
+    collectSwitchDrainProcessFromEnvText({
+      pid: 123,
+      command: "/bin/bash ./provider-child",
+      envText,
+      home: "/Users/alice/.first-tree",
+      clientId: "client_aabbccdd",
+      providers,
+      issues,
+    });
+
+    expect(issues).toEqual([]);
+    expect(providers).toEqual([
+      expect.objectContaining({ pid: 123, provider: "marked-descendant", command: "/bin/bash ./provider-child" }),
+    ]);
+  });
+
+  it("fails closed on unknown marked descendants without trusted drain version", () => {
+    const providers: Array<{ pid: number; provider: string; command: string }> = [];
+    const issues: Array<{ pid: number; command: string; reason: string }> = [];
+    const envText = ["FIRST_TREE_HOME=/Users/alice/.first-tree", "FIRST_TREE_CLIENT_ID=client_aabbccdd", ""].join("\0");
+
+    collectSwitchDrainProcessFromEnvText({
+      pid: 124,
+      command: "node worker.js",
+      envText,
+      home: "/Users/alice/.first-tree",
+      clientId: "client_aabbccdd",
+      providers,
+      issues,
+    });
+
+    expect(providers).toEqual([]);
+    expect(issues).toEqual([expect.objectContaining({ pid: 124, reason: "missing trusted switch drain markers" })]);
+  });
+
+  it("requires readable env only for known switch-drain process commands", () => {
+    expect(isSwitchDrainEnvRequired("/usr/bin/codex exec")).toBe(true);
+    expect(isSwitchDrainEnvRequired("node cli/index.mjs daemon start --foreground")).toBe(true);
+    expect(isSwitchDrainEnvRequired("/bin/bash unrelated-script")).toBe(false);
+  });
+});

--- a/apps/cli/src/__tests__/command-registration-smoke.test.ts
+++ b/apps/cli/src/__tests__/command-registration-smoke.test.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { describe, expect, it } from "vitest";
 import { registerAgentCommands } from "../commands/agent/index.js";
 import { registerChatCommands } from "../commands/chat/index.js";
+import { registerComputerCommands } from "../commands/computer/index.js";
 import { registerConfigCommands } from "../commands/config/index.js";
 import { registerDaemonCommands } from "../commands/daemon/index.js";
 import { registerDoctorCommand } from "../commands/doctor.js";
@@ -35,6 +36,7 @@ describe("CLI command registration", () => {
     registerUpgradeCommand(root);
     registerAgentCommands(root);
     registerChatCommands(root);
+    registerComputerCommands(root);
     registerOrgCommands(root);
     registerDaemonCommands(root);
     registerConfigCommands(root);
@@ -43,6 +45,7 @@ describe("CLI command registration", () => {
     expect(root.commands.map((entry) => entry.name()).sort()).toEqual([
       "agent",
       "chat",
+      "computer",
       "config",
       "daemon",
       "doctor",
@@ -55,10 +58,11 @@ describe("CLI command registration", () => {
     ]);
   });
 
-  it("registers agent, chat, daemon, config, and org subcommands", () => {
+  it("registers agent, chat, computer, daemon, config, and org subcommands", () => {
     const root = new Command();
     registerAgentCommands(root);
     registerChatCommands(root);
+    registerComputerCommands(root);
     registerDaemonCommands(root);
     registerConfigCommands(root);
     registerOrgCommands(root);
@@ -88,6 +92,7 @@ describe("CLI command registration", () => {
       "set-topic",
       "update",
     ]);
+    expect(subcommands(root, "computer")).toEqual(["reset"]);
     expect(subcommands(root, "daemon")).toEqual([
       "doctor",
       "home-info",
@@ -130,7 +135,7 @@ describe("CLI command registration", () => {
 
     const optionNames = (cmd: Command) => cmd.options.map((option) => option.long).sort();
 
-    expect(optionNames(command(root, "login"))).toEqual(["--no-start"]);
+    expect(optionNames(command(root, "login"))).toEqual(["--force-switch", "--no-start"]);
     expect(optionNames(command(command(root, "agent"), "create"))).toEqual([
       "--client-id",
       "--display-name",

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -24,6 +24,7 @@ const coreMocks = vi.hoisted(() => ({
   createLoggerRuntimeOutput: vi.fn(),
   declineUpdate: vi.fn(),
   ensureFreshAccessToken: vi.fn(),
+  getClientSwitchStartupBlock: vi.fn(),
   getClientServiceStatus: vi.fn(),
   handleClientOrgMismatch: vi.fn(),
   isServiceSupported: vi.fn(),
@@ -33,8 +34,10 @@ const coreMocks = vi.hoisted(() => ({
   migrateLocalAgentDirs: vi.fn(),
   promptMissingFields: vi.fn(),
   promptUpdate: vi.fn(),
+  registerClientRuntimeMarker: vi.fn(),
   reconcileLocalRuntimeProviders: vi.fn(),
   refreshServerUpdateTarget: vi.fn(),
+  resolveClientRuntimeStopReason: vi.fn(),
   startClientService: vi.fn(),
   uploadAgentSkills: vi.fn(),
   uploadClientCapabilities: vi.fn(),
@@ -127,6 +130,8 @@ beforeEach(() => {
   clientMocks.discoverClaudeCodeSkills.mockResolvedValue([{ name: "review", description: "Review code." }]);
   coreMocks.loadCredentials.mockReturnValue({ refreshToken: "refresh" });
   coreMocks.loadDaemonEnv.mockReturnValue([]);
+  coreMocks.getClientSwitchStartupBlock.mockReturnValue(null);
+  coreMocks.resolveClientRuntimeStopReason.mockReturnValue(undefined);
   coreMocks.isServiceSupported.mockReturnValue(false);
   coreMocks.getClientServiceStatus.mockReturnValue({
     platform: "launchd",
@@ -140,6 +145,7 @@ beforeEach(() => {
     { agentId: "agent-1", clientId: "client_1234abcd", runtimeProvider: "claude-code", status: "active" },
   ]);
   coreMocks.promptMissingFields.mockResolvedValue(undefined);
+  coreMocks.registerClientRuntimeMarker.mockReturnValue(vi.fn());
   coreMocks.createApiNameResolver.mockReturnValue(async () => "nova");
   coreMocks.createExecuteUpdate.mockReturnValue(async () => undefined);
   coreMocks.createLoggerRuntimeOutput.mockImplementation(
@@ -219,6 +225,32 @@ describe("daemon start command", () => {
 
     await expect(runStart()).rejects.toMatchObject({ code: "NO_CREDENTIALS", exitCode: 1 });
     expect(failMock).toHaveBeenCalledWith("NO_CREDENTIALS", expect.stringContaining("no credentials"), 1);
+  });
+
+  it("parks daemon startup before reading credentials while a client switch is in progress", async () => {
+    coreMocks.getClientSwitchStartupBlock.mockReturnValueOnce({
+      lockPath: join(home, "state", "client-switch.lock"),
+      journalPath: join(home, "state", "client-switch-journal.json"),
+    });
+
+    await expect(runStart()).resolves.toBeTruthy();
+
+    expect(coreMocks.loadCredentials).not.toHaveBeenCalled();
+    expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
+    expect(output()).toContain("client switch is in progress");
+  });
+
+  it("lets supervisor children exit 0 before root state reads during a client switch", async () => {
+    process.env.FIRST_TREE_SERVICE_MODE = "1";
+    coreMocks.getClientSwitchStartupBlock.mockReturnValueOnce({
+      lockPath: join(home, "state", "client-switch.lock"),
+      journalPath: join(home, "state", "client-switch-journal.json"),
+    });
+
+    await expect(runStart(["--no-interactive"])).rejects.toMatchObject({ exitCode: 0 });
+
+    expect(coreMocks.loadCredentials).not.toHaveBeenCalled();
+    expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
   });
 
   it("refuses when the background service is already active", async () => {
@@ -303,6 +335,10 @@ describe("daemon start command", () => {
       "client_1234abcd",
       expect.objectContaining({ currentVersion: "0.0.0-test" }),
     );
+    expect(coreMocks.registerClientRuntimeMarker).toHaveBeenCalledWith({
+      clientId: "client_1234abcd",
+      mode: "foreground",
+    });
     expect(runtimeInstance.addAgent).toHaveBeenCalledWith("nova", expect.objectContaining({ agentId: "agent-1" }));
     expect(runtimeInstance.start).toHaveBeenCalled();
     // Capability refresh is owned by the refresher: daemon start no longer runs
@@ -433,11 +469,9 @@ describe("daemon start command", () => {
     await expect(runStart(["--no-interactive"])).rejects.toMatchObject({ exitCode: 1 });
 
     expect(clientMocks.applyClientLoggerConfig).toHaveBeenCalledWith({ level: "error" });
-    expect(daemonLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining("client.yaml is owned by a different user"),
-    );
-    expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("first-tree-dev logout --purge"));
+    expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("client.yaml is not accepted"));
     expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("first-tree-dev login <token>"));
+    expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("first-tree-dev computer reset"));
     expect(output()).toBe("");
   });
 
@@ -458,8 +492,8 @@ describe("daemon start command", () => {
 
     expect(clientMocks.applyClientLoggerConfig).toHaveBeenCalledWith({ level: "warn" });
     expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("wrong org"));
-    expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("first-tree-dev logout --purge"));
     expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("first-tree-dev login <token>"));
+    expect(daemonLogger.error).toHaveBeenCalledWith(expect.stringContaining("first-tree-dev computer reset"));
     expect(output()).toBe("");
   });
 
@@ -497,9 +531,10 @@ describe("daemon start command", () => {
     runtimeInstance.start.mockRejectedValueOnce(new client.ClientUserMismatchError("wrong user"));
     await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
     const mismatchText = output();
-    expect(mismatchText).toContain("client.yaml is owned by a different user");
-    expect(mismatchText).toContain("logout --purge");
-    expect(mismatchText).toContain("local agent configs, workspaces, and session state");
+    expect(mismatchText).toContain("client.yaml is not accepted");
+    expect(mismatchText).toContain("valid server-side owner pair");
+    expect(mismatchText).toContain("login <token>");
+    expect(mismatchText).toContain("computer reset");
     // Purge-first account switching must NOT resurrect the removed server-side
     // transfer/unpin language.
     expect(mismatchText).not.toContain("transfer ownership");

--- a/apps/cli/src/__tests__/login-command.test.ts
+++ b/apps/cli/src/__tests__/login-command.test.ts
@@ -5,8 +5,10 @@ import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const cliFetchMock = vi.hoisted(() => vi.fn());
+const getClientServiceStatusMock = vi.hoisted(() => vi.fn());
 const installClientServiceMock = vi.hoisted(() => vi.fn());
 const isServiceSupportedMock = vi.hoisted(() => vi.fn());
+const stopClientServiceMock = vi.hoisted(() => vi.fn());
 const clientRuntimeMock = vi.hoisted(() => vi.fn());
 const createApiNameResolverMock = vi.hoisted(() => vi.fn());
 const createExecuteUpdateMock = vi.hoisted(() => vi.fn());
@@ -25,8 +27,10 @@ vi.mock("../core/cli-fetch.js", () => ({
 
 vi.mock("../core/service-install.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../core/service-install.js")>()),
+  getClientServiceStatus: getClientServiceStatusMock,
   installClientService: installClientServiceMock,
   isServiceSupported: isServiceSupportedMock,
+  stopClientService: stopClientServiceMock,
 }));
 
 vi.mock("../core/client-runtime.js", async (importOriginal) => ({
@@ -103,6 +107,134 @@ function writeCredentials(memberId: string, serverUrl = "http://old.test", sub =
   );
 }
 
+function writeActiveOwnerMetadata(opts: { clientId?: string; serverUrl?: string; userId?: string } = {}): void {
+  const clientId = opts.clientId ?? "client_aabbccdd";
+  const serverUrl = opts.serverUrl ?? "http://first-tree.test";
+  const userId = opts.userId ?? "user-new";
+  mkdirSync(join(home, "parked-clients"), { recursive: true });
+  writeFileSync(
+    join(home, "parked-clients", "index.json"),
+    JSON.stringify({
+      version: 1,
+      activeClientId: clientId,
+      accountDefaults: { [`${serverUrl}\n${userId}`]: clientId },
+      clients: {
+        [clientId]: {
+          clientId,
+          userId,
+          serverUrl,
+          storage: "active-root",
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    }),
+  );
+}
+
+function switchJournalMoves(toClientId?: string): Array<Record<string, unknown>> {
+  const oldClientId = "client_aabbccdd";
+  const parkedOld = join(home, "parked-clients", oldClientId);
+  const moves: Array<Record<string, unknown>> = [
+    {
+      kind: "park-client-yaml",
+      group: "park",
+      source: join(home, "config", "client.yaml"),
+      target: join(parkedOld, "config", "client.yaml"),
+      required: true,
+      state: "pending",
+    },
+    {
+      kind: "park-agents",
+      group: "park",
+      source: join(home, "config", "agents"),
+      target: join(parkedOld, "config", "agents"),
+      required: false,
+      state: "pending",
+    },
+    {
+      kind: "park-sessions",
+      group: "park",
+      source: join(home, "data", "sessions"),
+      target: join(parkedOld, "data", "sessions"),
+      required: false,
+      state: "pending",
+    },
+    {
+      kind: "park-workspaces",
+      group: "park",
+      source: join(home, "data", "workspaces"),
+      target: join(parkedOld, "data", "workspaces"),
+      required: false,
+      state: "pending",
+    },
+  ];
+  if (!toClientId) {
+    moves.push({
+      kind: "restore-client-yaml",
+      group: "restore",
+      source: join(home, "parked-clients", "__new-client__", "config", "client.yaml"),
+      target: join(home, "config", "client.yaml"),
+      required: true,
+      state: "create",
+    });
+    return moves;
+  }
+  const parkedTarget = join(home, "parked-clients", toClientId);
+  moves.push(
+    {
+      kind: "restore-client-yaml",
+      group: "restore",
+      source: join(parkedTarget, "config", "client.yaml"),
+      target: join(home, "config", "client.yaml"),
+      required: true,
+      state: "pending",
+    },
+    {
+      kind: "restore-agents",
+      group: "restore",
+      source: join(parkedTarget, "config", "agents"),
+      target: join(home, "config", "agents"),
+      required: false,
+      state: "pending",
+    },
+    {
+      kind: "restore-sessions",
+      group: "restore",
+      source: join(parkedTarget, "data", "sessions"),
+      target: join(home, "data", "sessions"),
+      required: false,
+      state: "pending",
+    },
+    {
+      kind: "restore-workspaces",
+      group: "restore",
+      source: join(parkedTarget, "data", "workspaces"),
+      target: join(home, "data", "workspaces"),
+      required: false,
+      state: "pending",
+    },
+  );
+  return moves;
+}
+
+function writePendingSwitchJournal(opts: { toClientId?: string } = {}): void {
+  mkdirSync(join(home, "state"), { recursive: true });
+  writeFileSync(join(home, "state", "client-switch.lock"), JSON.stringify({ pid: 123, createdAt: "now" }));
+  writeFileSync(
+    join(home, "state", "client-switch-journal.json"),
+    JSON.stringify({
+      version: 1,
+      id: "switch-test",
+      phase: "drain-clean",
+      from: { clientId: "client_aabbccdd", userId: "user-old", serverUrl: "http://first-tree.test" },
+      to: { clientId: opts.toClientId, userId: "user-new", serverUrl: "http://first-tree.test" },
+      moves: switchJournalMoves(opts.toClientId),
+      createdAt: "now",
+      updatedAt: "now",
+    }),
+  );
+}
+
 beforeEach(() => {
   vi.resetModules();
   home = join(tmpdir(), `ft-login-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -110,8 +242,10 @@ beforeEach(() => {
   process.env.FIRST_TREE_HOME = home;
   delete process.env.FIRST_TREE_SERVER_URL;
   cliFetchMock.mockReset();
+  getClientServiceStatusMock.mockReset();
   installClientServiceMock.mockReset();
   isServiceSupportedMock.mockReset();
+  stopClientServiceMock.mockReset();
   clientRuntimeMock.mockReset();
   createApiNameResolverMock.mockReset();
   createExecuteUpdateMock.mockReset();
@@ -125,7 +259,14 @@ beforeEach(() => {
   cliFetchMock.mockImplementation(async () =>
     response(200, { accessToken: jwt({ sub: "user-new" }), refreshToken: "r1" }),
   );
+  getClientServiceStatusMock.mockReturnValue({
+    platform: "launchd",
+    state: "not-installed",
+    label: "dev.first-tree",
+    logDir: join(home, "logs"),
+  });
   isServiceSupportedMock.mockReturnValue(false);
+  stopClientServiceMock.mockReturnValue({ ok: true });
   createApiNameResolverMock.mockReturnValue({ resolveName: vi.fn(async () => "nova") });
   createExecuteUpdateMock.mockReturnValue(async () => undefined);
   ensureFreshAccessTokenMock.mockResolvedValue("access-token");
@@ -153,12 +294,11 @@ afterEach(() => {
 
 // `runLogin` dynamic-imports `commands/login.js` on every test run, which
 // pulls in the credentials / config / runtime module graph fresh each time.
-// On hot caches that resolves in ~500 ms; on cold CI runners it has been
-// observed hitting ~5 s (vitest's default `testTimeout`). The tests do not
-// drive long-running work themselves, so the 5 s default is too tight for
-// CI's first-load cost — bump to 15 s across the describe to give cold
-// caches headroom without affecting hot-run latency.
-describe("login command", { timeout: 15_000 }, () => {
+// On hot caches that resolves in ~500 ms; on cold CI runners under the full
+// monorepo test fan-out it can be much slower than Vitest's default
+// `testTimeout`. The tests do not drive long-running work themselves, so give
+// this import-heavy command suite CI headroom without affecting hot-run latency.
+describe("login command", { timeout: 60_000 }, () => {
   it("exchanges a connect token, writes credentials/config, and honors --no-start", async () => {
     await runLogin(["login", jwt({ iss: "http://first-tree.test/" }), "--no-start"]);
 
@@ -175,7 +315,7 @@ describe("login command", { timeout: 15_000 }, () => {
     expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("--no-start");
   });
 
-  it("rejects cross-account login before overwriting local credentials", async () => {
+  it("requires explicit confirmation for cross-account login before overwriting local credentials", async () => {
     const yamlPath = join(home, "config", "client.yaml");
     writeFileSync(yamlPath, "client:\n  id: client_aabbccdd\n");
     writeCredentials("member-old", "http://first-tree.test", "user-old");
@@ -189,8 +329,93 @@ describe("login command", { timeout: 15_000 }, () => {
     expect(readFileSync(yamlPath, "utf8")).toContain("client_aabbccdd");
     expect(installClientServiceMock).not.toHaveBeenCalled();
     const output = stderrMock.mock.calls.map((call) => String(call[0])).join("");
-    expect(output).toContain("ACCOUNT_SWITCH_REQUIRES_PURGE");
-    expect(output).toContain("first-tree-dev logout --purge");
+    expect(output).toContain("ACCOUNT_SWITCH_REQUIRES_CONFIRMATION");
+    expect(output).toContain("--force-switch");
+  });
+
+  it("parks the old local client and creates a new active client when --force-switch confirms non-TTY switching", async () => {
+    const yamlPath = join(home, "config", "client.yaml");
+    writeFileSync(yamlPath, "server:\n  url: http://first-tree.test\nclient:\n  id: client_aabbccdd\n");
+    mkdirSync(join(home, "config", "agents", "nova"), { recursive: true });
+    writeFileSync(join(home, "config", "agents", "nova", "agent.yaml"), "agentId: agent-old\nruntime: claude-code\n");
+    mkdirSync(join(home, "data", "sessions"), { recursive: true });
+    writeFileSync(join(home, "data", "sessions", "nova.json"), "{}");
+    writeCredentials("member-old", "http://first-tree.test", "user-old");
+
+    await runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--no-start", "--force-switch"]);
+
+    const parkedRoot = join(home, "parked-clients", "client_aabbccdd");
+    expect(readFileSync(join(parkedRoot, "config", "client.yaml"), "utf8")).toContain("client_aabbccdd");
+    expect(readFileSync(join(parkedRoot, "config", "agents", "nova", "agent.yaml"), "utf8")).toContain("agent-old");
+    expect(readFileSync(join(parkedRoot, "data", "sessions", "nova.json"), "utf8")).toBe("{}");
+    expect(existsSync(join(parkedRoot, "config", "credentials.json"))).toBe(false);
+
+    expect(readFileSync(credentialsPath(), "utf8")).toContain("r1");
+    expect(readFileSync(credentialsPath(), "utf8")).not.toContain("old-refresh");
+    expect(readFileSync(yamlPath, "utf8")).not.toContain("client_aabbccdd");
+    expect(readFileSync(yamlPath, "utf8")).toContain("url: http://first-tree.test");
+    const index = JSON.parse(readFileSync(join(home, "parked-clients", "index.json"), "utf8")) as {
+      activeClientId: string;
+      clients: Record<string, { storage: string; userId: string }>;
+    };
+    expect(index.clients.client_aabbccdd).toMatchObject({ storage: "parked", userId: "user-old" });
+    expect(index.clients[index.activeClientId]).toMatchObject({ storage: "active-root", userId: "user-new" });
+    expect(installClientServiceMock).not.toHaveBeenCalled();
+    const output = stderrMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("Previous local client parked");
+  });
+
+  it("clears the switch guard when supervisor stop fails before root state movement", async () => {
+    const yamlPath = join(home, "config", "client.yaml");
+    writeFileSync(yamlPath, "server:\n  url: http://first-tree.test\nclient:\n  id: client_aabbccdd\n");
+    writeCredentials("member-old", "http://first-tree.test", "user-old");
+    getClientServiceStatusMock.mockReturnValueOnce({
+      platform: "launchd",
+      state: "active",
+      label: "dev.first-tree",
+      logDir: join(home, "logs"),
+    });
+    stopClientServiceMock.mockReturnValueOnce({ ok: false, reason: "permission denied" });
+
+    await expect(
+      runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--no-start", "--force-switch"]),
+    ).rejects.toThrow("process.exit");
+
+    expect(readFileSync(credentialsPath(), "utf8")).toContain("old-refresh");
+    expect(readFileSync(yamlPath, "utf8")).toContain("client_aabbccdd");
+    expect(existsSync(join(home, "state", "client-switch.lock"))).toBe(false);
+    expect(existsSync(join(home, "state", "client-switch-journal.json"))).toBe(false);
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("CLIENT_SWITCH_SUPERVISOR_UNSAFE");
+  });
+
+  it("refuses to move root state while a foreground runtime marker is still live", async () => {
+    const yamlPath = join(home, "config", "client.yaml");
+    writeFileSync(yamlPath, "server:\n  url: http://first-tree.test\nclient:\n  id: client_aabbccdd\n");
+    writeCredentials("member-old", "http://first-tree.test", "user-old");
+    mkdirSync(join(home, "state", "client-runtimes"), { recursive: true });
+    writeFileSync(
+      join(home, "state", "client-runtimes", `${process.pid}.json`),
+      JSON.stringify({
+        version: 1,
+        pid: process.pid,
+        clientId: "client_aabbccdd",
+        home,
+        mode: "foreground",
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    await expect(
+      runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--no-start", "--force-switch"]),
+    ).rejects.toThrow("process.exit");
+
+    expect(readFileSync(credentialsPath(), "utf8")).toContain("old-refresh");
+    expect(readFileSync(yamlPath, "utf8")).toContain("client_aabbccdd");
+    expect(existsSync(join(home, "state", "client-switch.lock"))).toBe(false);
+    expect(existsSync(join(home, "state", "client-switch-journal.json"))).toBe(false);
+    const output = stderrMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("CLIENT_SWITCH_RUNTIME_ACTIVE");
+    expect(output).toContain("runtime processes are still running");
   });
 
   it("allows same-user reauth without rotating the client identity", async () => {
@@ -212,6 +437,7 @@ describe("login command", { timeout: 15_000 }, () => {
     writeFileSync(yamlPath, "client:\n  id: client_aabbccdd\n");
     mkdirSync(join(home, "config", "agents", "nova"), { recursive: true });
     writeFileSync(join(home, "config", "agents", "nova", "agent.yaml"), "agentId: agent-1\nruntime: claude-code\n");
+    writeActiveOwnerMetadata();
 
     await runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--no-start"]);
 
@@ -220,6 +446,110 @@ describe("login command", { timeout: 15_000 }, () => {
     const output = stderrMock.mock.calls.map((call) => String(call[0])).join("");
     expect(output).toContain("Authenticated");
     expect(output).not.toContain("ACCOUNT_SWITCH_REQUIRES_PURGE");
+  });
+
+  it("switches local clients when credentials are missing but remembered owner differs", async () => {
+    const yamlPath = join(home, "config", "client.yaml");
+    writeFileSync(yamlPath, "server:\n  url: http://first-tree.test\nclient:\n  id: client_aabbccdd\n");
+    mkdirSync(join(home, "config", "agents", "nova"), { recursive: true });
+    writeFileSync(join(home, "config", "agents", "nova", "agent.yaml"), "agentId: agent-old\nruntime: claude-code\n");
+    writeActiveOwnerMetadata({ userId: "user-old" });
+
+    await runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--no-start", "--force-switch"]);
+
+    const parkedRoot = join(home, "parked-clients", "client_aabbccdd");
+    expect(readFileSync(join(parkedRoot, "config", "client.yaml"), "utf8")).toContain("client_aabbccdd");
+    expect(readFileSync(join(parkedRoot, "config", "agents", "nova", "agent.yaml"), "utf8")).toContain("agent-old");
+    expect(readFileSync(credentialsPath(), "utf8")).toContain("r1");
+    expect(readFileSync(yamlPath, "utf8")).not.toContain("client_aabbccdd");
+    const index = JSON.parse(readFileSync(join(home, "parked-clients", "index.json"), "utf8")) as {
+      activeClientId: string;
+      clients: Record<string, { storage: string; userId: string }>;
+    };
+    expect(index.clients.client_aabbccdd).toMatchObject({ storage: "parked", userId: "user-old" });
+    expect(index.clients[index.activeClientId]).toMatchObject({ storage: "active-root", userId: "user-new" });
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Previous local client parked");
+  });
+
+  it("switches when credentials match the target user but remembered owner still belongs to the old client", async () => {
+    const yamlPath = join(home, "config", "client.yaml");
+    writeFileSync(yamlPath, "server:\n  url: http://first-tree.test\nclient:\n  id: client_aabbccdd\n");
+    writeCredentials("member-new", "http://first-tree.test", "user-new");
+    writeActiveOwnerMetadata({ userId: "user-old" });
+
+    await runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--no-start", "--force-switch"]);
+
+    const parkedRoot = join(home, "parked-clients", "client_aabbccdd");
+    expect(readFileSync(join(parkedRoot, "config", "client.yaml"), "utf8")).toContain("client_aabbccdd");
+    expect(readFileSync(credentialsPath(), "utf8")).toContain("r1");
+    expect(readFileSync(credentialsPath(), "utf8")).not.toContain("old-refresh");
+    expect(readFileSync(yamlPath, "utf8")).not.toContain("client_aabbccdd");
+    const index = JSON.parse(readFileSync(join(home, "parked-clients", "index.json"), "utf8")) as {
+      activeClientId: string;
+      clients: Record<string, { storage: string; userId: string }>;
+    };
+    expect(index.clients.client_aabbccdd).toMatchObject({ storage: "parked", userId: "user-old" });
+    expect(index.clients[index.activeClientId]).toMatchObject({ storage: "active-root", userId: "user-new" });
+  });
+
+  it("rolls forward an interrupted switch after a partial root-state move", async () => {
+    writeCredentials("member-old", "http://first-tree.test", "user-old");
+    mkdirSync(join(home, "parked-clients", "client_aabbccdd", "config"), { recursive: true });
+    writeFileSync(
+      join(home, "parked-clients", "client_aabbccdd", "config", "client.yaml"),
+      "server:\n  url: http://first-tree.test\nclient:\n  id: client_aabbccdd\n",
+    );
+    mkdirSync(join(home, "config", "agents", "nova"), { recursive: true });
+    writeFileSync(join(home, "config", "agents", "nova", "agent.yaml"), "agentId: agent-old\nruntime: claude-code\n");
+    writePendingSwitchJournal();
+
+    await runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--no-start"]);
+
+    const parkedRoot = join(home, "parked-clients", "client_aabbccdd");
+    expect(readFileSync(join(parkedRoot, "config", "client.yaml"), "utf8")).toContain("client_aabbccdd");
+    expect(readFileSync(join(parkedRoot, "config", "agents", "nova", "agent.yaml"), "utf8")).toContain("agent-old");
+    expect(readFileSync(credentialsPath(), "utf8")).toContain("r1");
+    expect(readFileSync(join(home, "config", "client.yaml"), "utf8")).not.toContain("client_aabbccdd");
+    expect(existsSync(join(home, "state", "client-switch.lock"))).toBe(false);
+    expect(existsSync(join(home, "state", "client-switch-journal.json"))).toBe(false);
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "Interrupted local client switch recovered",
+    );
+  });
+
+  it("keeps the switch guard when journal recovery finds both source and target", async () => {
+    const yamlPath = join(home, "config", "client.yaml");
+    writeFileSync(yamlPath, "server:\n  url: http://first-tree.test\nclient:\n  id: client_aabbccdd\n");
+    writeCredentials("member-old", "http://first-tree.test", "user-old");
+    mkdirSync(join(home, "parked-clients", "client_aabbccdd", "config"), { recursive: true });
+    writeFileSync(join(home, "parked-clients", "client_aabbccdd", "config", "client.yaml"), "client:\n  id: stale\n");
+    writePendingSwitchJournal();
+
+    await expect(runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--no-start"])).rejects.toThrow(
+      "process.exit",
+    );
+
+    expect(readFileSync(yamlPath, "utf8")).toContain("client_aabbccdd");
+    expect(existsSync(join(home, "state", "client-switch.lock"))).toBe(true);
+    expect(existsSync(join(home, "state", "client-switch-journal.json"))).toBe(true);
+    const output = stderrMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("CLIENT_SWITCH_MANUAL_REPAIR_REQUIRED");
+    expect(output).toContain("both source and target exist");
+  });
+
+  it("fails closed when credentials are missing and active client owner is unknown", async () => {
+    const yamlPath = join(home, "config", "client.yaml");
+    writeFileSync(yamlPath, "client:\n  id: client_aabbccdd\n");
+
+    await expect(runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--no-start"])).rejects.toThrow(
+      "process.exit",
+    );
+
+    expect(existsSync(credentialsPath())).toBe(false);
+    expect(readFileSync(yamlPath, "utf8")).toContain("client_aabbccdd");
+    const output = stderrMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("CLIENT_OWNER_UNKNOWN_REQUIRES_RESET_OR_OWNER_LOGIN");
+    expect(output).toContain("remembered owner metadata");
   });
 
   it("maps invalid tokens and token exchange failures to CLI errors", async () => {
@@ -291,6 +621,8 @@ describe("login command", { timeout: 15_000 }, () => {
     exitMock.mockClear();
     writeCredentials("member-old");
     await expect(runLogin(["login", jwt({ iss: "http://hub.test" })])).rejects.toThrow("process.exit");
-    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("ACCOUNT_SWITCH_REQUIRES_PURGE");
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "ACCOUNT_SWITCH_REQUIRES_CONFIRMATION",
+    );
   });
 });

--- a/apps/cli/src/cli/index.ts
+++ b/apps/cli/src/cli/index.ts
@@ -12,6 +12,7 @@ import { applyClientLoggerConfig } from "@first-tree/client";
 import { Command } from "commander";
 import { registerAgentCommands } from "../commands/agent/index.js";
 import { registerChatCommands } from "../commands/chat/index.js";
+import { registerComputerCommands } from "../commands/computer/index.js";
 import { registerConfigCommands } from "../commands/config/index.js";
 import { registerDaemonCommands } from "../commands/daemon/index.js";
 import { registerDoctorCommand } from "../commands/doctor.js";
@@ -71,6 +72,7 @@ registerUpgradeCommand(program);
 
 registerAgentCommands(program);
 registerChatCommands(program);
+registerComputerCommands(program);
 registerGithubCommands(program);
 registerOrgCommands(program);
 registerDaemonCommands(program);

--- a/apps/cli/src/commands/computer/index.ts
+++ b/apps/cli/src/commands/computer/index.ts
@@ -1,0 +1,14 @@
+import type { Command } from "commander";
+import { channelConfig } from "../../core/channel.js";
+import { runLogout } from "../logout.js";
+
+export function registerComputerCommands(program: Command): void {
+  const computer = program.command("computer").description("Manage this computer's local First Tree client state");
+
+  computer
+    .command("reset")
+    .description("Stop the daemon and remove this computer's local client state")
+    .action(() => {
+      runLogout({ purge: true, retryCommand: `${channelConfig.binName} computer reset` });
+    });
+}

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -35,6 +35,7 @@ import {
   declineUpdate,
   ensureFreshAccessToken,
   getClientServiceStatus,
+  getClientSwitchStartupBlock,
   handleClientOrgMismatch,
   isServiceSupported,
   listPinnedAgents,
@@ -45,6 +46,8 @@ import {
   promptUpdate,
   reconcileLocalRuntimeProviders,
   refreshServerUpdateTarget,
+  registerClientRuntimeMarker,
+  resolveClientRuntimeStopReason,
   runRuntimeAuthLogin,
   startClientService,
   uploadAgentSkills,
@@ -92,6 +95,17 @@ export function registerDaemonStartCommand(daemon: Command): void {
       if (appliedDaemonEnv.length > 0) {
         writeLine(`  loaded ${appliedDaemonEnv.length} var(s) from daemon.env (${appliedDaemonEnv.join(", ")})\n`);
       }
+      const switchBlock = getClientSwitchStartupBlock();
+      if (switchBlock) {
+        const message =
+          "client switch is in progress; daemon startup is parked before reading root credentials/config.";
+        if (daemonOutput) {
+          writeStatus("•", message);
+          process.exit(0);
+        }
+        writeLine(`  ${message}\n`);
+        return;
+      }
       // Fail closed: never spin up the runtime without persisted credentials.
       // Hooking this in BEFORE the service-delegation branch keeps the policy
       // uniform — supervisor child, foreground debug, or background daemon
@@ -104,6 +118,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
         fail("NO_CREDENTIALS", message, 1);
       }
 
+      let unregisterRuntimeMarker: (() => void) | null = null;
       try {
         // Service-mode delegation. We split four cases so the user gets a
         // single coherent command:
@@ -193,6 +208,10 @@ export function registerDaemonStartCommand(daemon: Command): void {
         const config = await initConfig({
           schema: clientConfigSchema,
           role: "client",
+        });
+        unregisterRuntimeMarker = registerClientRuntimeMarker({
+          clientId: config.client.id,
+          mode: isSupervisorChild ? "service" : "foreground",
         });
 
         // Wire the resolved logLevel into the client logger — without this,
@@ -397,7 +416,9 @@ export function registerDaemonStartCommand(daemon: Command): void {
           writeLine("\n  Shutting down...\n");
           capabilityRefresher.stop();
           runtime.unwatchAgentsDir();
-          await runtime.stop();
+          await runtime.stop(resolveClientRuntimeStopReason());
+          unregisterRuntimeMarker?.();
+          unregisterRuntimeMarker = null;
           await flushClientSentry();
           process.exit(0);
         };
@@ -411,17 +432,16 @@ export function registerDaemonStartCommand(daemon: Command): void {
           if (daemonOutput) {
             writeStatus(
               "✗",
-              `client.yaml is owned by a different user; run \`${binName} logout --purge\`, then \`${binName} login <token>\` with the intended account. This signs out the current local client identity plus local agent configs, workspaces, and session state; server-side clients, agents, chats, and history are not deleted.`,
+              `client.yaml is not accepted for the current credentials; back up local workspaces, run \`${binName} computer reset\`, then run \`${binName} login <token>\` with the intended account.`,
             );
             process.exit(1);
           }
           writeLine("\n");
-          writeLine("  ⚠️  This client.yaml is owned by a different user.\n");
-          writeLine(`  Run \`${binName} logout --purge\` before logging in with another account.\n`);
-          writeLine("  This signs out the current user and removes this machine's local client\n");
-          writeLine("  identity plus local agent configs, workspaces, and session state. Server-side\n");
-          writeLine("  clients, agents, chats, and history are not deleted; the previous client and\n");
-          writeLine("  agents simply stop running from this machine unless they are set up again.\n\n");
+          writeLine("  ⚠️  This client.yaml is not accepted for the current credentials.\n");
+          writeLine("  The active client id and current credentials do not form a valid server-side owner pair.\n");
+          writeLine(
+            `  Back up local workspaces, run \`${binName} computer reset\`, then run \`${binName} login <token>\` with the intended account.\n\n`,
+          );
           process.exit(1);
         }
         if (error instanceof ClientOrgMismatchError) {
@@ -434,9 +454,12 @@ export function registerDaemonStartCommand(daemon: Command): void {
         }
         const msg = error instanceof Error ? error.message : String(error);
         captureClientException(error, { command: "daemon start" });
+        unregisterRuntimeMarker?.();
+        unregisterRuntimeMarker = null;
         await flushClientSentry();
         writeErrorAndExit(`Error: ${msg}`);
       } finally {
+        unregisterRuntimeMarker?.();
         // Reset singleton so other commands can reinit
         resetConfig();
         resetConfigMeta();

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { ClientOrgMismatchError } from "@first-tree/client";
 import {
   agentConfigSchema,
+  type ClientConfig,
   clientConfigSchema,
   defaultConfigDir,
   defaultDataDir,
@@ -18,18 +19,25 @@ import {
   ClientRuntime,
   COMMAND_VERSION,
   cliFetch,
+  confirmLocalClientSwitch,
   createApiNameResolver,
   createExecuteUpdate,
   ensureFreshAccessToken,
-  getClientServiceStatus,
   handleClientOrgMismatch,
+  hasIncompleteClientSwitch,
   installClientService,
   isServiceSupported,
   loadCredentials,
   migrateLocalAgentDirs,
   promptUpdate,
+  readActiveClientOwner,
+  readActiveRootClientId,
+  readRememberedLocalClientIdForAccount,
+  recordActiveClientOwner,
   refreshServerUpdateTarget,
+  resolveClientRuntimeStopReason,
   saveCredentials,
+  switchLocalClientForLogin,
 } from "../core/index.js";
 import { print } from "../core/output.js";
 import { decodeJwtPayload, deriveHubUrlFromToken, HubUrlDerivationError } from "./_shared/connect-token.js";
@@ -39,30 +47,6 @@ function readOwnerSub(token: string | undefined): string | null {
   if (!token) return null;
   const payload = decodeJwtPayload(token);
   return typeof payload?.sub === "string" ? payload.sub : null;
-}
-
-function formatServiceLine(): string {
-  const serviceStatus = getClientServiceStatus();
-  if (serviceStatus.state === "active") return `running (${serviceStatus.detail ?? "live"})`;
-  if (serviceStatus.state === "inactive") {
-    return `installed but not running${serviceStatus.detail ? ` — ${serviceStatus.detail}` : ""}`;
-  }
-  return "not installed";
-}
-
-function rejectAccountSwitch(opts: { reason: string; serverUrl?: string }): never {
-  const purgeCommand = `${channelConfig.binName} logout --purge`;
-  print.line("\n  This computer already has First Tree login state for another or unknown user.\n\n");
-  if (opts.serverUrl) print.line(`       Existing server:    ${opts.serverUrl}\n`);
-  print.line(`       Background service: ${formatServiceLine()}\n\n`);
-  print.line("  Refusing to overwrite local credentials or reuse this machine's client identity.\n");
-  print.line(`  To switch accounts, run \`${purgeCommand}\` first, then login again.\n\n`);
-  print.line("  `logout --purge` stops the current daemon, signs out the current user, and\n");
-  print.line("  removes this machine's local client identity plus local agent configs,\n");
-  print.line("  workspaces, and session state. Server-side clients, agents, chats, and\n");
-  print.line("  history are not deleted; the previous client and agents simply stop running\n");
-  print.line("  from this machine unless they are set up again.\n\n");
-  fail("ACCOUNT_SWITCH_REQUIRES_PURGE", opts.reason, 1);
 }
 
 async function exchangeToken(url: string, token: string): Promise<{ accessToken: string; refreshToken: string }> {
@@ -84,18 +68,18 @@ async function exchangeToken(url: string, token: string): Promise<{ accessToken:
  * `iss` claim carries the server URL so prod / staging / local environments are
  * tagged at issuance and the operator can never accidentally cross-target.
  *
- * Account switches are fail-closed when credentials already exist. The stored
- * access token owner is compared with the new server-issued access token's
- * `sub` claim; a mismatch must go through `logout --purge` before logging in
- * again. Without credentials, login preserves the local client identity so a
- * normal `logout` can be followed by same-user reconnect.
+ * Account switches are explicit local-client switches. The stored access token
+ * owner is compared with the new server-issued access token's `sub` claim; a
+ * mismatch prompts in TTY mode, requires `--force-switch` in non-TTY mode, then
+ * stops/drains the current runtime before moving root state.
  */
 export function registerLoginCommand(program: Command): void {
   program
     .command("login <token>")
     .description("Sign this computer into First Tree using a token from the web console")
     .option("--no-start", "Skip background daemon install/start (writes credentials and exits)")
-    .action(async (token: string, options: { start?: boolean }) => {
+    .option("--force-switch", "Confirm switching this computer to a different First Tree user in non-TTY mode")
+    .action(async (token: string, options: { start?: boolean; forceSwitch?: boolean }) => {
       try {
         let url: string;
         try {
@@ -110,30 +94,79 @@ export function registerLoginCommand(program: Command): void {
         const configDir = defaultConfigDir();
         const existingCredentials = loadCredentials();
         const previousOwnerSub = readOwnerSub(existingCredentials?.accessToken);
+        const rememberedOwner = readActiveClientOwner();
 
         const tokens = await exchangeToken(url, token);
         const newOwnerSub = readOwnerSub(tokens.accessToken);
         if (!newOwnerSub) {
           fail("AUTH_ERROR", "Server access token is missing the required `sub` claim.", 1);
         }
-        if (existingCredentials && (!previousOwnerSub || previousOwnerSub !== newOwnerSub)) {
-          rejectAccountSwitch({
-            reason:
-              "This connect token belongs to a different user than the credentials already stored on this machine.",
-            serverUrl: existingCredentials.serverUrl,
+        let config: ClientConfig | null = null;
+        if (existingCredentials && !previousOwnerSub) {
+          fail(
+            "CLIENT_OWNER_UNKNOWN_REQUIRES_RESET_OR_OWNER_LOGIN",
+            "Existing credentials do not expose an owner user id, so First Tree cannot safely decide whether this is a same-user refresh or account switch.",
+            1,
+          );
+        }
+        if (hasIncompleteClientSwitch()) {
+          config = await switchLocalClientForLogin({
+            targetTokens: { ...tokens, serverUrl: url },
+            targetOwnerSub: newOwnerSub,
           });
+          print.line("\n  ✓ Interrupted local client switch recovered\n");
+        }
+        const existingOwnerSub = previousOwnerSub;
+        const switchFrom = config
+          ? null
+          : existingCredentials && existingOwnerSub && existingOwnerSub !== newOwnerSub
+            ? { serverUrl: existingCredentials.serverUrl, userId: existingOwnerSub }
+            : rememberedOwner && rememberedOwner.userId !== newOwnerSub
+              ? { serverUrl: rememberedOwner.serverUrl, userId: rememberedOwner.userId }
+              : null;
+        if (switchFrom) {
+          await confirmLocalClientSwitch({
+            existingServerUrl: switchFrom.serverUrl,
+            targetServerUrl: url,
+            existingUserId: switchFrom.userId,
+            targetUserId: newOwnerSub,
+            existingClientId: readActiveRootClientId(configDir) ?? rememberedOwner?.clientId,
+            targetClientId: readRememberedLocalClientIdForAccount(url, newOwnerSub) ?? undefined,
+            forceSwitch: options.forceSwitch === true,
+          });
+          config = await switchLocalClientForLogin({
+            existingCredentials: {
+              accessToken: existingCredentials?.accessToken ?? "",
+              refreshToken: existingCredentials?.refreshToken ?? "",
+              serverUrl: switchFrom.serverUrl,
+            },
+            previousOwnerSub: switchFrom.userId,
+            targetTokens: { ...tokens, serverUrl: url },
+            targetOwnerSub: newOwnerSub,
+          });
+          print.line("\n  ✓ Previous local client parked\n");
+        }
+        if (!existingCredentials && !rememberedOwner && readActiveRootClientId(configDir)) {
+          fail(
+            "CLIENT_OWNER_UNKNOWN_REQUIRES_RESET_OR_OWNER_LOGIN",
+            `Existing client.yaml has no credentials or remembered owner metadata, so First Tree cannot safely decide whether this is a same-user reconnect or account switch. Run \`${channelConfig.binName} computer reset\` after backing up local state, or restore/log in from a state that still has the current owner's credentials.`,
+            1,
+          );
         }
 
-        const clientConfigPath = join(configDir, "client.yaml");
-        setConfigValue(clientConfigPath, "server.url", url);
         print.line(`\n  ✓ Server: ${url}\n`);
 
-        saveCredentials({ ...tokens, serverUrl: url });
-        print.line("  ✓ Authenticated\n");
+        if (!config) {
+          const clientConfigPath = join(configDir, "client.yaml");
+          setConfigValue(clientConfigPath, "server.url", url);
+          saveCredentials({ ...tokens, serverUrl: url });
 
-        resetConfig();
-        resetConfigMeta();
-        const config = await initConfig({ schema: clientConfigSchema, role: "client" });
+          resetConfig();
+          resetConfigMeta();
+          config = await initConfig({ schema: clientConfigSchema, role: "client" });
+          recordActiveClientOwner({ clientId: config.client.id, userId: newOwnerSub, serverUrl: url });
+        }
+        print.line("  ✓ Authenticated\n");
         print.line(`  ✓ Computer registered (id: ${config.client.id})\n`);
 
         const shouldInstallService = options.start !== false && isServiceSupported();
@@ -187,7 +220,7 @@ export function registerLoginCommand(program: Command): void {
         const shutdown = async () => {
           print.line("\n  Shutting down...\n");
           runtime.unwatchAgentsDir();
-          await runtime.stop();
+          await runtime.stop(resolveClientRuntimeStopReason());
           process.exit(0);
         };
         process.on("SIGINT", () => void shutdown());

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -1,64 +1,96 @@
 import { existsSync, rmSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
-import { defaultConfigDir, defaultDataDir } from "@first-tree/shared/config";
+import { defaultConfigDir, defaultDataDir, defaultHome } from "@first-tree/shared/config";
 import type { Command } from "commander";
 import { fail } from "../cli/output.js";
 import { channelConfig } from "../core/channel.js";
-import { getClientServiceStatus, isServiceSupported, stopClientService } from "../core/index.js";
+import {
+  getClientServiceStatus,
+  isServiceSupported,
+  loadCredentials,
+  readActiveRootClientId,
+  recordActiveClientOwner,
+  stopClientService,
+} from "../core/index.js";
 import { print } from "../core/output.js";
+import { decodeJwtPayload } from "./_shared/connect-token.js";
+
+function readOwnerSub(token: string | undefined): string | null {
+  if (!token) return null;
+  const payload = decodeJwtPayload(token);
+  return typeof payload?.sub === "string" ? payload.sub : null;
+}
 
 /**
  * `logout` — symmetric counterpart to `login`. Stops the
  * background daemon and removes persisted credentials. `client.yaml` and local
- * agent runtime state are kept by default; `--purge` opts in to wiping them so
- * a different user can log in on the same machine without reusing old state.
+ * agent runtime state are kept by default; `--purge` is the compatibility
+ * destructive reset path for damaged local client identity/state.
  */
 export function registerLogoutCommand(program: Command): void {
   program
     .command("logout")
     .description("Disconnect from First Tree — stop daemon and clear credentials (symmetric to `login`)")
-    .option("--purge", "Also remove client.yaml plus local agent configs, workspaces, and session state")
+    .option("--purge", "Also remove active and parked local client state")
     .action((options: { purge?: boolean }) => {
-      const configDir = defaultConfigDir();
-      const dataDir = defaultDataDir();
-      const purge = options.purge === true;
-      // 1. Stop daemon (best-effort).
-      if (isServiceSupported()) {
-        const svc = getClientServiceStatus();
-        if (svc.state === "active") {
-          const res = stopClientService();
-          if (!res.ok && purge) {
-            print.line(`  Could not stop ${svc.platform} service: ${res.reason}\n\n`);
-            print.line(
-              "  Refusing to purge local agent configs, workspaces, or session state while the daemon may still be running.\n",
-            );
-            print.line(
-              `  Run \`${channelConfig.binName} daemon stop\` or stop the service manually, then retry \`${channelConfig.binName} logout --purge\`.\n\n`,
-            );
-            fail("PURGE_DAEMON_STOP_FAILED", `Failed to stop active background service: ${res.reason}`, 1);
-          }
-          print.line(`  ✓ Stopped ${svc.platform} service${res.ok ? "" : ` (warning: ${res.reason})`}\n`);
-        }
-      }
-      // 2. Remove credentials.
-      const credsPath = join(configDir, "credentials.json");
-      if (existsSync(credsPath)) {
-        unlinkSync(credsPath);
-        print.line(`  ✓ Removed credentials\n`);
-      }
-      // 3. --purge: remove local machine identity and agent runtime state.
-      if (purge) {
-        for (const entry of [
-          { path: join(configDir, "client.yaml"), label: "client.yaml" },
-          { path: join(configDir, "agents"), label: "local agent configs" },
-          { path: join(dataDir, "sessions"), label: "agent session state" },
-          { path: join(dataDir, "workspaces"), label: "agent workspaces" },
-        ]) {
-          if (!existsSync(entry.path)) continue;
-          rmSync(entry.path, { recursive: true, force: true });
-          print.line(`  ✓ Removed ${entry.label}\n`);
-        }
-      }
-      print.line(`\n  Logged out. Run \`${channelConfig.binName} login <token>\` to reconnect.\n\n`);
+      runLogout({ purge: options.purge === true, retryCommand: `${channelConfig.binName} logout --purge` });
     });
+}
+
+export function runLogout(opts: { purge: boolean; retryCommand?: string }): void {
+  const home = defaultHome();
+  const configDir = defaultConfigDir();
+  const dataDir = defaultDataDir();
+  const retryCommand = opts.retryCommand ?? `${channelConfig.binName} logout --purge`;
+  // 1. Stop daemon (best-effort).
+  if (isServiceSupported()) {
+    const svc = getClientServiceStatus();
+    if (svc.state === "active") {
+      const res = stopClientService();
+      if (!res.ok && opts.purge) {
+        print.line(`  Could not stop ${svc.platform} service: ${res.reason}\n\n`);
+        print.line("  Refusing to purge First Tree local client state while the daemon may still be running.\n");
+        print.line(
+          `  Run \`${channelConfig.binName} daemon stop\` or stop the service manually, then retry \`${retryCommand}\`.\n\n`,
+        );
+        fail("PURGE_DAEMON_STOP_FAILED", `Failed to stop active background service: ${res.reason}`, 1);
+      }
+      print.line(`  ✓ Stopped ${svc.platform} service${res.ok ? "" : ` (warning: ${res.reason})`}\n`);
+    }
+  }
+  // 2. Remove credentials.
+  if (!opts.purge) {
+    const credentials = loadCredentials();
+    const ownerSub = readOwnerSub(credentials?.accessToken);
+    const clientId = readActiveRootClientId(configDir);
+    if (credentials && ownerSub && clientId) {
+      recordActiveClientOwner({
+        clientId,
+        userId: ownerSub,
+        serverUrl: credentials.serverUrl,
+      });
+    }
+  }
+  const credsPath = join(configDir, "credentials.json");
+  if (existsSync(credsPath)) {
+    unlinkSync(credsPath);
+    print.line(`  ✓ Removed credentials\n`);
+  }
+  // 3. purge: remove local machine identity and agent runtime state.
+  if (opts.purge) {
+    for (const entry of [
+      { path: join(configDir, "client.yaml"), label: "client.yaml" },
+      { path: join(configDir, "agents"), label: "local agent configs" },
+      { path: join(dataDir, "sessions"), label: "agent session state" },
+      { path: join(dataDir, "workspaces"), label: "agent workspaces" },
+      { path: join(home, "parked-clients"), label: "parked local clients" },
+      { path: join(home, "state", "client-switch.lock"), label: "client switch lock" },
+      { path: join(home, "state", "client-switch-journal.json"), label: "client switch journal" },
+    ]) {
+      if (!existsSync(entry.path)) continue;
+      rmSync(entry.path, { recursive: true, force: true });
+      print.line(`  ✓ Removed ${entry.label}\n`);
+    }
+  }
+  print.line(`\n  Logged out. Run \`${channelConfig.binName} login <token>\` to reconnect.\n\n`);
 }

--- a/apps/cli/src/core/client-reidentify.ts
+++ b/apps/cli/src/core/client-reidentify.ts
@@ -14,9 +14,11 @@ const printClientReidentifyOutput: ClientReidentifyOutput = {
 /**
  * Shared handler for legacy `CLIENT_ORG_MISMATCH` rejections. Current servers
  * reject cross-user reuse as `CLIENT_USER_MISMATCH`, but older deployments may
- * still emit this code. The CLI treats both as purge-first account switching:
- * do not rotate a client id in place, because that would leave old local agent
- * runtime state attached to a new account.
+ * still emit this code. Reaching this handler means the runtime already tried
+ * to register the active root client with the current credentials and the
+ * server rejected that pairing. Do not tell users to retry the same login in a
+ * loop; require local identity repair/reset unless they can return to a known
+ * owner state and let `login` switch before daemon startup.
  */
 export async function handleClientOrgMismatch(
   err: ClientOrgMismatchError,
@@ -28,11 +30,12 @@ export async function handleClientOrgMismatch(
   },
 ): Promise<never> {
   const output = opts.output ?? printClientReidentifyOutput;
-  const purgeCommand = `${channelConfig.binName} logout --purge`;
+  const loginCommand = `${channelConfig.binName} login <token>`;
+  const resetCommand = `${channelConfig.binName} computer reset`;
   if (opts.managed && opts.output?.status) {
     output.status?.(
       "✗",
-      `client identity is not accepted for this account (${err.message}); run \`${purgeCommand}\`, then \`${channelConfig.binName} login <token>\` with the intended account's connect token. Local client identity plus local agent configs, workspaces, and session state stay account-scoped; server-side clients, agents, chats, and history are not deleted.`,
+      `client identity is not accepted for this account (${err.message}); back up local workspaces, run \`${resetCommand}\`, then run \`${loginCommand}\` with the intended account's connect token.`,
     );
     process.exit(1);
   }
@@ -40,12 +43,9 @@ export async function handleClientOrgMismatch(
   output.line("  ⚠️  This machine's client identity is not accepted for this account.\n");
   output.line(`     Server message: ${err.message}\n`);
   output.blank();
-  output.line(`  To switch accounts, run \`${purgeCommand}\` first, then login again.\n\n`);
-  output.line("  `logout --purge` stops the current daemon, signs out the current user, and\n");
-  output.line("  removes this machine's local client identity plus local agent configs,\n");
-  output.line("  workspaces, and session state. Server-side clients, agents, chats, and\n");
-  output.line("  history are not deleted; the previous client and agents simply stop running\n");
-  output.line("  from this machine unless they are set up again.\n\n");
-  output.line(`  Then run \`${channelConfig.binName} login <token>\` with the intended account's connect token.\n\n`);
+  output.line("  The active client id and current credentials do not form a valid server-side owner pair.\n");
+  output.line(
+    `  Back up local workspaces, run \`${resetCommand}\`, then run \`${loginCommand}\` with the intended account's connect token.\n\n`,
+  );
   process.exit(1);
 }

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -391,12 +391,12 @@ export class ClientRuntime {
     }
   }
 
-  async stop(): Promise<void> {
+  async stop(reason?: string): Promise<void> {
     this.unwatchAgentsDir();
     this.stopCredentialsWatcher();
     this.updateManager?.dispose();
     this.updateManager = null;
-    await Promise.allSettled(this.agents.map((a) => a.slot.stop()));
+    await Promise.allSettled(this.agents.map((a) => a.slot.stop(reason)));
     await this.connection.disconnect();
     // Bug 3: sweep any subprocess we still track (git, npm install) so they
     // do not stay in our cgroup after the parent exits. AgentSlot.stop has

--- a/apps/cli/src/core/client-switch.ts
+++ b/apps/cli/src/core/client-switch.ts
@@ -1,0 +1,1115 @@
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import type { ClientConfig } from "@first-tree/shared/config";
+import {
+  clientConfigSchema,
+  defaultConfigDir,
+  defaultDataDir,
+  defaultHome,
+  initConfig,
+  readConfigFile,
+  resetConfig,
+  resetConfigMeta,
+  setConfigValue,
+} from "@first-tree/shared/config";
+import { confirm } from "@inquirer/prompts";
+import { fail } from "../cli/output.js";
+import { saveCredentials } from "./bootstrap.js";
+import { channelConfig } from "./channel.js";
+import { print } from "./output.js";
+import { getClientServiceStatus, stopClientService } from "./service-install.js";
+
+type StoredCredentials = {
+  accessToken: string;
+  refreshToken: string;
+  serverUrl: string;
+};
+
+type SwitchIndexEntry = {
+  clientId: string;
+  userId: string;
+  serverUrl: string;
+  storage: "active-root" | "parked";
+  parkedPath?: string;
+  updatedAt: string;
+};
+
+type SwitchIndex = {
+  version: 1;
+  activeClientId?: string;
+  accountDefaults: Record<string, string>;
+  clients: Record<string, SwitchIndexEntry>;
+};
+
+export type LocalClientOwner = {
+  clientId: string;
+  userId: string;
+  serverUrl: string;
+};
+
+type SwitchMoveState = "pending" | "done" | "absent" | "create";
+
+type SwitchMoveGroup = "park" | "restore";
+
+type SwitchMoveKind =
+  | "park-client-yaml"
+  | "park-agents"
+  | "park-sessions"
+  | "park-workspaces"
+  | "restore-client-yaml"
+  | "restore-agents"
+  | "restore-sessions"
+  | "restore-workspaces";
+
+type SwitchJournalMove = {
+  kind: SwitchMoveKind;
+  group: SwitchMoveGroup;
+  source: string;
+  target: string;
+  required: boolean;
+  state: SwitchMoveState;
+  updatedAt?: string;
+};
+
+type SwitchJournal = {
+  version: 1;
+  id: string;
+  phase:
+    | "locked"
+    | "service-stopped"
+    | "drain-clean"
+    | "parked-old-client"
+    | "restored-target-client"
+    | "credentials-written"
+    | "complete";
+  from: {
+    clientId: string;
+    userId: string;
+    serverUrl: string;
+  };
+  to: {
+    clientId?: string;
+    userId: string;
+    serverUrl: string;
+  };
+  moves?: SwitchJournalMove[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+type MarkedProviderProcess = {
+  pid: number;
+  provider: string;
+  agentId?: string;
+  chatId?: string;
+  command: string;
+};
+
+type ProviderMarkerIssue = {
+  pid: number;
+  command: string;
+  reason: string;
+};
+
+type RuntimeMarker = {
+  version: 1;
+  pid: number;
+  clientId: string;
+  home: string;
+  mode: "foreground" | "service";
+  createdAt: string;
+};
+
+type LiveRuntimeMarker = {
+  pid: number;
+  mode: RuntimeMarker["mode"];
+  command?: string;
+};
+
+type DrainSnapshot =
+  | { ok: true; providers: MarkedProviderProcess[] }
+  | { ok: false; code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED"; reason: string };
+
+const SWITCH_DRAIN_VERSION = "1";
+export const CLIENT_SWITCH_INTERRUPTED_REASON = "client_switch_interrupted";
+
+class ClientSwitchCommandError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly exitCode = 1,
+  ) {
+    super(message);
+    this.name = "ClientSwitchCommandError";
+  }
+}
+
+export function clientSwitchLockPath(home = defaultHome()): string {
+  return join(home, "state", "client-switch.lock");
+}
+
+export function clientSwitchJournalPath(home = defaultHome()): string {
+  return join(home, "state", "client-switch-journal.json");
+}
+
+export function clientRuntimeMarkerPath(home = defaultHome(), pid = process.pid): string {
+  return join(home, "state", "client-runtimes", `${pid}.json`);
+}
+
+export function registerClientRuntimeMarker(opts: {
+  clientId: string;
+  mode: RuntimeMarker["mode"];
+  home?: string;
+  pid?: number;
+}): () => void {
+  const home = opts.home ?? defaultHome();
+  const pid = opts.pid ?? process.pid;
+  const marker: RuntimeMarker = {
+    version: 1,
+    pid,
+    clientId: opts.clientId,
+    home,
+    mode: opts.mode,
+    createdAt: new Date().toISOString(),
+  };
+  writeJsonAtomic(clientRuntimeMarkerPath(home, pid), marker);
+  let cleared = false;
+  return () => {
+    if (cleared) return;
+    cleared = true;
+    rmSync(clientRuntimeMarkerPath(home, pid), { force: true });
+  };
+}
+
+export function getClientSwitchStartupBlock(home = defaultHome()): { lockPath: string; journalPath: string } | null {
+  const lockPath = clientSwitchLockPath(home);
+  const journalPath = clientSwitchJournalPath(home);
+  if (existsSync(lockPath) || existsSync(journalPath)) return { lockPath, journalPath };
+  return null;
+}
+
+export function resolveClientRuntimeStopReason(home = defaultHome()): string | undefined {
+  return getClientSwitchStartupBlock(home) ? CLIENT_SWITCH_INTERRUPTED_REASON : undefined;
+}
+
+export function readActiveRootClientId(configDir = defaultConfigDir()): string | null {
+  return readRootClientId(configDir);
+}
+
+export function readActiveClientOwner(home = defaultHome(), configDir = defaultConfigDir()): LocalClientOwner | null {
+  const clientId = readRootClientId(configDir);
+  if (!clientId) return null;
+  const entry = readSwitchIndex(home).clients[clientId];
+  if (!entry || entry.storage !== "active-root") return null;
+  return { clientId, userId: entry.userId, serverUrl: entry.serverUrl };
+}
+
+export function readRememberedLocalClientIdForAccount(
+  serverUrl: string,
+  userId: string,
+  home = defaultHome(),
+): string | null {
+  return readSwitchIndex(home).accountDefaults[accountKey(serverUrl, userId)] ?? null;
+}
+
+export function hasIncompleteClientSwitch(home = defaultHome()): boolean {
+  const journal = readJournal(home);
+  return !!journal && journal.phase !== "complete";
+}
+
+export function recordActiveClientOwner(owner: LocalClientOwner, home = defaultHome()): void {
+  const now = new Date().toISOString();
+  const index = readSwitchIndex(home);
+  for (const entry of Object.values(index.clients)) {
+    if (entry.clientId !== owner.clientId && entry.storage === "active-root") {
+      entry.storage = "parked";
+      entry.parkedPath = parkedClientRoot(home, entry.clientId);
+      entry.updatedAt = now;
+    }
+  }
+  index.clients[owner.clientId] = {
+    clientId: owner.clientId,
+    userId: owner.userId,
+    serverUrl: owner.serverUrl,
+    storage: "active-root",
+    updatedAt: now,
+  };
+  index.accountDefaults[accountKey(owner.serverUrl, owner.userId)] = owner.clientId;
+  index.activeClientId = owner.clientId;
+  writeJsonAtomic(indexPath(home), index);
+}
+
+export async function confirmLocalClientSwitch(opts: {
+  existingServerUrl: string;
+  targetServerUrl: string;
+  existingUserId?: string;
+  targetUserId?: string;
+  existingClientId?: string;
+  targetClientId?: string;
+  forceSwitch?: boolean;
+}): Promise<void> {
+  if (opts.forceSwitch === true) return;
+  if (process.stdin.isTTY !== true) {
+    fail(
+      "ACCOUNT_SWITCH_REQUIRES_CONFIRMATION",
+      "This connect token belongs to a different First Tree user. Re-run with `--force-switch` in non-interactive mode to confirm account switching. Safety checks still run and cannot be skipped.",
+      1,
+    );
+  }
+  const ok = await confirm({
+    message: formatSwitchConfirmationMessage(opts),
+    default: false,
+  });
+  if (!ok) {
+    fail("ACCOUNT_SWITCH_CANCELLED", "Account switch cancelled before changing local state.", 1);
+  }
+  if (opts.existingServerUrl !== opts.targetServerUrl) {
+    // Keep the cross-server case explicit in the console transcript. It is
+    // allowed, but it changes the account lookup key as well as the user id.
+    print.line(`  Switching server: ${opts.existingServerUrl} -> ${opts.targetServerUrl}\n`);
+  }
+}
+
+export async function switchLocalClientForLogin(opts: {
+  existingCredentials?: StoredCredentials;
+  previousOwnerSub?: string;
+  targetTokens: StoredCredentials;
+  targetOwnerSub: string;
+}): Promise<ClientConfig> {
+  const home = defaultHome();
+  const configDir = defaultConfigDir();
+  const dataDir = defaultDataDir();
+  const pendingJournal = readJournal(home);
+  if (pendingJournal?.phase === "complete") clearSwitchLock(home);
+  else if (pendingJournal) {
+    return completePendingSwitchForLogin({ home, configDir, journal: pendingJournal, opts });
+  }
+
+  const existingCredentials = opts.existingCredentials;
+  const previousOwnerSub = opts.previousOwnerSub;
+  if (!existingCredentials || !previousOwnerSub) {
+    fail(
+      "CLIENT_OWNER_UNKNOWN_REQUIRES_RESET_OR_OWNER_LOGIN",
+      `A previous owner could not be identified, so First Tree cannot safely park the active local client. Run \`${channelConfig.binName} computer reset\` after backing up local state, or log in as the current owner.`,
+      1,
+    );
+  }
+  const oldClientId = readRootClientId(configDir);
+  if (!oldClientId) {
+    fail(
+      "CLIENT_OWNER_UNKNOWN_REQUIRES_RESET_OR_OWNER_LOGIN",
+      `Existing client.yaml does not contain a valid client id, so First Tree cannot safely park the active local client. Run \`${channelConfig.binName} computer reset\` after backing up local state, or log in as the current owner.`,
+      1,
+    );
+  }
+
+  acquireSwitchLock(home);
+  const journal: SwitchJournal = {
+    version: 1,
+    id: `switch-${Date.now()}-${process.pid}`,
+    phase: "locked",
+    from: {
+      clientId: oldClientId,
+      userId: previousOwnerSub,
+      serverUrl: existingCredentials.serverUrl,
+    },
+    to: {
+      userId: opts.targetOwnerSub,
+      serverUrl: opts.targetTokens.serverUrl,
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  try {
+    writeJournal(home, journal);
+    stopServiceForSwitch();
+    updateJournal(home, journal, "service-stopped");
+
+    assertNoLiveRuntimeMarkers(home, oldClientId);
+    await assertSwitchDrainClean({ home, clientId: oldClientId });
+    updateJournal(home, journal, "drain-clean");
+
+    const index = readSwitchIndex(home);
+    const targetClientId = index.accountDefaults[accountKey(opts.targetTokens.serverUrl, opts.targetOwnerSub)];
+    if (targetClientId) journal.to.clientId = targetClientId;
+    writeJournal(home, journal);
+
+    const moves = buildSwitchMoves({ home, configDir, dataDir, fromClientId: oldClientId, toClientId: targetClientId });
+    preflightSwitchRenames(moves);
+    journal.moves = moves;
+    writeJournal(home, journal);
+
+    executeSwitchMoves(home, journal, "park");
+    updateJournal(home, journal, "parked-old-client");
+
+    executeSwitchMoves(home, journal, "restore");
+    updateJournal(home, journal, "restored-target-client");
+
+    rmSync(join(configDir, "credentials.json"), { force: true });
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    saveCredentials(opts.targetTokens);
+    updateJournal(home, journal, "credentials-written");
+
+    setConfigValue(join(configDir, "client.yaml"), "server.url", opts.targetTokens.serverUrl);
+    resetConfig();
+    resetConfigMeta();
+    const config = await initConfig({ schema: clientConfigSchema, role: "client" });
+
+    updateSwitchIndex(home, {
+      from: {
+        clientId: oldClientId,
+        userId: previousOwnerSub,
+        serverUrl: existingCredentials.serverUrl,
+      },
+      to: {
+        clientId: config.client.id,
+        userId: opts.targetOwnerSub,
+        serverUrl: opts.targetTokens.serverUrl,
+      },
+    });
+    journal.to.clientId = config.client.id;
+    updateJournal(home, journal, "complete");
+    clearSwitchLock(home);
+    return config;
+  } catch (err) {
+    const journal = readJournal(home);
+    if (!journalHasRootMovement(journal)) clearSwitchLock(home);
+    if (err instanceof ClientSwitchCommandError) {
+      fail(err.code, err.message, err.exitCode);
+    }
+    if (isExdevError(err)) {
+      fail(
+        "CLIENT_SWITCH_EXDEV",
+        "Cannot switch local clients because active and parked client state are on different filesystems. First Tree will not copy local workspaces implicitly.",
+        1,
+      );
+    }
+    throw err;
+  }
+}
+
+function formatSwitchConfirmationMessage(opts: {
+  existingServerUrl: string;
+  targetServerUrl: string;
+  existingUserId?: string;
+  targetUserId?: string;
+  existingClientId?: string;
+  targetClientId?: string;
+}): string {
+  const current = `${opts.existingUserId ?? "the current user"}${opts.existingClientId ? ` / ${opts.existingClientId}` : ""}`;
+  const target = `${opts.targetUserId ?? "the target user"}${opts.targetClientId ? ` / restore ${opts.targetClientId}` : " / create or restore a separate local client"}`;
+  return [
+    `Switch this computer from ${current} to ${target}?`,
+    "This will stop the current daemon and interrupt running agent work before local state is moved.",
+    "Inactive First Tree refresh tokens are not kept; switching back requires a fresh `login <token>`.",
+    "Provider auth is not isolated by First Tree and remains whatever this OS user is signed into.",
+    "If runtime, provider, filesystem, or journal safety gates fail, the switch aborts without changing users.",
+  ].join(" ");
+}
+
+async function completePendingSwitchForLogin(opts: {
+  home: string;
+  configDir: string;
+  journal: SwitchJournal;
+  opts: {
+    targetTokens: StoredCredentials;
+    targetOwnerSub: string;
+  };
+}): Promise<ClientConfig> {
+  const { home, configDir, journal } = opts;
+  try {
+    if (journal.to.userId !== opts.opts.targetOwnerSub || journal.to.serverUrl !== opts.opts.targetTokens.serverUrl) {
+      throwSwitchFailure(
+        "CLIENT_SWITCH_MANUAL_REPAIR_REQUIRED",
+        `A previous client switch is pending for user ${journal.to.userId} on ${journal.to.serverUrl}. Re-run login with that user's token, or inspect ${clientSwitchJournalPath(home)} before manual repair.`,
+      );
+    }
+    if (!journal.moves || journal.moves.length === 0) {
+      clearSwitchLock(home);
+      throwSwitchFailure(
+        "CLIENT_SWITCH_RETRY_REQUIRED",
+        "A previous client switch stopped before root state movement. The switch guard was cleared; re-run login to start a fresh switch.",
+      );
+    }
+
+    executeSwitchMoves(home, journal, "park");
+    updateJournal(home, journal, "parked-old-client");
+    executeSwitchMoves(home, journal, "restore");
+    updateJournal(home, journal, "restored-target-client");
+
+    rmSync(join(configDir, "credentials.json"), { force: true });
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    saveCredentials(opts.opts.targetTokens);
+    updateJournal(home, journal, "credentials-written");
+
+    setConfigValue(join(configDir, "client.yaml"), "server.url", opts.opts.targetTokens.serverUrl);
+    resetConfig();
+    resetConfigMeta();
+    const config = await initConfig({ schema: clientConfigSchema, role: "client" });
+
+    updateSwitchIndex(home, {
+      from: journal.from,
+      to: {
+        clientId: config.client.id,
+        userId: opts.opts.targetOwnerSub,
+        serverUrl: opts.opts.targetTokens.serverUrl,
+      },
+    });
+    journal.to.clientId = config.client.id;
+    updateJournal(home, journal, "complete");
+    clearSwitchLock(home);
+    return config;
+  } catch (err) {
+    if (err instanceof ClientSwitchCommandError) {
+      fail(err.code, err.message, err.exitCode);
+    }
+    if (isExdevError(err)) {
+      fail(
+        "CLIENT_SWITCH_EXDEV",
+        "Cannot recover local client switch because active and parked client state are on different filesystems. First Tree will not copy local workspaces implicitly.",
+        1,
+      );
+    }
+    throw err;
+  }
+}
+
+async function assertSwitchDrainClean(opts: { home: string; clientId: string }): Promise<void> {
+  const first = collectMarkedProviderProcesses(opts.home, opts.clientId);
+  if (!first.ok) throwSwitchFailure(first.code, first.reason);
+  if (first.providers.length > 0) {
+    throwSwitchFailure("CLIENT_SWITCH_DRAIN_TIMEOUT", formatLiveProviders(first.providers));
+  }
+  await sleep(500);
+  const second = collectMarkedProviderProcesses(opts.home, opts.clientId);
+  if (!second.ok) throwSwitchFailure(second.code, second.reason);
+  if (second.providers.length > 0) {
+    throwSwitchFailure("CLIENT_SWITCH_DRAIN_TIMEOUT", formatLiveProviders(second.providers));
+  }
+}
+
+function collectMarkedProviderProcesses(home: string, clientId: string): DrainSnapshot {
+  if (process.platform === "linux") return collectLinuxMarkedProviders(home, clientId);
+  if (process.platform === "darwin") return collectDarwinMarkedProviders(home, clientId);
+  return {
+    ok: false,
+    code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+    reason: `Client switch drain is not supported on ${process.platform}; refusing to move root state.`,
+  };
+}
+
+function collectDarwinMarkedProviders(home: string, clientId: string): DrainSnapshot {
+  let output: string;
+  try {
+    output = execFileSync("ps", ["-Eww", "-axo", "pid=,command="], {
+      encoding: "utf8",
+      timeout: 10_000,
+      maxBuffer: 8 * 1024 * 1024,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      reason: `Unable to inspect process environment for switch drain: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  const providers: MarkedProviderProcess[] = [];
+  const issues: ProviderMarkerIssue[] = [];
+  for (const line of output.split("\n")) {
+    const match = line.match(/^\s*(\d+)\s+(.*)$/);
+    if (!match) continue;
+    const pid = Number(match[1]);
+    const command = match[2] ?? "";
+    collectSwitchDrainProcessFromEnvText({ pid, command, envText: command, home, clientId, providers, issues });
+    collectDaemonFromEnvText({ pid, command, envText: command, home, clientId, issues });
+  }
+  if (issues.length > 0) return untrustedProviderSnapshot(issues);
+  return { ok: true, providers };
+}
+
+function collectLinuxMarkedProviders(home: string, clientId: string): DrainSnapshot {
+  let procEntries: string[];
+  try {
+    procEntries = readdirSync("/proc");
+  } catch (err) {
+    return {
+      ok: false,
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      reason: `Unable to inspect /proc for switch drain: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const providers: MarkedProviderProcess[] = [];
+  const issues: ProviderMarkerIssue[] = [];
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  for (const entry of procEntries) {
+    if (!/^\d+$/.test(entry)) continue;
+    const pid = Number(entry);
+    const procDir = join("/proc", entry);
+    if (uid !== null && linuxUid(procDir) !== uid) continue;
+    let command: string;
+    try {
+      command = readFileSync(join(procDir, "cmdline"), "utf8").replace(/\0/g, " ");
+    } catch (err) {
+      if (existsSync(procDir)) {
+        return {
+          ok: false,
+          code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+          reason: `Unable to read process ${pid} environment for switch drain: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        };
+      }
+      continue;
+    }
+    const envIsRequiredForDrain = isSwitchDrainEnvRequired(command);
+    let envText: string;
+    try {
+      envText = readFileSync(join(procDir, "environ"), "utf8");
+    } catch (err) {
+      if (existsSync(procDir) && envIsRequiredForDrain) {
+        return {
+          ok: false,
+          code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+          reason: `Unable to read process ${pid} environment for switch drain: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        };
+      }
+      continue;
+    }
+    collectSwitchDrainProcessFromEnvText({ pid, command, envText, home, clientId, providers, issues });
+    collectDaemonFromEnvText({ pid, command, envText, home, clientId, issues });
+  }
+  if (issues.length > 0) return untrustedProviderSnapshot(issues);
+  return { ok: true, providers };
+}
+
+function linuxUid(procDir: string): number | null {
+  try {
+    const status = readFileSync(join(procDir, "status"), "utf8");
+    const match = status.match(/^Uid:\s+(\d+)/m);
+    return match ? Number(match[1]) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function collectSwitchDrainProcessFromEnvText(opts: {
+  pid: number;
+  command: string;
+  envText: string;
+  home: string;
+  clientId: string;
+  providers: MarkedProviderProcess[];
+  issues: ProviderMarkerIssue[];
+}): void {
+  const markerHome = parseSwitchProcessEnvValue(opts.envText, "FIRST_TREE_HOME");
+  if (markerHome !== opts.home) return;
+
+  const knownProvider = isKnownProviderCommand(opts.command);
+  const provider = parseSwitchProcessEnvValue(opts.envText, "FIRST_TREE_PROVIDER");
+  const markerClientId = parseSwitchProcessEnvValue(opts.envText, "FIRST_TREE_CLIENT_ID");
+  const drainVersion = parseSwitchProcessEnvValue(opts.envText, "FIRST_TREE_SWITCH_DRAIN_VERSION");
+  if (!knownProvider && !provider && !markerClientId && !drainVersion && !isKnownDaemonRuntimeCommand(opts.command)) {
+    return;
+  }
+  if (
+    isKnownDaemonRuntimeCommand(opts.command) &&
+    !knownProvider &&
+    !provider &&
+    drainVersion !== SWITCH_DRAIN_VERSION
+  ) {
+    return;
+  }
+  if (!markerClientId || drainVersion !== SWITCH_DRAIN_VERSION) {
+    opts.issues.push({
+      pid: opts.pid,
+      command: opts.command,
+      reason: "missing trusted switch drain markers",
+    });
+    return;
+  }
+  if (markerClientId !== opts.clientId) {
+    opts.issues.push({
+      pid: opts.pid,
+      command: opts.command,
+      reason: `belongs to another client (${markerClientId})`,
+    });
+    return;
+  }
+  opts.providers.push({
+    pid: opts.pid,
+    provider: provider ?? (knownProvider ? "unknown-provider" : "marked-descendant"),
+    agentId: parseSwitchProcessEnvValue(opts.envText, "FIRST_TREE_AGENT_ID") ?? undefined,
+    chatId: parseSwitchProcessEnvValue(opts.envText, "FIRST_TREE_CHAT_ID") ?? undefined,
+    command: opts.command,
+  });
+}
+
+function collectDaemonFromEnvText(opts: {
+  pid: number;
+  command: string;
+  envText: string;
+  home: string;
+  clientId: string;
+  issues: ProviderMarkerIssue[];
+}): void {
+  if (!isKnownDaemonRuntimeCommand(opts.command)) return;
+  const markerHome = parseSwitchProcessEnvValue(opts.envText, "FIRST_TREE_HOME");
+  const sameDefaultHomeWithoutEnv = !markerHome && opts.home === defaultHome();
+  if (markerHome !== opts.home && !sameDefaultHomeWithoutEnv) return;
+
+  const markerClientId = parseSwitchProcessEnvValue(opts.envText, "FIRST_TREE_CLIENT_ID");
+  if (markerClientId && markerClientId !== opts.clientId) return;
+  opts.issues.push({
+    pid: opts.pid,
+    command: opts.command,
+    reason: markerClientId ? "daemon runtime is still active" : "daemon runtime lacks trusted switch drain markers",
+  });
+}
+
+function untrustedProviderSnapshot(issues: ProviderMarkerIssue[]): DrainSnapshot {
+  const lines = issues.slice(0, 8).map((issue) => `pid=${issue.pid} ${issue.reason}: ${issue.command}`);
+  const suffix = issues.length > lines.length ? `\n  ...and ${issues.length - lines.length} more` : "";
+  return {
+    ok: false,
+    code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+    reason: `Found First Tree provider-like processes without trusted switch-drain markers; refusing to move root state.\n  ${lines.join("\n  ")}${suffix}`,
+  };
+}
+
+export function parseSwitchProcessEnvValue(envText: string, key: string): string | null {
+  const prefix = `${key}=`;
+  if (envText.includes("\0")) {
+    for (const entry of envText.split("\0")) {
+      if (entry.startsWith(prefix)) return entry.slice(prefix.length);
+    }
+    return null;
+  }
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = envText.match(new RegExp(`(?:^|\\s)${escaped}=`));
+  if (!match || match.index === undefined) return null;
+  const valueStart = match.index + match[0].length;
+  const rest = envText.slice(valueStart);
+  const nextEnv = rest.search(/\s[A-Za-z_][A-Za-z0-9_]*=/);
+  if (nextEnv >= 0) return rest.slice(0, nextEnv);
+  const token = rest.match(/^[^\s\0]+/);
+  return token ? token[0] : "";
+}
+
+function isKnownProviderCommand(command: string): boolean {
+  return /(^|[/\s])(claude|codex)(\s|$)/i.test(command) || /@openai\/codex|claude-code/i.test(command);
+}
+
+function isKnownDaemonRuntimeCommand(command: string): boolean {
+  if (!/\bdaemon\s+start\b/.test(command)) return false;
+  return (
+    /(^|[/\s])first-tree(?:-(?:dev|staging))?(\s|$)/.test(command) ||
+    /(^|[/\s])(?:cli\/index|index)\.mjs(\s|$)/.test(command)
+  );
+}
+
+export function isSwitchDrainEnvRequired(command: string): boolean {
+  return isKnownProviderCommand(command) || isKnownDaemonRuntimeCommand(command);
+}
+
+function formatLiveProviders(providers: MarkedProviderProcess[]): string {
+  const lines = providers
+    .slice(0, 8)
+    .map(
+      (p) =>
+        `pid=${p.pid} provider=${p.provider}${p.agentId ? ` agent=${p.agentId}` : ""}${p.chatId ? ` chat=${p.chatId}` : ""}`,
+    );
+  const suffix = providers.length > lines.length ? `\n  ...and ${providers.length - lines.length} more` : "";
+  return `Provider processes are still running after account-switch interruption; refusing to move root state.\n  ${lines.join("\n  ")}${suffix}`;
+}
+
+function stopServiceForSwitch(): void {
+  const before = getClientServiceStatus();
+  if (before.state === "unknown") {
+    throwSwitchFailure(
+      "CLIENT_SWITCH_SUPERVISOR_UNSAFE",
+      `Background service state could not be determined (${before.platform}${before.detail ? `: ${before.detail}` : ""}).`,
+    );
+  }
+  if (before.state !== "active") return;
+  const stopped = stopClientService();
+  if (!stopped.ok) {
+    throwSwitchFailure(
+      "CLIENT_SWITCH_SUPERVISOR_UNSAFE",
+      `Failed to stop background service before switch: ${stopped.reason}`,
+    );
+  }
+  const after = getClientServiceStatus();
+  if (after.state === "active" || after.state === "unknown") {
+    throwSwitchFailure(
+      "CLIENT_SWITCH_SUPERVISOR_UNSAFE",
+      `Background service did not reach a safe stopped state (${after.platform}${after.detail ? `: ${after.detail}` : ""}).`,
+    );
+  }
+}
+
+function assertNoLiveRuntimeMarkers(home: string, clientId: string): void {
+  const markerDir = dirname(clientRuntimeMarkerPath(home, 0));
+  if (!existsSync(markerDir)) return;
+  const live: LiveRuntimeMarker[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(markerDir);
+  } catch (err) {
+    throwSwitchFailure(
+      "CLIENT_SWITCH_RUNTIME_MARKER_UNTRUSTED",
+      `Unable to inspect runtime markers before switch: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const markerPath = join(markerDir, entry);
+    let marker: RuntimeMarker;
+    try {
+      marker = JSON.parse(readFileSync(markerPath, "utf8")) as RuntimeMarker;
+    } catch (err) {
+      throwSwitchFailure(
+        "CLIENT_SWITCH_RUNTIME_MARKER_UNTRUSTED",
+        `Unable to read runtime marker ${markerPath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (marker.version !== 1 || marker.home !== home || marker.clientId !== clientId) continue;
+    if (!isPidAlive(marker.pid)) {
+      rmSync(markerPath, { force: true });
+      continue;
+    }
+    live.push({ pid: marker.pid, mode: marker.mode, command: readPidCommand(marker.pid) ?? undefined });
+  }
+  if (live.length > 0) {
+    throwSwitchFailure("CLIENT_SWITCH_RUNTIME_ACTIVE", formatLiveRuntimes(live));
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = typeof err === "object" && err !== null && "code" in err ? (err as { code?: unknown }).code : null;
+    return code !== "ESRCH";
+  }
+}
+
+function readPidCommand(pid: number): string | null {
+  if (process.platform === "linux") {
+    try {
+      return (
+        readFileSync(join("/proc", String(pid), "cmdline"), "utf8")
+          .replace(/\0/g, " ")
+          .trim() || null
+      );
+    } catch {
+      return null;
+    }
+  }
+  if (process.platform === "darwin") {
+    try {
+      return execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+        encoding: "utf8",
+        timeout: 2000,
+        maxBuffer: 1024 * 1024,
+      }).trim();
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function formatLiveRuntimes(runtimes: LiveRuntimeMarker[]): string {
+  const lines = runtimes
+    .slice(0, 8)
+    .map((runtime) => `pid=${runtime.pid} mode=${runtime.mode}${runtime.command ? ` command=${runtime.command}` : ""}`);
+  const suffix = runtimes.length > lines.length ? `\n  ...and ${runtimes.length - lines.length} more` : "";
+  return `First Tree runtime processes are still running after account-switch interruption; refusing to move root state.\n  ${lines.join("\n  ")}${suffix}`;
+}
+
+function throwSwitchFailure(code: string, message: string): never {
+  throw new ClientSwitchCommandError(code, message);
+}
+
+function buildSwitchMoves(opts: {
+  home: string;
+  configDir: string;
+  dataDir: string;
+  fromClientId: string;
+  toClientId?: string;
+}): SwitchJournalMove[] {
+  const fromParkedRoot = parkedClientRoot(opts.home, opts.fromClientId);
+  const moves: SwitchJournalMove[] = [
+    move(
+      "park-client-yaml",
+      "park",
+      join(opts.configDir, "client.yaml"),
+      join(fromParkedRoot, "config", "client.yaml"),
+      true,
+    ),
+    move("park-agents", "park", join(opts.configDir, "agents"), join(fromParkedRoot, "config", "agents"), false),
+    move("park-sessions", "park", join(opts.dataDir, "sessions"), join(fromParkedRoot, "data", "sessions"), false),
+    move(
+      "park-workspaces",
+      "park",
+      join(opts.dataDir, "workspaces"),
+      join(fromParkedRoot, "data", "workspaces"),
+      false,
+    ),
+  ];
+
+  if (!opts.toClientId) {
+    moves.push({
+      kind: "restore-client-yaml",
+      group: "restore",
+      source: join(opts.home, "parked-clients", "__new-client__", "config", "client.yaml"),
+      target: join(opts.configDir, "client.yaml"),
+      required: true,
+      state: "create",
+      updatedAt: new Date().toISOString(),
+    });
+    return moves;
+  }
+
+  const toParkedRoot = parkedClientRoot(opts.home, opts.toClientId);
+  moves.push(
+    move(
+      "restore-client-yaml",
+      "restore",
+      join(toParkedRoot, "config", "client.yaml"),
+      join(opts.configDir, "client.yaml"),
+      true,
+    ),
+    move("restore-agents", "restore", join(toParkedRoot, "config", "agents"), join(opts.configDir, "agents"), false),
+    move("restore-sessions", "restore", join(toParkedRoot, "data", "sessions"), join(opts.dataDir, "sessions"), false),
+    move(
+      "restore-workspaces",
+      "restore",
+      join(toParkedRoot, "data", "workspaces"),
+      join(opts.dataDir, "workspaces"),
+      false,
+    ),
+  );
+  return moves;
+}
+
+function move(
+  kind: SwitchMoveKind,
+  group: SwitchMoveGroup,
+  source: string,
+  target: string,
+  required: boolean,
+): SwitchJournalMove {
+  return { kind, group, source, target, required, state: "pending" };
+}
+
+function preflightSwitchRenames(moves: SwitchJournalMove[]): void {
+  for (const entry of moves) {
+    if (entry.state === "create" || !existsSync(entry.source)) continue;
+    assertSameDeviceRename(entry.source, entry.target);
+  }
+}
+
+function executeSwitchMoves(home: string, journal: SwitchJournal, group: SwitchMoveGroup): void {
+  for (const entry of journal.moves ?? []) {
+    if (entry.group !== group || entry.state !== "pending") continue;
+    const sourceExists = existsSync(entry.source);
+    const targetExists = existsSync(entry.target);
+    if (!sourceExists && targetExists) {
+      markMove(home, journal, entry, "done");
+      continue;
+    }
+    if (!sourceExists && !targetExists) {
+      if (!entry.required) {
+        markMove(home, journal, entry, "absent");
+        continue;
+      }
+      throwUnclassifiableMove(home, entry, "neither source nor target exists");
+    }
+    if (sourceExists && targetExists) {
+      throwUnclassifiableMove(home, entry, "both source and target exist");
+    }
+
+    mkdirSync(dirname(entry.target), { recursive: true, mode: 0o700 });
+    assertSameDeviceRename(entry.source, entry.target);
+    renameSync(entry.source, entry.target);
+    markMove(home, journal, entry, "done");
+  }
+}
+
+function markMove(home: string, journal: SwitchJournal, entry: SwitchJournalMove, state: SwitchMoveState): void {
+  entry.state = state;
+  entry.updatedAt = new Date().toISOString();
+  journal.updatedAt = entry.updatedAt;
+  writeJournal(home, journal);
+}
+
+function throwUnclassifiableMove(home: string, entry: SwitchJournalMove, detail: string): never {
+  throwSwitchFailure(
+    "CLIENT_SWITCH_MANUAL_REPAIR_REQUIRED",
+    `Client switch journal cannot safely recover ${entry.kind}: ${detail}. Inspect ${clientSwitchJournalPath(home)}, ${entry.source}, and ${entry.target} before manual repair.`,
+  );
+}
+
+function journalHasRootMovement(journal: SwitchJournal | null): boolean {
+  if (!journal) return false;
+  if (journal.moves && journal.moves.length > 0) return true;
+  return (
+    journal.phase === "parked-old-client" ||
+    journal.phase === "restored-target-client" ||
+    journal.phase === "credentials-written" ||
+    journal.phase === "complete"
+  );
+}
+
+function assertSameDeviceRename(source: string, target: string): void {
+  const sourceDev = statSync(source).dev;
+  const targetParent = dirname(target);
+  mkdirSync(targetParent, { recursive: true, mode: 0o700 });
+  const targetDev = statSync(targetParent).dev;
+  if (sourceDev !== targetDev) {
+    const err = new Error(`EXDEV preflight: ${source} -> ${target}`);
+    Object.assign(err, { code: "EXDEV" });
+    throw err;
+  }
+}
+
+function readRootClientId(configDir: string): string | null {
+  const raw = readConfigFile(join(configDir, "client.yaml"));
+  const client = raw.client;
+  if (typeof client !== "object" || client === null) return null;
+  const id = (client as { id?: unknown }).id;
+  return typeof id === "string" && /^client_[a-f0-9]{8}$/.test(id) ? id : null;
+}
+
+function readSwitchIndex(home: string): SwitchIndex {
+  try {
+    const raw = JSON.parse(readFileSync(indexPath(home), "utf8")) as SwitchIndex;
+    if (raw.version === 1 && raw.clients && raw.accountDefaults) return raw;
+  } catch {
+    // fall through
+  }
+  return { version: 1, accountDefaults: {}, clients: {} };
+}
+
+function updateSwitchIndex(
+  home: string,
+  opts: {
+    from: { clientId: string; userId: string; serverUrl: string };
+    to: { clientId: string; userId: string; serverUrl: string };
+  },
+): void {
+  const now = new Date().toISOString();
+  const index = readSwitchIndex(home);
+  index.clients[opts.from.clientId] = {
+    clientId: opts.from.clientId,
+    userId: opts.from.userId,
+    serverUrl: opts.from.serverUrl,
+    storage: "parked",
+    parkedPath: parkedClientRoot(home, opts.from.clientId),
+    updatedAt: now,
+  };
+  index.clients[opts.to.clientId] = {
+    clientId: opts.to.clientId,
+    userId: opts.to.userId,
+    serverUrl: opts.to.serverUrl,
+    storage: "active-root",
+    updatedAt: now,
+  };
+  index.accountDefaults[accountKey(opts.from.serverUrl, opts.from.userId)] = opts.from.clientId;
+  index.accountDefaults[accountKey(opts.to.serverUrl, opts.to.userId)] = opts.to.clientId;
+  index.activeClientId = opts.to.clientId;
+  writeJsonAtomic(indexPath(home), index);
+}
+
+function accountKey(serverUrl: string, userId: string): string {
+  return `${serverUrl}\n${userId}`;
+}
+
+function parkedClientRoot(home: string, clientId: string): string {
+  return join(home, "parked-clients", clientId);
+}
+
+function indexPath(home: string): string {
+  return join(home, "parked-clients", "index.json");
+}
+
+function acquireSwitchLock(home: string): void {
+  const lockPath = clientSwitchLockPath(home);
+  if (existsSync(lockPath) || existsSync(clientSwitchJournalPath(home))) {
+    fail(
+      "CLIENT_SWITCH_MANUAL_REPAIR_REQUIRED",
+      "A previous client switch did not complete cleanly. Start-up is blocked until the switch journal is repaired or removed after inspection.",
+      1,
+    );
+  }
+  mkdirSync(dirname(lockPath), { recursive: true, mode: 0o700 });
+  writeFileSync(lockPath, JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }, null, 2), {
+    flag: "wx",
+    mode: 0o600,
+  });
+}
+
+function clearSwitchLock(home: string): void {
+  rmSync(clientSwitchJournalPath(home), { force: true });
+  rmSync(clientSwitchLockPath(home), { force: true });
+}
+
+function readJournal(home: string): SwitchJournal | null {
+  try {
+    return JSON.parse(readFileSync(clientSwitchJournalPath(home), "utf8")) as SwitchJournal;
+  } catch {
+    return null;
+  }
+}
+
+function writeJournal(home: string, journal: SwitchJournal): void {
+  writeJsonAtomic(clientSwitchJournalPath(home), journal);
+}
+
+function updateJournal(home: string, journal: SwitchJournal, phase: SwitchJournal["phase"]): void {
+  journal.phase = phase;
+  journal.updatedAt = new Date().toISOString();
+  writeJournal(home, journal);
+}
+
+function writeJsonAtomic(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const tmp = `${path}.tmp.${process.pid}`;
+  try {
+    writeFileSync(tmp, JSON.stringify(value, null, 2), { mode: 0o600 });
+    renameSync(tmp, path);
+  } catch (err) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      // ignore cleanup failure
+    }
+    throw err;
+  }
+}
+
+function isExdevError(err: unknown): boolean {
+  return typeof err === "object" && err !== null && "code" in err && (err as { code?: unknown }).code === "EXDEV";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -23,6 +23,24 @@ export { handleClientOrgMismatch } from "./client-reidentify.js";
 export type { ClientRuntimeOptions, ClientRuntimeOutput } from "./client-runtime.js";
 // Client runtime
 export { ClientRuntime, createLoggerRuntimeOutput } from "./client-runtime.js";
+export type { LocalClientOwner } from "./client-switch.js";
+// Local client account switching
+export {
+  CLIENT_SWITCH_INTERRUPTED_REASON,
+  clientRuntimeMarkerPath,
+  clientSwitchJournalPath,
+  clientSwitchLockPath,
+  confirmLocalClientSwitch,
+  getClientSwitchStartupBlock,
+  hasIncompleteClientSwitch,
+  readActiveClientOwner,
+  readActiveRootClientId,
+  readRememberedLocalClientIdForAccount,
+  recordActiveClientOwner,
+  registerClientRuntimeMarker,
+  resolveClientRuntimeStopReason,
+  switchLocalClientForLogin,
+} from "./client-switch.js";
 // User-owned daemon environment (proxy etc.) — read, never written by us
 export { daemonEnvPath, loadDaemonEnv, parseDaemonEnv } from "./daemon-env.js";
 // Diagnostics (doctor)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,8 +35,9 @@ Requirements: Node.js ≥ 22.13 (24 recommended).
 
 ```
 first-tree
-├── login <token>            Sign this computer in
+├── login <token>            Sign this computer in or switch local clients
 ├── logout                   Stop the daemon and clear credentials
+├── computer ...             Computer-level local state recovery
 ├── status                   CLI + daemon + server + auth + agent overview
 ├── doctor                   Cross-subsystem readiness check
 ├── upgrade                  Self-update + restart the daemon
@@ -53,21 +54,23 @@ first-tree
 ## login
 
 ```
-first-tree login <token> [--no-start]
+first-tree login <token> [--no-start] [--force-switch]
 ```
 
 Sign this computer in using a connect token from the web console. The
 token's `iss` claim carries the server URL — no `--server` flag needed,
 and switching to a different deployment only requires a fresh token.
-If this machine already has credentials for another user, `login` refuses to
-overwrite them. If credentials are missing, `login` preserves `client.yaml` and
-local agent state so the same user can reconnect after a normal `logout`. Switch
-accounts by running `first-tree logout --purge` first, then login with the new
-token.
+If this machine already has credentials for another user, `login` asks for
+explicit confirmation and switches the active local client after stopping and
+draining the old runtime. In non-TTY automation, `--force-switch` is the only
+confirmation flag; it does not skip supervisor, drain, filesystem, or journal
+safety checks. If credentials are missing, `login` preserves `client.yaml` and
+local agent state so the same user can reconnect after a normal `logout`.
 
 | Flag | Effect |
 |---|---|
 | `--no-start` | Write credentials and exit without installing/starting the background daemon. |
+| `--force-switch` | Confirm a different-user local client switch in non-interactive mode. Safety gates still run. |
 
 ## logout
 
@@ -75,14 +78,38 @@ token.
 first-tree logout [--purge]
 ```
 
-Stop the daemon and clear credentials. `--purge` additionally removes
-`client.yaml`, local agent configs, agent workspaces, and session state. Use
-`--purge` before switching this machine to a different account. The purge is
-local-only: server-side clients, agents, chats, and history are not deleted,
-but the previous client and agents stop running from this machine unless they
-are set up again. If the daemon is active and cannot be stopped, `--purge`
-refuses to delete local agent state. The default keeps local client/agent state
-for the same user to reconnect later.
+Stop the daemon and clear credentials. `--purge` additionally removes active
+root client state, parked clients under `$FIRST_TREE_HOME/parked-clients/`, and
+switch lock/journal files. This is a destructive local reset path, not the
+normal account-switch path. To switch this computer to another First Tree user,
+run `first-tree login <token>` with the new user's connect token and confirm
+the switch. The purge is local-only: server-side clients, agents, chats, and
+history are not deleted, but the previous clients and agents stop running from
+this machine unless they are set up again. If the daemon is active and cannot
+be stopped, `--purge` refuses to delete local client state. The default keeps
+local client/agent state for the same user to reconnect later.
+
+## computer
+
+Computer-level local state recovery.
+
+```
+first-tree computer
+└── reset
+```
+
+### computer reset
+
+```
+first-tree computer reset
+```
+
+Stop the daemon and remove active root client state, parked clients under
+`$FIRST_TREE_HOME/parked-clients/`, switch lock/journal files, and active
+credentials. Use this when local identity state is damaged or when you
+intentionally want to discard every local First Tree client stored in this
+installation. Normal different-user switching should use
+`first-tree login <token>` instead, which parks inactive clients.
 
 ## status
 

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -88,7 +88,8 @@ name — there is no separate "local alias" to invent.
 | Cross-subsystem readiness check | `first-tree doctor` |
 | List local agent bindings | `first-tree agent list` |
 | List every agent you manage on the server | `first-tree agent list --remote` |
-| Switch a machine to another user | `first-tree logout --purge`, then `first-tree login <token>` |
+| Switch a machine to another user | `first-tree login <token>` with the new user's token, then confirm the switch |
+| Destructively reset damaged local client state | `first-tree computer reset` |
 | Send a chat message | `first-tree chat send <agent-name> "message"` |
 | List chats | `first-tree chat list` |
 | View chat history | `first-tree chat history <chat-id>` |
@@ -145,7 +146,7 @@ and ack via `connection.sendInboxAck(entryId)`.
 | `HTTP_401` | Invalid or revoked token | Run `first-tree login <token>` with a fresh token |
 | `HTTP_403` | Agent suspended or deleted | Check the agent's status in the admin UI |
 | `CONNECTION_ERROR` | Server unreachable | Verify `FIRST_TREE_SERVER_URL` or that the local server is running |
-| `CLIENT_USER_MISMATCH` (WS close 4403) | Machine already bound to another user | Run `first-tree logout --purge`, then `first-tree login <token>` |
+| `CLIENT_USER_MISMATCH` (WS close 4403) | Active client id is not accepted for the current credentials | Back up local workspaces, run `first-tree computer reset`, then run `first-tree login <token>` with the intended account |
 | `AMBIGUOUS_AGENT` | Multiple local agents and no `--agent` flag | Pass `--agent <name>` explicitly |
 
 ## For AI agents driving onboarding
@@ -159,10 +160,16 @@ and ack via `connection.sendInboxAck(entryId)`.
   it explicitly when more than one agent runs on the same client to
   avoid `AMBIGUOUS_AGENT`.
 - If the user already has local First Tree state for a different account
-  on this machine, run `first-tree logout --purge` before logging in with
-  the new connect token. This signs out the current user and removes the
-  local client identity plus local agent configs, workspaces, and session
-  state. Server-side clients, agents, chats, and history are not deleted.
+  on this machine, run `first-tree login <token>` with the new user's
+  connect token. Interactive terminals prompt for confirmation; non-TTY
+  automation must pass `--force-switch`. That flag only confirms the switch:
+  First Tree still stops and drains the old runtime, verifies switch gates,
+  parks inactive local client state, and refuses to move root state if any
+  safety gate fails.
+- Use `first-tree computer reset` only when local identity state is damaged
+  or the user intentionally wants to discard active and parked local
+  client/agent state in this installation. It is a destructive local reset;
+  server-side clients, agents, chats, and history are not deleted.
 
 ## See also
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -129,5 +129,5 @@ console:
 | One-screen overview of your install | `first-tree status` |
 | Send a message to another agent | `first-tree chat send <agent> "..."` |
 | Stop the daemon and sign out | `first-tree logout` |
-| Switch this computer to another account | `first-tree logout --purge`, then `first-tree login <token>` |
+| Switch this computer to another account | `first-tree login <token>` with the new user's token, then confirm the switch |
 | Update the CLI in place | `first-tree upgrade` |

--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -451,6 +451,27 @@ describe("buildAgentEnv", () => {
     expect(env.FIRST_TREE_CHAT_ID).toBe("chat-1");
   });
 
+  it("adds client switch drain markers when provider context is available", () => {
+    const env = buildAgentEnv({ PATH: "/usr/bin" } as NodeJS.ProcessEnv, {
+      sdk: { serverUrl: "http://first-tree" },
+      agent: {
+        agentId: "agent-a",
+        inboxId: "inbox-a",
+        displayName: "agent-a",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
+      chatId: "chat-1",
+      clientId: "client_aabbccdd",
+      provider: "codex",
+    });
+    expect(env.FIRST_TREE_CLIENT_ID).toBe("client_aabbccdd");
+    expect(env.FIRST_TREE_PROVIDER).toBe("codex");
+    expect(env.FIRST_TREE_SWITCH_DRAIN_VERSION).toBe("1");
+  });
+
   it("prepends FIRST_TREE_HOME/bin to PATH for channel-local CLI resolution", () => {
     const parent = {
       FIRST_TREE_HOME: "/first-tree-home",

--- a/packages/client/src/__tests__/client-connection-org-mismatch.test.ts
+++ b/packages/client/src/__tests__/client-connection-org-mismatch.test.ts
@@ -7,7 +7,7 @@ import { ClientConnection, ClientOrgMismatchError } from "../client-connection.j
  * Behavior contract: when the server rejects `client:register` with
  * `code: "CLIENT_ORG_MISMATCH"`, the SDK must
  *   1. reject the `connect()` promise with a typed `ClientOrgMismatchError`
- *      (CLI pattern-matches on `instanceof` to show purge-first recovery),
+ *      (CLI pattern-matches on `instanceof` to show local-client switch recovery),
  *   2. stop attempting to reconnect — a fresh connection with the same clientId
  *      would just re-trigger the same rejection forever.
  */
@@ -102,7 +102,7 @@ describe("ClientConnection — client:register CLIENT_ORG_MISMATCH", () => {
     connection.on("error", () => {});
 
     // No CLIENT_ORG_MISMATCH code → callers see a generic Error (triggers the
-    // default error branch in the CLI, not the purge-first branch).
+    // default error branch in the CLI, not the local-client switch branch).
     await expect(connection.connect()).rejects.toMatchObject({
       name: "Error",
     });

--- a/packages/client/src/__tests__/client-connection-user-mismatch.test.ts
+++ b/packages/client/src/__tests__/client-connection-user-mismatch.test.ts
@@ -8,7 +8,7 @@ import { ClientConnection, ClientUserMismatchError } from "../client-connection.
  * when the server rejects `client:register` with
  * `code: "CLIENT_USER_MISMATCH"`, the SDK must
  *   1. reject the `connect()` promise with a typed `ClientUserMismatchError`
- *      (CLI pattern-matches on `instanceof` to show purge-first recovery),
+ *      (CLI pattern-matches on `instanceof` to show local-client switch recovery),
  *   2. stop attempting to reconnect — the same clientId would hit the same
  *      rejection forever, so an auto-reconnect would devolve into a tight
  *      loop the operator can't see and would be a free attack surface

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -250,10 +250,10 @@ export class ClientOrgMismatchError extends Error {
 /**
  * Thrown when the server refuses `client:register` because the local
  * client.yaml is owned by a different user. The CLI detects this via
- * `instanceof` and guides the operator to run `logout --purge` before logging
- * in with another account. The purge is local-only: it removes this machine's
- * client identity and agent runtime state without deleting server-side clients,
- * pinned agents, chats, or history.
+ * `instanceof` and guides the operator through local-client switching before
+ * logging in with another account. The switch is local-only: it parks this
+ * machine's client identity and agent runtime state without deleting
+ * server-side clients, pinned agents, chats, or history.
  */
 export class ClientUserMismatchError extends Error {
   readonly code = "CLIENT_USER_MISMATCH";
@@ -1265,7 +1265,7 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       // Mark closing so the WS `close` handler does not auto-reconnect — a
       // reconnect with the same clientId would just re-trigger the rejection.
       // The caller (CLI) is expected to surface the mismatch to the user and
-      // guide account switches through `logout --purge` before another login.
+      // guide account switches through local-client switching.
       this.closing = true;
       const err =
         code === "CLIENT_USER_MISMATCH"

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -796,12 +796,12 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       await teardownTmux();
     },
 
-    async shutdown() {
+    async shutdown(reason?: string) {
       lifecycleFence.requestStop();
       turnAborted = true;
-      dropQueuedMessagesForRecovery("shutdown");
+      dropQueuedMessagesForRecovery(reason ?? "shutdown");
       await waitForStopFence();
-      dropQueuedMessagesForRecovery("shutdown");
+      dropQueuedMessagesForRecovery(reason ?? "shutdown");
       await teardownTmux();
 
       // Per agent-session-cwd-redesign: cwd is the per-agent home — shared

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -2223,7 +2223,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       return { kind: "owned", mode: "queued" };
     },
 
-    async suspend() {
+    async suspend(reason?: string) {
       ctx?.log("Suspending session");
 
       if (inputController) {
@@ -2246,12 +2246,12 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       // The session is no longer active — any pending replay inputs would be
       // moot. Resume goes through `handler.resume(message, sessionId)`, which
       // builds a fresh replay buffer from its own pushed inputs.
-      retryBufferedMessages("claude_suspend_before_terminal");
+      retryBufferedMessages(reason ?? "claude_suspend_before_terminal");
       injectDrainInProgress = false;
     },
 
-    async shutdown() {
-      await handler.suspend();
+    async shutdown(reason?: string) {
+      await handler.suspend(reason);
       // Per agent-session-cwd-redesign: cwd is the per-agent home — shared
       // by every chat. shutdown() of ONE chat must NOT remove it (would
       // wipe persistent state and worktrees other chats are using).

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -1614,9 +1614,9 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       resetThreadUsageTracking(null);
     },
 
-    async shutdown() {
+    async shutdown(reason?: string) {
       shutdownRequested = true;
-      retryQueuedMessages("codex_shutdown_before_terminal");
+      retryQueuedMessages(reason ?? "codex_shutdown_before_terminal");
       await interruptCurrentTurn();
       await appServer?.shutdown();
       appServer = null;

--- a/packages/client/src/handlers/codex/index.ts
+++ b/packages/client/src/handlers/codex/index.ts
@@ -86,8 +86,8 @@ export const createCodexHandler: HandlerFactory = (config) => {
       return active.suspend();
     },
 
-    shutdown() {
-      return active.shutdown();
+    shutdown(reason?: string) {
+      return active.shutdown(reason);
     },
   } satisfies AgentHandler;
 };

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -1550,8 +1550,8 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       pendingChatContextPrompt = null;
     },
 
-    async shutdown() {
-      retryQueuedMessages("codex_shutdown_before_terminal");
+    async shutdown(reason?: string) {
+      retryQueuedMessages(reason ?? "codex_shutdown_before_terminal");
       // suspend() releases the active turn. Per agent-session-cwd-redesign
       // we no longer rm the cwd or auto-remove predeclared worktrees — both
       // are agent-scoped persistent resources shared across chats.

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -39,6 +39,8 @@ export function buildAgentEnv(
     sdk: Pick<FirstTreeHubSDK, "serverUrl">;
     agent: AgentIdentity;
     chatId: string;
+    clientId?: string;
+    provider?: string;
     /**
      * Resolved doc-preview context for this session, so a `first-tree
      * chat send` sub-process can snapshot referenced `.md`. (The result-sink's
@@ -82,6 +84,13 @@ export function buildAgentEnv(
     FIRST_TREE_AGENT_ID: ctx.agent.agentId,
     FIRST_TREE_INBOX_ID: ctx.agent.inboxId,
     FIRST_TREE_CHAT_ID: ctx.chatId,
+    ...(ctx.clientId ? { FIRST_TREE_CLIENT_ID: ctx.clientId } : {}),
+    ...(ctx.provider
+      ? {
+          FIRST_TREE_PROVIDER: ctx.provider,
+          FIRST_TREE_SWITCH_DRAIN_VERSION: "1",
+        }
+      : {}),
     ...(ctx.docContext
       ? {
           FIRST_TREE_DOC_BASE: ctx.docContext.base,

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -427,9 +427,9 @@ export class AgentSlot {
     }
   }
 
-  async stop(): Promise<void> {
+  async stop(reason?: string): Promise<void> {
     if (this.stopping) return this.stopping;
-    this.stopping = this.stopOnce();
+    this.stopping = this.stopOnce(reason);
     try {
       await this.stopping;
     } finally {
@@ -437,7 +437,7 @@ export class AgentSlot {
     }
   }
 
-  private async stopOnce(): Promise<void> {
+  private async stopOnce(reason?: string): Promise<void> {
     this.bringupAbort?.abort();
     this.activeRuntimeChatIdsRefreshGeneration++;
     if (this.reconcileTimer) {
@@ -457,7 +457,7 @@ export class AgentSlot {
     }
     this.listeners = [];
     await this.clientConnection.unbindAgent(this.config.agentId);
-    await this.sessionManager?.shutdown();
+    await this.sessionManager?.shutdown(reason);
     this.sessionManager = null;
     this.agentConfigCache = null;
     this.sdk = null;

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -293,10 +293,10 @@ export type AgentHandler = {
   inject(message: SessionMessage, token?: DeliveryToken): HandlerRouteReceipt | undefined;
 
   /** Idle timeout. Close query, preserve state for resume. */
-  suspend(): Promise<void>;
+  suspend(reason?: string): Promise<void>;
 
   /** Eviction or runtime shutdown. Same as suspend(). */
-  shutdown(): Promise<void>;
+  shutdown(reason?: string): Promise<void>;
 };
 
 /**

--- a/packages/client/src/runtime/runtime.ts
+++ b/packages/client/src/runtime/runtime.ts
@@ -197,10 +197,10 @@ export class AgentRuntime {
     });
   }
 
-  async stop(): Promise<void> {
+  async stop(reason?: string): Promise<void> {
     this.updateManager?.dispose();
     this.updateManager = null;
-    await Promise.allSettled(this.slots.map((slot) => slot.stop()));
+    await Promise.allSettled(this.slots.map((slot) => slot.stop(reason)));
     await this.clientConnection.disconnect();
   }
 }

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -710,7 +710,7 @@ export class SessionManager {
   }
 
   /** Shut down all sessions gracefully. */
-  async shutdown(): Promise<void> {
+  async shutdown(reason?: string): Promise<void> {
     this.config.subprocessProbe?.stop();
     if (this.idleTimer) {
       clearInterval(this.idleTimer);
@@ -731,7 +731,7 @@ export class SessionManager {
     }
 
     const shutdowns = [...this.sessions.values()].map((s) =>
-      s.status === "active" ? s.handler.shutdown() : Promise.resolve(),
+      s.status === "active" ? s.handler.shutdown(reason) : Promise.resolve(),
     );
     await Promise.allSettled(shutdowns);
 
@@ -2034,6 +2034,11 @@ export class SessionManager {
       sdk: this.config.sdk,
       agent: this.config.agentIdentity,
       chatId,
+      clientId: typeof this.config.handlerConfig.clientId === "string" ? this.config.handlerConfig.clientId : undefined,
+      provider:
+        typeof this.config.handlerConfig.runtimeProvider === "string"
+          ? this.config.handlerConfig.runtimeProvider
+          : undefined,
       log,
       docContext: {
         base: docBase,

--- a/packages/server/src/__tests__/client-user-mismatch.test.ts
+++ b/packages/server/src/__tests__/client-user-mismatch.test.ts
@@ -12,8 +12,8 @@ import { createTestAdmin, createTestApp } from "./helpers.js";
  * because a clientId is org-visible (agent list) and must not double as a
  * transfer capability — with only-JWT auth it let any authenticated user
  * knock another user's machine offline. Machine handover is local-only:
- * `logout --purge` removes the old local identity before a new login registers
- * a fresh clientId.
+ * `login <token>` on the target user parks the old local identity before a
+ * separate client id is registered or restored.
  *
  * What remains server-side is the WS handshake refusal: a JWT for a
  * different user cannot register an already-owned clientId

--- a/packages/server/src/api/clients.ts
+++ b/packages/server/src/api/clients.ts
@@ -113,7 +113,7 @@ export async function clientRoutes(app: FastifyInstance): Promise<void> {
   // POST /:clientId/claim (cross-user ownership transfer) was removed: a
   // clientId is org-visible, so with only-JWT auth the route let any
   // authenticated user knock another user's machine offline. Machine handover
-  // is local-only: the operator must `logout --purge`, then login again so a
-  // fresh local client identity is generated (no server-side transfer protocol
-  // to secure).
+  // is local-only: the operator must `login <token>` as the target user so
+  // the old local client is parked and a separate local client identity is
+  // activated (no server-side transfer protocol to secure).
 }

--- a/packages/server/src/errors.ts
+++ b/packages/server/src/errors.ts
@@ -116,9 +116,9 @@ export class ClientOrgMismatchError extends AppError {
 /**
  * Thrown when a client.yaml is presented with a JWT whose user_id does not
  * match the row's owner. The CLI responds by guiding the operator through
- * `logout --purge` before logging in with another account. There is no
- * server-side ownership transfer; this row and its pinned agents stay with the
- * original owner (offline) until that owner removes them.
+ * local-client switching. There is no server-side ownership transfer; this row
+ * and its pinned agents stay with the original owner (offline) until that owner
+ * removes them.
  */
 export class ClientUserMismatchError extends AppError {
   readonly code = "CLIENT_USER_MISMATCH";

--- a/packages/server/src/services/client.ts
+++ b/packages/server/src/services/client.ts
@@ -22,7 +22,8 @@ import { recordClientHeartbeat } from "./runtime-liveness.js";
  * one user; cross-user admin access is no longer supported by this code path
  * (see decouple-client-from-identity-design §4.10.5 option A). There is no
  * cross-user ownership transfer: machine handover is local-only via
- * `logout --purge` followed by login, which generates a fresh clientId.
+ * `login <token>` on the target user, which parks the old local client and
+ * activates a separate client id.
  */
 export async function assertClientOwner(db: Database, clientId: string, scope: { userId: string }): Promise<void> {
   const [row] = await db
@@ -47,8 +48,8 @@ export async function assertClientOwner(db: Database, clientId: string, scope: {
  *     at first insert sticks for the row's lifetime.
  *   - Existing row with a different user_id → raises
  *     {@link ClientUserMismatchError} (WS close 4403). The CLI guides the
- *     operator through `logout --purge` before a new login; the previous
- *     owner's row stays untouched.
+ *     operator through local-client switching; the previous owner's row stays
+ *     untouched.
  */
 export async function registerClient(
   db: Database,
@@ -81,7 +82,7 @@ export async function registerClient(
   if (existing?.userId && existing.userId !== data.userId) {
     throw new ClientUserMismatchError(
       `Client "${data.clientId}" is owned by a different user. ` +
-        `Run \`${getServerCliBinding().binName} logout --purge\`, then login with the new account's connect token.`,
+        `Run \`${getServerCliBinding().binName} login <token>\` with the intended account to switch local clients before daemon startup; if this mismatch persists, back up local workspaces and run \`${getServerCliBinding().binName} computer reset\`.`,
     );
   }
 

--- a/packages/skill-evals/src/suites/first-tree-write/__tests__/post-model-verify.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-write/__tests__/post-model-verify.test.ts
@@ -49,7 +49,7 @@ function runPostModelVerify(caseId: string, paths: ReturnType<typeof createRunPa
   });
 }
 
-describe("first-tree-write post-model verify", () => {
+describe("first-tree-write post-model verify", { timeout: 20_000 }, () => {
   it("fails with the real validator when a model writes a broken soft_links target", () => {
     const { contextTreePath, paths } = setupVerifyFixture("post-model-verify-soft-links");
     try {


### PR DESCRIPTION
## Summary
- replaces cross-account `login <token>` purge-first refusal with confirmed local-client switch (`--force-switch` for non-TTY)
- adds switch lock/journal, supervisor startup guard, service stop/drain gates, same-device entry-level root-state park/restore, and parked-client index
- records root-state movement as per-entry journal moves so interrupted switches can roll forward when source/target state is classifiable and fail closed for manual repair when it is not
- injects provider drain markers (`FIRST_TREE_CLIENT_ID`, `FIRST_TREE_PROVIDER`, `FIRST_TREE_SWITCH_DRAIN_VERSION`) and blocks live marked provider descendants even when their command is not `claude`/`codex`
- adds `computer reset` as the formal destructive local-state reset command while keeping `logout --purge` compatible
- updates mismatch recovery copy to preserve server `clients.user_id` owner boundary; normal pre-daemon account switching uses `login <token>`, while damaged `CLIENT_USER_MISMATCH` recovery is reset-first
- stabilizes the first-tree-write post-model verify suite timeout so CI's real validator run is not capped by Vitest's 5s default

## Context
- Accepted proposal: https://github.com/agent-team-foundation/first-tree-context/pull/665
- Paired active Context Tree update: https://github.com/agent-team-foundation/first-tree-context/pull/666

## Safety gates
- `--force-switch` only confirms non-interactive switching; it does not skip supervisor, drain, filesystem, or journal checks
- daemon startup exits before reading root credentials/config when switch lock/journal exists
- provider drain fails closed for unsupported platforms, live marked providers or descendants, untrusted/missing provider markers, and unreadable env for known provider/runtime processes
- unknown same-UID Linux processes are scanned for trusted switch markers when their env is readable; unrelated unknown processes with unreadable env do not make switching unusable
- root `credentials.json` is not parked; inactive clients require fresh `login <token>` on reactivation
- root-state movement uses same-device rename preflight and rejects `EXDEV` instead of copying workspaces

## Verification
- `pnpm --dir apps/cli exec vitest run --passWithNoTests`
- `pnpm --dir apps/cli exec vitest run src/__tests__/client-switch.test.ts src/__tests__/login-command.test.ts --passWithNoTests`
- `pnpm --filter first-tree-dev typecheck`
- `pnpm --dir packages/skill-evals exec vitest run src/suites/first-tree-write/__tests__/post-model-verify.test.ts --passWithNoTests`
- `pnpm exec biome check apps/cli/src/core/client-switch.ts apps/cli/src/core/index.ts apps/cli/src/commands/login.ts apps/cli/src/__tests__/client-switch.test.ts apps/cli/src/__tests__/login-command.test.ts`
- `pnpm exec biome check packages/skill-evals/src/suites/first-tree-write/__tests__/post-model-verify.test.ts`
- `git diff --check`
