### PR TITLE
Portable installs: define bundled Node upgrade path

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,16 @@ At the "connect a computer" step, setup gives you the command to install the
 CLI and link the machine:
 
 ```bash
-npm install -g first-tree
-first-tree login <connect-token>
+# Use the exact command shown in the web console; production portable installs
+# have this shape:
+curl -fsSL https://downloads.first-tree.ai/prod/install.sh | sh
+~/.local/bin/first-tree login <connect-token>
 ```
 
-The binary lives at `first-tree`; a short alias `ft` is also installed.
+The portable installer bundles Node.js, so new users do not need to install
+Node separately. The npm global install path (`npm install -g first-tree`) is
+still supported for operators and fallback installs; npm mode uses your system
+Node runtime.
 
 ## CLI
 
@@ -167,6 +172,7 @@ Run `first-tree <namespace> --help` for the full list under any namespace.
 - [Onboarding Guide](docs/onboarding-guide.md) — CLI flow, SDK, troubleshooting
 - [CLI Reference](docs/cli-reference.md) — every command and environment variable
 - [Observability](docs/observability.md) — logs and OpenTelemetry traces
+- [Portable Node Runtime](docs/development/portable-node-runtime.md) — bundled Node policy for portable releases
 - [docs/development/](docs/development/) — contributor reference
 - [docs/troubleshooting/](docs/troubleshooting/) — environment-specific gotchas
 - [docs/migration/](docs/migration/) — coming from `first-tree@0.4.x`

--- a/apps/cli/src/__tests__/core-attention-update-extra.test.ts
+++ b/apps/cli/src/__tests__/core-attention-update-extra.test.ts
@@ -109,6 +109,48 @@ describe("core update helpers", () => {
     await expect(latestPromise).resolves.toEqual({ ok: true, mode: "global", installedVersion: null });
   });
 
