### PR TITLE
fix: resolve workspace sandbox cli from controlled path

### DIFF
--- a/packages/client/src/__tests__/workspace-sandbox.test.ts
+++ b/packages/client/src/__tests__/workspace-sandbox.test.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   assertPathInsideWorkspace,
@@ -64,6 +64,7 @@ describe("workspace-only sandbox", () => {
     const sandboxEnv = buildWorkspaceOnlyEnvironment(
       {
         FIRST_TREE_HOME: join(root, "first-tree-home"),
+        FIRST_TREE_CLI_BIN_DIR: cliBinDir,
         FIRST_TREE_SERVER_URL: "https://first-tree.test",
         OPENAI_API_KEY: "secret",
         GITHUB_TOKEN: "secret",
@@ -96,19 +97,43 @@ describe("workspace-only sandbox", () => {
     expect(args).not.toContain(outside);
   });
 
-  it("scrubs parent env and fails closed without a channel-local First Tree CLI", () => {
+  it("uses the controlled standard tool PATH when no explicit CLI bin dir is configured", () => {
+    setCliBinding({ binName: "sh", packageName: null });
     const firstTreeHome = join(root, "first-tree-home");
-    const cliBinDir = join(firstTreeHome, "bin");
-    mkdirSync(cliBinDir, { recursive: true });
+    const { env, readOnlyPaths } = buildWorkspaceOnlyEnvironment(
+      {
+        FIRST_TREE_HOME: firstTreeHome,
+        PATH: "/sensitive/bin:/usr/bin",
+      },
+      workspace,
+    );
 
-    expect(() =>
-      buildWorkspaceOnlyEnvironment({ FIRST_TREE_HOME: firstTreeHome, PATH: "/usr/bin" }, workspace),
-    ).toThrow(/channel-local First Tree CLI/);
+    const pathDirs = env.PATH?.split(delimiter) ?? [];
+    expect(pathDirs).toContain(env.FIRST_TREE_CLI_BIN_DIR);
+    expect(pathDirs).toContain("/usr/bin");
+    expect(pathDirs).toContain("/bin");
+    expect(env.PATH).not.toContain("/sensitive/bin");
+    expect(readOnlyPaths).toEqual([]);
+  });
+
+  it("fails closed when the channel CLI is absent from the controlled standard tool PATH", () => {
+    const firstTreeHome = join(root, "first-tree-home");
+
+    expect(() => buildWorkspaceOnlyEnvironment({ FIRST_TREE_HOME: firstTreeHome }, workspace)).toThrow(
+      /could not find channel-local First Tree CLI first-tree-test in controlled PATH directories/,
+    );
+  });
+
+  it("scrubs parent env and uses an explicit non-standard CLI bin dir", () => {
+    const firstTreeHome = join(root, "first-tree-home");
+    const cliBinDir = join(root, "explicit-cli-bin");
+    mkdirSync(cliBinDir, { recursive: true });
 
     writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
     const { env, readOnlyPaths } = buildWorkspaceOnlyEnvironment(
       {
         FIRST_TREE_HOME: firstTreeHome,
+        FIRST_TREE_CLI_BIN_DIR: cliBinDir,
         FIRST_TREE_SERVER_URL: "https://first-tree.test",
         FIRST_TREE_AGENT_ID: "agent-1",
         FIRST_TREE_CHAT_ID: "chat-1",
@@ -133,9 +158,25 @@ describe("workspace-only sandbox", () => {
     expect(env.GH_TOKEN).toBeUndefined();
     expect(env.FIRST_TREE_DOC_BASE).toBeUndefined();
     expect(env.FIRST_TREE_WORKSPACES_ROOT).toBeUndefined();
-    expect(env.PATH?.split(":")[0]).toBe(cliBinDir);
+    expect(env.PATH?.split(delimiter)[0]).toBe(cliBinDir);
     expect(env.PATH).not.toContain("/sensitive/bin");
     expect(readOnlyPaths).toEqual([cliBinDir]);
+  });
+
+  it("does not add an extra read-only bind for an explicit CLI dir covered by system mounts", () => {
+    setCliBinding({ binName: "sh", packageName: null });
+
+    const { env, readOnlyPaths } = buildWorkspaceOnlyEnvironment(
+      {
+        FIRST_TREE_HOME: join(root, "first-tree-home"),
+        FIRST_TREE_CLI_BIN_DIR: "/bin",
+      },
+      workspace,
+    );
+
+    expect(env.FIRST_TREE_CLI_BIN_DIR).toBe("/bin");
+    expect(env.PATH?.split(delimiter)[0]).toBe("/bin");
+    expect(readOnlyPaths).toEqual([]);
   });
 
   it("builds a workspace-local First Tree home with only scoped outbox credentials", () => {

--- a/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
+++ b/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
@@ -24,6 +24,12 @@ type WorkspaceOnlyEnvironment = {
   readOnlyPaths: string[];
 };
 
+type WorkspaceOnlyCliResolution = {
+  cliBinDir: string;
+  pathDirs: string[];
+  readOnlyPaths: string[];
+};
+
 type WorkspaceOnlyOutboxHomeOptions = {
   parentEnv: NodeJS.ProcessEnv;
   workspaceRoot: string;
@@ -131,6 +137,26 @@ function isCoveredBySystemBind(path: string): boolean {
   return READ_ONLY_SYSTEM_DIRS.some((dir) => existsSync(dir) && pathIsWithin(dir, path));
 }
 
+function existingDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function uniqueExistingDirs(paths: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const dirs: string[] = [];
+  for (const path of paths) {
+    const dir = isAbsolute(path) ? path : resolve(path);
+    if (!existingDirectory(dir) || seen.has(dir)) continue;
+    seen.add(dir);
+    dirs.push(dir);
+  }
+  return dirs;
+}
+
 function validateChannelCliBin(binDir: string, source: string): void {
   const { binName } = getCliBinding();
   const cliPath = join(binDir, binName);
@@ -141,23 +167,33 @@ function validateChannelCliBin(binDir: string, source: string): void {
   }
 }
 
-function resolveChannelCliBinDir(parentEnv: NodeJS.ProcessEnv): string {
+function resolveWorkspaceOnlyCli(parentEnv: NodeJS.ProcessEnv): WorkspaceOnlyCliResolution {
+  const defaultPathDirs = uniqueExistingDirs(WORKSPACE_ONLY_PATH_DIRS);
   const explicit = parentEnv.FIRST_TREE_CLI_BIN_DIR;
   if (explicit) {
     const binDir = isAbsolute(explicit) ? explicit : resolve(explicit);
     validateChannelCliBin(binDir, "FIRST_TREE_CLI_BIN_DIR");
-    return binDir;
+    return {
+      cliBinDir: binDir,
+      pathDirs: uniqueExistingDirs([binDir, ...WORKSPACE_ONLY_PATH_DIRS]),
+      readOnlyPaths: isCoveredBySystemBind(binDir) ? [] : [binDir],
+    };
   }
 
-  const home = parentEnv.FIRST_TREE_HOME;
-  if (!home) {
-    throw new Error(
-      "workspace-only sandbox requires FIRST_TREE_CLI_BIN_DIR, or FIRST_TREE_HOME with a legacy bin shim fallback",
-    );
+  for (const binDir of defaultPathDirs) {
+    try {
+      validateChannelCliBin(binDir, "controlled PATH");
+      return { cliBinDir: binDir, pathDirs: defaultPathDirs, readOnlyPaths: [] };
+    } catch {
+      // Keep searching the controlled tool PATH.
+    }
   }
-  const binDir = join(isAbsolute(home) ? home : resolve(home), "bin");
-  validateChannelCliBin(binDir, "legacy FIRST_TREE_HOME/bin fallback");
-  return binDir;
+
+  const { binName } = getCliBinding();
+  const searched = defaultPathDirs.length > 0 ? defaultPathDirs.join(", ") : "(no existing standard tool dirs)";
+  throw new Error(
+    `workspace-only sandbox could not find channel-local First Tree CLI ${binName} in controlled PATH directories: ${searched}. Install ${binName} in /usr/local/bin, /usr/bin, or /bin, or set FIRST_TREE_CLI_BIN_DIR to its directory.`,
+  );
 }
 
 function writePrivateFile(path: string, content: string): void {
@@ -170,7 +206,7 @@ export function prepareWorkspaceOnlyOutboxHome(options: WorkspaceOnlyOutboxHomeO
   cliBinDir: string;
 } {
   const realWorkspace = realpathExisting(options.workspaceRoot, "workspaceRoot");
-  const cliBinDir = resolveChannelCliBinDir(options.parentEnv);
+  const { cliBinDir } = resolveWorkspaceOnlyCli(options.parentEnv);
 
   const home = join(realWorkspace, ".first-tree-workspace", "outbox-home");
   const configDir = join(home, "config");
@@ -217,10 +253,7 @@ export function buildWorkspaceOnlyEnvironment(
     throw new Error("workspace-only sandbox requires FIRST_TREE_HOME for sandbox-local First Tree config");
   }
   const resolvedHome = isAbsolute(firstTreeHome) ? firstTreeHome : resolve(firstTreeHome);
-  const cliBinDir = resolveChannelCliBinDir({
-    FIRST_TREE_HOME: resolvedHome,
-    FIRST_TREE_CLI_BIN_DIR: parentEnv.FIRST_TREE_CLI_BIN_DIR,
-  });
+  const cli = resolveWorkspaceOnlyCli(parentEnv);
 
   const env: NodeJS.ProcessEnv = {};
   for (const key of SAFE_PASS_ENV_KEYS) {
@@ -230,9 +263,10 @@ export function buildWorkspaceOnlyEnvironment(
   env.FIRST_TREE_HOME = resolvedHome;
   env.HOME = realWorkspace;
   env.TMPDIR = "/tmp";
-  env.PATH = [cliBinDir, ...WORKSPACE_ONLY_PATH_DIRS].filter((entry) => existsSync(entry)).join(delimiter);
+  env.FIRST_TREE_CLI_BIN_DIR = cli.cliBinDir;
+  env.PATH = cli.pathDirs.join(delimiter);
 
-  return { env, readOnlyPaths: [cliBinDir] };
+  return { env, readOnlyPaths: cli.readOnlyPaths };
 }
 
 export function buildWorkspaceOnlyBubblewrapArgs(options: BuildBubblewrapArgsOptions): string[] {


### PR DESCRIPTION
## Summary

- Treat `FIRST_TREE_CLI_BIN_DIR` as an optional workspace-only override instead of a required default deployment setting.
- When the override is absent, resolve the channel CLI from the controlled sandbox tool path (`/usr/local/bin`, `/usr/bin`, `/bin`) and build the sandbox PATH from that allowlist rather than inheriting host PATH.
- Keep explicit non-standard CLI directories supported by validating the channel binary and adding only that directory as an extra read-only bind.
- Update workspace sandbox tests for standard-path discovery, missing CLI errors, explicit override precedence, and read-only bind behavior.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 src/__tests__/workspace-sandbox.test.ts src/__tests__/codex-app-server-handler.test.ts src/__tests__/codex-thread-options.test.ts src/__tests__/codex-handler-engine.test.ts`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm typecheck`
- `pnpm check` (exits 0 with existing warnings/info)
- `git diff --check`
