### PR TITLE
fix(client): require explicit CLI bin dir for agent PATH

### DIFF
--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -465,10 +465,35 @@ describe("buildAgentEnv", () => {
     expect(env.FIRST_TREE_SWITCH_DRAIN_VERSION).toBe("1");
   });
 
-  it("prepends FIRST_TREE_HOME/bin to PATH for channel-local CLI resolution", () => {
+  it("does not infer a CLI bin directory from FIRST_TREE_HOME", () => {
+    const logs: string[] = [];
     const parent = {
       FIRST_TREE_HOME: "/first-tree-home",
-      PATH: `/usr/bin${delimiter}/first-tree-home/bin${delimiter}/opt/bin`,
+      PATH: "/usr/bin",
+    } as NodeJS.ProcessEnv;
+    const env = buildAgentEnv(parent, {
+      sdk: { serverUrl: "http://first-tree" },
+      agent: {
+        agentId: "agent-a",
+        inboxId: "inbox-a",
+        displayName: "agent-a",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
+      chatId: "chat-1",
+      log: (msg) => logs.push(msg),
+    });
+    expect(env.PATH).toBe("/usr/bin");
+    expect(logs).toEqual([]);
+  });
+
+  it("prepends explicit FIRST_TREE_CLI_BIN_DIR to PATH for channel-local CLI resolution", () => {
+    const parent = {
+      FIRST_TREE_HOME: "/first-tree-home",
+      FIRST_TREE_CLI_BIN_DIR: "/first-tree-cli-bin",
+      PATH: `/usr/bin${delimiter}/first-tree-cli-bin${delimiter}/opt/bin`,
     } as NodeJS.ProcessEnv;
     const env = buildAgentEnv(parent, {
       sdk: { serverUrl: "http://first-tree" },
@@ -483,14 +508,14 @@ describe("buildAgentEnv", () => {
       },
       chatId: "chat-1",
     });
-    expect(env.PATH).toBe(`/first-tree-home/bin${delimiter}/usr/bin${delimiter}/opt/bin`);
+    expect(env.PATH).toBe(`/first-tree-cli-bin${delimiter}/usr/bin${delimiter}/opt/bin`);
   });
 
-  it("logs once when the channel-local CLI binary is not resolvable", () => {
+  it("logs once when explicit FIRST_TREE_CLI_BIN_DIR lacks the channel binary", () => {
     setCliBinding({ binName: "first-tree-staging", packageName: "first-tree-staging" });
-    const home = mkdtempSync(join(tmpdir(), "first-tree-agent-env-"));
+    const binDir = mkdtempSync(join(tmpdir(), "first-tree-agent-env-bin-"));
     const logs: string[] = [];
-    const parent = { FIRST_TREE_HOME: home, PATH: "/usr/bin" } as NodeJS.ProcessEnv;
+    const parent = { FIRST_TREE_CLI_BIN_DIR: binDir, PATH: "/usr/bin" } as NodeJS.ProcessEnv;
     const ctx = {
       sdk: { serverUrl: "http://first-tree" },
       agent: {
@@ -511,20 +536,19 @@ describe("buildAgentEnv", () => {
 
     expect(logs).toHaveLength(1);
     expect(logs[0]).toContain("first-tree-staging");
-    expect(logs[0]).toContain(join(home, "bin"));
+    expect(logs[0]).toContain(binDir);
   });
 
-  it("does not warn when the channel-local CLI binary exists", () => {
+  it("does not warn when explicit FIRST_TREE_CLI_BIN_DIR contains the channel binary", () => {
     setCliBinding({ binName: "first-tree-dev", packageName: null });
-    const home = mkdtempSync(join(tmpdir(), "first-tree-agent-env-"));
-    const binDir = join(home, "bin");
+    const binDir = mkdtempSync(join(tmpdir(), "first-tree-agent-env-bin-"));
     mkdirSync(binDir, { recursive: true });
     const binPath = join(binDir, "first-tree-dev");
     writeFileSync(binPath, "#!/bin/sh\n");
     chmodSync(binPath, 0o755);
     const logs: string[] = [];
 
-    buildAgentEnv({ FIRST_TREE_HOME: home, PATH: "/usr/bin" } as NodeJS.ProcessEnv, {
+    buildAgentEnv({ FIRST_TREE_CLI_BIN_DIR: binDir, PATH: "/usr/bin" } as NodeJS.ProcessEnv, {
       sdk: { serverUrl: "http://first-tree" },
       agent: {
         agentId: "agent-a",

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -436,10 +436,11 @@ afterEach(() => {
 describe("codex app-server handler", () => {
   it("wraps landing campaign trial app-server startup in workspace-only sandbox mode", async () => {
     const firstTreeHome = join(workspaceRoot, "first-tree-home");
-    const cliBinDir = join(firstTreeHome, "bin");
+    const cliBinDir = join(workspaceRoot, "first-tree-cli-bin");
     mkdirSync(cliBinDir, { recursive: true });
     writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
     vi.stubEnv("FIRST_TREE_HOME", firstTreeHome);
+    vi.stubEnv("FIRST_TREE_CLI_BIN_DIR", cliBinDir);
     vi.stubEnv("OPENAI_API_KEY", "secret-openai");
     vi.stubEnv("GITHUB_TOKEN", "secret-github");
 

--- a/packages/client/src/__tests__/workspace-sandbox.test.ts
+++ b/packages/client/src/__tests__/workspace-sandbox.test.ts
@@ -140,13 +140,14 @@ describe("workspace-only sandbox", () => {
 
   it("builds a workspace-local First Tree home with only scoped outbox credentials", () => {
     const hostHome = join(root, "host-first-tree-home");
-    const cliBinDir = join(hostHome, "bin");
+    const cliBinDir = join(root, "explicit-cli-bin");
     mkdirSync(cliBinDir, { recursive: true });
     writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
 
     const prepared = prepareWorkspaceOnlyOutboxHome({
       parentEnv: {
         FIRST_TREE_HOME: hostHome,
+        FIRST_TREE_CLI_BIN_DIR: cliBinDir,
         FIRST_TREE_SERVER_URL: "https://first-tree.test",
         OPENAI_API_KEY: "secret",
       },

--- a/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
+++ b/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
@@ -131,14 +131,33 @@ function isCoveredBySystemBind(path: string): boolean {
   return READ_ONLY_SYSTEM_DIRS.some((dir) => existsSync(dir) && pathIsWithin(dir, path));
 }
 
-function validateChannelCliBin(binDir: string): void {
+function validateChannelCliBin(binDir: string, source: string): void {
   const { binName } = getCliBinding();
   const cliPath = join(binDir, binName);
   try {
     accessSync(cliPath, process.platform === "win32" ? constants.F_OK : constants.X_OK);
   } catch {
-    throw new Error(`workspace-only sandbox requires channel-local First Tree CLI at ${cliPath}`);
+    throw new Error(`workspace-only sandbox ${source} must contain channel-local First Tree CLI at ${cliPath}`);
   }
+}
+
+function resolveChannelCliBinDir(parentEnv: NodeJS.ProcessEnv): string {
+  const explicit = parentEnv.FIRST_TREE_CLI_BIN_DIR;
+  if (explicit) {
+    const binDir = isAbsolute(explicit) ? explicit : resolve(explicit);
+    validateChannelCliBin(binDir, "FIRST_TREE_CLI_BIN_DIR");
+    return binDir;
+  }
+
+  const home = parentEnv.FIRST_TREE_HOME;
+  if (!home) {
+    throw new Error(
+      "workspace-only sandbox requires FIRST_TREE_CLI_BIN_DIR, or FIRST_TREE_HOME with a legacy bin shim fallback",
+    );
+  }
+  const binDir = join(isAbsolute(home) ? home : resolve(home), "bin");
+  validateChannelCliBin(binDir, "legacy FIRST_TREE_HOME/bin fallback");
+  return binDir;
 }
 
 function writePrivateFile(path: string, content: string): void {
@@ -151,12 +170,7 @@ export function prepareWorkspaceOnlyOutboxHome(options: WorkspaceOnlyOutboxHomeO
   cliBinDir: string;
 } {
   const realWorkspace = realpathExisting(options.workspaceRoot, "workspaceRoot");
-  const sourceHome = options.parentEnv.FIRST_TREE_HOME;
-  if (!sourceHome) {
-    throw new Error("workspace-only sandbox requires host FIRST_TREE_HOME so the channel-local CLI can be mounted");
-  }
-  const cliBinDir = join(isAbsolute(sourceHome) ? sourceHome : resolve(sourceHome), "bin");
-  validateChannelCliBin(cliBinDir);
+  const cliBinDir = resolveChannelCliBinDir(options.parentEnv);
 
   const home = join(realWorkspace, ".first-tree-workspace", "outbox-home");
   const configDir = join(home, "config");
@@ -203,9 +217,10 @@ export function buildWorkspaceOnlyEnvironment(
     throw new Error("workspace-only sandbox requires FIRST_TREE_HOME for sandbox-local First Tree config");
   }
   const resolvedHome = isAbsolute(firstTreeHome) ? firstTreeHome : resolve(firstTreeHome);
-  const cliBinDirValue = parentEnv.FIRST_TREE_CLI_BIN_DIR ?? join(resolvedHome, "bin");
-  const cliBinDir = isAbsolute(cliBinDirValue) ? cliBinDirValue : resolve(cliBinDirValue);
-  validateChannelCliBin(cliBinDir);
+  const cliBinDir = resolveChannelCliBinDir({
+    FIRST_TREE_HOME: resolvedHome,
+    FIRST_TREE_CLI_BIN_DIR: parentEnv.FIRST_TREE_CLI_BIN_DIR,
+  });
 
   const env: NodeJS.ProcessEnv = {};
   for (const key of SAFE_PASS_ENV_KEYS) {

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -27,11 +27,14 @@ import { findImagePath } from "./image-store.js";
 
 /**
  * Build the env for CLI sub-processes that need to call `<binName> ...`.
- * Layers the First Tree envelope variables on top of the parent env, and keeps
- * the channel-local CLI binary ahead of any globally installed sibling. Handlers
+ * Layers the First Tree envelope variables on top of the parent env. Handlers
  * that start sub-processes should call this so every one of them sees the same
  * envelope — enabling replyTo inference, access-token propagation, agent-id
- * binding, and channel-correct CLI calls without per-handler duplication.
+ * binding, and channel-correct CLI command text without per-handler duplication.
+ *
+ * `FIRST_TREE_HOME` is state/config storage, not a CLI install prefix. Only an
+ * explicit `FIRST_TREE_CLI_BIN_DIR` asks this helper to put a channel-specific
+ * CLI directory ahead of the parent PATH.
  */
 export function buildAgentEnv(
   parentEnv: NodeJS.ProcessEnv,
@@ -77,7 +80,7 @@ export function buildAgentEnv(
     log?: (msg: string) => void;
   },
 ): NodeJS.ProcessEnv {
-  const env = withChannelCliOnPath(parentEnv, ctx.log);
+  const env = withExplicitCliBinDirOnPath(parentEnv, ctx.log);
   return {
     ...env,
     FIRST_TREE_SERVER_URL: ctx.sdk.serverUrl,
@@ -107,30 +110,24 @@ export function buildAgentEnv(
 
 const warnedCliResolutionKeys = new Set<string>();
 
-function withChannelCliOnPath(parentEnv: NodeJS.ProcessEnv, log?: (msg: string) => void): NodeJS.ProcessEnv {
-  const firstTreeHome = parentEnv.FIRST_TREE_HOME;
-  if (!firstTreeHome) {
-    warnCliResolutionOnce(
-      "missing-home",
-      log,
-      "FIRST_TREE_HOME is not set; spawned agents cannot receive the channel-local CLI on PATH",
-    );
+function withExplicitCliBinDirOnPath(parentEnv: NodeJS.ProcessEnv, log?: (msg: string) => void): NodeJS.ProcessEnv {
+  const cliBinDir = parentEnv.FIRST_TREE_CLI_BIN_DIR;
+  if (!cliBinDir) {
     return { ...parentEnv };
   }
 
-  const binDir = join(firstTreeHome, "bin");
   const pathKey = resolvePathKey(parentEnv);
   const currentPath = parentEnv[pathKey] ?? "";
-  const existing = currentPath.split(delimiter).filter((part) => part.length > 0 && part !== binDir);
-  const nextPath = [binDir, ...existing].join(delimiter);
+  const existing = currentPath.split(delimiter).filter((part) => part.length > 0 && part !== cliBinDir);
+  const nextPath = [cliBinDir, ...existing].join(delimiter);
   const env = { ...parentEnv, [pathKey]: nextPath };
 
   const { binName } = getCliBinding();
-  if (!canResolveExecutable(binDir, binName, parentEnv)) {
+  if (!canResolveExecutable(cliBinDir, binName, parentEnv)) {
     warnCliResolutionOnce(
-      `missing-bin:${binDir}:${binName}`,
+      `missing-explicit-bin:${cliBinDir}:${binName}`,
       log,
-      `channel-local CLI ${binName} was not found at ${binDir}; spawned agents may resolve a stale or wrong-channel CLI from PATH`,
+      `FIRST_TREE_CLI_BIN_DIR is set to ${cliBinDir}, but ${binName} was not found there`,
     );
   }
 


### PR DESCRIPTION
## Summary

- stop treating `$FIRST_TREE_HOME/bin` as the default spawned-agent CLI install location
- only prepend a channel-specific CLI directory when `FIRST_TREE_CLI_BIN_DIR` is explicitly present
- keep workspace-only sandbox fail-closed, but make it prefer `FIRST_TREE_CLI_BIN_DIR` and describe `$FIRST_TREE_HOME/bin` only as a legacy fallback
- update client/runtime tests so QA-style binary shims are explicit instead of implied by state home

## Context

This cleans up the behavior introduced by #1164. The original trigger was an isolated QA harness issue: a candidate `first-tree-dev` binary was not on the real agent PATH, so the run fell through to a stale global `first-tree-staging` binary. That belongs in the QA harness setup, not as a product runtime assumption that every `$FIRST_TREE_HOME` has a `bin/` directory.

`FIRST_TREE_HOME` remains the state/config/data/logs home. A CLI binary directory is now an explicit runtime input (`FIRST_TREE_CLI_BIN_DIR`) when a sandbox or test harness needs one.

## Verification

- `pnpm --filter @first-tree/client test -- src/__tests__/agent-io.test.ts src/__tests__/workspace-sandbox.test.ts src/__tests__/codex-app-server-handler.test.ts` (exit 0; ran the full client suite: 115 files / 1199 tests)
- `pnpm --filter @first-tree/client typecheck`
- `pnpm exec biome check packages/client/src/runtime/agent-io.ts packages/client/src/__tests__/agent-io.test.ts packages/client/src/handlers/codex/app-server/workspace-sandbox.ts packages/client/src/__tests__/workspace-sandbox.test.ts packages/client/src/__tests__/codex-app-server-handler.test.ts`
- `pnpm check` (exit 0; existing unrelated warnings/info remain)
- `pnpm typecheck`
- `git diff --check`


## Companion Context Tree PR

- https://github.com/agent-team-foundation/first-tree-context/pull/673

The tree PR is intentionally draft until this code PR lands, per the tree/code PR coordination rule.
