### PR TITLE
fix(web): neutral GitHub install popup landing instead of false "Connected"

### DIFF
--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -1261,10 +1261,13 @@ describe("page SSR smoke coverage", () => {
     expect(html).toContain("Install Node.js");
 
     // The install-popup landing page (auto-closes the script-opened tab; the
-    // effect is a no-op under SSR). Confirms it renders + carries role=status.
+    // effect is a no-op under SSR). It makes no success claim — success vs
+    // pending-approval is owned by the origin tab — so it reads neutral and
+    // just points the user back. Confirms it renders + carries role=status.
     const connectedHtml = renderPage(<GithubConnectedPage />);
-    expect(connectedHtml).toContain("Connected");
+    expect(connectedHtml).toContain("Back to First Tree");
     expect(connectedHtml).toContain("close this tab");
+    expect(connectedHtml).not.toContain("Connected");
     expect(connectedHtml).toContain('role="status"');
 
     expect(await renderOnboardingStep(<StepTeam />, { activeStep: "create-team" })).toContain(

--- a/packages/web/src/pages/onboarding/github-connected.tsx
+++ b/packages/web/src/pages/onboarding/github-connected.tsx
@@ -1,23 +1,29 @@
-import { Check } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { useEffect } from "react";
 
 /**
  * Landing page for the GitHub App install popup — shared by every surface that
  * opens the install in a new tab with `next=/onboarding/connected`: onboarding
  * connect-code, the Context tab build entry, and Settings → GitHub. GitHub's
- * callback lands the popup here; we confirm and auto-close the tab (it was
- * script-opened, so `window.close()` is allowed) while the original tab detects
- * the new installation via its poll and updates on its own. If the browser
- * refuses to close the tab, the message tells the user to close it. Copy is kept
- * surface-neutral ("the other tab will update") so it reads correctly whether the
- * origin tab is an onboarding wizard or a settings page.
+ * callback lands the popup here; we auto-close the tab (it was script-opened, so
+ * `window.close()` is allowed) while the original tab detects the outcome via
+ * its own poll. If the browser refuses to close the tab, the message tells the
+ * user to close it.
+ *
+ * This page deliberately makes NO success claim. The same popup lands here for a
+ * genuine install AND for a non-owner's approval-request bounce (the install is
+ * pending an org owner's approval and nothing is connected yet), and the popup
+ * has no signal to tell the two apart. So it stays neutral ("head back to the
+ * tab you started from") and leaves the authoritative status to the origin tab,
+ * which polls the real install state. A green "Connected" here would read as
+ * false success for the pending-approval case.
  *
  * Public route (no auth gate): it does nothing sensitive, and gating it would
  * risk the redirect bouncing this throwaway tab elsewhere.
  */
 export function GithubConnectedPage() {
   useEffect(() => {
-    // A brief beat so the confirmation registers, then close.
+    // A brief beat so the message registers, then close.
     const timer = window.setTimeout(() => window.close(), 900);
     return () => window.clearTimeout(timer);
   }, []);
@@ -35,17 +41,17 @@ export function GithubConnectedPage() {
           width: "var(--sp-10)",
           height: "var(--sp-10)",
           borderRadius: "var(--radius-full)",
-          background: "color-mix(in oklch, var(--success) 16%, transparent)",
-          color: "var(--success)",
+          background: "color-mix(in oklch, var(--fg) 8%, transparent)",
+          color: "var(--fg-3)",
         }}
       >
-        <Check className="h-5 w-5" />
+        <ArrowLeft className="h-5 w-5" />
       </span>
       <p className="text-subtitle font-semibold" style={{ margin: 0, color: "var(--fg)" }}>
-        Connected
+        Back to First Tree
       </p>
       <p className="text-body" style={{ margin: 0, color: "var(--fg-3)", maxWidth: "22rem" }}>
-        You can close this tab — the other tab will update.
+        You can close this tab — your status will appear in the tab you started from.
       </p>
     </div>
   );


### PR DESCRIPTION
## Problem

The GitHub App install popup landing page (`/onboarding/connected`) unconditionally rendered a green **"Connected"** check. But that same popup is where GitHub's callback lands for **two different outcomes**:

1. a genuine install (owner installs directly), and
2. a **non-owner** First Tree admin's **approval-request bounce** — the admin isn't a GitHub org owner, so GitHub only records a request for an owner to approve (`setup_action=request`, no installation created, nothing connected yet).

For case 2 the green "Connected" is **false success**: the user is told they're connected when an owner hasn't approved anything.

## Change

Make the landing **neutral — no success claim**:

- `ArrowLeft` glyph in muted tokens (was a green `Check`)
- title **"Back to First Tree"** (was "Connected")
- body points the user to the tab they started from, which owns the authoritative status

The genuine install still gets its **"Connected as `<org>`"** confirmation on the origin tab; this popup auto-closes in 900ms and was never the success moment. Updated the one SSR-smoke assertion.

## Scope / follow-up

This is the popup half of the GitHub non-owner install-approval UX. The backend that auto-binds an approved request lands in **#1392 / #1422** (@liuchao-001). A follow-up will add a real **"waiting for an owner to approve"** state to the origin tab (needs a read-only request-status endpoint over #1422's `github_app_install_requests` table) so the non-owner flow reads correctly end-to-end.

## Verification

- `pnpm biome check` (changed files) — clean
- `pnpm --filter @first-tree/web typecheck` (incl. `lint:tokens`) — clean
- `pnpm --filter @first-tree/web test` — 1101 passed
