### PR TITLE
fix(server): re-review context tree prs after draft changes

### DIFF
--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -19,8 +19,6 @@ import { createAdminContext, useTestApp } from "./helpers.js";
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
 
-const FOLLOW_UP_NOTICE = "A new GitHub event was received. I'll check the current PR state.";
-
 function pullRequestPayload(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     action: "opened",
@@ -30,6 +28,7 @@ function pullRequestPayload(overrides: Partial<Record<string, unknown>> = {}) {
       html_url: "https://github.com/owner/context-tree/pull/123",
       base: { ref: "main" },
       head: { ref: "context-update" },
+      draft: false,
     },
     repository: { full_name: "owner/context-tree" },
     sender: { login: "writer", type: "User" },
@@ -120,6 +119,7 @@ describe("Context Reviewer PR prompt", () => {
       headRef: "context-update",
       senderLogin: "writer",
       triggerEvent: "pull_request.opened",
+      isDraft: false,
       commentUrl: null,
       commentAuthorLogin: null,
       organizationId: "org-1",
@@ -132,6 +132,11 @@ describe("Context Reviewer PR prompt", () => {
     expect(prompt).toContain("gh pr review 123 --repo owner/context-tree --request-changes --body-file");
     expect(prompt).toContain("gh pr review 123 --repo owner/context-tree --comment --body-file");
     expect(prompt).toContain("gh pr review 123 --repo owner/context-tree --approve --body-file");
+    expect(prompt).toContain("Draft status from webhook: ready for review");
+    expect(prompt).toContain(
+      "Treat `pull_request.synchronize` and `pull_request.ready_for_review` as fresh review requests",
+    );
+    expect(prompt).toContain("Do not rely on an older approval or comment review");
     expect(prompt).toContain("Context changes requested");
     expect(prompt).toContain("Still unclear or needs more detail");
     expect(prompt).toContain("review action was submitted: `approved`, `commented`, `changes_requested`, or `failed`");
@@ -147,6 +152,7 @@ describe("Context Reviewer PR prompt", () => {
       headRef: null,
       senderLogin: "writer",
       triggerEvent: "pull_request.synchronize",
+      isDraft: null,
       commentUrl: null,
       commentAuthorLogin: null,
       organizationId: "org-1",
@@ -155,9 +161,34 @@ describe("Context Reviewer PR prompt", () => {
     expect(prompt).toContain("Base ref: unknown");
     expect(prompt).toContain("Head ref: unknown");
     expect(prompt).toContain("Trigger event: pull_request.synchronize");
+    expect(prompt).toContain(
+      "Draft status from webhook: unknown; inspect the current PR state before choosing an outcome",
+    );
     expect(prompt).toContain("gh pr review 124 --repo owner/context-tree --request-changes --body-file");
     expect(prompt).toContain("gh pr review 124 --repo owner/context-tree --comment --body-file");
     expect(prompt).toContain("gh pr review 124 --repo owner/context-tree --approve --body-file");
+  });
+
+  it("renders draft-specific non-approval instructions", async () => {
+    const prompt = await renderContextReviewerPrPrompt({
+      repoFullName: "owner/context-tree",
+      prNumber: 126,
+      title: "Draft context",
+      htmlUrl: "https://github.com/owner/context-tree/pull/126",
+      baseRef: "main",
+      headRef: "draft-context",
+      senderLogin: "writer",
+      triggerEvent: "pull_request.opened",
+      isDraft: true,
+      commentUrl: null,
+      commentAuthorLogin: null,
+      organizationId: "org-1",
+    });
+
+    expect(prompt).toContain("Draft status from webhook: draft");
+    expect(prompt).toContain("If the pull request is still a draft, do not approve it");
+    expect(prompt).toContain("approval is deferred until the PR is ready for review");
+    expect(prompt).toContain("the pull request is not a draft");
   });
 
   it("renders comment trigger context when present", async () => {
@@ -170,6 +201,7 @@ describe("Context Reviewer PR prompt", () => {
       headRef: null,
       senderLogin: "writer",
       triggerEvent: "issue_comment.created",
+      isDraft: null,
       commentUrl: "https://github.com/owner/context-tree/pull/125#issuecomment-1",
       commentAuthorLogin: "commenter",
       organizationId: "org-1",
@@ -314,8 +346,10 @@ describe("handleContextReviewerPrEvent", () => {
     expect(message?.content).toContain("Context changes requested");
     expect(message?.content).toContain("Still unclear or needs more detail");
     expect(message?.content).toContain("Trigger event: pull_request.opened");
+    expect(message?.content).toContain("Draft status from webhook: ready for review");
     expect(message?.metadata).toMatchObject({
       contextTreeReviewer: true,
+      pullRequestDraft: false,
       mentions: [reviewer.uuid],
     });
 
@@ -351,8 +385,9 @@ describe("handleContextReviewerPrEvent", () => {
     const messageRows = await app.db.select({ id: messages.id }).from(messages);
     expect(messageRows).toHaveLength(2);
     const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
-    expect(followUp?.content).toBe(FOLLOW_UP_NOTICE);
-    expect(followUp?.content).not.toContain("gh pr review 123 --repo owner/context-tree");
+    expect(followUp?.content).toContain("Trigger event: pull_request.opened");
+    expect(followUp?.content).toContain("gh pr review 123 --repo owner/context-tree --approve --body-file");
+    expect(followUp?.content).toContain("Do not rely on an older approval or comment review");
     const chatRows = await app.db.select({ id: chats.id }).from(chats);
     expect(chatRows).toHaveLength(1);
   });
@@ -384,9 +419,10 @@ describe("handleContextReviewerPrEvent", () => {
     const followUp = messageRows.find((row) => row.id === second.messageId);
     expect(followUp?.source).toBe("github");
     expect(followUp?.format).toBe("markdown");
-    expect(followUp?.content).toBe(FOLLOW_UP_NOTICE);
-    expect(followUp?.content).not.toContain("clear, accurate");
-    expect(followUp?.content).not.toContain("gh pr review 123 --repo owner/context-tree");
+    expect(followUp?.content).toContain("Trigger event: pull_request.synchronize");
+    expect(followUp?.content).toContain("clear, accurate");
+    expect(followUp?.content).toContain("gh pr review 123 --repo owner/context-tree --approve --body-file");
+    expect(followUp?.content).toContain("Do not rely on an older approval or comment review");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
       event: "pull_request",
@@ -394,6 +430,7 @@ describe("handleContextReviewerPrEvent", () => {
       triggerEvent: "pull_request.synchronize",
       entityKey: "owner/context-tree#123",
       contextTreeReviewer: true,
+      pullRequestDraft: false,
       mentions: [reviewer.uuid],
     });
 
@@ -403,6 +440,45 @@ describe("handleContextReviewerPrEvent", () => {
       .where(and(eq(inboxEntries.messageId, second.messageId), eq(inboxEntries.inboxId, reviewer.inboxId)))
       .limit(1);
     expect(entry?.notify).toBe(true);
+  });
+
+  it("reuses the reviewer chat for pull_request.ready_for_review and requests a fresh review", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+
+    const first = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload({ pull_request: { ...pullRequestPayload().pull_request, draft: true } }),
+      organizationId: admin.organizationId,
+    });
+    if (!first.handled) throw new Error("expected first event handled");
+
+    const second = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload({ action: "ready_for_review" }),
+      organizationId: admin.organizationId,
+    });
+
+    expect(second).toMatchObject({ handled: true, reused: true, chatId: first.chatId });
+    if (!second.handled) throw new Error("expected second event handled");
+
+    const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
+    expect(followUp?.content).toContain("Trigger event: pull_request.ready_for_review");
+    expect(followUp?.content).toContain("Draft status from webhook: ready for review");
+    expect(followUp?.content).toContain("Do not rely on an older approval or comment review");
+    expect(followUp?.content).toContain("gh pr review 123 --repo owner/context-tree --approve --body-file");
+    expect(followUp?.metadata).toMatchObject({
+      source: "github",
+      event: "pull_request",
+      action: "ready_for_review",
+      triggerEvent: "pull_request.ready_for_review",
+      entityKey: "owner/context-tree#123",
+      contextTreeReviewer: true,
+      pullRequestDraft: false,
+      mentions: [reviewer.uuid],
+    });
   });
 
   it("reuses the reviewer chat for PR issue_comment.created and notifies the reviewer", async () => {
@@ -428,14 +504,10 @@ describe("handleContextReviewerPrEvent", () => {
     if (!second.handled) throw new Error("expected second event handled");
 
     const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
-    expect(followUp?.content).toBe(
-      [
-        FOLLOW_UP_NOTICE,
-        "Comment author: commenter",
-        "Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-1",
-      ].join("\n"),
-    );
-    expect(followUp?.content).not.toContain("gh pr review 123 --repo owner/context-tree");
+    expect(followUp?.content).toContain("Trigger event: issue_comment.created");
+    expect(followUp?.content).toContain("Comment author: commenter");
+    expect(followUp?.content).toContain("Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-1");
+    expect(followUp?.content).toContain("gh pr review 123 --repo owner/context-tree --approve --body-file");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
       event: "issue_comment",
@@ -479,14 +551,10 @@ describe("handleContextReviewerPrEvent", () => {
     if (!second.handled) throw new Error("expected second event handled");
 
     const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
-    expect(followUp?.content).toBe(
-      [
-        FOLLOW_UP_NOTICE,
-        "Comment author: reviewer-user",
-        "Comment URL: https://github.com/owner/context-tree/pull/123#discussion_r1",
-      ].join("\n"),
-    );
-    expect(followUp?.content).not.toContain("gh pr review 123 --repo owner/context-tree");
+    expect(followUp?.content).toContain("Trigger event: pull_request_review_comment.created");
+    expect(followUp?.content).toContain("Comment author: reviewer-user");
+    expect(followUp?.content).toContain("Comment URL: https://github.com/owner/context-tree/pull/123#discussion_r1");
+    expect(followUp?.content).toContain("gh pr review 123 --repo owner/context-tree --approve --body-file");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
       event: "pull_request_review_comment",
@@ -544,13 +612,10 @@ describe("handleContextReviewerPrEvent", () => {
       .where(eq(messages.chatId, first.chatId));
     expect(messageRows).toHaveLength(2);
     const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
-    expect(followUp?.content).toBe(
-      [
-        FOLLOW_UP_NOTICE,
-        "Comment author: MANAGER-LOGIN",
-        "Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-2",
-      ].join("\n"),
-    );
+    expect(followUp?.content).toContain("Trigger event: issue_comment.created");
+    expect(followUp?.content).toContain("Comment author: MANAGER-LOGIN");
+    expect(followUp?.content).toContain("Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-2");
+    expect(followUp?.content).toContain("gh pr review 123 --repo owner/context-tree --approve --body-file");
     expect(followUp?.metadata).toMatchObject({
       source: "github",
       event: "issue_comment",
@@ -642,13 +707,10 @@ describe("handleContextReviewerPrEvent", () => {
       .where(eq(messages.chatId, first.chatId));
     expect(messageRows).toHaveLength(2);
     const [followUp] = await app.db.select().from(messages).where(eq(messages.id, second.messageId)).limit(1);
-    expect(followUp?.content).toBe(
-      [
-        FOLLOW_UP_NOTICE,
-        "Comment author: unrelated-human",
-        "Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-3",
-      ].join("\n"),
-    );
+    expect(followUp?.content).toContain("Trigger event: issue_comment.created");
+    expect(followUp?.content).toContain("Comment author: unrelated-human");
+    expect(followUp?.content).toContain("Comment URL: https://github.com/owner/context-tree/pull/123#issuecomment-3");
+    expect(followUp?.content).toContain("gh pr review 123 --repo owner/context-tree --approve --body-file");
   });
 
   it("skips non-PR issue_comment.created without creating a reviewer chat", async () => {
@@ -683,6 +745,7 @@ describe("handleContextReviewerPrEvent", () => {
       baseRef: "main",
       headRef: "context-update",
       triggerEvent: "pull_request.opened",
+      isDraft: false,
     });
     expect(
       contextReviewerPrTestInternals.extractPullRequestPayloadInfo(
@@ -701,6 +764,17 @@ describe("handleContextReviewerPrEvent", () => {
       commentUrl: "https://github.com/owner/context-tree/pull/123#issuecomment-1",
       commentAuthorLogin: "commenter",
       triggerEvent: "issue_comment.created",
+      isDraft: null,
+    });
+    expect(
+      contextReviewerPrTestInternals.extractPullRequestPayloadInfo(
+        "pull_request",
+        pullRequestPayload({ action: "ready_for_review" }),
+        "org-1",
+      ),
+    ).toMatchObject({
+      triggerEvent: "pull_request.ready_for_review",
+      isDraft: false,
     });
   });
 });

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -16,7 +16,6 @@ import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 const APP_WEBHOOK_SECRET = "test-app-webhook-secret";
-const FOLLOW_UP_NOTICE = "A new GitHub event was received. I'll check the current PR state.";
 
 function signBody(secret: string, body: string): string {
   return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
@@ -147,6 +146,7 @@ function contextPullRequestPayload(installationId: number, repoFullName = "owner
       body: "",
       base: { ref: "main" },
       head: { ref: "context-reviewer" },
+      draft: false,
     },
     repository: { full_name: repoFullName },
     sender: { login: "context-writer", type: "User" },
@@ -1294,12 +1294,14 @@ describe("POST /webhooks/github-app", () => {
     expect(message?.content).toContain("gh pr review 42 --repo owner/context-tree --approve --body-file");
     expect(message?.content).toContain("Context changes requested");
     expect(message?.content).toContain("Still unclear or needs more detail");
+    expect(message?.content).toContain("Draft status from webhook: ready for review");
     expect(message?.metadata).toMatchObject({
       source: "github",
       event: "pull_request",
       action: "opened",
       triggerEvent: "pull_request.opened",
       contextTreeReviewer: true,
+      pullRequestDraft: false,
       mentions: [reviewer],
     });
   });
@@ -1334,14 +1336,12 @@ describe("POST /webhooks/github-app", () => {
       .where(eq(messages.chatId, chatRows[0]?.id ?? ""));
     expect(messageRows).toHaveLength(2);
     const followUpMessage = messageRows.find((message) => message.metadata.triggerEvent === "issue_comment.created");
-    expect(followUpMessage?.content).toBe(
-      [
-        FOLLOW_UP_NOTICE,
-        "Comment author: context-commenter",
-        "Comment URL: https://github.com/owner/context-tree/pull/42#issuecomment-2",
-      ].join("\n"),
+    expect(followUpMessage?.content).toContain("Trigger event: issue_comment.created");
+    expect(followUpMessage?.content).toContain("Comment author: context-commenter");
+    expect(followUpMessage?.content).toContain(
+      "Comment URL: https://github.com/owner/context-tree/pull/42#issuecomment-2",
     );
-    expect(followUpMessage?.content).not.toContain("gh pr review 42 --repo owner/context-tree");
+    expect(followUpMessage?.content).toContain("gh pr review 42 --repo owner/context-tree --approve --body-file");
     expect(followUpMessage?.metadata).toMatchObject({
       source: "github",
       event: "issue_comment",
@@ -1361,6 +1361,58 @@ describe("POST /webhooks/github-app", () => {
       .where(and(eq(inboxEntries.messageId, followUpMessage?.id ?? ""), eq(inboxEntries.inboxId, `inbox_${reviewer}`)))
       .limit(1);
     expect(entry?.notify).toBe(true);
+  });
+
+  it("pull_request.ready_for_review on a bound context PR wakes the existing Context Reviewer chat", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100044;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+    const reviewer = await configureContextReviewer(app, admin);
+
+    const draftOpenedPayload = contextPullRequestPayload(installationId);
+    draftOpenedPayload.pull_request.draft = true;
+    const opened = await postWebhook(app, "pull_request", draftOpenedPayload);
+    expect(opened.statusCode).toBe(200);
+    expect(opened.json()).toMatchObject({ contextReviewer: { handled: true, reused: false } });
+
+    const readyPayload = contextPullRequestPayload(installationId);
+    readyPayload.action = "ready_for_review";
+    readyPayload.pull_request.draft = false;
+    const ready = await postWebhook(app, "pull_request", readyPayload);
+
+    expect(ready.statusCode).toBe(200);
+    expect(ready.json()).toMatchObject({
+      ok: true,
+      event: "pull_request",
+      handled: false,
+      contextReviewer: { handled: true, reused: true },
+    });
+
+    const [chat] = await app.db.select().from(chats).limit(1);
+    const messageRows = await app.db
+      .select()
+      .from(messages)
+      .where(eq(messages.chatId, chat?.id ?? ""));
+    expect(messageRows).toHaveLength(2);
+    const followUpMessage = messageRows.find(
+      (message) => message.metadata.triggerEvent === "pull_request.ready_for_review",
+    );
+    expect(followUpMessage?.content).toContain("Trigger event: pull_request.ready_for_review");
+    expect(followUpMessage?.content).toContain("Draft status from webhook: ready for review");
+    expect(followUpMessage?.content).toContain("Do not rely on an older approval or comment review");
+    expect(followUpMessage?.content).toContain("gh pr review 42 --repo owner/context-tree --approve --body-file");
+    expect(followUpMessage?.metadata).toMatchObject({
+      source: "github",
+      event: "pull_request",
+      action: "ready_for_review",
+      triggerEvent: "pull_request.ready_for_review",
+      entityType: "pull_request",
+      entityKey: "owner/context-tree#42",
+      contextTreeReviewer: true,
+      pullRequestDraft: false,
+      mentions: [reviewer],
+    });
   });
 
   it("pull_request.opened on an ordinary code repo does not trigger Context Reviewer", async () => {

--- a/packages/server/src/api/webhooks/github-app.ts
+++ b/packages/server/src/api/webhooks/github-app.ts
@@ -100,7 +100,9 @@ function pullRequestStateFromIssuePayload(issue: Record<string, unknown>, action
 }
 
 function isContextReviewerCandidateEvent(eventType: string, action: string | null): boolean {
-  if (eventType === "pull_request") return action === "opened" || action === "synchronize";
+  if (eventType === "pull_request") {
+    return action === "opened" || action === "synchronize" || action === "ready_for_review";
+  }
   if (eventType === "issue_comment") return action === "created";
   if (eventType === "pull_request_review_comment") return action === "created" || action === "edited";
   return false;

--- a/packages/server/src/prompts/context-reviewer-pr.ejs
+++ b/packages/server/src/prompts/context-reviewer-pr.ejs
@@ -10,6 +10,7 @@ Base ref: <%= baseRef || "unknown" %>
 Head ref: <%= headRef || "unknown" %>
 Opened by: <%= senderLogin %>
 Trigger event: <%= triggerEvent %>
+Draft status from webhook: <%= isDraft === true ? "draft" : isDraft === false ? "ready for review" : "unknown; inspect the current PR state before choosing an outcome" %>
 <% if (commentAuthorLogin) { -%>
 Comment author: <%= commentAuthorLogin %>
 <% } -%>
@@ -28,9 +29,12 @@ Review goals:
 
 Required workflow:
 
-1. Inspect this pull request with `gh` commands before deciding on the review outcome.
+1. Inspect this pull request with `gh` commands before deciding on the review outcome. Confirm the current draft/readiness state and current head before reviewing.
 2. Write the review body to a temporary Markdown file and pass it with `--body-file <file>`. Do not inline multiline Markdown with `--body`; avoiding shell quoting issues is part of the required workflow.
-3. Submit exactly one GitHub PR review using one of these outcomes:
+3. Treat `pull_request.synchronize` and `pull_request.ready_for_review` as fresh review requests for the current PR head. Do not rely on an older approval or comment review; submit a new review that covers the content currently shown by GitHub.
+4. Submit exactly one GitHub PR review using one of these outcomes:
+
+- If the pull request is still a draft, do not approve it. If there are blocking Context Tree issues, request changes. If there are no blocking issues, submit a non-approving comment review that says approval is deferred until the PR is ready for review.
 
 - If Context is incorrect, misleading, contradictory, missing required durable rationale, or otherwise should block merge, run:
 
@@ -44,13 +48,13 @@ gh pr review <%= prNumber %> --repo <%= repoFullName %> --request-changes --body
 gh pr review <%= prNumber %> --repo <%= repoFullName %> --comment --body-file <file>
 ```
 
-- If inspection is complete, no blocking gaps remain, and the PR is safe to merge as durable Context Tree material, run:
+- If inspection is complete, the pull request is not a draft, no blocking gaps remain, and the PR is safe to merge as durable Context Tree material, run:
 
 ```bash
 gh pr review <%= prNumber %> --repo <%= repoFullName %> --approve --body-file <file>
 ```
 
-4. When changes or clarification are needed, structure the review body like this, separating incorrect or change-needed Context from Context that is still unclear or missing detail:
+5. When changes or clarification are needed, structure the review body like this, separating incorrect or change-needed Context from Context that is still unclear or missing detail:
 
 ```md
 ## Context changes requested
@@ -67,6 +71,6 @@ gh pr review <%= prNumber %> --repo <%= repoFullName %> --approve --body-file <f
 ```
 
 If one of those sections has no items, write `None.` under that heading.
-5. Approve only after inspection is complete and only when the PR is safe to merge as Context Tree material.
-6. Do not also post a top-level `gh pr comment` for the same outcome.
-7. After submitting the PR review, reply in this chat with a short summary and report which review action was submitted: `approved`, `commented`, `changes_requested`, or `failed`.
+6. Approve only after inspection is complete, the pull request is not a draft, and only when the PR is safe to merge as Context Tree material.
+7. Do not also post a top-level `gh pr comment` for the same outcome.
+8. After submitting the PR review, reply in this chat with a short summary and report which review action was submitted: `approved`, `commented`, `changes_requested`, or `failed`.

--- a/packages/server/src/services/context-reviewer-pr.ts
+++ b/packages/server/src/services/context-reviewer-pr.ts
@@ -20,7 +20,6 @@ import { applyMembershipWrite } from "./participant-mode.js";
 
 const log = createLogger("ContextReviewerPr");
 const require = createRequire(import.meta.url);
-const FOLLOW_UP_NOTICE = "A new GitHub event was received. I'll check the current PR state.";
 const REVIEWER_OPENED_ECHO_SUPPRESSION_WINDOW_SECONDS = 60 * 60;
 // EJS is published as CommonJS at runtime even though its types expose named
 // exports, so native ESM cannot import `render` directly.
@@ -43,6 +42,7 @@ export type ContextReviewerPrTemplateInput = {
   headRef: string | null;
   senderLogin: string;
   triggerEvent: string;
+  isDraft: boolean | null;
   commentUrl: string | null;
   commentAuthorLogin: string | null;
   organizationId: string;
@@ -63,14 +63,14 @@ export type ContextReviewerPrSkipReason =
 
 type PullRequestPayloadInfo = ContextReviewerPrTemplateInput & {
   eventType: "pull_request" | "issue_comment" | "pull_request_review_comment";
-  action: "opened" | "synchronize" | "created" | "edited";
+  action: "opened" | "synchronize" | "ready_for_review" | "created" | "edited";
   entityKey: string;
   senderType: string | null;
   commentAuthorType: string | null;
 };
 
 type ContextReviewerPrTrigger =
-  | { eventType: "pull_request"; action: "opened" | "synchronize"; triggerEvent: string }
+  | { eventType: "pull_request"; action: "opened" | "synchronize" | "ready_for_review"; triggerEvent: string }
   | { eventType: "issue_comment"; action: "created"; triggerEvent: string }
   | { eventType: "pull_request_review_comment"; action: "created" | "edited"; triggerEvent: string };
 
@@ -278,6 +278,7 @@ export async function handleContextReviewerPrEvent(
       };
     }
 
+    const prompt = await renderContextReviewerPrPrompt(info);
     const { message, recipients } = await sendMessage(
       app.db,
       existingChatId,
@@ -285,14 +286,20 @@ export async function handleContextReviewerPrEvent(
       {
         source: "github",
         format: "markdown",
-        content: contextReviewerFollowUpContent(info),
+        content: prompt,
         metadata: contextReviewerMessageMetadata(info, reviewer),
       },
       { normalizeMentionsInContent: false },
     );
     notifyRecipients(app.notifier, recipients, message.id);
     log.info(
-      { organizationId: input.organizationId, entityKey: info.entityKey, chatId: existingChatId },
+      {
+        organizationId: input.organizationId,
+        entityKey: info.entityKey,
+        chatId: existingChatId,
+        triggerEvent: info.triggerEvent,
+        isDraft: info.isDraft,
+      },
       "context reviewer task sent to existing chat",
     );
     return { handled: true, chatId: existingChatId, messageId: message.id, reused: true };
@@ -317,7 +324,13 @@ export async function handleContextReviewerPrEvent(
   await app.db.update(chats).set({ metadata }).where(eq(chats.id, created.chat.id));
   notifyRecipients(app.notifier, created.recipients, created.message.id);
   log.info(
-    { organizationId: input.organizationId, entityKey: info.entityKey, chatId: created.chat.id },
+    {
+      organizationId: input.organizationId,
+      entityKey: info.entityKey,
+      chatId: created.chat.id,
+      triggerEvent: info.triggerEvent,
+      isDraft: info.isDraft,
+    },
     "context reviewer task chat created",
   );
   return { handled: true, chatId: created.chat.id, messageId: created.message.id, reused: false };
@@ -339,7 +352,10 @@ function isSupportedContextReviewerPrEvent(eventType: string, action: string | n
 }
 
 function resolveContextReviewerPrTrigger(eventType: string, action: string | null): ContextReviewerPrTrigger | null {
-  if (eventType === "pull_request" && (action === "opened" || action === "synchronize")) {
+  if (
+    eventType === "pull_request" &&
+    (action === "opened" || action === "synchronize" || action === "ready_for_review")
+  ) {
     return { eventType, action, triggerEvent: `${eventType}.${action}` };
   }
   if (eventType === "issue_comment" && action === "created") {
@@ -389,6 +405,7 @@ function extractPullRequestPayloadInfo(
       htmlUrl,
       baseRef: readString(isRecord(pr?.base) ? pr.base.ref : null),
       headRef: readString(isRecord(pr?.head) ? pr.head.ref : null),
+      isDraft: readDraftStatus(pr),
       commentUrl: null,
       commentAuthorLogin: null,
       commentAuthorType: null,
@@ -412,6 +429,7 @@ function extractPullRequestPayloadInfo(
       htmlUrl,
       baseRef: null,
       headRef: null,
+      isDraft: null,
       commentUrl: readString(comment?.html_url),
       commentAuthorLogin: commentAuthor.login ?? senderLogin,
       commentAuthorType: commentAuthor.type ?? common.senderType,
@@ -434,6 +452,7 @@ function extractPullRequestPayloadInfo(
       htmlUrl,
       baseRef: readString(isRecord(pr?.base) ? pr.base.ref : null),
       headRef: readString(isRecord(pr?.head) ? pr.head.ref : null),
+      isDraft: readDraftStatus(pr),
       commentUrl: readString(comment?.html_url),
       commentAuthorLogin: commentAuthor.login ?? senderLogin,
       commentAuthorType: commentAuthor.type ?? common.senderType,
@@ -444,17 +463,14 @@ function extractPullRequestPayloadInfo(
   return null;
 }
 
+function readDraftStatus(pr: Record<string, unknown> | null): boolean | null {
+  if (!pr || typeof pr.draft !== "boolean") return null;
+  return pr.draft;
+}
+
 function readCommentAuthor(comment: Record<string, unknown> | null): { login: string | null; type: string | null } {
   const user = isRecord(comment?.user) ? comment.user : null;
   return { login: readString(user?.login), type: readString(user?.type) };
-}
-
-function contextReviewerFollowUpContent(info: PullRequestPayloadInfo): string {
-  const details = [
-    info.commentAuthorLogin ? `Comment author: ${info.commentAuthorLogin}` : null,
-    info.commentUrl ? `Comment URL: ${info.commentUrl}` : null,
-  ].filter((line): line is string => line !== null);
-  return [FOLLOW_UP_NOTICE, ...details].join("\n");
 }
 
 function contextReviewerMessageMetadata(
@@ -476,6 +492,9 @@ function contextReviewerMessageMetadata(
   }
   if (info.commentUrl) {
     metadata.commentUrl = info.commentUrl;
+  }
+  if (info.isDraft !== null) {
+    metadata.pullRequestDraft = info.isDraft;
   }
   return metadata;
 }
@@ -579,7 +598,6 @@ function isCommentAuthorBot(info: PullRequestPayloadInfo): boolean {
 }
 
 export const contextReviewerPrTestInternals = {
-  contextReviewerFollowUpContent,
   extractPullRequestPayloadInfo,
   findExistingReviewerChat,
   isSupportedContextReviewerPrEvent,


### PR DESCRIPTION
## Summary

- route `pull_request.ready_for_review` into the Context Tree PR Reviewer
- pass PR draft state into the reviewer prompt and message metadata
- send the full review workflow on follow-up wakes so `synchronize` and `ready_for_review` produce fresh reviews for the current PR head
- prevent draft Context Tree PRs from receiving approving reviews by instructing the reviewer to comment or request changes while approval is deferred

Fixes #1495.

## Context Tree

Companion draft Context Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/690

Per the Context Tree workflow, merge this code PR first. After this code PR lands, reconcile the tree PR against the final merged code and mark it ready.

## Tests

- `pnpm --filter @first-tree/server test -- packages/server/src/__tests__/context-reviewer-pr.test.ts` (runs the server test suite in this workspace: 178 files / 1747 tests)
- `pnpm check`
- `pnpm typecheck`
