### PR TITLE
fix: refresh runtime session transport after rebind

### DIFF
--- a/apps/cli/src/__tests__/agent-shared-helpers-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-shared-helpers-extra.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const clientMocks = vi.hoisted(() => {
@@ -46,6 +49,7 @@ vi.mock("../core/cli-fetch.js", () => ({ cliFetch: cliFetchMock }));
 
 const originalAgentId = process.env.FIRST_TREE_AGENT_ID;
 const originalRuntimeSessionToken = process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN;
+const originalRuntimeSessionTokenFile = process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE;
 const originalServerUrl = process.env.FIRST_TREE_SERVER_URL;
 
 function restoreEnv(): void {
@@ -63,6 +67,11 @@ function restoreEnv(): void {
     delete process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN;
   } else {
     process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN = originalRuntimeSessionToken;
+  }
+  if (originalRuntimeSessionTokenFile === undefined) {
+    delete process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE;
+  } else {
+    process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE = originalRuntimeSessionTokenFile;
   }
 }
 
@@ -121,6 +130,28 @@ describe("local agent shared helpers", () => {
         runtimeSessionToken: "runtime-token-1",
       }),
     );
+  });
+
+  it("prefers the runtime session token file over a stale inherited env token", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "first-tree-token-"));
+    try {
+      const tokenFile = join(dir, "runtime.token");
+      writeFileSync(tokenFile, "runtime-token-2\n", "utf8");
+      const { createSdk } = await import("../commands/_shared/local-agent.js");
+
+      process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN = "runtime-token-1";
+      process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE = tokenFile;
+      createSdk("nova");
+
+      expect(clientMocks.FirstTreeHubSDK).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "agent-1",
+          runtimeSessionToken: "runtime-token-2",
+        }),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("maps local agent resolution failures to CLI errors", async () => {

--- a/apps/cli/src/commands/_shared/local-agent.ts
+++ b/apps/cli/src/commands/_shared/local-agent.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { FirstTreeHubSDK, SdkError } from "@first-tree/client";
 import {
@@ -88,7 +89,7 @@ export function resolveLocalAgent(
 /** Build an SDK client scoped to the resolved local agent. */
 export function createSdk(agentName?: string): FirstTreeHubSDK {
   const { serverUrl, agentId } = resolveLocalAgent(agentName);
-  const runtimeSessionToken = process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN?.trim() || undefined;
+  const runtimeSessionToken = resolveRuntimeSessionToken();
   return new FirstTreeHubSDK({
     serverUrl,
     getAccessToken: (opts) => ensureFreshAccessToken(opts),
@@ -96,6 +97,19 @@ export function createSdk(agentName?: string): FirstTreeHubSDK {
     runtimeSessionToken,
     userAgent: CLI_USER_AGENT,
   });
+}
+
+function resolveRuntimeSessionToken(): string | undefined {
+  const tokenFile = process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE?.trim();
+  if (tokenFile) {
+    try {
+      return readFileSync(tokenFile, "utf8").trim() || undefined;
+    } catch (err) {
+      void err;
+      return undefined;
+    }
+  }
+  return process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN?.trim() || undefined;
 }
 
 /** Map an SdkError / connection error to the right CLI `fail()`. */

--- a/packages/client/src/__tests__/agent-config-cache.test.ts
+++ b/packages/client/src/__tests__/agent-config-cache.test.ts
@@ -104,6 +104,25 @@ describe("AgentConfigCache (Step 4)", () => {
     expect(cache.get("agent-1")?.version).toBe(2);
   });
 
+  it("retries waiters with the replacement SDK when an old in-flight fetch succeeds after rebind", async () => {
+    const firstFetch = deferred<AgentRuntimeConfig>();
+    const firstSdk = {
+      fetchAgentConfig: vi.fn(() => firstFetch.promise),
+      isHubReachable: vi.fn(),
+    } as unknown as FirstTreeHubSDK;
+    const secondSdk = makeSdkWithConfigs([makeConfig(3)]);
+    const cache = createAgentConfigCache({ sdk: firstSdk });
+
+    const pending = cache.refresh("agent-1");
+    cache.updateSdk(secondSdk);
+    firstFetch.resolve(makeConfig(2));
+
+    await expect(pending).resolves.toMatchObject({ version: 3 });
+    expect(firstSdk.fetchAgentConfig).toHaveBeenCalledTimes(1);
+    expect(secondSdk.fetchAgentConfig).toHaveBeenCalledTimes(1);
+    expect(cache.get("agent-1")?.version).toBe(3);
+  });
+
   it("refreshIfNewer is no-op when incoming <= local", async () => {
     const cfg = makeConfig(5);
     const sdk = makeSdkWithConfigs([cfg]);

--- a/packages/client/src/__tests__/agent-config-cache.test.ts
+++ b/packages/client/src/__tests__/agent-config-cache.test.ts
@@ -55,6 +55,20 @@ describe("AgentConfigCache (Step 4)", () => {
     expect(sdk.fetchAgentConfig).toHaveBeenCalledTimes(2);
   });
 
+  it("uses the replacement SDK after a runtime rebind", async () => {
+    const firstSdk = makeSdkWithConfigs([makeConfig(1)]);
+    const secondSdk = makeSdkWithConfigs([makeConfig(2)]);
+    const cache = createAgentConfigCache({ sdk: firstSdk });
+
+    await cache.refresh("agent-1");
+    cache.updateSdk(secondSdk);
+    const updated = await cache.refresh("agent-1");
+
+    expect(updated.version).toBe(2);
+    expect(firstSdk.fetchAgentConfig).toHaveBeenCalledTimes(1);
+    expect(secondSdk.fetchAgentConfig).toHaveBeenCalledTimes(1);
+  });
+
   it("refreshIfNewer is no-op when incoming <= local", async () => {
     const cfg = makeConfig(5);
     const sdk = makeSdkWithConfigs([cfg]);

--- a/packages/client/src/__tests__/agent-config-cache.test.ts
+++ b/packages/client/src/__tests__/agent-config-cache.test.ts
@@ -3,6 +3,22 @@ import { describe, expect, it, vi } from "vitest";
 import { type AgentConfigCacheLogger, createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function makeConfig(version: number, urls: string[] = []): AgentRuntimeConfig {
   return {
     agentId: "agent-1",
@@ -67,6 +83,25 @@ describe("AgentConfigCache (Step 4)", () => {
     expect(updated.version).toBe(2);
     expect(firstSdk.fetchAgentConfig).toHaveBeenCalledTimes(1);
     expect(secondSdk.fetchAgentConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries waiters with the replacement SDK when an old in-flight fetch fails after rebind", async () => {
+    const firstFetch = deferred<AgentRuntimeConfig>();
+    const firstSdk = {
+      fetchAgentConfig: vi.fn(() => firstFetch.promise),
+      isHubReachable: vi.fn(),
+    } as unknown as FirstTreeHubSDK;
+    const secondSdk = makeSdkWithConfigs([makeConfig(2)]);
+    const cache = createAgentConfigCache({ sdk: firstSdk });
+
+    const pending = cache.refresh("agent-1");
+    cache.updateSdk(secondSdk);
+    firstFetch.reject(new Error("Invalid agent runtime session"));
+
+    await expect(pending).resolves.toMatchObject({ version: 2 });
+    expect(firstSdk.fetchAgentConfig).toHaveBeenCalledTimes(1);
+    expect(secondSdk.fetchAgentConfig).toHaveBeenCalledTimes(1);
+    expect(cache.get("agent-1")?.version).toBe(2);
   });
 
   it("refreshIfNewer is no-op when incoming <= local", async () => {

--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -478,6 +478,26 @@ describe("buildAgentEnv", () => {
     expect(env.FIRST_TREE_RUNTIME_SESSION_TOKEN).toBe("runtime-token-1");
   });
 
+  it("injects a stable runtime session token file for long-lived child CLI calls", () => {
+    const env = buildAgentEnv({ PATH: "/usr/bin" } as NodeJS.ProcessEnv, {
+      sdk: { serverUrl: "http://first-tree", runtimeSessionToken: "runtime-token-1" },
+      agent: {
+        agentId: "agent-a",
+        inboxId: "inbox-a",
+        displayName: "agent-a",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
+      chatId: "chat-1",
+      runtimeSessionTokenFile: "/tmp/runtime-session-token",
+    });
+
+    expect(env.FIRST_TREE_RUNTIME_SESSION_TOKEN).toBe("runtime-token-1");
+    expect(env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE).toBe("/tmp/runtime-session-token");
+  });
+
   it("adds client switch drain markers when provider context is available", () => {
     const env = buildAgentEnv({ PATH: "/usr/bin" } as NodeJS.ProcessEnv, {
       sdk: { serverUrl: "http://first-tree" },

--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -89,6 +89,22 @@ describe("formatInboundContent", () => {
     expect(await formatInboundContent(msg, cache)).toBe("[From: alice · type=agent]\n\nhello");
   });
 
+  it("resolves the participant SDK lazily so rebound sessions use the current transport", async () => {
+    const firstSdk = mkSdk(async () => []);
+    const secondSdk = mkSdk(async () => participants);
+    let currentSdk = firstSdk;
+    const cache = createParticipantCache(
+      () => currentSdk,
+      "chat-1",
+      () => {},
+    );
+    currentSdk = secondSdk;
+
+    expect(await cache.get()).toEqual(participants);
+    expect(firstSdk.listChatParticipants).not.toHaveBeenCalled();
+    expect(secondSdk.listChatParticipants).toHaveBeenCalledWith("chat-1");
+  });
+
   it("does not append an agent-only directive for legacy First Tree onboarding metadata", async () => {
     const sdk = mkSdk(async () => participants);
     const cache = createParticipantCache(sdk, "chat-1", () => {});

--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { existsSync, readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ClientConnection, SessionReconcileResult } from "../client-connection.js";
 import type { AgentSlotConfig } from "../runtime/agent-slot.js";
@@ -100,6 +101,7 @@ function makeSdk(options?: {
   configErrorsThenSucceed?: { error: unknown; times: number };
   activeRuntimeChatIds?: string[];
   activeRuntimeChatIdsError?: unknown;
+  runtimeSessionToken?: string;
 }): FirstTreeHubSDK {
   const agent = options?.agent ?? makeAgent();
   let configCalls = 0;
@@ -127,6 +129,8 @@ function makeSdk(options?: {
         updatedBy: "user-1",
       };
     }),
+    serverUrl: "https://first-tree.example",
+    runtimeSessionToken: options?.runtimeSessionToken,
     listActiveRuntimeChatIds: vi.fn(async () => {
       if (options?.activeRuntimeChatIdsError) throw options.activeRuntimeChatIdsError;
       return { chatIds: options?.activeRuntimeChatIds ?? ["chat-1", "chat-2", "chat-evicted"] };
@@ -267,6 +271,7 @@ async function makeSlot(options?: {
   configErrorsThenSucceed?: { error: unknown; times: number };
   activeRuntimeChatIds?: string[];
   activeRuntimeChatIdsError?: unknown;
+  runtimeSessionToken?: string;
   runtimeType?: string;
   syncResult?: MockState["syncResult"];
   syncDelayMs?: number;
@@ -284,6 +289,7 @@ async function makeSlot(options?: {
     configErrorsThenSucceed: options?.configErrorsThenSucceed,
     activeRuntimeChatIds: options?.activeRuntimeChatIds,
     activeRuntimeChatIdsError: options?.activeRuntimeChatIdsError,
+    runtimeSessionToken: options?.runtimeSessionToken,
   });
   const connection = new FakeClientConnection(sdk);
   const { AgentSlot } = await import("../runtime/agent-slot.js");
@@ -607,11 +613,82 @@ describe("AgentSlot", () => {
     });
     await Promise.resolve();
     await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(vi.mocked(nextSdk.listActiveRuntimeChatIds)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(sdk.listActiveRuntimeChatIds)).not.toHaveBeenCalled();
     expect(session.updateTransport).toHaveBeenCalledWith(nextSdk, expect.anything());
 
+    await slot.stop();
+  });
+
+  it("writes a stable runtime session token file that updates after a reconnect rebind", async () => {
+    const tokenFile = "/tmp/first-tree-test-data/runtime-session-tokens/agent-1.token";
+    const { slot, connection, state } = await makeSlot({
+      activeRuntimeChatIds: ["chat-1"],
+      runtimeSessionToken: "runtime-token-1",
+    });
+
+    try {
+      await slot.start();
+      expect(readFileSync(tokenFile, "utf8").trim()).toBe("runtime-token-1");
+      expect((state.sessionConfigs[0] as { runtimeSessionTokenFile?: string }).runtimeSessionTokenFile).toBe(tokenFile);
+
+      const nextSdk = makeSdk({ activeRuntimeChatIds: ["chat-1"], runtimeSessionToken: "runtime-token-2" });
+      connection.emit("agent:bound", {
+        agentId: "agent-1",
+        displayName: "Agent One",
+        agentType: "agent",
+        sdk: nextSdk,
+        runtimeSessionToken: "runtime-token-2",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(readFileSync(tokenFile, "utf8").trim()).toBe("runtime-token-2");
+    } finally {
+      await slot.stop();
+    }
+
+    expect(existsSync(tokenFile)).toBe(false);
+  });
+
+  it("starts a fresh active-runtime-chat refresh after rebind even when the old refresh is in flight", async () => {
+    const { slot, connection, sdk, state } = await makeSlot({ activeRuntimeChatIds: ["chat-1"] });
+    await slot.start();
+    const session = state.sessions[0];
+    if (!session) throw new Error("session missing");
+    session.sessionStates = [
+      { chatId: "stale-chat", state: "active" },
+      { chatId: "chat-2", state: "active" },
+    ];
+
+    const refreshActiveRuntimeChatIds = Reflect.get(slot, "refreshActiveRuntimeChatIds");
+    if (typeof refreshActiveRuntimeChatIds !== "function") throw new Error("private method missing");
+    const staleRefresh = deferred<{ chatIds: string[] }>();
+    vi.mocked(sdk.listActiveRuntimeChatIds).mockImplementationOnce(() => staleRefresh.promise);
+    const stalePromise = refreshActiveRuntimeChatIds.call(slot, "periodic") as Promise<void>;
+    await Promise.resolve();
+
+    connection.reportSessionState.mockClear();
+    const nextSdk = makeSdk({ activeRuntimeChatIds: ["chat-2"], runtimeSessionToken: "runtime-token-2" });
+    connection.emit("agent:bound", {
+      agentId: "agent-1",
+      displayName: "Agent One",
+      agentType: "agent",
+      sdk: nextSdk,
+      runtimeSessionToken: "runtime-token-2",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(vi.mocked(nextSdk.listActiveRuntimeChatIds)).toHaveBeenCalledTimes(1);
+    expect(connection.reportSessionState).toHaveBeenCalledWith("agent-1", "chat-2", "active");
+    expect(connection.reportSessionState).not.toHaveBeenCalledWith("agent-1", "stale-chat", "active");
+
+    staleRefresh.resolve({ chatIds: ["stale-chat"] });
+    await stalePromise;
     await slot.stop();
   });
 

--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -25,6 +25,7 @@ type FakeSessionState = {
     typeof vi.fn<(chatId: string, type: "session:suspend" | "session:terminate") => Promise<void>>
   >;
   applyStaleChatIds: ReturnType<typeof vi.fn<(chatIds: string[]) => void>>;
+  updateTransport: ReturnType<typeof vi.fn<(sdk: unknown, agentConfigCache?: unknown) => void>>;
   shutdown: ReturnType<typeof vi.fn<(reason?: string, opts?: unknown) => Promise<void>>>;
 };
 
@@ -201,6 +202,7 @@ function installMocks(options: { syncResult?: MockState["syncResult"]; syncDelay
           dispatch: vi.fn(async () => {}),
           handleCommand: vi.fn(async () => {}),
           applyStaleChatIds: vi.fn(),
+          updateTransport: vi.fn(),
           shutdown: vi.fn(async () => {}),
         };
         state.sessions.push(this.state);
@@ -239,6 +241,10 @@ function installMocks(options: { syncResult?: MockState["syncResult"]; syncDelay
 
       applyStaleChatIds(chatIds: string[]): void {
         this.state.applyStaleChatIds(chatIds);
+      }
+
+      updateTransport(sdk: unknown, agentConfigCache?: unknown): void {
+        this.state.updateTransport(sdk, agentConfigCache);
       }
 
       getHeldChatIds(activeChatIds?: ReadonlySet<string> | null): string[] {
@@ -579,6 +585,32 @@ describe("AgentSlot", () => {
     connection.sendSessionReconcile.mockClear();
     reconcile.call(slot);
     expect(connection.sendSessionReconcile).toHaveBeenCalledWith("agent-1", ["chat-1", "chat-2"]);
+
+    await slot.stop();
+  });
+
+  it("adopts the latest runtime SDK after a reconnect rebind", async () => {
+    const { slot, connection, sdk, state } = await makeSlot({ activeRuntimeChatIds: ["chat-1"] });
+    await slot.start();
+    const session = state.sessions[0];
+    if (!session) throw new Error("session missing");
+
+    const nextSdk = makeSdk({ activeRuntimeChatIds: ["chat-2"] });
+    vi.mocked(sdk.listActiveRuntimeChatIds).mockClear();
+
+    connection.emit("agent:bound", {
+      agentId: "agent-1",
+      displayName: "Agent One",
+      agentType: "agent",
+      sdk: nextSdk,
+      runtimeSessionToken: "runtime-token-2",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(vi.mocked(nextSdk.listActiveRuntimeChatIds)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(sdk.listActiveRuntimeChatIds)).not.toHaveBeenCalled();
+    expect(session.updateTransport).toHaveBeenCalledWith(nextSdk, expect.anything());
 
     await slot.stop();
   });

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -125,6 +125,7 @@ function makeCache(
         }),
     ),
     refresh: vi.fn(),
+    updateSdk: vi.fn(),
     updateUrls: vi.fn(),
     allReferencedUrls: vi.fn(() => new Set<string>()),
     forget: vi.fn(),

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -148,6 +148,7 @@ function makeManager(
     onSessionRuntimeChange?: (chatId: string, state: TestRuntimeState) => void;
     onSessionEvent?: (chatId: string, event: SessionEvent) => void;
     workspaceRoot?: string;
+    runtimeSessionTokenFile?: string;
   } = {},
 ): SessionManager {
   const handlers = [...(opts.handlers ?? [handler()])];
@@ -177,6 +178,7 @@ function makeManager(
     log: silentLogger(),
     registryPath: opts.registryPath,
     agentConfigCache: opts.agentConfigCache,
+    runtimeSessionTokenFile: opts.runtimeSessionTokenFile,
     ackEntry: opts.ackEntry ?? vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined),
     recoverChat: opts.recoverChat,
     onStateChange: opts.onStateChange,
@@ -474,6 +476,7 @@ describe("SessionManager edge coverage", () => {
       sdk,
       workspaceRoot,
       agentConfigCache: cache,
+      runtimeSessionTokenFile: "/tmp/runtime-session-token",
     });
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-context" }));
@@ -490,6 +493,7 @@ describe("SessionManager edge coverage", () => {
     expect(env.FIRST_TREE_DOC_REPO_LOCAL_PATH).toBe("source-repos/project");
     expect(env.FIRST_TREE_WORKSPACES_ROOT).toBe(tmpdir());
     expect(env.FIRST_TREE_AGENT_SLUG).toBe(workspaceRoot.split("/").at(-1));
+    expect(env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE).toBe("/tmp/runtime-session-token");
 
     const formatted = await ctx.formatInboundContent({
       id: "msg-format",

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -301,6 +301,7 @@ describe("SessionManager", () => {
       get: vi.fn(),
       refreshIfNewer: vi.fn(() => refresh.promise),
       refresh: vi.fn(() => Promise.resolve(mockRuntimeConfig())),
+      updateSdk: vi.fn(),
       updateUrls: vi.fn(),
       allReferencedUrls: vi.fn(() => new Set<string>()),
       forget: vi.fn(),
@@ -1239,6 +1240,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
         return refreshCalls === 1 ? firstRefresh.promise : Promise.resolve({} as AgentRuntimeConfig);
       }),
       refresh: vi.fn(async () => ({}) as AgentRuntimeConfig),
+      updateSdk: vi.fn(),
       updateUrls: vi.fn(),
       allReferencedUrls: vi.fn(() => new Set<string>()),
       forget: vi.fn(),

--- a/packages/client/src/runtime/agent-config-cache.ts
+++ b/packages/client/src/runtime/agent-config-cache.ts
@@ -73,6 +73,47 @@ export function createAgentConfigCache(opts: AgentConfigCacheOptions): AgentConf
     return fetched;
   }
 
+  function refresh(agentId: string): Promise<AgentRuntimeConfig> {
+    const existing = entries.get(agentId);
+    if (existing?.inflight) return existing.inflight;
+    const slot: CachedEntry = existing ?? {
+      config: {
+        agentId,
+        version: 0,
+        payload: {
+          kind: "claude-code",
+          prompt: { append: "" },
+          model: "",
+          mcpServers: [],
+          env: [],
+          gitRepos: [],
+          resourceSkills: [],
+          reasoningEffort: "",
+        },
+        updatedAt: "",
+        updatedBy: "",
+      },
+      urls: new Set(),
+      inflight: null,
+    };
+    const generation = sdkGeneration;
+    let inflight!: Promise<AgentRuntimeConfig>;
+    inflight = doFetch(agentId, generation).catch((err) => {
+      if (slot.inflight === inflight) {
+        slot.inflight = null;
+      }
+      if (generation !== sdkGeneration) {
+        log?.warn({ agentId, err }, "agent config fetch failed after SDK replacement; retrying with latest transport");
+        return refresh(agentId);
+      }
+      log?.warn({ agentId, err }, "agent config fetch failed");
+      throw err;
+    });
+    slot.inflight = inflight;
+    entries.set(agentId, slot);
+    return inflight;
+  }
+
   return {
     get(agentId) {
       return entries.get(agentId)?.config;
@@ -86,38 +127,7 @@ export function createAgentConfigCache(opts: AgentConfigCacheOptions): AgentConf
       }
     },
 
-    async refresh(agentId) {
-      const existing = entries.get(agentId);
-      if (existing?.inflight) return existing.inflight;
-      const slot: CachedEntry = existing ?? {
-        config: {
-          agentId,
-          version: 0,
-          payload: {
-            kind: "claude-code",
-            prompt: { append: "" },
-            model: "",
-            mcpServers: [],
-            env: [],
-            gitRepos: [],
-            resourceSkills: [],
-            reasoningEffort: "",
-          },
-          updatedAt: "",
-          updatedBy: "",
-        },
-        urls: new Set(),
-        inflight: null,
-      };
-      const generation = sdkGeneration;
-      slot.inflight = doFetch(agentId, generation).catch((err) => {
-        slot.inflight = null;
-        log?.warn({ agentId, err }, "agent config fetch failed");
-        throw err;
-      });
-      entries.set(agentId, slot);
-      return slot.inflight;
-    },
+    refresh,
 
     async refreshIfNewer(agentId, incomingVersion) {
       const existing = entries.get(agentId);

--- a/packages/client/src/runtime/agent-config-cache.ts
+++ b/packages/client/src/runtime/agent-config-cache.ts
@@ -17,6 +17,8 @@ export type AgentConfigCacheLogger = pino.Logger;
 export interface AgentConfigCache {
   /** Snapshot of the currently cached config, if any. */
   get(agentId: string): AgentRuntimeConfig | undefined;
+  /** Swap the SDK transport after a WebSocket rebind mints a new runtime-session token. */
+  updateSdk(sdk: FirstTreeHubSDK): void;
   /**
    * Refresh from the server if `incomingVersion > local`; no-op otherwise.
    * Returns the in-cache value after the operation.
@@ -45,7 +47,8 @@ export type AgentConfigCacheOptions = {
 };
 
 export function createAgentConfigCache(opts: AgentConfigCacheOptions): AgentConfigCache {
-  const { sdk } = opts;
+  let sdk = opts.sdk;
+  let sdkGeneration = 0;
   const log = opts.log;
   const entries = new Map<string, CachedEntry>();
 
@@ -53,13 +56,15 @@ export function createAgentConfigCache(opts: AgentConfigCacheOptions): AgentConf
     return new Set(cfg.payload.gitRepos.map((r) => r.url));
   }
 
-  async function doFetch(agentId: string): Promise<AgentRuntimeConfig> {
-    const fetched = await sdk.fetchAgentConfig();
+  async function doFetch(agentId: string, generation: number): Promise<AgentRuntimeConfig> {
+    const fetchSdk = sdk;
+    const fetched = await fetchSdk.fetchAgentConfig();
     if (fetched.agentId !== agentId) {
       // Defensive: SDK token always maps to one agent, but this guards against
       // future multi-agent SDKs sharing a cache.
       throw new Error(`AgentConfigCache: fetched config for "${fetched.agentId}" but expected "${agentId}"`);
     }
+    if (generation !== sdkGeneration) return fetched;
     const entry: CachedEntry = entries.get(agentId) ?? { config: fetched, urls: new Set(), inflight: null };
     entry.config = fetched;
     entry.urls = urlsFromConfig(fetched);
@@ -71,6 +76,14 @@ export function createAgentConfigCache(opts: AgentConfigCacheOptions): AgentConf
   return {
     get(agentId) {
       return entries.get(agentId)?.config;
+    },
+
+    updateSdk(nextSdk) {
+      sdk = nextSdk;
+      sdkGeneration++;
+      for (const entry of entries.values()) {
+        entry.inflight = null;
+      }
     },
 
     async refresh(agentId) {
@@ -96,7 +109,8 @@ export function createAgentConfigCache(opts: AgentConfigCacheOptions): AgentConf
         urls: new Set(),
         inflight: null,
       };
-      slot.inflight = doFetch(agentId).catch((err) => {
+      const generation = sdkGeneration;
+      slot.inflight = doFetch(agentId, generation).catch((err) => {
         slot.inflight = null;
         log?.warn({ agentId, err }, "agent config fetch failed");
         throw err;

--- a/packages/client/src/runtime/agent-config-cache.ts
+++ b/packages/client/src/runtime/agent-config-cache.ts
@@ -98,17 +98,31 @@ export function createAgentConfigCache(opts: AgentConfigCacheOptions): AgentConf
     };
     const generation = sdkGeneration;
     let inflight!: Promise<AgentRuntimeConfig>;
-    inflight = doFetch(agentId, generation).catch((err) => {
-      if (slot.inflight === inflight) {
-        slot.inflight = null;
-      }
-      if (generation !== sdkGeneration) {
-        log?.warn({ agentId, err }, "agent config fetch failed after SDK replacement; retrying with latest transport");
-        return refresh(agentId);
-      }
-      log?.warn({ agentId, err }, "agent config fetch failed");
-      throw err;
-    });
+    inflight = doFetch(agentId, generation)
+      .then((fetched) => {
+        if (generation !== sdkGeneration) {
+          if (slot.inflight === inflight) {
+            slot.inflight = null;
+          }
+          log?.warn({ agentId }, "agent config fetch resolved after SDK replacement; retrying with latest transport");
+          return refresh(agentId);
+        }
+        return fetched;
+      })
+      .catch((err) => {
+        if (slot.inflight === inflight) {
+          slot.inflight = null;
+        }
+        if (generation !== sdkGeneration) {
+          log?.warn(
+            { agentId, err },
+            "agent config fetch failed after SDK replacement; retrying with latest transport",
+          );
+          return refresh(agentId);
+        }
+        log?.warn({ agentId, err }, "agent config fetch failed");
+        throw err;
+      });
     slot.inflight = inflight;
     entries.set(agentId, slot);
     return inflight;

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -43,6 +43,7 @@ export function buildAgentEnv(
     agent: AgentIdentity;
     chatId: string;
     clientId?: string;
+    runtimeSessionTokenFile?: string;
     provider?: string;
     /**
      * Resolved doc-preview context for this session, so a `first-tree
@@ -86,6 +87,7 @@ export function buildAgentEnv(
     FIRST_TREE_SERVER_URL: ctx.sdk.serverUrl,
     FIRST_TREE_AGENT_ID: ctx.agent.agentId,
     ...(ctx.sdk.runtimeSessionToken ? { FIRST_TREE_RUNTIME_SESSION_TOKEN: ctx.sdk.runtimeSessionToken } : {}),
+    ...(ctx.runtimeSessionTokenFile ? { FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE: ctx.runtimeSessionTokenFile } : {}),
     FIRST_TREE_INBOX_ID: ctx.agent.inboxId,
     FIRST_TREE_CHAT_ID: ctx.chatId,
     ...(ctx.clientId ? { FIRST_TREE_CLIENT_ID: ctx.clientId } : {}),

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -180,7 +180,7 @@ export type ParticipantCache = {
 };
 
 export function createParticipantCache(
-  sdk: Pick<FirstTreeHubSDK, "listChatParticipants">,
+  sdk: Pick<FirstTreeHubSDK, "listChatParticipants"> | (() => Pick<FirstTreeHubSDK, "listChatParticipants">),
   chatId: string,
   log: (msg: string) => void,
 ): ParticipantCache {
@@ -192,7 +192,8 @@ export function createParticipantCache(
       if (!inflight) {
         inflight = (async () => {
           try {
-            const rows = await sdk.listChatParticipants(chatId);
+            const currentSdk = typeof sdk === "function" ? sdk() : sdk;
+            const rows = await currentSdk.listChatParticipants(chatId);
             cached = rows;
             return rows;
           } catch (err) {

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -1,4 +1,5 @@
-import { join } from "node:path";
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import type {
   AgentRuntimeConfig,
   InboxDeliverFrame,
@@ -103,6 +104,7 @@ type ConnectionListener =
 export class AgentSlot {
   private sessionManager: SessionManager | null = null;
   private readonly config: AgentSlotConfig;
+  private readonly runtimeSessionTokenFile: string;
   private logger: pino.Logger;
   private agentConfigCache: AgentConfigCache | null = null;
   private sdk: FirstTreeHubSDK | null = null;
@@ -129,6 +131,7 @@ export class AgentSlot {
 
   constructor(config: AgentSlotConfig) {
     this.config = config;
+    this.runtimeSessionTokenFile = join(defaultDataDir(), "runtime-session-tokens", `${config.agentId}.token`);
     this.logger = createLogger("slot").child({ agentName: config.name, agentId: config.agentId });
   }
 
@@ -203,6 +206,7 @@ export class AgentSlot {
         if (!this.sessionManager) return;
         void this.refreshActiveRuntimeChatIds("bind").finally(() => {
           this.fullStateSync();
+          this.scheduleActiveRuntimeChatIdsRefresh();
           // One-shot post-bind reconcile catches operator-terminates that
           // landed while this client was offline. It is deliberately scheduled
           // after fullStateSync, so just-hydrated registry mappings are first
@@ -241,7 +245,6 @@ export class AgentSlot {
       bindSucceeded = true;
       const sdk = bound.sdk;
       this.adoptRuntimeTransport(sdk);
-      this.activeRuntimeChatIdsRefreshGeneration++;
       const agent = await sdk.register();
 
       this.logger.info({ displayName: agent.displayName }, "agent bound");
@@ -315,6 +318,7 @@ export class AgentSlot {
         log: this.logger,
         registryPath,
         agentConfigCache: this.agentConfigCache,
+        runtimeSessionTokenFile: this.runtimeSessionTokenFile,
         ackEntry,
         recoverChat,
         onStateChange: (chatId, state) => this.reportSessionState(chatId, state),
@@ -444,8 +448,29 @@ export class AgentSlot {
 
   private adoptRuntimeTransport(sdk: FirstTreeHubSDK): void {
     this.sdk = sdk;
+    this.persistRuntimeSessionToken(sdk.runtimeSessionToken);
+    this.activeRuntimeChatIdsRefreshGeneration++;
+    this.activeRuntimeChatIdsRefreshInFlight = null;
+    if (this.activeRuntimeChatIdsRefreshTimer) {
+      clearTimeout(this.activeRuntimeChatIdsRefreshTimer);
+      this.activeRuntimeChatIdsRefreshTimer = null;
+    }
     this.agentConfigCache?.updateSdk(sdk);
     this.sessionManager?.updateTransport(sdk, this.agentConfigCache ?? undefined);
+  }
+
+  private persistRuntimeSessionToken(token: string | undefined): void {
+    try {
+      if (!token) {
+        rmSync(this.runtimeSessionTokenFile, { force: true });
+        return;
+      }
+      mkdirSync(dirname(this.runtimeSessionTokenFile), { recursive: true, mode: 0o700 });
+      writeFileSync(this.runtimeSessionTokenFile, `${token}\n`, { encoding: "utf8", mode: 0o600 });
+      chmodSync(this.runtimeSessionTokenFile, 0o600);
+    } catch (err) {
+      this.logger.warn({ err }, "failed to persist runtime session token");
+    }
   }
 
   async stop(reason?: string, opts: AgentSlotStopOptions = {}): Promise<void> {
@@ -490,6 +515,7 @@ export class AgentSlot {
       firstError ??= err;
       this.logger.warn({ err }, "failed to shut down sessions while stopping");
     }
+    this.persistRuntimeSessionToken(undefined);
     this.sessionManager = null;
     this.agentConfigCache = null;
     this.sdk = null;
@@ -527,6 +553,7 @@ export class AgentSlot {
       }
     }
     await this.sessionManager?.shutdown();
+    this.persistRuntimeSessionToken(undefined);
     this.sessionManager = null;
     this.agentConfigCache = null;
     this.sdk = null;

--- a/packages/client/src/runtime/agent-slot.ts
+++ b/packages/client/src/runtime/agent-slot.ts
@@ -9,7 +9,7 @@ import type {
 } from "@first-tree/shared";
 import { runtimeProviderSchema } from "@first-tree/shared";
 import { defaultDataDir } from "@first-tree/shared/config";
-import type { ClientConnection, SessionReconcileResult } from "../client-connection.js";
+import type { BoundAgent, ClientConnection, SessionReconcileResult } from "../client-connection.js";
 import { createLogger, type pino } from "../observability/logger.js";
 import type { FirstTreeHubSDK, RegisterResult } from "../sdk.js";
 import { type AgentConfigCache, createAgentConfigCache } from "./agent-config-cache.js";
@@ -88,7 +88,7 @@ export type AgentSlotStopOptions = {
 
 type ConnectionListener =
   | { event: "inbox:deliver"; fn: (inboxId: string, frame: InboxDeliverFrame) => void }
-  | { event: "agent:bound"; fn: (agent: { agentId: string }) => void }
+  | { event: "agent:bound"; fn: (agent: BoundAgent) => void }
   | { event: "agent:unbound"; fn: (agentId: string, reason?: string) => void }
   | {
       event: "session:command";
@@ -188,8 +188,9 @@ export class AgentSlot {
         this.logger.warn({ err, entryId: frame.entryId }, "inbox:deliver dispatch error");
       });
     };
-    const onBound = (boundAgent: { agentId: string }) => {
+    const onBound = (boundAgent: BoundAgent) => {
       if (boundAgent.agentId === this.config.agentId) {
+        if (boundAgent.sdk) this.adoptRuntimeTransport(boundAgent.sdk);
         if (typeof this.sessionManager?.noteBindRecoveryComplete === "function") {
           this.sessionManager.noteBindRecoveryComplete();
         }
@@ -239,7 +240,7 @@ export class AgentSlot {
       const bound = await this.clientConnection.bindAgent(this.config.agentId, runtimeType, this.config.runtimeVersion);
       bindSucceeded = true;
       const sdk = bound.sdk;
-      this.sdk = sdk;
+      this.adoptRuntimeTransport(sdk);
       this.activeRuntimeChatIdsRefreshGeneration++;
       const agent = await sdk.register();
 
@@ -251,6 +252,7 @@ export class AgentSlot {
       }
 
       this.agentConfigCache = createAgentConfigCache({ sdk, log: this.logger });
+      this.adoptRuntimeTransport(sdk);
       const cfg = await this.loadAgentConfigWithRetry(agent.agentId);
       this.logger.info({ version: cfg.version }, "runtime config loaded");
 
@@ -438,6 +440,12 @@ export class AgentSlot {
         if (signal?.aborted) throw new Error("agent config fetch aborted — slot stopping");
       }
     }
+  }
+
+  private adoptRuntimeTransport(sdk: FirstTreeHubSDK): void {
+    this.sdk = sdk;
+    this.agentConfigCache?.updateSdk(sdk);
+    this.sessionManager?.updateTransport(sdk, this.agentConfigCache ?? undefined);
   }
 
   async stop(reason?: string, opts: AgentSlotStopOptions = {}): Promise<void> {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -475,6 +475,13 @@ export class SessionManager {
     this.loadPersistedSessions();
   }
 
+  updateTransport(sdk: FirstTreeHubSDK, agentConfigCache?: AgentConfigCache): void {
+    this.config.sdk = sdk;
+    if (agentConfigCache) {
+      this.config.agentConfigCache = agentConfigCache;
+    }
+  }
+
   /**
    * Dispatch an inbox entry. ACK is deferred until the handler reports a
    * completed turn via `ctx.finishTurn(...)`.
@@ -2095,6 +2102,7 @@ export class SessionManager {
 
   private buildSessionContext(chatId: string): SessionContext {
     const sessionLog = this.config.log.child({ chatId });
+    const currentSdk = () => this.config.sdk;
     // Runtime-facing string log (handler + result-sink expect a simple
     // `(msg: string) => void` signature). The child pino logger still goes
     // to other places that want structured fields.
@@ -2105,7 +2113,7 @@ export class SessionManager {
     // calls hit memory. v1 §四 改造 4 removed result-sink's dependency on
     // this cache (the trigger-sender mention branch is gone), so the cache
     // now flows only into the inbound-formatter path.
-    const participants = createParticipantCache(this.config.sdk, chatId, log);
+    const participants = createParticipantCache(currentSdk, chatId, log);
 
     // Cross-agent doc preview: `workspaceRoot` is `<workspaces>/<agentSlug>`
     // (see agent-slot.ts), so the shared common root is its parent and this
@@ -2146,7 +2154,14 @@ export class SessionManager {
     });
 
     const envCtx = {
-      sdk: this.config.sdk,
+      sdk: {
+        get serverUrl() {
+          return currentSdk().serverUrl;
+        },
+        get runtimeSessionToken() {
+          return currentSdk().runtimeSessionToken;
+        },
+      },
       agent: this.config.agentIdentity,
       chatId,
       clientId: typeof this.config.handlerConfig.clientId === "string" ? this.config.handlerConfig.clientId : undefined,
@@ -2166,7 +2181,9 @@ export class SessionManager {
 
     return {
       agent: this.config.agentIdentity,
-      sdk: this.config.sdk,
+      get sdk() {
+        return currentSdk();
+      },
       log,
       chatId,
       recordProviderActivity: () => {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -296,6 +296,8 @@ type SessionManagerConfig = {
   registryPath?: string;
   /** Step 4: optional config cache for refresh-before-dispatch on configVersion bump. */
   agentConfigCache?: AgentConfigCache;
+  /** Stable file path updated on every runtime-session rebind for long-lived child CLI calls. */
+  runtimeSessionTokenFile?: string;
   /**
    * Ack channel used by `dispatch` when an entry transitions out of `delivered`.
    * Wired to `clientConnection.sendInboxAck` so the entry is acked over the
@@ -2165,6 +2167,7 @@ export class SessionManager {
       agent: this.config.agentIdentity,
       chatId,
       clientId: typeof this.config.handlerConfig.clientId === "string" ? this.config.handlerConfig.clientId : undefined,
+      runtimeSessionTokenFile: this.config.runtimeSessionTokenFile,
       provider:
         typeof this.config.handlerConfig.runtimeProvider === "string"
           ? this.config.handlerConfig.runtimeProvider


### PR DESCRIPTION
## Summary
- Refresh AgentSlot runtime SDK after agent:bound so reconnect rebinds adopt the new runtime session token.
- Propagate replacement SDK into AgentConfigCache, SessionManager, SessionContext, envCtx, and participant cache.
- Add regression coverage for rebind and lazy SDK resolution paths.

## Root cause
After a WebSocket reconnect/rebind, ClientConnection produced a new FirstTreeHubSDK with a new runtimeSessionToken, but existing AgentSlot services kept the old SDK. Agent-scoped HTTP calls then sent a stale x-agent-runtime-session, which showed up locally as Invalid agent runtime session for first-tree-staging.

## Validation
- ./node_modules/.bin/vitest run src/__tests__/agent-config-cache.test.ts src/__tests__/agent-io.test.ts src/__tests__/agent-slot.test.ts src/__tests__/session-manager.test.ts src/__tests__/session-manager-edge-coverage.test.ts --passWithNoTests
- ../../node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/biome check packages/client/src/runtime/agent-config-cache.ts packages/client/src/runtime/agent-io.ts packages/client/src/runtime/session-manager.ts packages/client/src/runtime/agent-slot.ts packages/client/src/__tests__/agent-config-cache.test.ts packages/client/src/__tests__/agent-io.test.ts packages/client/src/__tests__/agent-slot.test.ts packages/client/src/__tests__/session-manager.test.ts packages/client/src/__tests__/session-manager-edge-coverage.test.ts
- PATH=/opt/homebrew/bin:$PATH corepack pnpm typecheck

## Notes
- Full corepack pnpm check is currently blocked by an existing nested Biome config under .claude/worktrees/wizardly-williams-e41b30/biome.json, unrelated to this branch.