### PR TITLE
feat: docloop M2 — web Docs section (library + reading view with anchored review comments)

### DIFF
--- a/apps/cli/src/commands/doc/publish.ts
+++ b/apps/cli/src/commands/doc/publish.ts
@@ -4,7 +4,7 @@ import type { Command } from "commander";
 import { fail, success } from "../../cli/output.js";
 import { channelConfig } from "../../core/channel.js";
 import { slugFromFilename, titleFromMarkdown } from "../../core/doc-review.js";
-import { createSdk, handleSdkError } from "../_shared/local-agent.js";
+import { createSdk, handleSdkError, resolveLocalAgent } from "../_shared/local-agent.js";
 import { parseDocStatus } from "./_shared.js";
 
 interface PublishOptions {
@@ -58,6 +58,7 @@ export function registerDocPublishCommand(doc: Command): void {
       const title = options.title ?? titleFromMarkdown(content) ?? undefined;
 
       try {
+        const { serverUrl } = resolveLocalAgent(options.agent);
         const sdk = createSdk(options.agent);
         const result = await sdk.publishDoc({
           slug,
@@ -68,11 +69,13 @@ export function registerDocPublishCommand(doc: Command): void {
           status,
           ifChanged: options.ifChanged === true,
         });
+        // Shareable reading view — paste it in chat so humans can review.
+        const url = `${serverUrl.replace(/\/+$/, "")}/context/docs/${encodeURIComponent(result.slug)}`;
         const hint = result.createdVersion
-          ? `Published as version ${result.version}. Pull review feedback later with ` +
+          ? `Published as version ${result.version}. Share ${url} for review; pull feedback later with ` +
             `\`${channelConfig.binName} doc comments ${result.slug} --status open\`.`
           : `Content unchanged — still at version ${result.version}, no new version created.`;
-        success({ ...result, hint });
+        success({ ...result, url, hint });
       } catch (error) {
         handleSdkError(error);
       }

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -191,6 +191,12 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
         completedAt: defaultRow?.onboardingCompletedAt ? defaultRow.onboardingCompletedAt.toISOString() : null,
       },
       inviteUrl,
+      // Deployment-level feature switches the web shell needs before it can
+      // decide what to render (e.g. the Context → Documents sub-tab). Server
+      // routes stay the enforcement point; this is presentation-only.
+      features: {
+        docs: app.config.docs.enabled,
+      },
     };
   });
 

--- a/packages/shared/src/__tests__/doc-anchor.test.ts
+++ b/packages/shared/src/__tests__/doc-anchor.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { buildDocAnchor, locateDocAnchor } from "../doc-anchor.js";
+
+const SOURCE = [
+  "# Design Doc",
+  "",
+  "We use soft delete because audit trails matter.",
+  "",
+  "The cache is per-tenant. The cache is per-tenant on purpose.",
+  "",
+  "```ts",
+  "const cache = new Map();",
+  "```",
+].join("\n");
+
+describe("buildDocAnchor", () => {
+  it("anchors a unique selection with raw-source context", () => {
+    const anchor = buildDocAnchor({ source: SOURCE, selectedText: "soft delete" });
+    expect(anchor).not.toBeNull();
+    expect(anchor?.exact).toBe("soft delete");
+    expect(anchor?.prefix?.endsWith("We use ")).toBe(true);
+    expect(anchor?.suffix?.startsWith(" because")).toBe(true);
+  });
+
+  it("survives whitespace differences between rendered selection and source", () => {
+    // Rendered text collapses the newline between the two sentences to a space.
+    const anchor = buildDocAnchor({
+      source: "line one\nline two ends here",
+      selectedText: "one line two",
+    });
+    expect(anchor?.exact).toBe("one\nline two");
+  });
+
+  it("disambiguates repeated text via rendered context", () => {
+    const anchor = buildDocAnchor({
+      source: SOURCE,
+      selectedText: "The cache is per-tenant",
+      renderedSuffix: " on purpose.",
+    });
+    expect(anchor).not.toBeNull();
+    // The second occurrence is the one followed by "on purpose".
+    expect(anchor?.suffix?.startsWith(" on purpose")).toBe(true);
+  });
+
+  it("returns null when the selection is absent from the source", () => {
+    expect(buildDocAnchor({ source: SOURCE, selectedText: "not in the document" })).toBeNull();
+    expect(buildDocAnchor({ source: SOURCE, selectedText: "   " })).toBeNull();
+  });
+});
+
+describe("locateDocAnchor", () => {
+  it("round-trips an anchor built from a selection", () => {
+    const anchor = buildDocAnchor({ source: SOURCE, selectedText: "audit trails matter" });
+    expect(anchor).not.toBeNull();
+    if (!anchor) return;
+    const range = locateDocAnchor(SOURCE, anchor);
+    expect(range).not.toBeNull();
+    if (!range) return;
+    expect(SOURCE.slice(range.start, range.end)).toBe("audit trails matter");
+  });
+
+  it("re-locates after unrelated edits (the re-anchor case)", () => {
+    const anchor = buildDocAnchor({ source: SOURCE, selectedText: "soft delete" });
+    if (!anchor) throw new Error("anchor expected");
+    const v2 = `# Design Doc v2\n\nIntro paragraph.\n\n${SOURCE.slice(SOURCE.indexOf("We use"))}`;
+    const range = locateDocAnchor(v2, anchor);
+    expect(range).not.toBeNull();
+    if (!range) return;
+    expect(v2.slice(range.start, range.end)).toBe("soft delete");
+  });
+
+  it("uses prefix/suffix to pick among repeated occurrences", () => {
+    const source = "alpha beta gamma. alpha beta delta.";
+    const range = locateDocAnchor(source, { exact: "alpha beta", suffix: " delta" });
+    expect(range).not.toBeNull();
+    if (!range) return;
+    expect(range.start).toBe(source.indexOf("alpha beta delta"));
+  });
+
+  it("returns null when the quoted text was deleted", () => {
+    const anchor = buildDocAnchor({ source: SOURCE, selectedText: "soft delete" });
+    if (!anchor) throw new Error("anchor expected");
+    const v2 = SOURCE.replace("soft delete", "hard delete");
+    expect(locateDocAnchor(v2, anchor)).toBeNull();
+  });
+
+  it("tolerates whitespace-only reflows of the quote", () => {
+    const anchor = { exact: "audit trails matter" };
+    const reflowed = SOURCE.replace("audit trails matter", "audit\n  trails   matter");
+    const range = locateDocAnchor(reflowed, anchor);
+    expect(range).not.toBeNull();
+    if (!range) return;
+    expect(reflowed.slice(range.start, range.end)).toBe("audit\n  trails   matter");
+  });
+});

--- a/packages/shared/src/__tests__/doc-anchor.test.ts
+++ b/packages/shared/src/__tests__/doc-anchor.test.ts
@@ -46,6 +46,17 @@ describe("buildDocAnchor", () => {
     expect(buildDocAnchor({ source: SOURCE, selectedText: "not in the document" })).toBeNull();
     expect(buildDocAnchor({ source: SOURCE, selectedText: "   " })).toBeNull();
   });
