### PR TITLE
feat(web): expandable full narration on the compose status bar

### DIFF
--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -12,6 +12,7 @@ import {
   computeWorking,
   getChatAgentStatuses,
   isRuntimeFresh,
+  previewAssistantTextFull,
   resolveAgentChatStatuses,
   withTurnNarration,
 } from "../services/agent-chat-status.js";
@@ -434,11 +435,49 @@ describe("agent-chat-status", () => {
     });
 
     it("attaches a collapsed narration as turnText without touching kind / label / detail", () => {
-      const out = withTurnNarration(base, "  Let me   check\nthe file  ");
+      const out = withTurnNarration(base, "  Let me   check the file  ");
       expect(out?.kind).toBe("tool_call");
       expect(out?.label).toBe("Bash");
       expect(out?.detail).toBe("npm test");
       expect(out?.turnText).toBe("Let me check the file");
+    });
+
+    it("omits turnTextFull for a short single-line narration (nothing more to expand)", () => {
+      const out = withTurnNarration(base, "Reworking the status bar");
+      expect(out?.turnText).toBe("Reworking the status bar");
+      expect(out?.turnTextFull).toBeUndefined();
+    });
+
+    it("attaches turnTextFull when the narration has line breaks turnText flattened", () => {
+      const out = withTurnNarration(base, "Plan:\n1. read\n2. edit");
+      expect(out?.turnText).toBe("Plan: 1. read 2. edit"); // flattened one-line
+      expect(out?.turnTextFull).toBe("Plan:\n1. read\n2. edit"); // newline-preserving
+    });
+
+    it("attaches turnTextFull when the narration is longer than the 120-char one-line preview", () => {
+      const long = `${"a".repeat(200)}`;
+      const out = withTurnNarration(base, long);
+      expect(out?.turnText).toHaveLength(120);
+      expect(out?.turnTextFull).toBe(long); // full up to 2000, no truncation at 200
+    });
+  });
+
+  describe("previewAssistantTextFull — newline-preserving full narration", () => {
+    it("returns undefined for non-strings and whitespace-only blocks", () => {
+      expect(previewAssistantTextFull(undefined)).toBeUndefined();
+      expect(previewAssistantTextFull(42)).toBeUndefined();
+      expect(previewAssistantTextFull("   \n\t ")).toBeUndefined();
+    });
+
+    it("preserves line breaks while collapsing intra-line whitespace and blank-line runs", () => {
+      expect(previewAssistantTextFull("  Step   one \n\n\n  Step  two  ")).toBe("Step one\n\nStep two");
+      expect(previewAssistantTextFull("a\r\nb")).toBe("a\nb"); // CRLF normalized
+    });
+
+    it("caps at ASSISTANT_TEXT_FULL_MAX with a trailing ellipsis", () => {
+      const out = previewAssistantTextFull("b".repeat(2500));
+      expect(out).toHaveLength(2000);
+      expect(out?.endsWith("…")).toBe(true);
     });
   });
 

