### PR TITLE
fix(portable): make install.sh recover existing clients

### DIFF
--- a/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
@@ -312,6 +312,32 @@ describe("daemon utility commands", () => {
     expect(output).toContain("Ctrl+C");
     expect(output).toContain("daemon start");
   });
+
+  it("restarts an active systemd service when ensure-service refreshes a drifted unit", async () => {
+    setPlatform("linux");
+    coreMocks.installClientService.mockClear();
+    coreMocks.restartClientService.mockClear();
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.loadCredentials.mockReturnValue({ refreshToken: "refresh" });
+    coreMocks.getClientServiceStatus
+      .mockReturnValueOnce({ state: "active", platform: "systemd", detail: "pid 123" })
+      .mockReturnValueOnce({ state: "active", platform: "systemd", detail: "pid 456" });
+    coreMocks.isServiceUnitDriftDetected.mockReturnValueOnce(true);
+    coreMocks.installClientService.mockReturnValueOnce({
+      platform: "systemd",
+      unitPath: "/tmp/first-tree.service",
+      state: "active",
+    });
+    coreMocks.restartClientService.mockReturnValueOnce({ ok: true });
+
+    await runDaemon(["ensure-service"]);
+
+    expect(coreMocks.installClientService).toHaveBeenCalledTimes(1);
+    expect(coreMocks.restartClientService).toHaveBeenCalledTimes(1);
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "systemd service refreshed and restarted",
+    );
+  });
 });
 
 describe("agent admin and local commands", () => {

--- a/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
@@ -41,6 +41,7 @@ const coreMocks = vi.hoisted(() => ({
   installClientService: vi.fn(),
   isServiceSupported: vi.fn(),
   isServiceUnitDriftDetected: vi.fn(),
+  loadCredentials: vi.fn(),
   refreshClientServiceUnitForUpdate: vi.fn(),
   removeLocalAgent: vi.fn(),
   restartClientService: vi.fn(),
@@ -130,11 +131,16 @@ beforeEach(() => {
   resolveAgentMock.mockResolvedValue({ uuid: "agent-1", name: "nova" });
   coreMocks.isServiceSupported.mockReturnValue(true);
   coreMocks.getClientServiceStatus.mockReturnValue({ state: "active", platform: "launchd", detail: "pid 123" });
+  coreMocks.loadCredentials.mockReturnValue({ refreshToken: "refresh" });
   coreMocks.stopClientService.mockReturnValue({ ok: true });
   coreMocks.restartClientService.mockReturnValue({ ok: true });
   coreMocks.isServiceUnitDriftDetected.mockReturnValue(true);
-  coreMocks.installClientService.mockReturnValue({ platform: "launchd", unitPath: "/tmp/unit.plist" });
-  coreMocks.refreshClientServiceUnitForUpdate.mockReturnValue({ platform: "launchd", unitPath: "/tmp/unit.plist" });
+  coreMocks.installClientService.mockReturnValue({ platform: "launchd", unitPath: "/tmp/unit.plist", state: "active" });
+  coreMocks.refreshClientServiceUnitForUpdate.mockReturnValue({
+    platform: "launchd",
+    unitPath: "/tmp/unit.plist",
+    state: "active",
+  });
   clientMocks.SessionRegistry.mockImplementation(() => ({ load: vi.fn(() => new Map()) }));
   clientMocks.cleanWorkspaces.mockReturnValue([]);
   localAgentMocks.createSdk.mockReturnValue({
@@ -244,9 +250,42 @@ describe("daemon utility commands", () => {
     coreMocks.refreshClientServiceUnitForUpdate.mockReturnValueOnce({
       platform: "systemd",
       unitPath: "/tmp/unit.service",
+      state: "active",
     });
     await runDaemon(["refresh-unit"]);
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("unit rewritten");
+
+    coreMocks.isServiceSupported.mockReturnValueOnce(false);
+    await runDaemon(["ensure-service"]);
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("not supported");
+
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.loadCredentials.mockReturnValueOnce(null);
+    await runDaemon(["ensure-service"]);
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("no credentials");
+
+    coreMocks.installClientService.mockClear();
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({ state: "active", platform: "launchd", detail: "pid 123" });
+    coreMocks.isServiceUnitDriftDetected.mockReturnValueOnce(false);
+    await runDaemon(["ensure-service"]);
+    expect(coreMocks.installClientService).not.toHaveBeenCalled();
+
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({ state: "inactive", platform: "systemd" });
+    coreMocks.isServiceUnitDriftDetected.mockReturnValueOnce(false);
+    coreMocks.installClientService.mockReturnValueOnce({
+      platform: "systemd",
+      unitPath: "/tmp/unit.service",
+      state: "active",
+    });
+    await runDaemon(["ensure-service"]);
+    expect(coreMocks.installClientService).toHaveBeenCalledTimes(1);
+
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({ state: "inactive", platform: "systemd" });
+    coreMocks.isServiceUnitDriftDetected.mockReturnValueOnce(false);
+    coreMocks.installClientService.mockImplementationOnce(() => {
+      throw new Error("service denied");
+    });
+    await expect(runDaemon(["ensure-service"])).rejects.toMatchObject({ code: 1 });
 
     const stdout = vi.fn((_chunk: string | Uint8Array) => true);
     process.stdout.write = stdout as unknown as typeof process.stdout.write;

--- a/apps/cli/src/__tests__/command-registration-smoke.test.ts
+++ b/apps/cli/src/__tests__/command-registration-smoke.test.ts
@@ -95,6 +95,7 @@ describe("CLI command registration", () => {
     expect(subcommands(root, "computer")).toEqual(["reset"]);
     expect(subcommands(root, "daemon")).toEqual([
       "doctor",
+      "ensure-service",
       "home-info",
       "install-claude",
       "install-codex",

--- a/apps/cli/src/__tests__/daemon-refresh-unit.test.ts
+++ b/apps/cli/src/__tests__/daemon-refresh-unit.test.ts
@@ -6,14 +6,16 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { registerDaemonCommands } from "../commands/daemon/index.js";
 import { isServiceUnitDriftDetected } from "../core/index.js";
 
-describe("daemon namespace — refresh-unit hidden subcommand", () => {
-  it("registers `refresh-unit` under `daemon` and keeps it hidden from --help", () => {
+describe("daemon namespace — hidden service-maintenance subcommands", () => {
+  it("registers service-maintenance hooks under `daemon` and keeps them hidden from --help", () => {
     const root = new Command();
     registerDaemonCommands(root);
     const daemonCmd = root.commands.find((c) => c.name() === "daemon");
     expect(daemonCmd, "daemon namespace should be registered").toBeDefined();
     const refresh = daemonCmd?.commands.find((c) => c.name() === "refresh-unit");
     expect(refresh, "refresh-unit subcommand should exist").toBeDefined();
+    const ensure = daemonCmd?.commands.find((c) => c.name() === "ensure-service");
+    expect(ensure, "ensure-service subcommand should exist").toBeDefined();
     // `hidden: true` is the contract documented in commands/daemon/refresh-unit.ts:
     // this is a supervisor-cooperation interface, not a user-facing verb.
     // We assert via `_hidden` (Commander internal flag) because Commander
@@ -22,6 +24,10 @@ describe("daemon namespace — refresh-unit hidden subcommand", () => {
     expect(
       (refresh as unknown as { _hidden?: boolean })._hidden,
       "refresh-unit must remain hidden from `daemon --help`",
+    ).toBe(true);
+    expect(
+      (ensure as unknown as { _hidden?: boolean })._hidden,
+      "ensure-service must remain hidden from `daemon --help`",
     ).toBe(true);
   });
 

--- a/apps/cli/src/commands/daemon/ensure-service.ts
+++ b/apps/cli/src/commands/daemon/ensure-service.ts
@@ -1,0 +1,59 @@
+import type { Command } from "commander";
+import { channelConfig } from "../../core/channel.js";
+import {
+  getClientServiceStatus,
+  installClientService,
+  isServiceSupported,
+  isServiceUnitDriftDetected,
+  loadCredentials,
+} from "../../core/index.js";
+import { print } from "../../core/output.js";
+
+/**
+ * Hidden recovery hook used by the portable installer after it has switched the
+ * channel shim to the freshly installed version. It is intentionally narrower
+ * than `login <token>`: credentials are never created or replaced here. If a
+ * previous login left valid credentials behind, this refreshes the supervised
+ * unit and starts it; if credentials are gone, the follow-up `login` owns that
+ * recovery step.
+ */
+export function registerDaemonEnsureServiceCommand(daemon: Command): void {
+  daemon
+    .command("ensure-service", { hidden: true })
+    .description("Ensure the background service is installed and running when credentials already exist")
+    .action(() => {
+      const binName = channelConfig.binName;
+      if (!isServiceSupported()) {
+        print.line(`  ensure-service: service control is not supported on ${process.platform}; skipping.\n`);
+        return;
+      }
+
+      if (!loadCredentials()) {
+        print.line(`  ensure-service: no credentials found; run \`${binName} login <token>\` after install.\n`);
+        return;
+      }
+
+      const svc = getClientServiceStatus();
+      const drift = isServiceUnitDriftDetected();
+      if (svc.state === "active" && !drift) {
+        print.line(`  ensure-service: ${svc.platform} service is already running.\n`);
+        return;
+      }
+
+      try {
+        const info = installClientService();
+        if (info.state !== "active") {
+          print.line(
+            `  ensure-service: ${info.platform} service installed but not running` +
+              `${info.detail ? ` (${info.detail})` : ""}.\n`,
+          );
+          process.exit(1);
+        }
+        print.line(`  ensure-service: ${info.platform} service installed and running.\n`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        print.line(`  ensure-service: failed to install/start service: ${msg}\n`);
+        process.exit(1);
+      }
+    });
+}

--- a/apps/cli/src/commands/daemon/ensure-service.ts
+++ b/apps/cli/src/commands/daemon/ensure-service.ts
@@ -6,6 +6,7 @@ import {
   isServiceSupported,
   isServiceUnitDriftDetected,
   loadCredentials,
+  restartClientService,
 } from "../../core/index.js";
 import { print } from "../../core/output.js";
 
@@ -42,6 +43,26 @@ export function registerDaemonEnsureServiceCommand(daemon: Command): void {
 
       try {
         const info = installClientService();
+        if (svc.state === "active") {
+          const restart = restartClientService();
+          if (!restart.ok) {
+            print.line(
+              `  ensure-service: ${info.platform} service refresh succeeded but restart failed: ${restart.reason}\n`,
+            );
+            process.exit(1);
+          }
+          const after = getClientServiceStatus();
+          if (after.state !== "active") {
+            print.line(
+              `  ensure-service: ${after.platform} service restarted but is not running` +
+                `${after.detail ? ` (${after.detail})` : ""}.\n`,
+            );
+            process.exit(1);
+          }
+          print.line(`  ensure-service: ${after.platform} service refreshed and restarted.\n`);
+          return;
+        }
+
         if (info.state !== "active") {
           print.line(
             `  ensure-service: ${info.platform} service installed but not running` +

--- a/apps/cli/src/commands/daemon/index.ts
+++ b/apps/cli/src/commands/daemon/index.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { registerDaemonDoctorCommand } from "./doctor.js";
+import { registerDaemonEnsureServiceCommand } from "./ensure-service.js";
 import { registerDaemonHomeInfoCommand } from "./home-info.js";
 import { registerDaemonInstallClaudeCommand } from "./install-claude.js";
 import { registerDaemonInstallCodexCommand } from "./install-codex.js";
@@ -22,6 +23,9 @@ export function registerDaemonCommands(program: Command): void {
   registerDaemonProbeCommand(daemon);
   registerDaemonInstallCodexCommand(daemon);
   registerDaemonInstallClaudeCommand(daemon);
+  // Hidden — portable installer recovery hook. It refreshes/starts the
+  // supervised daemon when credentials already exist, and no-ops before login.
+  registerDaemonEnsureServiceCommand(daemon);
   // Hidden — supervisor-cooperation interface invoked by `createExecuteUpdate`
   // after a self-install to refresh the unit file with the new binary's
   // templates before exit(75).

--- a/apps/cli/tests/portable-builder.test.ts
+++ b/apps/cli/tests/portable-builder.test.ts
@@ -105,7 +105,14 @@ describe("portable installer", () => {
     await mkdir(join(payload, "bin"), { recursive: true });
     await writeFile(
       join(payload, "node", "bin", "node"),
-      `#!/bin/sh\nif [ "$2" = "--version" ]; then echo ${version}; exit 0; fi\nif [ "$1" = "--version" ]; then echo ${version}; exit 0; fi\necho node-stub "$@"\n`,
+      `#!/bin/sh
+if [ -n "\${FT_TEST_NODE_ARGS_LOG:-}" ]; then
+  printf '%s\\n' "$*" >>"$FT_TEST_NODE_ARGS_LOG"
+fi
+if [ "$2" = "--version" ]; then echo ${version}; exit 0; fi
+if [ "$1" = "--version" ]; then echo ${version}; exit 0; fi
+echo node-stub "$@"
+`,
       { mode: 0o755 },
     );
     await writeFile(join(payload, "app", "cli", "index.mjs"), "// fixture\n");
@@ -199,6 +206,57 @@ describe("portable installer", () => {
     const shim = readFileSync(join(binDir, "first-tree"), "utf8");
     expect(shim).toContain("FIRST_TREE_INSTALL_MODE=portable");
     expect(shim).toContain("FIRST_TREE_PORTABLE_ROOT");
+  });
+
+  it("repairs PATH shadowing, cleans npm temp residue, and invokes daemon service recovery", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = await makeFixture(platform);
+    const home = tempDir("first-tree-home-");
+    const prefix = join(home, "prefix");
+    const binDir = join(home, "bin");
+    const npmBinDir = join(home, "npm-bin");
+    const npmRoot = join(home, "npm-root");
+    const wrapperDir = join(home, "wrappers");
+    const argsLog = join(home, "node-args.log");
+    await mkdir(npmBinDir, { recursive: true });
+    await mkdir(npmRoot, { recursive: true });
+    await mkdir(join(npmRoot, ".first-tree-deadbeef"), { recursive: true });
+    await mkdir(wrapperDir, { recursive: true });
+    await writeFile(join(npmBinDir, "first-tree"), "#!/bin/sh\necho npm-first-tree\n", { mode: 0o755 });
+    await writeFile(
+      join(wrapperDir, "npm"),
+      '#!/bin/sh\nif [ "$1" = "root" ] && [ "$2" = "-g" ]; then echo "$FT_TEST_NPM_ROOT"; exit 0; fi\nexit 1\n',
+      { mode: 0o755 },
+    );
+
+    const installArgs = [join(REPO_ROOT, "scripts", "portable", "install.sh"), "--prefix", prefix, "--bin-dir", binDir];
+    const env = {
+      ...process.env,
+      HOME: home,
+      SHELL: "/bin/zsh",
+      PATH: `${npmBinDir}:${wrapperDir}:${process.env.PATH ?? ""}`,
+      FIRST_TREE_PORTABLE_CHANNEL: "prod",
+      FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL: `file://${fixture}`,
+      FT_TEST_NODE_ARGS_LOG: argsLog,
+      FT_TEST_NPM_ROOT: npmRoot,
+    };
+
+    const firstInstall = spawnSync("sh", installArgs, { cwd: REPO_ROOT, env, encoding: "utf8" });
+    expect(firstInstall.status, firstInstall.stderr || firstInstall.stdout).toBe(0);
+    expect(() => readdirSync(join(npmRoot, ".first-tree-deadbeef"))).toThrow();
+    const zshrc = readFileSync(join(home, ".zshrc"), "utf8");
+    expect(zshrc.match(/# >>> first-tree portable >>>/g)).toHaveLength(1);
+    expect(zshrc).toContain(`export PATH="${binDir}:$PATH"`);
+
+    const secondInstall = spawnSync("sh", installArgs, { cwd: REPO_ROOT, env, encoding: "utf8" });
+    expect(secondInstall.status, secondInstall.stderr || secondInstall.stdout).toBe(0);
+    const rewrittenZshrc = readFileSync(join(home, ".zshrc"), "utf8");
+    expect(rewrittenZshrc.match(/# >>> first-tree portable >>>/g)).toHaveLength(1);
+
+    const nodeArgs = readFileSync(argsLog, "utf8");
+    expect(nodeArgs).toContain("app/cli/index.mjs --version");
+    expect(nodeArgs).toContain("app/cli/index.mjs daemon ensure-service");
   });
 
   it("replaces the current symlink itself when upgrading with the shell installer", async () => {

--- a/scripts/portable/install.sh
+++ b/scripts/portable/install.sh
@@ -9,6 +9,7 @@ PATH_MODE="auto"
 REQUESTED_VERSION=""
 PREFIX="$DEFAULT_PREFIX"
 BIN_DIR="$DEFAULT_BIN_DIR"
+ORIGINAL_PATH="${PATH:-}"
 
 START_MARKER="# >>> first-tree portable >>>"
 END_MARKER="# <<< first-tree portable <<<"
@@ -193,10 +194,20 @@ atomic_replace_current_link() {
 }
 
 path_contains_bin_dir() {
-  case ":${PATH:-}:" in
+  path_value="$1"
+  case ":${path_value}:" in
     *:"$BIN_DIR":*) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+portable_shim_wins_on_original_path() {
+  bin_name="$1"
+  old_path="${PATH:-}"
+  PATH="$ORIGINAL_PATH"
+  resolved="$(command -v "$bin_name" 2>/dev/null || true)"
+  PATH="$old_path"
+  [ "$resolved" = "$BIN_DIR/$bin_name" ]
 }
 
 profile_for_shell() {
@@ -238,8 +249,11 @@ rewrite_path_block() {
 }
 
 maybe_edit_path() {
+  bin_name="$1"
   [ "$PATH_MODE" != "off" ] || return 0
-  path_contains_bin_dir && return 0
+  if path_contains_bin_dir "$ORIGINAL_PATH" && portable_shim_wins_on_original_path "$bin_name"; then
+    return 0
+  fi
 
   if ! profile="$(profile_for_shell)"; then
     log "Installed successfully, but this shell is not recognized for automatic PATH setup."
@@ -271,6 +285,35 @@ maybe_edit_path() {
   fi
 }
 
+clean_npm_temp_residue() {
+  package_name="$1"
+  case "$package_name" in
+    first-tree|first-tree-staging) ;;
+    *) return 0 ;;
+  esac
+  command_exists npm || return 0
+
+  npm_root="$(npm root -g 2>/dev/null | sed -n '1p' || true)"
+  [ -n "$npm_root" ] || return 0
+  [ -d "$npm_root" ] || return 0
+
+  for residue in "$npm_root/.$package_name"-*; do
+    [ -e "$residue" ] || continue
+    [ -d "$residue" ] || continue
+    rm -rf "$residue"
+    log "Removed stale npm temp directory: $residue"
+  done
+}
+
+ensure_daemon_service() {
+  bin_name="$1"
+  if "$BIN_DIR/$bin_name" daemon ensure-service; then
+    return 0
+  fi
+  log "Background service repair failed or is not available yet."
+  log "Run $BIN_DIR/$bin_name login <token> to refresh credentials and service state."
+}
+
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/first-tree-portable.XXXXXX")"
 cleanup() {
   rm -rf "$WORK_DIR"
@@ -290,9 +333,11 @@ log "Downloading First Tree portable metadata: $MANIFEST_URL"
 download_to "$MANIFEST_URL" "$MANIFEST_FILE"
 
 VERSION="$(json_string "$MANIFEST_FILE" version)"
+PACKAGE_NAME="$(json_string "$MANIFEST_FILE" packageName)"
 BIN_NAME="$(json_string "$MANIFEST_FILE" binName)"
 ALIAS_NAME="$(json_string "$MANIFEST_FILE" aliasName)"
 [ -n "$VERSION" ] || die "metadata missing version"
+[ -n "$PACKAGE_NAME" ] || die "metadata missing packageName"
 [ -n "$BIN_NAME" ] || die "metadata missing binName"
 [ -n "$ALIAS_NAME" ] || die "metadata missing aliasName"
 
@@ -307,6 +352,7 @@ ASSET_SIZE="$(json_number "$ASSET_FILE" size)"
 [ -n "$ASSET_SHA" ] || die "asset missing sha256"
 [ -n "$ASSET_SIZE" ] || die "asset missing size"
 
+clean_npm_temp_residue "$PACKAGE_NAME"
 mkdir -p "$PREFIX/versions" "$PREFIX/.tmp" "$BIN_DIR"
 TARBALL="$WORK_DIR/payload.tar.gz"
 log "Downloading First Tree ${VERSION} for ${PLATFORM}"
@@ -340,8 +386,11 @@ atomic_replace_current_link "$NEW_LINK" "$CURRENT_LINK"
 write_shim "$BIN_DIR/$BIN_NAME" "$CURRENT_LINK"
 write_shim "$BIN_DIR/$ALIAS_NAME" "$CURRENT_LINK"
 
+PATH="$BIN_DIR:${PATH:-}"
+export PATH
 "$BIN_DIR/$BIN_NAME" --version >/dev/null
-maybe_edit_path
+maybe_edit_path "$BIN_NAME"
+ensure_daemon_service "$BIN_NAME"
 
 log "First Tree ${VERSION} installed at $FINAL_VERSION_DIR"
 log "Command: $BIN_DIR/$BIN_NAME"


### PR DESCRIPTION
## Summary
- make `scripts/portable/install.sh` keep portable shims ahead of shadowing npm installs and clean stale npm temp residue for the channel package
- add a hidden `daemon ensure-service` recovery hook that refreshes/starts the supervised daemon when credentials already exist, restarts an originally active service after a drifted unit refresh, and no-ops safely before `login`
- cover installer re-runs, PATH repair, npm residue cleanup, and the hidden daemon hook in tests

## Tests
- `sh -n scripts/portable/install.sh`
- `pnpm check` (passes; existing warnings remain in unrelated files)
- `pnpm typecheck`
- `pnpm --dir apps/cli exec vitest run tests/portable-builder.test.ts src/__tests__/cli-command-matrix-extra.test.ts src/__tests__/daemon-refresh-unit.test.ts src/__tests__/command-registration-smoke.test.ts`
- `env -u FIRST_TREE_AGENT_ID -u FIRST_TREE_AGENT_SLUG -u FIRST_TREE_CHAT_ID -u FIRST_TREE_CLIENT_ID -u FIRST_TREE_DOC_AGENT_HOME -u FIRST_TREE_DOC_BASE -u FIRST_TREE_DOC_REPO_LOCAL_PATH -u FIRST_TREE_HOME -u FIRST_TREE_INBOX_ID -u FIRST_TREE_PROVIDER -u FIRST_TREE_RUNTIME_SESSION_TOKEN -u FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE -u FIRST_TREE_SERVER_URL -u FIRST_TREE_SERVICE_MODE -u FIRST_TREE_SWITCH_DRAIN_VERSION -u FIRST_TREE_WORKSPACES_ROOT TURBO_CONCURRENCY=1 pnpm test`

## Context Tree
- Companion Context Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/693

Closes #1502
