### PR TITLE
feat: build Context Tree via agent-seed from the Context-tab CTA

### DIFF
--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -2073,11 +2073,9 @@ describe("web DOM interaction coverage", () => {
     await unmountRoot(view.root);
   });
 
-  it("builds a missing tree from the Context page entry via the tree setup chat", async () => {
+  it("builds a missing tree from the Context page entry via agent-seed (no provisioning)", async () => {
     const { ContextTreeBuildEntry } = await import("../context-tree-build-entry.js");
-    orgSettingsMocks.getContextTreeSetting
-      .mockResolvedValueOnce({ repo: "", branch: null })
-      .mockResolvedValueOnce({ repo: "https://github.com/acme/context-tree", branch: "main" });
+    orgSettingsMocks.getContextTreeSetting.mockResolvedValueOnce({ repo: "", branch: null });
 
     const view = await renderDom(<ContextTreeBuildEntry />);
     await waitForText("Build your Context Tree", view.container);
@@ -2087,13 +2085,15 @@ describe("web DOM interaction coverage", () => {
     );
     await waitForText("Building", view.container);
 
-    expect(contextTreeMocks.initializeContextTree).toHaveBeenCalledWith("org-1");
+    // agentSeed default: no Cloud provisioning. The agent sets the tree up from
+    // its actual state, launched through the org-level tree-setup chat.
+    expect(contextTreeMocks.initializeContextTree).not.toHaveBeenCalled();
     expect(onboardingEventMocks.startOnboardingChat).not.toHaveBeenCalled();
     expect(onboardingEventMocks.treeSetupStartChat).toHaveBeenCalledTimes(1);
     expect(onboardingEventMocks.treeSetupStartChat).toHaveBeenCalledWith(
       expect.objectContaining({
         agentUuid: "agent-1",
-        bootstrap: expect.stringContaining("This chat sets up team context for future agent work."),
+        bootstrap: expect.stringContaining("Please build out our Context Tree from our connected code"),
         topic: "Set up shared context",
         complete: true,
       }),

--- a/packages/web/src/pages/context-tree-build-entry.tsx
+++ b/packages/web/src/pages/context-tree-build-entry.tsx
@@ -33,9 +33,11 @@ const INSTALL_OWNER_HINT = {
 
 /**
  * The team's single "build your Context Tree" action, on the Context tab.
- * Building is one chat-driven flow: connect code (if needed) → provision or
- * reuse the binding → start the `tree` agent chat that seeds/updates it. This
- * replaced the standalone `/build-tree` wizard page — there is one build home.
+ * Building is one chat-driven flow: connect code (if needed) → start the tree
+ * setup chat, where the agent (first-tree-seed) sets the tree up from its actual
+ * state — creating + binding it from zero, or filling a bound-but-empty tree. No
+ * server-side provisioning. This replaced the standalone `/build-tree` wizard
+ * page — there is one build home.
  *
  * When no code is connected yet, the connect + repo pick happens INLINE here
  * (install the GitHub App, then choose from the repos it grants) instead of
@@ -47,7 +49,7 @@ const INSTALL_OWNER_HINT = {
  * breach the Context tab's read-only-perception boundary.
  */
 export function ContextTreeBuildEntry({
-  treeBindingPlan = "createBinding",
+  treeBindingPlan = "agentSeed",
   detectedTreeUrl = null,
 }: {
   treeBindingPlan?: TreeBindingPlan;
@@ -101,9 +103,9 @@ export function ContextTreeBuildEntry({
     setError(null);
     setPhase("building");
     try {
-      // New-tree setup registers the chosen repos before Cloud one-click creates
-      // the binding; a bound-tree recovery passes no repos and only re-sends the
-      // idempotent tree setup chat.
+      // New-tree setup registers the chosen repos, then the agent sets the tree
+      // up (create + bind + seed) in the chat; a bound-tree recovery passes no
+      // repos and only re-sends the idempotent tree setup chat.
       if (sourceRepos.length > 0) await ensureStartChatRepos(organizationId, sourceRepos);
       const chatId = await startTreeSetupChat({
         agent: chosenAgent,

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -675,7 +675,7 @@ function UnavailableState({
             {canInitialize ? (
               <div style={{ marginTop: "var(--sp-3)" }}>
                 <ContextTreeBuildEntry
-                  treeBindingPlan={snapshot.repo ? "useBoundTree" : "createBinding"}
+                  treeBindingPlan={snapshot.repo ? "useBoundTree" : "agentSeed"}
                   detectedTreeUrl={snapshot.repo}
                 />
               </div>

--- a/packages/web/src/pages/onboarding/onboarding-flow.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-flow.tsx
@@ -24,7 +24,16 @@ import {
   type StepId,
 } from "./steps.js";
 
-export type TreeBindingPlan = "createBinding" | "useBoundTree";
+/**
+ * How the tree-setup chat's Context Tree gets set up:
+ * - `agentSeed` — DEFAULT for the Context-tab build CTA. No server-side
+ *   provisioning; the agent (first-tree-seed) sets the tree up from its actual
+ *   state — creating + binding it from zero, or filling a bound-but-empty tree.
+ * - `useBoundTree` — the onboarding wizard's bound-tree path (fill/update).
+ * - `createBinding` — Cloud one-click provisions the binding first. Retained as
+ *   a fallback; no longer the default build path.
+ */
+export type TreeBindingPlan = "agentSeed" | "useBoundTree" | "createBinding";
 
 export type OnboardingFlowValue = {
   path: OnboardingPath;

--- a/packages/web/src/pages/onboarding/tree-setup-chat.ts
+++ b/packages/web/src/pages/onboarding/tree-setup-chat.ts
@@ -28,6 +28,10 @@ async function ensureTreeBindingForSetup(args: {
   treeBindingPlan: TreeBindingPlan;
   detectedTreeUrl: string | null;
 }): Promise<string | null> {
+  // Only `createBinding` provisions the tree server-side (Cloud one-click).
+  // `agentSeed` (the build CTA default) and `useBoundTree` skip provisioning —
+  // the agent sets the tree up — and here just resolve any existing binding URL
+  // to pass as a hint; the agent (first-tree-seed) re-checks the real state.
   if (args.treeBindingPlan === "createBinding") {
     await provisionNewTree(args.organizationId);
   }

--- a/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
@@ -105,6 +105,38 @@ describe("start-chat bootstrap prose", () => {
     expect(message).not.toContain("ask me which owner");
   });
 
+  it("builds agent-seed tree setup as visible user-voice text with no skill name", () => {
+    const message = buildTreeSetupBootstrap(["https://github.com/acme/web", "https://github.com/acme/api"], {
+      treeBindingPlan: "agentSeed",
+      treeUrl: null,
+    });
+
+    expect(message).toContain("Let's set up our team's shared context.");
+    expect(message).toContain("Please build out our Context Tree from our connected code");
+    expect(message).toContain("propose an initial structure for me to review");
+    expect(message).toContain("Connected code:");
+    expect(message).toContain("- https://github.com/acme/web");
+    expect(message).toContain("- https://github.com/acme/api");
+    // Visible user-voice task text — no skill names or operational directives.
+    expect(message).not.toContain("first-tree-seed");
+    expect(message).not.toContain("first-tree-read");
+    expect(message).not.toContain("first-tree-write");
+    expect(message).not.toContain("Operational note");
+    // No binding yet → no Context Tree hint line.
+    expect(message).not.toContain("Context Tree:");
+  });
+
+  it("includes the tree URL as a hint for agent-seed setup when a binding already exists", () => {
+    const message = buildTreeSetupBootstrap(["https://github.com/acme/web"], {
+      treeBindingPlan: "agentSeed",
+      treeUrl: "https://github.com/acme/context",
+    });
+
+    expect(message).toContain("Please build out our Context Tree from our connected code");
+    expect(message).toContain("Context Tree: https://github.com/acme/context");
+    expect(message).not.toContain("first-tree-seed");
+  });
+
   it("builds a value-first joining-teammate welcome without a raw tree URL or jargon", () => {
     const message = buildInviteeReadyBootstrap("Nova");
 

--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -13,7 +13,7 @@
  * needs the same prompts, hoist these builders to `packages/shared`.
  */
 
-export type TreeSetupBootstrapPlan = "createBinding" | "useBoundTree";
+export type TreeSetupBootstrapPlan = "agentSeed" | "useBoundTree" | "createBinding";
 
 function formatSourceList(sourceUrls: readonly string[], heading: string): string[] {
   return [heading, ...sourceUrls.map((u) => `- ${u}`)];
@@ -44,6 +44,21 @@ export function buildTreeSetupBootstrap(
   sourceUrls: readonly string[],
   opts: { treeBindingPlan: TreeSetupBootstrapPlan; treeUrl: string | null },
 ): string {
+  if (opts.treeBindingPlan === "agentSeed") {
+    // Visible, user-voice task text (onboarding kickoff contract: no skill names
+    // / hidden directives). The agent reaches first-tree-seed from the tree-less
+    // family map + skill descriptions, and seed adapts to the tree's ACTUAL state
+    // — creating + binding it from zero, or filling a bound-but-empty tree. The
+    // tree URL is included only as a hint when a binding already exists.
+    return [
+      "Let's set up our team's shared context.",
+      "",
+      "Please build out our Context Tree from our connected code — propose an initial structure for me to review, then fill it in.",
+      "",
+      ...formatSourceList(sourceUrls, "Connected code:"),
+      ...(opts.treeUrl ? ["", `Context Tree: ${opts.treeUrl}`] : []),
+    ].join("\n");
+  }
   const sourceLines = formatSourceList(sourceUrls, "Source code:");
   const treeLine = `Context Tree: ${opts.treeUrl ?? "resolved by First Tree Cloud"}`;
   return [


### PR DESCRIPTION
## What

The **"Build your Context Tree"** CTA on the Context tab converges to agent-seed.
It no longer provisions a binding via Cloud one-click. It starts the org-level
tree-setup chat (**no server-side provisioning**), where the agent
(`first-tree-seed`) sets the tree up **from its actual state** — creating +
binding it from zero, or filling a bound-but-empty tree. `createBinding` (Cloud
provisioning) is retained as a fallback but is no longer the default build path.

## Stacked on #1410 (onboarding kickoff contract)

This is stacked on #1410, which provides the two things agent-seed needs:

1. **Org-level idempotency** — tree-setup kicks off through
   `postTreeSetupStartChat`, keyed `${org}:tree-setup`. A second admin (or the
   same admin with a different agent) clicking Build converges on the **same**
   chat, so the unbound window can't spawn duplicate create/bind/seed runs.
2. **Visible-task-text contract** — the first message is visible user-facing
   task text via task `createChat`, with no hidden directive. So the bootstrap
   carries **no skill name**; the agent reaches `first-tree-seed` from the
   tree-less family map + skill descriptions.

These resolve the two findings from the earlier main-cut review (duplicate-create
idempotency + visible skill directive).

## Design: seed is the flexible executor

The setup message describes the goal in plain user voice and delegates state
handling to seed, whose Step 0 already adapts:

- **no tree** → `tree init` creates + binds the repo, then seeds it;
- **bound but empty** → skips creation, fills it;
- **already has structure** → refuses (that's `first-tree-write`).

So one setup flow covers "no tree → create" and "has tree → fill" without the web
hard-coding a from-zero special case. The tree URL is passed only as a hint when
a binding already exists.

## Changes (web-only)

- `TreeBindingPlan` / `TreeSetupBootstrapPlan` gain `agentSeed`
- `ensureTreeBindingForSetup` provisions only for `createBinding`; `agentSeed` +
  `useBoundTree` skip provisioning and resolve any existing binding URL as a hint
- `buildTreeSetupBootstrap` emits a general, no-skill-name setup message
- the Context-tab CTA defaults to `agentSeed`

Skill-side tuning (seed description / family-map wording) is handled separately;
this PR is web-only and relies on the existing build→seed routing.

## Tests / gates

- New `agentSeed` bootstrap unit tests (visible user-voice, no skill name; URL
  hint only when bound); the Context-entry build test now asserts **no**
  provisioning and the general setup message via the org-level tree-setup chat
- Full `@first-tree/web` suite green (1084); biome, typecheck, lint:tokens clean

## Verification

Runtime E2E after #1410 + this land: two admins clicking Build converge to one
tree-setup chat (org key); the agent reaches `first-tree-seed` from the visible
message + family map (not welcome); seed's `tree init` creates + binds the repo,
then fills it — the Context tab's "no tree" state clears.
