### PR TITLE
fix(server): drop "First Tree trial mode" from the landing kickoff message

### DIFF
--- a/docs/development/onboarding-kickoff-contract.md
+++ b/docs/development/onboarding-kickoff-contract.md
@@ -15,8 +15,7 @@ chats and the adjacent campaign quickstart handoff.
   That server-owned path creates the trial chat, binds the managed trial prompt
   guardrail, and wakes the agent from visible task text. The campaign skill is
   not server-materialized: the kickoff message instructs the trial agent to
-  clone the campaign's skill repo and run the named skill in First Tree trial
-  mode.
+  clone the campaign's skill repo and run the named skill on the connected repo.
 - A `/me/onboarding/kickoff` request carrying `campaign` is a stale quickstart
   request. It must not create an onboarding kickoff chat or campaign idempotency
   key; it returns `410 campaign_kickoff_moved` when landing campaigns are enabled

--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -452,7 +452,10 @@ describe("POST /me/landing-campaigns/start", () => {
     // The kickoff instructs the agent to fetch the external skill instead of
     // relying on a server-delivered body.
     expect(bootstrap?.content).toContain("clone https://github.com/agent-team-foundation/launch-readiness-scan");
-    expect(bootstrap?.content).toContain("run its production-scan skill on the repo above, in First Tree trial mode");
+    expect(bootstrap?.content).toContain("run its production-scan skill on the repo above");
+    // The kickoff no longer names a "trial mode" — the external skill is
+    // unconditionally trial-shaped, so the phrase would reference nothing.
+    expect(bootstrap?.content).not.toContain("trial mode");
     expect(bootstrap?.content).toContain("safe, read-only check before launch");
     expect(bootstrap?.metadata).toMatchObject({
       systemSender: "first_tree_onboarding",

--- a/packages/server/src/services/landing-campaigns/skills/catalog.ts
+++ b/packages/server/src/services/landing-campaigns/skills/catalog.ts
@@ -4,11 +4,11 @@
  * A campaign entry carries the trial agent's identity (agent name, chat topic)
  * plus the skill repo the agent clones at kickoff. The scan skill body is NOT
  * server-delivered: the bootstrap message tells the trial agent to clone the
- * campaign's skill repo and run the named skill in First Tree trial mode.
+ * campaign's skill repo and run the named skill on the connected repo.
  * Nothing is materialized, bound, or SHA-pinned server-side — the agent clones
- * the skill repo's default branch at session time and follows it, so the trial
- * runs the exact same skill version standalone users get and the skill stays a
- * single source of truth in its own repo, evolving without a server release.
+ * the skill repo's default branch at session time and follows it, so the skill
+ * stays a single source of truth in its own repo, evolving without a server
+ * release.
  *
  * The web quickstart flow only sends the campaign slug + repo; the server
  * resolves the slug here and seeds the kickoff chat. `version` is provenance
@@ -52,6 +52,6 @@ export function buildLandingCampaignBootstrap(skillSet: LandingCampaignSkillSet,
     "",
     "It's giving your code a safe, read-only check before launch — you'll get a score, the problems that actually matter, and a ready-to-use fix for the biggest one.",
     "",
-    `${skillSet.agentDisplayName} — clone ${skillSet.skillRepoUrl} and run its ${skillSet.skillName} skill on the repo above, in First Tree trial mode.`,
+    `${skillSet.agentDisplayName} — clone ${skillSet.skillRepoUrl} and run its ${skillSet.skillName} skill on the repo above.`,
   ].join("\n");
 }


### PR DESCRIPTION
## Summary

Follow-up to #1467. The external `production-scan` skill (agent-team-foundation/launch-readiness-scan) is now **unconditionally trial-shaped** — opt-in issue filing, no in-conversation repo fixes, and "fix these" routes to building a First Tree team. There is no separate "trial mode" to invoke, so the phrase in the kickoff message referenced nothing.

- Remove `, in First Tree trial mode.` from the kickoff bootstrap message.
- Reword the catalog doc comment to match, and drop the now-obsolete "same skill version standalone users get" framing (standalone install is no longer a product story).
- Test asserts the kickoff no longer contains `trial mode`.

## Context / decisions

- The skill-side change lives in [launch-readiness-scan#24](https://github.com/agent-team-foundation/launch-readiness-scan/pull/24) (opt-in issues, fix-as-conversion, S3 publish). The README/standalone-story cleanup happens in that repo separately.
- Auto-publish of the report is intentionally kept (content-hash key + expiry; nothing is discoverable unless the user shares the link).

## Validation

- `pnpm check` / `pnpm --filter @first-tree/server typecheck` green
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/landing-campaigns-start.test.ts` — 34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
