### PR TITLE
feat(web): add Microsoft Clarity tracking

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -93,6 +93,18 @@ The Docker release workflow passes `VITE_SENTRY_DSN` and
 the Web build, which makes Sentry enabled by default for the managed release
 path without committing the public DSN to the repo.
 
+## Web product analytics and session insights
+
+The Web Console loads Microsoft Clarity for production session insights. The
+project id is `xj2f9syfng`.
+
+Clarity is loaded from `packages/web/index.html` only when
+`window.location.hostname` is `cloud.first-tree.ai`. Local development hosts and
+staging hosts such as `dev.cloud.first-tree.ai` do not fetch the Clarity SDK and
+do not write into the production project. This mirrors the GA4 host gate in the
+same SPA shell and avoids requiring a Vite env var, Docker build argument, or
+secret for this fixed production tag.
+
 ### Client configuration
 
 ```bash

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -105,6 +105,13 @@ do not write into the production project. This mirrors the GA4 host gate in the
 same SPA shell and avoids requiring a Vite env var, Docker build argument, or
 secret for this fixed production tag.
 
+The Web Console treats Clarity as layout/session telemetry, not content
+telemetry. The React root (`#root`) carries `data-clarity-mask="true"` so chat
+messages, agent traces, connect commands, tokens, repo paths, and other
+customer/workspace text rendered by the app are masked before upload. Do not add
+`data-clarity-unmask` inside the app unless the surface is public/static and the
+privacy boundary has been reviewed with the exact content classes it can render.
+
 ### Client configuration
 
 ```bash

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -93,25 +93,6 @@ The Docker release workflow passes `VITE_SENTRY_DSN` and
 the Web build, which makes Sentry enabled by default for the managed release
 path without committing the public DSN to the repo.
 
-## Web product analytics and session insights
-
-The Web Console loads Microsoft Clarity for production session insights. The
-project id is `xj2f9syfng`.
-
-Clarity is loaded from `packages/web/index.html` only when
-`window.location.hostname` is `cloud.first-tree.ai`. Local development hosts and
-staging hosts such as `dev.cloud.first-tree.ai` do not fetch the Clarity SDK and
-do not write into the production project. This mirrors the GA4 host gate in the
-same SPA shell and avoids requiring a Vite env var, Docker build argument, or
-secret for this fixed production tag.
-
-The Web Console treats Clarity as layout/session telemetry, not content
-telemetry. The React root (`#root`) carries `data-clarity-mask="true"` so chat
-messages, agent traces, connect commands, tokens, repo paths, and other
-customer/workspace text rendered by the app are masked before upload. Do not add
-`data-clarity-unmask` inside the app unless the surface is public/static and the
-privacy boundary has been reviewed with the exact content classes it can render.
-
 ### Client configuration
 
 ```bash
@@ -134,6 +115,25 @@ The Client scrubber drops user identity, request bodies, cookies, query
 strings, breadcrumbs, bearer tokens, OAuth/token-like fields, and local home /
 workspace path prefixes before sending events. Runtime content fields such as
 provider prompts, model output, tool output, stdout, and stderr are redacted.
+
+## Web product analytics and session insights
+
+The Web Console loads Microsoft Clarity for production session insights. The
+project id is `xj2f9syfng`.
+
+Clarity is loaded from `packages/web/index.html` only when
+`window.location.hostname` is `cloud.first-tree.ai`. Local development hosts and
+staging hosts such as `dev.cloud.first-tree.ai` do not fetch the Clarity SDK and
+do not write into the production project. This mirrors the GA4 host gate in the
+same SPA shell and avoids requiring a Vite env var, Docker build argument, or
+secret for this fixed production tag.
+
+The Web Console treats Clarity as layout/session telemetry, not content
+telemetry. The React root (`#root`) carries `data-clarity-mask="true"` so chat
+messages, agent traces, connect commands, tokens, repo paths, and other
+customer/workspace text rendered by the app are masked before upload. Do not add
+`data-clarity-unmask` inside the app unless the surface is public/static and the
+privacy boundary has been reviewed with the exact content classes it can render.
 
 ## Multi-environment setup (one backend, many environments)
 

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -46,6 +46,8 @@
       Microsoft Clarity — session insights for the production Web Console.
       Like GA4, this is hostname-gated because the Docker build ships one dist
       across channels; staging/local must not write into the production project.
+      The React app root is masked below so customer/workspace text is not
+      uploaded in Clarity recordings by default.
     -->
     <script>
       (() => {
@@ -72,7 +74,7 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root" data-clarity-mask="true"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -42,6 +42,27 @@
         });
       })();
     </script>
+    <!--
+      Microsoft Clarity — session insights for the production Web Console.
+      Like GA4, this is hostname-gated because the Docker build ships one dist
+      across channels; staging/local must not write into the production project.
+    -->
+    <script>
+      (() => {
+        if (window.location.hostname !== "cloud.first-tree.ai") return;
+        window.clarity =
+          window.clarity ||
+          ((...args) => {
+            const queue = window.clarity.q || [];
+            window.clarity.q = queue;
+            queue.push(args);
+          });
+        const tag = document.createElement("script");
+        tag.async = true;
+        tag.src = "https://www.clarity.ms/tag/xj2f9syfng";
+        document.head.appendChild(tag);
+      })();
+    </script>
     <script>
       (() => {
         const t = localStorage.getItem("theme");


### PR DESCRIPTION

## Summary
- Add Microsoft Clarity project `xj2f9syfng` to the Web Console SPA shell.
- Gate the Clarity SDK to `cloud.first-tree.ai` so local and staging hosts do not write into the production project.
- Document the production-only Clarity setup in `docs/observability.md`.

## Validation
- `pnpm check` passed. Biome still reports pre-existing warnings outside this change.
- `pnpm typecheck` passed. Vite emitted the existing CSS optimizer/chunk-size warnings during nested web build.
- `pnpm --filter @first-tree/skill-evals test -- src/suites/first-tree-seed/__tests__/periodic.test.ts` passed after the full test timeout below.
- `pnpm --filter @first-tree/web build` passed. Vite emitted the existing CSS optimizer/chunk-size warnings.
- `rg -n "clarity\.ms/tag/xj2f9syfng|cloud\.first-tree\.ai|Microsoft Clarity" packages/web/dist/index.html` confirmed the built shell contains the Clarity tag and host gate.
- `pnpm test` failed twice in `@first-tree/skill-evals`: `src/suites/first-tree-seed/__tests__/periodic.test.ts > builds the real-source fixture from a run-scoped origin instead of the developer checkout` timed out at the 5000ms Vitest limit during concurrent full-suite execution. The same package/test file passed when rerun directly.

## Change Surface
- `packages/web/index.html`: production-only inline Clarity loader.
- `docs/observability.md`: Web product analytics/session insights documentation.

## Notes
- No Vite env var, Docker build arg, secret, or custom Clarity event tracking was added.


## Context Tree
- Draft tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/689
