### PR TITLE
fix: align chat image upload cap to shared attachment limit (5MB→10MB)

### DIFF
--- a/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { MAX_ATTACHMENT_BYTES } from "@first-tree/shared";
 import { act, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -381,8 +382,8 @@ describe("AskTakeover", () => {
     const c = await renderDom(
       <AskTakeover body="# Evidence?" payload={{ multiSelect: false }} onReply={onReply} onSkip={() => {}} />,
     );
-    // 5MB + 1 byte — over the per-image cap usePendingImages enforces.
-    const big = new File([new ArrayBuffer(5 * 1024 * 1024 + 1)], "big.png", { type: "image/png" });
+    // One byte over the per-image cap usePendingImages enforces.
+    const big = new File([new ArrayBuffer(MAX_ATTACHMENT_BYTES + 1)], "big.png", { type: "image/png" });
     const fileInput = c.querySelector<HTMLInputElement>('input[type="file"]');
     if (!fileInput) throw new Error("file input missing");
     await changeFiles(fileInput, [big]);

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -127,9 +127,9 @@ export function AskTakeover({
   // Keep the card (and its pinned footer) above the on-screen keyboard.
   const keyboardInset = useKeyboardInset();
 
-  // Staged image attachments — same hook (and same `image/* ≤5MB` rules + object-
-  // URL lifecycle) the chat composer uses. A local validation error (oversized
-  // image) renders alongside any host send error below.
+  // Staged image attachments — same hook (and same `image/*` + attachment-cap
+  // rules + object-URL lifecycle) the chat composer uses. A local validation
+  // error (oversized image) renders alongside any host send error below.
   const [imageError, setImageError] = useState<string | null>(null);
   const { pendingImages, addImages, removeImage } = usePendingImages({
     onError: setImageError,

--- a/packages/web/src/lib/use-pending-images.ts
+++ b/packages/web/src/lib/use-pending-images.ts
@@ -1,7 +1,5 @@
+import { MAX_ATTACHMENT_BYTES } from "@first-tree/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
-
-/** Claude API per-image byte limit (5 MB). */
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 
 export type PendingImage = {
   id: string;
@@ -21,7 +19,9 @@ export type UsePendingImages = {
 /**
  * Stages images for an outbound message — the shared backbone of both the
  * in-chat composer and the new-chat draft so they enforce identical image
- * rules (`image/*` only, ≤5 MB each) and the same object-URL lifecycle.
+ * rules (`image/*` only, up to the shared `MAX_ATTACHMENT_BYTES` cap — the same
+ * byte limit the attachment upload route enforces) and the same object-URL
+ * lifecycle.
  *
  * The host owns the actual upload (read → IndexedDB → `sendFileMessageBatch`);
  * this hook only validates and holds the `File` + a revocable preview URL.
@@ -62,10 +62,15 @@ export function usePendingImages(
     const imageFiles = files.filter((f) => f.type.startsWith("image/"));
     if (imageFiles.length === 0) return;
 
-    const oversized = imageFiles.find((f) => f.size > MAX_IMAGE_SIZE);
+    // Gate on the shared attachment byte cap: it's the binding limit for our
+    // path — an image the composer accepts is one the attachment upload route
+    // will store, and chat images reach the agent as on-disk files read via its
+    // Read tool (see the claude-code handler), not as raw base64 image blocks,
+    // so the raw-byte storage cap governs rather than any model image-block limit.
+    const oversized = imageFiles.find((f) => f.size > MAX_ATTACHMENT_BYTES);
     if (oversized) {
       optsRef.current.onError?.(
-        `Image too large (${(oversized.size / 1024 / 1024).toFixed(1)}MB). Maximum ${MAX_IMAGE_SIZE / 1024 / 1024}MB per image.`,
+        `Image too large (${(oversized.size / 1024 / 1024).toFixed(1)}MB). Maximum ${MAX_ATTACHMENT_BYTES / 1024 / 1024}MB per image.`,
       );
       return;
     }

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -116,9 +116,9 @@ export function NewChatDraft({
   const pickerContainerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Image staging shared with the in-chat composer (same image/* + 5 MB
-  // rules and object-URL lifecycle). Bytes are read and uploaded only on
-  // send, after the chat is created — see `createMut` below.
+  // Image staging shared with the in-chat composer (same image/* +
+  // attachment-cap rules and object-URL lifecycle). Bytes are read and
+  // uploaded only on send, after the chat is created — see `createMut` below.
   const { pendingImages, addImages, removeImage, clearImages } = usePendingImages({
     onError: setError,
     onChange: () => setError(null),


### PR DESCRIPTION
## What

The chat composer's per-image upload gate was hardcoded to **5MB** in `use-pending-images.ts`, with a comment claiming it was *"the Claude API per-image byte limit"*. That comment is inaccurate, and the gate was stricter than our own server already allows.

Facts (per [Anthropic vision docs](https://platform.claude.com/docs/en/build-with-claude/vision) → Image limits and costs):
- **Direct Claude API** per-image limit = **10MB** (base64).
- **5MB** is the **Amazon Bedrock / Google Cloud** limit — this repo uses neither.
- Our own attachment upload route already accepts up to `MAX_ATTACHMENT_BYTES` (**10MB**), enforced as the route `bodyLimit` (`api/orgs/attachments.ts`) **and** re-checked in `services/attachment.ts`.

So the composer's 5MB was both mislabeled and stricter than the rest of our stack — a user could upload a 6–10MB image in Claude Code but not here.

## Change

- `use-pending-images.ts`: replace the hardcoded `MAX_IMAGE_SIZE = 5MB` (+ wrong comment) with the shared `MAX_ATTACHMENT_BYTES` constant, so the composer gate tracks the real server-enforced cap from a single source of truth (no future drift). The error copy auto-updates to "Maximum 10MB per image".
- Fix two stale `≤5MB` comments in the consumers (`ask-takeover.tsx`, `new-chat-draft.tsx`).
- Update the boundary in `ask-takeover-dom.test.tsx` to `MAX_ATTACHMENT_BYTES + 1`.

## Why 10MB is safe for this path

Chat images are **not** sent to the model as raw base64 image blocks. They're stored as attachments, written to the agent's local disk, and read via the agent's **Read tool** (see the `claude-code` handler — the SDK does not reliably forward `{type: "image"}` blocks). So the binding limit is the raw-byte attachment storage cap (10MB), which the frontend now matches exactly.

## Verification

- `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens`) — clean.
- `biome check` on all changed files — clean.
- `ask-takeover-dom.test.tsx` — 18/18 pass (oversized-rejection path still exercised at cap+1).
- 2 independent code reviews (correctness + adversarial); transport/storage path confirmed safe to 10MB by both.
- **Not run:** a live end-to-end upload of a >5MB image through a running Claude agent (needs the full local stack). The transport is proven safe; the model-accept step relies on the agent's Read tool downsampling large images. Reviewers/maintainers: flag if you want that E2E before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