--- a/packages/server/src/services/agent-chat-status.ts
+++ b/packages/server/src/services/agent-chat-status.ts
@@ -2,6 +2,7 @@ import {
   type AgentChatStatus,
   type AgentEngagement,
   type AgentStatusReason,
+  ASSISTANT_TEXT_FULL_MAX,
   ASSISTANT_TEXT_PREVIEW_MAX,
   type AssistantTextEventPayload,
   buildAgentChatStatus,
@@ -95,6 +96,30 @@ export function previewAssistantText(text: unknown): string | undefined {
 }
 
 /**
+ * Full, **newline-preserving** narration for the compose status bar's expand
+ * card (`LiveActivity.turnTextFull`). Unlike {@link previewAssistantText} (which
+ * flattens all whitespace to a single line and caps at 120), this keeps the
+ * block's line structure — collapsing only intra-line runs of spaces/tabs and
+ * capping consecutive blank lines to one — and caps at
+ * {@link ASSISTANT_TEXT_FULL_MAX}. The card renders the whole string, so an
+ * explicit "…" marks a truncation. Returns undefined for an empty/whitespace-only
+ * block. Exported for unit testing.
+ */
+export function previewAssistantTextFull(text: unknown): string | undefined {
+  if (typeof text !== "string") return undefined;
+  const normalized = text
+    .replace(/\r\n?/g, "\n") // CRLF/CR → LF
+    .replace(/[ \t]+/g, " ") // collapse intra-line whitespace, keep newlines
+    .replace(/ *\n */g, "\n") // trim spaces hugging line breaks
+    .replace(/\n{3,}/g, "\n\n") // cap blank-line runs
+    .trim();
+  if (normalized.length === 0) return undefined;
+  return normalized.length > ASSISTANT_TEXT_FULL_MAX
+    ? `${normalized.slice(0, ASSISTANT_TEXT_FULL_MAX - 1)}…`
+    : normalized;
+}
+
+/**
  * Translate a `session_events` row into a `LiveActivity`, or null when the
  * kind is terminal (`turn_end` / `error`) or unrecognised. Pure & exported
  * for unit testing.
@@ -153,7 +178,13 @@ export function toLiveActivity(row: {
 export function withTurnNarration(base: LiveActivity | null, narrationText: unknown): LiveActivity | null {
   if (!base) return null;
   const narration = previewAssistantText(narrationText);
-  return narration ? { ...base, turnText: narration } : base;
+  if (!narration) return base;
+  const full = previewAssistantTextFull(narrationText);
+  // Attach `turnTextFull` only when it carries strictly more than the one-line
+  // `turnText` (source longer than 120 chars, or it has line breaks the preview
+  // flattened) — so "present" means "there is more to expand" for the client.
+  const hasMore = full !== undefined && full !== narration;
+  return { ...base, turnText: narration, ...(hasMore ? { turnTextFull: full } : {}) };
 }
 
 // ---------------------------------------------------------------------------
@@ -194,11 +225,11 @@ async function deriveActivities(
   const turnTextJoin = withTurn
     ? sql`
       LEFT JOIN LATERAL (
-        -- Generous raw prefix cap: bounds the bytes pulled from PG while
-        -- leaving ample margin for previewAssistantText (collapses whitespace,
-        -- then caps at ASSISTANT_TEXT_PREVIEW_MAX = 120). Wider than 120 so
-        -- pathological leading whitespace cannot starve the final value.
-        SELECT LEFT(se.payload->>'text', 500) AS text
+        -- Raw prefix cap: bounds the bytes pulled from PG while leaving margin
+        -- above ASSISTANT_TEXT_FULL_MAX (2000) — the newline-preserving
+        -- previewAssistantTextFull is the widest consumer, and margin keeps
+        -- pathological leading whitespace from starving the final value.
+        SELECT LEFT(se.payload->>'text', ${sql.raw(String(ASSISTANT_TEXT_FULL_MAX + 200))}) AS text
           FROM session_events se
          WHERE se.agent_id = acs.agent_id
            AND se.chat_id  = acs.chat_id

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -442,6 +442,7 @@ export {
 } from "./schemas/landing-campaign.js";
 export {
   type AddMeChatParticipants,
+  ASSISTANT_TEXT_FULL_MAX,
   ASSISTANT_TEXT_PREVIEW_MAX,
   addMeChatParticipantsSchema,
   CHAT_ENGAGEMENT_VIEWS,

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -162,6 +162,17 @@ export const liveActivitySchema = z.object({
    */
   turnText: z.string().optional(),
   /**
+   * The current turn's latest `assistant_text`, **newline-preserving** and capped
+   * to {@link ASSISTANT_TEXT_FULL_MAX} (2000) — the "expand to full" companion to
+   * the one-line {@link turnText}. Present ONLY when it carries strictly more than
+   * `turnText` does (source longer than the 120-char one-line preview, or it has
+   * real line breaks `turnText` flattened away); a short single-line narration
+   * omits it, so a client can treat "`turnTextFull` present" as "there is more to
+   * expand". Like `turnText` it rides only the per-agent `/agent-status`
+   * (`withTurnText`) path and is absent on the chat-list `liveActivity`.
+   */
+  turnTextFull: z.string().optional(),
+  /**
    * ISO timestamp at which this activity goes stale (= `startedAt` +
    * `LIVE_ACTIVITY_STALE_MS`). The server already drops stale activities at
    * read time; this lets a live surface's 1s ticker clear a lingering
@@ -184,6 +195,15 @@ export const LIVE_ACTIVITY_STALE_MS = 60_000;
  * and the on-screen ellipsis stays CSS-driven. No trailing "…" is appended.
  */
 export const ASSISTANT_TEXT_PREVIEW_MAX = 120;
+
+/**
+ * Max length of the **full** newline-preserving assistant-text narration surfaced
+ * on `LiveActivity.turnTextFull` for the compose status bar's expand card. Unlike
+ * {@link ASSISTANT_TEXT_PREVIEW_MAX} this is a real visible bound (the card
+ * renders the whole string, so an explicit "…" marks truncation) — kept well
+ * below the 8000-char stored block to bound the `/agent-status` wire payload.
+ */
+export const ASSISTANT_TEXT_FULL_MAX = 2000;
 
 export const meChatRowSchema = z.object({
   chatId: z.string(),

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -5,8 +5,8 @@ import {
   type LiveActivity,
 } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
-import { Brain, ChevronDown, Pencil, Wrench } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Brain, ChevronDown, ChevronsUpDown, Pencil, Wrench } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { chatAgentStatusQueryKey, fetchChatAgentStatuses } from "../../api/agent-status.js";
 import { viewOf } from "../../lib/agent-status-view.js";
 import { stripInlineMarkdown } from "../../lib/strip-inline-markdown.js";
@@ -126,6 +126,15 @@ export function ComposeStatusBar({
   agents: ChatParticipantDetail[];
 }) {
   const [expanded, setExpanded] = useState(false);
+  // Which agent's full-narration card is open (its agentId), or null. Keyed by
+  // agent — not a bare boolean — so the card auto-hides when the lead switches
+  // (no reset effect), and its trigger chevron (outside the card) is excluded
+  // from the outside-press close.
+  const [cardOpenFor, setCardOpenFor] = useState<string | null>(null);
+  const cardTriggerRef = useRef<HTMLButtonElement | null>(null);
+  // Stable so TurnTextCard's document-listener effect doesn't re-subscribe on
+  // every parent re-render (query refetch / elapsed tick).
+  const closeCard = useCallback(() => setCardOpenFor(null), []);
   const [lead, setLead] = useState<{ agentId: string; since: number } | null>(null);
   const { data: statuses } = useQuery({
     queryKey: chatAgentStatusQueryKey(chatId),
@@ -153,26 +162,68 @@ export function ComposeStatusBar({
   }, [statuses]);
 
   const attention = selectAttention(statuses ?? []);
-  if (attention.length === 0) return null; // all quiet → hidden
-
   // Resolve the held lead to a live row; fall back to the top of `attention`
   // before the effect has settled (or if the held agent just dropped out).
+  // Computed before the early returns so the stale-card effect below runs
+  // unconditionally (Rules of Hooks).
   const leadRow = (lead && attention.find((s) => s.agentId === lead.agentId)) ?? attention[0];
+  // The lead's full narration — present only when the server attached
+  // `turnTextFull` (strictly more than the one-line goal). Only working leads
+  // carry live activity.
+  const leadFull = leadRow?.main === "working" ? leadRow.activity?.turnTextFull : undefined;
+  // Forget a stale open-card key so the card never silently re-opens on its own:
+  // once the agent that owned it is no longer a working lead with a full
+  // narration (it switched away, or its narration shrank back below the
+  // "has more" threshold mid-turn), drop the open state instead of letting a
+  // later re-cross of that threshold re-materialize the card.
+  useEffect(() => {
+    if (cardOpenFor !== null && !(leadFull && leadRow?.agentId === cardOpenFor)) {
+      setCardOpenFor(null);
+    }
+  }, [cardOpenFor, leadFull, leadRow?.agentId]);
+
+  if (attention.length === 0) return null; // all quiet → hidden
   if (!leadRow) return null; // unreachable (attention is non-empty) — narrows the type
   const others = attention.filter((s) => s.agentId !== leadRow.agentId);
+  const cardOpen = cardOpenFor === leadRow.agentId;
 
   return (
     <div
       className="fade-in flex flex-col"
       style={{
+        position: "relative", // anchor for the full-narration card floating above
         marginBottom: "var(--sp-1)",
         paddingBottom: "var(--sp-1)",
         gap: "var(--sp-1)",
         borderBottom: "var(--hairline) solid var(--border-faint)",
       }}
     >
+      {cardOpen && leadFull ? (
+        <TurnTextCard
+          status={leadRow}
+          name={nameFor(agents)(leadRow.agentId)}
+          full={leadFull}
+          triggerRef={cardTriggerRef}
+          onClose={closeCard}
+        />
+      ) : null}
       <div className="flex items-center" style={{ gap: "var(--sp-1_5)" }}>
         <RailRow status={leadRow} nameOf={nameFor(agents)} mounted={mounted} />
+        {leadFull ? (
+          <button
+            type="button"
+            ref={cardTriggerRef}
+            aria-label={cardOpen ? "Collapse full narration" : "Expand full narration"}
+            aria-expanded={cardOpen}
+            onClick={() => setCardOpenFor((cur) => (cur === leadRow.agentId ? null : leadRow.agentId))}
+            className="inline-flex shrink-0 items-center"
+            style={{ border: 0, background: "transparent", padding: 0, cursor: "pointer", color: "var(--fg-4)" }}
+          >
+            {/* A distinct unfold glyph (not a single chevron) so it never reads
+                as, or collides with, the adjacent `+N` expand chevron. */}
+            <ChevronsUpDown className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
         {others.length > 0 ? (
           <button
             type="button"
@@ -400,5 +451,111 @@ function Sep() {
     <span aria-hidden="true" className="shrink-0" style={{ color: "var(--fg-4)" }}>
       ·
     </span>
+  );
+}
+
+/**
+ * Floating card that expands the lead's full multi-line narration (`turnTextFull`)
+ * over the message stream, anchored to the status bar and floating upward. It is
+ * absolutely positioned (out of flow) so opening it — and the live refresh while
+ * it's open — never reflows the conversation. A non-modal awareness surface (like
+ * the chat-summary popover), not a focus-trapping dialog: dismisses on Escape, a
+ * press outside it (ignoring the trigger, which owns the toggle), or the lead
+ * ceasing to be a working agent with a full narration (handled by the parent).
+ */
+function TurnTextCard({
+  status,
+  name,
+  full,
+  triggerRef,
+  onClose,
+}: {
+  status: AgentChatStatus;
+  name: string;
+  full: string;
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+  onClose: () => void;
+}) {
+  const cardRef = useRef<HTMLElement | null>(null);
+  const elapsed = useLiveElapsed(status.activity?.startedAt ?? null);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    const onDown = (e: PointerEvent) => {
+      const t = e.target as Node | null;
+      if (!t || cardRef.current?.contains(t) || triggerRef.current?.contains(t)) return;
+      onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    // Capture so the outside-press is seen before message-row handlers.
+    document.addEventListener("pointerdown", onDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("pointerdown", onDown, true);
+    };
+  }, [onClose, triggerRef]);
+
+  // Strip inline markdown per line so the block's line breaks survive.
+  const body = full
+    .split("\n")
+    .map((line) => stripInlineMarkdown(line))
+    .join("\n");
+
+  return (
+    <section
+      ref={cardRef}
+      aria-label={`${name} — full narration`}
+      className="fade-in flex flex-col"
+      style={{
+        position: "absolute",
+        left: 0,
+        right: 0,
+        bottom: "calc(100% + var(--sp-1))",
+        zIndex: 20,
+        background: "var(--bg-raised)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-dialog)",
+        boxShadow: "var(--shadow-md)",
+        maxHeight: "min(46vh, 26rem)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        className="text-caption flex items-center"
+        style={{
+          gap: "var(--sp-1_5)",
+          padding: "var(--sp-1_5) var(--sp-2)",
+          borderBottom: "var(--hairline) solid var(--border-faint)",
+          color: "var(--fg-3)",
+        }}
+      >
+        <StatusGlyph colorVar="var(--state-working)" shape="dot" pulse="working" size={7} ariaLabel="working" />
+        <span className="shrink-0 font-semibold" style={{ color: "var(--fg-2)" }}>
+          {name}
+        </span>
+        {/* Same live "means" segment the rail uses (goal-suppression off), so the
+            card header and the rail read identically — no bespoke duplicate. */}
+        {status.activity ? activityAction(status.activity, false) : null}
+        {elapsed ? (
+          <span className="mono shrink-0" style={{ marginLeft: "auto", color: "var(--fg-4)" }}>
+            {elapsed}
+          </span>
+        ) : null}
+      </div>
+      <div
+        className="text-body"
+        style={{
+          padding: "var(--sp-2)",
+          overflowY: "auto",
+          overscrollBehavior: "contain",
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          color: "var(--fg)",
+        }}
+      >
+        {body}
+      </div>
+    </section>
   );
 }

--- a/packages/web/src/pages/compose-status-bar-preview.tsx
+++ b/packages/web/src/pages/compose-status-bar-preview.tsx
@@ -123,6 +123,23 @@ const VARIANTS: Variant[] = [
     ],
   },
   {
+    name: "working · long multi-line goal (expand card)",
+    subtitle: "goal truncates on the rail; the ⌃ chevron opens the full turnText card (click to test)",
+    chatId: "v-expand",
+    agents: [DEV],
+    statuses: [
+      working("agent-dev", {
+        kind: "tool_call",
+        label: "Bash",
+        detail: "pnpm typecheck",
+        turnText: "Reworking the compose status bar so a long narration can expand to its full multi-line form",
+        turnTextFull:
+          "Reworking the compose status bar so a long narration can expand to its full multi-line form.\n\nPlan:\n1. Server derives a newline-preserving turnTextFull (capped at 2000), only when it carries more than the one-line goal.\n2. The rail keeps its single line; a dedicated ⌃ chevron opens a floating card.\n3. The card floats over the stream (absolute, out of flow) so the live ~1s refresh never reflows the conversation.",
+        startedAt: ago(23),
+      }),
+    ],
+  },
+  {
     name: "working · no prose yet (means leads)",
     subtitle: "turnText absent (opened with a tool) → tool leads, line not blank",
     chatId: "v-no-goal",


### PR DESCRIPTION
## What

The compose status bar's one-line goal (`turnText`) can now be **expanded to its full multi-line form**. A dedicated unfold control (`⇕`) on the lead row opens a **floating card** — absolutely positioned, out of flow — that shows the agent's whole current narration without reflowing the conversation. It dismisses on `Escape`, an outside press, or the lead ceasing to be a working agent that still has a full narration.

Only shows up when there is genuinely more to read: the control appears **only** when the narration is longer than the 120-char one-line goal or has line breaks the one-liner flattened.

## Why

The rail truncates the narration to one line (120 chars, whitespace-collapsed). When an agent's goal is long or multi-line, that detail was unreachable from the composer. This surfaces it on demand without turning the always-on, stable status bar into something that jumps or reflows the stream.

## How

**Shared** (`schemas/me-chat.ts`) — `LiveActivity` gains an optional, newline-preserving `turnTextFull` (`ASSISTANT_TEXT_FULL_MAX = 2000`). Present **only** when it carries strictly more than the one-line `turnText`, so a client can treat "present" as "there is more to expand".

**Server** (`services/agent-chat-status.ts`) — new `previewAssistantTextFull` (preserves `\n`, collapses intra-line whitespace, caps at 2000 with an explicit `…`); `withTurnNarration` attaches `turnTextFull` only when it differs from the one-liner. The full text already lives in `session_events`, so **no client change and no DB migration** — only the raw-prefix `LEFT()` cap in the existing LATERAL seek is widened. Rides only the per-agent `/agent-status` (`withTurnText`) path; the chat-list projection is unaffected.

**Web** (`components/chat/compose-status-bar.tsx`) — the unfold control + a floating `<section>` card that reuses the rail's existing `activityAction` for its header means. Open-state is keyed by agentId so it auto-hides on a lead switch and never silently re-opens; the trigger is excluded from the outside-press close.

## Verification

- `pnpm typecheck` (all packages) + `pnpm biome check` + `lint:tokens` — clean.
- Server unit tests for `previewAssistantTextFull` + `withTurnNarration` (`turnTextFull` present/absent, newline preservation, 2000-char cap). Full server suite green.
- Full web suite green.
- DEV `/preview/compose-status-bar` gallery, both themes: the control appears only on the long-multi-line variant; the card opens/closes and renders the full narration. (A preview variant was added.)
- Two independent code reviews (correctness + UI/design); their findings folded in (stale-open guard, `activityAction` reuse over a bespoke duplicate, `<section>` over a half-implemented `role="dialog"`, a distinct unfold glyph vs. the `+N` chevron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
