### PR TITLE
fix: stable keyset pagination for document lists

### DIFF
--- a/packages/server/src/__tests__/documents.test.ts
+++ b/packages/server/src/__tests__/documents.test.ts
@@ -154,6 +154,52 @@ describe("documents API", () => {
       expect(missing.statusCode).toBe(404);
     });
 
+    it("paginates stably across identical updatedAt timestamps", async () => {
+      const app = getApp();
+      const ctx = await createAdminContext(app);
+      const { docDocuments } = await import("../db/schema/index.js");
+
+      // Bulk-import shape: several documents sharing one exact timestamp. A
+      // timestamp-only cursor drops the tied rows at a page boundary.
+      const sameInstant = new Date("2026-07-05T12:00:00.123Z");
+      const tiedSlugs = Array.from({ length: 3 }, (_, i) => slug(`tied-${i}`));
+      for (const s of tiedSlugs) {
+        await app.db.insert(docDocuments).values({
+          id: uuidv7(),
+          organizationId: ctx.organizationId,
+          slug: s,
+          title: s,
+          status: "draft",
+          latestVersion: 1,
+          createdByKind: "human",
+          createdById: ctx.humanAgentUuid,
+          createdByName: "Test Admin",
+          createdAt: sameInstant,
+          updatedAt: sameInstant,
+        });
+      }
+
+      const req = humanRequest(app, ctx.accessToken);
+      const seen: string[] = [];
+      let cursor: string | null = null;
+      for (let i = 0; i < 100; i++) {
+        const url: string = `/api/v1/orgs/${ctx.organizationId}/documents?limit=1${
+          cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""
+        }`;
+        const page = await req("GET", url);
+        expect(page.statusCode).toBe(200);
+        for (const item of page.json().items) {
+          if (tiedSlugs.includes(item.slug)) seen.push(item.slug);
+        }
+        cursor = page.json().nextCursor;
+        if (cursor === null) break;
+      }
+
+      // Every tied document surfaces exactly once across the full walk.
+      expect([...seen].sort()).toEqual([...tiedSlugs].sort());
+      expect(new Set(seen).size).toBe(tiedSlugs.length);
+    });
+
     it("serializes concurrent first publishes of one slug", async () => {
       const app = getApp();
       const ctx = await createAdminContext(app);

--- a/packages/server/src/services/document.ts
+++ b/packages/server/src/services/document.ts
@@ -11,7 +11,7 @@ import type {
   PublishDocResponse,
 } from "@first-tree/shared";
 import { docCommentStatusSchema, docStatusSchema, locateDocAnchors } from "@first-tree/shared";
-import { and, asc, desc, eq, isNull, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { docComments, docDocuments, docVersions } from "../db/schema/index.js";
 import { BadRequestError, NotFoundError } from "../errors.js";
@@ -278,6 +278,23 @@ export async function getDocumentWithVersion(
   };
 }
 
+/**
+ * Keyset cursor: `<updatedAt ISO>|<id>`. The id tie-breaker keeps pagination
+ * stable when several documents share one `updated_at` (e.g. a bulk import) —
+ * a timestamp-only cursor silently drops same-timestamp rows at a page
+ * boundary, which would break `doc export`'s completeness guarantee.
+ */
+function parseDocListCursor(cursor: string): { date: Date; id: string } {
+  const separator = cursor.lastIndexOf("|");
+  const iso = separator === -1 ? cursor : cursor.slice(0, separator);
+  const id = separator === -1 ? "" : cursor.slice(separator + 1);
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime()) || id.length === 0) {
+    throw new BadRequestError("cursor must be the nextCursor value from a previous page");
+  }
+  return { date, id };
+}
+
 export async function listDocuments(
   db: Database,
   organizationId: string,
@@ -288,11 +305,18 @@ export async function listDocuments(
   if (query.project) conditions.push(eq(docDocuments.project, query.project));
   if (query.status) conditions.push(eq(docDocuments.status, query.status));
   if (query.cursor) {
-    const cursorDate = new Date(query.cursor);
-    if (Number.isNaN(cursorDate.getTime())) {
-      throw new BadRequestError("cursor must be an ISO timestamp from a previous page");
-    }
-    conditions.push(lt(docDocuments.updatedAt, cursorDate));
+    const { date, id } = parseDocListCursor(query.cursor);
+    // Row-wise tuple comparison, with updated_at truncated to milliseconds on
+    // the database side: Postgres stores microseconds but a JS Date (and the
+    // ISO cursor) carries only milliseconds, so comparing raw column values
+    // against the round-tripped cursor would skip rows sharing the cursor's
+    // millisecond. Truncation makes the equality leg of the tuple comparison
+    // exact, and the id leg breaks the tie deterministically.
+    // Raw-fragment params bypass drizzle's column mapping, so the Date must
+    // go over the wire as an ISO string with an explicit cast.
+    conditions.push(
+      sql`(date_trunc('milliseconds', ${docDocuments.updatedAt}), ${docDocuments.id}) < (${date.toISOString()}::timestamptz, ${id}::text)`,
+    );
   }
 
   const rows = await db
@@ -307,7 +331,7 @@ export async function listDocuments(
     })
     .from(docDocuments)
     .where(and(...conditions))
-    .orderBy(desc(docDocuments.updatedAt))
+    .orderBy(desc(docDocuments.updatedAt), desc(docDocuments.id))
     .limit(query.limit + 1);
 
   const hasMore = rows.length > query.limit;
@@ -315,7 +339,7 @@ export async function listDocuments(
   const last = page[page.length - 1];
   return {
     items: page.map(({ doc, openComments }) => toSummary(doc, openComments)),
-    nextCursor: hasMore && last ? last.doc.updatedAt.toISOString() : null,
+    nextCursor: hasMore && last ? `${last.doc.updatedAt.toISOString()}|${last.doc.id}` : null,
   };
 }
 

--- a/packages/shared/src/schemas/document.ts
+++ b/packages/shared/src/schemas/document.ts
@@ -157,7 +157,7 @@ export const listDocsQuerySchema = z.object({
   project: z.string().optional(),
   status: docStatusSchema.optional(),
   limit: z.coerce.number().int().min(1).max(200).optional().default(50),
-  /** Opaque cursor — the `updatedAt` ISO timestamp of the previous page's last item. */
+  /** Opaque keyset cursor — pass a previous page's `nextCursor` verbatim. */
   cursor: z.string().optional(),
 });
 export type ListDocsQuery = z.infer<typeof listDocsQuerySchema>;


### PR DESCRIPTION
Fixes the blocking data-correctness issue @yuezengwu found on #1434: the document-list cursor was `updated_at` alone, so documents sharing one timestamp (exactly the bulk-import shape) were silently dropped at page boundaries — and `doc export` depends on this loop for its completeness guarantee.

- Cursor is now `<updatedAt ISO>|<id>`; ordering is `(updated_at DESC, id DESC)`; the page condition is a row-wise tuple comparison.
- `updated_at` is **millisecond-truncated database-side** for the comparison: Postgres stores microseconds while the JS Date / ISO cursor only carries milliseconds, so comparing raw column values against the round-tripped cursor would ALSO skip rows inside the cursor's millisecond — the tie-breaker only works if the equality leg is exact.
- Regression test: three documents seeded with one identical `updated_at`, walked with `limit=1`; every document surfaces exactly once (17/17 suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)