### PR TITLE
fix: doc bylines prefer display names; resolve/reopen bumps document activity

### DIFF
--- a/packages/server/src/__tests__/documents.test.ts
+++ b/packages/server/src/__tests__/documents.test.ts
@@ -294,9 +294,16 @@ describe("documents API", () => {
       });
       expect(resolveReply.statusCode).toBe(400);
 
+      const beforeResolve = await req("GET", `/api/v1/documents/${doc.id}`);
       const resolved = await req("PATCH", `/api/v1/document-comments/${comment.json().id}`, { status: "resolved" });
       expect(resolved.statusCode).toBe(200);
       expect(resolved.json().status).toBe("resolved");
+
+      // Resolving is review activity: the document's list-order key moves.
+      const afterResolve = await req("GET", `/api/v1/documents/${doc.id}`);
+      expect(new Date(afterResolve.json().updatedAt).getTime()).toBeGreaterThan(
+        new Date(beforeResolve.json().updatedAt).getTime(),
+      );
 
       // Status filtering is thread-scoped: the reply follows its parent.
       const openLeft = await req("GET", `/api/v1/documents/${doc.id}/comments?status=open`);
@@ -426,7 +433,7 @@ describe("documents API", () => {
       const docId = published.json().id;
       const read = await request("GET", `/api/v1/agent/documents/${docId}`);
       expect(read.statusCode).toBe(200);
-      expect(read.json().createdBy).toMatchObject({ kind: "agent", id: agent.uuid, name: agent.name });
+      expect(read.json().createdBy).toMatchObject({ kind: "agent", id: agent.uuid, name: agent.displayName });
       expect(read.json().version.content).toBe("agent draft");
 
       // Slug resolution via list filter — the CLI's slug→id path.
@@ -439,7 +446,7 @@ describe("documents API", () => {
         anchor: { exact: "draft" },
       });
       expect(comment.statusCode).toBe(200);
-      expect(comment.json().author).toMatchObject({ kind: "agent", name: agent.name });
+      expect(comment.json().author).toMatchObject({ kind: "agent", name: agent.displayName });
 
       const reply = await request("POST", `/api/v1/agent/document-comments/${comment.json().id}/replies`, {
         body: "answered",

--- a/packages/server/src/services/doc-author.ts
+++ b/packages/server/src/services/doc-author.ts
@@ -17,12 +17,15 @@ import { UnauthorizedError } from "../errors.js";
  */
 export async function docAuthorForAgentUuid(db: Database, agentUuid: string): Promise<DocAuthor> {
   const [row] = await db
-    .select({ name: agents.name, type: agents.type })
+    .select({ name: agents.name, displayName: agents.displayName, type: agents.type })
     .from(agents)
     .where(eq(agents.uuid, agentUuid))
     .limit(1);
   if (!row) {
     throw new UnauthorizedError("Caller identity not found");
   }
-  return { kind: row.type === "human" ? "human" : "agent", id: agentUuid, name: row.name ?? "unknown" };
+  // Bylines prefer the user-facing display name over the unique slug — a
+  // renamed profile should not leave stale slug snapshots on every byline.
+  const name = row.displayName?.trim() ? row.displayName : (row.name ?? "unknown");
+  return { kind: row.type === "human" ? "human" : "agent", id: agentUuid, name };
 }

--- a/packages/server/src/services/document.ts
+++ b/packages/server/src/services/document.ts
@@ -395,6 +395,9 @@ export async function setCommentStatus(
     .where(eq(docComments.id, comment.id))
     .returning();
   if (!updated) throw new NotFoundError("Comment not found");
+  // Resolving/reopening changes the document's open-comment count and is
+  // review activity — bump the list-order key like comment creation does.
+  await db.update(docDocuments).set({ updatedAt: new Date() }).where(eq(docDocuments.id, comment.documentId));
   return toDocComment(updated);
 }
 


### PR DESCRIPTION
Addresses both Codex P2s on the integration PR #1434:

1. **Display-name bylines** — `docAuthorForAgentUuid` now snapshots `agents.display_name` (slug fallback), so profile renames don't leave permanently wrong bylines on documents/comments.
2. **Activity bump on resolve/reopen** — `setCommentStatus` also bumps `doc_documents.updated_at`; handled feedback now reorders the library like new comments do. Covered by a new updatedAt assertion in the comment-loop test.

Server documents suite 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)