### PR TITLE
Fix Windows symlink bootstrap fallbacks

### DIFF
--- a/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
@@ -74,6 +74,7 @@ vi.mock("../commands/_shared/local-agent.js", () => localAgentMocks);
 let tempDir = "";
 const originalExit = process.exit;
 const originalStdoutWrite = process.stdout.write;
+const originalPlatform = process.platform;
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {
   return {
@@ -112,6 +113,10 @@ async function runChat(args: string[]): Promise<void> {
   await runRegistered(registerChatCommands, ["chat", ...args]);
 }
 
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "ft-cli-matrix-"));
   vi.clearAllMocks();
@@ -146,6 +151,7 @@ afterEach(() => {
   rmSync(tempDir, { force: true, recursive: true });
   process.exit = originalExit;
   process.stdout.write = originalStdoutWrite;
+  setPlatform(originalPlatform);
   delete process.env.FIRST_TREE_CHAT_ID;
 });
 
@@ -251,6 +257,21 @@ describe("daemon utility commands", () => {
       configDir: join(tempDir, "config"),
       dataDir: join(tempDir, "data"),
     });
+  });
+
+  it("gives actionable Windows inline-daemon guidance when restart service control is unsupported", async () => {
+    setPlatform("win32");
+    coreMocks.isServiceSupported.mockReturnValue(false);
+
+    await runDaemon(["restart"]);
+
+    const output = printLineMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("Service control is not supported on Windows");
+    expect(output).toContain("First Tree runs inline");
+    expect(output).toContain("daemon probe");
+    expect(output).toContain("PowerShell");
+    expect(output).toContain("Ctrl+C");
+    expect(output).toContain("daemon start");
   });
 });
 

