### PR TITLE
feat: add growth landing feature flag

### DIFF
--- a/packages/server/src/__tests__/bootstrap-config.test.ts
+++ b/packages/server/src/__tests__/bootstrap-config.test.ts
@@ -4,7 +4,7 @@ import { useTestApp } from "./helpers.js";
 describe("GET /bootstrap/config", () => {
   const getApp = useTestApp();
 
-  it("returns the public server command version and release channel", async () => {
+  it("returns the public server command version, release channel, and disabled growth flag by default", async () => {
     const app = getApp();
 
     const res = await app.inject({
@@ -19,6 +19,7 @@ describe("GET /bootstrap/config", () => {
       // Surfaced so the web can gate channel-scoped UI (e.g. the staging-only
       // "hide agent final text" toggle). Test app defaults to the dev channel.
       channel: "dev",
+      growthLandingPagesEnabled: false,
     });
   });
 });
@@ -31,5 +32,19 @@ describe("GET /bootstrap/config — non-dev channel", () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().channel).toBe("staging");
+  });
+});
+
+describe("GET /bootstrap/config — growth landing flag", () => {
+  const getApp = useTestApp({ channel: "prod", growthLandingPagesEnabled: true });
+
+  it("reports the feature flag independently from release channel", async () => {
+    const res = await getApp().inject({ method: "GET", url: "/api/v1/bootstrap/config" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      channel: "prod",
+      growthLandingPagesEnabled: true,
+    });
   });
 });

