### PR TITLE
fix(server): align the landing kickoff value line with fix-as-conversion

### DIFF
--- a/packages/server/src/services/landing-campaigns/skills/catalog.ts
+++ b/packages/server/src/services/landing-campaigns/skills/catalog.ts
@@ -50,7 +50,7 @@ export function buildLandingCampaignBootstrap(skillSet: LandingCampaignSkillSet,
   return [
     `Welcome to First Tree. ${skillSet.agentDisplayName} is connected to your code: ${repoUrl}`,
     "",
-    "It's giving your code a safe, read-only check before launch — you'll get a score, the problems that actually matter, and a ready-to-use fix for the biggest one.",
+    "It's giving your code a safe, read-only check before launch — you'll get a score, the problems that actually matter, and the exact fix for each one.",
     "",
     `${skillSet.agentDisplayName} — clone ${skillSet.skillRepoUrl} and run its ${skillSet.skillName} skill on the repo above.`,
   ].join("\n");


### PR DESCRIPTION
## Summary

Follow-up to #1467/#1468, aligning the last stale phrase in the kickoff bootstrap with the external skill's fix-as-conversion flow ([launch-readiness-scan#24](https://github.com/agent-team-foundation/launch-readiness-scan/pull/24)):

- The trial no longer produces one ready-to-apply artifact in-conversation — the report carries an exact, copy-pasteable fix under **every** blocker, and applying them routes to building a First Tree team.
- Kickoff line: "…and a ready-to-use fix for the biggest one." → "…and the exact fix for each one."

One line in `catalog.ts`; no behavior change.

## Validation

- `pnpm check` / server `tsc --noEmit` green
- `landing-campaigns-start.test.ts`: 34 passed (no assertion pinned the old phrase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)