### PR TITLE
chore(scan): tighten landing-campaign trial bootstrap copy

### DIFF
--- a/packages/server/src/services/landing-campaigns/skills/catalog.ts
+++ b/packages/server/src/services/landing-campaigns/skills/catalog.ts
@@ -341,12 +341,9 @@ export function getLandingCampaignSkillSet(campaign: string): LandingCampaignSki
 }
 
 export function buildLandingCampaignBootstrap(skillSet: LandingCampaignSkillSet, repoUrl: string): string {
-  const closing = `${skillSet.agentDisplayName} will get oriented and flag a few things worth tightening before you ship — or just tell it what you'd like to focus on.`;
   return [
-    `Welcome to First Tree — this is your first chat with ${skillSet.agentDisplayName}.`,
+    `Welcome to First Tree. ${skillSet.agentDisplayName} is connected to your code: ${repoUrl}`,
     "",
-    `It's connected to your code: ${repoUrl}`,
-    "",
-    closing,
+    "It's running a read-only production-readiness scan and will come back with a security-weighted score, the must-fix blockers, and one fix ready to apply.",
   ].join("\n");
 }

--- a/packages/server/src/services/landing-campaigns/skills/catalog.ts
+++ b/packages/server/src/services/landing-campaigns/skills/catalog.ts
@@ -344,6 +344,6 @@ export function buildLandingCampaignBootstrap(skillSet: LandingCampaignSkillSet,
   return [
     `Welcome to First Tree. ${skillSet.agentDisplayName} is connected to your code: ${repoUrl}`,
     "",
-    "It's running a read-only production-readiness scan and will come back with a security-weighted score, the must-fix blockers, and one fix ready to apply.",
+    "It's running a read-only production-readiness scan and will come back with a security-weighted score, any must-fix blockers, and — where there's a real fix worth making — one ready to apply.",
   ].join("\n");
 }


### PR DESCRIPTION
## What

Rewrites the production-scan trial chat's opening (bootstrap) message.

**Before**
```
Welcome to First Tree — this is your first chat with Production Scanner.

It's connected to your code: <repo>

Production Scanner will get oriented and flag a few things worth tightening before you ship — or just tell it what you'd like to focus on.
```

**After**
```
Welcome to First Tree. Production Scanner is connected to your code: <repo>

It's running a read-only production-readiness scan and will come back with a security-weighted score, the must-fix blockers, and one fix ready to apply.
```

## Why

- The old closing (`get oriented and flag a few things` + `tell it what you'd like to focus on`) was vague and invited user input — but the trial chat needs **no** user input at the start: the agent activates the scan skill and runs immediately, and the only user interaction is the ask-user card after the report. The new copy states plainly that a read-only scan is running and what the user will get back.
- Removes the redundant steering prompt; states the deliverable (score + blockers + one ready-to-apply fix), which also fills the wait while the scan runs.

## Scope / safety

- Copy-only change to `buildLandingCampaignBootstrap()`. **No skill-body change**: the message keeps the `connected to your code:` phrase (the scan skill's Step 0 references it to locate the repo URL) and the `production-readiness scan` wording (activation signal, reinforced by the chat topic `Production readiness scan`). No skill version bump needed.
- `pnpm biome check` + server `typecheck` clean; full server test suite green (`landing-campaigns-start` 26/26; suite 1719/1719).

🤖 Generated with [Claude Code](https://claude.com/claude-code)