### PR TITLE
Add guardrail prompt for landing trial agents

### DIFF
--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -19,6 +19,10 @@ import { createAgent } from "../services/agent.js";
 import { bindAgentRuntimeSession, validateAgentRuntimeSession } from "../services/agent-runtime-session.js";
 import { signTokensForUser } from "../services/auth.js";
 import { completeLandingCampaignTrialAgentTurn } from "../services/landing-campaigns/chat-state.js";
+import {
+  LANDING_CAMPAIGN_TRIAL_PROMPT,
+  LANDING_CAMPAIGN_TRIAL_PROMPT_RESOURCE_NAME,
+} from "../services/landing-campaigns/trial-prompt.js";
 import { createMember } from "../services/member.js";
 import { sendMessage } from "../services/message.js";
 import { uuidv7 } from "../uuid.js";
@@ -332,6 +336,47 @@ describe("POST /me/landing-campaigns/start", () => {
       );
     expect(bindings).toHaveLength(1);
 
+    const [prompt] = await app.db
+      .select()
+      .from(resources)
+      .where(
+        and(eq(resources.ownerAgentId, body.agentUuid), eq(resources.type, "prompt"), eq(resources.scope, "agent")),
+      )
+      .limit(1);
+    expect(prompt?.name).toBe(LANDING_CAMPAIGN_TRIAL_PROMPT_RESOURCE_NAME);
+    expect(prompt?.defaultEnabled).toBeNull();
+    expect(prompt?.payload).toMatchObject({
+      body: LANDING_CAMPAIGN_TRIAL_PROMPT,
+    });
+
+    const promptBindings = await app.db
+      .select()
+      .from(agentResourceBindings)
+      .where(
+        and(
+          eq(agentResourceBindings.agentId, body.agentUuid),
+          eq(agentResourceBindings.type, "prompt"),
+          eq(agentResourceBindings.resourceId, prompt?.id ?? ""),
+        ),
+      );
+    expect(promptBindings).toHaveLength(1);
+    expect(promptBindings[0]?.inlinePromptBody).toBeNull();
+    expect(JSON.stringify(prompt?.payload)).toContain("Workspace access");
+    expect(JSON.stringify(prompt?.payload)).toContain("Privacy and secrets");
+    expect(JSON.stringify(prompt?.payload)).toContain("passwords");
+    expect(JSON.stringify(prompt?.payload)).toContain("tokens");
+
+    const resolvedConfig = await app.resourcesService.resolveRuntimeConfig(await app.configService.get(body.agentUuid));
+    expect(resolvedConfig.payload.prompt.sections).toEqual([
+      {
+        scope: "agent",
+        name: LANDING_CAMPAIGN_TRIAL_PROMPT_RESOURCE_NAME,
+        body: LANDING_CAMPAIGN_TRIAL_PROMPT,
+        editable: false,
+      },
+    ]);
+    expect(resolvedConfig.payload.prompt.append).toContain(LANDING_CAMPAIGN_TRIAL_PROMPT);
+
     const [chat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
     expect(chat?.topic).toBe("Production readiness scan");
     expect(chat?.onboardingKickoffKey).toContain("landing-campaign:");
@@ -454,6 +499,34 @@ describe("POST /me/landing-campaigns/start", () => {
     const thirdMessages = await app.db.select().from(messages).where(eq(messages.chatId, thirdBody.chatId));
     expect(firstMessages).toHaveLength(1);
     expect(thirdMessages).toHaveLength(1);
+
+    const prompts = await app.db
+      .select()
+      .from(resources)
+      .where(
+        and(
+          eq(resources.ownerAgentId, firstBody.agentUuid),
+          eq(resources.type, "prompt"),
+          eq(resources.scope, "agent"),
+        ),
+      );
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]?.payload).toMatchObject({
+      body: LANDING_CAMPAIGN_TRIAL_PROMPT,
+    });
+
+    const promptBindings = await app.db
+      .select()
+      .from(agentResourceBindings)
+      .where(
+        and(
+          eq(agentResourceBindings.agentId, firstBody.agentUuid),
+          eq(agentResourceBindings.type, "prompt"),
+          eq(agentResourceBindings.resourceId, prompts[0]?.id ?? ""),
+        ),
+      );
+    expect(promptBindings).toHaveLength(1);
+    expect(promptBindings[0]?.inlinePromptBody).toBeNull();
   });
 
   it("preserves runtime session metadata when reusing the trial agent for a new repo", async () => {

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -473,6 +473,7 @@ export async function startLandingCampaignTrial(
     repo,
   });
   await app.resourcesService.ensureAndBindCampaignScanSkill(trialAgent.uuid, body.campaign, serviceMember.id, setupUrl);
+  await app.resourcesService.ensureAndBindLandingCampaignTrialPrompt(trialAgent.uuid, serviceMember.id);
   notifyClientAgentPinned(app, trialAgent);
 
   const result = await ensureTrialChatAndBootstrap(app, {

--- a/packages/server/src/services/landing-campaigns/trial-prompt.ts
+++ b/packages/server/src/services/landing-campaigns/trial-prompt.ts
@@ -1,0 +1,7 @@
+export const LANDING_CAMPAIGN_TRIAL_PROMPT_RESOURCE_NAME = "Landing campaign trial guardrails";
+export const LANDING_CAMPAIGN_TRIAL_PROMPT_RESOURCE_DESCRIPTION =
+  "Server-managed guardrails for landing campaign trial agents.";
+
+export const LANDING_CAMPAIGN_TRIAL_PROMPT = `Workspace access: Only intentionally access files and directories in your assigned workspace. Sibling repositories inside that workspace may be read or maintained when they are required for the assigned task. Do not inspect or modify files outside the workspace.
+
+Privacy and secrets: Do not disclose personal private information, sensitive details about the host computer or runtime environment, account credentials, passwords, tokens, API keys, SSH keys, or other secrets.`;

--- a/packages/server/src/services/resources.ts
+++ b/packages/server/src/services/resources.ts
@@ -29,7 +29,7 @@ import {
   type UpdateAgentResources,
   type UpdateTeamResource,
 } from "@first-tree/shared";
-import { and, eq, inArray, ne, or, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { agentConfigs } from "../db/schema/agent-configs.js";
 import { agentResourceBindings } from "../db/schema/agent-resource-bindings.js";
@@ -39,6 +39,11 @@ import { resources } from "../db/schema/resources.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../errors.js";
 import { uuidv7 } from "../uuid.js";
 import { getCampaignScanSkill } from "./landing-campaigns/skills/catalog.js";
+import {
+  LANDING_CAMPAIGN_TRIAL_PROMPT,
+  LANDING_CAMPAIGN_TRIAL_PROMPT_RESOURCE_DESCRIPTION,
+  LANDING_CAMPAIGN_TRIAL_PROMPT_RESOURCE_NAME,
+} from "./landing-campaigns/trial-prompt.js";
 import type { Notifier } from "./notifier.js";
 
 type ResourceDbRow = typeof resources.$inferSelect;
@@ -65,6 +70,13 @@ export type ResourcesService = {
    * admin-only); no-op for an unknown campaign slug.
    */
   ensureAndBindCampaignScanSkill(agentId: string, campaign: string, actorId: string, setupUrl: string): Promise<void>;
+  /**
+   * Idempotently bind the service-owned initial prompt for landing campaign
+   * trial agents. The prompt is an agent-scoped managed resource so it projects
+   * through the normal runtime prompt stack without entering the editable
+   * standalone inline prompt path.
+   */
+  ensureAndBindLandingCampaignTrialPrompt(agentId: string, actorId: string): Promise<void>;
   resolveRuntimeConfig(config: AgentRuntimeConfig): Promise<AgentRuntimeConfig>;
   resolveEffectiveResources(agentId: string): Promise<EffectiveAgentResources>;
 };
@@ -647,7 +659,12 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
   }
 
   function renderPromptRow(name: string, source: EffectiveResourceRow["source"], body: string): string {
-    const title = source === "inline_prompt" ? "Agent Prompt (this agent only)" : `Team Prompt: ${name}`;
+    const title =
+      source === "inline_prompt"
+        ? "Agent Prompt (this agent only)"
+        : source === "agent_extra"
+          ? `Agent Prompt Override: ${name}`
+          : `Team Prompt: ${name}`;
     return `\n\n## ${title}\n\n${body.trim()}\n`;
   }
 
@@ -1125,6 +1142,152 @@ export function createResourcesService(opts: ResourcesServiceOptions): Resources
         bindings: bindingRows.map(bindingToInput),
         availableTeamResources: availableTeamResources.map(rowToResource),
       };
+    },
+
+    async ensureAndBindLandingCampaignTrialPrompt(agentId, actorId) {
+      const [agent] = await db
+        .select({ organizationId: agents.organizationId, managerId: agents.managerId, status: agents.status })
+        .from(agents)
+        .where(eq(agents.uuid, agentId))
+        .limit(1);
+      if (!agent || agent.status === "deleted") return;
+      const organizationId = agent.organizationId;
+
+      const [actor] = await db
+        .select({ organizationId: members.organizationId, role: members.role })
+        .from(members)
+        .where(eq(members.id, actorId))
+        .limit(1);
+      const isManager = agent.managerId === actorId;
+      const isOrgAdmin = !!actor && actor.organizationId === organizationId && actor.role === "admin";
+      if (!isManager && !isOrgAdmin) throw new NotFoundError(`Agent "${agentId}" not found`);
+
+      const desiredPayload = {
+        body: LANDING_CAMPAIGN_TRIAL_PROMPT,
+        description: LANDING_CAMPAIGN_TRIAL_PROMPT_RESOURCE_DESCRIPTION,
+      };
+      const payloadMatchesDesired = (stored: unknown): boolean =>
+        typeof stored === "object" &&
+        stored !== null &&
+        "body" in stored &&
+        stored.body === desiredPayload.body &&
+        "description" in stored &&
+        stored.description === desiredPayload.description;
+
+      const findPromptResourceId = async (database: Database): Promise<string | null> => {
+        const [row] = await database
+          .select({ id: resources.id })
+          .from(resources)
+          .where(
+            and(
+              eq(resources.organizationId, organizationId),
+              eq(resources.type, "prompt"),
+              eq(resources.scope, "agent"),
+              eq(resources.ownerAgentId, agentId),
+              eq(resources.name, LANDING_CAMPAIGN_TRIAL_PROMPT_RESOURCE_NAME),
+              inArray(resources.status, ["active", "stale"]),
+            ),
+          )
+          .limit(1);
+        return row?.id ?? null;
+      };
+
+      let needsNotify = false;
+      await db.transaction(async (tx) => {
+        const targetDb = tx as unknown as Database;
+        await targetDb.select({ uuid: agents.uuid }).from(agents).where(eq(agents.uuid, agentId)).for("update");
+
+        let resourceId = await findPromptResourceId(targetDb);
+        let contentChanged = false;
+        if (!resourceId) {
+          resourceId = uuidv7();
+          await targetDb.insert(resources).values({
+            id: resourceId,
+            organizationId,
+            type: "prompt",
+            scope: "agent",
+            ownerAgentId: agentId,
+            name: LANDING_CAMPAIGN_TRIAL_PROMPT_RESOURCE_NAME,
+            repoCanonicalKey: null,
+            defaultEnabled: null,
+            status: "active",
+            payload: desiredPayload,
+            createdBy: actorId,
+            updatedBy: actorId,
+          });
+        } else {
+          const [current] = await targetDb
+            .select({ payload: resources.payload })
+            .from(resources)
+            .where(eq(resources.id, resourceId))
+            .limit(1);
+          if (!payloadMatchesDesired(current?.payload)) {
+            await targetDb
+              .update(resources)
+              .set({ payload: desiredPayload, updatedAt: new Date(), updatedBy: actorId })
+              .where(eq(resources.id, resourceId));
+            contentChanged = true;
+          }
+        }
+
+        const staleInlineGuardrails = await targetDb
+          .select({ id: agentResourceBindings.id })
+          .from(agentResourceBindings)
+          .where(
+            and(
+              eq(agentResourceBindings.agentId, agentId),
+              eq(agentResourceBindings.type, "prompt"),
+              eq(agentResourceBindings.mode, "include"),
+              isNull(agentResourceBindings.resourceId),
+              eq(agentResourceBindings.inlinePromptBody, LANDING_CAMPAIGN_TRIAL_PROMPT),
+            ),
+          );
+        if (staleInlineGuardrails.length > 0) {
+          await targetDb.delete(agentResourceBindings).where(
+            inArray(
+              agentResourceBindings.id,
+              staleInlineGuardrails.map((row) => row.id),
+            ),
+          );
+          contentChanged = true;
+        }
+
+        const [already] = await targetDb
+          .select({ id: agentResourceBindings.id })
+          .from(agentResourceBindings)
+          .where(and(eq(agentResourceBindings.agentId, agentId), eq(agentResourceBindings.resourceId, resourceId)))
+          .limit(1);
+        if (already) {
+          if (contentChanged) {
+            await bumpAgentConfigVersions(targetDb, [agentId], actorId);
+            needsNotify = true;
+          }
+          return;
+        }
+
+        const existing = await targetDb
+          .select({ id: agentResourceBindings.id })
+          .from(agentResourceBindings)
+          .where(eq(agentResourceBindings.agentId, agentId));
+        await targetDb.insert(agentResourceBindings).values({
+          id: uuidv7(),
+          organizationId,
+          agentId,
+          type: "prompt",
+          mode: "include",
+          resourceId,
+          replacesResourceId: null,
+          inlinePromptBody: null,
+          repoRef: null,
+          repoLocalPath: null,
+          order: existing.length,
+          createdBy: actorId,
+          updatedBy: actorId,
+        });
+        await bumpAgentConfigVersions(targetDb, [agentId], actorId);
+        needsNotify = true;
+      });
+      if (needsNotify) await notifyAgents([agentId]);
     },
 
     async ensureAndBindCampaignScanSkill(agentId, campaign, actorId, setupUrl) {


### PR DESCRIPTION
## Summary

- Add a server-owned guardrail prompt for landing campaign trial agents.
- Bind the prompt idempotently as an inline agent prompt whenever a landing campaign trial agent is created or reused.
- Cover prompt binding, runtime prompt projection, and reuse/idempotency in landing campaign start tests.

## Verification

- `pnpm --filter @first-tree/server test -- src/__tests__/landing-campaigns-start.test.ts --maxWorkers=2 --minWorkers=1`
  - The server test script ran the full `@first-tree/server` Vitest suite: 178 files / 1722 tests passed.
- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/services/resources.ts packages/server/src/services/landing-campaigns/start.ts packages/server/src/services/landing-campaigns/trial-prompt.ts packages/server/src/__tests__/landing-campaigns-start.test.ts`
- `git diff --check`

## Review

- Reviewed by codex-reviewer in First Tree chat; no blocking issues found.
