### PR TITLE
feat(web): render landing-campaign trial chat in the normal workspace

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -324,10 +324,6 @@ export function App() {
                 /onboarding route (below); the workspace root redirects users
                 who haven't finished setup into it. */}
               <Route element={<RequireAuth />}>
-                {/* Reusable growth quickstart — full-screen, outside the
-                    workspace chrome. Login guard only; it owns its own campaign
-                    completion semantics and never writes onboarding stamps. */}
-                <Route path="/quickstart" element={<QuickstartPage />} />
                 {/* Standalone onboarding — full-screen, outside the workspace
                     chrome. The workspace root redirects incomplete users
                     here; this route redirects back once setup is complete. */}
@@ -340,6 +336,13 @@ export function App() {
                   }
                 >
                   <Route index element={<WorkspacePage />} />
+                  {/* Growth quickstart (landing-campaign trial). Lives INSIDE
+                      the Layout group so the trial chat renders with full
+                      workspace chrome — but as its own route, NOT the gated
+                      index, so an un-onboarded trial user is not bounced to
+                      /onboarding. It owns its own campaign completion semantics
+                      and never writes onboarding stamps. */}
+                  <Route path="quickstart" element={<QuickstartPage />} />
                   <Route path="context" element={<ContextPage />} />
                   <Route path="context/docs" element={<DocsListPage />} />
                   <Route path="context/docs/:slug" element={<DocPage />} />

--- a/packages/web/src/auth/__tests__/require-auth-scan.test.tsx
+++ b/packages/web/src/auth/__tests__/require-auth-scan.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RequireAuth, scanCampaignOAuthNext } from "../require-auth.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const authMock = vi.hoisted(() => ({
+  value: { isAuthenticated: false as boolean, meLoaded: false as boolean },
+}));
+vi.mock("../auth-context.js", () => ({ useAuth: () => authMock.value }));
+vi.mock("../../pages/landing/index.js", () => ({ LandingPage: () => <div>Landing content</div> }));
+
+const SCAN_URL = "/quickstart?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend";
+
+describe("scanCampaignOAuthNext", () => {
+  it("returns the quickstart URL for a known campaign handoff", () => {
+    expect(
+      scanCampaignOAuthNext({
+        pathname: "/quickstart",
+        search: "?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend",
+      }),
+    ).toBe(SCAN_URL);
+  });
+
+  it("returns null for an unknown campaign", () => {
+    expect(scanCampaignOAuthNext({ pathname: "/quickstart", search: "?campaign=bogus" })).toBeNull();
+  });
+
+  it("returns null when there is no campaign param", () => {
+    expect(scanCampaignOAuthNext({ pathname: "/quickstart", search: "" })).toBeNull();
+  });
+
+  it("returns null off the quickstart path", () => {
+    expect(scanCampaignOAuthNext({ pathname: "/settings", search: "?campaign=production-scan" })).toBeNull();
+  });
+});
+
+describe("RequireAuth — scan funnel login handoff", () => {
+  let root: Root | null = null;
+  let replaceSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    authMock.value = { isAuthenticated: false, meLoaded: false };
+    replaceSpy = vi.spyOn(window.location, "replace").mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    if (root) await act(async () => root?.unmount());
+    root = null;
+    replaceSpy.mockRestore();
+    document.body.innerHTML = "";
+  });
+
+  async function renderRoute(path: string): Promise<HTMLElement> {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    const queryClient = new QueryClient();
+    await act(async () => {
+      root?.render(
+        <MemoryRouter initialEntries={[path]}>
+          <QueryClientProvider client={queryClient}>
+            <Routes>
+              <Route element={<RequireAuth />}>
+                <Route path="/quickstart" element={<div>Quickstart</div>} />
+                <Route path="/settings" element={<div>Settings</div>} />
+              </Route>
+              <Route path="/login" element={<div>Login page</div>} />
+            </Routes>
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+    });
+    return container;
+  }
+
+  it("sends an unauthenticated scan visitor straight to GitHub OAuth, skipping /login", async () => {
+    const container = await renderRoute(SCAN_URL);
+    expect(replaceSpy).toHaveBeenCalledWith(`/api/v1/auth/github/start?next=${encodeURIComponent(SCAN_URL)}`);
+    expect(container.textContent).not.toContain("Login page");
+  });
+
+  it("keeps a normal unauthenticated deep link on the /login interstitial", async () => {
+    const container = await renderRoute("/settings");
+    expect(replaceSpy).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Login page");
+  });
+});

