### PR TITLE
fix(github): surface context reviewer self-approval blockers

### DIFF
--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
+import { authIdentities } from "../db/schema/auth-identities.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
@@ -29,6 +30,7 @@ function pullRequestPayload(overrides: Partial<Record<string, unknown>> = {}) {
       base: { ref: "main" },
       head: { ref: "context-update" },
       draft: false,
+      user: { login: "writer", type: "User" },
     },
     repository: { full_name: "owner/context-tree" },
     sender: { login: "writer", type: "User" },
@@ -43,6 +45,7 @@ function issueCommentPayload(overrides: Partial<Record<string, unknown>> = {}) {
       number: 123,
       title: "Clarify agent routing context",
       html_url: "https://github.com/owner/context-tree/issues/123",
+      user: { login: "writer", type: "User" },
       pull_request: { html_url: "https://github.com/owner/context-tree/pull/123" },
     },
     comment: {
@@ -65,6 +68,7 @@ function reviewCommentPayload(overrides: Partial<Record<string, unknown>> = {}) 
       html_url: "https://github.com/owner/context-tree/pull/123",
       base: { ref: "main" },
       head: { ref: "context-update" },
+      user: { login: "writer", type: "User" },
     },
     comment: {
       html_url: "https://github.com/owner/context-tree/pull/123#discussion_r1",
@@ -108,6 +112,18 @@ async function enableReviewer(app: App, admin: Awaited<ReturnType<typeof createA
   );
 }
 
