### PR TITLE
fix(client): install first-tree-seed + first-tree-write as core skills

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -383,12 +383,14 @@ describe("buildAgentBriefing — # Required Reading (unconditional skill-load ma
     expect(contextTreeIdx).toBeGreaterThan(requiredIdx);
   });
 
-  it("omits # Required Reading for tree-less agents (the skill payloads are not installed on disk for them)", () => {
-    // `installFirstTreeIntegration` is short-circuited when
-    // `contextTreePath === null`, so the SKILL.md payloads under
-    // `<workspace>/.agents/skills/` never get materialised. Mandating
-    // a load would point at files that aren't there. The Tree
-    // Location stub already surfaces the gap to a human.
+  it("omits # Required Reading for tree-less agents (tree-oriented guidance is gated on a binding)", () => {
+    // The `# Required Reading` mandate + family map are gated on
+    // `contextTreePath !== null` — Context-Tree-oriented guidance surfaced
+    // only once the agent is tree-bound. (Since seed/write are core, their
+    // payloads DO exist on disk in tree-less workspaces; the gate is a
+    // scoping choice, not a missing-file guard. Tree-less build-tree chats
+    // reach write's rules via `first-tree-seed`'s own reference to it.)
+    // The Tree Location stub already surfaces the no-tree state to a human.
     const briefing = buildAgentBriefing(makeOpts({ contextTreePath: null }));
     expect(briefing).not.toContain("# Required Reading");
   });

--- a/packages/client/src/__tests__/bootstrap.test.ts
+++ b/packages/client/src/__tests__/bootstrap.test.ts
@@ -358,8 +358,14 @@ function makeFixtureSkillsRoot(
   return root;
 }
 
-describe("installFirstTreeIntegration (inline skill installer)", () => {
-  const TREE_SKILLS = ["first-tree-write", "first-tree-read", "first-tree-seed"];
+// Exercises the shared inline installer engine (fast-path skip, VERSION
+// drift, SKILL.md content drift, missing-VERSION reinstall, clobbered-symlink
+// repair, partial-failure) across a MULTI-skill set. Driven through
+// installCoreSkills because core now ships three skills (welcome/seed/write);
+// the tree path (installFirstTreeIntegration) ships only first-tree-read and is
+// covered separately below.
+describe("inline skill installer engine (installCoreSkills, multi-skill)", () => {
+  const CORE_SKILLS = ["first-tree-welcome", "first-tree-seed", "first-tree-write"];
 
   function expectSkillInstalled(workspace: string, name: string): void {
     const agentsDir = join(workspace, ".agents", "skills", name);
@@ -377,19 +383,19 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     mkdirSync(workspace, { recursive: true });
     const bundledSkillsRoot = makeFixtureSkillsRoot(
       "happy",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot,
       log: (m) => logs.push(m),
     });
 
     expect(result, logs.join("\n")).toBe(true);
-    for (const name of TREE_SKILLS) expectSkillInstalled(workspace, name);
-    expect(logs.join("\n")).toContain("installed first-tree-write");
+    for (const name of CORE_SKILLS) expectSkillInstalled(workspace, name);
+    expect(logs.join("\n")).toContain("installed first-tree-welcome, first-tree-seed, first-tree-write");
   });
 
   it("skips skills whose on-disk VERSION + SKILL.md content both match bundled (fast path)", () => {
@@ -397,11 +403,11 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     mkdirSync(workspace, { recursive: true });
     const bundledSkillsRoot = makeFixtureSkillsRoot(
       "skip",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
 
     // First install populates the workspace.
-    installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
 
     // Drop a non-content marker into each installed skill so we can detect
     // whether the second install ran a full rm+cp (which wipes the marker)
@@ -409,19 +415,19 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // file is important — touching SKILL.md would itself trigger the
     // content-drift defense and force a reinstall, which is what the
     // separate "content drift" test below covers.
-    for (const name of TREE_SKILLS) {
+    for (const name of CORE_SKILLS) {
       writeFileSync(join(workspace, ".agents", "skills", name, ".sentinel"), "marker\n");
     }
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot,
       log: (m) => logs.push(m),
     });
 
     expect(result, logs.join("\n")).toBe(true);
-    for (const name of TREE_SKILLS) {
+    for (const name of CORE_SKILLS) {
       expect(
         existsSync(join(workspace, ".agents", "skills", name, ".sentinel")),
         `${name} should have been skipped`,
@@ -435,24 +441,24 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     mkdirSync(workspace, { recursive: true });
     const bundledV1 = makeFixtureSkillsRoot(
       "drift-v1",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
-    installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot: bundledV1, log: () => {} });
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot: bundledV1, log: () => {} });
 
     // Marker file (NOT SKILL.md) detects which skills got re-copied.
-    for (const name of TREE_SKILLS) {
+    for (const name of CORE_SKILLS) {
       writeFileSync(join(workspace, ".agents", "skills", name, ".sentinel"), "marker\n");
     }
 
     // New bundled root: bump only first-tree-write to 2.0.0; the rest stay at 1.0.0.
     const bundledMixed = makeFixtureSkillsRoot("drift-mixed", [
       { name: "first-tree-write", version: "2.0.0" },
-      { name: "first-tree-read", version: "1.0.0" },
+      { name: "first-tree-welcome", version: "1.0.0" },
       { name: "first-tree-seed", version: "1.0.0" },
     ]);
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot: bundledMixed,
       log: (m) => logs.push(m),
@@ -463,7 +469,7 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     expect(existsSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"))).toBe(false);
 
     // Others should have been skipped (marker preserved).
-    for (const name of TREE_SKILLS.filter((n) => n !== "first-tree-write")) {
+    for (const name of CORE_SKILLS.filter((n) => n !== "first-tree-write")) {
       expect(
         existsSync(join(workspace, ".agents", "skills", name, ".sentinel")),
         `${name} should have been skipped`,
@@ -477,11 +483,11 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
   it("returns false when a bundled skill source is missing", () => {
     const workspace = join(tmpBase, "integrate-missing");
     mkdirSync(workspace, { recursive: true });
-    // Bundled root has only first-tree-write; the other tree skills are missing.
+    // Bundled root has only first-tree-write; the other core skills are missing.
     const bundledSkillsRoot = makeFixtureSkillsRoot("missing", [{ name: "first-tree-write", version: "1.0.0" }]);
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot,
       log: (m) => logs.push(m),
@@ -490,9 +496,9 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     expect(result).toBe(false);
     // first-tree-write installs successfully, the others fail.
     expectSkillInstalled(workspace, "first-tree-write");
-    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-read"))).toBe(false);
-    expect(logs.join("\n")).toContain("failed first-tree-read, first-tree-seed");
-    expect(logs.join("\n")).toContain("First-tree skill install failed (first-tree-read)");
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-welcome"))).toBe(false);
+    expect(logs.join("\n")).toContain("failed first-tree-welcome, first-tree-seed");
+    expect(logs.join("\n")).toContain("Core skill install failed (first-tree-welcome)");
   });
 
   it("repairs a clobbered .claude symlink without re-copying the .agents tree", () => {
@@ -500,10 +506,10 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     mkdirSync(workspace, { recursive: true });
     const bundledSkillsRoot = makeFixtureSkillsRoot(
       "relink",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
 
-    installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
 
     // Operator clobbered .claude/skills/first-tree-write with a regular file.
     // rmSync without `recursive` follows symlink-to-directory on macOS
@@ -518,7 +524,7 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // SKILL.md drift as a reinstall trigger).
     writeFileSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"), "marker\n");
 
-    const result = installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
+    const result = installCoreSkills({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
     expect(result).toBe(true);
     // Symlink was repaired.
     expectSkillInstalled(workspace, "first-tree-write");
@@ -537,10 +543,10 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     mkdirSync(workspace, { recursive: true });
     const bundledSkillsRoot = makeFixtureSkillsRoot(
       "content-drift",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
 
-    installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
 
     // Simulate "developer edited SKILL.md on disk but VERSION never
     // changed" — same VERSION on both sides, but the installed
@@ -549,7 +555,7 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     writeFileSync(installedSkillPath, "STALE_CONTENT\n");
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot,
       log: (m) => logs.push(m),
@@ -574,9 +580,9 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // First install: bundled has VERSION.
     const bundledWith = makeFixtureSkillsRoot(
       "missing-version-with",
-      TREE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
+      CORE_SKILLS.map((n) => ({ name: n, version: "1.0.0" })),
     );
-    installFirstTreeIntegration({ workspacePath: workspace, bundledSkillsRoot: bundledWith, log: () => {} });
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot: bundledWith, log: () => {} });
 
     // Drop sentinel into installed skill so we can detect re-copy.
     writeFileSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"), "marker\n");
@@ -584,11 +590,11 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // Second install: bundled root has NO VERSION file for any skill.
     const bundledWithout = makeFixtureSkillsRoot(
       "missing-version-without",
-      TREE_SKILLS.map((n) => ({ name: n })),
+      CORE_SKILLS.map((n) => ({ name: n })),
     );
 
     const logs: string[] = [];
-    const result = installFirstTreeIntegration({
+    const result = installCoreSkills({
       workspacePath: workspace,
       bundledSkillsRoot: bundledWithout,
       log: (m) => logs.push(m),
@@ -598,7 +604,52 @@ describe("installFirstTreeIntegration (inline skill installer)", () => {
     // Sentinel gone — full reinstall ran because the fingerprint match
     // could not be proven.
     expect(existsSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"))).toBe(false);
-    expect(logs.join("\n")).toContain("installed first-tree-write");
+    expect(logs.join("\n")).toContain("installed first-tree-welcome");
+  });
+});
+
+describe("installFirstTreeIntegration (tree-only skills)", () => {
+  it("installs the tree-only skill (first-tree-read) and reports via its own log prefix", () => {
+    const workspace = join(tmpBase, "tree-only-happy");
+    mkdirSync(workspace, { recursive: true });
+    const bundledSkillsRoot = makeFixtureSkillsRoot("tree-only", [{ name: "first-tree-read", version: "1.0.0" }]);
+
+    const logs: string[] = [];
+    const result = installFirstTreeIntegration({
+      workspacePath: workspace,
+      bundledSkillsRoot,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result, logs.join("\n")).toBe(true);
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-read", "SKILL.md"))).toBe(true);
+    expect(readlinkSync(join(workspace, ".claude", "skills", "first-tree-read"))).toBe(
+      `../../${join(".agents", "skills", "first-tree-read")}`,
+    );
+    // seed/write are core — the tree path must NOT install them.
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-seed"))).toBe(false);
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-write"))).toBe(false);
+    expect(logs.join("\n")).toContain("First-tree skills: installed first-tree-read");
+  });
+
+  it("returns false and logs the tree-only per-skill failure when first-tree-read is missing", () => {
+    const workspace = join(tmpBase, "tree-only-missing");
+    mkdirSync(workspace, { recursive: true });
+    // Bundled root has no tree skill at all — first-tree-read cannot be copied.
+    const bundledSkillsRoot = makeFixtureSkillsRoot("tree-only-missing", [
+      { name: "first-tree-welcome", version: "1.0.0" },
+    ]);
+
+    const logs: string[] = [];
+    const result = installFirstTreeIntegration({
+      workspacePath: workspace,
+      bundledSkillsRoot,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result).toBe(false);
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-read"))).toBe(false);
+    expect(logs.join("\n")).toContain("First-tree skill install failed (first-tree-read)");
   });
 });
 
@@ -606,7 +657,11 @@ describe("installCoreSkills", () => {
   it("installs core skills even without a Context Tree binding", () => {
     const workspace = join(tmpBase, "core-skills");
     mkdirSync(workspace, { recursive: true });
-    const bundledSkillsRoot = makeFixtureSkillsRoot("core-skills", [{ name: "first-tree-welcome", version: "1.0.0" }]);
+    const bundledSkillsRoot = makeFixtureSkillsRoot("core-skills", [
+      { name: "first-tree-welcome", version: "1.0.0" },
+      { name: "first-tree-seed", version: "1.0.0" },
+      { name: "first-tree-write", version: "1.0.0" },
+    ]);
 
     const logs: string[] = [];
     const result = installCoreSkills({
@@ -616,10 +671,13 @@ describe("installCoreSkills", () => {
     });
 
     expect(result).toBe(true);
-    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-welcome", "SKILL.md"))).toBe(true);
-    expect(readlinkSync(join(workspace, ".claude", "skills", "first-tree-welcome"))).toBe(
-      `../../${join(".agents", "skills", "first-tree-welcome")}`,
-    );
+    // All three core skills land without a Context Tree binding — seed/write
+    // must be present so the tree-less build-tree chat can run first-tree-seed
+    // (which loads first-tree-write by reference).
+    for (const name of ["first-tree-welcome", "first-tree-seed", "first-tree-write"]) {
+      expect(existsSync(join(workspace, ".agents", "skills", name, "SKILL.md")), `${name} installed`).toBe(true);
+      expect(readlinkSync(join(workspace, ".claude", "skills", name))).toBe(`../../${join(".agents", "skills", name)}`);
+    }
     expect(logs.join("\n")).toContain("installed first-tree-welcome");
   });
 
@@ -640,6 +698,8 @@ describe("installCoreSkills", () => {
     );
     const bundledSkillsRoot = makeFixtureSkillsRoot("core-skills-retired", [
       { name: "first-tree-welcome", version: "1.0.0" },
+      { name: "first-tree-seed", version: "1.0.0" },
+      { name: "first-tree-write", version: "1.0.0" },
     ]);
 
     const result = installCoreSkills({
@@ -800,7 +860,9 @@ describe("deepEqualIdentity", () => {
  * giving it a complete vs incomplete bundled-skills layout.
  */
 describe("CLI-version pin contract (handler invariants)", () => {
-  const TREE_SKILLS = ["first-tree-write", "first-tree-read", "first-tree-seed"];
+  // Tree-only skill set (see TREE_SKILL_NAMES) — what installFirstTreeIntegration
+  // actually installs. seed/write are core and installed separately.
+  const TREE_SKILLS = ["first-tree-read"];
 
   it("does not overwrite the existing pin when integrate fails — next start retries", () => {
     const workspace = join(tmpBase, "cli-pin-failure-keeps-stale");
@@ -811,9 +873,9 @@ describe("CLI-version pin contract (handler invariants)", () => {
     const stalePinPath = join(workspace, BUNDLED_CLI_VERSION_REL);
     expect(readFileSync(stalePinPath, "utf-8")).toBe("0.5.2");
 
-    // Force failure: bundled root has only first-tree-write, the other
-    // tree skills are missing, so installFirstTreeIntegration returns false.
-    const incomplete = makeFixtureSkillsRoot("pin-fail", [{ name: "first-tree-write", version: "1.0.0" }]);
+    // Force failure: bundled root is missing the tree skill (first-tree-read),
+    // so installFirstTreeIntegration returns false.
+    const incomplete = makeFixtureSkillsRoot("pin-fail", [{ name: "first-tree-welcome", version: "1.0.0" }]);
     const ok = installFirstTreeIntegration({
       workspacePath: workspace,
       bundledSkillsRoot: incomplete,

--- a/packages/client/src/__tests__/skills-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/skills-state-reconcile.test.ts
@@ -13,7 +13,7 @@ import { existsSync, lstatSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, wri
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { installFirstTreeSkills, TREE_SKILL_NAMES } from "../runtime/first-tree-skills/installer.js";
+import { CORE_SKILL_NAMES, installFirstTreeSkills, TREE_SKILL_NAMES } from "../runtime/first-tree-skills/installer.js";
 import { readManagedState, writeManagedState } from "../runtime/managed-state.js";
 
 /**
@@ -109,9 +109,32 @@ describe("installFirstTreeSkills — state-based skill reconcile (PR #869 P1-3)"
       expect(existsSync(join(workspace, ".agents", "skills", name))).toBe(false);
       expect(() => lstatSync(join(workspace, ".claude", "skills", name))).toThrow();
     }
-    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-write", "SKILL.md"))).toBe(true);
-    expect(lstatSync(join(workspace, ".claude", "skills", "first-tree-write")).isSymbolicLink()).toBe(true);
+    // A current tree skill survives the reconcile (first-tree-read is the sole
+    // TREE_SKILL_NAMES member; seed/write are core, covered separately below).
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-read", "SKILL.md"))).toBe(true);
+    expect(lstatSync(join(workspace, ".claude", "skills", "first-tree-read")).isSymbolicLink()).toBe(true);
     expect(readManagedState(workspace)?.skills).toEqual([...TREE_SKILL_NAMES].sort());
+  });
+
+  it("does NOT remove a core skill listed in prev state but absent from TREE_SKILL_NAMES", () => {
+    // Regression for the seed/write → core promotion. A previously tree-bound
+    // agent's managed.json still lists first-tree-seed / first-tree-write under
+    // the old TREE tier. installCoreSkills installs them first; the tree
+    // reconcile MUST NOT delete them just because they left TREE_SKILL_NAMES.
+    for (const name of CORE_SKILL_NAMES) plantManagedSkill(workspace, name);
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      skills: [...TREE_SKILL_NAMES, ...CORE_SKILL_NAMES],
+    });
+
+    installFirstTreeSkills({ workspacePath: workspace, bundledSkillsRoot });
+
+    for (const name of CORE_SKILL_NAMES) {
+      expect(existsSync(join(workspace, ".agents", "skills", name, "SKILL.md")), `${name} must survive`).toBe(true);
+      expect(lstatSync(join(workspace, ".claude", "skills", name)).isSymbolicLink()).toBe(true);
+    }
   });
 
   it("leaves a user-added skill alone — only names in the recorded prev state are removed", () => {

--- a/packages/client/src/__tests__/workspace-migrations.test.ts
+++ b/packages/client/src/__tests__/workspace-migrations.test.ts
@@ -207,7 +207,7 @@ describe("workspace-migrations registry", () => {
     // Plant a currently-bundled skill alongside one of the legacy names.
     // The current skill must survive; the legacy one must go.
     mkdirSync(join(workspace, ".claude", "skills"), { recursive: true });
-    const currentName = "first-tree-write"; // still in TREE_SKILL_NAMES
+    const currentName = "first-tree-write"; // still a currently-bundled skill (now core)
     const legacyName = "first-tree-cloud"; // retired
     for (const name of [currentName, legacyName]) {
       const agentsDir = join(workspace, ".agents", "skills", name);

--- a/packages/client/src/runtime/agent-bootstrap.ts
+++ b/packages/client/src/runtime/agent-bootstrap.ts
@@ -190,12 +190,13 @@ export function ensureAgentBootstrap(params: AgentBootstrapParams): void {
 
   // Only pin the CLI version when integration ACTUALLY RAN and succeeded —
   // i.e. the agent is tree-bound. A tree-less session skips
-  // `installFirstTreeIntegration` (so no skills land) but `integrationOk` stays
-  // `true`; pinning here would set `cachedCliVersion` non-null, which then
-  // defeats the `integrationNeverPinned` trigger when the agent later becomes
-  // tree-bound (new-tree onboarding) — `ensureAgentBootstrap` would take the
-  // fast path and never install `first-tree-seed`. Gating on `contextTreePath`
-  // keeps the upgrade path's slow-bootstrap trigger intact.
+  // `installFirstTreeIntegration` (so no tree-only skills land — core skills,
+  // including `first-tree-seed`, are installed separately above) but
+  // `integrationOk` stays `true`; pinning here would set `cachedCliVersion`
+  // non-null, which then defeats the `integrationNeverPinned` trigger when the
+  // agent later becomes tree-bound (new-tree onboarding) — `ensureAgentBootstrap`
+  // would take the fast path and never install `first-tree-read`. Gating on
+  // `contextTreePath` keeps the upgrade path's slow-bootstrap trigger intact.
   if (contextTreePath !== null && integrationOk) {
     writeBundledCliVersion(workspace, currentCliVersion);
   }

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -146,11 +146,15 @@ function buildAgentBriefingRenderModel(opts: BuildAgentBriefingOptions): AgentBr
   // before doing any real work. Placing it
   // immediately before `# Context Tree` also keeps the mandate adjacent
   // to the content domains the two skills cover. Gated on
-  // `contextTreePath !== null` for the same reason `skillsSection`
-  // gates `firstTreeFamilyMap`: a tree-less agent has no First Tree
-  // skill payloads installed on disk (`installFirstTreeIntegration`
-  // is short-circuited in `agent-bootstrap.ts`), so mandating a load
-  // would point at files that don't exist.
+  // `contextTreePath !== null`, mirroring `skillsSection`'s
+  // `firstTreeFamilyMap` gate: the mandate + family map are
+  // Context-Tree-oriented guidance, surfaced only once the agent is
+  // tree-bound. NOTE: since seed/write were promoted to
+  // `CORE_SKILL_NAMES`, the `first-tree-write` payload IS on disk even in
+  // tree-less workspaces — so the old "would point at files that don't
+  // exist" rationale no longer holds; the gate is now a scoping choice.
+  // Tree-less build-tree chats still reach write's Hard Rules because
+  // `first-tree-seed` loads `../first-tree-write/SKILL.md` by reference.
   const requiredReading = requiredReadingSection(opts.contextTreePath, opts.workspacePath);
   const contextTreeBlock = contextTreeSection(
     opts.contextTreePath,

--- a/packages/client/src/runtime/first-tree-skills/installer.ts
+++ b/packages/client/src/runtime/first-tree-skills/installer.ts
@@ -43,21 +43,38 @@ import { readManagedState, updateManagedState } from "../managed-state.js";
 
 /**
  * Skills always shipped, regardless of whether the agent has a Context Tree
- * binding. Welcome is core because onboarding can start before a team has a
- * Context Tree, especially in the no-repo path.
+ * binding — installed by `installCoreSkills()` on every bootstrap.
+ *
+ * - `first-tree-welcome`: onboarding can start before a team has a Context
+ *   Tree, especially in the no-repo path.
+ * - `first-tree-seed`: agent-driven tree building runs in a *tree-less*
+ *   session (the whole point of the spawned build-tree chat is that no
+ *   binding exists yet), so seed must be present before any binding — it
+ *   cannot be gated on `contextTreePath`.
+ * - `first-tree-write`: `first-tree-seed` loads it by relative reference
+ *   (`../first-tree-write/SKILL.md`) and inherits its Hard Rules, so write
+ *   must be co-present wherever seed runs. Keeping them in the same install
+ *   tier avoids a dangling reference in the tree-less build-tree chat.
+ *
+ * NOTE: because these are core, `reconcileTreeSkillState` must never remove
+ * them (see the guard there) — otherwise a previously tree-bound agent whose
+ * managed state still lists seed/write under the old TREE tier would have
+ * them deleted right after core installed them.
  */
-export const CORE_SKILL_NAMES = ["first-tree-welcome"] as const;
+export const CORE_SKILL_NAMES = ["first-tree-welcome", "first-tree-seed", "first-tree-write"] as const;
 
 const RETIRED_CORE_SKILL_NAMES = ["first-tree-guide", "first-tree-kickoff"] as const;
 
 /**
- * Skills that ship for Context-Tree-bound agents. Installed by
+ * Skills that ship only for Context-Tree-bound agents. Installed by
  * `installFirstTreeSkills()` on every bootstrap when `contextTreePath` is
- * set. The list must stay in sync with `BUNDLED_SKILLS` in
+ * set. `first-tree-read` is here (not core) because reading the tree only
+ * makes sense once a bound tree exists; a tree-less session has nothing to
+ * read. The list must stay in sync with `BUNDLED_SKILLS` in
  * `scripts/copy-bundled-skills.mjs` — that script materialises these
  * directories under `<client-pkg>/skills/`.
  */
-export const TREE_SKILL_NAMES = ["first-tree-write", "first-tree-read", "first-tree-seed"] as const;
+export const TREE_SKILL_NAMES = ["first-tree-read"] as const;
 
 export type CoreSkillName = (typeof CORE_SKILL_NAMES)[number];
 export type TreeSkillName = (typeof TREE_SKILL_NAMES)[number];
@@ -361,10 +378,15 @@ function reconcileCoreSkillState(workspacePath: string): void {
  */
 function reconcileTreeSkillState(workspacePath: string): void {
   const currentSkills = new Set<string>(TREE_SKILL_NAMES);
+  // Never remove a core skill. A skill can leave TREE_SKILL_NAMES by being
+  // promoted to core (e.g. seed/write). For a previously tree-bound agent
+  // whose managed state still lists it under the old TREE tier, `installCoreSkills`
+  // runs first and installs it — dropping it here would delete it moments later.
+  const coreSkills = new Set<string>(CORE_SKILL_NAMES);
   const prev = readManagedState(workspacePath);
   if (prev) {
     for (const prevSkill of prev.skills) {
-      if (currentSkills.has(prevSkill)) continue;
+      if (currentSkills.has(prevSkill) || coreSkills.has(prevSkill)) continue;
       removeManagedSkill(workspacePath, prevSkill);
     }
   }


### PR DESCRIPTION
## Problem
`first-tree-welcome` delegates repo creation / binding / seeding to `first-tree-seed`, which runs in a **tree-less** spawned build-tree chat (it exists precisely because no Context Tree binding exists yet). The runtime installer shipped `first-tree-seed` and `first-tree-write` only via `TREE_SKILL_NAMES`, which `agent-bootstrap.ts` installs only `if (contextTreePath)`. So in the tree-less build-tree chat, seed was never on disk → the delegation broke → the agent fell back to raw `gh`.

## Fix
- Move `first-tree-seed` and `first-tree-write` from `TREE_SKILL_NAMES` to `CORE_SKILL_NAMES` (always installed, tree or not).
  - `first-tree-write` must move with `first-tree-seed`: `first-tree-seed/SKILL.md` loads `../first-tree-write/SKILL.md` by relative reference and inherits its Hard Rules. Installing seed without write leaves a dangling reference in the tree-less chat.
  - `first-tree-read` stays tree-only — there is nothing to read without a bound tree.
- Guard `reconcileTreeSkillState` so it never removes a `CORE_SKILL_NAMES` member. For an existing tree-bound agent whose `managed.json::skills` still lists seed/write under the old TREE tier, `installCoreSkills` installs them first; without the guard the tree reconcile would delete them immediately after.
- Sync two now-stale rationale comments (`agent-bootstrap.ts`, `agent-briefing.ts`) that assumed tree-less agents have no skill payloads on disk (they now do).

## Tests
- Retarget the multi-skill installer-engine describe block to `installCoreSkills` (now a 3-skill set) to preserve engine coverage (fast-path skip, VERSION drift, content drift, missing-VERSION reinstall, clobbered-symlink repair, partial failure).
- Add an `installFirstTreeIntegration (tree-only skills)` describe covering the `first-tree-read` happy path + per-skill failure log.
- Add a `skills-state-reconcile` regression proving core skills listed in prior managed state survive the reconcile (mutation-verified: fails without the guard).
- `@first-tree/client`: 1191 tests pass; `typecheck` + `biome` clean.

No DB / schema / API changes. Implementation-only — makes the already-documented `welcome → seed` delegation actually work; no Context Tree PR needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
