### PR TITLE
fix(web): hide the offline-agent notice on the trial surface

### DIFF
--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1265,7 +1265,11 @@ const ChatTimeline = memo(function ChatTimeline({
               </div>
             ) : null}
           </div>
-          <ChatOfflineNotice chatId={chatId} agents={awaitedAgents} />
+          {/* No offline-agent notice on the trial surface: its "Reconnect"
+              action navigates to /settings/computers (an escape hatch), and a
+              service-managed trial agent has no computer for the user to
+              reconnect anyway — liveness is First Tree's concern here. */}
+          {isTrial ? null : <ChatOfflineNotice chatId={chatId} agents={awaitedAgents} />}
           <div ref={messagesEndRef} />
         </div>
       </div>


### PR DESCRIPTION
Follow-up to #1460 — addresses @baixiaohang's post-merge review finding.

## Problem

`ChatTimeline` still rendered `<ChatOfflineNotice>` on trial chats. When the trial conversation awaits an offline agent, that notice's **"Reconnect"** button calls `navigate("/settings/computers")` (`chat-offline-notice.tsx:136`) — a visible route **out of** the controlled `/quickstart` pure-conversation surface, and meaningless for a service-managed trial agent the user has no computer to reconnect.

## Change

Gate the notice on `isTrial` (`chat-view.tsx`): the offline-agent notice is not rendered on the trial surface. A hosted trial agent's liveness is First Tree's concern, not a user "reconnect a computer" action.

Route-scoped, one render guard; normal chats keep the notice unchanged.

## Verification

`typecheck` + `lint:tokens` + biome clean; **1106 web tests pass**. (The offline state can't be forced on staging to E2E, and seeding a specific offline+awaited timeline in a unit test is impractical; this is a straightforward render guard on the already-threaded `isTrial`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