--- a/apps/cli/src/commands/daemon/restart.ts
+++ b/apps/cli/src/commands/daemon/restart.ts
@@ -9,8 +9,23 @@ export function registerDaemonRestartCommand(daemon: Command): void {
     .description("Restart the background service")
     .action(() => {
       if (!isServiceSupported()) {
-        print.line(`\n  Service control not supported on ${process.platform}.\n`);
-        print.line("  Restart your inline `daemon start` process manually.\n\n");
+        if (process.platform === "win32") {
+          print.line("\n  Service control is not supported on Windows.\n");
+          print.line("  First Tree runs inline on this platform.\n\n");
+          print.line("  If you are onboarding and need to refresh detected agents:\n");
+          print.line(`    ${channelConfig.binName} daemon probe\n\n`);
+          print.line("  If you need to restart the inline daemon:\n");
+          print.line(`    stop the PowerShell running \`${channelConfig.binName} daemon start\` with Ctrl+C,\n`);
+          print.line(`    then run \`${channelConfig.binName} daemon start\` again.\n\n`);
+        } else {
+          print.line(`\n  Service control is not supported on ${process.platform}.\n`);
+          print.line("  First Tree runs inline on this platform.\n\n");
+          print.line("  If you are onboarding and need to refresh detected agents:\n");
+          print.line(`    ${channelConfig.binName} daemon probe\n\n`);
+          print.line("  If you need to restart the inline daemon:\n");
+          print.line(`    stop the terminal running \`${channelConfig.binName} daemon start\` with Ctrl+C,\n`);
+          print.line(`    then run \`${channelConfig.binName} daemon start\` again.\n\n`);
+        }
         return;
       }
       const svc = getClientServiceStatus();

--- a/apps/cli/src/commands/daemon/stop.ts
+++ b/apps/cli/src/commands/daemon/stop.ts
@@ -9,8 +9,14 @@ export function registerDaemonStopCommand(daemon: Command): void {
     .description("Stop the background service (preserves auto-start; use `daemon start` to bring it back)")
     .action(() => {
       if (!isServiceSupported()) {
-        print.line(`\n  Service control not supported on ${process.platform}.\n`);
-        print.line("  If running inline, use Ctrl+C or kill the process.\n\n");
+        if (process.platform === "win32") {
+          print.line("\n  Service control is not supported on Windows.\n");
+          print.line("  First Tree runs inline on this platform.\n");
+          print.line(`  Stop the PowerShell running \`${channelConfig.binName} daemon start\` with Ctrl+C.\n\n`);
+        } else {
+          print.line(`\n  Service control is not supported on ${process.platform}.\n`);
+          print.line(`  Stop the terminal running \`${channelConfig.binName} daemon start\` with Ctrl+C.\n\n`);
+        }
         return;
       }
       const svc = getClientServiceStatus();

--- a/packages/client/src/__tests__/windows-symlink-fallback.test.ts
+++ b/packages/client/src/__tests__/windows-symlink-fallback.test.ts
@@ -1,0 +1,172 @@
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  symlinkSync: vi.fn(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    symlinkSync: fsMocks.symlinkSync,
+  };
+});
+
+import { installCoreSkills, writeAgentBriefing } from "../runtime/bootstrap.js";
+
+const originalPlatform = process.platform;
+const CORE_SKILLS = ["first-tree-welcome", "first-tree-write", "first-tree-seed", "first-tree-file-bug"] as const;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+function symlinkError(code: "EPERM" | "EACCES"): NodeJS.ErrnoException {
+  return Object.assign(new Error(`symlink ${code}`), { code });
+}
+
+function makeFixtureSkillsRoot(parent: string, version: string, label: string): string {
+  const root = join(parent, `skills-${label}`);
+  mkdirSync(root, { recursive: true });
+  for (const name of CORE_SKILLS) {
+    const dir = join(root, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "SKILL.md"), `---\nname: ${name}\n---\nfixture ${label} for ${name}\n`);
+    writeFileSync(join(dir, "VERSION"), version);
+  }
+  mkdirSync(join(root, "first-tree-write", "nested"), { recursive: true });
+  writeFileSync(join(root, "first-tree-write", "nested", "extra.txt"), `extra ${label}\n`);
+  return root;
+}
+
+describe("Windows symlink fallbacks", () => {
+  let tmpBase: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "ft-win-symlink-"));
+    fsMocks.symlinkSync.mockReset();
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+    setPlatform(originalPlatform);
+  });
+
+  it.each([
+    "EPERM",
+    "EACCES",
+  ] as const)("writes CLAUDE.md as a regular file on Windows %s and keeps later briefing updates in sync", (code) => {
+    setPlatform("win32");
+    fsMocks.symlinkSync.mockImplementation(() => {
+      throw symlinkError(code);
+    });
+    const workspace = join(tmpBase, `briefing-${code}`);
+    mkdirSync(workspace, { recursive: true });
+
+    writeAgentBriefing(workspace, "first briefing");
+    expect(readFileSync(join(workspace, "AGENTS.md"), "utf-8")).toBe("first briefing");
+    expect(readFileSync(join(workspace, "CLAUDE.md"), "utf-8")).toBe("first briefing");
+    expect(lstatSync(join(workspace, "CLAUDE.md")).isFile()).toBe(true);
+    expect(lstatSync(join(workspace, "CLAUDE.md")).isSymbolicLink()).toBe(false);
+
+    writeAgentBriefing(workspace, "updated briefing");
+    expect(readFileSync(join(workspace, "AGENTS.md"), "utf-8")).toBe("updated briefing");
+    expect(readFileSync(join(workspace, "CLAUDE.md"), "utf-8")).toBe("updated briefing");
+  });
+
+  it("does not swallow non-Windows symlink permission errors", () => {
+    setPlatform("linux");
+    fsMocks.symlinkSync.mockImplementation(() => {
+      throw symlinkError("EACCES");
+    });
+    const workspace = join(tmpBase, "briefing-linux-error");
+    mkdirSync(workspace, { recursive: true });
+
+    expect(() => writeAgentBriefing(workspace, "briefing")).toThrow("symlink EACCES");
+    expect(existsSync(join(workspace, "AGENTS.md"))).toBe(true);
+    expect(existsSync(join(workspace, "CLAUDE.md"))).toBe(false);
+  });
+
+  it("copies Claude skill payloads on Windows symlink EPERM", () => {
+    setPlatform("win32");
+    fsMocks.symlinkSync.mockImplementation(() => {
+      throw symlinkError("EPERM");
+    });
+    const workspace = join(tmpBase, "skills-copy");
+    mkdirSync(workspace, { recursive: true });
+    const bundledSkillsRoot = makeFixtureSkillsRoot(tmpBase, "1.0.0", "v1");
+    const logs: string[] = [];
+
+    const result = installCoreSkills({
+      workspacePath: workspace,
+      bundledSkillsRoot,
+      log: (message) => logs.push(message),
+    });
+
+    expect(result, logs.join("\n")).toBe(true);
+    const claudeSkill = join(workspace, ".claude", "skills", "first-tree-write");
+    expect(lstatSync(claudeSkill).isDirectory()).toBe(true);
+    expect(lstatSync(claudeSkill).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(claudeSkill, "SKILL.md"), "utf-8")).toContain("fixture v1 for first-tree-write");
+    expect(readFileSync(join(claudeSkill, "VERSION"), "utf-8")).toBe("1.0.0");
+    expect(readFileSync(join(claudeSkill, "nested", "extra.txt"), "utf-8")).toBe("extra v1\n");
+  });
+
+  it("accepts a current Claude skill directory copy on the fast path", () => {
+    setPlatform("win32");
+    fsMocks.symlinkSync.mockImplementation(() => {
+      throw symlinkError("EPERM");
+    });
+    const workspace = join(tmpBase, "skills-copy-fast-path");
+    mkdirSync(workspace, { recursive: true });
+    const bundledSkillsRoot = makeFixtureSkillsRoot(tmpBase, "1.0.0", "v1");
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot, log: () => {} });
+
+    writeFileSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"), "agents marker\n");
+    writeFileSync(join(workspace, ".claude", "skills", "first-tree-write", ".sentinel"), "claude marker\n");
+    fsMocks.symlinkSync.mockClear();
+    const logs: string[] = [];
+
+    const result = installCoreSkills({
+      workspacePath: workspace,
+      bundledSkillsRoot,
+      log: (message) => logs.push(message),
+    });
+
+    expect(result, logs.join("\n")).toBe(true);
+    expect(fsMocks.symlinkSync).not.toHaveBeenCalled();
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"))).toBe(true);
+    expect(existsSync(join(workspace, ".claude", "skills", "first-tree-write", ".sentinel"))).toBe(true);
+    expect(logs.join("\n")).toContain("up-to-date");
+  });
+
+  it("refreshes the Claude skill directory copy when the bundled payload drifts", () => {
+    setPlatform("win32");
+    fsMocks.symlinkSync.mockImplementation(() => {
+      throw symlinkError("EPERM");
+    });
+    const workspace = join(tmpBase, "skills-copy-refresh");
+    mkdirSync(workspace, { recursive: true });
+    const bundledV1 = makeFixtureSkillsRoot(tmpBase, "1.0.0", "v1");
+    installCoreSkills({ workspacePath: workspace, bundledSkillsRoot: bundledV1, log: () => {} });
+    writeFileSync(join(workspace, ".claude", "skills", "first-tree-write", ".sentinel"), "stale marker\n");
+
+    const bundledV2 = makeFixtureSkillsRoot(tmpBase, "2.0.0", "v2");
+    const logs: string[] = [];
+    const result = installCoreSkills({
+      workspacePath: workspace,
+      bundledSkillsRoot: bundledV2,
+      log: (message) => logs.push(message),
+    });
+
+    expect(result, logs.join("\n")).toBe(true);
+    const claudeSkill = join(workspace, ".claude", "skills", "first-tree-write");
+    expect(readFileSync(join(claudeSkill, "SKILL.md"), "utf-8")).toContain("fixture v2 for first-tree-write");
+    expect(readFileSync(join(claudeSkill, "VERSION"), "utf-8")).toBe("2.0.0");
+    expect(readFileSync(join(claudeSkill, "nested", "extra.txt"), "utf-8")).toBe("extra v2\n");
+    expect(existsSync(join(claudeSkill, ".sentinel"))).toBe(false);
+  });
+});

