### PR TITLE
fix: keep markdown quote replies outside blockquotes

### DIFF
--- a/packages/web/src/components/__tests__/markdown-quote-continuation.test.tsx
+++ b/packages/web/src/components/__tests__/markdown-quote-continuation.test.tsx
@@ -57,6 +57,15 @@ describe("Markdown quote continuation", () => {
     expect(container.textContent).toContain("Col B");
   });
 
+  it("preserves leading-pipe single-column tables without trailing pipes", () => {
+    renderMarkdown("| Col A\n| ---\n| A");
+
+    expect(container.querySelector("blockquote")).toBeNull();
+    expect(container.querySelector("table")).not.toBeNull();
+    expect(container.textContent).toContain("Col A");
+    expect(container.textContent).toContain("A");
+  });
+
   it("leaves quote-like lines inside fenced code blocks untouched", () => {
     renderMarkdown("```\n> quoted\n| quoted\n```\noutside");
 

--- a/packages/web/src/components/__tests__/markdown-quote-continuation.test.tsx
+++ b/packages/web/src/components/__tests__/markdown-quote-continuation.test.tsx
@@ -66,6 +66,16 @@ describe("Markdown quote continuation", () => {
     expect(container.textContent).toContain("A");
   });
 
+  it("keeps a single-column table outside a preceding blockquote", () => {
+    renderMarkdown("> quoted\n| Col A\n| ---\n| A");
+
+    const blockquote = container.querySelector("blockquote");
+    expect(blockquote).not.toBeNull();
+    expect(blockquote?.textContent?.trim()).toBe("quoted");
+    expect(container.querySelector("table")).not.toBeNull();
+    expect(container.textContent).toContain("Col A");
+  });
+
   it("leaves quote-like lines inside fenced code blocks untouched", () => {
     renderMarkdown("```\n> quoted\n| quoted\n```\noutside");
 

--- a/packages/web/src/components/__tests__/markdown-quote-continuation.test.tsx
+++ b/packages/web/src/components/__tests__/markdown-quote-continuation.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Markdown } from "../ui/markdown.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function renderMarkdown(markdown: string): void {
+  act(() => root.render((<Markdown>{markdown}</Markdown>) as ReactElement));
+}
+
+describe("Markdown quote continuation", () => {
+  it("keeps the line after a blockquote outside the quote without requiring a blank line", () => {
+    renderMarkdown("> quoted\nblah blah");
+
+    const blockquote = container.querySelector("blockquote");
+    expect(blockquote).not.toBeNull();
+    expect(blockquote?.textContent?.trim()).toBe("quoted");
+
+    const paragraphs = [...container.querySelectorAll("p")].map((paragraph) => paragraph.textContent);
+    expect(paragraphs).toEqual(["quoted", "blah blah"]);
+  });
+
+  it("supports a single-pipe chat quote shorthand without treating the following line as quoted", () => {
+    renderMarkdown("| quoted\nblah blah");
+
+    const blockquote = container.querySelector("blockquote");
+    expect(blockquote).not.toBeNull();
+    expect(blockquote?.textContent?.trim()).toBe("quoted");
+
+    const paragraphs = [...container.querySelectorAll("p")].map((paragraph) => paragraph.textContent);
+    expect(paragraphs).toEqual(["quoted", "blah blah"]);
+  });
+
+  it("preserves normal GFM tables that start with pipe characters", () => {
+    renderMarkdown("| Col A | Col B |\n| --- | --- |\n| A | B |");
+
+    expect(container.querySelector("blockquote")).toBeNull();
+    expect(container.querySelector("table")).not.toBeNull();
+    expect(container.textContent).toContain("Col A");
+    expect(container.textContent).toContain("Col B");
+  });
+
+  it("leaves quote-like lines inside fenced code blocks untouched", () => {
+    renderMarkdown("```\n> quoted\n| quoted\n```\noutside");
+
+    expect(container.querySelector("blockquote")).toBeNull();
+    expect(container.querySelector("pre")?.textContent).toContain("> quoted\n| quoted");
+    expect(container.textContent).toContain("outside");
+  });
+});

--- a/packages/web/src/components/__tests__/markdown-quote-continuation.test.tsx
+++ b/packages/web/src/components/__tests__/markdown-quote-continuation.test.tsx
@@ -64,4 +64,14 @@ describe("Markdown quote continuation", () => {
     expect(container.querySelector("pre")?.textContent).toContain("> quoted\n| quoted");
     expect(container.textContent).toContain("outside");
   });
+
+  it("does not treat pipe-prefixed indented code as quote shorthand", () => {
+    renderMarkdown("    | quoted\n    outside");
+
+    expect(container.querySelector("blockquote")).toBeNull();
+    expect(container.querySelector("pre")).not.toBeNull();
+    const codeText = container.querySelector("pre")?.textContent ?? "";
+    expect(codeText).toContain("| quoted\noutside");
+    expect(codeText).not.toContain("| quoted\n\noutside");
+  });
 });

