### PR TITLE
Fix quickstart login return flow

### DIFF
--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -63,6 +63,35 @@ describe("GitHub OAuth onboarding flow", () => {
     expect(memberRows[0]?.status).toBe("active");
   });
 
+  it("preserves quickstart campaign next for first-time solo signup", async () => {
+    const app = getApp();
+    const next = `/quickstart?campaign=production-scan&repo=${encodeURIComponent("https://github.com/acme/backend")}`;
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/dev-callback?githubId=43&login=quickstarter&next=${encodeURIComponent(next)}`,
+    });
+
+    expect(res.statusCode).toBe(302);
+    const fragment = res.headers.location?.split("#")[1] ?? "";
+    const params = new URLSearchParams(fragment);
+    expect(params.get("next")).toBe(next);
+    expect(params.get("joinPath")).toBe("solo");
+  });
+
+  it("still sends first-time solo signup with ordinary protected next to onboarding entry", async () => {
+    const app = getApp();
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/dev-callback?githubId=44&login=settingsnext&next=${encodeURIComponent("/settings/github")}`,
+    });
+
+    expect(res.statusCode).toBe(302);
+    const fragment = res.headers.location?.split("#")[1] ?? "";
+    const params = new URLSearchParams(fragment);
+    expect(params.get("next")).toBe("/");
+    expect(params.get("joinPath")).toBe("solo");
+  });
+
   it("second sign-in for same github id reuses the user", async () => {
     const app = getApp();
     await app.inject({

--- a/packages/server/src/api/auth/github.ts
+++ b/packages/server/src/api/auth/github.ts
@@ -542,7 +542,7 @@ async function completeOauthFlow(
       resolved = true;
       resolvedOrganizationId = personal.organizationId;
       orgPinned = true;
-      next = "/";
+      next = shouldPreserveSoloSignupNext(next) ? next : "/";
       // Onboarding funnel: structured log marker. Picked up by logfire/otel
       // pipelines via `event: "onboarding.team_created"` for funnel views.
       app.log.info(
@@ -608,4 +608,9 @@ async function completeOauthFlow(
   if (orgPinned) fragmentParams.orgPinned = "1";
   const fragment = new URLSearchParams(fragmentParams).toString();
   return reply.redirect(`/auth/github/complete#${fragment}`, 302);
+}
+
+function shouldPreserveSoloSignupNext(next: string): boolean {
+  const parsed = new URL(next, "http://first-tree.local");
+  return parsed.pathname === "/quickstart" && parsed.searchParams.get("campaign") === "production-scan";
 }

--- a/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
+++ b/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
@@ -42,6 +42,9 @@ vi.mock("../../../hooks/use-server-channel.js", () => ({
   useGrowthLandingPagesEnabled: () => growthLandingMock.value.enabled,
 }));
 vi.mock("../../../api/landing-campaigns.js", () => landingCampaignMock);
+vi.mock("../../workspace/center/chat-by-id.js", () => ({
+  ChatByIdView: ({ chatId }: { chatId: string }) => <div data-testid="quickstart-trial-chat">{chatId}</div>,
+}));
 
 function createStorage(): Storage {
   const data = new Map<string, string>();
@@ -134,7 +137,16 @@ describe("QuickstartPage — landing campaign trial flow", () => {
     });
     expect(authMock.value.refreshMe).toHaveBeenCalled();
     expect(readCampaignIntent()).toBeNull();
-    expect(navigateMock).toHaveBeenCalledWith("/?c=chat-1");
+    expect(navigateMock).toHaveBeenCalledWith("/quickstart?chat=chat-1", { replace: true });
+  });
+
+  it("renders an existing trial chat directly and does not restart the trial", async () => {
+    seedIntent("production-scan");
+    const container = await renderPage(["/quickstart?chat=chat-1"]);
+
+    expect(container.querySelector('[data-testid="quickstart-trial-chat"]')?.textContent).toBe("chat-1");
+    expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 
   it("ignores unsupported campaign handoffs", async () => {
@@ -203,6 +215,6 @@ describe("QuickstartPage — landing campaign trial flow", () => {
     await flush();
 
     expect(landingCampaignMock.startLandingCampaign).toHaveBeenCalledTimes(2);
-    expect(navigateMock).toHaveBeenCalledWith("/?c=chat-2");
+    expect(navigateMock).toHaveBeenCalledWith("/quickstart?chat=chat-2", { replace: true });
   });
 });

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { useGrowthLandingPagesState } from "../../hooks/use-server-channel.js";
 import { FlowHint, StatusRow, WorkingState } from "../onboarding/flow-ui.js";
+import { ChatByIdView } from "../workspace/center/chat-by-id.js";
 import { getCampaign } from "./campaigns.js";
 import {
   type CampaignIntent,
@@ -29,8 +30,10 @@ export function QuickstartPage() {
   const location = useLocation();
   const { organizationId, refreshMe } = useAuth();
   const { enabled: growthLandingPagesEnabled, settled } = useGrowthLandingPagesState();
+  const chatId = useMemo(() => new URLSearchParams(location.search).get("chat"), [location.search]);
 
   const intent = useMemo<CampaignIntent | null>(() => {
+    if (chatId) return null;
     const fromUrl = readCampaignHandoff(location);
     if (fromUrl) {
       writeCampaignIntent(fromUrl);
@@ -41,30 +44,30 @@ export function QuickstartPage() {
       return null;
     }
     return readCampaignIntent();
-  }, [location]);
+  }, [chatId, location]);
   const campaign = intent ? getCampaign(intent.campaign) : null;
 
   const startStartedRef = useRef(false);
   const [startError, setStartError] = useState<string | null>(null);
 
   const startTrial = useCallback(async () => {
-    if (!intent || !campaign || startStartedRef.current || !growthLandingPagesEnabled) return;
+    if (chatId || !intent || !campaign || startStartedRef.current || !growthLandingPagesEnabled) return;
     startStartedRef.current = true;
     setStartError(null);
     try {
-      const { chatId } = await startLandingCampaign({
+      const { chatId: trialChatId } = await startLandingCampaign({
         ...(organizationId ? { organizationId } : {}),
         campaign: intent.campaign,
         repoUrl: intent.url,
       });
       clearCampaignIntent();
       await refreshMe();
-      navigate(`/?c=${encodeURIComponent(chatId)}`);
+      navigate(`/quickstart?chat=${encodeURIComponent(trialChatId)}`, { replace: true });
     } catch (err) {
       startStartedRef.current = false;
       setStartError(err instanceof Error ? err.message : "Couldn't open your trial chat. Please try again.");
     }
-  }, [intent, campaign, organizationId, growthLandingPagesEnabled, refreshMe, navigate]);
+  }, [chatId, intent, campaign, organizationId, growthLandingPagesEnabled, refreshMe, navigate]);
 
   useEffect(() => {
     if (!settled || !growthLandingPagesEnabled) return;
@@ -72,12 +75,15 @@ export function QuickstartPage() {
   }, [settled, growthLandingPagesEnabled, startTrial]);
 
   useEffect(() => {
+    if (chatId) return;
     if (settled && !growthLandingPagesEnabled) navigate("/", { replace: true });
-  }, [settled, growthLandingPagesEnabled, navigate]);
+  }, [chatId, settled, growthLandingPagesEnabled, navigate]);
 
   const retryStart = useCallback(() => {
     void startTrial();
   }, [startTrial]);
+
+  if (chatId) return <QuickstartTrialChat chatId={chatId} />;
 
   if (!settled || !growthLandingPagesEnabled) {
     return (
@@ -130,6 +136,14 @@ export function QuickstartPage() {
         />
       )}
     </QuickstartShell>
+  );
+}
+
+function QuickstartTrialChat({ chatId }: { chatId: string }) {
+  return (
+    <div className="flex min-h-screen flex-col" style={{ background: "var(--bg)", color: "var(--fg)" }}>
+      <ChatByIdView chatId={chatId} narrow={false} onShowConversations={null} />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- preserve production-scan quickstart next during first-time solo OAuth signup
- keep landing campaign trial chat on `/quickstart?chat=...` instead of routing through workspace root
- add server and web regression coverage for quickstart return handling

## Tests
- `pnpm --filter @first-tree/web exec vitest run src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx --maxConcurrency=2 --pool=forks --poolOptions.forks.maxForks=2`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/oauth-flow.test.ts --maxConcurrency=2 --pool=forks --poolOptions.forks.maxForks=2`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/api/auth/github.ts packages/server/src/__tests__/oauth-flow.test.ts packages/web/src/pages/quickstart/quickstart-page.tsx packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx`