--- a/packages/web/src/auth/require-auth.tsx
+++ b/packages/web/src/auth/require-auth.tsx
@@ -1,5 +1,6 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { Navigate, Outlet, useLocation } from "react-router";
+import { isKnownCampaign } from "../pages/quickstart/campaigns.js";
 import { useAuth } from "./auth-context.js";
 
 /**
@@ -18,6 +19,38 @@ const LandingPage = lazy(() => import("../pages/landing/index.js").then((m) => (
  * even if the chunk takes a few hundred ms over slow 3G.
  */
 const LandingFallback = () => <div className="landing-marketing min-h-screen bg-background" />;
+
+/**
+ * The scan funnel's own login handoff. A logged-out visitor who arrives at
+ * `/quickstart?campaign=<known>&repo=...` is sent STRAIGHT to GitHub OAuth
+ * instead of the generic `/login` interstitial — that page is both an extra
+ * click and off-message ("Set up your team…") for someone who just clicked
+ * "scan my repo". Returns the OAuth `next` (the exact quickstart URL to come
+ * back to) when the skip applies, else `null` so normal `/login` routing runs.
+ *
+ * Only KNOWN campaigns skip: the server's `shouldPreserveSoloSignupNext`
+ * preserves the campaign `next` for the scan funnel, so an unknown campaign
+ * would OAuth then get dropped to `/` — better to keep those on `/login`.
+ * Exported for unit tests.
+ */
+export function scanCampaignOAuthNext(loc: { pathname: string; search: string }): string | null {
+  if (loc.pathname !== "/quickstart") return null;
+  const campaign = new URLSearchParams(loc.search).get("campaign");
+  if (!isKnownCampaign(campaign)) return null;
+  return loc.pathname + loc.search;
+}
+
+/**
+ * Full-page redirect into the server GitHub OAuth start endpoint. This is a
+ * server route (not a router path), so it must be a real navigation, not a
+ * `<Navigate>`. Renders the neutral landing fallback while the browser leaves.
+ */
+function OAuthStartRedirect({ next }: { next: string }) {
+  useEffect(() => {
+    window.location.replace(`/api/v1/auth/github/start?next=${encodeURIComponent(next)}`);
+  }, [next]);
+  return <LandingFallback />;
+}
 
 /**
  * Route guard for everything behind the dashboard chrome.
@@ -45,6 +78,10 @@ export function RequireAuth() {
         </Suspense>
       );
     }
+    // Scan funnel: skip the generic /login screen and go straight to GitHub
+    // OAuth, returning to this exact /quickstart?campaign=...&repo=... URL.
+    const scanNext = scanCampaignOAuthNext(location);
+    if (scanNext) return <OAuthStartRedirect next={scanNext} />;
     // Stash full location (pathname + search + hash) so a deep-link visitor
     // who logs in lands back on the page they originally requested.
     return <Navigate to="/login" replace state={{ from: location }} />;

--- a/packages/web/src/components/__tests__/layout-dom.test.tsx
+++ b/packages/web/src/components/__tests__/layout-dom.test.tsx
@@ -157,6 +157,7 @@ async function renderLayout(route: string): Promise<{ container: HTMLElement; ro
           <Routes>
             <Route element={<Layout />}>
               <Route index element={<div>Workspace child</div>} />
+              <Route path="quickstart" element={<div>Quickstart child</div>} />
               <Route path="context" element={<div>Context child</div>} />
               <Route path="settings" element={<div>Settings child</div>} />
             </Route>
@@ -238,6 +239,22 @@ describe("Layout", () => {
     expect(container.textContent).not.toContain("Mock command palette");
 
     await act(async () => root.unmount());
+  });
+
+  it("renders /quickstart in the full-bleed workspace outlet, not the 960 admin canvas", async () => {
+    // The landing-campaign trial renders the real WorkspaceBody at /quickstart;
+    // it needs the same bare, full-height outlet as `/` so its three-pane
+    // `flex flex-1` shell fills the viewport — NOT the centered 960 canvas the
+    // admin routes (Context / Team / Agent Detail) use.
+    const quickstart = await renderLayout("/quickstart");
+    expect(quickstart.container.textContent).toContain("Quickstart child");
+    expect(quickstart.container.querySelector('[style*="960"]')).toBeNull();
+    await act(async () => quickstart.root.unmount());
+
+    // Control: an admin route DOES get wrapped in the 960 content canvas.
+    const context = await renderLayout("/context");
+    expect(context.container.querySelector('[style*="960"]')).not.toBeNull();
+    await act(async () => context.root.unmount());
   });
 
   it("keeps status chips in the right controls before the compact command palette entry", async () => {

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -48,7 +48,12 @@ export function Layout() {
   }, []);
 
   const location = useLocation();
-  const isWorkspace = location.pathname === "/";
+  // The workspace shell (`WorkspaceBody`) needs the bare, full-height outlet so
+  // its `flex flex-1` three-pane layout fills the viewport. `/` is the gated
+  // index; `/quickstart` renders the SAME `WorkspaceBody` gate-free for the
+  // landing-campaign trial, so it needs the identical outlet — not the padded
+  // 960 admin canvas the `else` branch below wraps other routes in.
+  const isWorkspace = location.pathname === "/" || location.pathname === "/quickstart";
   // Settings owns its own two-column (sidebar + main) layout and centres a
   // ~1160 wrapper instead of the default 960 canvas — let it manage its
   // own width.

--- a/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
+++ b/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
@@ -163,6 +163,13 @@ describe("QuickstartPage — landing campaign trial flow", () => {
     expect(readCampaignIntent()).toBeNull();
   });
 
+  it("canonicalizes a legacy ?chat= trial link to ?c= and starts nothing", async () => {
+    await renderPage(["/quickstart?chat=chat-legacy"]);
+
+    expect(navigateMock).toHaveBeenCalledWith("/quickstart?c=chat-legacy", { replace: true });
+    expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
+  });
+
   it("does not start anything when the feature flag is disabled", async () => {
     growthLandingMock.value = { enabled: false, settled: true };
     seedIntent("production-scan");

--- a/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
+++ b/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
@@ -170,6 +170,16 @@ describe("QuickstartPage — landing campaign trial flow", () => {
     expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
   });
 
+  it("canonicalizes a legacy ?chat= link even with a stored intent, without starting a new trial", async () => {
+    // A leftover valid intent in the same tab must NOT hijack a legacy
+    // selected-chat link into launching a fresh trial before the redirect.
+    seedIntent("production-scan");
+    await renderPage(["/quickstart?chat=chat-legacy"]);
+
+    expect(navigateMock).toHaveBeenCalledWith("/quickstart?c=chat-legacy", { replace: true });
+    expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
+  });
+
   it("does not start anything when the feature flag is disabled", async () => {
     growthLandingMock.value = { enabled: false, settled: true };
     seedIntent("production-scan");

--- a/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
+++ b/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
@@ -42,8 +42,11 @@ vi.mock("../../../hooks/use-server-channel.js", () => ({
   useGrowthLandingPagesEnabled: () => growthLandingMock.value.enabled,
 }));
 vi.mock("../../../api/landing-campaigns.js", () => landingCampaignMock);
-vi.mock("../../workspace/center/chat-by-id.js", () => ({
-  ChatByIdView: ({ chatId }: { chatId: string }) => <div data-testid="quickstart-trial-chat">{chatId}</div>,
+// The trial chat now renders the real workspace shell; stub it so this unit
+// test stays focused on QuickstartPage's launcher/routing, not the whole
+// three-pane workspace. WorkspaceBody reads the selected chat from `?c=`.
+vi.mock("../../workspace/index.js", () => ({
+  WorkspaceBody: () => <div data-testid="quickstart-trial-chat" />,
 }));
 
 function createStorage(): Storage {
@@ -137,25 +140,25 @@ describe("QuickstartPage — landing campaign trial flow", () => {
     });
     expect(authMock.value.refreshMe).toHaveBeenCalled();
     expect(readCampaignIntent()).toBeNull();
-    expect(navigateMock).toHaveBeenCalledWith("/quickstart?chat=chat-1", { replace: true });
+    expect(navigateMock).toHaveBeenCalledWith("/quickstart?c=chat-1", { replace: true });
   });
 
-  it("renders an existing trial chat directly and does not restart the trial", async () => {
+  it("renders the workspace shell for an existing trial chat and does not restart the trial", async () => {
     seedIntent("production-scan");
-    const container = await renderPage(["/quickstart?chat=chat-1"]);
+    const container = await renderPage(["/quickstart?c=chat-1"]);
 
-    expect(container.querySelector('[data-testid="quickstart-trial-chat"]')?.textContent).toBe("chat-1");
+    expect(container.querySelector('[data-testid="quickstart-trial-chat"]')).not.toBeNull();
     expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
-  it("ignores unsupported campaign handoffs", async () => {
+  it("shows the workspace (no dead-end) for an unsupported campaign handoff", async () => {
     seedIntent("production-scan");
     const container = await renderPage([
       "/quickstart?campaign=agent-readiness&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend",
     ]);
 
-    expect(container.textContent).toContain("Start from a First Tree scan");
+    expect(container.querySelector('[data-testid="quickstart-trial-chat"]')).not.toBeNull();
     expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
     expect(readCampaignIntent()).toBeNull();
   });
@@ -181,10 +184,10 @@ describe("QuickstartPage — landing campaign trial flow", () => {
     expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
   });
 
-  it("missing campaign intent renders a pointer and starts nothing", async () => {
+  it("renders the workspace and starts nothing when there is no campaign intent", async () => {
     const container = await renderPage();
 
-    expect(container.textContent).toContain("Start from a First Tree scan");
+    expect(container.querySelector('[data-testid="quickstart-trial-chat"]')).not.toBeNull();
     expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
   });
@@ -215,6 +218,6 @@ describe("QuickstartPage — landing campaign trial flow", () => {
     await flush();
 
     expect(landingCampaignMock.startLandingCampaign).toHaveBeenCalledTimes(2);
-    expect(navigateMock).toHaveBeenCalledWith("/quickstart?chat=chat-2", { replace: true });
+    expect(navigateMock).toHaveBeenCalledWith("/quickstart?c=chat-2", { replace: true });
   });
 });

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -33,6 +33,11 @@ export function QuickstartPage() {
   // The trial chat is selected with the normal workspace `?c=` param so
   // `WorkspaceBody` picks it up unchanged — no bespoke `?chat=` handoff.
   const chatId = useMemo(() => new URLSearchParams(location.search).get("c"), [location.search]);
+  // Back-compat: trials minted before this migration used `?chat=<id>`.
+  // Canonicalize such a legacy URL to `?c=` (effect below) so an already-open
+  // trial tab, bookmark, copied link, or reload still opens the trial chat
+  // instead of silently falling through to the conversation rail.
+  const legacyChatId = useMemo(() => new URLSearchParams(location.search).get("chat"), [location.search]);
 
   const intent = useMemo<CampaignIntent | null>(() => {
     if (chatId) return null;
@@ -81,6 +86,14 @@ export function QuickstartPage() {
     if (settled && !growthLandingPagesEnabled) navigate("/", { replace: true });
   }, [chatId, settled, growthLandingPagesEnabled, navigate]);
 
+  // Canonicalize a legacy `?chat=<id>` trial link to `?c=<id>` (only when no
+  // `?c=` is already present) so pre-migration URLs keep opening the trial chat.
+  useEffect(() => {
+    if (!chatId && legacyChatId) {
+      navigate(`/quickstart?c=${encodeURIComponent(legacyChatId)}`, { replace: true });
+    }
+  }, [chatId, legacyChatId, navigate]);
+
   const retryStart = useCallback(() => {
     void startTrial();
   }, [startTrial]);
@@ -91,6 +104,17 @@ export function QuickstartPage() {
   // user sees the normal workspace here instead of being bounced to
   // /onboarding — and there is no bespoke trial-chat page to maintain.
   if (chatId) return <WorkspaceBody />;
+
+  // A legacy `?chat=` link is being canonicalized to `?c=` (effect above) —
+  // hold a neutral screen for the one tick before the `?c=` URL renders, so we
+  // don't flash the no-selection rail.
+  if (legacyChatId) {
+    return (
+      <QuickstartShell>
+        <StatusRow state="waiting" label="Loading..." />
+      </QuickstartShell>
+    );
+  }
 
   if (!settled || !growthLandingPagesEnabled) {
     return (

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -40,7 +40,11 @@ export function QuickstartPage() {
   const legacyChatId = useMemo(() => new URLSearchParams(location.search).get("chat"), [location.search]);
 
   const intent = useMemo<CampaignIntent | null>(() => {
-    if (chatId) return null;
+    // A selected chat — `?c=` OR a legacy `?chat=` about to be canonicalized —
+    // means "open this chat", not "launch a trial". Short-circuit both so a
+    // stored campaign intent in sessionStorage can't hijack a legacy link into
+    // starting a fresh trial before the redirect lands.
+    if (chatId || legacyChatId) return null;
     const fromUrl = readCampaignHandoff(location);
     if (fromUrl) {
       writeCampaignIntent(fromUrl);
@@ -51,14 +55,17 @@ export function QuickstartPage() {
       return null;
     }
     return readCampaignIntent();
-  }, [chatId, location]);
+  }, [chatId, legacyChatId, location]);
   const campaign = intent ? getCampaign(intent.campaign) : null;
 
   const startStartedRef = useRef(false);
   const [startError, setStartError] = useState<string | null>(null);
 
   const startTrial = useCallback(async () => {
-    if (chatId || !intent || !campaign || startStartedRef.current || !growthLandingPagesEnabled) return;
+    // `legacyChatId` guards alongside `chatId`: a legacy `?chat=` link is a
+    // selected chat being canonicalized, never a launch trigger — even if a
+    // stale campaign intent lingers in sessionStorage.
+    if (chatId || legacyChatId || !intent || !campaign || startStartedRef.current || !growthLandingPagesEnabled) return;
     startStartedRef.current = true;
     setStartError(null);
     try {
@@ -74,7 +81,7 @@ export function QuickstartPage() {
       startStartedRef.current = false;
       setStartError(err instanceof Error ? err.message : "Couldn't open your trial chat. Please try again.");
     }
-  }, [chatId, intent, campaign, organizationId, growthLandingPagesEnabled, refreshMe, navigate]);
+  }, [chatId, legacyChatId, intent, campaign, organizationId, growthLandingPagesEnabled, refreshMe, navigate]);
 
   useEffect(() => {
     if (!settled || !growthLandingPagesEnabled) return;

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { useGrowthLandingPagesState } from "../../hooks/use-server-channel.js";
 import { FlowHint, StatusRow, WorkingState } from "../onboarding/flow-ui.js";
-import { ChatByIdView } from "../workspace/center/chat-by-id.js";
+import { WorkspaceBody } from "../workspace/index.js";
 import { getCampaign } from "./campaigns.js";
 import {
   type CampaignIntent,
@@ -30,7 +30,9 @@ export function QuickstartPage() {
   const location = useLocation();
   const { organizationId, refreshMe } = useAuth();
   const { enabled: growthLandingPagesEnabled, settled } = useGrowthLandingPagesState();
-  const chatId = useMemo(() => new URLSearchParams(location.search).get("chat"), [location.search]);
+  // The trial chat is selected with the normal workspace `?c=` param so
+  // `WorkspaceBody` picks it up unchanged — no bespoke `?chat=` handoff.
+  const chatId = useMemo(() => new URLSearchParams(location.search).get("c"), [location.search]);
 
   const intent = useMemo<CampaignIntent | null>(() => {
     if (chatId) return null;
@@ -62,7 +64,7 @@ export function QuickstartPage() {
       });
       clearCampaignIntent();
       await refreshMe();
-      navigate(`/quickstart?chat=${encodeURIComponent(trialChatId)}`, { replace: true });
+      navigate(`/quickstart?c=${encodeURIComponent(trialChatId)}`, { replace: true });
     } catch (err) {
       startStartedRef.current = false;
       setStartError(err instanceof Error ? err.message : "Couldn't open your trial chat. Please try again.");
@@ -83,7 +85,12 @@ export function QuickstartPage() {
     void startTrial();
   }, [startTrial]);
 
-  if (chatId) return <QuickstartTrialChat chatId={chatId} />;
+  // Trial started: render the real workspace shell (full chrome) with the
+  // trial chat selected via `?c=`. This route sits inside the Layout group
+  // but is NOT the onboarding-gated index route, so an un-onboarded trial
+  // user sees the normal workspace here instead of being bounced to
+  // /onboarding — and there is no bespoke trial-chat page to maintain.
+  if (chatId) return <WorkspaceBody />;
 
   if (!settled || !growthLandingPagesEnabled) {
     return (
@@ -93,23 +100,11 @@ export function QuickstartPage() {
     );
   }
 
-  if (!intent || !campaign) {
-    return (
-      <QuickstartShell>
-        <h1 className="text-title" style={{ margin: 0 }}>
-          Start from a First Tree scan
-        </h1>
-        <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
-          Open this from a First Tree scan link so we know which repo to look at.
-        </p>
-        <div className="flex">
-          <Button asChild>
-            <a href="/">Go to your workspace</a>
-          </Button>
-        </div>
-      </QuickstartShell>
-    );
-  }
+  // No chat selected and no valid campaign handoff to launch — e.g. the user
+  // closed/backed out of the trial chat, or opened /quickstart without a scan
+  // link. Keep them in the real workspace (conversation rail) rather than a
+  // dead-end card: WorkspaceBody with no `?c=` shows their conversation list.
+  if (!intent || !campaign) return <WorkspaceBody />;
 
   return (
     <QuickstartShell repoSlug={intent.repoSlug}>
@@ -139,18 +134,13 @@ export function QuickstartPage() {
   );
 }
 
-function QuickstartTrialChat({ chatId }: { chatId: string }) {
-  return (
-    <div className="flex min-h-screen flex-col" style={{ background: "var(--bg)", color: "var(--fg)" }}>
-      <ChatByIdView chatId={chatId} narrow={false} onShowConversations={null} />
-    </div>
-  );
-}
-
 function QuickstartShell({ repoSlug, children }: { repoSlug?: string; children: ReactNode }) {
+  // `flex-1` (not `min-h-screen`): this launcher now renders inside the
+  // workspace Layout outlet, so it fills the available area under the header
+  // rather than forcing a full-viewport block that would overflow past it.
   return (
     <div
-      className="flex min-h-screen flex-col items-center"
+      className="flex flex-1 flex-col items-center justify-center overflow-y-auto"
       style={{ background: "var(--bg)", color: "var(--fg)", padding: "var(--sp-8) var(--sp-5)" }}
     >
       <div className="flex w-full flex-col" style={{ maxWidth: "30rem", gap: "var(--sp-5)" }}>

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -107,9 +107,49 @@ export function parseParticipantList(params: URLSearchParams): string[] {
 }
 
 export function WorkspacePage() {
-  const [searchParams, setSearchParams] = useSearchParams();
   const { meLoaded, onboardingStep, onboardingDismissedAt, onboardingCompletedAt, currentOrgHasPersonalAgent } =
     useAuth();
+
+  // Users who haven't finished setup go through the standalone /onboarding
+  // flow — including the server-`completed`-but-no-start-chat case. Only
+  // terminally completed or dismissed users fall through to the normal
+  // workspace; the old inline center-panel onboarding has been retired.
+  //
+  // The gate lives HERE (the `/` index route), not inside `shouldEnterOnboarding`
+  // or `WorkspaceBody`: the landing-campaign quickstart funnel renders the same
+  // `WorkspaceBody` at `/quickstart?c=<id>` WITHOUT this gate, so an un-onboarded
+  // trial user is not bounced to /onboarding. Keeping the skip at the route/caller
+  // level leaves `shouldEnterOnboarding` a pure, campaign-agnostic function.
+  if (
+    shouldEnterOnboarding({
+      meLoaded,
+      onboardingStep,
+      onboardingSuppressedAt: onboardingDismissedAt,
+      currentOrgHasPersonalAgent,
+      // Not read by the entry gate (auto-entry keys off connect + org
+      // personal-agent readiness only); supplied because both gates share
+      // OnboardingGateFacts.
+      onboardingCompletedAt,
+    })
+  ) {
+    return <Navigate to="/onboarding" replace />;
+  }
+
+  return <WorkspaceBody />;
+}
+
+/**
+ * Workspace body — the chat-first three-pane shell (conversation rail +
+ * center chat + doc-preview drawer) plus all the URL-backed rail state.
+ *
+ * Split out of `WorkspacePage` so the SAME shell renders in two places:
+ *   - `/` — behind the onboarding gate (via `WorkspacePage`).
+ *   - `/quickstart?c=<id>` — gate-free, inside the landing-campaign trial
+ *     funnel, so the trial chat shows the real workspace instead of a
+ *     bespoke standalone page.
+ */
+export function WorkspaceBody() {
+  const [searchParams, setSearchParams] = useSearchParams();
   const selectedChatId = searchParams.get("c");
   const legacyAgentId = searchParams.get("a");
   const legacySource = searchParams.get("source");
@@ -258,25 +298,6 @@ export function WorkspacePage() {
     // win and leave the URL in a half-cleared state.
     setSearchParams(nextParamsForClearFilters(searchParams), { replace: true });
   }, [searchParams, setSearchParams]);