+async function seedGithubIdentity(app: App, userId: string, login: string) {
+  await app.db.insert(authIdentities).values({
+    id: randomUUID(),
+    userId,
+    provider: "github",
+    identifier: randomUUID(),
+    email: null,
+    verifiedAt: new Date(),
+    metadata: { login },
+  });
+}
+
 describe("Context Reviewer PR prompt", () => {
   it("renders the EJS prompt with required review instructions", async () => {
     const prompt = await renderContextReviewerPrPrompt({
@@ -117,15 +133,23 @@ describe("Context Reviewer PR prompt", () => {
       htmlUrl: "https://github.com/owner/context-tree/pull/123",
       baseRef: "main",
       headRef: "context-update",
+      authorLogin: "writer",
       senderLogin: "writer",
       triggerEvent: "pull_request.opened",
       isDraft: false,
       commentUrl: null,
       commentAuthorLogin: null,
       organizationId: "org-1",
+      reviewerManagerGithubLogin: "reviewer-manager",
+      reviewerManagerIsPrAuthor: false,
     });
 
     expect(prompt).toContain("Context Reviewer");
+    expect(prompt).toContain("PR author: writer");
+    expect(prompt).toContain("Event sender: writer");
+    expect(prompt).toContain("Reviewer manager GitHub login: reviewer-manager");
+    expect(prompt).toContain("Known approval blocker: not known from First Tree metadata");
+    expect(prompt).toContain("gh api user --jq .login");
     expect(prompt).toContain("clear, accurate");
     expect(prompt).toContain("missing background");
     expect(prompt).toContain("excessive detail");
@@ -139,6 +163,7 @@ describe("Context Reviewer PR prompt", () => {
     expect(prompt).toContain("Do not rely on an older approval or comment review");
     expect(prompt).toContain("Context changes requested");
     expect(prompt).toContain("Still unclear or needs more detail");
+    expect(prompt).toContain("Independent approval required");
     expect(prompt).toContain("review action was submitted: `approved`, `commented`, `changes_requested`, or `failed`");
   });
 
@@ -150,12 +175,15 @@ describe("Context Reviewer PR prompt", () => {
       htmlUrl: "https://github.com/owner/context-tree/pull/124",
       baseRef: null,
       headRef: null,
+      authorLogin: "writer",
       senderLogin: "writer",
       triggerEvent: "pull_request.synchronize",
       isDraft: null,
       commentUrl: null,
       commentAuthorLogin: null,
       organizationId: "org-1",
+      reviewerManagerGithubLogin: null,
+      reviewerManagerIsPrAuthor: false,
     });
 
     expect(prompt).toContain("Base ref: unknown");
@@ -177,12 +205,15 @@ describe("Context Reviewer PR prompt", () => {
       htmlUrl: "https://github.com/owner/context-tree/pull/126",
       baseRef: "main",
       headRef: "draft-context",
+      authorLogin: "writer",
       senderLogin: "writer",
       triggerEvent: "pull_request.opened",
       isDraft: true,
       commentUrl: null,
       commentAuthorLogin: null,
       organizationId: "org-1",
+      reviewerManagerGithubLogin: null,
+      reviewerManagerIsPrAuthor: false,
     });
 
     expect(prompt).toContain("Draft status from webhook: draft");
@@ -199,17 +230,45 @@ describe("Context Reviewer PR prompt", () => {
       htmlUrl: "https://github.com/owner/context-tree/pull/125",
       baseRef: null,
       headRef: null,
+      authorLogin: "writer",
       senderLogin: "writer",
       triggerEvent: "issue_comment.created",
       isDraft: null,
       commentUrl: "https://github.com/owner/context-tree/pull/125#issuecomment-1",
       commentAuthorLogin: "commenter",
       organizationId: "org-1",
+      reviewerManagerGithubLogin: null,
+      reviewerManagerIsPrAuthor: false,
     });
 
     expect(prompt).toContain("Trigger event: issue_comment.created");
     expect(prompt).toContain("Comment author: commenter");
     expect(prompt).toContain("Comment URL: https://github.com/owner/context-tree/pull/125#issuecomment-1");
+  });
+
+  it("renders a known self-approval blocker as a failed approval path", async () => {
+    const prompt = await renderContextReviewerPrPrompt({
+      repoFullName: "owner/context-tree",
+      prNumber: 127,
+      title: "Self-authored context",
+      htmlUrl: "https://github.com/owner/context-tree/pull/127",
+      baseRef: "main",
+      headRef: "self-authored-context",
+      authorLogin: "writer",
+      senderLogin: "writer",
+      triggerEvent: "pull_request.opened",
+      isDraft: false,
+      commentUrl: null,
+      commentAuthorLogin: null,
+      organizationId: "org-1",
+      reviewerManagerGithubLogin: "Writer",
+      reviewerManagerIsPrAuthor: true,
+    });
+
+    expect(prompt).toContain("Known approval blocker: yes");
+    expect(prompt).toContain("GitHub requires a non-author approver");
+    expect(prompt).toContain("review action as `failed`");
+    expect(prompt).toContain("authenticated reviewer is the PR author");
   });
 });
 
@@ -347,9 +406,11 @@ describe("handleContextReviewerPrEvent", () => {
     expect(message?.content).toContain("Still unclear or needs more detail");
     expect(message?.content).toContain("Trigger event: pull_request.opened");
     expect(message?.content).toContain("Draft status from webhook: ready for review");
+    expect(message?.content).toContain("PR author: writer");
     expect(message?.metadata).toMatchObject({
       contextTreeReviewer: true,
       pullRequestDraft: false,
+      pullRequestAuthorLogin: "writer",
       mentions: [reviewer.uuid],
     });
 
@@ -359,6 +420,34 @@ describe("handleContextReviewerPrEvent", () => {
       .where(and(eq(inboxEntries.messageId, result.messageId), eq(inboxEntries.inboxId, reviewer.inboxId)))
       .limit(1);
     expect(entry?.notify).toBe(true);
+  });
+
+  it("marks approval as blocked when the reviewer manager GitHub login is the PR author", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    await seedGithubIdentity(app, admin.userId, "Writer");
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+
+    const result = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload(),
+      organizationId: admin.organizationId,
+    });
+
+    expect(result).toMatchObject({ handled: true, reused: false });
+    if (!result.handled) throw new Error("expected handled result");
+
+    const [message] = await app.db.select().from(messages).where(eq(messages.id, result.messageId)).limit(1);
+    expect(message?.content).toContain("Reviewer manager GitHub login: Writer");
+    expect(message?.content).toContain("Known approval blocker: yes");
+    expect(message?.content).toContain("Independent approval required");
+    expect(message?.metadata).toMatchObject({
+      contextTreeReviewer: true,
+      pullRequestAuthorLogin: "writer",
+      reviewerManagerGithubLogin: "Writer",
+      reviewerManagerIsPrAuthor: true,
+    });
   });
 
   it("reuses an existing reviewer chat for the same PR", async () => {
@@ -746,6 +835,7 @@ describe("handleContextReviewerPrEvent", () => {
       headRef: "context-update",
       triggerEvent: "pull_request.opened",
       isDraft: false,
+      authorLogin: "writer",
     });
     expect(
       contextReviewerPrTestInternals.extractPullRequestPayloadInfo(
@@ -765,6 +855,7 @@ describe("handleContextReviewerPrEvent", () => {
       commentAuthorLogin: "commenter",
       triggerEvent: "issue_comment.created",
       isDraft: null,
+      authorLogin: "writer",
     });
     expect(
       contextReviewerPrTestInternals.extractPullRequestPayloadInfo(

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -146,6 +146,7 @@ function contextPullRequestPayload(installationId: number, repoFullName = "owner
       base: { ref: "main" },
       head: { ref: "context-reviewer" },
       draft: false,
+      user: { login: "context-writer", type: "User" },
     },
     repository: { full_name: repoFullName },
     sender: { login: "context-writer", type: "User" },
@@ -160,6 +161,7 @@ function contextIssueCommentPayload(installationId: number, repoFullName = "owne
       number: 42,
       title: "Improve context review guidance",
       html_url: `https://github.com/${repoFullName}/issues/42`,
+      user: { login: "context-writer", type: "User" },
       pull_request: { html_url: `https://github.com/${repoFullName}/pull/42` },
     },
     comment: {

--- a/packages/server/src/prompts/context-reviewer-pr.ejs
+++ b/packages/server/src/prompts/context-reviewer-pr.ejs
@@ -8,7 +8,10 @@ Title: <%= title %>
 URL: <%= htmlUrl %>
 Base ref: <%= baseRef || "unknown" %>
 Head ref: <%= headRef || "unknown" %>
-Opened by: <%= senderLogin %>
+PR author: <%= authorLogin %>
+Event sender: <%= senderLogin %>
+Reviewer manager GitHub login: <%= reviewerManagerGithubLogin || "unknown" %>
+Known approval blocker: <%= reviewerManagerIsPrAuthor ? "yes — the configured reviewer's manager GitHub login is the PR author, so an approval from that GitHub identity would be rejected by GitHub" : "not known from First Tree metadata; still verify the active gh identity before approving" %>
 Trigger event: <%= triggerEvent %>
 Draft status from webhook: <%= isDraft === true ? "draft" : isDraft === false ? "ready for review" : "unknown; inspect the current PR state before choosing an outcome" %>
 <% if (commentAuthorLogin) { -%>
@@ -30,9 +33,10 @@ Review goals:
 Required workflow:
 
 1. Inspect this pull request with `gh` commands before deciding on the review outcome. Confirm the current draft/readiness state and current head before reviewing.
-2. Write the review body to a temporary Markdown file and pass it with `--body-file <file>`. Do not inline multiline Markdown with `--body`; avoiding shell quoting issues is part of the required workflow.
-3. Treat `pull_request.synchronize` and `pull_request.ready_for_review` as fresh review requests for the current PR head. Do not rely on an older approval or comment review; submit a new review that covers the content currently shown by GitHub.
-4. Submit exactly one GitHub PR review using one of these outcomes:
+2. Before approving, run `gh api user --jq .login` and compare the active GitHub login to the PR author above. GitHub rejects approvals from the PR author, so an author-authenticated session cannot satisfy review-required branch protection.
+3. Write the review body to a temporary Markdown file and pass it with `--body-file <file>`. Do not inline multiline Markdown with `--body`; avoiding shell quoting issues is part of the required workflow.
+4. Treat `pull_request.synchronize` and `pull_request.ready_for_review` as fresh review requests for the current PR head. Do not rely on an older approval or comment review; submit a new review that covers the content currently shown by GitHub.
+5. Submit exactly one GitHub PR review using one of these outcomes:
 
 - If the pull request is still a draft, do not approve it. If there are blocking Context Tree issues, request changes. If there are no blocking issues, submit a non-approving comment review that says approval is deferred until the PR is ready for review.
 
@@ -48,13 +52,15 @@ gh pr review <%= prNumber %> --repo <%= repoFullName %> --request-changes --body
 gh pr review <%= prNumber %> --repo <%= repoFullName %> --comment --body-file <file>
 ```
 
+- If inspection is complete, the pull request is not a draft, no blocking gaps remain, and the active `gh` login is the PR author, do not attempt approval and do not treat the non-approving review as a successful approval substitute. Submit a comment review whose first section is `## Independent approval required`, stating that the Context Tree material appears safe but GitHub requires a non-author approver, and ask for another GitHub user to approve. In your chat reply, report the review action as `failed` with the blocker `authenticated reviewer is the PR author`.
+
 - If inspection is complete, the pull request is not a draft, no blocking gaps remain, and the PR is safe to merge as durable Context Tree material, run:
 
 ```bash
 gh pr review <%= prNumber %> --repo <%= repoFullName %> --approve --body-file <file>
 ```
 
-5. When changes or clarification are needed, structure the review body like this, separating incorrect or change-needed Context from Context that is still unclear or missing detail:
+6. When changes or clarification are needed, structure the review body like this, separating incorrect or change-needed Context from Context that is still unclear or missing detail:
 
 ```md
 ## Context changes requested
@@ -71,6 +77,6 @@ gh pr review <%= prNumber %> --repo <%= repoFullName %> --approve --body-file <f
 ```
 
 If one of those sections has no items, write `None.` under that heading.
-6. Approve only after inspection is complete, the pull request is not a draft, and only when the PR is safe to merge as Context Tree material.
-7. Do not also post a top-level `gh pr comment` for the same outcome.
-8. After submitting the PR review, reply in this chat with a short summary and report which review action was submitted: `approved`, `commented`, `changes_requested`, or `failed`.
+7. Approve only after inspection is complete, the pull request is not a draft, the active `gh` login is not the PR author, and only when the PR is safe to merge as Context Tree material.
+8. Do not also post a top-level `gh pr comment` for the same outcome.
+9. After submitting the PR review, reply in this chat with a short summary and report which review action was submitted: `approved`, `commented`, `changes_requested`, or `failed`.

--- a/packages/server/src/services/context-reviewer-pr.ts
+++ b/packages/server/src/services/context-reviewer-pr.ts
@@ -8,6 +8,7 @@ import type { FastifyInstance } from "fastify";
 import { isRecord, readNumber, readString } from "../api/webhooks/github-entity.js";
 import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
+import { authIdentities } from "../db/schema/auth-identities.js";
 import { chats } from "../db/schema/chats.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
@@ -40,12 +41,15 @@ export type ContextReviewerPrTemplateInput = {
   htmlUrl: string;
   baseRef: string | null;
   headRef: string | null;
+  authorLogin: string;
   senderLogin: string;
   triggerEvent: string;
   isDraft: boolean | null;
   commentUrl: string | null;
   commentAuthorLogin: string | null;
   organizationId: string;
+  reviewerManagerGithubLogin: string | null;
+  reviewerManagerIsPrAuthor: boolean;
 };
 
 export type ContextReviewerPrResult =
@@ -61,7 +65,12 @@ export type ContextReviewerPrSkipReason =
   | "reviewer_agent_missing"
   | "reviewer_agent_invalid";
 
-type PullRequestPayloadInfo = ContextReviewerPrTemplateInput & {
+type ContextReviewerPrPayloadInput = Omit<
+  ContextReviewerPrTemplateInput,
+  "reviewerManagerGithubLogin" | "reviewerManagerIsPrAuthor"
+>;
+
+type PullRequestPayloadInfo = ContextReviewerPrPayloadInput & {
   eventType: "pull_request" | "issue_comment" | "pull_request_review_comment";
   action: "opened" | "synchronize" | "ready_for_review" | "created" | "edited";
   entityKey: string;
@@ -77,6 +86,7 @@ type ContextReviewerPrTrigger =
 type ReviewerAgent = {
   uuid: string;
   managerHumanAgentId: string;
+  managerGithubLogin: string | null;
 };
 
 let templateCache: Promise<string> | null = null;
@@ -278,7 +288,7 @@ export async function handleContextReviewerPrEvent(
       };
     }
 
-    const prompt = await renderContextReviewerPrPrompt(info);
+    const prompt = await renderContextReviewerPrPrompt(buildTemplateInput(info, reviewer));
     const { message, recipients } = await sendMessage(
       app.db,
       existingChatId,
@@ -305,7 +315,7 @@ export async function handleContextReviewerPrEvent(
     return { handled: true, chatId: existingChatId, messageId: message.id, reused: true };
   }
 
-  const prompt = await renderContextReviewerPrPrompt(info);
+  const prompt = await renderContextReviewerPrPrompt(buildTemplateInput(info, reviewer));
   const created = await createChat(app.db, {
     mode: "task",
     initiatorAgentId: reviewer.managerHumanAgentId,
@@ -403,6 +413,7 @@ function extractPullRequestPayloadInfo(
       prNumber,
       title,
       htmlUrl,
+      authorLogin: readUserLogin(pr) ?? senderLogin,
       baseRef: readString(isRecord(pr?.base) ? pr.base.ref : null),
       headRef: readString(isRecord(pr?.head) ? pr.head.ref : null),
       isDraft: readDraftStatus(pr),
@@ -427,6 +438,7 @@ function extractPullRequestPayloadInfo(
       prNumber,
       title,
       htmlUrl,
+      authorLogin: readUserLogin(issue) ?? senderLogin,
       baseRef: null,
       headRef: null,
       isDraft: null,
@@ -450,6 +462,7 @@ function extractPullRequestPayloadInfo(
       prNumber,
       title,
       htmlUrl,
+      authorLogin: readUserLogin(pr) ?? senderLogin,
       baseRef: readString(isRecord(pr?.base) ? pr.base.ref : null),
       headRef: readString(isRecord(pr?.head) ? pr.head.ref : null),
       isDraft: readDraftStatus(pr),
@@ -468,9 +481,22 @@ function readDraftStatus(pr: Record<string, unknown> | null): boolean | null {
   return pr.draft;
 }
 
+function readUserLogin(record: Record<string, unknown> | null): string | null {
+  const user = isRecord(record?.user) ? record.user : null;
+  return readString(user?.login);
+}
+
 function readCommentAuthor(comment: Record<string, unknown> | null): { login: string | null; type: string | null } {
   const user = isRecord(comment?.user) ? comment.user : null;
   return { login: readString(user?.login), type: readString(user?.type) };
+}
+
+function buildTemplateInput(info: PullRequestPayloadInfo, reviewer: ReviewerAgent): ContextReviewerPrTemplateInput {
+  return {
+    ...info,
+    reviewerManagerGithubLogin: reviewer.managerGithubLogin,
+    reviewerManagerIsPrAuthor: sameGithubLogin(reviewer.managerGithubLogin, info.authorLogin),
+  };
 }
 
 function contextReviewerMessageMetadata(
@@ -486,7 +512,12 @@ function contextReviewerMessageMetadata(
     entityKey: info.entityKey,
     contextTreeReviewer: true,
     mentions: [reviewer.uuid],
+    pullRequestAuthorLogin: info.authorLogin,
   };
+  if (reviewer.managerGithubLogin) {
+    metadata.reviewerManagerGithubLogin = reviewer.managerGithubLogin;
+    metadata.reviewerManagerIsPrAuthor = sameGithubLogin(reviewer.managerGithubLogin, info.authorLogin);
+  }
   if (info.commentAuthorLogin) {
     metadata.commentAuthorLogin = info.commentAuthorLogin;
   }
@@ -507,9 +538,11 @@ async function loadValidReviewerAgent(
     .select({
       uuid: agents.uuid,
       managerHumanAgentId: members.agentId,
+      managerGithubLogin: sql<string | null>`${authIdentities.metadata}->>'login'`,
     })
     .from(agents)
     .innerJoin(members, eq(members.id, agents.managerId))
+    .leftJoin(authIdentities, and(eq(authIdentities.userId, members.userId), eq(authIdentities.provider, "github")))
     .where(
       and(
         eq(agents.uuid, input.reviewerAgentUuid),
@@ -522,6 +555,17 @@ async function loadValidReviewerAgent(
     )
     .limit(1);
   return agent ?? null;
+}
+
+function sameGithubLogin(left: string | null, right: string | null): boolean {
+  const normalizedLeft = normalizeGithubLogin(left);
+  const normalizedRight = normalizeGithubLogin(right);
+  return normalizedLeft !== null && normalizedRight !== null && normalizedLeft === normalizedRight;
+}
+
+function normalizeGithubLogin(value: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLowerCase() : null;
 }
 
 async function findExistingReviewerChat(


### PR DESCRIPTION
## Summary

- Thread the real PR author through Context Reviewer payloads instead of treating each webhook sender as the opener.
- Load the configured reviewer's manager GitHub login and mark known self-approval blockers in reviewer task metadata.
- Update the Context Reviewer prompt to verify the active `gh` login before approval and surface an `Independent approval required` / `failed` path when the authenticated reviewer is the PR author.

## Tests

- `pnpm --filter @first-tree/server test -- context-reviewer-pr.test.ts`
- `pnpm --filter @first-tree/server test -- github-app-webhook-route.test.ts`
- `pnpm check`
- `pnpm typecheck`
- `pnpm test`

## Context Tree

No Context Tree PR is needed. The existing `system/cloud/github/context-tree-pr-reviewer.md` node already records that Context Reviewer approval must be independent of the PR author and must not create a self-approval shortcut; this PR aligns the implementation with that existing constraint.

Fixes #1498
