### PR TITLE
feat: docloop M3 — read-time re-anchoring, doc import/export, comments --watch

### DIFF
--- a/apps/cli/src/commands/doc/comments.ts
+++ b/apps/cli/src/commands/doc/comments.ts
@@ -1,13 +1,19 @@
+import type { FirstTreeHubSDK } from "@first-tree/client";
+import type { DocCommentStatus } from "@first-tree/shared";
 import type { Command } from "commander";
-import { success } from "../../cli/output.js";
+import { fail, success } from "../../cli/output.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
 import { parseDocCommentStatus, parseVersionNumber, resolveDocBySlug } from "./_shared.js";
 
 interface CommentsOptions {
   status?: string;
   version?: string;
+  watch?: string | boolean;
   agent?: string;
 }
+
+const DEFAULT_WATCH_SECONDS = 15;
+const MIN_WATCH_SECONDS = 5;
 
 export function registerDocCommentsCommand(doc: Command): void {
   doc
@@ -18,17 +24,71 @@ export function registerDocCommentsCommand(doc: Command): void {
     )
     .option("--status <status>", "Filter by thread status: open | resolved")
     .option("--version <n>", "Only comments made against one version")
+    .option(
+      "--watch [seconds]",
+      `After the initial listing, keep polling (default every ${DEFAULT_WATCH_SECONDS}s) and print each ` +
+        "NEW comment as one JSON line on stdout. Runs until interrupted.",
+    )
     .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
     .action(async (slug: string, options: CommentsOptions) => {
       const status = options.status === undefined ? undefined : parseDocCommentStatus(options.status);
       const versionNumber = options.version === undefined ? undefined : parseVersionNumber(options.version);
+      const watchSeconds = parseWatchSeconds(options.watch);
       try {
         const sdk = createSdk(options.agent);
         const summary = await resolveDocBySlug(sdk, slug);
         const { items } = await sdk.listDocComments(summary.id, { status, versionNumber });
         success({ documentId: summary.id, slug: summary.slug, latestVersion: summary.latestVersion, items });
+        if (watchSeconds !== null) {
+          await watchComments(
+            sdk,
+            summary.id,
+            { status, versionNumber },
+            watchSeconds,
+            items.map((c) => c.id),
+          );
+        }
       } catch (error) {
         handleSdkError(error);
       }
     });
+}
+
+function parseWatchSeconds(value: string | boolean | undefined): number | null {
+  if (value === undefined || value === false) return null;
+  if (value === true) return DEFAULT_WATCH_SECONDS;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < MIN_WATCH_SECONDS) {
+    fail("INVALID_INTERVAL", `Invalid --watch interval "${value}". Expected an integer ≥ ${MIN_WATCH_SECONDS}.`, 2);
+  }
+  return parsed;
+}
+
+/**
+ * Poll loop: each new comment prints as a single JSON line (NDJSON) after the
+ * initial `success()` envelope, so scripts can stream on top of the snapshot.
+ * Transient poll errors go to stderr and the loop keeps going.
+ */
+async function watchComments(
+  sdk: FirstTreeHubSDK,
+  documentId: string,
+  query: { status?: DocCommentStatus; versionNumber?: number },
+  intervalSeconds: number,
+  initialIds: string[],
+): Promise<never> {
+  const seen = new Set(initialIds);
+  while (true) {
+    await new Promise((resolve) => setTimeout(resolve, intervalSeconds * 1000));
+    try {
+      const { items } = await sdk.listDocComments(documentId, query);
+      for (const comment of items) {
+        if (seen.has(comment.id)) continue;
+        seen.add(comment.id);
+        process.stdout.write(`${JSON.stringify(comment)}\n`);
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${JSON.stringify({ ok: false, error: { code: "WATCH_POLL_FAILED", message: msg } })}\n`);
+    }
+  }
 }

--- a/apps/cli/src/commands/doc/export.ts
+++ b/apps/cli/src/commands/doc/export.ts
@@ -1,0 +1,65 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { DocSummary } from "@first-tree/shared";
+import type { Command } from "commander";
+import { fail, success } from "../../cli/output.js";
+import { createSdk, handleSdkError } from "../_shared/local-agent.js";
+import { parseDocStatus } from "./_shared.js";
+
+interface ExportOptions {
+  project?: string;
+  status?: string;
+  agent?: string;
+}
+
+export function registerDocExportCommand(doc: Command): void {
+  doc
+    .command("export <dir>")
+    .description(
+      "Export the org's document library to a directory: one <slug>.md per document (latest version) " +
+        "plus manifest.json with the metadata. The library never locks data in — this is the way out.",
+    )
+    .option("--project <project>", "Only export documents with this project label")
+    .option("--status <status>", "Only export documents in this status")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
+    .action(async (dir: string, options: ExportOptions) => {
+      const status = options.status === undefined ? undefined : parseDocStatus(options.status);
+
+      try {
+        mkdirSync(dir, { recursive: true });
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        fail("DIR_UNWRITABLE", `Cannot create directory "${dir}": ${msg}`, 2);
+      }
+
+      try {
+        const sdk = createSdk(options.agent);
+        const summaries: DocSummary[] = [];
+        let cursor: string | undefined;
+        do {
+          const page = await sdk.listDocs({ project: options.project, status, limit: 200, cursor });
+          summaries.push(...page.items);
+          cursor = page.nextCursor ?? undefined;
+        } while (cursor);
+
+        for (const summary of summaries) {
+          const full = await sdk.getDoc(summary.id);
+          writeFileSync(join(dir, `${summary.slug}.md`), full.version.content);
+        }
+        const manifest = summaries.map((s) => ({
+          slug: s.slug,
+          title: s.title,
+          project: s.project,
+          status: s.status,
+          latestVersion: s.latestVersion,
+          openCommentCount: s.openCommentCount,
+          createdBy: s.createdBy,
+          updatedAt: s.updatedAt,
+        }));
+        writeFileSync(join(dir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+        success({ exported: summaries.length, dir });
+      } catch (error) {
+        handleSdkError(error);
+      }
+    });
+}

--- a/apps/cli/src/commands/doc/import.ts
+++ b/apps/cli/src/commands/doc/import.ts
@@ -1,0 +1,76 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Command } from "commander";
+import { fail, success } from "../../cli/output.js";
+import { planMarkdownImport, titleFromMarkdown } from "../../core/doc-review.js";
+import { createSdk, handleSdkError } from "../_shared/local-agent.js";
+import { parseDocStatus } from "./_shared.js";
+
+interface ImportOptions {
+  project?: string;
+  status?: string;
+  dryRun?: boolean;
+  agent?: string;
+}
+
+export function registerDocImportCommand(doc: Command): void {
+  doc
+    .command("import <dir>")
+    .description(
+      "Bulk-publish every markdown file in a directory (non-recursive). Idempotent: publishes use " +
+        "--if-changed semantics, so re-running only adds versions for files whose content changed. " +
+        "NODE.md / README.md index files are skipped.",
+    )
+    .option("--project <project>", "Project label applied to every imported document")
+    .option("--status <status>", "Status applied to every imported document (default: draft)")
+    .option("--dry-run", "Print the import plan without publishing anything")
+    .option("--agent <name>", "Agent name on the First Tree server (default: first configured on this client)")
+    .action(async (dir: string, options: ImportOptions) => {
+      const status = options.status === undefined ? undefined : parseDocStatus(options.status);
+
+      let files: string[];
+      try {
+        files = readdirSync(dir, { withFileTypes: true })
+          .filter((entry) => entry.isFile())
+          .map((entry) => join(dir, entry.name))
+          .sort();
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        fail("DIR_UNREADABLE", `Cannot read directory "${dir}": ${msg}`, 2);
+      }
+
+      const plan = planMarkdownImport(files);
+      if (options.dryRun) {
+        success({ dryRun: true, candidates: plan.candidates, skipped: plan.skipped });
+        return;
+      }
+
+      try {
+        const sdk = createSdk(options.agent);
+        const imported = [];
+        for (const candidate of plan.candidates) {
+          const content = readFileSync(candidate.path, "utf8");
+          const result = await sdk.publishDoc({
+            slug: candidate.slug,
+            // First publish requires a title; fall back to the slug when the
+            // document carries no heading.
+            title: titleFromMarkdown(content) ?? candidate.slug,
+            content,
+            project: options.project,
+            status,
+            ifChanged: true,
+          });
+          imported.push({
+            path: candidate.path,
+            slug: result.slug,
+            version: result.version,
+            createdDocument: result.createdDocument,
+            createdVersion: result.createdVersion,
+          });
+        }
+        success({ imported, skipped: plan.skipped });
+      } catch (error) {
+        handleSdkError(error);
+      }
+    });
+}

--- a/apps/cli/src/commands/doc/import.ts
+++ b/apps/cli/src/commands/doc/import.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import type { Command } from "commander";
 import { fail, success } from "../../cli/output.js";
 import { planMarkdownImport, titleFromMarkdown } from "../../core/doc-review.js";
-import { createSdk, handleSdkError } from "../_shared/local-agent.js";
+import { createSdk } from "../_shared/local-agent.js";
 import { parseDocStatus } from "./_shared.js";
 
 interface ImportOptions {
@@ -45,10 +45,10 @@ export function registerDocImportCommand(doc: Command): void {
         return;
       }
 
-      try {
-        const sdk = createSdk(options.agent);
-        const imported = [];
-        for (const candidate of plan.candidates) {
+      const sdk = createSdk(options.agent);
+      const imported = [];
+      for (const candidate of plan.candidates) {
+        try {
           const content = readFileSync(candidate.path, "utf8");
           const result = await sdk.publishDoc({
             slug: candidate.slug,
@@ -67,10 +67,20 @@ export function registerDocImportCommand(doc: Command): void {
             createdDocument: result.createdDocument,
             createdVersion: result.createdVersion,
           });
+        } catch (error) {
+          // Fail fast, but never lose the progress report: publishes are
+          // idempotent, so fixing the cause and re-running resumes cleanly.
+          const msg = error instanceof Error ? error.message : String(error);
+          const done =
+            imported.length > 0 ? imported.map((entry) => `${entry.slug}@v${entry.version}`).join(", ") : "none";
+          fail(
+            "IMPORT_PARTIAL",
+            `Failed at "${candidate.path}": ${msg}. Imported before the failure: ${done}. ` +
+              "Imports are idempotent — fix the cause and re-run to resume.",
+            1,
+          );
         }
-        success({ imported, skipped: plan.skipped });
-      } catch (error) {
-        handleSdkError(error);
       }
+      success({ imported, skipped: plan.skipped });
     });
 }

--- a/apps/cli/src/commands/doc/index.ts
+++ b/apps/cli/src/commands/doc/index.ts
@@ -1,7 +1,9 @@
 import type { Command } from "commander";
 import { registerDocCommentCommand } from "./comment.js";
 import { registerDocCommentsCommand } from "./comments.js";
+import { registerDocExportCommand } from "./export.js";
 import { registerDocGetCommand } from "./get.js";
+import { registerDocImportCommand } from "./import.js";
 import { registerDocListCommand } from "./list.js";
 import { registerDocPublishCommand } from "./publish.js";
 import { registerDocReplyCommand } from "./reply.js";
@@ -23,4 +25,6 @@ export function registerDocCommands(program: Command): void {
   registerDocReplyCommand(doc);
   registerDocResolveCommand(doc);
   registerDocStatusCommand(doc);
+  registerDocImportCommand(doc);
+  registerDocExportCommand(doc);
 }

--- a/apps/cli/src/core/doc-review.ts
+++ b/apps/cli/src/core/doc-review.ts
@@ -1,9 +1,55 @@
 import { basename } from "node:path";
+import { docSlugSchema } from "@first-tree/shared";
 
 /**
  * Document review (docloop) CLI helpers — the pure logic behind the `doc`
  * namespace commands (apps/cli/src/commands/doc/).
  */
+
+/** Index-style files a directory import skips by default. */
+const IMPORT_SKIP_NAMES = new Set(["node.md", "readme.md"]);
+
+export type DocImportCandidate = { path: string; slug: string };
+export type DocImportPlan = {
+  candidates: DocImportCandidate[];
+  skipped: Array<{ path: string; reason: string }>;
+};
+
+/**
+ * Turn a directory listing into an import plan: one candidate per markdown
+ * file with a derivable, unique slug. Index files (NODE.md / README.md —
+ * tree-style directories carry them) and slug collisions are skipped with a
+ * reason rather than silently dropped, so `--dry-run` shows the full story.
+ */
+export function planMarkdownImport(filePaths: string[]): DocImportPlan {
+  const candidates: DocImportCandidate[] = [];
+  const skipped: Array<{ path: string; reason: string }> = [];
+  const taken = new Map<string, string>();
+  for (const filePath of filePaths) {
+    const name = basename(filePath).toLowerCase();
+    if (!name.endsWith(".md")) {
+      skipped.push({ path: filePath, reason: "not a markdown file" });
+      continue;
+    }
+    if (IMPORT_SKIP_NAMES.has(name)) {
+      skipped.push({ path: filePath, reason: "index file (NODE.md / README.md)" });
+      continue;
+    }
+    const slug = slugFromFilename(filePath);
+    if (!slug || !docSlugSchema.safeParse(slug).success) {
+      skipped.push({ path: filePath, reason: "cannot derive a valid slug from the filename" });
+      continue;
+    }
+    const holder = taken.get(slug);
+    if (holder) {
+      skipped.push({ path: filePath, reason: `slug "${slug}" already taken by ${holder}` });
+      continue;
+    }
+    taken.set(slug, filePath);
+    candidates.push({ path: filePath, slug });
+  }
+  return { candidates, skipped };
+}
 
 /**
  * Derive a publishable slug from a file path: basename without the extension,

--- a/apps/cli/src/core/doc-review.ts
+++ b/apps/cli/src/core/doc-review.ts
@@ -37,7 +37,13 @@ export function planMarkdownImport(filePaths: string[]): DocImportPlan {
     }
     const slug = slugFromFilename(filePath);
     if (!slug || !docSlugSchema.safeParse(slug).success) {
-      skipped.push({ path: filePath, reason: "cannot derive a valid slug from the filename" });
+      skipped.push({
+        path: filePath,
+        // Non-latin filenames (e.g. CJK) land here — the document itself is
+        // importable, it just needs an explicit slug.
+        reason:
+          "cannot derive a valid slug from the filename; publish it individually with `doc publish --slug <slug>`",
+      });
       continue;
     }
     const holder = taken.get(slug);

--- a/apps/cli/tests/doc.test.ts
+++ b/apps/cli/tests/doc.test.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { describe, expect, it } from "vitest";
 
 import { registerDocCommands } from "../src/commands/doc/index.js";
-import { slugFromFilename, titleFromMarkdown } from "../src/core/doc-review.js";
+import { planMarkdownImport, slugFromFilename, titleFromMarkdown } from "../src/core/doc-review.js";
 
 describe("slugFromFilename", () => {
   it("uses the basename without its extension", () => {
@@ -42,6 +42,28 @@ describe("titleFromMarkdown", () => {
   });
 });
 
+describe("planMarkdownImport", () => {
+  it("plans unique-slug markdown files and skips the rest with reasons", () => {
+    const plan = planMarkdownImport([
+      "/p/NODE.md",
+      "/p/README.md",
+      "/p/design-doc.md",
+      "/p/notes.txt",
+      "/p/设计文档.md",
+      "/p/design doc.md",
+    ]);
+    expect(plan.candidates).toEqual([{ path: "/p/design-doc.md", slug: "design-doc" }]);
+    expect(plan.skipped.map((s) => s.path)).toEqual([
+      "/p/NODE.md", // index file
+      "/p/README.md", // index file
+      "/p/notes.txt", // not markdown
+      "/p/设计文档.md", // no derivable slug
+      "/p/design doc.md", // slug collision with design-doc.md
+    ]);
+    expect(plan.skipped.find((s) => s.path === "/p/design doc.md")?.reason).toContain("already taken");
+  });
+});
+
 describe("registerDocCommands", () => {
   it("wires the doc namespace with every subcommand", () => {
     const program = new Command();
@@ -50,7 +72,18 @@ describe("registerDocCommands", () => {
     const doc = program.commands.find((c) => c.name() === "doc");
     expect(doc).toBeDefined();
     const names = (doc?.commands ?? []).map((c) => c.name()).sort();
-    expect(names).toEqual(["comment", "comments", "get", "list", "publish", "reply", "resolve", "status"]);
+    expect(names).toEqual([
+      "comment",
+      "comments",
+      "export",
+      "get",
+      "import",
+      "list",
+      "publish",
+      "reply",
+      "resolve",
+      "status",
+    ]);
   });
 
   it("keeps subcommand descriptions non-empty (agents discover the surface via --help)", () => {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -453,11 +453,14 @@ first-tree doc
 │                  [--note <n>] [--status <s>] [--if-changed]   # create or append a version
 ├── get <slug> [--version <n>]                                  # read metadata + markdown content
 ├── list [--project <p>] [--status <s>] [--limit <n>] [--cursor <c>]
-├── comments <slug> [--status open|resolved] [--version <n>]    # list review comments
+├── comments <slug> [--status open|resolved] [--version <n>]
+│                   [--watch [seconds]]                         # list; --watch streams new ones as JSON lines
 ├── comment <slug> <body> [--quote <exact> [--prefix <t>] [--suffix <t>]] [--version <n>]
 ├── reply <commentId> <body>                                    # reply in a thread
 ├── resolve <commentId> [--reopen]                              # close (or reopen) a thread
-└── status <slug> [--set draft|in_review|approved|archived]     # show or move status
+├── status <slug> [--set draft|in_review|approved|archived]     # show or move status
+├── import <dir> [--project <p>] [--status <s>] [--dry-run]     # bulk-publish a directory of .md files
+└── export <dir> [--project <p>] [--status <s>]                 # dump library to <slug>.md files + manifest.json
 ```
 
 ```bash
@@ -473,7 +476,11 @@ Slug defaults to the slugified filename; title defaults to the file's first
 markdown heading (required on the first publish). Comment anchors are
 TextQuoteSelector-style (`exact` / `prefix` / `suffix`) against the markdown
 source, so an agent can locate every comment in the file it holds without
-line-number conventions.
+line-number conventions. Comments whose quote no longer exists in the latest
+version come back with `outdated: true` (computed on read). `import` skips
+`NODE.md` / `README.md` index files and is idempotent (re-runs only add
+versions for changed content); `export` is the guaranteed way out — plain
+markdown files plus a `manifest.json` of metadata.
 
 ---
 

--- a/packages/server/src/__tests__/documents.test.ts
+++ b/packages/server/src/__tests__/documents.test.ts
@@ -309,6 +309,44 @@ describe("documents API", () => {
       expect(summary.json().openCommentCount).toBe(0);
     });
 
+    it("marks anchored comments outdated when their quote disappears from the latest version", async () => {
+      const app = getApp();
+      const ctx = await createAdminContext(app);
+      const doc = await publishDoc(app, ctx, { slug: slug("anchored"), title: "A", content: "alpha beta gamma" });
+      const req = humanRequest(app, ctx.accessToken);
+
+      const kept = await req("POST", `/api/v1/documents/${doc.id}/comments`, {
+        body: "keep me",
+        anchor: { exact: "alpha" },
+      });
+      const dropped = await req("POST", `/api/v1/documents/${doc.id}/comments`, {
+        body: "drop me",
+        anchor: { exact: "beta" },
+      });
+      expect(kept.statusCode).toBe(200);
+      expect(dropped.statusCode).toBe(200);
+
+      // v2 rewrites the text: "beta" is edited away, "alpha" survives a reflow.
+      await publishDoc(app, ctx, { slug: doc.slug, content: "alpha\n  gamma delta" });
+
+      const list = await req("GET", `/api/v1/documents/${doc.id}/comments`);
+      const items: Array<{ id: string; outdated?: boolean }> = list.json().items;
+      expect(items.find((c) => c.id === kept.json().id)?.outdated).toBe(false);
+      expect(items.find((c) => c.id === dropped.json().id)?.outdated).toBe(true);
+
+      // Comments on the current latest version carry no outdated flag at all.
+      const fresh = await req("POST", `/api/v1/documents/${doc.id}/comments`, {
+        body: "current",
+        anchor: { exact: "delta" },
+      });
+      expect(fresh.statusCode).toBe(200);
+      const relist = await req("GET", `/api/v1/documents/${doc.id}/comments`);
+      const freshRow: { outdated?: boolean } | undefined = relist
+        .json()
+        .items.find((c: { id: string }) => c.id === fresh.json().id);
+      expect(freshRow?.outdated).toBeUndefined();
+    });
+
     it("rejects bad comment targets", async () => {
       const app = getApp();
       const ctx = await createAdminContext(app);

--- a/packages/server/src/api/agent/documents.ts
+++ b/packages/server/src/api/agent/documents.ts
@@ -104,7 +104,7 @@ export async function agentDocumentRoutes(app: FastifyInstance): Promise<void> {
     const identity = requireAgent(request);
     const document = await requireOrgDocument(app.db, identity.organizationId, request.params.docId);
     const query = listDocCommentsQuerySchema.parse(request.query);
-    return { items: await listComments(app.db, document.id, query) };
+    return { items: await listComments(app.db, document, query) };
   });
 
   app.post<{ Params: { docId: string } }>("/documents/:docId/comments", async (request) => {

--- a/packages/server/src/api/documents.ts
+++ b/packages/server/src/api/documents.ts
@@ -48,7 +48,7 @@ export async function documentRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { docId: string } }>("/:docId/comments", async (request) => {
     const { document } = await requireDocumentAccess(request, app.db);
     const query = listDocCommentsQuerySchema.parse(request.query);
-    return { items: await listComments(app.db, document.id, query) };
+    return { items: await listComments(app.db, document, query) };
   });
 
   app.post<{ Params: { docId: string } }>("/:docId/comments", async (request) => {

--- a/packages/server/src/services/document.ts
+++ b/packages/server/src/services/document.ts
@@ -10,7 +10,7 @@ import type {
   PublishDocRequest,
   PublishDocResponse,
 } from "@first-tree/shared";
-import { docCommentStatusSchema, docStatusSchema } from "@first-tree/shared";
+import { docCommentStatusSchema, docStatusSchema, locateDocAnchor } from "@first-tree/shared";
 import { and, asc, desc, eq, isNull, lt, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { docComments, docDocuments, docVersions } from "../db/schema/index.js";
@@ -400,10 +400,10 @@ export async function setCommentStatus(
 
 export async function listComments(
   db: Database,
-  documentId: string,
+  document: DocDocumentRow,
   query: ListDocCommentsQuery,
 ): Promise<DocComment[]> {
-  const conditions = [eq(docComments.documentId, documentId)];
+  const conditions = [eq(docComments.documentId, document.id)];
   if (query.versionNumber !== undefined) conditions.push(eq(docComments.versionNumber, query.versionNumber));
 
   const rows = await db
@@ -412,15 +412,42 @@ export async function listComments(
     .where(and(...conditions))
     .orderBy(asc(docComments.createdAt));
 
-  if (query.status === undefined) return rows.map(toDocComment);
-
-  // Status filters operate on threads: a reply has no independent status, so
-  // it follows its top-level comment's.
-  const topLevelStatus = new Map<string, string>();
-  for (const row of rows) {
-    if (!row.parentId) topLevelStatus.set(row.id, row.status);
+  let filtered = rows;
+  if (query.status !== undefined) {
+    // Status filters operate on threads: a reply has no independent status,
+    // so it follows its top-level comment's.
+    const topLevelStatus = new Map<string, string>();
+    for (const row of rows) {
+      if (!row.parentId) topLevelStatus.set(row.id, row.status);
+    }
+    filtered = rows.filter((row) => (row.parentId ? topLevelStatus.get(row.parentId) : row.status) === query.status);
   }
-  return rows
-    .filter((row) => (row.parentId ? topLevelStatus.get(row.parentId) : row.status) === query.status)
-    .map(toDocComment);
+
+  const comments = filtered.map(toDocComment);
+  await markOutdatedAnchors(db, document, comments);
+  return comments;
+}
+
+/**
+ * Read-time re-anchoring: an anchored top-level comment made against an
+ * older version is "outdated" when its quote no longer locates in the
+ * LATEST version (whitespace-insensitive; same `locateDocAnchor` the web
+ * highlight path uses). Computed on read and never stored, so it always
+ * reflects the current head version.
+ */
+async function markOutdatedAnchors(db: Database, document: DocDocumentRow, comments: DocComment[]): Promise<void> {
+  const candidates = comments.filter((c) => c.anchor && !c.parentId && c.versionNumber !== document.latestVersion);
+  if (candidates.length === 0) return;
+
+  const [latest] = await db
+    .select({ content: docVersions.content })
+    .from(docVersions)
+    .where(and(eq(docVersions.documentId, document.id), eq(docVersions.number, document.latestVersion)))
+    .limit(1);
+  if (!latest) return;
+
+  for (const comment of candidates) {
+    if (!comment.anchor) continue;
+    comment.outdated = locateDocAnchor(latest.content, comment.anchor) === null;
+  }
 }

--- a/packages/server/src/services/document.ts
+++ b/packages/server/src/services/document.ts
@@ -10,7 +10,7 @@ import type {
   PublishDocRequest,
   PublishDocResponse,
 } from "@first-tree/shared";
-import { docCommentStatusSchema, docStatusSchema, locateDocAnchor } from "@first-tree/shared";
+import { docCommentStatusSchema, docStatusSchema, locateDocAnchors } from "@first-tree/shared";
 import { and, asc, desc, eq, isNull, lt, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { docComments, docDocuments, docVersions } from "../db/schema/index.js";
@@ -446,8 +446,13 @@ async function markOutdatedAnchors(db: Database, document: DocDocumentRow, comme
     .limit(1);
   if (!latest) return;
 
-  for (const comment of candidates) {
-    if (!comment.anchor) continue;
-    comment.outdated = locateDocAnchor(latest.content, comment.anchor) === null;
-  }
+  // Batch locate: the latest content is normalized once for all candidates.
+  const anchored = candidates.filter((c) => c.anchor !== null);
+  const ranges = locateDocAnchors(
+    latest.content,
+    anchored.map((c) => c.anchor).filter((a) => a !== null),
+  );
+  anchored.forEach((comment, i) => {
+    comment.outdated = ranges[i] === null;
+  });
 }

--- a/packages/shared/src/__tests__/doc-anchor.test.ts
+++ b/packages/shared/src/__tests__/doc-anchor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildDocAnchor, locateDocAnchor } from "../doc-anchor.js";
+import { buildDocAnchor, locateDocAnchor, locateDocAnchors } from "../doc-anchor.js";
 
 const SOURCE = [
   "# Design Doc",
@@ -102,5 +102,24 @@ describe("locateDocAnchor", () => {
     expect(range).not.toBeNull();
     if (!range) return;
     expect(reflowed.slice(range.start, range.end)).toBe("audit\n  trails   matter");
+  });
+});
+
+describe("locateDocAnchors", () => {
+  it("locates a batch against one source with per-anchor results", () => {
+    const ranges = locateDocAnchors(SOURCE, [
+      { exact: "soft delete" },
+      { exact: "no longer present" },
+      { exact: "The cache is per-tenant", suffix: " on purpose." },
+    ]);
+    expect(ranges).toHaveLength(3);
+    expect(ranges[0]).not.toBeNull();
+    expect(ranges[1]).toBeNull();
+    const third = ranges[2];
+    expect(third).not.toBeNull();
+    if (!third) return;
+    expect(SOURCE.slice(third.start, third.end)).toBe("The cache is per-tenant");
+    // Matches the single-anchor API result exactly.
+    expect(third).toEqual(locateDocAnchor(SOURCE, { exact: "The cache is per-tenant", suffix: " on purpose." }));
   });
 });

--- a/packages/shared/src/doc-anchor.ts
+++ b/packages/shared/src/doc-anchor.ts
@@ -184,6 +184,17 @@ export function buildDocAnchor(input: BuildDocAnchorInput): DocAnchor | null {
   };
 }
 
+function locateInNormalized(norm: NormalizedText, anchor: DocAnchor): DocAnchorRange | null {
+  const normExact = normalize(anchor.exact);
+  if (normExact.length === 0) return null;
+
+  const occurrences = findAllOccurrences(norm.text, normExact);
+  if (occurrences.length === 0) return null;
+
+  const picked = pickOccurrence(norm.text, occurrences, normExact.length, anchor.prefix, anchor.suffix);
+  return toRawRange(norm, picked.normStart, picked.normEnd);
+}
+
 /**
  * Locate an anchor inside (a possibly different version of) the source.
  * Whitespace-insensitive; ambiguity resolves through the stored
@@ -191,13 +202,15 @@ export function buildDocAnchor(input: BuildDocAnchorInput): DocAnchor | null {
  * exists — the caller decides what "outdated" means.
  */
 export function locateDocAnchor(source: string, anchor: DocAnchor): DocAnchorRange | null {
-  const normExact = normalize(anchor.exact);
-  if (normExact.length === 0) return null;
+  return locateInNormalized(normalizeWithMap(source), anchor);
+}
 
+/**
+ * Locate many anchors against ONE source, normalizing the source once —
+ * the read-time re-anchor pass over a comment list would otherwise pay
+ * O(anchors × source length) in repeated normalization.
+ */
+export function locateDocAnchors(source: string, anchors: DocAnchor[]): Array<DocAnchorRange | null> {
   const norm = normalizeWithMap(source);
-  const occurrences = findAllOccurrences(norm.text, normExact);
-  if (occurrences.length === 0) return null;
-
-  const picked = pickOccurrence(norm.text, occurrences, normExact.length, anchor.prefix, anchor.suffix);
-  return toRawRange(norm, picked.normStart, picked.normEnd);
+  return anchors.map((anchor) => locateInNormalized(norm, anchor));
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,6 +13,7 @@ export {
   buildDocAnchor,
   type DocAnchorRange,
   locateDocAnchor,
+  locateDocAnchors,
 } from "./doc-anchor.js";
 // -- Mention extraction (shared by the server fan-out resolver and other readers) --
 export { type BarePathMatch, scanBareDocPathTokens, stripDocPathLineSuffix } from "./lib/doc-link-scan.js";

--- a/packages/shared/src/schemas/document.ts
+++ b/packages/shared/src/schemas/document.ts
@@ -183,6 +183,13 @@ export const docCommentSchema = z.object({
   body: z.string(),
   anchor: docAnchorSchema.nullable(),
   status: docCommentStatusSchema,
+  /**
+   * Computed on read, never stored: true when the comment's anchor no longer
+   * locates in the document's LATEST version (the quoted text was edited
+   * away). Only set for anchored top-level comments made against an older
+   * version; readers treat absence as false.
+   */
+  outdated: z.boolean().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/packages/web/src/pages/__tests__/docs-pages-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/docs-pages-dom.test.tsx
@@ -172,7 +172,10 @@ describe("DocPage", () => {
     docsApiMocks.findDocBySlug.mockResolvedValue(summary());
     docsApiMocks.getDoc.mockResolvedValue(docWithVersion());
     docsApiMocks.listDocComments.mockResolvedValue({
-      items: [comment(), comment({ id: "c-2", parentId: "c-1", body: "audit trail reasons", anchor: null })],
+      items: [
+        comment({ versionNumber: 1, outdated: true }),
+        comment({ id: "c-2", parentId: "c-1", body: "audit trail reasons", anchor: null, versionNumber: 1 }),
+      ],
     });
   });
   afterEach(() => h.cleanup());
@@ -196,6 +199,10 @@ describe("DocPage", () => {
     expect(h.container.textContent).toContain("why rename by slug?");
     expect(h.container.textContent).toContain("audit trail reasons"); // threaded reply
     expect(h.container.textContent).toContain("1 open");
+    // Cross-version comment shows its origin version and the outdated marker
+    // (the anchor no longer locates in the latest version).
+    expect(h.container.textContent).toContain("on v1");
+    expect(h.container.textContent).toContain("outdated");
     // Approve shortcut shows while in review.
     const buttons = Array.from(h.container.querySelectorAll("button"));
     expect(buttons.some((b) => b.textContent?.includes("Approve"))).toBe(true);

--- a/packages/web/src/pages/docs/doc-comment-sidebar.tsx
+++ b/packages/web/src/pages/docs/doc-comment-sidebar.tsx
@@ -161,6 +161,15 @@ function ThreadCard({
             on v{root.versionNumber}
           </span>
         ) : null}
+        {root.outdated ? (
+          <span
+            className="text-caption"
+            style={{ color: "var(--fg-warn-strong)" }}
+            title="The quoted text no longer exists in the latest version"
+          >
+            outdated
+          </span>
+        ) : null}
         <div style={{ flex: 1 }} />
         {root.status === "open" ? (
           <button


### PR DESCRIPTION
## Summary

M3 of **docloop** (stacked: base `feat/docloop-m2-web` → retarget after M2 merges). Design: [first-tree-context#675](https://github.com/agent-team-foundation/first-tree-context/pull/675) §8.

### Read-time re-anchoring (`outdated`)
Anchored top-level comments from older versions are checked against the **latest** version content on every comments read (`locateDocAnchor`, the same shared call the web highlight path uses). A quote that was edited away comes back `outdated: true` — computed, never stored, so it always reflects the head version. Web thread cards show the marker next to the origin-version chip; CLI/JSON consumers get the field for free.

### `doc import <dir>` / `doc export <dir>`
- **import**: bulk-publish every markdown file in a directory. Idempotent (`ifChanged` semantics — re-runs only add versions for changed files); slug/title derived per file; `NODE.md`/`README.md` index files skipped; slug collisions and underivable names reported, previewable with `--dry-run`. This is the migration path for `raw-context/proposals/` (the library-replaces-proposals decision stays with liuchao-001, per the proposal).
- **export**: `<slug>.md` per document (latest version) + `manifest.json` metadata — the no-lock-in guarantee.

### `doc comments --watch [seconds]`
After the initial `success()` envelope, polls (default 15s, min 5s) and streams each NEW comment as one JSON line on stdout; poll errors go to stderr without killing the loop.

### Deliberately deferred
WS realtime push + activity feed: polling covers the loop today; wiring doc events into the org WS adds schema/review surface better justified by dogfooding feedback (goal/ 打磨 posture).

### Tests
Server 16/16 (new: outdated end-to-end — kept vs edited-away quote, no flag on current-version comments) · CLI 8/8 (import planning, registration) · web 7/7 (outdated badge) · shared anchor 10/10. `pnpm check`, monorepo typecheck, and the web `lint:tokens` gate all clean.

### Rollout note
After M1–M3 merge: set `FIRST_TREE_DOCS_ENABLED=1` on **staging** first (flag defaults off everywhere), dogfood with a real proposal import, then decide prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)