-
-  // Users who haven't finished setup go through the standalone /onboarding
-  // flow — including the server-`completed`-but-no-start-chat case. Only
-  // terminally completed or dismissed users fall through to the normal
-  // workspace; the old inline center-panel onboarding has been retired.
-  if (
-    shouldEnterOnboarding({
-      meLoaded,
-      onboardingStep,
-      onboardingSuppressedAt: onboardingDismissedAt,
-      currentOrgHasPersonalAgent,
-      // Not read by the entry gate (auto-entry keys off connect + org
-      // personal-agent readiness only); supplied because both gates share
-      // OnboardingGateFacts.
-      onboardingCompletedAt,
-    })
-  ) {
-    return <Navigate to="/onboarding" replace />;
-  }
 
   // Pick the width prop based on what role the rail is playing:
   //   - narrow + no chat → full-bleed (100% of the wrapper) so the list


### PR DESCRIPTION
Closes #1449.

## Problem

The landing-campaign (First Tree Scan) trial first chat rendered as a **bespoke standalone page** — `QuickstartTrialChat`, a bare `min-h-screen` div wrapping a stripped `ChatByIdView` at `/quickstart?chat=<id>`, kept outside the workspace `Layout` and the onboarding gate. It was a divergent second chat surface, a dead-end (no path into the product), and it contradicted the Landing Campaign Trial Runtime model that deliberately makes the trial an ordinary org + ordinary agent + ordinary chat.

