### PR TITLE
fix: order document lists by the cursor's own key expression

### DIFF
--- a/packages/server/src/__tests__/documents.test.ts
+++ b/packages/server/src/__tests__/documents.test.ts
@@ -200,6 +200,61 @@ describe("documents API", () => {
       expect(new Set(seen).size).toBe(tiedSlugs.length);
     });
 
+    it("paginates stably across microsecond differences within one millisecond", async () => {
+      const app = getApp();
+      const ctx = await createAdminContext(app);
+      const { docDocuments } = await import("../db/schema/index.js");
+      const { sql, eq: eqOp } = await import("drizzle-orm");
+
+      // Postgres keeps microseconds; the cursor only carries milliseconds.
+      // Give the LARGER (later) uuidv7 id to the row with the SMALLER
+      // microsecond part, so id order contradicts raw-timestamp order —
+      // the exact shape that exposed the predicate/ordering mismatch.
+      const idA = uuidv7();
+      const idB = uuidv7();
+      const seeds = [
+        { id: idA, slug: slug("us-high"), ts: "2026-07-05T15:00:00.123900Z" },
+        { id: idB, slug: slug("us-low"), ts: "2026-07-05T15:00:00.123800Z" },
+      ];
+      for (const seed of seeds) {
+        await app.db.insert(docDocuments).values({
+          id: seed.id,
+          organizationId: ctx.organizationId,
+          slug: seed.slug,
+          title: seed.slug,
+          status: "draft",
+          latestVersion: 1,
+          createdByKind: "human",
+          createdById: ctx.humanAgentUuid,
+          createdByName: "Test Admin",
+        });
+        await app.db
+          .update(docDocuments)
+          .set({ updatedAt: sql`${seed.ts}::timestamptz` })
+          .where(eqOp(docDocuments.id, seed.id));
+      }
+
+      const req = humanRequest(app, ctx.accessToken);
+      const wanted = seeds.map((s) => s.slug);
+      const seen: string[] = [];
+      let cursor: string | null = null;
+      for (let i = 0; i < 100; i++) {
+        const url: string = `/api/v1/orgs/${ctx.organizationId}/documents?limit=1${
+          cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""
+        }`;
+        const page = await req("GET", url);
+        expect(page.statusCode).toBe(200);
+        for (const item of page.json().items) {
+          if (wanted.includes(item.slug)) seen.push(item.slug);
+        }
+        cursor = page.json().nextCursor;
+        if (cursor === null) break;
+      }
+
+      expect([...seen].sort()).toEqual([...wanted].sort());
+      expect(new Set(seen).size).toBe(wanted.length);
+    });
+
     it("serializes concurrent first publishes of one slug", async () => {
       const app = getApp();
       const ctx = await createAdminContext(app);

--- a/packages/server/src/services/document.ts
+++ b/packages/server/src/services/document.ts
@@ -331,7 +331,12 @@ export async function listDocuments(
     })
     .from(docDocuments)
     .where(and(...conditions))
-    .orderBy(desc(docDocuments.updatedAt), desc(docDocuments.id))
+    // The sort key MUST be the same expression the cursor predicate compares
+    // (millisecond-truncated), or rows inside one millisecond are ordered by
+    // raw microseconds on page N and paged by truncated values on page N+1 —
+    // which can exclude them entirely. Team-scale lists don't need an index
+    // on the truncated expression yet.
+    .orderBy(sql`date_trunc('milliseconds', ${docDocuments.updatedAt}) DESC`, desc(docDocuments.id))
     .limit(query.limit + 1);
 
   const hasMore = rows.length > query.limit;


### PR DESCRIPTION
Follow-up to @yuezengwu's second review on #1434: the page predicate compared millisecond-truncated tuples but ORDER BY still used raw microsecond timestamps — inside one millisecond, page N's order and page N+1's predicate disagreed, and the adversarial shape (higher-µs row carrying the smaller id) dropped its sibling.

- ORDER BY now uses the exact predicate expression: `date_trunc('milliseconds', updated_at) DESC, id DESC`.
- Regression test per the review: two documents 100µs apart inside one millisecond, ids contradicting timestamp order, walked with `limit=1` — **verified to fail against the previous ordering** and pass with the fix (suite 18/18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)