### PR TITLE
fix(server): count confirmed landing trial turns

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -5,6 +5,7 @@ import type { SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexAppServerRpcError, CodexAppServerTransportError } from "../handlers/codex/app-server/client.js";
 import { createCodexAppServerHandler } from "../handlers/codex/app-server/index.js";
+import { LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED } from "../handlers/codex/turn-completion.js";
 import { writeAgentBriefing } from "../runtime/bootstrap.js";
 import { setCliBinding } from "../runtime/cli-binding.js";
 import type { DeliveryToken, SessionContext, SessionMessage } from "../runtime/handler.js";
@@ -624,17 +625,19 @@ describe("codex app-server handler", () => {
     await handler.shutdown();
   });
 
-  it("does not complete delivery when confirmed success turn_end is rejected", async () => {
+  it("leaves landing trial delivery recoverable when confirmed success turn_end is rejected", async () => {
     stubLandingTrialHostEnv("confirm-reject");
 
     const fake = new FakeAppServerClient();
     const token = makeDeliveryToken();
+    const failSessionForRecovery = vi.fn<NonNullable<SessionContext["failSessionForRecovery"]>>();
     const emitEventConfirmed = vi
       .fn<NonNullable<SessionContext["emitEventConfirmed"]>>()
       .mockRejectedValue(new Error("session event persist failed"));
     const handler = makeHandler(fake);
     const ctx = makeContext({
       emitEventConfirmed,
+      failSessionForRecovery,
       agentMetadata: trialAgentMetadata,
     });
     const message = makeMessage("m1", "first", 101);
@@ -643,14 +646,21 @@ describe("codex app-server handler", () => {
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
     completeTurn(fake, "turn-1", "final answer");
-    await expect(startPromise).rejects.toThrow("session event persist failed");
+    await expect(startPromise).resolves.toMatchObject({
+      sessionId: "thread-app-server",
+      route: { kind: "owned", mode: "processing" },
+    });
 
     expect(emitEventConfirmed).toHaveBeenCalledWith({
       kind: "turn_end",
       payload: { status: "success", turnCompletionId: "inbox:101" },
     });
     expect(token.complete).not.toHaveBeenCalled();
-    expect(token.retry).not.toHaveBeenCalled();
+    expect(token.retry).toHaveBeenCalledWith([message], LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED);
+    expect(failSessionForRecovery).toHaveBeenCalledWith(
+      LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED,
+      "thread-app-server",
+    );
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -168,8 +168,20 @@ class FakeAppServerClient {
 
 let workspaceRoot: string;
 
-function makeMessage(id: string, content: string): SessionMessage {
+const trialAgentMetadata = {
+  landingCampaignTrial: true,
+  campaign: "production-scan",
+  skillSetId: "production-scan",
+  skillSetVersion: "2026.07.02.1",
+  repo: {
+    url: "https://github.com/acme/backend",
+    canonicalKey: "github.com/acme/backend",
+  },
+};
+
+function makeMessage(id: string, content: string, inboxEntryId?: number): SessionMessage {
   return {
+    ...(inboxEntryId !== undefined ? { inboxEntryId } : {}),
     id,
     chatId: "chat-app-server",
     senderId: "sender-1",
@@ -189,6 +201,7 @@ function makeContext(
     retryTurn?: SessionContext["retryTurn"];
     failSessionForRecovery?: SessionContext["failSessionForRecovery"];
     emitEvent?: SessionContext["emitEvent"];
+    emitEventConfirmed?: SessionContext["emitEventConfirmed"];
     formatInboundContent?: SessionContext["formatInboundContent"];
     sendMessage?: ReturnType<typeof vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>>;
     createAgentOutboxToken?: ReturnType<
@@ -221,6 +234,7 @@ function makeContext(
     log: () => {},
     recordProviderActivity: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
+    ...(opts.emitEventConfirmed ? { emitEventConfirmed: opts.emitEventConfirmed } : {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-app-server"),
     ...(opts.finishTurn ? { finishTurn: opts.finishTurn } : {}),
     ...(opts.retryTurn ? { retryTurn: opts.retryTurn } : {}),
@@ -423,6 +437,17 @@ function activeTurnNotSteerableError(): CodexAppServerRpcError {
   });
 }
 
+function stubLandingTrialHostEnv(suffix: string): void {
+  const hostHome = join(workspaceRoot, "..", `host-home-${suffix}`);
+  const codexHome = join(hostHome, ".codex");
+  const cliBinDir = join(workspaceRoot, `first-tree-cli-bin-${suffix}`);
+  mkdirSync(cliBinDir, { recursive: true });
+  mkdirSync(codexHome, { recursive: true });
+  writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
+  vi.stubEnv("HOME", hostHome);
+  vi.stubEnv("FIRST_TREE_CLI_BIN_DIR", cliBinDir);
+}
+
 beforeEach(() => {
   workspaceRoot = realpathSync(mkdtempSync(join(tmpdir(), "ft-codex-app-server-")));
   setCliBinding({ binName: "first-tree-test", packageName: null });
@@ -457,6 +482,7 @@ describe("codex app-server handler", () => {
     const createAgentOutboxToken = vi
       .fn<(chatId: string) => Promise<{ accessToken: string; expiresIn: number }>>()
       .mockResolvedValue({ accessToken: "trial-outbox-token", expiresIn: 900 });
+    const emitEventConfirmed = vi.fn<NonNullable<SessionContext["emitEventConfirmed"]>>().mockResolvedValue();
     const handler = makeHandler(fake, {
       codexAppServerClientFactory: async (options: {
         env?: NodeJS.ProcessEnv;
@@ -475,16 +501,8 @@ describe("codex app-server handler", () => {
     });
     const ctx = makeContext({
       createAgentOutboxToken,
-      agentMetadata: {
-        landingCampaignTrial: true,
-        campaign: "production-scan",
-        skillSetId: "production-scan",
-        skillSetVersion: "2026.07.02.1",
-        repo: {
-          url: "https://github.com/acme/backend",
-          canonicalKey: "github.com/acme/backend",
-        },
-      },
+      emitEventConfirmed,
+      agentMetadata: trialAgentMetadata,
     });
 
     const startPromise = handler.start(makeMessage("m1", "first"), ctx);
@@ -535,6 +553,10 @@ describe("codex app-server handler", () => {
 
     completeTurn(fake, "turn-1", "final answer");
     await startPromise;
+    expect(emitEventConfirmed).toHaveBeenCalledWith({
+      kind: "turn_end",
+      payload: { status: "success", turnCompletionId: "message:m1" },
+    });
     await handler.shutdown();
   });
 
@@ -598,6 +620,68 @@ describe("codex app-server handler", () => {
 
     expect(finished.map((messages) => messages.map((message) => message.id))).toEqual([["m1", "m2"]]);
     expect(emitEvent.mock.calls.some(([event]) => event.kind === "token_usage")).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  it("does not complete delivery when confirmed success turn_end is rejected", async () => {
+    stubLandingTrialHostEnv("confirm-reject");
+
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const emitEventConfirmed = vi
+      .fn<NonNullable<SessionContext["emitEventConfirmed"]>>()
+      .mockRejectedValue(new Error("session event persist failed"));
+    const handler = makeHandler(fake);
+    const ctx = makeContext({
+      emitEventConfirmed,
+      agentMetadata: trialAgentMetadata,
+    });
+    const message = makeMessage("m1", "first", 101);
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    completeTurn(fake, "turn-1", "final answer");
+    await expect(startPromise).rejects.toThrow("session event persist failed");
+
+    expect(emitEventConfirmed).toHaveBeenCalledWith({
+      kind: "turn_end",
+      payload: { status: "success", turnCompletionId: "inbox:101" },
+    });
+    expect(token.complete).not.toHaveBeenCalled();
+    expect(token.retry).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
+  it("does not block ordinary Codex delivery on confirmed event rejection", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const emitEventConfirmed = vi
+      .fn<NonNullable<SessionContext["emitEventConfirmed"]>>()
+      .mockRejectedValue(new Error("session event persist failed"));
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ emitEvent, emitEventConfirmed });
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    completeTurn(fake, "turn-1", "final answer");
+    await expect(startPromise).resolves.toMatchObject({
+      sessionId: "thread-app-server",
+      route: { kind: "owned", mode: "processing" },
+    });
+
+    expect(emitEventConfirmed).not.toHaveBeenCalled();
+    expect(emitEvent).toHaveBeenCalledWith({
+      kind: "turn_end",
+      payload: { status: "success" },
+    });
+    expect(token.complete).toHaveBeenCalledWith([message], expect.objectContaining({ status: "success" }));
+    expect(token.retry).not.toHaveBeenCalled();
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/codex-usage-limit.test.ts
+++ b/packages/client/src/__tests__/codex-usage-limit.test.ts
@@ -123,6 +123,7 @@ function makeContext(
   opts: {
     sendMessage?: SendMessageMock;
     emitEvent?: SessionContext["emitEvent"];
+    emitEventConfirmed?: SessionContext["emitEventConfirmed"];
     log?: SessionContext["log"];
     retryTurn?: SessionContext["retryTurn"];
   } = {},
@@ -145,6 +146,7 @@ function makeContext(
     log: opts.log ?? (() => {}),
     recordProviderActivity: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
+    ...(opts.emitEventConfirmed ? { emitEventConfirmed: opts.emitEventConfirmed } : {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-usage-limit"),
     // Production-faithful: the final-text forward is retired, so it delivers
     // nothing. (mockCtxPlumbing's stub would proxy to sendMessage and mask
@@ -293,6 +295,37 @@ describe("codex usage-limit empty-turn (issue #971)", () => {
       events.some((event) => event.kind === "error" && event.payload.message.includes("codex usage limit reached")),
     ).toBe(false);
     expect(events.some((event) => event.kind === "turn_end" && event.payload.status === "success")).toBe(true);
+    expect(completedCounts).toEqual([1]);
+
+    await handler.shutdown();
+  });
+
+  it("does not block ordinary SDK delivery on confirmed event rejection", async () => {
+    state.turns = [
+      [
+        { type: "item.completed", item: { type: "agent_message", text: "here is your answer" } },
+        {
+          type: "turn.completed",
+          usage: { input_tokens: 200, cached_input_tokens: 0, output_tokens: 40, reasoning_output_tokens: 0 },
+        },
+      ],
+    ];
+
+    const completedCounts: Array<number | undefined> = [];
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const emitEventConfirmed = vi
+      .fn<NonNullable<SessionContext["emitEventConfirmed"]>>()
+      .mockRejectedValue(new Error("session event persist failed"));
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext((count) => completedCounts.push(count), { emitEvent, emitEventConfirmed });
+
+    await handler.start(makeMessage("m1", "hello"), ctx);
+
+    expect(emitEventConfirmed).not.toHaveBeenCalled();
+    expect(emitEvent).toHaveBeenCalledWith({
+      kind: "turn_end",
+      payload: { status: "success" },
+    });
     expect(completedCounts).toEqual([1]);
 
     await handler.shutdown();

--- a/packages/client/src/__tests__/codex-usage-limit.test.ts
+++ b/packages/client/src/__tests__/codex-usage-limit.test.ts
@@ -99,16 +99,29 @@ vi.mock("../runtime/chat-context.js", () => ({
   }),
 }));
 
-import { createCodexHandler } from "../handlers/codex/index.js";
+import { createCodexHandler, createCodexSdkHandler } from "../handlers/codex/index.js";
+import { LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED } from "../handlers/codex/turn-completion.js";
 
 const AGENT_ID = "019e71c9-88d2-70be-be67-fdb033b2ef0b";
 
 let workspaceRoot: string;
 
+const trialAgentMetadata = {
+  landingCampaignTrial: true,
+  campaign: "production-scan",
+  skillSetId: "production-scan",
+  skillSetVersion: "2026.07.02.1",
+  repo: {
+    url: "https://github.com/acme/backend",
+    canonicalKey: "github.com/acme/backend",
+  },
+};
+
 type SendMessageMock = ReturnType<typeof vi.fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>>;
 
-function makeMessage(id: string, content: string): SessionMessage {
+function makeMessage(id: string, content: string, inboxEntryId?: number): SessionMessage {
   return {
+    ...(inboxEntryId !== undefined ? { inboxEntryId } : {}),
     id,
     chatId: "chat-usage-limit",
     senderId: "sender-1",
@@ -124,8 +137,10 @@ function makeContext(
     sendMessage?: SendMessageMock;
     emitEvent?: SessionContext["emitEvent"];
     emitEventConfirmed?: SessionContext["emitEventConfirmed"];
+    failSessionForRecovery?: SessionContext["failSessionForRecovery"];
     log?: SessionContext["log"];
     retryTurn?: SessionContext["retryTurn"];
+    agentMetadata?: Record<string, unknown>;
   } = {},
 ): SessionContext {
   const sendMessage =
@@ -139,7 +154,7 @@ function makeContext(
       type: "agent",
       visibility: "organization",
       delegateMention: null,
-      metadata: {},
+      metadata: opts.agentMetadata ?? {},
     },
     sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
     chatId: "chat-usage-limit",
@@ -147,6 +162,7 @@ function makeContext(
     recordProviderActivity: () => {},
     emitEvent: opts.emitEvent ?? (() => {}),
     ...(opts.emitEventConfirmed ? { emitEventConfirmed: opts.emitEventConfirmed } : {}),
+    ...(opts.failSessionForRecovery ? { failSessionForRecovery: opts.failSessionForRecovery } : {}),
     ...mockCtxPlumbing({ sendMessage }, "chat-usage-limit"),
     // Production-faithful: the final-text forward is retired, so it delivers
     // nothing. (mockCtxPlumbing's stub would proxy to sendMessage and mask
@@ -327,6 +343,48 @@ describe("codex usage-limit empty-turn (issue #971)", () => {
       payload: { status: "success" },
     });
     expect(completedCounts).toEqual([1]);
+
+    await handler.shutdown();
+  });
+
+  it("leaves landing trial SDK delivery recoverable when confirmed success turn_end is rejected", async () => {
+    state.turns = [
+      [
+        { type: "item.completed", item: { type: "agent_message", text: "here is your answer" } },
+        {
+          type: "turn.completed",
+          usage: { input_tokens: 200, cached_input_tokens: 0, output_tokens: 40, reasoning_output_tokens: 0 },
+        },
+      ],
+    ];
+
+    const completedCounts: Array<number | undefined> = [];
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const failSessionForRecovery = vi.fn<NonNullable<SessionContext["failSessionForRecovery"]>>();
+    const emitEventConfirmed = vi
+      .fn<NonNullable<SessionContext["emitEventConfirmed"]>>()
+      .mockRejectedValue(new Error("session event persist failed"));
+    const handler = createCodexSdkHandler({ workspaceRoot });
+    const message = makeMessage("m1", "hello", 101);
+    const ctx = makeContext((count) => completedCounts.push(count), {
+      emitEventConfirmed,
+      failSessionForRecovery,
+      retryTurn,
+      agentMetadata: trialAgentMetadata,
+    });
+
+    await handler.start(message, ctx);
+
+    expect(emitEventConfirmed).toHaveBeenCalledWith({
+      kind: "turn_end",
+      payload: { status: "success", turnCompletionId: "inbox:101" },
+    });
+    expect(completedCounts).toEqual([]);
+    expect(retryTurn).toHaveBeenCalledWith([message], LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED);
+    expect(failSessionForRecovery).toHaveBeenCalledWith(
+      LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED,
+      "thread-usage-limit",
+    );
 
     await handler.shutdown();
   });

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -55,6 +55,7 @@ import {
   isCodexStreamDiagnosticMessage,
   isTransientCodexErrorMessage,
 } from "../sdk.js";
+import { turnCompletionIdForMessages } from "../turn-completion.js";
 import {
   CodexAppServerClient,
   type CodexAppServerClientOptions,
@@ -105,6 +106,18 @@ type ThreadTokenUsageSnapshot = {
   total: TokenUsageBreakdown;
   last: TokenUsageBreakdown;
 };
+
+async function emitTurnEnd(
+  sessionCtx: SessionContext,
+  event: Extract<SessionEvent, { kind: "turn_end" }>,
+): Promise<void> {
+  if (event.payload.status === "success" && isLandingCampaignTrialAgentMetadata(sessionCtx.agent.metadata)) {
+    if (!sessionCtx.emitEventConfirmed) throw new Error("confirmed session event channel unavailable");
+    await sessionCtx.emitEventConfirmed(event);
+    return;
+  }
+  sessionCtx.emitEvent(event);
+}
 
 type TurnErrorInfo = {
   message: string;
@@ -1312,10 +1325,20 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         consumedErrorReason,
         forwardFailed,
       });
-      sessionCtx.emitEvent({ kind: "turn_end", payload: { status: settlement.status } });
       if (settlement.action.kind === "complete") {
+        const isLandingTrial = isLandingCampaignTrialAgentMetadata(sessionCtx.agent.metadata);
+        await emitTurnEnd(sessionCtx, {
+          kind: "turn_end",
+          payload: {
+            status: settlement.status,
+            ...(settlement.status === "success" && isLandingTrial
+              ? { turnCompletionId: turnCompletionIdForMessages(turn.acceptedMessages) }
+              : {}),
+          },
+        });
         await turn.primaryToken.complete(turn.acceptedMessages, settlement.action.outcome);
       } else {
+        sessionCtx.emitEvent({ kind: "turn_end", payload: { status: settlement.status } });
         turn.primaryToken.retry(turn.acceptedMessages, settlement.action.reason);
         await closeAppServerAfterUncommittablePrefix(sessionCtx, settlement.action.reason);
         return;

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -55,7 +55,11 @@ import {
   isCodexStreamDiagnosticMessage,
   isTransientCodexErrorMessage,
 } from "../sdk.js";
-import { turnCompletionIdForMessages } from "../turn-completion.js";
+import {
+  LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED,
+  LandingTrialTurnCompletionConfirmError,
+  turnCompletionIdForMessages,
+} from "../turn-completion.js";
 import {
   CodexAppServerClient,
   type CodexAppServerClientOptions,
@@ -112,8 +116,14 @@ async function emitTurnEnd(
   event: Extract<SessionEvent, { kind: "turn_end" }>,
 ): Promise<void> {
   if (event.payload.status === "success" && isLandingCampaignTrialAgentMetadata(sessionCtx.agent.metadata)) {
-    if (!sessionCtx.emitEventConfirmed) throw new Error("confirmed session event channel unavailable");
-    await sessionCtx.emitEventConfirmed(event);
+    if (!sessionCtx.emitEventConfirmed) {
+      throw new LandingTrialTurnCompletionConfirmError("confirmed session event channel unavailable");
+    }
+    try {
+      await sessionCtx.emitEventConfirmed(event);
+    } catch (err) {
+      throw new LandingTrialTurnCompletionConfirmError(err);
+    }
     return;
   }
   sessionCtx.emitEvent(event);
@@ -1327,15 +1337,23 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       });
       if (settlement.action.kind === "complete") {
         const isLandingTrial = isLandingCampaignTrialAgentMetadata(sessionCtx.agent.metadata);
-        await emitTurnEnd(sessionCtx, {
-          kind: "turn_end",
-          payload: {
-            status: settlement.status,
-            ...(settlement.status === "success" && isLandingTrial
-              ? { turnCompletionId: turnCompletionIdForMessages(turn.acceptedMessages) }
-              : {}),
-          },
-        });
+        try {
+          await emitTurnEnd(sessionCtx, {
+            kind: "turn_end",
+            payload: {
+              status: settlement.status,
+              ...(settlement.status === "success" && isLandingTrial
+                ? { turnCompletionId: turnCompletionIdForMessages(turn.acceptedMessages) }
+                : {}),
+            },
+          });
+        } catch (err) {
+          if (!(err instanceof LandingTrialTurnCompletionConfirmError)) throw err;
+          sessionCtx.log(`landing trial turn completion confirmation failed after provider completion: ${err.message}`);
+          turn.primaryToken.retry(turn.acceptedMessages, LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED);
+          await closeAppServerAfterUncommittablePrefix(sessionCtx, LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED);
+          return;
+        }
         await turn.primaryToken.complete(turn.acceptedMessages, settlement.action.outcome);
       } else {
         sessionCtx.emitEvent({ kind: "turn_end", payload: { status: settlement.status } });

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -3,6 +3,7 @@ import {
   type AgentRuntimeConfigPayload,
   deriveRepoLocalPath,
   encodeProviderRetryEventMessage,
+  isLandingCampaignTrialAgentMetadata,
   runtimeProviderSchema,
   type SessionEvent,
   type ToolFileRef,
@@ -65,6 +66,7 @@ import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/works
 import { chunkAssistantText } from "../assistant-text.js";
 import { formatAuthHint, isCodexAuthError } from "../auth-error-hint.js";
 import { resolveTurnSettlement } from "../turn-settlement.js";
+import { turnCompletionIdForMessages } from "./turn-completion.js";
 
 /**
  * Codex SDK does not export its `CodexConfigObject` type, so reproduce the
@@ -75,6 +77,18 @@ type CodexConfigValue = string | number | boolean | CodexConfigValue[] | CodexCo
 type CodexConfigObject = { [key: string]: CodexConfigValue };
 
 const RESULT_PREVIEW_LIMIT = 400;
+
+async function emitTurnEnd(
+  sessionCtx: SessionContext,
+  event: Extract<SessionEvent, { kind: "turn_end" }>,
+): Promise<void> {
+  if (event.payload.status === "success" && isLandingCampaignTrialAgentMetadata(sessionCtx.agent.metadata)) {
+    if (!sessionCtx.emitEventConfirmed) throw new Error("confirmed session event channel unavailable");
+    await sessionCtx.emitEventConfirmed(event);
+    return;
+  }
+  sessionCtx.emitEvent(event);
+}
 
 /**
  * Chat-visible notice posted when a turn is detected as a usage-limit empty
@@ -1186,14 +1200,24 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
         sessionCtx.log(`Failed to emit token_usage: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
-    sessionCtx.emitEvent({
-      kind: "turn_end",
-      payload: { status: settlement.status },
-    });
     const turnDelivered = settlement.action.kind === "complete";
     if (settlement.action.kind === "complete") {
+      const isLandingTrial = isLandingCampaignTrialAgentMetadata(sessionCtx.agent.metadata);
+      await emitTurnEnd(sessionCtx, {
+        kind: "turn_end",
+        payload: {
+          status: settlement.status,
+          ...(settlement.status === "success" && isLandingTrial
+            ? { turnCompletionId: turnCompletionIdForMessages(messages) }
+            : {}),
+        },
+      });
       await token.complete(messages, settlement.action.outcome);
     } else {
+      sessionCtx.emitEvent({
+        kind: "turn_end",
+        payload: { status: settlement.status },
+      });
       token.retry(messages, settlement.action.reason);
     }
 

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -66,7 +66,11 @@ import { acquireAgentHome, markWorkspaceInitComplete } from "../../runtime/works
 import { chunkAssistantText } from "../assistant-text.js";
 import { formatAuthHint, isCodexAuthError } from "../auth-error-hint.js";
 import { resolveTurnSettlement } from "../turn-settlement.js";
-import { turnCompletionIdForMessages } from "./turn-completion.js";
+import {
+  LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED,
+  LandingTrialTurnCompletionConfirmError,
+  turnCompletionIdForMessages,
+} from "./turn-completion.js";
 
 /**
  * Codex SDK does not export its `CodexConfigObject` type, so reproduce the
@@ -83,8 +87,14 @@ async function emitTurnEnd(
   event: Extract<SessionEvent, { kind: "turn_end" }>,
 ): Promise<void> {
   if (event.payload.status === "success" && isLandingCampaignTrialAgentMetadata(sessionCtx.agent.metadata)) {
-    if (!sessionCtx.emitEventConfirmed) throw new Error("confirmed session event channel unavailable");
-    await sessionCtx.emitEventConfirmed(event);
+    if (!sessionCtx.emitEventConfirmed) {
+      throw new LandingTrialTurnCompletionConfirmError("confirmed session event channel unavailable");
+    }
+    try {
+      await sessionCtx.emitEventConfirmed(event);
+    } catch (err) {
+      throw new LandingTrialTurnCompletionConfirmError(err);
+    }
     return;
   }
   sessionCtx.emitEvent(event);
@@ -1203,15 +1213,23 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
     const turnDelivered = settlement.action.kind === "complete";
     if (settlement.action.kind === "complete") {
       const isLandingTrial = isLandingCampaignTrialAgentMetadata(sessionCtx.agent.metadata);
-      await emitTurnEnd(sessionCtx, {
-        kind: "turn_end",
-        payload: {
-          status: settlement.status,
-          ...(settlement.status === "success" && isLandingTrial
-            ? { turnCompletionId: turnCompletionIdForMessages(messages) }
-            : {}),
-        },
-      });
+      try {
+        await emitTurnEnd(sessionCtx, {
+          kind: "turn_end",
+          payload: {
+            status: settlement.status,
+            ...(settlement.status === "success" && isLandingTrial
+              ? { turnCompletionId: turnCompletionIdForMessages(messages) }
+              : {}),
+          },
+        });
+      } catch (err) {
+        if (!(err instanceof LandingTrialTurnCompletionConfirmError)) throw err;
+        sessionCtx.log(`landing trial turn completion confirmation failed after provider completion: ${err.message}`);
+        token.retry(messages, LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED);
+        await closeSdkSessionAfterUncommittablePrefix(sessionCtx, LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED);
+        return false;
+      }
       await token.complete(messages, settlement.action.outcome);
     } else {
       sessionCtx.emitEvent({
@@ -1357,6 +1375,19 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
     for (const queued of drained) {
       queued.token.retry(queued.message, reason);
     }
+  }
+
+  async function closeSdkSessionAfterUncommittablePrefix(sessionCtx: SessionContext, reason: string): Promise<void> {
+    retryQueuedMessages(reason);
+    currentAbort?.abort();
+    currentAbort = null;
+    currentTurnPromise = null;
+    const resumeThreadId = threadId ?? undefined;
+    thread = null;
+    codex = null;
+    initialTurnPreparing = false;
+    pendingChatContextPrompt = null;
+    sessionCtx.failSessionForRecovery?.(reason, resumeThreadId);
   }
 
   function ensureCodexBootstrap(

--- a/packages/client/src/handlers/codex/turn-completion.ts
+++ b/packages/client/src/handlers/codex/turn-completion.ts
@@ -1,5 +1,15 @@
 import type { SessionMessage } from "../../runtime/handler.js";
 
+export const LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED = "landing_trial_turn_completion_confirm_failed";
+
+export class LandingTrialTurnCompletionConfirmError extends Error {
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause));
+    this.name = "LandingTrialTurnCompletionConfirmError";
+    this.cause = cause;
+  }
+}
+
 export function turnCompletionIdForMessages(messages: readonly SessionMessage[]): string {
   const parts = messages.map((message) =>
     message.inboxEntryId !== undefined ? `inbox:${message.inboxEntryId}` : `message:${message.id}`,

--- a/packages/client/src/handlers/codex/turn-completion.ts
+++ b/packages/client/src/handlers/codex/turn-completion.ts
@@ -1,0 +1,9 @@
+import type { SessionMessage } from "../../runtime/handler.js";
+
+export function turnCompletionIdForMessages(messages: readonly SessionMessage[]): string {
+  const parts = messages.map((message) =>
+    message.inboxEntryId !== undefined ? `inbox:${message.inboxEntryId}` : `message:${message.id}`,
+  );
+  if (parts.length === 0) throw new Error("cannot build a turn completion id without messages");
+  return parts.join("+");
+}

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -138,6 +138,12 @@ export type SessionContext = HandlerContext & {
    * what the agent said. There is no separate chat-delivery path for it.
    */
   emitEvent: (event: SessionEvent) => void;
+  /**
+   * Persist a session event and resolve only after the server confirms it.
+   * Business-critical events, such as Codex landing trial turn completion,
+   * must await this before ACKing the inbox work that produced the turn.
+   */
+  emitEventConfirmed?: (event: SessionEvent) => Promise<void>;
 
   /**
    * Turn-completion hook the runtime calls at the end of a turn. It does NOT

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -2198,6 +2198,7 @@ export class SessionManager {
       emitEvent: (event) => {
         this.config.onSessionEvent?.(chatId, event);
       },
+      emitEventConfirmed: (event) => this.confirmSessionEventOrThrow(chatId, event),
       forwardResult,
       markMessagesConsumed: (messages) => {
         this.inboxDelivery.markProcessingStarted(chatId, messages);
@@ -2217,6 +2218,14 @@ export class SessionManager {
       resolveSenderLabel: async (senderId) => resolveSenderLabel(senderId, await participants.get()),
       formatFromHeader: (message) => buildFromHeader(message, participants),
     };
+  }
+
+  private async confirmSessionEventOrThrow(chatId: string, event: SessionEvent): Promise<void> {
+    if (!this.config.confirmSessionEvent) {
+      this.config.onSessionEvent?.(chatId, event);
+      throw new Error("confirmed session event channel unavailable");
+    }
+    await this.config.confirmSessionEvent(chatId, event);
   }
 
   private async resolveSelfFence(log: (msg: string) => void, chatId: string): Promise<SelfFence> {

--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -18,6 +18,7 @@ import { users } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
 import { bindAgentRuntimeSession, validateAgentRuntimeSession } from "../services/agent-runtime-session.js";
 import { signTokensForUser } from "../services/auth.js";
+import { completeLandingCampaignTrialAgentTurn } from "../services/landing-campaigns/chat-state.js";
 import { createMember } from "../services/member.js";
 import { sendMessage } from "../services/message.js";
 import { uuidv7 } from "../uuid.js";
@@ -275,7 +276,7 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(trialAgents).toHaveLength(0);
   });
 
-  it("creates the service-managed trial agent, installs the agent-scoped campaign skill, and starts a locked chat", async () => {
+  it("creates the service-managed trial agent, installs the agent-scoped campaign skill, and starts an unlocked capped chat", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     await seedOfficialRuntime(app, admin.organizationId);
@@ -341,7 +342,7 @@ describe("POST /me/landing-campaigns/start", () => {
       agentId: body.agentUuid,
       repo: { canonicalKey: "github.com/acme/backend" },
       state: "running",
-      inputLocked: true,
+      inputLocked: false,
       maxAgentTurns: 1,
       completedAgentTurns: 0,
     });
@@ -353,6 +354,51 @@ describe("POST /me/landing-campaigns/start", () => {
       systemSender: "first_tree_onboarding",
       campaign: "production-scan",
       landingCampaignTrial: true,
+    });
+  });
+
+  it("presents stale running trial chats as unlocked while turns remain", async () => {
+    const app = getMultiTurnApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const started = await startProductionScan(app, admin);
+    const body = started.json<{ chatId: string }>();
+
+    const [chat] = await app.db.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, body.chatId));
+    const trial = parseLandingCampaignTrialChatMetadata(chat?.metadata);
+    if (!chat || !trial) throw new Error("expected landing trial chat metadata");
+    await app.db
+      .update(chats)
+      .set({
+        metadata: {
+          ...chat.metadata,
+          landingCampaignTrial: { ...trial, state: "running", inputLocked: true, completedAgentTurns: 1 },
+        },
+      })
+      .where(eq(chats.id, body.chatId));
+
+    const detail = await app.inject({
+      method: "GET",
+      url: `/api/v1/chats/${body.chatId}`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(detail.statusCode).toBe(200);
+    const detailTrial = parseLandingCampaignTrialChatMetadata(
+      detail.json<{ metadata: Record<string, unknown> }>().metadata,
+    );
+    expect(detailTrial).toMatchObject({
+      state: "running",
+      inputLocked: false,
+      maxAgentTurns: 2,
+      completedAgentTurns: 1,
+    });
+
+    const [storedChat] = await app.db.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, body.chatId));
+    expect(parseLandingCampaignTrialChatMetadata(storedChat?.metadata)).toMatchObject({
+      state: "running",
+      inputLocked: true,
+      maxAgentTurns: 2,
+      completedAgentTurns: 1,
     });
   });
 
@@ -565,7 +611,7 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(metadata.statusCode).toBe(403);
   });
 
-  it("blocks ordinary chats and messages from continuing the single-run trial agent", async () => {
+  it("blocks ordinary chats while allowing trial-chat messages until the turn cap", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     await seedOfficialRuntime(app, admin.organizationId);
@@ -593,7 +639,16 @@ describe("POST /me/landing-campaigns/start", () => {
       headers: { authorization: `Bearer ${admin.accessToken}` },
       payload: { format: "text", content: "Can you do another thing?", metadata: { mentions: [body.agentUuid] } },
     });
-    expect(message.statusCode).toBe(403);
+    expect(message.statusCode).toBe(201);
+
+    await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "turn-default-cap");
+    const afterLimit = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${body.chatId}/messages`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { format: "text", content: "Can you keep going?", metadata: { mentions: [body.agentUuid] } },
+    });
+    expect(afterLimit.statusCode).toBe(403);
   });
 
   it("blocks adding ordinary participants to a landing campaign trial chat", async () => {
@@ -682,6 +737,23 @@ describe("POST /me/landing-campaigns/start", () => {
       },
     });
     expect(send.statusCode).toBe(201);
+    const [runningChat] = await app.db
+      .select({ metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, body.chatId));
+    expect(parseLandingCampaignTrialChatMetadata(runningChat?.metadata)).toMatchObject({
+      state: "running",
+      inputLocked: false,
+      completedAgentTurns: 0,
+    });
+
+    const completedTurn = await completeLandingCampaignTrialAgentTurn(
+      app.db,
+      body.chatId,
+      body.agentUuid,
+      "turn-outbox",
+    );
+    expect(completedTurn).toEqual({ advanced: true, reachedTurnLimit: true, duplicate: false });
     const [completedChat] = await app.db
       .select({ metadata: chats.metadata })
       .from(chats)
@@ -689,6 +761,7 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(parseLandingCampaignTrialChatMetadata(completedChat?.metadata)).toMatchObject({
       state: "completed",
       inputLocked: true,
+      completedAgentTurns: 1,
     });
 
     const sendAfterCompleted = await app.inject({
@@ -746,27 +819,44 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(wrongAgent.statusCode).toBe(401);
   });
 
-  it("allows ordinary human follow-up messages until the trial agent turn limit is reached", async () => {
+  it("allows ordinary human messages while running until completed agent turns reach the limit", async () => {
     const app = getMultiTurnApp();
     const admin = await createTestAdmin(app);
     await seedOfficialRuntime(app, admin.organizationId);
     const started = await startProductionScan(app, admin);
     const body = started.json<{ chatId: string; agentUuid: string }>();
 
-    await sendMessage(app.db, body.chatId, body.agentUuid, {
-      format: "text",
-      content: "Initial trial report.",
-      source: "api",
-      metadata: { mentions: [admin.humanAgentUuid] },
-    });
-    const [awaitingChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
-    expect(parseLandingCampaignTrialChatMetadata(awaitingChat?.metadata)).toMatchObject({
-      state: "awaiting_user",
+    const [initialChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
+    expect(parseLandingCampaignTrialChatMetadata(initialChat?.metadata)).toMatchObject({
+      state: "running",
       inputLocked: false,
-      awaitingUserKind: "follow_up",
+      maxAgentTurns: 2,
+      completedAgentTurns: 0,
+    });
+
+    const whileRunning = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${body.chatId}/messages`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {
+        format: "text",
+        content: "Can you include deploy risk while you are running?",
+        metadata: { mentions: [body.agentUuid] },
+      },
+    });
+    expect(whileRunning.statusCode).toBe(201);
+
+    const firstTurn = await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "turn-1");
+    expect(firstTurn).toEqual({ advanced: true, reachedTurnLimit: false, duplicate: false });
+    const [runningChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
+    const runningTrial = parseLandingCampaignTrialChatMetadata(runningChat?.metadata);
+    expect(runningTrial).toMatchObject({
+      state: "running",
+      inputLocked: false,
       maxAgentTurns: 2,
       completedAgentTurns: 1,
     });
+    expect(runningTrial?.awaitingUserKind).toBeUndefined();
 
     const followUp = await app.inject({
       method: "POST",
@@ -779,22 +869,9 @@ describe("POST /me/landing-campaigns/start", () => {
       },
     });
     expect(followUp.statusCode).toBe(201);
-    const [runningChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
-    const runningTrial = parseLandingCampaignTrialChatMetadata(runningChat?.metadata);
-    expect(runningTrial).toMatchObject({
-      state: "running",
-      inputLocked: true,
-      maxAgentTurns: 2,
-      completedAgentTurns: 1,
-    });
-    expect(runningTrial?.awaitingUserKind).toBeUndefined();
 
-    await sendMessage(app.db, body.chatId, body.agentUuid, {
-      format: "text",
-      content: "Second and final trial response.",
-      source: "api",
-      metadata: { mentions: [admin.humanAgentUuid] },
-    });
+    const finalTurn = await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "turn-2");
+    expect(finalTurn).toEqual({ advanced: true, reachedTurnLimit: true, duplicate: false });
     const [completedChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
     const completedTrial = parseLandingCampaignTrialChatMetadata(completedChat?.metadata);
     expect(completedTrial).toMatchObject({
@@ -818,7 +895,7 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(afterLimit.statusCode).toBe(403);
   });
 
-  it("serializes concurrent trial outbox writes so only one state transition wins", async () => {
+  it("serializes concurrent trial request writes so only one state transition wins", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     await seedOfficialRuntime(app, admin.organizationId);
@@ -829,18 +906,7 @@ describe("POST /me/landing-campaigns/start", () => {
     const tokenRes = await trialAgentRequest("POST", `/api/v1/agent/chats/${body.chatId}/outbox-token`);
     const outbox = tokenRes.json<{ accessToken: string }>();
 
-    const [finalRes, requestRes] = await Promise.all([
-      app.inject({
-        method: "POST",
-        url: `/api/v1/agent/chats/${body.chatId}/messages`,
-        headers: { authorization: `Bearer ${outbox.accessToken}`, "x-agent-id": body.agentUuid },
-        payload: {
-          format: "text",
-          content: "Final trial report.",
-          metadata: { mentions: [admin.humanAgentUuid] },
-          source: "cli",
-        },
-      }),
+    const [firstRequestRes, secondRequestRes] = await Promise.all([
       app.inject({
         method: "POST",
         url: `/api/v1/agent/chats/${body.chatId}/messages`,
@@ -852,22 +918,30 @@ describe("POST /me/landing-campaigns/start", () => {
           source: "cli",
         },
       }),
+      app.inject({
+        method: "POST",
+        url: `/api/v1/agent/chats/${body.chatId}/messages`,
+        headers: { authorization: `Bearer ${outbox.accessToken}`, "x-agent-id": body.agentUuid },
+        payload: {
+          format: MESSAGE_FORMATS.REQUEST,
+          content: "Need another answer?",
+          metadata: { mentions: [admin.humanAgentUuid] },
+          source: "cli",
+        },
+      }),
     ]);
 
-    expect([finalRes.statusCode, requestRes.statusCode].sort()).toEqual([201, 403]);
+    expect([firstRequestRes.statusCode, secondRequestRes.statusCode].sort()).toEqual([201, 403]);
     const trialMessages = await app.db
       .select({ id: messages.id, format: messages.format })
       .from(messages)
       .where(and(eq(messages.chatId, body.chatId), eq(messages.senderId, body.agentUuid)));
     expect(trialMessages).toHaveLength(1);
+    expect(trialMessages[0]?.format).toBe(MESSAGE_FORMATS.REQUEST);
 
     const [chat] = await app.db.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, body.chatId));
     const trial = parseLandingCampaignTrialChatMetadata(chat?.metadata);
-    if (finalRes.statusCode === 201) {
-      expect(trial).toMatchObject({ state: "completed", inputLocked: true });
-    } else {
-      expect(trial).toMatchObject({ state: "awaiting_user", inputLocked: false });
-    }
+    expect(trial).toMatchObject({ state: "awaiting_user", inputLocked: false, awaitingUserKind: "request" });
   });
 
   it("blocks agent-runtime participant removal on landing campaign trial chats", async () => {
@@ -1035,19 +1109,84 @@ describe("POST /me/landing-campaigns/start", () => {
     const [runningChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
     expect(parseLandingCampaignTrialChatMetadata(runningChat?.metadata)).toMatchObject({
       state: "running",
-      inputLocked: true,
+      inputLocked: false,
+      completedAgentTurns: 0,
     });
 
-    await sendMessage(app.db, body.chatId, body.agentUuid, {
-      format: "text",
-      content: "Here is the final report.",
-      source: "api",
-      metadata: { mentions: [admin.humanAgentUuid] },
-    });
+    const completedTurn = await completeLandingCampaignTrialAgentTurn(
+      app.db,
+      body.chatId,
+      body.agentUuid,
+      "turn-request-answer",
+    );
+    expect(completedTurn).toEqual({ advanced: true, reachedTurnLimit: true, duplicate: false });
     const [completedChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
     expect(parseLandingCampaignTrialChatMetadata(completedChat?.metadata)).toMatchObject({
       state: "completed",
       inputLocked: true,
+      completedAgentTurns: 1,
+    });
+  });
+
+  it("treats legacy awaiting_user trial chats without a kind as request waits", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const started = await startProductionScan(app, admin);
+    const body = started.json<{ chatId: string; agentUuid: string }>();
+
+    const ask = await sendMessage(app.db, body.chatId, body.agentUuid, {
+      format: MESSAGE_FORMATS.REQUEST,
+      content: "Choose a scan focus.",
+      source: "api",
+      metadata: { mentions: [admin.humanAgentUuid] },
+    });
+    const [awaitingChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
+    const awaitingTrial = parseLandingCampaignTrialChatMetadata(awaitingChat?.metadata);
+    if (!awaitingChat || !awaitingTrial) throw new Error("expected landing trial metadata");
+    const legacyTrial = { ...awaitingTrial };
+    delete legacyTrial.awaitingUserKind;
+    await app.db
+      .update(chats)
+      .set({
+        metadata: {
+          ...awaitingChat.metadata,
+          landingCampaignTrial: legacyTrial,
+        },
+      })
+      .where(eq(chats.id, body.chatId));
+
+    const plainMessageDuringLegacyRequest = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${body.chatId}/messages`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {
+        format: "text",
+        content: "I am not answering the legacy request yet.",
+        metadata: { mentions: [body.agentUuid] },
+      },
+    });
+    expect(plainMessageDuringLegacyRequest.statusCode).toBe(403);
+
+    const answer = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${body.chatId}/messages`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {
+        format: "text",
+        content: "Focus on deploy risk.",
+        metadata: {
+          mentions: [body.agentUuid],
+          resolves: { request: ask.message.id, kind: "answered" },
+        },
+      },
+    });
+    expect(answer.statusCode).toBe(201);
+    const [runningChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
+    expect(parseLandingCampaignTrialChatMetadata(runningChat?.metadata)).toMatchObject({
+      state: "running",
+      inputLocked: false,
+      completedAgentTurns: 0,
     });
   });
 

--- a/packages/server/src/__tests__/ws-session-event.test.ts
+++ b/packages/server/src/__tests__/ws-session-event.test.ts
@@ -1,3 +1,4 @@
+import { parseLandingCampaignTrialChatMetadata } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { SignJWT } from "jose";
@@ -10,6 +11,7 @@ import { members } from "../db/schema/members.js";
 import { users } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
 import * as contextTreeIoService from "../services/context-tree-io.js";
+import { buildLandingCampaignChatMetadata } from "../services/landing-campaigns/metadata.js";
 import { putOrgSetting } from "../services/org-settings.js";
 import { resolveDefaultOrgId } from "../services/organization.js";
 import * as sessionEventService from "../services/session-event.js";
@@ -265,6 +267,114 @@ describe("Agent WS — session event protocol (S10)", () => {
       expect(items).toHaveLength(1);
       expect(items[0]?.kind).toBe("error");
     } finally {
+      ws.close();
+      await new Promise<void>((r) => ws.once("close", () => r()));
+    }
+  }, 15000);
+
+  it("advances landing trial chat state once per confirmed turn completion id", async () => {
+    const seed = await seedBoundAgent("landing-turn-end", "codex");
+    const ws = await openBoundSocket(seed);
+    const chatId = `chat-${crypto.randomUUID()}`;
+    const notifySpy = vi.spyOn(app.notifier, "notifyChatUpdated").mockResolvedValue();
+
+    async function sendTurnEnd(ref: string, turnCompletionId: string) {
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          ref,
+          agentId: seed.agent.uuid,
+          chatId,
+          event: { kind: "turn_end", payload: { status: "success", turnCompletionId } },
+        }),
+      );
+      await waitForFrame(
+        ws,
+        (m) =>
+          (m as { type?: string; ref?: string }).type === "session:event:accepted" &&
+          (m as { ref?: string }).ref === ref,
+      );
+    }
+
+    try {
+      await app.db.insert(chats).values({
+        id: chatId,
+        organizationId: seed.organizationId,
+        type: "group",
+        metadata: buildLandingCampaignChatMetadata({
+          campaign: "production-scan",
+          agentId: seed.agent.uuid,
+          skillSetId: "production-scan",
+          skillSetVersion: "test",
+          repo: {
+            url: "https://github.com/acme/backend",
+            owner: "acme",
+            name: "backend",
+            canonicalKey: "github.com/acme/backend",
+          },
+          state: "running",
+          inputLocked: false,
+          maxAgentTurns: 2,
+          completedAgentTurns: 0,
+        }),
+      });
+
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          agentId: seed.agent.uuid,
+          chatId,
+          event: { kind: "turn_end", payload: { status: "success", turnCompletionId: "inbox:unconfirmed" } },
+        }),
+      );
+      await waitForCondition(async () => {
+        const { items } = await sessionEventService.listEvents(app.db, seed.agent.uuid, chatId, { limit: 10 });
+        return items.some((item) => item.kind === "turn_end") ? true : null;
+      });
+      const [unconfirmedChat] = await app.db
+        .select({ metadata: chats.metadata })
+        .from(chats)
+        .where(eq(chats.id, chatId));
+      expect(parseLandingCampaignTrialChatMetadata(unconfirmedChat?.metadata)).toMatchObject({
+        state: "running",
+        inputLocked: false,
+        completedAgentTurns: 0,
+        completedAgentTurnIds: [],
+      });
+
+      await sendTurnEnd("landing-turn-end-1", "inbox:101");
+      const [runningChat] = await app.db.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, chatId));
+      expect(parseLandingCampaignTrialChatMetadata(runningChat?.metadata)).toMatchObject({
+        state: "running",
+        inputLocked: false,
+        completedAgentTurns: 1,
+        completedAgentTurnIds: ["inbox:101"],
+        maxAgentTurns: 2,
+      });
+
+      await sendTurnEnd("landing-turn-end-1-duplicate", "inbox:101");
+      const [duplicateChat] = await app.db.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, chatId));
+      expect(parseLandingCampaignTrialChatMetadata(duplicateChat?.metadata)).toMatchObject({
+        state: "running",
+        inputLocked: false,
+        completedAgentTurns: 1,
+        completedAgentTurnIds: ["inbox:101"],
+        maxAgentTurns: 2,
+      });
+
+      await sendTurnEnd("landing-turn-end-2", "inbox:102");
+      const [completedChat] = await app.db.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, chatId));
+      expect(parseLandingCampaignTrialChatMetadata(completedChat?.metadata)).toMatchObject({
+        state: "completed",
+        inputLocked: true,
+        completedAgentTurns: 2,
+        completedAgentTurnIds: ["inbox:101", "inbox:102"],
+        maxAgentTurns: 2,
+      });
+      expect(notifySpy).toHaveBeenCalledTimes(2);
+      expect(notifySpy).toHaveBeenCalledWith(chatId);
+    } finally {
+      notifySpy.mockRestore();
       ws.close();
       await new Promise<void>((r) => ws.once("close", () => r()));
     }

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -50,6 +50,7 @@ import * as clientService from "../../services/client.js";
 import * as connectionManager from "../../services/connection-manager.js";
 import * as contextTreeIoService from "../../services/context-tree-io.js";
 import * as inboxService from "../../services/inbox.js";
+import * as landingCampaignChatStateService from "../../services/landing-campaigns/chat-state.js";
 import * as notificationService from "../../services/notification.js";
 import type { InboxPushHandler, Notifier } from "../../services/notifier.js";
 import * as presenceService from "../../services/presence.js";
@@ -1455,6 +1456,22 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                     payload.chatId,
                     payload.event,
                   );
+                  if (
+                    payload.ref &&
+                    payload.event.kind === "turn_end" &&
+                    payload.event.payload.status === "success" &&
+                    typeof payload.event.payload.turnCompletionId === "string"
+                  ) {
+                    const result = await landingCampaignChatStateService.completeLandingCampaignTrialAgentTurn(
+                      app.db,
+                      payload.chatId,
+                      agentId,
+                      payload.event.payload.turnCompletionId,
+                    );
+                    if (result.advanced) {
+                      notifier.notifyChatUpdated(payload.chatId).catch(() => {});
+                    }
+                  }
                   if (boundInfo) {
                     await contextTreeIoService
                       .recordFromSessionEvent(app.db, {

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -24,6 +24,10 @@ import { resolveAvatarImageUrl } from "../services/agent.js";
 import { getChatAgentStatuses } from "../services/agent-chat-status.js";
 import { ensureParticipant, leaveChat, updateChatMetadata } from "../services/chat.js";
 import { declareEntityFollow, listChatGithubEntities, removeEntityFollow } from "../services/github-entity-follow.js";
+import {
+  hasRemainingLandingCampaignTrialAgentTurns,
+  normalizeLandingCampaignTrialChatMetadataForRead,
+} from "../services/landing-campaigns/chat-state.js";
 import { assertNoLandingCampaignTrialAgents } from "../services/landing-campaigns/guards.js";
 import {
   addMeChatParticipants,
@@ -56,14 +60,12 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
     if (!trial) return;
     const resolves = body.metadata?.resolves;
     const resolvesRequest = resolves !== null && typeof resolves === "object";
-    if (
-      trial.state === "awaiting_user" &&
-      trial.inputLocked === false &&
-      (trial.awaitingUserKind === "follow_up" || resolvesRequest)
-    ) {
-      return;
+    if (trial.state === "completed" || trial.state === "failed" || !hasRemainingLandingCampaignTrialAgentTurns(trial)) {
+      throw new ForbiddenError("This landing campaign trial chat is locked.");
     }
-    throw new ForbiddenError("This landing campaign trial chat is locked.");
+    if (trial.state === "awaiting_user" && trial.awaitingUserKind !== "follow_up" && !resolvesRequest) {
+      throw new ForbiddenError("This landing campaign trial chat is waiting for a request answer.");
+    }
   }
 
   app.get<{ Params: { chatId: string } }>("/:chatId", async (request) => {
@@ -160,6 +162,7 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
 
     return {
       ...chat,
+      metadata: normalizeLandingCampaignTrialChatMetadataForRead(chat.metadata),
       title,
       firstMessagePreview,
       engagementStatus,

--- a/packages/server/src/services/landing-campaigns/chat-state.ts
+++ b/packages/server/src/services/landing-campaigns/chat-state.ts
@@ -1,0 +1,64 @@
+import { eq } from "drizzle-orm";
+import type { Database } from "../../db/connection.js";
+import { chats } from "../../db/schema/chats.js";
+import { getLandingCampaignTrialChat, withLandingCampaignChatState } from "./metadata.js";
+
+type LandingCampaignTrialChat = NonNullable<ReturnType<typeof getLandingCampaignTrialChat>>;
+
+export function hasRemainingLandingCampaignTrialAgentTurns(trial: LandingCampaignTrialChat): boolean {
+  return trial.completedAgentTurns < trial.maxAgentTurns;
+}
+
+export function normalizeLandingCampaignTrialChatMetadataForRead(
+  metadata: Record<string, unknown>,
+): Record<string, unknown> {
+  const trial = getLandingCampaignTrialChat({ metadata });
+  if (!trial || trial.state !== "running" || trial.inputLocked === false) return metadata;
+  if (!hasRemainingLandingCampaignTrialAgentTurns(trial)) return metadata;
+  return withLandingCampaignChatState(metadata, "running", false);
+}
+
+export async function completeLandingCampaignTrialAgentTurn(
+  db: Database,
+  chatId: string,
+  agentId: string,
+  turnCompletionId: string,
+): Promise<{ advanced: boolean; reachedTurnLimit: boolean; duplicate: boolean }> {
+  return db.transaction(async (tx) => {
+    const [chat] = await tx
+      .select({ metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, chatId))
+      .for("update")
+      .limit(1);
+    if (!chat) return { advanced: false, reachedTurnLimit: false, duplicate: false };
+
+    const trial = getLandingCampaignTrialChat(chat);
+    if (!trial || trial.agentId !== agentId || trial.state !== "running") {
+      return { advanced: false, reachedTurnLimit: false, duplicate: false };
+    }
+    if (trial.completedAgentTurnIds.includes(turnCompletionId)) {
+      return {
+        advanced: false,
+        reachedTurnLimit: !hasRemainingLandingCampaignTrialAgentTurns(trial),
+        duplicate: true,
+      };
+    }
+    if (!hasRemainingLandingCampaignTrialAgentTurns(trial)) {
+      return { advanced: false, reachedTurnLimit: true, duplicate: false };
+    }
+
+    const completedAgentTurns = trial.completedAgentTurns + 1;
+    const completedAgentTurnIds = [...trial.completedAgentTurnIds, turnCompletionId];
+    const reachedTurnLimit = completedAgentTurns >= trial.maxAgentTurns;
+    const nextMetadata = withLandingCampaignChatState(
+      chat.metadata,
+      reachedTurnLimit ? "completed" : "running",
+      reachedTurnLimit,
+      { completedAgentTurns, completedAgentTurnIds },
+    );
+
+    await tx.update(chats).set({ metadata: nextMetadata, updatedAt: new Date() }).where(eq(chats.id, chatId));
+    return { advanced: true, reachedTurnLimit, duplicate: false };
+  });
+}

--- a/packages/server/src/services/landing-campaigns/metadata.ts
+++ b/packages/server/src/services/landing-campaigns/metadata.ts
@@ -48,6 +48,7 @@ export function buildLandingCampaignChatMetadata(input: {
   awaitingUserKind?: LandingCampaignTrialAwaitingUserKind;
   maxAgentTurns?: number;
   completedAgentTurns?: number;
+  completedAgentTurnIds?: string[];
 }): Record<string, unknown> {
   return {
     landingCampaignTrial: {
@@ -61,6 +62,7 @@ export function buildLandingCampaignChatMetadata(input: {
       ...(input.awaitingUserKind ? { awaitingUserKind: input.awaitingUserKind } : {}),
       maxAgentTurns: input.maxAgentTurns ?? 1,
       completedAgentTurns: input.completedAgentTurns ?? 0,
+      completedAgentTurnIds: input.completedAgentTurnIds ?? [],
     },
   };
 }
@@ -72,6 +74,7 @@ export function withLandingCampaignChatState(
   updates: {
     awaitingUserKind?: LandingCampaignTrialAwaitingUserKind;
     completedAgentTurns?: number;
+    completedAgentTurnIds?: string[];
     maxAgentTurns?: number;
   } = {},
 ): Record<string, unknown> {

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -387,7 +387,7 @@ async function ensureTrialChatAndBootstrap(
     skillSetVersion: input.skillSet.version,
     repo: input.repo,
     state: "running",
-    inputLocked: true,
+    inputLocked: false,
     maxAgentTurns: app.config.growth.landingCampaignMaxAgentTurns,
     completedAgentTurns: 0,
   });

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -23,6 +23,7 @@ import { uuidv7 } from "../uuid.js";
 import { upsertSessionState } from "./activity.js";
 import { applyAfterFanOut, fireChatMessageKick } from "./chat-projection.js";
 import { validateDocumentContext, validateMessageAttachmentRefs } from "./doc-snapshots.js";
+import { hasRemainingLandingCampaignTrialAgentTurns } from "./landing-campaigns/chat-state.js";
 import { getLandingCampaignTrialChat, withLandingCampaignChatState } from "./landing-campaigns/metadata.js";
 
 const log = createLogger("message");
@@ -150,14 +151,15 @@ function assertLandingCampaignTrialMessageAllowed(input: {
       trial.state === "running";
     if (isSystemBootstrap) return;
 
-    const resolvesRequest = requestResolutionSchema.safeParse(input.metadataToStore.resolves).success;
-    if (
-      trial.state === "awaiting_user" &&
-      trial.inputLocked === false &&
-      (trial.awaitingUserKind === "follow_up" || resolvesRequest)
-    ) {
-      return;
+    if (!hasRemainingLandingCampaignTrialAgentTurns(trial)) {
+      throw new ForbiddenError("Landing campaign trial chat is locked.");
     }
+
+    const resolvesRequest = requestResolutionSchema.safeParse(input.metadataToStore.resolves).success;
+    if (trial.state === "awaiting_user" && trial.awaitingUserKind !== "follow_up" && !resolvesRequest) {
+      throw new ForbiddenError("Landing campaign trial chat is waiting for a request answer.");
+    }
+    return;
   }
 
   throw new ForbiddenError("Landing campaign trial chat is locked.");
@@ -821,25 +823,13 @@ async function sendMessageInner(
           nextMetadata = withLandingCampaignChatState(chatRow.metadata, "awaiting_user", false, {
             awaitingUserKind: "request",
           });
-        } else {
-          const completedAgentTurns = trial.completedAgentTurns + 1;
-          const reachedTurnLimit = completedAgentTurns >= trial.maxAgentTurns;
-          nextMetadata = withLandingCampaignChatState(
-            chatRow.metadata,
-            reachedTurnLimit ? "completed" : "awaiting_user",
-            reachedTurnLimit,
-            {
-              ...(reachedTurnLimit ? {} : { awaitingUserKind: "follow_up" as const }),
-              completedAgentTurns,
-            },
-          );
         }
       } else if (
         senderRow.type === "human" &&
         trial.state === "awaiting_user" &&
         (resolvedRequest || trial.awaitingUserKind === "follow_up")
       ) {
-        nextMetadata = withLandingCampaignChatState(chatRow.metadata, "running", true);
+        nextMetadata = withLandingCampaignChatState(chatRow.metadata, "running", false);
       }
       if (nextMetadata) {
         await tx.update(chats).set({ metadata: nextMetadata, updatedAt: new Date() }).where(eq(chats.id, chatId));

--- a/packages/shared/src/__tests__/session-event-schema.test.ts
+++ b/packages/shared/src/__tests__/session-event-schema.test.ts
@@ -234,6 +234,14 @@ describe("sessionEventSchema", () => {
       }
     });
 
+    it("parses an optional stable turn completion id", () => {
+      const r = sessionEventSchema.safeParse({
+        kind: "turn_end",
+        payload: { status: "success", turnCompletionId: "inbox:101" },
+      });
+      expect(r.success).toBe(true);
+    });
+
     it("rejects an unknown status", () => {
       const r = sessionEventSchema.safeParse({
         kind: "turn_end",

--- a/packages/shared/src/schemas/landing-campaign.ts
+++ b/packages/shared/src/schemas/landing-campaign.ts
@@ -56,6 +56,7 @@ export const landingCampaignTrialChatMetadataSchema = z.object({
     awaitingUserKind: landingCampaignTrialAwaitingUserKindSchema.optional(),
     maxAgentTurns: z.number().int().min(1).default(1),
     completedAgentTurns: z.number().int().min(0).default(0),
+    completedAgentTurnIds: z.array(z.string().min(1)).default([]),
   }),
 });
 export type LandingCampaignTrialChatMetadata = z.infer<typeof landingCampaignTrialChatMetadataSchema>;

--- a/packages/shared/src/schemas/session-event.ts
+++ b/packages/shared/src/schemas/session-event.ts
@@ -80,6 +80,7 @@ export type ThinkingEventPayload = z.infer<typeof thinkingEventPayload>;
  */
 export const turnEndEventPayload = z.object({
   status: z.enum(["success", "error"]),
+  turnCompletionId: z.string().min(1).optional(),
 });
 export type TurnEndEventPayload = z.infer<typeof turnEndEventPayload>;
 


### PR DESCRIPTION
## Summary

- Keep landing campaign trial chats writable until their configured agent-turn cap is reached, including while the agent is currently running.
- Count trial agent turns from confirmed `turn_end(success)` runtime events before inbox ACK, using a stable `turnCompletionId` derived from durable inbox/message ids instead of provider turn ids.
- Preserve normal Codex behavior: non-trial Codex success turns still emit fire-and-forget session events and ACK normally.
- Treat legacy `awaiting_user` trial metadata without `awaitingUserKind` as request waits, so ordinary human messages cannot bypass unresolved requests.

## Details

The previous follow-up implementation relied on chat message writes to advance the trial lifecycle, but Codex final-text mirror is retired and successful turns now surface as runtime `turn_end` events. This PR moves the landing trial turn budget transition to confirmed runtime events and makes it idempotent by storing processed logical completion ids in chat metadata.

The confirmed pre-ACK path is intentionally limited to landing campaign trial agents. For ordinary Codex agents, session events remain trace-only and do not gate inbox ACK.

## Verification

- `packages/client`: `pnpm exec vitest run src/__tests__/codex-app-server-handler.test.ts src/__tests__/codex-usage-limit.test.ts --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `packages/server`: `pnpm exec vitest run src/__tests__/landing-campaigns-start.test.ts src/__tests__/ws-session-event.test.ts --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `packages/shared`: `pnpm exec vitest run src/__tests__/session-event-schema.test.ts --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `packages/client`: full `pnpm test -- --maxWorkers=2 --minWorkers=1`
- `packages/server`: full `pnpm test -- --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/shared typecheck`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm typecheck`
- `pnpm exec biome check <changed files>`
- `git diff --check`
- `pnpm check` (exit 0; existing warnings/info only)