+
+  it("returns null when whitespace re-expansion pushes the raw exact past the schema cap", () => {
+    // Normalized selection is well under the cap, but the source stores the
+    // same words separated by huge whitespace runs — the raw slice would
+    // exceed DOC_ANCHOR_EXACT_MAX and be rejected server-side.
+    const words = Array.from({ length: 40 }, (_, i) => `word${i}`);
+    const source = `intro\n${words.join("\n".repeat(60))}\noutro`;
+    const selected = words.join(" ");
+    expect(selected.length).toBeLessThan(2_000);
+    expect(buildDocAnchor({ source, selectedText: selected })).toBeNull();
+  });
 });
 
 describe("locateDocAnchor", () => {

--- a/packages/shared/src/doc-anchor.ts
+++ b/packages/shared/src/doc-anchor.ts
@@ -169,10 +169,16 @@ export function buildDocAnchor(input: BuildDocAnchorInput): DocAnchor | null {
   );
   const range = toRawRange(norm, picked.normStart, picked.normEnd);
 
+  const exact = input.source.slice(range.start, range.end);
+  // The normalized selection fit the cap, but the RAW slice re-expands the
+  // collapsed whitespace — if that pushes past the schema limit the server
+  // would reject the comment, so degrade to the document-level fallback.
+  if (exact.length > DOC_ANCHOR_EXACT_MAX) return null;
+
   const prefix = input.source.slice(Math.max(0, range.start - ANCHOR_CONTEXT_CHARS), range.start);
   const suffix = input.source.slice(range.end, range.end + ANCHOR_CONTEXT_CHARS);
   return {
-    exact: input.source.slice(range.start, range.end),
+    exact,
     ...(prefix.length > 0 ? { prefix: prefix.slice(-DOC_ANCHOR_CONTEXT_MAX) } : {}),
     ...(suffix.length > 0 ? { suffix: suffix.slice(0, DOC_ANCHOR_CONTEXT_MAX) } : {}),
   };

--- a/packages/shared/src/doc-anchor.ts
+++ b/packages/shared/src/doc-anchor.ts
@@ -1,0 +1,197 @@
+import type { DocAnchor } from "./schemas/document.js";
+import { DOC_ANCHOR_CONTEXT_MAX, DOC_ANCHOR_EXACT_MAX } from "./schemas/document.js";
+
+/**
+ * Anchor building / locating for document review (docloop) comments.
+ *
+ * A comment anchors to a range of the markdown SOURCE via a W3C
+ * TextQuoteSelector-style `{ exact, prefix, suffix }`. The web UI builds
+ * anchors from a selection made on RENDERED markdown, so the selected text
+ * may differ from the source in whitespace and may omit inline syntax
+ * (`**`, `` ` ``, link targets). Matching is therefore done on a
+ * whitespace-normalized view of the source with an index map back to raw
+ * offsets, and ambiguity is resolved by scoring the rendered context against
+ * the source neighborhood.
+ *
+ * The same `locateDocAnchor` is what re-anchoring across versions uses:
+ * anchors that no longer locate are surfaced as outdated rather than
+ * silently dropped.
+ */
+
+/** Context captured around an anchor, in raw source characters. */
+const ANCHOR_CONTEXT_CHARS = 48;
+
+type NormalizedText = {
+  /** Whitespace runs collapsed to single spaces, edges trimmed. */
+  text: string;
+  /** `map[i]` = raw-string offset of normalized char `i`. */
+  map: number[];
+};
+
+/**
+ * Collapse every whitespace run to one space and record, for each normalized
+ * character, the raw offset it came from. Lets a match on the normalized view
+ * be translated back to exact raw offsets.
+ */
+function normalizeWithMap(raw: string): NormalizedText {
+  let text = "";
+  const map: number[] = [];
+  let pendingSpace = false;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i] as string;
+    if (/\s/.test(ch)) {
+      pendingSpace = text.length > 0;
+      continue;
+    }
+    if (pendingSpace) {
+      text += " ";
+      // A collapsed space maps to the raw offset of the char that follows it,
+      // which keeps range math monotonic.
+      map.push(i);
+      pendingSpace = false;
+    }
+    text += ch;
+    map.push(i);
+  }
+  return { text, map };
+}
+
+function normalize(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Collapse whitespace WITHOUT trimming. Context strings keep their edge
+ * spaces because the source neighborhood they are compared against retains
+ * the single separator space (e.g. suffix " delta" must match neighborhood
+ * " delta.", not "delta.").
+ */
+function collapseWhitespace(raw: string): string {
+  return raw.replace(/\s+/g, " ");
+}
+
+function findAllOccurrences(haystack: string, needle: string): number[] {
+  const out: number[] = [];
+  if (needle.length === 0) return out;
+  let idx = haystack.indexOf(needle);
+  while (idx !== -1) {
+    out.push(idx);
+    idx = haystack.indexOf(needle, idx + 1);
+  }
+  return out;
+}
+
+/** Longest suffix of `context` that is a suffix of `neighborhood`, in chars. */
+function suffixOverlap(context: string, neighborhood: string): number {
+  const max = Math.min(context.length, neighborhood.length);
+  let n = 0;
+  while (n < max && context[context.length - 1 - n] === neighborhood[neighborhood.length - 1 - n]) n++;
+  return n;
+}
+
+/** Longest prefix of `context` that is a prefix of `neighborhood`, in chars. */
+function prefixOverlap(context: string, neighborhood: string): number {
+  const max = Math.min(context.length, neighborhood.length);
+  let n = 0;
+  while (n < max && context[n] === neighborhood[n]) n++;
+  return n;
+}
+
+type Occurrence = { normStart: number; normEnd: number };
+
+function pickOccurrence(
+  normSource: string,
+  occurrences: number[],
+  needleLength: number,
+  beforeContext: string | undefined,
+  afterContext: string | undefined,
+): Occurrence {
+  const first = occurrences[0] as number;
+  if (occurrences.length === 1 || (!beforeContext && !afterContext)) {
+    return { normStart: first, normEnd: first + needleLength };
+  }
+  const normBefore = beforeContext ? collapseWhitespace(beforeContext) : "";
+  const normAfter = afterContext ? collapseWhitespace(afterContext) : "";
+  let best = first;
+  let bestScore = -1;
+  for (const start of occurrences) {
+    const neighborhoodBefore = normSource.slice(Math.max(0, start - 200), start);
+    const neighborhoodAfter = normSource.slice(start + needleLength, start + needleLength + 200);
+    const score = suffixOverlap(normBefore, neighborhoodBefore) + prefixOverlap(normAfter, neighborhoodAfter);
+    if (score > bestScore) {
+      bestScore = score;
+      best = start;
+    }
+  }
+  return { normStart: best, normEnd: best + needleLength };
+}
+
+/** Translate a normalized-view range back to raw offsets `{ start, end }`. */
+function toRawRange(norm: NormalizedText, normStart: number, normEnd: number): { start: number; end: number } {
+  const start = norm.map[normStart] as number;
+  const lastCharRaw = norm.map[normEnd - 1] as number;
+  return { start, end: lastCharRaw + 1 };
+}
+
+export type DocAnchorRange = { start: number; end: number };
+
+export type BuildDocAnchorInput = {
+  /** Markdown source of the version being commented on. */
+  source: string;
+  /** Text the user selected (typically from the rendered view). */
+  selectedText: string;
+  /** Rendered text immediately before the selection, for disambiguation. */
+  renderedPrefix?: string;
+  /** Rendered text immediately after the selection, for disambiguation. */
+  renderedSuffix?: string;
+};
+
+/**
+ * Build a source-based anchor from a (rendered) selection. Returns null when
+ * the selected text cannot be found in the source at all — e.g. the
+ * selection spans inline markdown syntax; callers should then fall back to a
+ * document-level comment that quotes the text in its body.
+ */
+export function buildDocAnchor(input: BuildDocAnchorInput): DocAnchor | null {
+  const normSelected = normalize(input.selectedText);
+  if (normSelected.length === 0 || normSelected.length > DOC_ANCHOR_EXACT_MAX) return null;
+
+  const norm = normalizeWithMap(input.source);
+  const occurrences = findAllOccurrences(norm.text, normSelected);
+  if (occurrences.length === 0) return null;
+
+  const picked = pickOccurrence(
+    norm.text,
+    occurrences,
+    normSelected.length,
+    input.renderedPrefix,
+    input.renderedSuffix,
+  );
+  const range = toRawRange(norm, picked.normStart, picked.normEnd);
+
+  const prefix = input.source.slice(Math.max(0, range.start - ANCHOR_CONTEXT_CHARS), range.start);
+  const suffix = input.source.slice(range.end, range.end + ANCHOR_CONTEXT_CHARS);
+  return {
+    exact: input.source.slice(range.start, range.end),
+    ...(prefix.length > 0 ? { prefix: prefix.slice(-DOC_ANCHOR_CONTEXT_MAX) } : {}),
+    ...(suffix.length > 0 ? { suffix: suffix.slice(0, DOC_ANCHOR_CONTEXT_MAX) } : {}),
+  };
+}
+
+/**
+ * Locate an anchor inside (a possibly different version of) the source.
+ * Whitespace-insensitive; ambiguity resolves through the stored
+ * prefix/suffix. Returns raw offsets, or null when the quote no longer
+ * exists — the caller decides what "outdated" means.
+ */
+export function locateDocAnchor(source: string, anchor: DocAnchor): DocAnchorRange | null {
+  const normExact = normalize(anchor.exact);
+  if (normExact.length === 0) return null;
+
+  const norm = normalizeWithMap(source);
+  const occurrences = findAllOccurrences(norm.text, normExact);
+  if (occurrences.length === 0) return null;
+
+  const picked = pickOccurrence(norm.text, occurrences, normExact.length, anchor.prefix, anchor.suffix);
+  return toRawRange(norm, picked.normStart, picked.normEnd);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,13 @@ export {
   findAssembledBriefingFingerprint,
 } from "./agent-briefing-guard.js";
 export { canonicalGitRepoUrl } from "./canonical-git-repo-url.js";
+// -- Document review (docloop) anchor building / locating --
+export {
+  type BuildDocAnchorInput,
+  buildDocAnchor,
+  type DocAnchorRange,
+  locateDocAnchor,
+} from "./doc-anchor.js";
 // -- Mention extraction (shared by the server fan-out resolver and other readers) --
 export { type BarePathMatch, scanBareDocPathTokens, stripDocPathLineSuffix } from "./lib/doc-link-scan.js";
 export {

--- a/packages/web/src/api/docs.ts
+++ b/packages/web/src/api/docs.ts
@@ -1,0 +1,74 @@
+import type {
+  CreateDocCommentRequest,
+  DocComment,
+  DocCommentStatus,
+  DocStatus,
+  DocSummary,
+  DocWithVersion,
+  ListDocCommentsResponse,
+  ListDocsResponse,
+} from "@first-tree/shared";
+import { api, withOrg } from "./client.js";
+
+/**
+ * Document review (docloop) API layer.
+ *
+ * List/publish are org-scoped (Class B, `withOrg`); everything addressing a
+ * specific document or comment goes through the resource surface (Class C,
+ * UUID locates the org server-side). Route contracts live in
+ * packages/server/src/api/{orgs/,}documents.ts.
+ */
+
+export type ListDocsQueryInput = {
+  slug?: string;
+  project?: string;
+  status?: DocStatus;
+  limit?: number;
+  cursor?: string;
+};
+
+function query(params: Record<string, string | number | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) search.set(key, String(value));
+  }
+  const qs = search.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export function listDocs(input: ListDocsQueryInput = {}): Promise<ListDocsResponse> {
+  return api.get<ListDocsResponse>(`${withOrg("/documents")}${query(input)}`);
+}
+
+/** Slug → summary resolution (slugs are org-unique; the URL uses them). */
+export async function findDocBySlug(slug: string): Promise<DocSummary | null> {
+  const { items } = await listDocs({ slug, limit: 1 });
+  return items[0] ?? null;
+}
+
+export function getDoc(docId: string, version?: number): Promise<DocWithVersion> {
+  return api.get<DocWithVersion>(`/documents/${encodeURIComponent(docId)}${query({ version })}`);
+}
+
+export function setDocStatus(docId: string, status: DocStatus): Promise<DocSummary> {
+  return api.patch<DocSummary>(`/documents/${encodeURIComponent(docId)}`, { status });
+}
+
+export function listDocComments(
+  docId: string,
+  input: { status?: DocCommentStatus; versionNumber?: number } = {},
+): Promise<ListDocCommentsResponse> {
+  return api.get<ListDocCommentsResponse>(`/documents/${encodeURIComponent(docId)}/comments${query(input)}`);
+}
+
+export function createDocComment(docId: string, body: CreateDocCommentRequest): Promise<DocComment> {
+  return api.post<DocComment>(`/documents/${encodeURIComponent(docId)}/comments`, body);
+}
+
+export function replyDocComment(commentId: string, body: string): Promise<DocComment> {
+  return api.post<DocComment>(`/document-comments/${encodeURIComponent(commentId)}/replies`, { body });
+}
+
+export function setDocCommentStatus(commentId: string, status: DocCommentStatus): Promise<DocComment> {
+  return api.patch<DocComment>(`/document-comments/${encodeURIComponent(commentId)}`, { status });
+}

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -15,6 +15,8 @@ import { RuntimeTab } from "./pages/agent-detail/runtime-tab.js";
 import { UsageTab } from "./pages/agent-detail/usage-tab.js";
 import { AgentDetailPage } from "./pages/agent-detail.js";
 import { ContextPage } from "./pages/context.js";
+import { DocPage } from "./pages/docs/doc-page.js";
+import { DocsListPage } from "./pages/docs/docs-list-page.js";
 import { InviteAcceptPage } from "./pages/invite-accept.js";
 import { LoginPage } from "./pages/login.js";
 import { OAuthCompletePage } from "./pages/oauth-complete.js";
@@ -339,6 +341,8 @@ export function App() {
                 >
                   <Route index element={<WorkspacePage />} />
                   <Route path="context" element={<ContextPage />} />
+                  <Route path="context/docs" element={<DocsListPage />} />
+                  <Route path="context/docs/:slug" element={<DocPage />} />
                   <Route path="agents/:uuid" element={<AgentDetailPage />}>
                     <Route index element={<Navigate to="profile" replace />} />
                     <Route path="profile" element={<ProfileTab />} />

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -37,6 +37,11 @@ type MeResponse = {
      */
     completedAt?: string | null;
   };
+  /** Deployment-level feature switches (presentation-only; routes enforce). */
+  features?: {
+    /** Document review (docloop): the Context → Documents sub-tab. */
+    docs?: boolean;
+  };
 };
 
 type AuthContextValue = {
@@ -91,6 +96,8 @@ type AuthContextValue = {
    * satisfy it.
    */
   currentOrgHasPersonalAgent: boolean;
+  /** Document review (docloop) surface is enabled on this deployment. */
+  docsEnabled: boolean;
   onboardingStep: "connect" | "create_agent" | "completed" | null;
   /**
    * ISO timestamp when the user dismissed onboarding ("finish later").
@@ -213,6 +220,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(() => !!getStoredTokens());
   const [user, setUser] = useState<MeUser | null>(null);
   const [memberships, setMemberships] = useState<MeMembership[]>([]);
+  const [docsEnabled, setDocsEnabled] = useState(false);
   const [selectedOrgId, setSelectedOrgId] = useState<string | null>(() => {
     const init = readSelectedOrgId(userIdFromToken());
     // Sync the API client's module-level override on first paint so the
@@ -256,6 +264,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setOnboardingStep(null);
     setOnboardingDismissedAt(null);
     setOnboardingCompletedAt(null);
+    setDocsEnabled(false);
     setMeLoaded(false);
     setSwitchingOrg(null);
   }, [queryClient]);
@@ -266,6 +275,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUser(data.user ?? null);
       const ms = data.memberships ?? [];
       setMemberships(ms);
+      setDocsEnabled(data.features?.docs === true);
       const nextStep = data.onboarding?.step ?? null;
       setOnboardingStep(nextStep);
       // Legacy fallback for older /me payloads. Modern payloads carry these
@@ -512,6 +522,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         orgHasOtherMembers: currentMembership?.orgHasOtherMembers ?? false,
         currentOrgHasUsableAgent: currentMembership?.hasUsableAgent ?? false,
         currentOrgHasPersonalAgent: currentMembership?.hasPersonalAgent ?? false,
+        docsEnabled,
         onboardingStep,
         onboardingDismissedAt: currentOnboardingDismissedAt,
         onboardingCompletedAt: currentOnboardingCompletedAt,

--- a/packages/web/src/pages/__tests__/docs-pages-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/docs-pages-dom.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment happy-dom
+
+import type { DocComment, DocSummary, DocWithVersion } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../test-utils/dom-harness.js";
+
+const docsApiMocks = vi.hoisted(() => ({
+  listDocs: vi.fn(),
+  findDocBySlug: vi.fn(),
+  getDoc: vi.fn(),
+  setDocStatus: vi.fn(),
+  listDocComments: vi.fn(),
+  createDocComment: vi.fn(),
+  replyDocComment: vi.fn(),
+  setDocCommentStatus: vi.fn(),
+}));
+
+const authMock = vi.hoisted(() => ({
+  value: {
+    organizationId: "org-1" as string | null,
+    docsEnabled: true,
+    role: "member" as "admin" | "member" | null,
+  },
+}));
+
+vi.mock("../../api/docs.js", () => docsApiMocks);
+vi.mock("../../auth/auth-context.js", () => ({
+  useAuth: () => authMock.value,
+}));
+
+import { DocPage } from "../docs/doc-page.js";
+import { DocsListPage } from "../docs/docs-list-page.js";
+
+const AUTHOR = { kind: "agent" as const, id: "agent-1", name: "liuchao-fable" };
+
+function summary(overrides: Partial<DocSummary> = {}): DocSummary {
+  return {
+    id: "doc-1",
+    slug: "chat-rename",
+    title: "Chat Rename Plan",
+    project: "first-tree",
+    status: "in_review",
+    latestVersion: 2,
+    openCommentCount: 1,
+    createdBy: AUTHOR,
+    createdAt: "2026-07-04T10:00:00.000Z",
+    updatedAt: "2026-07-04T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function docWithVersion(): DocWithVersion {
+  return {
+    ...summary(),
+    version: {
+      number: 2,
+      content: "# Chat Rename Plan\n\nWe rename chats by slug.",
+      note: "round 2",
+      author: AUTHOR,
+      createdAt: "2026-07-04T12:00:00.000Z",
+    },
+  };
+}
+
+function comment(overrides: Partial<DocComment> = {}): DocComment {
+  return {
+    id: "c-1",
+    documentId: "doc-1",
+    versionNumber: 2,
+    parentId: null,
+    author: { kind: "human", id: "human-1", name: "liuchao-001" },
+    body: "why rename by slug?",
+    anchor: { exact: "rename chats" },
+    status: "open",
+    createdAt: "2026-07-04T12:30:00.000Z",
+    updatedAt: "2026-07-04T12:30:00.000Z",
+    ...overrides,
+  };
+}
+
+function withProviders(ui: ReactElement, initialPath = "/context/docs"): ReactElement {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+/**
+ * Macrotask-aware waitFor: TanStack Query may schedule resolution across a
+ * timer tick, which the harness's microtask-only flush never reaches — so
+ * interleave real timeouts with flushes before asserting.
+ */
+async function waitForSettled(h: DomHarness, assertion: () => void): Promise<void> {
+  let lastErr: unknown;
+  for (let i = 0; i < 40; i++) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await h.flush();
+  }
+  throw lastErr;
+}
+
+describe("DocsListPage", () => {
+  let h: DomHarness;
+  beforeEach(() => {
+    h = createDomHarness();
+    vi.clearAllMocks();
+  });
+  afterEach(() => h.cleanup());
+
+  it("renders documents with status, version, and open-comment count", async () => {
+    docsApiMocks.listDocs.mockResolvedValue({
+      items: [summary(), summary({ id: "doc-2", slug: "other-doc", title: "Other Doc", status: "draft" })],
+      nextCursor: null,
+    });
+
+    h.render(withProviders(<DocsListPage />));
+    await waitForSettled(h, () => {
+      expect(h.container.textContent).toContain("Chat Rename Plan");
+      expect(h.container.textContent).toContain("Other Doc");
+    });
+    expect(h.container.textContent).toContain("In review");
+    expect(h.container.textContent).toContain("v2");
+    expect(h.container.textContent).toContain("liuchao-fable");
+  });
+
+  it("filters client-side via the search box", async () => {
+    docsApiMocks.listDocs.mockResolvedValue({
+      items: [summary(), summary({ id: "doc-2", slug: "other-doc", title: "Other Doc" })],
+      nextCursor: null,
+    });
+
+    h.render(withProviders(<DocsListPage />));
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("Other Doc"));
+
+    const input = h.container.querySelector<HTMLInputElement>("input[aria-label='Filter documents']");
+    expect(input).not.toBeNull();
+    if (!input) return;
+    // React overrides the value setter on controlled inputs — go through the
+    // native prototype setter so the dispatched event carries the new value.
+    const setValue = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+    setValue?.call(input, "rename");
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await waitForSettled(h, () => {
+      expect(h.container.textContent).toContain("Chat Rename Plan");
+      expect(h.container.textContent).not.toContain("Other Doc");
+    });
+  });
+
+  it("shows the empty-library hint", async () => {
+    docsApiMocks.listDocs.mockResolvedValue({ items: [], nextCursor: null });
+    h.render(withProviders(<DocsListPage />));
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("No documents yet"));
+  });
+});
+
+describe("DocPage", () => {
+  let h: DomHarness;
+  beforeEach(() => {
+    h = createDomHarness();
+    vi.clearAllMocks();
+    docsApiMocks.findDocBySlug.mockResolvedValue(summary());
+    docsApiMocks.getDoc.mockResolvedValue(docWithVersion());
+    docsApiMocks.listDocComments.mockResolvedValue({
+      items: [comment(), comment({ id: "c-2", parentId: "c-1", body: "audit trail reasons", anchor: null })],
+    });
+  });
+  afterEach(() => h.cleanup());
+
+  function renderDocPage(): void {
+    h.render(
+      withProviders(
+        <Routes>
+          <Route path="/context/docs/:slug" element={<DocPage />} />
+        </Routes>,
+        "/context/docs/chat-rename",
+      ),
+    );
+  }
+
+  it("renders the document content, metadata, and comment threads", async () => {
+    renderDocPage();
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("Chat Rename Plan"));
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("We rename chats by slug.")); // markdown body
+    expect(h.container.textContent).toContain("In review");
+    expect(h.container.textContent).toContain("why rename by slug?");
+    expect(h.container.textContent).toContain("audit trail reasons"); // threaded reply
+    expect(h.container.textContent).toContain("1 open");
+    // Approve shortcut shows while in review.
+    const buttons = Array.from(h.container.querySelectorAll("button"));
+    expect(buttons.some((b) => b.textContent?.includes("Approve"))).toBe(true);
+  });
+
+  it("resolves a thread from the sidebar", async () => {
+    docsApiMocks.setDocCommentStatus.mockResolvedValue(comment({ status: "resolved" }));
+    renderDocPage();
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("why rename by slug?"));
+
+    const resolveButton = h.container.querySelector<HTMLButtonElement>("button[aria-label='Resolve thread']");
+    expect(resolveButton).not.toBeNull();
+    resolveButton?.click();
+    await waitForSettled(h, () => expect(docsApiMocks.setDocCommentStatus).toHaveBeenCalledWith("c-1", "resolved"));
+  });
+
+  it("approves an in-review document from the header", async () => {
+    docsApiMocks.setDocStatus.mockResolvedValue(summary({ status: "approved" }));
+    renderDocPage();
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("Chat Rename Plan"));
+
+    const approve = Array.from(h.container.querySelectorAll("button")).find((b) => b.textContent?.includes("Approve"));
+    expect(approve).toBeDefined();
+    approve?.click();
+    await waitForSettled(h, () => expect(docsApiMocks.setDocStatus).toHaveBeenCalledWith("doc-1", "approved"));
+  });
+
+  it("shows a helpful miss state for an unknown slug", async () => {
+    docsApiMocks.findDocBySlug.mockResolvedValue(null);
+    renderDocPage();
+    await waitForSettled(h, () => expect(h.container.textContent).toContain('No document with slug "chat-rename"'));
+  });
+});

