### PR TITLE
fix(cli): avoid Windows cmd shims for npm and Codex

### DIFF
--- a/apps/cli/src/__tests__/core-attention-update-extra.test.ts
+++ b/apps/cli/src/__tests__/core-attention-update-extra.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveNpmInvocation } from "../core/npm-invocation.js";
 
 const bootstrapMocks = vi.hoisted(() => {
   class ServerUrlNotConfiguredError extends Error {
@@ -116,14 +117,21 @@ describe("core update helpers", () => {
       return {
         ...actual,
         existsSync: (path: Parameters<typeof actual.existsSync>[0]) =>
-          String(path).endsWith("/npm.cmd") || actual.existsSync(path),
+          String(path).replaceAll("\\", "/").endsWith("/node_modules/npm/bin/npm-cli.js") || actual.existsSync(path),
       };
     });
     spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "0.6.0\n", stderr: "" });
     const winUpdate = await import("../core/update.js");
 
     expect(winUpdate.fetchLatestVersion()).toEqual({ ok: true, version: "0.6.0" });
-    expect(String(spawnSyncMock.mock.calls[0]?.[0])).toMatch(/\/npm\.cmd$/);
+    expect(spawnSyncMock.mock.calls[0]?.[0]).toBe(process.execPath);
+    expect(spawnSyncMock.mock.calls[0]?.[1]).toEqual([
+      expect.stringMatching(/[\\/]node_modules[\\/]npm[\\/]bin[\\/]npm-cli\.js$/),
+      "view",
+      "first-tree",
+      "version",
+    ]);
+    expect(spawnSyncMock.mock.calls[0]?.[2]).toMatchObject({ shell: false });
 
     vi.resetModules();
     vi.doMock("node:fs", async () => {
@@ -131,7 +139,7 @@ describe("core update helpers", () => {
       return {
         ...actual,
         existsSync: (path: Parameters<typeof actual.existsSync>[0]) =>
-          String(path).endsWith("/npm") || actual.existsSync(path),
+          String(path).replaceAll("\\", "/").endsWith("/npm") || actual.existsSync(path),
       };
     });
     Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
@@ -139,7 +147,8 @@ describe("core update helpers", () => {
     const siblingUpdate = await import("../core/update.js");
 
     expect(siblingUpdate.fetchLatestVersion()).toEqual({ ok: true, version: "0.7.0" });
-    expect(String(spawnSyncMock.mock.calls[1]?.[0])).toMatch(/\/npm$/);
+    expect(String(spawnSyncMock.mock.calls[1]?.[0])).toMatch(/[\\/]npm$/);
+    expect(spawnSyncMock.mock.calls[1]?.[2]).toMatchObject({ shell: false });
   });
 
   it("runs npm installs through the child registry and parses installed versions", async () => {
@@ -165,13 +174,14 @@ describe("core update helpers", () => {
     child.stdout.emit("data", Buffer.from("+ first-tree@0.6.0,\n"));
     child.emit("exit", 0, null);
     await expect(resultPromise).resolves.toEqual({ ok: true, mode: "global", installedVersion: "0.6.0" });
+    const npm = resolveNpmInvocation(["install", "-g", "first-tree@0.6.0"]);
     expect(childRegistryMocks.getChildProcessRegistry().spawn).toHaveBeenCalledWith(
-      expect.stringMatching(/npm(?:\.cmd)?$/),
-      ["install", "-g", "first-tree@0.6.0"],
+      npm.command,
+      npm.args,
       expect.objectContaining({
         category: "npm-install",
         timeoutMs: 300_000,
-        shell: process.platform === "win32",
+        shell: npm.shell,
       }),
     );
 
@@ -495,6 +505,25 @@ describe("core update helpers", () => {
       ok: false,
       retryable: true,
       reasonCode: "npm_timeout",
+    });
+  });
+
+  it("maps synchronous registry spawn failures instead of rejecting the upgrade", async () => {
+    const spawnError = Object.assign(new Error("spawn EINVAL"), { code: "EINVAL" });
+    childRegistryMocks.classify.mockReturnValueOnce({ kind: "permanent", reasonCode: "spawn_einval" });
+    childRegistryMocks.getChildProcessRegistry.mockReturnValue({
+      spawn: vi.fn(() => {
+        throw spawnError;
+      }),
+    });
+    const { installGlobalSpec } = await import("../core/update.js");
+
+    await expect(installGlobalSpec("latest")).resolves.toEqual({
+      ok: false,
+      mode: "global",
+      reason: "spawn EINVAL",
+      retryable: false,
+      reasonCode: "spawn_einval",
     });
   });
 

--- a/apps/cli/src/__tests__/core-attention-update-extra.test.ts
+++ b/apps/cli/src/__tests__/core-attention-update-extra.test.ts
@@ -166,9 +166,13 @@ describe("core update helpers", () => {
     child.emit("exit", 0, null);
     await expect(resultPromise).resolves.toEqual({ ok: true, mode: "global", installedVersion: "0.6.0" });
     expect(childRegistryMocks.getChildProcessRegistry().spawn).toHaveBeenCalledWith(
-      expect.stringMatching(/npm(?:\\.cmd)?$/),
+      expect.stringMatching(/npm(?:\.cmd)?$/),
       ["install", "-g", "first-tree@0.6.0"],
-      expect.objectContaining({ category: "npm-install", timeoutMs: 300_000 }),
+      expect.objectContaining({
+        category: "npm-install",
+        timeoutMs: 300_000,
+        shell: process.platform === "win32",
+      }),
     );
 
     const child2 = new MockChild();

--- a/apps/cli/src/__tests__/npm-invocation.test.ts
+++ b/apps/cli/src/__tests__/npm-invocation.test.ts
@@ -1,0 +1,46 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveNpmInvocation } from "../core/npm-invocation.js";
+
+describe("npm invocation resolution", () => {
+  it("runs npm-cli.js with node.exe on Windows instead of spawning npm.cmd", () => {
+    const execPath = join("C:\\Program Files", "nodejs", "node.exe");
+    const npmCli = join(dirname(execPath), "node_modules", "npm", "bin", "npm-cli.js");
+    const invocation = resolveNpmInvocation(["--version"], {
+      platform: "win32",
+      execPath,
+      pathExists: (path) => path === npmCli,
+    });
+
+    expect(invocation).toEqual({
+      command: execPath,
+      args: [npmCli, "--version"],
+      shell: false,
+    });
+  });
+
+  it("uses a PATH shell fallback for non-standard Windows Node layouts", () => {
+    expect(
+      resolveNpmInvocation(["--version"], {
+        platform: "win32",
+        execPath: join("C:\\custom-node", "node.exe"),
+        pathExists: () => false,
+      }),
+    ).toEqual({ command: "npm", args: ["--version"], shell: true });
+  });
+
+  it.runIf(process.platform === "win32")("executes the real sibling npm CLI on Windows", () => {
+    const invocation = resolveNpmInvocation(["--version"]);
+    const result = spawnSync(invocation.command, invocation.args, {
+      encoding: "utf-8",
+      shell: invocation.shell,
+      timeout: 10_000,
+      windowsHide: true,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/apps/cli/src/__tests__/runtime-install-extra.test.ts
+++ b/apps/cli/src/__tests__/runtime-install-extra.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveNpmInvocation } from "../core/npm-invocation.js";
 
 const clientMocks = vi.hoisted(() => ({
   classify: vi.fn(() => ({ kind: "transient", reasonCode: "classified_transient" })),
@@ -108,14 +109,16 @@ describe("native runtime installers", () => {
     child.emit("exit", 0, null);
 
     await expect(result).resolves.toEqual({ ok: true, installedVersion: "0.140.0" });
+    const npm = resolveNpmInvocation(["install", "-g", "@openai/codex@0.140.0"]);
     expect(spawn).toHaveBeenCalledWith(
-      expect.stringMatching(/npm(?:\.cmd)?$/),
-      ["install", "-g", "@openai/codex@0.140.0"],
+      npm.command,
+      npm.args,
       expect.objectContaining({
         category: "npm-install",
         label: "npm install -g @openai/codex@0.140.0",
         timeoutMs: 480_000,
         stdio: ["ignore", "pipe", "pipe"],
+        shell: npm.shell,
       }),
     );
   });
@@ -129,14 +132,16 @@ describe("native runtime installers", () => {
     child.emit("exit", 0, null);
 
     await expect(result).resolves.toEqual({ ok: true, installedVersion: "2.1.84" });
+    const npm = resolveNpmInvocation(["install", "-g", "@anthropic-ai/claude-code@2.1.84"]);
     expect(spawn).toHaveBeenCalledWith(
-      expect.stringMatching(/npm(?:\.cmd)?$/),
-      ["install", "-g", "@anthropic-ai/claude-code@2.1.84"],
+      npm.command,
+      npm.args,
       expect.objectContaining({
         category: "npm-install",
         label: "npm install -g @anthropic-ai/claude-code@2.1.84",
         timeoutMs: 480_000,
         stdio: ["ignore", "pipe", "pipe"],
+        shell: npm.shell,
       }),
     );
   });
@@ -201,46 +206,6 @@ describe("native runtime installers", () => {
     });
   });
 
-  it("prefers platform-specific sibling npm commands when present", async () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
-    vi.resetModules();
-    vi.doMock("node:fs", async () => {
-      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
-      return {
-        ...actual,
-        existsSync: (path: Parameters<typeof actual.existsSync>[0]) => String(path).endsWith("/npm.cmd"),
-      };
-    });
-    const winChild = new MockChild();
-    const winSpawn = prepareSpawn(winChild).spawn;
-    const { installCodexRuntime } = await import("../core/install-codex-runtime.js");
-    const winResult = installCodexRuntime("latest");
-    winChild.emit("exit", 0, null);
-    await expect(winResult).resolves.toEqual({ ok: true, installedVersion: null });
-    expect(String(winSpawn.mock.calls[0]?.[0])).toMatch(/\/npm\.cmd$/);
-
-    Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
-    vi.resetModules();
-    vi.doMock("node:fs", async () => {
-      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
-      return {
-        ...actual,
-        existsSync: (path: Parameters<typeof actual.existsSync>[0]) => String(path).endsWith("/npm"),
-      };
-    });
-    const linuxChild = new MockChild();
-    const linuxSpawn = prepareSpawn(linuxChild).spawn;
-    const { installClaudeRuntime } = await import("../core/install-claude-runtime.js");
-    const linuxResult = installClaudeRuntime("latest");
-    linuxChild.emit("exit", 0, null);
-    await expect(linuxResult).resolves.toEqual({ ok: true, installedVersion: null });
-    expect(String(linuxSpawn.mock.calls[0]?.[0])).toMatch(/\/npm$/);
-
-    vi.doUnmock("node:fs");
-    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
-  });
-
   it("classifies Claude spawn errors, npm failures, and timeout exits", async () => {
     const { installClaudeRuntime } = await import("../core/install-claude-runtime.js");
 
@@ -274,6 +239,30 @@ describe("native runtime installers", () => {
       reason: expect.stringContaining("killed by signal SIGTERM (timeout)"),
       retryable: true,
       reasonCode: "npm_timeout",
+    });
+  });
+
+  it("maps synchronous registry spawn failures for both runtime installers", async () => {
+    const spawnError = Object.assign(new Error("spawn EINVAL"), { code: "EINVAL" });
+    clientMocks.getChildProcessRegistry.mockReturnValue({
+      spawn: vi.fn(() => {
+        throw spawnError;
+      }),
+    });
+    const { installCodexRuntime } = await import("../core/install-codex-runtime.js");
+    const { installClaudeRuntime } = await import("../core/install-claude-runtime.js");
+
+    await expect(installCodexRuntime()).resolves.toMatchObject({
+      ok: false,
+      reason: "spawn EINVAL",
+      retryable: true,
+      reasonCode: "classified_transient",
+    });
+    await expect(installClaudeRuntime()).resolves.toMatchObject({
+      ok: false,
+      reason: "spawn EINVAL",
+      retryable: true,
+      reasonCode: "classified_transient",
     });
   });
 });

--- a/apps/cli/src/core/install-claude-runtime.ts
+++ b/apps/cli/src/core/install-claude-runtime.ts
@@ -69,6 +69,7 @@ export async function installClaudeRuntime(spec = "latest"): Promise<InstallClau
       label: `npm install -g ${CLAUDE_RUNTIME_PACKAGE}@${spec}`,
       timeoutMs: CLAUDE_INSTALL_TIMEOUT_MS,
       stdio: ["ignore", "pipe", "pipe"],
+      shell: process.platform === "win32",
     });
 
     const stdoutChunks: Buffer[] = [];

--- a/apps/cli/src/core/install-claude-runtime.ts
+++ b/apps/cli/src/core/install-claude-runtime.ts
@@ -1,6 +1,6 @@
-import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import type { ChildProcess } from "node:child_process";
 import { classify, ERROR_KINDS, getChildProcessRegistry } from "@first-tree/client";
+import { resolveNpmInvocation } from "./npm-invocation.js";
 import { print } from "./output.js";
 
 /**
@@ -25,14 +25,6 @@ function isSafeInstallSpec(spec: string): boolean {
   if (typeof spec !== "string" || spec.length === 0 || spec.length > 128) return false;
   if (spec.startsWith("-")) return false;
   return /^[A-Za-z0-9.+-]+$/.test(spec);
-}
-
-/** Pick the `npm` binary, preferring the sibling of the launching Node. */
-function resolveNpmCommand(): string {
-  const binName = process.platform === "win32" ? "npm.cmd" : "npm";
-  const sibling = join(dirname(process.execPath), binName);
-  if (existsSync(sibling)) return sibling;
-  return "npm";
 }
 
 function parseInstalledVersion(stdout: string): string | null {
@@ -62,15 +54,27 @@ export async function installClaudeRuntime(spec = "latest"): Promise<InstallClau
   }
 
   return new Promise((resolvePromise) => {
-    const npmCmd = resolveNpmCommand();
-    const npmArgs = ["install", "-g", `${CLAUDE_RUNTIME_PACKAGE}@${spec}`];
-    const { child } = getChildProcessRegistry().spawn(npmCmd, npmArgs, {
-      category: "npm-install",
-      label: `npm install -g ${CLAUDE_RUNTIME_PACKAGE}@${spec}`,
-      timeoutMs: CLAUDE_INSTALL_TIMEOUT_MS,
-      stdio: ["ignore", "pipe", "pipe"],
-      shell: process.platform === "win32",
-    });
+    const npm = resolveNpmInvocation(["install", "-g", `${CLAUDE_RUNTIME_PACKAGE}@${spec}`]);
+    let child: ChildProcess;
+    try {
+      ({ child } = getChildProcessRegistry().spawn(npm.command, npm.args, {
+        category: "npm-install",
+        label: `npm install -g ${CLAUDE_RUNTIME_PACKAGE}@${spec}`,
+        timeoutMs: CLAUDE_INSTALL_TIMEOUT_MS,
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: npm.shell,
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const classification = classify(err, { source: "update" });
+      resolvePromise({
+        ok: false,
+        reason: message,
+        retryable: classification.kind === ERROR_KINDS.TRANSIENT,
+        reasonCode: classification.reasonCode,
+      });
+      return;
+    }
 
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];

--- a/apps/cli/src/core/install-codex-runtime.ts
+++ b/apps/cli/src/core/install-codex-runtime.ts
@@ -1,6 +1,6 @@
-import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import type { ChildProcess } from "node:child_process";
 import { classify, ERROR_KINDS, getChildProcessRegistry } from "@first-tree/client";
+import { resolveNpmInvocation } from "./npm-invocation.js";
 import { print } from "./output.js";
 
 /**
@@ -26,14 +26,6 @@ function isSafeInstallSpec(spec: string): boolean {
   if (typeof spec !== "string" || spec.length === 0 || spec.length > 128) return false;
   if (spec.startsWith("-")) return false;
   return /^[A-Za-z0-9.+-]+$/.test(spec);
-}
-
-/** Pick the `npm` binary, preferring the sibling of the launching Node. */
-function resolveNpmCommand(): string {
-  const binName = process.platform === "win32" ? "npm.cmd" : "npm";
-  const sibling = join(dirname(process.execPath), binName);
-  if (existsSync(sibling)) return sibling;
-  return "npm";
 }
 
 function parseInstalledVersion(stdout: string): string | null {
@@ -62,15 +54,27 @@ export async function installCodexRuntime(spec = "latest"): Promise<InstallCodex
   }
 
   return new Promise((resolvePromise) => {
-    const npmCmd = resolveNpmCommand();
-    const npmArgs = ["install", "-g", `${CODEX_RUNTIME_PACKAGE}@${spec}`];
-    const { child } = getChildProcessRegistry().spawn(npmCmd, npmArgs, {
-      category: "npm-install",
-      label: `npm install -g ${CODEX_RUNTIME_PACKAGE}@${spec}`,
-      timeoutMs: CODEX_INSTALL_TIMEOUT_MS,
-      stdio: ["ignore", "pipe", "pipe"],
-      shell: process.platform === "win32",
-    });
+    const npm = resolveNpmInvocation(["install", "-g", `${CODEX_RUNTIME_PACKAGE}@${spec}`]);
+    let child: ChildProcess;
+    try {
+      ({ child } = getChildProcessRegistry().spawn(npm.command, npm.args, {
+        category: "npm-install",
+        label: `npm install -g ${CODEX_RUNTIME_PACKAGE}@${spec}`,
+        timeoutMs: CODEX_INSTALL_TIMEOUT_MS,
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: npm.shell,
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const classification = classify(err, { source: "update" });
+      resolvePromise({
+        ok: false,
+        reason: message,
+        retryable: classification.kind === ERROR_KINDS.TRANSIENT,
+        reasonCode: classification.reasonCode,
+      });
+      return;
+    }
 
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];

--- a/apps/cli/src/core/install-codex-runtime.ts
+++ b/apps/cli/src/core/install-codex-runtime.ts
@@ -69,6 +69,7 @@ export async function installCodexRuntime(spec = "latest"): Promise<InstallCodex
       label: `npm install -g ${CODEX_RUNTIME_PACKAGE}@${spec}`,
       timeoutMs: CODEX_INSTALL_TIMEOUT_MS,
       stdio: ["ignore", "pipe", "pipe"],
+      shell: process.platform === "win32",
     });
 
     const stdoutChunks: Buffer[] = [];

--- a/apps/cli/src/core/npm-invocation.ts
+++ b/apps/cli/src/core/npm-invocation.ts
@@ -1,0 +1,50 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export type NpmInvocation = {
+  command: string;
+  args: string[];
+  shell: boolean;
+};
+
+type ResolveNpmInvocationOptions = {
+  platform?: NodeJS.Platform;
+  execPath?: string;
+  pathExists?: (path: string) => boolean;
+};
+
+/**
+ * Resolve npm without asking Windows to execute a `.cmd` shim directly.
+ *
+ * `child_process.spawn(".../npm.cmd", args)` synchronously throws EINVAL on
+ * Windows. Using that absolute path with `shell: true` is not sufficient
+ * either: cmd.exe truncates an unquoted `C:\Program Files\...` command at the
+ * first space. Standard Node installations ship npm's JavaScript entry point
+ * beside the launching Node, so invoke that entry point with the current
+ * `node.exe`. The PATH fallback keeps custom layouts working through cmd.exe
+ * without embedding an absolute path that needs shell quoting.
+ */
+export function resolveNpmInvocation(
+  npmArgs: readonly string[],
+  options: ResolveNpmInvocationOptions = {},
+): NpmInvocation {
+  const platform = options.platform ?? process.platform;
+  const execPath = options.execPath ?? process.execPath;
+  const pathExists = options.pathExists ?? existsSync;
+  const nodeDir = dirname(execPath);
+
+  if (platform === "win32") {
+    const npmCli = join(nodeDir, "node_modules", "npm", "bin", "npm-cli.js");
+    if (pathExists(npmCli)) {
+      return { command: execPath, args: [npmCli, ...npmArgs], shell: false };
+    }
+    return { command: "npm", args: [...npmArgs], shell: true };
+  }
+
+  const sibling = join(nodeDir, "npm");
+  return {
+    command: pathExists(sibling) ? sibling : "npm",
+    args: [...npmArgs],
+    shell: false,
+  };
+}

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { type ChildProcess, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { chmod, lstat, mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
@@ -22,6 +22,7 @@ import * as semver from "semver";
 import { resolveServerUrl, ServerUrlNotConfiguredError } from "./bootstrap.js";
 import { channelConfig } from "./channel.js";
 import { cliFetch } from "./cli-fetch.js";
+import { resolveNpmInvocation } from "./npm-invocation.js";
 import { print } from "./output.js";
 
 /** Hard ceiling on a single `npm install -g` invocation (5 min). */
@@ -49,20 +50,6 @@ type PortableMetadataIdentity = {
  * binaries are not published and refuse self-update entirely).
  */
 export const PACKAGE_NAME = channelConfig.packageName;
-
-/**
- * Pick the `npm` binary to invoke for self-update. Background service units
- * prepend the current Node directory to PATH, but also prefer the sibling
- * npm explicitly so self-update stays aligned with the Node toolchain that
- * launched the daemon. If that sibling is missing (e.g. corporate custom
- * layout), fall back to PATH lookup.
- */
-function resolveNpmCommand(): string {
-  const binName = process.platform === "win32" ? "npm.cmd" : "npm";
-  const sibling = join(dirname(process.execPath), binName);
-  if (existsSync(sibling)) return sibling;
-  return "npm";
-}
 
 /**
  * Detect how the CLI was launched. Used by the update path to decide whether
@@ -236,8 +223,10 @@ function parseNpmViewEngineRange(stdout: string): string | null {
 
 function lookupNpmTargetNodeEngineRange(spec: string): string | null {
   if (PACKAGE_NAME === null) return null;
-  const res = spawnSync(resolveNpmCommand(), ["view", `${PACKAGE_NAME}@${spec}`, "engines.node", "--json"], {
+  const npm = resolveNpmInvocation(["view", `${PACKAGE_NAME}@${spec}`, "engines.node", "--json"]);
+  const res = spawnSync(npm.command, npm.args, {
     encoding: "utf-8",
+    shell: npm.shell,
     timeout: NPM_METADATA_TIMEOUT_MS,
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -668,20 +657,33 @@ export async function installGlobalSpec(
     return engineMismatch;
   }
   return new Promise((resolvePromise) => {
-    const npmCmd = resolveNpmCommand();
-    const npmArgs = ["install", "-g", `${PACKAGE_NAME}@${spec}`];
+    const npm = resolveNpmInvocation(["install", "-g", `${PACKAGE_NAME}@${spec}`]);
     // Bug 4: route the subprocess through ChildProcessRegistry so it is
     // tracked and reaped by the lifecycle shutdown hook, AND give it a
     // 5-minute hard timeout (network blip on the registry used to block
     // the main process for 60s+ with no escalation). Failures are mapped
     // through the error taxonomy so UpdateManager knows whether to retry.
-    const { child } = getChildProcessRegistry().spawn(npmCmd, npmArgs, {
-      category: "npm-install",
-      label: `npm install -g ${PACKAGE_NAME}@${spec}`,
-      timeoutMs: NPM_INSTALL_TIMEOUT_MS,
-      stdio: ["ignore", "pipe", "pipe"],
-      shell: process.platform === "win32",
-    });
+    let child: ChildProcess;
+    try {
+      ({ child } = getChildProcessRegistry().spawn(npm.command, npm.args, {
+        category: "npm-install",
+        label: `npm install -g ${PACKAGE_NAME}@${spec}`,
+        timeoutMs: NPM_INSTALL_TIMEOUT_MS,
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: npm.shell,
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const classification = classify(err, { source: "update" });
+      resolvePromise({
+        ok: false,
+        mode: "global",
+        reason: message,
+        retryable: classification.kind === ERROR_KINDS.TRANSIENT,
+        reasonCode: classification.reasonCode,
+      });
+      return;
+    }
 
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
@@ -831,9 +833,10 @@ export function fetchLatestVersion(timeoutMs = 10_000): VersionLookupResult {
   if (PACKAGE_NAME === null) {
     return { ok: false, reason: "this binary's channel does not publish to npm (dev channel)." };
   }
-  const res = spawnSync(resolveNpmCommand(), ["view", PACKAGE_NAME, "version"], {
+  const npm = resolveNpmInvocation(["view", PACKAGE_NAME, "version"]);
+  const res = spawnSync(npm.command, npm.args, {
     encoding: "utf-8",
-    shell: process.platform === "win32",
+    shell: npm.shell,
     timeout: timeoutMs,
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -680,6 +680,7 @@ export async function installGlobalSpec(
       label: `npm install -g ${PACKAGE_NAME}@${spec}`,
       timeoutMs: NPM_INSTALL_TIMEOUT_MS,
       stdio: ["ignore", "pipe", "pipe"],
+      shell: process.platform === "win32",
     });
 
     const stdoutChunks: Buffer[] = [];
@@ -832,6 +833,7 @@ export function fetchLatestVersion(timeoutMs = 10_000): VersionLookupResult {
   }
   const res = spawnSync(resolveNpmCommand(), ["view", PACKAGE_NAME, "version"], {
     encoding: "utf-8",
+    shell: process.platform === "win32",
     timeout: timeoutMs,
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/packages/client/src/__tests__/codex-binary.test.ts
+++ b/packages/client/src/__tests__/codex-binary.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CodexBinaryVerifyTransientError,
   createCodexClientWithBinaryFallback,
+  type FindCodexExecutableDeps,
   findCodexExecutableOnPath,
   formatCodexBinaryMissingMessage,
   isCodexBinaryMissingError,
@@ -275,7 +276,9 @@ describe("codex binary resolution", () => {
     chmodSync(chatGptCodex, 0o755);
     chmodSync(legacyCodex, 0o755);
 
-    const deps = {
+    const deps: FindCodexExecutableDeps = {
+      platform: "linux",
+      pathDelimiter: delimiter,
       loginShellPathDirs: () => [],
       wellKnownDirs: () => [],
       desktopAppDirs: () => [chatGptResources, legacyResources],
@@ -303,6 +306,8 @@ describe("codex binary resolution", () => {
       findCodexExecutableOnPath(
         { PATH: "" },
         {
+          platform: "linux",
+          pathDelimiter: delimiter,
           wellKnownDirs: () => [],
           loginShellPathDirs: () => [loginDir],
           desktopAppDirs: () => [appResources],

--- a/packages/client/src/__tests__/codex-binary.test.ts
+++ b/packages/client/src/__tests__/codex-binary.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -94,7 +94,7 @@ describe("codex binary resolution", () => {
       thrown = err;
     }
     // A present-but-flaky binary must surface as the transient error the
-    // taxonomy retries — never as a permanent "binary missing".
+    // taxonomy retries; never as a permanent "binary missing".
     expect(thrown).toBeInstanceOf(CodexBinaryVerifyTransientError);
     expect((thrown as Error).message).not.toMatch(/binary is missing/i);
     expect(isCodexBinaryMissingError(thrown)).toBe(false);
@@ -132,38 +132,97 @@ describe("codex binary resolution", () => {
     writeFileSync(executable, "#!/bin/sh\nexit 0\n");
     chmodSync(executable, 0o755);
 
-    expect(findCodexExecutableOnPath({ PATH: `${tmp}${delimiter}/bin` }, { loginShellPathDirs: () => [] })).toBe(
-      executable,
+    expect(
+      findCodexExecutableOnPath(
+        { PATH: `${tmp}${delimiter}/bin` },
+        { platform: "linux", pathDelimiter: delimiter, loginShellPathDirs: () => [] },
+      ),
+    ).toBe(executable);
+  });
+
+  it("on Windows resolves an npm codex shim to the native codex.exe it wraps", () => {
+    tmp = mkdtempSync(join(tmpdir(), "ft-codex-win-shim-"));
+    const shim = join(tmp, "codex.cmd");
+    const codexPackageRoot = join(tmp, "node_modules", "@openai", "codex");
+    const platformPackageRoot = join(codexPackageRoot, "node_modules", "@openai", "codex-win32-x64");
+    const native = join(platformPackageRoot, "vendor", "x86_64-pc-windows-msvc", "bin", "codex.exe");
+    mkdirSync(join(platformPackageRoot, "vendor", "x86_64-pc-windows-msvc", "bin"), { recursive: true });
+    writeFileSync(join(codexPackageRoot, "package.json"), JSON.stringify({ name: "@openai/codex" }));
+    writeFileSync(join(platformPackageRoot, "package.json"), JSON.stringify({ name: "@openai/codex-win32-x64" }));
+    writeFileSync(shim, "@ECHO off\nnode node_modules\\@openai\\codex\\bin\\codex.js %*\n");
+    writeFileSync(native, "fake native exe");
+    chmodSync(shim, 0o755);
+    chmodSync(native, 0o755);
+
+    const found = findCodexExecutableOnPath(
+      { Path: tmp, PATHEXT: ".EXE;.CMD;.BAT;.COM" },
+      {
+        platform: "win32",
+        arch: "x64",
+        pathDelimiter: ";",
+        loginShellPathDirs: () => [],
+        wellKnownDirs: () => [],
+      },
     );
+
+    expect(found).not.toBeNull();
+    if (found === null) throw new Error("expected the native Windows codex executable");
+    expect(realpathSync(found)).toBe(realpathSync(native));
   });
 
-  it("verifyCodexExecutable: a deterministic crash signal is NOT transient (broken binary surfaces, no infinite retry)", () => {
-    tmp = mkdtempSync(join(tmpdir(), "ft-codex-crash-"));
-    const executable = join(tmp, "codex");
-    // Self-terminate with SIGSEGV: a binary that always faults on `--version`.
-    writeFileSync(executable, "#!/bin/sh\nkill -SEGV $$\n");
-    chmodSync(executable, 0o755);
+  it("on Windows does not return an npm cmd shim when the native codex.exe is absent", () => {
+    tmp = mkdtempSync(join(tmpdir(), "ft-codex-win-no-native-"));
+    const shim = join(tmp, "codex.cmd");
+    writeFileSync(shim, "@ECHO off\nnode node_modules\\@openai\\codex\\bin\\codex.js %*\n");
+    chmodSync(shim, 0o755);
 
-    const v = verifyCodexExecutable(executable, { PATH: "" });
-    expect(v.ok).toBe(false);
-    if (!v.ok) {
-      expect(v.transient).toBe(false);
-      expect(v.reason).toMatch(/SEGV/);
-    }
+    const found = findCodexExecutableOnPath(
+      { PATH: tmp, PATHEXT: ".CMD" },
+      {
+        platform: "win32",
+        arch: "x64",
+        pathDelimiter: ";",
+        loginShellPathDirs: () => [],
+        wellKnownDirs: () => [],
+      },
+    );
+
+    expect(found).toBeNull();
   });
 
-  it("verifyCodexExecutable: a termination kill (timeout-equivalent) IS transient", () => {
-    tmp = mkdtempSync(join(tmpdir(), "ft-codex-term-"));
-    const executable = join(tmp, "codex");
-    // SIGTERM is how a spawnSync timeout enforces its deadline — a host
-    // condition, not a broken binary.
-    writeFileSync(executable, "#!/bin/sh\nkill -TERM $$\n");
-    chmodSync(executable, 0o755);
+  it.skipIf(process.platform === "win32")(
+    "verifyCodexExecutable: a deterministic crash signal is NOT transient (broken binary surfaces, no infinite retry)",
+    () => {
+      tmp = mkdtempSync(join(tmpdir(), "ft-codex-crash-"));
+      const executable = join(tmp, "codex");
+      // Self-terminate with SIGSEGV: a binary that always faults on `--version`.
+      writeFileSync(executable, "#!/bin/sh\nkill -SEGV $$\n");
+      chmodSync(executable, 0o755);
 
-    const v = verifyCodexExecutable(executable, { PATH: "" });
-    expect(v.ok).toBe(false);
-    if (!v.ok) expect(v.transient).toBe(true);
-  });
+      const v = verifyCodexExecutable(executable, { PATH: "" });
+      expect(v.ok).toBe(false);
+      if (!v.ok) {
+        expect(v.transient).toBe(false);
+        expect(v.reason).toMatch(/SEGV/);
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "verifyCodexExecutable: a termination kill (timeout-equivalent) IS transient",
+    () => {
+      tmp = mkdtempSync(join(tmpdir(), "ft-codex-term-"));
+      const executable = join(tmp, "codex");
+      // SIGTERM is how a spawnSync timeout enforces its deadline - a host
+      // condition, not a broken binary.
+      writeFileSync(executable, "#!/bin/sh\nkill -TERM $$\n");
+      chmodSync(executable, 0o755);
+
+      const v = verifyCodexExecutable(executable, { PATH: "" });
+      expect(v.ok).toBe(false);
+      if (!v.ok) expect(v.transient).toBe(true);
+    },
+  );
 
   it("finds an executable codex via a login-shell-only PATH dir", () => {
     const dir = mkdtempSync(join(tmpdir(), "ft-codex-login-"));
@@ -174,9 +233,14 @@ describe("codex binary resolution", () => {
 
     const found = findCodexExecutableOnPath(
       { PATH: "", HOME: mkdtempSync(join(tmpdir(), "ft-codex-home-")) },
-      // wellKnownDirs:[] isolates from a real host codex (e.g. /opt/homebrew/bin)
-      // and desktopAppDirs:[] isolates from the installed macOS app bundle.
-      { loginShellPathDirs: () => [dir], wellKnownDirs: () => [], desktopAppDirs: () => [] },
+      // Isolate from both real host installs and the installed macOS app bundle.
+      {
+        platform: "linux",
+        pathDelimiter: delimiter,
+        loginShellPathDirs: () => [dir],
+        wellKnownDirs: () => [],
+        desktopAppDirs: () => [],
+      },
     );
     expect(found).toBe(executable);
   });
@@ -190,7 +254,12 @@ describe("codex binary resolution", () => {
     writeFileSync(executable, "#!/bin/sh\nexit 0\n");
     chmodSync(executable, 0o755);
 
-    expect(findCodexExecutableOnPath({ PATH: "", HOME: home }, { loginShellPathDirs: () => [] })).toBe(executable);
+    expect(
+      findCodexExecutableOnPath(
+        { PATH: "", HOME: home },
+        { platform: "linux", pathDelimiter: delimiter, loginShellPathDirs: () => [] },
+      ),
+    ).toBe(executable);
   });
 
   it("prefers the ChatGPT app CLI and falls back to the legacy Codex app CLI", () => {
@@ -261,18 +330,20 @@ describe("codex binary resolution", () => {
     const loginShellPathDirs = vi.fn(() => []);
     const desktopAppDirs = vi.fn(() => []);
 
-    expect(findCodexExecutableOnPath({ PATH: tmp }, { loginShellPathDirs, desktopAppDirs })).toBe(executable);
+    expect(
+      findCodexExecutableOnPath(
+        { PATH: tmp },
+        { platform: "linux", pathDelimiter: delimiter, loginShellPathDirs, desktopAppDirs },
+      ),
+    ).toBe(executable);
     expect(loginShellPathDirs).not.toHaveBeenCalled();
     expect(desktopAppDirs).not.toHaveBeenCalled();
   });
 
   it("verifies a candidate codex executable by launching --version", () => {
-    tmp = mkdtempSync(join(tmpdir(), "ft-codex-version-"));
-    const executable = join(tmp, "codex");
-    writeFileSync(executable, "#!/bin/sh\necho codex 0.139.0\n");
-    chmodSync(executable, 0o755);
-
-    expect(verifyCodexExecutable(executable)).toEqual({ ok: true, output: "codex 0.139.0" });
+    const verification = verifyCodexExecutable(process.execPath);
+    expect(verification.ok).toBe(true);
+    if (verification.ok) expect(verification.output).toContain(process.version);
   });
 
   it("formats binary-missing messages with the original cause", () => {

--- a/packages/client/src/runtime/codex-binary.ts
+++ b/packages/client/src/runtime/codex-binary.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { accessSync, constants } from "node:fs";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
-import { delimiter, isAbsolute, join, resolve } from "node:path";
+import { delimiter, dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { codexDesktopAppBinDirs, wellKnownBinDirs } from "./install-locations.js";
 import { getLoginShellPathDirs } from "./login-shell-path.js";
 
@@ -63,6 +64,11 @@ const DETERMINISTIC_CRASH_SIGNALS: ReadonlySet<NodeJS.Signals> = new Set([
   "SIGBUS",
   "SIGFPE",
 ]);
+
+const WINDOWS_CODEX_PLATFORM_PACKAGE_BY_ARCH: Readonly<Record<string, { triple: string; packageName: string }>> = {
+  x64: { triple: "x86_64-pc-windows-msvc", packageName: "@openai/codex-win32-x64" },
+  arm64: { triple: "aarch64-pc-windows-msvc", packageName: "@openai/codex-win32-arm64" },
+};
 
 /**
  * An externally resolved codex binary that EXISTS (resolution already found it) but whose
@@ -201,17 +207,24 @@ export type FindCodexExecutableDeps = {
   wellKnownDirs?: () => string[];
   /** Returns macOS desktop-app resource dirs; searched only after every PATH source misses. */
   desktopAppDirs?: () => string[];
+  /** Test seams for Windows PATH/shim behaviour without mutating process globals. */
+  platform?: NodeJS.Platform;
+  arch?: NodeJS.Architecture;
+  pathDelimiter?: string;
 };
 
 export function findCodexExecutableOnPath(
   env: Record<string, string | undefined> = process.env,
   deps: FindCodexExecutableDeps = {},
 ): string | null {
+  const platform = deps.platform ?? process.platform;
+  const arch = deps.arch ?? process.arch;
+  const pathDelimiter = deps.pathDelimiter ?? (platform === "win32" ? ";" : delimiter);
   const loginShellPathDirs = deps.loginShellPathDirs ?? getLoginShellPathDirs;
   const home = env.HOME && env.HOME.length > 0 ? env.HOME : homedir();
   const wellKnownDirs = deps.wellKnownDirs ?? (() => wellKnownBinDirs(home));
   const desktopAppDirs = deps.desktopAppDirs ?? (() => codexDesktopAppBinDirs(home));
-  const names = codexExecutableNames(env);
+  const names = codexExecutableNames(env, platform);
   const seen = new Set<string>();
 
   const search = (dirs: readonly string[]): string | null => {
@@ -222,7 +235,8 @@ export function findCodexExecutableOnPath(
       seen.add(base);
       for (const name of names) {
         const candidate = join(base, name);
-        if (isExecutable(candidate)) return candidate;
+        const executable = resolveSpawnableCodexCandidate(candidate, { platform, arch });
+        if (executable) return executable;
       }
     }
     return null;
@@ -234,8 +248,8 @@ export function findCodexExecutableOnPath(
   // intentional CLI install visible through nvm / fnm / volta / mise / asdf or
   // a custom export must keep its selected version and credential context.
   // Codex resolution is never on the daemon's pre-connect path.
-  const pathValue = readPathValue(env);
-  const fromDaemon = search(pathValue ? pathValue.split(delimiter) : []);
+  const pathValue = readPathValue(env, platform);
+  const fromDaemon = search(pathValue ? pathValue.split(pathDelimiter) : []);
   if (fromDaemon) return fromDaemon;
   const fromWellKnown = search(wellKnownDirs());
   if (fromWellKnown) return fromWellKnown;
@@ -259,25 +273,107 @@ function errorSearchText(input: unknown): string {
   return errorText(input);
 }
 
-function readPathValue(env: Record<string, string | undefined>): string | undefined {
-  if (process.platform !== "win32") return env.PATH;
+function readPathValue(env: Record<string, string | undefined>, platform = process.platform): string | undefined {
+  if (platform !== "win32") return env.PATH;
   const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === "path");
   return key ? env[key] : undefined;
 }
 
-function codexExecutableNames(env: Record<string, string | undefined>): string[] {
-  if (process.platform !== "win32") return ["codex"];
+function codexExecutableNames(env: Record<string, string | undefined>, platform = process.platform): string[] {
+  if (platform !== "win32") return ["codex"];
   const pathExt = env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM";
-  const exts = pathExt
-    .split(";")
-    .map((ext) => ext.trim())
-    .filter(Boolean);
-  return ["codex", ...exts.map((ext) => `codex${ext.toLowerCase()}`), ...exts.map((ext) => `codex${ext}`)];
+  const exts = uniqueStrings(
+    pathExt
+      .split(";")
+      .map((ext) => ext.trim())
+      .filter(Boolean),
+  );
+  const preferred = [".EXE", ".COM"].filter((ext) =>
+    exts.some((candidate) => candidate.toLowerCase() === ext.toLowerCase()),
+  );
+  const rest = exts.filter((ext) => !preferred.some((candidate) => candidate.toLowerCase() === ext.toLowerCase()));
+  return uniqueStrings([
+    ...preferred.map((ext) => `codex${ext.toLowerCase()}`),
+    ...preferred.map((ext) => `codex${ext}`),
+    "codex",
+    ...rest.map((ext) => `codex${ext.toLowerCase()}`),
+    ...rest.map((ext) => `codex${ext}`),
+  ]);
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+function resolveSpawnableCodexCandidate(
+  candidate: string,
+  host: { platform: NodeJS.Platform; arch: NodeJS.Architecture },
+): string | null {
+  if (!isExecutable(candidate)) return null;
+  if (host.platform !== "win32") return candidate;
+
+  const ext = extname(candidate).toLowerCase();
+  if (ext === ".exe" || ext === ".com") return candidate;
+
+  return resolveWindowsNativeCodexFromNpmShim(candidate, host);
+}
+
+function resolveWindowsNativeCodexFromNpmShim(
+  candidate: string,
+  host: { platform: NodeJS.Platform; arch: NodeJS.Architecture },
+): string | null {
+  if (host.platform !== "win32") return null;
+  const base = candidate
+    .slice(candidate.lastIndexOf("\\") + 1)
+    .slice(candidate.lastIndexOf("/") + 1)
+    .toLowerCase();
+  if (!base.startsWith("codex")) return null;
+
+  const target = WINDOWS_CODEX_PLATFORM_PACKAGE_BY_ARCH[host.arch];
+  if (!target) return null;
+
+  const packageRoot = join(dirname(candidate), "node_modules", "@openai", "codex");
+  const packageJson = join(packageRoot, "package.json");
+  if (!fileExists(packageJson)) return null;
+
+  let platformPackageRoot: string | null = null;
+  try {
+    const requireFromCodex = createRequire(packageJson);
+    platformPackageRoot = dirname(requireFromCodex.resolve(`${target.packageName}/package.json`));
+  } catch {
+    const nested = join(packageRoot, "node_modules", target.packageName);
+    if (fileExists(join(nested, "package.json"))) platformPackageRoot = nested;
+  }
+
+  const candidates = [
+    platformPackageRoot ? join(platformPackageRoot, "vendor", target.triple, "bin", "codex.exe") : null,
+    join(packageRoot, "vendor", target.triple, "bin", "codex.exe"),
+  ];
+  for (const resolved of candidates) {
+    if (resolved && isExecutable(resolved)) return resolved;
+  }
+  return null;
 }
 
 function isExecutable(filePath: string): boolean {
   try {
     accessSync(filePath, process.platform === "win32" ? constants.F_OK : constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fileExists(filePath: string): boolean {
+  try {
+    accessSync(filePath, constants.F_OK);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

- resolve Windows npm installs through `node.exe npm-cli.js` instead of spawning `.cmd` shims
- preserve a PATH + shell fallback for non-standard Node layouts without embedding an unquoted absolute path
- convert synchronous child-process spawn failures into normal installer failure results
- apply the shared npm invocation path to CLI self-upgrade, npm metadata probes, and Codex/Claude runtime installers
- keep the original Windows Codex native-binary resolution fix while rebasing onto current `main`
- normalize real paths in the Codex shim test to address the macOS `/var` vs `/private/var` review blocker

## Validation

- [x] affected-file Biome check
- [x] `pnpm typecheck` (10/10 Turbo tasks)
- [x] CLI focused tests: 27 passed
- [x] Client Codex tests: 17 passed, 2 platform-skipped
- [x] real Windows npm invocation smoke test (`npm --version` through `node.exe npm-cli.js`)
- [ ] `pnpm check` — blocked on Windows by the checkout-wide CRLF/LF mismatch (1594 pre-existing diagnostics); all 9 touched files pass Biome
- [ ] `pnpm test` — the existing Windows batch runner synchronously fails at `spawnSync vitest.cmd EINVAL`; direct full CLI Vitest runs but exposes existing Windows-only path/symlink/platform-mock failures. Focused changed-surface suites pass.

## Change Surface

- [x] `apps/cli` install and self-upgrade behavior
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

The reported failure was reproduced on Node v22.16.0 with the exact installed path `C:\Program Files\nodejs\npm.cmd`. Directly spawning that shim throws `EINVAL`; adding `shell: true` alone is insufficient because cmd.exe truncates the unquoted absolute path at `C:\Program`.