## What changed

Render the trial chat inside the **real workspace** (full chrome) while keeping the funnel's independent, gate-free `/quickstart` route:

- **Split `WorkspacePage`** into the onboarding gate + a shared exported `WorkspaceBody` (the three-pane shell + URL-backed rail state). `/` runs the gate then the body; the trial route renders `WorkspaceBody` **without** the gate. The gate skip lives at the route/caller level — `shouldEnterOnboarding` stays a **pure, campaign-agnostic** function (untouched).
- **Move `/quickstart` inside the `<Layout>` route group** and give it the full-bleed workspace outlet (`layout.tsx`), so the trial chat fills the viewport instead of the 960px admin canvas.
- **Unify chat selection on `?c=`**; delete the bespoke `QuickstartTrialChat`. When no chat is selected, show the real workspace conversation rail rather than a dead-end card.
- **Skip the `/login` interstitial for the scan funnel**: an unauthenticated visitor to `/quickstart?campaign=<known>` is sent straight to GitHub OAuth (`require-auth.tsx`), returning to the exact quickstart URL. That page is an extra click and off-message ("Set up your team…") for someone who clicked "scan my repo". Narrow: only `pathname === "/quickstart"` + a known campaign; everything else still uses `/login`.

The trial read-only lock stays metadata-driven (`isLandingCampaignTrialChatLocked`). **Server OAuth (`shouldPreserveSoloSignupNext`) is unchanged.**

