### PR TITLE
fix: tighten scoped outbox route checks

### DIFF
--- a/packages/server/src/__tests__/agent-bind-authorization.test.ts
+++ b/packages/server/src/__tests__/agent-bind-authorization.test.ts
@@ -250,6 +250,16 @@ describe("runtime-bound agent HTTP enforcement", () => {
     });
     expect(wrongPath.statusCode).toBe(401);
 
+    const wrongSibling = await app.inject({
+      method: "POST",
+      url: `/api/v1/agent/chats/${chatId}/outbox-token`,
+      headers: {
+        authorization: `Bearer ${outbox.accessToken}`,
+        "x-agent-id": sender.agent.uuid,
+      },
+    });
+    expect(wrongSibling.statusCode).toBe(401);
+
     const otherChatRes = await sender.request(
       "POST",
       "/api/v1/agent/chats",

--- a/packages/server/src/api/agent/messages.ts
+++ b/packages/server/src/api/agent/messages.ts
@@ -18,6 +18,9 @@ export async function agentMessageRoutes(app: FastifyInstance): Promise<void> {
     const identity = requireAgent(request);
     const user = requireUser(request);
     await chatService.assertParticipant(app.db, request.params.chatId, identity.uuid);
+    // Runtime-authenticated agents may delegate a narrow send-only capability
+    // to a scoped sandbox. The token is accepted only for this agent/chat's
+    // `POST /api/v1/agent/chats/:chatId/messages` path.
     return {
       accessToken: await signAgentOutboxToken(
         app.config.secrets.jwtSecret,

--- a/packages/server/src/middleware/user-auth.ts
+++ b/packages/server/src/middleware/user-auth.ts
@@ -97,14 +97,10 @@ function isAllowedAgentOutboxRequest(request: FastifyRequest, scope: { agentId: 
   if (request.headers[AGENT_SELECTOR_HEADER] !== scope.agentId) return false;
 
   const pathname = new URL(request.url, "http://first-tree.local").pathname;
-  const marker = "/agent/chats/";
-  const markerIndex = pathname.indexOf(marker);
-  if (markerIndex < 0) return false;
-  const tail = pathname.slice(markerIndex + marker.length);
-  const parts = tail.split("/");
-  if (parts.length !== 2 || parts[1] !== "messages") return false;
+  const match = /^\/api\/v1\/agent\/chats\/([^/]+)\/messages$/.exec(pathname);
+  if (!match) return false;
   try {
-    return decodeURIComponent(parts[0] ?? "") === scope.chatId;
+    return decodeURIComponent(match[1] ?? "") === scope.chatId;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

Follow-up to #1477 after the original runtime-enforcement fix was merged.

This tightens the `agent_outbox` request scope check from a substring search to an anchored exact route match for `POST /api/v1/agent/chats/:chatId/messages`, adds a same-method sibling route negative test for `POST /outbox-token`, and documents the outbox token as a runtime-delegated narrow send-only capability.

## Verification

- `pnpm --filter @first-tree/server exec vitest run --maxWorkers=2 src/__tests__/agent-bind-authorization.test.ts src/__tests__/landing-campaigns-start.test.ts`
- `pnpm check`
- `pnpm typecheck`

`pnpm check` still reports the existing unrelated 2 warnings / 1 info in client/web files.
