### PR TITLE
feat: sandbox landing campaign runtime

### DIFF
--- a/docs/development/http-path-conventions.md
+++ b/docs/development/http-path-conventions.md
@@ -9,11 +9,16 @@
 
 ## JWT scope
 
-JWT carries **only** `userId`. `request.user` is `{ userId }`. Anything beyond that — org, role, member — is resolved per-request via `scope/require-*` helpers, which probe the DB in real time. Reading `request.user.organizationId / memberId / role` is impossible (the fields don't exist) — that is the type-level enforcement of the rule.
+Normal user JWTs carry **only** `userId`. `request.user` is `{ userId }`. Anything beyond that — org, role, member — is resolved per-request via `scope/require-*` helpers, which probe the DB in real time. Reading `request.user.organizationId / memberId / role` is impossible (the fields don't exist) — that is the type-level enforcement of the rule.
 
 ```ts
 type AccessTokenPayload = { sub: string; type: "access"; iat: number; exp: number; jti: string };
 ```
+
+The only exception is the `agent_outbox` token used by workspace-only trial
+sandboxes. It is not a general user access token: it is accepted only for the
+current agent's `POST /api/v1/agent/chats/:chatId/messages` route in the
+current chat, and route middleware must reject it everywhere else.
 
 ## Decision tree
 
@@ -81,7 +86,7 @@ Example: `GET /api/v1/agent/me`, `POST /api/v1/agent/chats/:chatId/messages`, `W
 ## Forbidden
 
 - ❌ `/admin/...` prefix anywhere — role lives in middleware, not URL
-- ❌ Reading `request.user.organizationId` / `memberId` / `role` — these fields don't exist; JWT carries only `sub`
+- ❌ Reading `request.user.organizationId` / `memberId` / `role` — these fields don't exist; normal user JWTs carry only `sub`
 - ❌ `?organizationId=` query param for org scope — use `:orgId` path param
 - ❌ Class B route without `:orgId` in path — `requireOrgMembership` will fail to type-check
 - ❌ Class C route with `:orgId` in path — redundant; resource UUID locates the org

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionEvent } from "@first-tree/shared";
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexAppServerRpcError, CodexAppServerTransportError } from "../handlers/codex/app-server/client.js";
 import { createCodexAppServerHandler } from "../handlers/codex/app-server/index.js";
 import { writeAgentBriefing } from "../runtime/bootstrap.js";
+import { setCliBinding } from "../runtime/cli-binding.js";
 import type { DeliveryToken, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
@@ -190,11 +191,21 @@ function makeContext(
     emitEvent?: SessionContext["emitEvent"];
     formatInboundContent?: SessionContext["formatInboundContent"];
     sendMessage?: ReturnType<typeof vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>>;
+    createAgentOutboxToken?: ReturnType<
+      typeof vi.fn<(chatId: string) => Promise<{ accessToken: string; expiresIn: number }>>
+    >;
+    agentMetadata?: Record<string, unknown>;
   } = {},
 ): SessionContext {
   const sendMessage =
     opts.sendMessage ??
     vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>().mockResolvedValue(undefined);
+  const createAgentOutboxToken =
+    opts.createAgentOutboxToken ??
+    vi.fn<(chatId: string) => Promise<{ accessToken: string; expiresIn: number }>>().mockResolvedValue({
+      accessToken: "scoped-outbox-token",
+      expiresIn: 900,
+    });
   return {
     agent: {
       agentId: AGENT_ID,
@@ -203,9 +214,9 @@ function makeContext(
       type: "agent",
       visibility: "organization",
       delegateMention: null,
-      metadata: {},
+      metadata: opts.agentMetadata ?? {},
     },
-    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    sdk: { serverUrl: "http://test", sendMessage, createAgentOutboxToken } as unknown as SessionContext["sdk"],
     chatId: "chat-app-server",
     log: () => {},
     recordProviderActivity: () => {},
@@ -414,13 +425,104 @@ function activeTurnNotSteerableError(): CodexAppServerRpcError {
 
 beforeEach(() => {
   workspaceRoot = mkdtempSync(join(tmpdir(), "ft-codex-app-server-"));
+  setCliBinding({ binName: "first-tree-test", packageName: null });
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   rmSync(workspaceRoot, { recursive: true, force: true });
 });
 
 describe("codex app-server handler", () => {
+  it("wraps landing campaign trial app-server startup in workspace-only sandbox mode", async () => {
+    const firstTreeHome = join(workspaceRoot, "first-tree-home");
+    const cliBinDir = join(firstTreeHome, "bin");
+    mkdirSync(cliBinDir, { recursive: true });
+    writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
+    vi.stubEnv("FIRST_TREE_HOME", firstTreeHome);
+    vi.stubEnv("OPENAI_API_KEY", "secret-openai");
+    vi.stubEnv("GITHUB_TOKEN", "secret-github");
+
+    const fake = new FakeAppServerClient();
+    let capturedSpawnProcess: unknown;
+    let capturedEnv: NodeJS.ProcessEnv | undefined;
+    const createAgentOutboxToken = vi
+      .fn<(chatId: string) => Promise<{ accessToken: string; expiresIn: number }>>()
+      .mockResolvedValue({ accessToken: "trial-outbox-token", expiresIn: 900 });
+    const handler = makeHandler(fake, {
+      codexAppServerClientFactory: async (options: {
+        env?: NodeJS.ProcessEnv;
+        spawnProcess?: unknown;
+        onNotification?: NotificationHandler;
+        onClose?: CloseHandler;
+      }) => {
+        capturedSpawnProcess = options.spawnProcess;
+        capturedEnv = options.env;
+        fake.onNotification = options.onNotification ?? null;
+        fake.onClose = options.onClose ?? null;
+        return fake;
+      },
+    });
+    const ctx = makeContext({
+      createAgentOutboxToken,
+      agentMetadata: {
+        landingCampaignTrial: true,
+        campaign: "production-scan",
+        skillSetId: "production-scan",
+        skillSetVersion: "2026.07.02.1",
+        repo: {
+          url: "https://github.com/acme/backend",
+          canonicalKey: "github.com/acme/backend",
+        },
+      },
+    });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    expect(typeof capturedSpawnProcess).toBe("function");
+    expect(createAgentOutboxToken).toHaveBeenCalledWith("chat-app-server");
+    expect(capturedEnv?.FIRST_TREE_HOME).toBe(join(workspaceRoot, ".first-tree-workspace", "outbox-home"));
+    expect(capturedEnv?.PATH?.split(":")[0]).toBe(cliBinDir);
+    expect(capturedEnv?.OPENAI_API_KEY).toBeUndefined();
+    expect(capturedEnv?.GITHUB_TOKEN).toBeUndefined();
+    const threadStart = fake.requests.find((request) => request.method === "thread/start");
+    expect(threadStart?.params).toMatchObject({ sandbox: "workspace-write" });
+
+    completeTurn(fake, "turn-1", "final answer");
+    await startPromise;
+    await handler.shutdown();
+  });
+
+  it("leaves ordinary app-server startup unsandboxed", async () => {
+    const fake = new FakeAppServerClient();
+    let capturedSpawnProcess: unknown = "unset";
+    const handler = makeHandler(fake, {
+      codexAppServerClientFactory: async (options: {
+        spawnProcess?: unknown;
+        onNotification?: NotificationHandler;
+        onClose?: CloseHandler;
+      }) => {
+        capturedSpawnProcess = options.spawnProcess;
+        fake.onNotification = options.onNotification ?? null;
+        fake.onClose = options.onClose ?? null;
+        return fake;
+      },
+    });
+    const ctx = makeContext();
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    expect(capturedSpawnProcess).toBeUndefined();
+    const threadStart = fake.requests.find((request) => request.method === "thread/start");
+    expect(threadStart?.params).toMatchObject({ sandbox: "danger-full-access" });
+
+    completeTurn(fake, "turn-1", "final answer");
+    await startPromise;
+    await handler.shutdown();
+  });
+
   it("steers active-turn injects and acks the injected message with the current turn", async () => {
     const fake = new FakeAppServerClient();
     const finished: SessionMessage[][] = [];

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionEvent } from "@first-tree/shared";
@@ -424,7 +424,7 @@ function activeTurnNotSteerableError(): CodexAppServerRpcError {
 }
 
 beforeEach(() => {
-  workspaceRoot = mkdtempSync(join(tmpdir(), "ft-codex-app-server-"));
+  workspaceRoot = realpathSync(mkdtempSync(join(tmpdir(), "ft-codex-app-server-")));
   setCliBinding({ binName: "first-tree-test", packageName: null });
 });
 

--- a/packages/client/src/__tests__/codex-handler-engine.test.ts
+++ b/packages/client/src/__tests__/codex-handler-engine.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { createCodexHandler } from "../handlers/codex/index.js";
+import type { SessionContext, SessionMessage } from "../runtime/handler.js";
+
+const trialMetadata = {
+  landingCampaignTrial: true,
+  campaign: "production-scan",
+  skillSetId: "production-scan",
+  skillSetVersion: "2026.07.02.1",
+  repo: {
+    url: "https://github.com/acme/backend",
+    canonicalKey: "github.com/acme/backend",
+  },
+};
+
+function message(): SessionMessage {
+  return {
+    id: "m1",
+    chatId: "chat-1",
+    senderId: "human-1",
+    format: "text",
+    content: "start",
+    metadata: {},
+  };
+}
+
+function context(metadata: Record<string, unknown>): SessionContext {
+  return {
+    agent: {
+      agentId: "agent-1",
+      inboxId: "inbox_agent-1",
+      displayName: "Trial Agent",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata,
+    },
+  } as unknown as SessionContext;
+}
+
+describe("codex handler engine selection", () => {
+  it("fails closed instead of running landing campaign trials on the SDK engine", async () => {
+    const handler = createCodexHandler({
+      workspaceRoot: "/tmp/first-tree-codex-test",
+      runtimeProvider: "codex",
+      codexHandlerEngine: "sdk",
+    });
+
+    expect(() => handler.start(message(), context(trialMetadata))).toThrow(
+      /require the app-server workspace-only runtime/,
+    );
+  });
+});

--- a/packages/client/src/__tests__/codex-thread-options.test.ts
+++ b/packages/client/src/__tests__/codex-thread-options.test.ts
@@ -63,6 +63,12 @@ describe("buildCodexThreadOptions", () => {
     );
   });
 
+  it("uses codex workspace-write only when the caller already wrapped the process workspace-only", () => {
+    const opts = buildCodexThreadOptions(basePayload(), "/tmp/wsk", { workspaceOnly: true });
+
+    expect(opts.sandboxMode).toBe("workspace-write");
+  });
+
   it("derives additionalDirectories from gitRepos (with deriveRepoLocalPath fallback)", () => {
     const opts = buildCodexThreadOptions(
       basePayload({

--- a/packages/client/src/__tests__/workspace-sandbox.test.ts
+++ b/packages/client/src/__tests__/workspace-sandbox.test.ts
@@ -1,4 +1,13 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -15,7 +24,7 @@ let workspace: string;
 let outside: string;
 
 beforeEach(() => {
-  root = mkdtempSync(join(tmpdir(), "ft-workspace-sandbox-"));
+  root = realpathSync(mkdtempSync(join(tmpdir(), "ft-workspace-sandbox-")));
   workspace = join(root, "workspace");
   outside = join(root, "outside");
   mkdirSync(workspace);

--- a/packages/client/src/__tests__/workspace-sandbox.test.ts
+++ b/packages/client/src/__tests__/workspace-sandbox.test.ts
@@ -1,0 +1,165 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  assertPathInsideWorkspace,
+  buildWorkspaceOnlyBubblewrapArgs,
+  buildWorkspaceOnlyEnvironment,
+  prepareWorkspaceOnlyOutboxHome,
+} from "../handlers/codex/app-server/workspace-sandbox.js";
+import { setCliBinding } from "../runtime/cli-binding.js";
+
+let root: string;
+let workspace: string;
+let outside: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "ft-workspace-sandbox-"));
+  workspace = join(root, "workspace");
+  outside = join(root, "outside");
+  mkdirSync(workspace);
+  mkdirSync(outside);
+  setCliBinding({ binName: "first-tree-test", packageName: null });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("workspace-only sandbox", () => {
+  it("allows paths inside the workspace", () => {
+    const nested = join(workspace, "nested");
+    mkdirSync(nested);
+
+    expect(assertPathInsideWorkspace("nested", workspace, "cwd")).toBe(nested);
+    expect(assertPathInsideWorkspace(nested, workspace, "cwd")).toBe(nested);
+  });
+
+  it("rejects relative, absolute, and symlink escapes", () => {
+    const outsideChild = join(outside, "child");
+    mkdirSync(outsideChild);
+    symlinkSync(outsideChild, join(workspace, "escape"));
+
+    expect(() => assertPathInsideWorkspace("../outside", workspace, "cwd")).toThrow(/escapes workspace-only/);
+    expect(() => assertPathInsideWorkspace(outsideChild, workspace, "cwd")).toThrow(/escapes workspace-only/);
+    expect(() => assertPathInsideWorkspace("escape", workspace, "cwd")).toThrow(/escapes workspace-only/);
+  });
+
+  it("builds a bubblewrap command that binds the workspace read-write and hides ordinary host data paths", () => {
+    const command = join(workspace, "fake-codex");
+    writeFileSync(command, "#!/bin/sh\n");
+    const cliBinDir = join(root, "first-tree-home", "bin");
+    mkdirSync(cliBinDir, { recursive: true });
+    writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
+    const sandboxEnv = buildWorkspaceOnlyEnvironment(
+      {
+        FIRST_TREE_HOME: join(root, "first-tree-home"),
+        FIRST_TREE_SERVER_URL: "https://first-tree.test",
+        OPENAI_API_KEY: "secret",
+        GITHUB_TOKEN: "secret",
+        PATH: process.env.PATH ?? "",
+      },
+      workspace,
+    );
+
+    const args = buildWorkspaceOnlyBubblewrapArgs({
+      command,
+      args: ["app-server", "--stdio"],
+      workspaceRoot: workspace,
+      cwd: workspace,
+      env: sandboxEnv.env,
+      readOnlyPaths: sandboxEnv.readOnlyPaths,
+    });
+
+    expect(args).toContain("--unshare-all");
+    expect(args).toContain("--clearenv");
+    expect(args).toContain("--share-net");
+    expect(args).toEqual(expect.arrayContaining(["--bind", workspace, workspace]));
+    expect(args).toEqual(expect.arrayContaining(["--ro-bind", cliBinDir, cliBinDir]));
+    expect(args).toEqual(expect.arrayContaining(["--chdir", workspace]));
+    expect(args).toEqual(expect.arrayContaining(["--setenv", "HOME", workspace]));
+    expect(args).toEqual(expect.arrayContaining(["--setenv", "FIRST_TREE_SERVER_URL", "https://first-tree.test"]));
+    expect(args).not.toContain("OPENAI_API_KEY");
+    expect(args).not.toContain("GITHUB_TOKEN");
+    expect(args.slice(-3)).toEqual([command, "app-server", "--stdio"]);
+    expect(args).not.toContain(process.env.HOME ?? "/home");
+    expect(args).not.toContain(outside);
+  });
+
+  it("scrubs parent env and fails closed without a channel-local First Tree CLI", () => {
+    const firstTreeHome = join(root, "first-tree-home");
+    const cliBinDir = join(firstTreeHome, "bin");
+    mkdirSync(cliBinDir, { recursive: true });
+
+    expect(() =>
+      buildWorkspaceOnlyEnvironment({ FIRST_TREE_HOME: firstTreeHome, PATH: "/usr/bin" }, workspace),
+    ).toThrow(/channel-local First Tree CLI/);
+
+    writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
+    const { env, readOnlyPaths } = buildWorkspaceOnlyEnvironment(
+      {
+        FIRST_TREE_HOME: firstTreeHome,
+        FIRST_TREE_SERVER_URL: "https://first-tree.test",
+        FIRST_TREE_AGENT_ID: "agent-1",
+        FIRST_TREE_CHAT_ID: "chat-1",
+        OPENAI_API_KEY: "secret",
+        GH_TOKEN: "secret",
+        FIRST_TREE_DOC_BASE: outside,
+        FIRST_TREE_WORKSPACES_ROOT: root,
+        PATH: "/sensitive/bin:/usr/bin",
+      },
+      workspace,
+    );
+
+    expect(env).toMatchObject({
+      FIRST_TREE_HOME: firstTreeHome,
+      FIRST_TREE_SERVER_URL: "https://first-tree.test",
+      FIRST_TREE_AGENT_ID: "agent-1",
+      FIRST_TREE_CHAT_ID: "chat-1",
+      HOME: workspace,
+      TMPDIR: "/tmp",
+    });
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.GH_TOKEN).toBeUndefined();
+    expect(env.FIRST_TREE_DOC_BASE).toBeUndefined();
+    expect(env.FIRST_TREE_WORKSPACES_ROOT).toBeUndefined();
+    expect(env.PATH?.split(":")[0]).toBe(cliBinDir);
+    expect(env.PATH).not.toContain("/sensitive/bin");
+    expect(readOnlyPaths).toEqual([cliBinDir]);
+  });
+
+  it("builds a workspace-local First Tree home with only scoped outbox credentials", () => {
+    const hostHome = join(root, "host-first-tree-home");
+    const cliBinDir = join(hostHome, "bin");
+    mkdirSync(cliBinDir, { recursive: true });
+    writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
+
+    const prepared = prepareWorkspaceOnlyOutboxHome({
+      parentEnv: {
+        FIRST_TREE_HOME: hostHome,
+        FIRST_TREE_SERVER_URL: "https://first-tree.test",
+        OPENAI_API_KEY: "secret",
+      },
+      workspaceRoot: workspace,
+      agentId: "agent-trial",
+      runtimeProvider: "codex",
+      accessToken: "scoped-outbox-token",
+      serverUrl: "https://first-tree.test",
+    });
+
+    expect(prepared.home).toBe(join(workspace, ".first-tree-workspace", "outbox-home"));
+    expect(prepared.cliBinDir).toBe(cliBinDir);
+    expect(prepared.env.FIRST_TREE_HOME).toBe(prepared.home);
+    expect(prepared.env.FIRST_TREE_CLI_BIN_DIR).toBe(cliBinDir);
+    expect(existsSync(join(prepared.home, "config", "agents", "landing-campaign-trial", "agent.yaml"))).toBe(true);
+    expect(
+      readFileSync(join(prepared.home, "config", "agents", "landing-campaign-trial", "agent.yaml"), "utf8"),
+    ).toContain('agentId: "agent-trial"');
+    expect(JSON.parse(readFileSync(join(prepared.home, "config", "credentials.json"), "utf8"))).toMatchObject({
+      accessToken: "scoped-outbox-token",
+      refreshToken: "scoped-outbox-token",
+      serverUrl: "https://first-tree.test",
+    });
+  });
+});

--- a/packages/client/src/handlers/codex/app-server/client.ts
+++ b/packages/client/src/handlers/codex/app-server/client.ts
@@ -16,7 +16,7 @@ type PendingRequest = {
   timer: ReturnType<typeof setTimeout>;
 };
 
-type SpawnProcess = (
+export type SpawnProcess = (
   command: string,
   args: readonly string[],
   options: {

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -2,6 +2,7 @@ import { isAbsolute, join, resolve } from "node:path";
 import {
   type AgentRuntimeConfigPayload,
   encodeProviderRetryEventMessage,
+  isLandingCampaignTrialAgentMetadata,
   type SessionEvent,
   type ToolFileRef,
 } from "@first-tree/shared";
@@ -62,6 +63,11 @@ import {
   type CodexAppServerTransportError,
   isCodexAppServerTransientError,
 } from "./client.js";
+import {
+  buildWorkspaceOnlyEnvironment,
+  createWorkspaceOnlySpawnProcess,
+  prepareWorkspaceOnlyOutboxHome,
+} from "./workspace-sandbox.js";
 
 type CodexConfigValue = string | number | boolean | null | CodexConfigValue[] | CodexConfigObject;
 type CodexConfigObject = { [key: string]: CodexConfigValue };
@@ -175,6 +181,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
   let latestThreadUsageTotal: TokenUsageBreakdown | null = null;
   let latestCurrentSessionUsageTurnId: string | null = null;
+  let workspaceOnly = false;
 
   const pendingInputs: QueueEntry[] = [];
   const pendingNotificationsByTurn = new Map<string, CodexAppServerNotification[]>();
@@ -373,6 +380,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     briefingFingerprint: string;
   }> {
     cwd = acquireAgentHome(workspaceRoot);
+    workspaceOnly = isLandingCampaignTrialAgentMetadata(sessionCtx.agent.metadata);
     const { payload, resolved } = await resolvePayload(sessionCtx);
     const chatContext = await fetchChatContextOrLog(sessionCtx);
     pendingChatContextPrompt = renderChatContextPrompt(chatContext);
@@ -383,13 +391,35 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     markWorkspaceInitComplete(cwd);
     currentModel = payload.model || "";
     currentReasoningEffort = payload.kind === "codex" ? payload.reasoningEffort : "high";
-    return { payload, env: buildEnv(sessionCtx), briefingFingerprint: computeBriefingFingerprint(briefing) };
+    let env = buildEnv(sessionCtx);
+    if (workspaceOnly) {
+      const { accessToken } = await sessionCtx.sdk.createAgentOutboxToken(sessionCtx.chatId);
+      env = prepareWorkspaceOnlyOutboxHome({
+        parentEnv: env,
+        workspaceRoot: cwd,
+        agentId: sessionCtx.agent.agentId,
+        runtimeProvider: payload.kind,
+        accessToken,
+        serverUrl: env.FIRST_TREE_SERVER_URL ?? sessionCtx.sdk.serverUrl,
+      }).env;
+    }
+    return { payload, env, briefingFingerprint: computeBriefingFingerprint(briefing) };
   }
 
   async function startAppServer(sessionCtx: SessionContext, env: NodeJS.ProcessEnv): Promise<void> {
+    const workspacePath = cwd ?? workspaceRoot;
+    let workspaceSandbox: ReturnType<typeof buildWorkspaceOnlyEnvironment> | null = null;
+    if (workspaceOnly) {
+      try {
+        workspaceSandbox = buildWorkspaceOnlyEnvironment(env, workspacePath);
+      } catch (err) {
+        throw new CodexAppServerStartupError("workspace-sandbox", err);
+      }
+    }
+    const appServerEnv = workspaceSandbox?.env ?? env;
     let resolution: CodexBinaryResolution;
     try {
-      resolution = await resolveRuntimeBinary(env);
+      resolution = await resolveRuntimeBinary(appServerEnv);
     } catch (err) {
       throw new CodexAppServerStartupError("resolve-binary", err);
     }
@@ -397,8 +427,16 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     try {
       appServer = await clientFactory({
         binary: resolution.binary,
-        cwd: cwd ?? workspaceRoot,
-        env,
+        cwd: workspacePath,
+        env: appServerEnv,
+        ...(workspaceOnly
+          ? {
+              spawnProcess: createWorkspaceOnlySpawnProcess({
+                workspaceRoot: workspacePath,
+                readOnlyPaths: workspaceSandbox?.readOnlyPaths,
+              }),
+            }
+          : {}),
         onNotification: handleNotification,
         onClose: handleTransportClose,
         onLog: (message) => sessionCtx.log(message),
@@ -409,7 +447,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   }
 
   function threadParams(payload: AgentRuntimeConfigPayload): JsonRecord {
-    const opts = buildCodexThreadOptions(payload, cwd ?? workspaceRoot);
+    const opts = buildCodexThreadOptions(payload, cwd ?? workspaceRoot, { workspaceOnly });
     return {
       cwd: opts.workingDirectory,
       approvalPolicy: opts.approvalPolicy,
@@ -1611,6 +1649,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       await appServer?.shutdown();
       appServer = null;
       pendingChatContextPrompt = null;
+      workspaceOnly = false;
       resetThreadUsageTracking(null);
     },
 
@@ -1629,6 +1668,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       threadId = null;
       ctx = null;
       pendingChatContextPrompt = null;
+      workspaceOnly = false;
       resetThreadUsageTracking(null);
     },
   } satisfies AgentHandler;

--- a/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
+++ b/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
@@ -1,0 +1,302 @@
+import { spawn } from "node:child_process";
+import { accessSync, constants, existsSync, mkdirSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { delimiter, dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { getCliBinding } from "../../../runtime/cli-binding.js";
+import type { SpawnProcess } from "./client.js";
+
+type BuildBubblewrapArgsOptions = {
+  command: string;
+  args: readonly string[];
+  workspaceRoot: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  readOnlyPaths?: readonly string[];
+};
+
+type WorkspaceOnlySpawnOptions = {
+  workspaceRoot: string;
+  sandboxBinary?: string;
+  readOnlyPaths?: readonly string[];
+};
+
+type WorkspaceOnlyEnvironment = {
+  env: NodeJS.ProcessEnv;
+  readOnlyPaths: string[];
+};
+
+type WorkspaceOnlyOutboxHomeOptions = {
+  parentEnv: NodeJS.ProcessEnv;
+  workspaceRoot: string;
+  agentId: string;
+  runtimeProvider: string;
+  accessToken: string;
+  serverUrl: string;
+};
+
+const DEFAULT_SANDBOX_BINARY = "bwrap";
+const READ_ONLY_SYSTEM_DIRS = ["/usr", "/bin", "/sbin", "/lib", "/lib64"] as const;
+const READ_ONLY_ETC_PATHS = [
+  "/etc/ssl",
+  "/etc/ca-certificates",
+  "/etc/pki",
+  "/etc/hosts",
+  "/etc/resolv.conf",
+  "/etc/nsswitch.conf",
+  "/etc/protocols",
+  "/etc/services",
+] as const;
+const WORKSPACE_ONLY_PATH_DIRS = ["/usr/local/bin", "/usr/bin", "/bin"] as const;
+const SAFE_PASS_ENV_KEYS = new Set([
+  "FIRST_TREE_HOME",
+  "FIRST_TREE_SERVER_URL",
+  "FIRST_TREE_AGENT_ID",
+  "FIRST_TREE_INBOX_ID",
+  "FIRST_TREE_CHAT_ID",
+  "FIRST_TREE_CLIENT_ID",
+  "FIRST_TREE_PROVIDER",
+  "FIRST_TREE_SWITCH_DRAIN_VERSION",
+  "FIRST_TREE_CLI_BIN_DIR",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TERM",
+  "TZ",
+]);
+
+function pathIsWithin(parent: string, child: string): boolean {
+  return child === parent || child.startsWith(parent.endsWith(sep) ? parent : `${parent}${sep}`);
+}
+
+function realpathExisting(path: string, label: string): string {
+  try {
+    return realpathSync(path);
+  } catch (err) {
+    throw new Error(`${label} does not exist: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export function assertPathInsideWorkspace(path: string, workspaceRoot: string, label: string): string {
+  const realWorkspace = realpathExisting(workspaceRoot, "workspaceRoot");
+  const target = isAbsolute(path) ? path : resolve(realWorkspace, path);
+  const realTarget = realpathExisting(target, label);
+  if (!pathIsWithin(realWorkspace, realTarget)) {
+    throw new Error(`${label} escapes workspace-only sandbox: ${path}`);
+  }
+  return realTarget;
+}
+
+function findExecutableOnPath(command: string, env: NodeJS.ProcessEnv | undefined): string | null {
+  if (isAbsolute(command)) return existsSync(command) ? command : null;
+  const pathValue = env?.PATH ?? process.env.PATH ?? "";
+  for (const dir of pathValue.split(delimiter)) {
+    if (!dir) continue;
+    const candidate = resolve(dir, command);
+    if (!existsSync(candidate)) continue;
+    try {
+      const stat = statSync(candidate);
+      if (stat.isFile()) return candidate;
+    } catch {
+      // Ignore unreadable PATH entries; another entry may resolve.
+    }
+  }
+  return null;
+}
+
+function addExistingReadOnlyBind(args: string[], path: string): void {
+  if (!existsSync(path)) return;
+  args.push("--ro-bind", path, path);
+}
+
+function addReadOnlyBind(args: string[], path: string): void {
+  if (!existsSync(path)) return;
+  const source = realpathExisting(path, "readOnlyPath");
+  addParentDirs(args, path);
+  args.push("--ro-bind", source, path);
+}
+
+function addParentDirs(args: string[], path: string): void {
+  const alreadyPresent = new Set(["/tmp", "/proc", "/dev", "/run", "/etc", ...READ_ONLY_SYSTEM_DIRS]);
+  const dirs: string[] = [];
+  let current = dirname(path);
+  while (current && current !== "/") {
+    if (!alreadyPresent.has(current)) dirs.push(current);
+    current = dirname(current);
+  }
+  for (const dir of dirs.reverse()) {
+    args.push("--dir", dir);
+  }
+}
+
+function isCoveredBySystemBind(path: string): boolean {
+  return READ_ONLY_SYSTEM_DIRS.some((dir) => existsSync(dir) && pathIsWithin(dir, path));
+}
+
+function validateChannelCliBin(binDir: string): void {
+  const { binName } = getCliBinding();
+  const cliPath = join(binDir, binName);
+  try {
+    accessSync(cliPath, process.platform === "win32" ? constants.F_OK : constants.X_OK);
+  } catch {
+    throw new Error(`workspace-only sandbox requires channel-local First Tree CLI at ${cliPath}`);
+  }
+}
+
+function writePrivateFile(path: string, content: string): void {
+  writeFileSync(path, content, { mode: 0o600 });
+}
+
+export function prepareWorkspaceOnlyOutboxHome(options: WorkspaceOnlyOutboxHomeOptions): {
+  env: NodeJS.ProcessEnv;
+  home: string;
+  cliBinDir: string;
+} {
+  const realWorkspace = realpathExisting(options.workspaceRoot, "workspaceRoot");
+  const sourceHome = options.parentEnv.FIRST_TREE_HOME;
+  if (!sourceHome) {
+    throw new Error("workspace-only sandbox requires host FIRST_TREE_HOME so the channel-local CLI can be mounted");
+  }
+  const cliBinDir = join(isAbsolute(sourceHome) ? sourceHome : resolve(sourceHome), "bin");
+  validateChannelCliBin(cliBinDir);
+
+  const home = join(realWorkspace, ".first-tree-workspace", "outbox-home");
+  const configDir = join(home, "config");
+  const agentDir = join(configDir, "agents", "landing-campaign-trial");
+  mkdirSync(agentDir, { recursive: true, mode: 0o700 });
+  writePrivateFile(
+    join(configDir, "credentials.json"),
+    JSON.stringify(
+      {
+        accessToken: options.accessToken,
+        // Outbox tokens are deliberately non-refreshable. This placeholder
+        // satisfies the existing CLI credentials shape without exposing the
+        // service user's refresh token inside the sandbox.
+        refreshToken: options.accessToken,
+        serverUrl: options.serverUrl,
+      },
+      null,
+      2,
+    ),
+  );
+  writePrivateFile(
+    join(agentDir, "agent.yaml"),
+    `agentId: "${options.agentId}"\nruntime: ${options.runtimeProvider}\n`,
+  );
+
+  return {
+    env: {
+      ...options.parentEnv,
+      FIRST_TREE_HOME: home,
+      FIRST_TREE_CLI_BIN_DIR: cliBinDir,
+    },
+    home,
+    cliBinDir,
+  };
+}
+
+export function buildWorkspaceOnlyEnvironment(
+  parentEnv: NodeJS.ProcessEnv,
+  workspaceRoot: string,
+): WorkspaceOnlyEnvironment {
+  const realWorkspace = realpathExisting(workspaceRoot, "workspaceRoot");
+  const firstTreeHome = parentEnv.FIRST_TREE_HOME;
+  if (!firstTreeHome) {
+    throw new Error("workspace-only sandbox requires FIRST_TREE_HOME for sandbox-local First Tree config");
+  }
+  const resolvedHome = isAbsolute(firstTreeHome) ? firstTreeHome : resolve(firstTreeHome);
+  const cliBinDirValue = parentEnv.FIRST_TREE_CLI_BIN_DIR ?? join(resolvedHome, "bin");
+  const cliBinDir = isAbsolute(cliBinDirValue) ? cliBinDirValue : resolve(cliBinDirValue);
+  validateChannelCliBin(cliBinDir);
+
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of SAFE_PASS_ENV_KEYS) {
+    const value = parentEnv[key];
+    if (typeof value === "string") env[key] = value;
+  }
+  env.FIRST_TREE_HOME = resolvedHome;
+  env.HOME = realWorkspace;
+  env.TMPDIR = "/tmp";
+  env.PATH = [cliBinDir, ...WORKSPACE_ONLY_PATH_DIRS].filter((entry) => existsSync(entry)).join(delimiter);
+
+  return { env, readOnlyPaths: [cliBinDir] };
+}
+
+export function buildWorkspaceOnlyBubblewrapArgs(options: BuildBubblewrapArgsOptions): string[] {
+  const workspaceRoot = realpathExisting(options.workspaceRoot, "workspaceRoot");
+  const cwd = options.cwd ? assertPathInsideWorkspace(options.cwd, workspaceRoot, "cwd") : workspaceRoot;
+  const commandPath = findExecutableOnPath(options.command, options.env);
+  if (!commandPath) {
+    throw new Error(`workspace-only sandbox could not resolve executable: ${options.command}`);
+  }
+  const commandRealpath = realpathExisting(commandPath, "command");
+  if (!statSync(commandRealpath).isFile()) {
+    throw new Error(`workspace-only sandbox executable is not a file: ${commandRealpath}`);
+  }
+
+  const args = [
+    "--die-with-parent",
+    "--new-session",
+    "--clearenv",
+    "--unshare-all",
+    "--share-net",
+    "--proc",
+    "/proc",
+    "--dev",
+    "/dev",
+    "--tmpfs",
+    "/tmp",
+    "--dir",
+    "/run",
+    "--dir",
+    "/etc",
+  ];
+
+  for (const dir of READ_ONLY_SYSTEM_DIRS) {
+    addExistingReadOnlyBind(args, dir);
+  }
+  for (const path of READ_ONLY_ETC_PATHS) {
+    addExistingReadOnlyBind(args, path);
+  }
+  for (const path of options.readOnlyPaths ?? []) {
+    addReadOnlyBind(args, path);
+  }
+
+  args.push("--bind", workspaceRoot, workspaceRoot);
+  if (!pathIsWithin(workspaceRoot, commandRealpath) && !isCoveredBySystemBind(commandRealpath)) {
+    addParentDirs(args, commandRealpath);
+    args.push("--ro-bind", commandRealpath, commandRealpath);
+  }
+  args.push("--chdir", cwd);
+  for (const [key, value] of Object.entries({ ...(options.env ?? {}), HOME: workspaceRoot, TMPDIR: "/tmp" })) {
+    if (typeof value === "string") args.push("--setenv", key, value);
+  }
+  return [...args, "--", commandRealpath, ...options.args];
+}
+
+export function createWorkspaceOnlySpawnProcess(options: WorkspaceOnlySpawnOptions): SpawnProcess {
+  const workspaceRoot = realpathExisting(options.workspaceRoot, "workspaceRoot");
+  return (command, args, spawnOptions) => {
+    if (process.platform !== "linux") {
+      throw new Error("workspace-only sandbox requires Linux bubblewrap support");
+    }
+    const sandboxBinary = options.sandboxBinary ?? DEFAULT_SANDBOX_BINARY;
+    const resolvedSandbox = findExecutableOnPath(sandboxBinary, spawnOptions.env);
+    if (!resolvedSandbox) {
+      throw new Error("workspace-only sandbox requires bubblewrap (`bwrap`) on PATH");
+    }
+    const sandboxEnv = buildWorkspaceOnlyEnvironment(spawnOptions.env ?? {}, workspaceRoot);
+    const readOnlyPaths = [...new Set([...sandboxEnv.readOnlyPaths, ...(options.readOnlyPaths ?? [])])];
+    const sandboxArgs = buildWorkspaceOnlyBubblewrapArgs({
+      command,
+      args,
+      workspaceRoot,
+      cwd: spawnOptions.cwd,
+      env: sandboxEnv.env,
+      readOnlyPaths,
+    });
+    return spawn(resolvedSandbox, sandboxArgs, {
+      ...spawnOptions,
+      env: sandboxEnv.env,
+      cwd: workspaceRoot,
+    });
+  };
+}

--- a/packages/client/src/handlers/codex/index.ts
+++ b/packages/client/src/handlers/codex/index.ts
@@ -1,3 +1,4 @@
+import { isLandingCampaignTrialAgentMetadata } from "@first-tree/shared";
 import type { AgentHandler, HandlerFactory, SessionContext } from "../../runtime/handler.js";
 import { CodexAppServerStartupError, createCodexAppServerHandler } from "./app-server/index.js";
 import { createCodexSdkHandler } from "./sdk.js";
@@ -28,9 +29,37 @@ function readCodexHandlerEngine(value: unknown): CodexHandlerEngine | null {
   return null;
 }
 
+function assertCodexWorkspaceOnlySupported(ctx: SessionContext, engine: CodexHandlerEngine): void {
+  if (!isLandingCampaignTrialAgentMetadata(ctx.agent.metadata)) return;
+  if (engine === "sdk") {
+    throw new Error("Landing campaign Codex trials require the app-server workspace-only runtime.");
+  }
+}
+
 export const createCodexHandler: HandlerFactory = (config) => {
   const engine = readCodexHandlerEngine(config.codexHandlerEngine) ?? codexHandlerEngineFromEnv();
-  if (engine === "sdk") return createCodexSdkHandler(config);
+  if (engine === "sdk") {
+    const sdkHandler = createCodexSdkHandler(config);
+    return {
+      start(message, ctx, token) {
+        assertCodexWorkspaceOnlySupported(ctx, "sdk");
+        return sdkHandler.start(message, ctx, token);
+      },
+      resume(message, sessionId, ctx, token) {
+        assertCodexWorkspaceOnlySupported(ctx, "sdk");
+        return sdkHandler.resume(message, sessionId, ctx, token);
+      },
+      inject(message, token) {
+        return sdkHandler.inject(message, token);
+      },
+      suspend() {
+        return sdkHandler.suspend();
+      },
+      shutdown(reason?: string) {
+        return sdkHandler.shutdown(reason);
+      },
+    } satisfies AgentHandler;
+  }
   if (engine === "app-server") return createCodexAppServerHandler(config);
 
   let active: AgentHandler = createCodexAppServerHandler(config);
@@ -61,6 +90,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
         return await active.start(message, ctx, token);
       } catch (err) {
         if (usingFallback || !(err instanceof CodexAppServerStartupError)) throw err;
+        if (isLandingCampaignTrialAgentMetadata(ctx.agent.metadata)) throw err;
         await closeAppServerBeforeFallback(ctx, err);
         ctx.log(`${err.message}; falling back to @openai/codex-sdk handler`);
         return switchToSdk().start(message, ctx, token);
@@ -72,6 +102,7 @@ export const createCodexHandler: HandlerFactory = (config) => {
         return await active.resume(message, sessionId, ctx, token);
       } catch (err) {
         if (usingFallback || !(err instanceof CodexAppServerStartupError)) throw err;
+        if (isLandingCampaignTrialAgentMetadata(ctx.agent.metadata)) throw err;
         await closeAppServerBeforeFallback(ctx, err);
         ctx.log(`${err.message}; falling back to @openai/codex-sdk handler`);
         return switchToSdk().resume(message, sessionId, ctx, token);

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -206,7 +206,11 @@ function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
  * can lock the auth-mode-friendly defaults (notably `model` only set when
  * the operator chose one).
  */
-export function buildCodexThreadOptions(payload: AgentRuntimeConfigPayload, workspaceCwd: string): ThreadOptions {
+export function buildCodexThreadOptions(
+  payload: AgentRuntimeConfigPayload,
+  workspaceCwd: string,
+  options: { workspaceOnly?: boolean } = {},
+): ThreadOptions {
   const additionalDirectories: string[] = [];
   for (const repo of payload.gitRepos) {
     const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
@@ -224,16 +228,14 @@ export function buildCodexThreadOptions(payload: AgentRuntimeConfigPayload, work
   // matches the user's auth mode (e.g. ChatGPT-account auth rejects the
   // `gpt-5-codex` family, while API-key auth accepts it). Hard-coding a
   // default here would force one auth mode and silently fail on the other.
-  // Sandbox: codex is the agent's primary local-execution surface (docker,
-  // cross-directory writes, host tools all flow through it). `workspace-write`
-  // blocks unix sockets outside the workspace (notably ~/.docker/run/docker.sock)
-  // and any out-of-tree write the agent legitimately needs. We run with
-  // `danger-full-access` and rely on the agent to gate irreversible actions
-  // itself instead of a sandbox-level wall.
+  // Sandbox: ordinary codex agents remain `danger-full-access` because codex is
+  // their primary local-execution surface. Landing campaign trials run inside a
+  // process-level workspace-only sandbox; use codex's own workspace-write mode
+  // there as a second, scoped belt without changing the ordinary path.
   const opts: ThreadOptions = {
     workingDirectory: workspaceCwd,
     skipGitRepoCheck: true,
-    sandboxMode: "danger-full-access",
+    sandboxMode: options.workspaceOnly ? "workspace-write" : "danger-full-access",
     approvalPolicy: "never",
     // Operator-configured reasoning effort. Defaults to "high" (the value this
     // previously hard-coded). The codex variant's enum (low|medium|high|xhigh)

--- a/packages/client/src/sdk.ts
+++ b/packages/client/src/sdk.ts
@@ -299,6 +299,12 @@ export class FirstTreeHubSDK {
     });
   }
 
+  async createAgentOutboxToken(chatId: string): Promise<{ accessToken: string; expiresIn: number }> {
+    return this.requestJson(`/api/v1/agent/chats/${encodeURIComponent(chatId)}/outbox-token`, {
+      method: "POST",
+    });
+  }
+
   async createTaskChat(data: CreateTaskChat): Promise<{
     chatId: string;
     messageId: string;

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -61,6 +61,7 @@ export type CreateTestAppOptions = {
   growthLandingPagesEnabled?: boolean;
   landingCampaignServiceUserId?: string;
   landingCampaignClientId?: string;
+  landingCampaignRuntimeProvider?: "codex" | "claude-code";
   commandVersion?: string;
   rateLimit?: Partial<NonNullable<Config["rateLimit"]>>;
   connectBootstrap?: Config["connectBootstrap"];
@@ -92,11 +93,14 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
     channel: opts.channel ?? "dev",
     growth: {
       landingPagesEnabled: opts.growthLandingPagesEnabled ?? false,
-      ...(opts.landingCampaignServiceUserId !== undefined || opts.landingCampaignClientId !== undefined
+      ...(opts.landingCampaignServiceUserId !== undefined ||
+      opts.landingCampaignClientId !== undefined ||
+      opts.landingCampaignRuntimeProvider !== undefined
         ? {
             landingCampaigns: {
               serviceUserId: opts.landingCampaignServiceUserId,
               clientId: opts.landingCampaignClientId,
+              runtimeProvider: opts.landingCampaignRuntimeProvider ?? "codex",
             },
           }
         : {}),

--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -112,6 +112,12 @@ describe("POST /me/landing-campaigns/start", () => {
     landingCampaignServiceUserId: SERVICE_USER_ID,
     landingCampaignClientId: OFFICIAL_CLIENT_ID,
   });
+  const getClaudeProviderApp = useTestApp({
+    growthLandingPagesEnabled: true,
+    landingCampaignServiceUserId: SERVICE_USER_ID,
+    landingCampaignClientId: OFFICIAL_CLIENT_ID,
+    landingCampaignRuntimeProvider: "claude-code",
+  });
 
   it("feature flag off rejects before creating service member, trial agent, chat, or resource", async () => {
     const app = getDisabledApp();
@@ -121,6 +127,33 @@ describe("POST /me/landing-campaigns/start", () => {
 
     expect(res.statusCode).toBe(404);
     expect(res.json()).toMatchObject({ code: "feature_disabled" });
+    const serviceMembers = await app.db
+      .select()
+      .from(members)
+      .where(and(eq(members.userId, SERVICE_USER_ID), eq(members.organizationId, admin.organizationId)));
+    expect(serviceMembers).toHaveLength(0);
+    const trialAgents = await app.db
+      .select()
+      .from(agents)
+      .where(
+        and(
+          eq(agents.organizationId, admin.organizationId),
+          sql`${agents.metadata} ->> 'landingCampaignTrial' = 'true'`,
+        ),
+      );
+    expect(trialAgents).toHaveLength(0);
+  });
+
+  it("fails closed for Claude Code until landing campaign workspace-only is implemented", async () => {
+    const app = getClaudeProviderApp();
+    const admin = await createTestAdmin(app);
+
+    const res = await startProductionScan(app, admin);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toMatchObject({
+      error: expect.stringContaining("Claude Code runtime is not available"),
+    });
     const serviceMembers = await app.db
       .select()
       .from(members)
@@ -331,12 +364,12 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(trialChats).toHaveLength(1);
   });
 
-  it("rejects ordinary user attempts to spoof the official client or trial metadata", async () => {
+  it("keeps the official client ordinary outside trial metadata while preserving ownership and spoofing guards", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     await seedOfficialRuntime(app, admin.organizationId);
 
-    const officialClient = await app.inject({
+    const ordinaryUserOfficialClient = await app.inject({
       method: "POST",
       url: `/api/v1/orgs/${admin.organizationId}/agents`,
       headers: { authorization: `Bearer ${admin.accessToken}` },
@@ -347,7 +380,28 @@ describe("POST /me/landing-campaigns/start", () => {
         clientId: OFFICIAL_CLIENT_ID,
       },
     });
-    expect(officialClient.statusCode).toBe(403);
+    expect(ordinaryUserOfficialClient.statusCode).toBe(403);
+
+    const started = await startProductionScan(app, admin);
+    expect(started.statusCode).toBe(200);
+    const serviceAccessToken = await createLandingCampaignServiceAccessToken(app);
+    const serviceOwnedOrdinaryAgent = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${admin.organizationId}/agents`,
+      headers: { authorization: `Bearer ${serviceAccessToken}` },
+      payload: {
+        type: "agent",
+        name: "service-owned-ordinary",
+        displayName: "Service Owned Ordinary",
+        clientId: OFFICIAL_CLIENT_ID,
+      },
+    });
+    expect(serviceOwnedOrdinaryAgent.statusCode).toBe(201);
+    expect(
+      parseLandingCampaignTrialAgentMetadata(
+        serviceOwnedOrdinaryAgent.json<{ metadata: Record<string, unknown> }>().metadata,
+      ),
+    ).toBeNull();
 
     const metadata = await app.inject({
       method: "POST",
@@ -455,6 +509,151 @@ describe("POST /me/landing-campaigns/start", () => {
       .from(chatMembership)
       .where(and(eq(chatMembership.chatId, body.chatId), eq(chatMembership.agentId, ordinary.uuid)));
     expect(rows).toHaveLength(0);
+  });
+
+  it("issues an outbox token scoped to the current trial agent and chat message route", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const started = await startProductionScan(app, admin);
+    const body = started.json<{ chatId: string; agentUuid: string }>();
+    const ordinary = await createRunnableOrgAgent(app, admin, "ordinary-agent-outbox-scope");
+    const serviceAccessToken = await createLandingCampaignServiceAccessToken(app);
+    const trialAgentRequest = agentRequest(app, serviceAccessToken, body.agentUuid);
+
+    const tokenRes = await trialAgentRequest("POST", `/api/v1/agent/chats/${body.chatId}/outbox-token`);
+
+    expect(tokenRes.statusCode).toBe(200);
+    const outbox = tokenRes.json<{ accessToken: string; expiresIn: number }>();
+    expect(outbox.accessToken).toBeTruthy();
+    expect(outbox.expiresIn).toBeGreaterThan(0);
+
+    const send = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/chats/${body.chatId}/messages`,
+      headers: { authorization: `Bearer ${outbox.accessToken}`, "x-agent-id": body.agentUuid },
+      payload: {
+        format: "text",
+        content: "Final trial report.",
+        metadata: { mentions: [admin.humanAgentUuid] },
+        source: "cli",
+      },
+    });
+    expect(send.statusCode).toBe(201);
+    const [completedChat] = await app.db
+      .select({ metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, body.chatId));
+    expect(parseLandingCampaignTrialChatMetadata(completedChat?.metadata)).toMatchObject({
+      state: "completed",
+      inputLocked: true,
+    });
+
+    const sendAfterCompleted = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/chats/${body.chatId}/messages`,
+      headers: { authorization: `Bearer ${outbox.accessToken}`, "x-agent-id": body.agentUuid },
+      payload: {
+        format: "text",
+        content: "Follow-up after completion.",
+        metadata: { mentions: [admin.humanAgentUuid] },
+        source: "cli",
+      },
+    });
+    expect(sendAfterCompleted.statusCode).toBe(403);
+
+    const requestAfterCompleted = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/chats/${body.chatId}/messages`,
+      headers: { authorization: `Bearer ${outbox.accessToken}`, "x-agent-id": body.agentUuid },
+      payload: {
+        format: MESSAGE_FORMATS.REQUEST,
+        content: "Can you answer after completion?",
+        metadata: { mentions: [admin.humanAgentUuid] },
+        source: "cli",
+      },
+    });
+    expect(requestAfterCompleted.statusCode).toBe(403);
+    const [stillCompletedChat] = await app.db
+      .select({ metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, body.chatId));
+    expect(parseLandingCampaignTrialChatMetadata(stillCompletedChat?.metadata)).toMatchObject({
+      state: "completed",
+      inputLocked: true,
+    });
+
+    const me = await app.inject({
+      method: "GET",
+      url: "/api/v1/me",
+      headers: { authorization: `Bearer ${outbox.accessToken}` },
+    });
+    expect(me.statusCode).toBe(401);
+
+    const wrongAgent = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/chats/${body.chatId}/messages`,
+      headers: { authorization: `Bearer ${outbox.accessToken}`, "x-agent-id": ordinary.uuid },
+      payload: {
+        format: "text",
+        content: "Wrong agent.",
+        metadata: { mentions: [admin.humanAgentUuid] },
+        source: "cli",
+      },
+    });
+    expect(wrongAgent.statusCode).toBe(401);
+  });
+
+  it("serializes concurrent trial outbox writes so only one state transition wins", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const started = await startProductionScan(app, admin);
+    const body = started.json<{ chatId: string; agentUuid: string }>();
+    const serviceAccessToken = await createLandingCampaignServiceAccessToken(app);
+    const trialAgentRequest = agentRequest(app, serviceAccessToken, body.agentUuid);
+    const tokenRes = await trialAgentRequest("POST", `/api/v1/agent/chats/${body.chatId}/outbox-token`);
+    const outbox = tokenRes.json<{ accessToken: string }>();
+
+    const [finalRes, requestRes] = await Promise.all([
+      app.inject({
+        method: "POST",
+        url: `/api/v1/agent/chats/${body.chatId}/messages`,
+        headers: { authorization: `Bearer ${outbox.accessToken}`, "x-agent-id": body.agentUuid },
+        payload: {
+          format: "text",
+          content: "Final trial report.",
+          metadata: { mentions: [admin.humanAgentUuid] },
+          source: "cli",
+        },
+      }),
+      app.inject({
+        method: "POST",
+        url: `/api/v1/agent/chats/${body.chatId}/messages`,
+        headers: { authorization: `Bearer ${outbox.accessToken}`, "x-agent-id": body.agentUuid },
+        payload: {
+          format: MESSAGE_FORMATS.REQUEST,
+          content: "Need one more answer?",
+          metadata: { mentions: [admin.humanAgentUuid] },
+          source: "cli",
+        },
+      }),
+    ]);
+
+    expect([finalRes.statusCode, requestRes.statusCode].sort()).toEqual([201, 403]);
+    const trialMessages = await app.db
+      .select({ id: messages.id, format: messages.format })
+      .from(messages)
+      .where(and(eq(messages.chatId, body.chatId), eq(messages.senderId, body.agentUuid)));
+    expect(trialMessages).toHaveLength(1);
+
+    const [chat] = await app.db.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, body.chatId));
+    const trial = parseLandingCampaignTrialChatMetadata(chat?.metadata);
+    if (finalRes.statusCode === 201) {
+      expect(trial).toMatchObject({ state: "completed", inputLocked: true });
+    } else {
+      expect(trial).toMatchObject({ state: "awaiting_user", inputLocked: false });
+    }
   });
 
   it("blocks agent-runtime participant removal on landing campaign trial chats", async () => {
@@ -625,7 +824,7 @@ describe("POST /me/landing-campaigns/start", () => {
     });
   });
 
-  it("hides the service member and official client from ordinary org lists", async () => {
+  it("hides the service member but treats the official client as an ordinary admin-visible client", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     await seedOfficialRuntime(app, admin.organizationId);
@@ -645,7 +844,7 @@ describe("POST /me/landing-campaigns/start", () => {
       headers: { authorization: `Bearer ${admin.accessToken}` },
     });
     expect(clientsRes.statusCode).toBe(200);
-    expect(clientsRes.json<Array<{ id: string }>>().some((row) => row.id === OFFICIAL_CLIENT_ID)).toBe(false);
+    expect(clientsRes.json<Array<{ id: string }>>().some((row) => row.id === OFFICIAL_CLIENT_ID)).toBe(true);
 
     const meRes = await app.inject({
       method: "GET",

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -2,6 +2,8 @@ import { paginationQuerySchema, sendMessageSchema } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { requireAgent } from "../../middleware/require-identity.js";
+import { requireUser } from "../../scope/require-user.js";
+import { expiryToSeconds, signAgentOutboxToken } from "../../services/auth.js";
 import * as chatService from "../../services/chat.js";
 import * as messageService from "../../services/message.js";
 import { notifyRecipients } from "../../services/notifier.js";
@@ -12,6 +14,21 @@ const editMessageSchema = z.object({
 });
 
 export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
+  app.post<{ Params: { chatId: string } }>("/:chatId/outbox-token", async (request) => {
+    const identity = requireAgent(request);
+    const user = requireUser(request);
+    await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
+    return {
+      accessToken: await signAgentOutboxToken(
+        app.config.secrets.jwtSecret,
+        user.userId,
+        { agentId: identity.uuid, chatId: request.params.chatId },
+        app.config.auth.accessTokenExpiry,
+      ),
+      expiresIn: expiryToSeconds(app.config.auth.accessTokenExpiry),
+    };
+  });
+
   app.post<{ Params: { chatId: string } }>(
     "/:chatId/messages",
     { config: { otelRecordBody: true } },

--- a/packages/server/src/api/orgs/agents.ts
+++ b/packages/server/src/api/orgs/agents.ts
@@ -12,10 +12,7 @@ import { requireOrgMembership } from "../../scope/require-org.js";
 import * as agentService from "../../services/agent.js";
 import { resolveAvatarImageUrl } from "../../services/agent.js";
 import { sendToClient } from "../../services/connection-manager.js";
-import {
-  assertMetadataDoesNotClaimLandingCampaignTrial,
-  isLandingCampaignOfficialClient,
-} from "../../services/landing-campaigns/guards.js";
+import { assertMetadataDoesNotClaimLandingCampaignTrial } from "../../services/landing-campaigns/guards.js";
 
 function serializeNewChatDefaultCandidate(agent: agentService.NewChatDefaultCandidateAgent) {
   return { ...agent, createdAt: agent.createdAt.toISOString() };
@@ -144,9 +141,6 @@ export async function orgAgentRoutes(app: FastifyInstance): Promise<void> {
       throw new BadRequestError("Human agents are created through the member lifecycle");
     }
     assertMetadataDoesNotClaimLandingCampaignTrial(body.metadata);
-    if (isLandingCampaignOfficialClient(app.config, body.clientId)) {
-      throw new ForbiddenError("First Tree landing campaign client is not available for user-created agents");
-    }
     // member role: managerId forced to caller's member; admin role may
     // specify any managerId in the same org.
     const managerId = scope.role === "admin" ? (body.managerId ?? scope.memberId) : scope.memberId;

--- a/packages/server/src/api/orgs/clients.ts
+++ b/packages/server/src/api/orgs/clients.ts
@@ -3,7 +3,6 @@ import type { FastifyInstance } from "fastify";
 import { requireOrgAdmin } from "../../scope/require-org.js";
 import { expiryToSeconds } from "../../services/auth.js";
 import * as clientService from "../../services/client.js";
-import { isLandingCampaignOfficialClient } from "../../services/landing-campaigns/guards.js";
 import { serializeDate } from "../../utils.js";
 import { clientCommandVersionHint } from "../client-command-version.js";
 
@@ -16,9 +15,7 @@ export async function orgClientRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { orgId: string } }>("/", async (request) => {
     // Listing this collection requires admin in the target org.
     const scope = await requireOrgAdmin(request, app.db);
-    const clients = (await clientService.listClientsForOrgAdmin(app.db, scope.organizationId)).filter(
-      (client) => !isLandingCampaignOfficialClient(app.config, client.id),
-    );
+    const clients = await clientService.listClientsForOrgAdmin(app.db, scope.organizationId);
     const refreshExpirySeconds = expiryToSeconds(app.config.auth.refreshTokenExpiry);
     const binName = getChannelConfig(app.config.channel).binName;
     return clients.map((c) => ({

--- a/packages/server/src/middleware/agent-selector.ts
+++ b/packages/server/src/middleware/agent-selector.ts
@@ -61,6 +61,10 @@ export function agentSelectorHook(db: Database) {
       throw new ForbiddenError("Agent is not active");
     }
 
+    if (user.agentOutbox && user.agentOutbox.agentId !== row.uuid) {
+      throw new ForbiddenError("Agent outbox token is not valid for this agent");
+    }
+
     // Verify the caller has an active membership in the agent's own org.
     // No JWT default-org coupling — cross-org under a single user is
     // allowed; a revoked membership refuses immediately.

--- a/packages/server/src/middleware/user-auth.ts
+++ b/packages/server/src/middleware/user-auth.ts
@@ -1,3 +1,4 @@
+import { AGENT_SELECTOR_HEADER } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { jwtVerify } from "jose";
@@ -29,10 +30,10 @@ export function userAuthHook(db: Database, jwtSecret: string) {
 
     const token = header.slice(7);
 
-    let payload: { sub?: string; type?: string };
+    let payload: { sub?: string; type?: string; agentId?: unknown; chatId?: unknown };
     try {
       const { payload: p } = await jwtVerify(token, secret);
-      payload = p as typeof payload;
+      payload = p as typeof payload & { agentId?: unknown; chatId?: unknown };
     } catch (err) {
       // see jwt-trace.ts for the trace-only safety contract
       const untrusted = decodeJwtForTrace(token);
@@ -42,10 +43,22 @@ export function userAuthHook(db: Database, jwtSecret: string) {
       });
     }
 
-    if (payload.type !== "access" || !payload.sub) {
+    if ((payload.type !== "access" && payload.type !== "agent_outbox") || !payload.sub) {
       throw new UnauthorizedError("Invalid token type", {
         "auth.failure_reason": "wrong_token_type",
         "auth.token_type": String(payload.type ?? "<missing>"),
+      });
+    }
+
+    const agentOutbox = payload.type === "agent_outbox" ? parseAgentOutboxScope(payload.agentId, payload.chatId) : null;
+    if (payload.type === "agent_outbox" && !agentOutbox) {
+      throw new UnauthorizedError("Invalid agent outbox token", {
+        "auth.failure_reason": "invalid_agent_outbox_scope",
+      });
+    }
+    if (agentOutbox && !isAllowedAgentOutboxRequest(request, agentOutbox)) {
+      throw new UnauthorizedError("Agent outbox token is not valid for this request", {
+        "auth.failure_reason": "agent_outbox_scope_mismatch",
       });
     }
 
@@ -69,6 +82,30 @@ export function userAuthHook(db: Database, jwtSecret: string) {
       });
     }
 
-    request.user = { userId: user.id };
+    request.user = agentOutbox ? { userId: user.id, agentOutbox } : { userId: user.id };
   };
+}
+
+function parseAgentOutboxScope(agentId: unknown, chatId: unknown): { agentId: string; chatId: string } | null {
+  if (typeof agentId !== "string" || agentId.length === 0) return null;
+  if (typeof chatId !== "string" || chatId.length === 0) return null;
+  return { agentId, chatId };
+}
+
+function isAllowedAgentOutboxRequest(request: FastifyRequest, scope: { agentId: string; chatId: string }): boolean {
+  if (request.method !== "POST") return false;
+  if (request.headers[AGENT_SELECTOR_HEADER] !== scope.agentId) return false;
+
+  const pathname = new URL(request.url, "http://first-tree.local").pathname;
+  const marker = "/agent/chats/";
+  const markerIndex = pathname.indexOf(marker);
+  if (markerIndex < 0) return false;
+  const tail = pathname.slice(markerIndex + marker.length);
+  const parts = tail.split("/");
+  if (parts.length !== 2 || parts[1] !== "messages") return false;
+  try {
+    return decodeURIComponent(parts[0] ?? "") === scope.chatId;
+  } catch {
+    return false;
+  }
 }

--- a/packages/server/src/scope/types.ts
+++ b/packages/server/src/scope/types.ts
@@ -1,17 +1,25 @@
 /**
  * Scope types — what each route helper returns after gating the request.
  *
- * `UserScope` carries only the JWT-verified `userId`. Anything beyond that
- * (org, role, human-agent) requires a real-time DB probe via the `OrgScope`
- * helpers in `require-org.ts` and `require-resource.ts`.
+ * `UserScope` carries the JWT-verified `userId`. Anything org-scoped (org,
+ * role, human-agent) requires a real-time DB probe via the `OrgScope` helpers
+ * in `require-org.ts` and `require-resource.ts`. `agentOutbox` is a narrow
+ * route-scoped exception used only for workspace-only trial sandbox outbox
+ * tokens.
  *
  * The split is deliberate: it makes "scope = JWT" a hard type-level
  * impossibility, killing the JWT-ambient-scope bug class (#220 / #222 /
  * #238 / #239) at compile time.
  */
 
+export type AgentOutboxScope = {
+  agentId: string;
+  chatId: string;
+};
+
 export type UserScope = {
   userId: string;
+  agentOutbox?: AgentOutboxScope;
 };
 
 export type OrgScope = {

--- a/packages/server/src/services/auth.ts
+++ b/packages/server/src/services/auth.ts
@@ -25,15 +25,18 @@ const consumedConnectJtis = new Map<string, number>();
 const CONNECT_JTI_TTL_MS = 600_000;
 
 /**
- * JWT payload shape. Carries ONLY the user identity — no org / member /
- * role. Anything beyond `userId` is resolved per-request via the
- * `scope/require-*` helpers, which forces every authz decision through a
- * real-time DB probe (kills the JWT-ambient-scope bug class).
+ * JWT payload shape. Normal access/refresh/connect tokens carry only the user
+ * identity — no org / member / role. The `agent_outbox` token is a narrow
+ * route-scoped exception for workspace-only trial sandboxes: it may carry the
+ * current agent/chat ids, and `userAuthHook` accepts it only for that agent's
+ * message POST in that chat.
  */
 type TokenPayload = {
   sub: string;
-  type: "access" | "refresh" | "connect";
+  type: "access" | "refresh" | "connect" | "agent_outbox";
   iss?: string;
+  agentId?: string;
+  chatId?: string;
 };
 
 async function signToken(
@@ -72,6 +75,16 @@ export async function signTokensForUser(
   const accessToken = await signToken(secret, { sub: userId, type: "access" }, expiries.accessTokenExpiry);
   const refreshToken = await signToken(secret, { sub: userId, type: "refresh" }, expiries.refreshTokenExpiry);
   return { accessToken, refreshToken };
+}
+
+export async function signAgentOutboxToken(
+  jwtSecretKey: string,
+  userId: string,
+  scope: { agentId: string; chatId: string },
+  expiry: string,
+): Promise<string> {
+  const secret = new TextEncoder().encode(jwtSecretKey);
+  return signToken(secret, { sub: userId, type: "agent_outbox", agentId: scope.agentId, chatId: scope.chatId }, expiry);
 }
 
 /**

--- a/packages/server/src/services/landing-campaigns/guards.ts
+++ b/packages/server/src/services/landing-campaigns/guards.ts
@@ -6,10 +6,6 @@ import { agents } from "../../db/schema/agents.js";
 import { members } from "../../db/schema/members.js";
 import { ForbiddenError } from "../../errors.js";
 
-export function isLandingCampaignOfficialClient(config: Config, clientId: string | null | undefined): boolean {
-  return !!clientId && clientId === config.growth.landingCampaigns?.clientId;
-}
-
 export function isLandingCampaignOfficialUser(config: Config, userId: string | null | undefined): boolean {
   return !!userId && userId === config.growth.landingCampaigns?.serviceUserId;
 }

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -4,6 +4,7 @@ import {
   type LandingCampaignRepoMetadata,
   type LandingCampaignStartRequest,
   type LandingCampaignStartResponse,
+  type RuntimeProvider,
   type SendMessage,
 } from "@first-tree/shared";
 import { and, asc, eq, ne, sql } from "drizzle-orm";
@@ -43,13 +44,28 @@ type ActiveMembership = {
   createdAt: Date;
 };
 
-function requireLandingCampaignConfig(app: FastifyInstance): { serviceUserId: string; clientId: string } {
+function requireLandingCampaignConfig(app: FastifyInstance): {
+  serviceUserId: string;
+  clientId: string;
+  runtimeProvider: Extract<RuntimeProvider, "codex" | "claude-code">;
+} {
   const serviceUserId = app.config.growth.landingCampaigns?.serviceUserId;
   const clientId = app.config.growth.landingCampaigns?.clientId;
   if (!serviceUserId || !clientId) {
     throw new ServiceUnavailableError("Landing campaign official runtime is not configured");
   }
-  return { serviceUserId, clientId };
+  return { serviceUserId, clientId, runtimeProvider: app.config.growth.landingCampaigns?.runtimeProvider ?? "codex" };
+}
+
+function assertLandingCampaignRuntimeProviderSupported(provider: RuntimeProvider): void {
+  if (provider === "claude-code") {
+    throw new ServiceUnavailableError(
+      "Landing campaign Claude Code runtime is not available until Claude Code workspace-only is implemented.",
+    );
+  }
+  if (provider !== "codex") {
+    throw new ServiceUnavailableError(`Landing campaign runtime provider "${provider}" is not supported.`);
+  }
 }
 
 function parseRepo(repoUrl: string): LandingCampaignRepoMetadata {
@@ -215,6 +231,7 @@ async function ensureTrialAgent(
     organizationId: string;
     serviceMemberId: string;
     officialClientId: string;
+    runtimeProvider: RuntimeProvider;
     campaign: string;
     skillSet: NonNullable<ReturnType<typeof getLandingCampaignSkillSet>>;
     repo: LandingCampaignRepoMetadata;
@@ -245,7 +262,7 @@ async function ensureTrialAgent(
     if (
       existing.managerId !== input.serviceMemberId ||
       existing.clientId !== input.officialClientId ||
-      existing.runtimeProvider !== input.skillSet.runtimeProvider
+      existing.runtimeProvider !== input.runtimeProvider
     ) {
       throw new ConflictError(
         "Existing landing campaign trial agent is pinned to a different manager, client, or runtime provider.",
@@ -274,7 +291,7 @@ async function ensureTrialAgent(
     managerId: input.serviceMemberId,
     organizationId: input.organizationId,
     clientId: input.officialClientId,
-    runtimeProvider: input.skillSet.runtimeProvider,
+    runtimeProvider: input.runtimeProvider,
     metadata,
   });
 }
@@ -285,6 +302,7 @@ async function provisionTrialAgent(
     organizationId: string;
     serviceUserId: string;
     officialClientId: string;
+    runtimeProvider: RuntimeProvider;
     campaign: string;
     skillSet: NonNullable<ReturnType<typeof getLandingCampaignSkillSet>>;
     repo: LandingCampaignRepoMetadata;
@@ -302,6 +320,7 @@ async function provisionTrialAgent(
       organizationId: input.organizationId,
       serviceMemberId: serviceMember.id,
       officialClientId: input.officialClientId,
+      runtimeProvider: input.runtimeProvider,
       campaign: input.campaign,
       skillSet: input.skillSet,
       repo: input.repo,
@@ -416,6 +435,7 @@ export async function startLandingCampaignTrial(
   setupUrl: string,
 ): Promise<LandingCampaignStartResponse> {
   const config = requireLandingCampaignConfig(app);
+  assertLandingCampaignRuntimeProviderSupported(config.runtimeProvider);
   const skillSet = getLandingCampaignSkillSet(body.campaign);
   if (!skillSet) throw new NotFoundError(`Landing campaign "${body.campaign}" not found`);
   const repo = parseRepo(body.repoUrl);
@@ -429,6 +449,7 @@ export async function startLandingCampaignTrial(
     organizationId: caller.organizationId,
     serviceUserId: config.serviceUserId,
     officialClientId: config.clientId,
+    runtimeProvider: config.runtimeProvider,
     campaign: body.campaign,
     skillSet,
     repo,

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -121,6 +121,42 @@ function validateMessageContent(data: { format: string; content: unknown }): voi
   }
 }
 
+function assertLandingCampaignTrialMessageAllowed(input: {
+  chat: { metadata: Record<string, unknown> | null } | null | undefined;
+  senderId: string;
+  senderType: string;
+  data: SendMessage;
+  metadataToStore: Record<string, unknown>;
+  options: SendMessageOptions;
+}): void {
+  const trial = getLandingCampaignTrialChat(input.chat);
+  if (!trial) return;
+
+  if (trial.state === "completed" || trial.state === "failed") {
+    throw new ForbiddenError("Landing campaign trial chat is already complete.");
+  }
+
+  if (input.senderId === trial.agentId && input.senderType !== "human") {
+    if (trial.state !== "running") {
+      throw new ForbiddenError("Landing campaign trial agent can only send while the trial is running.");
+    }
+    return;
+  }
+
+  if (input.senderType === "human") {
+    const isSystemBootstrap =
+      input.options.allowSystemSender === true &&
+      input.metadataToStore.systemSender === "first_tree_onboarding" &&
+      trial.state === "running";
+    if (isSystemBootstrap) return;
+
+    const resolvesRequest = requestResolutionSchema.safeParse(input.metadataToStore.resolves).success;
+    if (trial.state === "awaiting_user" && resolvesRequest) return;
+  }
+
+  throw new ForbiddenError("Landing campaign trial chat is locked.");
+}
+
 export type SendMessageResult = {
   message: typeof messages.$inferSelect;
   /** Inbox IDs that received this message (for notification). */
@@ -500,7 +536,7 @@ async function sendMessageInner(
     //    v2: `chat_membership.mode` is **not** SELECTed — fan-out no longer
     //    reads it. Likewise `chats.type` is locked to 'group' since
     //    first-tree-context PR #465 and no longer drives any decision here.
-    const [participants, [senderRow], [chatRow]] = await Promise.all([
+    const [participants, [senderRow], [chatRowSnapshot]] = await Promise.all([
       tx
         .select({
           agentId: chatMembership.agentId,
@@ -523,6 +559,15 @@ async function sendMessageInner(
     if (!senderRow) {
       throw new NotFoundError(`Sender agent "${senderId}" not found`);
     }
+    const initialTrial = getLandingCampaignTrialChat(chatRowSnapshot);
+    // Trial chat state is a server-owned single-run state machine. Lock and
+    // re-read only those rows so concurrent outbox writes cannot apply stale
+    // running-state transitions after another send completes the trial.
+    const chatRow = initialTrial
+      ? (
+          await tx.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, chatId)).for("update").limit(1)
+        )[0]
+      : chatRowSnapshot;
 
     const prepared = preflightMessageSendIntent({
       chatId,
@@ -533,6 +578,15 @@ async function sendMessageInner(
       participants,
     });
     const { content: outboundContent, metadata: metadataToStore, mentionedAgentIds: mergedMentions } = prepared;
+
+    assertLandingCampaignTrialMessageAllowed({
+      chat: chatRow,
+      senderId,
+      senderType: senderRow.type,
+      data,
+      metadataToStore,
+      options,
+    });
 
     // 2b. Validate generic attachment refs (`metadata.attachments[]`) against
     //     the blob store: each referenced attachment must exist and its

--- a/packages/shared/src/config/__tests__/server-config.test.ts
+++ b/packages/shared/src/config/__tests__/server-config.test.ts
@@ -111,7 +111,51 @@ describe("server config", () => {
     expect(configured.growth.landingCampaigns).toEqual({
       serviceUserId: "user_service",
       clientId: "client_official",
+      runtimeProvider: "codex",
     });
+  });
+
+  it("defaults landing campaign runtime provider to codex and accepts claude-code", async () => {
+    const defaultDir = makeTempConfigDir();
+    stubRequiredProductionConfig();
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_SERVICE_USER_ID", "user_service");
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_CLIENT_ID", "client_official");
+
+    const defaultProvider = await initConfig({
+      schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+      role: "server",
+      configDir: defaultDir,
+    });
+
+    expect(defaultProvider.growth.landingCampaigns?.runtimeProvider).toBe("codex");
+
+    resetConfig();
+    const claudeDir = makeTempConfigDir();
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_RUNTIME_PROVIDER", "claude-code");
+
+    const claudeProvider = await initConfig({
+      schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+      role: "server",
+      configDir: claudeDir,
+    });
+
+    expect(claudeProvider.growth.landingCampaigns?.runtimeProvider).toBe("claude-code");
+  });
+
+  it("rejects unsupported landing campaign runtime providers", async () => {
+    const configDir = makeTempConfigDir();
+    stubRequiredProductionConfig();
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_SERVICE_USER_ID", "user_service");
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_CLIENT_ID", "client_official");
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_RUNTIME_PROVIDER", "claude-code-tui");
+
+    await expect(
+      initConfig({
+        schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+        role: "server",
+        configDir,
+      }),
+    ).rejects.toThrow(/Landing campaign runtime provider must be codex or claude-code/);
   });
 
   it("does not auto-generate server secrets when disabled", async () => {

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { z } from "zod";
 import { logFormatSchema, logLevelSchema } from "../observability/logger-core.js";
+import { runtimeProviderSchema } from "../schemas/runtime-provider.js";
 import { defaultDataDir } from "./resolver.js";
 import { defineConfig, field, optional } from "./schema.js";
 import { getConfig } from "./singleton.js";
@@ -11,6 +12,12 @@ const optionalTrimmedStringSchema = z.preprocess((value) => {
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
 }, z.string().min(1).optional());
+
+const landingCampaignRuntimeProviderSchema = runtimeProviderSchema
+  .refine((provider) => provider === "codex" || provider === "claude-code", {
+    message: "Landing campaign runtime provider must be codex or claude-code",
+  })
+  .default("codex");
 
 function serverSecretOptions(env: string, auto: string, autoGenerateSecrets: boolean) {
   return autoGenerateSecrets ? { env, auto, secret: true } : { env, secret: true };
@@ -71,6 +78,16 @@ export const serverConfigSchema = defineConfig({
        */
       clientId: field(optionalTrimmedStringSchema, {
         env: "FIRST_TREE_LANDING_CAMPAIGN_CLIENT_ID",
+      }),
+      /**
+       * Runtime provider assigned to newly provisioned landing campaign trial
+       * agents. The official client can advertise multiple providers; this
+       * switch only selects which provider the server pins on the agent row.
+       * Claude Code is accepted by config parsing but the start API remains
+       * fail-closed until its workspace-only runtime path exists.
+       */
+      runtimeProvider: field(landingCampaignRuntimeProviderSchema, {
+        env: "FIRST_TREE_LANDING_CAMPAIGN_RUNTIME_PROVIDER",
       }),
     }),
   },


### PR DESCRIPTION
## Summary

- Add `FIRST_TREE_LANDING_CAMPAIGN_RUNTIME_PROVIDER` with a default of `codex`, and fail closed for `claude-code` until Claude workspace-only support exists.
- Run Codex landing campaign trial agents through a Linux `bubblewrap` workspace-only spawn path keyed by `agent.metadata.landingCampaignTrial`, leaving ordinary Codex/Claude agents unaffected.
- Add a scoped `agent_outbox` token and sandbox-local First Tree home so trial agents can use `chat send` without exposing the service user's real local credentials.
- Guard landing campaign trial chat writes in the shared message service, including terminal-state and concurrent final/request transitions.
- Keep the official landing campaign client ordinary for non-trial use; trial semantics are tied to agent/chat metadata rather than client id.

## Not in this PR

- Claude Code workspace-only wrapper/provider resolver.
- Provider-specific landing campaign clients or skill catalog.
- GitHub token, network, CPU, memory, or disk quota governance.
- Reserved official client id registration guard.

## Verification

- `pnpm --filter @first-tree/shared exec vitest run --maxWorkers=2 src/config/__tests__/server-config.test.ts`
- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 src/__tests__/workspace-sandbox.test.ts src/__tests__/codex-app-server-handler.test.ts src/__tests__/codex-thread-options.test.ts src/__tests__/codex-handler-engine.test.ts`
- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 src/__tests__/landing-campaigns-start.test.ts src/__tests__/route-conventions.test.ts`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm typecheck`
- `pnpm check` (exits 0 with existing warnings/info)
- `git diff --check`

## Review

Reviewed in First Tree chat by `codex-reviewer`; latest review found no blocking issues.
