### PR TITLE
Fix landing trial ended copy and SSH command

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -464,11 +464,14 @@ describe("codex app-server handler", () => {
     const hostHome = join(workspaceRoot, "..", "host-home");
     const codexHome = join(hostHome, ".codex");
     const ghConfigDir = join(hostHome, ".config", "gh");
+    const sshKeyPath = join(hostHome, ".ssh", "id_ed25519");
     const firstTreeHome = join(workspaceRoot, "first-tree-home");
     const cliBinDir = join(workspaceRoot, "first-tree-cli-bin");
     mkdirSync(cliBinDir, { recursive: true });
     mkdirSync(codexHome, { recursive: true });
     mkdirSync(ghConfigDir, { recursive: true });
+    mkdirSync(join(hostHome, ".ssh"), { recursive: true });
+    writeFileSync(sshKeyPath, "ssh-secret\n", { mode: 0o600 });
     writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
     vi.stubEnv("HOME", hostHome);
     vi.stubEnv("FIRST_TREE_HOME", firstTreeHome);
@@ -525,6 +528,11 @@ describe("codex app-server handler", () => {
     expect(capturedEnv?.HOME).toBe(workspaceRoot);
     expect(capturedEnv?.CODEX_HOME).toBe(codexHome);
     expect(capturedEnv?.GH_CONFIG_DIR).toBe(ghConfigDir);
+    expect(capturedEnv?.GIT_SSH_COMMAND).toContain("-F /dev/null");
+    expect(capturedEnv?.GIT_SSH_COMMAND).toContain(sshKeyPath);
+    expect(capturedEnv?.GIT_SSH_COMMAND).toContain(
+      join(workspaceRoot, ".first-tree-workspace", "outbox-home", "ssh", "known_hosts"),
+    );
     expect(capturedEnv?.PATH?.split(":")[0]).toBe(cliBinDir);
     expect(capturedEnv?.OPENAI_API_KEY).toBeUndefined();
     expect(capturedEnv?.CODEX_API_KEY).toBeUndefined();
@@ -548,7 +556,6 @@ describe("codex app-server handler", () => {
             [workspaceRoot]: "write",
             [codexHome]: "deny",
             [join(hostHome, ".first-tree-staging")]: "deny",
-            [join(hostHome, ".ssh")]: "deny",
           },
           network: {
             enabled: true,

--- a/packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts
+++ b/packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts
@@ -15,6 +15,7 @@ import { setCliBinding } from "../runtime/cli-binding.js";
 
 const RUN_SMOKE = process.env.RUN_CODEX_LANDING_APP_SERVER_SMOKE === "1";
 const PROVIDER_CHECK_ENABLED = process.env.SKIP_CODEX_LANDING_PROVIDER_SMOKE !== "1";
+const GITHUB_SSH_CHECK_ENABLED = process.env.RUN_CODEX_LANDING_GITHUB_SSH_SMOKE === "1";
 const describeSmoke = RUN_SMOKE ? describe : describe.skip;
 
 type JsonRecord = Record<string, unknown>;
@@ -223,6 +224,8 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
               `if cat ${shellQuote(hostFirstTreeSecret)} >/dev/null 2>&1; then echo readable; else echo denied; fi`,
               'printf "host_ssh="',
               `if cat ${shellQuote(hostSshSecret)} >/dev/null 2>&1; then echo readable; else echo denied; fi`,
+              'printf "git_ssh_command="',
+              'if test -n "$GIT_SSH_COMMAND"; then echo set; else echo unset; fi',
               'printf "gh_config_dir="',
               'if test -n "$GH_CONFIG_DIR" && test -d "$GH_CONFIG_DIR"; then echo set; else echo unset; fi',
               'printf "resolv_conf="',
@@ -246,7 +249,8 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
       expect(commandExitCode(commandResult)).toBe(0);
       expect(stdout).toContain("codex_auth=denied");
       expect(stdout).toContain("host_first_tree=denied");
-      expect(stdout).toContain("host_ssh=denied");
+      expect(stdout).toContain("host_ssh=readable");
+      expect(stdout).toContain("git_ssh_command=set");
       expect(stdout).toContain("gh_config_dir=set");
       expect(stdout).toContain("resolv_conf=readable");
       expect(stdout).toContain("dns_lookup=ok");
@@ -338,6 +342,8 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
         `if cat ${shellQuote(hostFirstTreeSecret)} >/dev/null 2>&1; then echo readable; else echo denied; fi`,
         'printf "host_ssh="',
         `if cat ${shellQuote(hostSshSecret)} >/dev/null 2>&1; then echo readable; else echo denied; fi`,
+        'printf "git_ssh_command="',
+        'if test -n "$GIT_SSH_COMMAND"; then echo set; else echo unset; fi',
         'printf "gh_config_dir="',
         'if test -n "$GH_CONFIG_DIR" && test -d "$GH_CONFIG_DIR"; then echo set; else echo unset; fi',
         'printf "gh_version="',
@@ -389,7 +395,8 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
       expect(commandExitCode(commandResult)).toBe(0);
       expect(stdout).toContain("codex_auth=denied");
       expect(stdout).toContain("host_first_tree=denied");
-      expect(stdout).toContain("host_ssh=denied");
+      expect(stdout).toContain("host_ssh=readable");
+      expect(stdout).toContain("git_ssh_command=set");
       expect(stdout).toContain("gh_config_dir=set");
       expect(stdout).toContain("gh_version=ok");
       expect(stdout).toContain("workspace_write=ok");
@@ -447,4 +454,91 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
       await client.shutdown();
     }
   }, 300_000);
+
+  it.skipIf(!GITHUB_SSH_CHECK_ENABLED)(
+    "uses the host SSH key for GitHub SSH git operations",
+    async () => {
+      const codexBinary = resolveBinary("CODEX_SMOKE_BINARY", "codex");
+      const root = realpathSync(mkdtempSync(join(tmpdir(), "ft-landing-codex-git-ssh-smoke-")));
+      tempRoots.push(root);
+      const hostHome = homedir();
+      const hostSshKey = join(hostHome, ".ssh", "id_ed25519");
+      if (!existsSync(hostSshKey)) {
+        throw new Error(`GitHub SSH smoke requires ${hostSshKey} to exist`);
+      }
+
+      const workspace = join(root, "workspace");
+      const firstTreeHome = join(workspace, FIRST_TREE_WORKSPACE_MARKER, "outbox-home");
+      const codexHome = join(root, "codex-home");
+      mkdirSync(firstTreeHome, { recursive: true });
+      mkdirSync(codexHome, { recursive: true });
+      writeFileSync(join(codexHome, "auth.json"), "{}\n", { mode: 0o600 });
+
+      const cliPath = resolveCliPath();
+      setCliBinding({ binName: basename(cliPath), packageName: basename(cliPath) });
+
+      const appServerEnvironment = buildWorkspaceOnlyAppServerEnvironment(
+        {
+          ...process.env,
+          HOME: hostHome,
+          CODEX_HOME: codexHome,
+          FIRST_TREE_HOME: firstTreeHome,
+          FIRST_TREE_CLI_BIN_DIR: dirname(cliPath),
+        },
+        workspace,
+      );
+      const client = await CodexAppServerClient.start({
+        binary: codexBinary,
+        cwd: workspace,
+        env: appServerEnvironment.env,
+        appServerArgs: buildLandingCodexAppServerArgs(
+          workspace,
+          appServerEnvironment.codexHome,
+          appServerEnvironment.hostHome,
+        ),
+        requestTimeoutMs: 120_000,
+      });
+
+      try {
+        const commandResult = await client.request(
+          "command/exec",
+          {
+            command: [
+              "sh",
+              "-lc",
+              [
+                'printf "git_ssh_command="',
+                'if test -n "$GIT_SSH_COMMAND"; then echo set; else echo unset; fi',
+                'printf "git_ssh_config="',
+                'case "$GIT_SSH_COMMAND" in *"-F /dev/null"*) echo ignored-system-config;; *) echo missing;; exit 1;; esac',
+                'printf "gh_auth_status="',
+                "if gh auth status >landing-gh-auth.out 2>landing-gh-auth.err; then echo ok; else echo failed; cat landing-gh-auth.err; exit 1; fi",
+                'printf "git_ssh_remote="',
+                "if git ls-remote git@github.com:agent-team-foundation/first-tree.git HEAD >landing-git-ssh.out 2>landing-git-ssh.err; then echo ok; else echo failed; cat landing-git-ssh.err; exit 1; fi",
+              ].join("\n"),
+            ],
+            cwd: ".",
+            permissionProfile: LANDING_CODEX_PERMISSIONS_PROFILE,
+            timeoutMs: 30_000,
+            outputBytesCap: 65_536,
+          },
+          60_000,
+        );
+
+        const stdout = commandStdout(commandResult);
+        console.log(`[smoke] github ssh command stdout:\n${stdout}`);
+        const stderr = commandStderr(commandResult);
+        if (stderr.trim()) console.log(`[smoke] github ssh command stderr:\n${stderr}`);
+
+        expect(commandExitCode(commandResult)).toBe(0);
+        expect(stdout).toContain("git_ssh_command=set");
+        expect(stdout).toContain("git_ssh_config=ignored-system-config");
+        expect(stdout).toContain("gh_auth_status=ok");
+        expect(stdout).toContain("git_ssh_remote=ok");
+      } finally {
+        await client.shutdown();
+      }
+    },
+    120_000,
+  );
 });

--- a/packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts
+++ b/packages/client/src/__tests__/codex-landing-app-server-smoke.test.ts
@@ -510,7 +510,7 @@ describeSmoke("landing Codex app-server auth and sandbox smoke", () => {
                 'printf "git_ssh_command="',
                 'if test -n "$GIT_SSH_COMMAND"; then echo set; else echo unset; fi',
                 'printf "git_ssh_config="',
-                'case "$GIT_SSH_COMMAND" in *"-F /dev/null"*) echo ignored-system-config;; *) echo missing;; exit 1;; esac',
+                'case "$GIT_SSH_COMMAND" in *"-F /dev/null"*) echo ignored-system-config;; *) echo missing; exit 1;; esac',
                 'printf "gh_auth_status="',
                 "if gh auth status >landing-gh-auth.out 2>landing-gh-auth.err; then echo ok; else echo failed; cat landing-gh-auth.err; exit 1; fi",
                 'printf "git_ssh_remote="',

--- a/packages/client/src/__tests__/workspace-sandbox.test.ts
+++ b/packages/client/src/__tests__/workspace-sandbox.test.ts
@@ -172,12 +172,15 @@ describe("workspace-only sandbox", () => {
     const hostHome = join(root, "host-home");
     const codexHome = join(hostHome, ".codex");
     const ghConfigDir = join(hostHome, ".config", "gh");
+    const sshKeyPath = join(hostHome, ".ssh", "id_ed25519");
     const firstTreeHome = join(workspace, ".first-tree-workspace", "outbox-home");
     const cliBinDir = join(root, "explicit-cli-bin");
     mkdirSync(codexHome, { recursive: true });
     mkdirSync(ghConfigDir, { recursive: true });
+    mkdirSync(join(hostHome, ".ssh"), { recursive: true });
     mkdirSync(firstTreeHome, { recursive: true });
     mkdirSync(cliBinDir, { recursive: true });
+    writeFileSync(sshKeyPath, "ssh-secret\n", { mode: 0o600 });
     writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
 
     const {
@@ -200,6 +203,7 @@ describe("workspace-only sandbox", () => {
         GITHUB_TOKEN: "github-secret",
         HTTP_PROXY: "http://user:password@proxy.test:8080",
         HTTPS_PROXY: "http://user:password@proxy.test:8080",
+        GIT_SSH_COMMAND: "ssh -i /host/secret",
         SSL_CERT_FILE: join(outside, "ca.pem"),
         NODE_EXTRA_CA_CERTS: join(outside, "node-ca.pem"),
         PATH: "/sensitive/bin:/usr/bin",
@@ -218,6 +222,12 @@ describe("workspace-only sandbox", () => {
       GH_CONFIG_DIR: ghConfigDir,
       TMPDIR: "/tmp",
     });
+    expect(env.GIT_SSH_COMMAND).toContain("-F /dev/null");
+    expect(env.GIT_SSH_COMMAND).toContain(sshKeyPath);
+    expect(env.GIT_SSH_COMMAND).toContain(join(firstTreeHome, "ssh", "known_hosts"));
+    expect(env.GIT_SSH_COMMAND).toContain("IdentitiesOnly=yes");
+    expect(env.GIT_SSH_COMMAND).toContain("StrictHostKeyChecking=accept-new");
+    expect(env.GIT_SSH_COMMAND).not.toContain("/host/secret");
     expect(env.PATH?.split(delimiter)[0]).toBe(cliBinDir);
     expect(env.PATH).not.toContain("/sensitive/bin");
     expect(env.OPENAI_API_KEY).toBeUndefined();
@@ -259,6 +269,7 @@ describe("workspace-only sandbox", () => {
       expect(override).toContain(`${JSON.stringify(join(hostHome, relativePath))} = "deny"`);
     }
     expect(override).toContain(`${JSON.stringify(codexHome)} = "deny"`);
+    expect(override).not.toContain(`${JSON.stringify(join(hostHome, ".ssh"))} = "deny"`);
     expect(override).not.toContain(".config/gh");
     expect(override).not.toContain(".git-credentials");
   });

--- a/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
+++ b/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
@@ -76,13 +76,13 @@ const READ_ONLY_ETC_PATHS = [
 const LANDING_CODEX_ROOT_READ_PATH = ":root";
 export const LANDING_CODEX_HOST_CREDENTIAL_DENY_RELATIVE_PATHS = [
   ".codex",
-  ".ssh",
   ".first-tree",
   ".first-tree-staging",
   ".first-tree-dev",
   ".first-tree-local",
   ".first-tree-test",
 ] as const;
+const LANDING_CODEX_GIT_SSH_KEY_RELATIVE_PATH = join(".ssh", "id_ed25519");
 const WORKSPACE_ONLY_PATH_DIRS = ["/usr/local/bin", "/usr/bin", "/bin"] as const;
 const SAFE_PASS_ENV_KEYS = new Set([
   "FIRST_TREE_HOME",
@@ -227,6 +227,33 @@ function resolveHostCodexHome(parentEnv: NodeJS.ProcessEnv, hostHome: string): s
     return isAbsolute(rawCodexHome) ? rawCodexHome : resolve(hostHome, rawCodexHome);
   }
   return join(hostHome, ".codex");
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function landingCodexGitSshCommand(hostHome: string, firstTreeHome: string): string | null {
+  const keyPath = join(hostHome, LANDING_CODEX_GIT_SSH_KEY_RELATIVE_PATH);
+  if (!existsSync(keyPath)) return null;
+
+  const sshStateDir = join(firstTreeHome, "ssh");
+  mkdirSync(sshStateDir, { recursive: true, mode: 0o700 });
+  const knownHostsPath = join(sshStateDir, "known_hosts");
+
+  return [
+    "ssh",
+    "-F",
+    "/dev/null",
+    "-i",
+    shellQuote(keyPath),
+    "-o",
+    "IdentitiesOnly=yes",
+    "-o",
+    `UserKnownHostsFile=${shellQuote(knownHostsPath)}`,
+    "-o",
+    "StrictHostKeyChecking=accept-new",
+  ].join(" ");
 }
 
 function addDenyPath(paths: Set<string>, path: string): void {
@@ -432,6 +459,10 @@ export function buildWorkspaceOnlyAppServerEnvironment(
   const hostGhConfigDir = join(hostHome, ".config", "gh");
   if (existingDirectory(hostGhConfigDir)) {
     env.GH_CONFIG_DIR = hostGhConfigDir;
+  }
+  const gitSshCommand = landingCodexGitSshCommand(hostHome, resolvedFirstTreeHome);
+  if (gitSshCommand) {
+    env.GIT_SSH_COMMAND = gitSshCommand;
   }
   return { env, codexHome, hostHome };
 }

--- a/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
+++ b/packages/client/src/handlers/codex/app-server/workspace-sandbox.ts
@@ -82,6 +82,13 @@ export const LANDING_CODEX_HOST_CREDENTIAL_DENY_RELATIVE_PATHS = [
   ".first-tree-local",
   ".first-tree-test",
 ] as const;
+// Landing trial hosts intentionally leave `.ssh` readable so public-repo
+// workflows can use the host trial key. These official hosts must keep
+// `~/.ssh` limited to the low-permission GitHub trial keypair only; personal,
+// employee, admin, private-repo, or organization-privileged SSH credentials do
+// not belong there. Git operations still go through the controlled
+// GIT_SSH_COMMAND below (`-F /dev/null`, this key, and workspace-local
+// known_hosts).
 const LANDING_CODEX_GIT_SSH_KEY_RELATIVE_PATH = join(".ssh", "id_ed25519");
 const WORKSPACE_ONLY_PATH_DIRS = ["/usr/local/bin", "/usr/bin", "/bin"] as const;
 const SAFE_PASS_ENV_KEYS = new Set([

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -140,6 +140,9 @@ import { ChatRightSidebar } from "../right-sidebar/index.js";
 import { ChatSummary } from "./chat-summary.js";
 
 const SIDEBAR_OPEN_STORAGE_KEY = "first-tree:chat-right-sidebar:open:v1";
+const LANDING_TRIAL_CHAT_ENDED_PLACEHOLDER =
+  'Your trial chat has ended. To keep using First Tree, click "Set up First Tree for your team" ' +
+  "at the top of the page to create your team.";
 
 /**
  * Read the user's stored right-rail preference. Returns `null` when the
@@ -4111,7 +4114,7 @@ export function ChatView({
                           }}
                           placeholder={
                             landingCampaignChatLocked
-                              ? "This trial chat is read-only"
+                              ? LANDING_TRIAL_CHAT_ENDED_PLACEHOLDER
                               : isTrial
                                 ? // Trial: a single-agent, controlled conversation — no
                                   // slash commands or @mention (one agent), so the


### PR DESCRIPTION
## Summary
- update the locked landing trial chat placeholder to point users to the "Set up First Tree for your team" top-page CTA
- add a landing-trial-only controlled `GIT_SSH_COMMAND` with `-F /dev/null` so OpenSSH ignores host `/etc/ssh/ssh_config*`
- keep GitHub SSH operations on the explicit host trial key, `IdentitiesOnly=yes`, workspace-local `known_hosts`, and `StrictHostKeyChecking=accept-new`
- cover the SSH command in unit tests and add an opt-in GitHub SSH smoke check

## Validation
- `git diff --check`
- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2 src/__tests__/workspace-sandbox.test.ts src/__tests__/codex-app-server-handler.test.ts`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm check` (passes with existing warnings in unrelated files)
- `pnpm typecheck`
- manual: `GIT_SSH_COMMAND="ssh -F /dev/null -i '$HOME/.ssh/id_ed25519' ..." git ls-remote git@github.com:agent-team-foundation/first-tree.git HEAD`
