### PR TITLE
feat(web): consume the production-scan fix handoff (action=fix) on /quickstart

### DIFF
--- a/packages/web/src/pages/onboarding/steps/__tests__/step-start-chat-scan-fix.test.tsx
+++ b/packages/web/src/pages/onboarding/steps/__tests__/step-start-chat-scan-fix.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { writeScanFixHandoffFlag } from "../../../../utils/onboarding-flags.js";
+import { StepStartChat } from "../step-start-chat.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+// `AdminStartChat`'s repo-aware branches (ensureStartChatRepos,
+// buildValueFirstBootstrap) are dormant in the live flow because
+// `selectedRepoUrls` is always empty — see the comment in step-start-chat.tsx.
+// These tests exercise the `!hasRepos` branch only, matching that live shape.
+
+const flowMock = vi.hoisted(() => ({
+  path: "admin" as const,
+  organizationId: "org-1" as string | null,
+  selectedRepoUrls: [] as string[],
+  treeBindingPlan: "createBinding" as string,
+  setTreeBindingPlan: vi.fn(),
+  setTreeUrl: vi.fn(),
+  treeAutoDetectDone: true,
+  markTreeAutoDetectDone: vi.fn(),
+  completeAndEnterChat: vi.fn(async () => undefined),
+}));
+
+const resolveAgentMock = vi.hoisted(() => ({
+  resolveOnboardingAgent: vi.fn(async () => ({
+    uuid: "agent-1",
+    name: "agent",
+    displayName: "Cedar",
+    type: "cedar",
+    organizationId: "org-1",
+    inboxId: "inbox-1",
+    visibility: "org",
+    runtimeProvider: "claude",
+    clientId: "client-1",
+    status: "active",
+    avatarImageUrl: null,
+  })),
+}));
+
+const treeSetupChatMock = vi.hoisted(() => ({
+  ensureStartChatRepos: vi.fn(async () => undefined),
+  startOnboardingChat: vi.fn(async (_args: { topic: string; bootstrap: string }) => "chat-1"),
+}));
+
+vi.mock("../../onboarding-flow.js", async () => {
+  const actual = await vi.importActual<typeof import("../../onboarding-flow.js")>("../../onboarding-flow.js");
+  return { ...actual, useOnboardingFlow: () => flowMock };
+});
+vi.mock("../../resolve-agent.js", () => resolveAgentMock);
+vi.mock("../../tree-setup-chat.js", () => treeSetupChatMock);
+
+function createStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => [...data.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+let root: Root | null = null;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = "";
+  Object.defineProperty(window, "sessionStorage", { configurable: true, value: createStorage() });
+  Object.defineProperty(globalThis, "sessionStorage", { configurable: true, value: window.sessionStorage });
+  flowMock.organizationId = "org-1";
+  flowMock.selectedRepoUrls = [];
+  flowMock.treeBindingPlan = "createBinding";
+  flowMock.treeAutoDetectDone = true;
+  flowMock.completeAndEnterChat = vi.fn(async () => undefined);
+  treeSetupChatMock.startOnboardingChat.mockResolvedValue("chat-1");
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  root = null;
+  document.body.innerHTML = "";
+});
+
+async function renderStep(): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  await act(async () => {
+    root?.render(
+      <QueryClientProvider client={queryClient}>
+        <StepStartChat />
+      </QueryClientProvider>,
+    );
+  });
+  return container;
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+  });
+}
+
+function clickStart(container: HTMLElement): void {
+  const button = [...container.querySelectorAll("button")].find((b) => b.textContent && b.textContent.length > 0);
+  if (!button) throw new Error("expected a start button");
+  act(() => {
+    button.click();
+  });
+}
+
+function expectCall<T>(value: T | undefined): T {
+  if (value === undefined) throw new Error("expected startOnboardingChat to have been called");
+  return value;
+}
+
+describe("AdminStartChat — production-scan fix handoff", () => {
+  it("sends the scan-fix bootstrap and topic, and clears the flag once the chat exists", async () => {
+    writeScanFixHandoffFlag({ repoUrl: "https://github.com/acme/backend", reportKey: "acme-backend-20260101-abcdef" });
+
+    const container = await renderStep();
+    clickStart(container);
+    await flush();
+
+    expect(treeSetupChatMock.startOnboardingChat).toHaveBeenCalledTimes(1);
+    const call = expectCall(treeSetupChatMock.startOnboardingChat.mock.calls[0]?.[0]);
+    expect(call.topic).toBe("Fix production scan blockers");
+    expect(call.bootstrap).toContain(
+      "Machine-readable findings: https://report.first-tree.ai/acme-backend-20260101-abcdef.json",
+    );
+    expect(treeSetupChatMock.ensureStartChatRepos).not.toHaveBeenCalled();
+    expect(flowMock.completeAndEnterChat).toHaveBeenCalledWith("chat-1");
+    expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBeNull();
+  });
+
+  it("falls back to the normal no-repo bootstrap and topic when no handoff flag is set", async () => {
+    const container = await renderStep();
+    clickStart(container);
+    await flush();
+
+    expect(treeSetupChatMock.startOnboardingChat).toHaveBeenCalledTimes(1);
+    const call = expectCall(treeSetupChatMock.startOnboardingChat.mock.calls[0]?.[0]);
+    expect(call.topic).toBe("Get started with First Tree");
+    expect(call.bootstrap).toContain("Please help me get started with First Tree.");
+    expect(call.bootstrap).not.toContain("production readiness scan");
+    expect(flowMock.completeAndEnterChat).toHaveBeenCalledWith("chat-1");
+  });
+});

