### PR TITLE
fix: bound landing service visibility to service org

### DIFF
--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -60,6 +60,7 @@ export type CreateTestAppOptions = {
   channel?: Config["channel"];
   growthLandingPagesEnabled?: boolean;
   landingCampaignServiceUserId?: string;
+  landingCampaignServiceOrgId?: string;
   landingCampaignClientId?: string;
   landingCampaignRuntimeProvider?: "codex" | "claude-code";
   commandVersion?: string;
@@ -94,11 +95,13 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
     growth: {
       landingPagesEnabled: opts.growthLandingPagesEnabled ?? false,
       ...(opts.landingCampaignServiceUserId !== undefined ||
+      opts.landingCampaignServiceOrgId !== undefined ||
       opts.landingCampaignClientId !== undefined ||
       opts.landingCampaignRuntimeProvider !== undefined
         ? {
             landingCampaigns: {
               serviceUserId: opts.landingCampaignServiceUserId,
+              serviceOrgId: opts.landingCampaignServiceOrgId,
               clientId: opts.landingCampaignClientId,
               runtimeProvider: opts.landingCampaignRuntimeProvider ?? "codex",
             },

--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -12,20 +12,34 @@ import { chats } from "../db/schema/chats.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
+import { organizations } from "../db/schema/organizations.js";
 import { resources } from "../db/schema/resources.js";
 import { users } from "../db/schema/users.js";
+import { createAgent } from "../services/agent.js";
 import { signTokensForUser } from "../services/auth.js";
+import { createMember } from "../services/member.js";
 import { sendMessage } from "../services/message.js";
+import { uuidv7 } from "../uuid.js";
 import { agentRequest, createTestAdmin, INVALID_BCRYPT_PLACEHOLDER, useTestApp } from "./helpers.js";
 
 const SERVICE_USER_ID = "landing-campaign-service-user-test";
+const SERVICE_ORG_ID = "landing-campaign-service-org-test";
 const OFFICIAL_CLIENT_ID = "landing-campaign-client-test";
 const START_URL = "/api/v1/me/landing-campaigns/start";
 
 async function seedOfficialRuntime(
   app: ReturnType<ReturnType<typeof useTestApp>>,
-  organizationId: string,
+  _organizationId: string,
 ): Promise<void> {
+  const serviceOrgId = app.config.growth.landingCampaigns?.serviceOrgId ?? SERVICE_ORG_ID;
+  await app.db
+    .insert(organizations)
+    .values({
+      id: serviceOrgId,
+      name: `landing-campaign-service-${serviceOrgId.slice(-8)}`,
+      displayName: "Landing Campaign Service",
+    })
+    .onConflictDoNothing();
   await app.db
     .insert(users)
     .values({
@@ -43,14 +57,44 @@ async function seedOfficialRuntime(
     .values({
       id: OFFICIAL_CLIENT_ID,
       userId: SERVICE_USER_ID,
-      organizationId,
+      organizationId: serviceOrgId,
       status: "connected",
       hostname: "landing-campaign-host",
     })
     .onConflictDoUpdate({
       target: clients.id,
-      set: { userId: SERVICE_USER_ID, organizationId, status: "connected", hostname: "landing-campaign-host" },
+      set: {
+        userId: SERVICE_USER_ID,
+        organizationId: serviceOrgId,
+        status: "connected",
+        hostname: "landing-campaign-host",
+      },
     });
+}
+
+async function attachOrg(
+  app: ReturnType<ReturnType<typeof useTestApp>>,
+  userId: string,
+  role: "admin" | "member",
+): Promise<{ orgId: string; memberId: string; humanAgentId: string }> {
+  const orgId = `org-lc-${crypto.randomUUID().slice(0, 8)}`;
+  const memberId = uuidv7();
+  let humanAgentId = "";
+  await app.db.transaction(async (tx) => {
+    await tx
+      .insert(organizations)
+      .values({ id: orgId, name: `lc-${crypto.randomUUID().slice(0, 6)}`, displayName: "Landing Side" });
+    const human = await createAgent(tx as unknown as typeof app.db, {
+      name: `lc-h-${crypto.randomUUID().slice(0, 6)}`,
+      type: "human",
+      displayName: "Landing Side Human",
+      managerId: memberId,
+      organizationId: orgId,
+    });
+    humanAgentId = human.uuid;
+    await tx.insert(members).values({ id: memberId, userId, organizationId: orgId, agentId: human.uuid, role });
+  });
+  return { orgId, memberId, humanAgentId };
 }
 
 async function startProductionScan(
@@ -106,15 +150,18 @@ describe("POST /me/landing-campaigns/start", () => {
   const getApp = useTestApp({
     growthLandingPagesEnabled: true,
     landingCampaignServiceUserId: SERVICE_USER_ID,
+    landingCampaignServiceOrgId: SERVICE_ORG_ID,
     landingCampaignClientId: OFFICIAL_CLIENT_ID,
   });
   const getDisabledApp = useTestApp({
     landingCampaignServiceUserId: SERVICE_USER_ID,
+    landingCampaignServiceOrgId: SERVICE_ORG_ID,
     landingCampaignClientId: OFFICIAL_CLIENT_ID,
   });
   const getClaudeProviderApp = useTestApp({
     growthLandingPagesEnabled: true,
     landingCampaignServiceUserId: SERVICE_USER_ID,
+    landingCampaignServiceOrgId: SERVICE_ORG_ID,
     landingCampaignClientId: OFFICIAL_CLIENT_ID,
     landingCampaignRuntimeProvider: "claude-code",
   });
@@ -169,6 +216,20 @@ describe("POST /me/landing-campaigns/start", () => {
         ),
       );
     expect(trialAgents).toHaveLength(0);
+  });
+
+  it("rejects an official client registered outside the service org", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    await app.db
+      .update(clients)
+      .set({ organizationId: admin.organizationId })
+      .where(eq(clients.id, OFFICIAL_CLIENT_ID));
+
+    const res = await startProductionScan(app, admin);
+
+    expect(res.statusCode).toBe(503);
   });
 
   it("creates the service-managed trial agent, installs the agent-scoped campaign skill, and starts a locked chat", async () => {
@@ -824,7 +885,7 @@ describe("POST /me/landing-campaigns/start", () => {
     });
   });
 
-  it("hides the service member but treats the official client as an ordinary admin-visible client", async () => {
+  it("hides the service member and service client outside the service org", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     await seedOfficialRuntime(app, admin.organizationId);
@@ -844,7 +905,7 @@ describe("POST /me/landing-campaigns/start", () => {
       headers: { authorization: `Bearer ${admin.accessToken}` },
     });
     expect(clientsRes.statusCode).toBe(200);
-    expect(clientsRes.json<Array<{ id: string }>>().some((row) => row.id === OFFICIAL_CLIENT_ID)).toBe(true);
+    expect(clientsRes.json<Array<{ id: string }>>().some((row) => row.id === OFFICIAL_CLIENT_ID)).toBe(false);
 
     const meRes = await app.inject({
       method: "GET",
@@ -856,6 +917,58 @@ describe("POST /me/landing-campaigns/start", () => {
       .json<{ memberships: Array<{ organizationId: string; orgHasOtherMembers: boolean }> }>()
       .memberships.find((row) => row.organizationId === admin.organizationId);
     expect(currentOrg?.orgHasOtherMembers).toBe(false);
+  });
+
+  it("treats the service user and client as ordinary inside the service org", async () => {
+    const app = getApp();
+    if (!app.config.growth.landingCampaigns) throw new Error("landing campaign config missing");
+    const previousServiceOrgId = app.config.growth.landingCampaigns.serviceOrgId;
+    try {
+      const admin = await createTestAdmin(app);
+      app.config.growth.landingCampaigns.serviceOrgId = admin.organizationId;
+      await seedOfficialRuntime(app, admin.organizationId);
+      const [existingServiceMember] = await app.db
+        .select()
+        .from(members)
+        .where(and(eq(members.userId, SERVICE_USER_ID), eq(members.organizationId, admin.organizationId)))
+        .limit(1);
+      const serviceMember =
+        existingServiceMember ??
+        (await createMember(app.db, admin.organizationId, {
+          username: "first-tree-landing-service-test",
+          displayName: "First Tree",
+          role: "member",
+        }));
+
+      const membersRes = await app.inject({
+        method: "GET",
+        url: `/api/v1/orgs/${admin.organizationId}/members`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+      expect(membersRes.statusCode).toBe(200);
+      expect(membersRes.json<Array<{ userId: string }>>().some((row) => row.userId === SERVICE_USER_ID)).toBe(true);
+
+      const patchMember = await app.inject({
+        method: "PATCH",
+        url: `/api/v1/orgs/${admin.organizationId}/members/${serviceMember.id}`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+        payload: { displayName: "First Tree Service" },
+      });
+      expect(patchMember.statusCode).toBe(200);
+
+      const clientsRes = await app.inject({
+        method: "GET",
+        url: `/api/v1/orgs/${admin.organizationId}/clients`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+      expect(clientsRes.statusCode).toBe(200);
+      expect(clientsRes.json<Array<{ id: string }>>().some((row) => row.id === OFFICIAL_CLIENT_ID)).toBe(true);
+
+      const startInServiceOrg = await startProductionScan(app, admin);
+      expect(startInServiceOrg.statusCode).toBe(403);
+    } finally {
+      app.config.growth.landingCampaigns.serviceOrgId = previousServiceOrgId;
+    }
   });
 
   it("prevents deleting the service member and editing the trial agent through ordinary management APIs", async () => {
@@ -889,5 +1002,32 @@ describe("POST /me/landing-campaigns/start", () => {
       payload: { resources: [] },
     });
     expect(patchResources.statusCode).toBe(403);
+  });
+
+  it("returns scoped 404 when another org admin targets the campaign service member id", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const started = await startProductionScan(app, admin);
+    const body = started.json<{ agentUuid: string }>();
+    const [trialAgent] = await app.db.select().from(agents).where(eq(agents.uuid, body.agentUuid)).limit(1);
+    if (!trialAgent?.managerId) throw new Error("trial agent manager missing");
+
+    const otherAdmin = await createTestAdmin(app);
+    const otherOrg = await attachOrg(app, otherAdmin.userId, "admin");
+    const patchMember = await app.inject({
+      method: "PATCH",
+      url: `/api/v1/orgs/${otherOrg.orgId}/members/${trialAgent.managerId}`,
+      headers: { authorization: `Bearer ${otherAdmin.accessToken}` },
+      payload: { displayName: "Renamed" },
+    });
+    expect(patchMember.statusCode).toBe(404);
+
+    const deleteMember = await app.inject({
+      method: "DELETE",
+      url: `/api/v1/orgs/${otherOrg.orgId}/members/${trialAgent.managerId}`,
+      headers: { authorization: `Bearer ${otherAdmin.accessToken}` },
+    });
+    expect(deleteMember.statusCode).toBe(404);
   });
 });

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -30,6 +30,7 @@ import * as clientService from "../services/client.js";
 import { GithubApiError, listUserRepos } from "../services/github-oauth.js";
 import { GithubUserTokenError, getFreshGithubUserToken } from "../services/github-user-token.js";
 import { buildInviteUrl, findActiveByToken, getActiveInvitation, recordRedemption } from "../services/invitation.js";
+import { isLandingCampaignServiceMembership } from "../services/landing-campaigns/guards.js";
 import { updateOwnProfile } from "../services/member.js";
 import {
   countActiveMembersByOrgs,
@@ -116,7 +117,7 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
     const serviceUserId = app.config.growth.landingCampaigns?.serviceUserId;
     if (serviceUserId && memberships.length > 0) {
       const serviceMemberRows = await app.db
-        .select({ organizationId: members.organizationId })
+        .select({ userId: members.userId, organizationId: members.organizationId })
         .from(members)
         .where(
           and(
@@ -129,6 +130,7 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
           ),
         );
       for (const row of serviceMemberRows) {
+        if (!isLandingCampaignServiceMembership(app.config, row)) continue;
         memberCounts.set(row.organizationId, Math.max(0, (memberCounts.get(row.organizationId) ?? 0) - 1));
       }
     }

--- a/packages/server/src/api/orgs/clients.ts
+++ b/packages/server/src/api/orgs/clients.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance } from "fastify";
 import { requireOrgAdmin } from "../../scope/require-org.js";
 import { expiryToSeconds } from "../../services/auth.js";
 import * as clientService from "../../services/client.js";
+import { isLandingCampaignServiceMembership } from "../../services/landing-campaigns/guards.js";
 import { serializeDate } from "../../utils.js";
 import { clientCommandVersionHint } from "../client-command-version.js";
 
@@ -15,7 +16,13 @@ export async function orgClientRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { orgId: string } }>("/", async (request) => {
     // Listing this collection requires admin in the target org.
     const scope = await requireOrgAdmin(request, app.db);
-    const clients = await clientService.listClientsForOrgAdmin(app.db, scope.organizationId);
+    const clients = (await clientService.listClientsForOrgAdmin(app.db, scope.organizationId)).filter(
+      (client) =>
+        !isLandingCampaignServiceMembership(app.config, {
+          userId: client.userId,
+          organizationId: scope.organizationId,
+        }),
+    );
     const refreshExpirySeconds = expiryToSeconds(app.config.auth.refreshTokenExpiry);
     const binName = getChannelConfig(app.config.channel).binName;
     return clients.map((c) => ({

--- a/packages/server/src/api/orgs/members.ts
+++ b/packages/server/src/api/orgs/members.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from "fastify";
 import { requireOrgAdmin, requireOrgMembership } from "../../scope/require-org.js";
 import {
   assertMemberIsNotLandingCampaignServiceMember,
-  isLandingCampaignOfficialUser,
+  isLandingCampaignServiceMembership,
 } from "../../services/landing-campaigns/guards.js";
 import * as memberService from "../../services/member.js";
 
@@ -12,7 +12,7 @@ export async function orgMemberRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { orgId: string } }>("/", async (request) => {
     const scope = await requireOrgMembership(request, app.db);
     const rows = await memberService.listMembers(app.db, scope.organizationId);
-    return rows.filter((row) => !isLandingCampaignOfficialUser(app.config, row.userId));
+    return rows.filter((row) => !isLandingCampaignServiceMembership(app.config, row));
   });
 
   app.post<{ Params: { orgId: string } }>("/", async (request, reply) => {
@@ -25,13 +25,13 @@ export async function orgMemberRoutes(app: FastifyInstance): Promise<void> {
   app.patch<{ Params: { orgId: string; id: string } }>("/:id", async (request) => {
     const scope = await requireOrgAdmin(request, app.db);
     const body = updateMemberSchema.parse(request.body);
-    await assertMemberIsNotLandingCampaignServiceMember(app.db, app.config, request.params.id);
+    await assertMemberIsNotLandingCampaignServiceMember(app.db, app.config, request.params.id, scope.organizationId);
     return memberService.updateMember(app.db, request.params.id, body, scope.organizationId);
   });
 
   app.delete<{ Params: { orgId: string; id: string } }>("/:id", async (request, reply) => {
     const scope = await requireOrgAdmin(request, app.db);
-    await assertMemberIsNotLandingCampaignServiceMember(app.db, app.config, request.params.id);
+    await assertMemberIsNotLandingCampaignServiceMember(app.db, app.config, request.params.id, scope.organizationId);
     await memberService.deleteMember(app.db, request.params.id, scope.organizationId);
     return reply.status(204).send();
   });

--- a/packages/server/src/services/landing-campaigns/guards.ts
+++ b/packages/server/src/services/landing-campaigns/guards.ts
@@ -6,8 +6,21 @@ import { agents } from "../../db/schema/agents.js";
 import { members } from "../../db/schema/members.js";
 import { ForbiddenError } from "../../errors.js";
 
-export function isLandingCampaignOfficialUser(config: Config, userId: string | null | undefined): boolean {
-  return !!userId && userId === config.growth.landingCampaigns?.serviceUserId;
+export function isLandingCampaignServiceOrg(config: Config, organizationId: string | null | undefined): boolean {
+  const serviceOrgId = config.growth.landingCampaigns?.serviceOrgId;
+  return !!organizationId && !!serviceOrgId && organizationId === serviceOrgId;
+}
+
+export function isLandingCampaignServiceMembership(
+  config: Config,
+  row: { userId: string | null | undefined; organizationId: string | null | undefined },
+): boolean {
+  const serviceConfig = config.growth.landingCampaigns;
+  const serviceUserId = serviceConfig?.serviceUserId;
+  const serviceOrgId = serviceConfig?.serviceOrgId;
+  if (!serviceUserId || !serviceOrgId || row.userId !== serviceUserId) return false;
+  if (!row.organizationId) return false;
+  return row.organizationId !== serviceOrgId;
 }
 
 export function assertMetadataDoesNotClaimLandingCampaignTrial(metadata: Record<string, unknown> | undefined): void {
@@ -41,11 +54,14 @@ export async function assertMemberIsNotLandingCampaignServiceMember(
   db: Database,
   config: Config,
   memberId: string,
+  organizationId: string,
 ): Promise<void> {
-  const serviceUserId = config.growth.landingCampaigns?.serviceUserId;
-  if (!serviceUserId) return;
-  const [member] = await db.select({ userId: members.userId }).from(members).where(eq(members.id, memberId)).limit(1);
-  if (member?.userId === serviceUserId) {
+  const [member] = await db
+    .select({ userId: members.userId, organizationId: members.organizationId })
+    .from(members)
+    .where(and(eq(members.id, memberId), eq(members.organizationId, organizationId)))
+    .limit(1);
+  if (member && isLandingCampaignServiceMembership(config, member)) {
     throw new ForbiddenError("First Tree landing campaign service member is managed by First Tree.");
   }
 }

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -31,6 +31,7 @@ import { sendToClient } from "../connection-manager.js";
 import { MEMBER_STATUSES, reactivateMembership } from "../membership.js";
 import { sendMessage } from "../message.js";
 import { notifyRecipients } from "../notifier.js";
+import { isLandingCampaignServiceOrg } from "./guards.js";
 import { buildLandingCampaignAgentMetadata, buildLandingCampaignChatMetadata } from "./metadata.js";
 import { buildLandingCampaignBootstrap, getLandingCampaignSkillSet } from "./skills/catalog.js";
 
@@ -46,15 +47,22 @@ type ActiveMembership = {
 
 function requireLandingCampaignConfig(app: FastifyInstance): {
   serviceUserId: string;
+  serviceOrgId: string;
   clientId: string;
   runtimeProvider: Extract<RuntimeProvider, "codex" | "claude-code">;
 } {
   const serviceUserId = app.config.growth.landingCampaigns?.serviceUserId;
+  const serviceOrgId = app.config.growth.landingCampaigns?.serviceOrgId;
   const clientId = app.config.growth.landingCampaigns?.clientId;
-  if (!serviceUserId || !clientId) {
+  if (!serviceUserId || !serviceOrgId || !clientId) {
     throw new ServiceUnavailableError("Landing campaign official runtime is not configured");
   }
-  return { serviceUserId, clientId, runtimeProvider: app.config.growth.landingCampaigns?.runtimeProvider ?? "codex" };
+  return {
+    serviceUserId,
+    serviceOrgId,
+    clientId,
+    runtimeProvider: app.config.growth.landingCampaigns?.runtimeProvider ?? "codex",
+  };
 }
 
 function assertLandingCampaignRuntimeProviderSupported(provider: RuntimeProvider): void {
@@ -193,14 +201,19 @@ async function ensureServiceMember(
   return created;
 }
 
-async function assertOfficialClient(db: Database, clientId: string, serviceUserId: string): Promise<void> {
+async function assertOfficialClient(
+  db: Database,
+  clientId: string,
+  serviceUserId: string,
+  serviceOrgId: string,
+): Promise<void> {
   const [client] = await db
-    .select({ id: clients.id, userId: clients.userId })
+    .select({ id: clients.id, userId: clients.userId, organizationId: clients.organizationId })
     .from(clients)
     .where(eq(clients.id, clientId))
     .limit(1);
-  if (!client || client.userId !== serviceUserId) {
-    throw new ServiceUnavailableError("Landing campaign official client is not configured");
+  if (!client || client.userId !== serviceUserId || client.organizationId !== serviceOrgId) {
+    throw new ServiceUnavailableError("Landing campaign official client is not configured in the service organization");
   }
 }
 
@@ -443,8 +456,11 @@ export async function startLandingCampaignTrial(
   if (caller.role !== "admin") {
     throw new ForbiddenError("Only organization admins can start a First Tree landing campaign trial.");
   }
+  if (isLandingCampaignServiceOrg(app.config, caller.organizationId)) {
+    throw new ForbiddenError("Landing campaign trials cannot be started in the First Tree service organization.");
+  }
 
-  await assertOfficialClient(app.db, config.clientId, config.serviceUserId);
+  await assertOfficialClient(app.db, config.clientId, config.serviceUserId, config.serviceOrgId);
   const { serviceMember, trialAgent } = await provisionTrialAgent(app, {
     organizationId: caller.organizationId,
     serviceUserId: config.serviceUserId,

--- a/packages/shared/src/config/__tests__/server-config.test.ts
+++ b/packages/shared/src/config/__tests__/server-config.test.ts
@@ -100,6 +100,7 @@ describe("server config", () => {
     resetConfig();
     const configuredDir = makeTempConfigDir();
     vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_SERVICE_USER_ID", "  user_service  ");
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_SERVICE_ORG_ID", "  org_service  ");
     vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_CLIENT_ID", "  client_official  ");
 
     const configured = await initConfig({
@@ -110,6 +111,7 @@ describe("server config", () => {
 
     expect(configured.growth.landingCampaigns).toEqual({
       serviceUserId: "user_service",
+      serviceOrgId: "org_service",
       clientId: "client_official",
       runtimeProvider: "codex",
     });
@@ -119,6 +121,7 @@ describe("server config", () => {
     const defaultDir = makeTempConfigDir();
     stubRequiredProductionConfig();
     vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_SERVICE_USER_ID", "user_service");
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_SERVICE_ORG_ID", "org_service");
     vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_CLIENT_ID", "client_official");
 
     const defaultProvider = await initConfig({
@@ -131,6 +134,7 @@ describe("server config", () => {
 
     resetConfig();
     const claudeDir = makeTempConfigDir();
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_SERVICE_ORG_ID", "org_service");
     vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_RUNTIME_PROVIDER", "claude-code");
 
     const claudeProvider = await initConfig({
@@ -146,6 +150,7 @@ describe("server config", () => {
     const configDir = makeTempConfigDir();
     stubRequiredProductionConfig();
     vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_SERVICE_USER_ID", "user_service");
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_SERVICE_ORG_ID", "org_service");
     vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_CLIENT_ID", "client_official");
     vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_RUNTIME_PROVIDER", "claude-code-tui");
 

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -66,11 +66,19 @@ export const serverConfigSchema = defineConfig({
       /**
        * First Tree official service user that manages landing campaign trial
        * agents inside customer orgs. Optional at boot so the feature flag can
-       * remain off by default; the start API checks both ids before creating
-       * anything.
+       * remain off by default; the start API checks the official service user,
+       * service org, and client ids before creating anything.
        */
       serviceUserId: field(optionalTrimmedStringSchema, {
         env: "FIRST_TREE_LANDING_CAMPAIGN_SERVICE_USER_ID",
+      }),
+      /**
+       * Organization where the official service user is a normal team member.
+       * In every other org, that same user is treated as the campaign-managed
+       * service membership created only to host landing trial agents.
+       */
+      serviceOrgId: field(optionalTrimmedStringSchema, {
+        env: "FIRST_TREE_LANDING_CAMPAIGN_SERVICE_ORG_ID",
       }),
       /**
        * Official client row owned by `serviceUserId`. Trial agents are pinned

--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -302,6 +302,29 @@ describe("IdentitySection (display-only)", () => {
     expect(buttonByText(inactive.container, "Edit")).toBeNull();
     await act(async () => inactive.root.unmount());
   });
+
+  it("shows landing trial agents as First Tree managed instead of leaking the service member id", async () => {
+    const { IdentitySection } = await import("../identity-section.js");
+    const trial = await renderDom(
+      <IdentitySection
+        agent={agent({
+          managerId: "service-member-hidden",
+          metadata: {
+            landingCampaignTrial: true,
+            campaign: "production-scan",
+            skillSetId: "production-scan",
+            skillSetVersion: "2026.07.02.1",
+            repo: { url: "https://github.com/acme/backend", canonicalKey: "github.com/acme/backend" },
+          },
+        })}
+      />,
+    );
+    await flush();
+
+    expect(trial.container.textContent).toContain("First Tree managed");
+    expect(trial.container.textContent).not.toContain("service-member-hidden");
+    await act(async () => trial.root.unmount());
+  });
 });
 
 describe("ProfileEditDialog (merged identity + appearance)", () => {

--- a/packages/web/src/pages/agent-detail/identity-section.tsx
+++ b/packages/web/src/pages/agent-detail/identity-section.tsx
@@ -1,4 +1,4 @@
-import { AGENT_VISIBILITY, type Agent } from "@first-tree/shared";
+import { AGENT_VISIBILITY, type Agent, isLandingCampaignTrialAgentMetadata } from "@first-tree/shared";
 import { Pencil } from "lucide-react";
 import type { ReactNode } from "react";
 import { AgentChip } from "../../components/agent-chip.js";
@@ -51,7 +51,11 @@ export function IdentitySection({
   const domains = Array.isArray(treeMeta?.domains)
     ? (treeMeta?.domains as unknown[]).filter((d): d is string => typeof d === "string")
     : [];
-  const managerName = agent.managerId ? resolveMember(agent.managerId) : null;
+  const managerName = isLandingCampaignTrialAgentMetadata(metadata)
+    ? "First Tree managed"
+    : agent.managerId
+      ? resolveMember(agent.managerId)
+      : null;
   const delegateIdentity = agent.delegateMention ? resolveAgent(agent.delegateMention) : null;
   const handle = agent.name ?? agent.uuid.slice(0, 8);
   const hasOrganizationContext = role || domains.length > 0;


### PR DESCRIPTION
## Summary
- add `FIRST_TREE_LANDING_CAMPAIGN_SERVICE_ORG_ID` / `landingCampaigns.serviceOrgId`
- treat the landing service user/member/client as ordinary inside the service org and campaign-managed only in other orgs
- require the official landing campaign client to belong to the configured service org before starting a trial
- hide service-owned computers from customer org admin lists while keeping service org lists ordinary
- show landing trial agent owners as `First Tree managed` instead of leaking a hidden member id

## Review
- Code-only review completed by `codex-reviewer`; no blockers after follow-up fixes.

## Testing
- Not run, per request.
- `git diff --check` passed.
