### PR TITLE
feat(cli): show tree branch

### DIFF
--- a/apps/cli/src/__tests__/tree-tree-command.test.ts
+++ b/apps/cli/src/__tests__/tree-tree-command.test.ts
@@ -19,6 +19,14 @@ function makeTempDir(prefix: string): string {
   return dir;
 }
 
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
 function frontmatter(fields: string): string {
   return `---\n${fields}---\n`;
 }
@@ -56,7 +64,6 @@ function makeTreeFixture(): string {
   mkdirSync(missingOwners, { recursive: true });
   mkdirSync(emptyOwners, { recursive: true });
   mkdirSync(scratch, { recursive: true });
-  mkdirSync(join(root, ".git"), { recursive: true });
 
   writeNode(root, "Root Node", "Root description");
   writeNode(docs, "Docs", "Documentation");
@@ -85,6 +92,12 @@ function makeTreeFixture(): string {
     writeNode(ignored, "Should Skip Generated", "Generated");
     writeLeaf(join(ignored, "ignored.md"), "Should Skip Leaf", "Generated");
   }
+
+  git(root, "init", "-b", "main");
+  git(root, "config", "user.email", "agent@example.com");
+  git(root, "config", "user.name", "Agent");
+  git(root, "add", ".");
+  git(root, "commit", "-m", "seed tree");
 
   return root;
 }