--- a/packages/web/src/pages/onboarding/steps/__tests__/step-start-chat-scan-fix.test.tsx
+++ b/packages/web/src/pages/onboarding/steps/__tests__/step-start-chat-scan-fix.test.tsx
@@ -18,7 +18,7 @@ const flowMock = vi.hoisted(() => ({
   path: "admin" as const,
   organizationId: "org-1" as string | null,
   selectedRepoUrls: [] as string[],
-  treeBindingPlan: "createBinding" as string,
+  treeBindingPlan: "createBinding",
   setTreeBindingPlan: vi.fn(),
   setTreeUrl: vi.fn(),
   treeAutoDetectDone: true,

--- a/packages/web/src/pages/onboarding/steps/__tests__/step-start-chat-scan-fix.test.tsx
+++ b/packages/web/src/pages/onboarding/steps/__tests__/step-start-chat-scan-fix.test.tsx
@@ -146,6 +146,18 @@ describe("AdminStartChat — production-scan fix handoff", () => {
     expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBeNull();
   });
 
+  it("keeps the handoff flag when the start-chat call fails", async () => {
+    writeScanFixHandoffFlag({ repoUrl: "https://github.com/acme/backend", reportKey: "acme-backend-20260101-abcdef" });
+    treeSetupChatMock.startOnboardingChat.mockRejectedValueOnce(new Error("boom"));
+
+    const container = await renderStep();
+    clickStart(container);
+    await flush();
+
+    expect(flowMock.completeAndEnterChat).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).not.toBeNull();
+  });
+
   it("falls back to the normal no-repo bootstrap and topic when no handoff flag is set", async () => {
     const container = await renderStep();
     clickStart(container);

--- a/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
@@ -5,9 +5,11 @@ import { listOrgGithubRepos } from "../../../api/github.js";
 import { getGithubAppInstallationExists } from "../../../api/github-app.js";
 import { getContextTreeSetting } from "../../../api/org-settings.js";
 import { Button } from "../../../components/ui/button.js";
+import { readScanFixHandoffFlag, writeScanFixHandoffFlag } from "../../../utils/onboarding-flags.js";
 import {
   buildInviteeReadyBootstrap,
   buildNoRepoBootstrap,
+  buildScanFixBootstrap,
   buildValueFirstBootstrap,
 } from "../../workspace/center/onboarding/bootstrap-prose.js";
 import { COPY } from "../copy.js";
@@ -65,6 +67,11 @@ function AdminStartChat() {
   const [phase, setPhase] = useState<"form" | "starting">("form");
   const [error, setError] = useState<string | null>(null);
 
+  // Production-scan fix conversion captured by /quickstart (`action=fix`).
+  // Read straight off the session flag; cleared once the chat exists so
+  // `finishLater` keeps it for a resumed run.
+  const [scanFixHandoff] = useState(() => readScanFixHandoffFlag());
+
   // `selectedRepoUrls` is only populated by StepConnectCode, which the
   // value-first redesign removed from the onboarding sequence (see steps.ts).
   // So in the live flow `hasRepos` is currently always false and the repo-aware
@@ -102,11 +109,18 @@ function AdminStartChat() {
     try {
       if (!hasRepos) {
         await runStartChat({
-          bootstrap: (agent) => buildNoRepoBootstrap(agent.displayName || "your agent"),
+          bootstrap: (agent) =>
+            scanFixHandoff
+              ? buildScanFixBootstrap(agent.displayName || "your agent", scanFixHandoff)
+              : buildNoRepoBootstrap(agent.displayName || "your agent"),
           organizationId,
-          topic: "Get started with First Tree",
+          topic: scanFixHandoff ? "Fix production scan blockers" : "Get started with First Tree",
           treeBindingPlan: "none",
-          complete: completeAndEnterChat,
+          complete: async (chatId) => {
+            // The chat now exists with the fix bootstrap — the handoff is consumed.
+            writeScanFixHandoffFlag(null);
+            await completeAndEnterChat(chatId);
+          },
         });
         return;
       }

--- a/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
@@ -170,7 +170,13 @@ function AdminStartChat() {
           organizationId,
           topic: "Get started with First Tree",
           treeBindingPlan: "none",
-          complete: completeAndEnterChat,
+          complete: async (chatId) => {
+          // Scan-fix handoffs are consumed by the admin fix path only — drop
+          // any stale flag once a non-fix first chat exists, so a later
+          // onboarding run in this tab cannot consume someone else's scan.
+          writeScanFixHandoffFlag(null);
+          await completeAndEnterChat(chatId);
+        },
         });
         return;
       }
@@ -356,7 +362,13 @@ function InviteeReady() {
         topic: "Get settled on First Tree",
         treeBindingPlan: "useBoundTree",
         joinPath: "invite",
-        complete: completeAndEnterChat,
+        complete: async (chatId) => {
+          // Scan-fix handoffs are consumed by the admin fix path only — drop
+          // any stale flag once a non-fix first chat exists, so a later
+          // onboarding run in this tab cannot consume someone else's scan.
+          writeScanFixHandoffFlag(null);
+          await completeAndEnterChat(chatId);
+        },
       });
     } catch (err) {
       setError(startChatErrorMessage(err, COPY.errors.chatFailed));
@@ -412,7 +424,13 @@ function InviteeNotReady() {
         topic: "Get settled on First Tree",
         treeBindingPlan: "none",
         joinPath: "invite",
-        complete: completeAndEnterChat,
+        complete: async (chatId) => {
+          // Scan-fix handoffs are consumed by the admin fix path only — drop
+          // any stale flag once a non-fix first chat exists, so a later
+          // onboarding run in this tab cannot consume someone else's scan.
+          writeScanFixHandoffFlag(null);
+          await completeAndEnterChat(chatId);
+        },
       });
     } catch (err) {
       setError(startChatErrorMessage(err, COPY.errors.chatFailed));

--- a/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
@@ -171,12 +171,12 @@ function AdminStartChat() {
           topic: "Get started with First Tree",
           treeBindingPlan: "none",
           complete: async (chatId) => {
-          // Scan-fix handoffs are consumed by the admin fix path only — drop
-          // any stale flag once a non-fix first chat exists, so a later
-          // onboarding run in this tab cannot consume someone else's scan.
-          writeScanFixHandoffFlag(null);
-          await completeAndEnterChat(chatId);
-        },
+            // Scan-fix handoffs are consumed by the admin fix path only — drop
+            // any stale flag once a non-fix first chat exists, so a later
+            // onboarding run in this tab cannot consume someone else's scan.
+            writeScanFixHandoffFlag(null);
+            await completeAndEnterChat(chatId);
+          },
         });
         return;
       }

--- a/packages/web/src/pages/quickstart/__tests__/intent.test.ts
+++ b/packages/web/src/pages/quickstart/__tests__/intent.test.ts
@@ -5,8 +5,10 @@ import {
   type CampaignIntent,
   clearCampaignIntent,
   normalizeGitHubRepoUrl,
+  normalizeReportKey,
   readCampaignHandoff,
   readCampaignIntent,
+  readScanFixHandoff,
   writeCampaignIntent,
 } from "../intent.js";
 
