### PR TITLE
feat(scan): Step 6 onboarding-setup CTA; stop github-follow leak; hide internals

### DIFF
--- a/packages/server/src/__tests__/campaign-scan-skill.test.ts
+++ b/packages/server/src/__tests__/campaign-scan-skill.test.ts
@@ -38,6 +38,13 @@ describe("campaign scan skills", () => {
       // Even after consent the gh write is fenced to PR/issue creation only.
       expect(body).toContain("gh pr create");
       expect(body).toContain("no other mutating");
+      // Growth flow does NOT auto-follow the PR — on a fresh org that surfaces an
+      // "install the GitHub App" admin error; the skill forbids it and forbids
+      // surfacing any such failure to the user.
+      expect(body).toContain("github follow");
+      expect(body).toContain("install the GitHub App");
+      // Never leak internal workspace mechanics (clones/worktrees/collisions) to the user.
+      expect(body).toContain("never expose your internal working mechanics");
     }
     // The agent-readiness hero deliverable is a tailored AGENTS.md.
     expect(getCampaignScanSkill("agent-readiness")?.body).toContain("AGENTS.md");
@@ -58,21 +65,20 @@ describe("campaign scan skills", () => {
       // Step 6 conversion INVARIANTS — lock behavior, not marketing wording, so the
       // copy can be tuned without churning tests; only a real behavior change breaks these.
       expect(body).toContain("Step 6");
-      // (1) the apply-offer gate phrase is present (the copy fires the conversion ask
-      //     only after it resolves; this asserts the gate exists, not its ordering).
+      // (1) gated on the apply offer resolving first.
       expect(body).toContain("apply offer");
-      // (2) primary next step = convert to a First Tree team + build this repo's context tree.
-      expect(body).toContain("First Tree team");
-      expect(body).toContain("build the context tree");
-      // (3) one ask at a time — never a stacked second ask.
-      expect(body).toContain("ONE ask at a time");
-      // (4) explicit stop condition — no re-pitch when unanswered / declined / quiet.
+      // (2) Step 6 is a PLAIN MESSAGE carrying the env-templated setup link — NOT an
+      //     ask-user card (it hands off to a web onboarding flow). The server replaces
+      //     the placeholder with the env-correct URL at skill materialization.
+      expect(body).toContain("{{FIRST_TREE_SETUP_URL}}");
+      expect(body).toContain("NOT an ask-user card");
+      // (3) the CTA drives First Tree setup (connect own computer + create own agent).
+      expect(body).toContain("Set up First Tree for your team");
+      // (4) explicit stop condition — one invitation, no re-pitch, never a menu.
       expect(body).toContain("don't re-pitch");
-      // (5) BOTH the apply-consent offer and the Step 6 conversion are raised as
-      //     tracked ask-user decisions (chat ask) — the two asks in the flow — and
-      //     the conversion stays a single yes/no, never a multi-option menu.
-      expect((body.match(/chat ask/g) ?? []).length).toBeGreaterThanOrEqual(2);
       expect(body).toContain("never a menu");
+      // (5) the Step 5 apply-consent offer is still a tracked ask-user card.
+      expect(body).toContain("tracked ask-user");
     }
   });
 });

