### PR TITLE
fix: allow scoped outbox sends under runtime enforcement

### DIFF
--- a/packages/server/src/__tests__/agent-bind-authorization.test.ts
+++ b/packages/server/src/__tests__/agent-bind-authorization.test.ts
@@ -200,6 +200,100 @@ describe("runtime-bound agent HTTP enforcement", () => {
     expect(res.statusCode).toBe(200);
   });
 
+  it("accepts scoped agent outbox message writes without a runtime session token", async () => {
+    const app = getApp();
+    const sender = await createTestAgent(app, { name: `outbox-sender-${crypto.randomUUID().slice(0, 6)}` });
+    const recipient = await createTestAgent(app, { name: `outbox-recipient-${crypto.randomUUID().slice(0, 6)}` });
+    const runtimeSessionToken = await bindAgentRuntimeSession(app.db, sender.agent.uuid, sender.clientId);
+
+    const chatRes = await sender.request(
+      "POST",
+      "/api/v1/agent/chats",
+      {
+        type: "group",
+        participantIds: [recipient.agent.uuid],
+      },
+      { [AGENT_RUNTIME_SESSION_HEADER]: runtimeSessionToken },
+    );
+    expect(chatRes.statusCode).toBe(201);
+    const chatId = chatRes.json<{ id: string }>().id;
+
+    const tokenRes = await sender.request("POST", `/api/v1/agent/chats/${chatId}/outbox-token`, undefined, {
+      [AGENT_RUNTIME_SESSION_HEADER]: runtimeSessionToken,
+    });
+    expect(tokenRes.statusCode).toBe(200);
+    const outbox = tokenRes.json<{ accessToken: string }>();
+
+    const send = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/chats/${chatId}/messages`,
+      headers: {
+        authorization: `Bearer ${outbox.accessToken}`,
+        "x-agent-id": sender.agent.uuid,
+      },
+      payload: {
+        format: "text",
+        content: "Final trial report.",
+        metadata: { mentions: [recipient.agent.uuid] },
+        source: "cli",
+      },
+    });
+    expect(send.statusCode).toBe(201);
+
+    const wrongPath = await app.inject({
+      method: "GET",
+      url: `/api/v1/agent/chats/${chatId}/messages`,
+      headers: {
+        authorization: `Bearer ${outbox.accessToken}`,
+        "x-agent-id": sender.agent.uuid,
+      },
+    });
+    expect(wrongPath.statusCode).toBe(401);
+
+    const otherChatRes = await sender.request(
+      "POST",
+      "/api/v1/agent/chats",
+      {
+        type: "group",
+        participantIds: [recipient.agent.uuid],
+      },
+      { [AGENT_RUNTIME_SESSION_HEADER]: runtimeSessionToken },
+    );
+    expect(otherChatRes.statusCode).toBe(201);
+    const otherChatId = otherChatRes.json<{ id: string }>().id;
+    const wrongChat = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/chats/${otherChatId}/messages`,
+      headers: {
+        authorization: `Bearer ${outbox.accessToken}`,
+        "x-agent-id": sender.agent.uuid,
+      },
+      payload: {
+        format: "text",
+        content: "Wrong chat.",
+        metadata: { mentions: [recipient.agent.uuid] },
+        source: "cli",
+      },
+    });
+    expect(wrongChat.statusCode).toBe(401);
+
+    const wrongAgent = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/chats/${chatId}/messages`,
+      headers: {
+        authorization: `Bearer ${outbox.accessToken}`,
+        "x-agent-id": recipient.agent.uuid,
+      },
+      payload: {
+        format: "text",
+        content: "Wrong sender.",
+        metadata: { mentions: [sender.agent.uuid] },
+        source: "cli",
+      },
+    });
+    expect(wrongAgent.statusCode).toBe(401);
+  });
+
   it("rejects stale runtime session tokens after DB revocation", async () => {
     const app = getApp();
     const { agent, clientId, accessToken } = await createTestAgent(app);

--- a/packages/server/src/middleware/agent-selector.ts
+++ b/packages/server/src/middleware/agent-selector.ts
@@ -71,7 +71,8 @@ export function agentSelectorHook(db: Database, options: AgentSelectorOptions = 
       throw new ForbiddenError("Agent is not active");
     }
 
-    if (user.agentOutbox && user.agentOutbox.agentId !== row.uuid) {
+    const agentOutbox = user.agentOutbox;
+    if (agentOutbox && agentOutbox.agentId !== row.uuid) {
       throw new ForbiddenError("Agent outbox token is not valid for this agent");
     }
 
@@ -103,7 +104,7 @@ export function agentSelectorHook(db: Database, options: AgentSelectorOptions = 
       // Rule R-RUN: non-human agents must be pinned to a client owned by the
       // caller's user.
       throw new ForbiddenError("Agent not runnable by this user");
-    } else {
+    } else if (!agentOutbox) {
       const runtimeSessionToken = request.headers[AGENT_RUNTIME_SESSION_HEADER];
       if (typeof runtimeSessionToken === "string" && runtimeSessionToken.length > 0) {
         if (!(await validateAgentRuntimeSession(db, row.uuid, row.clientId, runtimeSessionToken))) {
@@ -118,6 +119,12 @@ export function agentSelectorHook(db: Database, options: AgentSelectorOptions = 
           "legacy agent-scoped HTTP without runtime session token accepted",
         );
       }
+    } else {
+      // `agent_outbox` JWTs are already route-scoped by userAuthHook to
+      // POST /api/v1/agent/chats/:chatId/messages for this agent. Landing
+      // trial sandboxes intentionally do not receive the broader runtime
+      // session secret, so the scoped outbox token is the message-write
+      // authority for that narrow path.
     }
 
     request.agent = {


### PR DESCRIPTION
## Summary

- allow scoped `agent_outbox` JWTs to pass `agentSelectorHook` without `x-agent-runtime-session`
- keep existing Rule R-RUN checks intact before the outbox exemption
- add enforcement coverage for scoped outbox sends, wrong route, wrong chat, and wrong agent

## Why

Landing trial Codex sandboxes intentionally scrub the broader runtime-session secret and use a narrow `agent_outbox` token for current-chat message writes. With runtime-session enforcement enabled, the server accepted the outbox token in `userAuthHook` but then rejected it in `agentSelectorHook` for missing `x-agent-runtime-session`.

## Verification

- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 src/__tests__/agent-bind-authorization.test.ts src/__tests__/landing-campaigns-start.test.ts`
- `pnpm check`
- `pnpm typecheck`
- Accidental broader run while correcting the test command: two full `@first-tree/server` test runs passed (`177` files, `1721` tests each).

Notes: `pnpm check` still reports existing non-blocking warnings in unrelated files (`assistant-text.test.ts`, `workspace-migrations.ts`, `packages/web/src/index.css`).
