### PR TITLE
fix: tolerate pre-rewritten portable release channel

### DIFF
--- a/apps/cli/tests/portable-builder.test.ts
+++ b/apps/cli/tests/portable-builder.test.ts
@@ -41,6 +41,8 @@ import {
   resolveNodeVersion,
   resolvePinnedDependenciesFromPnpmList,
   rewriteBinShimBuildRoots,
+  rewriteBundleChannel,
+  rewriteBundleChannelText,
   sanitizePortableBinShims,
   validateChannelVersion,
   writeDeterministicTarGz,
@@ -162,6 +164,29 @@ describe("portable builder helpers", () => {
   it("uses immutable artifact names", () => {
     expect(artifactFileName({ packageName: "first-tree", version: "1.2.3", platform: "linux-x64" })).toBe(
       "first-tree-1.2.3-linux-x64.tar.gz",
+    );
+  });
+
+  it("rewrites historical and current bundled channel shapes", () => {
+    expect(rewriteBundleChannelText('const channelConfig = getChannelConfig("dev");', "staging")).toEqual({
+      content: 'const channelConfig = getChannelConfig("staging");',
+      replacements: 1,
+    });
+    expect(
+      rewriteBundleChannelText('var CHANNEL = "dev";\nconst channelConfig = getChannelConfig(CHANNEL);', "prod"),
+    ).toEqual({
+      content: 'var CHANNEL = "prod";\nconst channelConfig = getChannelConfig(CHANNEL);',
+      replacements: 1,
+    });
+  });
+
+  it("accepts already-channel-built bundles without a rewrite target", async () => {
+    const appDir = tempDir("first-tree-portable-bundle-channel-");
+    writeFileSync(join(appDir, "index.mjs"), 'const bundled = "already staging";\n');
+
+    await expect(rewriteBundleChannel(appDir, "staging", { sourceChannel: "staging" })).resolves.toBeUndefined();
+    await expect(rewriteBundleChannel(appDir, "prod", { sourceChannel: "dev" })).rejects.toThrow(
+      /expected to rewrite exactly one bundled channel constant/,
     );
   });
 

--- a/scripts/portable/build-portable.mjs
+++ b/scripts/portable/build-portable.mjs
@@ -317,23 +317,51 @@ export async function writeDeterministicTarGz({ sourceDir, tarballPath, generate
   }
 }
 
-async function rewriteBundleChannel(appDir, channel) {
+export function readSourceTreeChannel(source = readFileSync(join(CLI_ROOT, "src", "build-info.ts"), "utf8")) {
+  const match = source.match(/export const CHANNEL(?::\s*ChannelName)?\s*=\s*["'](dev|staging|prod)["'];/);
+  return match?.[1] ?? null;
+}
+
+export function rewriteBundleChannelText(source, channel) {
+  const rewrites = [
+    {
+      re: /\b(const\s+channelConfig\s*=\s*getChannelConfig\()\s*["'](?:dev|staging|prod)["'](\s*\)\s*;)/g,
+      replace: (_match, prefix, suffix) => `${prefix}"${channel}"${suffix}`,
+    },
+    {
+      re: /\b((?:const|let|var)\s+CHANNEL\s*=\s*)["'](?:dev|staging|prod)["'](\s*;)/g,
+      replace: (_match, prefix, suffix) => `${prefix}"${channel}"${suffix}`,
+    },
+  ];
+
+  let content = source;
+  let replacements = 0;
+  for (const rewrite of rewrites) {
+    content = content.replace(rewrite.re, (...args) => {
+      replacements += 1;
+      return rewrite.replace(...args);
+    });
+  }
+
+  return { content, replacements };
+}
+
+export async function rewriteBundleChannel(appDir, channel, options = {}) {
   const files = (await listFiles(appDir)).filter((path) => path.endsWith(".mjs"));
-  const re = /const channelConfig = getChannelConfig\("(dev|staging|prod)"\);/g;
   let replacements = 0;
   for (const file of files) {
     const before = await readFile(file, "utf8");
-    const matches = [...before.matchAll(re)];
-    if (matches.length === 0) continue;
-    const after = before.replace(re, () => {
-      replacements += 1;
-      return `const channelConfig = getChannelConfig("${channel}");`;
-    });
-    await writeFile(file, after, "utf8");
+    const rewritten = rewriteBundleChannelText(before, channel);
+    replacements += rewritten.replacements;
+    if (rewritten.replacements > 0) await writeFile(file, rewritten.content, "utf8");
   }
-  if (replacements !== 1) {
-    fail(`expected to rewrite exactly one bundled channel constant, rewrote ${replacements}`);
+  if (replacements === 1) return;
+
+  const sourceChannel = options.sourceChannel ?? readSourceTreeChannel();
+  if (replacements === 0 && sourceChannel === channel) {
+    return;
   }
+  fail(`expected to rewrite exactly one bundled channel constant, rewrote ${replacements}`);
 }
 
 function copyPruneScripts(appDir) {


### PR DESCRIPTION
## Summary
- tolerate portable release bundles that were already built from a CI-rewritten `build-info.ts` channel
- keep rewriting historical/current bundle channel shapes when the portable builder needs to flip a dev build
- add portable builder coverage for both rewrite shapes and already-channel-built bundles

## Verification
- `pnpm exec biome check scripts/portable/build-portable.mjs apps/cli/tests/portable-builder.test.ts`
- `pnpm --filter first-tree-dev exec vitest run tests/portable-builder.test.ts`
- `node scripts/portable/build-portable.mjs --channel staging --version 0.5.12-staging.test.2 --git-sha d54bb52741456174aa78fb7dbc0dbd233c52cc29 --node-version v24.18.0 --platform darwin-arm64 --out-dir /Users/yuezengwu/.first-tree-staging/data/workspaces/yzw-codex/tmp/portable-repro-postfix-$$ --generated-at 2026-01-01T00:00:00Z`
- `pnpm check` (passes with existing warnings in unrelated files)
- `pnpm typecheck`
- `pnpm --filter first-tree-dev test -- apps/cli/tests/portable-builder.test.ts` (this matched the full CLI suite: 71 files / 661 tests passed)

## Release note
This is scoped to the npm/portable release path. It does not create a release tag or publish a package by itself.
