### PR TITLE
[codex] Allow delegate agent runtime switches

### DIFF
--- a/packages/server/src/__tests__/agent-runtime-switch.test.ts
+++ b/packages/server/src/__tests__/agent-runtime-switch.test.ts
@@ -132,6 +132,71 @@ describe("POST /agents/:uuid/switch-runtime", () => {
     expect(events).toEqual([]);
   });
 
+  it("switches a delegate agent without clearing the member delegate mention", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    await setClientRuntimeSupport(app, ctx.clientId, {
+      "claude-code": capability("ok"),
+      codex: capability("ok"),
+    });
+    const agent = await createAgent(app.db, {
+      name: `switch-delegate-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Switch Delegate",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    });
+    await app.db.update(agents).set({ delegateMention: agent.uuid }).where(eq(agents.uuid, ctx.humanAgentUuid));
+    const oldRuntimeSessionToken = await bindAgentRuntimeSession(app.db, agent.uuid, ctx.clientId);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${agent.uuid}/switch-runtime`,
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+      payload: {
+        clientId: ctx.clientId,
+        runtimeProvider: "codex",
+        confirmLocalDataLoss: true,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      uuid: agent.uuid,
+      clientId: ctx.clientId,
+      runtimeProvider: "codex",
+      status: "active",
+    });
+
+    const [human] = await app.db
+      .select({ delegateMention: agents.delegateMention })
+      .from(agents)
+      .where(eq(agents.uuid, ctx.humanAgentUuid))
+      .limit(1);
+    expect(human?.delegateMention).toBe(agent.uuid);
+
+    const [row] = await app.db
+      .select({ metadata: agents.metadata, runtimeProvider: agents.runtimeProvider })
+      .from(agents)
+      .where(eq(agents.uuid, agent.uuid))
+      .limit(1);
+    expect(row?.runtimeProvider).toBe("codex");
+    expect(row?.metadata.runtimeSwitch).toBeUndefined();
+    expect(row?.metadata.runtimeSession).toBeUndefined();
+
+    const staleRuntimeHttp = await app.inject({
+      method: "GET",
+      url: "/api/v1/agent/me",
+      headers: {
+        authorization: `Bearer ${ctx.accessToken}`,
+        "x-agent-id": agent.uuid,
+        "x-agent-runtime-session": oldRuntimeSessionToken,
+      },
+    });
+    expect(staleRuntimeHttp.statusCode).toBe(403);
+  });
+
   it("allows an offline target client when its known version and capabilities are sufficient", async () => {
     const app = getApp();
     const ctx = await createAdminContext(app);

--- a/packages/server/src/services/agent-runtime-switch.ts
+++ b/packages/server/src/services/agent-runtime-switch.ts
@@ -6,7 +6,7 @@ import {
   defaultRuntimeConfigPayload,
   type RuntimeProvider,
 } from "@first-tree/shared";
-import { and, eq, ne, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import * as semver from "semver";
 import type { Database } from "../db/connection.js";
 import { agentConfigs } from "../db/schema/agent-configs.js";
@@ -264,22 +264,6 @@ export async function switchAgentRuntime(
   }
   assertRuntimeSwitchClientVersion(targetClient.sdkVersion);
   await ensureClientSupportsRuntimeProvider(db, targetClient.id, input.runtimeProvider);
-
-  const [delegate] = await db
-    .select({ uuid: agents.uuid })
-    .from(agents)
-    .where(
-      and(
-        eq(agents.organizationId, current.organizationId),
-        eq(agents.type, AGENT_TYPES.HUMAN),
-        eq(agents.delegateMention, current.uuid),
-        ne(agents.status, AGENT_STATUSES.DELETED),
-      ),
-    )
-    .limit(1);
-  if (delegate) {
-    throw new ConflictError("Clear member delegate mention before switching this agent's runtime");
-  }
 
   const claim: RuntimeSwitchClaim = {
     claimId: uuidv7(),


### PR DESCRIPTION
## Summary

Remove the runtime-switch precondition that forced members to clear `delegateMention` before switching the delegate agent's runtime.

## Why

`delegateMention` points from the human agent row to the delegate agent UUID. Runtime switching preserves the agent identity and chat membership while changing the client/provider route, so the delegate reference does not become dirty. Requiring users to clear it would interrupt GitHub/follow routing and force them to manually restore the delegate afterward.

## Changes

- Removed the `delegateMention === current.uuid` hard blocker from `switchAgentRuntime`.
- Added a server regression test covering a delegate agent switch while the human row keeps `delegateMention` pointing at that agent.
- The test also verifies the provider changes and the old runtime-session token is revoked.

## Validation

- `pnpm --filter @first-tree/server test -- agent-runtime-switch.test.ts` (ran server test suite: 177 files / 1720 tests passed)
- `pnpm exec biome check packages/server/src/services/agent-runtime-switch.ts packages/server/src/__tests__/agent-runtime-switch.test.ts`
- `pnpm --filter @first-tree/server typecheck`