--- a/packages/web/src/pages/context.tsx
+++ b/packages/web/src/pages/context.tsx
@@ -17,6 +17,7 @@ import { Identicon } from "../components/identicon.js";
 import { PageHeader } from "../components/ui/page-header.js";
 import { Panel, PanelBody } from "../components/ui/panel.js";
 import { ContextTreeBuildEntry } from "./context-tree-build-entry.js";
+import { ContextSectionTabs } from "./docs/context-section-tabs.js";
 
 const CONTEXT_WINDOW = "7d";
 // Live-feed refetch cadence. The usage feed inside the snapshot is what wants
@@ -64,6 +65,7 @@ export function ContextPage({ previewSnapshot }: { previewSnapshot?: ContextTree
         subtitle="Your team's Context Tree."
         right={liveStatusReady ? <LiveStatus snapshot={snapshot} /> : null}
       />
+      {!preview && <ContextSectionTabs active="tree" />}
       <div className="context-live-page">
         {!preview && query.isLoading ? <LoadingState /> : null}
         {!preview && query.error ? (

--- a/packages/web/src/pages/docs/context-section-tabs.tsx
+++ b/packages/web/src/pages/docs/context-section-tabs.tsx
@@ -1,0 +1,27 @@
+import { useNavigate } from "react-router";
+import { useAuth } from "../../auth/auth-context.js";
+import { SegmentedControl } from "../../components/ui/segmented-control.js";
+
+/**
+ * Context-surface section switcher: the Context Tree view and the document
+ * library (docloop) share the Context top-level tab — the library is the
+ * team's raw shared-memory layer, review included. Hidden entirely when the
+ * deployment has the docs feature off.
+ */
+export function ContextSectionTabs({ active }: { active: "tree" | "docs" }) {
+  const navigate = useNavigate();
+  const { docsEnabled } = useAuth();
+  if (!docsEnabled) return null;
+  return (
+    <div style={{ padding: "0 var(--sp-5) var(--sp-2)" }}>
+      <SegmentedControl
+        options={[
+          { value: "tree", label: "Context Tree" },
+          { value: "docs", label: "Documents" },
+        ]}
+        value={active}
+        onChange={(next) => navigate(next === "tree" ? "/context" : "/context/docs")}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/pages/docs/doc-comment-sidebar.tsx
+++ b/packages/web/src/pages/docs/doc-comment-sidebar.tsx
@@ -1,0 +1,275 @@
+import type { DocComment } from "@first-tree/shared";
+import { useMutation } from "@tanstack/react-query";
+import { CheckCircle2, RotateCcw } from "lucide-react";
+import type { RefObject } from "react";
+import { useMemo, useState } from "react";
+import { replyDocComment, setDocCommentStatus } from "../../api/docs.js";
+import { Button } from "../../components/ui/button.js";
+import { Textarea } from "../../components/ui/textarea.js";
+import { formatRelative } from "../../lib/utils.js";
+import { DocAuthorLabel } from "./doc-meta.js";
+
+type Thread = { root: DocComment; replies: DocComment[] };
+
+/**
+ * Threaded review comments. Threads group by the top-level comment; a
+ * thread's status lives on its root (replies follow). Clicking a quote
+ * scrolls the rendered content to the first text match — a lightweight
+ * locator that keeps the markdown renderer untouched.
+ */
+export function DocCommentSidebar({
+  comments,
+  currentVersion,
+  contentRef,
+  onChanged,
+}: {
+  comments: DocComment[];
+  currentVersion: number;
+  contentRef: RefObject<HTMLDivElement | null>;
+  onChanged: () => void;
+}) {
+  const { open, resolved } = useMemo(() => {
+    const roots = comments.filter((c) => c.parentId === null);
+    const byParent = new Map<string, DocComment[]>();
+    for (const c of comments) {
+      if (!c.parentId) continue;
+      const list = byParent.get(c.parentId) ?? [];
+      list.push(c);
+      byParent.set(c.parentId, list);
+    }
+    const toThread = (root: DocComment): Thread => ({ root, replies: byParent.get(root.id) ?? [] });
+    return {
+      open: roots.filter((r) => r.status === "open").map(toThread),
+      resolved: roots.filter((r) => r.status === "resolved").map(toThread),
+    };
+  }, [comments]);
+
+  const [showResolved, setShowResolved] = useState(false);
+
+  return (
+    <aside style={{ width: 320, flexShrink: 0 }} aria-label="Review comments">
+      <h2 className="m-0 text-label font-semibold" style={{ color: "var(--fg-2)", marginBottom: "var(--sp-2)" }}>
+        Comments {open.length > 0 ? `(${open.length} open)` : ""}
+      </h2>
+      {open.length === 0 ? (
+        <p className="text-caption" style={{ color: "var(--fg-3)" }}>
+          No open comments. Select text in the document to start one.
+        </p>
+      ) : null}
+      <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
+        {open.map((thread) => (
+          <ThreadCard
+            key={thread.root.id}
+            thread={thread}
+            currentVersion={currentVersion}
+            contentRef={contentRef}
+            onChanged={onChanged}
+          />
+        ))}
+      </div>
+
+      {resolved.length > 0 ? (
+        <div style={{ marginTop: "var(--sp-4)" }}>
+          <button
+            type="button"
+            className="text-caption"
+            style={{ color: "var(--fg-3)", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+            onClick={() => setShowResolved((prev) => !prev)}
+          >
+            {showResolved ? "Hide" : "Show"} {resolved.length} resolved
+          </button>
+          {showResolved ? (
+            <div className="flex flex-col" style={{ gap: "var(--sp-3)", marginTop: "var(--sp-2)", opacity: 0.75 }}>
+              {resolved.map((thread) => (
+                <ThreadCard
+                  key={thread.root.id}
+                  thread={thread}
+                  currentVersion={currentVersion}
+                  contentRef={contentRef}
+                  onChanged={onChanged}
+                />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </aside>
+  );
+}
+
+function ThreadCard({
+  thread,
+  currentVersion,
+  contentRef,
+  onChanged,
+}: {
+  thread: Thread;
+  currentVersion: number;
+  contentRef: RefObject<HTMLDivElement | null>;
+  onChanged: () => void;
+}) {
+  const { root, replies } = thread;
+  const [replyBody, setReplyBody] = useState("");
+  const [replyOpen, setReplyOpen] = useState(false);
+
+  const replyMutation = useMutation({
+    mutationFn: () => replyDocComment(root.id, replyBody.trim()),
+    onSuccess: () => {
+      setReplyBody("");
+      setReplyOpen(false);
+      onChanged();
+    },
+  });
+  const statusMutation = useMutation({
+    mutationFn: (status: "open" | "resolved") => setDocCommentStatus(root.id, status),
+    onSettled: onChanged,
+  });
+
+  return (
+    <div
+      style={{
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-input)",
+        padding: "var(--sp-3)",
+        background: "var(--bg-raised)",
+      }}
+    >
+      {root.anchor ? (
+        <button
+          type="button"
+          onClick={() => scrollToQuote(contentRef.current, root.anchor?.exact ?? "")}
+          className="block w-full text-left text-caption truncate"
+          style={{
+            color: "var(--fg-3)",
+            borderLeft: "2px solid var(--primary)",
+            paddingLeft: "var(--sp-2)",
+            marginBottom: "var(--sp-2)",
+            background: "none",
+            border: "none",
+            borderInlineStart: "2px solid var(--primary)",
+            cursor: "pointer",
+          }}
+          title="Locate in document"
+        >
+          {root.anchor.exact}
+        </button>
+      ) : null}
+      <div className="flex items-center gap-2" style={{ marginBottom: 2 }}>
+        <DocAuthorLabel author={root.author} />
+        <span className="text-caption" style={{ color: "var(--fg-3)" }}>
+          {formatRelative(root.createdAt)}
+        </span>
+        {root.versionNumber !== currentVersion ? (
+          <span className="text-caption" style={{ color: "var(--fg-3)" }}>
+            on v{root.versionNumber}
+          </span>
+        ) : null}
+        <div style={{ flex: 1 }} />
+        {root.status === "open" ? (
+          <button
+            type="button"
+            aria-label="Resolve thread"
+            title="Resolve"
+            onClick={() => statusMutation.mutate("resolved")}
+            style={{ background: "none", border: "none", cursor: "pointer", color: "var(--fg-3)", padding: 0 }}
+          >
+            <CheckCircle2 size={15} />
+          </button>
+        ) : (
+          <button
+            type="button"
+            aria-label="Reopen thread"
+            title="Reopen"
+            onClick={() => statusMutation.mutate("open")}
+            style={{ background: "none", border: "none", cursor: "pointer", color: "var(--fg-3)", padding: 0 }}
+          >
+            <RotateCcw size={15} />
+          </button>
+        )}
+      </div>
+      <p className="m-0 text-label" style={{ color: "var(--fg)", whiteSpace: "pre-wrap" }}>
+        {root.body}
+      </p>
+
+      {replies.map((reply) => (
+        <div key={reply.id} style={{ marginTop: "var(--sp-2)", paddingLeft: "var(--sp-3)" }}>
+          <div className="flex items-center gap-2">
+            <DocAuthorLabel author={reply.author} />
+            <span className="text-caption" style={{ color: "var(--fg-3)" }}>
+              {formatRelative(reply.createdAt)}
+            </span>
+          </div>
+          <p className="m-0 text-label" style={{ color: "var(--fg)", whiteSpace: "pre-wrap" }}>
+            {reply.body}
+          </p>
+        </div>
+      ))}
+
+      {replyOpen ? (
+        <div style={{ marginTop: "var(--sp-2)" }}>
+          <Textarea
+            value={replyBody}
+            onChange={(event) => setReplyBody(event.target.value)}
+            placeholder="Reply…"
+            rows={2}
+            autoFocus
+          />
+          <div className="flex justify-end gap-2" style={{ marginTop: "var(--sp-1)" }}>
+            <Button size="sm" variant="ghost" onClick={() => setReplyOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => replyMutation.mutate()}
+              disabled={replyBody.trim().length === 0 || replyMutation.isPending}
+            >
+              Reply
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="text-caption"
+          style={{
+            color: "var(--fg-3)",
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            padding: 0,
+            marginTop: "var(--sp-2)",
+          }}
+          onClick={() => setReplyOpen(true)}
+        >
+          Reply
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Scroll the rendered content to the first element containing the quoted
+ * text (whitespace-insensitive) and flash it. Best-effort locator — an
+ * unlocatable quote (edited away in this version) simply doesn't scroll.
+ */
+function scrollToQuote(container: HTMLDivElement | null, quote: string): void {
+  if (!container || quote.trim().length === 0) return;
+  const needle = quote.replace(/\s+/g, " ").trim().toLowerCase();
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let node = walker.nextNode();
+  while (node) {
+    const parent = node.parentElement;
+    if (parent && (parent.textContent ?? "").replace(/\s+/g, " ").toLowerCase().includes(needle)) {
+      parent.scrollIntoView({ behavior: "smooth", block: "center" });
+      const previous = parent.style.backgroundColor;
+      parent.style.backgroundColor = "var(--bg-active)";
+      parent.style.transition = "background-color 1.2s ease";
+      window.setTimeout(() => {
+        parent.style.backgroundColor = previous;
+      }, 1200);
+      return;
+    }
+    node = walker.nextNode();
+  }
+}

--- a/packages/web/src/pages/docs/doc-comment-sidebar.tsx
+++ b/packages/web/src/pages/docs/doc-comment-sidebar.tsx
@@ -138,15 +138,12 @@ function ThreadCard({
         <button
           type="button"
           onClick={() => scrollToQuote(contentRef.current, root.anchor?.exact ?? "")}
-          className="block w-full text-left text-caption truncate"
+          className="block w-full border-0 border-l-2 border-solid border-l-[var(--primary)] text-left text-caption truncate"
           style={{
             color: "var(--fg-3)",
-            borderLeft: "2px solid var(--primary)",
             paddingLeft: "var(--sp-2)",
             marginBottom: "var(--sp-2)",
             background: "none",
-            border: "none",
-            borderInlineStart: "2px solid var(--primary)",
             cursor: "pointer",
           }}
           title="Locate in document"
@@ -262,12 +259,18 @@ function scrollToQuote(container: HTMLDivElement | null, quote: string): void {
     const parent = node.parentElement;
     if (parent && (parent.textContent ?? "").replace(/\s+/g, " ").toLowerCase().includes(needle)) {
       parent.scrollIntoView({ behavior: "smooth", block: "center" });
-      const previous = parent.style.backgroundColor;
-      parent.style.backgroundColor = "var(--bg-active)";
-      parent.style.transition = "background-color 1.2s ease";
-      window.setTimeout(() => {
-        parent.style.backgroundColor = previous;
-      }, 1200);
+      // A re-click during an active flash must not capture the highlight
+      // color as the value to restore.
+      if (parent.dataset.docFlash !== "1") {
+        parent.dataset.docFlash = "1";
+        const previous = parent.style.backgroundColor;
+        parent.style.backgroundColor = "var(--bg-active)";
+        parent.style.transition = "background-color 1.2s ease";
+        window.setTimeout(() => {
+          parent.style.backgroundColor = previous;
+          delete parent.dataset.docFlash;
+        }, 1200);
+      }
       return;
     }
     node = walker.nextNode();

--- a/packages/web/src/pages/docs/doc-meta.tsx
+++ b/packages/web/src/pages/docs/doc-meta.tsx
@@ -11,8 +11,8 @@ export const DOC_STATUS_LABELS: Record<DocStatus, string> = {
 
 const DOC_STATUS_COLORS: Record<DocStatus, { fg: string; bg: string }> = {
   draft: { fg: "var(--fg-3)", bg: "var(--bg-active)" },
-  in_review: { fg: "var(--warning-fg, #a16207)", bg: "var(--warning-bg, rgba(234,179,8,0.12))" },
-  approved: { fg: "var(--success-fg, #15803d)", bg: "var(--success-bg, rgba(34,197,94,0.12))" },
+  in_review: { fg: "var(--fg-warn-strong)", bg: "var(--bg-warn-soft)" },
+  approved: { fg: "var(--fg-success-strong)", bg: "var(--bg-success-soft)" },
   archived: { fg: "var(--fg-3)", bg: "transparent" },
 };
 

--- a/packages/web/src/pages/docs/doc-meta.tsx
+++ b/packages/web/src/pages/docs/doc-meta.tsx
@@ -1,0 +1,44 @@
+import type { DocAuthor, DocStatus } from "@first-tree/shared";
+import { Bot, User } from "lucide-react";
+
+/** Sentence-case labels for the four document statuses. */
+export const DOC_STATUS_LABELS: Record<DocStatus, string> = {
+  draft: "Draft",
+  in_review: "In review",
+  approved: "Approved",
+  archived: "Archived",
+};
+
+const DOC_STATUS_COLORS: Record<DocStatus, { fg: string; bg: string }> = {
+  draft: { fg: "var(--fg-3)", bg: "var(--bg-active)" },
+  in_review: { fg: "var(--warning-fg, #a16207)", bg: "var(--warning-bg, rgba(234,179,8,0.12))" },
+  approved: { fg: "var(--success-fg, #15803d)", bg: "var(--success-bg, rgba(34,197,94,0.12))" },
+  archived: { fg: "var(--fg-3)", bg: "transparent" },
+};
+
+export function DocStatusChip({ status }: { status: DocStatus }) {
+  const colors = DOC_STATUS_COLORS[status];
+  return (
+    <span
+      className="inline-flex items-center rounded-[var(--radius-chip)] px-2 py-0.5 text-caption font-semibold"
+      style={{
+        color: colors.fg,
+        background: colors.bg,
+        border: status === "archived" ? "var(--hairline) solid var(--border)" : "none",
+      }}
+    >
+      {DOC_STATUS_LABELS[status]}
+    </span>
+  );
+}
+
+/** Author byline: agents and humans are both first-class, visually tagged. */
+export function DocAuthorLabel({ author }: { author: DocAuthor }) {
+  const Icon = author.kind === "agent" ? Bot : User;
+  return (
+    <span className="inline-flex items-center gap-1 text-label" style={{ color: "var(--fg-2)" }}>
+      <Icon size={12} aria-label={author.kind} />
+      {author.name}
+    </span>
+  );
+}

--- a/packages/web/src/pages/docs/doc-page.tsx
+++ b/packages/web/src/pages/docs/doc-page.tsx
@@ -3,8 +3,9 @@ import { buildDocAnchor } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, MessageSquarePlus } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { Link, useParams } from "react-router";
+import { Link, Navigate, useParams } from "react-router";
 import { createDocComment, findDocBySlug, getDoc, listDocComments, setDocStatus } from "../../api/docs.js";
+import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { Markdown } from "../../components/ui/markdown.js";
 import { PageHeader } from "../../components/ui/page-header.js";
@@ -32,13 +33,14 @@ type PendingSelection = {
  */
 export function DocPage() {
   const { slug } = useParams<{ slug: string }>();
+  const { docsEnabled } = useAuth();
   const queryClient = useQueryClient();
   const [viewVersion, setViewVersion] = useState<number | null>(null);
 
   const summaryQuery = useQuery({
     queryKey: ["doc-by-slug", slug],
     queryFn: () => findDocBySlug(slug ?? ""),
-    enabled: !!slug,
+    enabled: !!slug && docsEnabled,
   });
   const summary = summaryQuery.data ?? null;
 
@@ -72,7 +74,6 @@ export function DocPage() {
   const [pending, setPending] = useState<PendingSelection | null>(null);
   const [composerOpen, setComposerOpen] = useState(false);
   const [composerBody, setComposerBody] = useState("");
-  const [anchorFallback, setAnchorFallback] = useState(false);
 
   const captureSelection = useCallback(() => {
     if (composerOpen) return;
@@ -93,13 +94,18 @@ export function DocPage() {
       return;
     }
     // Rendered context on both sides of the selection, for anchor scoring
-    // when the quoted text appears more than once in the source.
+    // when the quoted text appears more than once in the source. Bound the
+    // ranges by the selection's own endpoints rather than slicing by
+    // `text.length` — Range vs Selection whitespace serialization differs
+    // across browsers, and endpoint-bounded ranges cannot drift.
     const before = range.cloneRange();
     before.setStart(wrap, 0);
-    const renderedPrefix = before.toString().slice(0, -text.length).slice(-SELECTION_CONTEXT_CHARS);
+    before.setEnd(range.startContainer, range.startOffset);
+    const renderedPrefix = before.toString().slice(-SELECTION_CONTEXT_CHARS);
     const after = range.cloneRange();
+    after.setStart(range.endContainer, range.endOffset);
     after.setEnd(wrap, wrap.childNodes.length);
-    const renderedSuffix = after.toString().slice(text.length).slice(0, SELECTION_CONTEXT_CHARS);
+    const renderedSuffix = after.toString().slice(0, SELECTION_CONTEXT_CHARS);
 
     const rect = range.getBoundingClientRect();
     const wrapRect = wrap.getBoundingClientRect();
@@ -112,15 +118,25 @@ export function DocPage() {
     });
   }, [composerOpen]);
 
+  // Built once per selection — the composer hint and the submit path share it
+  // (a large document would otherwise pay for two full normalizations).
+  const pendingAnchor = useMemo(
+    () =>
+      pending && doc
+        ? buildDocAnchor({
+            source: doc.version.content,
+            selectedText: pending.text,
+            renderedPrefix: pending.renderedPrefix,
+            renderedSuffix: pending.renderedSuffix,
+          })
+        : null,
+    [pending, doc],
+  );
+
   const commentMutation = useMutation({
     mutationFn: async () => {
       if (!doc || !pending) throw new Error("Nothing selected");
-      const anchor = buildDocAnchor({
-        source: doc.version.content,
-        selectedText: pending.text,
-        renderedPrefix: pending.renderedPrefix,
-        renderedSuffix: pending.renderedSuffix,
-      });
+      const anchor = pendingAnchor;
       const body = composerBody.trim();
       if (anchor) {
         return createDocComment(doc.id, { body, anchor, versionNumber: doc.version.number });
@@ -137,7 +153,6 @@ export function DocPage() {
       setComposerOpen(false);
       setComposerBody("");
       setPending(null);
-      setAnchorFallback(false);
       window.getSelection()?.removeAllRanges();
       invalidate();
     },
@@ -151,6 +166,11 @@ export function DocPage() {
     });
   }, [summary?.latestVersion]);
 
+  // Deep links while the deployment flag is off land on the Context tree
+  // view instead of a half-broken page (the server 404s the API anyway).
+  if (!docsEnabled) {
+    return <Navigate to="/context" replace />;
+  }
   if (summaryQuery.isLoading) {
     return <PageHeader title="Documents" subtitle="Loading…" />;
   }
@@ -171,7 +191,7 @@ export function DocPage() {
   }
 
   const shownVersion = doc?.version.number ?? summary.latestVersion;
-  const readOnlyOldVersion = shownVersion !== summary.latestVersion;
+  const viewingOldVersion = shownVersion !== summary.latestVersion;
 
   return (
     <>
@@ -231,7 +251,7 @@ export function DocPage() {
           onMouseUp={captureSelection}
           onKeyUp={captureSelection}
         >
-          {readOnlyOldVersion ? (
+          {viewingOldVersion ? (
             <p
               className="text-caption"
               style={{
@@ -259,22 +279,7 @@ export function DocPage() {
 
           {pending && !composerOpen ? (
             <div style={{ position: "absolute", top: pending.top, left: pending.left, zIndex: 20 }}>
-              <Button
-                size="sm"
-                onClick={() => {
-                  setAnchorFallback(
-                    doc
-                      ? buildDocAnchor({
-                          source: doc.version.content,
-                          selectedText: pending.text,
-                          renderedPrefix: pending.renderedPrefix,
-                          renderedSuffix: pending.renderedSuffix,
-                        }) === null
-                      : false,
-                  );
-                  setComposerOpen(true);
-                }}
-              >
+              <Button size="sm" onClick={() => setComposerOpen(true)}>
                 <MessageSquarePlus size={14} style={{ marginRight: 4 }} />
                 Comment
               </Button>
@@ -292,15 +297,15 @@ export function DocPage() {
                 background: "var(--bg-raised)",
                 border: "var(--hairline) solid var(--border)",
                 borderRadius: "var(--radius-input)",
-                boxShadow: "var(--shadow-overlay, 0 8px 24px rgba(0,0,0,0.16))",
+                boxShadow: "var(--shadow-md)",
                 padding: "var(--sp-3)",
               }}
             >
               <p className="m-0 text-caption truncate" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-2)" }}>
                 “{pending.text.length > 120 ? `${pending.text.slice(0, 120)}…` : pending.text}”
               </p>
-              {anchorFallback ? (
-                <p className="m-0 text-caption" style={{ color: "var(--warning-fg, #a16207)" }}>
+              {pendingAnchor === null ? (
+                <p className="m-0 text-caption" style={{ color: "var(--fg-warn-strong)" }}>
                   This selection spans formatting, so it will post as a document-level comment quoting the text.
                 </p>
               ) : null}

--- a/packages/web/src/pages/docs/doc-page.tsx
+++ b/packages/web/src/pages/docs/doc-page.tsx
@@ -1,0 +1,347 @@
+import type { DocStatus } from "@first-tree/shared";
+import { buildDocAnchor } from "@first-tree/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, MessageSquarePlus } from "lucide-react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Link, useParams } from "react-router";
+import { createDocComment, findDocBySlug, getDoc, listDocComments, setDocStatus } from "../../api/docs.js";
+import { Button } from "../../components/ui/button.js";
+import { Markdown } from "../../components/ui/markdown.js";
+import { PageHeader } from "../../components/ui/page-header.js";
+import { Select } from "../../components/ui/select.js";
+import { Textarea } from "../../components/ui/textarea.js";
+import { DocCommentSidebar } from "./doc-comment-sidebar.js";
+import { DOC_STATUS_LABELS, DocAuthorLabel, DocStatusChip } from "./doc-meta.js";
+
+/** Rendered-context window captured around a selection for anchor scoring. */
+const SELECTION_CONTEXT_CHARS = 64;
+
+type PendingSelection = {
+  text: string;
+  renderedPrefix: string;
+  renderedSuffix: string;
+  /** Popover position relative to the content wrapper. */
+  top: number;
+  left: number;
+};
+
+/**
+ * Document reading view: rendered markdown with text-selection commenting,
+ * a threaded comment sidebar, version switching, and status controls. The
+ * agent-facing mirror of this loop is `first-tree doc …`.
+ */
+export function DocPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const queryClient = useQueryClient();
+  const [viewVersion, setViewVersion] = useState<number | null>(null);
+
+  const summaryQuery = useQuery({
+    queryKey: ["doc-by-slug", slug],
+    queryFn: () => findDocBySlug(slug ?? ""),
+    enabled: !!slug,
+  });
+  const summary = summaryQuery.data ?? null;
+
+  const docQuery = useQuery({
+    queryKey: ["doc", summary?.id, viewVersion ?? "latest"],
+    queryFn: () => getDoc(summary?.id ?? "", viewVersion ?? undefined),
+    enabled: !!summary,
+  });
+  const doc = docQuery.data ?? null;
+
+  const commentsQuery = useQuery({
+    queryKey: ["doc-comments", summary?.id],
+    queryFn: () => listDocComments(summary?.id ?? ""),
+    enabled: !!summary,
+  });
+  const comments = commentsQuery.data?.items ?? [];
+
+  const invalidate = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["doc-by-slug", slug] });
+    queryClient.invalidateQueries({ queryKey: ["doc", summary?.id] });
+    queryClient.invalidateQueries({ queryKey: ["doc-comments", summary?.id] });
+  }, [queryClient, slug, summary?.id]);
+
+  const statusMutation = useMutation({
+    mutationFn: (status: DocStatus) => setDocStatus(summary?.id ?? "", status),
+    onSettled: invalidate,
+  });
+
+  // ── Text-selection commenting ─────────────────────────────────────────
+  const contentWrapRef = useRef<HTMLDivElement | null>(null);
+  const [pending, setPending] = useState<PendingSelection | null>(null);
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [composerBody, setComposerBody] = useState("");
+  const [anchorFallback, setAnchorFallback] = useState(false);
+
+  const captureSelection = useCallback(() => {
+    if (composerOpen) return;
+    const wrap = contentWrapRef.current;
+    const selection = window.getSelection();
+    if (!wrap || !selection || selection.isCollapsed || selection.rangeCount === 0) {
+      setPending(null);
+      return;
+    }
+    const range = selection.getRangeAt(0);
+    if (!wrap.contains(range.startContainer) || !wrap.contains(range.endContainer)) {
+      setPending(null);
+      return;
+    }
+    const text = selection.toString();
+    if (text.trim().length === 0) {
+      setPending(null);
+      return;
+    }
+    // Rendered context on both sides of the selection, for anchor scoring
+    // when the quoted text appears more than once in the source.
+    const before = range.cloneRange();
+    before.setStart(wrap, 0);
+    const renderedPrefix = before.toString().slice(0, -text.length).slice(-SELECTION_CONTEXT_CHARS);
+    const after = range.cloneRange();
+    after.setEnd(wrap, wrap.childNodes.length);
+    const renderedSuffix = after.toString().slice(text.length).slice(0, SELECTION_CONTEXT_CHARS);
+
+    const rect = range.getBoundingClientRect();
+    const wrapRect = wrap.getBoundingClientRect();
+    setPending({
+      text,
+      renderedPrefix,
+      renderedSuffix,
+      top: rect.bottom - wrapRect.top + 6,
+      left: Math.max(0, rect.left - wrapRect.left),
+    });
+  }, [composerOpen]);
+
+  const commentMutation = useMutation({
+    mutationFn: async () => {
+      if (!doc || !pending) throw new Error("Nothing selected");
+      const anchor = buildDocAnchor({
+        source: doc.version.content,
+        selectedText: pending.text,
+        renderedPrefix: pending.renderedPrefix,
+        renderedSuffix: pending.renderedSuffix,
+      });
+      const body = composerBody.trim();
+      if (anchor) {
+        return createDocComment(doc.id, { body, anchor, versionNumber: doc.version.number });
+      }
+      // The selection spans markdown syntax and cannot be located in the
+      // source — degrade VISIBLY to a document-level comment quoting it.
+      const quoted = pending.text
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+      return createDocComment(doc.id, { body: `${quoted}\n\n${body}`, versionNumber: doc.version.number });
+    },
+    onSuccess: () => {
+      setComposerOpen(false);
+      setComposerBody("");
+      setPending(null);
+      setAnchorFallback(false);
+      window.getSelection()?.removeAllRanges();
+      invalidate();
+    },
+  });
+
+  const versionOptions = useMemo(() => {
+    const latest = summary?.latestVersion ?? 1;
+    return Array.from({ length: latest }, (_, i) => {
+      const n = latest - i;
+      return { value: String(n), label: n === latest ? `v${n} (latest)` : `v${n}` };
+    });
+  }, [summary?.latestVersion]);
+
+  if (summaryQuery.isLoading) {
+    return <PageHeader title="Documents" subtitle="Loading…" />;
+  }
+  if (!summary) {
+    return (
+      <>
+        <PageHeader title="Documents" />
+        <div style={{ padding: "0 var(--sp-5)" }}>
+          <p className="text-label" style={{ color: "var(--fg-3)" }}>
+            No document with slug "{slug}".{" "}
+            <Link to="/context/docs" style={{ color: "var(--primary)" }}>
+              Back to the library
+            </Link>
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  const shownVersion = doc?.version.number ?? summary.latestVersion;
+  const readOnlyOldVersion = shownVersion !== summary.latestVersion;
+
+  return (
+    <>
+      <PageHeader
+        title={summary.title}
+        subtitle={
+          <span className="inline-flex items-center gap-2">
+            <Link
+              to="/context/docs"
+              aria-label="Back to documents"
+              className="inline-flex items-center gap-1"
+              style={{ color: "var(--fg-3)" }}
+            >
+              <ArrowLeft size={13} />
+              Documents
+            </Link>
+            <span>·</span>
+            {summary.slug}
+            {summary.project ? <span>· {summary.project}</span> : null}
+            <DocAuthorLabel author={summary.createdBy} />
+          </span>
+        }
+        right={
+          <div className="flex items-center gap-2">
+            <DocStatusChip status={summary.status} />
+            <Select
+              value={String(shownVersion)}
+              onChange={(value) => setViewVersion(Number.parseInt(value, 10))}
+              options={versionOptions}
+              aria-label="Version"
+              triggerClassName="w-28"
+            />
+            <Select
+              value={summary.status}
+              onChange={(value) => statusMutation.mutate(value as DocStatus)}
+              options={Object.entries(DOC_STATUS_LABELS).map(([value, label]) => ({ value, label }))}
+              aria-label="Set status"
+              triggerClassName="w-32"
+            />
+            {summary.status === "in_review" ? (
+              <Button size="sm" onClick={() => statusMutation.mutate("approved")} disabled={statusMutation.isPending}>
+                Approve
+              </Button>
+            ) : null}
+          </div>
+        }
+      />
+
+      <div
+        className="flex"
+        style={{ gap: "var(--sp-4)", padding: "0 var(--sp-5) var(--sp-5)", alignItems: "flex-start" }}
+      >
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: passive selection capture, not click semantics — the handlers only read window.getSelection() after mouse (mouseup) or keyboard (shift+arrows → keyup) selections; there is nothing to activate. */}
+        <div
+          style={{ flex: 1, minWidth: 0, position: "relative" }}
+          ref={contentWrapRef}
+          onMouseUp={captureSelection}
+          onKeyUp={captureSelection}
+        >
+          {readOnlyOldVersion ? (
+            <p
+              className="text-caption"
+              style={{
+                color: "var(--fg-3)",
+                background: "var(--bg-active)",
+                borderRadius: "var(--radius-input)",
+                padding: "var(--sp-1) var(--sp-2)",
+              }}
+            >
+              Viewing v{shownVersion} — comments go to the version you are viewing.
+              {doc?.version.note ? ` Note: ${doc.version.note}` : ""}
+            </p>
+          ) : doc?.version.note ? (
+            <p className="text-caption" style={{ color: "var(--fg-3)" }}>
+              v{shownVersion} note: {doc.version.note}
+            </p>
+          ) : null}
+
+          {docQuery.isLoading ? (
+            <p className="text-label" style={{ color: "var(--fg-3)" }}>
+              Loading content…
+            </p>
+          ) : null}
+          {doc ? <Markdown>{doc.version.content}</Markdown> : null}
+
+          {pending && !composerOpen ? (
+            <div style={{ position: "absolute", top: pending.top, left: pending.left, zIndex: 20 }}>
+              <Button
+                size="sm"
+                onClick={() => {
+                  setAnchorFallback(
+                    doc
+                      ? buildDocAnchor({
+                          source: doc.version.content,
+                          selectedText: pending.text,
+                          renderedPrefix: pending.renderedPrefix,
+                          renderedSuffix: pending.renderedSuffix,
+                        }) === null
+                      : false,
+                  );
+                  setComposerOpen(true);
+                }}
+              >
+                <MessageSquarePlus size={14} style={{ marginRight: 4 }} />
+                Comment
+              </Button>
+            </div>
+          ) : null}
+
+          {pending && composerOpen ? (
+            <div
+              style={{
+                position: "absolute",
+                top: pending.top,
+                left: Math.min(pending.left, 320),
+                zIndex: 20,
+                width: 360,
+                background: "var(--bg-raised)",
+                border: "var(--hairline) solid var(--border)",
+                borderRadius: "var(--radius-input)",
+                boxShadow: "var(--shadow-overlay, 0 8px 24px rgba(0,0,0,0.16))",
+                padding: "var(--sp-3)",
+              }}
+            >
+              <p className="m-0 text-caption truncate" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-2)" }}>
+                “{pending.text.length > 120 ? `${pending.text.slice(0, 120)}…` : pending.text}”
+              </p>
+              {anchorFallback ? (
+                <p className="m-0 text-caption" style={{ color: "var(--warning-fg, #a16207)" }}>
+                  This selection spans formatting, so it will post as a document-level comment quoting the text.
+                </p>
+              ) : null}
+              <Textarea
+                value={composerBody}
+                onChange={(event) => setComposerBody(event.target.value)}
+                placeholder="Leave a review comment…"
+                rows={3}
+                autoFocus
+              />
+              <div className="flex justify-end gap-2" style={{ marginTop: "var(--sp-2)" }}>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => {
+                    setComposerOpen(false);
+                    setComposerBody("");
+                    setPending(null);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => commentMutation.mutate()}
+                  disabled={composerBody.trim().length === 0 || commentMutation.isPending}
+                >
+                  Comment
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <DocCommentSidebar
+          comments={comments}
+          currentVersion={shownVersion}
+          contentRef={contentWrapRef}
+          onChanged={invalidate}
+        />
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/pages/docs/docs-list-page.tsx
+++ b/packages/web/src/pages/docs/docs-list-page.tsx
@@ -2,7 +2,7 @@ import type { DocStatus, DocSummary } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
 import { FileText, MessageSquare } from "lucide-react";
 import { useMemo, useState } from "react";
-import { useNavigate } from "react-router";
+import { Navigate, useNavigate } from "react-router";
 import { listDocs } from "../../api/docs.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Input } from "../../components/ui/input.js";
@@ -27,7 +27,7 @@ const STATUS_FILTERS: Array<{ value: string; label: string }> = [
  */
 export function DocsListPage() {
   const navigate = useNavigate();
-  const { organizationId } = useAuth();
+  const { organizationId, docsEnabled } = useAuth();
   const [statusFilter, setStatusFilter] = useState("all");
   const [search, setSearch] = useState("");
 
@@ -35,7 +35,7 @@ export function DocsListPage() {
   const query = useQuery({
     queryKey: ["docs", organizationId, status ?? "all"],
     queryFn: () => listDocs({ status, limit: 200 }),
-    enabled: !!organizationId,
+    enabled: !!organizationId && docsEnabled,
   });
 
   const items = useMemo(() => {
@@ -46,6 +46,12 @@ export function DocsListPage() {
       [doc.title, doc.slug, doc.project ?? ""].some((field) => field.toLowerCase().includes(needle)),
     );
   }, [query.data, search]);
+
+  // Deep links while the deployment flag is off land on the Context tree
+  // view instead of a half-broken page (the server 404s the API anyway).
+  if (!docsEnabled) {
+    return <Navigate to="/context" replace />;
+  }
 
   return (
     <>
@@ -77,7 +83,7 @@ export function DocsListPage() {
           </p>
         ) : null}
         {query.error ? (
-          <p className="text-label" style={{ color: "var(--destructive, #b91c1c)" }}>
+          <p className="text-label" style={{ color: "var(--danger)" }}>
             {query.error instanceof Error ? query.error.message : "Failed to load documents"}
           </p>
         ) : null}

--- a/packages/web/src/pages/docs/docs-list-page.tsx
+++ b/packages/web/src/pages/docs/docs-list-page.tsx
@@ -1,0 +1,142 @@
+import type { DocStatus, DocSummary } from "@first-tree/shared";
+import { useQuery } from "@tanstack/react-query";
+import { FileText, MessageSquare } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { listDocs } from "../../api/docs.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { Input } from "../../components/ui/input.js";
+import { PageHeader } from "../../components/ui/page-header.js";
+import { Select } from "../../components/ui/select.js";
+import { formatRelative } from "../../lib/utils.js";
+import { ContextSectionTabs } from "./context-section-tabs.js";
+import { DOC_STATUS_LABELS, DocAuthorLabel, DocStatusChip } from "./doc-meta.js";
+
+const STATUS_FILTERS: Array<{ value: string; label: string }> = [
+  { value: "all", label: "All statuses" },
+  { value: "in_review", label: DOC_STATUS_LABELS.in_review },
+  { value: "draft", label: DOC_STATUS_LABELS.draft },
+  { value: "approved", label: DOC_STATUS_LABELS.approved },
+  { value: "archived", label: DOC_STATUS_LABELS.archived },
+];
+
+/**
+ * Document library (docloop) list. Status filters go to the server; the
+ * search box narrows the loaded page client-side across title/slug/project —
+ * server-side full-text search is the M3 upgrade path.
+ */
+export function DocsListPage() {
+  const navigate = useNavigate();
+  const { organizationId } = useAuth();
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [search, setSearch] = useState("");
+
+  const status = statusFilter === "all" ? undefined : (statusFilter as DocStatus);
+  const query = useQuery({
+    queryKey: ["docs", organizationId, status ?? "all"],
+    queryFn: () => listDocs({ status, limit: 200 }),
+    enabled: !!organizationId,
+  });
+
+  const items = useMemo(() => {
+    const all = query.data?.items ?? [];
+    const needle = search.trim().toLowerCase();
+    if (!needle) return all;
+    return all.filter((doc) =>
+      [doc.title, doc.slug, doc.project ?? ""].some((field) => field.toLowerCase().includes(needle)),
+    );
+  }, [query.data, search]);
+
+  return (
+    <>
+      <PageHeader
+        title="Documents"
+        subtitle="Design docs published for team review — the raw layer of shared memory."
+      />
+      <ContextSectionTabs active="docs" />
+      <div style={{ padding: "0 var(--sp-5) var(--sp-5)" }}>
+        <div className="flex items-center gap-2" style={{ marginBottom: "var(--sp-3)", maxWidth: 720 }}>
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Filter by title, slug, or project…"
+            aria-label="Filter documents"
+          />
+          <Select
+            value={statusFilter}
+            onChange={setStatusFilter}
+            options={STATUS_FILTERS}
+            aria-label="Status filter"
+            triggerClassName="w-40"
+          />
+        </div>
+
+        {query.isLoading ? (
+          <p className="text-label" style={{ color: "var(--fg-3)" }}>
+            Loading documents…
+          </p>
+        ) : null}
+        {query.error ? (
+          <p className="text-label" style={{ color: "var(--destructive, #b91c1c)" }}>
+            {query.error instanceof Error ? query.error.message : "Failed to load documents"}
+          </p>
+        ) : null}
+        {!query.isLoading && !query.error && items.length === 0 ? (
+          <div
+            className="flex flex-col items-center gap-2 text-label"
+            style={{ color: "var(--fg-3)", padding: "var(--sp-5) 0" }}
+          >
+            <FileText size={20} />
+            <span>
+              {search
+                ? "No documents match the filter."
+                : "No documents yet. Agents publish with `first-tree doc publish <file>`."}
+            </span>
+          </div>
+        ) : null}
+
+        <div className="flex flex-col" style={{ gap: 2 }}>
+          {items.map((doc) => (
+            <DocRow key={doc.id} doc={doc} onOpen={() => navigate(`/context/docs/${encodeURIComponent(doc.slug)}`)} />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function DocRow({ doc, onOpen }: { doc: DocSummary; onOpen: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex items-center gap-3 rounded-[var(--radius-input)] text-left hover:bg-[var(--bg-hover)]"
+      style={{ padding: "var(--sp-2) var(--sp-3)", border: "none", background: "transparent", cursor: "pointer" }}
+    >
+      <FileText size={16} style={{ color: "var(--fg-3)", flexShrink: 0 }} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="truncate font-medium" style={{ color: "var(--fg)" }}>
+            {doc.title}
+          </span>
+          <span className="text-caption" style={{ color: "var(--fg-3)" }}>
+            {doc.slug}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 text-caption" style={{ color: "var(--fg-3)" }}>
+          {doc.project ? <span>{doc.project}</span> : null}
+          <span>v{doc.latestVersion}</span>
+          <DocAuthorLabel author={doc.createdBy} />
+          <span>{formatRelative(doc.updatedAt)}</span>
+        </div>
+      </div>
+      {doc.openCommentCount > 0 ? (
+        <span className="inline-flex items-center gap-1 text-caption" style={{ color: "var(--fg-2)" }}>
+          <MessageSquare size={13} />
+          {doc.openCommentCount}
+        </span>
+      ) : null}
+      <DocStatusChip status={doc.status} />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

M2 of **docloop** (stacked on #1431 — base is `feat/docloop-m1`, retarget to `main` after M1 merges). Design doc: [first-tree-context#675](https://github.com/agent-team-foundation/first-tree-context/pull/675).

### IA decision (per `product/surfaces/surface-model.md`)
No fifth top-level tab: the document library is the **raw layer of shared memory**, so it lives inside the **Context** surface — a Tree | Documents segmented switcher. The switcher (and routes) only appear when the deployment has `FIRST_TREE_DOCS_ENABLED` on, carried to the shell via a new `features.docs` field on `/me` (presentation-only; server routes stay the enforcement point).

### What's in
- **`/context/docs`** — library list: server-side status filter, client-side title/slug/project search (server FTS is M3), open-comment counts, agent/human author bylines.
- **`/context/docs/:slug`** — reading view:
  - rendered markdown (existing `<Markdown>` component);
  - **text-selection commenting**: selection → `buildDocAnchor` (new in `@first-tree/shared`) turns the rendered selection into a source-based TextQuoteSelector anchor via whitespace-normalized matching + context-scored disambiguation; selections spanning markdown syntax degrade **visibly** to a document-level comment quoting the text;
  - threaded comment sidebar: reply, resolve/reopen, quote-click scroll-to-text, resolved section collapsed, cross-version badges;
  - version switcher (older-version banner; comments target the viewed version), status select + **Approve** shortcut.
- **CLI**: `doc publish` output now includes the shareable `/context/docs/<slug>` URL for pasting into chat.
- **shared**: `buildDocAnchor` / `locateDocAnchor` — `locateDocAnchor` is deliberately the same call the M3 re-anchor pass will use server-side.

### Tests
- 9 shared anchor unit tests (round-trip, whitespace reflow, repeated-text disambiguation, deletion → null).
- 7 happy-dom page tests (list render / search filter / empty state; doc render with threads; resolve; approve; unknown slug). Note: the repo's web test convention is happy-dom component tests — there is no Playwright infra — so the e2e-style coverage promised in the proposal lands as these page tests plus M1's real-HTTP API coverage.
- Full suites green: server 1707/1707 · shared 504/504 · web 1088/1088 · `pnpm check`/`typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)