### PR TITLE
fix(web): keep the trial composer send button right-aligned

### DIFF
--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -4288,7 +4288,10 @@ export function ChatView({
                             />
                           </span>
                         )}
-                        <span className="flex items-center" style={{ gap: 8 }}>
+                        {/* `ml-auto` keeps the send cluster hard-right even when the
+                            left @/attach cluster is gone (trial surface) — otherwise
+                            `justify-between` with a single child left-aligns it. */}
+                        <span className="flex items-center ml-auto" style={{ gap: 8 }}>
                           {uploading && (
                             <span className="mono text-caption" style={{ color: "var(--primary)" }}>
                               uploading…


### PR DESCRIPTION
Follow-up to the minimal trial composer (#1463) — reported by gandy testing on staging.

## Problem

The composer footer is a `justify-between` row: left = @/attach cluster, right = send cluster. #1463 gated the left cluster out on the trial surface, which left the row with a single child — and `justify-between` then **left-aligns** it. So the trial send button rendered at the bottom-**left** instead of bottom-right (screenshot from gandy confirmed).

## Fix

Add `ml-auto` to the send cluster so it stays hard-right whether or not the left cluster is present. Normal workspace chats are unaffected (left cluster at start + `ml-auto` send = same right-aligned result as `justify-between`).

## Verification

`typecheck` + biome clean; **1106 web tests pass**. E2E on this branch vs real staging data: the trial composer's send button is now at the bottom-right (measured `x≈1063` in a 1280 viewport). (Position isn't assertable in jsdom, so this is E2E-verified rather than unit-tested.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
