### PR TITLE
Surface terminal provider failures as runtime notices

### DIFF
--- a/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseProviderRetryEventMessage, RUNTIME_NOTICE_METADATA_KEY, type SessionEvent } from "@first-tree/shared";
+import { type ProviderRetryEventPayload, parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 const BILLING_RESULT = "Failed to authenticate. API Error: 403 Insufficient account balance.";
@@ -56,6 +56,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { SessionContext, TurnOutcome } from "../runtime/handler.js";
+import { formatProviderFailureRuntimeNotice } from "../runtime/runtime-notice.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 const AGENT_ID = "019ef431-0000-7000-9000-000000000002";
@@ -81,6 +82,19 @@ function buildCache() {
     }),
   } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
   return createAgentConfigCache({ sdk: stubSdk });
+}
+
+function providerRetryPayloads(emitted: readonly SessionEvent[]): ProviderRetryEventPayload[] {
+  return emitted
+    .filter((event) => event.kind === "error")
+    .map((event) => parseProviderRetryEventMessage(event.payload.message))
+    .filter((payload): payload is ProviderRetryEventPayload => payload !== null);
+}
+
+function firstProviderPayload(payloads: readonly ProviderRetryEventPayload[]): ProviderRetryEventPayload {
+  const payload = payloads[0];
+  if (!payload) throw new Error("expected provider retry event");
+  return payload;
 }
 
 async function runSingleResultTurn() {
@@ -136,7 +150,7 @@ async function runSingleResultTurn() {
 }
 
 describe("claude-code handler — structured provider error result", () => {
-  it("posts a runtime notice and consumes a billing failure instead of forwarding final text", async () => {
+  it("emits a provider failure and consumes a billing failure instead of forwarding final text", async () => {
     mockState.nextMessages = [
       {
         type: "result",
@@ -149,20 +163,10 @@ describe("claude-code handler — structured provider error result", () => {
     const { sendMessage, forwardResult, emitted, completed, logs } = await runSingleResultTurn();
 
     expect(forwardResult).not.toHaveBeenCalled();
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
-      source: "api",
-      format: "text",
-      metadata: { [RUNTIME_NOTICE_METADATA_KEY]: true },
-      purpose: "agent-final-text",
-    });
-    expect(String(sendMessage.mock.calls[0]?.[1].content)).toContain("insufficient account balance");
+    expect(sendMessage).not.toHaveBeenCalled();
     expect(logs.some((line) => line.includes("Claude SDK provider failure"))).toBe(true);
 
-    const providerPayloads = emitted
-      .filter((event) => event.kind === "error")
-      .map((event) => parseProviderRetryEventMessage(event.payload.message))
-      .filter((payload) => payload !== null);
+    const providerPayloads = providerRetryPayloads(emitted);
     expect(providerPayloads).toHaveLength(1);
     expect(providerPayloads[0]).toMatchObject({
       event: "provider_failure_terminal",
@@ -172,6 +176,9 @@ describe("claude-code handler — structured provider error result", () => {
       reasonCode: "provider_billing_limit",
       userSeverity: "error",
     });
+    expect(formatProviderFailureRuntimeNotice(firstProviderPayload(providerPayloads))).toContain(
+      "insufficient account balance",
+    );
 
     expect(
       emitted.some(
@@ -208,13 +215,9 @@ describe("claude-code handler — structured provider error result", () => {
     const { sendMessage, forwardResult, emitted, completed } = await runSingleResultTurn();
 
     expect(forwardResult).not.toHaveBeenCalled();
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(String(sendMessage.mock.calls[0]?.[1].content)).toContain("`claude auth login`");
+    expect(sendMessage).not.toHaveBeenCalled();
 
-    const providerPayloads = emitted
-      .filter((event) => event.kind === "error")
-      .map((event) => parseProviderRetryEventMessage(event.payload.message))
-      .filter((payload) => payload !== null);
+    const providerPayloads = providerRetryPayloads(emitted);
     expect(providerPayloads[0]).toMatchObject({
       event: "provider_failure_terminal",
       provider: "claude-code",
@@ -223,6 +226,7 @@ describe("claude-code handler — structured provider error result", () => {
       reasonCode: "provider_credential_required",
       userSeverity: "error",
     });
+    expect(formatProviderFailureRuntimeNotice(firstProviderPayload(providerPayloads))).toContain("`claude auth login`");
     expect(completed[0]?.outcome).toMatchObject({
       status: "error",
       terminal: true,
@@ -251,13 +255,10 @@ describe("claude-code handler — structured provider error result", () => {
 
     expect(mockState.queryCalls).toBe(1);
     expect(forwardResult).not.toHaveBeenCalled();
-    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
     expect(emitted.some((event) => event.kind === "assistant_text")).toBe(true);
 
-    const providerPayloads = emitted
-      .filter((event) => event.kind === "error")
-      .map((event) => parseProviderRetryEventMessage(event.payload.message))
-      .filter((payload) => payload !== null);
+    const providerPayloads = providerRetryPayloads(emitted);
     expect(providerPayloads[0]).toMatchObject({
       event: "provider_failure_terminal",
       provider: "claude-code",
@@ -266,6 +267,9 @@ describe("claude-code handler — structured provider error result", () => {
       reasonCode: "unsafe_replay",
       replaySafety: "user_visible",
     });
+    expect(formatProviderFailureRuntimeNotice(firstProviderPayload(providerPayloads))).toContain(
+      "Anthropic connection failed after retry handling",
+    );
     expect(completed[0]?.outcome).toMatchObject({
       status: "error",
       terminal: true,
@@ -291,15 +295,12 @@ describe("claude-code handler — structured provider error result", () => {
     const { sendMessage, forwardResult, emitted, completed } = await runSingleResultTurn();
 
     expect(forwardResult).not.toHaveBeenCalled();
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    const notice = String(sendMessage.mock.calls[0]?.[1].content);
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    const providerPayloads = providerRetryPayloads(emitted);
+    const notice = formatProviderFailureRuntimeNotice(firstProviderPayload(providerPayloads));
     expect(notice).toContain("insufficient account balance");
     expect(notice).not.toContain("`claude auth login`");
-
-    const providerPayloads = emitted
-      .filter((event) => event.kind === "error")
-      .map((event) => parseProviderRetryEventMessage(event.payload.message))
-      .filter((payload) => payload !== null);
     expect(providerPayloads[0]).toMatchObject({
       event: "provider_failure_terminal",
       provider: "claude-code",
@@ -333,7 +334,9 @@ describe("claude-code handler — structured provider error result", () => {
     ];
     const { sendMessage, emitted } = await runSingleResultTurn();
 
-    const notice = String(sendMessage.mock.calls[0]?.[1].content);
+    expect(sendMessage).not.toHaveBeenCalled();
+    const providerPayloads = providerRetryPayloads(emitted);
+    const notice = formatProviderFailureRuntimeNotice(firstProviderPayload(providerPayloads));
     expect(notice).toContain("before authentication");
     expect(notice).toContain("daemon.env");
     expect(notice).not.toContain("rejected the local Claude authentication");
@@ -361,9 +364,11 @@ describe("claude-code handler — structured provider error result", () => {
         result: "Failed to authenticate. API Error: 403 Request not allowed",
       },
     ];
-    const { sendMessage } = await runSingleResultTurn();
+    const { sendMessage, emitted } = await runSingleResultTurn();
 
-    const notice = String(sendMessage.mock.calls[0]?.[1].content);
+    expect(sendMessage).not.toHaveBeenCalled();
+    const providerPayloads = providerRetryPayloads(emitted);
+    const notice = formatProviderFailureRuntimeNotice(firstProviderPayload(providerPayloads));
     expect(notice).toContain("before authentication");
     expect(notice).not.toContain("rejected the local Claude authentication");
   });

--- a/packages/client/src/__tests__/claude-code-session-limit-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-session-limit-result.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseProviderRetryEventMessage, RUNTIME_NOTICE_METADATA_KEY, type SessionEvent } from "@first-tree/shared";
+import { type ProviderRetryEventPayload, parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 const SESSION_LIMIT_RESULT = "You've hit your session limit \u00b7 resets 9:50pm (Asia/Shanghai)";
@@ -37,6 +37,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { SessionContext, TurnOutcome } from "../runtime/handler.js";
+import { formatProviderFailureRuntimeNotice } from "../runtime/runtime-notice.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 const AGENT_ID = "019ef431-0000-7000-9000-000000000001";
@@ -62,6 +63,19 @@ function buildCache() {
     }),
   } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
   return createAgentConfigCache({ sdk: stubSdk });
+}
+
+function providerRetryPayloads(emitted: readonly SessionEvent[]): ProviderRetryEventPayload[] {
+  return emitted
+    .filter((event) => event.kind === "error")
+    .map((event) => parseProviderRetryEventMessage(event.payload.message))
+    .filter((payload): payload is ProviderRetryEventPayload => payload !== null);
+}
+
+function firstProviderPayload(payloads: readonly ProviderRetryEventPayload[]): ProviderRetryEventPayload {
+  const payload = payloads[0];
+  if (!payload) throw new Error("expected provider retry event");
+  return payload;
 }
 
 describe("claude-code handler — session-limit success result", () => {
@@ -113,16 +127,10 @@ describe("claude-code handler — session-limit success result", () => {
     await new Promise((r) => setImmediate(r));
 
     expect(forwardResult).not.toHaveBeenCalled();
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage.mock.calls[0]?.[1].purpose).toBe("agent-final-text");
-    expect(sendMessage.mock.calls[0]?.[1].metadata).toMatchObject({ [RUNTIME_NOTICE_METADATA_KEY]: true });
-    expect(String(sendMessage.mock.calls[0]?.[1].content)).toContain("capacity or usage limit");
+    expect(sendMessage).not.toHaveBeenCalled();
     expect(logs.some((line) => line.includes("Claude SDK provider failure"))).toBe(true);
 
-    const providerPayloads = emitted
-      .filter((event) => event.kind === "error")
-      .map((event) => parseProviderRetryEventMessage(event.payload.message))
-      .filter((payload) => payload !== null);
+    const providerPayloads = providerRetryPayloads(emitted);
     expect(providerPayloads).toHaveLength(1);
     expect(providerPayloads[0]).toMatchObject({
       event: "provider_failure_terminal",
@@ -132,6 +140,9 @@ describe("claude-code handler — session-limit success result", () => {
       reasonCode: "capacity_wait_required",
       userSeverity: "warning",
     });
+    expect(formatProviderFailureRuntimeNotice(firstProviderPayload(providerPayloads))).toContain(
+      "capacity or usage limit",
+    );
 
     expect(
       emitted.some(

--- a/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
+import { type ProviderRetryEventPayload, parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 /**
@@ -23,13 +23,20 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 // into its retry-catch). respawnQuery's next query() call throws
 // SYNCHRONOUSLY, triggering the auto-resume-failed branch.
 const SECOND_PROMPT = "tail prompt";
+const DEFAULT_INITIAL_CRASH_MESSAGE = "initial sdk transport crash";
+const DEFAULT_RESPAWN_FAILURE_MESSAGE = "respawn build failed: sdk module unavailable";
+const RAW_TOKEN = "sk-ant-abcdefghijklmnopqrstuvwxyz1234567890";
 let queryCallCount = 0;
+let initialCrashMessage = DEFAULT_INITIAL_CRASH_MESSAGE;
+let respawnFailureMessage = DEFAULT_RESPAWN_FAILURE_MESSAGE;
 const observedInputMessages: Array<{ attempt: number; content: string }> = [];
 const requiredInputsBeforeThrowByAttempt = new Map<number, number>();
 const throwReleaseGates = new Map<number, Promise<void>>();
 
 function resetSdkMockState(): void {
   queryCallCount = 0;
+  initialCrashMessage = DEFAULT_INITIAL_CRASH_MESSAGE;
+  respawnFailureMessage = DEFAULT_RESPAWN_FAILURE_MESSAGE;
   observedInputMessages.length = 0;
   requiredInputsBeforeThrowByAttempt.clear();
   throwReleaseGates.clear();
@@ -73,7 +80,7 @@ function makeFailingQuery(promptIterable: AsyncIterable<{ message: { content: un
         next: async () => {
           await waitForObservedInputs(attempt, requiredInputsForAttempt(attempt));
           await throwReleaseGates.get(attempt);
-          throw new Error("initial sdk transport crash");
+          throw new Error(initialCrashMessage);
         },
       };
     },
@@ -90,7 +97,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
         // Synchronous throw — buildQuery has no try/catch around the `query()`
         // call, so this surfaces as a throw out of respawnQuery and lands in
         // the auto-resume-failed catch.
-        throw new Error("respawn build failed: sdk module unavailable");
+        throw new Error(respawnFailureMessage);
       }
       return makeFailingQuery(args.prompt, queryCallCount);
     },
@@ -125,6 +132,13 @@ function buildCache() {
     }),
   } as unknown as Parameters<typeof createAgentConfigCache>[0]["sdk"];
   return createAgentConfigCache({ sdk: stubSdk });
+}
+
+function providerRetryPayloads(emitted: readonly SessionEvent[]): ProviderRetryEventPayload[] {
+  return emitted
+    .filter((event) => event.kind === "error")
+    .map((event) => parseProviderRetryEventMessage(event.payload.message))
+    .filter((payload): payload is ProviderRetryEventPayload => payload !== null);
 }
 
 describe("claude-code handler — auto-resume failure surfacing", () => {
@@ -177,6 +191,21 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
     expect(err.payload.message).toContain("Auto-resume failed");
     expect(err.payload.message).toContain("respawn build failed");
 
+    const providerPayloads = providerRetryPayloads(emitted);
+    expect(providerPayloads.map((payload) => payload.event)).toEqual([
+      "provider_retry_scheduled",
+      "provider_failure_terminal",
+    ]);
+    expect(providerPayloads[1]).toMatchObject({
+      event: "provider_failure_terminal",
+      provider: "claude-code",
+      scope: "provider_turn",
+      reasonCode: "claude_auto_resume_failed",
+      userSeverity: "error",
+    });
+    expect(providerPayloads[1]?.messagePreview).toContain("initial sdk transport crash");
+    expect(providerPayloads[1]?.messagePreview).toContain("respawn build failed");
+
     const turnEnds = emitted.filter((e) => e.kind === "turn_end");
     expect(turnEnds).toHaveLength(1);
     const te = turnEnds[0];
@@ -194,6 +223,66 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
     // and the in-process Deduplicator collapses every bind-reset replay
     // (entry → server → push → dispatch dedup skip → never re-acked).
     expect(finishTurnCalled).toHaveBeenCalledTimes(1);
+  });
+
+  it("redacts and truncates auto-resume terminal provider previews", async () => {
+    resetSdkMockState();
+    initialCrashMessage = `initial sdk transport crash Authorization: Bearer ${RAW_TOKEN} ${"x".repeat(1200)}`;
+    respawnFailureMessage = `respawn build failed: sdk module unavailable api_key=${RAW_TOKEN} ${"y".repeat(1200)}`;
+
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const emitted: SessionEvent[] = [];
+
+    const cache = buildCache();
+    await cache.refresh(AGENT_ID);
+
+    const handler = createClaudeCodeHandler({ workspaceRoot, agentConfigCache: cache });
+    const ctx: SessionContext = {
+      agent: {
+        agentId: AGENT_ID,
+        inboxId: "inbox-test",
+        displayName: "test",
+        type: "agent",
+        visibility: "organization",
+        delegateMention: null,
+        metadata: {},
+      },
+      sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+      chatId: "chat-resume-fail",
+      log: () => {},
+      recordProviderActivity: () => {},
+      emitEvent: (e) => emitted.push(e),
+      ...mockCtxPlumbing({ sendMessage }, "chat-resume-fail"),
+      finishTurn: async () => {},
+    };
+
+    await handler.start(
+      { id: "m1", chatId: "chat-resume-fail", senderId: "u", format: "text", content: "hi", metadata: null },
+      ctx,
+    );
+    await handler.suspend();
+    await new Promise((r) => setImmediate(r));
+
+    const errorMessages = emitted.filter((event) => event.kind === "error").map((event) => event.payload.message);
+    expect(errorMessages.every((message) => !message.includes(RAW_TOKEN))).toBe(true);
+    expect(errorMessages.some((message) => message.includes("[REDACTED"))).toBe(true);
+
+    const terminalPayload = providerRetryPayloads(emitted).find(
+      (payload) => payload.event === "provider_failure_terminal",
+    );
+    expect(terminalPayload).toMatchObject({
+      event: "provider_failure_terminal",
+      reasonCode: "claude_auto_resume_failed",
+      userSeverity: "error",
+    });
+    const preview = terminalPayload?.messagePreview;
+    if (!preview) throw new Error("expected terminal provider message preview");
+    // `buildProviderRetryEvent` truncates to the 256-char preview budget, then
+    // appends an ellipsis marker. The schema budget is 800, so this must parse.
+    expect(preview.length).toBeLessThanOrEqual(257);
+    expect(preview).toContain("respawn build failed");
+    expect(preview).toContain("[REDACTED");
+    expect(preview).not.toContain(RAW_TOKEN);
   });
 
   it("retries an unentered tail after auto-resume failure settles the provider-entered prefix", async () => {
@@ -276,6 +365,11 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
     await new Promise((r) => setImmediate(r));
 
     expect(logs.some((l) => l.includes("Auto-resume failed: respawn build failed"))).toBe(true);
+    const providerPayloads = providerRetryPayloads(emitted);
+    expect(providerPayloads.at(-1)).toMatchObject({
+      event: "provider_failure_terminal",
+      reasonCode: "claude_auto_resume_failed",
+    });
 
     const attempt1Inputs = observedInputMessages.filter((message) => message.attempt === 1);
     expect(attempt1Inputs.map((message) => message.content)).toEqual([expect.stringContaining("hi")]);

--- a/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-sdk-error.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseProviderRetryEventMessage, RUNTIME_NOTICE_METADATA_KEY, type SessionEvent } from "@first-tree/shared";
+import { parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 /**
@@ -44,6 +44,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
 import { createClaudeCodeHandler } from "../handlers/claude-code.js";
 import { createAgentConfigCache } from "../runtime/agent-config-cache.js";
 import type { SessionContext } from "../runtime/handler.js";
+import { formatProviderFailureRuntimeNotice } from "../runtime/runtime-notice.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
 
 const AGENT_ID = "019d9a97-90b0-716b-8317-a8c0be8430d8";
@@ -105,16 +106,9 @@ describe("claude-code handler — turn_end on SDK-reported subtype error", () =>
     await handler.suspend();
     await new Promise((r) => setImmediate(r));
 
-    // Success path was NOT taken; the only chat write is an explicit runtime
-    // notice, not final-text forwarding.
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
-      source: "api",
-      format: "text",
-      metadata: { [RUNTIME_NOTICE_METADATA_KEY]: true },
-      purpose: "agent-final-text",
-    });
-    expect(String(sendMessage.mock.calls[0]?.[1].content)).toContain("exceeded max turns");
+    // Success path was NOT taken; durable chat notice delivery is owned by
+    // SessionManager after it sees the structured provider event.
+    expect(sendMessage).not.toHaveBeenCalled();
 
     // Error event carries the SDK-reported cause.
     const errors = emitted.filter((e) => e.kind === "error");
@@ -125,6 +119,8 @@ describe("claude-code handler — turn_end on SDK-reported subtype error", () =>
       provider: "claude-code",
       scope: "provider_turn",
     });
+    if (!providerPayload) throw new Error("expected provider retry event");
+    expect(formatProviderFailureRuntimeNotice(providerPayload)).toContain("exceeded max turns");
     const sdkErr = errors.find((event) => event.payload.source === "sdk");
     if (!sdkErr || sdkErr.kind !== "error") throw new Error("expected sdk error event");
     expect(sdkErr.payload.message).toContain("exceeded max turns");

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -1,7 +1,12 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AgentRuntimeConfig, SessionEvent } from "@first-tree/shared";
+import {
+  type AgentRuntimeConfig,
+  encodeProviderRetryEventMessage,
+  RUNTIME_NOTICE_METADATA_KEY,
+  type SessionEvent,
+} from "@first-tree/shared";
 import type pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
@@ -92,6 +97,53 @@ async function finishEntry(
     },
     { status: "success", terminal: true },
   );
+}
+
+function emitCodexTerminalProviderFailure(ctx: SessionContext, messagePreview: string): void {
+  ctx.emitEvent({
+    kind: "error",
+    payload: {
+      source: "runtime",
+      message: encodeProviderRetryEventMessage({
+        event: "provider_failure_terminal",
+        provider: "codex",
+        scope: "provider_turn",
+        category: "credential",
+        reasonCode: "provider_credential_required",
+        replaySafety: "provider_entered",
+        userSeverity: "error",
+        messagePreview,
+      }),
+    },
+  });
+}
+
+function emitClaudeProviderFailure(
+  ctx: SessionContext,
+  input: {
+    event?: "provider_failure_terminal" | "provider_retry_exhausted";
+    category: "credential" | "provider_capacity" | "transient_transport";
+    reasonCode: string;
+    messagePreview: string;
+    userSeverity?: "info" | "warning" | "error";
+  },
+): void {
+  ctx.emitEvent({
+    kind: "error",
+    payload: {
+      source: "runtime",
+      message: encodeProviderRetryEventMessage({
+        event: input.event ?? "provider_failure_terminal",
+        provider: "claude-code",
+        scope: "provider_turn",
+        category: input.category,
+        reasonCode: input.reasonCode,
+        replaySafety: "provider_entered",
+        userSeverity: input.userSeverity ?? "error",
+        messagePreview: input.messagePreview,
+      }),
+    },
+  });
 }
 
 function createSessionManager(opts: {
@@ -1854,6 +1906,347 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(ackEntry).toHaveBeenCalledTimes(1);
     expect(ackEntry).toHaveBeenCalledWith(19);
     expect(recoverChat).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("posts a durable runtime notice before ACKing a terminal provider failure", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockResolvedValue({ id: "runtime-notice" });
+    const sdk = {
+      register: vi.fn(),
+      sendMessage,
+      sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+    } as unknown as FirstTreeHubSDK;
+    let capturedCtx: SessionContext | undefined;
+    let capturedToken: DeliveryToken | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      start: vi.fn(async (message, ctx, token) => {
+        capturedMessage = message;
+        capturedCtx = ctx;
+        capturedToken = token;
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "queued" } as const };
+      }),
+    });
+    const sm = createSessionManager({
+      handler,
+      ackEntry,
+      sdk,
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
+    });
+
+    await sm.dispatch(mockEntry({ id: 21, chatId: "chat-provider-terminal", messageId: "msg-provider-terminal" }));
+    if (!capturedCtx || !capturedToken || !capturedMessage) throw new Error("delivery was not captured");
+
+    emitCodexTerminalProviderFailure(
+      capturedCtx,
+      "Your access token could not be refreshed because your refresh token was revoked.",
+    );
+    await capturedToken.complete(capturedMessage, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_credential_required",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "chat-provider-terminal",
+      expect.objectContaining({
+        source: "api",
+        format: "text",
+        metadata: { [RUNTIME_NOTICE_METADATA_KEY]: true },
+        purpose: "agent-final-text",
+      }),
+    );
+    const notice = String(sendMessage.mock.calls[0]?.[1].content);
+    expect(notice).toContain("Codex could not run this turn");
+    expect(notice).toContain("credentials need attention");
+    expect(notice).toContain("refresh token was revoked");
+    expect(ackEntry).toHaveBeenCalledWith(21);
+    const [noticeOrder] = sendMessage.mock.invocationCallOrder;
+    const [ackOrder] = ackEntry.mock.invocationCallOrder;
+    if (noticeOrder === undefined || ackOrder === undefined) throw new Error("expected notice and ack order");
+    expect(noticeOrder).toBeLessThan(ackOrder);
+
+    await sm.shutdown();
+  });
+
+  it("posts a durable runtime notice for Claude provider-turn terminal failures", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockResolvedValue({ id: "runtime-notice" });
+    const sdk = {
+      register: vi.fn(),
+      sendMessage,
+      sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+    } as unknown as FirstTreeHubSDK;
+    let capturedCtx: SessionContext | undefined;
+    let capturedToken: DeliveryToken | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      start: vi.fn(async (message, ctx, token) => {
+        capturedMessage = message;
+        capturedCtx = ctx;
+        capturedToken = token;
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "queued" } as const };
+      }),
+    });
+    const sm = createSessionManager({
+      handler,
+      ackEntry,
+      sdk,
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "claude-code" },
+    });
+
+    await sm.dispatch(mockEntry({ id: 24, chatId: "chat-claude-terminal", messageId: "msg-claude-terminal" }));
+    if (!capturedCtx || !capturedToken || !capturedMessage) throw new Error("delivery was not captured");
+
+    emitClaudeProviderFailure(capturedCtx, {
+      category: "credential",
+      reasonCode: "provider_credential_required",
+      messagePreview: "Failed to authenticate. API Error: 403 Request not allowed",
+    });
+    await capturedToken.complete(capturedMessage, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_credential_required",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const notice = String(sendMessage.mock.calls[0]?.[1].content);
+    expect(notice).toContain("Claude Code could not run this turn");
+    expect(notice).toContain("before authentication");
+    expect(notice).toContain("daemon.env");
+    expect(notice).not.toContain("rejected the local Claude authentication");
+    expect(ackEntry).toHaveBeenCalledWith(24);
+    const [noticeOrder] = sendMessage.mock.invocationCallOrder;
+    const [ackOrder] = ackEntry.mock.invocationCallOrder;
+    if (noticeOrder === undefined || ackOrder === undefined) throw new Error("expected notice and ack order");
+    expect(noticeOrder).toBeLessThan(ackOrder);
+
+    await sm.shutdown();
+  });
+
+  it("posts a durable runtime notice for Claude retry-exhausted provider-turn failures", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockResolvedValue({ id: "runtime-notice" });
+    const sdk = {
+      register: vi.fn(),
+      sendMessage,
+      sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+    } as unknown as FirstTreeHubSDK;
+    let capturedCtx: SessionContext | undefined;
+    let capturedToken: DeliveryToken | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      start: vi.fn(async (message, ctx, token) => {
+        capturedMessage = message;
+        capturedCtx = ctx;
+        capturedToken = token;
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "queued" } as const };
+      }),
+    });
+    const sm = createSessionManager({
+      handler,
+      ackEntry,
+      sdk,
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "claude-code" },
+    });
+
+    await sm.dispatch(
+      mockEntry({ id: 25, chatId: "chat-claude-retry-exhausted", messageId: "msg-claude-retry-exhausted" }),
+    );
+    if (!capturedCtx || !capturedToken || !capturedMessage) throw new Error("delivery was not captured");
+
+    emitClaudeProviderFailure(capturedCtx, {
+      event: "provider_retry_exhausted",
+      category: "transient_transport",
+      reasonCode: "claude_sdk_error_exhausted",
+      messagePreview: "socket connection was closed unexpectedly",
+    });
+    await capturedToken.complete(capturedMessage, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "retry_exhausted_notice_posted",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const notice = String(sendMessage.mock.calls[0]?.[1].content);
+    expect(notice).toContain("Anthropic connection failed after retry handling");
+    expect(notice).toContain("socket connection was closed unexpectedly");
+    expect(ackEntry).toHaveBeenCalledWith(25);
+
+    await sm.shutdown();
+  });
+
+  it("posts a durable runtime notice before ACKing Claude auto-resume failures", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockResolvedValue({ id: "runtime-notice" });
+    const sdk = {
+      register: vi.fn(),
+      sendMessage,
+      sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+    } as unknown as FirstTreeHubSDK;
+    let capturedCtx: SessionContext | undefined;
+    let capturedToken: DeliveryToken | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      start: vi.fn(async (message, ctx, token) => {
+        capturedMessage = message;
+        capturedCtx = ctx;
+        capturedToken = token;
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "queued" } as const };
+      }),
+    });
+    const sm = createSessionManager({
+      handler,
+      ackEntry,
+      sdk,
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "claude-code" },
+    });
+
+    await sm.dispatch(
+      mockEntry({ id: 26, chatId: "chat-claude-auto-resume-failed", messageId: "msg-claude-auto-resume-failed" }),
+    );
+    if (!capturedCtx || !capturedToken || !capturedMessage) throw new Error("delivery was not captured");
+
+    emitClaudeProviderFailure(capturedCtx, {
+      category: "transient_transport",
+      reasonCode: "claude_auto_resume_failed",
+      messagePreview: "initial sdk transport crash\nAuto-resume failed: respawn build failed: sdk module unavailable",
+    });
+    await capturedToken.complete(capturedMessage, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "auto_resume_failed_notice_posted",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const notice = String(sendMessage.mock.calls[0]?.[1].content);
+    expect(notice).toContain("Anthropic connection failed after retry handling");
+    expect(notice).toContain("initial sdk transport crash");
+    expect(notice).toContain("respawn build failed");
+    expect(ackEntry).toHaveBeenCalledWith(26);
+    const [noticeOrder] = sendMessage.mock.invocationCallOrder;
+    const [ackOrder] = ackEntry.mock.invocationCallOrder;
+    if (noticeOrder === undefined || ackOrder === undefined) throw new Error("expected notice and ack order");
+    expect(noticeOrder).toBeLessThan(ackOrder);
+
+    await sm.shutdown();
+  });
+
+  it("does not ACK a terminal provider failure when the durable runtime notice cannot be posted", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const recoverChat = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockRejectedValue(new Error("send failed"));
+    const sdk = {
+      register: vi.fn(),
+      sendMessage,
+      sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+    } as unknown as FirstTreeHubSDK;
+    const emitted: SessionEvent[] = [];
+    let capturedCtx: SessionContext | undefined;
+    let capturedToken: DeliveryToken | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      start: vi.fn(async (message, ctx, token) => {
+        capturedMessage = message;
+        capturedCtx = ctx;
+        capturedToken = token;
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "queued" } as const };
+      }),
+    });
+    const sm = createSessionManager({
+      handler,
+      ackEntry,
+      recoverChat,
+      sdk,
+      onSessionEvent: (_chatId, event) => emitted.push(event),
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
+    });
+
+    await sm.dispatch(
+      mockEntry({ id: 22, chatId: "chat-provider-notice-fail", messageId: "msg-provider-notice-fail" }),
+    );
+    if (!capturedCtx || !capturedToken || !capturedMessage) throw new Error("delivery was not captured");
+
+    emitCodexTerminalProviderFailure(capturedCtx, "revoked refresh token");
+    await capturedToken.complete(capturedMessage, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_credential_required",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(ackEntry).not.toHaveBeenCalled();
+    expect(recoverChat).toHaveBeenCalledWith("chat-provider-notice-fail");
+    expect(
+      emitted.some(
+        (event) =>
+          event.kind === "error" &&
+          event.payload.source === "runtime" &&
+          event.payload.message.includes("runtime failure notice delivery failed"),
+      ),
+    ).toBe(true);
+    sendMessage.mockReset();
+    sendMessage.mockResolvedValue({ id: "later-runtime-notice" });
+    await capturedCtx.finishTurn(capturedMessage, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "forward_failed",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    await sm.shutdown();
+  });
+
+  it("clears stale terminal provider notices when the delivery is retried instead of consumed", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockResolvedValue({ id: "runtime-notice" });
+    const sdk = {
+      register: vi.fn(),
+      sendMessage,
+      sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+    } as unknown as FirstTreeHubSDK;
+    let capturedCtx: SessionContext | undefined;
+    let capturedToken: DeliveryToken | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      start: vi.fn(async (message, ctx, token) => {
+        capturedMessage = message;
+        capturedCtx = ctx;
+        capturedToken = token;
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "queued" } as const };
+      }),
+    });
+    const sm = createSessionManager({
+      handler,
+      ackEntry,
+      sdk,
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
+    });
+
+    await sm.dispatch(mockEntry({ id: 23, chatId: "chat-provider-retry", messageId: "msg-provider-retry" }));
+    if (!capturedCtx || !capturedToken || !capturedMessage) throw new Error("delivery was not captured");
+
+    emitCodexTerminalProviderFailure(capturedCtx, "pre-provider retry exhausted");
+    capturedToken.retry(capturedMessage, "provider_retry_exhausted_pre_provider");
+
+    await capturedCtx.finishTurn(capturedMessage, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "forward_failed",
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(ackEntry).not.toHaveBeenCalled();
 
     await sm.shutdown();
   });

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -23,7 +23,6 @@ import {
   encodeProviderRetryEventMessage,
   isImageBatchRefContent,
   isImageRefContent,
-  RUNTIME_NOTICE_METADATA_KEY,
   runtimeProviderSchema,
   SUPPORTED_IMAGE_MIMES as SHARED_SUPPORTED_IMAGE_MIMES,
 } from "@first-tree/shared";
@@ -57,6 +56,7 @@ import {
   type ProviderFailureClassification,
   type ProviderRetryDecision,
 } from "../runtime/provider-retry-policy.js";
+import { redactErrorPreview } from "../runtime/redact-error-preview.js";
 import { materializeResourceSkills } from "../runtime/resource-skills.js";
 import {
   buildBriefingUpdateNotice,
@@ -73,7 +73,6 @@ import {
   type ClaudeProviderFailure,
   claudeFailureFromAssistantMessage,
   claudeFailureFromSdkResult,
-  formatClaudeProviderFailureNotice,
   isEgressForbiddenText,
   mergeClaudeProviderFailures,
 } from "./claude-provider-error.js";
@@ -859,6 +858,43 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     });
   }
 
+  function emitAutoResumeFailedTerminalEvent(input: {
+    sessionCtx: SessionContext;
+    classification: ProviderFailureClassification;
+    replaySafety: ReplaySafety;
+    providerMessagePreview: string;
+    resumeMsg: string;
+  }): void {
+    const decision: ProviderRetryDecision = {
+      action: "stop",
+      reasonCode: "claude_auto_resume_failed",
+      terminalKind: "exhausted",
+      replaySafety: input.replaySafety,
+      userSeverity: "error",
+    };
+    const messagePreview = `Auto-resume failed: ${input.resumeMsg}\nProvider failure: ${input.providerMessagePreview}`;
+    input.sessionCtx.emitEvent({
+      kind: "error",
+      payload: {
+        source: "runtime",
+        message: encodeProviderRetryEventMessage(
+          buildProviderRetryEvent({
+            event: "provider_failure_terminal",
+            provider: runtimeProvider,
+            scope: "provider_turn",
+            classification: input.classification,
+            decision,
+            messagePreview,
+          }),
+        ),
+      },
+    });
+  }
+
+  function formatAutoResumeFailedMessage(resumeMsg: string): string {
+    return `Auto-resume failed: ${redactErrorPreview(resumeMsg, 800)}`;
+  }
+
   function emitProviderTurnSettlementEvent(sessionCtx: SessionContext, settlement: ProviderAttemptSettlement): void {
     sessionCtx.emitEvent({
       kind: "error",
@@ -867,29 +903,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         message: encodeProviderRetryEventMessage(settlement.eventPayload),
       },
     });
-  }
-
-  async function sendClaudeProviderFailureNotice(
-    sessionCtx: SessionContext,
-    settlement: ProviderAttemptSettlement,
-  ): Promise<boolean> {
-    try {
-      await sessionCtx.sdk.sendMessage(sessionCtx.chatId, {
-        source: "api",
-        format: "text",
-        content: formatClaudeProviderFailureNotice(settlement.classification, settlement.messagePreview),
-        metadata: { [RUNTIME_NOTICE_METADATA_KEY]: true },
-        purpose: "agent-final-text",
-      });
-      return true;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      sessionCtx.emitEvent({
-        kind: "error",
-        payload: { source: "runtime", message: `claude provider failure notice delivery failed: ${msg}` },
-      });
-      return false;
-    }
   }
 
   function consumedReasonForProviderSettlement(
@@ -1582,9 +1595,16 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                     } catch (resumeErr) {
                       const resumeMsg = resumeErr instanceof Error ? resumeErr.message : String(resumeErr);
                       sessionCtx.log(`Auto-resume failed after Claude SDK provider failure: ${resumeMsg}`);
+                      emitAutoResumeFailedTerminalEvent({
+                        sessionCtx,
+                        classification: settlement.classification,
+                        replaySafety: settlement.decision.replaySafety,
+                        providerMessagePreview: settlement.messagePreview,
+                        resumeMsg,
+                      });
                       sessionCtx.emitEvent({
                         kind: "error",
-                        payload: { source: "runtime", message: `Auto-resume failed: ${resumeMsg.slice(0, 800)}` },
+                        payload: { source: "runtime", message: formatAutoResumeFailedMessage(resumeMsg) },
                       });
                       sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
                       await ackTurnClose("error", "auto_resume_failed_notice_posted", providerEnteredPrefix);
@@ -1599,8 +1619,8 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                   // The result now reveals whether a deferred auth signal is a
                   // genuine credential failure or a network-egress 403 that only
                   // looks like auth. Flush the auth hint for the former; for
-                  // egress, suppress it — the chat notice below carries the
-                  // correct proxy-first guidance.
+                  // egress, suppress it — the runtime notice posted at
+                  // settlement carries the correct proxy-first guidance.
                   const settledEgressForbidden = isEgressForbiddenText(settlement.messagePreview);
                   if (pendingAuthHint !== null) {
                     if (!settledEgressForbidden && settlement.classification.category === "credential") {
@@ -1628,12 +1648,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                   }
                   sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
                   retryCount = 0;
-                  const noticePosted = await sendClaudeProviderFailureNotice(sessionCtx, settlement);
-                  if (!noticePosted) {
-                    retryBufferedMessages("claude_provider_failure_notice_delivery_failed");
-                    failFatalSessionForRecovery(sessionCtx, "claude_provider_failure_notice_delivery_failed");
-                    return;
-                  }
                   await ackTurnClose("error", consumedReasonForProviderSettlement(settlement), providerEnteredPrefix);
                   resetTurnReplaySafety();
                   continue;
@@ -1852,9 +1866,16 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
             // Mirror the MAX_RETRIES branch above and close the turn
             // deterministically so the slot can be reclaimed.
             try {
+              emitAutoResumeFailedTerminalEvent({
+                sessionCtx,
+                classification,
+                replaySafety: decision.replaySafety,
+                providerMessagePreview: errMsg,
+                resumeMsg,
+              });
               sessionCtx.emitEvent({
                 kind: "error",
-                payload: { source: "runtime", message: `Auto-resume failed: ${resumeMsg.slice(0, 800)}` },
+                payload: { source: "runtime", message: formatAutoResumeFailedMessage(resumeMsg) },
               });
               sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
             } catch (emitErr) {

--- a/packages/client/src/handlers/claude-provider-error.ts
+++ b/packages/client/src/handlers/claude-provider-error.ts
@@ -1,9 +1,8 @@
 import type { SDKAssistantMessageError } from "@anthropic-ai/claude-agent-sdk";
-import type { ProviderFailureCategory, ReplaySafety } from "@first-tree/shared";
-import { daemonEnvFile } from "@first-tree/shared/config";
+import type { ReplaySafety } from "@first-tree/shared";
 import type { ProviderAttemptSignal } from "../runtime/provider-attempt.js";
 import type { ProviderFailureClassification } from "../runtime/provider-retry-policy.js";
-import { redactErrorPreview } from "../runtime/redact-error-preview.js";
+import { formatProviderFailureRuntimeNotice, isEgressForbiddenText } from "../runtime/runtime-notice.js";
 
 type ClaudeProviderErrorShape = {
   name: "ClaudeSdkProviderError";
@@ -94,12 +93,15 @@ export function formatClaudeProviderFailureNotice(
   classification: ProviderFailureClassification,
   messagePreview: string,
 ): string {
-  const detail = redactErrorPreview(messagePreview.trim(), 500);
-  const suffix = detail.length > 0 ? ` Original provider message: ${detail}` : "";
-  const lead = looksLikeEgressForbidden(classification, messagePreview)
-    ? egressForbiddenLead()
-    : noticeLead(classification.category, classification.reasonCode);
-  return `${lead}${suffix}`;
+  return formatProviderFailureRuntimeNotice({
+    event: "provider_failure_terminal",
+    provider: "claude-code",
+    scope: "provider_turn",
+    category: classification.category,
+    reasonCode: classification.reasonCode,
+    userSeverity: "error",
+    messagePreview,
+  });
 }
 
 /**
@@ -112,38 +114,7 @@ export function formatClaudeProviderFailureNotice(
  * lead, which sends operators chasing an auth problem that does not exist.
  * Instead we enumerate the real causes in priority order.
  */
-function looksLikeEgressForbidden(classification: ProviderFailureClassification, messagePreview: string): boolean {
-  return classification.category === "credential" && isEgressForbiddenText(messagePreview);
-}
-
-/**
- * True when a provider message carries Anthropic's pre-auth edge-block signature
- * (`403 Request not allowed`). Shared with the Claude handler so the early auth
- * hint and the final failure notice make the same egress-vs-auth call.
- *
- * Requires both the `Request not allowed` phrase AND a `403` / `forbidden`
- * co-marker so a genuine credential error (e.g. a 401 whose body happens to
- * contain the phrase) is not mis-routed to the egress guidance and have its
- * auth hint suppressed.
- */
-export function isEgressForbiddenText(text: string): boolean {
-  return /request not allowed/i.test(text) && /\b403\b|forbidden/i.test(text);
-}
-
-function egressForbiddenLead(): string {
-  // Channel-correct path: dogfood / staging daemons live under
-  // ~/.first-tree-staging (dev under ~/.first-tree-dev), so a hardcoded
-  // ~/.first-tree would send those users to a file the daemon never reads —
-  // re-introducing the very misdiagnosis this lead exists to prevent.
-  return (
-    'Claude Code could not run this turn: Anthropic returned 403 "Request not allowed". ' +
-    "This status comes back before authentication, so it is usually NOT a login problem — most often " +
-    "the background daemon cannot reach Anthropic (e.g. it is not going through your network proxy). " +
-    `Check, in order: (1) if you use a proxy, give the daemon its proxy env via ${daemonEnvFile()} ` +
-    "and restart it; (2) your Anthropic plan / region entitlement; (3) only if those are fine, " +
-    "re-authenticate with `claude auth login`."
-  );
-}
+export { isEgressForbiddenText };
 
 function readResultMessage(message: unknown): {
   subtype: string;
@@ -276,32 +247,4 @@ function firstNonEmpty(...values: Array<string | undefined>): string {
     if (trimmed) return trimmed;
   }
   return "Claude SDK provider failure";
-}
-
-function noticeLead(category: ProviderFailureCategory, reasonCode: string): string {
-  if (category === "credential") {
-    return "Claude Code could not run this turn: Anthropic rejected the local Claude authentication. Run `claude auth login` on this machine, then retry.";
-  }
-  if (category === "provider_capacity") {
-    if (reasonCode === "provider_billing_limit") {
-      return "Claude Code could not run this turn: Anthropic reports insufficient account balance or unavailable billing credits. Add credits or switch accounts, then retry.";
-    }
-    if (reasonCode === "provider_rate_limited") {
-      return "Claude Code could not run this turn: Anthropic rate-limited this account. Wait for the limit to reset, then retry.";
-    }
-    return "Claude Code could not run this turn: Anthropic reported a capacity or usage limit. Wait or switch accounts, then retry.";
-  }
-  if (category === "transient_transport") {
-    return "Claude Code could not run this turn: the Anthropic connection failed after retry handling. Retry later.";
-  }
-  if (category === "configuration") {
-    return "Claude Code could not run this turn: the Claude runtime configuration is invalid. Update the agent or provider configuration, then retry.";
-  }
-  if (category === "deterministic_input") {
-    return "Claude Code could not run this turn: Anthropic rejected this request as invalid. Adjust the request or configuration, then retry.";
-  }
-  if (category === "capability") {
-    return "Claude Code could not run this turn: the Claude runtime is not launchable on this machine. Fix the local runtime, then retry.";
-  }
-  return "Claude Code could not run this turn: Claude SDK reported a provider failure. Retry after checking the provider status.";
 }

--- a/packages/client/src/runtime/runtime-notice.ts
+++ b/packages/client/src/runtime/runtime-notice.ts
@@ -1,0 +1,129 @@
+import {
+  type ProviderRetryEventPayload,
+  type ProviderRetryScope,
+  RUNTIME_NOTICE_METADATA_KEY,
+  type RuntimeProvider,
+} from "@first-tree/shared";
+import { daemonEnvFile } from "@first-tree/shared/config";
+import type { FirstTreeHubSDK } from "../sdk.js";
+import { redactErrorPreview } from "./redact-error-preview.js";
+
+export function shouldPostProviderFailureRuntimeNotice(payload: ProviderRetryEventPayload): boolean {
+  return payload.event === "provider_failure_terminal" || payload.event === "provider_retry_exhausted";
+}
+
+export function formatProviderFailureRuntimeNotice(payload: ProviderRetryEventPayload): string {
+  const lead = noticeLead(payload);
+  const detail = redactErrorPreview((payload.messagePreview ?? "").trim(), 500);
+  return detail.length > 0 ? `${lead} Original provider message: ${detail}` : lead;
+}
+
+export async function postProviderFailureRuntimeNotice(
+  sdk: FirstTreeHubSDK,
+  chatId: string,
+  payload: ProviderRetryEventPayload,
+): Promise<void> {
+  await sdk.sendMessage(chatId, {
+    source: "api",
+    format: "text",
+    content: formatProviderFailureRuntimeNotice(payload),
+    metadata: { [RUNTIME_NOTICE_METADATA_KEY]: true },
+    purpose: "agent-final-text",
+  });
+}
+
+function providerLabel(provider: RuntimeProvider): string {
+  switch (provider) {
+    case "codex":
+      return "Codex";
+    case "claude-code":
+    case "claude-code-tui":
+      return "Claude Code";
+    default:
+      return provider;
+  }
+}
+
+function actionLabel(scope: ProviderRetryScope): string {
+  switch (scope) {
+    case "session_start":
+      return "start this chat session";
+    case "session_resume":
+      return "resume this chat session";
+    case "provider_turn":
+      return "run this turn";
+  }
+}
+
+function noticeLead(payload: ProviderRetryEventPayload): string {
+  if (payload.scope === "provider_turn" && isClaudeProvider(payload.provider)) {
+    return claudeProviderTurnNoticeLead(payload);
+  }
+  const provider = providerLabel(payload.provider);
+  const action = actionLabel(payload.scope);
+  switch (payload.category) {
+    case "credential":
+      return `${provider} could not ${action}: credentials need attention. Please sign in again and retry.`;
+    case "capability":
+      return `${provider} could not ${action}: the runtime is unavailable on this machine. Install or repair the runtime, then retry.`;
+    case "configuration":
+      return `${provider} could not ${action}: runtime configuration needs attention. Fix the configuration and retry.`;
+    case "deterministic_input":
+      return `${provider} could not ${action}: this input cannot be processed as-is. Adjust the request or start a new thread, then retry.`;
+    case "provider_capacity":
+      return `${provider} could not ${action}: provider capacity or quota blocked the request. Retry after the provider is available or the limit resets.`;
+    case "transient_transport":
+      return `${provider} could not ${action} after retrying a transient provider or network failure. Retry when the provider is available.`;
+    case "unknown":
+      return `${provider} could not ${action}: the provider stopped with an unknown terminal failure. Retry after checking the runtime.`;
+  }
+  return `${provider} could not ${action}: ${payload.reasonCode}.`;
+}
+
+function isClaudeProvider(provider: RuntimeProvider): boolean {
+  return provider === "claude-code" || provider === "claude-code-tui";
+}
+
+function claudeProviderTurnNoticeLead(payload: ProviderRetryEventPayload): string {
+  if (payload.category === "credential") {
+    if (isEgressForbiddenText(payload.messagePreview ?? "")) return claudeEgressForbiddenLead();
+    return "Claude Code could not run this turn: Anthropic rejected the local Claude authentication. Run `claude auth login` on this machine, then retry.";
+  }
+  if (payload.category === "provider_capacity") {
+    if (payload.reasonCode === "provider_billing_limit") {
+      return "Claude Code could not run this turn: Anthropic reports insufficient account balance or unavailable billing credits. Add credits or switch accounts, then retry.";
+    }
+    if (payload.reasonCode === "provider_rate_limited") {
+      return "Claude Code could not run this turn: Anthropic rate-limited this account. Wait for the limit to reset, then retry.";
+    }
+    return "Claude Code could not run this turn: Anthropic reported a capacity or usage limit. Wait or switch accounts, then retry.";
+  }
+  if (payload.category === "transient_transport") {
+    return "Claude Code could not run this turn: the Anthropic connection failed after retry handling. Retry later.";
+  }
+  if (payload.category === "configuration") {
+    return "Claude Code could not run this turn: the Claude runtime configuration is invalid. Update the agent or provider configuration, then retry.";
+  }
+  if (payload.category === "deterministic_input") {
+    return "Claude Code could not run this turn: Anthropic rejected this request as invalid. Adjust the request or configuration, then retry.";
+  }
+  if (payload.category === "capability") {
+    return "Claude Code could not run this turn: the Claude runtime is not launchable on this machine. Fix the local runtime, then retry.";
+  }
+  return "Claude Code could not run this turn: Claude SDK reported a provider failure. Retry after checking the provider status.";
+}
+
+export function isEgressForbiddenText(text: string): boolean {
+  return /request not allowed/i.test(text) && /\b403\b|forbidden/i.test(text);
+}
+
+function claudeEgressForbiddenLead(): string {
+  return (
+    'Claude Code could not run this turn: Anthropic returned 403 "Request not allowed". ' +
+    "This status comes back before authentication, so it is usually NOT a login problem — most often " +
+    "the background daemon cannot reach Anthropic (e.g. it is not going through your network proxy). " +
+    `Check, in order: (1) if you use a proxy, give the daemon its proxy env via ${daemonEnvFile()} ` +
+    "and restart it; (2) your Anthropic plan / region entitlement; (3) only if those are fine, " +
+    "re-authenticate with `claude auth login`."
+  );
+}

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -4,6 +4,7 @@ import type {
   AgentRuntimeConfigPayload,
   GitRepo,
   InboxEntryWithMessage,
+  ProviderRetryEventPayload,
   RuntimeProvider,
   RuntimeState,
   SessionEvent,
@@ -14,6 +15,7 @@ import {
   encodeProviderRetryEventMessage,
   isImageBatchRefContent,
   isImageRefContent,
+  parseProviderRetryEventMessage,
   runtimeProviderSchema,
   SOURCE_REPOS_DIRNAME,
 } from "@first-tree/shared";
@@ -56,6 +58,7 @@ import {
 } from "./provider-retry-policy.js";
 import { redactErrorPreview } from "./redact-error-preview.js";
 import { createResultSink, type Trigger } from "./result-sink.js";
+import { postProviderFailureRuntimeNotice, shouldPostProviderFailureRuntimeNotice } from "./runtime-notice.js";
 import { SessionRegistry } from "./session-registry.js";
 
 type SessionEntry = {
@@ -101,6 +104,16 @@ type SessionEntry = {
    * injects these only after the handler is live again.
    */
   retryQueuedMessages: SessionMessage[];
+  /**
+   * Latest terminal, user-actionable provider failure observed on the session
+   * event channel. Posting the durable chat notice at the delivery-settlement
+   * boundary keeps the policy centralized: handlers classify and emit
+   * `provider.retry`, while SessionManager decides whether ACK may consume the
+   * user's inbox entry. Non-consuming delivery paths clear this cache so a
+   * provider failure from one delivery cannot be posted as evidence for a later
+   * delivery on the same session.
+   */
+  pendingRuntimeFailureNotice: ProviderRetryEventPayload | null;
   /**
    * When we entered transient-retry mode this is set to the evicted mapping
    * captured at startNewSession time. Lets a retry re-use the same resume
@@ -590,14 +603,14 @@ export class SessionManager {
         const deliveryKind: SlotDeliveryKind = isRecoveryRedelivery ? "recovery" : "fresh";
         routePromise = this.routeMessage(chatId, message, deliveryKind).catch((err) => {
           if (this.inboxDelivery.hasEntry(work)) {
-            this.inboxDelivery.retryTurn(chatId, message, "route_message_failed");
+            this.retryDeliveryTurn(chatId, message, "route_message_failed");
           }
           throw err;
         });
       });
     } catch (err) {
       if (this.inboxDelivery.hasEntry(work)) {
-        this.inboxDelivery.retryTurn(chatId, message, "admission_failed");
+        this.retryDeliveryTurn(chatId, message, "admission_failed");
       }
       throw err;
     }
@@ -893,6 +906,60 @@ export class SessionManager {
     return parsed.success ? parsed.data : "claude-code";
   }
 
+  private captureRuntimeFailureNotice(chatId: string, event: SessionEvent): void {
+    if (event.kind !== "error") return;
+    const payload = parseProviderRetryEventMessage(event.payload.message);
+    if (!payload || !shouldPostProviderFailureRuntimeNotice(payload)) return;
+
+    const entry = this.sessions.get(chatId);
+    if (!entry) return;
+    entry.pendingRuntimeFailureNotice = payload;
+  }
+
+  private clearPendingRuntimeFailureNotice(chatId: string): void {
+    const entry = this.sessions.get(chatId);
+    if (entry) entry.pendingRuntimeFailureNotice = null;
+  }
+
+  private retryDeliveryTurn(
+    chatId: string,
+    messages: SessionMessage | readonly SessionMessage[],
+    reason: string,
+  ): void {
+    this.clearPendingRuntimeFailureNotice(chatId);
+    this.inboxDelivery.retryTurn(chatId, messages, reason);
+  }
+
+  private emitRuntimeFailureNoticeDeliveryFailure(chatId: string, err: unknown): void {
+    try {
+      this.config.onSessionEvent?.(chatId, {
+        kind: "error",
+        payload: {
+          source: "runtime",
+          message: `runtime failure notice delivery failed: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      });
+    } catch (emitErr) {
+      this.config.log.warn({ chatId, emitErr }, "runtime failure notice delivery error event emit failed");
+    }
+  }
+
+  private async postPendingRuntimeFailureNotice(chatId: string): Promise<boolean> {
+    const entry = this.sessions.get(chatId);
+    const payload = entry?.pendingRuntimeFailureNotice;
+    if (!entry || !payload) return true;
+
+    try {
+      await postProviderFailureRuntimeNotice(this.config.sdk, chatId, payload);
+      entry.pendingRuntimeFailureNotice = null;
+      return true;
+    } catch (err) {
+      this.config.log.warn({ chatId, err, reasonCode: payload.reasonCode }, "runtime failure notice delivery failed");
+      this.emitRuntimeFailureNoticeDeliveryFailure(chatId, err);
+      return false;
+    }
+  }
+
   private retryClassificationForEntry(entry: SessionEntry): ProviderFailureClassification {
     return {
       category: entry.lastRetryCategory ?? "unknown",
@@ -983,9 +1050,19 @@ export class SessionManager {
     const retryReason = this.errorCompletionRetryReason(outcome);
     if (retryReason) {
       this.warnRejectedErrorCompletion(chatId, outcome, retryReason);
-      this.inboxDelivery.retryTurn(chatId, messages, retryReason);
+      this.retryDeliveryTurn(chatId, messages, retryReason);
       this.projectSessionRuntime(chatId);
       return;
+    }
+    if (outcome.status === "success") {
+      this.clearPendingRuntimeFailureNotice(chatId);
+    } else if (outcome.completion === "consumed") {
+      const noticePosted = await this.postPendingRuntimeFailureNotice(chatId);
+      if (!noticePosted) {
+        this.retryDeliveryTurn(chatId, messages, "runtime_failure_notice_delivery_failed");
+        this.projectSessionRuntime(chatId);
+        return;
+      }
     }
     await this.inboxDelivery.finishTurn(chatId, messages, outcome);
     this.projectSessionRuntime(chatId);
@@ -1013,11 +1090,17 @@ export class SessionManager {
       },
       retry: (messages, reason) => {
         if (!claimTerminal("retry")) return;
-        this.inboxDelivery.retryTurn(chatId, messages, reason);
+        this.retryDeliveryTurn(chatId, messages, reason);
         this.projectSessionRuntime(chatId);
       },
       terminalRejected: async (messages, reason, evidence) => {
         if (!claimTerminal("terminalRejected")) return;
+        const noticePosted = await this.postPendingRuntimeFailureNotice(chatId);
+        if (!noticePosted) {
+          this.retryDeliveryTurn(chatId, messages, "runtime_failure_notice_delivery_failed");
+          this.projectSessionRuntime(chatId);
+          return;
+        }
         await this.inboxDelivery.terminalRejected(chatId, messages, reason, evidence);
         this.projectSessionRuntime(chatId);
       },
@@ -1034,7 +1117,7 @@ export class SessionManager {
         { chatId, messageId: message.id, entryId: message.inboxEntryId, reason: receipt.reason },
         "handler rejected inbox delivery before custody",
       );
-      this.inboxDelivery.retryTurn(chatId, message, `handler_rejected:${receipt.reason}`);
+      this.retryDeliveryTurn(chatId, message, `handler_rejected:${receipt.reason}`);
       return "lost";
     }
     if (message.inboxEntryId === undefined) return "owned";
@@ -1174,6 +1257,7 @@ export class SessionManager {
       lastRetryRawError: null,
       startMessage: message,
       retryQueuedMessages: [],
+      pendingRuntimeFailureNotice: null,
       retryFromEvicted: evicted ?? null,
     };
 
@@ -1453,6 +1537,7 @@ export class SessionManager {
     if (this.config.confirmSessionEvent) {
       try {
         await this.config.confirmSessionEvent(chatId, event);
+        this.captureRuntimeFailureNotice(chatId, event);
         return true;
       } catch (emitErr) {
         this.config.log.warn({ chatId, emitErr }, "confirmed session event emit failed");
@@ -1461,6 +1546,7 @@ export class SessionManager {
     }
     try {
       this.config.onSessionEvent?.(chatId, event);
+      this.captureRuntimeFailureNotice(chatId, event);
     } catch (emitErr) {
       this.config.log.warn({ chatId, emitErr }, "session error event emit failed");
     }
@@ -1479,7 +1565,7 @@ export class SessionManager {
         status: "error",
         terminal: true,
         completion: "consumed",
-        reason: `session_failure_notice_posted:${handling.reasonCode}`,
+        reason: `session_failure_terminal:${handling.reasonCode}`,
       });
     } else {
       await this.inboxDelivery.drainForTerminate(chatId);
@@ -1698,7 +1784,7 @@ export class SessionManager {
         entry.lastActivity = Date.now();
       } catch (err) {
         this.config.log.warn({ chatId: entry.chatId, messageId: message.id, err }, "retry queued inject failed");
-        this.inboxDelivery.retryTurn(entry.chatId, message, "retry_queued_inject_failed");
+        this.retryDeliveryTurn(entry.chatId, message, "retry_queued_inject_failed");
         break;
       }
     }
@@ -1902,7 +1988,7 @@ export class SessionManager {
         const hasInboxEntryId = next.message?.inboxEntryId !== undefined;
         this.config.log.warn({ chatId: next.chatId, hasInboxEntryId, err }, "pending drain error");
         if (next.message && hasInboxEntryId) {
-          this.inboxDelivery.retryTurn(next.chatId, next.message, "pending_drain_failed");
+          this.retryDeliveryTurn(next.chatId, next.message, "pending_drain_failed");
         } else {
           this.pendingQueue.unshift(next);
         }
@@ -1936,7 +2022,7 @@ export class SessionManager {
       const hasInboxEntryId = message.inboxEntryId !== undefined;
       this.config.log.warn({ chatId: next.chatId, hasInboxEntryId, err }, "pending drain error");
       if (hasInboxEntryId) {
-        this.inboxDelivery.retryTurn(next.chatId, message, "pending_drain_failed");
+        this.retryDeliveryTurn(next.chatId, message, "pending_drain_failed");
       } else {
         this.pendingQueue.unshift(next);
       }
@@ -2197,6 +2283,7 @@ export class SessionManager {
       },
       emitEvent: (event) => {
         this.config.onSessionEvent?.(chatId, event);
+        this.captureRuntimeFailureNotice(chatId, event);
       },
       emitEventConfirmed: (event) => this.confirmSessionEventOrThrow(chatId, event),
       forwardResult,
@@ -2207,7 +2294,7 @@ export class SessionManager {
         return this.completeDeliveryTurn(chatId, messages, outcome);
       },
       retryTurn: (messages, reason) => {
-        this.inboxDelivery.retryTurn(chatId, messages, reason);
+        this.retryDeliveryTurn(chatId, messages, reason);
         this.projectSessionRuntime(chatId);
       },
       failSessionForRecovery: (reason, sessionId) => {
@@ -2235,6 +2322,7 @@ export class SessionManager {
       throw new Error("confirmed session event channel unavailable");
     }
     await this.config.confirmSessionEvent(chatId, event);
+    this.captureRuntimeFailureNotice(chatId, event);
   }
 
   private async resolveSelfFence(log: (msg: string) => void, chatId: string): Promise<SelfFence> {


### PR DESCRIPTION
## Summary
- Add a runtime-level notice formatter for terminal/user-actionable provider retry events.
- Capture terminal `provider.retry` session events in `SessionManager` and post a durable runtime notice before ACKing consumed provider failures.
- Retry/recover the delivery instead of ACKing if the durable runtime notice cannot be posted.
- Centralize Claude provider-turn durable notices in the same SessionManager settlement path, preserving the existing Claude-specific wording.
- Cover notice-before-ACK, stale pending notice cleanup, notice-delivery-failure, Claude provider-turn, retry-exhausted, and auto-resume-failure behavior in client runtime tests.

## Notes
- This keeps provider failure durable notices out of individual handlers: handlers emit structured provider retry events; `SessionManager` decides whether a durable chat notice is required at the delivery settlement boundary.
- Non-consuming retry/recovery paths clear the pending runtime failure notice before returning delivery work to recovery, so a terminal provider event cannot be posted as stale evidence for a later delivery.
- Claude provider-turn notices now use the centralized runtime notice formatter, including the existing billing/rate/session-limit/auth and egress/proxy guidance.
- Claude auto-resume build failures now emit a terminal structured provider payload through `buildProviderRetryEvent(...)` before ACKing the consumed prefix, so this sibling path gets durable notice-before-ACK treatment with the same redaction/truncation guarantees as other provider retry events.

## Verification
- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1 src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts src/__tests__/session-manager.test.ts`
- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1 src/__tests__/session-manager.test.ts src/__tests__/claude-code-provider-error-result.test.ts src/__tests__/claude-code-session-limit-result.test.ts src/__tests__/claude-code-turn-end-sdk-error.test.ts src/__tests__/claude-provider-error.test.ts src/__tests__/claude-code-turn-end-retry-exhausted.test.ts src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts`
- `pnpm check` (passes; reports existing warnings in unrelated files)
- `pnpm typecheck`
- Previous full client run on this PR: `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1`
