### PR TITLE
fix(client): preserve Codex auth for landing trials

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "coverage": "vitest run --coverage --testTimeout=10000 --passWithNoTests",
-    "smoke:codex-sandbox": "node scripts/codex-sandbox-smoke.mjs"
+    "smoke:codex-sandbox": "node scripts/codex-sandbox-smoke.mjs",
+    "smoke:landing-codex-auth-sandbox": "RUN_CODEX_LANDING_APP_SERVER_SMOKE=1 vitest run --passWithNoTests --maxWorkers=1 --minWorkers=1 src/__tests__/codex-landing-app-server-smoke.test.ts"
   },
   "engines": {
     "node": ">=22.13.0"

--- a/packages/client/src/__tests__/codex-app-server-client.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-client.test.ts
@@ -40,6 +40,29 @@ function makeChild(exitOnSignals: readonly NodeJS.Signals[] = []) {
 }
 
 describe("CodexAppServerClient lifecycle", () => {
+  it("passes app-server config args to the spawned Codex process", async () => {
+    const { child, signals, stdout } = makeChild(["SIGTERM"]);
+    let capturedArgs: readonly string[] | null = null;
+    const startPromise = CodexAppServerClient.start({
+      binary: "/tmp/fake-codex",
+      requestTimeoutMs: RESPONSE_OK_TIMEOUT_MS,
+      appServerArgs: ["-c", 'permissions={"first-tree-landing-trial" = {}}'],
+      spawnProcess: (_command, args) => {
+        capturedArgs = args;
+        return child;
+      },
+    });
+    setImmediate(() => {
+      stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
+    });
+
+    const client = await startPromise;
+    await client.shutdown();
+
+    expect(capturedArgs).toEqual(["app-server", "--stdio", "-c", 'permissions={"first-tree-landing-trial" = {}}']);
+    expect(signals).toEqual(["SIGTERM"]);
+  });
+
   it("cleans up the child process when initialize times out", async () => {
     const { child, signals } = makeChild(["SIGTERM"]);
     const onClose = vi.fn();

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -434,19 +434,26 @@ afterEach(() => {
 });
 
 describe("codex app-server handler", () => {
-  it("wraps landing campaign trial app-server startup in workspace-only sandbox mode", async () => {
+  it("starts landing campaign trial app-server with host Codex auth and managed workspace-only permissions", async () => {
+    const hostHome = join(workspaceRoot, "..", "host-home");
+    const codexHome = join(hostHome, ".codex");
     const firstTreeHome = join(workspaceRoot, "first-tree-home");
     const cliBinDir = join(workspaceRoot, "first-tree-cli-bin");
     mkdirSync(cliBinDir, { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
     writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
+    vi.stubEnv("HOME", hostHome);
     vi.stubEnv("FIRST_TREE_HOME", firstTreeHome);
     vi.stubEnv("FIRST_TREE_CLI_BIN_DIR", cliBinDir);
     vi.stubEnv("OPENAI_API_KEY", "secret-openai");
+    vi.stubEnv("CODEX_API_KEY", "secret-codex");
     vi.stubEnv("GITHUB_TOKEN", "secret-github");
+    vi.stubEnv("FIRST_TREE_RUNTIME_SESSION_TOKEN", "runtime-session-token");
 
     const fake = new FakeAppServerClient();
     let capturedSpawnProcess: unknown;
     let capturedEnv: NodeJS.ProcessEnv | undefined;
+    let capturedAppServerArgs: readonly string[] | undefined;
     const createAgentOutboxToken = vi
       .fn<(chatId: string) => Promise<{ accessToken: string; expiresIn: number }>>()
       .mockResolvedValue({ accessToken: "trial-outbox-token", expiresIn: 900 });
@@ -454,11 +461,13 @@ describe("codex app-server handler", () => {
       codexAppServerClientFactory: async (options: {
         env?: NodeJS.ProcessEnv;
         spawnProcess?: unknown;
+        appServerArgs?: readonly string[];
         onNotification?: NotificationHandler;
         onClose?: CloseHandler;
       }) => {
         capturedSpawnProcess = options.spawnProcess;
         capturedEnv = options.env;
+        capturedAppServerArgs = options.appServerArgs;
         fake.onNotification = options.onNotification ?? null;
         fake.onClose = options.onClose ?? null;
         return fake;
@@ -481,14 +490,45 @@ describe("codex app-server handler", () => {
     const startPromise = handler.start(makeMessage("m1", "first"), ctx);
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
-    expect(typeof capturedSpawnProcess).toBe("function");
+    expect(capturedSpawnProcess).toBeUndefined();
+    expect(capturedAppServerArgs?.[0]).toBe("-c");
+    expect(capturedAppServerArgs?.[1]).toContain("permissions=");
+    expect(capturedAppServerArgs?.[1]).toContain("first-tree-landing-trial");
+    expect(capturedAppServerArgs?.[1]).toContain(codexHome);
+    expect(capturedAppServerArgs?.[1]).toContain(workspaceRoot);
     expect(createAgentOutboxToken).toHaveBeenCalledWith("chat-app-server");
     expect(capturedEnv?.FIRST_TREE_HOME).toBe(join(workspaceRoot, ".first-tree-workspace", "outbox-home"));
+    expect(capturedEnv?.HOME).toBe(workspaceRoot);
+    expect(capturedEnv?.CODEX_HOME).toBe(codexHome);
     expect(capturedEnv?.PATH?.split(":")[0]).toBe(cliBinDir);
     expect(capturedEnv?.OPENAI_API_KEY).toBeUndefined();
+    expect(capturedEnv?.CODEX_API_KEY).toBeUndefined();
     expect(capturedEnv?.GITHUB_TOKEN).toBeUndefined();
+    expect(capturedEnv?.FIRST_TREE_RUNTIME_SESSION_TOKEN).toBeUndefined();
     const threadStart = fake.requests.find((request) => request.method === "thread/start");
-    expect(threadStart?.params).toMatchObject({ sandbox: "workspace-write" });
+    const threadStartParams = threadStart?.params as Record<string, unknown> | undefined;
+    expect(threadStartParams).toMatchObject({
+      permissions: "first-tree-landing-trial",
+      runtimeWorkspaceRoots: [workspaceRoot],
+    });
+    expect(threadStartParams?.sandbox).toBeUndefined();
+    expect(threadStartParams?.config).toMatchObject({
+      permissions: {
+        "first-tree-landing-trial": {
+          workspace_roots: {
+            [workspaceRoot]: true,
+          },
+          filesystem: {
+            ":minimal": "read",
+            [workspaceRoot]: "write",
+            [codexHome]: "deny",
+          },
+          network: {
+            enabled: true,
+          },
+        },
+      },
+    });
 
     completeTurn(fake, "turn-1", "final answer");
     await startPromise;
@@ -498,13 +538,16 @@ describe("codex app-server handler", () => {
   it("leaves ordinary app-server startup unsandboxed", async () => {
     const fake = new FakeAppServerClient();
     let capturedSpawnProcess: unknown = "unset";
+    let capturedAppServerArgs: readonly string[] | undefined;
     const handler = makeHandler(fake, {
       codexAppServerClientFactory: async (options: {
         spawnProcess?: unknown;
+        appServerArgs?: readonly string[];
         onNotification?: NotificationHandler;
         onClose?: CloseHandler;
       }) => {
         capturedSpawnProcess = options.spawnProcess;
+        capturedAppServerArgs = options.appServerArgs;
         fake.onNotification = options.onNotification ?? null;
         fake.onClose = options.onClose ?? null;
         return fake;
@@ -516,8 +559,10 @@ describe("codex app-server handler", () => {
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     expect(capturedSpawnProcess).toBeUndefined();
+    expect(capturedAppServerArgs).toBeUndefined();
     const threadStart = fake.requests.find((request) => request.method === "thread/start");
     expect(threadStart?.params).toMatchObject({ sandbox: "danger-full-access" });
+    expect((threadStart?.params as Record<string, unknown> | undefined)?.permissions).toBeUndefined();
 
     completeTurn(fake, "turn-1", "final answer");
     await startPromise;

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -491,11 +491,14 @@ describe("codex app-server handler", () => {
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     expect(capturedSpawnProcess).toBeUndefined();
+    expect(capturedAppServerArgs).toHaveLength(4);
     expect(capturedAppServerArgs?.[0]).toBe("-c");
     expect(capturedAppServerArgs?.[1]).toContain("permissions=");
     expect(capturedAppServerArgs?.[1]).toContain("first-tree-landing-trial");
     expect(capturedAppServerArgs?.[1]).toContain(codexHome);
     expect(capturedAppServerArgs?.[1]).toContain(workspaceRoot);
+    expect(capturedAppServerArgs?.[2]).toBe("-c");
+    expect(capturedAppServerArgs?.[3]).toBe('default_permissions="first-tree-landing-trial"');
     expect(createAgentOutboxToken).toHaveBeenCalledWith("chat-app-server");
     expect(capturedEnv?.FIRST_TREE_HOME).toBe(join(workspaceRoot, ".first-tree-workspace", "outbox-home"));
     expect(capturedEnv?.HOME).toBe(workspaceRoot);

--- a/packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts
+++ b/packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts
@@ -5,8 +5,8 @@ import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CodexAppServerClient, type CodexAppServerNotification } from "../handlers/codex/app-server/client.js";
 import {
+  buildLandingCodexAppServerArgs,
   buildLandingCodexPermissionProfile,
-  buildLandingCodexPermissionsConfigOverride,
   buildWorkspaceOnlyAppServerEnvironment,
   LANDING_CODEX_PERMISSIONS_PROFILE,
 } from "../handlers/codex/app-server/workspace-sandbox.js";
@@ -159,6 +159,75 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
     }
   });
 
+  it("starts command execution with a clean Codex config", async () => {
+    const codexBinary = resolveBinary("CODEX_SMOKE_BINARY", "codex");
+    const codexVersion = commandOutput(`${shellQuote(codexBinary)} --version || true`);
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-landing-codex-clean-smoke-")));
+    tempRoots.push(root);
+    const workspace = join(root, "workspace");
+    const outside = join(root, "outside");
+    const codexHome = join(root, "clean-codex-home");
+    const firstTreeHome = join(workspace, FIRST_TREE_WORKSPACE_MARKER, "outbox-home");
+    mkdirSync(firstTreeHome, { recursive: true });
+    mkdirSync(outside);
+    mkdirSync(codexHome);
+    const outsideSentinel = join(outside, "sentinel.txt");
+    writeFileSync(outsideSentinel, "outside-secret\n", { mode: 0o600 });
+
+    const cliPath = resolveCliPath();
+    setCliBinding({ binName: basename(cliPath), packageName: basename(cliPath) });
+
+    const appServerEnvironment = buildWorkspaceOnlyAppServerEnvironment(
+      {
+        ...process.env,
+        CODEX_HOME: codexHome,
+        FIRST_TREE_HOME: firstTreeHome,
+        FIRST_TREE_CLI_BIN_DIR: dirname(cliPath),
+      },
+      workspace,
+    );
+    const client = await CodexAppServerClient.start({
+      binary: codexBinary,
+      cwd: workspace,
+      env: appServerEnvironment.env,
+      appServerArgs: buildLandingCodexAppServerArgs(workspace, appServerEnvironment.codexHome),
+      requestTimeoutMs: 120_000,
+    });
+
+    try {
+      console.log(`[smoke] clean-config codex binary: ${codexBinary}`);
+      console.log(`[smoke] clean-config codex version: ${codexVersion}`);
+      console.log(`[smoke] clean-config CODEX_HOME  : ${appServerEnvironment.codexHome}`);
+
+      const commandResult = await client.request(
+        "command/exec",
+        {
+          command: [
+            "sh",
+            "-lc",
+            [
+              `if cat ${shellQuote(outsideSentinel)} >/dev/null 2>&1; then echo outside=readable; else echo outside=denied; fi`,
+              'printf ok > clean-config-smoke.txt && cat clean-config-smoke.txt && printf "\\n"',
+            ].join("\n"),
+          ],
+          cwd: ".",
+          permissionProfile: LANDING_CODEX_PERMISSIONS_PROFILE,
+          timeoutMs: 20_000,
+          outputBytesCap: 65_536,
+        },
+        60_000,
+      );
+
+      const stdout = commandStdout(commandResult);
+      console.log(`[smoke] clean-config command stdout:\n${stdout}`);
+      expect(commandExitCode(commandResult)).toBe(0);
+      expect(stdout).toContain("outside=denied");
+      expect(stdout).toMatch(/^ok$/m);
+    } finally {
+      await client.shutdown();
+    }
+  }, 120_000);
+
   it("uses host Codex auth while command execution stays workspace-only", async () => {
     const codexBinary = resolveBinary("CODEX_SMOKE_BINARY", "codex");
     const codexVersion = commandOutput(`${shellQuote(codexBinary)} --version || true`);
@@ -202,13 +271,12 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
     );
 
     const permissionProfile = buildLandingCodexPermissionProfile(workspace, appServerEnvironment.codexHome);
-    const permissionsOverride = buildLandingCodexPermissionsConfigOverride(workspace, appServerEnvironment.codexHome);
     const recorder = createNotificationRecorder();
     const client = await CodexAppServerClient.start({
       binary: codexBinary,
       cwd: workspace,
       env: appServerEnvironment.env,
-      appServerArgs: ["-c", permissionsOverride],
+      appServerArgs: buildLandingCodexAppServerArgs(workspace, appServerEnvironment.codexHome),
       requestTimeoutMs: 120_000,
       onNotification: recorder.onNotification,
     });

--- a/packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts
+++ b/packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts
@@ -1,0 +1,313 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CodexAppServerClient, type CodexAppServerNotification } from "../handlers/codex/app-server/client.js";
+import {
+  buildLandingCodexPermissionProfile,
+  buildLandingCodexPermissionsConfigOverride,
+  buildWorkspaceOnlyAppServerEnvironment,
+  LANDING_CODEX_PERMISSIONS_PROFILE,
+} from "../handlers/codex/app-server/workspace-sandbox.js";
+import { FIRST_TREE_WORKSPACE_MARKER } from "../runtime/bootstrap.js";
+import { setCliBinding } from "../runtime/cli-binding.js";
+
+const RUN_SMOKE = process.env.RUN_CODEX_LANDING_APP_SERVER_SMOKE === "1";
+const PROVIDER_CHECK_ENABLED = process.env.SKIP_CODEX_LANDING_PROVIDER_SMOKE !== "1";
+const describeSmoke = RUN_SMOKE ? describe : describe.skip;
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : null;
+}
+
+function commandOutput(command: string): string {
+  return execFileSync("sh", ["-lc", command], { encoding: "utf8" }).trim();
+}
+
+function resolveBinary(envName: string, fallbackCommand: string): string {
+  const explicit = process.env[envName]?.trim();
+  if (explicit) return explicit;
+  return commandOutput(`command -v ${fallbackCommand}`);
+}
+
+function resolveCliPath(): string {
+  const explicit = process.env.FIRST_TREE_SMOKE_CLI?.trim();
+  if (explicit) return explicit;
+  return commandOutput("command -v first-tree-staging || command -v first-tree");
+}
+
+function hostCodexHome(): string {
+  const raw = process.env.CODEX_HOME?.trim();
+  if (raw) return isAbsolute(raw) ? raw : resolve(homedir(), raw);
+  return join(homedir(), ".codex");
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function readTurnId(value: unknown): string | null {
+  const record = asRecord(value);
+  if (!record) return null;
+  const direct = record.turnId ?? record.turn_id;
+  if (typeof direct === "string") return direct;
+  const turn = asRecord(record.turn);
+  if (!turn) return null;
+  const nested = turn.id ?? turn.turnId ?? turn.turn_id;
+  return typeof nested === "string" ? nested : null;
+}
+
+function commandExitCode(value: unknown): number {
+  const record = asRecord(value);
+  const code = record?.exitCode ?? record?.exit_code;
+  return typeof code === "number" ? code : NaN;
+}
+
+function commandStdout(value: unknown): string {
+  const record = asRecord(value);
+  return typeof record?.stdout === "string" ? record.stdout : "";
+}
+
+function commandStderr(value: unknown): string {
+  const record = asRecord(value);
+  return typeof record?.stderr === "string" ? record.stderr : "";
+}
+
+function createNotificationRecorder() {
+  const notifications: CodexAppServerNotification[] = [];
+  const waiters = new Set<{
+    predicate: (notification: CodexAppServerNotification) => boolean;
+    resolve: (notification: CodexAppServerNotification) => void;
+    reject: (err: Error) => void;
+  }>();
+
+  return {
+    notifications,
+    onNotification(notification: CodexAppServerNotification): void {
+      notifications.push(notification);
+      for (const waiter of waiters) {
+        let matched = false;
+        try {
+          matched = waiter.predicate(notification);
+        } catch (err) {
+          waiters.delete(waiter);
+          waiter.reject(err instanceof Error ? err : new Error(String(err)));
+          continue;
+        }
+        if (!matched) continue;
+        waiters.delete(waiter);
+        waiter.resolve(notification);
+      }
+    },
+    waitFor(
+      predicate: (notification: CodexAppServerNotification) => boolean,
+      label: string,
+      timeoutMs = 180_000,
+    ): Promise<CodexAppServerNotification> {
+      const existing = notifications.find((notification) => {
+        try {
+          return predicate(notification);
+        } catch {
+          return false;
+        }
+      });
+      if (existing) return Promise.resolve(existing);
+      return new Promise((resolveWaiter, reject) => {
+        const waiter = {
+          predicate,
+          resolve: (notification: CodexAppServerNotification) => {
+            clearTimeout(timer);
+            resolveWaiter(notification);
+          },
+          reject: (err: Error) => {
+            clearTimeout(timer);
+            reject(err);
+          },
+        };
+        const timer = setTimeout(() => {
+          waiters.delete(waiter);
+          reject(new Error(`timed out waiting for ${label}`));
+        }, timeoutMs);
+        waiters.add(waiter);
+      });
+    },
+  };
+}
+
+async function waitForTurnCompleted(
+  recorder: ReturnType<typeof createNotificationRecorder>,
+  turnId: string,
+): Promise<void> {
+  await recorder.waitFor((notification) => {
+    const notificationTurnId = readTurnId(notification.params);
+    if (notification.method === "turn/failed" && (!notificationTurnId || notificationTurnId === turnId)) {
+      throw new Error(`turn failed: ${JSON.stringify(notification.params)}`);
+    }
+    return notification.method === "turn/completed" && (!notificationTurnId || notificationTurnId === turnId);
+  }, `turn/completed for ${turnId}`);
+}
+
+describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(() => {
+    for (const tempRoot of tempRoots.splice(0)) {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("uses host Codex auth while command execution stays workspace-only", async () => {
+    const codexBinary = resolveBinary("CODEX_SMOKE_BINARY", "codex");
+    const codexVersion = commandOutput(`${shellQuote(codexBinary)} --version || true`);
+    const codexHome = hostCodexHome();
+    const authPath = join(codexHome, "auth.json");
+    if (!existsSync(authPath)) {
+      throw new Error(`Codex auth smoke requires ${authPath} to exist`);
+    }
+
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-landing-codex-smoke-")));
+    tempRoots.push(root);
+    const workspace = join(root, "workspace");
+    const outside = join(root, "outside");
+    const firstTreeHome = join(workspace, FIRST_TREE_WORKSPACE_MARKER, "outbox-home");
+    mkdirSync(firstTreeHome, { recursive: true });
+    mkdirSync(outside);
+    const outsideSentinel = join(outside, "sentinel.txt");
+    writeFileSync(outsideSentinel, "outside-secret\n", { mode: 0o600 });
+
+    const cliPath = resolveCliPath();
+    setCliBinding({ binName: basename(cliPath), packageName: basename(cliPath) });
+
+    const appServerEnvironment = buildWorkspaceOnlyAppServerEnvironment(
+      {
+        ...process.env,
+        CODEX_HOME: codexHome,
+        FIRST_TREE_HOME: firstTreeHome,
+        FIRST_TREE_CLI_BIN_DIR: dirname(cliPath),
+        OPENAI_API_KEY: "smoke-openai-secret",
+        CODEX_API_KEY: "smoke-codex-secret",
+        GITHUB_TOKEN: "smoke-github-secret",
+        GH_TOKEN: "smoke-gh-secret",
+        FIRST_TREE_RUNTIME_SESSION_TOKEN: "smoke-runtime-secret",
+        FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE: join(outside, "runtime-token"),
+        HTTP_PROXY: "http://user:password@proxy.test:8080",
+        HTTPS_PROXY: "http://user:password@proxy.test:8080",
+        SSL_CERT_FILE: join(outside, "ca.pem"),
+        NODE_EXTRA_CA_CERTS: join(outside, "node-ca.pem"),
+      },
+      workspace,
+    );
+
+    const permissionProfile = buildLandingCodexPermissionProfile(workspace, appServerEnvironment.codexHome);
+    const permissionsOverride = buildLandingCodexPermissionsConfigOverride(workspace, appServerEnvironment.codexHome);
+    const recorder = createNotificationRecorder();
+    const client = await CodexAppServerClient.start({
+      binary: codexBinary,
+      cwd: workspace,
+      env: appServerEnvironment.env,
+      appServerArgs: ["-c", permissionsOverride],
+      requestTimeoutMs: 120_000,
+      onNotification: recorder.onNotification,
+    });
+
+    try {
+      console.log(`[smoke] codex binary: ${codexBinary}`);
+      console.log(`[smoke] codex version: ${codexVersion}`);
+      console.log(`[smoke] workspace   : ${workspace}`);
+      console.log(`[smoke] CODEX_HOME  : ${appServerEnvironment.codexHome}`);
+
+      const commandScript = [
+        'printf "codex_auth="',
+        'if cat "$CODEX_HOME/auth.json" >/dev/null 2>&1; then echo readable; else echo denied; fi',
+        `printf "outside="`,
+        `if cat ${shellQuote(outsideSentinel)} >/dev/null 2>&1; then echo readable; else echo denied; fi`,
+        'printf "workspace_write="',
+        'printf ok > workspace-smoke.txt && cat workspace-smoke.txt && printf "\\n"',
+        'printf "leaked_env="',
+        [
+          "env",
+          "|",
+          "awk -F= '/^(OPENAI_API_KEY|CODEX_API_KEY|GITHUB_TOKEN|GH_TOKEN|FIRST_TREE_RUNTIME_SESSION_TOKEN|FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE|HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY|http_proxy|https_proxy|all_proxy|no_proxy|SSL_CERT_FILE|SSL_CERT_DIR|NODE_EXTRA_CA_CERTS|REQUESTS_CA_BUNDLE|CURL_CA_BUNDLE)=/ {print $1}'",
+          "|",
+          "sort",
+          "|",
+          "paste -sd, -",
+        ].join(" "),
+      ].join("\n");
+
+      const commandResult = await client.request(
+        "command/exec",
+        {
+          command: ["sh", "-lc", commandScript],
+          cwd: ".",
+          permissionProfile: LANDING_CODEX_PERMISSIONS_PROFILE,
+          timeoutMs: 20_000,
+          outputBytesCap: 65_536,
+        },
+        60_000,
+      );
+
+      const stdout = commandStdout(commandResult);
+      console.log(`[smoke] command stdout:\n${stdout}`);
+      const stderr = commandStderr(commandResult);
+      if (stderr.trim()) console.log(`[smoke] command stderr:\n${stderr}`);
+
+      expect(commandExitCode(commandResult)).toBe(0);
+      expect(stdout).toContain("codex_auth=denied");
+      expect(stdout).toContain("outside=denied");
+      expect(stdout).toContain("workspace_write=ok");
+      expect(stdout).toMatch(/^leaked_env=$/m);
+
+      if (PROVIDER_CHECK_ENABLED) {
+        const threadStart = await client.request(
+          "thread/start",
+          {
+            cwd: workspace,
+            approvalPolicy: "never",
+            permissions: LANDING_CODEX_PERMISSIONS_PROFILE,
+            runtimeWorkspaceRoots: [workspace],
+            config: {
+              project_root_markers: [FIRST_TREE_WORKSPACE_MARKER],
+              permissions: {
+                [LANDING_CODEX_PERMISSIONS_PROFILE]: permissionProfile,
+              },
+            },
+            sessionStartSource: "startup",
+          },
+          120_000,
+        );
+        const thread = asRecord(asRecord(threadStart)?.thread);
+        const threadId = typeof thread?.id === "string" ? thread.id : null;
+        expect(threadId).toBeTruthy();
+
+        const turnStart = await client.request(
+          "turn/start",
+          {
+            threadId,
+            clientUserMessageId: "landing-codex-auth-smoke",
+            input: [
+              {
+                type: "text",
+                text: 'Reply exactly "LANDING_CODEX_AUTH_OK" and do not run any commands.',
+              },
+            ],
+            cwd: workspace,
+            approvalPolicy: "never",
+            permissions: LANDING_CODEX_PERMISSIONS_PROFILE,
+            runtimeWorkspaceRoots: [workspace],
+          },
+          120_000,
+        );
+        const turnId = readTurnId(turnStart);
+        expect(turnId).toBeTruthy();
+        await waitForTurnCompleted(recorder, turnId ?? "");
+        console.log(`[smoke] provider turn completed: ${turnId}`);
+      }
+    } finally {
+      await client.shutdown();
+    }
+  }, 300_000);
+});

--- a/packages/client/src/__tests__/codex-thread-options.test.ts
+++ b/packages/client/src/__tests__/codex-thread-options.test.ts
@@ -63,12 +63,6 @@ describe("buildCodexThreadOptions", () => {
     );
   });
 
-  it("uses codex workspace-write only when the caller already wrapped the process workspace-only", () => {
-    const opts = buildCodexThreadOptions(basePayload(), "/tmp/wsk", { workspaceOnly: true });
-
-    expect(opts.sandboxMode).toBe("workspace-write");
-  });
-
   it("derives additionalDirectories from gitRepos (with deriveRepoLocalPath fallback)", () => {
     const opts = buildCodexThreadOptions(
       basePayload({

--- a/packages/client/src/__tests__/workspace-sandbox.test.ts
+++ b/packages/client/src/__tests__/workspace-sandbox.test.ts
@@ -13,9 +13,12 @@ import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   assertPathInsideWorkspace,
+  buildLandingCodexAppServerArgs,
+  buildLandingCodexPermissionsConfigOverride,
   buildWorkspaceOnlyAppServerEnvironment,
   buildWorkspaceOnlyBubblewrapArgs,
   buildWorkspaceOnlyEnvironment,
+  LANDING_CODEX_PERMISSIONS_PROFILE,
   prepareWorkspaceOnlyOutboxHome,
 } from "../handlers/codex/app-server/workspace-sandbox.js";
 import { setCliBinding } from "../runtime/cli-binding.js";
@@ -219,6 +222,18 @@ describe("workspace-only sandbox", () => {
     expect(env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE).toBeUndefined();
     expect(env.FIRST_TREE_DOC_BASE).toBeUndefined();
     expect(env.FIRST_TREE_WORKSPACES_ROOT).toBeUndefined();
+  });
+
+  it("builds landing Codex app-server args with a default permissions profile", () => {
+    const codexHome = join(root, "host-home", ".codex");
+    mkdirSync(codexHome, { recursive: true });
+
+    expect(buildLandingCodexAppServerArgs(workspace, codexHome)).toEqual([
+      "-c",
+      buildLandingCodexPermissionsConfigOverride(workspace, codexHome),
+      "-c",
+      `default_permissions=${JSON.stringify(LANDING_CODEX_PERMISSIONS_PROFILE)}`,
+    ]);
   });
 
   it("does not add an extra read-only bind for an explicit CLI dir covered by system mounts", () => {

--- a/packages/client/src/__tests__/workspace-sandbox.test.ts
+++ b/packages/client/src/__tests__/workspace-sandbox.test.ts
@@ -13,6 +13,7 @@ import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   assertPathInsideWorkspace,
+  buildWorkspaceOnlyAppServerEnvironment,
   buildWorkspaceOnlyBubblewrapArgs,
   buildWorkspaceOnlyEnvironment,
   prepareWorkspaceOnlyOutboxHome,
@@ -161,6 +162,63 @@ describe("workspace-only sandbox", () => {
     expect(env.PATH?.split(delimiter)[0]).toBe(cliBinDir);
     expect(env.PATH).not.toContain("/sensitive/bin");
     expect(readOnlyPaths).toEqual([cliBinDir]);
+  });
+
+  it("builds a landing app-server env that keeps Codex auth location without leaking host secrets", () => {
+    const hostHome = join(root, "host-home");
+    const codexHome = join(hostHome, ".codex");
+    const firstTreeHome = join(workspace, ".first-tree-workspace", "outbox-home");
+    const cliBinDir = join(root, "explicit-cli-bin");
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(firstTreeHome, { recursive: true });
+    mkdirSync(cliBinDir, { recursive: true });
+    writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
+
+    const { env, codexHome: resolvedCodexHome } = buildWorkspaceOnlyAppServerEnvironment(
+      {
+        HOME: hostHome,
+        FIRST_TREE_HOME: firstTreeHome,
+        FIRST_TREE_CLI_BIN_DIR: cliBinDir,
+        FIRST_TREE_SERVER_URL: "https://first-tree.test",
+        FIRST_TREE_AGENT_ID: "agent-1",
+        FIRST_TREE_RUNTIME_SESSION_TOKEN: "runtime-secret",
+        FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE: "/host/runtime-token",
+        FIRST_TREE_DOC_BASE: outside,
+        FIRST_TREE_WORKSPACES_ROOT: root,
+        OPENAI_API_KEY: "openai-secret",
+        CODEX_API_KEY: "codex-secret",
+        GITHUB_TOKEN: "github-secret",
+        HTTP_PROXY: "http://user:password@proxy.test:8080",
+        HTTPS_PROXY: "http://user:password@proxy.test:8080",
+        SSL_CERT_FILE: join(outside, "ca.pem"),
+        NODE_EXTRA_CA_CERTS: join(outside, "node-ca.pem"),
+        PATH: "/sensitive/bin:/usr/bin",
+      },
+      workspace,
+    );
+
+    expect(resolvedCodexHome).toBe(codexHome);
+    expect(env).toMatchObject({
+      FIRST_TREE_HOME: firstTreeHome,
+      FIRST_TREE_SERVER_URL: "https://first-tree.test",
+      FIRST_TREE_AGENT_ID: "agent-1",
+      HOME: workspace,
+      CODEX_HOME: codexHome,
+      TMPDIR: "/tmp",
+    });
+    expect(env.PATH?.split(delimiter)[0]).toBe(cliBinDir);
+    expect(env.PATH).not.toContain("/sensitive/bin");
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.CODEX_API_KEY).toBeUndefined();
+    expect(env.GITHUB_TOKEN).toBeUndefined();
+    expect(env.HTTP_PROXY).toBeUndefined();
+    expect(env.HTTPS_PROXY).toBeUndefined();
+    expect(env.SSL_CERT_FILE).toBeUndefined();
+    expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
+    expect(env.FIRST_TREE_RUNTIME_SESSION_TOKEN).toBeUndefined();
+    expect(env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE).toBeUndefined();
+    expect(env.FIRST_TREE_DOC_BASE).toBeUndefined();
+    expect(env.FIRST_TREE_WORKSPACES_ROOT).toBeUndefined();
   });
 
   it("does not add an extra read-only bind for an explicit CLI dir covered by system mounts", () => {

--- a/packages/client/src/handlers/codex/app-server/client.ts
+++ b/packages/client/src/handlers/codex/app-server/client.ts
@@ -36,6 +36,7 @@ export type CodexAppServerClientOptions = {
   binary: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  appServerArgs?: readonly string[];
   requestTimeoutMs?: number;
   spawnProcess?: SpawnProcess;
   onNotification?: (notification: CodexAppServerNotification) => void;
@@ -91,7 +92,7 @@ export class CodexAppServerClient {
 
   private constructor(options: Required<Pick<CodexAppServerClientOptions, "binary">> & CodexAppServerClientOptions) {
     const spawnProcess = options.spawnProcess ?? spawn;
-    this.child = spawnProcess(options.binary, ["app-server", "--stdio"], {
+    this.child = spawnProcess(options.binary, ["app-server", "--stdio", ...(options.appServerArgs ?? [])], {
       cwd: options.cwd,
       env: options.env,
       stdio: ["pipe", "pipe", "pipe"],

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -64,8 +64,10 @@ import {
   isCodexAppServerTransientError,
 } from "./client.js";
 import {
-  buildWorkspaceOnlyEnvironment,
-  createWorkspaceOnlySpawnProcess,
+  buildLandingCodexPermissionProfile,
+  buildLandingCodexPermissionsConfigOverride,
+  buildWorkspaceOnlyAppServerEnvironment,
+  LANDING_CODEX_PERMISSIONS_PROFILE,
   prepareWorkspaceOnlyOutboxHome,
 } from "./workspace-sandbox.js";
 
@@ -151,7 +153,6 @@ const CODEX_CONTEXT_WINDOW_FAILURE_MESSAGE =
   "Start a new thread or clear earlier history before retrying.";
 const CODEX_COMPACT_FAILURE_MESSAGE =
   "Codex failed to compact this thread before answering. Start a new thread or clear earlier history before retrying.";
-
 export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfig): AgentHandler => {
   const workspaceRoot = config.workspaceRoot as string;
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
@@ -182,6 +183,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   let latestThreadUsageTotal: TokenUsageBreakdown | null = null;
   let latestCurrentSessionUsageTurnId: string | null = null;
   let workspaceOnly = false;
+  let workspaceOnlyCodexHome: string | null = null;
 
   const pendingInputs: QueueEntry[] = [];
   const pendingNotificationsByTurn = new Map<string, CodexAppServerNotification[]>();
@@ -309,6 +311,18 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     return cfg;
   }
 
+  function buildLandingCodexConfig(payload: AgentRuntimeConfigPayload, workspacePath: string): CodexConfigObject {
+    const codexHome = workspaceOnlyCodexHome;
+    if (!codexHome) {
+      throw new CodexAppServerStartupError("workspace-sandbox", "missing workspace-only Codex home");
+    }
+    const cfg = buildCodexConfig(payload);
+    cfg.permissions = {
+      [LANDING_CODEX_PERMISSIONS_PROFILE]: buildLandingCodexPermissionProfile(workspacePath, codexHome),
+    };
+    return cfg;
+  }
+
   function buildBriefing(sessionCtx: SessionContext, payload: AgentRuntimeConfigPayload, workspaceCwd: string): string {
     return buildAgentBriefing({
       identity: sessionCtx.agent,
@@ -394,7 +408,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     let env = buildEnv(sessionCtx);
     if (workspaceOnly) {
       const { accessToken } = await sessionCtx.sdk.createAgentOutboxToken(sessionCtx.chatId);
-      env = prepareWorkspaceOnlyOutboxHome({
+      const outboxEnv = prepareWorkspaceOnlyOutboxHome({
         parentEnv: env,
         workspaceRoot: cwd,
         agentId: sessionCtx.agent.agentId,
@@ -402,41 +416,38 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         accessToken,
         serverUrl: env.FIRST_TREE_SERVER_URL ?? sessionCtx.sdk.serverUrl,
       }).env;
+      try {
+        const appServerEnv = buildWorkspaceOnlyAppServerEnvironment(outboxEnv, cwd);
+        env = appServerEnv.env;
+        workspaceOnlyCodexHome = appServerEnv.codexHome;
+      } catch (err) {
+        throw new CodexAppServerStartupError("workspace-sandbox", err);
+      }
+    } else {
+      workspaceOnlyCodexHome = null;
     }
     return { payload, env, briefingFingerprint: computeBriefingFingerprint(briefing) };
   }
 
   async function startAppServer(sessionCtx: SessionContext, env: NodeJS.ProcessEnv): Promise<void> {
     const workspacePath = cwd ?? workspaceRoot;
-    let workspaceSandbox: ReturnType<typeof buildWorkspaceOnlyEnvironment> | null = null;
-    if (workspaceOnly) {
-      try {
-        workspaceSandbox = buildWorkspaceOnlyEnvironment(env, workspacePath);
-      } catch (err) {
-        throw new CodexAppServerStartupError("workspace-sandbox", err);
-      }
-    }
-    const appServerEnv = workspaceSandbox?.env ?? env;
     let resolution: CodexBinaryResolution;
     try {
-      resolution = await resolveRuntimeBinary(appServerEnv);
+      resolution = await resolveRuntimeBinary(env);
     } catch (err) {
       throw new CodexAppServerStartupError("resolve-binary", err);
     }
     if (!resolution.ok) throw new CodexAppServerStartupError("resolve-binary", resolution.error);
     try {
+      const appServerArgs =
+        workspaceOnly && workspaceOnlyCodexHome
+          ? ["-c", buildLandingCodexPermissionsConfigOverride(workspacePath, workspaceOnlyCodexHome)]
+          : undefined;
       appServer = await clientFactory({
         binary: resolution.binary,
         cwd: workspacePath,
-        env: appServerEnv,
-        ...(workspaceOnly
-          ? {
-              spawnProcess: createWorkspaceOnlySpawnProcess({
-                workspaceRoot: workspacePath,
-                readOnlyPaths: workspaceSandbox?.readOnlyPaths,
-              }),
-            }
-          : {}),
+        env,
+        ...(appServerArgs ? { appServerArgs } : {}),
         onNotification: handleNotification,
         onClose: handleTransportClose,
         onLog: (message) => sessionCtx.log(message),
@@ -447,14 +458,21 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   }
 
   function threadParams(payload: AgentRuntimeConfigPayload): JsonRecord {
-    const opts = buildCodexThreadOptions(payload, cwd ?? workspaceRoot, { workspaceOnly });
-    return {
+    const workspacePath = cwd ?? workspaceRoot;
+    const opts = buildCodexThreadOptions(payload, workspacePath);
+    const params: JsonRecord = {
       cwd: opts.workingDirectory,
       approvalPolicy: opts.approvalPolicy,
-      sandbox: opts.sandboxMode,
-      config: buildCodexConfig(payload),
+      config: workspaceOnly ? buildLandingCodexConfig(payload, workspacePath) : buildCodexConfig(payload),
       ...(opts.model ? { model: opts.model } : {}),
     };
+    if (workspaceOnly) {
+      params.permissions = LANDING_CODEX_PERMISSIONS_PROFILE;
+      params.runtimeWorkspaceRoots = [workspacePath];
+    } else {
+      params.sandbox = opts.sandboxMode;
+    }
+    return params;
   }
 
   async function startThread(payload: AgentRuntimeConfigPayload): Promise<string> {
@@ -1650,6 +1668,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       appServer = null;
       pendingChatContextPrompt = null;
       workspaceOnly = false;
+      workspaceOnlyCodexHome = null;
       resetThreadUsageTracking(null);
     },
 
@@ -1669,6 +1688,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       ctx = null;
       pendingChatContextPrompt = null;
       workspaceOnly = false;
+      workspaceOnlyCodexHome = null;
       resetThreadUsageTracking(null);
     },
   } satisfies AgentHandler;

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -64,8 +64,8 @@ import {
   isCodexAppServerTransientError,
 } from "./client.js";
 import {
+  buildLandingCodexAppServerArgs,
   buildLandingCodexPermissionProfile,
-  buildLandingCodexPermissionsConfigOverride,
   buildWorkspaceOnlyAppServerEnvironment,
   LANDING_CODEX_PERMISSIONS_PROFILE,
   prepareWorkspaceOnlyOutboxHome,
@@ -441,7 +441,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     try {
       const appServerArgs =
         workspaceOnly && workspaceOnlyCodexHome
-          ? ["-c", buildLandingCodexPermissionsConfigOverride(workspacePath, workspaceOnlyCodexHome)]
+          ? buildLandingCodexAppServerArgs(workspacePath, workspaceOnlyCodexHome)
           : undefined;
       appServer = await clientFactory({
         binary: resolution.binary,

--- a/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
+++ b/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
@@ -264,6 +264,15 @@ export function buildLandingCodexPermissionsConfigOverride(workspacePath: string
   })}`;
 }
 
+export function buildLandingCodexAppServerArgs(workspacePath: string, codexHome: string): string[] {
+  return [
+    "-c",
+    buildLandingCodexPermissionsConfigOverride(workspacePath, codexHome),
+    "-c",
+    `default_permissions=${JSON.stringify(LANDING_CODEX_PERMISSIONS_PROFILE)}`,
+  ];
+}
+
 function resolveWorkspaceOnlyCli(parentEnv: NodeJS.ProcessEnv): WorkspaceOnlyCliResolution {
   const defaultPathDirs = uniqueExistingDirs(WORKSPACE_ONLY_PATH_DIRS);
   const explicit = parentEnv.FIRST_TREE_CLI_BIN_DIR;

--- a/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
+++ b/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { accessSync, constants, existsSync, mkdirSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { delimiter, dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { getCliBinding } from "../../../runtime/cli-binding.js";
 import type { SpawnProcess } from "./client.js";
@@ -22,6 +23,26 @@ type WorkspaceOnlySpawnOptions = {
 type WorkspaceOnlyEnvironment = {
   env: NodeJS.ProcessEnv;
   readOnlyPaths: string[];
+};
+
+type WorkspaceOnlyAppServerEnvironment = {
+  env: NodeJS.ProcessEnv;
+  codexHome: string;
+};
+
+type LandingCodexPermissionProfileConfig = {
+  description: string;
+  workspace_roots: Record<string, true>;
+  filesystem: Record<string, "read" | "write" | "deny">;
+  network: {
+    enabled: true;
+  };
+};
+
+type TomlInlinePrimitive = string | number | boolean;
+type TomlInlineValue = TomlInlinePrimitive | TomlInlineObject;
+type TomlInlineObject = {
+  [key: string]: TomlInlineValue;
 };
 
 type WorkspaceOnlyCliResolution = {
@@ -68,6 +89,22 @@ const SAFE_PASS_ENV_KEYS = new Set([
   "TERM",
   "TZ",
 ]);
+const WORKSPACE_ONLY_APP_SERVER_PASS_ENV_KEYS = new Set([
+  "FIRST_TREE_SERVER_URL",
+  "FIRST_TREE_AGENT_ID",
+  "FIRST_TREE_INBOX_ID",
+  "FIRST_TREE_CHAT_ID",
+  "FIRST_TREE_CLIENT_ID",
+  "FIRST_TREE_PROVIDER",
+  "FIRST_TREE_SWITCH_DRAIN_VERSION",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TERM",
+  "TZ",
+]);
+
+export const LANDING_CODEX_PERMISSIONS_PROFILE = "first-tree-landing-trial";
 
 function pathIsWithin(parent: string, child: string): boolean {
   return child === parent || child.startsWith(parent.endsWith(sep) ? parent : `${parent}${sep}`);
@@ -165,6 +202,66 @@ function validateChannelCliBin(binDir: string, source: string): void {
   } catch {
     throw new Error(`workspace-only sandbox ${source} must contain channel-local First Tree CLI at ${cliPath}`);
   }
+}
+
+function resolveHostCodexHome(parentEnv: NodeJS.ProcessEnv, workspaceRoot: string): string {
+  const rawCodexHome = parentEnv.CODEX_HOME?.trim();
+  const hostHome = parentEnv.HOME && parentEnv.HOME !== workspaceRoot ? parentEnv.HOME : homedir();
+  if (rawCodexHome) {
+    return isAbsolute(rawCodexHome) ? rawCodexHome : resolve(hostHome, rawCodexHome);
+  }
+  return join(hostHome, ".codex");
+}
+
+export function landingCodexDenyPaths(codexHome: string): string[] {
+  const paths = new Set([codexHome]);
+  if (existsSync(codexHome)) {
+    try {
+      paths.add(realpathSync(codexHome));
+    } catch {
+      // A lexical deny still blocks the configured Codex home.
+    }
+  }
+  return [...paths];
+}
+
+export function buildLandingCodexPermissionProfile(
+  workspacePath: string,
+  codexHome: string,
+): LandingCodexPermissionProfileConfig {
+  const filesystem: LandingCodexPermissionProfileConfig["filesystem"] = {
+    ":minimal": "read",
+    [workspacePath]: "write",
+  };
+  for (const path of landingCodexDenyPaths(codexHome)) {
+    filesystem[path] = "deny";
+  }
+
+  return {
+    description: "First Tree landing trial workspace-only profile",
+    workspace_roots: {
+      [workspacePath]: true,
+    },
+    filesystem,
+    network: {
+      enabled: true,
+    },
+  };
+}
+
+function tomlInline(value: TomlInlineValue): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number") return String(value);
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return `{ ${Object.entries(value)
+    .map(([key, child]) => `${JSON.stringify(key)} = ${tomlInline(child)}`)
+    .join(", ")} }`;
+}
+
+export function buildLandingCodexPermissionsConfigOverride(workspacePath: string, codexHome: string): string {
+  return `permissions=${tomlInline({
+    [LANDING_CODEX_PERMISSIONS_PROFILE]: buildLandingCodexPermissionProfile(workspacePath, codexHome),
+  })}`;
 }
 
 function resolveWorkspaceOnlyCli(parentEnv: NodeJS.ProcessEnv): WorkspaceOnlyCliResolution {
@@ -267,6 +364,33 @@ export function buildWorkspaceOnlyEnvironment(
   env.PATH = cli.pathDirs.join(delimiter);
 
   return { env, readOnlyPaths: cli.readOnlyPaths };
+}
+
+export function buildWorkspaceOnlyAppServerEnvironment(
+  parentEnv: NodeJS.ProcessEnv,
+  workspaceRoot: string,
+): WorkspaceOnlyAppServerEnvironment {
+  const realWorkspace = realpathExisting(workspaceRoot, "workspaceRoot");
+  const firstTreeHome = parentEnv.FIRST_TREE_HOME;
+  if (!firstTreeHome) {
+    throw new Error("workspace-only app-server requires FIRST_TREE_HOME for sandbox-local First Tree config");
+  }
+  const resolvedFirstTreeHome = assertPathInsideWorkspace(firstTreeHome, realWorkspace, "FIRST_TREE_HOME");
+  const cli = resolveWorkspaceOnlyCli(parentEnv);
+  const codexHome = resolveHostCodexHome(parentEnv, realWorkspace);
+
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of WORKSPACE_ONLY_APP_SERVER_PASS_ENV_KEYS) {
+    const value = parentEnv[key];
+    if (typeof value === "string") env[key] = value;
+  }
+  env.FIRST_TREE_HOME = resolvedFirstTreeHome;
+  env.HOME = realWorkspace;
+  env.CODEX_HOME = codexHome;
+  env.TMPDIR = "/tmp";
+  env.FIRST_TREE_CLI_BIN_DIR = cli.cliBinDir;
+  env.PATH = cli.pathDirs.join(delimiter);
+  return { env, codexHome };
 }
 
 export function buildWorkspaceOnlyBubblewrapArgs(options: BuildBubblewrapArgsOptions): string[] {

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -206,11 +206,7 @@ function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
  * can lock the auth-mode-friendly defaults (notably `model` only set when
  * the operator chose one).
  */
-export function buildCodexThreadOptions(
-  payload: AgentRuntimeConfigPayload,
-  workspaceCwd: string,
-  options: { workspaceOnly?: boolean } = {},
-): ThreadOptions {
+export function buildCodexThreadOptions(payload: AgentRuntimeConfigPayload, workspaceCwd: string): ThreadOptions {
   const additionalDirectories: string[] = [];
   for (const repo of payload.gitRepos) {
     const localPath = repo.localPath ?? deriveRepoLocalPath(repo.url);
@@ -229,13 +225,13 @@ export function buildCodexThreadOptions(
   // `gpt-5-codex` family, while API-key auth accepts it). Hard-coding a
   // default here would force one auth mode and silently fail on the other.
   // Sandbox: ordinary codex agents remain `danger-full-access` because codex is
-  // their primary local-execution surface. Landing campaign trials run inside a
-  // process-level workspace-only sandbox; use codex's own workspace-write mode
-  // there as a second, scoped belt without changing the ordinary path.
+  // their primary local-execution surface. Landing campaign trials are forced
+  // through the app-server handler, which supplies a custom managed permissions
+  // profile instead of this SDK-only legacy sandbox field.
   const opts: ThreadOptions = {
     workingDirectory: workspaceCwd,
     skipGitRepoCheck: true,
-    sandboxMode: options.workspaceOnly ? "workspace-write" : "danger-full-access",
+    sandboxMode: "danger-full-access",
     approvalPolicy: "never",
     // Operator-configured reasoning effort. Defaults to "high" (the value this
     // previously hard-coded). The codex variant's enum (low|medium|high|xhigh)


### PR DESCRIPTION
## Summary

- Let landing campaign Codex trial app-server processes keep host Codex auth by setting `CODEX_HOME` to the host Codex home while keeping `HOME` pointed at the trial workspace.
- Move the landing trial filesystem boundary to Codex managed permissions: the app-server starts with a `first-tree-landing-trial` profile (`:minimal` read, workspace write, host `CODEX_HOME` deny-read, network enabled), sets `default_permissions="first-tree-landing-trial"` for clean Codex configs, and thread start/resume selects that active profile.
- Scrub provider/API/GitHub/runtime token env vars, plus proxy/cert env vars, from the landing app-server environment.
- Add gated real app-server smoke coverage for both clean Codex config initialization and host-provider-auth workspace-only tool execution against a real Codex binary.

## Validation

- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1 src/__tests__/codex-app-server-client.test.ts src/__tests__/codex-app-server-handler.test.ts src/__tests__/workspace-sandbox.test.ts src/__tests__/codex-thread-options.test.ts src/__tests__/codex-landing-app-server-smoke.test.ts`
  - 58 passed, 2 skipped
- `pnpm --filter @first-tree/client smoke:landing-codex-auth-sandbox`
  - 2 passed
  - real binary: `/usr/local/bin/codex`, `codex-cli 0.142.5`
  - clean config smoke: temporary empty `CODEX_HOME`, app-server initialized, `outside=denied`, workspace write `ok`
  - host-auth smoke: `CODEX_HOME=/home/bai/.codex`, `codex_auth=denied`, `outside=denied`, `workspace_write=ok`, `leaked_env=`, provider turn completed
- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1`
  - 115 files passed, 1225 tests passed, gated smoke skipped
- `pnpm --filter @first-tree/client typecheck`
- `pnpm exec biome check packages/client/src/handlers/codex/app-server/workspace-sandbox.ts packages/client/src/handlers/codex/app-server/index.ts packages/client/src/__tests__/codex-app-server-handler.test.ts packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts packages/client/src/__tests__/workspace-sandbox.test.ts`
- `git diff --check`
- `pnpm check`
  - exit 0; existing unrelated warning/info only
- `pnpm typecheck`

## Deployment note

The real smoke was run with `codex-cli 0.142.5`. Official client machines need a Codex version with equivalent managed permissions behavior for the landing trial workspace-only boundary.

## Review

First Tree `codex-reviewer` reviewed the security boundary changes and the follow-up clean-config default permissions fix. No blocking issues found.
