### PR TITLE
Fail closed on unusable runtime token file

### DIFF
--- a/apps/cli/src/__tests__/agent-shared-helpers-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-shared-helpers-extra.test.ts
@@ -154,6 +154,49 @@ describe("local agent shared helpers", () => {
     }
   });
 
+  it("fails clearly instead of falling back when the runtime session token file is missing", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "first-tree-token-"));
+    try {
+      const tokenFile = join(dir, "missing.token");
+      const { createSdk } = await import("../commands/_shared/local-agent.js");
+
+      process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN = "stale-runtime-token";
+      process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE = tokenFile;
+
+      expect(() => createSdk("nova")).toThrow();
+      expect(outputMocks.fail).toHaveBeenLastCalledWith(
+        "RUNTIME_SESSION_TOKEN_FILE_UNREADABLE",
+        expect.stringContaining(tokenFile),
+        2,
+      );
+      expect(clientMocks.FirstTreeHubSDK).not.toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails clearly instead of falling back when the runtime session token file is empty", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "first-tree-token-"));
+    try {
+      const tokenFile = join(dir, "runtime.token");
+      writeFileSync(tokenFile, "\n", "utf8");
+      const { createSdk } = await import("../commands/_shared/local-agent.js");
+
+      process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN = "stale-runtime-token";
+      process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE = tokenFile;
+
+      expect(() => createSdk("nova")).toThrow();
+      expect(outputMocks.fail).toHaveBeenLastCalledWith(
+        "RUNTIME_SESSION_TOKEN_FILE_EMPTY",
+        `FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE is set to "${tokenFile}", but the file is empty.`,
+        2,
+      );
+      expect(clientMocks.FirstTreeHubSDK).not.toHaveBeenCalled();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("maps local agent resolution failures to CLI errors", async () => {
     const { readClientId, resolveLocalAgent } = await import("../commands/_shared/local-agent.js");
 

--- a/apps/cli/src/commands/_shared/local-agent.ts
+++ b/apps/cli/src/commands/_shared/local-agent.ts
@@ -102,12 +102,25 @@ export function createSdk(agentName?: string): FirstTreeHubSDK {
 function resolveRuntimeSessionToken(): string | undefined {
   const tokenFile = process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE?.trim();
   if (tokenFile) {
+    let token: string;
     try {
-      return readFileSync(tokenFile, "utf8").trim() || undefined;
+      token = readFileSync(tokenFile, "utf8").trim();
     } catch (err) {
-      void err;
-      return undefined;
+      const detail = err instanceof Error ? err.message : String(err);
+      fail(
+        "RUNTIME_SESSION_TOKEN_FILE_UNREADABLE",
+        `FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE is set to "${tokenFile}", but the file could not be read: ${detail}`,
+        2,
+      );
     }
+    if (!token) {
+      fail(
+        "RUNTIME_SESSION_TOKEN_FILE_EMPTY",
+        `FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE is set to "${tokenFile}", but the file is empty.`,
+        2,
+      );
+    }
+    return token;
   }
   return process.env.FIRST_TREE_RUNTIME_SESSION_TOKEN?.trim() || undefined;
 }


### PR DESCRIPTION
## Summary

- fail closed when `FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE` is set but missing/unreadable
- fail closed when the token file is empty instead of falling back to a stale env token
- add regression coverage that missing/empty token files do not construct an SDK with the inherited env token

## Verification

- `pnpm --filter first-tree-dev test -- src/__tests__/agent-shared-helpers-extra.test.ts` (Vitest collected full CLI suite: 70 files / 624 tests passed)
- `pnpm --filter first-tree-dev typecheck`
- `pnpm exec biome check apps/cli/src/commands/_shared/local-agent.ts apps/cli/src/__tests__/agent-shared-helpers-extra.test.ts`
- `pnpm --filter @first-tree/server test -- src/__tests__/agent-bind-authorization.test.ts` (Vitest collected full server suite: 178 files / 1756 tests passed)
