### PR TITLE
feat: open GitHub App install in a new tab from Settings

### DIFF
--- a/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
@@ -95,6 +95,9 @@ function buttonByText(container: ParentNode, text: string): HTMLButtonElement | 
 beforeEach(() => {
   document.body.innerHTML = "";
   vi.clearAllMocks();
+  // The panel persists a per-tab install-attempt marker in sessionStorage; clear
+  // it so one test's in-flight attempt doesn't lock the CTA in the next.
+  window.sessionStorage.clear();
   authMock.value = { organizationId: "org-1" };
   githubMocks.getGithubAppInstallation.mockResolvedValue(installation());
   githubMocks.getGithubAppInstallUrl.mockResolvedValue("https://github.com/apps/first-tree/installations/new");
@@ -144,32 +147,75 @@ describe("GithubAppInstallationPanel", () => {
     await act(async () => root.unmount());
   });
 
-  it("opens a freshly minted install URL, surfaces missing slug, and reports generic install URL errors", async () => {
-    githubMocks.getGithubAppInstallation.mockResolvedValueOnce(null);
+  it("mints a fresh install URL into a new tab, then waits without leaving this tab", async () => {
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
+    const fakeTab = { location: { href: "" }, close: vi.fn() };
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(fakeTab as unknown as Window);
     const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
     const first = await renderDom(<GithubAppInstallationPanel />);
     await waitForText(first.container, "Install the GitHub App");
 
     await click(buttonByText(first.container, "Install on GitHub"));
-    expect(githubMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1");
-    expect(window.location.assign).toHaveBeenCalledWith("https://github.com/apps/first-tree/installations/new");
-    await act(async () => first.root.unmount());
+    // Opens in a new tab (self-closing connected page as post-install target) and
+    // navigates THAT tab — this tab stays put and shows the waiting affordance.
+    expect(githubMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/onboarding/connected");
+    expect(fakeTab.location.href).toBe("https://github.com/apps/first-tree/installations/new");
+    expect(window.location.assign).not.toHaveBeenCalled();
+    await waitForText(first.container, "Waiting for GitHub");
+    // CTA locked while an attempt is in flight (a second mint would clobber the
+    // in-flight nonce cookie); "Start over" re-enables it.
+    expect(buttonByText(first.container, "Install on GitHub")?.disabled).toBe(true);
+    await click(buttonByText(first.container, "Start over"));
+    expect(buttonByText(first.container, "Install on GitHub")?.disabled).toBe(false);
 
-    githubMocks.getGithubAppInstallation.mockResolvedValueOnce(null);
+    openSpy.mockRestore();
+    await act(async () => first.root.unmount());
+  });
+
+  it("falls back to a full-page redirect when the install popup is blocked", async () => {
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
+    // Popup blocked → window.open returns null → full-page redirect. `next` is
+    // omitted so the server applies its `/settings/github` default (returning
+    // this tab to the panel after install).
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const { container, root } = await renderDom(<GithubAppInstallationPanel />);
+    await waitForText(container, "Install the GitHub App");
+
+    await click(buttonByText(container, "Install on GitHub"));
+    expect(githubMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", undefined);
+    expect(window.location.assign).toHaveBeenCalledWith("https://github.com/apps/first-tree/installations/new");
+
+    openSpy.mockRestore();
+    await act(async () => root.unmount());
+  });
+
+  it("surfaces missing slug and reports generic install URL errors (closing the opened tab)", async () => {
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
     githubMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new ApiError(503, "slug missing"));
+    const slugTab = { location: { href: "" }, close: vi.fn() };
+    const slugOpen = vi.spyOn(window, "open").mockReturnValue(slugTab as unknown as Window);
     const missingSlug = await renderDom(<GithubAppInstallationPanel />);
     await waitForText(missingSlug.container, "Install the GitHub App");
     await click(buttonByText(missingSlug.container, "Install on GitHub"));
     await waitForText(missingSlug.container, "FIRST_TREE_GITHUB_APP_SLUG");
     expect(buttonByText(missingSlug.container, "Install on GitHub")).toBeNull();
+    // The prematurely-opened tab is closed on failure so no blank tab lingers.
+    expect(slugTab.close).toHaveBeenCalled();
+    slugOpen.mockRestore();
     await act(async () => missingSlug.root.unmount());
 
-    githubMocks.getGithubAppInstallation.mockResolvedValueOnce(null);
     githubMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new Error("oauth state failed"));
+    const genericTab = { location: { href: "" }, close: vi.fn() };
+    const genericOpen = vi.spyOn(window, "open").mockReturnValue(genericTab as unknown as Window);
     const generic = await renderDom(<GithubAppInstallationPanel />);
     await waitForText(generic.container, "Install the GitHub App");
     await click(buttonByText(generic.container, "Install on GitHub"));
     await waitForText(generic.container, "oauth state failed");
+    expect(genericTab.close).toHaveBeenCalled();
+    genericOpen.mockRestore();
     await act(async () => generic.root.unmount());
   });
 

--- a/packages/web/src/pages/github-app-installation-panel.tsx
+++ b/packages/web/src/pages/github-app-installation-panel.tsx
@@ -1,10 +1,19 @@
 import type { GithubAppInstallationOutput } from "@first-tree/shared";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { Building2, ChevronRight, ExternalLink, PauseCircle, User } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ApiError } from "../api/client.js";
 import { getGithubAppInstallation, getGithubAppInstallUrl } from "../api/github-app.js";
 import { useAuth } from "../auth/auth-context.js";
+
+/**
+ * Per-tab marker set when the admin kicks off an install. It locks the CTA (a
+ * second mint would overwrite the first attempt's `oauth_state_nonce` cookie and
+ * break its callback) and gates the "waiting for GitHub" affordance. Cleared once
+ * an install is observed. Mirrors the connect-code / Context-build entries, which
+ * use the same open-popup-in-a-new-tab-then-poll flow.
+ */
+const INSTALL_ATTEMPT_KEY = "settings:github:install-attempt";
 
 /**
  * Settings → GitHub panel for the GitHub App installation. The page header
@@ -15,8 +24,9 @@ import { useAuth } from "../auth/auth-context.js";
  *
  *   - **Loading**     — initial fetch.
  *   - **Not bound**   — 404 from the admin API. Renders an "Install on
- *                       GitHub" CTA that triggers the OAuth + install
- *                       redirect via `/auth/github/start`.
+ *                       GitHub" CTA that opens GitHub's install dialog in a
+ *                       new tab and polls until the install lands, then flips
+ *                       this tab to the bound state on its own.
  *   - **Bound**       — account login + type and a "Manage on GitHub" link.
  *                       The granted permissions, subscribed events, and
  *                       installation id are tucked behind a collapsed
@@ -35,7 +45,19 @@ export function GithubAppInstallationPanel() {
     queryKey: ["github-app-installation", organizationId],
     queryFn: () => (organizationId ? getGithubAppInstallation(organizationId) : Promise.reject(new Error("no org"))),
     enabled: !!organizationId,
+    // The install opens in a new tab and self-closes on GitHub's callback; this
+    // tab keeps polling until the installation row appears, then renders the
+    // bound state on its own (no manual refresh). Stops once installed.
+    refetchInterval: (query) => (query.state.data ? false : 4000),
   });
+
+  // Once the poll flips this tab to the bound state, drop the per-tab install
+  // marker so a later uninstall/reinstall starts from a clean CTA.
+  useEffect(() => {
+    if (installationQuery.data && typeof window !== "undefined") {
+      window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
+    }
+  }, [installationQuery.data]);
 
   // Only the bound card draws a top hairline (it anchors "Connected as"); the
   // loading / error / not-installed states sit flush under the page header so
@@ -64,34 +86,61 @@ export function GithubAppInstallationPanel() {
 }
 
 function NotInstalledState({ organizationId }: { organizationId: string | null }) {
-  // The install URL is fetched (not statically built) because the server
-  // mints a signed `state` JWT + sets the matching `oauth_state_nonce`
-  // cookie before handing back the `https://github.com/apps/<slug>/installations/new?state=…`
-  // URL. We navigate the browser to it via `window.location` so the
-  // cookie set on this XHR response rides along to GitHub's post-install
-  // redirect (codex P1-1).
-  //
-  // Codex P2 follow-up: the previous implementation used `useQuery`,
-  // which preloaded the URL on first render. The signed state JWT and
-  // nonce cookie both expire after 10 minutes, so an admin who left
-  // the Settings page open longer than that would land on a stale
-  // `state` and the post-install callback would 401. Switched to
-  // `useMutation` fired in the click handler — the URL (and cookie)
-  // are minted at the moment the user actually navigates, so freshness
-  // is guaranteed.
+  // Reads the INSTALL_ATTEMPT_KEY marker (see its definition above) to lock the
+  // CTA and gate the "waiting for GitHub" affordance; the parent's poll flips
+  // this tab to the bound state once the install lands.
+  const [attempted, setAttempted] = useState(
+    () => typeof window !== "undefined" && !!window.sessionStorage.getItem(INSTALL_ATTEMPT_KEY),
+  );
+
+  // The install URL is minted on click (not preloaded): the server signs a
+  // `state` JWT and sets the matching `oauth_state_nonce` cookie before handing
+  // back the `installations/new?state=…` URL, and both expire after 10 minutes.
+  // Minting at click time keeps them fresh (codex P2 follow-up).
   const installUrlMutation = useMutation({
-    mutationFn: () => {
+    mutationFn: (next: string | undefined) => {
       if (!organizationId) throw new Error("No organization selected");
-      return getGithubAppInstallUrl(organizationId);
-    },
-    onSuccess: (installUrl) => {
-      window.location.assign(installUrl);
+      return getGithubAppInstallUrl(organizationId, next);
     },
   });
 
+  const handleInstall = (): void => {
+    if (!organizationId) return;
+    // Open the tab synchronously inside the click gesture so the browser doesn't
+    // treat the post-await open as a blocked popup; fill its location once the
+    // URL is minted, or close it on failure. GitHub installs in that tab and
+    // lands it on the self-closing /onboarding/connected page, while this tab
+    // keeps polling and flips to the bound state on its own. The nonce cookie is
+    // set on this tab's XHR but shared across tabs, so it rides along to GitHub's
+    // callback in the new tab.
+    const installTab = window.open("", "_blank");
+    // Popup opened → the new tab returns to the self-closing connected page;
+    // popup blocked → the full-page redirect must return THIS tab to Settings →
+    // GitHub (undefined lets the server apply its `/settings/github` default).
+    const next = installTab ? "/onboarding/connected" : undefined;
+    installUrlMutation.mutate(next, {
+      onSuccess: (installUrl) => {
+        window.sessionStorage.setItem(INSTALL_ATTEMPT_KEY, String(Date.now()));
+        setAttempted(true);
+        if (installTab) installTab.location.href = installUrl;
+        else window.location.assign(installUrl); // popup blocked — full redirect
+      },
+      onError: () => installTab?.close(),
+    });
+  };
+
+  // Explicit re-mint after a stuck install (GitHub tab closed without
+  // installing): a fresh URL overwrites the nonce cookie, so retry is a
+  // conscious action, never an auto re-click while the first tab may be mid-flow.
+  const handleStartOver = (): void => {
+    window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
+    setAttempted(false);
+    installUrlMutation.reset();
+  };
+
   const slugMissing = installUrlMutation.error instanceof ApiError && installUrlMutation.error.status === 503;
   const isPending = installUrlMutation.isPending;
-  const disabled = !organizationId || isPending;
+  const disabled = !organizationId || isPending || attempted;
 
   return (
     <div>
@@ -106,12 +155,12 @@ function NotInstalledState({ organizationId }: { organizationId: string | null }
         </p>
       ) : (
         <>
-          {/* Button (not anchor) because the install URL is minted on click
-              — fetch first, then `window.location.assign`. Keeps the state
-              JWT + nonce cookie fresh (codex P2 follow-up). */}
+          {/* Button (not anchor) because the install URL is minted on click,
+              then a synchronously-opened new tab is navigated to it — keeps the
+              state JWT + nonce cookie fresh and the popup unblocked. */}
           <button
             type="button"
-            onClick={() => installUrlMutation.mutate()}
+            onClick={handleInstall}
             disabled={disabled}
             className="inline-flex items-center justify-center font-medium"
             style={{
@@ -134,6 +183,33 @@ function NotInstalledState({ organizationId }: { organizationId: string | null }
                 ? installUrlMutation.error.message
                 : "Failed to build the install URL"}
             </p>
+          )}
+          {/* After the tab opens, this tab waits for the poll to detect the
+              install. If the GitHub tab didn't work, "Start over" re-mints (the
+              only safe retry — see handleStartOver). */}
+          {attempted && !isPending && (
+            <div
+              className="flex items-center"
+              style={{ gap: "var(--sp-2_5)", marginTop: "var(--sp-3)", flexWrap: "wrap" }}
+            >
+              <span className="text-label" style={{ color: "var(--fg-3)" }}>
+                Waiting for GitHub…
+              </span>
+              <button
+                type="button"
+                onClick={handleStartOver}
+                className="text-label underline underline-offset-2"
+                style={{
+                  background: "transparent",
+                  border: "none",
+                  padding: 0,
+                  color: "var(--fg-3)",
+                  cursor: "pointer",
+                }}
+              >
+                Didn't work? Start over
+              </button>
+            </div>
           )}
         </>
       )}

--- a/packages/web/src/pages/onboarding/github-connected.tsx
+++ b/packages/web/src/pages/onboarding/github-connected.tsx
@@ -2,15 +2,18 @@ import { Check } from "lucide-react";
 import { useEffect } from "react";
 
 /**
- * Landing page for the connect-code install popup. The connect-code step opens
- * the GitHub App install in a new tab with `next=/onboarding/connected`, so
- * GitHub's callback lands the popup here. We confirm and auto-close the tab (it
- * was script-opened, so `window.close()` is allowed); the original setup tab
- * detects the new installation via its poll and advances on its own. If the
- * browser refuses to close the tab, the message tells the user to close it.
+ * Landing page for the GitHub App install popup — shared by every surface that
+ * opens the install in a new tab with `next=/onboarding/connected`: onboarding
+ * connect-code, the Context tab build entry, and Settings → GitHub. GitHub's
+ * callback lands the popup here; we confirm and auto-close the tab (it was
+ * script-opened, so `window.close()` is allowed) while the original tab detects
+ * the new installation via its poll and updates on its own. If the browser
+ * refuses to close the tab, the message tells the user to close it. Copy is kept
+ * surface-neutral ("the other tab will update") so it reads correctly whether the
+ * origin tab is an onboarding wizard or a settings page.
  *
  * Public route (no auth gate): it does nothing sensitive, and gating it would
- * risk the onboarding redirect bouncing this throwaway tab elsewhere.
+ * risk the redirect bouncing this throwaway tab elsewhere.
  */
 export function GithubConnectedPage() {
   useEffect(() => {
@@ -42,7 +45,7 @@ export function GithubConnectedPage() {
         Connected
       </p>
       <p className="text-body" style={{ margin: 0, color: "var(--fg-3)", maxWidth: "22rem" }}>
-        You can close this tab — setup continues in your other tab.
+        You can close this tab — the other tab will update.
       </p>
     </div>
   );

--- a/packages/web/src/pages/settings-github-preview.tsx
+++ b/packages/web/src/pages/settings-github-preview.tsx
@@ -212,8 +212,14 @@ function InstalledCard({ suspended = false, detailsOpen = false }: { suspended?:
   );
 }
 
-/** Not-installed CTA — flush under the header, no hairline (matches the real panel). */
-function NotInstalledCard() {
+/**
+ * Not-installed CTA — flush under the header, no hairline (matches the real
+ * panel). `waiting` mirrors the post-click state: the install opened in a new
+ * tab, the CTA is locked (a second mint would clobber the in-flight nonce
+ * cookie), and this tab shows the "waiting + start over" affordance while it
+ * polls for the install to land.
+ */
+function NotInstalledCard({ waiting = false }: { waiting?: boolean }) {
   return (
     <PageShell>
       <div>
@@ -223,6 +229,7 @@ function NotInstalledCard() {
         </p>
         <button
           type="button"
+          disabled={waiting}
           className="inline-flex items-center justify-center font-medium"
           style={{
             gap: "var(--sp-1)",
@@ -231,12 +238,36 @@ function NotInstalledCard() {
             color: "var(--primary-on)",
             border: "none",
             borderRadius: "var(--radius-input)",
-            cursor: "pointer",
+            cursor: waiting ? "default" : "pointer",
+            opacity: waiting ? 0.6 : 1,
           }}
         >
           Install on GitHub
           <ExternalLink className="h-3 w-3" />
         </button>
+        {waiting && (
+          <div
+            className="flex items-center"
+            style={{ gap: "var(--sp-2_5)", marginTop: "var(--sp-3)", flexWrap: "wrap" }}
+          >
+            <span className="text-label" style={{ color: "var(--fg-3)" }}>
+              Waiting for GitHub…
+            </span>
+            <button
+              type="button"
+              className="text-label underline underline-offset-2"
+              style={{
+                background: "transparent",
+                border: "none",
+                padding: 0,
+                color: "var(--fg-3)",
+                cursor: "pointer",
+              }}
+            >
+              Didn't work? Start over
+            </button>
+          </div>
+        )}
       </div>
     </PageShell>
   );
@@ -317,6 +348,13 @@ export function SettingsGithubPreviewPage() {
 
       <Frame label="Not installed" note="the Install on GitHub CTA — flush under the header, no orphaned rule">
         <NotInstalledCard />
+      </Frame>
+
+      <Frame
+        label="Not installed — waiting"
+        note="after the install opened in a new tab: CTA locked, waiting for the poll + Start over"
+      >
+        <NotInstalledCard waiting />
       </Frame>
 
       <Frame label="Loading" note="initial fetch — flush under the header">


### PR DESCRIPTION
## What

Settings → GitHub **Install on GitHub** used to navigate the current tab away with `window.location.assign`, so the whole app disappeared to github.com and came back via a full reload.

This change makes it open the install dialog in a **new tab** and keep the settings page put, mirroring the already-shipped onboarding / Context-build flow:

- Synchronously open a new tab inside the click gesture (keeps the popup unblocked), then navigate it to the freshly-minted `installations/new?state=…` URL. The signed state JWT + `oauth_state_nonce` cookie stay fresh (minted on click) and the cookie is shared across tabs, so GitHub's post-install callback in the new tab binds correctly.
- The new tab lands on the self-closing `/onboarding/connected` page; **this** tab polls the installation query (`refetchInterval` 4s while unbound) and flips to the connected state on its own — no manual refresh.
- **Popup blocked** → fall back to a full-page redirect (server-default `/settings/github`).
- After a click the CTA locks (a second mint would clobber the in-flight nonce cookie) and shows a `Waiting for GitHub… / Didn't work? Start over` affordance; **Start over** re-mints.

## Also

- Generalize the shared `/onboarding/connected` auto-close landing copy to be surface-neutral (`the other tab will update`) now that onboarding, the Context build entry, and Settings all use it.
- Add a **Not installed — waiting** state to the DEV `/preview/settings-github` gallery and align the waiting/retry copy with the sibling connect-code strings.

## Test

- `github-app-installation-panel-dom.test.tsx` updated: new-tab happy path (mints with `next=/onboarding/connected`, navigates the opened tab, stays on this tab, locks CTA, Start over re-enables), popup-blocked full-redirect fallback (`next=undefined`), and error-closes-the-opened-tab for both 503-slug and generic errors.
- Full `@first-tree/web` suite green (1077 tests), `tsc` + `lint:tokens` + biome clean.
- Visually verified all `/preview/settings-github` states incl. the new waiting state.

## Reviews

Two independent agent reviews (correctness + consistency). No blocking issues. Follow-ups deliberately **not** folded in (kept this PR focused):
- Extract a shared `useGithubInstallFlow` hook — this is now the third copy of the open-tab-then-poll flow (onboarding, Context-build, Settings); a genuine rule-of-three refactor that would touch two already-shipped surfaces, so it belongs in its own refactor.
- On a **failed** install callback, the throwaway popup's recovery link lands on `/onboarding` (server normalizes `/onboarding/connected`→`/onboarding`) rather than `/settings/github`. Low impact, pre-existing pattern shared with Context-build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)