### PR TITLE
feat: add landing trial token budget

### DIFF
--- a/packages/server/src/__tests__/bootstrap.test.ts
+++ b/packages/server/src/__tests__/bootstrap.test.ts
@@ -31,7 +31,7 @@ function makeTempConfigDir(): string {
 
 const baseServerConfig: ServerConfig = {
   channel: "dev",
-  growth: { landingPagesEnabled: false, landingCampaignMaxAgentTurns: 1 },
+  growth: { landingPagesEnabled: false, landingCampaignMaxAgentTurns: 1, landingCampaignMaxEstimatedTokens: undefined },
   docs: { enabled: false },
   database: { url: process.env.DATABASE_URL ?? "", provider: "external" },
   server: { port: 0, host: "127.0.0.1", publicUrl: "https://first-tree.example" },

--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -16,7 +16,7 @@ import type { Config } from "../config.js";
  */
 const baseConfig: Config = {
   channel: "dev",
-  growth: { landingPagesEnabled: false, landingCampaignMaxAgentTurns: 1 },
+  growth: { landingPagesEnabled: false, landingCampaignMaxAgentTurns: 1, landingCampaignMaxEstimatedTokens: undefined },
   docs: { enabled: false },
   database: { url: process.env.DATABASE_URL ?? "", provider: "external" },
   server: { port: 0, host: "127.0.0.1", publicUrl: undefined },

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -66,6 +66,7 @@ export type CreateTestAppOptions = {
   landingCampaignClientId?: string;
   landingCampaignRuntimeProvider?: "codex" | "claude-code";
   landingCampaignMaxAgentTurns?: number;
+  landingCampaignMaxEstimatedTokens?: number;
   commandVersion?: string;
   rateLimit?: Partial<NonNullable<Config["rateLimit"]>>;
   connectBootstrap?: Config["connectBootstrap"];
@@ -100,6 +101,7 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
     growth: {
       landingPagesEnabled: opts.growthLandingPagesEnabled ?? false,
       landingCampaignMaxAgentTurns: opts.landingCampaignMaxAgentTurns ?? 1,
+      landingCampaignMaxEstimatedTokens: opts.landingCampaignMaxEstimatedTokens,
       ...(opts.landingCampaignServiceUserId !== undefined ||
       opts.landingCampaignServiceOrgId !== undefined ||
       opts.landingCampaignClientId !== undefined ||

--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../services/landing-campaigns/trial-prompt.js";
 import { createMember } from "../services/member.js";
 import { sendMessage } from "../services/message.js";
+import * as sessionEventService from "../services/session-event.js";
 import { uuidv7 } from "../uuid.js";
 import { agentRequest, createTestAdmin, INVALID_BCRYPT_PLACEHOLDER, useTestApp } from "./helpers.js";
 
@@ -187,6 +188,38 @@ describe("POST /me/landing-campaigns/start", () => {
     landingCampaignClientId: OFFICIAL_CLIENT_ID,
     landingCampaignMaxAgentTurns: 2,
   });
+  const getBudgetApp = useTestApp({
+    growthLandingPagesEnabled: true,
+    landingCampaignServiceUserId: SERVICE_USER_ID,
+    landingCampaignServiceOrgId: SERVICE_ORG_ID,
+    landingCampaignClientId: OFFICIAL_CLIENT_ID,
+    landingCampaignMaxAgentTurns: 3,
+    landingCampaignMaxEstimatedTokens: 500,
+  });
+
+  it("parses legacy trial chat metadata with estimated token defaults", () => {
+    const trial = parseLandingCampaignTrialChatMetadata({
+      landingCampaignTrial: {
+        campaign: "production-scan",
+        agentId: "agent-1",
+        skillSetId: "production-scan",
+        skillSetVersion: "test",
+        repo: { url: "https://github.com/acme/backend", canonicalKey: "github.com/acme/backend" },
+        state: "running",
+        inputLocked: false,
+      },
+    });
+
+    expect(trial).toMatchObject({
+      maxAgentTurns: 1,
+      completedAgentTurns: 0,
+      completedAgentTurnIds: [],
+      maxEstimatedTokens: null,
+      estimatedTokensUsed: 0,
+      lastObservedEstimatedTokens: 0,
+    });
+  });
+
   it("feature flag off rejects before creating service member, trial agent, chat, or resource", async () => {
     const app = getDisabledApp();
     const admin = await createTestAdmin(app);
@@ -390,6 +423,9 @@ describe("POST /me/landing-campaigns/start", () => {
       inputLocked: false,
       maxAgentTurns: 1,
       completedAgentTurns: 0,
+      maxEstimatedTokens: null,
+      estimatedTokensUsed: 0,
+      lastObservedEstimatedTokens: 0,
     });
 
     const [bootstrap] = await app.db.select().from(messages).where(eq(messages.chatId, body.chatId)).limit(1);
@@ -826,7 +862,13 @@ describe("POST /me/landing-campaigns/start", () => {
       body.agentUuid,
       "turn-outbox",
     );
-    expect(completedTurn).toEqual({ advanced: true, reachedTurnLimit: true, duplicate: false });
+    expect(completedTurn).toEqual({
+      advanced: true,
+      reachedTurnLimit: true,
+      reachedLimit: true,
+      limitReason: "turns",
+      duplicate: false,
+    });
     const [completedChat] = await app.db
       .select({ metadata: chats.metadata })
       .from(chats)
@@ -920,7 +962,13 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(whileRunning.statusCode).toBe(201);
 
     const firstTurn = await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "turn-1");
-    expect(firstTurn).toEqual({ advanced: true, reachedTurnLimit: false, duplicate: false });
+    expect(firstTurn).toEqual({
+      advanced: true,
+      reachedTurnLimit: false,
+      reachedLimit: false,
+      limitReason: null,
+      duplicate: false,
+    });
     const [runningChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
     const runningTrial = parseLandingCampaignTrialChatMetadata(runningChat?.metadata);
     expect(runningTrial).toMatchObject({
@@ -944,7 +992,13 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(followUp.statusCode).toBe(201);
 
     const finalTurn = await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "turn-2");
-    expect(finalTurn).toEqual({ advanced: true, reachedTurnLimit: true, duplicate: false });
+    expect(finalTurn).toEqual({
+      advanced: true,
+      reachedTurnLimit: true,
+      reachedLimit: true,
+      limitReason: "turns",
+      duplicate: false,
+    });
     const [completedChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
     const completedTrial = parseLandingCampaignTrialChatMetadata(completedChat?.metadata);
     expect(completedTrial).toMatchObject({
@@ -966,6 +1020,238 @@ describe("POST /me/landing-campaigns/start", () => {
       },
     });
     expect(afterLimit.statusCode).toBe(403);
+  });
+
+  it("keeps turn-only behavior when the estimated token cap is not configured", async () => {
+    const app = getMultiTurnApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const started = await startProductionScan(app, admin);
+    const body = started.json<{ chatId: string; agentUuid: string }>();
+
+    await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
+      kind: "token_usage",
+      payload: {
+        provider: "codex",
+        model: "gpt-5",
+        inputTokens: 100_000,
+        cachedInputTokens: 10_000,
+        outputTokens: 20_000,
+      },
+    });
+
+    const firstTurn = await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "uncapped-1");
+    expect(firstTurn).toEqual({
+      advanced: true,
+      reachedTurnLimit: false,
+      reachedLimit: false,
+      limitReason: null,
+      duplicate: false,
+    });
+    const [runningChat] = await app.db
+      .select({ metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, body.chatId));
+    expect(parseLandingCampaignTrialChatMetadata(runningChat?.metadata)).toMatchObject({
+      state: "running",
+      inputLocked: false,
+      maxAgentTurns: 2,
+      completedAgentTurns: 1,
+      maxEstimatedTokens: null,
+      estimatedTokensUsed: 130_000,
+      lastObservedEstimatedTokens: 130_000,
+    });
+
+    const followUp = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${body.chatId}/messages`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {
+        format: "text",
+        content: "Can you keep going after a large uncapped turn?",
+        metadata: { mentions: [body.agentUuid] },
+      },
+    });
+    expect(followUp.statusCode).toBe(201);
+  });
+
+  it("locks a trial chat when the estimated token cap is reached before the turn cap", async () => {
+    const app = getBudgetApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const started = await startProductionScan(app, admin);
+    const body = started.json<{ chatId: string; agentUuid: string }>();
+
+    const [initialChat] = await app.db
+      .select({ metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, body.chatId));
+    expect(parseLandingCampaignTrialChatMetadata(initialChat?.metadata)).toMatchObject({
+      state: "running",
+      inputLocked: false,
+      maxAgentTurns: 3,
+      completedAgentTurns: 0,
+      maxEstimatedTokens: 500,
+      estimatedTokensUsed: 0,
+      lastObservedEstimatedTokens: 0,
+    });
+
+    await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
+      kind: "token_usage",
+      payload: { provider: "codex", model: "gpt-5", inputTokens: 100, cachedInputTokens: 25, outputTokens: 50 },
+    });
+    await sessionEventService.appendEvent(app.db, uuidv7(), body.chatId, {
+      kind: "token_usage",
+      payload: {
+        provider: "codex",
+        model: "gpt-5",
+        inputTokens: 10_000,
+        cachedInputTokens: 1_000,
+        outputTokens: 2_000,
+      },
+    });
+    const firstTurn = await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "budget-1");
+    expect(firstTurn).toEqual({
+      advanced: true,
+      reachedTurnLimit: false,
+      reachedLimit: false,
+      limitReason: null,
+      duplicate: false,
+    });
+    const [afterFirstChat] = await app.db
+      .select({ metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, body.chatId));
+    expect(parseLandingCampaignTrialChatMetadata(afterFirstChat?.metadata)).toMatchObject({
+      state: "running",
+      inputLocked: false,
+      completedAgentTurns: 1,
+      estimatedTokensUsed: 175,
+      lastObservedEstimatedTokens: 175,
+    });
+
+    const whileUnderBudget = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${body.chatId}/messages`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {
+        format: "text",
+        content: "Please continue while the token budget remains.",
+        metadata: { mentions: [body.agentUuid] },
+      },
+    });
+    expect(whileUnderBudget.statusCode).toBe(201);
+
+    await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
+      kind: "token_usage",
+      payload: { provider: "codex", model: "gpt-5", inputTokens: 200, cachedInputTokens: 50, outputTokens: 100 },
+    });
+    const secondTurn = await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "budget-2");
+    expect(secondTurn).toEqual({
+      advanced: true,
+      reachedTurnLimit: false,
+      reachedLimit: true,
+      limitReason: "tokens",
+      duplicate: false,
+    });
+    const [lockedChat] = await app.db.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, body.chatId));
+    expect(parseLandingCampaignTrialChatMetadata(lockedChat?.metadata)).toMatchObject({
+      state: "completed",
+      inputLocked: true,
+      maxAgentTurns: 3,
+      completedAgentTurns: 2,
+      maxEstimatedTokens: 500,
+      estimatedTokensUsed: 525,
+      lastObservedEstimatedTokens: 525,
+      limitReason: "tokens",
+    });
+
+    const duplicate = await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "budget-2");
+    expect(duplicate).toEqual({
+      advanced: false,
+      reachedTurnLimit: false,
+      reachedLimit: true,
+      limitReason: "tokens",
+      duplicate: true,
+    });
+    const [afterDuplicateChat] = await app.db
+      .select({ metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, body.chatId));
+    expect(parseLandingCampaignTrialChatMetadata(afterDuplicateChat?.metadata)).toMatchObject({
+      completedAgentTurns: 2,
+      estimatedTokensUsed: 525,
+      completedAgentTurnIds: ["budget-1", "budget-2"],
+    });
+
+    const afterBudget = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${body.chatId}/messages`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {
+        format: "text",
+        content: "Can we keep going after the token budget?",
+        metadata: { mentions: [body.agentUuid] },
+      },
+    });
+    expect(afterBudget.statusCode).toBe(403);
+  });
+
+  it("continues charging estimated tokens after session event traces reset", async () => {
+    const app = getBudgetApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const started = await startProductionScan(app, admin);
+    const body = started.json<{ chatId: string; agentUuid: string }>();
+
+    await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
+      kind: "token_usage",
+      payload: { provider: "codex", model: "gpt-5", inputTokens: 300, cachedInputTokens: 50, outputTokens: 50 },
+    });
+    const firstTurn = await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "reset-1");
+    expect(firstTurn).toEqual({
+      advanced: true,
+      reachedTurnLimit: false,
+      reachedLimit: false,
+      limitReason: null,
+      duplicate: false,
+    });
+    const [afterFirstChat] = await app.db
+      .select({ metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, body.chatId));
+    expect(parseLandingCampaignTrialChatMetadata(afterFirstChat?.metadata)).toMatchObject({
+      state: "running",
+      inputLocked: false,
+      completedAgentTurns: 1,
+      estimatedTokensUsed: 400,
+      lastObservedEstimatedTokens: 400,
+    });
+
+    await sessionEventService.clearEvents(app.db, body.agentUuid, body.chatId);
+    await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
+      kind: "token_usage",
+      payload: { provider: "codex", model: "gpt-5", inputTokens: 75, cachedInputTokens: 25, outputTokens: 25 },
+    });
+    const secondTurn = await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "reset-2");
+    expect(secondTurn).toEqual({
+      advanced: true,
+      reachedTurnLimit: false,
+      reachedLimit: true,
+      limitReason: "tokens",
+      duplicate: false,
+    });
+    const [lockedChat] = await app.db.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, body.chatId));
+    expect(parseLandingCampaignTrialChatMetadata(lockedChat?.metadata)).toMatchObject({
+      state: "completed",
+      inputLocked: true,
+      completedAgentTurns: 2,
+      completedAgentTurnIds: ["reset-1", "reset-2"],
+      maxEstimatedTokens: 500,
+      estimatedTokensUsed: 525,
+      lastObservedEstimatedTokens: 125,
+      limitReason: "tokens",
+    });
   });
 
   it("serializes concurrent trial request writes so only one state transition wins", async () => {
@@ -1192,7 +1478,13 @@ describe("POST /me/landing-campaigns/start", () => {
       body.agentUuid,
       "turn-request-answer",
     );
-    expect(completedTurn).toEqual({ advanced: true, reachedTurnLimit: true, duplicate: false });
+    expect(completedTurn).toEqual({
+      advanced: true,
+      reachedTurnLimit: true,
+      reachedLimit: true,
+      limitReason: "turns",
+      duplicate: false,
+    });
     const [completedChat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
     expect(parseLandingCampaignTrialChatMetadata(completedChat?.metadata)).toMatchObject({
       state: "completed",

--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -196,6 +196,14 @@ describe("POST /me/landing-campaigns/start", () => {
     landingCampaignMaxAgentTurns: 3,
     landingCampaignMaxEstimatedTokens: 500,
   });
+  const getResetBudgetApp = useTestApp({
+    growthLandingPagesEnabled: true,
+    landingCampaignServiceUserId: SERVICE_USER_ID,
+    landingCampaignServiceOrgId: SERVICE_ORG_ID,
+    landingCampaignClientId: OFFICIAL_CLIENT_ID,
+    landingCampaignMaxAgentTurns: 3,
+    landingCampaignMaxEstimatedTokens: 900,
+  });
 
   it("parses legacy trial chat metadata with estimated token defaults", () => {
     const trial = parseLandingCampaignTrialChatMetadata({
@@ -217,6 +225,7 @@ describe("POST /me/landing-campaigns/start", () => {
       maxEstimatedTokens: null,
       estimatedTokensUsed: 0,
       lastObservedEstimatedTokens: 0,
+      lastObservedTokenUsageEventId: null,
     });
   });
 
@@ -426,6 +435,7 @@ describe("POST /me/landing-campaigns/start", () => {
       maxEstimatedTokens: null,
       estimatedTokensUsed: 0,
       lastObservedEstimatedTokens: 0,
+      lastObservedTokenUsageEventId: null,
     });
 
     const [bootstrap] = await app.db.select().from(messages).where(eq(messages.chatId, body.chatId)).limit(1);
@@ -1029,7 +1039,7 @@ describe("POST /me/landing-campaigns/start", () => {
     const started = await startProductionScan(app, admin);
     const body = started.json<{ chatId: string; agentUuid: string }>();
 
-    await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
+    const uncappedEvent = await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
       kind: "token_usage",
       payload: {
         provider: "codex",
@@ -1060,6 +1070,7 @@ describe("POST /me/landing-campaigns/start", () => {
       maxEstimatedTokens: null,
       estimatedTokensUsed: 130_000,
       lastObservedEstimatedTokens: 130_000,
+      lastObservedTokenUsageEventId: uncappedEvent.id,
     });
 
     const followUp = await app.inject({
@@ -1094,9 +1105,10 @@ describe("POST /me/landing-campaigns/start", () => {
       maxEstimatedTokens: 500,
       estimatedTokensUsed: 0,
       lastObservedEstimatedTokens: 0,
+      lastObservedTokenUsageEventId: null,
     });
 
-    await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
+    const firstUsage = await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
       kind: "token_usage",
       payload: { provider: "codex", model: "gpt-5", inputTokens: 100, cachedInputTokens: 25, outputTokens: 50 },
     });
@@ -1128,6 +1140,7 @@ describe("POST /me/landing-campaigns/start", () => {
       completedAgentTurns: 1,
       estimatedTokensUsed: 175,
       lastObservedEstimatedTokens: 175,
+      lastObservedTokenUsageEventId: firstUsage.id,
     });
 
     const whileUnderBudget = await app.inject({
@@ -1142,7 +1155,7 @@ describe("POST /me/landing-campaigns/start", () => {
     });
     expect(whileUnderBudget.statusCode).toBe(201);
 
-    await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
+    const secondUsage = await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
       kind: "token_usage",
       payload: { provider: "codex", model: "gpt-5", inputTokens: 200, cachedInputTokens: 50, outputTokens: 100 },
     });
@@ -1163,6 +1176,7 @@ describe("POST /me/landing-campaigns/start", () => {
       maxEstimatedTokens: 500,
       estimatedTokensUsed: 525,
       lastObservedEstimatedTokens: 525,
+      lastObservedTokenUsageEventId: secondUsage.id,
       limitReason: "tokens",
     });
 
@@ -1198,13 +1212,13 @@ describe("POST /me/landing-campaigns/start", () => {
   });
 
   it("continues charging estimated tokens after session event traces reset", async () => {
-    const app = getBudgetApp();
+    const app = getResetBudgetApp();
     const admin = await createTestAdmin(app);
     await seedOfficialRuntime(app, admin.organizationId);
     const started = await startProductionScan(app, admin);
     const body = started.json<{ chatId: string; agentUuid: string }>();
 
-    await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
+    const firstUsage = await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
       kind: "token_usage",
       payload: { provider: "codex", model: "gpt-5", inputTokens: 300, cachedInputTokens: 50, outputTokens: 50 },
     });
@@ -1226,12 +1240,13 @@ describe("POST /me/landing-campaigns/start", () => {
       completedAgentTurns: 1,
       estimatedTokensUsed: 400,
       lastObservedEstimatedTokens: 400,
+      lastObservedTokenUsageEventId: firstUsage.id,
     });
 
     await sessionEventService.clearEvents(app.db, body.agentUuid, body.chatId);
-    await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
+    const secondUsage = await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
       kind: "token_usage",
-      payload: { provider: "codex", model: "gpt-5", inputTokens: 75, cachedInputTokens: 25, outputTokens: 25 },
+      payload: { provider: "codex", model: "gpt-5", inputTokens: 450, cachedInputTokens: 50, outputTokens: 100 },
     });
     const secondTurn = await completeLandingCampaignTrialAgentTurn(app.db, body.chatId, body.agentUuid, "reset-2");
     expect(secondTurn).toEqual({
@@ -1247,9 +1262,10 @@ describe("POST /me/landing-campaigns/start", () => {
       inputLocked: true,
       completedAgentTurns: 2,
       completedAgentTurnIds: ["reset-1", "reset-2"],
-      maxEstimatedTokens: 500,
-      estimatedTokensUsed: 525,
-      lastObservedEstimatedTokens: 125,
+      maxEstimatedTokens: 900,
+      estimatedTokensUsed: 1000,
+      lastObservedEstimatedTokens: 600,
+      lastObservedTokenUsageEventId: secondUsage.id,
       limitReason: "tokens",
     });
   });

--- a/packages/server/src/__tests__/ws-session-event.test.ts
+++ b/packages/server/src/__tests__/ws-session-event.test.ts
@@ -296,6 +296,27 @@ describe("Agent WS — session event protocol (S10)", () => {
       );
     }
 
+    async function sendTokenUsage(
+      ref: string,
+      tokens: { inputTokens: number; cachedInputTokens: number; outputTokens: number },
+    ) {
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          ref,
+          agentId: seed.agent.uuid,
+          chatId,
+          event: { kind: "token_usage", payload: { provider: "codex", model: "gpt-5", ...tokens } },
+        }),
+      );
+      await waitForFrame(
+        ws,
+        (m) =>
+          (m as { type?: string; ref?: string }).type === "session:event:accepted" &&
+          (m as { ref?: string }).ref === ref,
+      );
+    }
+
     try {
       await app.db.insert(chats).values({
         id: chatId,
@@ -314,7 +335,8 @@ describe("Agent WS — session event protocol (S10)", () => {
           },
           state: "running",
           inputLocked: false,
-          maxAgentTurns: 2,
+          maxAgentTurns: 3,
+          maxEstimatedTokens: 400,
           completedAgentTurns: 0,
         }),
       });
@@ -340,8 +362,15 @@ describe("Agent WS — session event protocol (S10)", () => {
         inputLocked: false,
         completedAgentTurns: 0,
         completedAgentTurnIds: [],
+        estimatedTokensUsed: 0,
+        lastObservedEstimatedTokens: 0,
       });
 
+      await sendTokenUsage("landing-token-usage-1", {
+        inputTokens: 100,
+        cachedInputTokens: 10,
+        outputTokens: 40,
+      });
       await sendTurnEnd("landing-turn-end-1", "inbox:101");
       const [runningChat] = await app.db.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, chatId));
       expect(parseLandingCampaignTrialChatMetadata(runningChat?.metadata)).toMatchObject({
@@ -349,7 +378,10 @@ describe("Agent WS — session event protocol (S10)", () => {
         inputLocked: false,
         completedAgentTurns: 1,
         completedAgentTurnIds: ["inbox:101"],
-        maxAgentTurns: 2,
+        maxAgentTurns: 3,
+        maxEstimatedTokens: 400,
+        estimatedTokensUsed: 150,
+        lastObservedEstimatedTokens: 150,
       });
 
       await sendTurnEnd("landing-turn-end-1-duplicate", "inbox:101");
@@ -359,9 +391,17 @@ describe("Agent WS — session event protocol (S10)", () => {
         inputLocked: false,
         completedAgentTurns: 1,
         completedAgentTurnIds: ["inbox:101"],
-        maxAgentTurns: 2,
+        maxAgentTurns: 3,
+        maxEstimatedTokens: 400,
+        estimatedTokensUsed: 150,
+        lastObservedEstimatedTokens: 150,
       });
 
+      await sendTokenUsage("landing-token-usage-2", {
+        inputTokens: 200,
+        cachedInputTokens: 20,
+        outputTokens: 80,
+      });
       await sendTurnEnd("landing-turn-end-2", "inbox:102");
       const [completedChat] = await app.db.select({ metadata: chats.metadata }).from(chats).where(eq(chats.id, chatId));
       expect(parseLandingCampaignTrialChatMetadata(completedChat?.metadata)).toMatchObject({
@@ -369,7 +409,11 @@ describe("Agent WS — session event protocol (S10)", () => {
         inputLocked: true,
         completedAgentTurns: 2,
         completedAgentTurnIds: ["inbox:101", "inbox:102"],
-        maxAgentTurns: 2,
+        maxAgentTurns: 3,
+        maxEstimatedTokens: 400,
+        estimatedTokensUsed: 450,
+        lastObservedEstimatedTokens: 450,
+        limitReason: "tokens",
       });
       expect(notifySpy).toHaveBeenCalledTimes(2);
       expect(notifySpy).toHaveBeenCalledWith(chatId);

--- a/packages/server/src/api/chats.ts
+++ b/packages/server/src/api/chats.ts
@@ -25,7 +25,7 @@ import { getChatAgentStatuses } from "../services/agent-chat-status.js";
 import { ensureParticipant, leaveChat, updateChatMetadata } from "../services/chat.js";
 import { declareEntityFollow, listChatGithubEntities, removeEntityFollow } from "../services/github-entity-follow.js";
 import {
-  hasRemainingLandingCampaignTrialAgentTurns,
+  hasRemainingLandingCampaignTrialBudget,
   normalizeLandingCampaignTrialChatMetadataForRead,
 } from "../services/landing-campaigns/chat-state.js";
 import { assertNoLandingCampaignTrialAgents } from "../services/landing-campaigns/guards.js";
@@ -60,7 +60,7 @@ export async function chatRoutes(app: FastifyInstance): Promise<void> {
     if (!trial) return;
     const resolves = body.metadata?.resolves;
     const resolvesRequest = resolves !== null && typeof resolves === "object";
-    if (trial.state === "completed" || trial.state === "failed" || !hasRemainingLandingCampaignTrialAgentTurns(trial)) {
+    if (trial.state === "completed" || trial.state === "failed" || !hasRemainingLandingCampaignTrialBudget(trial)) {
       throw new ForbiddenError("This landing campaign trial chat is locked.");
     }
     if (trial.state === "awaiting_user" && trial.awaitingUserKind !== "follow_up" && !resolvesRequest) {

--- a/packages/server/src/services/landing-campaigns/chat-state.ts
+++ b/packages/server/src/services/landing-campaigns/chat-state.ts
@@ -100,6 +100,12 @@ export async function completeLandingCampaignTrialAgentTurn(
           coalesce((${sessionEvents.payload}->>'cachedInputTokens')::bigint, 0) +
           coalesce((${sessionEvents.payload}->>'outputTokens')::bigint, 0)
         ), 0)::text`,
+        latestTokenUsageEventId: sql<string | null>`
+          (array_agg(${sessionEvents.id} order by ${sessionEvents.seq} desc))[1]
+        `,
+        hasLastObservedTokenUsageEvent: trial.lastObservedTokenUsageEventId
+          ? sql<boolean>`bool_or(${sessionEvents.id} = ${trial.lastObservedTokenUsageEventId})`
+          : sql<boolean>`false`,
       })
       .from(sessionEvents)
       .where(
@@ -111,8 +117,9 @@ export async function completeLandingCampaignTrialAgentTurn(
       );
 
     const observedEstimatedTokens = Number(usageRow?.estimatedTokens ?? 0);
+    const currentTraceContainsLastObservation = Boolean(usageRow?.hasLastObservedTokenUsageEvent);
     const turnEstimatedTokens =
-      observedEstimatedTokens >= trial.lastObservedEstimatedTokens
+      currentTraceContainsLastObservation && observedEstimatedTokens >= trial.lastObservedEstimatedTokens
         ? observedEstimatedTokens - trial.lastObservedEstimatedTokens
         : observedEstimatedTokens;
     const estimatedTokensUsed = trial.estimatedTokensUsed + turnEstimatedTokens;
@@ -135,6 +142,7 @@ export async function completeLandingCampaignTrialAgentTurn(
         completedAgentTurnIds,
         estimatedTokensUsed,
         lastObservedEstimatedTokens: observedEstimatedTokens,
+        lastObservedTokenUsageEventId: usageRow?.latestTokenUsageEventId ?? null,
         ...(limitReason ? { limitReason } : {}),
       },
     );

