### PR TITLE
fix: install first-tree-seed for tree-less onboarding

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -383,12 +383,13 @@ describe("buildAgentBriefing — # Required Reading (unconditional skill-load ma
     expect(contextTreeIdx).toBeGreaterThan(requiredIdx);
   });
 
-  it("omits # Required Reading for tree-less agents (the skill payloads are not installed on disk for them)", () => {
-    // `installFirstTreeIntegration` is short-circuited when
-    // `contextTreePath === null`, so the SKILL.md payloads under
-    // `<workspace>/.agents/skills/` never get materialised. Mandating
-    // a load would point at files that aren't there. The Tree
-    // Location stub already surfaces the gap to a human.
+  it("omits # Required Reading for tree-less agents (the unconditional write mandate is a tree-ops discipline)", () => {
+    // `# Required Reading` mandates loading `first-tree-write` UNCONDITIONALLY
+    // on every task — a tree-ops discipline for reflecting sources into an
+    // existing tree. A tree-less agent DOES carry write on disk now (it ships
+    // core as first-tree-seed's dependency), but should load it only when seed
+    // pulls it in, not on every task, so the mandate stays tree-bound. The
+    // tree-less core skills are surfaced by the First Tree Family map instead.
     const briefing = buildAgentBriefing(makeOpts({ contextTreePath: null }));
     expect(briefing).not.toContain("# Required Reading");
   });
@@ -1103,15 +1104,27 @@ describe("buildAgentBriefing — # Skills (Skill Map)", () => {
     expect(skillsSection).toContain("## First Tree Family");
   });
 
-  it("omits the First Tree Family map for tree-less agents (skills are gated on `installFirstTreeIntegration`)", () => {
-    // A no-tree agent's `tree skill install` never runs, so listing the
-    // First Tree family would tell it to load skills that the runtime
-    // never put on disk. The map must be gated.
+  it("emits a core-skills First Tree Family map for tree-less agents (routes the tree-build task to first-tree-seed)", () => {
+    // A tree-less agent now carries the core skills on disk (welcome + the
+    // from-zero build pair seed/write), so the map lists exactly those — and
+    // NOT `first-tree-read`, which stays tree-bound. This is the routing
+    // surface a welcome-spawned tree-build chat uses to reach first-tree-seed,
+    // whose brief names no skill by design.
     const briefing = buildAgentBriefing(makeOpts({ contextTreePath: null }));
-    expect(briefing).not.toContain("## First Tree Family");
-    // And without Team Skills, the bare `# Skills` umbrella is skipped
-    // entirely — a header with no body is just visual noise.
-    expect(briefing).not.toMatch(/^# Skills\b/m);
+    expect(briefing).toContain("# Skills (First Tree Managed)");
+    const familyStart = briefing.indexOf("## First Tree Family");
+    expect(familyStart).toBeGreaterThanOrEqual(0);
+    // Bound the assertion to the map's own block (up to the next heading) so a
+    // later section that legitimately mentions read can't taint the check.
+    const afterStart = briefing.slice(familyStart + "## First Tree Family".length);
+    const nextHeadingRel = afterStart.search(/\n#{1,3} /);
+    const familyMap = nextHeadingRel === -1 ? afterStart : afterStart.slice(0, nextHeadingRel);
+    expect(familyMap).toContain("first-tree-welcome");
+    expect(familyMap).toContain("first-tree-seed");
+    expect(familyMap).toContain("first-tree-write");
+    expect(familyMap).not.toContain("first-tree-read");
+    // Tree-less map must not lean on the (omitted) # Required Reading section.
+    expect(familyMap).not.toContain("# Required Reading");
   });
 
   it("keeps the `# Skills` umbrella for tree-less agents that DO have Team Skills (resource skills land regardless)", () => {
@@ -1140,9 +1153,11 @@ describe("buildAgentBriefing — # Skills (Skill Map)", () => {
     expect(briefing).toContain("# Skills");
     expect(briefing).toContain("## Team Skills");
     expect(briefing).toContain("internal-playbook");
-    // Still no First Tree Family — those skills aren't installed for
-    // tree-less agents.
-    expect(briefing).not.toContain("## First Tree Family");
+    // The tree-less core-skills First Tree Family map is also emitted now, and
+    // sits after Team Skills under the shared `# Skills` umbrella.
+    expect(briefing).toContain("## First Tree Family");
+    const skills = briefing.slice(briefing.indexOf("# Skills"));
+    expect(skills.indexOf("## Team Skills")).toBeLessThan(skills.indexOf("## First Tree Family"));
   });
 });
 

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -358,8 +358,13 @@ function makeFixtureSkillsRoot(
   return root;
 }
 
-describe("installFirstTreeIntegration (inline skill installer)", () => {
-  const TREE_SKILLS = ["first-tree-write", "first-tree-read", "first-tree-seed"];
+describe("inline skill installer — copy/version/symlink mechanics", () => {
+  // Exercised via installCoreSkills, which carries the 3-skill set
+  // (welcome + write + seed) after write/seed moved TREE→CORE. The tree path
+  // (installFirstTreeIntegration) now installs the single remaining tree skill;
+  // its reconcile is covered by skills-state-reconcile.test.ts and its pin
+  // contract by the CLI-version pin describe below.
+  const CORE_SKILLS = ["first-tree-welcome", "first-tree-write", "first-tree-seed"];
 
   function expectSkillInstalled(workspace: string, name: string): void {
     const agentsDir = join(workspace, ".agents", "skills", name);
@@ -377,19 +382,19 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     mkdirSync(workspace, { recursive: true });
     const bundledSkillsRoot = makeFixtureSkillsRoot(
       "happy",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot,
       log: (m) => logs.push(m),
     });
 
     expect(result, logs.join("\n")).toBe(true);
-    for (const name of TREE_SKILLS) expectSkillInstalled(workspace, name);
-    expect(logs.join("\n")).toContain("installed first-tree-write");
+    for (const name of CORE_SKILLS) expectSkillInstalled(workspace, name);
+    expect(logs.join("\n")).toMatch(/installed[^\n]*first-tree-write/);
   });
 
   it("skips skills whose on-disk VERSION + SKILL.md content both match bundled (fast path)", () => {
@@ -397,11 +402,11 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     mkdirSync(workspace, { recursive: true });
     const bundledSkillsRoot = makeFixtureSkillsRoot(
       "skip",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
 
     // First install populates the workspace.
-    installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
 
     // Drop a non-content marker into each installed skill so we can detect
     // whether the second install ran a full rm+cp (which wipes the marker)
@@ -409,19 +414,19 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // file is important — touching SKILL.md would itself trigger the
     // content-drift defense and force a reinstall, which is what the
     // separate "content drift" test below covers.
-    for (const name of TREE_SKILLS) {
+    for (const name of CORE_SKILLS) {
       writeFileSync(join(workspace, ".agents", "skills", name, ".sentinel"), "marker\n");
     }
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot,
       log: (m) => logs.push(m),
     });
 
     expect(result, logs.join("\n")).toBe(true);
-    for (const name of TREE_SKILLS) {
+    for (const name of CORE_SKILLS) {
       expect(
         existsSync(join(workspace, ".agents", "skills", name, ".sentinel")),
         `${name} should have been skipped`,
@@ -435,24 +440,24 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     mkdirSync(workspace, { recursive: true });
     const bundledV1 = makeFixtureSkillsRoot(
       "drift-v1",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
-    installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot: bundledV1, log: () => {} });
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot: bundledV1, log: () => {} });
 
     // Marker file (NOT SKILL.md) detects which skills got re-copied.
-    for (const name of TREE_SKILLS) {
+    for (const name of CORE_SKILLS) {
       writeFileSync(join(workspace, ".agents", "skills", name, ".sentinel"), "marker\n");
     }
 
     // New bundled root: bump only first-tree-write to 2.0.0; the rest stay at 1.0.0.
     const bundledMixed = makeFixtureSkillsRoot("drift-mixed", [
+      { name: "first-tree-welcome", version: "1.0.0" },
       { name: "first-tree-write", version: "2.0.0" },
-      { name: "first-tree-read", version: "1.0.0" },
       { name: "first-tree-seed", version: "1.0.0" },
     ]);
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot: bundledMixed,
       log: (m) => logs.push(m),
@@ -463,36 +468,36 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     expect(existsSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"))).toBe(false);
 
     // Others should have been skipped (marker preserved).
-    for (const name of TREE_SKILLS.filter((n) => n !== "first-tree-write")) {
+    for (const name of CORE_SKILLS.filter((n) => n !== "first-tree-write")) {
       expect(
         existsSync(join(workspace, ".agents", "skills", name, ".sentinel")),
         `${name} should have been skipped`,
       ).toBe(true);
     }
 
-    expect(logs.join("\n")).toContain("installed first-tree-write");
+    expect(logs.join("\n")).toMatch(/installed[^\n]*first-tree-write/);
     expect(logs.join("\n")).toContain("up-to-date");
   });
 
   it("returns false when a bundled skill source is missing", () => {
     const workspace = join(tmpBase, "integrate-missing");
     mkdirSync(workspace, { recursive: true });
-    // Bundled root has only first-tree-write; the other tree skills are missing.
+    // Bundled root has only first-tree-write; the other core skills are missing.
     const bundledSkillsRoot = makeFixtureSkillsRoot("missing", [{ name: "first-tree-write", version: "1.0.0" }]);
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot,
       log: (m) => logs.push(m),
     });
 
     expect(result).toBe(false);
-    // first-tree-write installs successfully, the others fail.
+    // first-tree-write installs successfully, welcome + seed fail (missing sources).
     expectSkillInstalled(workspace, "first-tree-write");
-    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-read"))).toBe(false);
-    expect(logs.join("\n")).toContain("failed first-tree-read, first-tree-seed");
-    expect(logs.join("\n")).toContain("First-tree skill install failed (first-tree-read)");
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-seed"))).toBe(false);
+    expect(logs.join("\n")).toContain("failed first-tree-welcome, first-tree-seed");
+    expect(logs.join("\n")).toContain("Core skill install failed (first-tree-welcome)");
   });
 
   it("repairs a clobbered .claude symlink without re-copying the .agents tree", () => {
@@ -500,10 +505,10 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     mkdirSync(workspace, { recursive: true });
     const bundledSkillsRoot = makeFixtureSkillsRoot(
       "relink",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
 
-    installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
 
     // Operator clobbered .claude/skills/first-tree-write with a regular file.
     // rmSync without `recursive` follows symlink-to-directory on macOS
@@ -518,7 +523,7 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // SKILL.md drift as a reinstall trigger).
     writeFileSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"), "marker\n");
 
-    const result = installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
+    const result = installCoreSkills({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
     expect(result).toBe(true);
     // Symlink was repaired.
     expectSkillInstalled(workspace, "first-tree-write");
@@ -537,10 +542,10 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     mkdirSync(workspace, { recursive: true });
     const bundledSkillsRoot = makeFixtureSkillsRoot(
       "content-drift",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
 
-    installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
 
     // Simulate "developer edited SKILL.md on disk but VERSION never
     // changed" — same VERSION on both sides, but the installed
@@ -549,7 +554,7 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     writeFileSync(installedSkillPath, "STALE_CONTENT\n");
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot,
       log: (m) => logs.push(m),
@@ -560,7 +565,7 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // (not the SENTINEL anymore), confirming the installer detected the
     // drift and ran a full reinstall instead of taking the fast path.
     expect(readFileSync(installedSkillPath, "utf-8")).not.toContain("STALE_CONTENT");
-    expect(logs.join("\n")).toContain("installed first-tree-write");
+    expect(logs.join("\n")).toMatch(/installed[^\n]*first-tree-write/);
   });
 
   it("falls through to reinstall when bundled VERSION is missing (cannot prove match)", () => {
@@ -574,9 +579,9 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // First install: bundled has VERSION.
     const bundledWith = makeFixtureSkillsRoot(
       "missing-version-with",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
-    installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot: bundledWith, log: () => {} });
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot: bundledWith, log: () => {} });
 
     // Drop sentinel into installed skill so we can detect re-copy.
     writeFileSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"), "marker\n");
@@ -584,11 +589,11 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // Second install: bundled root has NO VERSION file for any skill.
     const bundledWithout = makeFixtureSkillsRoot(
       "missing-version-without",
-      TREE_SKILLS.map((n) => ({ name: n })),
+      CORE_SKILLS.map((n) => ({ name: n })),
     );
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot: bundledWithout,
       log: (m) => logs.push(m),
@@ -598,7 +603,7 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // Sentinel gone — full reinstall ran because the fingerprint match
     // could not be proven.
     expect(existsSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"))).toBe(false);
-    expect(logs.join("\n")).toContain("installed first-tree-write");
+    expect(logs.join("\n")).toMatch(/installed[^\n]*first-tree-write/);
   });
 });
 
@@ -606,7 +611,11 @@ describe("installCoreSkills", () => {
   it("installs core skills even without a Context Tree binding", () => {
     const workspace = join(tmpBase, "core-skills");
     mkdirSync(workspace, { recursive: true });
-    const bundledSkillsRoot = makeFixtureSkillsRoot("core-skills", [{ name: "first-tree-welcome", version: "1.0.0" }]);
+    const bundledSkillsRoot = makeFixtureSkillsRoot("core-skills", [
+      { name: "first-tree-welcome", version: "1.0.0" },
+      { name: "first-tree-write", version: "1.0.0" },
+      { name: "first-tree-seed", version: "1.0.0" },
+    ]);
 
     const logs: string[] = [];
     const result = installCoreSkills({
@@ -640,6 +649,8 @@ describe("installCoreSkills", () => {
     );
     const bundledSkillsRoot = makeFixtureSkillsRoot("core-skills-retired", [
       { name: "first-tree-welcome", version: "1.0.0" },
+      { name: "first-tree-write", version: "1.0.0" },
+      { name: "first-tree-seed", version: "1.0.0" },
     ]);
 
     const result = installCoreSkills({
@@ -800,7 +811,10 @@ describe("deepEqualIdentity", () => {
  * giving it a complete vs incomplete bundled-skills layout.
  */
 describe("CLI-version pin contract (handler invariants)", () => {
-  const TREE_SKILLS = ["first-tree-write", "first-tree-read", "first-tree-seed"];
+  // The tree skill(s) installFirstTreeIntegration actually installs — just
+  // first-tree-read now that write/seed are CORE. A "complete" bundle for the
+  // success case only needs these present.
+  const TREE_SKILLS = ["first-tree-read"];
 
   it("does not overwrite the existing pin when integrate fails — next start retries", () => {
     const workspace = join(tmpBase, "cli-pin-failure-keeps-stale");

--- a/packages/client/src/__tests__/skills-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/skills-state-reconcile.test.ts
@@ -109,8 +109,36 @@ describe("installFirstTreeSkills — state-based skill reconcile (PR #869 P1-3)"
       expect(existsSync(join(workspace, ".agents", "skills", name))).toBe(false);
       expect(() => lstatSync(join(workspace, ".claude", "skills", name))).toThrow();
     }
-    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-write", "SKILL.md"))).toBe(true);
-    expect(lstatSync(join(workspace, ".claude", "skills", "first-tree-write")).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-read", "SKILL.md"))).toBe(true);
+    expect(lstatSync(join(workspace, ".claude", "skills", "first-tree-read")).isSymbolicLink()).toBe(true);
+    expect(readManagedState(workspace)?.skills).toEqual([...TREE_SKILL_NAMES].sort());
+  });
+
+  it("keeps CORE skills (seed/write) a prior version recorded as TREE skills — they moved tiers, not retired", () => {
+    // Before the seed/write→CORE move, an agent recorded `first-tree-write`
+    // and `first-tree-seed` in managed state as TREE skills. After upgrade
+    // their payloads are on disk (installCoreSkills plants them earlier in the
+    // same bootstrap), but they're no longer in TREE_SKILL_NAMES. The TREE
+    // reconcile must NOT delete them: they're CORE skills now, not retired.
+    plantManagedSkill(workspace, "first-tree-write");
+    plantManagedSkill(workspace, "first-tree-seed");
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "pre-core-move",
+      updatedAt: new Date(0).toISOString(),
+      skills: ["first-tree-write", "first-tree-read", "first-tree-seed"], // old TREE set
+    });
+
+    installFirstTreeSkills({ workspacePath: workspace, bundledSkillsRoot });
+
+    for (const name of ["first-tree-write", "first-tree-seed"]) {
+      expect(existsSync(join(workspace, ".agents", "skills", name, "SKILL.md")), `${name} payload survives`).toBe(true);
+      expect(lstatSync(join(workspace, ".claude", "skills", name)).isSymbolicLink(), `${name} symlink survives`).toBe(
+        true,
+      );
+    }
+    // The ledger still rolls forward to the TREE set only; CORE skills are
+    // tracked via RETIRED_CORE_SKILL_NAMES, not this reconcile.
     expect(readManagedState(workspace)?.skills).toEqual([...TREE_SKILL_NAMES].sort());
   });
 

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -146,11 +146,12 @@ function buildAgentBriefingRenderModel(opts: BuildAgentBriefingOptions): AgentBr
   // before doing any real work. Placing it
   // immediately before `# Context Tree` also keeps the mandate adjacent
   // to the content domains the two skills cover. Gated on
-  // `contextTreePath !== null` for the same reason `skillsSection`
-  // gates `firstTreeFamilyMap`: a tree-less agent has no First Tree
-  // skill payloads installed on disk (`installFirstTreeIntegration`
-  // is short-circuited in `agent-bootstrap.ts`), so mandating a load
-  // would point at files that don't exist.
+  // `contextTreePath !== null` because the UNCONDITIONAL mandate to load
+  // `first-tree-write` on every task is a tree-ops discipline (reflecting
+  // sources into an existing tree). A tree-less agent DOES carry write on disk
+  // now — it ships core as `first-tree-seed`'s dependency — but should load it
+  // only when seed pulls it in, not on every task; its installed core skills
+  // are still surfaced by the tree-less family map in `skillsSection`.
   const requiredReading = requiredReadingSection(opts.contextTreePath, opts.workspacePath);
   const contextTreeBlock = contextTreeSection(
     opts.contextTreePath,
@@ -1147,11 +1148,12 @@ function skillsSection(
   // header so we can splice it under the new `# Skills` umbrella.
   const teamBlock = buildResourceSkillsBriefing(workspacePath, payload).trim();
 
-  // The full First Tree family map is gated on `contextTreePath` because most
-  // rows are tree-bound skills installed by `installFirstTreeIntegration`.
-  // Core skills (for example onboarding kickoff) are installed separately and
-  // can still be invoked directly by a system kickoff in a tree-less workspace.
-  const familyBlock = contextTreePath !== null ? firstTreeFamilyMap() : null;
+  // The First Tree family map is emitted in both modes, but its rows are scoped
+  // to what is actually installed: tree-bound agents get the full four, while
+  // tree-less agents get only the core skills on disk (welcome + the from-zero
+  // build pair seed/write). A tree-less map matters because a welcome-spawned
+  // tree-build chat needs a routing surface to reach `first-tree-seed`.
+  const familyBlock = firstTreeFamilyMap(contextTreePath);
 
   // Skip the `# Skills` umbrella entirely when both inner blocks are
   // empty — a bare header without rows is just visual noise.
@@ -1163,12 +1165,34 @@ function skillsSection(
   return blocks.join("\n\n");
 }
 
-function firstTreeFamilyMap(): string {
-  // Listed skills MUST match what the inline installer actually deploys
-  // (`CORE_SKILL_NAMES` + `TREE_SKILL_NAMES`). Adding an aspirational row here
-  // would tell every agent to load a skill the runtime never puts on disk.
-  // Tests lock this map against the repo's `skills/` directory and the prebuild
-  // copy script.
+function firstTreeFamilyMap(contextTreePath: string | null): string {
+  // Listed skills MUST match what the inline installer actually deploys for
+  // THIS agent: `CORE_SKILL_NAMES` always, plus `TREE_SKILL_NAMES` only when
+  // tree-bound. Listing a skill the runtime never puts on disk would tell the
+  // agent to load a payload that isn't there; omitting an installed one leaves
+  // it with no First Tree routing surface. Tests lock this against the
+  // installer constants and the repo's `skills/` directory.
+  if (contextTreePath === null) {
+    // Tree-less: only the core skills are on disk — `first-tree-welcome` plus
+    // the from-zero build pair (`first-tree-seed` and its `first-tree-write`
+    // dependency). `first-tree-read` is tree-bound and NOT installed here, so
+    // it is omitted. This map is the routing surface a welcome-spawned
+    // tree-build chat relies on to reach `first-tree-seed`: that chat's opening
+    // brief names no skill by design, so without this the agent would fall back
+    // to provider auto-discovery instead of First Tree's own routing.
+    return `## First Tree Family
+
+These First Tree skills are installed even before your team has a Context
+Tree; each row's \`description\` drives progressive disclosure. If the task is
+to build the team's Context Tree from the connected code, load
+\`first-tree-seed\`.
+
+| Skill | Load when |
+|---|---|
+| \`first-tree-welcome\` | a First Tree onboarding welcome / intro / value-first first chat |
+| \`first-tree-seed\` | building the team's Context Tree from zero — it creates + binds the repo and seeds it; refuses once a tree exists |
+| \`first-tree-write\` | pulled in by \`first-tree-seed\` as its authoring dependency (source-driven tree writes) |`;
+  }
   return `## First Tree Family
 
 \`first-tree-write\` is **unconditional** — load it on every task per

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -334,11 +334,14 @@ prompt.*`,
  *    `decisionLocksCode`), the Double Test, Node Shape, and the
  *    Worked Examples.
  *
- * Both are gated on `contextTreePath !== null` because the runtime only
- * installs the SKILL.md payloads to disk when a Context Tree is bound
- * (see `runtime/first-tree-skills/installer.ts` and the short-circuit in
- * `agent-bootstrap.ts`). Telling a tree-less agent to load them would
- * point at files that aren't there.
+ * This section is gated on `contextTreePath !== null` because the
+ * UNCONDITIONAL mandate to load `first-tree-write` on every task is a
+ * tree-ops discipline (reflecting sources into an existing tree). Since the
+ * seed/write→core move, a tree-less agent DOES carry `first-tree-write` on
+ * disk (it ships core as `first-tree-seed`'s dependency), but should load it
+ * only when seed pulls it in — not on every task — so the mandate stays
+ * tree-bound. A tree-less agent's installed core skills are surfaced by the
+ * tree-less First Tree Family map in `skillsSection` instead.
  */
 function requiredReadingSection(contextTreePath: string | null, workspacePath: string): string | null {
   if (contextTreePath === null) return null;

--- a/packages/client/src/runtime/first-tree-skills/installer.ts
+++ b/packages/client/src/runtime/first-tree-skills/installer.ts
@@ -43,21 +43,32 @@ import { readManagedState, updateManagedState } from "../managed-state.js";
 
 /**
  * Skills always shipped, regardless of whether the agent has a Context Tree
- * binding. Welcome is core because onboarding can start before a team has a
- * Context Tree, especially in the no-repo path.
+ * binding — the capabilities an agent needs *before* a tree exists.
+ *
+ *   - `first-tree-welcome` launches onboarding, which can start before a team
+ *     has a Context Tree (especially the no-repo path).
+ *   - `first-tree-seed` builds a tree from zero. Onboarding runs the build in a
+ *     still-tree-less session (the welcome launcher spawns a dedicated
+ *     tree-build chat, which has no binding yet), so seed must ship there too —
+ *     gating it on a binding would hide the very skill whose job is to create
+ *     that binding.
+ *   - `first-tree-write` rides along because seed's Required Reading loads it as
+ *     a hard dependency; without its payload on disk, seed breaks on its first
+ *     step.
  */
-export const CORE_SKILL_NAMES = ["first-tree-welcome"] as const;
+export const CORE_SKILL_NAMES = ["first-tree-welcome", "first-tree-write", "first-tree-seed"] as const;
 
 const RETIRED_CORE_SKILL_NAMES = ["first-tree-guide", "first-tree-kickoff"] as const;
 
 /**
- * Skills that ship for Context-Tree-bound agents. Installed by
- * `installFirstTreeSkills()` on every bootstrap when `contextTreePath` is
- * set. The list must stay in sync with `BUNDLED_SKILLS` in
- * `scripts/copy-bundled-skills.mjs` — that script materialises these
- * directories under `<client-pkg>/skills/`.
+ * Skills that ship only for Context-Tree-bound agents — they operate on an
+ * existing tree, so they are pointless before one is bound. Installed by
+ * `installFirstTreeSkills()` on every bootstrap when `contextTreePath` is set.
+ * The UNION with `CORE_SKILL_NAMES` must stay in sync with `BUNDLED_SKILLS` in
+ * `scripts/copy-bundled-skills.mjs` — that script materialises every skill
+ * directory under `<client-pkg>/skills/`.
  */
-export const TREE_SKILL_NAMES = ["first-tree-write", "first-tree-read", "first-tree-seed"] as const;
+export const TREE_SKILL_NAMES = ["first-tree-read"] as const;
 
 export type CoreSkillName = (typeof CORE_SKILL_NAMES)[number];
 export type TreeSkillName = (typeof TREE_SKILL_NAMES)[number];
@@ -360,17 +371,27 @@ function reconcileCoreSkillState(workspacePath: string): void {
  * pass diffs against today's reality.
  */
 function reconcileTreeSkillState(workspacePath: string): void {
-  const currentSkills = new Set<string>(TREE_SKILL_NAMES);
+  // Never remove a skill that either tier currently ships. A skill that moved
+  // from TREE to CORE (`first-tree-seed` / `first-tree-write`) is still on
+  // disk — `installCoreSkills` places it earlier in the same bootstrap — so
+  // treating it as a "dropped TREE skill" here would delete a payload the
+  // runtime still ships. Protect the CORE set alongside TREE; removal is only
+  // for names that left BOTH lists (genuinely retired skills).
+  const protectedSkills = new Set<string>([...TREE_SKILL_NAMES, ...CORE_SKILL_NAMES]);
   const prev = readManagedState(workspacePath);
   if (prev) {
     for (const prevSkill of prev.skills) {
-      if (currentSkills.has(prevSkill)) continue;
+      if (protectedSkills.has(prevSkill)) continue;
       removeManagedSkill(workspacePath, prevSkill);
     }
   }
+  // Managed state records only the TREE set: it is the reconcile ledger for
+  // this install path. CORE skills are cleaned up via
+  // `RETIRED_CORE_SKILL_NAMES` in `reconcileCoreSkillState`, not by diffing
+  // this ledger, so recording them here would double-count their lifecycle.
   updateManagedState(workspacePath, resolveBundledCliVersion(), (current) => ({
     ...current,
-    skills: [...currentSkills].sort(),
+    skills: [...TREE_SKILL_NAMES].sort(),
   }));
 }
 


### PR DESCRIPTION
**Paired Context Tree PR (draft, merges after this):** agent-team-foundation/first-tree-context#668 — reclassifies the skill topology (seed/write core) in the tree nodes.

## Problem

New teams onboarding from zero can't build a proper Context Tree. `first-tree-welcome` spawns a dedicated tree-build chat that loads `first-tree-seed` to create + bind + seed the tree — but that chat is **tree-less** (no binding yet), and `first-tree-seed` was gated behind `TREE_SKILL_NAMES` (installed only when a Context Tree binding exists). So seed was never on disk in the build chat; the agent fell back to raw `gh` and produced an unbound, unseeded placeholder repo instead of a real Context Tree.

## Fix

Move `first-tree-seed` and `first-tree-write` from `TREE_SKILL_NAMES` to `CORE_SKILL_NAMES` (installed on every bootstrap, tree or not):

- **`first-tree-seed`** is the *from-zero* build skill — it must be available precisely when there's no tree yet. Gating it behind a binding is a chicken-and-egg: the skill whose job is to create the binding required the binding to already exist.
- **`first-tree-write`** is seed's hard dependency (seed's Required Reading loads it), so it must ship alongside.
- **`first-tree-read`** stays TREE — it only operates on an existing tree.

Guard `reconcileTreeSkillState` so the moved skills aren't deleted as "dropped TREE skills": `installCoreSkills` places seed/write earlier in the same bootstrap, and the subsequent tree reconcile must not strip them. Removal now targets only names that left **both** tiers (genuinely retired skills). `CORE ∪ TREE` is unchanged, so `BUNDLED_SKILLS` and the briefing family map stay in sync.

## Scope

Client skill-classification only. Does **not** touch the server-side onboarding slimming (kickoff `kind` removal, CTA routing, recovery probe) — that's a separate change.

## Tests

- **New reconcile regression test** (`skills-state-reconcile.test.ts`): an agent whose managed-state ledger still lists seed/write as TREE skills keeps their payloads after upgrade. Verified load-bearing — it fails if the guard is reverted.
- Repointed the copy-mechanics `describe` in `bootstrap.test.ts` to `installCoreSkills` (now the 3-skill set) so version-drift / partial-failure / fast-path / symlink-repair coverage survives.
- Full client suite green (1189/1189); `pnpm check` (biome) + `pnpm typecheck` clean; independent adversarial review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