@@ -124,5 +126,77 @@ describe("campaign intent sessionStorage", () => {
     writeCampaignIntent(INTENT);
     clearCampaignIntent();
     expect(readCampaignIntent()).toBeNull();
+  });
+});
+
+describe("readScanFixHandoff", () => {
+  const loc = (search: string) => ({ search, hash: "" });
+
+  it("parses a fix handoff with a report key", () => {
+    const h = readScanFixHandoff(
+      loc("?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix&report=octo-app-20260707-ab12cd3"),
+    );
+    expect(h).toEqual({
+      campaign: "production-scan",
+      owner: "octo",
+      repo: "app",
+      repoSlug: "octo/app",
+      url: "https://github.com/octo/app",
+      reportKey: "octo-app-20260707-ab12cd3",
+    });
+  });
+
+  it("strips a .html/.json suffix off the report key", () => {
+    const h = readScanFixHandoff(
+      loc("?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix&report=octo-app-20260707-ab12cd3.html"),
+    );
+    expect(h?.reportKey).toBe("octo-app-20260707-ab12cd3");
+  });
+
+  it("degrades an invalid report key to null instead of rejecting the handoff", () => {
+    for (const bad of ["../../etc", "a/b", "https://evil.example", "", "-leading-dash-ok?no"]) {
+      const h = readScanFixHandoff(
+        loc(`?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix&report=${encodeURIComponent(bad)}`),
+      );
+      expect(h).not.toBeNull();
+      expect(h?.reportKey).toBeNull();
+    }
+  });
+
+  it("returns null without action=fix, an unknown campaign, or a bad repo", () => {
+    expect(readScanFixHandoff(loc("?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp"))).toBeNull();
+    expect(readScanFixHandoff(loc("?campaign=nope&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix"))).toBeNull();
+    expect(readScanFixHandoff(loc("?campaign=production-scan&repo=notaurl&action=fix"))).toBeNull();
+  });
+
+  it("parses from the hash after a login round-trip", () => {
+    const h = readScanFixHandoff({
+      search: "",
+      hash: "#?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix&report=k1",
+    });
+    expect(h?.reportKey).toBe("k1");
+  });
+});
+
+describe("readCampaignHandoff vs action=fix", () => {
+  it("does NOT treat a fix link as a trial handoff", () => {
+    expect(
+      readCampaignHandoff({
+        search: "?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix&report=k1",
+        hash: "",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("normalizeReportKey", () => {
+  it("accepts the documented key shape", () => {
+    expect(normalizeReportKey("octo-app-20260707-ab12cd3")).toBe("octo-app-20260707-ab12cd3");
+    expect(normalizeReportKey("o.wner-re.po-20260707-ff00aa1.json")).toBe("o.wner-re.po-20260707-ff00aa1");
+  });
+  it("rejects path/URL shapes", () => {
+    expect(normalizeReportKey("a/b")).toBeNull();
+    expect(normalizeReportKey("..")).toBeNull();
+    expect(normalizeReportKey(null)).toBeNull();
   });
 });

--- a/packages/web/src/pages/quickstart/__tests__/intent.test.ts
+++ b/packages/web/src/pages/quickstart/__tests__/intent.test.ts
@@ -134,7 +134,9 @@ describe("readScanFixHandoff", () => {
 
   it("parses a fix handoff with a report key", () => {
     const h = readScanFixHandoff(
-      loc("?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix&report=octo-app-20260707-ab12cd3"),
+      loc(
+        "?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix&report=octo-app-20260707-ab12cd3",
+      ),
     );
     expect(h).toEqual({
       campaign: "production-scan",
@@ -148,7 +150,9 @@ describe("readScanFixHandoff", () => {
 
   it("strips a .html/.json suffix off the report key", () => {
     const h = readScanFixHandoff(
-      loc("?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix&report=octo-app-20260707-ab12cd3.html"),
+      loc(
+        "?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix&report=octo-app-20260707-ab12cd3.html",
+      ),
     );
     expect(h?.reportKey).toBe("octo-app-20260707-ab12cd3");
   });
@@ -156,7 +160,9 @@ describe("readScanFixHandoff", () => {
   it("degrades an invalid report key to null instead of rejecting the handoff", () => {
     for (const bad of ["../../etc", "a/b", "https://evil.example", "", "-leading-dash-ok?no"]) {
       const h = readScanFixHandoff(
-        loc(`?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix&report=${encodeURIComponent(bad)}`),
+        loc(
+          `?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Focto%2Fapp&action=fix&report=${encodeURIComponent(bad)}`,
+        ),
       );
       expect(h).not.toBeNull();
       expect(h?.reportKey).toBeNull();

--- a/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
+++ b/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import type { LandingCampaignStartRequest, LandingCampaignStartResponse } from "@first-tree/shared";
+import type { CreateTaskChat, LandingCampaignStartRequest, LandingCampaignStartResponse } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -36,6 +36,16 @@ const landingCampaignMock = vi.hoisted(() => ({
     }),
   ),
 }));
+const agentsApiMock = vi.hoisted(() => ({
+  getNewChatDefaultCandidates: vi.fn(
+    async (): Promise<{ agent: { uuid: string; displayName: string } | null }> => ({
+      agent: { uuid: "agent-dev-1", displayName: "Dev Agent" },
+    }),
+  ),
+}));
+const meChatsApiMock = vi.hoisted(() => ({
+  createMeTaskChat: vi.fn(async (_body: CreateTaskChat): Promise<{ chatId: string }> => ({ chatId: "chat-fix-1" })),
+}));
 
 vi.mock("react-router", async () => {
   const actual = await vi.importActual<typeof import("react-router")>("react-router");
@@ -47,6 +57,8 @@ vi.mock("../../../hooks/use-server-channel.js", () => ({
   useGrowthLandingPagesEnabled: () => growthLandingMock.value.enabled,
 }));
 vi.mock("../../../api/landing-campaigns.js", () => landingCampaignMock);
+vi.mock("../../../api/agents.js", () => agentsApiMock);
+vi.mock("../../../api/me-chats.js", () => meChatsApiMock);
 // The trial chat now renders the real workspace shell; stub it so this unit
 // test stays focused on QuickstartPage's launcher/routing, not the whole
 // three-pane workspace. WorkspaceBody reads the selected chat from `?c=`.
@@ -95,6 +107,10 @@ beforeEach(() => {
     campaign: "production-scan",
     repoCanonicalKey: "github.com/acme/backend",
   });
+  agentsApiMock.getNewChatDefaultCandidates.mockResolvedValue({
+    agent: { uuid: "agent-dev-1", displayName: "Dev Agent" },
+  });
+  meChatsApiMock.createMeTaskChat.mockResolvedValue({ chatId: "chat-fix-1" });
 });
 
 afterEach(async () => {
@@ -266,7 +282,7 @@ describe("QuickstartPage — production-scan fix handoff (action=fix)", () => {
     );
   });
 
-  it("onboarded user: stores the handoff, does not start a trial (Task 6 owns the destination)", async () => {
+  it("onboarded user: opens a direct fix task chat, clears the handoff, never starts a trial", async () => {
     authMock.value = {
       ...authMock.value,
       onboardingStep: "completed",
@@ -279,12 +295,46 @@ describe("QuickstartPage — production-scan fix handoff (action=fix)", () => {
 
     expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalledWith("/onboarding", { replace: true });
+    expect(agentsApiMock.getNewChatDefaultCandidates).toHaveBeenCalledTimes(1);
+    expect(meChatsApiMock.createMeTaskChat).toHaveBeenCalledTimes(1);
+    const body = meChatsApiMock.createMeTaskChat.mock.calls[0]?.[0];
+    expect(body).toMatchObject({
+      mode: "task",
+      topic: "Fix production scan blockers",
+      initialRecipientAgentIds: ["agent-dev-1"],
+    });
+    expect(body?.initialMessage).toMatchObject({ format: "text", source: "web" });
+    expect(body?.initialMessage.content).toContain(
+      "Machine-readable findings: https://report.first-tree.ai/acme-backend-20260101-abcdef.json",
+    );
+    expect(navigateMock).toHaveBeenCalledWith("/?c=chat-fix-1", { replace: true });
+    expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBeNull();
+  });
+
+  it("onboarded user with no connectable agent: shows an error with retry, keeps the handoff", async () => {
+    authMock.value = {
+      ...authMock.value,
+      onboardingStep: "completed",
+      currentOrgHasPersonalAgent: true,
+      onboardingCompletedAt: "2026-01-01T00:00:00.000Z",
+    };
+    agentsApiMock.getNewChatDefaultCandidates.mockResolvedValueOnce({ agent: null });
+    const container = await renderPage([
+      "/quickstart?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend&action=fix&report=acme-backend-20260101-abcdef",
+    ]);
+
+    expect(meChatsApiMock.createMeTaskChat).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("No connected agent yet");
     expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBe(
       JSON.stringify({
         repoUrl: "https://github.com/acme/backend",
         reportKey: "acme-backend-20260101-abcdef",
       }),
     );
+    const retryBtn = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Try again"),
+    );
+    expect(retryBtn).toBeTruthy();
   });
 
   it("plain campaign handoff (no action) still calls startLandingCampaign — regression guard", async () => {

--- a/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
+++ b/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
@@ -307,8 +307,70 @@ describe("QuickstartPage — production-scan fix handoff (action=fix)", () => {
     expect(body?.initialMessage.content).toContain(
       "Machine-readable findings: https://report.first-tree.ai/acme-backend-20260101-abcdef.json",
     );
+    // Direct path uses the greeting-free bootstrap: the agent isn't being onboarded.
+    expect(body?.initialMessage.content).not.toContain("welcome aboard");
     expect(navigateMock).toHaveBeenCalledWith("/?c=chat-fix-1", { replace: true });
     expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBeNull();
+  });
+
+  it("waits for /me: with meLoaded=false a fix link routes nowhere and calls nothing", async () => {
+    authMock.value = {
+      ...authMock.value,
+      meLoaded: false,
+      onboardingStep: "completed",
+      currentOrgHasPersonalAgent: true,
+      onboardingCompletedAt: "2026-01-01T00:00:00.000Z",
+    };
+    await renderPage([
+      "/quickstart?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend&action=fix&report=acme-backend-20260101-abcdef",
+    ]);
+
+    expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
+    expect(agentsApiMock.getNewChatDefaultCandidates).not.toHaveBeenCalled();
+    expect(meChatsApiMock.createMeTaskChat).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("a stale trial intent cannot hijack a fix link into a trial", async () => {
+    seedIntent("production-scan");
+    authMock.value = {
+      ...authMock.value,
+      onboardingStep: "completed",
+      currentOrgHasPersonalAgent: true,
+      onboardingCompletedAt: "2026-01-01T00:00:00.000Z",
+    };
+    await renderPage([
+      "/quickstart?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend&action=fix&report=acme-backend-20260101-abcdef",
+    ]);
+
+    expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
+    expect(meChatsApiMock.createMeTaskChat).toHaveBeenCalledTimes(1);
+  });
+
+  it("direct fix chat failure surfaces an error with retry and keeps the handoff", async () => {
+    authMock.value = {
+      ...authMock.value,
+      onboardingStep: "completed",
+      currentOrgHasPersonalAgent: true,
+      onboardingCompletedAt: "2026-01-01T00:00:00.000Z",
+    };
+    meChatsApiMock.createMeTaskChat.mockRejectedValueOnce(new Error("server unavailable"));
+    const container = await renderPage([
+      "/quickstart?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend&action=fix&report=acme-backend-20260101-abcdef",
+    ]);
+
+    expect(container.textContent).toContain("server unavailable");
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBe(
+      JSON.stringify({
+        repoUrl: "https://github.com/acme/backend",
+        reportKey: "acme-backend-20260101-abcdef",
+      }),
+    );
+    const retryBtn = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Try again"),
+    );
+    expect(retryBtn).toBeTruthy();
   });
 
   it("onboarded user with no connectable agent: shows an error with retry, keeps the handoff", async () => {

--- a/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
+++ b/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
@@ -331,6 +331,29 @@ describe("QuickstartPage — production-scan fix handoff (action=fix)", () => {
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
+  it("finish-later member (dismissed, no completion stamp) resumes onboarding, never direct chat", async () => {
+    authMock.value = {
+      ...authMock.value,
+      onboardingStep: "completed",
+      currentOrgHasPersonalAgent: true,
+      onboardingDismissedAt: "2026-01-01T00:00:00.000Z",
+      onboardingCompletedAt: null,
+    };
+    await renderPage([
+      "/quickstart?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend&action=fix&report=acme-backend-20260101-abcdef",
+    ]);
+
+    expect(agentsApiMock.getNewChatDefaultCandidates).not.toHaveBeenCalled();
+    expect(meChatsApiMock.createMeTaskChat).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith("/onboarding", { replace: true });
+    expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBe(
+      JSON.stringify({
+        repoUrl: "https://github.com/acme/backend",
+        reportKey: "acme-backend-20260101-abcdef",
+      }),
+    );
+  });
+
   it("a stale trial intent cannot hijack a fix link into a trial", async () => {
     seedIntent("production-scan");
     authMock.value = {

--- a/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
+++ b/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
@@ -16,6 +16,11 @@ const authMock = vi.hoisted(() => ({
   value: {
     organizationId: "org-1" as string | null,
     refreshMe: vi.fn(async () => undefined),
+    meLoaded: true,
+    onboardingStep: "connect" as "connect" | "create_agent" | "completed" | null,
+    onboardingDismissedAt: null as string | null,
+    onboardingCompletedAt: null as string | null,
+    currentOrgHasPersonalAgent: false,
   },
 }));
 const growthLandingMock = vi.hoisted(() => ({
@@ -77,6 +82,11 @@ beforeEach(() => {
   authMock.value = {
     organizationId: "org-1",
     refreshMe: vi.fn(async () => undefined),
+    meLoaded: true,
+    onboardingStep: "connect",
+    onboardingDismissedAt: null,
+    onboardingCompletedAt: null,
+    currentOrgHasPersonalAgent: false,
   };
   growthLandingMock.value = { enabled: true, settled: true };
   landingCampaignMock.startLandingCampaign.mockResolvedValue({
@@ -236,5 +246,64 @@ describe("QuickstartPage — landing campaign trial flow", () => {
 
     expect(landingCampaignMock.startLandingCampaign).toHaveBeenCalledTimes(2);
     expect(navigateMock).toHaveBeenCalledWith("/quickstart?c=chat-2", { replace: true });
+  });
+});
+
+describe("QuickstartPage — production-scan fix handoff (action=fix)", () => {
+  it("un-onboarded user: stores the handoff, routes to /onboarding, never starts a trial", async () => {
+    authMock.value = { ...authMock.value, onboardingStep: "connect", currentOrgHasPersonalAgent: false };
+    await renderPage([
+      "/quickstart?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend&action=fix&report=acme-backend-20260101-abcdef",
+    ]);
+
+    expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith("/onboarding", { replace: true });
+    expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBe(
+      JSON.stringify({
+        repoUrl: "https://github.com/acme/backend",
+        reportKey: "acme-backend-20260101-abcdef",
+      }),
+    );
+  });
+
+  it("onboarded user: stores the handoff, does not start a trial (Task 6 owns the destination)", async () => {
+    authMock.value = {
+      ...authMock.value,
+      onboardingStep: "completed",
+      currentOrgHasPersonalAgent: true,
+      onboardingCompletedAt: "2026-01-01T00:00:00.000Z",
+    };
+    await renderPage([
+      "/quickstart?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend&action=fix&report=acme-backend-20260101-abcdef",
+    ]);
+
+    expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalledWith("/onboarding", { replace: true });
+    expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBe(
+      JSON.stringify({
+        repoUrl: "https://github.com/acme/backend",
+        reportKey: "acme-backend-20260101-abcdef",
+      }),
+    );
+  });
+
+  it("plain campaign handoff (no action) still calls startLandingCampaign — regression guard", async () => {
+    await renderPage(["/quickstart?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend"]);
+
+    expect(landingCampaignMock.startLandingCampaign).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBeNull();
+  });
+
+  it("action=fix with an invalid report stores reportKey: null and still routes", async () => {
+    authMock.value = { ...authMock.value, onboardingStep: "connect", currentOrgHasPersonalAgent: false };
+    await renderPage([
+      "/quickstart?campaign=production-scan&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend&action=fix&report=..%2F..%2Fetc%2Fpasswd",
+    ]);
+
+    expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith("/onboarding", { replace: true });
+    expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBe(
+      JSON.stringify({ repoUrl: "https://github.com/acme/backend", reportKey: null }),
+    );
   });
 });

--- a/packages/web/src/pages/quickstart/intent.ts
+++ b/packages/web/src/pages/quickstart/intent.ts
@@ -22,7 +22,18 @@ export type RepoIntent = {
 /** A campaign handoff: a known campaign slug + the repo it targets. */
 export type CampaignIntent = RepoIntent & { campaign: CampaignSlug };
 
+/** A production-scan fix conversion: the trial's "fix these" CTA landing back on Cloud. */
+export type ScanFixHandoff = CampaignIntent & {
+  /** Hosted-report key stem (no extension), or null when the link carried none or an invalid one. */
+  reportKey: string | null;
+};
+
 const NAME_RE = /^[A-Za-z0-9_.-]+$/u;
+
+// S3 object basename stem: `<owner>-<repo>-<YYYYMMDD>-<hash>`; owner/repo may
+// contain dots. Whitelist, never blacklist — the key is embedded into
+// report.first-tree.ai URLs in bootstrap prose.
+const REPORT_KEY_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,119}$/u;
 
 function cleanRepoName(repo: string): string {
   return repo.replace(/\.git$/u, "");
@@ -58,14 +69,40 @@ function normalizeCampaign(input: string | null): CampaignSlug | null {
   return isKnownCampaign(slug) ? slug : null;
 }
 
+export function normalizeReportKey(raw: string | null): string | null {
+  if (!raw) return null;
+  const stem = raw.trim().replace(/\.(html|json)$/u, "");
+  return REPORT_KEY_RE.test(stem) ? stem : null;
+}
+
 function paramsFromHash(hash: string): URLSearchParams {
   const raw = hash.startsWith("#") ? hash.slice(1) : hash;
   return new URLSearchParams(raw.startsWith("?") ? raw.slice(1) : raw);
 }
 
+function isFixAction(params: URLSearchParams): boolean {
+  return (params.get("action") ?? "").trim().toLowerCase() === "fix";
+}
+
+/** Read a production-scan fix handoff off the current location (query first, then hash). */
+export function readScanFixHandoff(location: Pick<Location, "search" | "hash">): ScanFixHandoff | null {
+  for (const params of [new URLSearchParams(location.search ?? ""), paramsFromHash(location.hash ?? "")]) {
+    if (!isFixAction(params)) continue;
+    const campaign = normalizeCampaign(params.get("campaign") ?? params.get("intent"));
+    if (campaign !== "production-scan") continue;
+    const repoRaw = params.get("repo");
+    if (!repoRaw) continue;
+    const repo = normalizeGitHubRepoUrl(repoRaw);
+    if (repo) return { campaign, ...repo, reportKey: normalizeReportKey(params.get("report")) };
+  }
+  return null;
+}
+
 /** Read a campaign handoff off the current location (query first, then hash). */
 export function readCampaignHandoff(location: Pick<Location, "search" | "hash">): CampaignIntent | null {
   for (const params of [new URLSearchParams(location.search ?? ""), paramsFromHash(location.hash ?? "")]) {
+    // A fix conversion is not a trial launch — see readScanFixHandoff.
+    if (isFixAction(params)) continue;
     const campaign = normalizeCampaign(params.get("campaign") ?? params.get("intent"));
     if (!campaign) continue;
     const repoRaw = params.get("repo");

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -9,7 +9,7 @@ import { Button } from "../../components/ui/button.js";
 import { useGrowthLandingPagesState } from "../../hooks/use-server-channel.js";
 import { writeScanFixHandoffFlag } from "../../utils/onboarding-flags.js";
 import { FlowHint, StatusRow, WorkingState } from "../onboarding/flow-ui.js";
-import { shouldEnterOnboarding } from "../onboarding/steps.js";
+import { shouldLeaveOnboarding } from "../onboarding/steps.js";
 import { buildScanFixBootstrap } from "../workspace/center/onboarding/bootstrap-prose.js";
 import { WorkspaceBody } from "../workspace/index.js";
 import { getCampaign } from "./campaigns.js";
@@ -178,13 +178,17 @@ export function QuickstartPage() {
   }, [fixHandoff, navigate]);
 
   useEffect(() => {
-    // `meLoaded` must gate this: `shouldEnterOnboarding` returns false while
-    // /me is still loading, which this branch would misread as "onboarded" and
-    // fire the direct-chat path for a user who actually needs onboarding.
     if (!fixHandoff || !settled || !growthLandingPagesEnabled || !meLoaded) return;
     writeScanFixHandoffFlag({ repoUrl: fixHandoff.url, reportKey: fixHandoff.reportKey });
+    // Direct-chat eligibility is `shouldLeaveOnboarding` — the membership is
+    // terminally done (past connect, has a personal agent, AND carries the
+    // completion stamp). Its inverse gate, `shouldEnterOnboarding`, returns
+    // false for a "finish later" (dismissed) membership, which is only an
+    // auto-entry suppressor — using it here would misroute dismissed-but-
+    // incomplete members into the direct-chat path. `meLoaded` is re-checked
+    // in the guard above because both gates return false on unloaded /me.
     if (
-      shouldEnterOnboarding({
+      shouldLeaveOnboarding({
         meLoaded,
         onboardingStep,
         onboardingSuppressedAt: onboardingDismissedAt,
@@ -192,9 +196,9 @@ export function QuickstartPage() {
         onboardingCompletedAt,
       })
     ) {
-      navigate("/onboarding", { replace: true });
-    } else {
       void startFixChat();
+    } else {
+      navigate("/onboarding", { replace: true });
     }
   }, [
     fixHandoff,

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -161,10 +161,11 @@ export function QuickstartPage() {
         contextParticipantNames: [],
         initialMessage: {
           format: "text",
-          content: buildScanFixBootstrap(agent.displayName || "your agent", {
-            repoUrl: fixHandoff.url,
-            reportKey: fixHandoff.reportKey,
-          }),
+          content: buildScanFixBootstrap(
+            agent.displayName || "your agent",
+            { repoUrl: fixHandoff.url, reportKey: fixHandoff.reportKey },
+            "direct",
+          ),
           source: "web",
         },
       });
@@ -177,7 +178,10 @@ export function QuickstartPage() {
   }, [fixHandoff, navigate]);
 
   useEffect(() => {
-    if (!fixHandoff || !settled || !growthLandingPagesEnabled) return;
+    // `meLoaded` must gate this: `shouldEnterOnboarding` returns false while
+    // /me is still loading, which this branch would misread as "onboarded" and
+    // fire the direct-chat path for a user who actually needs onboarding.
+    if (!fixHandoff || !settled || !growthLandingPagesEnabled || !meLoaded) return;
     writeScanFixHandoffFlag({ repoUrl: fixHandoff.url, reportKey: fixHandoff.reportKey });
     if (
       shouldEnterOnboarding({

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -5,7 +5,9 @@ import { startLandingCampaign } from "../../api/landing-campaigns.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { useGrowthLandingPagesState } from "../../hooks/use-server-channel.js";
+import { writeScanFixHandoffFlag } from "../../utils/onboarding-flags.js";
 import { FlowHint, StatusRow, WorkingState } from "../onboarding/flow-ui.js";
+import { shouldEnterOnboarding } from "../onboarding/steps.js";
 import { WorkspaceBody } from "../workspace/index.js";
 import { getCampaign } from "./campaigns.js";
 import {
@@ -14,6 +16,7 @@ import {
   hasCampaignHandoff,
   readCampaignHandoff,
   readCampaignIntent,
+  readScanFixHandoff,
   writeCampaignIntent,
 } from "./intent.js";
 
@@ -28,7 +31,15 @@ import {
 export function QuickstartPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { organizationId, refreshMe } = useAuth();
+  const {
+    organizationId,
+    refreshMe,
+    meLoaded,
+    onboardingStep,
+    onboardingDismissedAt,
+    onboardingCompletedAt,
+    currentOrgHasPersonalAgent,
+  } = useAuth();
   const { enabled: growthLandingPagesEnabled, settled } = useGrowthLandingPagesState();
   // The trial chat is selected with the normal workspace `?c=` param so
   // `WorkspaceBody` picks it up unchanged — no bespoke `?chat=` handoff.
@@ -39,7 +50,17 @@ export function QuickstartPage() {
   // instead of silently falling through to the no-chat state.
   const legacyChatId = useMemo(() => new URLSearchParams(location.search).get("chat"), [location.search]);
 
+  // A fix conversion (`action=fix`) is not a trial launch: store the handoff and
+  // send the user to normal onboarding (their own agent does the fixing). The
+  // trial-intent memo below must never see these params — readCampaignHandoff
+  // skips action=fix, and this memo short-circuits it too.
+  const fixHandoff = useMemo(() => {
+    if (chatId || legacyChatId) return null;
+    return readScanFixHandoff(location);
+  }, [chatId, legacyChatId, location]);
+
   const intent = useMemo<CampaignIntent | null>(() => {
+    if (fixHandoff) return null;
     // A selected chat — `?c=` OR a legacy `?chat=` about to be canonicalized —
     // means "open this chat", not "launch a trial". Short-circuit both so a
     // stored campaign intent in sessionStorage can't hijack a legacy link into
@@ -55,7 +76,7 @@ export function QuickstartPage() {
       return null;
     }
     return readCampaignIntent();
-  }, [chatId, legacyChatId, location]);
+  }, [fixHandoff, chatId, legacyChatId, location]);
   const campaign = intent ? getCampaign(intent.campaign) : null;
 
   const startStartedRef = useRef(false);
@@ -64,8 +85,18 @@ export function QuickstartPage() {
   const startTrial = useCallback(async () => {
     // `legacyChatId` guards alongside `chatId`: a legacy `?chat=` link is a
     // selected chat being canonicalized, never a launch trigger — even if a
-    // stale campaign intent lingers in sessionStorage.
-    if (chatId || legacyChatId || !intent || !campaign || startStartedRef.current || !growthLandingPagesEnabled) return;
+    // stale campaign intent lingers in sessionStorage. `fixHandoff` guards too
+    // so a fix link can never start a trial even transiently.
+    if (
+      chatId ||
+      legacyChatId ||
+      fixHandoff ||
+      !intent ||
+      !campaign ||
+      startStartedRef.current ||
+      !growthLandingPagesEnabled
+    )
+      return;
     startStartedRef.current = true;
     setStartError(null);
     try {
@@ -81,7 +112,7 @@ export function QuickstartPage() {
       startStartedRef.current = false;
       setStartError(err instanceof Error ? err.message : "Couldn't open your trial chat. Please try again.");
     }
-  }, [chatId, legacyChatId, intent, campaign, organizationId, growthLandingPagesEnabled, refreshMe, navigate]);
+  }, [chatId, legacyChatId, fixHandoff, intent, campaign, organizationId, growthLandingPagesEnabled, refreshMe, navigate]);
 
   useEffect(() => {
     if (!settled || !growthLandingPagesEnabled) return;
@@ -92,6 +123,36 @@ export function QuickstartPage() {
     if (chatId) return;
     if (settled && !growthLandingPagesEnabled) navigate("/", { replace: true });
   }, [chatId, settled, growthLandingPagesEnabled, navigate]);
+
+  useEffect(() => {
+    if (!fixHandoff || !settled || !growthLandingPagesEnabled) return;
+    writeScanFixHandoffFlag({ repoUrl: fixHandoff.url, reportKey: fixHandoff.reportKey });
+    if (
+      shouldEnterOnboarding({
+        meLoaded,
+        onboardingStep,
+        onboardingSuppressedAt: onboardingDismissedAt,
+        currentOrgHasPersonalAgent,
+        onboardingCompletedAt,
+      })
+    ) {
+      navigate("/onboarding", { replace: true });
+    } else {
+      // Temporary: Task 6 replaces this with direct task-chat creation before
+      // this PR opens. The stored handoff survives either way.
+      navigate("/", { replace: true });
+    }
+  }, [
+    fixHandoff,
+    settled,
+    growthLandingPagesEnabled,
+    meLoaded,
+    onboardingStep,
+    onboardingDismissedAt,
+    onboardingCompletedAt,
+    currentOrgHasPersonalAgent,
+    navigate,
+  ]);
 
   // Canonicalize a legacy `?chat=<id>` trial link to `?c=<id>` (only when no
   // `?c=` is already present) so pre-migration URLs keep opening the trial chat.

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -115,7 +115,17 @@ export function QuickstartPage() {
       startStartedRef.current = false;
       setStartError(err instanceof Error ? err.message : "Couldn't open your trial chat. Please try again.");
     }
-  }, [chatId, legacyChatId, fixHandoff, intent, campaign, organizationId, growthLandingPagesEnabled, refreshMe, navigate]);
+  }, [
+    chatId,
+    legacyChatId,
+    fixHandoff,
+    intent,
+    campaign,
+    organizationId,
+    growthLandingPagesEnabled,
+    refreshMe,
+    navigate,
+  ]);
 
   useEffect(() => {
     if (!settled || !growthLandingPagesEnabled) return;

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -1,13 +1,16 @@
 import { ArrowRight } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
+import { getNewChatDefaultCandidates } from "../../api/agents.js";
 import { startLandingCampaign } from "../../api/landing-campaigns.js";
+import { createMeTaskChat } from "../../api/me-chats.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { useGrowthLandingPagesState } from "../../hooks/use-server-channel.js";
 import { writeScanFixHandoffFlag } from "../../utils/onboarding-flags.js";
 import { FlowHint, StatusRow, WorkingState } from "../onboarding/flow-ui.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
+import { buildScanFixBootstrap } from "../workspace/center/onboarding/bootstrap-prose.js";
 import { WorkspaceBody } from "../workspace/index.js";
 import { getCampaign } from "./campaigns.js";
 import {
@@ -124,6 +127,45 @@ export function QuickstartPage() {
     if (settled && !growthLandingPagesEnabled) navigate("/", { replace: true });
   }, [chatId, settled, growthLandingPagesEnabled, navigate]);
 
+  const fixStartedRef = useRef(false);
+  const [fixError, setFixError] = useState<string | null>(null);
+
+  // Already-onboarded users skip onboarding: hand the scan findings straight to
+  // their default agent as a task chat. The handoff flag is cleared only after
+  // the chat exists — on failure it stays, and re-clicking the fix link retries.
+  const startFixChat = useCallback(async () => {
+    if (!fixHandoff || fixStartedRef.current) return;
+    fixStartedRef.current = true;
+    setFixError(null);
+    try {
+      const { agent } = await getNewChatDefaultCandidates({});
+      if (!agent) {
+        throw new Error("No connected agent yet. Connect your computer, then open the fix link again.");
+      }
+      const created = await createMeTaskChat({
+        mode: "task",
+        topic: "Fix production scan blockers",
+        initialRecipientAgentIds: [agent.uuid],
+        initialRecipientNames: [],
+        contextParticipantAgentIds: [],
+        contextParticipantNames: [],
+        initialMessage: {
+          format: "text",
+          content: buildScanFixBootstrap(agent.displayName || "your agent", {
+            repoUrl: fixHandoff.url,
+            reportKey: fixHandoff.reportKey,
+          }),
+          source: "web",
+        },
+      });
+      writeScanFixHandoffFlag(null);
+      navigate(`/?c=${encodeURIComponent(created.chatId)}`, { replace: true });
+    } catch (err) {
+      fixStartedRef.current = false;
+      setFixError(err instanceof Error ? err.message : "Couldn't start the fix chat. Please try again.");
+    }
+  }, [fixHandoff, navigate]);
+
   useEffect(() => {
     if (!fixHandoff || !settled || !growthLandingPagesEnabled) return;
     writeScanFixHandoffFlag({ repoUrl: fixHandoff.url, reportKey: fixHandoff.reportKey });
@@ -138,9 +180,7 @@ export function QuickstartPage() {
     ) {
       navigate("/onboarding", { replace: true });
     } else {
-      // Temporary: Task 6 replaces this with direct task-chat creation before
-      // this PR opens. The stored handoff survives either way.
-      navigate("/", { replace: true });
+      void startFixChat();
     }
   }, [
     fixHandoff,
@@ -152,6 +192,7 @@ export function QuickstartPage() {
     onboardingCompletedAt,
     currentOrgHasPersonalAgent,
     navigate,
+    startFixChat,
   ]);
 
   // Canonicalize a legacy `?chat=<id>` trial link to `?c=<id>` (only when no
@@ -165,6 +206,10 @@ export function QuickstartPage() {
   const retryStart = useCallback(() => {
     void startTrial();
   }, [startTrial]);
+
+  const retryFixChat = useCallback(() => {
+    void startFixChat();
+  }, [startFixChat]);
 
   // Trial started: render the real workspace shell — as trial chrome, since
   // this is the `/quickstart` route (stripped header + no rail; see Layout /
@@ -189,6 +234,35 @@ export function QuickstartPage() {
     return (
       <QuickstartShell>
         <StatusRow state="waiting" label="Loading..." />
+      </QuickstartShell>
+    );
+  }
+
+  // A fix conversion in flight: hold the launcher shell while the effect above
+  // routes to onboarding or opens the direct fix chat; surface failures with a
+  // retry (the stored handoff survives, so retrying is safe).
+  if (fixHandoff) {
+    return (
+      <QuickstartShell repoSlug={fixHandoff.repoSlug}>
+        <h1 className="text-title" style={{ margin: 0 }}>
+          Starting your fix chat...
+        </h1>
+
+        {fixError ? (
+          <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
+            <FlowHint tone="error" role="alert">
+              {fixError}
+            </FlowHint>
+            <div className="flex">
+              <Button type="button" onClick={retryFixChat}>
+                <span>Try again</span>
+                <ArrowRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <WorkingState label="Opening your fix chat..." hint="Handing the scan findings to your agent." />
+        )}
       </QuickstartShell>
     );
   }

--- a/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
@@ -173,4 +173,12 @@ describe("buildScanFixBootstrap", () => {
     expect(s).toContain("Repository: https://github.com/octo/app");
     expect(s).toContain("re-run the scan");
   });
+
+  it("direct opening drops the onboarding greeting but keeps the recognition phrase", () => {
+    const s = buildScanFixBootstrap("Dev", handoff, "direct");
+    expect(s).not.toContain("welcome aboard");
+    expect(s).toContain("Dev, please help me fix the launch blockers found by my production readiness scan.");
+    expect(s).toContain("Repository: https://github.com/octo/app");
+    expect(s).toContain("Machine-readable findings: https://report.first-tree.ai/octo-app-20260707-ab12cd3.json");
+  });
 });

--- a/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildInviteeReadyBootstrap,
   buildNoRepoBootstrap,
+  buildScanFixBootstrap,
   buildTreeSetupBootstrap,
   buildValueFirstBootstrap,
 } from "../bootstrap-prose.js";
@@ -149,5 +150,27 @@ describe("start-chat bootstrap prose", () => {
     // A brand-new teammate is NOT asked to write to or seed the tree.
     expect(message).not.toContain("first-tree-seed");
     expect(message).not.toContain("reflect them into the tree");
+  });
+});
+
+describe("buildScanFixBootstrap", () => {
+  const handoff = {
+    repoUrl: "https://github.com/octo/app",
+    reportKey: "octo-app-20260707-ab12cd3",
+  };
+
+  it("includes repo, hosted report, and findings JSON URLs", () => {
+    const s = buildScanFixBootstrap("Dev", handoff);
+    expect(s).toContain("Repository: https://github.com/octo/app");
+    expect(s).toContain("https://report.first-tree.ai/octo-app-20260707-ab12cd3.html");
+    expect(s).toContain("Machine-readable findings: https://report.first-tree.ai/octo-app-20260707-ab12cd3.json");
+    expect(s).toContain("production readiness scan");
+  });
+
+  it("degrades without a report key: no report URLs, asks to re-run or share", () => {
+    const s = buildScanFixBootstrap("Dev", { ...handoff, reportKey: null });
+    expect(s).not.toContain("report.first-tree.ai");
+    expect(s).toContain("Repository: https://github.com/octo/app");
+    expect(s).toContain("re-run the scan");
   });
 });

--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -84,3 +84,35 @@ export function buildInviteeReadyBootstrap(agentDisplayName: string): string {
     "\n",
   );
 }
+
+/**
+ * First chat for a production-scan fix conversion: the user arrived from the
+ * trial's "fix these" CTA. Visible prose only (kickoff contract) — the welcome
+ * skill recognizes the scan reference + findings link and launches the fix as
+ * the pre-selected first task. `report.first-tree.ai` mirrors the scan skill's
+ * BASE constant; the findings JSON expires ~30 days after the scan.
+ */
+export function buildScanFixBootstrap(
+  agentDisplayName: string,
+  handoff: { repoUrl: string; reportKey: string | null },
+): string {
+  const reportLines = handoff.reportKey
+    ? [
+        `Hosted report: https://report.first-tree.ai/${handoff.reportKey}.html`,
+        `Machine-readable findings: https://report.first-tree.ai/${handoff.reportKey}.json`,
+      ]
+    : [];
+  const closing = handoff.reportKey
+    ? "Start from the machine-readable findings and fix the blockers in severity order. If the findings link has expired, or the repository isn't accessible from here, say exactly what is needed — a re-run of the scan, the narrowest GitHub access, or a local path."
+    : "The scan report link didn't carry over, so start by checking access to the repository, then ask me to share the report or re-run the scan.";
+  return [
+    `${agentDisplayName}, welcome aboard.`,
+    "",
+    "Please help me fix the launch blockers found by my production readiness scan.",
+    "",
+    `Repository: ${handoff.repoUrl}`,
+    ...reportLines,
+    "",
+    closing,
+  ].join("\n");
+}

--- a/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/bootstrap-prose.ts
@@ -91,10 +91,16 @@ export function buildInviteeReadyBootstrap(agentDisplayName: string): string {
  * skill recognizes the scan reference + findings link and launches the fix as
  * the pre-selected first task. `report.first-tree.ai` mirrors the scan skill's
  * BASE constant; the findings JSON expires ~30 days after the scan.
+ *
+ * `opening: "direct"` is the already-onboarded path (quickstart opens the task
+ * chat itself): no "welcome aboard" greeting — the agent isn't being onboarded,
+ * and the greeting-free shape keeps the welcome skill's launcher flow from
+ * treating an already-dedicated fix chat as a launcher.
  */
 export function buildScanFixBootstrap(
   agentDisplayName: string,
   handoff: { repoUrl: string; reportKey: string | null },
+  opening: "onboarding" | "direct" = "onboarding",
 ): string {
   const reportLines = handoff.reportKey
     ? [
@@ -105,14 +111,13 @@ export function buildScanFixBootstrap(
   const closing = handoff.reportKey
     ? "Start from the machine-readable findings and fix the blockers in severity order. If the findings link has expired, or the repository isn't accessible from here, say exactly what is needed — a re-run of the scan, the narrowest GitHub access, or a local path."
     : "The scan report link didn't carry over, so start by checking access to the repository, then ask me to share the report or re-run the scan.";
-  return [
-    `${agentDisplayName}, welcome aboard.`,
-    "",
-    "Please help me fix the launch blockers found by my production readiness scan.",
-    "",
-    `Repository: ${handoff.repoUrl}`,
-    ...reportLines,
-    "",
-    closing,
-  ].join("\n");
+  const openingLines =
+    opening === "direct"
+      ? [`${agentDisplayName}, please help me fix the launch blockers found by my production readiness scan.`]
+      : [
+          `${agentDisplayName}, welcome aboard.`,
+          "",
+          "Please help me fix the launch blockers found by my production readiness scan.",
+        ];
+  return [...openingLines, "", `Repository: ${handoff.repoUrl}`, ...reportLines, "", closing].join("\n");
 }

--- a/packages/web/src/utils/__tests__/onboarding-flags-scan-fix.test.ts
+++ b/packages/web/src/utils/__tests__/onboarding-flags-scan-fix.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readScanFixHandoffFlag, writeScanFixHandoffFlag } from "../onboarding-flags.js";
+
+function createStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => [...data.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      data.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+beforeEach(() => {
+  const storage = createStorage();
+  Object.defineProperty(window, "sessionStorage", { configurable: true, value: storage });
+  Object.defineProperty(globalThis, "sessionStorage", { configurable: true, value: storage });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("scan-fix handoff flag", () => {
+  afterEach(() => writeScanFixHandoffFlag(null));
+
+  it("round-trips a handoff", () => {
+    const h = { repoUrl: "https://github.com/octo/app", reportKey: "octo-app-20260707-ab12cd3" };
+    writeScanFixHandoffFlag(h);
+    expect(readScanFixHandoffFlag()).toEqual(h);
+  });
+
+  it("round-trips a null report key", () => {
+    writeScanFixHandoffFlag({ repoUrl: "https://github.com/octo/app", reportKey: null });
+    expect(readScanFixHandoffFlag()?.reportKey).toBeNull();
+  });
+
+  it("clears on write(null) and rejects malformed stored values", () => {
+    writeScanFixHandoffFlag({ repoUrl: "https://github.com/octo/app", reportKey: null });
+    writeScanFixHandoffFlag(null);
+    expect(readScanFixHandoffFlag()).toBeNull();
+    window.sessionStorage.setItem("onboarding:scanFixHandoff", JSON.stringify({ nope: 1 }));
+    expect(readScanFixHandoffFlag()).toBeNull();
+    expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBeNull();
+  });
+});

--- a/packages/web/src/utils/onboarding-flags.ts
+++ b/packages/web/src/utils/onboarding-flags.ts
@@ -112,3 +112,40 @@ export function clearOnboardingSessionFlags(): void {
   }
   for (const k of toRemove) ss.removeItem(k);
 }
+
+const SCAN_FIX_HANDOFF_KEY = "onboarding:scanFixHandoff";
+
+/**
+ * Production-scan fix conversion captured by /quickstart (`action=fix`).
+ * Global like `agentUuid` (the fix link carries no org); consumed and cleared
+ * by the onboarding start-chat completion, kept by `finishLater`. The durable
+ * fallback is the fix link itself — the user can always re-click it.
+ */
+export type StoredScanFixHandoff = {
+  repoUrl: string;
+  reportKey: string | null;
+};
+
+export function readScanFixHandoffFlag(): StoredScanFixHandoff | null {
+  if (typeof window === "undefined") return null;
+  const raw = window.sessionStorage.getItem(SCAN_FIX_HANDOFF_KEY);
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) throw new Error("not an object");
+    const o = parsed as Record<string, unknown>;
+    if (typeof o.repoUrl !== "string" || !(typeof o.reportKey === "string" || o.reportKey === null)) {
+      throw new Error("invalid scan-fix handoff");
+    }
+    return { repoUrl: o.repoUrl, reportKey: o.reportKey };
+  } catch {
+    window.sessionStorage.removeItem(SCAN_FIX_HANDOFF_KEY);
+    return null;
+  }
+}
+
+export function writeScanFixHandoffFlag(handoff: StoredScanFixHandoff | null): void {
+  if (typeof window === "undefined") return;
+  if (handoff === null) window.sessionStorage.removeItem(SCAN_FIX_HANDOFF_KEY);
+  else window.sessionStorage.setItem(SCAN_FIX_HANDOFF_KEY, JSON.stringify(handoff));
+}


### PR DESCRIPTION
## What

Closes the broken half of the production-scan trial's fix→team conversion: the trial's "fix these → build your First Tree team" CTA currently loops users back into the same scan trial and drops the `report` key on the floor. This PR teaches the web app to consume `/quickstart?campaign=production-scan&repo=<url>&action=fix&report=<key>`:

- **`intent.ts`** — new `readScanFixHandoff` parser (whitelist-validated `report` key, invalid keys degrade to `null` instead of dead-ending) and `readCampaignHandoff` now skips `action=fix` params so a fix link can never start a trial.
- **`onboarding-flags.ts`** — a global sessionStorage flag (`onboarding:scanFixHandoff`, `{repoUrl, reportKey}`) that survives the OAuth bounce and onboarding's full-page redirects, matching the existing `agentUuid` flag style.
- **`quickstart-page.tsx`** — `action=fix` branch: store the flag, then route by `shouldEnterOnboarding`: un-onboarded users go to `/onboarding`; already-onboarded users get a direct "Fix production scan blockers" task chat via `getNewChatDefaultCandidates` + `createMeTaskChat` (error + retry state when no agent is connectable; the flag survives failures so re-clicking the link retries).
- **`bootstrap-prose.ts` + `step-start-chat.tsx`** — the onboarding first chat opens with a scan-fix bootstrap (repo URL, hosted report URL, findings JSON URL, expiry/access fallbacks) instead of the generic first-chat text; the flag is cleared once the chat exists, so `finishLater` keeps it for a resumed run.

No server changes: the bootstrap is client-composed visible task text through the existing kickoff endpoint, per docs/development/onboarding-kickoff-contract.md (no `campaign` param, no hidden metadata directives).

## Cross-repo sequencing

The link format (`&action=fix&report=<key>`) is emitted by the `production-scan` skill's `CLOUD_HANDOFF` contract in agent-team-foundation/launch-readiness-scan. That repo is merge-= -production, so its PR must land only AFTER this PR (and the welcome-skill PR) deploys. Until then this code is dormant: no existing link carries `action=fix`.

## Known limitations (deliberate v1 scope)

- Only the admin onboarding path consumes the handoff; the invitee path ignores it (fix-clickers are admins of their own trial org; an invitee clicking someone else's link gets a normal first chat).
- The handoff lives in per-tab sessionStorage; closing the tab mid-onboarding drops it. The durable fallback is re-clicking the fix link (the findings JSON is retained ~30 days).

## Test plan

- `pnpm --filter @first-tree/web test` — 1126/1126 passing (new: 8 parser cases, 3 flag cases, 2 prose cases, 4 quickstart fix-flow cases incl. trial regression guard, 2 start-chat cases)
- `pnpm --filter @first-tree/web run typecheck` — clean (incl. design-token guardrails)
- `biome check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)