--- a/packages/server/src/__tests__/resources-phase1.test.ts
+++ b/packages/server/src/__tests__/resources-phase1.test.ts
@@ -77,7 +77,12 @@ describe("Resources Phase 1", () => {
     const owner = await createOrgUser(app, "member");
     const agent = await createRuntimeAgent(app, owner);
 
-    await app.resourcesService.ensureAndBindCampaignScanSkill(agent.uuid, "production-scan", owner.memberId);
+    await app.resourcesService.ensureAndBindCampaignScanSkill(
+      agent.uuid,
+      "production-scan",
+      owner.memberId,
+      "https://ft.test/onboarding",
+    );
 
     // Agent-PRIVATE resource (scope=agent, owned by this agent) — not an org
     // team resource, so it never lands in the org catalogue.
@@ -110,7 +115,12 @@ describe("Resources Phase 1", () => {
 
     // Idempotent: a returning user's second campaign / a retry neither
     // duplicates the resource nor the binding, and does not re-bump the version.
-    await app.resourcesService.ensureAndBindCampaignScanSkill(agent.uuid, "production-scan", owner.memberId);
+    await app.resourcesService.ensureAndBindCampaignScanSkill(
+      agent.uuid,
+      "production-scan",
+      owner.memberId,
+      "https://ft.test/onboarding",
+    );
     const skillsAfter = await app.db
       .select()
       .from(resources)
@@ -135,7 +145,12 @@ describe("Resources Phase 1", () => {
     const owner = await createOrgUser(app, "member");
     const agent = await createRuntimeAgent(app, owner);
 
-    await app.resourcesService.ensureAndBindCampaignScanSkill(agent.uuid, "production-scan", owner.memberId);
+    await app.resourcesService.ensureAndBindCampaignScanSkill(
+      agent.uuid,
+      "production-scan",
+      owner.memberId,
+      "https://ft.test/onboarding",
+    );
 
     // Simulate a skill provisioned by an older server: overwrite the stored
     // payload with a stale body, leaving the lookup key (the `name` column)
@@ -149,7 +164,12 @@ describe("Resources Phase 1", () => {
       .set({ payload: { name: "production-scan", description: "stale", body: "STALE BODY", metadata: {} } })
       .where(eq(resources.id, before?.id ?? ""));
 
-    await app.resourcesService.ensureAndBindCampaignScanSkill(agent.uuid, "production-scan", owner.memberId);
+    await app.resourcesService.ensureAndBindCampaignScanSkill(
+      agent.uuid,
+      "production-scan",
+      owner.memberId,
+      "https://ft.test/onboarding",
+    );
 
     // Payload refreshed back to the current server-owned rubric.
     const [after] = await app.db
@@ -177,10 +197,20 @@ describe("Resources Phase 1", () => {
     // Simulate a prior run that created the agent-private resource but failed
     // before binding. Re-running must find the existing resource and bind it,
     // not duplicate.
-    await app.resourcesService.ensureAndBindCampaignScanSkill(agent.uuid, "production-scan", owner.memberId);
+    await app.resourcesService.ensureAndBindCampaignScanSkill(
+      agent.uuid,
+      "production-scan",
+      owner.memberId,
+      "https://ft.test/onboarding",
+    );
     await app.db.delete(agentResourceBindings).where(eq(agentResourceBindings.agentId, agent.uuid));
 
-    await app.resourcesService.ensureAndBindCampaignScanSkill(agent.uuid, "production-scan", owner.memberId);
+    await app.resourcesService.ensureAndBindCampaignScanSkill(
+      agent.uuid,
+      "production-scan",
+      owner.memberId,
+      "https://ft.test/onboarding",
+    );
     const skills = await app.db
       .select()
       .from(resources)
@@ -206,7 +236,12 @@ describe("Resources Phase 1", () => {
     const attacker = await createOrgUser(app, "admin");
 
     await expect(
-      app.resourcesService.ensureAndBindCampaignScanSkill(victimAgent.uuid, "production-scan", attacker.memberId),
+      app.resourcesService.ensureAndBindCampaignScanSkill(
+        victimAgent.uuid,
+        "production-scan",
+        attacker.memberId,
+        "https://ft.test/onboarding",
+      ),
     ).rejects.toThrow();
 
     const skills = await app.db
@@ -225,7 +260,12 @@ describe("Resources Phase 1", () => {
     const app = getApp();
     const owner = await createOrgUser(app, "member");
     const agent = await createRuntimeAgent(app, owner);
-    await app.resourcesService.ensureAndBindCampaignScanSkill(agent.uuid, "production-scan", owner.memberId);
+    await app.resourcesService.ensureAndBindCampaignScanSkill(
+      agent.uuid,
+      "production-scan",
+      owner.memberId,
+      "https://ft.test/onboarding",
+    );
 
     // The web resource/prompt editors re-submit the FULL binding array on every
     // save — which now includes the agent-private scan-skill binding. A normal
@@ -252,7 +292,12 @@ describe("Resources Phase 1", () => {
     const owner = await createOrgUser(app, "member");
     const agent = await createRuntimeAgent(app, owner);
 
-    await app.resourcesService.ensureAndBindCampaignScanSkill(agent.uuid, "not-a-real-campaign", owner.memberId);
+    await app.resourcesService.ensureAndBindCampaignScanSkill(
+      agent.uuid,
+      "not-a-real-campaign",
+      owner.memberId,
+      "https://ft.test/onboarding",
+    );
 
     const skills = await app.db
       .select()

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -283,7 +283,16 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       ...(campaign
         ? {
             campaign,
-            onChatReady: () => app.resourcesService.ensureAndBindCampaignScanSkill(body.agentUuid, campaign, memberId),
+            // The scan skill's Step 6 CTA links to the env-correct onboarding
+            // page; resolve it here (dev/staging/prod) and let the materializer
+            // template it into the skill body's `{{FIRST_TREE_SETUP_URL}}`.
+            onChatReady: () =>
+              app.resourcesService.ensureAndBindCampaignScanSkill(
+                body.agentUuid,
+                campaign,
+                memberId,
+                `${resolvePublicUrl(app, request)}/onboarding`,
+              ),
           }
         : {}),
     });

--- a/packages/server/src/services/campaign-scan-skill.ts
+++ b/packages/server/src/services/campaign-scan-skill.ts
@@ -38,6 +38,8 @@ to proceed — goes through a **tracked ask-user card** (your \`chat ask\`), nev
 plain message: Yes/No or a few clean options, one ask at a time, dropped if they
 decline or go quiet.
 
+**What the user sees:** never expose your internal working mechanics to the user — clone / worktree / branch names, temp paths, git collisions, "worked around…", or how you set up your workspace. Show only value and results: the report, the deliverable, the PR/issue link, and the next step.
+
 ## Step 0 — get the repo
 Get the target repo before scanning. **Fastest path (preferred):** the repo's
 GitHub URL is in the opening chat message ("connected to your code: …") —
@@ -134,41 +136,34 @@ that explicit go-ahead. Even after a yes, use **only** \`gh pr create\` /
 force-push, no deleting or modifying existing branches, no closing or editing
 existing issues or PRs, no other mutating \`gh\` command.
 
-## Step 6 — after the apply offer is resolved, turn the win into a standing setup for their team (one ask at a time)
+This overrides your usual "follow what you create" default: do NOT run \`github follow\` — or any First Tree event-tracking / attention wiring — on the PR or issue you create: this is a value-first scan and the org isn't set up for webhooks, so just share the link and stop there. If any follow/tracking step is attempted and errors, never surface it to the user as an error or an "install the GitHub App" task — drop it silently.
+
+## Step 6 — after the apply offer is resolved, invite them to set up First Tree for their team (one message + the setup link)
 The gap this scan exposed is real and recurring, and the artifact you produced is a
-one-time patch. The point of the scan is to get the user onto First Tree so this
-stays maintained for their whole team — not a one-off. Once the apply offer is
-resolved (the user answered, or the PR/issue is open), make ONE next-step ask —
-never a menu.
+one-time patch. The point of the scan is to get the user set up on First Tree so an
+agent that knows their repo is there for every task, for their whole team — not a
+one-off. Once the apply offer is resolved (the user answered, or the PR/issue is
+open), send ONE short message inviting them to set up — never a menu, never a nag.
 
-**Primary ask — convert to a First Tree team + context tree.** Anchor it to the
-specific gap THIS report exposed and the fix you just delivered (they are the
-proof). The case, in one breath: First Tree turns that one-time patch into your
-team's **living context tree** — shared, versioned in Git, and kept current by you
-and your agents through reviewed updates as you work — so every future agent task
-and every teammate starts from it instead of re-learning the repo. That is the
-difference from the static file you just wrote: it's the team's durable, reviewed
-source of context that stays useful as work happens, not a doc that quietly goes
-stale. Then make the
-concrete ask as a **tracked ask-user decision** — your \`chat ask\` posing a single
-Yes/No card: a **Set it up** confirm and a **Not now** decline, each with a short
-label (≤5 words) and a one-line description (\`chat ask\` requires both). Phrase it
-like "Set up your First Tree team and build the context tree for this repo?" — a
-single clear yes/no, **never a multi-option menu**. If they pick yes, walk them through only the standard setup
-steps they haven't already done — their team, their agent, and the context tree — skipping anything
-the current flow already handled. This is the confident default, tied to their
-demonstrated pain, not a soft footnote.
+**This is a plain message with one clear, clickable link — NOT an ask-user card**
+(it hands off to a web setup flow, not a Yes/No in chat). Keep it value-first and
+tied to what they just got; **do not mention how the work was done, or that any
+agent (hosted or otherwise) produced it** — just the value and the next step. Use
+this shape, adapt lightly, keep it tight:
 
-**Secondary (lighter) — only if they decline the team AND explicitly want to keep
-going:** offer exactly one lighter next step instead, **as a plain conversational
-offer — not another ask-user card** — turn the next blocker into a fix, or scan
-another (or a private) repo. This is offered instead of re-pitching
-the team; it is never a second ask stacked after a no.
+"Want this on every task, not just once? Set up First Tree for your team. → Get
+started: {{FIRST_TREE_SETUP_URL}}"
 
-Otherwise, **stop.** ONE ask at a time is the rule, and the stop condition is
-explicit: if the apply offer is still unanswered, or the user is done, goes quiet,
-or declines without asking for more — stop and don't re-pitch. A single unanswered
-offer is the ceiling. You convert by being genuinely useful, not by nagging.
+Use the link **exactly** as it appears in {{FIRST_TREE_SETUP_URL}} — never invent,
+alter, or drop it. That page walks them through setting up their own First Tree
+(their team, their own computer, their own agent).
+
+Send it **once**. If the apply offer is still unanswered, or the user is done, goes
+quiet, or declines — stop, and don't re-pitch: a single invitation is the ceiling.
+You convert by being genuinely useful, not by nagging. If they decline the setup
+but want to keep going, offer exactly one lighter next step as a plain
+conversational message (turn the next blocker into a fix, or scan another repo) —
+never a second link-pitch after a no.
 `;
 
 const AGENT_READINESS_BODY = `# Agent Readiness Scan
@@ -181,6 +176,8 @@ structured agent-readiness report. **READ-ONLY**: do not modify anything.
 to proceed — goes through a **tracked ask-user card** (your \`chat ask\`), never a
 plain message: Yes/No or a few clean options, one ask at a time, dropped if they
 decline or go quiet.
+
+**What the user sees:** never expose your internal working mechanics to the user — clone / worktree / branch names, temp paths, git collisions, "worked around…", or how you set up your workspace. Show only value and results: the report, the deliverable, the PR/issue link, and the next step.
 
 ## Step 0 — get the repo
 Get the target repo before scanning. **Fastest path (preferred):** the repo's
@@ -277,41 +274,34 @@ against a new branch on **the same repo you scanned** — no force-push, no
 deleting or modifying existing branches, no closing or editing existing issues
 or PRs, no other mutating \`gh\` command.
 
-## Step 6 — after the apply offer is resolved, turn the win into a standing setup for their team (one ask at a time)
+This overrides your usual "follow what you create" default: do NOT run \`github follow\` — or any First Tree event-tracking / attention wiring — on the PR or issue you create: this is a value-first scan and the org isn't set up for webhooks, so just share the link and stop there. If any follow/tracking step is attempted and errors, never surface it to the user as an error or an "install the GitHub App" task — drop it silently.
+
+## Step 6 — after the apply offer is resolved, invite them to set up First Tree for their team (one message + the setup link)
 The gap this scan exposed is real and recurring, and the artifact you produced is a
-one-time patch. The point of the scan is to get the user onto First Tree so this
-stays maintained for their whole team — not a one-off. Once the apply offer is
-resolved (the user answered, or the PR/issue is open), make ONE next-step ask —
-never a menu.
+one-time patch. The point of the scan is to get the user set up on First Tree so an
+agent that knows their repo is there for every task, for their whole team — not a
+one-off. Once the apply offer is resolved (the user answered, or the PR/issue is
+open), send ONE short message inviting them to set up — never a menu, never a nag.
 
-**Primary ask — convert to a First Tree team + context tree.** Anchor it to the
-specific gap THIS report exposed and the fix you just delivered (they are the
-proof). The case, in one breath: First Tree turns that one-time patch into your
-team's **living context tree** — shared, versioned in Git, and kept current by you
-and your agents through reviewed updates as you work — so every future agent task
-and every teammate starts from it instead of re-learning the repo. That is the
-difference from the static file you just wrote: it's the team's durable, reviewed
-source of context that stays useful as work happens, not a doc that quietly goes
-stale. Then make the
-concrete ask as a **tracked ask-user decision** — your \`chat ask\` posing a single
-Yes/No card: a **Set it up** confirm and a **Not now** decline, each with a short
-label (≤5 words) and a one-line description (\`chat ask\` requires both). Phrase it
-like "Set up your First Tree team and build the context tree for this repo?" — a
-single clear yes/no, **never a multi-option menu**. If they pick yes, walk them through only the standard setup
-steps they haven't already done — their team, their agent, and the context tree — skipping anything
-the current flow already handled. This is the confident default, tied to their
-demonstrated pain, not a soft footnote.
+**This is a plain message with one clear, clickable link — NOT an ask-user card**
+(it hands off to a web setup flow, not a Yes/No in chat). Keep it value-first and
+tied to what they just got; **do not mention how the work was done, or that any
+agent (hosted or otherwise) produced it** — just the value and the next step. Use
+this shape, adapt lightly, keep it tight:
 
-**Secondary (lighter) — only if they decline the team AND explicitly want to keep
-going:** offer exactly one lighter next step instead, **as a plain conversational
-offer — not another ask-user card** — turn the next blocker into a fix, or scan
-another (or a private) repo. This is offered instead of re-pitching
-the team; it is never a second ask stacked after a no.
+"Want this on every task, not just once? Set up First Tree for your team. → Get
+started: {{FIRST_TREE_SETUP_URL}}"
 
-Otherwise, **stop.** ONE ask at a time is the rule, and the stop condition is
-explicit: if the apply offer is still unanswered, or the user is done, goes quiet,
-or declines without asking for more — stop and don't re-pitch. A single unanswered
-offer is the ceiling. You convert by being genuinely useful, not by nagging.
+Use the link **exactly** as it appears in {{FIRST_TREE_SETUP_URL}} — never invent,
+alter, or drop it. That page walks them through setting up their own First Tree
+(their team, their own computer, their own agent).
+
+Send it **once**. If the apply offer is still unanswered, or the user is done, goes
+quiet, or declines — stop, and don't re-pitch: a single invitation is the ceiling.
+You convert by being genuinely useful, not by nagging. If they decline the setup
+but want to keep going, offer exactly one lighter next step as a plain
+conversational message (turn the next blocker into a fix, or scan another repo) —
+never a second link-pitch after a no.
 `;
 
 const CAMPAIGN_SCAN_SKILLS: Record<string, CampaignScanSkill> = {

--- a/packages/server/src/services/resources.ts
+++ b/packages/server/src/services/resources.ts
@@ -64,7 +64,7 @@ export type ResourcesService = {
    * works for non-admin quickstart actors (the team-resource HTTP route is
    * admin-only); no-op for an unknown campaign slug.
    */
-  ensureAndBindCampaignScanSkill(agentId: string, campaign: string, actorId: string): Promise<void>;
+  ensureAndBindCampaignScanSkill(agentId: string, campaign: string, actorId: string, setupUrl: string): Promise<void>;
   resolveRuntimeConfig(config: AgentRuntimeConfig): Promise<AgentRuntimeConfig>;
   resolveEffectiveResources(agentId: string): Promise<EffectiveAgentResources>;
 };
@@ -1127,9 +1127,16 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
       };
     },
 
-    async ensureAndBindCampaignScanSkill(agentId, campaign, actorId) {
+    async ensureAndBindCampaignScanSkill(agentId, campaign, actorId, setupUrl) {
       const skill = getCampaignScanSkill(campaign);
       if (!skill) return;
+      // Env-correct setup link (dev/staging/prod) is templated in at
+      // materialization: the skill body ships an env-agnostic
+      // `{{FIRST_TREE_SETUP_URL}}` placeholder (campaign-scan-skill.ts Step 6).
+      // Use `body` everywhere below — payload AND the change-check — so a
+      // same-env re-scan compares templated-vs-templated and doesn't churn the
+      // config version on every kickoff.
+      const body = skill.body.replaceAll("{{FIRST_TREE_SETUP_URL}}", setupUrl);
       const [agent] = await db
         .select({ organizationId: agents.organizationId, managerId: agents.managerId, status: agents.status })
         .from(agents)
@@ -1190,7 +1197,7 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
       const desiredPayload = {
         name: skill.name,
         description: skill.description,
-        body: skill.body,
+        body,
         metadata: {},
       };
       // `body` and `description` are the only server-mutable fields of a
@@ -1202,7 +1209,7 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
         typeof stored === "object" &&
         stored !== null &&
         "body" in stored &&
-        stored.body === skill.body &&
+        stored.body === body &&
         "description" in stored &&
         stored.description === skill.description;
 


### PR DESCRIPTION
## Why
Live testing of the campaign scan flow surfaced three issues; this batches the skill fixes plus the server plumbing for the new conversion step. Designed for the target growth model (scan on a hosted agent → convert to "set up your own First Tree").

## What (both scan bodies + server)
- **Step 6 rewrite (CP3):** from an ask-user card into a **plain message with one clickable setup link** — the conversion is "set up your own First Tree (your team, your own computer, your own agent)", pointing at the onboarding flow. Copy is value-first; the skill forbids mentioning that any (hosted) agent produced the work. The Step 5 apply-consent ask-user card is **unchanged**.
- **No `github follow` (CP1):** Step 5 forbids auto-following the created PR/issue and forbids surfacing any follow/tracking failure to the user — on a fresh org that surfaced an "install the GitHub App" admin chore that broke the value-first flow. Explicitly overrides the base "follow what you create" default.
- **No internal-mechanics leak (CP2):** new top-level rule — never put clone/worktree/branch names, temp paths, or git collisions into user-facing messages.

## Env-correct link (server)
The body ships an env-agnostic `{{FIRST_TREE_SETUP_URL}}` placeholder; `ensureAndBindCampaignScanSkill` gains a `setupUrl` param and templates it in **at materialization** (uses `body`, not `skill.body`, for both payload and the change-check, so a same-env re-scan doesn't churn the config version); the kickoff route passes `${resolvePublicUrl(app, request)}/onboarding`. Only prod caller updated + interface + all test call sites.

## Review + verification
Two independent reviews: **correctness = CLEAN**; **conversion/taste = non-blocking** (one optional "pain-anchor the CTA" nit, deferred to product). `biome` clean; `pnpm --filter @first-tree/server typecheck` exit 0; full server suite **1638/1638** green (incl. campaign-scan-skill 4/4, resources-phase1 22/22).

## Note (not in this PR)
Target-model dependency: the hosted computer/agent (in progress by others). One coordination item for that work — the hosted agent must not count as the user's "personal agent," or `/onboarding` would skip the create-your-own-agent step (#1337).
