### PR TITLE
Refactor generated agent briefing

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -130,9 +130,9 @@ describe("buildAgentBriefing — generated skeleton", () => {
       190,
     );
     expect(lineCount(topLevelSection(briefing, "# Required Reading (First Tree Managed)"))).toBeLessThanOrEqual(18);
-    expect(lineCount(topLevelSection(briefing, "# Context Tree (First Tree Managed)"))).toBeLessThanOrEqual(75);
+    expect(lineCount(topLevelSection(briefing, "# Context Tree (First Tree Managed)"))).toBeLessThanOrEqual(80);
     expect(lineCount(topLevelSection(briefing, "# Skills (First Tree Managed)"))).toBeLessThanOrEqual(20);
-    expect(lineCount(briefing)).toBeLessThanOrEqual(420);
+    expect(lineCount(briefing)).toBeLessThanOrEqual(440);
   });
 
   it("renders identity from visibility", () => {
@@ -326,6 +326,8 @@ describe("buildAgentBriefing — Working in First Tree hard rules", () => {
     const communication = briefing.slice(briefing.indexOf("## Communication"));
 
     expect(communication).toMatch(/business action changes the workspace\s+or outside world/);
+    expect(communication).toContain("Replying to a human is required, not optional");
+    expect(communication).toContain("never to a\nfresh human-directed message");
     expect(communication).toContain("Blocking questions never ride inside plain `chat send`");
     expect(communication).toContain("route by dependency, not importance");
     expect(communication).toContain("chat update --description -");
@@ -397,11 +399,18 @@ describe("buildAgentBriefing — asking humans, GitHub, and CLI overview", () =>
     const chatTopic = briefing.slice(briefing.indexOf("## Chat Topic & Description"));
 
     expect(chatTopic).toContain('provider-injected "Current Chat Context"');
+    expect(chatTopic).toContain("short (<= 30 chars)");
+    expect(chatTopic).toContain("调研 chat rename 方案");
+    expect(chatTopic).toContain("本周 ship 计划");
     expect(chatTopic).toContain("chat update --topic");
     expect(chatTopic).toContain("chat update --description");
     expect(chatTopic).toContain("deprecated alias");
+    expect(chatTopic).toContain("a 403 means\nstop, not retry");
     expect(chatTopic).toContain("leave it stable");
     expect(chatTopic).toContain("within 1500 characters");
+    expect(chatTopic).toContain("Rewrite it in place");
+    expect(chatTopic).toContain("history\nis the log");
+    expect(chatTopic).toContain("Markdown is supported");
     expect(chatTopic).toMatch(/use\s+`first-tree chat ask <human>`/);
     expect(chatTopic).toContain("chat list");
     expect(chatTopic).toContain("chat history <chat>");
@@ -455,6 +464,7 @@ describe("buildAgentBriefing — Context Tree", () => {
     expect(tree).toContain("load `first-tree-read`");
 
     expect(tree).toContain("repo/path/feature/domain/owner/source signal");
+    expect(tree).toContain("code, CLI, review, repo,\npath, bug, and error tasks");
     expect(tree).toContain("first-tree tree tree --help");
     expect(tree).toContain("tree tree` selectors");
     expect(tree).toContain("root `NODE.md`");

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -1,6 +1,4 @@
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readdirSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -14,8 +12,6 @@ import type { PredeclaredSourceRepo } from "../runtime/bootstrap.js";
 import { setCliBinding } from "../runtime/cli-binding.js";
 import type { AgentIdentity } from "../runtime/handler.js";
 
-// Pin the CLI binding to the prod identity so `${bin}` interpolations in
-// the rendered briefing match the literals these tests assert against.
 beforeAll(() => {
   setCliBinding({ binName: "first-tree", packageName: "first-tree" });
 });
@@ -46,8 +42,22 @@ function makeOpts(overrides?: Partial<BuildAgentBriefingOptions>): BuildAgentBri
   };
 }
 
-describe("buildAgentBriefing — top-level structure & section order", () => {
-  it("resolves the checked-in source EJS template and renders through it", () => {
+function topLevelSection(briefing: string, heading: string): string {
+  const marker = `\n${heading}\n`;
+  const start = briefing.indexOf(marker);
+  expect(start, `missing section ${heading}`).toBeGreaterThanOrEqual(0);
+  const contentStart = start + 1;
+  const next = briefing.slice(contentStart + heading.length + 1).search(/\n# [^\n]+\n/u);
+  if (next === -1) return briefing.slice(contentStart);
+  return briefing.slice(contentStart, contentStart + heading.length + 1 + next);
+}
+
+function lineCount(text: string): number {
+  return text.split(/\r?\n/u).length;
+}
+
+describe("buildAgentBriefing — generated skeleton", () => {
+  it("renders through the checked-in EJS template and ends with a newline", () => {
     const templatePath = resolveAgentBriefingTemplatePath();
 
     expect(templatePath).toBe(
@@ -59,117 +69,86 @@ describe("buildAgentBriefing — top-level structure & section order", () => {
     expect(briefing.endsWith("\n")).toBe(true);
   });
 
-  it("emits stable shared sections without per-chat Current Chat Context", () => {
-    // Tree-bound case so every shared header in the expected order list is
-    // present; tree-less cases are exercised in their dedicated describe
-    // blocks below. Per-chat context is provider/session injected and must not
-    // appear in this shared file.
-    const briefing = buildAgentBriefing(
-      makeOpts({
-        contextTreePath: "/var/lib/context-trees/example",
-      }),
-    );
-
-    // Per-agent header ordering invariant: every # / ## that is part of the
-    // briefing skeleton must appear in this order. Runtime-injected
-    // per-chat context is deliberately absent so the prompt cache stays warm
-    // and sibling chats cannot overwrite each other through AGENTS.md.
-    // Runtime-injected sections carry the `(First Tree Managed)` provenance
-    // suffix so an agent reading the assembled file can tell which sections
-    // its prompt config does NOT own (the anti-"copy AGENTS.md back into
-    // config" defense, together with the generated-file banner).
+  it("keeps top-level section order stable and excludes per-chat Current Chat Context", () => {
+    const briefing = buildAgentBriefing(makeOpts({ contextTreePath: "/tree" }));
     const expectedOrder = [
       "# Identity",
       "# Working in First Tree (First Tree Managed)",
-      "## Working Directory",
-      "## Worktrees (how you read AND write a bare source repo)",
-      "## Communication",
-      "## Workspace Collaboration",
-      "## GitHub Entity Attention",
-      "## Asking Humans",
-      "## Chat Topic & Description",
-      "## CLI Overview",
       "# Required Reading (First Tree Managed)",
       "# Context Tree (First Tree Managed)",
-      "## Core Model",
-      "## Reading the Tree",
-      "## Writing the Tree",
-      "## Tree Location (agent-managed clone)",
       "# Skills (First Tree Managed)",
-      "## First Tree Family",
     ];
+
     let last = -1;
-    for (const header of expectedOrder) {
-      // The generated-file banner precedes every section, so each header —
-      // including the first — sits after a newline.
-      const idx = briefing.indexOf(`\n${header}\n`, Math.max(last, 0));
-      expect(idx, `header "${header}" missing or out of order`).toBeGreaterThan(last);
+    for (const heading of expectedOrder) {
+      const idx = briefing.indexOf(`\n${heading}\n`, Math.max(last, 0));
+      expect(idx, `${heading} missing or out of order`).toBeGreaterThan(last);
       last = idx;
     }
+
     expect(briefing).not.toContain("## Current Chat Context");
     expect(briefing).not.toContain("Chat ID:");
+    expect(briefing).not.toContain("Participants:");
   });
 
-  it("opens with the generated-file banner: marker + edit map for Team / Agent Prompt", () => {
+  it("opens with generated provenance and prompt edit boundaries", () => {
     const briefing = buildAgentBriefing(makeOpts());
-    // Banner must be the very first content so any reader (or any tool that
-    // copies the file) hits the marker before anything else.
     expect(briefing.startsWith("<!--")).toBe(true);
-    // The literal marker is what the server / CLI write-side guard keys on
-    // (AGENT_BRIEFING_GENERATED_MARKER) — pin it as a string so a rename
-    // breaks this test and forces the guard to be updated in lockstep.
     expect(briefing).toContain("first-tree:generated");
     expect(briefing).toContain("NEVER copy this file");
-    // Edit map: where each editable section actually lives, with the
-    // channel-resolved binary name interpolated.
     expect(briefing).toContain("first-tree agent config prompt show <agent> --raw");
     expect(briefing).toContain("first-tree agent config prompt set <agent> -f <file>");
     expect(briefing).toContain("Every other section is First Tree Managed");
   });
 
-  it("renders identity as personal-assistant when visibility=private", () => {
-    const briefing = buildAgentBriefing(
-      makeOpts({ identity: makeIdentity({ visibility: "private", displayName: "Aly" }) }),
-    );
-    expect(briefing).toContain("# Identity\n\nYou are Aly, a personal assistant agent.");
-  });
-
-  it("renders identity as autonomous when visibility=organization", () => {
-    const briefing = buildAgentBriefing(
-      makeOpts({ identity: makeIdentity({ visibility: "organization", displayName: "Aly" }) }),
-    );
-    expect(briefing).toContain("# Identity\n\nYou are Aly, an autonomous agent.");
-  });
-
-  it("emits the legacy `## Agent-Specific Prompt` fallback only when prompt.sections is absent and append is non-empty", () => {
-    // No payload → block omitted.
-    expect(buildAgentBriefing(makeOpts({ payload: null }))).not.toContain("## Agent-Specific Prompt");
-
-    // Empty / whitespace-only append → block omitted.
-    const emptyPayload = {
+  it("keeps First Tree Managed sections within a compact briefing budget", () => {
+    const sourceRepos: PredeclaredSourceRepo[] = [
+      { absolutePath: `${AGENT_HOME}/source-repos/first-tree`, url: "https://github.com/example/first-tree" },
+    ];
+    const promptLines = Array.from({ length: 90 }, (_, index) => `Prompt line ${index + 1}`).join("\n");
+    const payload = {
       kind: "claude-code" as const,
       model: "",
-      prompt: { append: "   \n  " },
+      prompt: { append: promptLines },
       mcpServers: [],
       env: [],
       gitRepos: [],
       resourceSkills: [],
       reasoningEffort: "" as const,
     };
-    expect(buildAgentBriefing(makeOpts({ payload: emptyPayload }))).not.toContain("## Agent-Specific Prompt");
+    const briefing = buildAgentBriefing(
+      makeOpts({
+        payload,
+        sourceRepos,
+        contextTreePath: "/var/lib/context-trees/example",
+        contextTreeRepoUrl: "https://github.com/example/context",
+        contextTreeBranch: "main",
+      }),
+    );
 
-    // Legacy server (no structured sections) with real content → fallback
-    // block emitted with the trimmed payload text. The legacy blob may mix
-    // team and agent content, so it must NOT be presented under the editable
-    // `# Agent Prompt` heading.
-    const realPayload = { ...emptyPayload, prompt: { append: "Follow the local implementation plan." } };
-    const briefing = buildAgentBriefing(makeOpts({ payload: realPayload }));
-    expect(briefing).toContain("## Agent-Specific Prompt\n\nFollow the local implementation plan.");
-    expect(briefing).not.toContain("# Agent Prompt (this agent only — editable)");
+    expect(lineCount(topLevelSection(briefing, "# Working in First Tree (First Tree Managed)"))).toBeLessThanOrEqual(
+      190,
+    );
+    expect(lineCount(topLevelSection(briefing, "# Required Reading (First Tree Managed)"))).toBeLessThanOrEqual(18);
+    expect(lineCount(topLevelSection(briefing, "# Context Tree (First Tree Managed)"))).toBeLessThanOrEqual(75);
+    expect(lineCount(topLevelSection(briefing, "# Skills (First Tree Managed)"))).toBeLessThanOrEqual(20);
+    expect(lineCount(briefing)).toBeLessThanOrEqual(420);
+  });
+
+  it("renders identity from visibility", () => {
+    const privateBriefing = buildAgentBriefing(
+      makeOpts({ identity: makeIdentity({ visibility: "private", displayName: "Aly" }) }),
+    );
+    expect(privateBriefing).toContain("# Identity\n\nYou are Aly, a personal assistant agent.");
+
+    const orgBriefing = buildAgentBriefing(
+      makeOpts({ identity: makeIdentity({ visibility: "organization", displayName: "Aly" }) }),
+    );
+    expect(orgBriefing).toContain("# Identity\n\nYou are Aly, an autonomous agent.");
   });
 });
 
-describe("buildAgentBriefing — # Team Prompt / # Agent Prompt (structured prompt sections)", () => {
+describe("buildAgentBriefing — prompt provenance sections", () => {
   const basePayload = {
     kind: "claude-code" as const,
     model: "",
@@ -181,342 +160,116 @@ describe("buildAgentBriefing — # Team Prompt / # Agent Prompt (structured prom
     reasoningEffort: "" as const,
   };
 
-  it("renders team sections read-only and the agent fragment editable, under separate provenance headings", () => {
+  it("renders legacy append only as the legacy fallback", () => {
+    expect(buildAgentBriefing(makeOpts({ payload: null }))).not.toContain("## Agent-Specific Prompt");
+
+    const payload = { ...basePayload, prompt: { append: "Follow the local plan." } };
+    const briefing = buildAgentBriefing(makeOpts({ payload }));
+    expect(briefing).toContain("## Agent-Specific Prompt\n\nFollow the local plan.");
+    expect(briefing).not.toContain("# Agent Prompt (this agent only — editable)");
+  });
+
+  it("separates team prompt, editable agent prompt, and non-editable overrides", () => {
     const payload = {
       ...basePayload,
       prompt: {
-        // Legacy merged blob is still populated by the server for old
-        // clients — when structured sections exist it must be IGNORED, or
-        // team content would render twice.
-        append: "## Team Resource: Review Rules\n\nAlways review twice.",
+        append: "legacy blob must be ignored",
         sections: [
           { scope: "team" as const, name: "Review Rules", body: "Always review twice.", editable: false },
           { scope: "agent" as const, name: "", body: "Prefer terse replies.", editable: true },
+          { scope: "agent" as const, name: "Tone guide", body: "Override body.", editable: false },
         ],
       },
     };
-    const briefing = buildAgentBriefing(makeOpts({ payload }));
 
-    // Team block: provenance heading + read-only warning + the resource body
-    // under its own `##` name.
+    const briefing = buildAgentBriefing(makeOpts({ payload }));
     expect(briefing).toContain("# Team Prompt (team-shared — read-only for agents)");
     expect(briefing).toContain("## Review Rules\n\nAlways review twice.");
     expect(briefing).toMatch(/do NOT copy any of this into\nyour per-agent prompt/);
-
-    // Agent block: provenance heading + copy-pasteable round-trip commands
-    // using the CLI-addressable agent name (agentId, not display name).
     expect(briefing).toContain("# Agent Prompt (this agent only — editable)");
     expect(briefing).toContain("Prefer terse replies.");
     expect(briefing).toContain("first-tree agent config prompt show test-agent --raw");
     expect(briefing).toContain("first-tree agent config prompt set test-agent");
-
-    // Structured sections supersede the legacy single-blob rendering.
-    expect(briefing).not.toContain("## Agent-Specific Prompt");
-
-    // Order: Identity → Team Prompt → Agent Prompt → Working in First Tree.
-    // Anchor on the full heading lines (the banner's edit map also mentions
-    // `# Team Prompt` / `# Agent Prompt` as indented references).
-    const identityIdx = briefing.indexOf("\n# Identity\n");
-    const teamIdx = briefing.indexOf("\n# Team Prompt (team-shared — read-only for agents)\n");
-    const agentIdx = briefing.indexOf("\n# Agent Prompt (this agent only — editable)\n");
-    const workingIdx = briefing.indexOf("\n# Working in First Tree (First Tree Managed)\n");
-    expect(teamIdx).toBeGreaterThan(identityIdx);
-    expect(agentIdx).toBeGreaterThan(teamIdx);
-    expect(workingIdx).toBeGreaterThan(agentIdx);
-  });
-
-  it("omits each provenance heading when no section of that scope has content", () => {
-    // Anchor on the full heading lines — the banner's edit map mentions
-    // `# Team Prompt` / `# Agent Prompt` as indented references, so bare
-    // substring checks would false-positive on every briefing.
-    const teamHeading = "\n# Team Prompt (team-shared — read-only for agents)\n";
-    const agentHeading = "\n# Agent Prompt (this agent only — editable)\n";
-
-    const teamOnly = {
-      ...basePayload,
-      prompt: { append: "", sections: [{ scope: "team" as const, name: "Rules", body: "Body." }] },
-    };
-    const teamOnlyBriefing = buildAgentBriefing(makeOpts({ payload: teamOnly }));
-    expect(teamOnlyBriefing).toContain(teamHeading);
-    expect(teamOnlyBriefing).not.toContain(agentHeading);
-
-    const agentOnly = {
-      ...basePayload,
-      prompt: { append: "", sections: [{ scope: "agent" as const, name: "", body: "Mine.", editable: true }] },
-    };
-    const agentOnlyBriefing = buildAgentBriefing(makeOpts({ payload: agentOnly }));
-    expect(agentOnlyBriefing).not.toContain(teamHeading);
-    expect(agentOnlyBriefing).toContain(agentHeading);
-
-    // Whitespace-only bodies count as empty.
-    const blank = {
-      ...basePayload,
-      prompt: { append: "", sections: [{ scope: "team" as const, name: "Rules", body: "  \n " }] },
-    };
-    const blankBriefing = buildAgentBriefing(makeOpts({ payload: blank }));
-    expect(blankBriefing).not.toContain(teamHeading);
-    expect(blankBriefing).not.toContain(agentHeading);
-  });
-
-  it("falls back to a default `## Team prompt` sub-heading when a team section has no name", () => {
-    const payload = {
-      ...basePayload,
-      prompt: { append: "", sections: [{ scope: "team" as const, name: "  ", body: "Unnamed body." }] },
-    };
-    const briefing = buildAgentBriefing(makeOpts({ payload }));
-    expect(briefing).toContain("## Team prompt\n\nUnnamed body.");
-  });
-
-  it("renders non-editable agent-scope sections under # Agent Prompt Overrides, never under the editable heading", () => {
-    // An inline *replacement* of a team prompt projects as scope "agent"
-    // without `editable` — the `prompt show --raw` / `prompt set` round-trip
-    // cannot touch it, so presenting it under "editable" would instruct the
-    // agent to use a flow that cannot edit the content it sees.
-    const payload = {
-      ...basePayload,
-      prompt: {
-        append: "",
-        sections: [
-          { scope: "agent" as const, name: "", body: "My own fragment.", editable: true },
-          { scope: "agent" as const, name: "Tone guide", body: "Agent-specific tone override.", editable: false },
-        ],
-      },
-    };
-    const briefing = buildAgentBriefing(makeOpts({ payload }));
-
-    const agentHeading = "\n# Agent Prompt (this agent only — editable)\n";
-    const overridesHeading = "\n# Agent Prompt Overrides (this agent only — managed via resource bindings)\n";
-    expect(briefing).toContain(agentHeading);
-    expect(briefing).toContain(overridesHeading);
-    expect(briefing).toContain("## Tone guide\n\nAgent-specific tone override.");
+    expect(briefing).toContain("# Agent Prompt Overrides (this agent only — managed via resource bindings)");
+    expect(briefing).toContain("## Tone guide\n\nOverride body.");
     expect(briefing).toMatch(/NOT editable with `prompt set`/);
-
-    // The override body must live in the overrides section, after the
-    // editable section — not inside it.
-    const agentIdx = briefing.indexOf(agentHeading);
-    const overridesIdx = briefing.indexOf(overridesHeading);
-    const overrideBodyIdx = briefing.indexOf("Agent-specific tone override.");
-    expect(overridesIdx).toBeGreaterThan(agentIdx);
-    expect(overrideBodyIdx).toBeGreaterThan(overridesIdx);
-
-    // Overrides alone (no editable fragment) must not produce the editable
-    // heading — and must not fall back to the legacy single-blob rendering.
-    const overridesOnly = {
-      ...basePayload,
-      prompt: {
-        append: "legacy blob",
-        sections: [{ scope: "agent" as const, name: "Tone guide", body: "Override only.", editable: false }],
-      },
-    };
-    const overridesOnlyBriefing = buildAgentBriefing(makeOpts({ payload: overridesOnly }));
-    expect(overridesOnlyBriefing).not.toContain(agentHeading);
-    expect(overridesOnlyBriefing).toContain(overridesHeading);
-    expect(overridesOnlyBriefing).not.toContain("## Agent-Specific Prompt");
+    expect(briefing).not.toContain("## Agent-Specific Prompt");
   });
 });
 
-describe("buildAgentBriefing — # Required Reading (unconditional skill-load mandate)", () => {
-  // The inline briefing is a routing index, not a substitute for the
-  // skill payloads. `# Required Reading` is the hard mandate that
-  // guarantees `first-tree-write` gets loaded on
-  // every task — otherwise progressive disclosure (keyword-triggered)
-  // can silently skip them and the agent acts without the rules in
-  // that skill (tree concept model, hard write rules, etc.).
-
-  it("emits the # Required Reading section for tree-bound agents with MUST framing and the write skill", () => {
+describe("buildAgentBriefing — Required Reading and skill routing", () => {
+  it("emits the tree-bound first-tree-write mandate without implying a retired skill", () => {
     const briefing = buildAgentBriefing(makeOpts({ contextTreePath: "/tree" }));
 
-    expect(briefing).toContain("# Required Reading");
     expect(briefing).toMatch(/you MUST\s+load \*\*`first-tree-write`\*\*/);
     expect(briefing).toContain("source-system boundary");
-    expect(briefing).toContain("Hard Rules + Double Test");
-    // Claude Code's transcript exposes a skill listing, but native skill-body
-    // injection is still provider-owned. The briefing must give a direct
-    // filesystem fallback so "unconditional" is actionable even when the
-    // provider only listed the skill names.
+    expect(briefing).toContain("Hard Rules +\nDouble Test");
     expect(briefing).toContain(`${AGENT_HOME}/.agents/skills/first-tree-write/SKILL.md`);
-    expect(briefing).toMatch(/minimum\s+mechanics you need to operate at all/);
-    expect(briefing).toMatch(/inline briefing only summarises/);
-    // Calls out the on-demand-only sibling so the agent doesn't
-    // over-load every First Tree family skill on every task.
     expect(briefing).toContain("`first-tree-read`");
     expect(briefing).toContain("`first-tree-seed`");
     expect(briefing).not.toContain(`${AGENT_HOME}/.agents/skills/first-tree/SKILL.md`);
     expect(briefing).not.toContain(`${AGENT_HOME}/.agents/skills/first-tree-context/SKILL.md`);
   });
 
-  it("places # Required Reading immediately after # Working in First Tree (its CLI Overview tail) and before # Context Tree", () => {
-    // Placement rationale: the agent first reads the inline
-    // workspace-collab basics (chat send, working directory,
-    // communication) it needs to operate at all, then hits the hard
-    // mandate to load `first-tree-write` before any real work. The
-    // mandate sits adjacent to `# Context Tree` because that skill covers
-    // the tree concept/write rules for that section.
-    const payload = {
-      kind: "claude-code" as const,
-      model: "",
-      prompt: { append: "You are staff: design, implement, and coordinate review." },
-      mcpServers: [],
-      env: [],
-      gitRepos: [],
-      resourceSkills: [],
-      reasoningEffort: "" as const,
-    };
-    const briefing = buildAgentBriefing(makeOpts({ payload, contextTreePath: "/tree" }));
-
-    const identityIdx = briefing.indexOf("# Identity");
-    const agentPromptIdx = briefing.indexOf("## Agent-Specific Prompt");
-    const workingIdx = briefing.indexOf("# Working in First Tree");
-    const cliOverviewIdx = briefing.indexOf("## CLI Overview");
-    const requiredIdx = briefing.indexOf("# Required Reading");
-    const contextTreeIdx = briefing.indexOf("# Context Tree");
-
-    expect(identityIdx).toBeGreaterThanOrEqual(0);
-    expect(agentPromptIdx).toBeGreaterThan(identityIdx);
-    expect(workingIdx).toBeGreaterThan(agentPromptIdx);
-    // CLI Overview is the last subsection of `# Working in First Tree`,
-    // so Required Reading must land after it.
-    expect(cliOverviewIdx).toBeGreaterThan(workingIdx);
-    expect(requiredIdx).toBeGreaterThan(cliOverviewIdx);
-    // And immediately before `# Context Tree` — no other top-level
-    // section may slip between them.
-    expect(contextTreeIdx).toBeGreaterThan(requiredIdx);
-  });
-
-  it("omits # Required Reading for tree-less agents (the unconditional write mandate is a tree-ops discipline)", () => {
-    // `# Required Reading` mandates loading `first-tree-write` UNCONDITIONALLY
-    // on every task — a tree-ops discipline for reflecting sources into an
-    // existing tree. A tree-less agent DOES carry write on disk now (it ships
-    // core as first-tree-seed's dependency), but should load it only when seed
-    // pulls it in, not on every task, so the mandate stays tree-bound. The
-    // tree-less core skills are surfaced by the First Tree Family map instead.
+  it("omits Required Reading for tree-less agents", () => {
     const briefing = buildAgentBriefing(makeOpts({ contextTreePath: null }));
     expect(briefing).not.toContain("# Required Reading");
   });
 
-  it("flags `first-tree-write` as unconditional in the ## First Tree Family map (consistent with # Required Reading)", () => {
-    // The Skill Map's framing has to match the # Required Reading
-    // mandate, otherwise the agent gets contradictory signals
-    // (progressive-disclosure-only vs. unconditional). Pin both
-    // rows' new "unconditional" label and the head paragraph that
-    // calls them out.
-    const briefing = buildAgentBriefing(makeOpts({ contextTreePath: "/tree" }));
-    const familyMap = briefing.slice(briefing.indexOf("## First Tree Family"));
-
-    // Head paragraph explicitly names the unconditional skill and
-    // points back at the # Required Reading anchor.
-    expect(familyMap).toMatch(
-      /`first-tree-write` is \*\*unconditional\*\* — load it on every task per\s+`# Required Reading` above\./,
+  it("marks first-tree-write unconditional only for tree-bound agents", () => {
+    const familyMap = topLevelSection(
+      buildAgentBriefing(makeOpts({ contextTreePath: "/tree" })),
+      "# Skills (First Tree Managed)",
     );
+    expect(familyMap).toMatch(/`first-tree-write` is \*\*unconditional\*\*/);
+    expect(familyMap).toMatch(/\|\s*`first-tree-write`\s*\| unconditional \(see `# Required Reading`\)/);
+    expect(familyMap).toMatch(/\|\s*`first-tree-read`\s*\| read relevant Context Tree files before acting/);
 
-    // The unconditional row must carry the "unconditional" label
-    // inline so the table is self-explanatory even when read in
-    // isolation.
-    const writeRow = familyMap.match(/\|\s*`first-tree-write`\s*\|[^\n]*/)?.[0] ?? "";
-    expect(writeRow).toContain("unconditional");
-    expect(writeRow).toContain("`# Required Reading`");
-    expect(writeRow).toContain("concept model");
-    expect(writeRow).toContain("source-driven tree writes");
-    expect(writeRow).not.toContain("read context before acting");
-
-    // On-demand rows must NOT pick up the unconditional label by
-    // accident — they're triggered by keyword / task signal.
-    const readRow = familyMap.match(/\|\s*`first-tree-read`\s*\|[^\n]*/)?.[0] ?? "";
-    expect(readRow).not.toContain("unconditional");
-    expect(readRow).toContain("before acting");
-
-    const seedRow = familyMap.match(/\|\s*`first-tree-seed`\s*\|[^\n]*/)?.[0] ?? "";
-    expect(seedRow).not.toContain("unconditional");
+    const treelessFamily = topLevelSection(
+      buildAgentBriefing(makeOpts({ contextTreePath: null })),
+      "# Skills (First Tree Managed)",
+    );
+    expect(treelessFamily).toContain("first-tree-welcome");
+    expect(treelessFamily).toContain("first-tree-seed");
+    expect(treelessFamily).toContain("first-tree-write");
+    expect(treelessFamily).not.toContain("first-tree-read");
+    expect(treelessFamily).not.toContain("# Required Reading");
   });
 });
 
-describe("buildAgentBriefing — # Working in First Tree subsections", () => {
-  it("emits the runtime intro block: chat send reaches any teammate, ask/update for humans, courtesy-send guard, Issue #389", () => {
+describe("buildAgentBriefing — Working in First Tree hard rules", () => {
+  it("anchors console/outbox and chat send/ask/update behavior", () => {
     const briefing = buildAgentBriefing(makeOpts());
 
-    // `chat send` reaches any teammate — agent or human (a plain send to a human
-    // is a free reply); a human also has `chat ask` (decisions) and
-    // `chat update --description` (progress).
-    expect(briefing).toContain("`first-tree chat send <name>` reaches any teammate — agent or human");
-    expect(briefing).toContain("first-tree chat ask <human>");
+    expect(briefing).toMatch(/the "user" your underlying agent addresses is the First\s+Tree runtime/);
+    expect(briefing).toMatch(/visible live reasoning\/activity trace/);
+    expect(briefing).toContain("This is your **console**");
+    expect(briefing).toContain("Teammates are reached through the **outbox**");
+    expect(briefing).toContain("first-tree chat send");
+    expect(briefing).toContain("first-tree chat ask");
     expect(briefing).toContain("first-tree chat update --description");
-    expect(briefing).not.toMatch(/server rejects a `?chat send`? to a human/);
-
-    // yuezengwu 2026-06-26: rebind, rather than negate, the agent's native
-    // output model with one provider-neutral boundary rule — everything apart
-    // from an explicit chat command is the console (addressed to the First Tree
-    // runtime); the chat commands are the outbox (the only path to a teammate).
-    // Stating it by exclusion binds the turn-closing message (Codex's `final`
-    // prior) without naming a provider. Keep the PRECISE product boundary
-    // (codex R1/R5): the output is not an addressed reply, yet it is visible —
-    // a one-line preview surfaces as live session activity to viewers.
-    expect(briefing).toMatch(/the "user" your underlying agent addresses is the First\s+Tree runtime/i);
-    expect(briefing).toMatch(/Everything you produce apart from an explicit chat\s+command/i);
-    expect(briefing).toMatch(/message that closes your turn/i);
-    expect(briefing).toMatch(/live reasoning\/activity trace/i);
-    expect(briefing).toMatch(/treating it as visible/i);
-    expect(briefing).toMatch(/live session activity/i);
-    expect(briefing).toMatch(/This is your \*\*console\*\*/i);
-    expect(briefing).toMatch(/the outbox: the explicit\s+commands/i);
-    expect(briefing).toMatch(/places your message in front of\s+a teammate/i);
-    // The outbox-completion rule is scoped to HUMAN-directed turns, so it never
-    // contradicts the adjacent agent no-courtesy-send brake (codex review R5):
-    // an agent no-op wake-up must still be allowed to end without a send.
-    expect(briefing).toMatch(/A human-directed\s+turn is complete once you deliver your reply through the outbox/i);
-    expect(briefing).toMatch(/an agent\s+wake-up with nothing new to act on can end without a send/i);
-    expect(briefing).not.toMatch(/teammate triggered is complete/i);
-    // The retired mirror term stays out — there is no `agent-final-text` row
-    // post-#1190.
-    expect(briefing).not.toContain("agent-final-text");
-    // Provider-neutral: the brief no longer names a specific harness.
-    expect(briefing).not.toMatch(/Claude Code harness/i);
-
-    // Courtesy-send guard stays — the brake is on the *send* side.
-    expect(briefing).toContain("Don't fire a courtesy");
-    expect(briefing).toContain("end the turn without sending");
-    expect(briefing).not.toMatch(/\boutput nothing\b/);
-
-    // Issue #389: pin the anti-double-encode rule (rationale now in the
-    // Communication block, where the shell-mechanics WHY was moved).
-    expect(briefing).toContain("Issue #389");
-    expect(briefing).toContain("JSON.stringify");
-    // Pin the `-F`/stdin body rule (the shell-quote regression fix): a concise
-    // affirmative principle up top, with the detailed shell-mechanics rationale
-    // (heredoc residue `@EOF`, the CLI cannot repair it) moved down into the
-    // Communication block.
-    expect(briefing).toMatch(/Form a rich body as a file or stdin/i);
-    expect(briefing).toMatch(/-F|stdin/);
-    expect(briefing).toContain("-f markdown");
-    expect(briefing).toMatch(/Why a rich body goes through a file or stdin/i);
-    expect(briefing).toContain("@EOF");
+    expect(briefing).toMatch(/Human message: finish with one/);
+    expect(briefing).toMatch(/Agent handoff: `first-tree chat send <agent>`/);
+    expect(briefing).toMatch(/Do not send\s+courtesy acknowledgements to agents/);
+    expect(briefing).toContain("-F <file>");
+    expect(briefing).toContain("-F -");
+    expect(briefing).toContain("--description -");
+    expect(briefing).toContain("never `JSON.stringify`");
   });
 
-  it("interpolates the agent home into the Working Directory block", () => {
+  it("interpolates the working directory and worktree paths", () => {
     const briefing = buildAgentBriefing(makeOpts());
-    expect(briefing).toContain("## Working Directory");
     expect(briefing).toContain(`Your fixed working directory is \`${AGENT_HOME}\`.`);
-    expect(briefing).toContain("absolute");
     expect(briefing).toContain("persistent state");
-  });
-
-  it("emits the Worktrees block (read + write worktree convention) regardless of source repos presence", () => {
-    const briefing = buildAgentBriefing(makeOpts());
     expect(briefing).toContain("## Worktrees");
     expect(briefing).toContain("No worktrees are pre-created");
-    // Bare-clone worktree commands run against the clone with `git -C <source>`.
-    expect(briefing).toContain("worktree add");
-    // Bare-clone model: both a read worktree and a task (write) worktree are
-    // documented. Only `<name>` / `<task-name>` / `<new-branch>` are literal
-    // placeholders; the home prefix is interpolated.
     expect(briefing).toContain(`${AGENT_HOME}/worktrees/<name>-read`);
     expect(briefing).toContain(`${AGENT_HOME}/worktrees/<task-name>`);
     expect(briefing).toContain("worktree remove");
-    // No literal `<placeholder>` for the home prefix — LLMs sometimes copy
-    // those verbatim.
     expect(briefing).not.toContain("<agent-home>/worktrees/");
   });
 
-  it("renders predeclared source repos with source-repos/ paths and upstream coordinates", () => {
+  it("renders source repos with bare-clone fail-closed protocol and compact legacy gates", () => {
     const sourceRepos: PredeclaredSourceRepo[] = [
       {
         absolutePath: `${AGENT_HOME}/source-repos/api`,
@@ -532,337 +285,63 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
     const briefing = buildAgentBriefing(makeOpts({ sourceRepos }));
 
     expect(briefing).toContain("## Source Repositories (agent-managed, bare)");
-    // Source clones live under `source-repos/`, not at the workspace root and
-    // not under `worktrees/`.
     expect(briefing).toContain(`\`${AGENT_HOME}/source-repos/api\``);
-    expect(briefing).not.toContain(`\`${AGENT_HOME}/worktrees/api\``);
-    expect(briefing).not.toContain(`\`${AGENT_HOME}/api\``);
     expect(briefing).toContain("url=git@github.com:example/api.git");
     expect(briefing).toContain("ref=main");
     expect(briefing).toContain("branch=session/test-agent");
     expect(briefing).toContain(`\`${AGENT_HOME}/source-repos/web\``);
-    // Partial entry — only url should appear, ref/branch parens omitted.
-    expect(briefing).not.toMatch(/url=git@github\.com:example\/web\.git,\s*ref=/);
-    // Agent-managed bare protocol: the agent maintains bare clones itself
-    // and reads/writes only through worktrees.
-    expect(briefing).toContain("**You manage these clones yourself**");
-    expect(briefing).toContain("bare");
+    expect(briefing).not.toContain(`\`${AGENT_HOME}/api\``);
+    expect(briefing).not.toContain(`\`${AGENT_HOME}/worktrees/api\``);
+
+    expect(briefing).toMatch(/\*\*You manage these clones yourself\*\*/);
     expect(briefing).toContain("git clone --bare <url> <path>");
-    // refspec config makes refs/remotes/origin/* available for worktrees.
     expect(briefing).toContain("git -C <path> config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'");
-    // Clones live under the workspace's `source-repos/` directory. `git clone`
-    // does create the missing parent on its own (verified), but the protocol
-    // makes it explicit with `mkdir -p` so an agent that deviates from the exact
-    // clone command can't trip over a missing `source-repos/` parent.
-    expect(briefing).toContain("source-repos/");
-    expect(briefing).toContain("immediate child of your workspace's");
-    expect(briefing).toContain('mkdir -p "$(dirname <path>)"');
-    // Read goes through a worktree, not the clone path; skills scan there too.
-    expect(briefing).toContain("Read through a worktree, not the clone path.");
-    expect(briefing).toContain("first-tree-seed");
-    expect(briefing).not.toContain("first-tree-sync");
-    expect(briefing).toContain("fetch origin");
-    expect(briefing).toContain("origin/main");
-    // Fail-closed repoint guard — carries main's #1058 invariant (a source
-    // path repointed from repoA to repoB must not silently serve the old
-    // clone) into the agent-managed protocol. The agent verifies the existing
-    // clone's origin against the declared url and blocks on a mismatch instead
-    // of reusing it unconditionally.
-    expect(briefing).toContain("fail closed");
     expect(briefing).toContain("git -C <path> remote get-url origin");
-    expect(briefing).toMatch(/does NOT match/);
-    // Reuse is now CONDITIONAL on the origin matching — not an unconditional
-    // "reuse the existing path as-is".
-    expect(briefing).toContain("**If it matches**, reuse the clone");
-    // One-time legacy-layout migration: an agent provisioned under the old
-    // non-bare-checkout-at-workspace-root layout gets a safe, scoped recipe
-    // to retire it — drop only clean + already-merged worktrees, then the
-    // checkout — and is told to stay inside its OWN workspace.
-    expect(briefing).toContain("One-time legacy-layout migration");
-    expect(briefing).toContain("never reach into a sibling agent's");
-    expect(briefing).toContain("merge-base --is-ancestor <wt-HEAD> origin/<default>");
-    // P0 (issue #1086): the retire target must be mechanically constrained, not
-    // hand-filled. A path preflight derives `$legacy` from the manifest and
-    // proves it is exactly the intended legacy checkout before the git-state
-    // gates run — resolve workspace root from `.first-tree/workspace.json`,
-    // realpath + immediate-child check, reject reserved workspace dirs and
-    // symlinks, require the toplevel/non-bare/origin to all match.
-    expect(briefing).toContain('[ -f "$d/.first-tree/workspace.json" ]');
-    expect(briefing).toContain("assert_legacy_target() {");
-    expect(briefing).toContain("reserved workspace dir");
-    expect(briefing).toContain(".first-tree|source-repos|worktrees|context-tree)");
-    // Every gate runs against `$candidate`, never `$legacy`.
-    expect(briefing).toContain('real=$(realpath "$candidate")');
-    expect(briefing).toContain("reject: target is the workspace root");
-    expect(briefing).toContain("is not an immediate child of");
-    expect(briefing).toContain('git -C "$candidate" rev-parse --show-toplevel');
-    expect(briefing).toContain("rev-parse --is-bare-repository");
-    expect(briefing).toContain('git -C "$candidate" remote get-url origin');
-    // Blocker (yuezengwu / codex-bot on PR #1087): `$legacy` is cleared on entry
-    // and only published after EVERY gate passes, so a rejected/failed call can
-    // never leave a stale target for the git-state gates that follow.
-    expect(briefing).toContain("name=$1 want=$2 legacy= candidate=$WS/$name");
-    expect(briefing).toContain("  legacy=$candidate");
-    // Blocker (codex-assistant on PR #1087, per #1086): the origin compare is
-    // canonical — `.git` and the https/http/ssh/git/scp transport forms all
-    // collapse to host/path, so a legitimate checkout cloned via a different URL
-    // form is not rejected as wrong-origin (behaviorally exercised below).
-    expect(briefing).toContain("canon_url() {");
-    expect(briefing).toContain('[ "$(canon_url "$got")" = "$(canon_url "$want")" ]');
-    // The candidate path is derived per declared source and baked from the
-    // manifest, so the agent never hand-fills a naked `<legacy>` placeholder.
-    expect(briefing).toContain("assert_legacy_target 'api' 'git@github.com:example/api.git'");
-    expect(briefing).toContain("assert_legacy_target 'web' 'git@github.com:example/web.git'");
-    // Git-state gates now run against the validated `$legacy` variable, not a
-    // raw `<legacy>` placeholder.
-    expect(briefing).toContain('git -C "$legacy" status --porcelain');
-    expect(briefing).toContain("merge-base --is-ancestor HEAD origin/<default>");
-    // P1 (codex-assistant, PR #1083 follow-up): the retire also destroys
-    // local-only history the working-tree/HEAD checks don't see — branches not
-    // checked out in any worktree, and stashes. Guard those too before delete.
-    expect(briefing).toContain('git -C "$legacy" branch --no-merged origin/<default>');
-    expect(briefing).toContain('git -C "$legacy" stash list');
-    expect(briefing).toContain("only after ALL of the above are clear");
-    // P0 (issue #1086): the final destructive action is a reversible quarantine
-    // move, not an in-place irreversible `rm -rf`; deletion is a separate
-    // human-confirmed step.
+    expect(briefing).toMatch(/compare it canonically/);
+    expect(briefing).toMatch(/https\/http\/ssh\/git\/scp transport/);
+    expect(briefing).toMatch(/If it does\s+\*\*not\*\* match, stop/);
+    expect(briefing).toContain("git -C <path> fetch origin");
+    expect(briefing).toContain("Credential failures are reportable");
+
+    expect(briefing).toContain("Legacy non-bare workspace checkout");
+    expect(briefing).toContain(".first-tree/workspace.json");
+    expect(briefing).toContain("reserved workspace dirs");
+    expect(briefing).toContain("status --porcelain");
+    expect(briefing).toContain("merge-base --is-ancestor");
+    expect(briefing).toContain("branch --no-merged origin/<default>");
+    expect(briefing).toContain("stash list");
     expect(briefing).toContain('mv -- "$legacy" "$legacy.retired.$(date +%Y%m%d%H%M%S)"');
+    expect(briefing).not.toContain("assert_legacy_target() {");
     expect(briefing).not.toContain("rm -rf <legacy>");
-    expect(briefing).toContain("a separate step a human confirms");
-    // The context-tree symlink case points at the existing Tree Location block.
-    expect(briefing).toMatch(/`context-tree` \*\*symlink\*\* migrates the same/);
   });
 
-  it("preflight canon_url collapses .git / https / http / ssh / git / scp origin forms for the same repo but not a different one (issue #1086)", () => {
-    const briefing = buildAgentBriefing(
-      makeOpts({
-        sourceRepos: [{ absolutePath: `${AGENT_HOME}/source-repos/api`, url: "https://github.com/org/api" }],
-      }),
-    );
-    // Extract the shipped `canon_url` shell function verbatim from the recipe
-    // and exercise it — a string assertion alone cannot prove the transport
-    // forms actually collapse. codex-assistant (PR #1087) asked for a test that
-    // accepts equivalent SSH/HTTPS origins while still rejecting a different repo.
-    // Use plain indexOf/slice rather than a regex — a backtracking pattern over
-    // the (analysis-uncontrolled) briefing string trips the ReDoS check.
-    const fnStart = briefing.indexOf("canon_url() {\n");
-    expect(fnStart).toBeGreaterThanOrEqual(0);
-    const fnEnd = briefing.indexOf("\n}", fnStart);
-    expect(fnEnd).toBeGreaterThan(fnStart);
-    const canonFn = briefing.slice(fnStart, fnEnd + 2);
-
-    // Run the shipped function from a script file with the URL passed as a
-    // positional argument — never interpolated into a shell command string — so
-    // the test exercises the real `sed` pipeline without constructing a command
-    // from a variable (which a static-analysis command-injection check flags).
-    const dir = mkdtempSync(join(tmpdir(), "canon-url-"));
-    try {
-      const scriptPath = join(dir, "canon.sh");
-      writeFileSync(scriptPath, `${canonFn}\ncanon_url "$1"\n`);
-      const canon = (url: string): string => execFileSync("sh", [scriptPath, url], { encoding: "utf8" }).trim();
-
-      const key = canon("https://github.com/agent-team-foundation/first-tree.git");
-      expect(key).toBe("github.com/agent-team-foundation/first-tree");
-      const sameRepo = [
-        "https://github.com/agent-team-foundation/first-tree.git",
-        "https://github.com/agent-team-foundation/first-tree",
-        "http://github.com/agent-team-foundation/first-tree",
-        "git@github.com:agent-team-foundation/first-tree.git",
-        "git@github.com:agent-team-foundation/first-tree",
-        "ssh://git@github.com/agent-team-foundation/first-tree.git",
-        "git://github.com/agent-team-foundation/first-tree.git",
-      ];
-      for (const url of sameRepo) {
-        expect(canon(url), `expected ${url} to canonicalize to ${key}`).toBe(key);
-      }
-      // Genuinely different repos must NOT collapse to the same canonical key —
-      // canonicalization stays fail-closed (no false-accept of another repo).
-      expect(canon("https://github.com/agent-team-foundation/other")).not.toBe(key);
-      expect(canon("git@gitlab.com:agent-team-foundation/first-tree.git")).not.toBe(key);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it("omits the Source Repositories block when no repos are predeclared", () => {
+  it("omits the Source Repositories block when no repos are declared", () => {
     const briefing = buildAgentBriefing(makeOpts({ sourceRepos: [] }));
     expect(briefing).not.toContain("## Source Repositories");
-    // The Worktrees block still appears though (agent may clone ad-hoc
-    // repos that still follow the convention).
     expect(briefing).toContain("## Worktrees");
   });
 
-  it("emits Communication, Workspace Collaboration, Asking Humans, Chat Topic & Description, and CLI Overview subsections", () => {
+  it("keeps the Communication matrix markers and rich-body safety rules", () => {
     const briefing = buildAgentBriefing(makeOpts());
-    expect(briefing).toContain("## Communication");
-    // Action classification (the 07:22 root fix): reply transport is framed as
-    // a real command you run with the chat CLI (binds "reply" to executing a
-    // command, per real-agent QA 2026-06-26), and stated as a principle so a
-    // "hold off / discuss only" instruction scopes business actions and never
-    // suppresses the reply.
-    expect(briefing).toMatch(/is\s+a real command you run with the chat CLI/i);
-    expect(briefing).toMatch(/running it delivers your words to a teammate/i);
-    expect(briefing).toMatch(/A business action\s+is anything that changes the workspace or the world/i);
-    expect(briefing).toMatch(/hold off from acting/i);
-    // Communication routing: `chat send` reaches any teammate (a plain send to a
-    // human is a free reply); a human also has `chat ask` (decisions) and
-    // `chat update --description` (progress). The courtesy-send guard prevents
-    // echo loops.
-    expect(briefing).toMatch(/\*\*Asking a human\*\*/);
-    expect(briefing).toMatch(/\*\*Reporting progress to a human\*\*/);
-    expect(briefing).toMatch(/\*\*Reaching an agent to make them act\*\*/);
-    // A human-directed message gets a required reply, gathered into ONE concise
-    // message. The human-vs-agent asymmetry is explicit: a human never auto-wakes
-    // from a reply (no loop risk in answering), and the courtesy-send brake is
-    // scoped to agents only.
-    expect(briefing).toContain("Replying to a human is required, not optional");
-    expect(briefing).toContain("no loop risk in always answering");
-    // The send/ask boundary routes by dependency, not importance: a send is
-    // self-sufficient (readable, then ignorable); a turn that ends blocked on
-    // the human ends with a `chat ask` — a blocking question never rides in a
-    // plain send (liuchao-001 2026-07-06).
-    expect(briefing).toMatch(/A send must be self-sufficient/);
-    expect(briefing).toMatch(/never a send with a blocking question\s+folded in/);
-    expect(briefing).toMatch(/Route by\s+dependency, not importance/);
-    expect(briefing).toMatch(/This brake is for agents/);
-    // Anti-spam discipline: at most one plain human reply per turn; ongoing
-    // progress goes to `chat update --description`. The only skip-the-reply case
-    // is a re-delivery / no-op wake-up, NOT a fresh human message judged "covered".
-    expect(briefing).toContain("Don't stream a human through repeated");
-    expect(briefing).toContain("at most one plain human reply");
-    expect(briefing).toMatch(/skip a human reply entirely is a turn/);
-    expect(briefing).toMatch(/not merely because you judge a fresh/);
-    // A decision the human must make goes through `chat ask`, not a plain send.
-    expect(briefing).toMatch(/must decide, approve, or answer before you proceed/);
-    expect(briefing).toContain("chat invite <name>");
-    expect(briefing).toContain("stage or role handoff inside the same task stays in this chat");
-    expect(briefing).toMatch(/\*\*Starting separate work\*\*/);
-    expect(briefing).toMatch(/chat create --to <name>/);
-    expect(briefing).toContain("After an agent handoff, continue only independent work");
-    expect(briefing).toContain("do not poll status");
-    expect(briefing).toContain("Don't fire a courtesy");
-    expect(briefing).not.toContain("**Fallback**");
+    const communication = briefing.slice(briefing.indexOf("## Communication"));
 
-    expect(briefing).toContain("## Workspace Collaboration");
-    expect(briefing).toContain("first-tree chat --help");
-
-    expect(briefing).toContain("## Asking Humans");
-    // Asking Humans prescribes `chat ask` (the request mechanism moved off
-    // `chat send`). The ask schema is body-is-the-ask + optional `--options`
-    // JSON (NOT the retired `--question`/`--option`/`--close` flags). `chat ask`
-    // is ask-ONLY: the human resolves in the web UI, so the briefing carries no
-    // CLI resolution flag.
-    expect(briefing).toMatch(/chat ask <human>/);
-    expect(briefing).toContain("body IS the ask");
-    expect(briefing).toContain("--options");
-    expect(briefing).toContain("--multi-select");
-    expect(briefing).toMatch(/cannot.*mark a question answered or close it/i);
-    expect(briefing).not.toContain("--answer");
-    expect(briefing).not.toContain("--question");
-    expect(briefing).not.toContain("--close");
-    // Usage discipline: importance governs whether a question should exist at
-    // all (never manufacture progress / permission checks); dependency governs
-    // routing — a genuine blocking question is ALWAYS an ask, never a question
-    // folded into a plain send (liuchao-001 2026-07-06).
-    expect(briefing).toMatch(/The routing test is \*\*dependency, not importance\*\*/);
-    expect(briefing).toMatch(/genuinely the user's to make/);
-    expect(briefing).toMatch(/Do NOT manufacture progress or[\s\n]+permission checks/);
-    expect(briefing).toContain("can I continue?");
-    // The ask body is decision-self-sufficient: three fixed markdown sections
-    // a human who remembers nothing of this chat can decide from — they run
-    // many chats in parallel, and a future cross-chat review surface may show
-    // the ask alone, outside the chat.
-    // Section labels match the example headings exactly (a future cross-chat
-    // ask-review surface may parse them): Why this question exists / Recent
-    // context / The question.
-    expect(briefing).toContain("decision-self-sufficient");
-    expect(briefing).toContain("Why this question exists");
-    expect(briefing).toContain("Recent context");
-    expect(briefing).toMatch(/\*\*The question\*\* — ONE question, plus your recommendation/);
-    // Reader-context bar (l42y 2026-07-06): the ask may not assume
-    // familiarity with, understanding of, or recall of the underlying
-    // context — a shorthand is undecidable not because it is technical but
-    // because its meaning lives in context the reader does not hold. And asks
-    // decrease over time as the agent learns the human's decision patterns
-    // from earlier answers.
-    expect(briefing).toMatch(/Assume no familiarity with the underlying context/);
-    expect(briefing).toMatch(/Unpack every compressed\s+reference/);
-    expect(briefing).toMatch(/meaning lives in\s+context the reader does not hold/);
-    expect(briefing).toMatch(/cannot produce a good\s+decision/);
-    // Evidence boundary (codex-assistant): a prior answer suppresses an ask
-    // only when citable — visible transcript, durable record, or just-provided
-    // material; an inferred preference settles nothing.
-    expect(briefing).toMatch(/only when you can\s+actually cite them/);
-    expect(briefing).toMatch(/without such a\s+source the question is not settled — ask/);
-    expect(briefing).toMatch(/Ask volume should fall as\s+you learn/);
-
-    expect(briefing).toContain("## Chat Topic & Description");
-    expect(briefing).toContain("first-tree chat update");
-    // The block documents updating the description independently through
-    // `chat update`, and carries the upgraded description discipline keys
-    // (human-facing status report + Markdown), with set-topic kept as a
-    // deprecated alias.
-    expect(briefing).toContain("chat update --description");
-    expect(briefing).toMatch(/status report/);
-    expect(briefing).toMatch(/deprecated alias/);
-    expect(briefing).toMatch(/Self-locate/);
-    expect(briefing).toContain("Once set, leave the topic unchanged");
-    expect(briefing).toContain("stable topic helps humans find the chat");
-    expect(briefing).not.toContain("Rename only");
-    expect(briefing).not.toContain("subject itself changed");
-    // The Chat Topic block points at provider-injected per-chat context, not
-    // a block written into this shared briefing file.
-    expect(briefing).toContain('provider-injected "Current Chat Context"');
-    expect(briefing).not.toContain("bottom of this briefing");
+    expect(communication).toMatch(/business action changes the workspace\s+or outside world/);
+    expect(communication).toContain("Blocking questions never ride inside plain `chat send`");
+    expect(communication).toContain("route by dependency, not importance");
+    expect(communication).toContain("chat update --description -");
+    expect(communication).toContain("Do not send courtesy acknowledgements");
+    expect(communication).toMatch(/group chats reject no-recipient/i);
+    expect(communication).toContain("chat create --to <name>");
+    expect(communication).toContain("@EOF");
+    expect(communication).toContain("Issue #389");
+    expect(communication).toMatch(/Use\s+`-f markdown`/);
   });
 
-  it("emits the GitHub Entity Attention block with the follow-after-create default inline (not skill-gated)", () => {
-    // Why inline: see the githubAttentionBlock comment in agent-briefing.ts.
-    const briefing = buildAgentBriefing(makeOpts()); // tree-less default
-    expect(briefing).toContain("## GitHub Entity Attention");
-    // Default posture: follow what you create, immediately.
-    expect(briefing).toContain("**Default: follow what you create.**");
-    expect(briefing).toContain("first-tree github follow <url>");
-    // The single exception: clearly unrelated to the chat's task.
-    expect(briefing).toMatch(/clearly unrelated to this\s+chat's task/);
-    // Unfollow is human-explicit-stop only, not a PR/Issue completion ritual.
-    expect(briefing).toContain("first-tree github unfollow <entity>");
-    expect(briefing).toMatch(/human explicitly asks to stop tracking/);
-    expect(briefing).toMatch(/Do not proactively unfollow\s+merely because a PR or Issue completed/);
-    // Creation never auto-follows — the extractor is gone (#979).
-    expect(briefing).toMatch(/there\s+is no auto-binding/);
-  });
-
-  it("emits the GitHub working posture before entity-follow rules", () => {
-    const briefing = buildAgentBriefing(makeOpts());
-    expect(briefing).toContain("## GitHub Working Posture");
-    expect(briefing.indexOf("## GitHub Working Posture")).toBeLessThan(briefing.indexOf("## GitHub Entity Attention"));
-    expect(briefing).toContain("try the host `gh` CLI first");
-    expect(briefing).toContain("GitHub URLs are not, by themselves, a reason to ask for First Tree GitHub App");
-    expect(briefing).toContain("Ask for First Tree GitHub access only when the desired outcome needs platform");
-    expect(briefing).toContain("If the current member is not an org admin");
-    expect(briefing).toContain("do not ask them to install the");
-    expect(briefing).toContain("Do not use agent-accessible local files or tree snapshots as a hidden server");
-  });
-
-  it("keeps the GitHub Entity Attention full-guide pointer on CLI help", () => {
-    const treeless = buildAgentBriefing(makeOpts());
-    expect(treeless).not.toContain("`first-tree-github` skill");
-    expect(treeless).toContain("first-tree github follow --help");
-
-    const treeBound = buildAgentBriefing(makeOpts({ contextTreePath: "/var/lib/context-trees/example" }));
-    expect(treeBound).not.toContain("`first-tree-github` skill");
-    expect(treeBound).toContain("first-tree github follow --help");
-  });
-
-  it("uses the channel-resolved binary name in the surviving chat-send invariant", () => {
+  it("uses the channel-resolved binary name in chat commands", () => {
     setCliBinding({ binName: "first-tree-staging", packageName: "first-tree-staging" });
     try {
       const briefing = buildAgentBriefing(makeOpts());
       expect(briefing).toContain("first-tree-staging chat send");
-      // The hardcoded prod name must NOT leak through as a CLI literal
-      // (anchor on the literal CLI form `first-tree chat ` only — backtick
-      // pointer text mentioning `first-tree` is fine).
       expect(briefing).not.toMatch(/\bfirst-tree chat /);
     } finally {
       setCliBinding({ binName: "first-tree", packageName: "first-tree" });
@@ -870,52 +349,79 @@ describe("buildAgentBriefing — # Working in First Tree subsections", () => {
   });
 });
 
-describe("buildAgentBriefing — ## CLI Overview accuracy", () => {
-  // Pre-CLI-Overview-rev the table listed `tree read/write/publish` and a
-  // `github scan` namespace, both of which don't exist in the registered
-  // CLI surface. This suite pins the table against the actually-registered
-  // commands so we can't regress.
-
-  it("lists only registered namespaces and never mentions the retired `github scan`", () => {
+describe("buildAgentBriefing — asking humans, GitHub, and CLI overview", () => {
+  it("keeps chat ask dependency routing and self-sufficient body schema", () => {
     const briefing = buildAgentBriefing(makeOpts());
+    const asking = briefing.slice(briefing.indexOf("## Asking Humans"));
 
-    // Real namespaces — each must appear inside the CLI Overview table.
-    // `tree` is scoped to registered concrete subcommands rather than
-    // `tree …`; `org` is operator-only and was removed from the
-    // agent-facing table in the same edit.
+    expect(asking).toContain("raises a tracked open question");
+    expect(asking).toContain("The routing test is **dependency, not importance**");
+    expect(asking).toContain("genuinely the user's to make");
+    expect(asking).toContain("Do NOT manufacture");
+    expect(asking).toContain("can I continue?");
+    expect(asking).toContain("can cite them");
+    expect(asking).toContain("Ask volume should fall");
+    expect(asking).toContain("body IS the ask");
+    expect(asking).toContain("decision-self-sufficient");
+    expect(asking).toContain("Why this question exists");
+    expect(asking).toContain("Recent context");
+    expect(asking).toContain("**The question**");
+    expect(asking).toContain("--options");
+    expect(asking).toContain("--multi-select");
+    expect(asking).toContain("human resolves");
+    expect(asking).not.toContain("--answer");
+    expect(asking).not.toContain("--question");
+    expect(asking).not.toContain("--close");
+  });
+
+  it("keeps GitHub posture and follow-after-create rules inline", () => {
+    const briefing = buildAgentBriefing(makeOpts());
+    expect(briefing).toContain("## GitHub Working Posture");
+    expect(briefing.indexOf("## GitHub Working Posture")).toBeLessThan(briefing.indexOf("## GitHub Entity Attention"));
+    expect(briefing).toContain("try the host `gh` CLI first");
+    expect(briefing).toContain("not by itself a reason to ask for First Tree GitHub App");
+    expect(briefing).toContain("If the current member is not an org admin");
+    expect(briefing).toContain("hidden server sync path");
+
+    expect(briefing).toContain("Creating a PR or issue **never** follows it");
+    expect(briefing).toContain("first-tree github follow <url>");
+    expect(briefing).toMatch(/clearly unrelated to this chat's task/);
+    expect(briefing).toContain("first-tree github unfollow <entity>");
+    expect(briefing).toMatch(/human explicitly asks to stop tracking/);
+    expect(briefing).toContain("first-tree github follow --help");
+    expect(briefing).not.toContain("`first-tree-github` skill");
+  });
+
+  it("keeps chat metadata rules compact but actionable", () => {
+    const briefing = buildAgentBriefing(makeOpts());
+    const chatTopic = briefing.slice(briefing.indexOf("## Chat Topic & Description"));
+
+    expect(chatTopic).toContain('provider-injected "Current Chat Context"');
+    expect(chatTopic).toContain("chat update --topic");
+    expect(chatTopic).toContain("chat update --description");
+    expect(chatTopic).toContain("deprecated alias");
+    expect(chatTopic).toContain("leave it stable");
+    expect(chatTopic).toContain("within 1500 characters");
+    expect(chatTopic).toMatch(/use\s+`first-tree chat ask <human>`/);
+    expect(chatTopic).toContain("chat list");
+    expect(chatTopic).toContain("chat history <chat>");
+    expect(chatTopic).toContain("GitHub-sourced topics");
+    expect(chatTopic).not.toContain("bottom of this briefing");
+  });
+
+  it("lists only registered CLI namespaces and tree subcommands", () => {
+    const briefing = buildAgentBriefing(makeOpts());
     const overview = briefing.slice(briefing.indexOf("## CLI Overview"));
+
     expect(overview).toContain("first-tree chat …");
     expect(overview).toContain("first-tree agent …");
     expect(overview).toContain("first-tree daemon …");
     expect(overview).toContain("first-tree github …");
     expect(overview).toContain("first-tree tree verify");
     expect(overview).toContain("first-tree tree tree");
-
-    // Retired / unregistered surface must NOT appear.
     expect(overview).not.toContain("github scan");
-    // The old `tree …` catch-all row must not have come back — agents
-    // following it would try retired subcommands.
     expect(overview).not.toContain("first-tree tree …");
-  });
 
-  it("CLI Overview lists only registered `tree` subcommands — retired commands must stay out", () => {
-    // Post-2026-06 the `tree` namespace was retired to concrete
-    // registered subcommands: `verify` for validation and `tree` for
-    // hierarchy browsing. The briefing's CLI Overview must NOT advertise
-    // any deleted subcommand or the agent will burn a turn on `unknown
-    // command`. This test is the runtime counterpart to the
-    // `command-registration-smoke` test that pins the actual registered
-    // surface.
-    const briefing = buildAgentBriefing(makeOpts());
-    const overview = briefing.slice(briefing.indexOf("## CLI Overview"));
-
-    // The surviving subcommands must be listed.
-    expect(overview).toContain("tree verify");
-    expect(overview).toContain("tree tree");
-
-    // Every retired tree subcommand must NOT appear in the CLI Overview
-    // text. Use word-boundary regex (not `.toContain`) so prose like
-    // "workspace ↔ tree binding" doesn't false-positive on `tree bind`.
     for (const retired of [
       "status",
       "init",
@@ -931,114 +437,63 @@ describe("buildAgentBriefing — ## CLI Overview accuracy", () => {
       "write",
       "publish",
     ]) {
-      // Match `first-tree tree <retired>` or `ft tree <retired>` followed
-      // by a word boundary (so `tree bind` does NOT match `tree binding`).
       const re = new RegExp(`\\b(?:first-tree|ft)\\s+tree\\s+${retired}\\b`, "u");
-      expect(overview, `CLI Overview must not advertise retired \`tree ${retired}\``).not.toMatch(re);
+      expect(overview, `CLI Overview must not advertise retired tree ${retired}`).not.toMatch(re);
     }
   });
 });
 
-describe("buildAgentBriefing — # Context Tree", () => {
-  it("emits Core Model / Reading the Tree / Writing the Tree / Tree Location with the tree path interpolated", () => {
+describe("buildAgentBriefing — Context Tree", () => {
+  it("keeps read/write triggers, root files, verify, and PR ordering", () => {
     const treePath = "/var/lib/context-trees/example";
     const briefing = buildAgentBriefing(makeOpts({ contextTreePath: treePath }));
+    const tree = topLevelSection(briefing, "# Context Tree (First Tree Managed)");
 
-    expect(briefing).toContain("# Context Tree");
-    expect(briefing).toContain("## Core Model");
-    expect(briefing).toContain("## Reading the Tree");
-    expect(briefing).toContain("## Writing the Tree");
-    expect(briefing).toContain("## Tree Location");
+    expect(tree).toContain("## Core Model");
+    expect(tree).toContain("decisions,\nconstraints, ownership, and cross-domain relationships");
+    expect(tree).toContain("load `first-tree-write`");
+    expect(tree).toContain("load `first-tree-read`");
 
-    // Reading discipline anchors.
-    expect(briefing).toContain("root `NODE.md`");
-    expect(briefing).toContain("load `first-tree-read`");
-    expect(briefing).toContain("hierarchy command");
-    // Reading the Tree must also point the agent at root `AGENTS.md` when
-    // present — orgs put mandatory rules there and the de-injection
-    // direction would otherwise lose them silently. The check anchors on
-    // the conditional phrasing rather than the bare filename so it can't
-    // accidentally pass on a hit elsewhere in the briefing (e.g. the
-    // legacy "`AGENTS.md`" string in someone's `prompt.append`).
-    expect(briefing).toMatch(/If the root also contains an `AGENTS\.md`, ?\s*read it too/);
-    expect(briefing).toContain("mandatory rules the org expects every agent");
-    expect(briefing).toContain("before you act on any instruction");
-    expect(briefing).toContain("the tree wins");
-    expect(briefing).toContain("eagerly, not lazily");
+    expect(tree).toContain("repo/path/feature/domain/owner/source signal");
+    expect(tree).toContain("first-tree tree tree --help");
+    expect(tree).toContain("tree tree` selectors");
+    expect(tree).toContain("root `NODE.md`");
+    expect(tree).toMatch(/If the root also contains an\s+`AGENTS\.md`, read it too/);
+    expect(tree).toContain("the tree wins");
 
-    // Writing discipline anchors — fresh vs persistent context framing, the
-    // co-open + cross-link PR coordination rule, and the tightened merge
-    // order: the tree PR opens as a draft so it can't land ahead, the code PR
-    // merges first, then the tree PR is reconciled against the final merged
-    // code and marked ready. The prose wraps the emphasised phrases across
-    // lines, so allow either single-line or wrapped forms.
-    expect(briefing).toContain("fresh context");
-    expect(briefing).toMatch(/\*\*persistent[\s\n]+context\*\*/);
-    expect(briefing).toMatch(/request explicitly includes[\s\n]+creating and updating the needed tree-node files/);
-    expect(briefing).toContain("`NODE.md` and other");
-    expect(briefing).toContain("`*.md` nodes");
-    expect(briefing).toMatch(
-      /open the tree PR and the code[\s\n]+PR[\s\n]+together and cross-link them in the PR descriptions/,
-    );
-    expect(briefing).toMatch(/Merge the code PR first, then[\s\n]+the tree PR/);
-    expect(briefing).toMatch(/open the tree PR as a draft/);
-    expect(briefing).toContain("final merged");
-    expect(briefing).not.toContain("need not merge first");
-    expect(briefing).toContain("Implementation-only changes skip the tree");
+    expect(tree).toContain("fresh context");
+    expect(tree).toContain("persistent context");
+    expect(tree).toContain("specific PR, design doc");
+    expect(tree).toMatch(/request explicitly includes\s+creating and updating the needed tree-node\s+files/);
+    expect(tree).toContain("`NODE.md` and other `*.md` nodes");
+    expect(tree).toMatch(/Implementation-only changes skip\s+the tree write/);
+    expect(tree).toContain("If there is no specific source artifact");
+    expect(tree).toContain("first-tree tree verify");
+    expect(tree).toContain("open them together");
+    expect(tree).toContain("cross-link");
+    expect(tree).toContain("open the tree PR as a draft");
+    expect(tree).toContain("merge the code PR first");
+    expect(tree).toContain("final merged code");
+    expect(tree).not.toContain("need not merge first");
+    expect(tree).not.toContain("`first-tree-context`");
+    expect(tree).not.toContain("`first-tree-sync`");
 
-    // Tree path interpolated under Tree Location.
-    expect(briefing).toContain(treePath);
+    expect(tree).toContain(treePath);
   });
 
-  it("Writing the Tree routing table only references shipped skills", () => {
-    const briefing = buildAgentBriefing(makeOpts({ contextTreePath: "/tree" }));
-    const writingBlock = briefing.slice(briefing.indexOf("## Writing the Tree"));
-
-    // The surviving rows must point at shipped skills.
-    expect(writingBlock).toContain("`first-tree-write`");
-
-    // Retired skills must not appear:
-    //   - `first-tree-context` was replaced by `first-tree-write`.
-    //   - `first-tree-sync` has no shipped replacement in this pass.
-    //   - `first-tree-onboarding` was retired with the old tree
-    //     provisioning commands.
-    //   - `first-tree-github-scan` predates both and never shipped.
-    expect(writingBlock).not.toContain("`first-tree-context`");
-    expect(writingBlock).not.toContain("`first-tree-sync`");
-    expect(writingBlock).not.toContain("`first-tree-onboarding`");
-    expect(writingBlock).not.toContain("`first-tree-github-scan`");
-  });
-
-  it("substitutes a tree-less Tree Location stub that surfaces the gap for ordinary tasks but carves out the seed admin create+bind", () => {
+  it("surfaces tree-less binding as a human/operator gap", () => {
     const briefing = buildAgentBriefing(makeOpts({ contextTreePath: null }));
-    // Section header still emitted so the briefing's # Context Tree always
-    // contains all four subsections — predictable for the agent and for
-    // section-order assertions above.
-    expect(briefing).toContain("## Tree Location");
-    const treeLocationStart = briefing.indexOf("## Tree Location");
-    const stub = briefing.slice(treeLocationStart);
-    expect(stub).toContain("This agent has no Context Tree bound");
-    // Ordinary task with no tree → still an operator action; surface the gap.
-    expect(stub).toContain("surface that gap to a human");
-    expect(stub).toContain("operator action");
-    // Carve-out: a build / set-up-the-tree task IS the sanctioned in-agent
-    // create + bind for a confirmed admin — the agent must not turn that
-    // happy-path into a "who runs the bind?" question (reconciles the briefing
-    // with first-tree-seed State A).
-    expect(stub).toContain("build / set up the Context Tree");
-    expect(stub).toContain("confirmed org admin");
-    expect(stub).toContain('"who runs the bind?"');
-    // The retired onboarding skill must not be named.
-    expect(stub).not.toContain("first-tree-onboarding");
+    const tree = topLevelSection(briefing, "# Context Tree (First Tree Managed)");
+    expect(tree).toContain("This agent has no Context Tree bound");
+    expect(tree).toMatch(/surface that\s+gap to a human/);
+    expect(tree).toContain("operator action");
+    expect(tree).toContain("build / set up the Context Tree");
+    expect(tree).toContain("confirmed org admin");
+    expect(tree).toContain('"who runs the bind?"');
+    expect(tree).not.toContain("first-tree-onboarding");
   });
 
-  it("shell-quotes interpolated branch / URL / path in the Tree Location clone command (S5)", () => {
-    // baixiaohang #4 / S5: branch / URL / tree path can legitimately carry
-    // spaces, `$`, or other shell metacharacters (e.g. a `feature with space`
-    // branch, a `release/$VERSION` branch, a path under a username with a
-    // dot). Without quoting, a literal copy-paste of the briefing's `git
-    // clone` line either parses wrong (extra positional args) or expands a
-    // shell variable that is empty / wrong on the agent's host.
+  it("shell-quotes interpolated tree clone command values", () => {
     const briefing = buildAgentBriefing(
       makeOpts({
         contextTreePath: "/var/lib/context trees/example",
@@ -1048,45 +503,29 @@ describe("buildAgentBriefing — # Context Tree", () => {
     );
     const treeLocation = briefing.slice(briefing.indexOf("## Tree Location"));
 
-    // The clone command lives inside an indented code block — match against
-    // its single-quoted form. The interpolated branch must NOT appear bare
-    // (which would let the shell split on the space).
     expect(treeLocation).toContain(
       "git clone --branch 'feature with space' --single-branch 'https://example.com/release/$VERSION.git' '/var/lib/context trees/example'",
     );
-    // The path also flows into the `rm` / `pull` / `worktree add` snippets —
-    // every interpolated absolute path must be single-quoted there too.
     expect(treeLocation).toContain("rm '/var/lib/context trees/example'");
     expect(treeLocation).toContain("git -C '/var/lib/context trees/example' pull --ff-only");
     expect(treeLocation).toContain("git -C '/var/lib/context trees/example' worktree add");
-  });
 
-  it("escapes an embedded single quote in the Tree Location quoted values (S5 edge)", () => {
-    // POSIX-safe single quoting closes the quoted block, inserts an escaped
-    // quote, then reopens — verify the canonical `'\''` form lands in the
-    // briefing for a branch / path that already contains a quote.
-    const briefing = buildAgentBriefing(
+    const singleQuote = buildAgentBriefing(
       makeOpts({
         contextTreePath: "/tmp/it's-fine",
         contextTreeRepoUrl: "https://example.com/x.git",
         contextTreeBranch: "main",
       }),
     );
-    const treeLocation = briefing.slice(briefing.indexOf("## Tree Location"));
-    expect(treeLocation).toContain("'/tmp/it'\\''s-fine'");
+    expect(singleQuote.slice(singleQuote.indexOf("## Tree Location"))).toContain("'/tmp/it'\\''s-fine'");
   });
 });
 
-describe("buildAgentBriefing — # Skills (Skill Map)", () => {
-  it("lists only the shipped First Tree family skills — drift detector against the on-disk skills/ directory", () => {
-    // Compute repo root from the test file location, then enumerate
-    // `skills/<name>/SKILL.md` payloads. If a future PR adds a skill to
-    // `skills/` (or removes one) without updating the Skill Map, this
-    // assertion fails so the doc stays honest.
+describe("buildAgentBriefing — Skills", () => {
+  it("lists only shipped First Tree family skills", () => {
     const testFileDir = dirname(fileURLToPath(import.meta.url));
     const repoRoot = resolve(testFileDir, "..", "..", "..", "..");
     const skillsDir = join(repoRoot, "skills");
-
     const shippedSkills = readdirSync(skillsDir).filter((name) => {
       const skillMd = join(skillsDir, name, "SKILL.md");
       try {
@@ -1098,23 +537,19 @@ describe("buildAgentBriefing — # Skills (Skill Map)", () => {
 
     expect(new Set(shippedSkills)).toEqual(new Set(FIRST_TREE_FAMILY_SKILL_NAMES));
 
-    // Use a tree-bound briefing so the First Tree Family map is emitted —
-    // the tree-less omission case is exercised by its dedicated test below.
-    const briefing = buildAgentBriefing(makeOpts({ contextTreePath: "/tree" }));
-    const skillMap = briefing.slice(briefing.indexOf("## First Tree Family"));
-
-    // Every shipped skill must appear; no unshipped names allowed.
+    const skillMap = topLevelSection(
+      buildAgentBriefing(makeOpts({ contextTreePath: "/tree" })),
+      "# Skills (First Tree Managed)",
+    );
     for (const name of shippedSkills) {
       expect(skillMap).toContain(`\`${name}\``);
     }
-    // The pre-revision Skill Map advertised three skills the runtime never
-    // installs; pin them out so a future edit doesn't regress.
     expect(skillMap).not.toContain("`first-tree-github-scan`");
     expect(skillMap).not.toContain("`attention`");
     expect(skillMap).not.toContain("`github-scan`");
   });
 
-  it("nests `## Team Skills` (per-agent resource skills) under `# Skills` when payload.resourceSkills is non-empty (tree-bound)", () => {
+  it("nests Team Skills before First Tree Family when resource skills exist", () => {
     const payload = {
       kind: "claude-code" as const,
       model: "",
@@ -1134,85 +569,11 @@ describe("buildAgentBriefing — # Skills (Skill Map)", () => {
       reasoningEffort: "" as const,
     };
     const briefing = buildAgentBriefing(makeOpts({ payload, contextTreePath: "/tree" }));
+    const skills = topLevelSection(briefing, "# Skills (First Tree Managed)");
 
-    const skillsSection = briefing.slice(briefing.indexOf("# Skills"));
-    expect(skillsSection).toContain("## Team Skills");
-    expect(skillsSection).toContain("internal-playbook: Team-internal playbook");
-    expect(skillsSection).toContain("## First Tree Family");
-    // Team Skills must precede First Tree Family inside the # Skills block.
-    expect(skillsSection.indexOf("## Team Skills")).toBeLessThan(skillsSection.indexOf("## First Tree Family"));
-  });
-
-  it("omits `## Team Skills` when payload.resourceSkills is empty (First Tree Family is still emitted for tree-bound agents)", () => {
-    // Tree-bound agent → First Tree Family is the only entry under # Skills.
-    const briefing = buildAgentBriefing(makeOpts({ contextTreePath: "/tree" }));
-    const skillsSection = briefing.slice(briefing.indexOf("# Skills"));
-    expect(skillsSection).not.toContain("## Team Skills");
-    expect(skillsSection).toContain("## First Tree Family");
-  });
-
-  it("emits a core-skills First Tree Family map for tree-less agents (routes the tree-build task to first-tree-seed)", () => {
-    // A tree-less agent now carries the core skills on disk (welcome + the
-    // from-zero build pair seed/write), so the map lists exactly those — and
-    // NOT `first-tree-read`, which stays tree-bound. This is the routing
-    // surface a welcome-spawned tree-build chat uses to reach first-tree-seed,
-    // whose brief names no skill by design.
-    const briefing = buildAgentBriefing(makeOpts({ contextTreePath: null }));
-    expect(briefing).toContain("# Skills (First Tree Managed)");
-    const familyStart = briefing.indexOf("## First Tree Family");
-    expect(familyStart).toBeGreaterThanOrEqual(0);
-    // Bound the assertion to the map's own block (up to the next heading) so a
-    // later section that legitimately mentions read can't taint the check.
-    const afterStart = briefing.slice(familyStart + "## First Tree Family".length);
-    const nextHeadingRel = afterStart.search(/\n#{1,3} /);
-    const familyMap = nextHeadingRel === -1 ? afterStart : afterStart.slice(0, nextHeadingRel);
-    expect(familyMap).toContain("first-tree-welcome");
-    expect(familyMap).toContain("first-tree-seed");
-    expect(familyMap).toContain("first-tree-write");
-    expect(familyMap).not.toContain("first-tree-read");
-    // Tree-less map must not lean on the (omitted) # Required Reading section.
-    expect(familyMap).not.toContain("# Required Reading");
-  });
-
-  it("keeps the `# Skills` umbrella for tree-less agents that DO have Team Skills (resource skills land regardless)", () => {
-    // Resource skills are installed via `materializeResourceSkills`, which
-    // runs irrespective of Context Tree binding — so a tree-less agent
-    // with team skills configured still needs the `# Skills` header.
-    const payload = {
-      kind: "claude-code" as const,
-      model: "",
-      prompt: { append: "" },
-      mcpServers: [],
-      env: [],
-      gitRepos: [],
-      resourceSkills: [
-        {
-          resourceId: "res-1",
-          name: "internal-playbook",
-          description: "Team-internal playbook",
-          metadata: {},
-          body: "# Playbook",
-        },
-      ],
-      reasoningEffort: "" as const,
-    };
-    const briefing = buildAgentBriefing(makeOpts({ payload, contextTreePath: null }));
-    expect(briefing).toContain("# Skills");
-    expect(briefing).toContain("## Team Skills");
-    expect(briefing).toContain("internal-playbook");
-    // The tree-less core-skills First Tree Family map is also emitted now, and
-    // sits after Team Skills under the shared `# Skills` umbrella.
-    expect(briefing).toContain("## First Tree Family");
-    const skills = briefing.slice(briefing.indexOf("# Skills"));
+    expect(skills).toContain("## Team Skills");
+    expect(skills).toContain("internal-playbook: Team-internal playbook");
+    expect(skills).toContain("## First Tree Family");
     expect(skills.indexOf("## Team Skills")).toBeLessThan(skills.indexOf("## First Tree Family"));
-  });
-});
-
-describe("buildAgentBriefing — provider-injected Current Chat Context boundary", () => {
-  it("never writes per-chat Current Chat Context into the shared briefing", () => {
-    const briefing = buildAgentBriefing(makeOpts());
-    expect(briefing).not.toContain("## Current Chat Context");
-    expect(briefing).not.toContain("Chat ID:");
-    expect(briefing).not.toContain("Participants:");
   });
 });

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -508,6 +508,9 @@ reply transport for a human-directed turn.
 | Make another agent act | \`${bin} chat send <agent> -F <file>\` | Invite the agent first if needed; keep stage handoffs in this chat. |
 | Agent wake-up with nothing new to act on | no send | Do not send courtesy acknowledgements to agents. |
 
+Replying to a human is required, not optional. The \`no send\` case applies
+only to agent no-op wake-ups or duplicate/system no-op turns, never to a
+fresh human-directed message.
 Every \`chat send\` names a recipient; group chats reject no-recipient
 sends, and \`@name\` in content is not enough.
 Start separate work with \`${bin} chat create --to <name>\` only when the
@@ -611,7 +614,8 @@ function chatTopicBlock(bin: string): string {
 Each chat has two self-describing metadata fields, both maintained with
 \`chat update\` and both visible in the provider-injected "Current Chat Context":
 
-- **topic** — short, stable label for the chat list.
+- **topic** — short (<= 30 chars), stable label for the chat list, e.g.
+  "调研 chat rename 方案" or "本周 ship 计划".
 - **description** — Markdown work summary and status report: background,
   plan, progress, and current blockers that are not human decisions.
 Use \`${bin} chat update --topic "<short label>"\` and
@@ -619,10 +623,13 @@ Use \`${bin} chat update --topic "<short label>"\` and
 \`chat set-topic\` is a deprecated alias.
 
 Maintain these only when you own the chat: you created it, or no agent owner
-is present because a human created it or the creator left. If topic is unset,
-set one before ending the turn; once set, leave it stable. Keep description
-current only on substantive progress, within 1500 characters, in the session
-language. Do not put human decisions in the description; use
+is present because a human created it or the creator left. If another agent
+owns the chat and is still present, leave metadata to that agent; a 403 means
+stop, not retry. If topic is unset, set one before ending the turn; once set,
+leave it stable. Keep description current only on substantive progress,
+within 1500 characters, in the session language. Rewrite it in place (history
+is the log), not as busywork; if nothing substantive changed, keep working.
+Markdown is supported. Do not put human decisions in the description; use
 \`${bin} chat ask <human>\`. Self-locate with \`${bin} chat list\` and
 \`${bin} chat history <chat>\`.
 
@@ -671,7 +678,8 @@ When a task has a repo/path/feature/domain/owner/source signal, load
 \`first-tree-read\` before acting. The skill is read-only and requires
 you to inspect \`${getCliBinding().binName} tree tree --help\` inside the tree repo,
 then use \`tree tree\` selectors to find focused files before reading their
-Markdown content with normal file reads.
+Markdown content with normal file reads. Treat code, CLI, review, repo,
+path, bug, and error tasks as tree-read signals.
 
 At minimum start with the root \`NODE.md\`; **If the root also contains an \`AGENTS.md\`, read it too**
 because it carries org-level rules. Follow

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -348,28 +348,20 @@ function requiredReadingSection(contextTreePath: string | null, workspacePath: s
   const writeSkillPath = `${workspacePath}/.agents/skills/first-tree-write/SKILL.md`;
   return `# Required Reading (First Tree Managed)
 
-Before responding to any non-trivial instruction in this chat, you MUST
-load **\`first-tree-write\`** before acting. The \`# Working in First Tree\`
-section above carries the minimum mechanics you need to operate at all
-(chat send, working directory, CLI surface); the skill carries the
-durable Context Tree concept model, source-system boundary, authorship
-read-discipline, and the Hard Rules + Double Test that govern every
-tree write.
+Before any non-trivial instruction in a tree-bound workspace, you MUST
+load **\`first-tree-write\`** before acting. The inline briefing is only
+the routing index; the skill carries the Context Tree concept model,
+source-system boundary, authorship read-discipline, and Hard Rules +
+Double Test that prevent bad tree writes.
 
-If your runtime does not automatically inject the full skill body after
-selecting a skill from the skill listing, read the local payload file
-directly before acting:
+If the runtime does not inject the full skill body after selection, read
+the local payload directly:
 
 - \`${writeSkillPath}\`
 
-This skill is unconditional. The remaining First Tree skills
-(\`first-tree-read\`, \`first-tree-seed\`) load on demand based on the
-task signal as listed in the First Tree Family map below.
-
-Skipping it costs you the source-system boundary and the write-side
-Hard Rules + Double Test — content the inline briefing only summarises.
-Acting without it is the #1 source of advice that conflicts with
-reality.`;
+This mandate is tree-bound and unconditional. \`first-tree-read\` and
+\`first-tree-seed\` remain on-demand as listed in the First Tree Family
+map below.`;
 }
 
 // --- # Working in First Tree -------------------------------------------------
@@ -387,41 +379,19 @@ function workingInFirstTreeSection(opts: WorkingInFirstTreeOpts, bin: string): s
 
 You are running inside **First Tree**, a messaging platform for agent teams.
 
-- Messages from other team members arrive as your prompt input. Each message
-  has a \`[From: <name> · type=<human|agent> · sent=<timestamp>]\` header — the
-  name is what you pass back to \`chat send\`, \`type\` tells you which reply
-  discipline applies (see below), and \`sent\` is when it was sent. (The
-  annotations are omitted when unknown.)
-- **\`${bin} chat send <name>\` reaches any teammate — agent or human.** Use it
-  to make an agent act, or to send a human a free reply / conversational answer.
-  For a human you can also raise a tracked decision with \`${bin} chat ask
-  <human>\`, or push progress with \`${bin} chat update --description\`.
-- **Inside First Tree, the "user" your underlying agent addresses is the First
-  Tree runtime.** Everything you produce apart from an explicit chat command —
-  your reasoning, your progress, and the message that closes your turn alike —
-  is addressed to that runtime and recorded as a live reasoning/activity trace.
-  Think, plan, and narrate there freely, treating it as visible: a one-line
-  preview can surface as live session activity. This is your **console**.
-- **A teammate is reached through the outbox: the explicit commands
-  \`chat send\`, \`chat ask\`, and \`chat update\`.** The console addresses the
-  runtime; the outbox places your message in front of a teammate. A human-directed
-  turn is complete once you deliver your reply through the outbox; an agent
-  wake-up with nothing new to act on can end without a send.
-- **Reply to a human; don't fire a courtesy \`chat send\` to an agent.** A
-  message a human directs at you gets a \`chat send\` reply before you end the
-  turn — a human never auto-wakes from your reply, so there is no loop risk and
-  silence just reads as no reply. Between agents it is the opposite: if a
-  wake-up leaves nothing new to act on, end the turn without sending — a
-  courteous "got it" between two agents is how loops start.
-- **Form a rich body as a file or stdin, so the markdown reaches the chat
-  verbatim.** Write a \`chat send\`/\`chat ask\` body — or a \`chat update
-  --description\` — to a file and send it with \`-F\`, or pipe it via stdin
-  (\`chat update\` reads \`--description -\`): \`${bin} chat send <name> -f markdown -F <file>\`.
-  Reserve inline \`"..."\` for a short, plain, single-line string. Markdown needs
-  \`-f markdown\` (the default \`text\` shows \`**bold**\`, lists, and \`\`code\`\`
-  as literal characters), and the body is a raw string — never \`JSON.stringify\`
-  it. Why a file/stdin is the verbatim-safe path — and the Issue #389
-  double-encode trap — is in \`## Communication\`.`);
+- Incoming messages carry \`[From: <name> · type=<human|agent> · sent=<timestamp>]\`;
+  use \`name\` as the chat recipient and \`type\` for the routing rules.
+- Inside First Tree, the "user" your underlying agent addresses is the First
+  Tree runtime. Non-command output is a visible live reasoning/activity trace,
+  not a teammate reply. This is your **console**.
+- Teammates are reached through the **outbox**: \`${bin} chat send\`,
+  \`${bin} chat ask\`, and \`${bin} chat update\`.
+- Human message: finish with one \`${bin} chat send <human>\` unless blocked
+  on a human decision; then use \`${bin} chat ask <human>\`. Progress/status
+  uses \`${bin} chat update --description\`.
+- Agent handoff: \`${bin} chat send <agent>\`; no courtesy acknowledgements.
+- Rich markdown bodies go through \`-F <file>\`, \`-F -\`, or
+  \`--description -\`; never \`JSON.stringify\` a chat body.`);
 
   blocks.push(workingDirectoryBlock(opts.agentHome));
 
@@ -444,22 +414,16 @@ You are running inside **First Tree**, a messaging platform for agent teams.
 function workingDirectoryBlock(agentHome: string): string {
   return `## Working Directory
 
-Your fixed working directory is \`${agentHome}\`. This directory is shared
-by every chat you participate in for this agent — files you create in one
-chat are visible from another. Operate accordingly:
-
-- Refer to paths by their **absolute** form (the values listed below) so
-  switching into a subdirectory does not break references.
-- Treat the agent home as persistent state. Memory, caches, and notes
-  accumulate across chats by design.`;
+Your fixed working directory is \`${agentHome}\`. It is shared persistent state
+for this agent, so files, caches, and notes persist across tasks. Use
+**absolute** paths so subdirectory changes do not break references.`;
 }
 
 function sourceRepositoriesBlock(sourceRepos: ReadonlyArray<PredeclaredSourceRepo>): string {
   const lines: string[] = ["## Source Repositories (agent-managed, bare)", ""];
   lines.push(
-    "The following repositories are declared for this agent at the listed",
-    "paths. **You manage these clones yourself** — First Tree never runs git",
-    "on your behalf (no auto-clone, no auto-update):",
+    "The following source repos are declared for this agent. **You manage these clones yourself**",
+    "— First Tree does not auto-clone, auto-fetch, or update worktrees:",
   );
   lines.push("");
   for (const repo of sourceRepos) {
@@ -470,171 +434,23 @@ function sourceRepositoriesBlock(sourceRepos: ReadonlyArray<PredeclaredSourceRep
   }
   lines.push("");
   lines.push(
-    "Each path is a **bare** clone — a git object store with no working",
-    "tree. You never read or write files at the clone path directly;",
-    "**every read AND write happens inside a worktree** you create off it",
-    "(see `## Worktrees`). Bare is deliberate: with no checked-out files",
-    "the clone can never go stale-mislead or dirty, and concurrent chats",
-    "can't trip over a shared working tree.",
+    "Each path is a **bare** clone under `source-repos/`. Never read or write files there;",
+    "every source read/write goes through a worktree (see `## Worktrees`).",
     "",
-    "Management protocol (shared by every chat of this agent):",
-    "",
-    "1. **Ensure** — if a listed path is missing, create it as a bare clone.",
-    "   Each listed path is an immediate child of your workspace's",
-    "   `source-repos/` directory (`<workspace>/source-repos/<name>`). Create the",
-    "   `source-repos/` parent first, then clone into it:",
-    "",
+    "**Protocol:**",
+    "1. **Ensure missing clones** under the declared path:",
     "   ```bash",
-    '   mkdir -p "$(dirname <path>)"   # ensure the source-repos/ parent exists',
+    '   mkdir -p "$(dirname <path>)"',
     "   git clone --bare <url> <path>",
     "   git -C <path> config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'",
     "   git -C <path> fetch origin",
     "   ```",
+    "2. **Verify before reuse — fail closed on mismatch.** If `<path>` exists, run `git -C <path> remote get-url origin` and compare it canonically with the declared URL (ignore trailing `.git` and https/http/ssh/git/scp transport differences). If it does **not** match, stop: do not fetch, add a worktree, delete, re-clone, or re-point. Report both URLs.",
+    "3. **Refresh before worktrees** with `git -C <path> fetch origin`.",
+    "4. **Credential failures are reportable.** Tell a human what failed; continue only with safe local state.",
     "",
-    "   The refspec + fetch populate `refs/remotes/origin/*` so worktrees can",
-    "   branch off `origin/<default>`.",
-    "2. **Verify before reuse — fail closed on a repo mismatch.** If the path",
-    "   **already exists**, do NOT blindly reuse it. The same `localPath` can be",
-    "   repointed to a different `url` in config, so first confirm the existing",
-    "   clone is the SAME repo as the declared `url` above:",
-    "",
-    "   ```bash",
-    "   git -C <path> remote get-url origin",
-    "   ```",
-    "",
-    "   Compare that to the declared `url` canonically (ignore a trailing",
-    "   `.git` and the http/https/ssh form). **If it matches**, reuse the clone",
-    "   as-is — never delete or re-clone it (sibling chats may hold worktrees",
-    "   rooted in it). **If it does NOT match** — the directory was cloned from",
-    "   a different repo — STOP: do not fetch, do not add a worktree, and do",
-    "   NOT delete, re-clone, or re-point it (a sibling chat may have a worktree",
-    "   on the old repo). Report the mismatch to a human in the chat (declared",
-    "   `url` vs. the clone's actual `origin`) and stop using that source until",
-    "   they resolve it. Silently serving worktrees off the wrong repo is the",
-    "   exact failure this guard exists to prevent.",
-    "3. **Refresh** — once the clone is confirmed to match (or you just created",
-    "   it), before creating any worktree run `git -C <path> fetch origin` so",
-    "   `origin/<default>` is current.",
-    "4. **Read through a worktree, not the clone path.** A bare clone has no",
-    "   files to read. To read source — `grep`, `cat`, `git log`, or a",
-    "   shipped skill scan (`first-tree-seed`) — create a",
-    "   read worktree off `origin/<default>` (or the pinned `ref`), read",
-    "   inside it, and remove it when done. To write, create a task worktree",
-    "   on a new branch. Both flows are in `## Worktrees`.",
-    "5. **Credential failures are reportable events** — if clone/fetch fails",
-    "   with an auth error, tell a human in the chat what failed and continue",
-    "   with what you have locally; do not retry silently.",
-  );
-  lines.push(
-    "",
-    "**One-time legacy-layout migration — do this once, and only in your",
-    "OWN workspace.** Some agents were first provisioned with a single",
-    "**non-bare** checkout as an immediate child of the workspace root",
-    "(`<workspace>/<source-name>`) instead of a bare clone under",
-    "`source-repos/`, often with task worktrees hanging off it. If you find",
-    "one, migrate it — never reach into a sibling agent's workspace. Create",
-    "the bare clone per **Ensure** above (its new home is",
-    "`<workspace>/source-repos/<source-name>`), then retire the legacy",
-    "checkout.",
-    "",
-    "Retiring is irreversible, so clear **two** bars in order before",
-    "touching anything. First a **path preflight** that proves the target is",
-    "exactly the intended legacy checkout — derived from the manifest, not a",
-    "hand-typed path. Only if that passes do the **git-state gates** prove",
-    "the checkout holds no unmigrated work. The preflight matters because a",
-    "mistaken target (the workspace root, `context-tree`, `source-repos`,",
-    "`worktrees`, `.first-tree`, an unbound sibling, or another repo that is",
-    "also clean + merged) would otherwise sail through the git-state gates",
-    "and get the wrong data quarantined.",
-    "",
-    "Path preflight — resolve the workspace root from its manifest, derive",
-    "`$legacy` from the declared source name, and validate it. The per-source",
-    "calls at the end are baked from your manifest; act only on a `$legacy`",
-    "that printed `ok:`:",
-    "",
-    "```bash",
-    "# Resolve the workspace root from its manifest — never hand-type it.",
-    "WS=; d=$PWD",
-    'while [ "$d" != / ]; do',
-    '  [ -f "$d/.first-tree/workspace.json" ] && { WS=$(realpath "$d"); break; }',
-    '  d=$(dirname "$d")',
-    "done",
-    '[ -n "$WS" ] || echo "stop: no .first-tree/workspace.json at or above $PWD"',
-    "",
-    "# Canonicalize a GitHub remote URL to host/path so the `.git` suffix and",
-    "# the https/http/ssh/git/scp transport forms all compare equal (the same",
-    "# canonical match the reuse guard above requires, per #1086).",
-    "canon_url() {",
-    "  printf '%s' \"$1\" | sed -E 's#\\.git$##; s#^(ssh|git|https?)://##; s#^[^/@]*@##; s#^([^/:]+):#\\1/#'",
-    "}",
-    "",
-    "# Validate ONE candidate. Args: <source-name> <declared-origin-url>.",
-    "# Clears $legacy on entry and republishes it only after EVERY gate passes,",
-    "# so a rejected/failed call cannot leave a stale target for the gates below.",
-    "assert_legacy_target() {",
-    "  name=$1 want=$2 legacy= candidate=$WS/$name",
-    "  case $name in",
-    "    ''|.|..|*/*) echo \"reject: bad source name '$name'\"; return 1;;",
-    "    .first-tree|source-repos|worktrees|context-tree)",
-    "      echo \"reject: reserved workspace dir '$name'\"; return 1;;",
-    "  esac",
-    '  [ -e "$candidate" ] || { echo "skip: nothing at $candidate"; return 1; }',
-    '  [ -L "$candidate" ] && { echo "reject: $candidate is a symlink"; return 1; }',
-    '  real=$(realpath "$candidate")',
-    '  [ "$real" = "$WS" ] && { echo "reject: target is the workspace root"; return 1; }',
-    '  [ "$(dirname "$real")" = "$WS" ] \\',
-    '    || { echo "reject: $real is not an immediate child of $WS"; return 1; }',
-    '  top=$(git -C "$candidate" rev-parse --show-toplevel 2>/dev/null) \\',
-    '    || { echo "reject: $candidate is not a git checkout"; return 1; }',
-    '  [ "$top" = "$real" ] || { echo "reject: $candidate sits inside another repo ($top)"; return 1; }',
-    '  [ "$(git -C "$candidate" rev-parse --is-bare-repository 2>/dev/null)" = false ] \\',
-    '    || { echo "reject: $candidate is bare, not a flat checkout"; return 1; }',
-    '  got=$(git -C "$candidate" remote get-url origin 2>/dev/null)',
-    '  [ "$(canon_url "$got")" = "$(canon_url "$want")" ] \\',
-    "    || { echo \"reject: origin '$got' != declared '$want'\"; return 1; }",
-    "  legacy=$candidate",
-    '  echo "ok: $legacy"',
-    "}",
-    "",
-    "# One call per declared source — values baked from your manifest:",
-  );
-  for (const repo of sourceRepos) {
-    const sourceName = repo.absolutePath.split("/").filter(Boolean).pop() ?? "";
-    lines.push(`assert_legacy_target ${shellQuote(sourceName)} ${shellQuote(repo.url)}`);
-  }
-  lines.push(
-    "```",
-    "",
-    "Git-state gates — run only for a `$legacy` the preflight passed (re-run",
-    "`assert_legacy_target` to set `$legacy`). Clear the same zero-data-loss",
-    "bar for **everything** the retire would destroy: its linked worktrees,",
-    "its own working tree, AND any local-only history in its `.git` (branches",
-    "checked out in no worktree, plus stashes). If any check below is",
-    "non-empty, stop — push / migrate that work or ask a human:",
-    "",
-    "```bash",
-    'git -C "$legacy" fetch origin        # refresh origin/<default> so the merge checks are real',
-    'git -C "$legacy" worktree list       # the checkout + every worktree on it',
-    "# each LINKED worktree — clean + already merged, then drop it:",
-    "git -C <wt> status --porcelain       # empty ⇒ no uncommitted work",
-    'git -C "$legacy" merge-base --is-ancestor <wt-HEAD> origin/<default>  # exit 0 ⇒ already merged',
-    'git -C "$legacy" worktree remove <wt>  # repeat per worktree; refuses if dirty',
-    "# the checkout ITSELF — `worktree remove` won't touch a main tree, and the",
-    "# move below also carries local-only refs/stashes; clear the full bar by hand:",
-    'git -C "$legacy" status --porcelain  # empty ⇒ no uncommitted work',
-    'git -C "$legacy" merge-base --is-ancestor HEAD origin/<default>  # exit 0 ⇒ HEAD merged',
-    'git -C "$legacy" branch --no-merged origin/<default>  # empty ⇒ no unmerged local branch',
-    'git -C "$legacy" stash list          # empty ⇒ no stashed work',
-    "# Quarantine, don't delete — keep the retire reversible:",
-    'mv -- "$legacy" "$legacy.retired.$(date +%Y%m%d%H%M%S)"  # only after ALL of the above are clear',
-    "```",
-    "",
-    "The quarantined `*.retired.*` directory is harmless to leave in place;",
-    "the irreversible `rm -rf` of it is a separate step a human confirms once",
-    "they are satisfied nothing was lost.",
-    "",
-    "The legacy `context-tree` **symlink** migrates the same one-time way —",
-    "see `## Tree Location` (remove the symlink only, then clone).",
+    "**Legacy non-bare workspace checkout.** If you find `<workspace>/<source-name>`, stay inside **your own workspace** and retire it only after: path preflight from `.first-tree/workspace.json` rejects symlinks, reserved workspace dirs (`.first-tree`, `source-repos`, `worktrees`, `context-tree`), non-immediate children, nested/bare repos, and origin mismatches; git-state gates show clean worktrees/checkout (`status --porcelain`), merged history (`merge-base --is-ancestor ... origin/<default>`), no local-only branches (`branch --no-merged origin/<default>`), and no stashes (`stash list`).",
+    'When every gate is clear, quarantine rather than delete: `mv -- "$legacy" "$legacy.retired.$(date +%Y%m%d%H%M%S)"`. If unsure, stop and ask/report; never use `rm -rf`. A legacy `context-tree` symlink follows Tree Location: remove only the symlink, then clone.',
   );
   return lines.join("\n");
 }
@@ -651,12 +467,9 @@ function worktreesBlock(agentHome: string, sourceRepos: ReadonlyArray<Predeclare
   const taskWorktreePath = shellQuote(`${agentHome}/worktrees/<task-name>`);
   return `## Worktrees (how you read AND write a bare source repo)
 
-The source clones are **bare**, so every read and every write goes
-through a worktree you create off the bare clone and remove when done.
-**No worktrees are pre-created.**
+Source clones are **bare**. Every source read/write happens in a worktree you create off the clone. **No worktrees are pre-created.**
 
-**Read worktree** — grep / browse / a skill scan, off the latest default
-branch:
+**Read worktree** — for grep, browsing, logs, or a skill scan:
 
 \`\`\`bash
 # <source> is one of the bare clone paths listed under Source Repositories, e.g. ${exampleSource}
@@ -666,145 +479,72 @@ git -C <source> worktree add ${readWorktreePath} origin/main
 git -C <source> worktree remove ${readWorktreePath}
 \`\`\`
 
-**Task (write) worktree** — one per task, frozen for the PR's life:
+**Task worktree** — one per task branch, frozen for the PR's life:
 
 \`\`\`bash
 git -C <source> fetch origin
 git -C <source> worktree add ${taskWorktreePath} -b <new-branch> origin/main
 \`\`\`
 
-Replace \`<source>\`, \`<name>\`, \`<task-name>\`, \`<new-branch>\`, and
-\`origin/main\` to fit. A pinned \`ref\` (when listed in Source Repositories)
-is the base to branch from instead of \`origin/main\`.
-
-- **Frozen for the task's life**: a task worktree stays on its branch
-  point for the whole PR — do not rebase/merge \`origin/main\` into it
-  mid-task unless a human asks.
-- **Cleanup is yours**: remove a read worktree as soon as the read is
-  done; remove a task worktree when the task closes (PR merged or
-  abandoned) with \`git -C <source> worktree remove <path>\`. Sweep stale
-  worktrees of finished tasks when you notice them.`;
+Replace placeholders to fit. If a repo declares a pinned \`ref\`, branch
+from that ref instead of \`origin/main\`. Do not rebase/merge mid-task
+unless a human asks. Remove read worktrees after use and task worktrees
+when the PR closes.`;
 }
 
 function communicationBlock(bin: string): string {
   return `## Communication
 
-\`chat send\` reaches any teammate — agent or human. A human also has two
-intent-specific channels: \`chat ask\` (decisions) and \`chat update
---description\` (progress). Decision guide (based on participant \`type\` in
-the Current Chat Context block):
+\`chat send\`, \`chat ask\`, and \`chat update\` are real CLI commands that
+deliver words/status to teammates. A business action changes the workspace
+or outside world; "hold off" scopes business actions, not the required
+reply transport for a human-directed turn.
 
-A reply-transport command — \`chat send\`, \`chat ask\`, or \`chat update\` — is
-a real command you run with the chat CLI, the same execution path you use for
-any other tool; running it delivers your words to a teammate. A business action
-is anything that changes the workspace or the world beyond that delivery. When a
-teammate asks you to hold off from acting, that scope governs changes to things,
-while running the chat CLI to deliver your reply stays the way you finish a
-human-directed turn, because that delivery changes nothing beyond placing your
-message in the chat.
+| Situation | Use | Rule |
+|---|---|---|
+| Human asks / reports something and no answer is needed from them | \`${bin} chat send <human> -f markdown -F <file>\` | Send exactly one self-contained reply before ending the turn. |
+| Your next step depends on a human decision, approval, or answer | \`${bin} chat ask <human> -F <file>\` | Blocking questions never ride inside plain \`chat send\`; route by dependency, not importance. |
+| Progress/status during longer work | \`${bin} chat update --description -\` | Update status instead of streaming repeated plain sends. |
+| Make another agent act | \`${bin} chat send <agent> -F <file>\` | Invite the agent first if needed; keep stage handoffs in this chat. |
+| Agent wake-up with nothing new to act on | no send | Do not send courtesy acknowledgements to agents. |
 
-- **Replying to a human is required, not optional** → when a human directs a
-  message at you, end the turn with one \`${bin} chat send <name> "..."\`
-  carrying the result — what you did, decisions made, non-human blockers you
-  are waiting out (CI, another agent), and the next step —
-  gathered into ONE concise message. A turn that ends without it is, to the
-  human, no reply at all. A plain send is informational, raises no red dot,
-  and never auto-wakes the human, so there is no loop risk in always answering.
-  A send must be self-sufficient: the human can read it and move on — nothing
-  in it waits for their answer. If the turn instead ends blocked on the human,
-  the turn-ending message is a \`chat ask\` whose body carries the report as
-  background (see \`## Asking Humans\`), never a send with a blocking question
-  folded in.
-- **Don't stream a human through repeated \`chat send\`.** Within a turn, send
-  at most one plain human reply; merge related updates into that single
-  message, and use \`${bin} chat update --description\` for ongoing
-  progress/status. The one case where you skip a human reply entirely is a turn
-  with genuinely nothing to answer — a re-delivery of a message you already
-  handled, or a system / no-op wake-up — not merely because you judge a fresh
-  human message already covered.
-- **Asking a human** for a decision, approval, or answer → \`${bin} chat ask
-  <human>\` (see \`## Asking Humans\` for the required body structure). The
-  message body IS the ask. This raises a tracked open question (red-dot /
-  open-request count) and blocks the chat for them until they answer. Route by
-  dependency, not importance: use this — not a plain send — whenever the human
-  must decide, approve, or answer before you proceed, no matter how small the
-  question feels.
-- **Reporting progress to a human** → \`${bin} chat update --description
-  "..."\` (see \`## Chat Topic & Description\`).
-- **Reaching an agent to make them act** → \`${bin} chat send <name> "..."\`.
-  Agents only act on explicit \`chat send\`. If the agent is not already in
-  this chat, first run \`${bin} chat invite <name>\`, then send normally. A
-  stage or role handoff inside the same task stays in this chat; do not create
-  a new chat just to move the task from one agent to another.
-- **Starting separate work** → \`${bin} chat create --to <name> "..."\` only
-  when the work should have its own task-conversation boundary.
-- After an agent handoff, continue only independent work. If their reply is the
-  only remaining input, end the turn and wait to be woken; do not poll status
-  or escalate on delayed replies alone.
-- **Don't fire a courtesy \`chat send\` between agents.** If an agent wake-up
-  leaves nothing new to act on, end the turn without sending — agent↔agent "got
-  it" replies are how loops start. This brake is for agents: a human who
-  directed a message at you still gets a reply (first bullet). The list above is
-  exhaustive for the *send* side.
+Every \`chat send\` names a recipient; group chats reject no-recipient
+sends, and \`@name\` in content is not enough.
+Start separate work with \`${bin} chat create --to <name>\` only when the
+work needs its own task boundary. After an agent handoff, continue only
+independent work; do not poll solely because that agent has not replied.
 
-Every \`chat send\` names a recipient — there is no no-mention send. A group
-chat rejects a message that addresses no one; pass \`<name>\` to @mention the
-recipient.
-
-**Why a rich body goes through a file or stdin.** An inline \`"..."\` body is
-parsed by the shell before the CLI runs: it executes backticks and \`$(...)\`,
-expands \`$VAR\`, ends the string early on a quote, and collapses a botched
-heredoc into residue like a bare \`@EOF\` — silent corruption the CLI cannot see
-or repair. A file (\`-F <path>\`) or a pipe (stdin) hands the bytes to the CLI
-untouched, so backticks, quotes, \`$\`, and newlines arrive verbatim; \`chat
-update\` takes its description the same way via \`--description -\`. For the same
-reason pass the body as a raw string and never \`JSON.stringify\` it — outer
-quotes plus \`\\n\` escapes persist as a literal \`"@x ...\\n..."\` row the UI
-cannot render as markdown (Issue #389).`;
+**Rich bodies use files or stdin.** Inline \`"..."\` is parsed by the shell:
+backticks and \`$(...)\` execute, \`$VAR\` expands, quotes can end the string,
+and broken heredocs leave \`@EOF\`. A file/stdin preserves Markdown, code,
+quotes, dollars, and newlines. Pass raw strings, never \`JSON.stringify\`;
+escaped \`\\n\` rows caused the Issue #389 double-encode failure. Use
+\`-f markdown\` when you want Markdown rendering.`;
 }
 
 function workspaceCollaborationBlock(bin: string): string {
   return `## Workspace Collaboration
 
-The Communication block above is the in-agent contract for \`chat send\`,
-\`chat ask\`, and \`chat update\`: sends reach any teammate, asks put a
-tracked question to a human, no courtesy sends, and raw markdown bodies.
-For flags, stdin
-forms, history, invite, and related command details, use
-\`${bin} chat --help\` and the relevant subcommand help.
+The Communication matrix is the in-agent contract for teammate delivery:
+\`chat send\` reaches humans or agents, \`chat ask\` raises tracked human
+decisions, \`chat update --description\` reports progress, and agent no-op
+wake-ups do not get courtesy sends. For flags, stdin forms, history, invite,
+and related details, use \`${bin} chat --help\` and subcommand help.
 
-Substitute this agent's CLI binary, \`${bin}\`, anywhere external docs
-show the literal \`first-tree\`.`;
+Substitute this agent's CLI binary, \`${bin}\`, anywhere docs show the
+literal \`first-tree\`.`;
 }
 
 function githubWorkingPostureBlock(): string {
   return `## GitHub Working Posture
 
-For GitHub URLs, PRs, Issues, Actions runs, repo metadata, comments, and
-ordinary PR / Issue creation, try the host \`gh\` CLI first when available.
-GitHub URLs are not, by themselves, a reason to ask for First Tree GitHub App
-installation or repo authorization.
+For GitHub URLs, PRs, Issues, Actions runs, repo metadata, comments, and ordinary PR / Issue creation, try the host \`gh\` CLI first. A GitHub URL is not by itself a reason to ask for First Tree GitHub App installation or repo authorization.
 
-If \`gh\` is missing, unauthenticated, or lacks access, explain that specific
-capability gap and choose the narrowest non-platform recovery first: local
-clone path, GitHub CLI install, or \`gh\` auth/access.
+If \`gh\` is missing, unauthenticated, or lacks access, report that gap and choose the narrowest recovery: local clone path, GitHub CLI install, or \`gh\` auth/access. Ask for First Tree GitHub access only for platform capabilities such as webhook following, team repo resources, Context Tree provisioning, installation-token access, or cross-session/team access. If the current member is not an org admin, do not ask them to install the GitHub App or bind repos/trees; continue with local path / host \`gh\`.
 
-Ask for First Tree GitHub access only when the desired outcome needs platform
-capabilities beyond this local session: follow, webhook events, team repo
-resources, Context Tree provisioning, installation-token repo access, or
-cross-session/team access.
-
-If the current member is not an org admin, do not ask them to install the
-GitHub App, change repo authorization, or create/bind a Context Tree. Explain
-that those are admin-owned team setup actions and continue with local path /
-host \`gh\` when possible.
-
-Do not use agent-accessible local files or tree snapshots as a hidden server
-sync path. User-visible task output is fine; background bulk upload is not.`;
+Do not use local files or tree snapshots as a hidden server sync path.`;
 }
 
-// Inline (not skill-only) on purpose: the follow-after-create default has to
-// fire at PR/issue-creation time, and progressive disclosure of the
 // Inline on purpose: the follow-after-create default has to fire at
 // PR/issue-creation time. Without this always-present rule, agents create
 // entities and never wire their event streams (the session-event auto-binder
@@ -813,231 +553,81 @@ sync path. User-visible task output is fine; background bulk upload is not.`;
 function githubAttentionBlock(bin: string, _treeBound: boolean): string {
   return `## GitHub Entity Attention
 
-Creating a PR or issue **never** follows it — no creation path
-(\`gh pr create\`, curl, GitHub MCP, the web UI) wires anything for you,
-and there is no auto-binding. Declaring the dependency is your job:
+Creating a PR or issue **never** follows it; \`gh pr create\`, curl, GitHub MCP, and the web UI do not auto-bind the entity to this chat.
 
-- **Default: follow what you create.** Immediately after creating a PR or
-  issue — in the same breath as creation — wire it into the current chat:
+- **Default: follow what you create.** After creating a PR or issue for this task, wire it into the current chat:
 
       ${bin} github follow <url>
 
-  Skip the follow only when the entity is clearly unrelated to this
-  chat's task.
+  Skip the follow only when the entity is clearly unrelated to this chat's task.
 - **If the follow fails because the org has not installed the First Tree
-  GitHub App**, do not dismiss it as "no action needed." You just delivered
-  something the user cares about (the PR/issue) — treat installing the App as
-  an optional value upgrade, in plain product language: it makes this entity's
-  live activity (CI results, review comments, merge) flow back into this chat,
-  and lets future PRs or issues you follow flow back here too (the App is
-  required for that; you still follow each one). Installing is an org-admin
-  action, so route by who you are talking to: if the human can set up the team
-  (an org admin — e.g. from the onboarding greeting), point them to
-  **Settings → GitHub** in the First Tree web app (you cannot mint the install
-  link yourself); if they are not an admin or you are unsure, say an
-  organization admin can enable it and offer to hand over the exact steps. Be
-  honest — it is optional and the PR/issue works either way — and never surface
-  the raw error code or \`github follow\` mechanics to the user. Say it in a
-  tight line or two, not a wall of text; users skim.
+  GitHub App**, explain the optional value upgrade in product language: live
+  PR/issue activity (CI, reviews, merge) can flow back into this chat after an
+  org admin enables **Settings → GitHub** in the First Tree web app. Do not
+  expose raw error codes or \`github follow\` mechanics; say the PR/issue still
+  works either way.
 - **Unfollow only when the human explicitly asks to stop tracking** the
-  entity (\`${bin} github unfollow <entity>\`). Do not proactively unfollow
-  merely because a PR or Issue completed, merged, or closed; terminal
-  entities may still carry aftermath this chat should hear.
+  entity (\`${bin} github unfollow <entity>\`). Do not proactively unfollow merely because a PR or Issue completed, merged, or closed.
 
-For the full flag surface, upstream-dependency follows, \`409\` /
-\`--rebind\` conflict handling, and the error contract, see
-\`${bin} github follow --help\` / \`${bin} github unfollow --help\`.`;
+For upstream-dependency follows, \`409\` / \`--rebind\`, and full flags, see
+\`${bin} github follow --help\` and \`${bin} github unfollow --help\`.`;
 }
 
 function askingHumansBlock(bin: string): string {
   return `## Asking Humans
 
-When you need something only a human can give — a decision, sign-off, or an
-answer — use **\`chat ask\`**, never a question folded into a plain send.
-\`chat ask\` raises a tracked open question on the
-human's side (red-dot / open-question count) AND **blocks that chat for the
-human**: their UI pins the question and hides every message after it until
-they answer, so the ask cannot be scrolled past. When several questions are
-open for them, they clear them oldest-first.
+Use **\`chat ask\`** only when your next step depends on a human decision,
+sign-off, or answer. It raises a tracked open question and blocks that chat
+for the human. Do not put a blocking question inside plain \`chat send\`; use
+\`${bin} chat ask <human> -F <file>\`.
 
-The routing test is **dependency, not importance**: the moment your next step
-depends on the human's answer, the question goes through \`chat ask\` — always,
-even when it feels too small to "deserve" a tracked question. A blocking
-question inside a \`chat send\` is a mis-routed ask: nothing tracks it, the
-human can scroll past it, and the work silently stalls. Importance governs a
-different call — whether a question should exist at all. Raise only a decision
-that is **genuinely the user's to make** AND **cannot be settled from the
-request, the code, or a reasonable default** — a product/scope fork, a
-safety-sensitive or irreversible action, or ambiguous requirements whose
-branches differ materially. Do NOT manufacture progress or permission checks
-("is the plan ready?", "can I continue?", "does this look right?"): decide,
-proceed, and report status via \`chat update --description\`. The human's
-earlier answers are a source you settle from too — but only when you can
-actually cite them: an answer in the visible transcript, a durable record (a
-Context Tree node, a memory note), or something the human just provided. An
-inferred preference you cannot point to is not evidence; without such a
-source the question is not settled — ask. When a citable pattern shows how
-they decide cases like this one, apply it and report the call instead of
-re-asking. Ask volume should fall as
-you learn how the human decides; interruption that never decreases means you
-are not learning. But once a
-genuine blocking question exists, it is an ask — in no case does it ride in a
-plain send.
+The routing test is **dependency, not importance**. Ask only when the
+decision is genuinely the user's to make and cannot be settled from the
+request, code, durable records, or a reasonable default. Do NOT manufacture
+progress or permission checks ("is the plan ready?", "can I continue?", "does this look right?"). Earlier answers settle a case only when you can cite them; inferred preference is not evidence. Ask volume should fall as you learn. \`chat ask\` is human-directed; reach agents with \`chat send\`.
 
-\`chat ask\` is **human-directed** — the server rejects it
-unless the recipient is a human member, so you cannot open a tracked question
-against another agent (reach agents with \`chat send\`).
+The message **body IS the ask** and must be decision-self-sufficient. Assume
+the human remembers none of the chat and may see the ask alone. Unpack every
+compressed reference and include exactly these sections:
 
-### The body must be decision-self-sufficient
+1. **Why this question exists** — what forced the fork and why you cannot settle it.
+2. **Recent context** — a short recap of the last relevant rounds.
+3. **The question** — one question plus your recommendation, phrased by user
+   consequence rather than implementation label.
 
-The human you are asking runs many chats in parallel and may answer hours or
-days later — possibly on a review surface that shows the ask alone, outside
-the chat. Assume no familiarity with the underlying context, no memory of
-this chat, and no recall of what any shorthand refers to; deciding must not
-require re-living the work. The message **body IS the ask**, and it must
-carry everything needed to decide on its own, structured in three markdown
-sections (written in the session's working language). Unpack every compressed
-reference: a term of art, an internal shorthand, or an option label is
-undecidable not because it is technical but because its meaning lives in
-context the reader does not hold — state what it concretely means and changes
-here. A question the reader can only guess at cannot produce a good
-decision:
+Prefer a free-text answer; omit \`--options\` by default. Add \`--options\`
+(2-4 short \`{label, description, preview?}\` entries) only when each choice
+is mutually exclusive and easy to pick; add \`--multi-select\` only when more
+than one option can be chosen. Use a file or stdin for the multi-line body.
 
-1. **Why this question exists** — what you were doing, what forced the fork,
-   and why you cannot settle it yourself.
-2. **Recent context** — a few-line recap of the last rounds between you and
-   the human (what they asked, what you did, what changed), written for a
-   reader who remembers none of it — not even their own last message.
-3. **The question** — ONE question, plus your recommendation (the option you
-   would pick and why), so a bare "approved" is a complete answer. Phrase
-   each choice by its consequence for the user, not an implementation label.
-
-A one-line ask ("which option?", "ok to proceed?") defeats the channel: it
-forces the human to reconstruct your context by scrolling. A well-formed ask
-body is inherently multi-line — pipe it via stdin or \`--message-file\`:
-
-\`\`\`bash
-cat <<'EOF' | ${bin} chat ask <human>
-## Why this question exists
-...
-## Recent context
-...
-## The question
-... (+ the option you would pick, and why)
-EOF
-\`\`\`
-
-### Prefer a free-text answer; add options only when each is a clean pick
-
-By DEFAULT ask a free-text question — **omit \`--options\`**. Dense option lists
-are hard to choose from: when the choices carry a lot of information or overlap
-in meaning, the human cannot weigh them at a glance, so a free-text answer is
-the better ask.
-
-\`\`\`bash
-${bin} chat ask <human> -F ask-body.md \\
-  --options '[{"label":"Ship","description":"Roll to 20% now"},{"label":"Hold","description":"Wait 24h"}]'
-\`\`\`
-
-Add \`--options\` (a JSON array of 2–4 \`{label, description, preview?}\`) **only**
-when every option is semantically single — a short, unambiguous,
-mutually-exclusive pick (e.g. Approve / Hold, Friday / Monday). Add
-\`--multi-select\` (requires \`--options\`) to let them pick more than one. If an
-option needs a clause to be understood, or two options could both be "right",
-drop the options and let them answer in free text.
-
-### How it resolves
-
-**You only ask — the human resolves.** The human answers in their web UI, and
-**any answer resolves the question**: picking an option OR typing free text both
-clear the red dot and unblock the chat. Their answer comes back to you as the
-resolving reply — the question does not linger in a separate "discuss" state. An
-agent **cannot** mark a question answered or close it (there is no resolve
-command); resolution is entirely the human's web answer. If their answer pushes
-back or you need more, **re-ask**: a new \`chat ask\` opens a fresh question (and a
-fresh block). Re-asking never auto-supersedes the old one; if a prior ask is now
-moot, just leave it and re-ask (the human works open questions oldest-first).
-A re-ask is a fresh ask: it carries the full self-sufficient body again (the
-pushback becomes part of its Recent context), never a bare follow-up line.`;
+The human resolves the question in the web UI; an agent cannot mark a
+question answered or close it. If you need a new answer after pushback,
+open a fresh \`chat ask\` with a full self-sufficient body.`;
 }
 
 function chatTopicBlock(bin: string): string {
   return `## Chat Topic & Description
 
-Each chat carries two pieces of self-describing metadata, both set
-through the **\`chat update\`** command — topic and description update
-independently:
+Each chat has two self-describing metadata fields, both maintained with
+\`chat update\` and both visible in the provider-injected "Current Chat Context":
 
-- **topic** — a short (≤ 30 chars) label the workspace chat list shows,
-  e.g. "调研 chat rename 方案" or "本周 ship 计划".
-- **description** — the chat's work summary **and** status report. It
-  serves two readers at once: you (or a teammate) reconstructing what the
-  task is and where it stands, **and** the human reading the current task
-  status. It carries the task's **background + plan + progress**, renders
-  as **Markdown**, and shows by default at the top of the chat's right
-  sidebar.
+- **topic** — short, stable label for the chat list.
+- **description** — Markdown work summary and status report: background,
+  plan, progress, and current blockers that are not human decisions.
+Use \`${bin} chat update --topic "<short label>"\` and
+\`${bin} chat update --description "<task background + plan + progress>"\`;
+\`chat set-topic\` is a deprecated alias.
 
-Both current values appear in the provider-injected "Current Chat Context"
-JSON payload as \`topic\` / \`description\` properties, with \`null\` meaning
-unset.
+Maintain these only when you own the chat: you created it, or no agent owner
+is present because a human created it or the creator left. If topic is unset,
+set one before ending the turn; once set, leave it stable. Keep description
+current only on substantive progress, within 1500 characters, in the session
+language. Do not put human decisions in the description; use
+\`${bin} chat ask <human>\`. Self-locate with \`${bin} chat list\` and
+\`${bin} chat history <chat>\`.
 
-    ${bin} chat update --topic "<short label>"
-    ${bin} chat update --description "<task background + plan + progress>"
-    ${bin} chat update --topic "<label>" --description "<state>"
-
-(\`chat set-topic\` is a retained deprecated alias — prefer \`chat update\`.)
-
-**Only the chat's owner maintains these — and you count as the owner in
-two cases:** (a) you created the chat, or (b) no agent owner is present —
-a **human** created it (Web-created and GitHub-minted chats both work
-this way) or the creating agent has since left. There every worker agent
-in the chat counts as the owner and maintains these fields on the
-owner's behalf. Only when **another agent** created the chat and is
-still in it are you not the owner: you are **not** asked to set or
-refresh them, and the command refuses you with a 403 — leave them to
-that agent. Rules 1–2 below are the owner's duty; rules 3–4 apply to
-everyone (reading a description to self-locate needs no ownership).
-
-**Hard rules:**
-
-1. **(Owner) Topic unset → set one before ending this turn.** The auto-derived
-   fallback ("first 50 chars of the first message" / "alice, bob-bot")
-   is rarely distinctive — naming the chat is a cheap win.
-
-   **Once set, leave the topic unchanged.** Users and agents locate a
-   specific chat by its topic, so a stable topic helps humans find the chat
-   again quickly. Do not rename an existing topic to track progress, reflect
-   a passing focus, or restate a changed subject. Progress and current scope
-   belong in the description, not the topic.
-
-2. **(Owner) Description → keep it current as a status report.** The
-   description is **meant to move with the work**, but refresh it only on
-   **substantive progress** — rewrite it in place (the message history is
-   the log), not as busywork. **If nothing substantive changed this turn,
-   keep working rather than re-touching the description.** Keep it within
-   **1500 characters** and cover the task's **background + plan +
-   progress**, leading with the concrete current task ("reviewing PR #X")
-   so anyone scanning \`${bin} chat list\` — and the human reading it as a
-   status report — knows what this is and where it stands. **Keep blockers
-   and decisions OUT of the description**: when you need a human decision,
-   sign-off, or answer, raise a \`${bin} chat ask <human>\` instead. Markdown
-   is supported (bullets, bold, links).
-
-3. **Language follows the session's working language** — Chinese
-   session, Chinese description; English session, English.
-
-4. **Self-locate by reading descriptions.** When you wake unsure where
-   a thread stands, or hold several chats and must choose what to
-   advance, run \`${bin} chat list\` and read each description to
-   reconstruct what you've done / what's in flight, then drill in with
-   \`${bin} chat history <chat>\`. If you own the chat, refresh any
-   description that no longer matches what the thread has actually done.
-
-**Exception: GitHub-sourced topics — leave them alone.** Topics like
-\`PR repo#307: title\`, \`Issue repo#42\`, \`Commit repo@sha\` are
-auto-set and kept in sync by First Tree from the upstream entity;
-overriding the topic loses the repo / entity-id anchor. This applies to
-the **topic only** — the owner still maintains the description.`;
+Leave GitHub-sourced topics such as \`PR repo#307: title\`, \`Issue repo#42\`,
+and \`Commit repo@sha\` unchanged; the owner still maintains the description.`;
 }
 
 function cliOverviewBlock(bin: string): string {
@@ -1048,26 +638,8 @@ function cliOverviewBlock(bin: string): string {
   // namespace is operator-only and not surfaced to in-agent use.
   return `## CLI Overview
 
-The \`${bin}\` CLI spans two arms — **workspace collaboration** (talking
-to people and other agents) and **context management** (the Context Tree):
-
-| Namespace | What it owns |
-|---|---|
-| \`${bin} chat …\`   | messaging — \`send\`, \`invite\`, \`list\`, \`history\`, \`update\` |
-| \`${bin} agent …\`  | self-introspection — \`status\`, \`session\`, \`config show\` |
-| \`${bin} daemon …\` | daemon (read-only from inside an agent) — \`status\`, \`doctor\` |
-| \`${bin} github …\` | GitHub entity attention — \`follow\` / \`unfollow\` / \`following\` an entity's event stream for the current chat |
-| \`${bin} tree verify\` | validate a Context Tree's structure |
-| \`${bin} tree tree\` | browse Context Tree nodes as a hierarchy |
-
-Operator-only (\`login\`, \`daemon install\`, \`agent create / bind\`) runs from
-the web console or a human terminal — **never from inside a running agent**.
-Binding a workspace to a Context Tree is operator-owned too, with **one
-sanctioned in-agent exception**: the seed skill's own create + bind, which a
-**confirmed org admin** (with authenticated \`gh\`) runs directly on a
-build-the-tree task — no human hand-off, and never a "who runs the bind?"
-question. Stop and ask a human only if the caller is not an admin or \`gh\` is
-unauthenticated. Full surface: \`docs/cli-reference.md\`.`;
+Use \`${bin} chat …\` for messaging, \`${bin} agent …\` for self-introspection, \`${bin} daemon …\` for read-only daemon status/doctor, \`${bin} github …\` for follow/unfollow/following, \`${bin} tree verify\` for Context Tree validation, and \`${bin} tree tree\` for hierarchy browsing.
+Operator-only commands (\`login\`, \`daemon install\`, \`agent create / bind\`) run from the web console or a human terminal — **never from inside a running agent**. Context Tree binding is operator-owned too, with one sanctioned in-agent exception: on a **build / set up the Context Tree** task, \`first-tree-seed\` may create + bind directly for a **confirmed org admin** with authenticated \`gh\`; ask a human only if the caller is not an admin or \`gh\` is unauthenticated. Full surface: \`docs/cli-reference.md\`.`;
 }
 
 // --- # Context Tree ---------------------------------------------------------
@@ -1085,10 +657,9 @@ function contextTreeSection(
 
 The Context Tree is the team's source of truth for **decisions,
 constraints, ownership, and cross-domain relationships**. Execution
-detail stays in source systems; the tree carries the *what* and *why*
-you need to act correctly across repos and teams. Each domain is a
-directory; each node is a markdown file with frontmatter (\`owners\`,
-\`soft_links\`) plus the actual content.
+detail stays in source systems. The tree carries the durable *what* and
+*why* a future agent must respect. Each domain is a directory; each node
+is Markdown with frontmatter such as \`owners\` and \`soft_links\`.
 
 For node anatomy, ownership tiers, and soft_link navigation, load
 \`first-tree-write\`. For task-scoped file selection and operational
@@ -1096,77 +667,43 @@ read workflow, load \`first-tree-read\`.`);
 
   blocks.push(`## Reading the Tree
 
-**Read the tree before you act on any instruction — every task, even
-ones that look like pure code, CLI, or review work.** An instruction is
-underspecified on its own; in this org the tree supplies the background,
-requirements, and constraints that make acting on it correct.
+When a task has a repo/path/feature/domain/owner/source signal, load
+\`first-tree-read\` before acting. The skill is read-only and requires
+you to inspect \`${getCliBinding().binName} tree tree --help\` inside the tree repo,
+then use \`tree tree\` selectors to find focused files before reading their
+Markdown content with normal file reads.
 
-For the operational reader workflow, load \`first-tree-read\` and use
-the hierarchy command it describes to select focused files. At minimum,
-start at the tree's **root \`NODE.md\`** — the team's domain directory.
-**If the root also contains an \`AGENTS.md\`, read it too** — it carries
-mandatory rules the org expects every agent to follow before acting.
-From there, follow the index / \`soft_links\` down to the nodes your
-task touches.
+At minimum start with the root \`NODE.md\`; **If the root also contains an \`AGENTS.md\`, read it too**
+because it carries org-level rules. Follow
+indexes and \`soft_links\` to the nodes your task touches.
 
 Where the tree's requirements or constraints **conflict with the
 instruction, the tree wins** — follow it and surface the conflict.
-(Local memory is the opposite: it yields to the instruction.)
-
-**Refresh before you read**: the tree clone is yours to keep fresh —
-run \`git pull --ff-only\` in it before every tree read (see
-\`## Tree Location\` for the full protocol). A stale tree is the #1
-source of designs that conflict with current decisions.
-
-Read eagerly, not lazily — acting before reading is the #1 source of
-advice that conflicts with reality. On scope shift to a new
-domain/repo/owner, read those nodes first; in doubt, re-read.`);
+On scope shift to a new domain/repo/owner, read those nodes first. The
+tree hierarchy command normally refreshes with \`git pull --ff-only\`; if
+you read manually, refresh first per Tree Location.`);
 
   blocks.push(`## Writing the Tree
 
-A chat is **fresh context** — the in-the-moment understanding you and
-your teammates build while doing the work. The tree is **persistent
-context** — the durable record the next agent will read in six months.
-The moment your code PR is ready to land, the job is to translate fresh
-context + the code change back into tree context, so the next agent
-picks up where you left off.
-
-When a task calls for a tree write, the request explicitly includes
-creating and updating the needed tree-node files (\`NODE.md\` and other
-\`*.md\` nodes) as structured persistent-context output.
-
-The write trigger is **task completion** — the moment you're ready to
-open the code PR. If the task touched decisions, constraints, ownership,
-or cross-domain relationships, **open the tree PR and the code PR
-together and cross-link them in the PR descriptions**, so a reviewer on
-the code PR can reach the decision and its rationale from the linked
-tree PR; when review reshapes the design, update both PRs together so
-they never describe different things. **Merge the code PR first, then
-the tree PR.** To hold that order, **open the tree PR as a draft**: a
-draft stays cross-linked and fully readable — a code reviewer still
-reaches the decision and rationale from it — but cannot merge, so it
-can't land ahead of the code PR or auto-merge on green. The code PR is
-the source of truth for what was decided, so let it settle first. Once
-the code PR merges, reconcile the tree PR against the **final merged**
-code PR — fold in any last-round review changes so it reflects the
-code's final conclusion, not an earlier draft — then mark the tree PR
-**ready**. Its own review and merge happen at that point, against the
-final code; keep it prompt so the tree does not trail the merged code
-for long.
-Implementation-only changes skip the tree write — not the read.
-
-Before writing, you MUST load the relevant skill first and follow its
-guidance:
-
-| Task | Skill |
-|---|---|
-| Reflect one specific PR / doc / note into the tree | \`first-tree-write\` |
+Tree writes are source-driven. A chat is **fresh context**; the tree is
+**persistent context** for future agents. When a specific PR, design doc,
+meeting note, review thread, or pasted source changes a durable decision,
+constraint, owner, or cross-domain relationship, load \`first-tree-write\`
+and make the smallest correct tree diff. When a task calls for a tree write,
+the request explicitly includes creating and updating the needed tree-node
+files (\`NODE.md\` and other \`*.md\` nodes) as structured persistent-context
+output. Implementation-only changes skip the tree write — not the read.
 
 If there is no specific source artifact, there is no write task yet:
 ask for the PR, design doc, meeting note, or pasted source before
-editing the tree. Do not invent ad-hoc tree edits without loading the
-skill — the operating guide covers staging, review routing, and
-ownership rules you will not remember by default.`);
+editing the tree. Before editing, read the target/parent/soft-linked
+nodes the skill identifies; after editing, run \`${getCliBinding().binName} tree verify\`.
+
+When a code PR and tree PR are both needed, open them together, cross-link
+the PR descriptions, open the tree PR as a draft, merge the code PR first,
+then reconcile the tree PR against the final merged code and mark it ready.
+Do not put PR numbers, commit history, diffs, or implementation details in
+tree node prose.`);
 
   if (contextTreePath) {
     const branch = contextTreeBranch ?? "main";
@@ -1187,7 +724,7 @@ The Context Tree for this workspace lives at:
 
     ${contextTreePath}${upstream}
 
-**You maintain this clone yourself** — the runtime never runs git on it:
+**You maintain this clone yourself** — the runtime never runs git on it.
 
 - **Missing** → clone it:
 
@@ -1196,15 +733,11 @@ The Context Tree for this workspace lives at:
 - **A symlink at this path** (legacy shared-pool layout) → remove the
   symlink itself (\`rm ${quotedPath}\` — this deletes only the link,
   never its target), then clone as above.
-- **Before every tree read** → \`git -C ${quotedPath} pull --ff-only\`.
-  On network/credential failure: use the local copy, and report the
-  failure to a human in the chat. On a dirty-tree failure: the read-only
-  rule below was violated — stash or re-clone, then report.
+- **Refresh** → \`git -C ${quotedPath} pull --ff-only\` before manual
+  reads. On network/credential failure, use the local copy and report it.
 - **Read-only**: never edit this clone in place. Tree writes branch a
-  worktree off it (\`git -C ${quotedPath} worktree add …\`) and go
-  through a PR, per the Writing the Tree rules above.
-
-Read the root \`NODE.md\` first to map the domains before you act.`);
+  worktree off it (\`git -C ${quotedPath} worktree add …\`) and go through
+  a PR.`);
   } else {
     // Tree-less stub. For ordinary tasks, binding stays operator-owned —
     // surface the gap rather than self-serving a bind. The ONE sanctioned

--- a/packages/skill-evals/docs/agent-briefing-manual-eval.md
+++ b/packages/skill-evals/docs/agent-briefing-manual-eval.md
@@ -1,0 +1,42 @@
+# Agent Briefing Manual Eval
+
+This checklist is for manual validation after changing the generated
+workspace `AGENTS.md` briefing. It focuses on agent behavior that is hard to
+fully automate: chat channel choice and First Tree skill routing.
+
+## Run Record
+
+- Branch / commit:
+- Generated `AGENTS.md` line count:
+- Model / provider:
+- Date:
+- Evaluator:
+- Notes:
+
+For each case, keep the transcript plus any command trace. If using a
+skill-evals workspace with the `first-tree-staging` shim, attach
+`events.jsonl`. For tree-writing cases, also attach the tree diff and
+`first-tree tree verify` output.
+
+## Cases
+
+| Case | Prompt shape | Expected behavior | Evidence |
+| --- | --- | --- | --- |
+| `chat-send-human-reply` | A human asks for a non-blocking analysis or result. | The agent ends the turn with exactly one `chat send <human>` reply. Rich Markdown goes through `-F` or stdin, not an inline shell string. | Transcript or shim event showing `chat send <human>` and body transport. |
+| `chat-ask-blocking-decision` | The next step requires a human decision, approval, or answer before work can continue. | The agent uses `chat ask <human> -F ...` or stdin. The ask body includes `Why this question exists`, `Recent context`, and `The question` with a recommendation. It does not hide the blocking question inside `chat send`. | Shim event plus ask body. |
+| `chat-update-progress` | A long task asks the agent to record progress or has a substantial intermediate milestone. | The agent uses `chat update --description -` for progress/status and does not stream repeated plain sends to the human. | Shim event and rendered description. |
+| `agent-handoff` | The task requires another agent to implement or review. | The agent invites/sends the target agent with `chat send <agent>`. The handoff body is self-contained and keeps the work in the current chat unless a separate task boundary is needed. | Shim event and handoff body. |
+| `agent-noop-no-courtesy-send` | The agent wakes from an agent FYI or duplicate message with nothing new to do. | The agent does not send a courtesy acknowledgement to another agent. | No `chat send` event, plus final trace explains no action if needed. |
+| `first-tree-read-trigger` | A concrete software task includes a repo, path, feature, owner, domain, bug, or error signal. | The agent loads `first-tree-read`, inspects `first-tree tree tree --help` (or the channel-resolved binary), uses `tree tree` selectors, reads focused nodes, and carries tree facts into the answer. | Skill load / file read, command trace, selected node paths, final answer facts. |
+| `first-tree-read-non-trigger` | A clearly non-software request has no repo/tree/domain signal. | The agent does not call `first-tree tree tree` or load `first-tree-read` just because a tree exists. | No tree command events; natural answer. |
+| `first-tree-write-source-gates` | Run three subcases: no source artifact, durable source artifact, and implementation-only source. | No source: no tree diff; ask/refuse and request a PR/doc/note/pasted source. Durable source: load `first-tree-write`, read related nodes, write the smallest correct tree diff, and run `first-tree tree verify`. Implementation-only: no tree diff, with a short explanation. | Shim events, tree diff or lack of diff, verify output. |
+
+## Pass Criteria
+
+- Channel choice matches the expected command, not just the final prose.
+- Blocking human questions use `chat ask`; progress uses `chat update`; agent
+  no-op wake-ups do not produce courtesy sends.
+- `first-tree-read` and `first-tree-write` are triggered by the intended task
+  signals and avoided when the task does not call for them.
+- Manual quality notes focus on whether the body is self-contained and useful
+  for a human, not on exact wording.

--- a/packages/skill-evals/src/core/__tests__/select.test.ts
+++ b/packages/skill-evals/src/core/__tests__/select.test.ts
@@ -72,6 +72,51 @@ describe("skill eval selection", () => {
     ]);
   });
 
+  it("recommends related skill behavior baselines for generated briefing changes", () => {
+    const summary = selectSkillEvalRecommendations([
+      "packages/client/src/runtime/agent-briefing.ts",
+      "packages/client/src/runtime/templates/agent-briefing.ejs",
+    ]);
+
+    expect(summary.recommendations).toEqual([
+      {
+        command: "pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-read",
+        kind: "periodic",
+        reason:
+          "packages/client/src/runtime/agent-briefing.ts changes generated briefing text; run related skill behavior baseline",
+        suite: "first-tree-read",
+      },
+      {
+        command: "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write",
+        kind: "gate",
+        reason:
+          "packages/client/src/runtime/agent-briefing.ts changes generated briefing text; run related skill behavior baseline",
+        suite: "first-tree-write",
+      },
+    ]);
+  });
+
+  it("recommends related skill behavior baselines for generated briefing template changes", () => {
+    const summary = selectSkillEvalRecommendations(["packages/client/src/runtime/templates/agent-briefing.ejs"]);
+
+    expect(summary.recommendations).toEqual([
+      {
+        command: "pnpm --filter @first-tree/skill-evals eval:periodic -- --suite first-tree-read",
+        kind: "periodic",
+        reason:
+          "packages/client/src/runtime/templates/agent-briefing.ejs changes generated briefing text; run related skill behavior baseline",
+        suite: "first-tree-read",
+      },
+      {
+        command: "pnpm --filter @first-tree/skill-evals eval:gate -- --suite first-tree-write",
+        kind: "gate",
+        reason:
+          "packages/client/src/runtime/templates/agent-briefing.ejs changes generated briefing text; run related skill behavior baseline",
+        suite: "first-tree-write",
+      },
+    ]);
+  });
+
   it("selects only periodic for shared periodic framework changes", () => {
     const summary = selectSkillEvalRecommendations(["packages/skill-evals/src/core/periodic.ts"]);
 

--- a/packages/skill-evals/src/core/select.ts
+++ b/packages/skill-evals/src/core/select.ts
@@ -137,6 +137,21 @@ function addProviderRecommendations(recommendations: Map<string, EvalRecommendat
   });
 }
 
+function addAgentBriefingRecommendations(recommendations: Map<string, EvalRecommendation>, reason: string): void {
+  addRecommendation(recommendations, {
+    command: periodicCommand("first-tree-read"),
+    kind: "periodic",
+    reason,
+    suite: "first-tree-read",
+  });
+  addRecommendation(recommendations, {
+    command: gateCommand("first-tree-write"),
+    kind: "gate",
+    reason,
+    suite: "first-tree-write",
+  });
+}
+
 function matchingSkill(path: string): ShippedSkillName | null {
   for (const entry of SKILL_BY_PATH) {
     if (entry.paths.some((prefix) => path.startsWith(prefix))) {
@@ -188,6 +203,13 @@ function isSkillEvalDocsOnly(path: string): boolean {
   return path === "packages/skill-evals/README.md" || path.startsWith("packages/skill-evals/docs/");
 }
 
+function isAgentBriefingRuntimePath(path: string): boolean {
+  return (
+    path === "packages/client/src/runtime/agent-briefing.ts" ||
+    path === "packages/client/src/runtime/templates/agent-briefing.ejs"
+  );
+}
+
 export function selectSkillEvalRecommendations(
   changedFilesInput: readonly string[],
   base: string | null = null,
@@ -203,6 +225,14 @@ export function selectSkillEvalRecommendations(
     if (unevaluatedSkill !== null) {
       notes.push(
         `${path} belongs to ${unevaluatedSkill}, a shipped skill intentionally outside skill-evals (see UNEVALUATED_SHIPPED_SKILLS); no eval selected.`,
+      );
+      continue;
+    }
+
+    if (isAgentBriefingRuntimePath(path)) {
+      addAgentBriefingRecommendations(
+        recommendations,
+        `${path} changes generated briefing text; run related skill behavior baseline`,
       );
       continue;
     }


### PR DESCRIPTION
## Summary

- Compress the First Tree managed generated `AGENTS.md` briefing while preserving hard behavior rules for console/outbox routing, `chat send/ask/update`, agent handoff/no-courtesy, rich body `-F`/stdin usage, bare source repo/worktree handling, Context Tree read/write, skill triggers, and generated provenance.
- Rework deterministic `buildAgentBriefing()` tests around structure, compact budgets, and hard markers instead of pinning the old long prose.
- Add `eval:select` recommendations for generated briefing text changes as related `first-tree-read` / `first-tree-write` behavior baselines, and add a manual behavior checklist at `packages/skill-evals/docs/agent-briefing-manual-eval.md`.

## Line Count

A representative codex-architect-shaped generated briefing is now 419 lines (89-line agent prompt, one source repo, tree-bound), down from the previously observed 858 lines.

## Testing

- `pnpm exec biome check packages/client/src/runtime/agent-briefing.ts packages/client/src/__tests__/agent-briefing.test.ts packages/skill-evals/src/core/select.ts packages/skill-evals/src/core/__tests__/select.test.ts packages/skill-evals/docs/agent-briefing-manual-eval.md`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1 src/__tests__/agent-briefing.test.ts`
- `FIRST_TREE_EVAL_VERIFY_BIN=first-tree-staging pnpm --filter @first-tree/skill-evals exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file packages/client/src/runtime/agent-briefing.ts`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file packages/client/src/runtime/templates/agent-briefing.ejs`
- `pnpm --filter @first-tree/shared build && pnpm --filter @first-tree/client build`
- `git diff --check`

## Notes

- Live model eval was intentionally not added or run for this PR. The requested validation path for `chat send/ask/update` and `first-tree-read/write` behavior is the new manual checklist.
- In this workspace, the plain `pnpm --filter @first-tree/skill-evals test` path requires `FIRST_TREE_EVAL_VERIFY_BIN=first-tree-staging` because the global `/usr/local/bin/first-tree` points at a missing portable node path. With that override, the suite passes.
- `codex-reviewer` reviewed the pre-PR diff and found no blocking issues; both review suggestions were addressed before opening this PR.