+  it("preflights npm-mode target engines and points incompatible users at Node or portable install", async () => {
+    vi.resetModules();
+    vi.doMock("../core/channel.js", () => ({
+      channelConfig: {
+        channel: "prod",
+        binName: "first-tree",
+        aliasName: "ft",
+        packageName: "first-tree",
+        defaultHome: "/tmp/home",
+        defaultServerUrl: "https://cloud.first-tree.ai",
+        serviceUnitFile: "first-tree.service",
+        launchdLabel: "first-tree",
+        launchdPlistFile: "first-tree.plist",
+        displayName: "First Tree",
+        portable: {
+          channelPrefix: "prod",
+          publicInstallerPath: "prod/install.sh",
+          downloadBaseUrl: "https://downloads.first-tree.ai",
+        },
+      },
+    }));
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: JSON.stringify(">=999.0.0"), stderr: "" });
+    const child = new MockChild();
+    installSpawn(child);
+
+    const { installGlobalSpec } = await import("../core/update.js");
+    const output = vi.fn();
+    const result = await installGlobalSpec("0.6.0", { output });
+
+    expect(result).toMatchObject({
+      ok: false,
+      mode: "global",
+      retryable: false,
+      reasonCode: "npm_ebadengine",
+    });
+    if (result.ok) throw new Error("expected engine mismatch");
+    expect(result.reason).toContain("npm-mode updates cannot replace the system Node runtime");
+    expect(result.reason).toContain("https://downloads.first-tree.ai/prod/install.sh");
+    expect(childRegistryMocks.getChildProcessRegistry().spawn).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledWith(expect.stringContaining("requires Node >=999.0.0"));
+  });
+
   it("classifies child errors, non-zero exits, and timeouts", async () => {
     vi.resetModules();
     vi.doMock("../core/channel.js", () => ({

--- a/apps/cli/src/__tests__/update-portable-install.test.ts
+++ b/apps/cli/src/__tests__/update-portable-install.test.ts
@@ -39,11 +39,13 @@ function sha256(path: string): string {
 async function makeArtifactPayload(options: {
   version: string;
   platform: string;
+  nodeVersion?: string;
   packageName?: string;
   binName?: string;
   aliasName?: string;
 }): Promise<string> {
   const payload = tempDir("ft-portable-payload-");
+  const nodeVersion = options.nodeVersion ?? "v24.0.0";
   const packageName = options.packageName ?? "first-tree";
   const binName = options.binName ?? "first-tree";
   const aliasName = options.aliasName ?? "ft";
@@ -64,7 +66,7 @@ async function makeArtifactPayload(options: {
       channel: "prod",
       version: options.version,
       gitSha: "abc123",
-      nodeVersion: "v24.0.0",
+      nodeVersion,
       packageName,
       binName,
       aliasName,
@@ -80,11 +82,12 @@ async function makeArtifactPayload(options: {
 }
 
 async function makePortableFixture(
-  options: { version?: string; packageName?: string; binName?: string; aliasName?: string } = {},
+  options: { version?: string; nodeVersion?: string; packageName?: string; binName?: string; aliasName?: string } = {},
 ): Promise<{ root: string; latestPath: string; manifestPath: string; tarball: string; platform: string }> {
   const platform = currentPlatform();
   if (platform === null) throw new Error("unsupported test platform");
   const version = options.version ?? "1.2.3";
+  const nodeVersion = options.nodeVersion ?? "v24.0.0";
   const packageName = options.packageName ?? "first-tree";
   const binName = options.binName ?? "first-tree";
   const aliasName = options.aliasName ?? "ft";
@@ -93,7 +96,7 @@ async function makePortableFixture(
   const versionDir = join(channelDir, version);
   mkdirSync(versionDir, { recursive: true });
 
-  const payload = await makeArtifactPayload({ version, platform, packageName, binName, aliasName });
+  const payload = await makeArtifactPayload({ version, platform, nodeVersion, packageName, binName, aliasName });
   const tarball = join(versionDir, `${packageName}-${version}-${platform}.tar.gz`);
   const tar = spawnSync("tar", ["-czf", tarball, "-C", payload, "."], { encoding: "utf8" });
   if (tar.status !== 0) throw new Error(tar.stderr);
@@ -103,7 +106,7 @@ async function makePortableFixture(
     channel: "prod",
     version,
     gitSha: "abc123",
-    nodeVersion: "v24.0.0",
+    nodeVersion,
     packageName,
     binName,
     aliasName,
@@ -126,7 +129,8 @@ async function makePortableFixture(
   return { root, latestPath, manifestPath, tarball, platform };
 }
 
-async function seedOldInstall(prefix: string): Promise<void> {
+async function seedOldInstall(prefix: string, options: { nodeVersion?: string } = {}): Promise<void> {
+  const nodeVersion = options.nodeVersion ?? "v24.0.0";
   await mkdir(join(prefix, "versions", "old"), { recursive: true });
   await writeFile(join(prefix, "versions", "old", "VERSION"), "old\n");
   await writeFile(
@@ -136,7 +140,7 @@ async function seedOldInstall(prefix: string): Promise<void> {
       channel: "prod",
       version: "0.1.0",
       gitSha: "old",
-      nodeVersion: "v24.0.0",
+      nodeVersion,
       packageName: "first-tree",
       binName: "first-tree",
       aliasName: "ft",
@@ -229,6 +233,32 @@ describe("installPortableSpec", () => {
     const { installPortableSpec } = await importProdUpdateModule();
     const result = await installPortableSpec("2.0.0");
     expect(result).toEqual({ ok: true, mode: "portable", installedVersion: "2.0.0" });
+    expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("2.0.0\n");
+  });
+
+  it("hands portable installs across bundled Node major upgrades", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = await makePortableFixture({ version: "2.0.0", nodeVersion: "v25.0.0" });
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix, { nodeVersion: "v24.11.1" });
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+    vi.stubEnv("HOME", home);
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    const result = await installPortableSpec("latest");
+    expect(result).toEqual({ ok: true, mode: "portable", installedVersion: "2.0.0" });
+
+    const currentInstall = JSON.parse(readFileSync(join(prefix, "current", "INSTALL.json"), "utf8")) as {
+      nodeVersion: string;
+    };
+    const oldInstall = JSON.parse(readFileSync(join(prefix, "versions", "old", "INSTALL.json"), "utf8")) as {
+      nodeVersion: string;
+    };
+    expect(oldInstall.nodeVersion).toBe("v24.11.1");
+    expect(currentInstall.nodeVersion).toBe("v25.0.0");
     expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("2.0.0\n");
   });
 

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -26,6 +26,8 @@ import { print } from "./output.js";
 
 /** Hard ceiling on a single `npm install -g` invocation (5 min). */
 const NPM_INSTALL_TIMEOUT_MS = 5 * 60 * 1000;
+/** Short metadata probe used only to catch guaranteed npm-mode engine mismatch. */
+const NPM_METADATA_TIMEOUT_MS = 10 * 1000;
 
 export type InstallMode = "global" | "npx" | "source" | "portable";
 export type VersionLookupResult = { ok: true; version: string } | { ok: false; reason: string };
@@ -204,6 +206,68 @@ function isSafeInstallSpec(spec: string): boolean {
 /** Does this spec look like a concrete SemVer (vs a dist-tag like "latest")? */
 function looksLikeVersion(spec: string): boolean {
   return /^\d+\.\d+\.\d+(?:-|$)/.test(spec);
+}
+
+function parseNpmViewEngineRange(stdout: string): string | null {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0 || trimmed === "null" || trimmed === "undefined") return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (typeof parsed === "string" && parsed.trim().length > 0) return parsed.trim();
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const record = parsed as Record<string, unknown>;
+  if (typeof record["engines.node"] === "string" && record["engines.node"].trim().length > 0) {
+    return record["engines.node"].trim();
+  }
+  const engines = record.engines;
+  if (engines !== null && typeof engines === "object" && !Array.isArray(engines)) {
+    const node = (engines as Record<string, unknown>).node;
+    if (typeof node === "string" && node.trim().length > 0) return node.trim();
+  }
+  return null;
+}
+
+function lookupNpmTargetNodeEngineRange(spec: string): string | null {
+  if (PACKAGE_NAME === null) return null;
+  const res = spawnSync(resolveNpmCommand(), ["view", `${PACKAGE_NAME}@${spec}`, "engines.node", "--json"], {
+    encoding: "utf-8",
+    timeout: NPM_METADATA_TIMEOUT_MS,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (res.status !== 0) return null;
+  return parseNpmViewEngineRange(res.stdout ?? "");
+}
+
+function portableMigrationHint(): string {
+  const baseUrl = channelConfig.portable.downloadBaseUrl?.replace(/\/+$/, "");
+  const installerPath = channelConfig.portable.publicInstallerPath;
+  if (baseUrl && installerPath) {
+    return `or migrate to the portable install path from the web console (installer: ${baseUrl}/${installerPath})`;
+  }
+  return "or migrate to the portable install path from the web console";
+}
+
+function checkNpmTargetNodeEngine(spec: string): Extract<ExecuteUpdateResult, { ok: false }> | null {
+  const range = lookupNpmTargetNodeEngineRange(spec);
+  if (range === null) return null;
+  const normalizedRange = semver.validRange(range);
+  if (normalizedRange === null) return null;
+  if (semver.satisfies(process.version, normalizedRange, { includePrerelease: true })) return null;
+  const packageSpec = PACKAGE_NAME === null ? channelConfig.binName : `${PACKAGE_NAME}@${spec}`;
+  return {
+    ok: false,
+    mode: "global",
+    reason:
+      `Cannot install ${packageSpec}: this npm-mode install is running on Node ${process.version}, ` +
+      `but the target package requires Node ${range}. npm-mode updates cannot replace the system Node runtime; ` +
+      `upgrade system Node and rerun \`${channelConfig.binName} upgrade\`, ${portableMigrationHint()}.`,
+    retryable: false,
+    reasonCode: "npm_ebadengine",
+  };
 }
 
 function failPortable(reason: string, retryable = false, reasonCode?: string): ExecuteUpdateResult {
@@ -594,6 +658,11 @@ export async function installGlobalSpec(
       writeInstallOutput(options, `  [update] ${reason}\n`);
       return { ok: false, mode: "global", reason };
     }
+  }
+  const engineMismatch = checkNpmTargetNodeEngine(spec);
+  if (engineMismatch) {
+    writeInstallOutput(options, `  [update] ${engineMismatch.reason}\n`);
+    return engineMismatch;
   }
   return new Promise((resolvePromise) => {
     const npmCmd = resolveNpmCommand();

--- a/apps/cli/tests/portable-builder.test.ts
+++ b/apps/cli/tests/portable-builder.test.ts
@@ -5,8 +5,13 @@ import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
-import { artifactFileName, parsePlatform, validateChannelVersion } from "../../../scripts/portable/build-portable.mjs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  artifactFileName,
+  parsePlatform,
+  resolveNodeVersion,
+  validateChannelVersion,
+} from "../../../scripts/portable/build-portable.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 
@@ -70,6 +75,7 @@ exec "$FT_TEST_REAL_MV" "$@"
 }
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
   tmpDirs = [];
 });
@@ -92,6 +98,18 @@ describe("portable builder helpers", () => {
     expect(artifactFileName({ packageName: "first-tree", version: "1.2.3", platform: "linux-x64" })).toBe(
       "first-tree-1.2.3-linux-x64.tar.gz",
     );
+  });
+
+  it("resolves latest-v<major>.x Node pins from the Node.js dist index", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      text: async () => JSON.stringify([{ version: "v25.3.1" }, { version: "v25.3.0" }, { version: "v24.11.0" }]),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(resolveNodeVersion("latest-v25.x")).resolves.toBe("v25.3.1");
+    await expect(resolveNodeVersion("24.11.0")).resolves.toBe("v24.11.0");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,12 +15,22 @@ human-friendly index over them.
 ## Install
 
 ```bash
+curl -fsSL https://downloads.first-tree.ai/prod/install.sh | sh
+~/.local/bin/first-tree --version
+```
+
+The default public install path is portable and bundles Node.js. The binary
+lives at `first-tree`; the short alias `ft` is also installed.
+
+The npm global install path remains supported for operators and fallback
+installs:
+
+```bash
 npm install -g first-tree
 first-tree --version
 ```
 
-The binary lives at `first-tree`; the short alias `ft` is also installed.
-Requirements: Node.js ≥ 22.13 (24 recommended).
+npm mode uses your system Node.js runtime and requires Node.js ≥ 22.13.
 
 ## Global flags
 
@@ -145,10 +155,13 @@ first-tree upgrade [--check] [--latest] [--no-restart]
 ```
 
 Self-update for the CLI: query the configured server for its recommended
-Command version, install that exact version globally, refresh the systemd
-unit / launchd plist on top of the new bits, then restart the client
-service. Use `--latest` only when you intentionally want to bypass the
-server target and install npm latest directly.
+Command version, install that exact version through the current install mode,
+refresh the systemd unit / launchd plist on top of the new bits, then restart
+the client service. Portable installs download the channel manifest and
+verified tarball, including the bundled Node.js runtime. npm installs run
+`npm install -g` against the channel package and keep using the system Node.js
+runtime. Use `--latest` only when you intentionally want to bypass the server
+target and install the channel's latest release data directly.
 
 | Flag | Effect |
 |---|---|
@@ -160,6 +173,12 @@ Refusing to run from a source checkout (anywhere under a `.git`
 ancestor) is intentional — keeps a dev build from accidentally
 `npm i -g`-overwriting a prod global. For local development use
 `scripts/dev-install.sh` (see [docs/development/local-dev-isolation.md](development/local-dev-isolation.md)).
+
+In npm mode, `upgrade` checks the target package's `engines.node` metadata
+before install when npm can provide it. If the target requires a newer Node.js
+than the current process is running, the command fails before install with a
+system-Node upgrade hint and a portable-install migration hint. npm-mode
+updates do not replace Node.js themselves.
 
 ---
 

--- a/docs/development/portable-node-runtime.md
+++ b/docs/development/portable-node-runtime.md
@@ -1,0 +1,101 @@
+# Portable Node Runtime Policy
+
+First Tree's portable installer ships a bundled Node.js runtime inside each
+portable release artifact:
+
+```text
+<prefix>/versions/<version>/
+  node/   # bundled Node.js runtime
+  app/    # built CLI package
+```
+
+Portable users do not depend on the Node.js version installed on the host
+machine. Each portable self-update installs the target release artifact into a
+new `versions/<version>` directory, switches `current`, rewrites the shims, and
+lets the service manager restart through the shim. The restarted process then
+uses the Node.js runtime bundled with the target artifact.
+
+## Ownership
+
+The Distribution / Portable Node owner owns the bundled Node.js policy and bump
+PRs. The current Context Tree owner for portable Node distribution is
+`bestony`. Normal repository CODEOWNERS still apply for review, but the owner
+of this area is responsible for noticing when the runtime line must move and
+for cutting a First Tree release when a Node patch needs to reach portable
+users.
+
+## Pin Location
+
+The release-default bundled Node.js line is:
+
+```js
+// scripts/portable/build-portable.mjs
+export const DEFAULT_NODE_VERSION = "latest-v24.x";
+```
+
+The portable smoke job also passes an explicit `--node-version latest-v24.x` in
+`.github/workflows/ci.yml`. A major bump PR must update both locations in the
+same change so CI exercises the candidate line before release.
+
+`latest-v<major>.x` is resolved against `https://nodejs.org/dist/index.json` at
+portable artifact build time. That means each published First Tree artifact
+contains the newest patch in the configured major line at the time the release
+was built. Pass an exact `--node-version` only for one-off validation or release
+rehearsal.
+
+## Bump Triggers
+
+Bump the bundled Node.js major when any of these is true:
+
+- The currently bundled major is approaching end of life and the next supported
+  major has had enough staging exposure.
+- First Tree needs a runtime or dependency feature that is only supported on a
+  newer Node.js major.
+- A Node.js security advisory makes staying on the current major an unacceptable
+  risk, or the fixed line requires moving majors.
+
+Patch-level security fixes are coupled to First Tree releases. Because
+`latest-v<major>.x` resolves during artifact build, portable users receive a
+new Node.js patch only when a new First Tree portable release is cut. For a
+high-impact Node.js advisory that affects the bundled major, cut a First Tree
+release even if the app code did not otherwise need one.
+
+## Cross-Major Verification
+
+Before the first real bump to a new Node.js major, run the automated portable
+handover test and the portable artifact smoke:
+
+```bash
+pnpm --filter first-tree-dev test -- update-portable-install
+pnpm --filter first-tree-dev test -- portable-builder
+```
+
+The handover test covers the critical invariant: an old portable install can
+run the updater while the target artifact contains a different bundled Node.js
+major, because the new runtime is not executed in place before the symlink
+switch and service restart.
+
+For release rehearsal, build a staging portable artifact with the candidate
+Node line, update an older staging portable install to it, then verify:
+
+- `$FIRST_TREE_HOME` still points through the channel shim.
+- `<prefix>/current/INSTALL.json` records the candidate `nodeVersion`.
+- `first-tree-staging status` reports the target CLI version after restart.
+
+## npm-Mode Runtime Policy
+
+The npm global install path remains supported for operators and fallback
+installs, but npm mode uses the user's system Node.js runtime. It does not and
+cannot replace Node.js during `first-tree upgrade`.
+
+Before npm-mode self-update runs `npm install -g`, the CLI performs a
+best-effort metadata preflight against the target package's `engines.node`.
+When the current process Node.js version does not satisfy the target package's
+range, the update fails before install with guidance to either:
+
+- upgrade the system Node.js runtime and rerun `first-tree upgrade`; or
+- migrate to the portable install path from the web console.
+
+If npm metadata cannot be read, the CLI falls back to the existing npm install
+path and classifies npm's own error output. `EBADENGINE` remains a permanent
+operator-action failure.

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -15,8 +15,12 @@ everything online.
 
 ## Prerequisites
 
-- **Node.js** ≥ 22.13 (24 recommended).
-- **The CLI** — `npm install -g first-tree && first-tree --version`.
+- **The CLI**. Prefer the portable command shown in the web console's
+  *Computers → New Connection* dialog; it bundles Node.js. For headless
+  production installs, the portable installer has this shape:
+  `curl -fsSL https://downloads.first-tree.ai/prod/install.sh | sh`.
+- **Node.js** ≥ 22.13 only when you choose the npm fallback path
+  (`npm install -g first-tree`).
 - **A connect token** — generated from the web console's *Computers → New
   Connection* dialog. The token's `iss` claim carries the server URL, so
   the CLI does not need a server flag.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,8 +17,9 @@ and you can leave and resume later. This page mirrors that flow.
 ## Before you start
 
 - A **GitHub account** to sign in with.
-- **Node.js ≥ 22.13** (24 recommended) on the computer your agent will run
-  on. Setup installs the CLI for you, but Node must already be present.
+- A macOS or Linux computer where your agent will run. The default portable
+  install bundles Node.js, so Node does not need to be installed separately.
+  If you choose the npm fallback path, that machine needs Node.js ≥ 22.13.
 
 ## 1. Sign in and name your team
 
@@ -32,11 +33,14 @@ Your agent runs on a real machine, so the next step links one to your team.
 Copy the command the page shows and run it in a terminal on that machine:
 
 ```bash
-npm install -g first-tree
-first-tree login <connect-token>
+# Use the exact command from the page; production portable installs have this shape:
+curl -fsSL https://downloads.first-tree.ai/prod/install.sh | sh
+~/.local/bin/first-tree login <connect-token>
 ```
 
-This installs the CLI and signs the computer in. `first-tree login`:
+This installs the CLI and signs the computer in. The npm global install path
+(`npm install -g first-tree`) remains available for operators and fallback
+installs, but it uses your system Node runtime. `first-tree login`:
 
 - Reads the server URL from the token's `iss` claim — **no `--server` flag
   needed**, and switching servers only takes a new token.

--- a/scripts/portable/build-portable.mjs
+++ b/scripts/portable/build-portable.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 export const PORTABLE_PLATFORMS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"];
 export const DEFAULT_NODE_VERSION = "latest-v24.x";
 export const DEFAULT_DOWNLOAD_BASE_URL = "https://downloads.first-tree.ai";
+const LATEST_NODE_MAJOR_SPEC_RE = /^latest-v(\d+)\.x$/;
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..", "..");
@@ -109,7 +110,7 @@ function printHelp() {
   console.log(`Usage: node scripts/portable/build-portable.mjs --channel prod|staging --version <semver> --git-sha <sha> --out-dir <path> [options]
 
 Options:
-  --node-version <version>          Node.js version or latest-v24.x (default: ${DEFAULT_NODE_VERSION})
+  --node-version <version>          Node.js version or latest-v<major>.x (default: ${DEFAULT_NODE_VERSION})
   --download-base-url <url>         Public artifact base URL (default: ${DEFAULT_DOWNLOAD_BASE_URL})
   --platform <platform>             Repeatable: ${PORTABLE_PLATFORMS.join(", ")}
   --help                            Show this help
@@ -281,11 +282,13 @@ async function downloadFile(url, dest) {
   await writeFile(dest, body);
 }
 
-async function resolveNodeVersion(versionSpec) {
-  if (versionSpec === "latest-v24.x") {
+export async function resolveNodeVersion(versionSpec) {
+  const latestMajor = LATEST_NODE_MAJOR_SPEC_RE.exec(versionSpec);
+  if (latestMajor) {
+    const major = latestMajor[1];
     const index = JSON.parse(await downloadText("https://nodejs.org/dist/index.json"));
-    const found = index.find((entry) => typeof entry.version === "string" && entry.version.startsWith("v24."));
-    if (!found) fail("could not resolve latest Node.js v24.x from nodejs.org/dist/index.json");
+    const found = index.find((entry) => typeof entry.version === "string" && entry.version.startsWith(`v${major}.`));
+    if (!found) fail(`could not resolve latest Node.js v${major}.x from nodejs.org/dist/index.json`);
     return found.version;
   }
   return normalizeNodeVersion(versionSpec);


### PR DESCRIPTION
## Summary

- Document the portable bundled Node.js upgrade policy, including bump triggers, owner, pin locations, and npm-mode behavior.
- Generalize portable build resolution from a hard-coded `latest-v24.x` branch to `latest-v<major>.x` so a future Node 25 line can be selected by changing the pins.
- Add coverage for cross-Node-major portable self-update handover and npm-mode `engines.node` preflight guidance.
- Update public install docs to describe portable install as the default path and npm global install as the operator/fallback path.

## Context Tree

- Draft tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/694

## Verification

- `pnpm --filter first-tree-dev exec vitest run src/__tests__/update-portable-install.test.ts tests/portable-builder.test.ts src/__tests__/core-attention-update-extra.test.ts`
- `pnpm --filter first-tree-dev typecheck`
- `pnpm exec biome check scripts/portable/build-portable.mjs apps/cli/src/core/update.ts apps/cli/src/__tests__/update-portable-install.test.ts apps/cli/src/__tests__/core-attention-update-extra.test.ts apps/cli/tests/portable-builder.test.ts .github/workflows/ci.yml README.md docs/quickstart.md docs/onboarding-guide.md docs/cli-reference.md docs/development/portable-node-runtime.md`
- `git diff --check`

Closes #1504.
