### PR TITLE
fix(client): allow landing trial system reads

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -463,10 +463,12 @@ describe("codex app-server handler", () => {
   it("starts landing campaign trial app-server with host Codex auth and managed workspace-only permissions", async () => {
     const hostHome = join(workspaceRoot, "..", "host-home");
     const codexHome = join(hostHome, ".codex");
+    const ghConfigDir = join(hostHome, ".config", "gh");
     const firstTreeHome = join(workspaceRoot, "first-tree-home");
     const cliBinDir = join(workspaceRoot, "first-tree-cli-bin");
     mkdirSync(cliBinDir, { recursive: true });
     mkdirSync(codexHome, { recursive: true });
+    mkdirSync(ghConfigDir, { recursive: true });
     writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
     vi.stubEnv("HOME", hostHome);
     vi.stubEnv("FIRST_TREE_HOME", firstTreeHome);
@@ -522,6 +524,7 @@ describe("codex app-server handler", () => {
     expect(capturedEnv?.FIRST_TREE_HOME).toBe(join(workspaceRoot, ".first-tree-workspace", "outbox-home"));
     expect(capturedEnv?.HOME).toBe(workspaceRoot);
     expect(capturedEnv?.CODEX_HOME).toBe(codexHome);
+    expect(capturedEnv?.GH_CONFIG_DIR).toBe(ghConfigDir);
     expect(capturedEnv?.PATH?.split(":")[0]).toBe(cliBinDir);
     expect(capturedEnv?.OPENAI_API_KEY).toBeUndefined();
     expect(capturedEnv?.CODEX_API_KEY).toBeUndefined();
@@ -541,9 +544,11 @@ describe("codex app-server handler", () => {
             [workspaceRoot]: true,
           },
           filesystem: {
-            ":minimal": "read",
+            ":root": "read",
             [workspaceRoot]: "write",
             [codexHome]: "deny",
+            [join(hostHome, ".first-tree-staging")]: "deny",
+            [join(hostHome, ".ssh")]: "deny",
           },
           network: {
             enabled: true,

--- a/packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts
+++ b/packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts
@@ -164,15 +164,21 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
     const codexVersion = commandOutput(`${shellQuote(codexBinary)} --version || true`);
     const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-landing-codex-clean-smoke-")));
     tempRoots.push(root);
-    const workspace = join(root, "workspace");
-    const outside = join(root, "outside");
-    const codexHome = join(root, "clean-codex-home");
+    const hostHome = join(root, "host-home");
+    const workspace = join(hostHome, ".first-tree-staging", "data", "workspaces", "clean-smoke");
+    const codexHome = join(hostHome, ".codex");
     const firstTreeHome = join(workspace, FIRST_TREE_WORKSPACE_MARKER, "outbox-home");
+    const hostFirstTreeSecret = join(hostHome, ".first-tree-staging", "config", "credentials.json");
+    const hostSshSecret = join(hostHome, ".ssh", "id_ed25519");
+    const ghConfigDir = join(hostHome, ".config", "gh");
     mkdirSync(firstTreeHome, { recursive: true });
-    mkdirSync(outside);
-    mkdirSync(codexHome);
-    const outsideSentinel = join(outside, "sentinel.txt");
-    writeFileSync(outsideSentinel, "outside-secret\n", { mode: 0o600 });
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(dirname(hostFirstTreeSecret), { recursive: true });
+    mkdirSync(dirname(hostSshSecret), { recursive: true });
+    mkdirSync(ghConfigDir, { recursive: true });
+    writeFileSync(join(codexHome, "auth.json"), "{}\n", { mode: 0o600 });
+    writeFileSync(hostFirstTreeSecret, "first-tree-host-secret\n", { mode: 0o600 });
+    writeFileSync(hostSshSecret, "ssh-secret\n", { mode: 0o600 });
 
     const cliPath = resolveCliPath();
     setCliBinding({ binName: basename(cliPath), packageName: basename(cliPath) });
@@ -180,6 +186,7 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
     const appServerEnvironment = buildWorkspaceOnlyAppServerEnvironment(
       {
         ...process.env,
+        HOME: hostHome,
         CODEX_HOME: codexHome,
         FIRST_TREE_HOME: firstTreeHome,
         FIRST_TREE_CLI_BIN_DIR: dirname(cliPath),
@@ -190,7 +197,11 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
       binary: codexBinary,
       cwd: workspace,
       env: appServerEnvironment.env,
-      appServerArgs: buildLandingCodexAppServerArgs(workspace, appServerEnvironment.codexHome),
+      appServerArgs: buildLandingCodexAppServerArgs(
+        workspace,
+        appServerEnvironment.codexHome,
+        appServerEnvironment.hostHome,
+      ),
       requestTimeoutMs: 120_000,
     });
 
@@ -206,7 +217,19 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
             "sh",
             "-lc",
             [
-              `if cat ${shellQuote(outsideSentinel)} >/dev/null 2>&1; then echo outside=readable; else echo outside=denied; fi`,
+              'printf "codex_auth="',
+              'if cat "$CODEX_HOME/auth.json" >/dev/null 2>&1; then echo readable; else echo denied; fi',
+              'printf "host_first_tree="',
+              `if cat ${shellQuote(hostFirstTreeSecret)} >/dev/null 2>&1; then echo readable; else echo denied; fi`,
+              'printf "host_ssh="',
+              `if cat ${shellQuote(hostSshSecret)} >/dev/null 2>&1; then echo readable; else echo denied; fi`,
+              'printf "gh_config_dir="',
+              'if test -n "$GH_CONFIG_DIR" && test -d "$GH_CONFIG_DIR"; then echo set; else echo unset; fi',
+              'printf "resolv_conf="',
+              "if test -r /etc/resolv.conf; then echo readable; else echo missing; fi",
+              'printf "dns_lookup="',
+              "if getent hosts dev.cloud.first-tree.ai >/dev/null 2>&1; then echo ok; else echo failed; fi",
+              'printf "workspace_write="',
               'printf ok > clean-config-smoke.txt && cat clean-config-smoke.txt && printf "\\n"',
             ].join("\n"),
           ],
@@ -221,8 +244,13 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
       const stdout = commandStdout(commandResult);
       console.log(`[smoke] clean-config command stdout:\n${stdout}`);
       expect(commandExitCode(commandResult)).toBe(0);
-      expect(stdout).toContain("outside=denied");
-      expect(stdout).toMatch(/^ok$/m);
+      expect(stdout).toContain("codex_auth=denied");
+      expect(stdout).toContain("host_first_tree=denied");
+      expect(stdout).toContain("host_ssh=denied");
+      expect(stdout).toContain("gh_config_dir=set");
+      expect(stdout).toContain("resolv_conf=readable");
+      expect(stdout).toContain("dns_lookup=ok");
+      expect(stdout).toContain("workspace_write=ok");
     } finally {
       await client.shutdown();
     }
@@ -239,13 +267,18 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
 
     const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-landing-codex-smoke-")));
     tempRoots.push(root);
+    const hostHome = join(root, "host-home");
     const workspace = join(root, "workspace");
-    const outside = join(root, "outside");
     const firstTreeHome = join(workspace, FIRST_TREE_WORKSPACE_MARKER, "outbox-home");
+    const hostFirstTreeSecret = join(hostHome, ".first-tree-staging", "config", "credentials.json");
+    const hostSshSecret = join(hostHome, ".ssh", "id_ed25519");
+    const ghConfigDir = join(hostHome, ".config", "gh");
     mkdirSync(firstTreeHome, { recursive: true });
-    mkdirSync(outside);
-    const outsideSentinel = join(outside, "sentinel.txt");
-    writeFileSync(outsideSentinel, "outside-secret\n", { mode: 0o600 });
+    mkdirSync(dirname(hostFirstTreeSecret), { recursive: true });
+    mkdirSync(dirname(hostSshSecret), { recursive: true });
+    mkdirSync(ghConfigDir, { recursive: true });
+    writeFileSync(hostFirstTreeSecret, "first-tree-host-secret\n", { mode: 0o600 });
+    writeFileSync(hostSshSecret, "ssh-secret\n", { mode: 0o600 });
 
     const cliPath = resolveCliPath();
     setCliBinding({ binName: basename(cliPath), packageName: basename(cliPath) });
@@ -253,6 +286,7 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
     const appServerEnvironment = buildWorkspaceOnlyAppServerEnvironment(
       {
         ...process.env,
+        HOME: hostHome,
         CODEX_HOME: codexHome,
         FIRST_TREE_HOME: firstTreeHome,
         FIRST_TREE_CLI_BIN_DIR: dirname(cliPath),
@@ -261,22 +295,32 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
         GITHUB_TOKEN: "smoke-github-secret",
         GH_TOKEN: "smoke-gh-secret",
         FIRST_TREE_RUNTIME_SESSION_TOKEN: "smoke-runtime-secret",
-        FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE: join(outside, "runtime-token"),
+        FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE: join(root, "runtime-token"),
         HTTP_PROXY: "http://user:password@proxy.test:8080",
         HTTPS_PROXY: "http://user:password@proxy.test:8080",
-        SSL_CERT_FILE: join(outside, "ca.pem"),
-        NODE_EXTRA_CA_CERTS: join(outside, "node-ca.pem"),
+        SSL_CERT_FILE: join(root, "ca.pem"),
+        NODE_EXTRA_CA_CERTS: join(root, "node-ca.pem"),
       },
       workspace,
     );
 
-    const permissionProfile = buildLandingCodexPermissionProfile(workspace, appServerEnvironment.codexHome);
+    const permissionProfile = buildLandingCodexPermissionProfile(
+      workspace,
+      appServerEnvironment.codexHome,
+      appServerEnvironment.hostHome,
+    );
     const recorder = createNotificationRecorder();
+    const serverUrl = appServerEnvironment.env.FIRST_TREE_SERVER_URL ?? "https://dev.cloud.first-tree.ai";
+    const serverHost = new URL(serverUrl).hostname;
     const client = await CodexAppServerClient.start({
       binary: codexBinary,
       cwd: workspace,
       env: appServerEnvironment.env,
-      appServerArgs: buildLandingCodexAppServerArgs(workspace, appServerEnvironment.codexHome),
+      appServerArgs: buildLandingCodexAppServerArgs(
+        workspace,
+        appServerEnvironment.codexHome,
+        appServerEnvironment.hostHome,
+      ),
       requestTimeoutMs: 120_000,
       onNotification: recorder.onNotification,
     });
@@ -290,10 +334,29 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
       const commandScript = [
         'printf "codex_auth="',
         'if cat "$CODEX_HOME/auth.json" >/dev/null 2>&1; then echo readable; else echo denied; fi',
-        `printf "outside="`,
-        `if cat ${shellQuote(outsideSentinel)} >/dev/null 2>&1; then echo readable; else echo denied; fi`,
+        'printf "host_first_tree="',
+        `if cat ${shellQuote(hostFirstTreeSecret)} >/dev/null 2>&1; then echo readable; else echo denied; fi`,
+        'printf "host_ssh="',
+        `if cat ${shellQuote(hostSshSecret)} >/dev/null 2>&1; then echo readable; else echo denied; fi`,
+        'printf "gh_config_dir="',
+        'if test -n "$GH_CONFIG_DIR" && test -d "$GH_CONFIG_DIR"; then echo set; else echo unset; fi',
+        'printf "gh_version="',
+        "if gh --version >/dev/null 2>&1; then echo ok; else echo failed; fi",
         'printf "workspace_write="',
         'printf ok > workspace-smoke.txt && cat workspace-smoke.txt && printf "\\n"',
+        'printf "resolv_conf="',
+        "if test -r /etc/resolv.conf; then echo readable; else echo missing; fi",
+        'printf "dns_lookup="',
+        `if getent hosts ${shellQuote(serverHost)} >/dev/null 2>&1; then echo ok; else echo failed; fi`,
+        'printf "server_fetch="',
+        [
+          "node",
+          "-e",
+          shellQuote(
+            "fetch(process.argv[1]).then((response) => { console.log('status:' + response.status); }).catch((err) => { console.error(err); process.exit(1); });",
+          ),
+          shellQuote(serverUrl),
+        ].join(" "),
         'printf "leaked_env="',
         [
           "env",
@@ -325,8 +388,14 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
 
       expect(commandExitCode(commandResult)).toBe(0);
       expect(stdout).toContain("codex_auth=denied");
-      expect(stdout).toContain("outside=denied");
+      expect(stdout).toContain("host_first_tree=denied");
+      expect(stdout).toContain("host_ssh=denied");
+      expect(stdout).toContain("gh_config_dir=set");
+      expect(stdout).toContain("gh_version=ok");
       expect(stdout).toContain("workspace_write=ok");
+      expect(stdout).toContain("resolv_conf=readable");
+      expect(stdout).toContain("dns_lookup=ok");
+      expect(stdout).toMatch(/^server_fetch=status:\d+$/m);
       expect(stdout).toMatch(/^leaked_env=$/m);
 
       if (PROVIDER_CHECK_ENABLED) {

--- a/packages/client/src/__tests__/workspace-sandbox.test.ts
+++ b/packages/client/src/__tests__/workspace-sandbox.test.ts
@@ -18,6 +18,7 @@ import {
   buildWorkspaceOnlyAppServerEnvironment,
   buildWorkspaceOnlyBubblewrapArgs,
   buildWorkspaceOnlyEnvironment,
+  LANDING_CODEX_HOST_CREDENTIAL_DENY_RELATIVE_PATHS,
   LANDING_CODEX_PERMISSIONS_PROFILE,
   prepareWorkspaceOnlyOutboxHome,
 } from "../handlers/codex/app-server/workspace-sandbox.js";
@@ -170,14 +171,20 @@ describe("workspace-only sandbox", () => {
   it("builds a landing app-server env that keeps Codex auth location without leaking host secrets", () => {
     const hostHome = join(root, "host-home");
     const codexHome = join(hostHome, ".codex");
+    const ghConfigDir = join(hostHome, ".config", "gh");
     const firstTreeHome = join(workspace, ".first-tree-workspace", "outbox-home");
     const cliBinDir = join(root, "explicit-cli-bin");
     mkdirSync(codexHome, { recursive: true });
+    mkdirSync(ghConfigDir, { recursive: true });
     mkdirSync(firstTreeHome, { recursive: true });
     mkdirSync(cliBinDir, { recursive: true });
     writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
 
-    const { env, codexHome: resolvedCodexHome } = buildWorkspaceOnlyAppServerEnvironment(
+    const {
+      env,
+      codexHome: resolvedCodexHome,
+      hostHome: resolvedHostHome,
+    } = buildWorkspaceOnlyAppServerEnvironment(
       {
         HOME: hostHome,
         FIRST_TREE_HOME: firstTreeHome,
@@ -201,12 +208,14 @@ describe("workspace-only sandbox", () => {
     );
 
     expect(resolvedCodexHome).toBe(codexHome);
+    expect(resolvedHostHome).toBe(hostHome);
     expect(env).toMatchObject({
       FIRST_TREE_HOME: firstTreeHome,
       FIRST_TREE_SERVER_URL: "https://first-tree.test",
       FIRST_TREE_AGENT_ID: "agent-1",
       HOME: workspace,
       CODEX_HOME: codexHome,
+      GH_CONFIG_DIR: ghConfigDir,
       TMPDIR: "/tmp",
     });
     expect(env.PATH?.split(delimiter)[0]).toBe(cliBinDir);
@@ -225,15 +234,33 @@ describe("workspace-only sandbox", () => {
   });
 
   it("builds landing Codex app-server args with a default permissions profile", () => {
-    const codexHome = join(root, "host-home", ".codex");
+    const hostHome = join(root, "host-home");
+    const codexHome = join(hostHome, ".codex");
     mkdirSync(codexHome, { recursive: true });
 
-    expect(buildLandingCodexAppServerArgs(workspace, codexHome)).toEqual([
+    expect(buildLandingCodexAppServerArgs(workspace, codexHome, hostHome)).toEqual([
       "-c",
-      buildLandingCodexPermissionsConfigOverride(workspace, codexHome),
+      buildLandingCodexPermissionsConfigOverride(workspace, codexHome, hostHome),
       "-c",
       `default_permissions=${JSON.stringify(LANDING_CODEX_PERMISSIONS_PROFILE)}`,
     ]);
+  });
+
+  it("allows host system reads while denying selected host credentials in the landing Codex profile", () => {
+    const hostHome = join(root, "host-home");
+    const codexHome = join(hostHome, ".codex");
+    mkdirSync(codexHome, { recursive: true });
+
+    const override = buildLandingCodexPermissionsConfigOverride(workspace, codexHome, hostHome);
+
+    expect(override).toContain(`${JSON.stringify(":root")} = "read"`);
+    expect(override).toContain(`${JSON.stringify(workspace)} = "write"`);
+    for (const relativePath of LANDING_CODEX_HOST_CREDENTIAL_DENY_RELATIVE_PATHS) {
+      expect(override).toContain(`${JSON.stringify(join(hostHome, relativePath))} = "deny"`);
+    }
+    expect(override).toContain(`${JSON.stringify(codexHome)} = "deny"`);
+    expect(override).not.toContain(".config/gh");
+    expect(override).not.toContain(".git-credentials");
   });
 
   it("does not add an extra read-only bind for an explicit CLI dir covered by system mounts", () => {

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -207,6 +207,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   let latestCurrentSessionUsageTurnId: string | null = null;
   let workspaceOnly = false;
   let workspaceOnlyCodexHome: string | null = null;
+  let workspaceOnlyHostHome: string | null = null;
 
   const pendingInputs: QueueEntry[] = [];
   const pendingNotificationsByTurn = new Map<string, CodexAppServerNotification[]>();
@@ -336,12 +337,13 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
 
   function buildLandingCodexConfig(payload: AgentRuntimeConfigPayload, workspacePath: string): CodexConfigObject {
     const codexHome = workspaceOnlyCodexHome;
-    if (!codexHome) {
-      throw new CodexAppServerStartupError("workspace-sandbox", "missing workspace-only Codex home");
+    const hostHome = workspaceOnlyHostHome;
+    if (!codexHome || !hostHome) {
+      throw new CodexAppServerStartupError("workspace-sandbox", "missing workspace-only Codex host paths");
     }
     const cfg = buildCodexConfig(payload);
     cfg.permissions = {
-      [LANDING_CODEX_PERMISSIONS_PROFILE]: buildLandingCodexPermissionProfile(workspacePath, codexHome),
+      [LANDING_CODEX_PERMISSIONS_PROFILE]: buildLandingCodexPermissionProfile(workspacePath, codexHome, hostHome),
     };
     return cfg;
   }
@@ -443,11 +445,13 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         const appServerEnv = buildWorkspaceOnlyAppServerEnvironment(outboxEnv, cwd);
         env = appServerEnv.env;
         workspaceOnlyCodexHome = appServerEnv.codexHome;
+        workspaceOnlyHostHome = appServerEnv.hostHome;
       } catch (err) {
         throw new CodexAppServerStartupError("workspace-sandbox", err);
       }
     } else {
       workspaceOnlyCodexHome = null;
+      workspaceOnlyHostHome = null;
     }
     return { payload, env, briefingFingerprint: computeBriefingFingerprint(briefing) };
   }
@@ -463,8 +467,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     if (!resolution.ok) throw new CodexAppServerStartupError("resolve-binary", resolution.error);
     try {
       const appServerArgs =
-        workspaceOnly && workspaceOnlyCodexHome
-          ? buildLandingCodexAppServerArgs(workspacePath, workspaceOnlyCodexHome)
+        workspaceOnly && workspaceOnlyCodexHome && workspaceOnlyHostHome
+          ? buildLandingCodexAppServerArgs(workspacePath, workspaceOnlyCodexHome, workspaceOnlyHostHome)
           : undefined;
       appServer = await clientFactory({
         binary: resolution.binary,
@@ -1710,6 +1714,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       pendingChatContextPrompt = null;
       workspaceOnly = false;
       workspaceOnlyCodexHome = null;
+      workspaceOnlyHostHome = null;
       resetThreadUsageTracking(null);
     },
 
@@ -1730,6 +1735,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       pendingChatContextPrompt = null;
       workspaceOnly = false;
       workspaceOnlyCodexHome = null;
+      workspaceOnlyHostHome = null;
       resetThreadUsageTracking(null);
     },
   } satisfies AgentHandler;

--- a/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
+++ b/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
@@ -28,6 +28,7 @@ type WorkspaceOnlyEnvironment = {
 type WorkspaceOnlyAppServerEnvironment = {
   env: NodeJS.ProcessEnv;
   codexHome: string;
+  hostHome: string;
 };
 
 type LandingCodexPermissionProfileConfig = {
@@ -71,6 +72,16 @@ const READ_ONLY_ETC_PATHS = [
   "/etc/nsswitch.conf",
   "/etc/protocols",
   "/etc/services",
+] as const;
+const LANDING_CODEX_ROOT_READ_PATH = ":root";
+export const LANDING_CODEX_HOST_CREDENTIAL_DENY_RELATIVE_PATHS = [
+  ".codex",
+  ".ssh",
+  ".first-tree",
+  ".first-tree-staging",
+  ".first-tree-dev",
+  ".first-tree-local",
+  ".first-tree-test",
 ] as const;
 const WORKSPACE_ONLY_PATH_DIRS = ["/usr/local/bin", "/usr/bin", "/bin"] as const;
 const SAFE_PASS_ENV_KEYS = new Set([
@@ -204,23 +215,36 @@ function validateChannelCliBin(binDir: string, source: string): void {
   }
 }
 
-function resolveHostCodexHome(parentEnv: NodeJS.ProcessEnv, workspaceRoot: string): string {
+function resolveHostHome(parentEnv: NodeJS.ProcessEnv, workspaceRoot: string): string {
+  const rawHome = parentEnv.HOME?.trim();
+  const hostHome = rawHome && rawHome !== workspaceRoot ? rawHome : homedir();
+  return isAbsolute(hostHome) ? hostHome : resolve(hostHome);
+}
+
+function resolveHostCodexHome(parentEnv: NodeJS.ProcessEnv, hostHome: string): string {
   const rawCodexHome = parentEnv.CODEX_HOME?.trim();
-  const hostHome = parentEnv.HOME && parentEnv.HOME !== workspaceRoot ? parentEnv.HOME : homedir();
   if (rawCodexHome) {
     return isAbsolute(rawCodexHome) ? rawCodexHome : resolve(hostHome, rawCodexHome);
   }
   return join(hostHome, ".codex");
 }
 
-export function landingCodexDenyPaths(codexHome: string): string[] {
-  const paths = new Set([codexHome]);
-  if (existsSync(codexHome)) {
+function addDenyPath(paths: Set<string>, path: string): void {
+  paths.add(path);
+  if (existsSync(path)) {
     try {
-      paths.add(realpathSync(codexHome));
+      paths.add(realpathSync(path));
     } catch {
-      // A lexical deny still blocks the configured Codex home.
+      // A lexical deny still blocks the configured path.
     }
+  }
+}
+
+export function landingCodexDenyPaths(codexHome: string, hostHome: string): string[] {
+  const paths = new Set([codexHome]);
+  addDenyPath(paths, codexHome);
+  for (const relativePath of LANDING_CODEX_HOST_CREDENTIAL_DENY_RELATIVE_PATHS) {
+    addDenyPath(paths, join(hostHome, relativePath));
   }
   return [...paths];
 }
@@ -228,17 +252,18 @@ export function landingCodexDenyPaths(codexHome: string): string[] {
 export function buildLandingCodexPermissionProfile(
   workspacePath: string,
   codexHome: string,
+  hostHome: string,
 ): LandingCodexPermissionProfileConfig {
   const filesystem: LandingCodexPermissionProfileConfig["filesystem"] = {
-    ":minimal": "read",
+    [LANDING_CODEX_ROOT_READ_PATH]: "read",
     [workspacePath]: "write",
   };
-  for (const path of landingCodexDenyPaths(codexHome)) {
+  for (const path of landingCodexDenyPaths(codexHome, hostHome)) {
     filesystem[path] = "deny";
   }
 
   return {
-    description: "First Tree landing trial workspace-only profile",
+    description: "First Tree landing trial root-read profile with selected host credential denies",
     workspace_roots: {
       [workspacePath]: true,
     },
@@ -258,16 +283,20 @@ function tomlInline(value: TomlInlineValue): string {
     .join(", ")} }`;
 }
 
-export function buildLandingCodexPermissionsConfigOverride(workspacePath: string, codexHome: string): string {
+export function buildLandingCodexPermissionsConfigOverride(
+  workspacePath: string,
+  codexHome: string,
+  hostHome: string,
+): string {
   return `permissions=${tomlInline({
-    [LANDING_CODEX_PERMISSIONS_PROFILE]: buildLandingCodexPermissionProfile(workspacePath, codexHome),
+    [LANDING_CODEX_PERMISSIONS_PROFILE]: buildLandingCodexPermissionProfile(workspacePath, codexHome, hostHome),
   })}`;
 }
 
-export function buildLandingCodexAppServerArgs(workspacePath: string, codexHome: string): string[] {
+export function buildLandingCodexAppServerArgs(workspacePath: string, codexHome: string, hostHome: string): string[] {
   return [
     "-c",
-    buildLandingCodexPermissionsConfigOverride(workspacePath, codexHome),
+    buildLandingCodexPermissionsConfigOverride(workspacePath, codexHome, hostHome),
     "-c",
     `default_permissions=${JSON.stringify(LANDING_CODEX_PERMISSIONS_PROFILE)}`,
   ];
@@ -386,7 +415,8 @@ export function buildWorkspaceOnlyAppServerEnvironment(
   }
   const resolvedFirstTreeHome = assertPathInsideWorkspace(firstTreeHome, realWorkspace, "FIRST_TREE_HOME");
   const cli = resolveWorkspaceOnlyCli(parentEnv);
-  const codexHome = resolveHostCodexHome(parentEnv, realWorkspace);
+  const hostHome = resolveHostHome(parentEnv, realWorkspace);
+  const codexHome = resolveHostCodexHome(parentEnv, hostHome);
 
   const env: NodeJS.ProcessEnv = {};
   for (const key of WORKSPACE_ONLY_APP_SERVER_PASS_ENV_KEYS) {
@@ -399,7 +429,11 @@ export function buildWorkspaceOnlyAppServerEnvironment(
   env.TMPDIR = "/tmp";
   env.FIRST_TREE_CLI_BIN_DIR = cli.cliBinDir;
   env.PATH = cli.pathDirs.join(delimiter);
-  return { env, codexHome };
+  const hostGhConfigDir = join(hostHome, ".config", "gh");
+  if (existingDirectory(hostGhConfigDir)) {
+    env.GH_CONFIG_DIR = hostGhConfigDir;
+  }
+  return { env, codexHome, hostHome };
 }
 
 export function buildWorkspaceOnlyBubblewrapArgs(options: BuildBubblewrapArgsOptions): string[] {


### PR DESCRIPTION
## Summary

- Change the landing Codex trial permission profile from strict `:minimal` reads to `:root` read with selected host credential denies, so sandboxed tool commands can read Linux DNS/TLS/system config needed by common CLIs.
- Keep the landing workspace writable and continue denying host Codex auth, host First Tree state dirs, and host SSH keys from tool commands.
- Preserve host `gh` usability by passing `GH_CONFIG_DIR` when the host GitHub CLI config exists; this is an explicit product tradeoff for landing trials that need public-repo PR/comment workflows.
- Extend the real Codex app-server smoke to prove DNS/server fetch works while selected credentials remain unreadable.

## Security boundary

This PR intentionally changes the landing trial tool boundary from strict workspace-only reads to root-read plus selected credential denies. The app-server process still uses host `CODEX_HOME` for provider auth, but tool commands cannot read that Codex auth path. First Tree runtime token/API/GitHub/proxy/cert env vars remain scrubbed.

The selected host credential deny list covers:

- host `CODEX_HOME` / `~/.codex`
- `~/.ssh`
- common host First Tree state dirs: `~/.first-tree*`

It does not deny host `gh` config, because landing trial agents are expected to use the configured public-repo GitHub capability on the staging machine.

## Product/security decision

Human decision in the First Tree `agent托管方案` chat on 2026-07-06: keep the current landing trial model as `:root=read` plus the small selected deny list above, instead of denying the whole host home and reopening only selected subtrees.

Operational assumption for this hosted landing-trial model: machines running these public-repo landing trials are treated as low-sensitive trial hosts. They must not contain unapproved high-value host credentials outside the explicit deny list. The configured `gh` account is intentionally available for public-repo PR/comment workflows.

## Verification

- `pnpm exec vitest run src/__tests__/workspace-sandbox.test.ts src/__tests__/codex-app-server-handler.test.ts src/__tests__/codex-landing-app-server-smoke.test.ts --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `SKIP_CODEX_LANDING_PROVIDER_SMOKE=1 pnpm --filter @first-tree/client smoke:landing-codex-auth-sandbox`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm exec biome check packages/client/src/handlers/codex/app-server/workspace-sandbox.ts packages/client/src/handlers/codex/app-server/index.ts packages/client/src/__tests__/workspace-sandbox.test.ts packages/client/src/__tests__/codex-app-server-handler.test.ts packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts`
- `git diff --check`
- Full client suite: `pnpm exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1` from `packages/client` -> 115 files passed + 1 skipped; 1230 passed + 2 skipped
- `pnpm typecheck`
- `pnpm check` exits 0; existing warnings/info only outside this diff

Real smoke key output with `codex-cli 0.142.5` and provider turn skipped:

```text
clean-config:
codex_auth=denied
host_first_tree=denied
host_ssh=denied
gh_config_dir=set
resolv_conf=readable
dns_lookup=ok
workspace_write=ok

host-auth:
codex_auth=denied
host_first_tree=denied
host_ssh=denied
gh_config_dir=set
gh_version=ok
workspace_write=ok
resolv_conf=readable
dns_lookup=ok
server_fetch=status:200
leaked_env=
```