--- a/packages/client/src/runtime/bootstrap.ts
+++ b/packages/client/src/runtime/bootstrap.ts
@@ -94,7 +94,9 @@ export const IDENTITY_JSON_REL = join(FIRST_TREE_RUNTIME_DIR, "identity.json");
 
 /**
  * Materialise the unified agent briefing at `<workspacePath>/AGENTS.md` and
- * keep `<workspacePath>/CLAUDE.md` as a relative symlink to it.
+ * keep `<workspacePath>/CLAUDE.md` as a relative symlink to it where the host
+ * permits symlink creation. Windows hosts without symlink privileges fall back
+ * to a regular `CLAUDE.md` copy so Claude Code can still read the briefing.
  *
  * One file, both providers: Codex's `project_root_markers` walk finds
  * `AGENTS.md` directly; Claude Code's `settingSources: ["project"]` follows
@@ -103,13 +105,15 @@ export const IDENTITY_JSON_REL = join(FIRST_TREE_RUNTIME_DIR, "identity.json");
  */
 export function writeAgentBriefing(workspacePath: string, content: string): void {
   writeFileSync(join(workspacePath, "AGENTS.md"), content, "utf-8");
-  ensureClaudeMdSymlink(workspacePath);
+  ensureClaudeMdSymlink(workspacePath, content);
 }
 
 /**
- * Make `<workspacePath>/CLAUDE.md` a relative symlink to `AGENTS.md`. Replaces
- * a stale regular file or broken/mis-targeted symlink left from earlier
- * bootstrap formats; a no-op when the symlink is already correct.
+ * Make `<workspacePath>/CLAUDE.md` a relative symlink to `AGENTS.md` where
+ * possible. Replaces a stale regular file or broken/mis-targeted symlink left
+ * from earlier bootstrap formats; a no-op when the symlink is already correct.
+ * On Windows symlink permission failures (`EPERM` / `EACCES`), falls back to a
+ * regular file copy carrying the same briefing content.
  *
  * Atomically swaps in the new symlink via `rename` so two concurrent
  * same-agent starts can't race the unlink/symlink pair into an `EEXIST`
@@ -130,7 +134,7 @@ export function writeAgentBriefing(workspacePath: string, content: string): void
  * double-load — re-run the manual probes documented in tree-context PR
  * #397 before upgrading the SDK major version.
  */
