### PR TITLE
Recover Codex sessions with missing rollouts

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -69,6 +69,7 @@ class FakeAppServerClient {
   onNotification: NotificationHandler | null = null;
   onClose: CloseHandler | null = null;
   steerError: Error | null = null;
+  threadResumeError: Error | null = null;
   turnStartError: Error | null = null;
   beforeTurnStartError: (() => void) | null = null;
   beforeTurnStartReturn: (() => void) | null = null;
@@ -90,6 +91,7 @@ class FakeAppServerClient {
     }
     if (method === "thread/resume") {
       this.beforeThreadResumeReturn?.();
+      if (this.threadResumeError) throw this.threadResumeError;
       return { thread: { id: "thread-app-server" } };
     }
     if (method === "turn/start") {
@@ -201,6 +203,7 @@ function makeContext(
     finishTurn?: SessionContext["finishTurn"];
     retryTurn?: SessionContext["retryTurn"];
     failSessionForRecovery?: SessionContext["failSessionForRecovery"];
+    replaceSessionId?: SessionContext["replaceSessionId"];
     emitEvent?: SessionContext["emitEvent"];
     emitEventConfirmed?: SessionContext["emitEventConfirmed"];
     formatInboundContent?: SessionContext["formatInboundContent"];
@@ -240,6 +243,7 @@ function makeContext(
     ...(opts.finishTurn ? { finishTurn: opts.finishTurn } : {}),
     ...(opts.retryTurn ? { retryTurn: opts.retryTurn } : {}),
     ...(opts.failSessionForRecovery ? { failSessionForRecovery: opts.failSessionForRecovery } : {}),
+    ...(opts.replaceSessionId ? { replaceSessionId: opts.replaceSessionId } : {}),
     ...(opts.formatInboundContent ? { formatInboundContent: opts.formatInboundContent } : {}),
   };
 }
@@ -890,6 +894,31 @@ describe("codex app-server handler", () => {
     });
 
     await handler.shutdown();
+  });
+
+  it("fresh-starts and rebinds when thread/resume reports a missing rollout", async () => {
+    const fake = new FakeAppServerClient();
+    fake.threadResumeError = new Error(
+      "thread/resume: thread/resume failed: no rollout found for thread id thread-stale (code -32600)",
+    );
+    const replaceSessionId = vi.fn<NonNullable<SessionContext["replaceSessionId"]>>();
+    const retryTurn = vi.fn<SessionContext["retryTurn"]>();
+    const failSessionForRecovery = vi.fn<NonNullable<SessionContext["failSessionForRecovery"]>>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ replaceSessionId, retryTurn, failSessionForRecovery });
+    const token = makeDeliveryToken();
+
+    const resumePromise = handler.resume(makeMessage("m1", "first"), "thread-stale", ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+    completeTurn(fake, "turn-1", "fresh answer");
+    const result = await resumePromise;
+
+    expect(fake.requests.map((request) => request.method)).toEqual(["thread/resume", "thread/start", "turn/start"]);
+    expect(result).toEqual({ sessionId: "thread-app-server", route: { kind: "owned", mode: "processing" } });
+    expect(replaceSessionId).toHaveBeenCalledWith("thread-app-server", "codex_stale_rollout_recovered");
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(retryTurn).not.toHaveBeenCalled();
+    expect(failSessionForRecovery).not.toHaveBeenCalled();
   });
 
   it("uses late replayed cumulative usage as the current resumed turn baseline", async () => {

--- a/packages/client/src/__tests__/codex-stale-rollout.test.ts
+++ b/packages/client/src/__tests__/codex-stale-rollout.test.ts
@@ -1,0 +1,174 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatContext } from "../runtime/chat-context.js";
+import type { DeliveryToken, SessionContext, SessionMessage } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const STALE_THREAD_ID = "019f2943-c0af-75b0-9d7b-d58679594749";
+
+const state = vi.hoisted(() => ({
+  runCalls: [] as Array<{ threadId: string; input: unknown }>,
+  resumeThreadIds: [] as string[],
+  startThreadIds: [] as string[],
+  nextFreshThreadId: "fresh-thread-1",
+}));
+
+vi.mock("@openai/codex-sdk", () => {
+  const usage = {
+    input_tokens: 1,
+    cached_input_tokens: 0,
+    output_tokens: 1,
+    reasoning_output_tokens: 0,
+  };
+
+  function makeThread(threadId: string, stale: boolean) {
+    return {
+      id: threadId,
+      async runStreamed(input: unknown) {
+        state.runCalls.push({ threadId, input });
+        if (stale) {
+          throw new Error(
+            `Codex Exec exited with code 1: Reading prompt from stdin...\nError: thread/resume: thread/resume failed: no rollout found for thread id ${threadId} (code -32600)`,
+          );
+        }
+        return {
+          events: (async function* () {
+            yield { type: "thread.started", thread_id: threadId };
+            yield { type: "item.completed", item: { type: "agent_message", text: "fresh answer" } };
+            yield { type: "turn.completed", usage };
+          })(),
+        };
+      },
+    };
+  }
+
+  return {
+    Codex: class {
+      startThread() {
+        state.startThreadIds.push(state.nextFreshThreadId);
+        return makeThread(state.nextFreshThreadId, false);
+      }
+      resumeThread(threadId: string) {
+        state.resumeThreadIds.push(threadId);
+        return makeThread(threadId, true);
+      }
+    },
+  };
+});
+
+vi.mock("../runtime/bootstrap.js", () => ({
+  FIRST_TREE_RUNTIME_DIR: ".first-tree-workspace",
+  FIRST_TREE_WORKSPACE_MARKER: ".first-tree-workspace",
+  bootstrapWorkspace: vi.fn(),
+  deepEqualIdentity: vi.fn(() => true),
+  ensureWorkspaceRuntimeDir: vi.fn((workspacePath: string) => {
+    const dir = join(workspacePath, ".first-tree-workspace");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }),
+  installCoreSkills: vi.fn(),
+  installFirstTreeIntegration: vi.fn(() => true),
+  isHubWorktreeMarker: vi.fn(() => false),
+  readCachedBundledCliVersion: vi.fn(() => null),
+  readCachedContextTreeHead: vi.fn(() => null),
+  readContextTreeHead: vi.fn(() => null),
+  resolveBundledCliVersion: vi.fn(() => "0.0.0-test"),
+  writeAgentBriefing: vi.fn(),
+  writeBundledCliVersion: vi.fn(),
+  writeContextTreeHead: vi.fn(),
+}));
+
+vi.mock("../runtime/chat-context.js", () => ({
+  fetchChatContext: vi.fn(async (): Promise<ChatContext> => {
+    return {
+      chatId: "chat-stale-rollout",
+      title: "stale rollout",
+      topic: null,
+      description: null,
+      participants: [],
+    };
+  }),
+}));
+
+import { createCodexSdkHandler } from "../handlers/codex/index.js";
+
+const AGENT_ID = "019e71c9-88d2-70be-be67-fdb033b2ef0b";
+
+let workspaceRoot: string;
+
+function makeMessage(id: string, content: string): SessionMessage {
+  return {
+    id,
+    chatId: "chat-stale-rollout",
+    senderId: "sender-1",
+    format: "text",
+    content,
+    metadata: {},
+  };
+}
+
+function makeContext(opts: { replaceSessionId?: SessionContext["replaceSessionId"] } = {}): SessionContext {
+  const sendMessage = vi
+    .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+    .mockResolvedValue({});
+  return {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: `inbox_${AGENT_ID}`,
+      displayName: "codex-assistant",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    chatId: "chat-stale-rollout",
+    log: () => {},
+    recordProviderActivity: () => {},
+    emitEvent: () => {},
+    ...mockCtxPlumbing({ sendMessage }, "chat-stale-rollout"),
+    ...(opts.replaceSessionId ? { replaceSessionId: opts.replaceSessionId } : {}),
+  };
+}
+
+function makeToken(): DeliveryToken {
+  return {
+    processingStarted: vi.fn(),
+    complete: vi.fn<DeliveryToken["complete"]>().mockResolvedValue(undefined),
+    retry: vi.fn(),
+    terminalRejected: vi.fn<DeliveryToken["terminalRejected"]>().mockResolvedValue(undefined),
+  };
+}
+
+describe("codex stale rollout recovery", () => {
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), "codex-stale-rollout-"));
+    state.runCalls = [];
+    state.resumeThreadIds = [];
+    state.startThreadIds = [];
+    state.nextFreshThreadId = "fresh-thread-1";
+  });
+
+  afterEach(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it("fresh-starts the same resume turn and returns the replacement thread id", async () => {
+    const replaceSessionId = vi.fn<NonNullable<SessionContext["replaceSessionId"]>>();
+    const handler = createCodexSdkHandler({ workspaceRoot });
+    const ctx = makeContext({ replaceSessionId });
+    const token = makeToken();
+
+    const result = await handler.resume(makeMessage("m1", "hello"), STALE_THREAD_ID, ctx, token);
+
+    expect(result).toEqual({ sessionId: "fresh-thread-1", route: { kind: "owned", mode: "processing" } });
+    expect(state.resumeThreadIds).toEqual([STALE_THREAD_ID]);
+    expect(state.startThreadIds).toEqual(["fresh-thread-1"]);
+    expect(state.runCalls.map((call) => call.threadId)).toEqual([STALE_THREAD_ID, "fresh-thread-1"]);
+    expect(replaceSessionId).toHaveBeenCalledWith("fresh-thread-1", "codex_stale_rollout_recovered");
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(token.complete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AgentRuntimeConfig, SessionEvent } from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
@@ -110,6 +113,7 @@ function createSessionManager(opts: {
   recoverChat?: (chatId: string) => Promise<void>;
   onSessionEvent?: (chatId: string, event: SessionEvent) => void;
   subprocessProbe?: SubprocessProbe;
+  registryPath?: string;
 }) {
   const handler = opts.handler ?? createMockHandler();
   const factory: HandlerFactory = opts.handlerFactory ?? (() => handler);
@@ -140,6 +144,7 @@ function createSessionManager(opts: {
     },
     sdk,
     log: opts.log ?? silentLogger(),
+    registryPath: opts.registryPath,
     ackEntry: opts.ackEntry ?? mockAckEntry(),
     recoverChat: opts.recoverChat,
     agentConfigCache: opts.agentConfigCache,
@@ -199,6 +204,31 @@ describe("SessionManager", () => {
     expect(ackEntry).toHaveBeenCalledWith(42);
 
     await sm.shutdown();
+  });
+
+  it("persists a handler-replaced session id", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "session-manager-rebind-"));
+    const registryPath = join(dir, "sessions.json");
+    let capturedCtx: SessionContext | undefined;
+    const handler = createMockHandler({
+      async start(_msg, ctx) {
+        capturedCtx = ctx;
+        return { sessionId: "session-old", route: { kind: "owned", mode: "processing" } as const };
+      },
+    });
+    const sm = createSessionManager({ handler, registryPath });
+    try {
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-rebind" }));
+      capturedCtx?.replaceSessionId?.("session-new", "codex_stale_rollout_recovered");
+      await sm.shutdown();
+
+      const raw = JSON.parse(readFileSync(registryPath, "utf-8")) as {
+        entries: Record<string, { claudeSessionId: string }>;
+      };
+      expect(raw.entries["chat-rebind"]?.claudeSessionId).toBe("session-new");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("deduplicates messages with same message ID", async () => {

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -57,6 +57,11 @@ import {
   isTransientCodexErrorMessage,
 } from "../sdk.js";
 import {
+  extractCodexStaleRolloutThreadId,
+  isCodexStaleRolloutError,
+  staleRolloutRecoveryMessage,
+} from "../stale-rollout.js";
+import {
   LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED,
   LandingTrialTurnCompletionConfirmError,
   turnCompletionIdForMessages,
@@ -193,6 +198,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   let threadId: string | null = null;
   let currentModel = "";
   let currentReasoningEffort = "high";
+  let activePayload: AgentRuntimeConfigPayload | null = null;
   let currentTurn: CurrentTurn | null = null;
   let currentTurnPromise: Promise<void> | null = null;
   let turnSettlementInProgress = false;
@@ -533,6 +539,23 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       throw new CodexAppServerStartupError("thread-resume", err);
     }
     threadId = sessionId;
+  }
+
+  async function startFreshThreadAfterStaleRollout(
+    payload: AgentRuntimeConfigPayload,
+    sessionCtx: SessionContext,
+    staleThreadId: string | null,
+  ): Promise<string> {
+    const recoveryMessage = staleRolloutRecoveryMessage(staleThreadId);
+    sessionCtx.emitEvent({ kind: "error", payload: { source: "runtime", message: recoveryMessage } });
+    sessionCtx.log(recoveryMessage);
+    const replacementThreadId = await startThread(payload);
+    sessionCtx.replaceSessionId?.(replacementThreadId, "codex_stale_rollout_recovered");
+    sessionCtx.emitEvent({
+      kind: "error",
+      payload: { source: "runtime", message: staleRolloutRecoveryMessage(staleThreadId, replacementThreadId) },
+    });
+    return replacementThreadId;
   }
 
   function emitToolCall(
@@ -980,6 +1003,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     messages: readonly SessionMessage[],
     token: DeliveryToken,
     sessionCtx: SessionContext,
+    allowStaleRolloutRecovery = true,
   ): Promise<boolean> {
     const client = appServer;
     if (!client || !threadId) {
@@ -995,6 +1019,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       return false;
     }
 
+    const promptSnapshot = pendingChatContextPrompt;
     const providerInputText = consumePendingChatContext(inputText);
     gitWriteTracker.captureBaseline();
     let result: unknown;
@@ -1011,6 +1036,13 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       });
     } catch (err) {
       turnStartInProgress = false;
+      if (allowStaleRolloutRecovery && isCodexStaleRolloutError(err) && activePayload) {
+        turnStartAttempt = null;
+        pendingChatContextPrompt = promptSnapshot;
+        const staleThreadId = extractCodexStaleRolloutThreadId(err) ?? threadId;
+        await startFreshThreadAfterStaleRollout(activePayload, sessionCtx, staleThreadId);
+        return runTurnFromText(inputText, messages, token, sessionCtx, false);
+      }
       const attempt = turnStartAttempt ?? createProviderAttempt();
       turnStartAttempt = null;
       const syntheticFailure = {
@@ -1625,6 +1657,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       ctx = sessionCtx;
       try {
         const { payload, env, briefingFingerprint } = await prepareSession(sessionCtx);
+        activePayload = payload;
         await startAppServer(sessionCtx, env);
         const id = await startThread(payload);
         let input: string;
@@ -1656,6 +1689,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       ctx = sessionCtx;
       try {
         const { payload, env, briefingFingerprint } = await prepareSession(sessionCtx);
+        activePayload = payload;
         // Briefing-staleness notice: a resumed Codex thread read AGENTS.md once
         // at thread init and never re-reads it. If the briefing changed since
         // this session last ran a turn — or there is no baseline (a session
@@ -1672,7 +1706,14 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
           sessionCtx.log(`Resume: briefing changed since last turn — prepending re-read notice (${sessionId})`);
         }
         await startAppServer(sessionCtx, env);
-        await resumeThread(sessionId, payload);
+        let effectiveSessionId = sessionId;
+        try {
+          await resumeThread(sessionId, payload);
+        } catch (err) {
+          if (!isCodexStaleRolloutError(err)) throw err;
+          const staleThreadId = extractCodexStaleRolloutThreadId(err) ?? sessionId;
+          effectiveSessionId = await startFreshThreadAfterStaleRollout(payload, sessionCtx, staleThreadId);
+        }
         if (message) {
           let input: string;
           try {
@@ -1682,16 +1723,19 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
             sessionCtx.log(
               `codex app-server resume formatInboundContent failed: ${err instanceof Error ? err.message : String(err)}`,
             );
-            return hasExplicitDeliveryToken ? { sessionId, route: { kind: "owned", mode: "queued" } } : sessionId;
+            return hasExplicitDeliveryToken
+              ? { sessionId: effectiveSessionId, route: { kind: "owned", mode: "queued" } }
+              : effectiveSessionId;
           }
           const delivered = await runTurnFromText(input, [message], deliveryToken, sessionCtx);
+          effectiveSessionId = threadId ?? effectiveSessionId;
           // Advance the baseline ONLY when the notice-bearing turn actually
           // delivered; a retried / pre-provider turn leaves it for redelivery.
-          if (cwd && delivered) writeSessionBriefingFingerprint(cwd, sessionId, briefingFingerprint);
+          if (cwd && delivered) writeSessionBriefingFingerprint(cwd, effectiveSessionId, briefingFingerprint);
         }
         return hasExplicitDeliveryToken
-          ? { sessionId, route: message ? { kind: "owned", mode: "processing" } : null }
-          : sessionId;
+          ? { sessionId: effectiveSessionId, route: message ? { kind: "owned", mode: "processing" } : null }
+          : effectiveSessionId;
       } finally {
         startupTurnPending = false;
         schedulePendingDrain();
@@ -1713,6 +1757,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       await interruptCurrentTurn();
       await appServer?.shutdown();
       appServer = null;
+      activePayload = null;
       pendingChatContextPrompt = null;
       workspaceOnly = false;
       workspaceOnlyCodexHome = null;
@@ -1726,6 +1771,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       await interruptCurrentTurn();
       await appServer?.shutdown();
       appServer = null;
+      activePayload = null;
       currentTurn = null;
       currentTurnPromise = null;
       startupTurnPending = false;

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -68,6 +68,12 @@ import { chunkAssistantText } from "../assistant-text.js";
 import { formatAuthHint, isCodexAuthError } from "../auth-error-hint.js";
 import { resolveTurnSettlement } from "../turn-settlement.js";
 import {
+  CodexStaleRolloutError,
+  extractCodexStaleRolloutThreadId,
+  isCodexStaleRolloutError,
+  staleRolloutRecoveryMessage,
+} from "./stale-rollout.js";
+import {
   LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED,
   LandingTrialTurnCompletionConfirmError,
   turnCompletionIdForMessages,
@@ -416,6 +422,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
   const workspaceRoot = config.workspaceRoot as string;
   const runtimeProvider = runtimeProviderSchema.parse(config.runtimeProvider ?? "codex");
   const providerTurnMaxRetries = maxProviderTurnRetryAttempts();
+  let activePayload: AgentRuntimeConfigPayload | null = null;
   const agentConfigCache = (config.agentConfigCache as AgentConfigCache | undefined) ?? null;
   const contextTreePath = (config.contextTreePath as string | undefined) ?? null;
   const contextTreeRepoUrl = (config.contextTreeRepoUrl as string | undefined) ?? null;
@@ -953,6 +960,9 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
             }
           } catch (err) {
             if (abort.signal.aborted) return;
+            if (isCodexStaleRolloutError(err)) {
+              throw new CodexStaleRolloutError(err, threadId);
+            }
             const msg = err instanceof Error ? err.message : String(err);
             const classification = providerAttempt.recordSignal({
               kind: "local_error",
@@ -1262,6 +1272,45 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
     return turnDelivered;
   }
 
+  async function runTurnWithStaleRolloutRecovery(
+    input: Input,
+    sessionCtx: SessionContext,
+    messages: readonly SessionMessage[],
+    token: DeliveryToken,
+    payload: AgentRuntimeConfigPayload,
+  ): Promise<boolean> {
+    const promptSnapshot = pendingChatContextPrompt;
+    const staleThreadIdBeforeTurn = threadId;
+    try {
+      return await runTurn(input, sessionCtx, messages, token);
+    } catch (err) {
+      if (!isCodexStaleRolloutError(err)) throw err;
+      const staleThreadId = extractCodexStaleRolloutThreadId(err) ?? staleThreadIdBeforeTurn ?? threadId ?? null;
+      if (!codex || !cwd) throw err;
+
+      pendingChatContextPrompt = promptSnapshot;
+      const recoveryMessage = staleRolloutRecoveryMessage(staleThreadId);
+      sessionCtx.emitEvent({ kind: "error", payload: { source: "runtime", message: recoveryMessage } });
+      sessionCtx.log(recoveryMessage);
+
+      thread = codex.startThread(buildCodexThreadOptions(payload, cwd));
+      threadId = null;
+      prevCumulativeUsage = null;
+      threadIsFresh = true;
+
+      const delivered = await runTurn(input, sessionCtx, messages, token);
+      if (!threadId) threadId = thread?.id ?? null;
+      if (threadId) {
+        sessionCtx.replaceSessionId?.(threadId, "codex_stale_rollout_recovered");
+        sessionCtx.emitEvent({
+          kind: "error",
+          payload: { source: "runtime", message: staleRolloutRecoveryMessage(staleThreadId, threadId) },
+        });
+      }
+      return delivered;
+    }
+  }
+
   function scheduleQueuedMessagesDrain(): void {
     if (drainScheduled || drainInProgress) return;
     if (queuedMessages.length === 0 || !ctx || !thread || currentTurnPromise || initialTurnPreparing) return;
@@ -1366,7 +1415,10 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       pendingChatContextPrompt = pendingChatContextPrompt ? `${notice}\n\n${pendingChatContextPrompt}` : notice;
       sessionCtx.log(`Active session briefing changed — prepending re-read notice (${threadId})`);
     }
-    const delivered = await runTurn(inputs.join("\n\n"), sessionCtx, messages, token);
+    const payload = activePayload;
+    const delivered = payload
+      ? await runTurnWithStaleRolloutRecovery(inputs.join("\n\n"), sessionCtx, messages, token, payload)
+      : await runTurn(inputs.join("\n\n"), sessionCtx, messages, token);
     if (refreshed?.changed && delivered && cwd && threadId) {
       writeSessionBriefingFingerprint(cwd, threadId, refreshed.fingerprint);
     }
@@ -1455,6 +1507,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       markWorkspaceInitComplete(cwd);
 
       codex = createCodexClient({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) }, sessionCtx);
+      activePayload = payload;
       thread = codex.startThread(buildCodexThreadOptions(payload, cwd));
       currentModel = payload.model || "";
       // Brand-new thread: the first `turn.completed` cumulative IS turn 1, so
@@ -1547,6 +1600,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       }
 
       codex = createCodexClient({ env: buildEnv(sessionCtx), config: buildCodexConfig(payload) }, sessionCtx);
+      activePayload = payload;
       // Footgun F2: resumeThread does NOT inherit first-call ThreadOptions —
       // re-pass them every time.
       thread = codex.resumeThread(sessionId, buildCodexThreadOptions(payload, cwd));
@@ -1559,7 +1613,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
         let turnDelivered = false;
         try {
           const input = await toCodexInput(message, sessionCtx);
-          turnDelivered = await runTurn(input, sessionCtx, [message], deliveryToken);
+          turnDelivered = await runTurnWithStaleRolloutRecovery(input, sessionCtx, [message], deliveryToken, payload);
           initialTurnCompleted = true;
         } finally {
           initialTurnPreparing = false;
@@ -1569,11 +1623,11 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
         // delivered (settled complete). A pre-provider / retried turn consumed
         // the notice without the model seeing it, so leaving the baseline
         // unchanged lets the redelivery's resume re-surface it.
-        if (turnDelivered) writeSessionBriefingFingerprint(cwd, sessionId, briefingFingerprint);
+        if (turnDelivered && threadId) writeSessionBriefingFingerprint(cwd, threadId, briefingFingerprint);
       }
       return hasExplicitDeliveryToken
-        ? { sessionId, route: message ? { kind: "owned", mode: "processing" } : null }
-        : sessionId;
+        ? { sessionId: threadId ?? sessionId, route: message ? { kind: "owned", mode: "processing" } : null }
+        : (threadId ?? sessionId);
     },
 
     inject(message, token) {
@@ -1601,6 +1655,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       currentTurnPromise = null;
       thread = null;
       codex = null;
+      activePayload = null;
       initialTurnPreparing = false;
       pendingChatContextPrompt = null;
     },
@@ -1620,6 +1675,7 @@ export const createCodexSdkHandler: HandlerFactory = (config) => {
       currentTurnPromise = null;
       thread = null;
       codex = null;
+      activePayload = null;
 
       // Source repos, the Context Tree clone, and on-demand worktrees under
       // `<cwd>/worktrees/<name>/` are all agent-managed state — the agent

--- a/packages/client/src/handlers/codex/stale-rollout.ts
+++ b/packages/client/src/handlers/codex/stale-rollout.ts
@@ -1,0 +1,63 @@
+const THREAD_ID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i;
+const NO_ROLLOUT_RE = /thread\/resume[\s\S]*no rollout found/i;
+
+export class CodexStaleRolloutError extends Error {
+  readonly threadId: string | null;
+  readonly causeValue: unknown;
+
+  constructor(cause: unknown, fallbackThreadId?: string | null) {
+    const causeMessage = errorMessage(cause);
+    const threadId = extractCodexStaleRolloutThreadId(cause) ?? fallbackThreadId ?? null;
+    super(
+      threadId ? `codex stale rollout for thread ${threadId}: ${causeMessage}` : `codex stale rollout: ${causeMessage}`,
+    );
+    this.name = "CodexStaleRolloutError";
+    this.threadId = threadId;
+    this.causeValue = cause;
+  }
+}
+
+export function isCodexStaleRolloutError(err: unknown): boolean {
+  if (err instanceof CodexStaleRolloutError) return true;
+  return NO_ROLLOUT_RE.test(errorText(err));
+}
+
+export function extractCodexStaleRolloutThreadId(err: unknown): string | null {
+  const text = errorText(err);
+  const match = text.match(/no rollout found for thread id\s+([0-9a-f-]{36})/i) ?? text.match(THREAD_ID_RE);
+  return match?.[1] ?? match?.[0] ?? null;
+}
+
+export function staleRolloutRecoveryMessage(staleThreadId: string | null, replacementThreadId?: string | null): string {
+  const stale = staleThreadId ? ` for stale thread ${staleThreadId}` : "";
+  const replacement = replacementThreadId ? `; replacement thread ${replacementThreadId}` : "";
+  return `codex local rollout missing${stale}; starting fresh thread${replacement}`;
+}
+
+function errorText(err: unknown): string {
+  if (err instanceof CodexStaleRolloutError) {
+    const cause = errorText(err.causeValue);
+    return `${err.message}\n${cause}`;
+  }
+  if (err instanceof Error) {
+    const record = err as unknown as Record<string, unknown>;
+    const parts = [err.name, err.message];
+    if (record.code !== undefined) parts.push(String(record.code));
+    if (record.reason !== undefined) parts.push(String(record.reason));
+    if (record.cause !== undefined) parts.push(errorText(record.cause));
+    return parts.filter(Boolean).join("\n");
+  }
+  if (typeof err === "string") return err;
+  if (!err || typeof err !== "object") return String(err);
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return String(err);
+}

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -185,6 +185,14 @@ export type SessionContext = HandlerContext & {
   failSessionForRecovery?: (reason: string, sessionId?: string) => void;
 
   /**
+   * Rebind the active runtime session to a provider-minted replacement id
+   * without dropping inbox custody. Used by handlers that can safely recover a
+   * stale local provider transcript/rollout by cold-starting the same inbound
+   * turn under a fresh provider thread.
+   */
+  replaceSessionId?: (sessionId: string, reason: string) => void;
+
+  /**
    * Build env for CLI sub-processes that shell out to the First Tree CLI.
    * Layers First Tree envelope vars (server/agent/inbox/chat IDs) on
    * top of the parent env. Handlers pass their own cleaned `process.env`.

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -2213,6 +2213,15 @@ export class SessionManager {
       failSessionForRecovery: (reason, sessionId) => {
         this.failSessionForRecovery(chatId, reason, sessionId);
       },
+      replaceSessionId: (sessionId, reason) => {
+        const entry = this.sessions.get(chatId);
+        if (!entry) return;
+        const previousSessionId = entry.claudeSessionId;
+        entry.claudeSessionId = sessionId;
+        entry.lastActivity = Date.now();
+        this.config.log.info({ chatId, previousSessionId, sessionId, reason }, "session id replaced by handler");
+        this.persistRegistry();
+      },
       buildAgentEnv: (parentEnv) => buildAgentEnv(parentEnv, envCtx),
       formatInboundContent: (message) => formatInboundContent(message, participants),
       resolveSenderLabel: async (senderId) => resolveSenderLabel(senderId, await participants.get()),


### PR DESCRIPTION
## Summary
- detect Codex `thread/resume ... no rollout found` as stale local rollout state instead of a terminal provider failure
- recover SDK and app-server Codex sessions by fresh-starting a replacement thread and replaying the same inbound turn
- persist the replacement thread id through `SessionContext.replaceSessionId` so later messages do not keep resuming the stale id

## Why
Codex keeps thread rollout state in local `~/.codex/sessions/.../rollout-<timestamp>-<threadId>.jsonl` files. If First Tree still has a persisted Codex session id but the local rollout file was deleted, moved, or created under another Codex home, resume fails with `no rollout found`. The user-facing failure was repeating because the runtime kept the stale id.

## QA
Local QA covered both real runtime paths:
- Codex app-server/default: move original rollout aside, restart daemon, send next inbound message, verify replacement thread recovery and follow-up restart
- Codex SDK: same stale rollout simulation, verify replacement thread recovery and follow-up restart

QA result: PASS. No durable `provider_failure_terminal`; session events recorded stale and replacement thread ids; replacement rollout files existed.

## Testing
- `pnpm --dir packages/client exec vitest run src/__tests__/codex-stale-rollout.test.ts src/__tests__/codex-app-server-handler.test.ts src/__tests__/session-manager.test.ts`
- `pnpm --dir packages/client typecheck`
- `pnpm exec biome check packages/client/src/handlers/codex/stale-rollout.ts packages/client/src/handlers/codex/sdk.ts packages/client/src/handlers/codex/app-server/index.ts packages/client/src/runtime/handler.ts packages/client/src/runtime/session-manager.ts packages/client/src/__tests__/codex-stale-rollout.test.ts packages/client/src/__tests__/codex-app-server-handler.test.ts packages/client/src/__tests__/session-manager.test.ts`
- `git diff --check`
