### PR TITLE
fix: format release build-info rewrite

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -146,12 +146,18 @@ jobs:
             "ft": "./dist/cli/index.mjs",
           };
           fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+          const clientSentryDsn = JSON.stringify(process.env.FIRST_TREE_CLIENT_SENTRY_DSN || "");
+          const clientSentryDsnAssignment = `export const CLIENT_SENTRY_DSN = ${clientSentryDsn};`;
+          const formattedClientSentryDsn =
+            clientSentryDsnAssignment.length > 120
+              ? `export const CLIENT_SENTRY_DSN =\n  ${clientSentryDsn};\n`
+              : `${clientSentryDsnAssignment}\n`;
           fs.writeFileSync(
             "src/build-info.ts",
             'import type { ChannelName } from "@first-tree/shared/channel";\n' +
               'export const CHANNEL: ChannelName = "prod";\n' +
               `export const GIT_SHA = ${JSON.stringify(process.env.RELEASE_GIT_SHA)};\n` +
-              `export const CLIENT_SENTRY_DSN = ${JSON.stringify(process.env.FIRST_TREE_CLIENT_SENTRY_DSN || "")};\n`,
+              formattedClientSentryDsn,
           );
           NODE
           echo "✓ Rewrote apps/cli/package.json + src/build-info.ts for prod publish"
@@ -350,12 +356,18 @@ jobs:
             "fts": "./dist/cli/index.mjs",
           };
           fs.writeFileSync("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+          const clientSentryDsn = JSON.stringify(process.env.FIRST_TREE_CLIENT_SENTRY_DSN || "");
+          const clientSentryDsnAssignment = `export const CLIENT_SENTRY_DSN = ${clientSentryDsn};`;
+          const formattedClientSentryDsn =
+            clientSentryDsnAssignment.length > 120
+              ? `export const CLIENT_SENTRY_DSN =\n  ${clientSentryDsn};\n`
+              : `${clientSentryDsnAssignment}\n`;
           fs.writeFileSync(
             "src/build-info.ts",
             'import type { ChannelName } from "@first-tree/shared/channel";\n' +
               'export const CHANNEL: ChannelName = "staging";\n' +
               `export const GIT_SHA = ${JSON.stringify(process.env.RELEASE_GIT_SHA)};\n` +
-              `export const CLIENT_SENTRY_DSN = ${JSON.stringify(process.env.FIRST_TREE_CLIENT_SENTRY_DSN || "")};\n`,
+              formattedClientSentryDsn,
           );
           NODE
           echo "✓ Rewrote apps/cli/package.json + src/build-info.ts for staging publish"


### PR DESCRIPTION
## Summary

- Fix the `npm Publish` workflow rewrite of `apps/cli/src/build-info.ts` so generated `CLIENT_SENTRY_DSN` assignments are already Biome-formatted.
- Apply the same formatting logic to both prod and staging publish jobs.
- Keep package identity/channel rewrite semantics unchanged.

## Root Cause

The publish workflow writes `apps/cli/src/build-info.ts` inside the ephemeral CI workspace before running `pnpm check`. When `FIRST_TREE_CLIENT_SENTRY_DSN` is long, the generated single-line assignment exceeds Biome formatting expectations, causing the publish job to fail before build/typecheck/publish.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm typecheck`
- `git diff --check`
- Simulated generated `build-info.ts` for prod/staging with both long and empty Sentry DSN values, then ran `pnpm exec biome check` on all generated files.

## Release Note

This only repairs release automation. It does not create a release bump, tag, GitHub Release, or npm publish.