-export function ensureClaudeMdSymlink(workspacePath: string): void {
+export function ensureClaudeMdSymlink(workspacePath: string, fallbackContent?: string): void {
   const claudeMd = join(workspacePath, "CLAUDE.md");
   const targetRel = "AGENTS.md";
   try {
@@ -140,7 +144,19 @@ export function ensureClaudeMdSymlink(workspacePath: string): void {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
   }
   const tempPath = join(workspacePath, `.CLAUDE.md.${randomBytes(6).toString("hex")}.tmp`);
-  symlinkSync(targetRel, tempPath);
+  try {
+    symlinkSync(targetRel, tempPath);
+  } catch (err) {
+    try {
+      rmSync(tempPath, { force: true, recursive: true });
+    } catch {
+      // Best-effort cleanup — surface the original symlink failure unless
+      // Windows can use the regular-file fallback below.
+    }
+    if (!isWindowsSymlinkPermissionError(err)) throw err;
+    writeClaudeMdFallbackFile(workspacePath, fallbackContent);
+    return;
+  }
   try {
     renameSync(tempPath, claudeMd);
   } catch (err) {
@@ -151,6 +167,29 @@ export function ensureClaudeMdSymlink(workspacePath: string): void {
     }
     throw err;
   }
+}
+
+function writeClaudeMdFallbackFile(workspacePath: string, content?: string): void {
+  const claudeMd = join(workspacePath, "CLAUDE.md");
+  const nextContent = content ?? readFileSync(join(workspacePath, "AGENTS.md"), "utf8");
+  const tempPath = join(workspacePath, `.CLAUDE.md.${randomBytes(6).toString("hex")}.tmp`);
+  writeFileSync(tempPath, nextContent, "utf-8");
+  try {
+    renameSync(tempPath, claudeMd);
+  } catch (err) {
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Best-effort cleanup — surface the original rename failure.
+    }
+    throw err;
+  }
+}
+
+function isWindowsSymlinkPermissionError(err: unknown): boolean {
+  if (process.platform !== "win32") return false;
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === "EPERM" || code === "EACCES";
 }
 
 /**

--- a/packages/client/src/runtime/first-tree-skills/installer.ts
+++ b/packages/client/src/runtime/first-tree-skills/installer.ts
@@ -100,7 +100,7 @@ type SkillLayout = {
   sourceDir: string;
   /** Workspace-relative path of the installed payload. */
   agentsRelPath: string;
-  /** Workspace-relative path of the `.claude/skills/<name>` symlink. */
+  /** Workspace-relative path of the `.claude/skills/<name>` companion entry. */
   claudeRelPath: string;
   /** Symlink target for `.claude/skills/<name>` → `../../.agents/skills/<name>`. */
   claudeSymlinkTarget: string;
@@ -193,9 +193,33 @@ function inspectPath(p: string): SymlinkInspection {
   return { kind: "file" };
 }
 
+function isWindowsSymlinkPermissionError(err: unknown): boolean {
+  if (process.platform !== "win32") return false;
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === "EPERM" || code === "EACCES";
+}
+
+function isMatchingSkillDirectory(candidateDir: string, sourceDir: string): boolean {
+  const candidateVersion = readVersionFile(candidateDir);
+  const sourceVersion = readVersionFile(sourceDir);
+  if (candidateVersion === null || sourceVersion === null || candidateVersion !== sourceVersion) return false;
+  const candidateSkill = readSkillMd(candidateDir);
+  const sourceSkill = readSkillMd(sourceDir);
+  return candidateSkill !== null && sourceSkill !== null && candidateSkill === sourceSkill;
+}
+
+function isClaudeCompanionCurrent(workspacePath: string, layout: SkillLayout, agentsFull: string): boolean {
+  const claudeFull = join(workspacePath, layout.claudeRelPath);
+  const claudeState = inspectPath(claudeFull);
+  if (claudeState.kind === "symlink" && claudeState.target === layout.claudeSymlinkTarget) return true;
+  return claudeState.kind === "directory" && isMatchingSkillDirectory(claudeFull, agentsFull);
+}
+
 /**
  * Make `<workspacePath>/.claude/skills/<name>` a relative symlink to the
- * matching `.agents/skills/<name>` directory.
+ * matching `.agents/skills/<name>` directory where symlink creation is
+ * available. Windows hosts without symlink privileges fall back to a regular
+ * directory copy so Claude Code still sees the shipped skill payload.
  *
  * Uses the same temp-path + rename atomic-swap pattern as
  * `ensureClaudeMdSymlink` in `bootstrap.ts` (PR #797 nit) so two
@@ -209,16 +233,28 @@ function inspectPath(p: string): SymlinkInspection {
  * Skips the swap entirely when the existing entry already points at
  * the correct target (the steady-state fast path on every session
  * start). Replaces anything else — a stale symlink, a clobbered
- * regular file, or even a directory that ended up there by mistake.
+ * regular file, or even a stale fallback directory.
  */
-function ensureClaudeSymlink(workspacePath: string, layout: SkillLayout): void {
+function ensureClaudeSymlink(workspacePath: string, layout: SkillLayout, agentsFull: string): void {
   const claudeFull = join(workspacePath, layout.claudeRelPath);
   mkdirSync(dirname(claudeFull), { recursive: true });
   const existing = inspectPath(claudeFull);
   if (existing.kind === "symlink" && existing.target === layout.claudeSymlinkTarget) return;
 
   const tempPath = `${claudeFull}.${randomBytes(6).toString("hex")}.tmp`;
-  symlinkSync(layout.claudeSymlinkTarget, tempPath);
+  try {
+    symlinkSync(layout.claudeSymlinkTarget, tempPath);
+  } catch (err) {
+    try {
+      rmSync(tempPath, { force: true, recursive: true });
+    } catch {
+      // Best-effort cleanup — surface the original symlink failure unless
+      // Windows can use the directory-copy fallback below.
+    }
+    if (!isWindowsSymlinkPermissionError(err)) throw err;
+    ensureClaudeDirectoryCopy(workspacePath, layout, agentsFull);
+    return;
+  }
   try {
     // `renameSync` overwrites a regular file or symlink in place atomically
     // on POSIX; on a directory it returns ENOTDIR / EISDIR depending on
@@ -233,6 +269,27 @@ function ensureClaudeSymlink(workspacePath: string, layout: SkillLayout): void {
       unlinkSync(tempPath);
     } catch {
       // Best-effort cleanup — surface the original rename failure.
+    }
+    throw err;
+  }
+}
+
+function ensureClaudeDirectoryCopy(workspacePath: string, layout: SkillLayout, agentsFull: string): void {
+  const claudeFull = join(workspacePath, layout.claudeRelPath);
+  mkdirSync(dirname(claudeFull), { recursive: true });
+  if (inspectPath(claudeFull).kind === "directory" && isMatchingSkillDirectory(claudeFull, agentsFull)) return;
+
+  const tempPath = `${claudeFull}.${randomBytes(6).toString("hex")}.tmp`;
+  rmSync(tempPath, { force: true, recursive: true });
+  try {
+    cpSync(agentsFull, tempPath, { recursive: true });
+    rmSync(claudeFull, { force: true, recursive: true });
+    renameSync(tempPath, claudeFull);
+  } catch (err) {
+    try {
+      rmSync(tempPath, { force: true, recursive: true });
+    } catch {
+      // Best-effort cleanup — surface the original copy/rename failure.
     }
     throw err;
   }
@@ -259,14 +316,14 @@ export function installOneSkill(workspacePath: string, layout: SkillLayout): "in
   const installedVersion = inspectPath(agentsFull).kind === "directory" ? readVersionFile(agentsFull) : null;
 
   // Fast path: same VERSION on both sides AND SKILL.md content matches
-  // AND the claude symlink looks right. Comparing SKILL.md content as
+  // AND the Claude companion entry looks right. Comparing SKILL.md content as
   // well as VERSION is a defense-in-depth against the human-forgot-to-
   // bump-VERSION failure mode (PR #844 review — yuezengwu): without it,
   // a developer who edits SKILL.md but leaves VERSION at the previous
   // value would silently serve stale skills to every running agent. The
   // SKILL.md read is a few KB per skill per session start — negligible.
-  // If only the claude symlink is wrong, fall through so we rewrite it
-  // without a full re-copy.
+  // If only the Claude companion entry is wrong, fall through so we rewrite
+  // it without a full re-copy.
   const fingerprintsAgree =
     bundledVersion !== null &&
     installedVersion !== null &&
@@ -277,19 +334,15 @@ export function installOneSkill(workspacePath: string, layout: SkillLayout): "in
       return bundledSkill !== null && installedSkill !== null && bundledSkill === installedSkill;
     })();
   if (fingerprintsAgree) {
-    const claudeFull = join(workspacePath, layout.claudeRelPath);
-    const claudeState = inspectPath(claudeFull);
-    if (claudeState.kind === "symlink" && claudeState.target === layout.claudeSymlinkTarget) {
-      return "skipped";
-    }
-    ensureClaudeSymlink(workspacePath, layout);
+    if (isClaudeCompanionCurrent(workspacePath, layout, agentsFull)) return "skipped";
+    ensureClaudeSymlink(workspacePath, layout, agentsFull);
     return "skipped";
   }
 
   mkdirSync(dirname(agentsFull), { recursive: true });
   rmSync(agentsFull, { force: true, recursive: true });
   cpSync(layout.sourceDir, agentsFull, { recursive: true });
-  ensureClaudeSymlink(workspacePath, layout);
+  ensureClaudeSymlink(workspacePath, layout, agentsFull);
   return "installed";
 }
 