--- a/packages/server/src/services/landing-campaigns/chat-state.ts
+++ b/packages/server/src/services/landing-campaigns/chat-state.ts
@@ -1,12 +1,35 @@
-import { eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { Database } from "../../db/connection.js";
 import { chats } from "../../db/schema/chats.js";
+import { sessionEvents } from "../../db/schema/session-events.js";
 import { getLandingCampaignTrialChat, withLandingCampaignChatState } from "./metadata.js";
 
 type LandingCampaignTrialChat = NonNullable<ReturnType<typeof getLandingCampaignTrialChat>>;
+type LandingCampaignTrialLimitReason = NonNullable<LandingCampaignTrialChat["limitReason"]>;
+type LandingCampaignTrialCompletionResult = {
+  advanced: boolean;
+  reachedTurnLimit: boolean;
+  reachedLimit: boolean;
+  limitReason: LandingCampaignTrialLimitReason | null;
+  duplicate: boolean;
+};
 
 export function hasRemainingLandingCampaignTrialAgentTurns(trial: LandingCampaignTrialChat): boolean {
   return trial.completedAgentTurns < trial.maxAgentTurns;
+}
+
+export function hasRemainingLandingCampaignTrialBudget(trial: LandingCampaignTrialChat): boolean {
+  return (
+    hasRemainingLandingCampaignTrialAgentTurns(trial) &&
+    (trial.maxEstimatedTokens === null || trial.estimatedTokensUsed < trial.maxEstimatedTokens)
+  );
+}
+
+function limitReasonForTrial(trial: LandingCampaignTrialChat): LandingCampaignTrialLimitReason | null {
+  if (trial.limitReason) return trial.limitReason;
+  if (!hasRemainingLandingCampaignTrialAgentTurns(trial)) return "turns";
+  if (trial.maxEstimatedTokens !== null && trial.estimatedTokensUsed >= trial.maxEstimatedTokens) return "tokens";
+  return null;
 }
 
 export function normalizeLandingCampaignTrialChatMetadataForRead(
@@ -14,7 +37,7 @@ export function normalizeLandingCampaignTrialChatMetadataForRead(
 ): Record<string, unknown> {
   const trial = getLandingCampaignTrialChat({ metadata });
   if (!trial || trial.state !== "running" || trial.inputLocked === false) return metadata;
-  if (!hasRemainingLandingCampaignTrialAgentTurns(trial)) return metadata;
+  if (!hasRemainingLandingCampaignTrialBudget(trial)) return metadata;
   return withLandingCampaignChatState(metadata, "running", false);
 }
 
@@ -23,7 +46,7 @@ export async function completeLandingCampaignTrialAgentTurn(
   chatId: string,
   agentId: string,
   turnCompletionId: string,
-): Promise<{ advanced: boolean; reachedTurnLimit: boolean; duplicate: boolean }> {
+): Promise<LandingCampaignTrialCompletionResult> {
   return db.transaction(async (tx) => {
     const [chat] = await tx
       .select({ metadata: chats.metadata })
@@ -31,34 +54,92 @@ export async function completeLandingCampaignTrialAgentTurn(
       .where(eq(chats.id, chatId))
       .for("update")
       .limit(1);
-    if (!chat) return { advanced: false, reachedTurnLimit: false, duplicate: false };
+    if (!chat) {
+      return { advanced: false, reachedTurnLimit: false, reachedLimit: false, limitReason: null, duplicate: false };
+    }
 
     const trial = getLandingCampaignTrialChat(chat);
-    if (!trial || trial.agentId !== agentId || trial.state !== "running") {
-      return { advanced: false, reachedTurnLimit: false, duplicate: false };
+    if (!trial || trial.agentId !== agentId) {
+      return { advanced: false, reachedTurnLimit: false, reachedLimit: false, limitReason: null, duplicate: false };
     }
     if (trial.completedAgentTurnIds.includes(turnCompletionId)) {
+      const limitReason = limitReasonForTrial(trial);
       return {
         advanced: false,
-        reachedTurnLimit: !hasRemainingLandingCampaignTrialAgentTurns(trial),
+        reachedTurnLimit: limitReason === "turns",
+        reachedLimit: limitReason !== null,
+        limitReason,
         duplicate: true,
       };
     }
-    if (!hasRemainingLandingCampaignTrialAgentTurns(trial)) {
-      return { advanced: false, reachedTurnLimit: true, duplicate: false };
+    if (trial.state !== "running") {
+      const limitReason = limitReasonForTrial(trial);
+      return {
+        advanced: false,
+        reachedTurnLimit: limitReason === "turns",
+        reachedLimit: limitReason !== null,
+        limitReason,
+        duplicate: false,
+      };
+    }
+    if (!hasRemainingLandingCampaignTrialBudget(trial)) {
+      const limitReason = limitReasonForTrial(trial);
+      return {
+        advanced: false,
+        reachedTurnLimit: limitReason === "turns",
+        reachedLimit: limitReason !== null,
+        limitReason,
+        duplicate: false,
+      };
     }
 
+    const [usageRow] = await tx
+      .select({
+        estimatedTokens: sql<string>`coalesce(sum(
+          coalesce((${sessionEvents.payload}->>'inputTokens')::bigint, 0) +
+          coalesce((${sessionEvents.payload}->>'cachedInputTokens')::bigint, 0) +
+          coalesce((${sessionEvents.payload}->>'outputTokens')::bigint, 0)
+        ), 0)::text`,
+      })
+      .from(sessionEvents)
+      .where(
+        and(
+          eq(sessionEvents.agentId, agentId),
+          eq(sessionEvents.chatId, chatId),
+          eq(sessionEvents.kind, "token_usage"),
+        ),
+      );
+
+    const observedEstimatedTokens = Number(usageRow?.estimatedTokens ?? 0);
+    const turnEstimatedTokens =
+      observedEstimatedTokens >= trial.lastObservedEstimatedTokens
+        ? observedEstimatedTokens - trial.lastObservedEstimatedTokens
+        : observedEstimatedTokens;
+    const estimatedTokensUsed = trial.estimatedTokensUsed + turnEstimatedTokens;
     const completedAgentTurns = trial.completedAgentTurns + 1;
     const completedAgentTurnIds = [...trial.completedAgentTurnIds, turnCompletionId];
     const reachedTurnLimit = completedAgentTurns >= trial.maxAgentTurns;
+    const reachedTokenLimit = trial.maxEstimatedTokens !== null && estimatedTokensUsed >= trial.maxEstimatedTokens;
+    const limitReason: LandingCampaignTrialLimitReason | null = reachedTokenLimit
+      ? "tokens"
+      : reachedTurnLimit
+        ? "turns"
+        : null;
+    const reachedLimit = limitReason !== null;
     const nextMetadata = withLandingCampaignChatState(
       chat.metadata,
-      reachedTurnLimit ? "completed" : "running",
-      reachedTurnLimit,
-      { completedAgentTurns, completedAgentTurnIds },
+      reachedLimit ? "completed" : "running",
+      reachedLimit,
+      {
+        completedAgentTurns,
+        completedAgentTurnIds,
+        estimatedTokensUsed,
+        lastObservedEstimatedTokens: observedEstimatedTokens,
+        ...(limitReason ? { limitReason } : {}),
+      },
     );
 
     await tx.update(chats).set({ metadata: nextMetadata, updatedAt: new Date() }).where(eq(chats.id, chatId));
-    return { advanced: true, reachedTurnLimit, duplicate: false };
+    return { advanced: true, reachedTurnLimit, reachedLimit, limitReason, duplicate: false };
   });
 }

--- a/packages/server/src/services/landing-campaigns/metadata.ts
+++ b/packages/server/src/services/landing-campaigns/metadata.ts
@@ -2,6 +2,7 @@ import {
   type LandingCampaignRepoMetadata,
   type LandingCampaignTrialAwaitingUserKind,
   type LandingCampaignTrialChatState,
+  type LandingCampaignTrialLimitReason,
   parseLandingCampaignTrialAgentMetadata,
   parseLandingCampaignTrialChatMetadata,
 } from "@first-tree/shared";
@@ -49,6 +50,10 @@ export function buildLandingCampaignChatMetadata(input: {
   maxAgentTurns?: number;
   completedAgentTurns?: number;
   completedAgentTurnIds?: string[];
+  maxEstimatedTokens?: number | null;
+  estimatedTokensUsed?: number;
+  lastObservedEstimatedTokens?: number;
+  limitReason?: LandingCampaignTrialLimitReason;
 }): Record<string, unknown> {
   return {
     landingCampaignTrial: {
@@ -63,6 +68,10 @@ export function buildLandingCampaignChatMetadata(input: {
       maxAgentTurns: input.maxAgentTurns ?? 1,
       completedAgentTurns: input.completedAgentTurns ?? 0,
       completedAgentTurnIds: input.completedAgentTurnIds ?? [],
+      maxEstimatedTokens: input.maxEstimatedTokens ?? null,
+      estimatedTokensUsed: input.estimatedTokensUsed ?? 0,
+      lastObservedEstimatedTokens: input.lastObservedEstimatedTokens ?? 0,
+      ...(input.limitReason ? { limitReason: input.limitReason } : {}),
     },
   };
 }
@@ -76,6 +85,10 @@ export function withLandingCampaignChatState(
     completedAgentTurns?: number;
     completedAgentTurnIds?: string[];
     maxAgentTurns?: number;
+    maxEstimatedTokens?: number | null;
+    estimatedTokensUsed?: number;
+    lastObservedEstimatedTokens?: number;
+    limitReason?: LandingCampaignTrialLimitReason;
   } = {},
 ): Record<string, unknown> {
   const current = parseLandingCampaignTrialChatMetadata(metadata);
@@ -88,6 +101,9 @@ export function withLandingCampaignChatState(
   };
   if (state !== "awaiting_user") {
     delete nextTrial.awaitingUserKind;
+  }
+  if (state !== "completed") {
+    delete nextTrial.limitReason;
   }
   return {
     ...metadata,

--- a/packages/server/src/services/landing-campaigns/metadata.ts
+++ b/packages/server/src/services/landing-campaigns/metadata.ts
@@ -53,6 +53,7 @@ export function buildLandingCampaignChatMetadata(input: {
   maxEstimatedTokens?: number | null;
   estimatedTokensUsed?: number;
   lastObservedEstimatedTokens?: number;
+  lastObservedTokenUsageEventId?: string | null;
   limitReason?: LandingCampaignTrialLimitReason;
 }): Record<string, unknown> {
   return {
@@ -71,6 +72,7 @@ export function buildLandingCampaignChatMetadata(input: {
       maxEstimatedTokens: input.maxEstimatedTokens ?? null,
       estimatedTokensUsed: input.estimatedTokensUsed ?? 0,
       lastObservedEstimatedTokens: input.lastObservedEstimatedTokens ?? 0,
+      lastObservedTokenUsageEventId: input.lastObservedTokenUsageEventId ?? null,
       ...(input.limitReason ? { limitReason: input.limitReason } : {}),
     },
   };
@@ -88,6 +90,7 @@ export function withLandingCampaignChatState(
     maxEstimatedTokens?: number | null;
     estimatedTokensUsed?: number;
     lastObservedEstimatedTokens?: number;
+    lastObservedTokenUsageEventId?: string | null;
     limitReason?: LandingCampaignTrialLimitReason;
   } = {},
 ): Record<string, unknown> {

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -390,6 +390,9 @@ async function ensureTrialChatAndBootstrap(
     inputLocked: false,
     maxAgentTurns: app.config.growth.landingCampaignMaxAgentTurns,
     completedAgentTurns: 0,
+    maxEstimatedTokens: app.config.growth.landingCampaignMaxEstimatedTokens ?? null,
+    estimatedTokensUsed: 0,
+    lastObservedEstimatedTokens: 0,
   });
 
   let chatId: string;

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -393,6 +393,7 @@ async function ensureTrialChatAndBootstrap(
     maxEstimatedTokens: app.config.growth.landingCampaignMaxEstimatedTokens ?? null,
     estimatedTokensUsed: 0,
     lastObservedEstimatedTokens: 0,
+    lastObservedTokenUsageEventId: null,
   });
 
   let chatId: string;

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -23,7 +23,7 @@ import { uuidv7 } from "../uuid.js";
 import { upsertSessionState } from "./activity.js";
 import { applyAfterFanOut, fireChatMessageKick } from "./chat-projection.js";
 import { validateDocumentContext, validateMessageAttachmentRefs } from "./doc-snapshots.js";
-import { hasRemainingLandingCampaignTrialAgentTurns } from "./landing-campaigns/chat-state.js";
+import { hasRemainingLandingCampaignTrialBudget } from "./landing-campaigns/chat-state.js";
 import { getLandingCampaignTrialChat, withLandingCampaignChatState } from "./landing-campaigns/metadata.js";
 
 const log = createLogger("message");
@@ -151,7 +151,7 @@ function assertLandingCampaignTrialMessageAllowed(input: {
       trial.state === "running";
     if (isSystemBootstrap) return;
 
-    if (!hasRemainingLandingCampaignTrialAgentTurns(trial)) {
+    if (!hasRemainingLandingCampaignTrialBudget(trial)) {
       throw new ForbiddenError("Landing campaign trial chat is locked.");
     }
 

--- a/packages/shared/src/config/__tests__/server-config.test.ts
+++ b/packages/shared/src/config/__tests__/server-config.test.ts
@@ -72,11 +72,13 @@ describe("server config", () => {
 
     expect(defaultConfig.growth.landingPagesEnabled).toBe(false);
     expect(defaultConfig.growth.landingCampaignMaxAgentTurns).toBe(1);
+    expect(defaultConfig.growth.landingCampaignMaxEstimatedTokens).toBeUndefined();
 
     resetConfig();
     const enabledConfigDir = makeTempConfigDir();
     vi.stubEnv("FIRST_TREE_GROWTH_LANDING_PAGES_ENABLED", "true");
     vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_MAX_AGENT_TURNS", "4");
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_MAX_ESTIMATED_TOKENS", "12000");
 
     const enabledConfig = await initConfig({
       schema: createServerConfigSchema({ autoGenerateSecrets: false }),
@@ -86,6 +88,7 @@ describe("server config", () => {
 
     expect(enabledConfig.growth.landingPagesEnabled).toBe(true);
     expect(enabledConfig.growth.landingCampaignMaxAgentTurns).toBe(4);
+    expect(enabledConfig.growth.landingCampaignMaxEstimatedTokens).toBe(12000);
   });
 
   it("resolves landing campaign official service ids only when configured", async () => {
@@ -133,6 +136,20 @@ describe("server config", () => {
         configDir,
       }),
     ).rejects.toThrow(/landingCampaignMaxAgentTurns/);
+  });
+
+  it("rejects invalid landing campaign estimated token limits", async () => {
+    const configDir = makeTempConfigDir();
+    stubRequiredProductionConfig();
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_MAX_ESTIMATED_TOKENS", "0");
+
+    await expect(
+      initConfig({
+        schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+        role: "server",
+        configDir,
+      }),
+    ).rejects.toThrow(/landingCampaignMaxEstimatedTokens/);
   });
 
   it("defaults landing campaign runtime provider to codex and accepts claude-code", async () => {

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -70,6 +70,14 @@ export const serverConfigSchema = defineConfig({
     landingCampaignMaxAgentTurns: field(z.number().int().min(1).max(20).default(1), {
       env: "FIRST_TREE_LANDING_CAMPAIGN_MAX_AGENT_TURNS",
     }),
+    /**
+     * Optional approximate token budget for each landing campaign trial chat.
+     * When unset, trial quota remains turn-only. When set, successful agent
+     * turns advance both the turn count and this metadata-backed estimate.
+     */
+    landingCampaignMaxEstimatedTokens: field(z.number().int().min(1).optional(), {
+      env: "FIRST_TREE_LANDING_CAMPAIGN_MAX_ESTIMATED_TOKENS",
+    }),
     landingCampaigns: optional({
       /**
        * First Tree official service user that manages landing campaign trial

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -490,6 +490,7 @@ export {
   type LandingCampaignTrialAwaitingUserKind,
   type LandingCampaignTrialChatMetadata,
   type LandingCampaignTrialChatState,
+  type LandingCampaignTrialLimitReason,
   landingCampaignRepoMetadataSchema,
   landingCampaignSlugSchema,
   landingCampaignStartRequestSchema,
@@ -498,6 +499,7 @@ export {
   landingCampaignTrialAwaitingUserKindSchema,
   landingCampaignTrialChatMetadataSchema,
   landingCampaignTrialChatStateSchema,
+  landingCampaignTrialLimitReasonSchema,
   parseLandingCampaignTrialAgentMetadata,
   parseLandingCampaignTrialChatMetadata,
 } from "./schemas/landing-campaign.js";

--- a/packages/shared/src/schemas/landing-campaign.ts
+++ b/packages/shared/src/schemas/landing-campaign.ts
@@ -62,6 +62,7 @@ export const landingCampaignTrialChatMetadataSchema = z.object({
     maxEstimatedTokens: z.number().int().min(1).nullable().default(null),
     estimatedTokensUsed: z.number().int().min(0).default(0),
     lastObservedEstimatedTokens: z.number().int().min(0).default(0),
+    lastObservedTokenUsageEventId: z.string().min(1).nullable().default(null),
     limitReason: landingCampaignTrialLimitReasonSchema.optional(),
   }),
 });

--- a/packages/shared/src/schemas/landing-campaign.ts
+++ b/packages/shared/src/schemas/landing-campaign.ts
@@ -43,6 +43,8 @@ export const landingCampaignTrialChatStateSchema = z.enum(["running", "awaiting_
 export type LandingCampaignTrialChatState = z.infer<typeof landingCampaignTrialChatStateSchema>;
 export const landingCampaignTrialAwaitingUserKindSchema = z.enum(["request", "follow_up"]);
 export type LandingCampaignTrialAwaitingUserKind = z.infer<typeof landingCampaignTrialAwaitingUserKindSchema>;
+export const landingCampaignTrialLimitReasonSchema = z.enum(["turns", "tokens"]);
+export type LandingCampaignTrialLimitReason = z.infer<typeof landingCampaignTrialLimitReasonSchema>;
 
 export const landingCampaignTrialChatMetadataSchema = z.object({
   landingCampaignTrial: z.object({
@@ -57,6 +59,10 @@ export const landingCampaignTrialChatMetadataSchema = z.object({
     maxAgentTurns: z.number().int().min(1).default(1),
     completedAgentTurns: z.number().int().min(0).default(0),
     completedAgentTurnIds: z.array(z.string().min(1)).default([]),
+    maxEstimatedTokens: z.number().int().min(1).nullable().default(null),
+    estimatedTokensUsed: z.number().int().min(0).default(0),
+    lastObservedEstimatedTokens: z.number().int().min(0).default(0),
+    limitReason: landingCampaignTrialLimitReasonSchema.optional(),
   }),
 });
 export type LandingCampaignTrialChatMetadata = z.infer<typeof landingCampaignTrialChatMetadataSchema>;


### PR DESCRIPTION
## Summary

- add an optional per-trial-chat estimated token budget for landing campaign trials
- persist budget state in `chats.metadata.landingCampaignTrial` with defaults for existing metadata
- advance turn count and estimated token usage together on confirmed successful trial turn completion
- lock trial chats when either turn cap or token cap is reached, including direct message API guards

## Notes

- `FIRST_TREE_LANDING_CAMPAIGN_MAX_ESTIMATED_TOKENS` is optional; when unset, existing turn-only behavior is preserved.
- Token usage is estimated from persisted `token_usage` events for the trial agent and chat. `estimatedTokensUsed` remains the metadata-backed cumulative source of truth; the observed session-event total is only a reset-aware cursor.
- This does not change Cloud HTTP rate limiting and does not add a campaign/global ledger.

## Tests

- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter @first-tree/shared exec vitest run src/config/__tests__/server-config.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/landing-campaigns-start.test.ts src/__tests__/ws-session-event.test.ts src/__tests__/session-event.test.ts --maxWorkers=2`
- `pnpm exec turbo run test --concurrency=2 -- --maxWorkers=2`
- `git diff --check`