## Guardrails honored

- No campaign branch in `shouldEnterOnboarding`.
- Campaign start writes no `onboardingCompletedAt` / suppression.
- Hosted trial agent is not treated as the user's real personal agent.
- Standard onboarding is entered only when the user explicitly acts.
- OAuth `next` is always same-origin `/quickstart` (+ `encodeURIComponent` + server `safeRedirectPath`) — no open redirect.

## Review

Two independent reviews (correctness/regression + constraints/security). Both independently caught one blocker: `Layout` keyed its full-height outlet on `pathname === "/"`, so `/quickstart` would render the trial workspace inside the constrained 960 admin canvas — **fixed** here (`layout.tsx`) plus a Layout DOM test. All five hard constraints were independently confirmed honored.

## Tests

`pnpm --filter @first-tree/web typecheck` + `lint:tokens` + biome clean; **1096 web tests pass**. New/updated:
- `require-auth-scan.test.tsx`: known-campaign → OAuth start, unknown/other paths → `/login`, redirect target.
- `layout-dom.test.tsx`: `/quickstart` uses the full-bleed outlet, not the 960 canvas.
- `quickstart-page.e2e.test.tsx`: start → `/quickstart?c=`, reload does not re-start, `?c=` renders the workspace shell, no-chat/unsupported-campaign renders the workspace rail.
- Regression: an un-onboarded user at `/` still redirects to `/onboarding` (`workspace-page-dom.test.tsx`).

Draft pending a live browse pass of the rendered trial chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
