### PR TITLE
fix(server): cap landing campaign trial starts

### DIFF
--- a/packages/server/src/__tests__/bootstrap.test.ts
+++ b/packages/server/src/__tests__/bootstrap.test.ts
@@ -31,7 +31,12 @@ function makeTempConfigDir(): string {
 
 const baseServerConfig: ServerConfig = {
   channel: "dev",
-  growth: { landingPagesEnabled: false, landingCampaignMaxAgentTurns: 1, landingCampaignMaxEstimatedTokens: undefined },
+  growth: {
+    landingPagesEnabled: false,
+    landingCampaignMaxAgentTurns: 1,
+    landingCampaignMaxEstimatedTokens: 120_000,
+    landingCampaignMaxTrialsPerUserPer24Hours: 5,
+  },
   docs: { enabled: false },
   database: { url: process.env.DATABASE_URL ?? "", provider: "external" },
   server: { port: 0, host: "127.0.0.1", publicUrl: "https://first-tree.example" },

--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -16,7 +16,12 @@ import type { Config } from "../config.js";
  */
 const baseConfig: Config = {
   channel: "dev",
-  growth: { landingPagesEnabled: false, landingCampaignMaxAgentTurns: 1, landingCampaignMaxEstimatedTokens: undefined },
+  growth: {
+    landingPagesEnabled: false,
+    landingCampaignMaxAgentTurns: 1,
+    landingCampaignMaxEstimatedTokens: 120_000,
+    landingCampaignMaxTrialsPerUserPer24Hours: 5,
+  },
   docs: { enabled: false },
   database: { url: process.env.DATABASE_URL ?? "", provider: "external" },
   server: { port: 0, host: "127.0.0.1", publicUrl: undefined },

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -67,6 +67,7 @@ export type CreateTestAppOptions = {
   landingCampaignRuntimeProvider?: "codex" | "claude-code";
   landingCampaignMaxAgentTurns?: number;
   landingCampaignMaxEstimatedTokens?: number;
+  landingCampaignMaxTrialsPerUserPer24Hours?: number;
   commandVersion?: string;
   rateLimit?: Partial<NonNullable<Config["rateLimit"]>>;
   connectBootstrap?: Config["connectBootstrap"];
@@ -101,7 +102,8 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
     growth: {
       landingPagesEnabled: opts.growthLandingPagesEnabled ?? false,
       landingCampaignMaxAgentTurns: opts.landingCampaignMaxAgentTurns ?? 1,
-      landingCampaignMaxEstimatedTokens: opts.landingCampaignMaxEstimatedTokens,
+      landingCampaignMaxEstimatedTokens: opts.landingCampaignMaxEstimatedTokens ?? 120_000,
+      landingCampaignMaxTrialsPerUserPer24Hours: opts.landingCampaignMaxTrialsPerUserPer24Hours ?? 5,
       ...(opts.landingCampaignServiceUserId !== undefined ||
       opts.landingCampaignServiceOrgId !== undefined ||
       opts.landingCampaignClientId !== undefined ||

--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -114,9 +114,28 @@ async function startProductionScan(
   return startCampaign(app, admin, "production-scan", repoUrl);
 }
 
+async function startProductionScanInOrg(
+  app: ReturnType<ReturnType<typeof useTestApp>>,
+  admin: Awaited<ReturnType<typeof createTestAdmin>>,
+  organizationId: string,
+  repoUrl = "https://github.com/acme/backend",
+) {
+  return startCampaignInOrg(app, admin, organizationId, "production-scan", repoUrl);
+}
+
 async function startCampaign(
   app: ReturnType<ReturnType<typeof useTestApp>>,
   admin: Awaited<ReturnType<typeof createTestAdmin>>,
+  campaign: string,
+  repoUrl = "https://github.com/acme/backend",
+) {
+  return startCampaignInOrg(app, admin, admin.organizationId, campaign, repoUrl);
+}
+
+async function startCampaignInOrg(
+  app: ReturnType<ReturnType<typeof useTestApp>>,
+  admin: Awaited<ReturnType<typeof createTestAdmin>>,
+  organizationId: string,
   campaign: string,
   repoUrl = "https://github.com/acme/backend",
 ) {
@@ -124,7 +143,7 @@ async function startCampaign(
     method: "POST",
     url: START_URL,
     headers: { authorization: `Bearer ${admin.accessToken}` },
-    payload: { organizationId: admin.organizationId, campaign, repoUrl },
+    payload: { organizationId, campaign, repoUrl },
   });
 }
 
@@ -162,6 +181,23 @@ async function createLandingCampaignServiceAccessToken(
 ): Promise<string> {
   const tokens = await signTokensForUser(app.config.secrets.jwtSecret, SERVICE_USER_ID, app.config.auth);
   return tokens.accessToken;
+}
+
+async function countTrialChatsForUser(app: ReturnType<ReturnType<typeof useTestApp>>, userId: string): Promise<number> {
+  const [row] = await app.db
+    .select({ count: sql<number>`count(DISTINCT ${chats.id})::int` })
+    .from(chats)
+    .innerJoin(
+      chatMembership,
+      and(
+        eq(chatMembership.chatId, chats.id),
+        eq(chatMembership.role, "owner"),
+        eq(chatMembership.accessMode, "speaker"),
+      ),
+    )
+    .innerJoin(members, eq(members.agentId, chatMembership.agentId))
+    .where(and(eq(members.userId, userId), sql`${chats.metadata} ? 'landingCampaignTrial'`));
+  return row?.count ?? 0;
 }
 
 describe("POST /me/landing-campaigns/start", () => {
@@ -217,6 +253,13 @@ describe("POST /me/landing-campaigns/start", () => {
     landingCampaignClientId: OFFICIAL_CLIENT_ID,
     landingCampaignMaxAgentTurns: 3,
     landingCampaignMaxEstimatedTokens: 900,
+  });
+  const getSingleTrialQuotaApp = useTestApp({
+    growthLandingPagesEnabled: true,
+    landingCampaignServiceUserId: SERVICE_USER_ID,
+    landingCampaignServiceOrgId: SERVICE_ORG_ID,
+    landingCampaignClientId: OFFICIAL_CLIENT_ID,
+    landingCampaignMaxTrialsPerUserPer24Hours: 1,
   });
 
   it("parses legacy trial chat metadata with estimated token defaults", () => {
@@ -360,8 +403,8 @@ describe("POST /me/landing-campaigns/start", () => {
       landingCampaignTrial: true,
       campaign: "production-scan",
       skillSetId: "production-scan",
-      repo: { canonicalKey: "github.com/acme/backend" },
     });
+    expect(agentMeta?.repo).toBeUndefined();
 
     const [serviceMember] = await app.db
       .select()
@@ -441,7 +484,7 @@ describe("POST /me/landing-campaigns/start", () => {
       inputLocked: false,
       maxAgentTurns: 1,
       completedAgentTurns: 0,
-      maxEstimatedTokens: null,
+      maxEstimatedTokens: 120_000,
       estimatedTokensUsed: 0,
       lastObservedEstimatedTokens: 0,
       lastObservedTokenUsageEventId: null,
@@ -660,6 +703,72 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(promptBindings[0]?.inlinePromptBody).toBeNull();
   });
 
+  it("does not charge quota for the same repo replay but rejects a second new repo in the rolling window", async () => {
+    const app = getSingleTrialQuotaApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+
+    const first = await startProductionScan(app, admin);
+    const replay = await startProductionScan(app, admin);
+    const secondRepo = await startProductionScan(app, admin, "https://github.com/acme/api");
+
+    expect(first.statusCode).toBe(200);
+    expect(replay.statusCode).toBe(200);
+    expect(replay.json<{ chatId: string }>().chatId).toBe(first.json<{ chatId: string }>().chatId);
+    expect(secondRepo.statusCode).toBe(403);
+    expect(secondRepo.json<{ error: string }>().error).toContain("free trial limit");
+    expect(await countTrialChatsForUser(app, admin.userId)).toBe(1);
+  });
+
+  it("counts landing trial quota across organizations for the same user", async () => {
+    const app = getSingleTrialQuotaApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    const otherOrg = await attachOrg(app, admin.userId, "admin");
+
+    const first = await startProductionScan(app, admin);
+    const secondOrg = await startProductionScanInOrg(app, admin, otherOrg.orgId, "https://github.com/acme/api");
+
+    expect(first.statusCode).toBe(200);
+    expect(secondOrg.statusCode).toBe(403);
+    expect(secondOrg.json<{ error: string }>().error).toContain("last 24 hours");
+    expect(await countTrialChatsForUser(app, admin.userId)).toBe(1);
+  });
+
+  it("allows another new repo after the rolling 24-hour quota window expires", async () => {
+    const app = getSingleTrialQuotaApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+
+    const first = await startProductionScan(app, admin);
+    expect(first.statusCode).toBe(200);
+    const firstBody = first.json<{ chatId: string }>();
+    await app.db
+      .update(chats)
+      .set({ createdAt: new Date(Date.now() - 25 * 60 * 60 * 1000) })
+      .where(eq(chats.id, firstBody.chatId));
+
+    const second = await startProductionScan(app, admin, "https://github.com/acme/api");
+
+    expect(second.statusCode).toBe(200);
+    expect(second.json<{ chatId: string }>().chatId).not.toBe(firstBody.chatId);
+    expect(await countTrialChatsForUser(app, admin.userId)).toBe(2);
+  });
+
+  it("serializes concurrent new repo starts against the per-user quota", async () => {
+    const app = getSingleTrialQuotaApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+
+    const results = await Promise.all([
+      startProductionScan(app, admin, "https://github.com/acme/backend"),
+      startProductionScan(app, admin, "https://github.com/acme/api"),
+    ]);
+
+    expect(results.map((res) => res.statusCode).sort()).toEqual([200, 403]);
+    expect(await countTrialChatsForUser(app, admin.userId)).toBe(1);
+  });
+
   it("resends the bootstrap when a running trial has been silent past the retry window", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
@@ -803,8 +912,8 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(parseLandingCampaignTrialAgentMetadata(trialAgent?.metadata)).toMatchObject({
       landingCampaignTrial: true,
       campaign: "production-scan",
-      repo: { canonicalKey: "github.com/acme/api" },
     });
+    expect(parseLandingCampaignTrialAgentMetadata(trialAgent?.metadata)?.repo).toBeUndefined();
     const runtimeSession = (trialAgent?.metadata as Record<string, unknown> | undefined)?.runtimeSession;
     expect(runtimeSession).toMatchObject({
       clientId: OFFICIAL_CLIENT_ID,
@@ -1281,12 +1390,27 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(afterLimit.statusCode).toBe(403);
   });
 
-  it("keeps turn-only behavior when the estimated token cap is not configured", async () => {
+  it("keeps turn-only behavior for legacy uncapped trial metadata", async () => {
     const app = getMultiTurnApp();
     const admin = await createTestAdmin(app);
     await seedOfficialRuntime(app, admin.organizationId);
     const started = await startProductionScan(app, admin);
     const body = started.json<{ chatId: string; agentUuid: string }>();
+    const [initialChat] = await app.db
+      .select({ metadata: chats.metadata })
+      .from(chats)
+      .where(eq(chats.id, body.chatId));
+    const initialTrial = parseLandingCampaignTrialChatMetadata(initialChat?.metadata);
+    if (!initialChat || !initialTrial) throw new Error("expected trial chat metadata");
+    await app.db
+      .update(chats)
+      .set({
+        metadata: {
+          ...initialChat.metadata,
+          landingCampaignTrial: { ...initialTrial, maxEstimatedTokens: null },
+        },
+      })
+      .where(eq(chats.id, body.chatId));
 
     const uncappedEvent = await sessionEventService.appendEvent(app.db, body.agentUuid, body.chatId, {
       kind: "token_usage",

--- a/packages/server/src/services/landing-campaigns/guards.ts
+++ b/packages/server/src/services/landing-campaigns/guards.ts
@@ -1,10 +1,16 @@
 import { parseLandingCampaignTrialAgentMetadata } from "@first-tree/shared";
-import { and, eq, inArray, ne } from "drizzle-orm";
+import { and, eq, gte, inArray, ne, sql } from "drizzle-orm";
 import type { Config } from "../../config.js";
 import type { Database } from "../../db/connection.js";
 import { agents } from "../../db/schema/agents.js";
+import { chatMembership } from "../../db/schema/chat-membership.js";
+import { chats } from "../../db/schema/chats.js";
 import { members } from "../../db/schema/members.js";
 import { ForbiddenError } from "../../errors.js";
+
+const TRIAL_QUOTA_WINDOW_MS = 24 * 60 * 60 * 1000;
+const TRIAL_QUOTA_EXCEEDED_MESSAGE =
+  "You've reached the free trial limit for the last 24 hours. Try again later, or connect your own First Tree workspace to keep going.";
 
 export function isLandingCampaignServiceOrg(config: Config, organizationId: string | null | undefined): boolean {
   const serviceOrgId = config.growth.landingCampaigns?.serviceOrgId;
@@ -47,6 +53,34 @@ export async function assertNoLandingCampaignTrialAgents(db: Database, agentIds:
     throw new ForbiddenError(
       `Agent "${trial.displayName}" is a single-run landing campaign agent. Start it from the landing page flow.`,
     );
+  }
+}
+
+export async function assertTrialQuota(db: Database, config: Config, userId: string): Promise<void> {
+  const maxTrials = config.growth.landingCampaignMaxTrialsPerUserPer24Hours;
+  const windowStart = new Date(Date.now() - TRIAL_QUOTA_WINDOW_MS);
+  const [usage] = await db
+    .select({ count: sql<number>`count(DISTINCT ${chats.id})::int` })
+    .from(chats)
+    .innerJoin(
+      chatMembership,
+      and(
+        eq(chatMembership.chatId, chats.id),
+        eq(chatMembership.role, "owner"),
+        eq(chatMembership.accessMode, "speaker"),
+      ),
+    )
+    .innerJoin(members, eq(members.agentId, chatMembership.agentId))
+    .where(
+      and(
+        eq(members.userId, userId),
+        sql`${chats.metadata} ? 'landingCampaignTrial'`,
+        gte(chats.createdAt, windowStart),
+      ),
+    );
+
+  if ((usage?.count ?? 0) >= maxTrials) {
+    throw new ForbiddenError(TRIAL_QUOTA_EXCEEDED_MESSAGE);
   }
 }
 

--- a/packages/server/src/services/landing-campaigns/metadata.ts
+++ b/packages/server/src/services/landing-campaigns/metadata.ts
@@ -27,14 +27,12 @@ export function buildLandingCampaignAgentMetadata(input: {
   campaign: string;
   skillSetId: string;
   skillSetVersion: string;
-  repo: LandingCampaignRepoMetadata;
 }): Record<string, unknown> {
   return {
     landingCampaignTrial: true,
     campaign: input.campaign,
     skillSetId: input.skillSetId,
     skillSetVersion: input.skillSetVersion,
-    repo: input.repo,
   };
 }
 

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -427,7 +427,8 @@ async function ensureTrialChatAndBootstrap(
     if (existing) return existing.id;
 
     await assertTrialQuota(db, app.config, input.userId);
-    const created = await createChat(app.db, {
+    // Keep chat inserts and participant rows on the advisory-lock connection.
+    const created = await createChat(db, {
       mode: "legacy-empty-agent",
       creatorAgentId: input.humanAgentId,
       participantAgentIds: [input.agentId],

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -34,7 +34,7 @@ import { sendToClient } from "../connection-manager.js";
 import { MEMBER_STATUSES, reactivateMembership } from "../membership.js";
 import { sendMessage } from "../message.js";
 import { notifyRecipients } from "../notifier.js";
-import { isLandingCampaignServiceOrg } from "./guards.js";
+import { assertTrialQuota, isLandingCampaignServiceOrg } from "./guards.js";
 import {
   buildLandingCampaignAgentMetadata,
   buildLandingCampaignChatMetadata,
@@ -268,14 +268,12 @@ async function ensureTrialAgent(
     runtimeProvider: RuntimeProvider;
     campaign: string;
     skillSet: LandingCampaignSkillSet;
-    repo: LandingCampaignRepoMetadata;
   },
 ) {
   const metadata = buildLandingCampaignAgentMetadata({
     campaign: input.campaign,
     skillSetId: input.skillSet.id,
     skillSetVersion: input.skillSet.version,
-    repo: input.repo,
   });
 
   const [existing] = await db
@@ -339,7 +337,6 @@ async function provisionTrialAgent(
     runtimeProvider: RuntimeProvider;
     campaign: string;
     skillSet: LandingCampaignSkillSet;
-    repo: LandingCampaignRepoMetadata;
   },
 ): Promise<{
   serviceMember: typeof members.$inferSelect;
@@ -357,7 +354,6 @@ async function provisionTrialAgent(
       runtimeProvider: input.runtimeProvider,
       campaign: input.campaign,
       skillSet: input.skillSet,
-      repo: input.repo,
     });
     return { serviceMember, trialAgent };
   });
@@ -386,6 +382,7 @@ function notifyClientAgentPinned(app: FastifyInstance, agent: Awaited<ReturnType
 async function ensureTrialChatAndBootstrap(
   app: FastifyInstance,
   input: {
+    userId: string;
     humanAgentId: string;
     agentId: string;
     campaign: string;
@@ -417,15 +414,19 @@ async function ensureTrialChatAndBootstrap(
     lastObservedTokenUsageEventId: null,
   });
 
-  let chatId: string;
-  const [existing] = await app.db
-    .select({ id: chats.id })
-    .from(chats)
-    .where(eq(chats.onboardingKickoffKey, kickoffKey))
-    .limit(1);
-  if (existing) {
-    chatId = existing.id;
-  } else {
+  const chatId = await app.db.transaction(async (tx) => {
+    const db = tx as unknown as Database;
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext('landing_campaign_trial_quota'), hashtext(${input.userId}))`,
+    );
+    const [existing] = await tx
+      .select({ id: chats.id })
+      .from(chats)
+      .where(eq(chats.onboardingKickoffKey, kickoffKey))
+      .limit(1);
+    if (existing) return existing.id;
+
+    await assertTrialQuota(db, app.config, input.userId);
     const created = await createChat(app.db, {
       mode: "legacy-empty-agent",
       creatorAgentId: input.humanAgentId,
@@ -435,8 +436,8 @@ async function ensureTrialChatAndBootstrap(
       onboardingKickoffKey: kickoffKey,
       allowLandingCampaignTrial: true,
     });
-    chatId = created.id;
-  }
+    return created.id;
+  });
 
   let sent: { recipients: string[]; messageId: string } | undefined;
   await app.db.transaction(async (tx) => {
@@ -550,13 +551,13 @@ export async function startLandingCampaignTrial(
     runtimeProvider: config.runtimeProvider,
     campaign: body.campaign,
     skillSet,
-    repo,
   });
   await app.resourcesService.unbindLegacyCampaignScanSkill(trialAgent.uuid, body.campaign, serviceMember.id);
   await app.resourcesService.ensureAndBindLandingCampaignTrialPrompt(trialAgent.uuid, serviceMember.id);
   notifyClientAgentPinned(app, trialAgent);
 
   const result = await ensureTrialChatAndBootstrap(app, {
+    userId,
     humanAgentId: caller.agentId,
     agentId: trialAgent.uuid,
     campaign: body.campaign,

--- a/packages/shared/src/config/__tests__/server-config.test.ts
+++ b/packages/shared/src/config/__tests__/server-config.test.ts
@@ -72,13 +72,15 @@ describe("server config", () => {
 
     expect(defaultConfig.growth.landingPagesEnabled).toBe(false);
     expect(defaultConfig.growth.landingCampaignMaxAgentTurns).toBe(6);
-    expect(defaultConfig.growth.landingCampaignMaxEstimatedTokens).toBeUndefined();
+    expect(defaultConfig.growth.landingCampaignMaxEstimatedTokens).toBe(120_000);
+    expect(defaultConfig.growth.landingCampaignMaxTrialsPerUserPer24Hours).toBe(5);
 
     resetConfig();
     const enabledConfigDir = makeTempConfigDir();
     vi.stubEnv("FIRST_TREE_GROWTH_LANDING_PAGES_ENABLED", "true");
     vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_MAX_AGENT_TURNS", "4");
     vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_MAX_ESTIMATED_TOKENS", "12000");
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_MAX_TRIALS_PER_USER_PER_24_HOURS", "7");
 
     const enabledConfig = await initConfig({
       schema: createServerConfigSchema({ autoGenerateSecrets: false }),
@@ -89,6 +91,7 @@ describe("server config", () => {
     expect(enabledConfig.growth.landingPagesEnabled).toBe(true);
     expect(enabledConfig.growth.landingCampaignMaxAgentTurns).toBe(4);
     expect(enabledConfig.growth.landingCampaignMaxEstimatedTokens).toBe(12000);
+    expect(enabledConfig.growth.landingCampaignMaxTrialsPerUserPer24Hours).toBe(7);
   });
 
   it("resolves landing campaign official service ids only when configured", async () => {
@@ -150,6 +153,20 @@ describe("server config", () => {
         configDir,
       }),
     ).rejects.toThrow(/landingCampaignMaxEstimatedTokens/);
+  });
+
+  it("rejects invalid landing campaign trial quota limits", async () => {
+    const configDir = makeTempConfigDir();
+    stubRequiredProductionConfig();
+    vi.stubEnv("FIRST_TREE_LANDING_CAMPAIGN_MAX_TRIALS_PER_USER_PER_24_HOURS", "0");
+
+    await expect(
+      initConfig({
+        schema: createServerConfigSchema({ autoGenerateSecrets: false }),
+        role: "server",
+        configDir,
+      }),
+    ).rejects.toThrow(/landingCampaignMaxTrialsPerUserPer24Hours/);
   });
 
   it("defaults landing campaign runtime provider to codex and accepts claude-code", async () => {

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -72,12 +72,19 @@ export const serverConfigSchema = defineConfig({
       env: "FIRST_TREE_LANDING_CAMPAIGN_MAX_AGENT_TURNS",
     }),
     /**
-     * Optional approximate token budget for each landing campaign trial chat.
-     * When unset, trial quota remains turn-only. When set, successful agent
-     * turns advance both the turn count and this metadata-backed estimate.
+     * Approximate token budget for each landing campaign trial chat. Successful
+     * agent turns advance both the turn count and this metadata-backed estimate.
      */
-    landingCampaignMaxEstimatedTokens: field(z.number().int().min(1).optional(), {
+    landingCampaignMaxEstimatedTokens: field(z.number().int().min(1).default(120_000), {
       env: "FIRST_TREE_LANDING_CAMPAIGN_MAX_ESTIMATED_TOKENS",
+    }),
+    /**
+     * Maximum number of new landing campaign trial chats a user can create
+     * across all organizations in a rolling 24-hour window. Idempotent starts
+     * for an existing campaign/repo chat do not consume this quota.
+     */
+    landingCampaignMaxTrialsPerUserPer24Hours: field(z.number().int().min(1).default(5), {
+      env: "FIRST_TREE_LANDING_CAMPAIGN_MAX_TRIALS_PER_USER_PER_24_HOURS",
     }),
     landingCampaigns: optional({
       /**

--- a/packages/shared/src/schemas/landing-campaign.ts
+++ b/packages/shared/src/schemas/landing-campaign.ts
@@ -35,7 +35,7 @@ export const landingCampaignTrialAgentMetadataSchema = z.object({
   campaign: landingCampaignSlugSchema,
   skillSetId: z.string().min(1),
   skillSetVersion: z.string().min(1),
-  repo: landingCampaignRepoMetadataSchema,
+  repo: landingCampaignRepoMetadataSchema.optional(),
 });
 export type LandingCampaignTrialAgentMetadata = z.infer<typeof landingCampaignTrialAgentMetadataSchema>;
 


### PR DESCRIPTION
## Summary

Implements the confirmed landing campaign trial scope from #1484:

- caps new landing trial chats to 5 per user in a rolling 24-hour window by default
- checks the quota across all organizations for the same user
- keeps same campaign/repo replays idempotent, so they reuse the existing chat and do not consume quota
- adds a friendly `403` message when the free trial limit is reached
- gives landing trial chats a real default estimated token cap of `120_000`
- stops writing repo metadata on the trial agent; repo metadata remains on the trial chat

The global daily circuit breaker from the original issue is intentionally not included here because the follow-up product decision narrowed this PR to the per-user limit.

Refs #1484

## Tests

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/landing-campaigns-start.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/shared exec vitest run src/config/__tests__/server-config.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/bootstrap.test.ts src/__tests__/build-app-validation.test.ts --maxWorkers=2`
- `pnpm --filter @first-tree/server typecheck`
- `pnpm --filter @first-tree/shared typecheck`
- `pnpm exec biome check --write packages/server/src/__tests__/helpers.ts packages/server/src/__tests__/landing-campaigns-start.test.ts packages/server/src/__tests__/bootstrap.test.ts packages/server/src/__tests__/build-app-validation.test.ts packages/server/src/services/landing-campaigns/guards.ts packages/server/src/services/landing-campaigns/metadata.ts packages/server/src/services/landing-campaigns/start.ts packages/shared/src/config/__tests__/server-config.test.ts packages/shared/src/config/server-config.ts packages/shared/src/schemas/landing-campaign.ts`
- accidental broader run: `pnpm --filter @first-tree/server test -- --run src/__tests__/landing-campaigns-start.test.ts --maxWorkers=2` passed the full server suite (`178` files, `1744` tests)