@@ -243,6 +256,7 @@ describe("tree tree command action", () => {
     expect(readMockOutput(stdout)).toBe("");
     expect(readMockOutput(stderr)).toBe(
       `${[
+        "Branch: main",
         "knowledge/ [Root Node] -> Root description",
         "└── docs/ [Docs] -> Documentation",
         "    └── docs/development/ [Development]",
@@ -252,6 +266,38 @@ describe("tree tree command action", () => {
       ].join("\n")}\n`,
     );
     expect(process.exitCode).toBeUndefined();
+  });
+
+  it("does not warn for origin/main as a mainline branch", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    git(root, "switch", "-c", "origin/main");
+    process.chdir(root);
+
+    runTreeTreeCommand(context(commandWithOptions({}, ["docs/development"])));
+
+    const output = readMockOutput(stderr);
+    expect(readMockOutput(stdout)).toBe("");
+    expect(output).toContain("Branch: origin/main");
+    expect(output).not.toContain("Warning: current branch");
+  });
+
+  it("warns when the current tree branch is not mainline", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    git(root, "switch", "-c", "feature/stale-tree");
+    process.chdir(root);
+
+    runTreeTreeCommand(context(commandWithOptions({}, ["docs/development"])));
+
+    const output = readMockOutput(stderr);
+    expect(readMockOutput(stdout)).toBe("");
+    expect(output).toContain("Branch: feature/stale-tree");
+    expect(output).toContain(
+      'Warning: current branch "feature/stale-tree" is not main/master; it may be stale. Switch to main/master.',
+    );
   });
 
   it("treats a non-numeric -L value as a path only when no positional path is present", () => {
@@ -278,6 +324,7 @@ describe("tree tree command action", () => {
     expect(readMockOutput(stdout)).toBe("");
     expect(readMockOutput(stderr)).toBe(
       `${[
+        "Branch: main",
         "knowledge/ [Root Node] -> Root description",
         "└── docs/ [Docs] -> Documentation",
         "    └── docs/development/ [Development]",
@@ -310,6 +357,11 @@ describe("tree tree command action", () => {
           level: 1,
           pattern: "HTTP*",
           path: "docs/development",
+        },
+        branch: {
+          name: "main",
+          isMainline: true,
+          warning: null,
         },
         tree: {
           kind: "directory",
@@ -369,6 +421,29 @@ describe("tree tree command action", () => {
     ]);
   });
 
+  it("includes non-mainline branch details in JSON without human stderr", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    git(root, "switch", "-c", "feature/stale-tree");
+    process.chdir(root);
+
+    runTreeTreeCommand(context(commandWithOptions({}, ["docs/development"]), { json: true }));
+
+    expect(readMockOutput(stderr)).toBe("");
+    expect(JSON.parse(readMockOutput(stdout))).toMatchObject({
+      ok: true,
+      data: {
+        branch: {
+          name: "feature/stale-tree",
+          isMainline: false,
+          warning:
+            'Warning: current branch "feature/stale-tree" is not main/master; it may be stale. Switch to main/master.',
+        },
+      },
+    });
+  });
+
   it("prints JSON when the global Print layer is already in JSON mode", () => {
     const root = makeTreeFixture();
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
@@ -389,6 +464,11 @@ describe("tree tree command action", () => {
         options: {
           level: 0,
           path: "docs/development",
+        },
+        branch: {
+          name: "main",
+          isMainline: true,
+          warning: null,
         },
         tree: {
           name: "knowledge",
@@ -507,10 +587,6 @@ describe("tree tree command action", () => {
 });
 
 describe("tree tree pull refresh", () => {
-  function git(cwd: string, ...args: string[]): void {
-    execFileSync("git", args, { cwd, stdio: "ignore" });
-  }
-
   // A real origin (bare) + a regular working-tree clone tracking it, so a
   // `git pull --ff-only` against the clone genuinely advances the working
   // tree. Mirrors the production tree model: the agent maintains a regular

--- a/apps/cli/src/__tests__/tree-tree-command.test.ts
+++ b/apps/cli/src/__tests__/tree-tree-command.test.ts
@@ -102,6 +102,20 @@ function makeTreeFixture(): string {
   return root;
 }
 
+function makeRemoteBackedTreeFixture(): { clone: string; seed: string } {
+  const seed = makeTreeFixture();
+  const base = makeTempDir("ft-tree-remote-");
+  const origin = join(base, "origin.git");
+  const clone = join(base, "clone");
+
+  execFileSync("git", ["init", "--bare", "-b", "main", origin], { stdio: "ignore" });
+  git(seed, "remote", "add", "origin", origin);
+  git(seed, "push", "-u", "origin", "main");
+  execFileSync("git", ["clone", origin, clone], { stdio: "ignore" });
+
+  return { clone, seed };
+}
+
 function commandWithOptions(options: Record<string, unknown>, args: string[] = []): Command {
   const command = new Command("test");
   command.args = args;
@@ -268,12 +282,12 @@ describe("tree tree command action", () => {
     expect(process.exitCode).toBeUndefined();
   });
 
-  it("does not warn for origin/main as a mainline branch", () => {
-    const root = makeTreeFixture();
+  it("does not warn for a detached origin/main checkout", () => {
+    const { clone } = makeRemoteBackedTreeFixture();
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    git(root, "switch", "-c", "origin/main");
-    process.chdir(root);
+    git(clone, "checkout", "origin/main");
+    process.chdir(clone);
 
     runTreeTreeCommand(context(commandWithOptions({}, ["docs/development"])));
 
@@ -281,6 +295,30 @@ describe("tree tree command action", () => {
     expect(readMockOutput(stdout)).toBe("");
     expect(output).toContain("Branch: origin/main");
     expect(output).not.toContain("Warning: current branch");
+  });
+
+  it("warns for detached commits that do not match origin/main", () => {
+    const { clone } = makeRemoteBackedTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    git(clone, "config", "user.email", "agent@example.com");
+    git(clone, "config", "user.name", "Agent");
+    writeLeaf(join(clone, "local-only.md"), "Local Only", "Detached commit");
+    git(clone, "add", ".");
+    git(clone, "commit", "-m", "local-only commit");
+    const shortSha = git(clone, "rev-parse", "--short", "HEAD");
+    git(clone, "checkout", "--detach", "HEAD");
+    process.chdir(clone);
+
+    runTreeTreeCommand(context(commandWithOptions({}, ["docs/development"])));
+
+    const output = readMockOutput(stderr);
+    const branchName = `detached:${shortSha}`;
+    expect(readMockOutput(stdout)).toBe("");
+    expect(output).toContain(`Branch: ${branchName}`);
+    expect(output).toContain(
+      `Warning: current branch "${branchName}" is not main/master; it may be stale. Switch to main/master.`,
+    );
   });
 
   it("warns when the current tree branch is not mainline", () => {
@@ -439,6 +477,28 @@ describe("tree tree command action", () => {
           isMainline: false,
           warning:
             'Warning: current branch "feature/stale-tree" is not main/master; it may be stale. Switch to main/master.',
+        },
+      },
+    });
+  });
+
+  it("reports a detached origin/main checkout as mainline in JSON", () => {
+    const { clone } = makeRemoteBackedTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    git(clone, "checkout", "origin/main");
+    process.chdir(clone);
+
+    runTreeTreeCommand(context(commandWithOptions({}, ["docs/development"]), { json: true }));
+
+    expect(readMockOutput(stderr)).toBe("");
+    expect(JSON.parse(readMockOutput(stdout))).toMatchObject({
+      ok: true,
+      data: {
+        branch: {
+          name: "origin/main",
+          isMainline: true,
+          warning: null,
         },
       },
     });

--- a/apps/cli/src/commands/tree/tree.ts
+++ b/apps/cli/src/commands/tree/tree.ts
@@ -45,6 +45,16 @@ export type ContextTreeSnapshot = {
   tree: ContextTreeNode;
 };
 
+type ContextTreeBranchInfo = {
+  name: string;
+  isMainline: boolean;
+  warning: string | null;
+};
+
+type ContextTreeCommandData = ContextTreeSnapshot & {
+  branch: ContextTreeBranchInfo;
+};
+
 type ParsedTreeTreeOptions = {
   level?: number;
   pattern?: string;
@@ -69,6 +79,7 @@ const SKIPPED_DIRECTORY_NAMES = new Set(["node_modules", "__pycache__", "dist", 
 const TREE_TREE_INVALID_LEVEL = "TREE_TREE_INVALID_LEVEL";
 const TREE_TREE_INVALID_PATH = "TREE_TREE_INVALID_PATH";
 const TREE_TREE_FAILED = "TREE_TREE_FAILED";
+const MAINLINE_BRANCHES = new Set(["main", "master", "origin/main"]);
 
 class TreeTreeCommandError extends Error {
   constructor(
@@ -489,6 +500,45 @@ function pullContextTreeRepo(root: string): void {
   }
 }
 
+function branchWarning(name: string): string {
+  return `Warning: current branch "${name}" is not main/master; it may be stale. Switch to main/master.`;
+}
+
+function readCurrentBranchName(root: string): string {
+  try {
+    const branch = runCommand("git", ["branch", "--show-current"], root);
+
+    if (branch.length > 0) {
+      return branch;
+    }
+  } catch {
+    return "unknown";
+  }
+
+  try {
+    const shortSha = runCommand("git", ["rev-parse", "--short", "HEAD"], root);
+
+    if (shortSha.length > 0) {
+      return `detached:${shortSha}`;
+    }
+  } catch {
+    return "unknown";
+  }
+
+  return "unknown";
+}
+
+function readContextTreeBranch(root: string): ContextTreeBranchInfo {
+  const name = readCurrentBranchName(root);
+  const isMainline = MAINLINE_BRANCHES.has(name);
+
+  return {
+    name,
+    isMainline,
+    warning: isMainline ? null : branchWarning(name),
+  };
+}
+
 function normalizeSnapshotOptions(options: ReadContextTreeSnapshotOptions): ReadContextTreeSnapshotOptions {
   const normalized: ReadContextTreeSnapshotOptions = {};
 
@@ -604,6 +654,17 @@ function renderContextTreeSnapshot(snapshot: ContextTreeSnapshot): string {
   return lines.join("\n");
 }
 
+function renderContextTreeCommandData(data: ContextTreeCommandData): string {
+  const lines = [`Branch: ${data.branch.name}`];
+
+  if (data.branch.warning !== null) {
+    lines.push(data.branch.warning);
+  }
+
+  lines.push(renderContextTreeSnapshot(data));
+  return lines.join("\n");
+}
+
 export function renderContextTree(root: string, options: RenderContextTreeOptions = {}): string {
   return renderContextTreeSnapshot(
     readContextTreeSnapshot(root, {
@@ -644,13 +705,17 @@ export function runTreeTreeCommand(context: CommandContext): void {
       path: parsedOptions.path,
       target: resolvedTarget.targetRelativePath,
     });
+    const data: ContextTreeCommandData = {
+      ...snapshot,
+      branch: readContextTreeBranch(resolvedTarget.repoRoot),
+    };
 
     if (context.options.json || isJsonMode()) {
-      print.result(snapshot);
+      print.result(data);
       return;
     }
 
-    print.line(`${renderContextTreeSnapshot(snapshot)}\n`);
+    print.line(`${renderContextTreeCommandData(data)}\n`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const code =

--- a/apps/cli/src/commands/tree/tree.ts
+++ b/apps/cli/src/commands/tree/tree.ts
@@ -516,6 +516,18 @@ function readCurrentBranchName(root: string): string {
   }
 
   try {
+    const head = runCommand("git", ["rev-parse", "--verify", "HEAD"], root);
+    const originMain = runCommand("git", ["rev-parse", "--verify", "refs/remotes/origin/main"], root);
+
+    if (head.length > 0 && head === originMain) {
+      return "origin/main";
+    }
+  } catch {
+    // Detached checkouts without an origin/main ref still fall through to the
+    // stable detached:<shortSha> label below.
+  }
+
+  try {
     const shortSha = runCommand("git", ["rev-parse", "--short", "HEAD"], root);
 
     if (shortSha.length > 0) {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -606,6 +606,8 @@ skipped.
 Human output starts with the Context Tree git checkout branch, then the
 rendered tree. When the current branch is not exactly `main`, `master`, or
 `origin/main`, the branch line is followed by a stale-tree warning:
+Detached HEAD checkouts whose commit matches `refs/remotes/origin/main` are
+reported as `origin/main`.
 
 ```text
 Branch: feature/stale-tree
@@ -635,8 +637,9 @@ git repo root, `data.target` is the resolved target directory relative to
 that root, and `data.options` records the parsed `level`, `pattern`, and
 effective `path`. `data.branch` reports the current tree checkout as
 `{ name, isMainline, warning }`; `warning` is `null` for `main`, `master`,
-and `origin/main`, otherwise it contains the same stale-tree warning string
-shown in human mode. `data.tree` contains the same filtered hierarchy as
+and `origin/main`, including detached HEAD checkouts that match
+`refs/remotes/origin/main`; otherwise it contains the same stale-tree warning
+string shown in human mode. `data.tree` contains the same filtered hierarchy as
 structured nodes with `kind`, `name`, `relativePath`, `depth`, `metadata`,
 `hasNode`, and `children` fields; `metadata` includes `title`, optional
 `description`, and `owners`. Human tree text and branch warnings are not

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -603,7 +603,16 @@ shown in human output. Hidden paths and common generated directories
 (`node_modules`, `__pycache__`, `dist`, `build`, `.next`, `.turbo`) are
 skipped.
 
-Human output is written as a tree whose node labels use:
+Human output starts with the Context Tree git checkout branch, then the
+rendered tree. When the current branch is not exactly `main`, `master`, or
+`origin/main`, the branch line is followed by a stale-tree warning:
+
+```text
+Branch: feature/stale-tree
+Warning: current branch "feature/stale-tree" is not main/master; it may be stale. Switch to main/master.
+```
+
+The rendered tree's node labels use:
 
 ```text
 relative/path/ [Title] -> Description
@@ -624,11 +633,15 @@ With global `--json` or `FIRST_TREE_JSON=1`, `first-tree tree tree`
 emits a single `{ ok: true, data }` envelope on stdout. `data.root` is the
 git repo root, `data.target` is the resolved target directory relative to
 that root, and `data.options` records the parsed `level`, `pattern`, and
-effective `path`. `data.tree` contains the same filtered hierarchy as
+effective `path`. `data.branch` reports the current tree checkout as
+`{ name, isMainline, warning }`; `warning` is `null` for `main`, `master`,
+and `origin/main`, otherwise it contains the same stale-tree warning string
+shown in human mode. `data.tree` contains the same filtered hierarchy as
 structured nodes with `kind`, `name`, `relativePath`, `depth`, `metadata`,
 `hasNode`, and `children` fields; `metadata` includes `title`, optional
-`description`, and `owners`. Human tree text is written to stderr so stdout
-stays reserved for machine-readable JSON.
+`description`, and `owners`. Human tree text and branch warnings are not
+written to stderr in JSON mode, so stdout stays reserved for machine-readable
+JSON.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary

- Show the current Context Tree checkout branch before `first-tree tree tree` human output.
- Warn when the branch is not exactly `main`, `master`, or `origin/main`.
- Add `data.branch` to JSON output and document the field.
- Cover mainline, stale branch, JSON, and pull-refresh behavior in tests.

## Tests

- `pnpm --filter first-tree-dev exec vitest run src/__tests__/tree-tree-command.test.ts`
- `pnpm check`
- `pnpm typecheck`
- `pnpm test` (fails outside this change: existing `login-command.test.ts` process.exit failures, `@first-tree/skill-evals` git commit/timeout failures, and `@first-tree/web` localStorage.clear failures)


## Paired tree PR

- https://github.com/agent-team-foundation/first-tree-context/pull/669