--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -61,6 +61,11 @@ function startsPipeTable(lines: string[], index: number): boolean {
   return isPipeTableRow(lines[index] ?? "") && isPipeTableDelimiter(lines[index + 1]);
 }
 
+function isQuoteContinuationLine(lines: string[], index: number): boolean {
+  if (startsPipeTable(lines, index)) return false;
+  return quoteLineKind(lines[index] ?? "") !== null;
+}
+
 function fenceMarker(line: string): { char: "`" | "~"; length: number } | null {
   const match = /^(?: {0,3})(`{3,}|~{3,})/.exec(line);
   if (!match) return null;
@@ -109,7 +114,7 @@ function normalizeQuoteContinuations(markdown: string): string {
 
     if (kind) {
       const nextLine = lines[index + 1];
-      if (nextLine?.trim() && quoteLineKind(nextLine) === null) {
+      if (nextLine?.trim() && !isQuoteContinuationLine(lines, index + 1)) {
         normalized.push("");
       }
       continue;

--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -7,6 +7,8 @@ import { cn } from "../../lib/utils.js";
 
 type RehypePlugins = ComponentProps<typeof ReactMarkdown>["rehypePlugins"];
 
+type QuoteLineKind = "standard" | "pipe";
+
 /**
  * react-markdown's `defaultUrlTransform` sanitizes hrefs and STRIPS any
  * unrecognized scheme to an empty string before our `a` component override
@@ -19,6 +21,66 @@ type RehypePlugins = ComponentProps<typeof ReactMarkdown>["rehypePlugins"];
 function previewSafeUrlTransform(url: string): string {
   if (url.startsWith("attachment:") || url.startsWith("#doc-failed")) return url;
   return defaultUrlTransform(url);
+}
+
+function quoteLineKind(line: string): QuoteLineKind | null {
+  if (/^ {0,3}>/.test(line)) return "standard";
+
+  const trimmed = line.trimStart();
+  if (!trimmed.startsWith("|")) return null;
+  if (trimmed.length > 1 && !/\s/.test(trimmed[1] ?? "")) return null;
+
+  const content = trimmed.slice(1).trimEnd();
+  return content.includes("|") ? null : "pipe";
+}
+
+function normalizePipeQuoteLine(line: string): string {
+  return line.replace(/^([ \t]{0,3})\|[ \t]?/, "$1> ");
+}
+
+function fenceMarker(line: string): { char: "`" | "~"; length: number } | null {
+  const match = /^(?: {0,3})(`{3,}|~{3,})/.exec(line);
+  if (!match) return null;
+  const marker = match[1] ?? "";
+  const char = marker[0] as "`" | "~";
+  return { char, length: marker.length };
+}
+
+function closesFence(line: string, fence: { char: "`" | "~"; length: number }): boolean {
+  const match = /^(?: {0,3})(`{3,}|~{3,})\s*$/.exec(line);
+  return Boolean(match?.[1]?.startsWith(fence.char) && match[1].length >= fence.length);
+}
+
+function normalizeQuoteContinuations(markdown: string): string {
+  const lines = markdown.split(/\r?\n/);
+  const normalized: string[] = [];
+  let openFence: { char: "`" | "~"; length: number } | null = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+
+    if (openFence) {
+      normalized.push(line);
+      if (closesFence(line, openFence)) openFence = null;
+      continue;
+    }
+
+    const kind = quoteLineKind(line);
+    const normalizedLine = kind === "pipe" ? normalizePipeQuoteLine(line) : line;
+    normalized.push(normalizedLine);
+
+    if (kind) {
+      const nextLine = lines[index + 1];
+      if (nextLine?.trim() && quoteLineKind(nextLine) === null) {
+        normalized.push("");
+      }
+      continue;
+    }
+
+    openFence = fenceMarker(line);
+  }
+
+  return normalized.join("\n");
 }
 
 export type MarkdownProps = {
@@ -38,6 +100,8 @@ export type MarkdownProps = {
  * detail page without a theme switch.
  */
 export function Markdown({ children, className, components, rehypePlugins }: MarkdownProps) {
+  const normalizedChildren = normalizeQuoteContinuations(children);
+
   return (
     <div
       className={cn(
@@ -81,7 +145,7 @@ export function Markdown({ children, className, components, rehypePlugins }: Mar
           ...components,
         }}
       >
-        {children}
+        {normalizedChildren}
       </ReactMarkdown>
     </div>
   );

--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -26,16 +26,18 @@ function previewSafeUrlTransform(url: string): string {
 function quoteLineKind(line: string): QuoteLineKind | null {
   if (/^ {0,3}>/.test(line)) return "standard";
 
-  const trimmed = line.trimStart();
-  if (!trimmed.startsWith("|")) return null;
-  if (trimmed.length > 1 && !/\s/.test(trimmed[1] ?? "")) return null;
+  const pipeMatch = /^ {0,3}\|(.*)$/.exec(line);
+  if (!pipeMatch) return null;
 
-  const content = trimmed.slice(1).trimEnd();
+  const markerTail = pipeMatch[1] ?? "";
+  if (markerTail && !/^\s/.test(markerTail)) return null;
+
+  const content = markerTail.trimEnd();
   return content.includes("|") ? null : "pipe";
 }
 
 function normalizePipeQuoteLine(line: string): string {
-  return line.replace(/^([ \t]{0,3})\|[ \t]?/, "$1> ");
+  return line.replace(/^( {0,3})\|[ \t]?/, "$1> ");
 }
 
 function fenceMarker(line: string): { char: "`" | "~"; length: number } | null {

--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -40,6 +40,27 @@ function normalizePipeQuoteLine(line: string): string {
   return line.replace(/^( {0,3})\|[ \t]?/, "$1> ");
 }
 
+function isPipeTableRow(line: string): boolean {
+  return /^ {0,3}\|/.test(line);
+}
+
+function isPipeTableDelimiter(line: string | undefined): boolean {
+  if (!line || !isPipeTableRow(line)) return false;
+
+  const trimmed = line.trim();
+  const cells = trimmed
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+
+  return cells.length > 0 && cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+}
+
+function startsPipeTable(lines: string[], index: number): boolean {
+  return isPipeTableRow(lines[index] ?? "") && isPipeTableDelimiter(lines[index + 1]);
+}
+
 function fenceMarker(line: string): { char: "`" | "~"; length: number } | null {
   const match = /^(?: {0,3})(`{3,}|~{3,})/.exec(line);
   if (!match) return null;
@@ -57,6 +78,7 @@ function normalizeQuoteContinuations(markdown: string): string {
   const lines = markdown.split(/\r?\n/);
   const normalized: string[] = [];
   let openFence: { char: "`" | "~"; length: number } | null = null;
+  let insidePipeTable = false;
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? "";
@@ -64,6 +86,20 @@ function normalizeQuoteContinuations(markdown: string): string {
     if (openFence) {
       normalized.push(line);
       if (closesFence(line, openFence)) openFence = null;
+      continue;
+    }
+
+    if (insidePipeTable) {
+      if (isPipeTableRow(line)) {
+        normalized.push(line);
+        continue;
+      }
+      insidePipeTable = false;
+    }
+
+    if (startsPipeTable(lines, index)) {
+      insidePipeTable = true;
+      normalized.push(line);
       continue;
     }
 


### PR DESCRIPTION
## Summary
- normalize quote lines before React Markdown parsing so the next unquoted line renders outside the blockquote without requiring a blank line
- support the single-pipe chat quote shorthand for non-table lines
- add DOM regression coverage for standard quotes, pipe shorthand, tables, and fenced code blocks

## Tests
- `pnpm exec biome check packages/web/src/components/ui/markdown.tsx packages/web/src/components/__tests__/markdown-quote-continuation.test.tsx`
- `pnpm --filter @first-tree/web exec vitest run src/components/__tests__/markdown-quote-continuation.test.tsx src/components/__tests__/markdown-link-guard.test.tsx src/components/__tests__/markdown-overflow-wrap.test.tsx`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/web test`