--- a/packages/server/src/__tests__/bootstrap.test.ts
+++ b/packages/server/src/__tests__/bootstrap.test.ts
@@ -31,6 +31,7 @@ function makeTempConfigDir(): string {
 
 const baseServerConfig: ServerConfig = {
   channel: "dev",
+  growth: { landingPagesEnabled: false },
   database: { url: process.env.DATABASE_URL ?? "", provider: "external" },
   server: { port: 0, host: "127.0.0.1", publicUrl: "https://first-tree.example" },
   workspace: { root: "/tmp/first-tree-test-workspaces" },

--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -16,6 +16,7 @@ import type { Config } from "../config.js";
  */
 const baseConfig: Config = {
   channel: "dev",
+  growth: { landingPagesEnabled: false },
   database: { url: process.env.DATABASE_URL ?? "", provider: "external" },
   server: { port: 0, host: "127.0.0.1", publicUrl: undefined },
   workspace: { root: "/tmp/first-tree-test-workspaces" },

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -58,6 +58,7 @@ type AgentRequestFn = (
  */
 export type CreateTestAppOptions = {
   channel?: Config["channel"];
+  growthLandingPagesEnabled?: boolean;
   commandVersion?: string;
   rateLimit?: Partial<NonNullable<Config["rateLimit"]>>;
   connectBootstrap?: Config["connectBootstrap"];
@@ -87,6 +88,9 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
   };
   const config: Config = {
     channel: opts.channel ?? "dev",
+    growth: {
+      landingPagesEnabled: opts.growthLandingPagesEnabled ?? false,
+    },
     database: {
       url: process.env.DATABASE_URL ?? "",
       provider: "external",

--- a/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
+++ b/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
@@ -39,7 +39,8 @@ const KICKOFF_URL = "/api/v1/me/onboarding/kickoff";
 const TREE_STATUS_URL = "/api/v1/me/onboarding/tree-setup-status";
 
 describe("POST /me/onboarding/kickoff", () => {
-  const getApp = useTestApp();
+  const getApp = useTestApp({ growthLandingPagesEnabled: true });
+  const getGrowthDisabledApp = useTestApp();
 
   it("creates the chat, sends the bootstrap, and stamps completion", async () => {
     const app = getApp();
@@ -331,6 +332,33 @@ describe("POST /me/onboarding/kickoff", () => {
     const [readyChat] = await app.db.select().from(chats).where(eq(chats.id, readyChatId)).limit(1);
     expect(scanChat?.onboardingKickoffKey).toBe(`${admin.humanAgentUuid}:${agent.uuid}:work:production-scan`);
     expect(readyChat?.onboardingKickoffKey).toBe(`${admin.humanAgentUuid}:${agent.uuid}:work:agent-readiness`);
+  });
+
+  it("rejects campaign kickoff when growth landing pages are disabled", async () => {
+    const app = getGrowthDisabledApp();
+    const admin = await createTestAdmin(app);
+    const agent = await createOrgAgent(app, admin);
+
+    const res = await app.inject({
+      method: "POST",
+      url: KICKOFF_URL,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {
+        organizationId: admin.organizationId,
+        agentUuid: agent.uuid,
+        bootstrap: "Campaign work kickoff.",
+        kind: "work",
+        campaign: "production-scan",
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({ code: "feature_disabled" });
+    const rows = await app.db
+      .select()
+      .from(chats)
+      .where(eq(chats.onboardingKickoffKey, `${admin.humanAgentUuid}:${agent.uuid}:work:production-scan`));
+    expect(rows).toHaveLength(0);
   });
 
   it("omits the campaign segment when no campaign is passed, keeping the legacy key", async () => {

--- a/packages/server/src/api/bootstrap/config.ts
+++ b/packages/server/src/api/bootstrap/config.ts
@@ -17,6 +17,9 @@ export async function bootstrapConfigRoutes(app: FastifyInstance): Promise<void>
       // the web gate channel-scoped affordances (e.g. the staging-only "hide
       // agent final text" view toggle) without shipping prod-visible dev UI.
       channel: app.config.channel,
+      // Product flag for growth landing funnels. Kept separate from release
+      // channel so staging/dev do not implicitly expose public campaigns.
+      growthLandingPagesEnabled: app.config.growth.landingPagesEnabled,
     };
   });
 }

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -266,8 +266,13 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
   app.post("/me/onboarding/kickoff", async (request, reply) => {
     const { userId } = requireUser(request);
     const body = kickoffOnboardingSchema.parse(request.body);
-    const { memberId, humanAgentId } = await resolveOnboardingMember(app, userId, body.organizationId);
     const campaign = body.campaign;
+    if (campaign && !app.config.growth.landingPagesEnabled) {
+      return reply
+        .status(404)
+        .send({ error: "Growth landing pages are disabled on this First Tree deployment.", code: "feature_disabled" });
+    }
+    const { memberId, humanAgentId } = await resolveOnboardingMember(app, userId, body.organizationId);
     const result = await kickoffOnboarding(app.db, {
       memberId,
       humanAgentId,

--- a/packages/shared/src/config/__tests__/server-config.test.ts
+++ b/packages/shared/src/config/__tests__/server-config.test.ts
@@ -60,6 +60,31 @@ describe("server config", () => {
     expect(fieldSchema.parse("   ")).toBeUndefined();
   });
 
+  it("keeps growth landing pages disabled by default and enables them via env", async () => {
+    const defaultConfigDir = makeTempConfigDir();
+    stubRequiredProductionConfig();
+
+    const defaultConfig = await initConfig({
+      schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+      role: "server",
+      configDir: defaultConfigDir,
+    });
+
+    expect(defaultConfig.growth.landingPagesEnabled).toBe(false);
+
+    resetConfig();
+    const enabledConfigDir = makeTempConfigDir();
+    vi.stubEnv("FIRST_TREE_GROWTH_LANDING_PAGES_ENABLED", "true");
+
+    const enabledConfig = await initConfig({
+      schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+      role: "server",
+      configDir: enabledConfigDir,
+    });
+
+    expect(enabledConfig.growth.landingPagesEnabled).toBe(true);
+  });
+
   it("does not auto-generate server secrets when disabled", async () => {
     const configDir = makeTempConfigDir();
     vi.stubEnv("FIRST_TREE_DATABASE_URL", "postgres://first-tree:test@localhost:5432/firsttree");

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -45,6 +45,17 @@ export const serverConfigSchema = defineConfig({
   channel: field(z.enum(["dev", "staging", "prod"]).default("dev"), {
     env: "FIRST_TREE_CHANNEL",
   }),
+  growth: {
+    /**
+     * Enables public growth landing pages such as `/scan/:campaign` and their
+     * `/quickstart?campaign=...` handoff. This is a product feature flag, not
+     * a release-channel property: dev/staging/prod all default to off until an
+     * operator explicitly enables the funnel.
+     */
+    landingPagesEnabled: field(z.boolean().default(false), {
+      env: "FIRST_TREE_GROWTH_LANDING_PAGES_ENABLED",
+    }),
+  },
   database: {
     url: field(z.string(), {
       env: "FIRST_TREE_DATABASE_URL",

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -151,8 +151,8 @@ export function App() {
               {/* Public: the connect-code install popup lands here to auto-close. */}
               <Route path="/onboarding/connected" element={<GithubConnectedPage />} />
               <Route path="/invite/:token" element={<InviteAcceptPage />} />
-              {/* Public top-of-funnel scan landing. Dev/staging-only via its own
-                  channel gate; feeds /quickstart with campaign + repo. */}
+              {/* Public top-of-funnel scan landing. Feature-flagged in the page;
+                  feeds /quickstart with campaign + repo. */}
               <Route path="/scan/:campaign" element={<ScanLandingPage />} />
               {ContextPreviewPage ? (
                 <Route

--- a/packages/web/src/hooks/__tests__/use-server-channel.test.ts
+++ b/packages/web/src/hooks/__tests__/use-server-channel.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { extractChannel } from "../use-server-channel.js";
+import { extractChannel, extractGrowthLandingPagesEnabled } from "../use-server-channel.js";
 
 /**
- * Pure-function unit tests for the bootstrap-config channel probe. The hook
- * wires this into React Query (fetched once, cached for the session); the
- * staging-only toggle it gates is covered by manual e2e.
+ * Pure-function unit tests for public bootstrap-config probes. The hook wires
+ * these into React Query (fetched once, cached for the session); callers cover
+ * their own render gates.
  */
 describe("extractChannel", () => {
   it("returns each known channel from a well-formed bootstrap config", () => {
@@ -24,5 +24,19 @@ describe("extractChannel", () => {
     expect(extractChannel({ serverCommandVersion: "1.2.3" })).toBeNull();
     expect(extractChannel({ channel: "qa" })).toBeNull();
     expect(extractChannel({ channel: 1 })).toBeNull();
+  });
+});
+
+describe("extractGrowthLandingPagesEnabled", () => {
+  it("returns true only for an explicit true bootstrap flag", () => {
+    expect(extractGrowthLandingPagesEnabled({ growthLandingPagesEnabled: true })).toBe(true);
+    expect(extractGrowthLandingPagesEnabled({ growthLandingPagesEnabled: false })).toBe(false);
+  });
+
+  it("fails closed for older or malformed bootstrap configs", () => {
+    expect(extractGrowthLandingPagesEnabled(null)).toBe(false);
+    expect(extractGrowthLandingPagesEnabled({})).toBe(false);
+    expect(extractGrowthLandingPagesEnabled({ growthLandingPagesEnabled: "true" })).toBe(false);
+    expect(extractGrowthLandingPagesEnabled({ growthLandingPagesEnabled: 1 })).toBe(false);
   });
 });

--- a/packages/web/src/hooks/use-server-channel.ts
+++ b/packages/web/src/hooks/use-server-channel.ts
@@ -2,6 +2,11 @@ import type { ChannelName } from "@first-tree/shared/channel";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client.js";
 
+type ServerBootstrapConfig = {
+  channel: ChannelName | null;
+  growthLandingPagesEnabled: boolean;
+};
+
 /**
  * Narrow the bootstrap `/config` payload to its release channel without an
  * `as` cast. Returns null for any unrecognised shape (older server that does
@@ -16,9 +21,43 @@ export function extractChannel(data: unknown): ChannelName | null {
   return null;
 }
 
-async function fetchServerChannel(): Promise<ChannelName | null> {
+/**
+ * Narrow the growth landing feature flag from the public bootstrap config.
+ * Older servers and malformed payloads resolve to false so public growth
+ * funnels fail closed.
+ */
+export function extractGrowthLandingPagesEnabled(data: unknown): boolean {
+  if (typeof data === "object" && data !== null && "growthLandingPagesEnabled" in data) {
+    const { growthLandingPagesEnabled } = data;
+    return growthLandingPagesEnabled === true;
+  }
+  return false;
+}
+
+function extractServerBootstrapConfig(data: unknown): ServerBootstrapConfig {
+  return {
+    channel: extractChannel(data),
+    growthLandingPagesEnabled: extractGrowthLandingPagesEnabled(data),
+  };
+}
+
+async function fetchServerBootstrapConfig(): Promise<ServerBootstrapConfig> {
   const data = await api.get<unknown>("/bootstrap/config");
-  return extractChannel(data);
+  return extractServerBootstrapConfig(data);
+}
+
+function useServerBootstrapConfig(): { config: ServerBootstrapConfig | null; settled: boolean } {
+  const { data, status } = useQuery({
+    queryKey: ["server-bootstrap-config"],
+    queryFn: fetchServerBootstrapConfig,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+    refetchOnWindowFocus: false,
+  });
+  // With infinite staleTime `pending` is the only not-yet-resolved status;
+  // `success` (a config object) and `error` both count as settled, so safe
+  // defaults apply the moment we know.
+  return { config: data ?? null, settled: status !== "pending" };
 }
 
 /**
@@ -32,17 +71,8 @@ async function fetchServerChannel(): Promise<ChannelName | null> {
  * and cached for the session.
  */
 export function useServerChannelState(): { channel: ChannelName | null; settled: boolean } {
-  const { data, status } = useQuery({
-    queryKey: ["server-channel"],
-    queryFn: fetchServerChannel,
-    staleTime: Number.POSITIVE_INFINITY,
-    gcTime: Number.POSITIVE_INFINITY,
-    refetchOnWindowFocus: false,
-  });
-  // With infinite staleTime `pending` is the only not-yet-resolved status;
-  // `success` (a channel or an unrecognised body → null) and `error` both
-  // count as settled, so the prod-safe default applies the moment we know.
-  return { channel: data ?? null, settled: status !== "pending" };
+  const { config, settled } = useServerBootstrapConfig();
+  return { channel: config?.channel ?? null, settled };
 }
 
 /**
@@ -53,4 +83,19 @@ export function useServerChannelState(): { channel: ChannelName | null; settled:
  */
 export function useServerChannel(): ChannelName | null {
   return useServerChannelState().channel;
+}
+
+/**
+ * Whether growth landing pages are explicitly enabled by the server. This is
+ * independent from release channel: unknown / older servers and fetch errors
+ * fail closed to `false`, while `settled` lets redirecting callers avoid a
+ * loading-time bounce.
+ */
+export function useGrowthLandingPagesState(): { enabled: boolean; settled: boolean } {
+  const { config, settled } = useServerBootstrapConfig();
+  return { enabled: config?.growthLandingPagesEnabled ?? false, settled };
+}
+
+export function useGrowthLandingPagesEnabled(): boolean {
+  return useGrowthLandingPagesState().enabled;
 }

--- a/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
+++ b/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
@@ -36,12 +36,12 @@ const computerMock = vi.hoisted(() => ({
     retry: vi.fn(),
   },
   // Captures the `enabled` arg the page passes to useComputerConnection so a
-  // test can assert the channel gate keeps the connection off in prod/loading.
+  // test can assert the feature gate keeps the connection off when disabled/loading.
   lastEnabled: undefined as boolean | undefined,
 }));
 
-const channelMock = vi.hoisted(() => ({
-  value: { channel: "dev" as "dev" | "staging" | "prod" | null, settled: true },
+const growthLandingMock = vi.hoisted(() => ({
+  value: { enabled: true, settled: true },
 }));
 
 type CreateAgentArgs = {
@@ -82,8 +82,8 @@ vi.mock("../../../features/agent-setup/use-computer-connection.js", () => ({
   },
 }));
 vi.mock("../../../hooks/use-server-channel.js", () => ({
-  useServerChannelState: () => channelMock.value,
-  useServerChannel: () => channelMock.value.channel,
+  useGrowthLandingPagesState: () => growthLandingMock.value,
+  useGrowthLandingPagesEnabled: () => growthLandingMock.value.enabled,
 }));
 vi.mock("../../../features/agent-setup/use-agent-creation.js", () => ({
   useAgentCreation: (opts?: { onOnline?: (uuid: string) => void }) => {
@@ -166,9 +166,9 @@ beforeEach(() => {
   agentsListMock.mockResolvedValue([]);
   updateAgentMock.mockReset();
   updateAgentMock.mockResolvedValue({});
-  // Default to dev (allowed + settled) so existing flow tests run unchanged;
-  // the channel-gate tests override this per case.
-  channelMock.value = { channel: "dev", settled: true };
+  // Default to enabled + settled so existing flow tests run unchanged; the
+  // feature-gate tests override this per case.
+  growthLandingMock.value = { enabled: true, settled: true };
   computerMock.lastEnabled = undefined;
 });
 
@@ -471,11 +471,11 @@ describe("QuickstartPage — full flow (e2e)", () => {
     expect(navigateMock).toHaveBeenCalledWith("/?c=chat-1");
   });
 
-  it("prod channel: redirects home and fires no connect/agent side effects", async () => {
+  it("disabled feature flag: redirects home and fires no connect/agent side effects", async () => {
     // Even a fully connected computer with a usable runtime must not set up in
-    // prod — the gate blocks the whole flow (connection enable + setup effect)
-    // and sends the user home.
-    channelMock.value = { channel: "prod", settled: true };
+    // a disabled deployment — the gate blocks the whole flow (connection enable
+    // + setup effect) and sends the user home.
+    growthLandingMock.value = { enabled: false, settled: true };
     seedIntent("production-scan");
     connectedWith("claude-code");
     await renderPage();
@@ -484,26 +484,13 @@ describe("QuickstartPage — full flow (e2e)", () => {
     });
 
     expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
-    expect(computerMock.lastEnabled).toBe(false); // connection never enabled in prod
+    expect(computerMock.lastEnabled).toBe(false); // connection never enabled when disabled
     expect(agentCreationMock.create).not.toHaveBeenCalled();
     expect(onboardingMocks.postOnboardingStartChat).not.toHaveBeenCalled();
   });
 
-  it("unknown channel (old server / unreadable): treated as prod — redirects, creates nothing", async () => {
-    channelMock.value = { channel: null, settled: true };
-    seedIntent("production-scan");
-    connectedWith("claude-code");
-    await renderPage();
-    await act(async () => {
-      for (let i = 0; i < 8; i++) await Promise.resolve();
-    });
-
-    expect(navigateMock).toHaveBeenCalledWith("/", { replace: true });
-    expect(agentCreationMock.create).not.toHaveBeenCalled();
-  });
-
-  it("channel still loading: holds a neutral screen, no redirect, no side effects", async () => {
-    channelMock.value = { channel: null, settled: false };
+  it("feature flag still loading: holds a neutral screen, no redirect, no side effects", async () => {
+    growthLandingMock.value = { enabled: false, settled: false };
     seedIntent("production-scan");
     connectedWith("claude-code");
     const container = await renderPage();
@@ -511,14 +498,14 @@ describe("QuickstartPage — full flow (e2e)", () => {
       for (let i = 0; i < 8; i++) await Promise.resolve();
     });
 
-    expect(navigateMock).not.toHaveBeenCalled(); // must NOT bounce a dev/staging user mid-fetch
-    expect(computerMock.lastEnabled).toBe(false); // connection waits until the channel settles
+    expect(navigateMock).not.toHaveBeenCalled(); // must NOT bounce an enabled deployment mid-fetch
+    expect(computerMock.lastEnabled).toBe(false); // connection waits until the flag settles
     expect(agentCreationMock.create).not.toHaveBeenCalled();
     expect(container.textContent).not.toContain("npx @first-tree/cli login"); // not the connect step
   });
 
-  it("staging channel: allowed — connection enabled, no redirect", async () => {
-    channelMock.value = { channel: "staging", settled: true };
+  it("enabled feature flag: connection enabled, no redirect", async () => {
+    growthLandingMock.value = { enabled: true, settled: true };
     seedIntent("production-scan");
     await renderPage();
     await act(async () => {

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { useAgentCreation } from "../../features/agent-setup/use-agent-creation.js";
 import { useComputerConnection } from "../../features/agent-setup/use-computer-connection.js";
-import { useServerChannelState } from "../../hooks/use-server-channel.js";
+import { useGrowthLandingPagesState } from "../../hooks/use-server-channel.js";
 import { runtimeProviderLabel } from "../clients/cards/shared/providers.js";
 import { CommandBox, FlowHint, StatusRow, WorkingState } from "../onboarding/flow-ui.js";
 import { getCampaign, QUICKSTART_AGENT_NAME } from "./campaigns.js";
@@ -36,15 +36,13 @@ export function QuickstartPage() {
   const location = useLocation();
   const { organizationId, refreshMe, currentOrgHasPersonalAgent } = useAuth();
 
-  // This growth entry is dev/staging-only — it must not run in prod. The
-  // prod-safe default falls out of the channel hook (unknown / old server →
-  // null → not allowed). `channelAllowed` gates the render, the
-  // `useComputerConnection` enable, the setup/resume effects, and the redirect
-  // below — so prod never connects a computer, creates an agent, or starts a
-  // chat. `settled` lets us hold a neutral screen while the channel resolves
-  // instead of bouncing a dev/staging visitor mid-fetch.
-  const { channel, settled } = useServerChannelState();
-  const channelAllowed = channel === "dev" || channel === "staging";
+  // This growth entry is controlled by an explicit server feature flag, not by
+  // release channel. Unknown / old server → disabled. The flag gates render,
+  // `useComputerConnection`, setup/resume effects, and redirect — so disabled
+  // deployments never connect a computer, create an agent, or start a chat.
+  // `settled` lets us hold a neutral screen while the flag resolves instead of
+  // bouncing an enabled visitor mid-fetch.
+  const { enabled: growthLandingPagesEnabled, settled } = useGrowthLandingPagesState();
 
   // Resolve the campaign handoff once. Prefer the URL — the landing CTA and the
   // post-login `next` round-trip land the params here — and persist it so a
@@ -59,7 +57,7 @@ export function QuickstartPage() {
   }, [location]);
   const campaign = intent ? getCampaign(intent.campaign) : null;
 
-  const computer = useComputerConnection(Boolean(intent && campaign) && channelAllowed);
+  const computer = useComputerConnection(Boolean(intent && campaign) && growthLandingPagesEnabled);
   const setupStartedRef = useRef(false);
   const startChatStartedRef = useRef(false);
   const onlineAgentRef = useRef<{ uuid: string; displayName: string } | null>(null);
@@ -183,7 +181,7 @@ export function QuickstartPage() {
   // button, no picker. Fires once; skipped when an agent was already created
   // this attempt (remount) — the resume effect below handles that.
   useEffect(() => {
-    if (setupStartedRef.current || stashedAgentUuid || !intent || !campaign || !channelAllowed) return;
+    if (setupStartedRef.current || stashedAgentUuid || !intent || !campaign || !growthLandingPagesEnabled) return;
     if (!computer.connectedClient || !computer.selectedRuntime || phase !== "idle") return;
     setupStartedRef.current = true;
     void setupAgent();
@@ -195,24 +193,24 @@ export function QuickstartPage() {
     campaign,
     setupAgent,
     stashedAgentUuid,
-    channelAllowed,
+    growthLandingPagesEnabled,
   ]);
 
   // Remount after the agent was already created (refresh while waiting, or the
   // timeout/error screen): reuse the stashed agent and resume start chat.
   useEffect(() => {
-    if (resumeStartedRef.current || !stashedAgentUuid || !intent || !campaign || !channelAllowed) return;
+    if (resumeStartedRef.current || !stashedAgentUuid || !intent || !campaign || !growthLandingPagesEnabled) return;
     resumeStartedRef.current = true;
     void startChat(stashedAgentUuid, QUICKSTART_AGENT_NAME);
-  }, [stashedAgentUuid, intent, campaign, startChat, channelAllowed]);
+  }, [stashedAgentUuid, intent, campaign, startChat, growthLandingPagesEnabled]);
 
-  // Channel gate redirect: once the channel has settled, a prod (or
+  // Feature gate redirect: once the flag has settled, a disabled (or
   // unknown/old-server) visitor is sent home. Imperative to match the success
-  // navigate above; the side effects are already gated on `channelAllowed`, so
-  // nothing fires here even in the render before this runs.
+  // navigate above; the side effects are already gated, so nothing fires here
+  // even in the render before this runs.
   useEffect(() => {
-    if (settled && !channelAllowed) navigate("/", { replace: true });
-  }, [settled, channelAllowed, navigate]);
+    if (settled && !growthLandingPagesEnabled) navigate("/", { replace: true });
+  }, [settled, growthLandingPagesEnabled, navigate]);
 
   const retryStartChat = useCallback(() => {
     const a = onlineAgentRef.current;
@@ -229,10 +227,11 @@ export function QuickstartPage() {
     void setupAgent();
   }, [phase, retryAgent, setupAgent]);
 
-  // Channel gate render. `!settled`: channel still resolving — neutral hold.
-  // `!channelAllowed`: prod/unknown — the redirect effect is taking us home;
-  // render neutral, never the flow (the connect step would flash first).
-  if (!settled || !channelAllowed) {
+  // Feature gate render. `!settled`: flag still resolving — neutral hold.
+  // `!growthLandingPagesEnabled`: disabled/unknown — the redirect effect is
+  // taking us home; render neutral, never the flow (the connect step would
+  // flash first).
+  if (!settled || !growthLandingPagesEnabled) {
     return (
       <QuickstartShell>
         <StatusRow state="waiting" label="Loading…" />

--- a/packages/web/src/pages/scan/__tests__/scan-landing-page.test.tsx
+++ b/packages/web/src/pages/scan/__tests__/scan-landing-page.test.tsx
@@ -7,10 +7,10 @@ import { describe, expect, it, vi } from "vitest";
 import { readCampaignHandoff } from "../../quickstart/intent.js";
 import { buildScanHandoffHref, ScanLandingPage } from "../scan-landing-page.js";
 
-// Mock the channel hook so each test pins dev / staging / prod / loading.
-const channelMock = vi.hoisted(() => ({ value: { channel: "dev" as string | null, settled: true } }));
+// Mock the growth flag hook so each test pins enabled / disabled / loading.
+const growthLandingMock = vi.hoisted(() => ({ value: { enabled: true, settled: true } }));
 vi.mock("../../../hooks/use-server-channel.js", () => ({
-  useServerChannelState: () => channelMock.value,
+  useGrowthLandingPagesState: () => growthLandingMock.value,
 }));
 
 const INPUT_LABEL = "GitHub repository URL";
@@ -50,38 +50,33 @@ describe("buildScanHandoffHref — landing → quickstart contract", () => {
   });
 });
 
-describe("ScanLandingPage — dev/staging-only channel gate", () => {
-  it("renders the scan form on dev for a known campaign", () => {
-    channelMock.value = { channel: "dev", settled: true };
+describe("ScanLandingPage — growth landing feature gate", () => {
+  it("renders the scan form when enabled for a known campaign", () => {
+    growthLandingMock.value = { enabled: true, settled: true };
     const markup = renderScan("/scan/production-scan");
     expect(markup).toContain(INPUT_LABEL);
     expect(markup).toContain("Is your repo ready to ship?");
   });
 
-  it("renders on staging too", () => {
-    channelMock.value = { channel: "staging", settled: true };
+  it("renders other known campaigns when enabled", () => {
+    growthLandingMock.value = { enabled: true, settled: true };
     expect(renderScan("/scan/agent-readiness")).toContain(INPUT_LABEL);
   });
 
-  it("does NOT render the form in prod — the whole funnel is hidden", () => {
-    channelMock.value = { channel: "prod", settled: true };
+  it("does NOT render the form when disabled — the whole funnel is hidden", () => {
+    growthLandingMock.value = { enabled: false, settled: true };
     expect(renderScan("/scan/production-scan")).not.toContain(INPUT_LABEL);
   });
 
-  it("does NOT render the form for an unknown/old server (null channel)", () => {
-    channelMock.value = { channel: null, settled: true };
-    expect(renderScan("/scan/production-scan")).not.toContain(INPUT_LABEL);
-  });
-
-  it("holds a neutral surface (no form) while the channel is still loading", () => {
-    channelMock.value = { channel: null, settled: false };
+  it("holds a neutral surface (no form) while the feature flag is still loading", () => {
+    growthLandingMock.value = { enabled: false, settled: false };
     const markup = renderScan("/scan/production-scan");
     expect(markup).not.toContain(INPUT_LABEL);
     expect(markup).toContain("landing-marketing");
   });
 
-  it("redirects an unknown campaign slug even on dev", () => {
-    channelMock.value = { channel: "dev", settled: true };
+  it("redirects an unknown campaign slug even when enabled", () => {
+    growthLandingMock.value = { enabled: true, settled: true };
     expect(renderScan("/scan/bogus-campaign")).not.toContain(INPUT_LABEL);
   });
 });

--- a/packages/web/src/pages/scan/scan-landing-page.tsx
+++ b/packages/web/src/pages/scan/scan-landing-page.tsx
@@ -3,7 +3,7 @@ import { type FormEvent, useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { Button } from "../../components/ui/button.js";
 import { Input } from "../../components/ui/input.js";
-import { useServerChannelState } from "../../hooks/use-server-channel.js";
+import { useGrowthLandingPagesState } from "../../hooks/use-server-channel.js";
 import { Footer } from "../landing/footer.js";
 import { LandingNav } from "../landing/nav.js";
 import { type CampaignSlug, isKnownCampaign } from "../quickstart/campaigns.js";
@@ -30,18 +30,17 @@ export function buildScanHandoffHref(campaign: CampaignSlug, repoUrl: string): s
  * connecting a computer, and starting the campaign's first chat. This page does
  * one job: validate the repo and build that handoff URL.
  *
- * Dev/staging-only, exactly like the quickstart it feeds: the same prod-safe
- * channel gate (unknown / old server → null → not allowed) keeps the whole
- * funnel hidden in prod until we open it. Public route (no auth) — login
- * happens later, inside quickstart, carried by the `next` round-trip.
+ * Feature-flagged, exactly like the quickstart it feeds: older servers and
+ * fetch failures resolve to disabled, keeping the whole funnel hidden until an
+ * operator explicitly opens it. Public route (no auth) — login happens later,
+ * inside quickstart, carried by the `next` round-trip.
  */
 export function ScanLandingPage() {
   const navigate = useNavigate();
   const { campaign: slugParam } = useParams<{ campaign: string }>();
   const campaign: CampaignSlug | null = isKnownCampaign(slugParam) ? slugParam : null;
 
-  const { channel, settled } = useServerChannelState();
-  const channelAllowed = channel === "dev" || channel === "staging";
+  const { enabled: growthLandingPagesEnabled, settled } = useGrowthLandingPagesState();
 
   const copy = campaign ? SCAN_LANDING_COPY[campaign] : null;
 
@@ -57,14 +56,13 @@ export function ScanLandingPage() {
   const [repoInput, setRepoInput] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  // Hold a neutral surface while the channel resolves — never flash the form
-  // for a prod visitor mid-fetch (mirrors the quickstart gate).
+  // Hold a neutral surface while the feature flag resolves — never flash the
+  // form for a disabled deployment mid-fetch (mirrors the quickstart gate).
   if (!settled) {
     return <div className="landing-marketing min-h-screen bg-background" />;
   }
-  // Prod / unknown server, or a campaign slug we don't recognise → send home.
-  // The funnel simply does not exist outside dev/staging.
-  if (!channelAllowed || !campaign || !copy) {
+  // Disabled / old server, or a campaign slug we don't recognise → send home.
+  if (!growthLandingPagesEnabled || !campaign || !copy) {
     return <Navigate to="/" replace />;
   }
 


### PR DESCRIPTION
## Summary
- Add FIRST_TREE_GROWTH_LANDING_PAGES_ENABLED server config, defaulting off.
- Expose growthLandingPagesEnabled from /bootstrap/config while keeping channel as release identity.
- Gate /scan/:campaign and /quickstart?campaign=... on the explicit growth flag instead of dev/staging channel.

## Tests
- pnpm --filter @first-tree/shared test -- src/config/__tests__/server-config.test.ts (ran shared package tests)
- pnpm --filter @first-tree/web test -- src/hooks/__tests__/use-server-channel.test.ts src/pages/scan/__tests__/scan-landing-page.test.tsx src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx (ran web package tests)
- pnpm --filter @first-tree/server test -- src/__tests__/bootstrap-config.test.ts (ran server package tests)
- pnpm check
- pnpm typecheck
