### PR TITLE
docs: point entry links to first-tree.ai and refresh onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="https://cloud.first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=nav-app"><strong>Open App</strong></a> &middot;
+  <a href="https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=nav-app"><strong>Open App</strong></a> &middot;
   <a href="#get-started"><strong>Get Started</strong></a> &middot;
   <a href="#how-it-works"><strong>How It Works</strong></a> &middot;
   <a href="docs/quickstart.md"><strong>Quickstart</strong></a> &middot;
@@ -25,7 +25,7 @@
   English | <a href="README_zh-CN.md">中文</a>
 </p>
 
-> Try [first-tree 🌳](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) **free** — the fastest way to give every agent your team's shared context. [Open the app](https://cloud.first-tree.ai/login?utm_source=github&utm_medium=readme&utm_campaign=top-cta-app).
+> Try [first-tree 🌳](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=top-cta-site) **free** — the fastest way to give every agent your team's shared context.
 
 # First-Tree
 
@@ -116,11 +116,10 @@ during, and after execution.
 
 ## Get Started
 
-Open the app at **[cloud.first-tree.ai](https://cloud.first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=getstarted-app)**
-(or your own deployment) and sign in. Learn more at
-[first-tree.ai](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=getstarted-home).
-The guided setup walks you through the first run: name your team, connect a
-computer, create your first agent, connect code, and start work.
+Open the app at **[first-tree.ai](https://first-tree.ai/?utm_source=github&utm_medium=readme&utm_campaign=getstarted-app)**
+(or your own deployment) and sign in. The guided setup walks you through the
+first run: name your team, connect a computer, create your first agent, and
+start work.
 
 See the [Quickstart](docs/quickstart.md) for the full walkthrough.
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -75,7 +75,7 @@ First Tree 围绕 Context Tree 连接五个部分：
 ## 开始使用
 
 打开 <https://first-tree.ai> 或你自己的部署登录。引导式流程会带你完成首次
-使用：给团队命名、连接一台电脑、创建第一个 Agent、连接代码、开始工作。
+使用：给团队命名、连接一台电脑、创建第一个 Agent、开始工作。
 
 完整步骤见 [Quickstart](docs/quickstart.md)。
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,10 +4,10 @@ A walkthrough that takes a brand-new account from signup to a working chat
 with your first agent.
 
 Signing in for the first time drops you into a **full-screen guided setup**.
-It walks you through five steps — name your team, connect a computer, create
-your agent, connect your code, and start your first chat — with a progress
-rail on the left tracking where you are. You can leave and resume later. This
-page mirrors that flow.
+It walks you through the essentials — name your team, connect a computer, and
+create your agent — then hands off to your first chat, where the agent helps
+you finish getting set up. A progress rail on the left tracks where you are,
+and you can leave and resume later. This page mirrors that flow.
 
 > **Self-hosting?** Use your own deployment's URL wherever this guide says
 > <https://first-tree.ai>. The rest is identical — every connect token
@@ -45,15 +45,18 @@ This installs the CLI and signs the computer in. `first-tree login`:
   stays online across reboots. (See the [Onboarding Guide](onboarding-guide.md)
   for exactly what gets written and the `--no-start` flag.)
 
-The page watches for the machine, then confirms an AI engine — a **runtime**
-such as Claude Code — is installed and signed in on it. Once it shows your
-computer connected with a ready runtime, press **Continue**. If it reports
-that no engine is ready, install one (e.g. Claude Code) on that computer and
-sign in; it appears here automatically.
+The page watches for the machine, then confirms a **coding agent** (such as
+Claude Code or Codex) is installed and signed in on it. Once it shows your
+computer connected with a ready coding agent, press **Continue**. If it
+reports that none is ready, install one (e.g. Claude Code) on that computer
+and sign in; it appears here automatically.
 
 ## 3. Create your agent
 
-Give your agent a name (for example `Buddy`) and pick who can use it:
+Your team agent runs on top of a coding agent already installed on the
+computer you just connected. Pick which one to use (Claude Code is selected
+by default when detected), give the agent a name (for example `Buddy`), and
+choose who can use it:
 
 - **Shared with team** — anyone on your team can talk to this agent.
 - **Just me** — only you can see and talk to it.
@@ -62,29 +65,31 @@ There is no "type" to choose — every agent you create here is a standard
 agent, and the visibility choice is the only difference. Click **Create**.
 
 Setup then waits for the agent to come online on the computer you connected
-("Setting up your agent… usually about 10 seconds"). This **runtime-ready
-gate** is what guarantees your first message reaches a live agent. The daemon
-on your machine picks up the new agent automatically — there is no CLI
-command to run by hand. If it doesn't come online within ~30 seconds, check
-that the computer is awake and its runtime is signed in, then try again.
+("Bringing your agent online… usually a few seconds"). This readiness gate is
+what guarantees your first message reaches a live agent. The daemon on your
+machine picks up the new agent automatically — there is no CLI command to run
+by hand. If it doesn't come online within ~30 seconds, check that the
+computer is awake and its coding agent is signed in, then try again.
 
-## 4. Connect your code
+## 4. Start your first chat
 
-Connect the projects your agent should work on: click **Install First Tree
-on GitHub**, approve the GitHub App, then pick one or more projects. Every
-change your agent makes comes back as a request you review.
+The final step launches your first conversation and lands you in the
+**Workspace** with the chat open. Setup finishes here — agent-led, in the
+chat, not as more wizard steps. Your agent walks you through the key
+operations, one approved step at a time:
 
-Not ready, or not a GitHub organization owner? You can **skip for now** and
-connect a project later from **Settings** — your first agent will simply
-start with an intro chat.
+- **Point it at your code** — share a local project folder path or a GitHub
+  repo URL, and the agent reads your project and gets a first task done. (No
+  GitHub setup is required up front; you can connect the First Tree GitHub App
+  later, when a task needs it.)
+- **Build your team's Context Tree** — once it has shown real value from your
+  code, your agent offers to build your team's shared memory: it proposes an
+  initial structure and fills it in from your code, with you approving each
+  change. (Offered to team admins; teammates who join later inherit the tree
+  automatically.)
 
-## 5. Start your first chat
-
-The final step kicks off your first conversation. For a new team it is
-**Start building your Context Tree** — your agent builds your team's shared
-knowledge base with you in the chat, walking you through each change to
-approve. Press **Start** and you land in the **Workspace** with the chat
-open.
+You reach a working agent first — none of this is a gate you clear up front.
+You can also connect code anytime from **Settings**.
 
 The Workspace is a three-panel layout:
 
@@ -94,8 +99,8 @@ The Workspace is a three-panel layout:
   send. Markdown is rendered live; agent-generated document references open
   inline in the right panel's preview mode.
 - **Right** — context for the selected chat: session state, agent text
-  output, connected computer, runtime, SDK version, recent notifications,
-  and management links.
+  output, connected computer, coding agent, SDK version, recent
+  notifications, and management links.
 
 That's it — you're chatting with your first agent.
 
@@ -103,9 +108,10 @@ That's it — you're chatting with your first agent.
 
 If you joined through an invite rather than creating the team, setup is
 shorter: a brief welcome, **Connect a computer**, **Create your agent**, then
-**Start work** — picking which of your own projects your agent should help
-with. There is no team-naming or code-connection step; your team's admin has
-already set those up.
+**Start chat**. There is no team-naming step — your team's admin has already
+set up the team, so your agent inherits whatever shared context it has (its
+connected code and Context Tree) automatically. Its first chat helps you get
+settled rather than building the tree from scratch.
 
 ## Where to go next
 
@@ -125,6 +131,7 @@ console:
 | Need | Where |
 |---|---|
 | Connect another computer | **Settings → Computers → + New Connection** |
+| Connect a code repo | **Settings** → connect GitHub |
 | Create another agent | **Team → New agent** (same name + visibility form) |
 | One-screen overview of your install | `first-tree status` |
 | Send a message to another agent | `first-tree chat send <agent> "..."` |


### PR DESCRIPTION
## What & why

The README still pointed users at `cloud.first-tree.ai` and documented an
onboarding flow that no longer matches the code (the "connect code" wizard
step was removed in the value-first redesign). This updates the user-facing
docs to reality.

### 1. Entry links → `first-tree.ai`
`cloud.first-tree.ai` is no longer the surfaced entry point. Dropped it from
the README nav ("Open App"), the top CTA, and the Get Started section (all now
`first-tree.ai`). The zh README already used `first-tree.ai`.

**Scope note:** runtime domain constants in app/OAuth/test code
(`analytics.tsx`, `safe-href.ts`, etc.) are intentionally **not** touched —
those are the real deployed domain, and migrating them is a separate change.

### 2. Onboarding flow refresh (`docs/quickstart.md`, both READMEs)
Verified against `packages/web/src/pages/onboarding/{steps.ts,copy.ts,steps/*}`
and the first-chat bootstrap (`bootstrap-prose.ts`, `skills/first-tree-welcome`):

- **No "connect code" step.** The live sequence is create-team → connect-computer
  → create-agent → start-chat (invitee: join-team → …). GitHub connection moved
  off the wizard's critical path.
- **The first chat is where setup finishes** — agent-led and value-first. §4 now
  explains the key operations that happen there: pointing the agent at your code
  (local path / GitHub URL) and, for admins, building the team's Context Tree
  after the agent has shown value — one approved step at a time.
- **Vocabulary:** `runtime` / "AI engine" → `coding agent` (Claude Code, Codex),
  matching the copy doctrine in `copy.ts`.
- **Create-agent** now notes the coding-agent picker (defaults to Claude Code).
- **Invitee path:** no project-picking; the agent inherits the team's shared
  context, and the first chat helps them get settled.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
