### PR TITLE
feat: make GitHub settings member-readable

### DIFF
--- a/packages/server/src/__tests__/github-app-installation-details.test.ts
+++ b/packages/server/src/__tests__/github-app-installation-details.test.ts
@@ -1,0 +1,64 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { members } from "../db/schema/members.js";
+import { users } from "../db/schema/users.js";
+import { bindInstallationToOrg, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+describe("GET /orgs/:orgId/github-app-installation", () => {
+  const getApp = useTestApp();
+
+  async function seedInstallation(app: ReturnType<typeof getApp>, orgId: string, installationId: number) {
+    await upsertInstallationFromMetadata(app.db, {
+      installation: {
+        id: installationId,
+        accountType: "Organization",
+        accountLogin: `org-${installationId}`,
+        accountGithubId: installationId * 10,
+        permissions: { contents: "read" },
+        events: ["issues"],
+        suspendedAt: null,
+      },
+    });
+    await bindInstallationToOrg(app.db, installationId, orgId);
+  }
+
+  async function demoteAndLogin(app: ReturnType<typeof getApp>, admin: Awaited<ReturnType<typeof createTestAdmin>>) {
+    const userId = (
+      await app.db.select({ id: users.id }).from(users).where(eq(users.username, admin.username)).limit(1)
+    )[0]?.id;
+    expect(userId).toBeDefined();
+    await app.db
+      .update(members)
+      .set({ role: "member" })
+      .where(eq(members.userId, userId ?? ""));
+    const loginRes = await app.inject({
+      method: "POST",
+      url: "/api/v1/auth/login",
+      payload: { username: admin.username, password: admin.password },
+    });
+    return loginRes.json<{ accessToken: string }>().accessToken;
+  }
+
+  it("is member-readable so Settings GitHub can show read-only connection details", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `gh-member-${crypto.randomUUID().slice(0, 8)}` });
+    await seedInstallation(app, admin.organizationId, 901_001);
+    const memberToken = await demoteAndLogin(app, admin);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation`,
+      headers: { authorization: `Bearer ${memberToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      installationId: 901_001,
+      accountLogin: "org-901001",
+      accountType: "Organization",
+      permissions: { contents: "read" },
+      events: ["issues"],
+    });
+  });
+});

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -118,10 +118,10 @@ export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
 
   /**
    * GET `/exists` — member-readable boolean "does this team have a GitHub
-   * App installation?". The full GET above is admin-only because it exposes
-   * installation-id / permissions / events that regular members shouldn't
-   * see; this endpoint redacts everything except the bare presence bit so
-   * the invitee onboarding path can authoritatively detect the
+   * App installation?". The full GET above is also member-readable for
+   * Settings → GitHub, while this endpoint keeps a narrower redacted shape
+   * for callers that only need a presence bit. It lets the invitee onboarding
+   * path authoritatively detect the
    * "admin set up the tree but never connected code" failure mode (without
    * which we either block every invitee of a working team — if 403 maps to
    * `missing` — or never trip the warning at all — if 403 maps to

--- a/packages/server/src/api/orgs/github-app.ts
+++ b/packages/server/src/api/orgs/github-app.ts
@@ -67,8 +67,8 @@ export function resolvePostInstallNext(requested: string | undefined): string {
 /**
  * Class B — `/api/v1/orgs/:orgId/github-app-installation`.
  *
- * Read-only admin view of the GitHub App installation bound to this First Tree
- * team. Powers the Settings → Integrations panel. 404 when no install is
+ * Read-only member view of the GitHub App installation bound to this First Tree
+ * team. Powers the Settings → GitHub panel. 404 when no install is
  * bound (the panel renders the "Install on GitHub" prompt in that case).
  *
  * Distinct from `/orgs/:orgId/settings/:namespace` because installations
@@ -77,12 +77,13 @@ export function resolvePostInstallNext(requested: string | undefined): string {
  * OAuth callback. The Settings panel surfaces it for visibility but the
  * write path is upstream.
  *
- * Admin-only: the installation block exposes account-level metadata
- * (login, permissions, events) that a regular member doesn't need.
+ * Member-readable: Settings → GitHub is the source repo + connection status
+ * surface for the whole team. Mutations and installation catalog APIs below
+ * remain admin-only.
  */
 export async function orgGithubAppRoutes(app: FastifyInstance): Promise<void> {
   app.get<{ Params: { orgId: string } }>("/", async (request) => {
-    const scope = await requireOrgAdmin(request, app.db);
+    const scope = await requireOrgMembership(request, app.db);
     const row = await findInstallationByOrg(app.db, scope.organizationId);
     if (!row) {
       throw new NotFoundError("No GitHub App installation is bound to this team");

--- a/packages/web/src/api/github-app.ts
+++ b/packages/web/src/api/github-app.ts
@@ -29,12 +29,12 @@ export async function getGithubAppInstallation(organizationId: string): Promise<
 /**
  * Member-readable "is the GitHub App installed for this team?" probe.
  *
- * The full installation endpoint above is admin-only because it exposes
- * install-id / permissions / events. This redacted boolean view exists so
- * non-admin onboarding paths (specifically invitee start-chat) can detect
- * the "admin set up the tree but never connected code" failure mode
- * without either (a) silently 403-ing every invitee out of the flow or
- * (b) never tripping at all. Presence is the whole answer — no 404 path.
+ * The full installation endpoint above is also member-readable for
+ * Settings → GitHub. This redacted boolean view exists so onboarding paths
+ * that only need presence (specifically invitee start-chat) can detect the
+ * "admin set up the tree but never connected code" failure mode without
+ * pulling the full installation details. Presence is the whole answer — no
+ * 404 path.
  */
 export async function getGithubAppInstallationExists(organizationId: string): Promise<boolean> {
   const r = await api.get<{ exists: boolean }>(`/orgs/${organizationId}/github-app-installation/exists`);

--- a/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/github-app-installation-panel-dom.test.tsx
@@ -184,6 +184,25 @@ describe("GithubAppInstallationPanel", () => {
     await act(async () => root.unmount());
   });
 
+  it("renders the summary read-only for members", async () => {
+    const { GithubAppInstallationPanel } = await import("../github-app-installation-panel.js");
+    const bound = await renderDom(<GithubAppInstallationPanel readOnly />);
+
+    await waitForText(bound.container, "Connected to");
+    expect(bound.container.textContent).toContain("github.com/acme");
+    expect(buttonByText(bound.container, "Manage connection")).toBeNull();
+    expect([...bound.container.querySelectorAll("a")].some((a) => a.textContent?.includes("Manage on GitHub"))).toBe(
+      false,
+    );
+    await act(async () => bound.root.unmount());
+
+    githubMocks.getGithubAppInstallation.mockResolvedValue(null);
+    const unbound = await renderDom(<GithubAppInstallationPanel readOnly />);
+    await waitForText(unbound.container, "isn't connected to GitHub yet");
+    expect(buttonByText(unbound.container, "Connect GitHub")).toBeNull();
+    await act(async () => unbound.root.unmount());
+  });
+
   it("mints a fresh install URL into a new tab, then waits without leaving this tab", async () => {
     githubMocks.getGithubAppInstallation.mockResolvedValue(null);
     const fakeTab = { location: { href: "" }, close: vi.fn() };
@@ -262,7 +281,7 @@ describe("GithubAppInstallationPanel", () => {
     await act(async () => generic.root.unmount());
   });
 
-  it("lists panel installations by status and connects a connectable one", async () => {
+  it("lists all panel installations under one Available to connect section and connects a connectable one", async () => {
     githubMocks.getGithubAppInstallation.mockResolvedValue(null);
     githubMocks.getGithubAppConnectPanel.mockResolvedValue({
       installations: [
@@ -288,7 +307,7 @@ describe("GithubAppInstallationPanel", () => {
     expect(container.textContent).toContain("github.com/free-org");
     expect(container.textContent).toContain("Connected to this team");
     expect(container.textContent).toContain("github.com/mine-org");
-    expect(container.textContent).toContain("Connected to other teams");
+    expect(container.textContent).not.toContain("Connected to other teams");
     expect(container.textContent).toContain("Connected to Other Team");
 
     await click(buttonByText(container, "Connect"));

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -942,9 +942,9 @@ describe("page SSR smoke coverage", () => {
     expect(renderPage(<SettingsResourcesPage />)).toContain("Resources");
 
     authMock.value = { ...authMock.value, role: "member" };
-    // Admin-only surfaces redirect members out (empty render); Context tree
-    // and Resources stay visible (read-only) for members.
-    expect(renderPage(<SettingsGithubPage />)).toBe("");
+    // Settings GitHub, Context tree, and Resources stay visible (read-only)
+    // for members.
+    expect(renderPage(<SettingsGithubPage />)).toContain("GitHub");
     expect(renderPage(<SettingsContextTreePage />)).toContain("Context tree");
     expect(renderPage(<SettingsResourcesPage />)).toContain("Resources");
 

--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -314,7 +314,7 @@ describe("settings panels", () => {
     const narrow = await renderDom(<SettingsLayout />);
     expect(narrow.container.querySelector("aside")).toBeNull();
     expect(narrow.container.textContent).toContain("Computers");
-    expect(narrow.container.textContent).not.toContain("GitHub");
+    expect(narrow.container.textContent).toContain("GitHub");
     expect(narrow.container.textContent).not.toContain("Onboarding");
     await act(async () => narrow.root.unmount());
 

--- a/packages/web/src/pages/github-app-installation-panel.tsx
+++ b/packages/web/src/pages/github-app-installation-panel.tsx
@@ -43,7 +43,7 @@ const CONNECT_PANEL_POLL_MS = 2000;
  *     holds them. Binding is always an explicit click here — installs
  *     never auto-connect.
  */
-export function GithubAppInstallationPanel() {
+export function GithubAppInstallationPanel({ readOnly = false }: { readOnly?: boolean }) {
   const { organizationId } = useAuth();
   const [panelOpen, setPanelOpen] = useState(false);
 
@@ -87,40 +87,52 @@ export function GithubAppInstallationPanel() {
   // organizationId hasn't loaded) both render the empty state; the loading
   // branch above already caught the in-flight case.
   if (installationQuery.data == null) {
-    return <NotConnectedSummary disabled={!organizationId} onOpenPanel={() => setPanelOpen(true)} />;
+    return (
+      <NotConnectedSummary disabled={!organizationId} readOnly={readOnly} onOpenPanel={() => setPanelOpen(true)} />
+    );
   }
-  return <InstalledState data={installationQuery.data} onOpenPanel={() => setPanelOpen(true)} />;
+  return <InstalledState data={installationQuery.data} readOnly={readOnly} onOpenPanel={() => setPanelOpen(true)} />;
 }
 
 /**
  * Unbound summary: the team has no GitHub connection yet, so the whole
  * surface is one prominent entry point into the connect panel.
  */
-function NotConnectedSummary({ disabled, onOpenPanel }: { disabled: boolean; onOpenPanel: () => void }) {
+function NotConnectedSummary({
+  disabled,
+  readOnly,
+  onOpenPanel,
+}: {
+  disabled: boolean;
+  readOnly: boolean;
+  onOpenPanel: () => void;
+}) {
   return (
     <div>
       <p className="text-body" style={{ color: "var(--fg-2)", marginBottom: "var(--sp-3)" }}>
         This team isn't connected to GitHub yet. Connect a GitHub App installation to start receiving issues, pull
         requests, and reviews as routed messages.
       </p>
-      <button
-        type="button"
-        onClick={onOpenPanel}
-        disabled={disabled}
-        className="inline-flex items-center justify-center font-medium"
-        style={{
-          gap: "var(--sp-1)",
-          padding: "var(--sp-2) var(--sp-3)",
-          background: "var(--primary)",
-          color: "var(--primary-on)",
-          border: "none",
-          borderRadius: "var(--radius-input)",
-          cursor: disabled ? "default" : "pointer",
-          opacity: disabled ? 0.6 : 1,
-        }}
-      >
-        Connect GitHub
-      </button>
+      {!readOnly && (
+        <button
+          type="button"
+          onClick={onOpenPanel}
+          disabled={disabled}
+          className="inline-flex items-center justify-center font-medium"
+          style={{
+            gap: "var(--sp-1)",
+            padding: "var(--sp-2) var(--sp-3)",
+            background: "var(--primary)",
+            color: "var(--primary-on)",
+            border: "none",
+            borderRadius: "var(--radius-input)",
+            cursor: disabled ? "default" : "pointer",
+            opacity: disabled ? 0.6 : 1,
+          }}
+        >
+          Connect GitHub
+        </button>
+      )}
     </div>
   );
 }
@@ -134,7 +146,15 @@ function githubAccountPath(login: string): string {
   return `github.com/${login}`;
 }
 
-function InstalledState({ data, onOpenPanel }: { data: GithubAppInstallationOutput; onOpenPanel: () => void }) {
+function InstalledState({
+  data,
+  readOnly,
+  onOpenPanel,
+}: {
+  data: GithubAppInstallationOutput;
+  readOnly: boolean;
+  onOpenPanel: () => void;
+}) {
   const AccountIcon = data.accountType === "Organization" ? Building2 : User;
   return (
     // No borderTop of its own: the page's Section frame already draws the
@@ -177,41 +197,43 @@ function InstalledState({ data, onOpenPanel }: { data: GithubAppInstallationOutp
         </div>
       </div>
 
-      <div className="flex items-center" style={{ gap: "var(--sp-2)", flexWrap: "wrap" }}>
-        <button
-          type="button"
-          onClick={onOpenPanel}
-          className="inline-flex items-center text-body"
-          style={{
-            gap: "var(--sp-1)",
-            padding: "var(--sp-1_5) var(--sp-2_5)",
-            border: "var(--hairline) solid var(--border)",
-            borderRadius: "var(--radius-input)",
-            background: "transparent",
-            color: "var(--fg)",
-            cursor: "pointer",
-          }}
-        >
-          Manage connection
-        </button>
-        <a
-          href={data.manageUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex items-center text-body"
-          style={{
-            gap: "var(--sp-1)",
-            padding: "var(--sp-1_5) var(--sp-2_5)",
-            border: "var(--hairline) solid var(--border)",
-            borderRadius: "var(--radius-input)",
-            color: "var(--fg)",
-            textDecoration: "none",
-          }}
-        >
-          Manage on GitHub
-          <ExternalLink className="h-3 w-3" />
-        </a>
-      </div>
+      {!readOnly && (
+        <div className="flex items-center" style={{ gap: "var(--sp-2)", flexWrap: "wrap" }}>
+          <button
+            type="button"
+            onClick={onOpenPanel}
+            className="inline-flex items-center text-body"
+            style={{
+              gap: "var(--sp-1)",
+              padding: "var(--sp-1_5) var(--sp-2_5)",
+              border: "var(--hairline) solid var(--border)",
+              borderRadius: "var(--radius-input)",
+              background: "transparent",
+              color: "var(--fg)",
+              cursor: "pointer",
+            }}
+          >
+            Manage connection
+          </button>
+          <a
+            href={data.manageUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center text-body"
+            style={{
+              gap: "var(--sp-1)",
+              padding: "var(--sp-1_5) var(--sp-2_5)",
+              border: "var(--hairline) solid var(--border)",
+              borderRadius: "var(--radius-input)",
+              color: "var(--fg)",
+              textDecoration: "none",
+            }}
+          >
+            Manage on GitHub
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+      )}
     </div>
   );
 }
@@ -249,8 +271,6 @@ function ConnectPanel({
 
   const installations = panelQuery.data?.installations ?? [];
   const connectable = installations.filter((i) => i.status === "connectable");
-  const connectedHere = installations.filter((i) => i.status === "connected-here");
-  const connectedElsewhere = installations.filter((i) => i.status === "connected-elsewhere");
 
   // Install-attempt marker: locks the install CTA and shows the waiting
   // affordance until something connectable appears (the thing to click next).
@@ -492,77 +512,24 @@ function ConnectPanel({
         </p>
       )}
 
-      {connectedHere.length > 0 && (
-        <InstallationGroup label="Connected to this team">
-          {connectedHere.map((installation) => (
+      <InstallationGroup label="Available to connect">
+        {!panelQuery.isLoading && installations.length === 0 ? (
+          <p className="text-body" style={{ color: "var(--fg-3)", margin: 0 }}>
+            No installations are linked to your GitHub account yet. Install the App above, or ask the teammate who
+            installed it to connect it from their panel.
+          </p>
+        ) : (
+          installations.map((installation) => (
             <InstallationRow key={installation.installationId} installation={installation}>
-              <button
-                type="button"
-                onClick={() => disconnectMutation.mutate()}
-                disabled={disconnectMutation.isPending}
-                className="text-body"
-                style={{
-                  padding: "var(--sp-1) var(--sp-2)",
-                  border: "var(--hairline) solid var(--border)",
-                  borderRadius: "var(--radius-input)",
-                  background: "transparent",
-                  color: "var(--state-error)",
-                  cursor: disconnectMutation.isPending ? "default" : "pointer",
-                }}
-              >
-                {disconnectMutation.isPending ? "Disconnecting…" : "Disconnect"}
-              </button>
+              <InstallationAction
+                installation={installation}
+                connectMutation={connectMutation}
+                disconnectMutation={disconnectMutation}
+              />
             </InstallationRow>
-          ))}
-        </InstallationGroup>
-      )}
-
-      {connectable.length > 0 && (
-        <InstallationGroup label="Available to connect">
-          {connectable.map((installation) => (
-            <InstallationRow key={installation.installationId} installation={installation}>
-              <button
-                type="button"
-                onClick={() => connectMutation.mutate(installation.installationId)}
-                disabled={connectMutation.isPending}
-                className="text-body font-medium"
-                style={{
-                  padding: "var(--sp-1) var(--sp-2)",
-                  border: "none",
-                  borderRadius: "var(--radius-input)",
-                  background: "var(--primary)",
-                  color: "var(--primary-on)",
-                  cursor: connectMutation.isPending ? "default" : "pointer",
-                  opacity: connectMutation.isPending ? 0.6 : 1,
-                }}
-              >
-                {connectMutation.isPending && connectMutation.variables === installation.installationId
-                  ? "Connecting…"
-                  : "Connect"}
-              </button>
-            </InstallationRow>
-          ))}
-        </InstallationGroup>
-      )}
-
-      {connectedElsewhere.length > 0 && (
-        <InstallationGroup label="Connected to other teams">
-          {connectedElsewhere.map((installation) => (
-            <InstallationRow key={installation.installationId} installation={installation}>
-              <span className="text-label" style={{ color: "var(--fg-3)" }}>
-                Connected to {installation.connectedTeamName ?? "another team"}
-              </span>
-            </InstallationRow>
-          ))}
-        </InstallationGroup>
-      )}
-
-      {!panelQuery.isLoading && installations.length === 0 && (
-        <p className="text-body" style={{ color: "var(--fg-3)", margin: 0 }}>
-          No installations are linked to your GitHub account yet. Install the App above, or ask the teammate who
-          installed it to connect it from their panel.
-        </p>
-      )}
+          ))
+        )}
+      </InstallationGroup>
     </div>
   );
 }
@@ -582,6 +549,72 @@ function InstallationGroup({ label, children }: { label: string; children: React
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-2)" }}>{children}</div>
     </div>
+  );
+}
+
+function InstallationAction({
+  installation,
+  connectMutation,
+  disconnectMutation,
+}: {
+  installation: GithubAppConnectPanelInstallation;
+  connectMutation: ReturnType<typeof useMutation<void, Error, number>>;
+  disconnectMutation: ReturnType<typeof useMutation<void, Error, void>>;
+}) {
+  if (installation.status === "connectable") {
+    return (
+      <button
+        type="button"
+        onClick={() => connectMutation.mutate(installation.installationId)}
+        disabled={connectMutation.isPending}
+        className="text-body font-medium"
+        style={{
+          padding: "var(--sp-1) var(--sp-2)",
+          border: "none",
+          borderRadius: "var(--radius-input)",
+          background: "var(--primary)",
+          color: "var(--primary-on)",
+          cursor: connectMutation.isPending ? "default" : "pointer",
+          opacity: connectMutation.isPending ? 0.6 : 1,
+        }}
+      >
+        {connectMutation.isPending && connectMutation.variables === installation.installationId
+          ? "Connecting…"
+          : "Connect"}
+      </button>
+    );
+  }
+
+  if (installation.status === "connected-here") {
+    return (
+      <div className="flex items-center" style={{ gap: "var(--sp-2)", justifyContent: "flex-end" }}>
+        <span className="text-label" style={{ color: "var(--fg-3)" }}>
+          Connected to this team
+        </span>
+        <button
+          type="button"
+          onClick={() => disconnectMutation.mutate()}
+          disabled={disconnectMutation.isPending}
+          className="text-body"
+          style={{
+            padding: "var(--sp-1) var(--sp-2)",
+            border: "var(--hairline) solid var(--border)",
+            borderRadius: "var(--radius-input)",
+            background: "transparent",
+            color: "var(--state-error)",
+            cursor: disconnectMutation.isPending ? "default" : "pointer",
+          }}
+        >
+          {disconnectMutation.isPending ? "Disconnecting…" : "Disconnect"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <span className="text-label" style={{ color: "var(--fg-3)" }}>
+      Connected to {installation.connectedTeamName ?? "another team"}
+    </span>
   );
 }
 

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -34,7 +34,8 @@ import { cn } from "../lib/utils.js";
  *                   to all members (read-only); only admins can edit.
  *   Resources     — org-scoped runtime resources (repo / prompt / skill / mcp).
  *                   Visible to all members (read-only); only admins can manage.
- *   GitHub        — admin-only platform integration
+ *   GitHub        — GitHub connection + source repos. Visible to all members
+ *                   (read-only); only admins can manage the connection/resources.
  *   Onboarding    — guided-setup stepper enable/disable (hidden once
  *                   onboarding is permanently completed)
  */
@@ -42,34 +43,30 @@ import { cn } from "../lib/utils.js";
 type Item = {
   to: string;
   label: string;
-  adminOnly?: boolean;
 };
 
 const ITEMS: Item[] = [
   { to: "/settings/computers", label: "Computers" },
   { to: "/settings/context", label: "Context tree" },
   { to: "/settings/resources", label: "Resources" },
-  { to: "/settings/github", label: "GitHub", adminOnly: true },
+  { to: "/settings/github", label: "GitHub" },
   { to: "/settings/onboarding", label: "Onboarding" },
 ];
 
 export function SettingsLayout() {
-  const { role, onboardingCompletedAt, meLoaded } = useAuth();
+  const { onboardingCompletedAt, meLoaded } = useAuth();
   const viewport = useWorkspaceViewport();
-  // Wait for `/me` to resolve before rendering the nav — otherwise a fresh
-  // direct hit on /settings/github would briefly paint the member-view nav
-  // (no GitHub) before `role` flips to "admin".
+  // Wait for `/me` to resolve before rendering the nav so role-dependent
+  // entries such as Onboarding do not flicker during a fresh page load.
   if (!meLoaded) {
     return null;
   }
-  const isAdmin = role === "admin";
   // Once onboarding completes, the wizard is terminal and the entry is hidden.
   // Direct URL access to /settings/onboarding still redirects out via the page's
   // own guard.
   const hasCompletedOnboarding = onboardingCompletedAt !== null;
 
   const visible = ITEMS.filter((it) => {
-    if (it.adminOnly && !isAdmin) return false;
     if (it.to === "/settings/onboarding" && hasCompletedOnboarding) return false;
     return true;
   });

--- a/packages/web/src/pages/settings/github.tsx
+++ b/packages/web/src/pages/settings/github.tsx
@@ -1,4 +1,3 @@
-import { Navigate } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
 import { PageHeader } from "../../components/ui/page-header.js";
 import { Section } from "../../components/ui/section.js";
@@ -6,13 +5,12 @@ import { GithubAppInstallationPanel } from "../github-app-installation-panel.js"
 import { ResourceTypeSections } from "./resource-sections.js";
 
 /**
- * Settings → GitHub. Admin-only — the App installation admin API is
- * admin-gated server-side, so a member landing here would just see a
- * 403 in the panel. Redirect them out instead.
+ * Settings → GitHub. Members can read the team's GitHub connection and source
+ * repo catalog; admin-only actions stay hidden in the panel/resource sections.
  *
  * Two sections:
  *   - GitHub Connection — the GitHub App installation panel (connect /
- *     disconnect / install).
+ *     disconnect / install for admins; read-only state for members).
  *   - Source Repos — the team's `repo` runtime resources, moved here from
  *     Settings → Resources so the repos agents work on sit next to the
  *     GitHub connection their code and events flow through.
@@ -26,16 +24,14 @@ export function SettingsGithubPage() {
       </div>
     );
   }
-  if (role !== "admin") {
-    return <Navigate to="/settings/computers" replace />;
-  }
+  const isAdmin = role === "admin";
 
   return (
     <>
       <PageHeader title="GitHub" subtitle="GitHub App connection and the source repos agents work on" />
       <div className="flex flex-col" style={{ gap: "var(--sp-5)", padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
         <Section title="GitHub Connection">
-          <GithubAppInstallationPanel />
+          <GithubAppInstallationPanel readOnly={!isAdmin} />
         </Section>
         <ResourceTypeSections types={["repo"]} titleFor={() => "Source Repos"} />
       </div>


### PR DESCRIPTION
## Summary
- make Settings -> GitHub visible to team members as a read-only page while keeping install/connect/disconnect/resource mutations admin-only
- make the bound GitHub installation details endpoint member-readable for the page summary
- simplify the manage connection panel into one "Available to connect" list with row-level actions/status instead of three segmented groups

## Verification
- `pnpm --filter @first-tree/web test -- github-app-installation-panel-dom.test.tsx settings-panels-dom.test.tsx page-ssr-smoke.test.tsx` (Vitest ran the full web suite: 137 files / 1146 tests passed)
- `pnpm --filter @first-tree/server test -- github-app-installation-details.test.ts github-app-installation-exists.test.ts github-app-connect-panel.test.ts` (Vitest ran the full server suite: 179 files / 1773 tests passed)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm check` (passes with existing unrelated warnings in `assistant-text.test.ts`, `workspace-migrations.ts`, and `index.css`)

Supersedes #1525, which used a non-compliant branch name.
