### PR TITLE
[codex] Fix disconnect chip healthy client check

### DIFF
--- a/packages/web/src/components/disconnect-chip.tsx
+++ b/packages/web/src/components/disconnect-chip.tsx
@@ -7,10 +7,10 @@ type DisconnectChipProps = {
 };
 
 /**
- * Topbar warning chip — surfaces in `Layout` whenever any of the caller's
- * own computers is disconnected and still has agents bound. Click jumps to
- * the Computers settings page. Renders nothing in the healthy case so the
- * topbar stays clean.
+ * Topbar warning chip — surfaces in `Layout` when none of the caller's local
+ * clients are connected and at least one disconnected computer still has
+ * agents bound. Click jumps to the Computers settings page. Renders nothing in
+ * the healthy case so the topbar stays clean.
  */
 export function DisconnectChip({ compact = false }: DisconnectChipProps) {
   const navigate = useNavigate();

--- a/packages/web/src/hooks/__tests__/use-disconnected-computers.test.ts
+++ b/packages/web/src/hooks/__tests__/use-disconnected-computers.test.ts
@@ -49,10 +49,16 @@ describe("selectDisconnectedComputers", () => {
     expect(selectDisconnectedComputers([mine, theirs], ME)).toEqual([mine]);
   });
 
-  it("excludes rows whose status is connected", () => {
-    const offline = client({ id: "offline" });
-    const online = client({ id: "online", status: "connected" });
-    expect(selectDisconnectedComputers([offline, online], ME)).toEqual([offline]);
+  it("returns empty when the current user has any connected client", () => {
+    const oldClient = client({ id: "old-client" });
+    const currentClient = client({ id: "current-client", status: "connected", agentCount: 0 });
+    expect(selectDisconnectedComputers([oldClient, currentClient], ME)).toEqual([]);
+  });
+
+  it("does not treat another user's connected client as mine", () => {
+    const mine = client({ id: "mine" });
+    const theirs = client({ id: "theirs", userId: OTHER, status: "connected" });
+    expect(selectDisconnectedComputers([mine, theirs], ME)).toEqual([mine]);
   });
 
   it("excludes rows with no bound agents (no-op fleet — not a 'product unusable' case)", () => {
@@ -63,7 +69,7 @@ describe("selectDisconnectedComputers", () => {
 
   it("preserves input order across mixed lists", () => {
     const a = client({ id: "a", hostname: "alpha" });
-    const skip = client({ id: "skip", status: "connected" });
+    const skip = client({ id: "skip", agentCount: 0 });
     const b = client({ id: "b", hostname: "bravo" });
     expect(selectDisconnectedComputers([a, skip, b], ME).map((c) => c.id)).toEqual(["a", "b"]);
   });

--- a/packages/web/src/hooks/use-disconnected-computers.ts
+++ b/packages/web/src/hooks/use-disconnected-computers.ts
@@ -10,12 +10,17 @@ export type DisconnectedSummary = {
 /**
  * Pure filter rule. Exported so the unit test can pin the contract — drift
  * here changes when the topbar warning shows up. Scope is strictly the
- * caller's own clients (no admin widening); only computers that were
- * actively serving agents and are now offline qualify.
+ * caller's own clients (no admin widening). A connected client means the
+ * operator still has a usable local computer, so stale disconnected rows from
+ * an older local client should not raise the global topbar warning. Only when
+ * none of the caller's clients are connected do offline computers that were
+ * actively serving agents qualify.
  */
 export function selectDisconnectedComputers(clients: HubClient[], userId: string): HubClient[] {
   if (!userId) return [];
-  return clients.filter((c) => c.userId === userId && c.status === "disconnected" && c.agentCount > 0);
+  const myClients = clients.filter((c) => c.userId === userId);
+  if (myClients.some((c) => c.status === "connected")) return [];
+  return myClients.filter((c) => c.status === "disconnected" && c.agentCount > 0);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Treat the current user's connected client as the healthy signal for the topbar disconnect chip.
- Keep disconnected rows visible only when none of the caller's clients are connected and the stale disconnected computer still has bound agents.
- Add unit coverage for old disconnected client plus new connected client, and preserve same-user scoping.

## Root Cause

The chip previously warned whenever any of the caller's own client rows was `disconnected` with `agentCount > 0`. After creating a new local client, the old logged-out client row could remain disconnected and keep triggering the global warning even though another computer was connected and usable.

## User Impact

If a user creates a new client or switches local client state, the Web topbar no longer shows `Computer disconnected` while the user has at least one normally connected computer.

## Paired Context Tree PR

Paired with agent-team-foundation/first-tree-context#685.

## Validation

- `pnpm --filter @first-tree/web test -- use-disconnected-computers` (Vitest ran the full web suite: 135 files / 1107 tests passed)
- `pnpm exec biome check packages/web/src/hooks/use-disconnected-computers.ts packages/web/src/hooks/__tests__/use-disconnected-computers.test.ts packages/web/src/components/disconnect-chip.tsx`
