### PR TITLE
feat(web): trial chrome — a pure conversation for the scan trial surface

### DIFF
--- a/packages/web/src/components/__tests__/layout-dom.test.tsx
+++ b/packages/web/src/components/__tests__/layout-dom.test.tsx
@@ -257,6 +257,31 @@ describe("Layout", () => {
     await act(async () => context.root.unmount());
   });
 
+  it("renders trial chrome on /quickstart: no nav tabs / switcher / palette, one conversion CTA", async () => {
+    const trial = await renderLayout("/quickstart");
+    // Escape hatches are gone: nav tabs, team switcher, and the ⌘K palette entry.
+    expect(trial.container.textContent).not.toContain("Context");
+    expect(trial.container.textContent).not.toContain("Settings");
+    expect(trial.container.textContent).not.toContain("Workspace");
+    expect(trial.container.querySelector('[data-testid="team-switcher"]')).toBeNull();
+    expect(trial.container.querySelector('button[aria-label="Jump to… (⌘K)"]')).toBeNull();
+    // The one intentional way out: a "Set up First Tree" CTA → /onboarding.
+    expect(trial.container.textContent).toContain("Set up First Tree");
+    const cta = [...trial.container.querySelectorAll("a")].find((a) => /Set up First Tree/.test(a.textContent ?? ""));
+    expect(cta?.getAttribute("href")).toBe("/onboarding");
+    // The trial child still renders (full-bleed outlet, no 960 canvas).
+    expect(trial.container.textContent).toContain("Quickstart child");
+    await act(async () => trial.root.unmount());
+
+    // Control: an ordinary route keeps the full chrome and shows no CTA.
+    const context = await renderLayout("/context");
+    expect(context.container.textContent).toContain("Context");
+    expect(context.container.querySelector('[data-testid="team-switcher"]')).not.toBeNull();
+    expect(context.container.querySelector('button[aria-label="Jump to… (⌘K)"]')).not.toBeNull();
+    expect(context.container.textContent).not.toContain("Set up First Tree");
+    await act(async () => context.root.unmount());
+  });
+
   it("keeps status chips in the right controls before the compact command palette entry", async () => {
     disconnectMock.value = {
       firstHostname: "Yue-MacPro.local",

--- a/packages/web/src/components/layout.tsx
+++ b/packages/web/src/components/layout.tsx
@@ -1,16 +1,18 @@
-import { Search } from "lucide-react";
+import { ArrowRight, Search } from "lucide-react";
 import { useEffect, useState } from "react";
-import { NavLink, Outlet, useLocation } from "react-router";
+import { Link, NavLink, Outlet, useLocation } from "react-router";
 import { useAuth } from "../auth/auth-context.js";
 import { useNewVersionAvailable } from "../hooks/use-version-check.js";
 import { useWorkspaceViewport } from "../hooks/use-viewport.js";
 import { cn } from "../lib/utils.js";
+import { isLandingTrialSurface } from "../pages/quickstart/route.js";
 import { CommandPalette } from "../pages/workspace/palette/command-palette.js";
 import { DisconnectChip } from "./disconnect-chip.js";
 import { FirstTreeLogo } from "./first-tree-logo.js";
 import { NewVersionChip } from "./new-version-chip.js";
 import { TeamSwitchOverlay } from "./team-switch-overlay.js";
 import { TeamSwitcher } from "./team-switcher.js";
+import { Button } from "./ui/button.js";
 import { ThemeToggle } from "./ui/theme-toggle.js";
 import { UserMenu } from "./user-menu.js";
 
@@ -30,13 +32,20 @@ const PARENT_URL = "https://first-tree.ai";
 export function Layout() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const { organizationId } = useAuth();
+  const location = useLocation();
+  // Landing-campaign trial surface (`/quickstart`): render a stripped "trial
+  // chrome" — brand + one conversion CTA + user menu — with none of the normal
+  // workspace escape hatches (nav tabs, team switcher, command palette, rail).
+  const isTrial = isLandingTrialSurface(location.pathname);
 
   // ⌘K / Ctrl+K to open the Jump-to palette from anywhere. Listens at
   // window-level so the shortcut survives inside textareas / editable
   // surfaces; that mirrors how Linear / GitHub / Slack treat their global
   // command palette and matches the existing "Jump to…" affordance, which
-  // is the only top-bar control reachable without a click.
+  // is the only top-bar control reachable without a click. Disabled on the
+  // trial surface — the palette is an escape hatch there.
   useEffect(() => {
+    if (isTrial) return;
     function onKeyDown(e: KeyboardEvent) {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();
@@ -45,9 +54,8 @@ export function Layout() {
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, []);
+  }, [isTrial]);
 
-  const location = useLocation();
   // The workspace shell (`WorkspaceBody`) needs the bare, full-height outlet so
   // its `flex flex-1` three-pane layout fills the viewport. `/` is the gated
   // index; `/quickstart` renders the SAME `WorkspaceBody` gate-free for the
@@ -105,200 +113,249 @@ export function Layout() {
       // on phones.
       style={{ height: "100vh", minHeight: "100dvh", background: "var(--bg)" }}
     >
-      {/* Top bar */}
-      <header
-        className="relative shrink-0 grid items-center"
-        style={{
-          height: 48,
-          // 1fr auto 1fr keeps the centre column (tabs) anchored to the
-          // page midpoint regardless of how the brand cluster grows. The
-          // disconnect chip can appear/disappear without shifting tabs.
-          // When the right controls collapse (md/narrow) we drop to
-          // `1fr auto`; when the brand also collapses (narrow) we go to
-          // a single column so the tabs anchor to the left edge.
-          gridTemplateColumns: headerColumns,
-          gap: "var(--sp-3)",
-          padding: "0 var(--sp-3)",
-          borderBottom: "var(--hairline) solid var(--border)",
-          background: "var(--bg-raised)",
-        }}
-      >
-        {/* Brand cluster: logo + name welded together, then the team anchor. On
-            narrow the cluster is dropped, but the anchor must stay reachable —
-            it surfaces icon-only in its own leading column. */}
-        {dropBrand ? (
-          showAnchor ? (
-            <div style={{ justifySelf: "start", minWidth: 0 }}>
-              <TeamSwitcher variant="compact" />
-            </div>
-          ) : null
-        ) : (
-          <div className="flex items-center" style={{ gap: "var(--sp-3_5)", justifySelf: "start", minWidth: 0 }}>
-            {/* Brand links out to the parent marketing site in a new tab. */}
-            <a
-              href={PARENT_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="First Tree — open first-tree.ai in a new tab"
-              className="flex items-center cursor-pointer"
-              style={{ gap: 10, flexShrink: 0 }}
-            >
-              <FirstTreeLogo width={16} height={18} style={{ color: "var(--fg)" }} />
-              {/* Brand uses the `text-title` token (16 / 600 / -0.2 letter-spacing). */}
+      {/* Top bar. Trial surface gets a stripped header (brand + one conversion
+          CTA + user menu); everything else gets the full workspace chrome. */}
+      {isTrial ? (
+        <header
+          className="relative shrink-0 grid items-center"
+          style={{
+            height: 48,
+            // Centre column is `minmax(0, auto)` so the CTA can shrink (label
+            // truncates) instead of overflowing the row on very narrow phones.
+            gridTemplateColumns: "minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr)",
+            gap: "var(--sp-3)",
+            padding: "0 var(--sp-3)",
+            borderBottom: "var(--hairline) solid var(--border)",
+            background: "var(--bg-raised)",
+          }}
+        >
+          {/* Brand only — no team switcher (switching org is an escape hatch). */}
+          <a
+            href={PARENT_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="First Tree — open first-tree.ai in a new tab"
+            className="flex items-center cursor-pointer"
+            style={{ gap: 10, justifySelf: "start", minWidth: 0 }}
+          >
+            <FirstTreeLogo width={16} height={18} style={{ color: "var(--fg)", flexShrink: 0 }} />
+            {!dropBrand && (
               <span className="text-title" style={{ color: "var(--fg)" }}>
                 First Tree
               </span>
-            </a>
-            {/* Team anchor sits next to the brand (workspace identity, left side),
-                separated by a hairline rule; absent when no org is selected. */}
-            {showAnchor && (
-              <>
-                <span aria-hidden style={{ width: 1, height: 18, background: "var(--border)", flexShrink: 0 }} />
-                <TeamSwitcher variant="full" />
-              </>
             )}
-          </div>
-        )}
+          </a>
 
-        {/* Tabs */}
-        <nav
-          className="flex"
+          {/* The single intentional way out of the trial → standard onboarding. */}
+          <Button asChild size="sm" className="min-w-0" style={{ justifySelf: "center" }}>
+            <Link to="/onboarding">
+              <span className="truncate">Set up First Tree{dropBrand ? "" : " for your team"}</span>
+              <ArrowRight className="h-4 w-4 shrink-0" />
+            </Link>
+          </Button>
+
+          {/* User menu (sign out) stays reachable at every width. */}
+          <div className="flex items-center shrink-0" style={{ gap: 6, justifySelf: "end" }}>
+            {showThemeToggle ? <ThemeToggle /> : null}
+            <UserMenu />
+          </div>
+        </header>
+      ) : (
+        <header
+          className="relative shrink-0 grid items-center"
           style={{
-            gap: 2,
-            // `pointerEvents: none` lets the centred (xl/md) nav's empty flanks
-            // pass clicks through; on `narrow` the nav is a real scroll
-            // container in a shrunk track, so it needs to receive touch.
-            pointerEvents: dropBrand ? "auto" : "none",
-            // On `narrow` the brand collapses and the tabs share the row with
-            // the compact controls — anchor the tabs to the start so they sit
-            // at the left edge rather than centring against the avatar.
-            justifySelf: dropBrand ? "start" : "center",
-            // Narrow track is `minmax(0, 1fr)`: let the row scroll horizontally
-            // if the tabs can't all fit (tiny phones / long i18n labels) rather
-            // than overflow and clip the avatar. No-op when the tabs fit.
-            ...(dropBrand ? { minWidth: 0, width: "100%", overflowX: "auto" } : null),
+            height: 48,
+            // 1fr auto 1fr keeps the centre column (tabs) anchored to the
+            // page midpoint regardless of how the brand cluster grows. The
+            // disconnect chip can appear/disappear without shifting tabs.
+            // When the right controls collapse (md/narrow) we drop to
+            // `1fr auto`; when the brand also collapses (narrow) we go to
+            // a single column so the tabs anchor to the left edge.
+            gridTemplateColumns: headerColumns,
+            gap: "var(--sp-3)",
+            padding: "0 var(--sp-3)",
+            borderBottom: "var(--hairline) solid var(--border)",
+            background: "var(--bg-raised)",
           }}
         >
-          {navTabs.map((tab) => (
-            <NavLink
-              key={tab.to}
-              to={tab.to}
-              end={tab.end}
-              style={{ pointerEvents: "auto" }}
-              className={({ isActive }) =>
-                // `shrink-0` keeps each tab its natural width inside the narrow
-                // scrollable nav, so labels never compress or wrap.
-                cn("inline-flex shrink-0 items-center transition-colors", isActive ? "" : "hover:text-[var(--fg)]")
-              }
-            >
-              {({ isActive }) => (
-                <span
-                  className="inline-flex items-center text-subtitle font-medium"
-                  style={{
-                    padding: "var(--sp-1_5) var(--sp-3)",
-                    gap: 6,
-                    borderRadius: 5,
-                    color: isActive ? "var(--fg)" : "var(--fg-3)",
-                    background: isActive ? "var(--bg-hover)" : "transparent",
-                  }}
-                >
-                  {tab.label}
+          {/* Brand cluster: logo + name welded together, then the team anchor. On
+            narrow the cluster is dropped, but the anchor must stay reachable —
+            it surfaces icon-only in its own leading column. */}
+          {dropBrand ? (
+            showAnchor ? (
+              <div style={{ justifySelf: "start", minWidth: 0 }}>
+                <TeamSwitcher variant="compact" />
+              </div>
+            ) : null
+          ) : (
+            <div className="flex items-center" style={{ gap: "var(--sp-3_5)", justifySelf: "start", minWidth: 0 }}>
+              {/* Brand links out to the parent marketing site in a new tab. */}
+              <a
+                href={PARENT_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="First Tree — open first-tree.ai in a new tab"
+                className="flex items-center cursor-pointer"
+                style={{ gap: 10, flexShrink: 0 }}
+              >
+                <FirstTreeLogo width={16} height={18} style={{ color: "var(--fg)" }} />
+                {/* Brand uses the `text-title` token (16 / 600 / -0.2 letter-spacing). */}
+                <span className="text-title" style={{ color: "var(--fg)" }}>
+                  First Tree
                 </span>
+              </a>
+              {/* Team anchor sits next to the brand (workspace identity, left side),
+                separated by a hairline rule; absent when no org is selected. */}
+              {showAnchor && (
+                <>
+                  <span aria-hidden style={{ width: 1, height: 18, background: "var(--border)", flexShrink: 0 }} />
+                  <TeamSwitcher variant="full" />
+                </>
               )}
-            </NavLink>
-          ))}
-        </nav>
+            </div>
+          )}
 
-        {/* Right controls. The user menu (avatar) renders at every breakpoint
+          {/* Tabs */}
+          <nav
+            className="flex"
+            style={{
+              gap: 2,
+              // `pointerEvents: none` lets the centred (xl/md) nav's empty flanks
+              // pass clicks through; on `narrow` the nav is a real scroll
+              // container in a shrunk track, so it needs to receive touch.
+              pointerEvents: dropBrand ? "auto" : "none",
+              // On `narrow` the brand collapses and the tabs share the row with
+              // the compact controls — anchor the tabs to the start so they sit
+              // at the left edge rather than centring against the avatar.
+              justifySelf: dropBrand ? "start" : "center",
+              // Narrow track is `minmax(0, 1fr)`: let the row scroll horizontally
+              // if the tabs can't all fit (tiny phones / long i18n labels) rather
+              // than overflow and clip the avatar. No-op when the tabs fit.
+              ...(dropBrand ? { minWidth: 0, width: "100%", overflowX: "auto" } : null),
+            }}
+          >
+            {navTabs.map((tab) => (
+              <NavLink
+                key={tab.to}
+                to={tab.to}
+                end={tab.end}
+                style={{ pointerEvents: "auto" }}
+                className={({ isActive }) =>
+                  // `shrink-0` keeps each tab its natural width inside the narrow
+                  // scrollable nav, so labels never compress or wrap.
+                  cn("inline-flex shrink-0 items-center transition-colors", isActive ? "" : "hover:text-[var(--fg)]")
+                }
+              >
+                {({ isActive }) => (
+                  <span
+                    className="inline-flex items-center text-subtitle font-medium"
+                    style={{
+                      padding: "var(--sp-1_5) var(--sp-3)",
+                      gap: 6,
+                      borderRadius: 5,
+                      color: isActive ? "var(--fg)" : "var(--fg-3)",
+                      background: isActive ? "var(--bg-hover)" : "transparent",
+                    }}
+                  >
+                    {tab.label}
+                  </span>
+                )}
+              </NavLink>
+            ))}
+          </nav>
+
+          {/* Right controls. The user menu (avatar) renders at every breakpoint
             so sign-out / org-switch stay reachable on phones and tablets; the
             theme toggle and command-palette entry drop on `narrow`. Status
             stays visible at every width: full text on `xl`, compact icons
             below it so the right track cannot crowd the centred tabs. */}
-        <div className="flex items-center shrink-0" style={{ gap: 6, justifySelf: "end" }}>
-          {showFullStatusChips ? (
-            <>
-              <DisconnectChip />
-              <NewVersionChip show={newVersionAvailable} />
-            </>
-          ) : (
-            <>
-              <DisconnectChip compact />
-              <NewVersionChip show={newVersionAvailable} compact />
-            </>
-          )}
-          {showJumpButton ? (
-            <>
-              <button
-                type="button"
-                onClick={() => setPaletteOpen(true)}
-                aria-label="Jump to… (⌘K)"
-                aria-keyshortcuts="Meta+K Control+K"
-                title="Jump to… (⌘K / Ctrl+K)"
-                className="inline-flex items-center transition-colors text-body"
-                style={{
-                  gap: 7,
-                  height: 30,
-                  minWidth: showJumpLabel ? 112 : undefined,
-                  padding: "0 var(--sp-2)",
-                  color: "var(--fg-3)",
-                  border: "var(--hairline) solid var(--border)",
-                  borderRadius: "var(--radius-input)",
-                  background: "var(--bg-sunken)",
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.color = "var(--fg)";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.color = "var(--fg-3)";
-                }}
-              >
-                <Search aria-hidden="true" size={14} style={{ flexShrink: 0 }} />
-                {showJumpLabel ? <span>Search</span> : null}
-                <span
-                  aria-hidden
-                  className="text-caption font-mono"
+          <div className="flex items-center shrink-0" style={{ gap: 6, justifySelf: "end" }}>
+            {showFullStatusChips ? (
+              <>
+                <DisconnectChip />
+                <NewVersionChip show={newVersionAvailable} />
+              </>
+            ) : (
+              <>
+                <DisconnectChip compact />
+                <NewVersionChip show={newVersionAvailable} compact />
+              </>
+            )}
+            {showJumpButton ? (
+              <>
+                <button
+                  type="button"
+                  onClick={() => setPaletteOpen(true)}
+                  aria-label="Jump to… (⌘K)"
+                  aria-keyshortcuts="Meta+K Control+K"
+                  title="Jump to… (⌘K / Ctrl+K)"
+                  className="inline-flex items-center transition-colors text-body"
                   style={{
-                    padding: "var(--sp-0_5) var(--sp-1_25)",
-                    border: "var(--hairline) solid var(--border)",
-                    borderRadius: "var(--radius-chip)",
+                    gap: 7,
+                    height: 30,
+                    minWidth: showJumpLabel ? 112 : undefined,
+                    padding: "0 var(--sp-2)",
                     color: "var(--fg-3)",
-                    background: "var(--bg-raised)",
+                    border: "var(--hairline) solid var(--border)",
+                    borderRadius: "var(--radius-input)",
+                    background: "var(--bg-sunken)",
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.color = "var(--fg)";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.color = "var(--fg-3)";
                   }}
                 >
-                  ⌘K
-                </span>
-              </button>
-              <span
-                style={{
-                  width: 1,
-                  height: 18,
-                  background: "var(--border)",
-                  margin: "0 var(--sp-1)",
-                }}
-              />
-            </>
-          ) : null}
-          {showThemeToggle ? (
-            <>
-              <ThemeToggle />
-              <span
-                style={{
-                  width: 1,
-                  height: 18,
-                  background: "var(--border)",
-                  margin: "0 var(--sp-1)",
-                }}
-              />
-            </>
-          ) : null}
-          <UserMenu />
-        </div>
-      </header>
+                  <Search aria-hidden="true" size={14} style={{ flexShrink: 0 }} />
+                  {showJumpLabel ? <span>Search</span> : null}
+                  <span
+                    aria-hidden
+                    className="text-caption font-mono"
+                    style={{
+                      padding: "var(--sp-0_5) var(--sp-1_25)",
+                      border: "var(--hairline) solid var(--border)",
+                      borderRadius: "var(--radius-chip)",
+                      color: "var(--fg-3)",
+                      background: "var(--bg-raised)",
+                    }}
+                  >
+                    ⌘K
+                  </span>
+                </button>
+                <span
+                  style={{
+                    width: 1,
+                    height: 18,
+                    background: "var(--border)",
+                    margin: "0 var(--sp-1)",
+                  }}
+                />
+              </>
+            ) : null}
+            {showThemeToggle ? (
+              <>
+                <ThemeToggle />
+                <span
+                  style={{
+                    width: 1,
+                    height: 18,
+                    background: "var(--border)",
+                    margin: "0 var(--sp-1)",
+                  }}
+                />
+              </>
+            ) : null}
+            <UserMenu />
+          </div>
+        </header>
+      )}
 
       {/* One intentional veil over the content while an org switch runs. */}
       <TeamSwitchOverlay />
 
-      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+      {/* No command palette on the trial surface (it's an escape hatch). */}
+      {!isTrial && <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />}
 
       {/* Main content */}
       {isWorkspace ? (

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -36,7 +36,7 @@ export function QuickstartPage() {
   // Back-compat: trials minted before this migration used `?chat=<id>`.
   // Canonicalize such a legacy URL to `?c=` (effect below) so an already-open
   // trial tab, bookmark, copied link, or reload still opens the trial chat
-  // instead of silently falling through to the conversation rail.
+  // instead of silently falling through to the no-chat state.
   const legacyChatId = useMemo(() => new URLSearchParams(location.search).get("chat"), [location.search]);
 
   const intent = useMemo<CampaignIntent | null>(() => {
@@ -105,16 +105,17 @@ export function QuickstartPage() {
     void startTrial();
   }, [startTrial]);
 
-  // Trial started: render the real workspace shell (full chrome) with the
-  // trial chat selected via `?c=`. This route sits inside the Layout group
-  // but is NOT the onboarding-gated index route, so an un-onboarded trial
-  // user sees the normal workspace here instead of being bounced to
-  // /onboarding — and there is no bespoke trial-chat page to maintain.
+  // Trial started: render the real workspace shell — as trial chrome, since
+  // this is the `/quickstart` route (stripped header + no rail; see Layout /
+  // WorkspaceBody `isLandingTrialSurface`) — with the trial chat selected via
+  // `?c=`. This route sits inside the Layout group but is NOT the
+  // onboarding-gated index route, so an un-onboarded trial user is not bounced
+  // to /onboarding — and there is no bespoke trial-chat page to maintain.
   if (chatId) return <WorkspaceBody />;
 
   // A legacy `?chat=` link is being canonicalized to `?c=` (effect above) —
   // hold a neutral screen for the one tick before the `?c=` URL renders, so we
-  // don't flash the no-selection rail.
+  // don't flash the no-chat state.
   if (legacyChatId) {
     return (
       <QuickstartShell>
@@ -133,8 +134,9 @@ export function QuickstartPage() {
 
   // No chat selected and no valid campaign handoff to launch — e.g. the user
   // closed/backed out of the trial chat, or opened /quickstart without a scan
-  // link. Keep them in the real workspace (conversation rail) rather than a
-  // dead-end card: WorkspaceBody with no `?c=` shows their conversation list.
+  // link. Render the trial workspace body (no rail on this surface); with no
+  // `?c=` it shows NoChatView's trial empty state, which points back to the
+  // header "Set up First Tree" CTA rather than a create-chat dead-end.
   if (!intent || !campaign) return <WorkspaceBody />;
 
   return (

--- a/packages/web/src/pages/quickstart/route.ts
+++ b/packages/web/src/pages/quickstart/route.ts
@@ -1,0 +1,17 @@
+/**
+ * The landing-campaign (Scan) trial funnel renders the real workspace shell at
+ * this path, gate-free (see `app.tsx` + `WorkspaceBody`). The trial is a
+ * single-run, controlled surface — the tree's Landing Campaign Trial Runtime
+ * makes the trial chat the only supported user-facing chat surface — so on this
+ * route the shell drops the escape hatches a normal workspace has (nav tabs,
+ * team switcher, command palette, conversation rail) and shows one intentional
+ * "set up First Tree" conversion CTA instead.
+ *
+ * Keying trial chrome off the ROUTE keeps it out of `shouldEnterOnboarding`
+ * (which stays pure/campaign-agnostic) and off the trial agent's identity.
+ */
+export const QUICKSTART_PATH = "/quickstart";
+
+export function isLandingTrialSurface(pathname: string): boolean {
+  return pathname === QUICKSTART_PATH;
+}

--- a/packages/web/src/pages/workspace/__tests__/workspace-page-dom.test.tsx
+++ b/packages/web/src/pages/workspace/__tests__/workspace-page-dom.test.tsx
@@ -173,6 +173,15 @@ async function renderDom(initialEntry: string, element: ReactElement): Promise<{
             }
           />
           <Route
+            path="/quickstart"
+            element={
+              <>
+                <LocationProbe />
+                {element}
+              </>
+            }
+          />
+          <Route
             path="/onboarding"
             element={
               <>
@@ -311,6 +320,29 @@ describe("WorkspacePage DOM behavior", () => {
     expect(container.querySelector('[data-testid="center-panel"]')).toBeNull();
     expect(container.querySelector('[data-testid="doc-preview"]')).toBeTruthy();
 
+    await act(async () => root.unmount());
+  });
+
+  it("drops the conversation rail on the trial surface and renders the chat full-bleed", async () => {
+    const { WorkspaceBody } = await import("../index.js");
+    viewportMock.value = "md";
+    const { container, root } = await renderDom("/quickstart?c=trial-1", <WorkspaceBody />);
+
+    // No rail (nor its narrow-overlay hamburger) — the trial chat is the whole surface.
+    expect(container.querySelector('[data-testid="conversation-list"]')).toBeNull();
+    expect(buttonByText(container, "Show conversations")).toBeNull();
+    // The chat still renders, selected via ?c=.
+    expect(container.querySelector('[data-testid="center-panel"]')).toBeTruthy();
+    expect(container.textContent).toContain("center:trial-1:wide");
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps the conversation rail on the normal workspace root", async () => {
+    const { WorkspaceBody } = await import("../index.js");
+    viewportMock.value = "md";
+    const { container, root } = await renderDom("/?c=chat-1", <WorkspaceBody />);
+    expect(container.querySelector('[data-testid="conversation-list"]')).toBeTruthy();
     await act(async () => root.unmount());
   });
 

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -744,6 +744,30 @@ afterEach(() => {
 });
 
 describe("ChatView", () => {
+  it("hides chat-management affordances on the trial surface even when read-only (route-scoped)", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    // A persisted-open sidebar must NOT re-appear on the trial surface.
+    localStorage.setItem("first-tree:chat-right-sidebar:open:v1", "1");
+    // `isTrial` + `readOnly` together = the watcher branch of a `/quickstart`
+    // chat. The trial-chrome guarantee is route-scoped, so the participant /
+    // details cluster, the chat-details sidebar toggle, and rename must all be
+    // gone here — `readOnly` alone would not hide them all (nor the hovercard).
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" isTrial readOnly />,
+      undefined,
+      "/",
+    );
+
+    await waitForText(container, "Launch planning");
+
+    expect(container.querySelector('button[aria-label="Add participant"]')).toBeNull();
+    expect(container.querySelector('button[aria-label="Show chat details"]')).toBeNull();
+    expect(container.querySelector('button[aria-label="Hide chat details"]')).toBeNull();
+    expect(buttonByTitle(container, "Click to rename")).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
   it("uses matching initial chat detail without an immediate detail refetch", async () => {
     const { ChatView } = await import("../chat-view.js");
     const initialChatDetail = chatDetail({ title: "Initial detail title", topic: "Initial detail title" });

--- a/packages/web/src/pages/workspace/center/__tests__/no-chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/no-chat-view-dom.test.tsx
@@ -48,4 +48,19 @@ describe("NoChatView", () => {
 
     await act(async () => root.unmount());
   });
+
+  it("hides the New chat CTA on the trial surface (no escape hatch)", async () => {
+    const onNewChat = vi.fn();
+    const { NoChatView } = await import("../no-chat-view.js");
+    const { container, root } = await renderDom(<NoChatView onNewChat={onNewChat} isTrial />);
+
+    expect(container.textContent).toContain("No chat selected");
+    // The create-chat affordance and its copy are gone; a calm pointer replaces them.
+    expect([...container.querySelectorAll("button")].some((b) => b.textContent?.includes("New chat"))).toBe(false);
+    expect(container.textContent).not.toContain("Start a new chat");
+    expect(container.textContent).not.toContain("from the list");
+    expect(container.textContent).toContain("Set up First Tree");
+
+    await act(async () => root.unmount());
+  });
 });

--- a/packages/web/src/pages/workspace/center/chat-by-id.tsx
+++ b/packages/web/src/pages/workspace/center/chat-by-id.tsx
@@ -204,6 +204,11 @@ export function ChatByIdView({
         chatId={chatId}
         initialChatDetail={chatDetail}
         readOnly
+        // Forward `isTrial` on the watcher branch too: the trial-chrome
+        // guarantee is route-scoped, so `/quickstart?c=<any>` must stay a pure
+        // conversation even if the viewer resolves as a watcher (readOnly
+        // hides some surfaces, but not the per-message hovercard).
+        isTrial={isTrial}
         titleFallback={chatDetail?.title ?? null}
         joinAction={{
           onJoin: () => joinMut.mutate(),

--- a/packages/web/src/pages/workspace/center/chat-by-id.tsx
+++ b/packages/web/src/pages/workspace/center/chat-by-id.tsx
@@ -66,11 +66,15 @@ export function ChatByIdView({
   narrow,
   onShowConversations,
   onClearChat = null,
+  isTrial = false,
 }: {
   chatId: string;
   narrow: boolean;
   onShowConversations: (() => void) | null;
   onClearChat?: (() => void) | null;
+  /** Trial surface: forwarded to ChatView to hide chat-management escape
+   *  hatches (add participant, agent pause/resume). */
+  isTrial?: boolean;
 }) {
   const queryClient = useQueryClient();
   const { agentId: myAgentId, organizationId: currentOrgId, selectOrganization, memberships, switchingOrg } = useAuth();
@@ -219,6 +223,7 @@ export function ChatByIdView({
       initialChatDetail={chatDetail}
       narrow={narrow}
       onShowConversations={onShowConversations}
+      isTrial={isTrial}
     />
   );
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -545,6 +545,10 @@ type MessageRowProps = {
   agentAvatarFn: (id: string) => string | null;
   agentColorTokenFn: (id: string) => string | null;
   mentionParticipants: MentionParticipant[];
+  /** Trial surface: render sender avatar/name as plain identity, without the
+   *  AgentHovercard whose actions ("Open details" → /agents/:id, "Chat" →
+   *  /?c=draft) would navigate out of the controlled trial conversation. */
+  isTrial: boolean;
 };
 
 type MessageBodyProps = {
@@ -762,6 +766,7 @@ const MessageRow = memo(function MessageRow({
   agentAvatarFn,
   agentColorTokenFn,
   mentionParticipants,
+  isTrial,
 }: MessageRowProps) {
   // GitHub-dispatcher cards keep the human-agent uuid in `senderId` so
   // routing / read-receipts / mention-resolution stay consistent, but we
@@ -789,6 +794,15 @@ const MessageRow = memo(function MessageRow({
     >
       {isGithubSystem ? (
         <GithubSystemAvatar size={20} />
+      ) : isTrial ? (
+        <span className="block self-start rounded-full">
+          <Avatar
+            name={senderName}
+            imageUrl={agentAvatarFn(msg.senderId)}
+            seed={msg.senderId}
+            colorToken={agentColorTokenFn(msg.senderId)}
+          />
+        </span>
       ) : (
         <AgentHovercard
           agentId={msg.senderId}
@@ -807,7 +821,7 @@ const MessageRow = memo(function MessageRow({
       )}
       <div className="min-w-0">
         <div className="flex items-baseline" style={{ gap: 8 }}>
-          {isSystem ? (
+          {isSystem || isTrial ? (
             <span className="mono text-body font-semibold" style={{ color: isSelf ? "var(--fg)" : "var(--primary)" }}>
               {senderName}
             </span>
@@ -844,6 +858,7 @@ function areMessageRowPropsEqual(prev: MessageRowProps, next: MessageRowProps): 
     prev.agentNameFn === next.agentNameFn &&
     prev.agentAvatarFn === next.agentAvatarFn &&
     prev.agentColorTokenFn === next.agentColorTokenFn &&
+    prev.isTrial === next.isTrial &&
     mentionParticipantsEqual(prev.mentionParticipants, next.mentionParticipants)
   );
 }
@@ -1085,6 +1100,9 @@ type ChatTimelineProps = {
   visibleItems: readonly TimelineItem[];
   hiddenByBlock: number;
   readOnly: boolean;
+  /** Trial surface: forwarded to each MessageRow to render plain sender
+   *  identity (no navigating hovercard). */
+  isTrial: boolean;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
   /** The timeline's `relative` wrapper, used as the chat-summary overlay's
    *  positioning context (the summary card is portaled into it). */
@@ -1116,6 +1134,7 @@ const ChatTimeline = memo(function ChatTimeline({
   visibleItems,
   hiddenByBlock,
   readOnly,
+  isTrial,
   scrollContainerRef,
   overlayContainerRef,
   messagesEndRef,
@@ -1207,6 +1226,7 @@ const ChatTimeline = memo(function ChatTimeline({
                     agentAvatarFn={agentAvatarFn}
                     agentColorTokenFn={agentColorTokenFn}
                     mentionParticipants={mentionParticipants}
+                    isTrial={isTrial}
                   />
                 );
               }
@@ -1301,6 +1321,7 @@ export function ChatView({
   joinAction,
   narrow = false,
   onShowConversations = null,
+  isTrial = false,
 }: {
   agentId: string;
   chatId: string;
@@ -1310,6 +1331,10 @@ export function ChatView({
   /** When true, render watching mode: timeline only, no rename, no [+] participant,
    *  composer slot replaced with a Join panel. */
   readOnly?: boolean;
+  /** Landing-campaign trial surface: hide chat-management escape hatches
+   *  (add participant, agent pause/resume) without switching to watcher mode —
+   *  the trial keeps its live composer for the awaiting-user answer flow. */
+  isTrial?: boolean;
   /** Pre-loaded title shown while `chatDetail` is still fetching — typically
    *  the row's `title` from the `me/chats` cache the chat list already has hot.
    *  Without it, the header flashes "…" on every cold open. */
@@ -3490,6 +3515,12 @@ export function ChatView({
                       watching
                     </span>
                   </span>
+                ) : isTrial ? (
+                  // Trial surface: the title is not renamable (a write on the
+                  // controlled single-run chat) — render it as plain text.
+                  <span className="truncate text-subtitle font-semibold" style={{ color: "var(--fg)" }}>
+                    {chatDetail?.title ?? titleFallback ?? "…"}
+                  </span>
                 ) : renaming ? (
                   <span className="inline-flex items-center" style={{ gap: "var(--sp-2)" }}>
                     <input
@@ -3595,67 +3626,76 @@ export function ChatView({
                     Read-only on the web — written by the owning agent via
                     `chat update --description`. */}
               </div>
-              {/* Audience — compact stats icon + quick-add icon. Replaces
+              {/* Trial surface hides the entire audience/details cluster
+                  (participant stats, add participant, chat-details toggle) —
+                  the trial is a pure conversation with no side rail. */}
+              {!isTrial && (
+                <>
+                  {/* Audience — compact stats icon + quick-add icon. Replaces
               the previous chip-row, which one-shot the panel width once
               chats grew past three participants. Stats icon shows count
               + hover popover with full name list; the quick-add icon
               opens the same dropdown the sidebar's "+ Add participant"
               uses (shared backend mutation, single one-way-door notice). */}
-              <ParticipantsStats
-                participants={chatDetail?.participants ?? []}
-                chatId={chatId}
-                agentIdentity={chatScopedAgentIdentity}
-                onOpen={() => setSidebarByUser(true)}
-              />
-              {/* Vertical divider splits "look" (avatar strip = identity +
+                  <ParticipantsStats
+                    participants={chatDetail?.participants ?? []}
+                    chatId={chatId}
+                    agentIdentity={chatScopedAgentIdentity}
+                    onOpen={() => setSidebarByUser(true)}
+                  />
+                  {/* Vertical divider splits "look" (avatar strip = identity +
                   state) from "do" (add / open details). Keeps the four
                   icons from reading as one undifferentiated cluster. */}
-              <span
-                aria-hidden="true"
-                className="shrink-0"
-                style={{
-                  width: "var(--hairline)",
-                  height: "var(--sp-4)",
-                  background: "var(--border)",
-                  marginLeft: "var(--sp-1)",
-                  marginRight: "var(--sp-1)",
-                }}
-              />
-              {readOnly ? null : (
-                <AddParticipantDropdown
-                  variant="icon"
-                  chatId={chatId}
-                  participantIds={chatDetail?.participants?.map((p) => p.agentId) ?? [agentId]}
-                  onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
-                />
-              )}
-              {/* Hide agent final-text toggle — TEMPORARY, staging/dev only
+                  <span
+                    aria-hidden="true"
+                    className="shrink-0"
+                    style={{
+                      width: "var(--hairline)",
+                      height: "var(--sp-4)",
+                      background: "var(--border)",
+                      marginLeft: "var(--sp-1)",
+                      marginRight: "var(--sp-1)",
+                    }}
+                  />
+                  {readOnly ? null : (
+                    <AddParticipantDropdown
+                      variant="icon"
+                      chatId={chatId}
+                      participantIds={chatDetail?.participants?.map((p) => p.agentId) ?? [agentId]}
+                      onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
+                    />
+                  )}
+                  {/* Hide agent final-text toggle — TEMPORARY, staging/dev only
               (gated on `finalTextToggleEnabled`). Filters the per-turn
               final-text mirrors out of the timeline so a human watcher sees
               only deliberate sends + human messages. Eye / EyeOff conveys the
               show/hide state; pressed styling marks "currently hiding". */}
-              {finalTextToggleEnabled && (
-                <button
-                  type="button"
-                  onClick={toggleHideAgentFinalText}
-                  aria-label={hideAgentFinalText ? "Show agent final messages" : "Hide agent final messages"}
-                  aria-pressed={hideAgentFinalText}
-                  title={hideAgentFinalText ? "Show agent final messages" : "Hide agent final messages"}
-                  className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
-                  style={{
-                    width: 28,
-                    height: 28,
-                    border: 0,
-                    background: hideAgentFinalText ? "var(--bg-sunken)" : "transparent",
-                    borderRadius: "var(--radius-input)",
-                    color: hideAgentFinalText ? "var(--fg)" : "var(--fg-3)",
-                    cursor: "pointer",
-                  }}
-                >
-                  {hideAgentFinalText ? <EyeOff size={16} strokeWidth={2.25} /> : <Eye size={16} strokeWidth={2.25} />}
-                </button>
-              )}
-              {/* Chat details toggle — opens the right rail (Participants /
+                  {finalTextToggleEnabled && (
+                    <button
+                      type="button"
+                      onClick={toggleHideAgentFinalText}
+                      aria-label={hideAgentFinalText ? "Show agent final messages" : "Hide agent final messages"}
+                      aria-pressed={hideAgentFinalText}
+                      title={hideAgentFinalText ? "Show agent final messages" : "Hide agent final messages"}
+                      className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+                      style={{
+                        width: 28,
+                        height: 28,
+                        border: 0,
+                        background: hideAgentFinalText ? "var(--bg-sunken)" : "transparent",
+                        borderRadius: "var(--radius-input)",
+                        color: hideAgentFinalText ? "var(--fg)" : "var(--fg-3)",
+                        cursor: "pointer",
+                      }}
+                    >
+                      {hideAgentFinalText ? (
+                        <EyeOff size={16} strokeWidth={2.25} />
+                      ) : (
+                        <Eye size={16} strokeWidth={2.25} />
+                      )}
+                    </button>
+                  )}
+                  {/* Chat details toggle — opens the right rail (Participants /
               GitHub / Chat actions). Sits at the panel's far right,
               mirroring the rail's position. The PanelRight glyph is the
               panel-toggle convention (Linear / Notion / VS Code); the same
@@ -3663,26 +3703,28 @@ export function ChatView({
               background + darker foreground) carries the open/closed state.
               An ellipsis is reserved for overflow-action menus (see
               row-actions-menu.tsx), so it would mislead here. */}
-              <button
-                type="button"
-                onClick={toggleSidebar}
-                aria-label={showSidebar ? "Hide chat details" : "Show chat details"}
-                aria-expanded={showSidebar}
-                aria-pressed={showSidebar}
-                title={showSidebar ? "Hide chat details" : "Show chat details"}
-                className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
-                style={{
-                  width: 28,
-                  height: 28,
-                  border: 0,
-                  background: showSidebar ? "var(--bg-sunken)" : "transparent",
-                  borderRadius: "var(--radius-input)",
-                  color: showSidebar ? "var(--fg)" : "var(--fg-3)",
-                  cursor: "pointer",
-                }}
-              >
-                <PanelRight size={16} strokeWidth={2.25} />
-              </button>
+                  <button
+                    type="button"
+                    onClick={toggleSidebar}
+                    aria-label={showSidebar ? "Hide chat details" : "Show chat details"}
+                    aria-expanded={showSidebar}
+                    aria-pressed={showSidebar}
+                    title={showSidebar ? "Hide chat details" : "Show chat details"}
+                    className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
+                    style={{
+                      width: 28,
+                      height: 28,
+                      border: 0,
+                      background: showSidebar ? "var(--bg-sunken)" : "transparent",
+                      borderRadius: "var(--radius-input)",
+                      color: showSidebar ? "var(--fg)" : "var(--fg-3)",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <PanelRight size={16} strokeWidth={2.25} />
+                  </button>
+                </>
+              )}
             </div>
           </div>
 
@@ -3748,6 +3790,7 @@ export function ChatView({
             visibleItems={visibleItems}
             hiddenByBlock={hiddenByBlock}
             readOnly={readOnly}
+            isTrial={isTrial}
             scrollContainerRef={scrollContainerRef}
             overlayContainerRef={overlayContainerRef}
             messagesEndRef={messagesEndRef}
@@ -4266,7 +4309,10 @@ export function ChatView({
             </div>
           }
         </div>
-        {showSidebar ? (
+        {/* No chat-details right rail on the trial surface — a pure
+            conversation. `!isTrial` also defends against a persisted
+            `showSidebar=true` carried over from a prior non-trial session. */}
+        {showSidebar && !isTrial ? (
           narrow ? (
             // Narrow viewport: rail floats over the chat instead of
             // pushing it aside. A scrim catches outside-clicks for

--- a/packages/web/src/pages/workspace/center/index.tsx
+++ b/packages/web/src/pages/workspace/center/index.tsx
@@ -23,10 +23,15 @@ export function CenterPanel({
   narrow,
   onShowConversations,
   initialParticipantIds,
+  isTrial = false,
 }: {
   selectedChatId: string | null;
   onSelectChat: (chatId: string) => void;
   onClearChat: () => void;
+  /** Landing-campaign trial surface: hide chat-management escape hatches
+   *  (new chat, add participant, agent pause/resume) — the trial chat is a
+   *  controlled, single-run surface. */
+  isTrial?: boolean;
   /** True when the workspace shell is in narrow-viewport mode (<768).
    *  Propagated to `ChatView` so it can swap the right rail to an
    *  overlay and surface the conv-list summon button. */
@@ -70,9 +75,10 @@ export function CenterPanel({
         narrow={narrow}
         onShowConversations={onShowConversations}
         onClearChat={onClearChat}
+        isTrial={isTrial}
       />
     );
   }
 
-  return <NoChatView onNewChat={() => onSelectChat(DRAFT_CHAT_ID)} />;
+  return <NoChatView onNewChat={() => onSelectChat(DRAFT_CHAT_ID)} isTrial={isTrial} />;
 }

--- a/packages/web/src/pages/workspace/center/no-chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/no-chat-view.tsx
@@ -17,21 +17,28 @@ import { Button } from "../../../components/ui/button.js";
  * "one hero per surface" is honoured by keeping the persistent rail CTA
  * as the canonical home and treating this as a discoverability echo.
  */
-export function NoChatView({ onNewChat }: { onNewChat: () => void }) {
+export function NoChatView({ onNewChat, isTrial = false }: { onNewChat: () => void; isTrial?: boolean }) {
+  // On the trial surface there is no "new chat" affordance — creating chats is
+  // an escape hatch, and the trial's single chat is the whole surface. The
+  // empty state becomes a calm pointer rather than a create-chat CTA.
   return (
     <div className="flex-1 flex items-center justify-center p-8">
       <div className="text-center max-w-sm">
         <FirstTreeLogo width={36} height={40} className="mx-auto mb-3 text-primary opacity-60" />
         <div className="text-subtitle mb-1">No chat selected</div>
         <div className="text-body text-muted-foreground mb-4">
-          Start a new chat to put your agent to work, or open an existing one from the list.
+          {isTrial
+            ? "Your trial chat isn’t open. Use “Set up First Tree” above to continue."
+            : "Start a new chat to put your agent to work, or open an existing one from the list."}
         </div>
-        <div className="flex justify-center">
-          <Button type="button" variant="default" onClick={onNewChat}>
-            <Plus className="h-3.5 w-3.5" />
-            <span>New chat</span>
-          </Button>
-        </div>
+        {isTrial ? null : (
+          <div className="flex justify-center">
+            <Button type="button" variant="default" onClick={onNewChat}>
+              <Plus className="h-3.5 w-3.5" />
+              <span>New chat</span>
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/packages/web/src/pages/workspace/index.tsx
+++ b/packages/web/src/pages/workspace/index.tsx
@@ -1,11 +1,12 @@
 import { CHAT_SOURCES, type ChatEngagementView, type ChatSource, chatEngagementViewSchema } from "@first-tree/shared";
 import { useCallback, useEffect, useState } from "react";
-import { Navigate, useSearchParams } from "react-router";
+import { Navigate, useLocation, useSearchParams } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
 import { DocPreviewDrawer } from "../../components/doc-preview-drawer.js";
 import { useAdminWs } from "../../hooks/use-admin-ws.js";
 import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
+import { isLandingTrialSurface } from "../quickstart/route.js";
 import { CenterPanel } from "./center/index.js";
 import {
   DEFAULT_GROUP_MODE,
@@ -150,6 +151,11 @@ export function WorkspacePage() {
  */
 export function WorkspaceBody() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
+  // Trial surface (`/quickstart`): the single-run trial chat is the only
+  // supported surface, so drop the conversation rail (and its new-chat /
+  // filter affordances) and show the chat full-bleed.
+  const isTrial = isLandingTrialSurface(location.pathname);
   const selectedChatId = searchParams.get("c");
   const legacyAgentId = searchParams.get("a");
   const legacySource = searchParams.get("source");
@@ -298,6 +304,28 @@ export function WorkspaceBody() {
     // win and leave the URL in a half-cleared state.
     setSearchParams(nextParamsForClearFilters(searchParams), { replace: true });
   }, [searchParams, setSearchParams]);
+
+  // Trial surface: no conversation rail (and no narrow overlay) — the trial
+  // chat renders full-bleed. Escape-hatch affordances (new chat, filters) live
+  // in the rail, so dropping it is what keeps the trial a controlled surface.
+  if (isTrial) {
+    return (
+      <div className="flex flex-1 overflow-hidden relative">
+        <main className="flex-1 flex flex-col overflow-hidden min-w-0" style={{ background: "var(--bg)" }}>
+          <CenterPanel
+            selectedChatId={selectedChatId}
+            onSelectChat={selectChat}
+            onClearChat={clearSelectedChat}
+            narrow={isNarrow}
+            onShowConversations={null}
+            initialParticipantIds={participants}
+            isTrial
+          />
+        </main>
+        <DocPreviewDrawer />
+      </div>
+    );
+  }
 
   // Pick the width prop based on what role the rail is playing:
   //   - narrow + no chat → full-bleed (100% of the wrapper) so the list


### PR DESCRIPTION
Follow-up to #1450.

## Problem

#1450 renders the landing-campaign Scan trial chat inside the **normal workspace** at `/quickstart`. That gave a controlled, single-run trial user the workspace's full set of **escape hatches** — clicking "Workspace" bounced them to `/onboarding`, and nav tabs / team switcher / ⌘K / new-chat / add-participant / agent pause-resume / chat rename / the message-avatar hovercard all let them wander out of the trial. The Context Tree makes the trial chat the *only* supported user-facing surface, so these need to be gone.

## Change

A **route-scoped trial chrome** (`isLandingTrialSurface(pathname) === "/quickstart"`, `pages/quickstart/route.ts`) that makes the trial a **pure conversation**:

- **Layout** — stripped header: brand + one **"Set up First Tree" CTA** (→ `/onboarding`) + theme + user menu (sign out). No nav tabs, team switcher, or ⌘K palette (the keydown effect and the palette render are both gated off).
- **WorkspaceBody** — drop the conversation rail (and its new-chat / filters / narrow overlay).
- **ChatView** — hide the entire chat-header controls cluster (participant stats, add participant, chat-details toggle); don't render the right details sidebar (also defends a persisted `showSidebar=true`); make the title non-renamable; render each message's sender avatar/name as **plain identity** (no `AgentHovercard`, whose "Open details" → `/agents/:id` and "Chat" → `/?c=draft` actions navigated out of the trial).
- **NoChatView** — hide "New chat"; the empty state points at the header CTA (not "the list", which no longer exists on trial).

**Route-scoped only.** `shouldEnterOnboarding`, the trial agent identity, and chat rendering/width are untouched. Normal workspace chats are unaffected (verified).

## Review

Two rounds of two independent reviews. The second round caught a real high-severity hole — the per-message `AgentHovercard` navigated out of the trial on every agent turn — now fixed (plain sender identity on trial) and E2E-confirmed. All other affordances (composer slash/mention, attach, agent markdown links via `isNavigableWebHref`, doc-preview drawer, user menu) were audited and are benign. Known boundary: chrome is keyed on the route, so `/quickstart?c=<any>` strips and a trial chat at `/?c=` would not (saved by the onboarding gate).

## Verification

E2E against real staging data with this branch's code (local Vite → staging API): trial header (desktop + mobile), no rail / palette / sidebar / header controls, non-renamable title, message avatar opens nothing, CTA → `/onboarding`; control `/` and `/?c=` keep full chrome + all affordances. `pnpm --filter @first-tree/web typecheck` + `lint:tokens` + biome clean; **1105 web tests pass** (new: layout trial chrome, rail drop, NoChatView trial — all with non-trial controls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
