### PR TITLE
feat(server): re-send landing campaign bootstrap when a trial run goes silent

### DIFF
--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -3,7 +3,7 @@ import {
   parseLandingCampaignTrialAgentMetadata,
   parseLandingCampaignTrialChatMetadata,
 } from "@first-tree/shared";
-import { and, eq, sql } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agentConfigs } from "../db/schema/agent-configs.js";
 import { agentResourceBindings } from "../db/schema/agent-resource-bindings.js";
@@ -657,6 +657,88 @@ describe("POST /me/landing-campaigns/start", () => {
       );
     expect(promptBindings).toHaveLength(1);
     expect(promptBindings[0]?.inlinePromptBody).toBeNull();
+  });
+
+  it("resends the bootstrap when a running trial has been silent past the retry window", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const first = await startProductionScan(app, admin);
+    expect(first.statusCode).toBe(200);
+    const firstBody = first.json<{ chatId: string }>();
+    await app.db
+      .update(messages)
+      .set({ createdAt: new Date(Date.now() - 11 * 60 * 1000) })
+      .where(eq(messages.chatId, firstBody.chatId));
+
+    const second = await startProductionScan(app, admin);
+
+    expect(second.statusCode).toBe(200);
+    expect(second.json<{ chatId: string }>().chatId).toBe(firstBody.chatId);
+    const chatMessages = await app.db
+      .select()
+      .from(messages)
+      .where(eq(messages.chatId, firstBody.chatId))
+      .orderBy(asc(messages.createdAt));
+    expect(chatMessages).toHaveLength(2);
+    const retry = chatMessages[1];
+    expect(retry?.metadata).toMatchObject({
+      systemSender: "first_tree_onboarding",
+      landingCampaignTrial: true,
+      bootstrapRetry: true,
+    });
+    expect(retry?.content).toContain("restarted");
+    expect(retry?.content).toContain("run its production-scan skill on https://github.com/acme/backend");
+  });
+
+  it("does not resend the bootstrap while the agent shows recent session activity", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const first = await startProductionScan(app, admin);
+    expect(first.statusCode).toBe(200);
+    const firstBody = first.json<{ chatId: string; agentUuid: string }>();
+    await app.db
+      .update(messages)
+      .set({ createdAt: new Date(Date.now() - 11 * 60 * 1000) })
+      .where(eq(messages.chatId, firstBody.chatId));
+    await sessionEventService.appendEvent(app.db, firstBody.agentUuid, firstBody.chatId, {
+      kind: "thinking",
+      payload: {},
+    });
+
+    const second = await startProductionScan(app, admin);
+
+    expect(second.statusCode).toBe(200);
+    expect(second.json<{ chatId: string }>().chatId).toBe(firstBody.chatId);
+    const chatMessages = await app.db.select().from(messages).where(eq(messages.chatId, firstBody.chatId));
+    expect(chatMessages).toHaveLength(1);
+  });
+
+  it("does not resend the bootstrap when the trial agent has already replied", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const first = await startProductionScan(app, admin);
+    expect(first.statusCode).toBe(200);
+    const firstBody = first.json<{ chatId: string; agentUuid: string }>();
+    await sendMessage(app.db, firstBody.chatId, firstBody.agentUuid, {
+      format: "text",
+      content: "Cloning the scan skill now.",
+      source: "api",
+      metadata: { mentions: [admin.humanAgentUuid] },
+    });
+    await app.db
+      .update(messages)
+      .set({ createdAt: new Date(Date.now() - 11 * 60 * 1000) })
+      .where(eq(messages.chatId, firstBody.chatId));
+
+    const second = await startProductionScan(app, admin);
+
+    expect(second.statusCode).toBe(200);
+    expect(second.json<{ chatId: string }>().chatId).toBe(firstBody.chatId);
+    const chatMessages = await app.db.select().from(messages).where(eq(messages.chatId, firstBody.chatId));
+    expect(chatMessages).toHaveLength(2);
   });
 
   it("preserves runtime session metadata when reusing the trial agent for a new repo", async () => {

--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@first-tree/shared";
 import { and, asc, eq, sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
 import { agentConfigs } from "../db/schema/agent-configs.js";
 import { agentResourceBindings } from "../db/schema/agent-resource-bindings.js";
 import { agents } from "../db/schema/agents.js";
@@ -706,6 +707,41 @@ describe("POST /me/landing-campaigns/start", () => {
       kind: "thinking",
       payload: {},
     });
+
+    const second = await startProductionScan(app, admin);
+
+    expect(second.statusCode).toBe(200);
+    expect(second.json<{ chatId: string }>().chatId).toBe(firstBody.chatId);
+    const chatMessages = await app.db.select().from(messages).where(eq(messages.chatId, firstBody.chatId));
+    expect(chatMessages).toHaveLength(1);
+  });
+
+  it("does not resend the bootstrap while the runtime reports fresh working state without session events", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const first = await startProductionScan(app, admin);
+    expect(first.statusCode).toBe(200);
+    const firstBody = first.json<{ chatId: string; agentUuid: string }>();
+    await app.db
+      .update(messages)
+      .set({ createdAt: new Date(Date.now() - 11 * 60 * 1000) })
+      .where(eq(messages.chatId, firstBody.chatId));
+    // Codex no-events case: a long turn is in flight (fresh per-chat
+    // runtime_state='working') but has emitted zero session events.
+    await app.db
+      .insert(agentChatSessions)
+      .values({
+        agentId: firstBody.agentUuid,
+        chatId: firstBody.chatId,
+        state: "active",
+        runtimeState: "working",
+        runtimeStateAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [agentChatSessions.agentId, agentChatSessions.chatId],
+        set: { state: "active", runtimeState: "working", runtimeStateAt: new Date() },
+      });
 
     const second = await startProductionScan(app, admin);
 

--- a/packages/server/src/services/landing-campaigns/skills/catalog.ts
+++ b/packages/server/src/services/landing-campaigns/skills/catalog.ts
@@ -55,3 +55,17 @@ export function buildLandingCampaignBootstrap(skillSet: LandingCampaignSkillSet,
     `${skillSet.agentDisplayName} — clone ${skillSet.skillRepoUrl} and run its ${skillSet.skillName} skill on the repo above.`,
   ].join("\n");
 }
+
+/**
+ * Re-kick message for a trial whose run went silent. Self-contained on
+ * purpose: the runtime session may be brand new (lost rollout), so the repo
+ * URL, skill repo, and skill name must all be restated rather than referring
+ * to "the repo above".
+ */
+export function buildLandingCampaignRetryBootstrap(skillSet: LandingCampaignSkillSet, repoUrl: string): string {
+  return [
+    `The scan didn't get started, so First Tree has restarted it. Same safe, read-only check on: ${repoUrl}`,
+    "",
+    `${skillSet.agentDisplayName} — if a scan is already in progress in this chat, continue where you left off. Otherwise clone ${skillSet.skillRepoUrl} and run its ${skillSet.skillName} skill on ${repoUrl}.`,
+  ].join("\n");
+}

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -10,6 +10,7 @@ import {
 import { and, asc, desc, eq, gt, ne, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import type { Database } from "../../db/connection.js";
+import { agentChatSessions } from "../../db/schema/agent-chat-sessions.js";
 import { agents } from "../../db/schema/agents.js";
 import { chats } from "../../db/schema/chats.js";
 import { clients } from "../../db/schema/clients.js";
@@ -26,6 +27,7 @@ import {
 } from "../../errors.js";
 import { uuidv7 } from "../../uuid.js";
 import { agentMetadataUpdateExpressionPreservingRuntimeState, createAgent, legacyWireAgentType } from "../agent.js";
+import { computeWorking } from "../agent-chat-status.js";
 import { pickDefaultMembership } from "../auth.js";
 import { createChat } from "../chat.js";
 import { sendToClient } from "../connection-manager.js";
@@ -469,6 +471,21 @@ async function ensureTrialChatAndBootstrap(
         .where(and(eq(messages.chatId, chatId), eq(messages.senderId, input.agentId)))
         .limit(1);
       if (agentMessage) return;
+      // Authoritative in-flight signal: fresh per-chat runtime_state='working'
+      // covers the codex no-events case (a long turn that emits nothing until
+      // turn_end), which the session_events silence check below can never see.
+      // Old clients that never reported per-chat runtime (NULL stamp) fall
+      // through to the events check, which is their legacy working proxy.
+      const [runtimeSession] = await tx
+        .select({
+          state: agentChatSessions.state,
+          runtimeState: agentChatSessions.runtimeState,
+          runtimeStateAt: agentChatSessions.runtimeStateAt,
+        })
+        .from(agentChatSessions)
+        .where(and(eq(agentChatSessions.agentId, input.agentId), eq(agentChatSessions.chatId, chatId)))
+        .limit(1);
+      if (computeWorking(runtimeSession, null, Date.now())) return;
       const [recentEvent] = await tx
         .select({ id: sessionEvents.id })
         .from(sessionEvents)

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -7,7 +7,7 @@ import {
   type RuntimeProvider,
   type SendMessage,
 } from "@first-tree/shared";
-import { and, asc, eq, ne, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, ne, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import type { Database } from "../../db/connection.js";
 import { agents } from "../../db/schema/agents.js";
@@ -15,6 +15,7 @@ import { chats } from "../../db/schema/chats.js";
 import { clients } from "../../db/schema/clients.js";
 import { members } from "../../db/schema/members.js";
 import { messages } from "../../db/schema/messages.js";
+import { sessionEvents } from "../../db/schema/session-events.js";
 import { users } from "../../db/schema/users.js";
 import {
   BadRequestError,
@@ -32,14 +33,28 @@ import { MEMBER_STATUSES, reactivateMembership } from "../membership.js";
 import { sendMessage } from "../message.js";
 import { notifyRecipients } from "../notifier.js";
 import { isLandingCampaignServiceOrg } from "./guards.js";
-import { buildLandingCampaignAgentMetadata, buildLandingCampaignChatMetadata } from "./metadata.js";
+import {
+  buildLandingCampaignAgentMetadata,
+  buildLandingCampaignChatMetadata,
+  getLandingCampaignTrialChat,
+} from "./metadata.js";
 import {
   buildLandingCampaignBootstrap,
+  buildLandingCampaignRetryBootstrap,
   getLandingCampaignSkillSet,
   type LandingCampaignSkillSet,
 } from "./skills/catalog.js";
 
 const SERVICE_MEMBER_AGENT_BASE_NAME = "first-tree-campaigns";
+
+/**
+ * How long a running trial may stay silent (no agent message, no session
+ * events, last message still the bootstrap) before a repeated start for the
+ * same repo re-sends the bootstrap instead of returning the chat untouched.
+ * Failed turns never consume trial budget, so the re-kick restores a dead run
+ * without any counter reset. Sized to outlast a slow skill-repo clone.
+ */
+const TRIAL_BOOTSTRAP_RETRY_AFTER_MS = 10 * 60 * 1000;
 
 type ActiveMembership = {
   id: string;
@@ -423,22 +438,63 @@ async function ensureTrialChatAndBootstrap(
 
   let sent: { recipients: string[]; messageId: string } | undefined;
   await app.db.transaction(async (tx) => {
-    await tx.select({ id: chats.id }).from(chats).where(eq(chats.id, chatId)).for("update");
-    const [firstMessage] = await tx
-      .select({ id: messages.id })
+    const [chatRow] = await tx
+      .select({ id: chats.id, metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, chatId))
+      .for("update")
+      .limit(1);
+    const [lastMessage] = await tx
+      .select({ senderId: messages.senderId, metadata: messages.metadata, createdAt: messages.createdAt })
       .from(messages)
       .where(eq(messages.chatId, chatId))
+      .orderBy(desc(messages.createdAt))
       .limit(1);
-    if (firstMessage) return;
+
+    let content: string;
+    let retryMetadata: Record<string, unknown> = {};
+    if (!lastMessage) {
+      content = buildLandingCampaignBootstrap(input.skillSet, input.repo.url);
+    } else {
+      // The chat already has messages: only re-kick a run that looks dead.
+      // A repeated start for a live or finished trial stays a pure no-op.
+      const trial = getLandingCampaignTrialChat({ metadata: chatRow?.metadata ?? null });
+      if (!trial || trial.state !== "running") return;
+      if (lastMessage.senderId === input.agentId) return;
+      if (lastMessage.metadata.systemSender !== "first_tree_onboarding") return;
+      if (Date.now() - lastMessage.createdAt.getTime() < TRIAL_BOOTSTRAP_RETRY_AFTER_MS) return;
+      const [agentMessage] = await tx
+        .select({ id: messages.id })
+        .from(messages)
+        .where(and(eq(messages.chatId, chatId), eq(messages.senderId, input.agentId)))
+        .limit(1);
+      if (agentMessage) return;
+      const [recentEvent] = await tx
+        .select({ id: sessionEvents.id })
+        .from(sessionEvents)
+        .where(
+          and(
+            eq(sessionEvents.agentId, input.agentId),
+            eq(sessionEvents.chatId, chatId),
+            gt(sessionEvents.createdAt, new Date(Date.now() - TRIAL_BOOTSTRAP_RETRY_AFTER_MS)),
+          ),
+        )
+        .limit(1);
+      if (recentEvent) return;
+      content = buildLandingCampaignRetryBootstrap(input.skillSet, input.repo.url);
+      retryMetadata = { bootstrapRetry: true };
+    }
+
     const message: SendMessage = {
       format: "text",
-      content: buildLandingCampaignBootstrap(input.skillSet, input.repo.url),
+      content,
       source: "api",
       metadata: {
         systemSender: "first_tree_onboarding",
         campaign: input.campaign,
         landingCampaignTrial: true,
         repo: input.repo,
+        ...retryMetadata,
       },
     };
     const result = await sendMessage(tx as unknown as Database, chatId, input.humanAgentId, message, {


### PR DESCRIPTION
## Problem

A landing campaign trial whose run dies before the agent ever replies (skill-repo clone failure, lost Codex rollout, official client hiccup) leaves the chat permanently stuck. The same-repo idempotent start finds an existing first message and returns the dead chat untouched, so the user's natural recovery action — re-clicking the landing CTA — can never revive it. The user sees a silent chat with a single bootstrap message and no way forward short of switching repos.

Two properties of the existing design make a minimal fix possible:

- Turn/token accounting only advances on `turn_end status="success"` (`packages/server/src/api/agent/ws-client.ts`), so a failed run consumes **zero** budget — a dead chat is `running` with its budget intact.
- A fresh inbox message re-activates the runtime through normal delivery, so "append one message" is a complete re-kick.

## Change

Make the idempotent start liveness-aware. `ensureTrialChatAndBootstrap` re-sends a bootstrap into the **same chat** only when every one of these holds:

1. the trial chat is still `running`;
2. the trial agent has never sent a message in the chat;
3. the last message is our own bootstrap (`systemSender: "first_tree_onboarding"`) and is older than 10 minutes;
4. there are no session events within the last 10 minutes (a slow-but-alive run is left alone).

Everything else — live runs, `awaiting_user`, `completed`, human-message-last chats, fresh bootstraps — keeps the exact current no-op behavior. Re-clicking the landing CTA is now the retry button; no new states, endpoints, chats, budget resets, or config.

The resent message is a new self-contained variant (`buildLandingCampaignRetryBootstrap`): the runtime session may be brand new, so repo URL, skill repo, and skill name are restated instead of referring to "the repo above"; a resumed session is told to continue rather than restart. It carries `bootstrapRetry: true` in metadata, which doubles as the throttle marker and a resend-rate metric hook.

## Tests

- new: silent past the retry window → bootstrap resent with `bootstrapRetry: true`, same chatId, self-contained instruction;
- new: recent session activity → no resend;
- new: agent already replied → no resend (also guards the equal-`createdAt` ordering edge, which is why the any-agent-message check exists alongside the last-message check);
- full `@first-tree/server` suite green (177 files / 1724 tests); `@first-tree/client` (1233), `@first-tree/shared` (507), `@first-tree/web` (1133) green; `pnpm check` + `pnpm typecheck` clean. Pre-existing local-environment failures untouched by this server-only diff: the `@first-tree/skill-evals` fixture-clone timeout and 3 `apps/cli` login-command cases (both packages byte-identical to `main`).

Related: #1484 tracks the separate trial quota work (per-user daily cap, global circuit breaker); the two mechanisms are deliberately decoupled — this retry consumes neither budget nor quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
