### PR TITLE
fix(web): keep empty runtime capabilities detecting

### DIFF
--- a/packages/web/src/features/agent-setup/__tests__/setup-hooks.test.tsx
+++ b/packages/web/src/features/agent-setup/__tests__/setup-hooks.test.tsx
@@ -165,6 +165,62 @@ describe("shared setup hooks", () => {
     expect(eventMocks.reportOnboardingEvent).not.toHaveBeenCalled();
   });
 
+  it("keeps an empty capability snapshot in detecting state until a provider report arrives", async () => {
+    const latest = { current: null as ComputerConnection | null };
+    const client = {
+      id: "client-1",
+      userId: "user-self",
+      status: "connected",
+      authState: "ok",
+      binName: "first-tree-dev",
+      sdkVersion: "0.5.0",
+      hostname: "gandy-macbook",
+      os: "darwin",
+      agentCount: 0,
+      connectedAt: "2026-05-28T00:00:00.000Z",
+      lastSeenAt: "2026-05-28T12:00:00.000Z",
+      capabilities: {},
+    };
+    activityMocks.listClients.mockResolvedValue([client]);
+    activityMocks.getClientCapabilities.mockResolvedValueOnce({ ...client, capabilities: {} }).mockResolvedValueOnce({
+      ...client,
+      capabilities: {
+        codex: {
+          state: "ok",
+          available: true,
+          authenticated: true,
+          authMethod: "none",
+          detectedAt: "2026-05-28T12:00:05.000Z",
+        },
+      },
+    });
+
+    function Probe() {
+      latest.current = useComputerConnection(true);
+      return <div>{latest.current.selectedRuntime ?? "none"}</div>;
+    }
+
+    await renderProbe(<Probe />);
+    await flush();
+    await flush();
+
+    expect(expectHookValue(latest.current).connectedClient?.id).toBe("client-1");
+    expect(expectHookValue(latest.current).capabilitiesLoaded).toBe(false);
+    expect(expectHookValue(latest.current).okRuntimes).toEqual([]);
+    expect(expectHookValue(latest.current).selectedRuntime).toBeNull();
+
+    const tick = visibilityMocks.runVisibilityAwareInterval.mock.calls[0]?.[0];
+    if (!tick) throw new Error("visibility-aware interval was not registered");
+    await act(async () => {
+      await tick();
+    });
+    await flush();
+
+    expect(expectHookValue(latest.current).capabilitiesLoaded).toBe(true);
+    expect(expectHookValue(latest.current).okRuntimes).toEqual(["codex"]);
+    expect(expectHookValue(latest.current).selectedRuntime).toBe("codex");
+  });
+
   it("creates an agent and reports lifecycle through callbacks only", async () => {
     const latest = { current: null as ReturnType<typeof useAgentCreation> | null };
     const onOnline = vi.fn();

--- a/packages/web/src/features/agent-setup/use-computer-connection.ts
+++ b/packages/web/src/features/agent-setup/use-computer-connection.ts
@@ -51,6 +51,10 @@ function pickPreferredRuntime(caps: ClientCapabilities): string | null {
   return first ? first[0] : null;
 }
 
+function hasReportedCapabilities(caps: ClientCapabilities | null): caps is ClientCapabilities {
+  return !!caps && Object.keys(caps).length > 0;
+}
+
 export function useComputerConnection(enabled: boolean): ComputerConnection {
   const [connectedClient, setConnectedClient] = useState<HubClient | null>(null);
   const [capabilities, setCapabilities] = useState<ClientCapabilities | null>(null);
@@ -173,7 +177,10 @@ export function useComputerConnection(enabled: boolean): ComputerConnection {
     setRetryNonce((n) => n + 1);
   }, []);
 
-  const activeCapabilities = connectedClient && capabilitiesClientId === connectedClient.id ? capabilities : null;
+  const activeCapabilities =
+    connectedClient && capabilitiesClientId === connectedClient.id && hasReportedCapabilities(capabilities)
+      ? capabilities
+      : null;
 
   // Auto-pick the preferred ready runtime; keep a still-valid prior choice.
   useEffect(() => {


### PR DESCRIPTION
## Summary

- keep onboarding/shared computer setup in the detecting state when the server returns an empty capability snapshot
- only treat capabilities as loaded once the connected client has reported at least one provider entry
- add regression coverage for empty snapshot -> later provider report

## Test plan

- `pnpm exec biome check packages/web/src/features/agent-setup/use-computer-connection.ts packages/web/src/features/agent-setup/__tests__/setup-hooks.test.tsx`
- `pnpm --filter @first-tree/web test -- packages/web/src/features/agent-setup/__tests__/setup-hooks.test.tsx` (runs the web Vitest suite via the package script; 137 files / 1136 tests passed)
