### PR TITLE
fix(server): preserve landing trial runtime sessions

### DIFF
--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -16,6 +16,7 @@ import { organizations } from "../db/schema/organizations.js";
 import { resources } from "../db/schema/resources.js";
 import { users } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
+import { bindAgentRuntimeSession, validateAgentRuntimeSession } from "../services/agent-runtime-session.js";
 import { signTokensForUser } from "../services/auth.js";
 import { createMember } from "../services/member.js";
 import { sendMessage } from "../services/message.js";
@@ -398,6 +399,42 @@ describe("POST /me/landing-campaigns/start", () => {
     const thirdMessages = await app.db.select().from(messages).where(eq(messages.chatId, thirdBody.chatId));
     expect(firstMessages).toHaveLength(1);
     expect(thirdMessages).toHaveLength(1);
+  });
+
+  it("preserves runtime session metadata when reusing the trial agent for a new repo", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+
+    const first = await startProductionScan(app, admin);
+    expect(first.statusCode).toBe(200);
+    const firstBody = first.json<{ agentUuid: string }>();
+    const runtimeSessionToken = await bindAgentRuntimeSession(app.db, firstBody.agentUuid, OFFICIAL_CLIENT_ID);
+    expect(
+      await validateAgentRuntimeSession(app.db, firstBody.agentUuid, OFFICIAL_CLIENT_ID, runtimeSessionToken),
+    ).toBe(true);
+
+    const second = await startProductionScan(app, admin, "https://github.com/acme/api");
+
+    expect(second.statusCode).toBe(200);
+    const secondBody = second.json<{ agentUuid: string; repoCanonicalKey: string }>();
+    expect(secondBody.agentUuid).toBe(firstBody.agentUuid);
+    expect(secondBody.repoCanonicalKey).toBe("github.com/acme/api");
+    expect(
+      await validateAgentRuntimeSession(app.db, firstBody.agentUuid, OFFICIAL_CLIENT_ID, runtimeSessionToken),
+    ).toBe(true);
+    const [trialAgent] = await app.db.select().from(agents).where(eq(agents.uuid, firstBody.agentUuid)).limit(1);
+    expect(parseLandingCampaignTrialAgentMetadata(trialAgent?.metadata)).toMatchObject({
+      landingCampaignTrial: true,
+      campaign: "production-scan",
+      repo: { canonicalKey: "github.com/acme/api" },
+    });
+    const runtimeSession = (trialAgent?.metadata as Record<string, unknown> | undefined)?.runtimeSession;
+    expect(runtimeSession).toMatchObject({
+      clientId: OFFICIAL_CLIENT_ID,
+      boundAt: expect.any(String),
+      tokenHash: expect.any(String),
+    });
   });
 
   it("serializes concurrent starts for the same campaign and repo into one trial agent and chat", async () => {

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -72,7 +72,8 @@ export function stripReservedAgentMetadata(metadata: unknown): Record<string, un
   return publicMetadata;
 }
 
-function userMetadataUpdateExpression(metadata: Record<string, unknown>) {
+// Callers provide public metadata; internal runtime state is copied from the existing row.
+export function agentMetadataUpdateExpressionPreservingRuntimeState(metadata: Record<string, unknown>) {
   return sql`${JSON.stringify(metadata)}::jsonb || jsonb_strip_nulls(jsonb_build_object(
     'runtimeSwitch', ${agents.metadata}->'runtimeSwitch',
     'runtimeSession', ${agents.metadata}->'runtimeSession'
@@ -1066,7 +1067,7 @@ export async function updateAgent(db: Database, uuid: string, data: UpdateAgent)
   if (data.visibility !== undefined) updates.visibility = data.visibility;
   if (data.metadata !== undefined) {
     assertUserAgentMetadataHasNoReservedKeys(data.metadata);
-    (updates as Record<string, unknown>).metadata = userMetadataUpdateExpression(data.metadata);
+    (updates as Record<string, unknown>).metadata = agentMetadataUpdateExpressionPreservingRuntimeState(data.metadata);
   }
   // Explicit null clears the override (renderer falls back to djb2 hash).
   // Omitting the field leaves the column untouched.

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -24,7 +24,7 @@ import {
   ServiceUnavailableError,
 } from "../../errors.js";
 import { uuidv7 } from "../../uuid.js";
-import { createAgent, legacyWireAgentType } from "../agent.js";
+import { agentMetadataUpdateExpressionPreservingRuntimeState, createAgent, legacyWireAgentType } from "../agent.js";
 import { pickDefaultMembership } from "../auth.js";
 import { createChat } from "../chat.js";
 import { sendToClient } from "../connection-manager.js";
@@ -286,7 +286,7 @@ async function ensureTrialAgent(
       .set({
         visibility: "organization",
         displayName: input.skillSet.agentDisplayName,
-        metadata,
+        metadata: agentMetadataUpdateExpressionPreservingRuntimeState(metadata),
         updatedAt: new Date(),
       })
       .where(eq(agents.uuid, existing.uuid))


### PR DESCRIPTION
## Summary
- Preserve internal agent runtime metadata when landing campaigns reuse an existing trial agent.
- Reuse the existing agent metadata merge expression so landing campaign metadata can refresh without deleting `runtimeSession` or `runtimeSwitch`.
- Add a regression test that binds a runtime session, reuses the trial agent for a new repo, and verifies the original runtime token remains valid.

## Root Cause
`ensureTrialAgent` rebuilt and overwrote `agents.metadata` for existing landing campaign trial agents. That removed the runtime session binding written by `bindAgentRuntimeSession`, causing the official runtime to later fail agent config/session requests with `Invalid agent runtime session`.

## Verification
- `VITEST_MAX_FORKS=2 pnpm --dir packages/server exec vitest run src/__tests__/landing-campaigns-start.test.ts`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/services/agent.ts packages/server/src/services/landing-campaigns/start.ts packages/server/src/__tests__/landing-campaigns-start.test.ts`
- Also ran `VITEST_MAX_FORKS=2 pnpm --filter @first-tree/server test -- landing-campaigns-start.test.ts`; due script argument forwarding this executed the full server suite: 178 files / 1717 tests passed.

Reviewed in First Tree by `codex-reviewer`: no blocking issues found.