@@ -406,7 +459,7 @@ function reconcileTreeSkillState(workspacePath: string): void {
 
 /**
  * Remove a previously-managed skill's on-disk payload AND its Claude Code
- * symlink. Either step is best-effort and only operates on entries that
+ * companion entry. Either step is best-effort and only operates on entries that
  * actually exist; anything the user added later (a custom skill payload
  * under `.agents/skills/<user-skill>/`) is never touched because we look
  * up by NAME, not by listing the directory.
@@ -417,15 +470,17 @@ function removeManagedSkill(workspacePath: string, name: string): void {
   try {
     rmSync(agentsFull, { recursive: true, force: true });
   } catch {
-    // Best-effort — the symlink-side cleanup below still runs.
+    // Best-effort — the Claude companion cleanup below still runs.
   }
-  // The Claude-side entry is a symlink; we don't care whether it currently
-  // resolves. `lstat`-then-unlink mirrors the pattern in
-  // `ensureClaudeSymlink` for atomic replacement.
   try {
-    lstatSync(claudeFull);
-    unlinkSync(claudeFull);
+    const claudeState = inspectPath(claudeFull);
+    if (claudeState.kind === "missing") return;
+    if (claudeState.kind === "directory") {
+      rmSync(claudeFull, { recursive: true, force: true });
+    } else {
+      unlinkSync(claudeFull);
+    }
   } catch {
-    // Either missing or unlink failed — both acceptable here.
+    // Either missing or remove failed — both acceptable here.
   }
 }


### PR DESCRIPTION
## Summary

- Add a Windows-only `EPERM` / `EACCES` fallback for `CLAUDE.md -> AGENTS.md` symlink creation by writing a regular `CLAUDE.md` copy that stays in sync with `AGENTS.md`.
- Add a Windows-only `.claude/skills/<name>` symlink fallback that copies the installed `.agents/skills/<name>` payload, including fast-path detection and refresh on payload drift.
- Improve unsupported service guidance for inline Windows daemon restart/stop flows, especially `daemon probe`, Ctrl+C in the PowerShell running `daemon start`, and starting again.

Refs #1490

## Tests

- `pnpm --filter @first-tree/client test --maxWorkers=2 --minWorkers=1 src/__tests__/windows-symlink-fallback.test.ts src/__tests__/bootstrap.test.ts src/__tests__/skills-state-reconcile.test.ts`
- `pnpm --filter first-tree-dev test --maxWorkers=2 --minWorkers=1 src/__tests__/cli-command-matrix-extra.test.ts`
- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm test -- --maxWorkers=2 --minWorkers=1 --testTimeout=20000`

Note: default `pnpm test -- --maxWorkers=2 --minWorkers=1` hit the existing 5s timeout in `@first-tree/skill-evals` `first-tree-seed` periodic fixture under full-suite load; rerunning that test and the full suite with `--testTimeout=20000` passed.
