### PR TITLE
test: improve cli and server branch coverage

### DIFF
--- a/apps/cli/src/__tests__/agent-config-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-config-commands-extra.test.ts
@@ -400,6 +400,130 @@ describe("agent config command behavior", () => {
     );
   });
 
+  it("matches repo resources from payload fallback and preserves unrelated bindings", async () => {
+    fetcherMocks.getAgentResources.mockResolvedValueOnce({
+      version: 6,
+      bindings: [
+        {
+          id: "prompt-binding",
+          type: "prompt",
+          mode: "include",
+          resourceId: null,
+          inlinePromptBody: "Keep me.",
+          order: 1,
+        },
+        {
+          id: "team-binding",
+          type: "repo",
+          mode: "include",
+          resourceId: "payload-team-repo",
+          order: 4,
+        },
+      ],
+      effective: {
+        version: 6,
+        repos: [
+          {
+            id: "binding:team-binding:enabled",
+            bindingId: "team-binding",
+            resourceId: "payload-team-repo",
+            replacesResourceId: null,
+            type: "repo",
+            name: "web",
+            scope: "team",
+            source: "team_available",
+            mode: "enabled",
+            defaultEnabled: "available",
+            payload: { url: "git@github.com:Acme/Web.git" },
+            repo: null,
+            promptBody: null,
+            unavailableReason: null,
+            order: 4,
+          },
+        ],
+        prompts: [],
+        skills: [],
+        mcp: [],
+        unavailable: [],
+      },
+      availableTeamResources: [],
+    });
+
+    await runConfig(["add-repo", "nova", "https://github.com/acme/web.git"]);
+
+    expect(fetcherMocks.patchAgentResources).toHaveBeenLastCalledWith(
+      "https://hub.example",
+      "admin-token",
+      "agent-uuid",
+      {
+        expectedVersion: 6,
+        bindings: [
+          {
+            id: "prompt-binding",
+            type: "prompt",
+            mode: "include",
+            resourceId: null,
+            inlinePromptBody: "Keep me.",
+            order: 1,
+          },
+          {
+            type: "repo",
+            mode: "include",
+            resourceId: "payload-team-repo",
+            repoRef: undefined,
+            repoLocalPath: undefined,
+            order: 4,
+          },
+        ],
+      },
+    );
+  });
+
+  it("adds invalid repo URLs as agent extras without canonical matching", async () => {
+    fetcherMocks.getAgentResources.mockResolvedValueOnce({
+      version: 7,
+      bindings: [
+        {
+          id: "keep-repo",
+          type: "repo",
+          mode: "include",
+          agentExtraRepo: { url: "not a canonical url either" },
+          order: 1,
+        },
+      ],
+      effective: { version: 7, repos: [], prompts: [], skills: [], mcp: [], unavailable: [] },
+      availableTeamResources: [],
+    });
+
+    await runConfig(["add-repo", "nova", "not a repo url"]);
+
+    expect(fetcherMocks.patchAgentResources).toHaveBeenLastCalledWith(
+      "https://hub.example",
+      "admin-token",
+      "agent-uuid",
+      {
+        expectedVersion: 7,
+        bindings: [
+          {
+            id: "keep-repo",
+            type: "repo",
+            mode: "include",
+            agentExtraRepo: { url: "not a canonical url either" },
+            order: 1,
+          },
+          {
+            type: "repo",
+            mode: "include",
+            agentExtraRepo: { url: "not a repo url" },
+            repoRef: undefined,
+            repoLocalPath: undefined,
+            order: 2,
+          },
+        ],
+      },
+    );
+  });
+
   it("`prompt set` replaces the inline fragment exactly like append-prompt", async () => {
     const promptFile = join(tempDir, "fragment.md");
     writeFileSync(promptFile, "Prefer small diffs.");
@@ -626,6 +750,81 @@ describe("agent config command behavior", () => {
     expect(out).toContain("prompt show <agent> --raw");
     expect(out).toContain("prompt set <agent> -f");
     expect(out).toContain("team prompts are managed in Cloud");
+  });
+
+  it("`prompt show` renders empty effective and fragment states", async () => {
+    fetcherMocks.getAgentResources.mockResolvedValueOnce({
+      version: 8,
+      bindings: [],
+      effective: {
+        version: 8,
+        repos: [],
+        prompts: [],
+        skills: [],
+        mcp: [],
+        unavailable: [],
+      },
+      availableTeamResources: [],
+    });
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    await runConfig(["prompt", "show", "nova"]);
+    const out = stdout.mock.calls.map((call) => String(call[0])).join("");
+    stdout.mockRestore();
+
+    expect(out).toContain("  (none)");
+    expect(out).toContain("Per-agent fragment: (empty)");
+  });
+
+  it("`prompt show` describes empty and disabled prompt rows", async () => {
+    fetcherMocks.getAgentResources.mockResolvedValueOnce({
+      version: 9,
+      bindings: [],
+      effective: {
+        version: 9,
+        repos: [],
+        prompts: [
+          {
+            id: "team-disabled",
+            bindingId: null,
+            resourceId: "team-disabled",
+            replacesResourceId: null,
+            type: "prompt",
+            name: "Dormant guide",
+            scope: "team",
+            source: "team_available",
+            mode: "disabled",
+            defaultEnabled: "available",
+            payload: { body: "" },
+            repo: null,
+            promptBody: "",
+            unavailableReason: null,
+            order: 1,
+          },
+        ],
+        skills: [],
+        mcp: [],
+        unavailable: [],
+      },
+      availableTeamResources: [],
+    });
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    await runConfig(["prompt", "show", "nova"]);
+    const out = stdout.mock.calls.map((call) => String(call[0])).join("");
+    stdout.mockRestore();
+
+    expect(out).toContain("[team] Dormant guide (disabled)");
+  });
+
+  it("`prompt set` fails when no file is provided and stdin is interactive", async () => {
+    const stdinSpy = vi.spyOn(process, "stdin", "get").mockReturnValue({ isTTY: true } as typeof process.stdin);
+    try {
+      await expect(runConfig(["prompt", "set", "nova"])).rejects.toMatchObject({
+        code: "MISSING_INPUT",
+        exitCode: 2,
+      });
+    } finally {
+      stdinSpy.mockRestore();
+    }
   });
 
   it("shows config and prints dry-run diffs", async () => {

--- a/apps/cli/src/__tests__/agent-config-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-config-commands-extra.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 
 import {
   type AgentRuntimeConfig,
@@ -421,6 +422,38 @@ describe("agent config command behavior", () => {
       },
     );
     expect(outputMocks.success).toHaveBeenLastCalledWith({ agentId: "agent-uuid", version: 2, append_length: 19 });
+  });
+
+  it("`prompt set` reads the fragment from piped stdin when no file is provided", async () => {
+    const stdin = new PassThrough();
+    Object.defineProperty(stdin, "isTTY", { value: false });
+    const stdinSpy = vi.spyOn(process, "stdin", "get").mockReturnValue(stdin as unknown as typeof process.stdin);
+
+    try {
+      const pending = runConfig(["prompt", "set", "nova"]);
+      stdin.end("Prefer stdin fragments.");
+      await pending;
+    } finally {
+      stdinSpy.mockRestore();
+    }
+
+    expect(fetcherMocks.patchAgentResources).toHaveBeenLastCalledWith(
+      "https://hub.example",
+      "admin-token",
+      "agent-uuid",
+      {
+        expectedVersion: 1,
+        bindings: [
+          {
+            type: "prompt",
+            mode: "include",
+            resourceId: null,
+            inlinePromptBody: "Prefer stdin fragments.",
+            order: 1,
+          },
+        ],
+      },
+    );
   });
 
   it("`prompt set` hard-rejects a body carrying the generated-briefing marker (no --force escape)", async () => {

--- a/apps/cli/src/__tests__/agent-config-fetchers.test.ts
+++ b/apps/cli/src/__tests__/agent-config-fetchers.test.ts
@@ -112,6 +112,108 @@ describe("agent config fetch helpers", () => {
     );
   });
 
+  it("wraps resource endpoints, agent resolution, and no-body admin fetches", async () => {
+    const { adminFetch, getAgentResources, patchAgentResources, resolveAgentRecord } = await import(
+      "../commands/agent/config/_shared/fetchers.js"
+    );
+    fetchMock.mockResolvedValueOnce(jsonResponse({ pong: true }));
+
+    await expect(
+      adminFetch<{ pong: boolean }>("https://first-tree.example/api/v1/ping", {
+        method: "GET",
+        adminToken: "admin-token",
+      }),
+    ).resolves.toEqual({ pong: true });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://first-tree.example/api/v1/ping",
+      expect.objectContaining({
+        method: "GET",
+        headers: { Authorization: "Bearer admin-token" },
+      }),
+    );
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ prompt: [], skills: [], resources: [] }));
+    await expect(getAgentResources("https://first-tree.example", "admin-token", "agent-1")).resolves.toEqual({
+      prompt: [],
+      skills: [],
+      resources: [],
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://first-tree.example/api/v1/agents/agent-1/resources",
+      expect.objectContaining({ method: "GET" }),
+    );
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ prompt: [{ id: "p1" }], skills: [], resources: [] }));
+    const patchBody = {
+      expectedVersion: 1,
+      bindings: [
+        {
+          type: "prompt" as const,
+          mode: "include" as const,
+          resourceId: null,
+          inlinePromptBody: "Prefer concise updates.",
+          order: 1,
+        },
+      ],
+    };
+    await expect(
+      patchAgentResources("https://first-tree.example", "admin-token", "agent-1", patchBody),
+    ).resolves.toMatchObject({ prompt: [{ id: "p1" }] });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://first-tree.example/api/v1/agents/agent-1/resources",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify(patchBody),
+      }),
+    );
+
+    fetchMock.mockResolvedValueOnce(jsonResponse([{ uuid: "agent-1", name: "nova", displayName: "Nova" }]));
+    await expect(resolveAgentRecord("https://first-tree.example", "admin-token", "nova")).resolves.toEqual({
+      uuid: "agent-1",
+      name: "nova",
+      displayName: "Nova",
+    });
+  });
+
+  it("prints unset config fields and handles blank HTTP error bodies", async () => {
+    const { adminFetch, printConfig } = await import("../commands/agent/config/_shared/fetchers.js");
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      json: async () => ({}),
+      text: async () => "",
+    } as Response);
+
+    await expect(
+      adminFetch("https://first-tree.example/api/v1/broken", {
+        method: "GET",
+        adminToken: "admin-token",
+      }),
+    ).rejects.toMatchObject({ code: "HTTP_500", message: "Server Error", exitCode: 1 });
+
+    printConfig(
+      config({
+        payload: {
+          kind: "claude-code",
+          prompt: { append: "" },
+          model: "",
+          reasoningEffort: "",
+          mcpServers: [],
+          env: [],
+          gitRepos: [{ url: "https://github.com/acme/api.git" }],
+          resourceSkills: [],
+        },
+      }),
+    );
+
+    expect(output()).toContain("Model:    (unset)");
+    expect(output()).toContain("Reasoning effort: (unset");
+    expect(output()).toContain("Prompt append: (empty)");
+    expect(output()).toContain("MCP servers (0)");
+    expect(output()).toContain("https://github.com/acme/api.git");
+  });
+
   it("prints a readable runtime config summary", async () => {
     const { printConfig } = await import("../commands/agent/config/_shared/fetchers.js");
 

--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -9,6 +9,10 @@ const clientSdkMocks = vi.hoisted(() => ({
   FirstTreeHubSDK: vi.fn(),
 }));
 
+const promptMocks = vi.hoisted(() => ({
+  confirm: vi.fn(),
+}));
+
 const configMocks = vi.hoisted(() => ({
   agentConfigSchema: {},
   clientConfigSchema: {},
@@ -68,6 +72,7 @@ const outputMocks = vi.hoisted(() => ({
 
 const printLineMock = vi.hoisted(() => vi.fn());
 
+vi.mock("@inquirer/prompts", () => promptMocks);
 vi.mock("@first-tree/client", () => clientSdkMocks);
 vi.mock("@first-tree/shared/config", () => configMocks);
 vi.mock("../core/bootstrap.js", () => bootstrapMocks);
@@ -135,6 +140,7 @@ beforeEach(() => {
   coreMocks.readActiveRootClientId.mockReturnValue(null);
   coreMocks.stopClientRuntimeProcess.mockResolvedValue({ ok: true });
   cliFetchMock.mockReset();
+  promptMocks.confirm.mockResolvedValue(true);
   coreMocks.promptAddAgent.mockResolvedValue({ name: "nova", agentId: "agent-1" });
   coreMocks.findStaleAliases.mockResolvedValue([
     { name: "old", agentId: "agent-old", reason: "unpinned" },
@@ -226,6 +232,44 @@ describe("agent lifecycle CLI commands", () => {
     await expect(
       runAgent(["create", "bot", "--type", "agent", "--client-id", "client-1", "--org", "missing"]),
     ).rejects.toMatchObject({ code: "CREATE_ERROR", exitCode: 1 });
+
+    cliFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          memberships: [
+            { organizationId: "org-1", organizationName: "Acme", role: "admin" },
+            { organizationId: "org-2", organizationName: "Beta", role: "member" },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ uuid: "agent-created", name: "scoped" }));
+    await runAgent(["create", "scoped", "--type", "agent", "--client-id", "client-1", "--org", "org-2"]);
+    expect(cliFetchMock).toHaveBeenLastCalledWith(
+      "https://hub.example/api/v1/orgs/org-2/agents",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    cliFetchMock.mockResolvedValueOnce(jsonResponse({ memberships: [] }));
+    await expect(runAgent(["create", "none", "--type", "agent", "--client-id", "client-1"])).rejects.toMatchObject({
+      code: "CREATE_ERROR",
+      exitCode: 1,
+    });
+
+    cliFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ memberships: [{ organizationId: "org-1", organizationName: "Acme", role: "admin" }] }),
+      )
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: vi.fn(async () => {
+          throw new Error("not json");
+        }),
+        text: vi.fn(async () => "bad gateway"),
+      } as unknown as Response);
+    await expect(
+      runAgent(["create", "fail-create", "--type", "agent", "--client-id", "client-1"]),
+    ).rejects.toMatchObject({ code: "CREATE_ERROR", exitCode: 1 });
   });
 
   it("lists local and remote agents, including empty and error paths", async () => {
@@ -269,6 +313,20 @@ describe("agent lifecycle CLI commands", () => {
 
     cliFetchMock.mockResolvedValueOnce(jsonResponse("nope", false, 503));
     await expect(runAgent(["list", "--remote"])).rejects.toMatchObject({ code: "LIST_ERROR", exitCode: 1 });
+
+    configMocks.loadAgents.mockReturnValueOnce(new Map());
+    await runAgent(["list"]);
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("No agents configured");
+
+    configMocks.loadAgents.mockImplementationOnce(() => {
+      throw new Error("bad local config");
+    });
+    await runAgent(["list"]);
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("No agents configured");
+
+    cliFetchMock.mockResolvedValueOnce(jsonResponse([]));
+    await runAgent(["list", "--remote"]);
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("No agents found");
   });
 
   it("prunes stale aliases with dry-run, confirmation skip, removal failures, and missing client id", async () => {
@@ -293,6 +351,17 @@ describe("agent lifecycle CLI commands", () => {
 
     configMocks.resolveConfigReadonly.mockReturnValueOnce({ client: {} });
     await expect(runAgent(["prune", "--yes"])).rejects.toMatchObject({ code: "PRUNE_ERROR", exitCode: 1 });
+  });
+
+  it("cancels interactive prune when the confirmation is rejected or interrupted", async () => {
+    promptMocks.confirm.mockResolvedValueOnce(false);
+    await runAgent(["prune"]);
+    expect(coreMocks.removeLocalAgent).not.toHaveBeenCalled();
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Cancelled.");
+
+    promptMocks.confirm.mockRejectedValueOnce(new Error("prompt closed"));
+    await runAgent(["prune"]);
+    expect(coreMocks.removeLocalAgent).not.toHaveBeenCalled();
   });
 });
 
@@ -453,6 +522,56 @@ describe("logout and upgrade commands", () => {
     expect(() => readFileSync(join(agentsDir, "agent.yaml"), "utf8")).toThrow();
     const output = printLineMock.mock.calls.map((call) => String(call[0])).join("");
     expect(output).toContain("Stopped foreground daemon pid 4321");
+  });
+
+  it("logout without purge warns but continues when foreground daemon marker inspection fails", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(credentials, "{}");
+    coreMocks.isServiceSupported.mockReturnValue(false);
+    coreMocks.loadCredentials.mockReturnValue({
+      accessToken: jwt({ sub: "user-old" }),
+      refreshToken: "refresh",
+      serverUrl: "https://first-tree.example",
+    });
+    coreMocks.readActiveRootClientId.mockReturnValue("client-1");
+    coreMocks.listLiveClientRuntimeMarkers.mockImplementationOnce(() => {
+      throw new Error("marker dir unreadable");
+    });
+
+    const { registerLogoutCommand } = await import("../commands/logout.js");
+    await runTopLevel(registerLogoutCommand, ["logout"]);
+
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "Warning: could not inspect foreground daemon runtime markers: marker dir unreadable",
+    );
+    expect(existsSync(credentials)).toBe(false);
+  });
+
+  it("logout without purge warns on untrusted or unstoppable foreground markers and still removes credentials", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(credentials, "{}");
+    coreMocks.isServiceSupported.mockReturnValue(false);
+    coreMocks.loadCredentials.mockReturnValue({
+      accessToken: jwt({ sub: "user-old" }),
+      refreshToken: "refresh",
+      serverUrl: "https://first-tree.example",
+    });
+    coreMocks.readActiveRootClientId.mockReturnValue("client-1");
+    coreMocks.listLiveClientRuntimeMarkers.mockReturnValue([
+      { pid: 1111, clientId: "client-1", mode: "foreground", command: "" },
+      { pid: 2222, clientId: "client-1", mode: "foreground", command: "first-tree-dev daemon start --foreground" },
+    ]);
+    coreMocks.stopClientRuntimeProcess.mockResolvedValueOnce({ ok: false, reason: "still running" });
+
+    const { registerLogoutCommand } = await import("../commands/logout.js");
+    await runTopLevel(registerLogoutCommand, ["logout"]);
+
+    const output = printLineMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("could not read command for pid 1111");
+    expect(output).toContain("Warning: could not stop foreground daemon pid 2222: still running");
+    expect(existsSync(credentials)).toBe(false);
   });
 
   it("computer reset uses the same guarded local-state removal without server retire", async () => {
@@ -642,6 +761,71 @@ describe("logout and upgrade commands", () => {
     expect(output).toContain("sleep 1000");
   });
 
+  it("refuses logout purge when marker inspection fails before deleting local state", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    const clientYaml = join(tempDir, "client.yaml");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(credentials, "{}");
+    writeFileSync(clientYaml, "client:\n  id: client-1\n");
+    coreMocks.isServiceSupported.mockReturnValue(false);
+    coreMocks.readActiveRootClientId.mockReturnValue("client-1");
+    coreMocks.listLiveClientRuntimeMarkers.mockImplementationOnce(() => {
+      throw new Error("marker dir unreadable");
+    });
+
+    const { registerLogoutCommand } = await import("../commands/logout.js");
+    await expect(runTopLevel(registerLogoutCommand, ["logout", "--purge"])).rejects.toMatchObject({
+      code: "PURGE_FOREGROUND_DAEMON_STOP_FAILED",
+      exitCode: 1,
+    });
+
+    expect(readFileSync(credentials, "utf8")).toBe("{}");
+    expect(readFileSync(clientYaml, "utf8")).toContain("client-1");
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Could not inspect");
+  });
+
+  it("refuses logout purge when credentials or client id are unavailable for server retire", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(credentials, "{}");
+    coreMocks.isServiceSupported.mockReturnValue(false);
+    coreMocks.loadCredentials.mockReturnValue(null);
+    coreMocks.readActiveRootClientId.mockReturnValue(null);
+
+    const { registerLogoutCommand } = await import("../commands/logout.js");
+    await expect(runTopLevel(registerLogoutCommand, ["logout", "--purge"])).rejects.toMatchObject({
+      code: "PURGE_CLIENT_RETIRE_UNAVAILABLE",
+      exitCode: 1,
+    });
+
+    expect(cliFetchMock).not.toHaveBeenCalled();
+    expect(readFileSync(credentials, "utf8")).toBe("{}");
+  });
+
+  it("refuses logout purge when refreshing credentials for server retire fails", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(credentials, "{}");
+    coreMocks.isServiceSupported.mockReturnValue(false);
+    coreMocks.loadCredentials.mockReturnValue({
+      accessToken: jwt({ sub: "user-old" }),
+      refreshToken: "refresh",
+      serverUrl: "https://first-tree.example",
+    });
+    coreMocks.readActiveRootClientId.mockReturnValue("client-1");
+    coreMocks.ensureFreshAccessToken.mockRejectedValueOnce(new Error("refresh denied"));
+
+    const { registerLogoutCommand } = await import("../commands/logout.js");
+    await expect(runTopLevel(registerLogoutCommand, ["logout", "--purge"])).rejects.toMatchObject({
+      code: "PURGE_CLIENT_RETIRE_FAILED",
+      exitCode: 1,
+    });
+
+    expect(cliFetchMock).not.toHaveBeenCalled();
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("refresh denied");
+    expect(readFileSync(credentials, "utf8")).toBe("{}");
+  });
+
   it("refuses logout purge before deleting local state when server retire fails", async () => {
     const credentials = join(tempDir, "credentials.json");
     const clientYaml = join(tempDir, "client.yaml");
@@ -674,6 +858,42 @@ describe("logout and upgrade commands", () => {
     expect(output).toContain("delete pinned agents first");
   });
 
+  it("prints server retire message or text error bodies when logout purge fails", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    const clientYaml = join(tempDir, "client.yaml");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(credentials, "{}");
+    writeFileSync(clientYaml, "client:\n  id: client-1\n");
+    coreMocks.isServiceSupported.mockReturnValue(false);
+    coreMocks.loadCredentials.mockReturnValue({
+      accessToken: jwt({ sub: "user-old" }),
+      refreshToken: "refresh",
+      serverUrl: "https://first-tree.example",
+    });
+    coreMocks.readActiveRootClientId.mockReturnValue("client-1");
+    cliFetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "message body wins" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const { registerLogoutCommand } = await import("../commands/logout.js");
+    await expect(runTopLevel(registerLogoutCommand, ["logout", "--purge"])).rejects.toMatchObject({
+      code: "PURGE_CLIENT_RETIRE_FAILED",
+      exitCode: 1,
+    });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("message body wins");
+
+    printLineMock.mockClear();
+    cliFetchMock.mockResolvedValueOnce(new Response("plain failure", { status: 502 }));
+    await expect(runTopLevel(registerLogoutCommand, ["logout", "--purge"])).rejects.toMatchObject({
+      code: "PURGE_CLIENT_RETIRE_FAILED",
+      exitCode: 1,
+    });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("plain failure");
+  });
+
   it("upgrade covers source, npx, check-only, install failure, no service, inactive service, and restart failure paths", async () => {
     process.exit = vi.fn(((code?: number) => {
       throw Object.assign(new Error("process.exit"), { code });
@@ -694,6 +914,24 @@ describe("logout and upgrade commands", () => {
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
       "first-tree-dev upgrade --latest",
     );
+
+    coreMocks.fetchLatestVersion.mockReturnValueOnce({ ok: false, reason: "npm down" });
+    await expect(runTopLevel(registerUpgradeCommand, ["upgrade", "--latest"])).rejects.toMatchObject({ code: 1 });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "Could not fetch latest version",
+    );
+
+    coreMocks.detectInstallMode.mockReturnValue("portable");
+    coreMocks.fetchPortableLatestVersion.mockResolvedValueOnce({ ok: false, reason: "metadata down" });
+    await expect(runTopLevel(registerUpgradeCommand, ["upgrade", "--latest"])).rejects.toMatchObject({ code: 1 });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "Could not fetch portable update target",
+    );
+
+    coreMocks.detectInstallMode.mockReturnValue("global");
+    coreMocks.fetchServerCommandVersion.mockResolvedValueOnce({ ok: true, version: "0.4.0" });
+    await runTopLevel(registerUpgradeCommand, ["upgrade"]);
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Already on 0.5.0");
 
     await runTopLevel(registerUpgradeCommand, ["upgrade", "--check"]);
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Upgrade available");

--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -329,6 +329,45 @@ describe("agent lifecycle CLI commands", () => {
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("No agents found");
   });
 
+  it("stringifies non-Error failures across agent command catch paths", async () => {
+    process.exit = vi.fn(((code?: number) => {
+      throw Object.assign(new Error("process.exit"), { code });
+    }) as never);
+
+    coreMocks.promptAddAgent.mockRejectedValueOnce("prompt string failure");
+    await expect(runAgent(["add"])).rejects.toMatchObject({ code: 1 });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("prompt string failure");
+
+    bootstrapMocks.ensureFreshAccessToken.mockRejectedValueOnce("create token string");
+    await expect(runAgent(["create", "nova", "--type", "agent", "--client-id", "client-1"])).rejects.toMatchObject({
+      code: "CREATE_ERROR",
+      exitCode: 1,
+    });
+    expect(outputMocks.fail).toHaveBeenLastCalledWith("CREATE_ERROR", "create token string");
+
+    bootstrapMocks.ensureFreshAccessToken.mockRejectedValueOnce("list token string");
+    await expect(runAgent(["list", "--remote"])).rejects.toMatchObject({ code: "LIST_ERROR", exitCode: 1 });
+    expect(outputMocks.fail).toHaveBeenLastCalledWith("LIST_ERROR", "list token string");
+
+    bootstrapMocks.ensureFreshAccessToken.mockRejectedValueOnce("reset token string");
+    await expect(runAgent(["reset", "nova"])).rejects.toMatchObject({ code: "RESET_ERROR", exitCode: 1 });
+    expect(outputMocks.fail).toHaveBeenLastCalledWith("RESET_ERROR", "reset token string");
+
+    bootstrapMocks.ensureFreshAccessToken.mockRejectedValueOnce("session list token string");
+    await expect(runAgent(["session", "list", "nova"])).rejects.toMatchObject({
+      code: "SESSIONS_ERROR",
+      exitCode: 1,
+    });
+    expect(outputMocks.fail).toHaveBeenLastCalledWith("SESSIONS_ERROR", "session list token string");
+
+    bootstrapMocks.ensureFreshAccessToken.mockRejectedValueOnce("session command token string");
+    await expect(runAgent(["session", "suspend", "nova", "chat-1"])).rejects.toMatchObject({
+      code: "SESSION_CMD_ERROR",
+      exitCode: 1,
+    });
+    expect(outputMocks.fail).toHaveBeenLastCalledWith("SESSION_CMD_ERROR", "session command token string");
+  });
+
   it("prunes stale aliases with dry-run, confirmation skip, removal failures, and missing client id", async () => {
     await runAgent(["prune", "--dry-run"]);
     expect(coreMocks.removeLocalAgent).not.toHaveBeenCalled();
@@ -572,6 +611,124 @@ describe("logout and upgrade commands", () => {
     expect(output).toContain("could not read command for pid 1111");
     expect(output).toContain("Warning: could not stop foreground daemon pid 2222: still running");
     expect(existsSync(credentials)).toBe(false);
+  });
+
+  it("logout skips owner recording when the token is missing or lacks a string subject", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(credentials, "{}");
+    coreMocks.isServiceSupported.mockReturnValue(false);
+    coreMocks.readActiveRootClientId.mockReturnValue("client-1");
+    coreMocks.loadCredentials.mockReturnValueOnce({
+      accessToken: "",
+      refreshToken: "refresh",
+      serverUrl: "https://first-tree.example",
+    });
+
+    const { runLogout } = await import("../commands/logout.js");
+    await runLogout({ purge: false });
+
+    expect(coreMocks.recordActiveClientOwner).not.toHaveBeenCalled();
+
+    writeFileSync(credentials, "{}");
+    coreMocks.loadCredentials.mockReturnValueOnce({
+      accessToken: jwt({ sub: 42 }),
+      refreshToken: "refresh",
+      serverUrl: "https://first-tree.example",
+    });
+
+    await runLogout({ purge: false });
+
+    expect(coreMocks.recordActiveClientOwner).not.toHaveBeenCalled();
+    expect(existsSync(credentials)).toBe(false);
+  });
+
+  it("logout handles non-Error foreground inspection failures and already-stopped runtime markers", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(credentials, "{}");
+    coreMocks.isServiceSupported.mockReturnValue(false);
+    coreMocks.loadCredentials.mockReturnValue({
+      accessToken: jwt({ sub: "user-old" }),
+      refreshToken: "refresh",
+      serverUrl: "https://first-tree.example",
+    });
+    coreMocks.readActiveRootClientId.mockReturnValue("client-1");
+    coreMocks.listLiveClientRuntimeMarkers.mockImplementationOnce(() => {
+      throw "marker string failure";
+    });
+
+    const { runLogout } = await import("../commands/logout.js");
+    await runLogout({ purge: false });
+
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("marker string failure");
+
+    printLineMock.mockClear();
+    writeFileSync(credentials, "{}");
+    coreMocks.listLiveClientRuntimeMarkers.mockReturnValueOnce([
+      {
+        pid: 3333,
+        clientId: "client-1",
+        mode: "foreground",
+        command: "/usr/local/bin/first-tree-dev daemon start --foreground",
+      },
+    ]);
+    coreMocks.stopClientRuntimeProcess.mockResolvedValueOnce({ ok: true, alreadyStopped: true });
+
+    await runLogout({ purge: false });
+
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "Stopped foreground daemon pid 3333 (already stopped)",
+    );
+  });
+
+  it("logout purge reports default retry guidance, service warnings, and empty retire bodies", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    const clientYaml = join(tempDir, "client.yaml");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(credentials, "{}");
+    writeFileSync(clientYaml, "client:\n  id: client-1\n");
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({ state: "active", platform: "launchd" });
+    coreMocks.stopClientService.mockReturnValueOnce({ ok: false, reason: "best effort failed" });
+    coreMocks.loadCredentials.mockReturnValue({
+      accessToken: jwt({ sub: "user-old" }),
+      refreshToken: "refresh",
+      serverUrl: "https://first-tree.example",
+    });
+    coreMocks.readActiveRootClientId.mockReturnValue("client-1");
+
+    const { runLogout } = await import("../commands/logout.js");
+    await runLogout({ purge: false });
+
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "Stopped launchd service (warning: best effort failed)",
+    );
+
+    printLineMock.mockClear();
+    writeFileSync(credentials, "{}");
+    writeFileSync(clientYaml, "client:\n  id: client-1\n");
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({ state: "unknown", platform: "launchd" });
+    await expect(runLogout({ purge: true, retireServerClient: true })).rejects.toMatchObject({
+      code: "PURGE_DAEMON_STATE_UNKNOWN",
+      exitCode: 1,
+    });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("first-tree-dev logout --purge");
+
+    printLineMock.mockClear();
+    coreMocks.isServiceSupported.mockReturnValue(false);
+    cliFetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: vi.fn(async () => ""),
+    } as unknown as Response);
+    await expect(runLogout({ purge: true, retireServerClient: true })).rejects.toMatchObject({
+      code: "PURGE_CLIENT_RETIRE_FAILED",
+      exitCode: 1,
+    });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "server-side client retire failed (HTTP 500)",
+    );
   });
 
   it("computer reset uses the same guarded local-state removal without server retire", async () => {

--- a/apps/cli/src/__tests__/agent-prune.test.ts
+++ b/apps/cli/src/__tests__/agent-prune.test.ts
@@ -1,8 +1,8 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { findStaleAliases, type PinnedAgent } from "../core/agent-prune.js";
+import { findStaleAliases, formatStaleReason, type PinnedAgent, removeLocalAgent } from "../core/agent-prune.js";
 
 /**
  * Pins the four cases that drove the rewrite:
@@ -26,6 +26,7 @@ function writeAlias(agentsDir: string, name: string, body: string): void {
 }
 
 let agentsDir: string;
+const originalHome = process.env.FIRST_TREE_HOME;
 
 beforeEach(() => {
   agentsDir = mkdtempSync(join(tmpdir(), "fthub-prune-"));
@@ -33,6 +34,8 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(agentsDir, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.FIRST_TREE_HOME;
+  else process.env.FIRST_TREE_HOME = originalHome;
 });
 
 describe("findStaleAliases", () => {
@@ -153,5 +156,41 @@ describe("findStaleAliases", () => {
       listPinnedAgents: async () => [],
     });
     expect(stale).toEqual([]);
+  });
+
+  it("ignores entries that vanish before stat", async (ctx) => {
+    try {
+      symlinkSync(join(agentsDir, "missing"), join(agentsDir, "broken-link"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    const stale = await findStaleAliases({
+      agentsDir,
+      clientId: THIS_CLIENT,
+      listPinnedAgents: async () => [],
+    });
+
+    expect(stale).toEqual([]);
+  });
+
+  it("formats stale reasons and removes local agent footprints", () => {
+    const home = mkdtempSync(join(tmpdir(), "fthub-prune-home-"));
+    process.env.FIRST_TREE_HOME = home;
+    mkdirSync(join(home, "config", "agents", "stale"), { recursive: true });
+    mkdirSync(join(home, "data", "workspaces", "stale"), { recursive: true });
+    mkdirSync(join(home, "data", "sessions"), { recursive: true });
+    writeFileSync(join(home, "data", "sessions", "stale.json"), "{}");
+
+    expect(formatStaleReason({ kind: "unreadable", error: "bad yaml" })).toBe("unreadable: bad yaml");
+    expect(formatStaleReason({ kind: "unowned" })).toContain("no longer owned");
+    expect(formatStaleReason({ kind: "pinned-elsewhere", clientId: OTHER_CLIENT })).toContain(OTHER_CLIENT);
+
+    removeLocalAgent("stale");
+
+    expect(existsSync(join(home, "config", "agents", "stale"))).toBe(false);
+    expect(existsSync(join(home, "data", "workspaces", "stale"))).toBe(false);
+    expect(existsSync(join(home, "data", "sessions", "stale.json"))).toBe(false);
+    rmSync(home, { recursive: true, force: true });
   });
 });

--- a/apps/cli/src/__tests__/agent-shared-helpers-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-shared-helpers-extra.test.ts
@@ -216,6 +216,14 @@ describe("local agent shared helpers", () => {
       expect.stringContaining("Use --agent."),
       2,
     );
+    process.env.FIRST_TREE_AGENT_ID = "missing";
+    configMocks.loadAgents.mockReturnValueOnce(new Map([["nova", { agentId: "agent-1" }]]));
+    expect(() => resolveLocalAgent()).toThrow();
+    expect(outputMocks.fail).toHaveBeenLastCalledWith(
+      "ENV_AGENT_NOT_LOCAL",
+      expect.stringContaining("Pick one explicitly with `--agent <senderName>`."),
+      2,
+    );
 
     delete process.env.FIRST_TREE_AGENT_ID;
     configMocks.loadAgents.mockReturnValueOnce(
@@ -226,6 +234,26 @@ describe("local agent shared helpers", () => {
     );
     expect(() => resolveLocalAgent(undefined, { ambiguous: "Pick one." })).toThrow();
     expect(outputMocks.fail).toHaveBeenLastCalledWith("AMBIGUOUS_AGENT", expect.stringContaining("Pick one."), 2);
+    configMocks.loadAgents.mockReturnValueOnce(
+      new Map([
+        ["nova", { agentId: "agent-1" }],
+        ["mira", { agentId: "agent-2" }],
+      ]),
+    );
+    expect(() => resolveLocalAgent()).toThrow();
+    expect(outputMocks.fail).toHaveBeenLastCalledWith(
+      "AMBIGUOUS_AGENT",
+      expect.stringContaining("Specify it explicitly with `--agent <senderName>`."),
+      2,
+    );
+
+    configMocks.loadAgents.mockReturnValueOnce(new Map([["nova", { agentId: "agent-1" }]]));
+    expect(() => resolveLocalAgent("missing")).toThrow();
+    expect(outputMocks.fail).toHaveBeenLastCalledWith(
+      "UNKNOWN_AGENT",
+      'Agent "missing" not found in /tmp/first-tree-config/agents',
+      2,
+    );
 
     configMocks.loadAgents.mockReturnValueOnce(new Map([["nova", { agentId: "agent-1" }]]));
     bootstrapMocks.resolveServerUrl.mockImplementationOnce(() => {
@@ -233,6 +261,13 @@ describe("local agent shared helpers", () => {
     });
     expect(() => resolveLocalAgent()).toThrow();
     expect(outputMocks.fail).toHaveBeenLastCalledWith("MISSING_SERVER_URL", "missing server", 2);
+
+    configMocks.loadAgents.mockReturnValueOnce(new Map([["nova", { agentId: "agent-1" }]]));
+    bootstrapMocks.resolveServerUrl.mockImplementationOnce(() => {
+      throw "missing server string";
+    });
+    expect(() => resolveLocalAgent()).toThrow();
+    expect(outputMocks.fail).toHaveBeenLastCalledWith("MISSING_SERVER_URL", "missing server string", 2);
 
     configMocks.resolveConfigReadonly.mockReturnValueOnce({ client: {} });
     expect(() => readClientId()).toThrow();
@@ -257,5 +292,8 @@ describe("local agent shared helpers", () => {
 
     expect(() => handleSdkError("boom")).toThrow();
     expect(outputMocks.fail).toHaveBeenLastCalledWith("UNKNOWN_ERROR", "boom", 1);
+
+    expect(() => handleSdkError(new Error("plain error"))).toThrow();
+    expect(outputMocks.fail).toHaveBeenLastCalledWith("UNKNOWN_ERROR", "plain error", 1);
   });
 });

--- a/apps/cli/src/__tests__/agent-status-command.test.ts
+++ b/apps/cli/src/__tests__/agent-status-command.test.ts
@@ -154,6 +154,72 @@ describe("agent status command", () => {
     expect(output()).toContain('Agent "missing-agent" is not running');
   });
 
+  it("skips failed org activity responses and renders nullable runtime fields", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ memberships: [{ organizationId: "org-a" }, { organizationId: "org-b" }] }))
+      .mockResolvedValueOnce(jsonResponse("down", false, 503))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          total: 1,
+          running: 1,
+          byState: { idle: 0, working: 0, blocked: 1, error: 0 },
+          clients: 1,
+          agents: [
+            {
+              agentId: "agent-nullable",
+              clientId: null,
+              runtimeType: null,
+              runtimeState: null,
+              activeSessions: 3,
+              totalSessions: null,
+            },
+            {
+              agentId: null,
+              clientId: null,
+              runtimeType: null,
+              runtimeState: null,
+              activeSessions: null,
+              totalSessions: null,
+            },
+          ],
+        }),
+      );
+
+    await runStatus();
+
+    expect(output()).toContain("agent-nullable");
+    expect(output()).toContain("3/0");
+    expect(output()).toContain("—");
+
+    printLineMock.mockClear();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ memberships: [{ organizationId: "org-a" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          total: 1,
+          running: 1,
+          byState: { idle: 0, working: 0, blocked: 1, error: 0 },
+          clients: 1,
+          agents: [
+            {
+              agentId: "agent-nullable",
+              clientId: null,
+              runtimeType: null,
+              runtimeState: null,
+              activeSessions: 3,
+              totalSessions: null,
+            },
+          ],
+        }),
+      );
+
+    await runStatus(["agent-nullable"]);
+
+    expect(output()).toContain("Runtime: —");
+    expect(output()).toContain("State: —");
+    expect(output()).toContain("Sessions: 3 active / 0 total");
+  });
+
   it("maps /me failures and unexpected errors to clean CLI failures", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse("nope", false, 503));
 
@@ -167,5 +233,11 @@ describe("agent status command", () => {
 
     await expect(runStatus()).rejects.toMatchObject({ code: "STATUS_ERROR" });
     expect(failMock).toHaveBeenCalledWith("STATUS_ERROR", "credentials missing");
+
+    failMock.mockClear();
+    bootstrapMocks.ensureFreshAccessToken.mockRejectedValueOnce("credentials string");
+
+    await expect(runStatus()).rejects.toMatchObject({ code: "STATUS_ERROR" });
+    expect(failMock).toHaveBeenCalledWith("STATUS_ERROR", "credentials string");
   });
 });

--- a/apps/cli/src/__tests__/agent-status-command.test.ts
+++ b/apps/cli/src/__tests__/agent-status-command.test.ts
@@ -192,26 +192,24 @@ describe("agent status command", () => {
     expect(output()).toContain("—");
 
     printLineMock.mockClear();
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse({ memberships: [{ organizationId: "org-a" }] }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          total: 1,
-          running: 1,
-          byState: { idle: 0, working: 0, blocked: 1, error: 0 },
-          clients: 1,
-          agents: [
-            {
-              agentId: "agent-nullable",
-              clientId: null,
-              runtimeType: null,
-              runtimeState: null,
-              activeSessions: 3,
-              totalSessions: null,
-            },
-          ],
-        }),
-      );
+    fetchMock.mockResolvedValueOnce(jsonResponse({ memberships: [{ organizationId: "org-a" }] })).mockResolvedValueOnce(
+      jsonResponse({
+        total: 1,
+        running: 1,
+        byState: { idle: 0, working: 0, blocked: 1, error: 0 },
+        clients: 1,
+        agents: [
+          {
+            agentId: "agent-nullable",
+            clientId: null,
+            runtimeType: null,
+            runtimeState: null,
+            activeSessions: 3,
+            totalSessions: null,
+          },
+        ],
+      }),
+    );
 
     await runStatus(["agent-nullable"]);
 

--- a/apps/cli/src/__tests__/capability-refresh.test.ts
+++ b/apps/cli/src/__tests__/capability-refresh.test.ts
@@ -432,10 +432,7 @@ describe("CapabilityRefresher", () => {
 
     await refresher.start();
     await vi.advanceTimersByTimeAsync(0);
-    expect(log).toHaveBeenCalledWith(
-      "⚠️",
-      expect.stringContaining("startup capability re-probe skipped after"),
-    );
+    expect(log).toHaveBeenCalledWith("⚠️", expect.stringContaining("startup capability re-probe skipped after"));
     expect(log.mock.calls.map((call) => String(call[1])).join("\n")).toContain("provider crashed");
 
     await vi.advanceTimersByTimeAsync(BASE * 2);

--- a/apps/cli/src/__tests__/capability-refresh.test.ts
+++ b/apps/cli/src/__tests__/capability-refresh.test.ts
@@ -82,6 +82,7 @@ const MAX = 400;
 describe("stableCapabilitySyncJson", () => {
   it("sorts object keys while preserving array order in stable JSON", () => {
     expect(stableCapabilitiesJson({ z: [{ b: 2, a: 1 }], a: true })).toBe('{"a":true,"z":[{"a":1,"b":2}]}');
+    expect(stableCapabilitiesJson(undefined)).toBe("null");
   });
 
   it("ignores volatile probe metadata", () => {
@@ -393,6 +394,19 @@ describe("CapabilityRefresher", () => {
     expect(revalidate).not.toHaveBeenCalled();
   });
 
+  it("ignores reconnects and later provider updates after stop", async () => {
+    const { refresher, revalidate, reprobe } = makeRefresher({ initial: codexMissing() });
+    await refresher.start();
+    refresher.stop();
+
+    refresher.onReconnect();
+    await refresher.setProviderEntry("codex", missing({ error: "still missing" }));
+    await vi.advanceTimersByTimeAsync(MAX * 4);
+
+    expect(reprobe).not.toHaveBeenCalled();
+    expect(revalidate).not.toHaveBeenCalled();
+  });
+
   it("starts an immediate background full probe when no startup snapshot exists", async () => {
     const gate = deferred<{ capabilities: ClientCapabilities; mode: "full" | "revalidate" }>();
     const { refresher, upload, log, reprobe, revalidate } = makeRefresher({ initial: null });
@@ -408,6 +422,24 @@ describe("CapabilityRefresher", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(upload).toHaveBeenCalledWith(allOk());
     expect(log).toHaveBeenCalledWith("•", expect.stringContaining("runtime capabilities re-probed (startup, full)"));
+    refresher.stop();
+  });
+
+  it("keeps polling after a startup probe fails before any snapshot exists", async () => {
+    const { refresher, log, reprobe, revalidate } = makeRefresher({ initial: null });
+    reprobe.mockRejectedValueOnce("provider crashed");
+    revalidate.mockResolvedValueOnce(allOk());
+
+    await refresher.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(log).toHaveBeenCalledWith(
+      "⚠️",
+      expect.stringContaining("startup capability re-probe skipped after"),
+    );
+    expect(log.mock.calls.map((call) => String(call[1])).join("\n")).toContain("provider crashed");
+
+    await vi.advanceTimersByTimeAsync(BASE * 2);
+    expect(revalidate).toHaveBeenCalledTimes(1);
     refresher.stop();
   });
 

--- a/apps/cli/src/__tests__/capability-refresh.test.ts
+++ b/apps/cli/src/__tests__/capability-refresh.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CapabilityRefresher,
   type CapabilityRefresherDeps,
+  stableCapabilitiesJson,
   stableCapabilitySyncJson,
 } from "../core/capability-refresh.js";
 
@@ -79,6 +80,10 @@ const BASE = 100;
 const MAX = 400;
 
 describe("stableCapabilitySyncJson", () => {
+  it("sorts object keys while preserving array order in stable JSON", () => {
+    expect(stableCapabilitiesJson({ z: [{ b: 2, a: 1 }], a: true })).toBe('{"a":true,"z":[{"a":1,"b":2}]}');
+  });
+
   it("ignores volatile probe metadata", () => {
     expect(
       stableCapabilitySyncJson({
@@ -162,6 +167,18 @@ describe("CapabilityRefresher", () => {
     expect(refresher.currentEntry("codex")?.pendingAuth).toBeDefined();
     // …and the unchanged snapshot is NOT re-uploaded (no panel flicker).
     expect(upload).toHaveBeenCalledTimes(1);
+    refresher.stop();
+  });
+
+  it("logs setProviderEntry upload failures and keeps polling", async () => {
+    const { refresher, upload, log, revalidate } = makeRefresher({ initial: codexMissing() });
+    upload.mockRejectedValueOnce(new Error("PATCH failed"));
+
+    await refresher.setProviderEntry("codex", codexPending());
+
+    expect(log).toHaveBeenCalledWith("⚠️", expect.stringContaining("capabilities upload skipped"));
+    await vi.advanceTimersByTimeAsync(BASE);
+    expect(revalidate).toHaveBeenCalledTimes(1);
     refresher.stop();
   });
 
@@ -326,6 +343,19 @@ describe("CapabilityRefresher", () => {
 
     await vi.advanceTimersByTimeAsync(MAX * 4);
     expect(revalidate).toHaveBeenCalledTimes(2); // healthy + synced → no more polls
+    refresher.stop();
+  });
+
+  it("logs transient probe failures and retries the background poll", async () => {
+    const { refresher, log, revalidate } = makeRefresher({ initial: codexMissing() });
+    revalidate.mockRejectedValueOnce(new Error("provider crashed")).mockResolvedValueOnce(codexMissing());
+
+    await refresher.start();
+    await vi.advanceTimersByTimeAsync(BASE);
+
+    expect(log).toHaveBeenCalledWith("⚠️", expect.stringContaining("poll capability re-probe skipped"));
+    await vi.advanceTimersByTimeAsync(BASE * 2);
+    expect(revalidate).toHaveBeenCalledTimes(2);
     refresher.stop();
   });
 

--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -159,6 +159,51 @@ describe("chat command behavior", () => {
     await expect(runChat(["send", "nova"])).rejects.toMatchObject({ code: "NO_MESSAGE", exitCode: 2 });
   });
 
+  it("chat send merges captured metadata without caller metadata and continues through defensive fail fallbacks", async () => {
+    const sdk = localAgentMocks.createSdk();
+
+    docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({
+      content: "attachment only",
+      attachments: [{ kind: "doc", id: "doc-attachment" }],
+    });
+    await runChat(["send", "nova", "attachment only"]);
+    expect(sdk.sendMessage).toHaveBeenLastCalledWith(
+      "chat-env",
+      expect.objectContaining({
+        metadata: { attachments: [{ kind: "doc", id: "doc-attachment" }] },
+      }),
+    );
+
+    docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({
+      content: "context only",
+      documentContext: [{ path: "docs/context.md", content: "Context" }],
+    });
+    await runChat(["send", "nova", "context only"]);
+    expect(sdk.sendMessage).toHaveBeenLastCalledWith(
+      "chat-env",
+      expect.objectContaining({
+        metadata: { documentContext: [{ path: "docs/context.md", content: "Context" }] },
+      }),
+    );
+
+    outputMocks.fail.mockImplementationOnce(() => undefined as never);
+    await runChat(["send"]);
+    expect(sdk.sendMessage).toHaveBeenLastCalledWith(
+      "chat-env",
+      expect.objectContaining({ content: "stdin message", source: "cli" }),
+    );
+    expect(sdk.sendMessage).toHaveBeenLastCalledWith(
+      "chat-env",
+      expect.not.objectContaining({ receiverNames: expect.any(Array) }),
+    );
+
+    outputMocks.fail.mockImplementationOnce(() => undefined as never);
+    ioMocks.readStdin.mockResolvedValueOnce(null);
+    docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({ content: "" });
+    await runChat(["send", "nova"]);
+    expect(docCaptureMock.captureOutboundDocs).toHaveBeenCalledWith("", expect.objectContaining({ chatId: "chat-env" }));
+  });
+
   it("chat ask sends an open question with the body as the ask and JSON --options", async () => {
     const sdk = localAgentMocks.createSdk();
     await runChat([
@@ -315,6 +360,58 @@ describe("chat command behavior", () => {
     );
   });
 
+  it("chat ask merges attachment and document capture metadata without caller metadata", async () => {
+    const sdk = localAgentMocks.createSdk();
+
+    docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({
+      content: "attachment only",
+      attachments: [{ kind: "doc", id: "doc-attachment" }],
+    });
+    await runChat(["ask", "nova", "attachment only"]);
+    expect(sdk.sendMessage).toHaveBeenLastCalledWith(
+      "chat-env",
+      expect.objectContaining({
+        metadata: { request: {}, attachments: [{ kind: "doc", id: "doc-attachment" }] },
+      }),
+    );
+
+    docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({
+      content: "context only",
+      documentContext: [{ path: "docs/context.md", content: "Context" }],
+    });
+    await runChat(["ask", "nova", "context only"]);
+    expect(sdk.sendMessage).toHaveBeenLastCalledWith(
+      "chat-env",
+      expect.objectContaining({
+        metadata: { request: {}, documentContext: [{ path: "docs/context.md", content: "Context" }] },
+      }),
+    );
+  });
+
+  it("chat ask continues through defensive non-throwing fail fallbacks", async () => {
+    const sdk = localAgentMocks.createSdk();
+    outputMocks.fail.mockImplementationOnce(() => undefined as never);
+
+    await runChat(["ask"]);
+
+    expect(sdk.sendMessage).toHaveBeenLastCalledWith(
+      "chat-env",
+      expect.objectContaining({ content: "stdin message", source: "cli" }),
+    );
+    expect(sdk.sendMessage).toHaveBeenLastCalledWith(
+      "chat-env",
+      expect.not.objectContaining({ receiverNames: expect.any(Array) }),
+    );
+
+    outputMocks.fail.mockImplementationOnce(() => undefined as never);
+    ioMocks.readStdin.mockResolvedValueOnce(null);
+    docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({ content: "" });
+
+    await runChat(["ask", "nova"]);
+
+    expect(docCaptureMock.captureOutboundDocs).toHaveBeenCalledWith("", expect.objectContaining({ chatId: "chat-env" }));
+  });
+
   it("chat ask is ask-only: it accepts neither --answer nor --reply-to", async () => {
     // The agent can only ASK; the human resolves in the web UI. `--answer`
     // (resolve) and `--reply-to` (thread) were both removed, so each is an
@@ -439,6 +536,25 @@ describe("chat command behavior", () => {
     });
   });
 
+  it("creates task chats with attachment-only doc capture metadata", async () => {
+    docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({
+      content: "see attached notes",
+      attachments: [{ id: "att-1", kind: "document" }],
+    });
+    const sdk = localAgentMocks.createSdk();
+
+    await runChat(["create", "see attached notes", "--to", "nova"]);
+
+    expect(sdk.createTaskChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextParticipantNames: [],
+        initialMessage: expect.objectContaining({
+          metadata: { attachments: [{ id: "att-1", kind: "document" }] },
+        }),
+      }),
+    );
+  });
+
   it("validates chat create input and treats uncertain create outcomes as non-retryable", async () => {
     const sdk = localAgentMocks.createSdk();
 
@@ -476,6 +592,26 @@ describe("chat command behavior", () => {
       code: "CREATE_RESULT_UNKNOWN",
       exitCode: 6,
     });
+
+    const abortError = new Error("request aborted");
+    abortError.name = "AbortError";
+    sdk.createTaskChat.mockRejectedValueOnce(abortError);
+    await expect(runChat(["create", "body", "--to", "nova"])).rejects.toMatchObject({
+      code: "CREATE_RESULT_UNKNOWN",
+      exitCode: 6,
+    });
+
+    const nestedTimeout = new Error("wrapped timeout");
+    Object.assign(nestedTimeout, { cause: { name: "TimeoutError" } });
+    sdk.createTaskChat.mockRejectedValueOnce(nestedTimeout);
+    await expect(runChat(["create", "body", "--to", "nova"])).rejects.toMatchObject({
+      code: "CREATE_RESULT_UNKNOWN",
+      exitCode: 6,
+    });
+
+    sdk.createTaskChat.mockRejectedValueOnce("plain sdk failure");
+    await expect(runChat(["create", "body", "--to", "nova"])).rejects.toBe("plain sdk failure");
+    expect(localAgentMocks.handleSdkError).toHaveBeenCalledWith("plain sdk failure");
 
     const certainError = new Error("validation failed");
     Object.assign(certainError, { cause: { code: "EINVAL" } });
@@ -735,5 +871,109 @@ describe("chat command behavior", () => {
 
     expect(() => emitter.emit("close")).toThrow("process.exit");
     expect(globalThis.clearInterval).toHaveBeenCalledWith(99);
+  });
+
+  it("chat open uses agent id fallbacks and ignores failed polling responses", async () => {
+    resolveAgentMock.mockResolvedValueOnce({ uuid: "agent-fallback" });
+    const emitter = new EventEmitter() as EventEmitter & { prompt: () => void };
+    emitter.prompt = vi.fn();
+    readlineMocks.createInterface.mockReturnValue(emitter);
+    let intervalCallback: (() => void) | undefined;
+    globalThis.setInterval = vi.fn((callback: () => void) => {
+      intervalCallback = callback;
+      return 100 as unknown as NodeJS.Timeout;
+    }) as unknown as typeof setInterval;
+    globalThis.clearInterval = vi.fn() as unknown as typeof clearInterval;
+    cliFetchMock
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-fallback" }))
+      .mockResolvedValueOnce(jsonResponse({ items: [{ id: "old", senderId: "agent-fallback", content: "old", createdAt: "1" }] }))
+      .mockResolvedValueOnce(jsonResponse("poll failed", false, 502));
+
+    await runChat(["open", "fallback"]);
+    intervalCallback?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const output = printLineMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("Chat with agent-fallback");
+
+    cliFetchMock.mockRejectedValueOnce("send string failure");
+    emitter.emit("line", "hello");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("send string failure");
+
+    expect(() => emitter.emit("close")).toThrow("process.exit");
+    expect(globalThis.clearInterval).toHaveBeenCalledWith(100);
+  });
+
+  it("chat open prints short string previews with name and generic sender fallbacks", async () => {
+    const namedEmitter = new EventEmitter() as EventEmitter & { prompt: () => void };
+    namedEmitter.prompt = vi.fn();
+    readlineMocks.createInterface.mockReturnValueOnce(namedEmitter);
+    let namedInterval: (() => void) | undefined;
+    globalThis.setInterval = vi.fn((callback: () => void) => {
+      namedInterval = callback;
+      return 101 as unknown as NodeJS.Timeout;
+    }) as unknown as typeof setInterval;
+    globalThis.clearInterval = vi.fn() as unknown as typeof clearInterval;
+    resolveAgentMock.mockResolvedValueOnce({ uuid: "agent-named", name: "NamedOnly" });
+    cliFetchMock
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-named" }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: "old", senderId: "agent-named", content: "old", createdAt: "2026-06-01T00:00:00.000Z" }],
+        }),
+      );
+
+    await runChat(["open", "named"]);
+    cliFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [{ id: "new", senderId: "agent-named", content: "short reply", createdAt: "2026-06-01T00:00:02.000Z" }],
+      }),
+    );
+    namedInterval?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("[NamedOnly] short reply");
+    expect(() => namedEmitter.emit("close")).toThrow("process.exit");
+
+    const genericEmitter = new EventEmitter() as EventEmitter & { prompt: () => void };
+    genericEmitter.prompt = vi.fn();
+    readlineMocks.createInterface.mockReturnValueOnce(genericEmitter);
+    let genericInterval: (() => void) | undefined;
+    globalThis.setInterval = vi.fn((callback: () => void) => {
+      genericInterval = callback;
+      return 102 as unknown as NodeJS.Timeout;
+    }) as unknown as typeof setInterval;
+    resolveAgentMock.mockResolvedValueOnce({ uuid: "agent-generic" });
+    cliFetchMock
+      .mockResolvedValueOnce(jsonResponse({ id: "dm-generic" }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          items: [{ id: "old", senderId: "agent-generic", content: "old", createdAt: "2026-06-01T00:00:00.000Z" }],
+        }),
+      );
+
+    await runChat(["open", "generic"]);
+    cliFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          { id: "new", senderId: "agent-generic", content: { text: "short object" }, createdAt: "2026-06-01T00:00:02.000Z" },
+        ],
+      }),
+    );
+    genericInterval?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain('[agent] {"text":"short object"}');
+    expect(() => genericEmitter.emit("close")).toThrow("process.exit");
+  });
+
+  it("chat open reports non-Error top-level failures", async () => {
+    resolveAgentMock.mockRejectedValueOnce("agent lookup failed");
+
+    await expect(runChat(["open", "nova"])).rejects.toMatchObject({ code: "CHAT_ERROR" });
+    expect(outputMocks.fail).toHaveBeenCalledWith("CHAT_ERROR", "agent lookup failed");
   });
 });

--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -201,7 +201,10 @@ describe("chat command behavior", () => {
     ioMocks.readStdin.mockResolvedValueOnce(null);
     docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({ content: "" });
     await runChat(["send", "nova"]);
-    expect(docCaptureMock.captureOutboundDocs).toHaveBeenCalledWith("", expect.objectContaining({ chatId: "chat-env" }));
+    expect(docCaptureMock.captureOutboundDocs).toHaveBeenCalledWith(
+      "",
+      expect.objectContaining({ chatId: "chat-env" }),
+    );
   });
 
   it("chat ask sends an open question with the body as the ask and JSON --options", async () => {
@@ -409,7 +412,10 @@ describe("chat command behavior", () => {
 
     await runChat(["ask", "nova"]);
 
-    expect(docCaptureMock.captureOutboundDocs).toHaveBeenCalledWith("", expect.objectContaining({ chatId: "chat-env" }));
+    expect(docCaptureMock.captureOutboundDocs).toHaveBeenCalledWith(
+      "",
+      expect.objectContaining({ chatId: "chat-env" }),
+    );
   });
 
   it("chat ask is ask-only: it accepts neither --answer nor --reply-to", async () => {
@@ -886,7 +892,9 @@ describe("chat command behavior", () => {
     globalThis.clearInterval = vi.fn() as unknown as typeof clearInterval;
     cliFetchMock
       .mockResolvedValueOnce(jsonResponse({ id: "dm-fallback" }))
-      .mockResolvedValueOnce(jsonResponse({ items: [{ id: "old", senderId: "agent-fallback", content: "old", createdAt: "1" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ id: "old", senderId: "agent-fallback", content: "old", createdAt: "1" }] }),
+      )
       .mockResolvedValueOnce(jsonResponse("poll failed", false, 502));
 
     await runChat(["open", "fallback"]);
@@ -918,13 +926,11 @@ describe("chat command behavior", () => {
     }) as unknown as typeof setInterval;
     globalThis.clearInterval = vi.fn() as unknown as typeof clearInterval;
     resolveAgentMock.mockResolvedValueOnce({ uuid: "agent-named", name: "NamedOnly" });
-    cliFetchMock
-      .mockResolvedValueOnce(jsonResponse({ id: "dm-named" }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          items: [{ id: "old", senderId: "agent-named", content: "old", createdAt: "2026-06-01T00:00:00.000Z" }],
-        }),
-      );
+    cliFetchMock.mockResolvedValueOnce(jsonResponse({ id: "dm-named" })).mockResolvedValueOnce(
+      jsonResponse({
+        items: [{ id: "old", senderId: "agent-named", content: "old", createdAt: "2026-06-01T00:00:00.000Z" }],
+      }),
+    );
 
     await runChat(["open", "named"]);
     cliFetchMock.mockResolvedValueOnce(
@@ -947,26 +953,31 @@ describe("chat command behavior", () => {
       return 102 as unknown as NodeJS.Timeout;
     }) as unknown as typeof setInterval;
     resolveAgentMock.mockResolvedValueOnce({ uuid: "agent-generic" });
-    cliFetchMock
-      .mockResolvedValueOnce(jsonResponse({ id: "dm-generic" }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          items: [{ id: "old", senderId: "agent-generic", content: "old", createdAt: "2026-06-01T00:00:00.000Z" }],
-        }),
-      );
+    cliFetchMock.mockResolvedValueOnce(jsonResponse({ id: "dm-generic" })).mockResolvedValueOnce(
+      jsonResponse({
+        items: [{ id: "old", senderId: "agent-generic", content: "old", createdAt: "2026-06-01T00:00:00.000Z" }],
+      }),
+    );
 
     await runChat(["open", "generic"]);
     cliFetchMock.mockResolvedValueOnce(
       jsonResponse({
         items: [
-          { id: "new", senderId: "agent-generic", content: { text: "short object" }, createdAt: "2026-06-01T00:00:02.000Z" },
+          {
+            id: "new",
+            senderId: "agent-generic",
+            content: { text: "short object" },
+            createdAt: "2026-06-01T00:00:02.000Z",
+          },
         ],
       }),
     );
     genericInterval?.();
     await Promise.resolve();
     await Promise.resolve();
-    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain('[agent] {"text":"short object"}');
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      '[agent] {"text":"short object"}',
+    );
     expect(() => genericEmitter.emit("close")).toThrow("process.exit");
   });
 

--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -144,6 +144,12 @@ describe("chat command behavior", () => {
     await expect(runChat(["send", "nova", "hello"])).rejects.toMatchObject({ code: "NO_CHAT_CONTEXT", exitCode: 2 });
 
     process.env.FIRST_TREE_CHAT_ID = "chat-env";
+    await expect(runChat(["send"])).rejects.toMatchObject({ code: "NO_TARGET", exitCode: 2 });
+    await expect(runChat(["send", "nova", "hello", "--message-file", "-"])).rejects.toMatchObject({
+      code: "CONFLICTING_ARGS",
+      exitCode: 2,
+    });
+
     await expect(runChat(["send", "nova", "hello", "--metadata", "{bad"])).rejects.toMatchObject({
       code: "INVALID_METADATA",
       exitCode: 2,
@@ -267,6 +273,46 @@ describe("chat command behavior", () => {
       code: "MULTISELECT_NEEDS_OPTIONS",
       exitCode: 2,
     });
+  });
+
+  it("chat ask validates context, target, body source, escaped newlines, metadata, and doc capture metadata", async () => {
+    const sdk = localAgentMocks.createSdk();
+
+    delete process.env.FIRST_TREE_CHAT_ID;
+    await expect(runChat(["ask", "nova", "body"])).rejects.toMatchObject({ code: "NO_CHAT_CONTEXT", exitCode: 2 });
+
+    process.env.FIRST_TREE_CHAT_ID = "chat-env";
+    await expect(runChat(["ask"])).rejects.toMatchObject({ code: "NO_TARGET", exitCode: 2 });
+    await expect(runChat(["ask", "nova", "inline", "--message-file", "body.md"])).rejects.toMatchObject({
+      code: "CONFLICTING_ARGS",
+      exitCode: 2,
+    });
+    await expect(runChat(["ask", "nova", "line1\\n\\nline2"])).rejects.toMatchObject({
+      code: "ESCAPED_NEWLINES",
+      exitCode: 2,
+    });
+    await expect(runChat(["ask", "nova", "body", "--metadata", "{bad"])).rejects.toMatchObject({
+      code: "INVALID_METADATA",
+      exitCode: 2,
+    });
+
+    docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({
+      content: "body with docs",
+      attachments: [{ kind: "doc", id: "doc-1" }],
+      documentContext: [{ path: "docs/plan.md", content: "Plan" }],
+    });
+    await runChat(["ask", "nova", "body with docs", "--metadata", '{"priority":1}']);
+    expect(sdk.sendMessage).toHaveBeenLastCalledWith(
+      "chat-env",
+      expect.objectContaining({
+        content: "body with docs",
+        metadata: expect.objectContaining({
+          priority: 1,
+          attachments: [{ kind: "doc", id: "doc-1" }],
+          documentContext: [{ path: "docs/plan.md", content: "Plan" }],
+        }),
+      }),
+    );
   });
 
   it("chat ask is ask-only: it accepts neither --answer nor --reply-to", async () => {
@@ -414,6 +460,28 @@ describe("chat command behavior", () => {
       exitCode: 6,
     });
     expect(sdk.createTaskChat).toHaveBeenCalledTimes(1);
+
+    const nestedNetworkError = new TypeError("fetch failed");
+    Object.assign(nestedNetworkError, { cause: { cause: { code: "ECONNRESET" } } });
+    sdk.createTaskChat.mockRejectedValueOnce(nestedNetworkError);
+    await expect(runChat(["create", "body", "--to", "nova"])).rejects.toMatchObject({
+      code: "CREATE_RESULT_UNKNOWN",
+      exitCode: 6,
+    });
+
+    const nestedPlainError = new Error("socket failed");
+    Object.assign(nestedPlainError, { cause: { name: "Wrapper", cause: { code: "UND_ERR_SOCKET" } } });
+    sdk.createTaskChat.mockRejectedValueOnce(nestedPlainError);
+    await expect(runChat(["create", "body", "--to", "nova"])).rejects.toMatchObject({
+      code: "CREATE_RESULT_UNKNOWN",
+      exitCode: 6,
+    });
+
+    const certainError = new Error("validation failed");
+    Object.assign(certainError, { cause: { code: "EINVAL" } });
+    sdk.createTaskChat.mockRejectedValueOnce(certainError);
+    await expect(runChat(["create", "body", "--to", "nova"])).rejects.toThrow("validation failed");
+    expect(localAgentMocks.handleSdkError).toHaveBeenCalledWith(certainError);
   });
 
   it("sets, clears, and validates chat topics", async () => {
@@ -455,11 +523,28 @@ describe("chat command behavior", () => {
       code: "CONFLICTING_ARGS",
       exitCode: 2,
     });
+    ioMocks.readStdin.mockResolvedValueOnce(null);
+    await expect(runChat(["set-topic", "--description", "-"])).rejects.toMatchObject({
+      code: "NO_STDIN",
+      exitCode: 2,
+    });
     await expect(runChat(["set-topic", "--description", "   "])).rejects.toMatchObject({
       code: "EMPTY_DESCRIPTION",
       exitCode: 2,
     });
     await expect(runChat(["set-topic"])).rejects.toMatchObject({ code: "NOTHING_TO_UPDATE", exitCode: 2 });
+  });
+
+  it("delegates chat history SDK failures to the shared handler", async () => {
+    const error = new Error("history failed");
+    localAgentMocks.createSdk.mockReturnValueOnce({
+      listMessages: vi.fn(async () => {
+        throw error;
+      }),
+    });
+
+    await expect(runChat(["history", "chat-1"])).rejects.toBe(error);
+    expect(localAgentMocks.handleSdkError).toHaveBeenCalledWith(error);
   });
 
   it("updates topic and description independently via `chat update`", async () => {
@@ -596,5 +681,59 @@ describe("chat command behavior", () => {
     emitter.emit("line", "   ");
     expect(() => emitter.emit("close")).toThrow("process.exit");
     expect(globalThis.clearInterval).toHaveBeenCalledWith(42);
+  });
+
+  it("chat open handles DM creation failures, polling updates, and send exceptions", async () => {
+    cliFetchMock.mockResolvedValueOnce(jsonResponse("denied", false, 403));
+    await expect(runChat(["open", "nova"])).rejects.toMatchObject({ code: "CHAT_ERROR" });
+
+    const emitter = new EventEmitter() as EventEmitter & { prompt: () => void };
+    emitter.prompt = vi.fn();
+    readlineMocks.createInterface.mockReturnValue(emitter);
+    let intervalCallback: (() => void) | undefined;
+    globalThis.setInterval = vi.fn((callback: () => void) => {
+      intervalCallback = callback;
+      return 99 as unknown as NodeJS.Timeout;
+    }) as unknown as typeof setInterval;
+    globalThis.clearInterval = vi.fn() as unknown as typeof clearInterval;
+    cliFetchMock.mockResolvedValueOnce(jsonResponse({ id: "dm-2" })).mockResolvedValueOnce(
+      jsonResponse({
+        items: [{ id: "old", senderId: "agent-1", content: "old", createdAt: "2026-06-01T00:00:00.000Z" }],
+      }),
+    );
+
+    await runChat(["open", "nova"]);
+    cliFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        items: [
+          {
+            id: "new",
+            senderId: "agent-1",
+            content: { card: "x".repeat(520) },
+            createdAt: "2026-06-01T00:00:02.000Z",
+          },
+          { id: "other", senderId: "member-1", content: "ignore", createdAt: "2026-06-01T00:00:01.000Z" },
+        ],
+      }),
+    );
+    intervalCallback?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("[Nova]");
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("...");
+
+    cliFetchMock.mockRejectedValueOnce(new Error("poll down"));
+    intervalCallback?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    cliFetchMock.mockRejectedValueOnce(new Error("network down"));
+    emitter.emit("line", "hello");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("network down");
+
+    expect(() => emitter.emit("close")).toThrow("process.exit");
+    expect(globalThis.clearInterval).toHaveBeenCalledWith(99);
   });
 });

--- a/apps/cli/src/__tests__/cli-command-branch-sweeper.test.ts
+++ b/apps/cli/src/__tests__/cli-command-branch-sweeper.test.ts
@@ -1,0 +1,327 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const bootstrapMocks = vi.hoisted(() => ({
+  ensureFreshAccessToken: vi.fn(),
+  resolveServerUrl: vi.fn(),
+  saveAgentConfig: vi.fn(),
+  loadConfig: vi.fn(),
+  loadAgentConfig: vi.fn(),
+  readActiveRootClientId: vi.fn(),
+}));
+
+const ioMocks = vi.hoisted(() => ({
+  readStdin: vi.fn(),
+  readMessageBody: vi.fn(),
+  guardInlineDescription: vi.fn(),
+  guardInlineShellResidue: vi.fn(),
+  looksLikeEscapedNewlineBody: vi.fn(),
+}));
+
+const sdkMocks = vi.hoisted(() => ({
+  createSdk: vi.fn(),
+  handleSdkError: vi.fn((error: unknown) => {
+    throw error instanceof Error ? error : new Error(String(error));
+  }),
+}));
+
+const outputMocks = vi.hoisted(() => ({
+  fail: vi.fn((code: string, message: string, exitCode = 1) => {
+    throw Object.assign(new Error(message), { code, exitCode });
+  }),
+  success: vi.fn(),
+  printLine: vi.fn(),
+}));
+
+const fetchMock = vi.hoisted(() => vi.fn());
+const captureOutboundDocsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../core/bootstrap.js", () => bootstrapMocks);
+vi.mock("../core/cli-fetch.js", () => ({ cliFetch: fetchMock }));
+vi.mock("../core/doc-capture.js", () => ({ captureOutboundDocs: captureOutboundDocsMock }));
+vi.mock("../commands/chat/_shared/io.js", () => ioMocks);
+vi.mock("../commands/_shared/local-agent.js", () => sdkMocks);
+vi.mock("../cli/output.js", () => ({
+  fail: outputMocks.fail,
+  success: outputMocks.success,
+}));
+vi.mock("../core/output.js", () => ({
+  print: { line: outputMocks.printLine },
+  isJsonMode: () => false,
+  setJsonMode: vi.fn(),
+}));
+
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 500): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Failed",
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  } as Response;
+}
+
+function makeSdk(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    createTaskChat: vi.fn(async () => ({ chatId: "chat_1" })),
+    sendMessage: vi.fn(async () => ({ messageId: "msg_1" })),
+    listDocs: vi.fn(async () => ({ items: [], nextCursor: null })),
+    ...overrides,
+  };
+}
+
+async function runWith(register: (program: Command) => void, args: string[]): Promise<void> {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeOut: () => undefined, writeErr: () => undefined });
+  program.option("--json");
+  program.option("--debug");
+  program.option("--quiet");
+  register(program);
+  await program.parseAsync(["node", "first-tree", ...args]);
+}
+
+describe("CLI command branch sweeper", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.FIRST_TREE_CHAT_ID;
+    bootstrapMocks.resolveServerUrl.mockReturnValue("https://first-tree.example");
+    bootstrapMocks.ensureFreshAccessToken.mockResolvedValue("access-token");
+    bootstrapMocks.saveAgentConfig.mockReturnValue("/tmp/agent-alpha");
+    ioMocks.readStdin.mockResolvedValue("stdin body");
+    ioMocks.readMessageBody.mockResolvedValue("file body");
+    ioMocks.looksLikeEscapedNewlineBody.mockReturnValue(false);
+    captureOutboundDocsMock.mockImplementation(async (content: string) => ({ content }));
+    sdkMocks.createSdk.mockReturnValue(makeSdk());
+  });
+
+  it("exercises agent create org selection and error branches", async () => {
+    const { registerAgentCommands } = await import("../commands/agent/index.js");
+
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          memberships: [{ organizationId: "org-one", organizationName: "One", role: "admin" }],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ uuid: "agent-uuid", name: null }));
+
+    await runWith(registerAgentCommands, [
+      "agent",
+      "create",
+      "agent-alpha",
+      "--type",
+      "agent",
+      "--client-id",
+      "client-a",
+      "--runtime",
+      "codex",
+      "--display-name",
+      "Agent Alpha",
+    ]);
+
+    expect(outputMocks.success).not.toHaveBeenCalled();
+    expect(outputMocks.printLine.mock.calls.join("\n")).toContain("agent-uuid");
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        memberships: [
+          { organizationId: "org-one", organizationName: "One", role: "admin" },
+          { organizationId: "org-two", organizationName: "Two", role: "member" },
+        ],
+      }),
+    );
+    await expect(
+      runWith(registerAgentCommands, ["agent", "create", "agent-beta", "--type", "agent", "--client-id", "client-a"]),
+    ).rejects.toMatchObject({ code: "CREATE_ERROR" });
+    expect(outputMocks.fail).toHaveBeenCalledWith(
+      "AMBIGUOUS_ORG",
+      expect.stringContaining("multiple organizations"),
+      1,
+    );
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ memberships: [] }));
+    await expect(
+      runWith(registerAgentCommands, ["agent", "create", "agent-gamma", "--type", "human", "--client-id", "client-a"]),
+    ).rejects.toMatchObject({ code: "CREATE_ERROR" });
+    expect(outputMocks.fail).toHaveBeenCalledWith("NO_ORG", "You don't belong to any organization", 1);
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        memberships: [{ organizationId: "org-one", organizationName: "One", role: "admin" }],
+      }),
+    );
+    await expect(
+      runWith(registerAgentCommands, [
+        "agent",
+        "create",
+        "agent-delta",
+        "--type",
+        "agent",
+        "--client-id",
+        "client-a",
+        "--org",
+        "missing",
+      ]),
+    ).rejects.toMatchObject({ code: "CREATE_ERROR" });
+    expect(outputMocks.fail).toHaveBeenCalledWith(
+      "ORG_NOT_FOUND",
+      'Not an active member of organization "missing"',
+      1,
+    );
+
+    fetchMock.mockResolvedValueOnce(jsonResponse("down", false, 503));
+    await expect(
+      runWith(registerAgentCommands, ["agent", "create", "agent-epsilon", "--type", "agent", "--client-id", "client-a"]),
+    ).rejects.toMatchObject({ code: "CREATE_ERROR" });
+    expect(outputMocks.fail).toHaveBeenCalledWith("FETCH_ERROR", "Failed to fetch /me: HTTP 503", 1);
+  });
+
+  it("exercises chat create optional payload and validation branches", async () => {
+    const { registerChatCommands } = await import("../commands/chat/index.js");
+    const sdk = makeSdk();
+    sdkMocks.createSdk.mockReturnValue(sdk);
+    captureOutboundDocsMock.mockResolvedValueOnce({
+      content: "captured body",
+      attachments: [{ documentId: "doc_1" }],
+      documentContext: { excerpts: [] },
+    });
+
+    await runWith(registerChatCommands, [
+      "chat",
+      "create",
+      "hello",
+      "--to",
+      "alice",
+      "--with",
+      "bob",
+      "--topic",
+      "Topic",
+      "--description",
+      "Inline description",
+      "--metadata",
+      '{"source":"test"}',
+      "--request",
+      "--options",
+      '[{"label":"Yes","description":"Approve"},{"label":"No","description":"Reject"}]',
+      "--multi-select",
+    ]);
+
+    expect(sdk.createTaskChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextParticipantNames: ["bob"],
+        topic: "Topic",
+        description: "Inline description",
+        initialMessage: expect.objectContaining({
+          format: "request",
+          metadata: expect.objectContaining({
+            source: "test",
+            attachments: [{ documentId: "doc_1" }],
+            documentContext: { excerpts: [] },
+          }),
+        }),
+      }),
+    );
+
+    await expect(runWith(registerChatCommands, ["chat", "create", "hello"])).rejects.toMatchObject({
+      code: "NO_TARGET",
+    });
+    await expect(
+      runWith(registerChatCommands, ["chat", "create", "hello", "--to", "alice", "--to", "bob", "--request"]),
+    ).rejects.toMatchObject({ code: "REQUEST_NEEDS_ONE_TARGET" });
+    await expect(
+      runWith(registerChatCommands, ["chat", "create", "hello", "--to", "alice", "--metadata", "{bad"]),
+    ).rejects.toMatchObject({ code: "INVALID_METADATA" });
+    await expect(
+      runWith(registerChatCommands, ["chat", "create", "hello", "--to", "alice", "--format", "xml"]),
+    ).rejects.toMatchObject({ code: "INVALID_FORMAT" });
+  });
+
+  it("exercises chat send optional payload and validation branches", async () => {
+    const { registerChatCommands } = await import("../commands/chat/index.js");
+    const sdk = makeSdk();
+    sdkMocks.createSdk.mockReturnValue(sdk);
+    process.env.FIRST_TREE_CHAT_ID = "chat_1";
+    captureOutboundDocsMock.mockResolvedValueOnce({
+      content: "captured file body",
+      attachments: [{ documentId: "doc_1" }],
+      documentContext: { excerpts: [] },
+    });
+
+    await runWith(registerChatCommands, [
+      "chat",
+      "send",
+      "alice",
+      "--message-file",
+      "message.md",
+      "--metadata",
+      '{"kind":"status"}',
+      "--reply-to",
+      "msg_parent",
+    ]);
+
+    expect(sdk.sendMessage).toHaveBeenCalledWith(
+      "chat_1",
+      expect.objectContaining({
+        receiverNames: ["alice"],
+        inReplyTo: "msg_parent",
+        metadata: expect.objectContaining({
+          kind: "status",
+          attachments: [{ documentId: "doc_1" }],
+          documentContext: { excerpts: [] },
+        }),
+      }),
+    );
+
+    await expect(runWith(registerChatCommands, ["chat", "send", "alice", "inline", "--message-file", "x"])).rejects.toMatchObject({
+      code: "CONFLICTING_ARGS",
+    });
+
+    ioMocks.looksLikeEscapedNewlineBody.mockReturnValueOnce(true);
+    await expect(runWith(registerChatCommands, ["chat", "send", "alice", "line\\nline"])).rejects.toMatchObject({
+      code: "ESCAPED_NEWLINES",
+    });
+
+    ioMocks.looksLikeEscapedNewlineBody.mockReturnValue(false);
+    await expect(runWith(registerChatCommands, ["chat", "send", "alice", "hello", "--metadata", "{bad"])).rejects.toMatchObject({
+      code: "INVALID_METADATA",
+    });
+
+    delete process.env.FIRST_TREE_CHAT_ID;
+    await expect(runWith(registerChatCommands, ["chat", "send", "alice", "hello"])).rejects.toMatchObject({
+      code: "NO_CHAT_CONTEXT",
+    });
+  });
+
+  it("exercises doc list option parsing branches", async () => {
+    const { registerDocCommands } = await import("../commands/doc/index.js");
+    const sdk = makeSdk();
+    sdkMocks.createSdk.mockReturnValue(sdk);
+
+    await runWith(registerDocCommands, [
+      "doc",
+      "list",
+      "--project",
+      "alpha",
+      "--status",
+      "approved",
+      "--limit",
+      "25",
+      "--cursor",
+      "next",
+      "--agent",
+      "agent-alpha",
+    ]);
+
+    expect(sdk.listDocs).toHaveBeenCalledWith({
+      project: "alpha",
+      status: "approved",
+      limit: 25,
+      cursor: "next",
+    });
+
+    await expect(runWith(registerDocCommands, ["doc", "list", "--status", "unknown"])).rejects.toMatchObject({
+      code: "INVALID_STATUS",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/cli-command-branch-sweeper.test.ts
+++ b/apps/cli/src/__tests__/cli-command-branch-sweeper.test.ts
@@ -164,15 +164,19 @@ describe("CLI command branch sweeper", () => {
         "missing",
       ]),
     ).rejects.toMatchObject({ code: "CREATE_ERROR" });
-    expect(outputMocks.fail).toHaveBeenCalledWith(
-      "ORG_NOT_FOUND",
-      'Not an active member of organization "missing"',
-      1,
-    );
+    expect(outputMocks.fail).toHaveBeenCalledWith("ORG_NOT_FOUND", 'Not an active member of organization "missing"', 1);
 
     fetchMock.mockResolvedValueOnce(jsonResponse("down", false, 503));
     await expect(
-      runWith(registerAgentCommands, ["agent", "create", "agent-epsilon", "--type", "agent", "--client-id", "client-a"]),
+      runWith(registerAgentCommands, [
+        "agent",
+        "create",
+        "agent-epsilon",
+        "--type",
+        "agent",
+        "--client-id",
+        "client-a",
+      ]),
     ).rejects.toMatchObject({ code: "CREATE_ERROR" });
     expect(outputMocks.fail).toHaveBeenCalledWith("FETCH_ERROR", "Failed to fetch /me: HTTP 503", 1);
   });
@@ -273,7 +277,9 @@ describe("CLI command branch sweeper", () => {
       }),
     );
 
-    await expect(runWith(registerChatCommands, ["chat", "send", "alice", "inline", "--message-file", "x"])).rejects.toMatchObject({
+    await expect(
+      runWith(registerChatCommands, ["chat", "send", "alice", "inline", "--message-file", "x"]),
+    ).rejects.toMatchObject({
       code: "CONFLICTING_ARGS",
     });
 
@@ -283,7 +289,9 @@ describe("CLI command branch sweeper", () => {
     });
 
     ioMocks.looksLikeEscapedNewlineBody.mockReturnValue(false);
-    await expect(runWith(registerChatCommands, ["chat", "send", "alice", "hello", "--metadata", "{bad"])).rejects.toMatchObject({
+    await expect(
+      runWith(registerChatCommands, ["chat", "send", "alice", "hello", "--metadata", "{bad"]),
+    ).rejects.toMatchObject({
       code: "INVALID_METADATA",
     });
 

--- a/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
@@ -26,6 +26,7 @@ const bootstrapMocks = vi.hoisted(() => ({
 const cliFetchMock = vi.hoisted(() => vi.fn());
 
 const resolveAgentMock = vi.hoisted(() => vi.fn());
+const doctorChecksMock = vi.hoisted(() => vi.fn());
 
 const outputMocks = vi.hoisted(() => ({
   fail: vi.fn((code: string, message: string, exitCode = 1) => {
@@ -42,6 +43,7 @@ const coreMocks = vi.hoisted(() => ({
   isServiceSupported: vi.fn(),
   isServiceUnitDriftDetected: vi.fn(),
   loadCredentials: vi.fn(),
+  printResults: vi.fn(),
   refreshClientServiceUnitForUpdate: vi.fn(),
   removeLocalAgent: vi.fn(),
   restartClientService: vi.fn(),
@@ -64,6 +66,7 @@ vi.mock("@first-tree/shared/config", () => sharedConfigMocks);
 vi.mock("../core/bootstrap.js", () => bootstrapMocks);
 vi.mock("../core/cli-fetch.js", () => ({ cliFetch: cliFetchMock }));
 vi.mock("../commands/_shared/resolve-agent.js", () => ({ resolveAgent: resolveAgentMock }));
+vi.mock("../commands/_shared/doctor-checks.js", () => ({ runDaemonChecks: doctorChecksMock }));
 vi.mock("../cli/output.js", () => outputMocks);
 vi.mock("../core/output.js", () => ({
   print: { line: printLineMock, result: outputMocks.success, fail: outputMocks.fail },
@@ -129,6 +132,7 @@ beforeEach(() => {
   bootstrapMocks.ensureFreshAccessToken.mockResolvedValue("access-token");
   bootstrapMocks.resolveServerUrl.mockReturnValue("https://hub.example");
   resolveAgentMock.mockResolvedValue({ uuid: "agent-1", name: "nova" });
+  doctorChecksMock.mockResolvedValue([{ label: "daemon", ok: true, detail: "ready" }]);
   coreMocks.isServiceSupported.mockReturnValue(true);
   coreMocks.getClientServiceStatus.mockReturnValue({ state: "active", platform: "launchd", detail: "pid 123" });
   coreMocks.loadCredentials.mockReturnValue({ refreshToken: "refresh" });
@@ -183,6 +187,10 @@ describe("config commands", () => {
     await runConfig(["get", "server.missing"]);
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("server.missing: (not set)");
 
+    sharedConfigMocks.getConfigValue.mockReturnValueOnce(undefined);
+    await runConfig(["show", "server.missing"]);
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("server.missing: (not set)");
+
     await runConfig(["set", "update.restart_check_interval_seconds", "15"]);
     expect(sharedConfigMocks.setConfigValue).toHaveBeenLastCalledWith(
       join(tempDir, "config", "client.yaml"),
@@ -226,16 +234,29 @@ describe("daemon utility commands", () => {
     await runDaemon(["stop"]);
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Stopped launchd service");
 
+    setPlatform("win32");
+    coreMocks.isServiceSupported.mockReturnValueOnce(false);
+    await runDaemon(["stop"]);
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Stop the PowerShell");
+    setPlatform(originalPlatform);
+
     coreMocks.isServiceSupported.mockReturnValueOnce(false);
     await runDaemon(["restart"]);
     coreMocks.isServiceSupported.mockReturnValue(true);
     coreMocks.getClientServiceStatus.mockReturnValueOnce({ state: "not-installed", platform: "systemd" });
     await expect(runDaemon(["restart"])).rejects.toMatchObject({ code: 1 });
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({ state: "active", platform: "systemd" });
+    coreMocks.restartClientService.mockReturnValueOnce({ ok: false, reason: "restart failed" });
+    await expect(runDaemon(["restart"])).rejects.toMatchObject({ code: 1 });
     coreMocks.getClientServiceStatus
       .mockReturnValueOnce({ state: "active", platform: "systemd" })
       .mockReturnValueOnce({ state: "active", platform: "systemd", detail: "pid 42" });
+    coreMocks.restartClientService.mockReturnValueOnce({ ok: true });
     await runDaemon(["restart"]);
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Restarted systemd service");
+
+    await runDaemon(["doctor"]);
+    expect(coreMocks.printResults).toHaveBeenCalledWith([{ label: "daemon", ok: true, detail: "ready" }]);
 
     coreMocks.isServiceSupported.mockReturnValueOnce(false);
     await runDaemon(["refresh-unit"]);
@@ -338,6 +359,50 @@ describe("daemon utility commands", () => {
       "systemd service refreshed and restarted",
     );
   });
+
+  it("surfaces ensure-service restart and inactive install failures", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.loadCredentials.mockReturnValue({ refreshToken: "refresh" });
+
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({ state: "active", platform: "systemd", detail: "pid 1" });
+    coreMocks.isServiceUnitDriftDetected.mockReturnValueOnce(true);
+    coreMocks.installClientService.mockReturnValueOnce({
+      platform: "systemd",
+      unitPath: "/tmp/first-tree.service",
+      state: "active",
+    });
+    coreMocks.restartClientService.mockReturnValueOnce({ ok: false, reason: "restart denied" });
+    await expect(runDaemon(["ensure-service"])).rejects.toMatchObject({ code: 1 });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("restart failed");
+
+    coreMocks.getClientServiceStatus
+      .mockReturnValueOnce({ state: "active", platform: "launchd", detail: "pid 2" })
+      .mockReturnValueOnce({ state: "inactive", platform: "launchd", detail: "stopped" });
+    coreMocks.isServiceUnitDriftDetected.mockReturnValueOnce(true);
+    coreMocks.installClientService.mockReturnValueOnce({
+      platform: "launchd",
+      unitPath: "/tmp/first-tree.plist",
+      state: "active",
+    });
+    coreMocks.restartClientService.mockReturnValueOnce({ ok: true });
+    await expect(runDaemon(["ensure-service"])).rejects.toMatchObject({ code: 1 });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "service restarted but is not running",
+    );
+
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({ state: "inactive", platform: "systemd" });
+    coreMocks.isServiceUnitDriftDetected.mockReturnValueOnce(false);
+    coreMocks.installClientService.mockReturnValueOnce({
+      platform: "systemd",
+      unitPath: "/tmp/first-tree.service",
+      state: "inactive",
+      detail: "not loaded",
+    });
+    await expect(runDaemon(["ensure-service"])).rejects.toMatchObject({ code: 1 });
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "service installed but not running",
+    );
+  });
 });
 
 describe("agent admin and local commands", () => {
@@ -355,6 +420,9 @@ describe("agent admin and local commands", () => {
     cliFetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
     await runAgent(["reset", "agent-1"]);
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain('Agent "agent-1" reset');
+
+    cliFetchMock.mockResolvedValueOnce(jsonResponse("nope", false, 503));
+    await expect(runAgent(["reset", "agent-1"])).rejects.toMatchObject({ code: "RESET_ERROR", exitCode: 1 });
 
     const agentDir = join(tempDir, "config", "agents", "nova");
     mkdirSync(agentDir, { recursive: true });

--- a/apps/cli/src/__tests__/cli-fetch.test.ts
+++ b/apps/cli/src/__tests__/cli-fetch.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cliFetch } from "../core/cli-fetch.js";
+import { CLI_USER_AGENT } from "../core/version.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("cliFetch", () => {
+  it("adds the CLI user agent across supported header input shapes", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await cliFetch("https://example.test/plain");
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://example.test/plain",
+      expect.objectContaining({ headers: { "User-Agent": CLI_USER_AGENT } }),
+    );
+
+    await cliFetch("https://example.test/headers", { headers: new Headers({ Accept: "application/json" }) });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://example.test/headers",
+      expect.objectContaining({ headers: { accept: "application/json", "User-Agent": CLI_USER_AGENT } }),
+    );
+
+    await cliFetch("https://example.test/tuples", { headers: [["X-Test", "1"]] });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://example.test/tuples",
+      expect.objectContaining({ headers: { "X-Test": "1", "User-Agent": CLI_USER_AGENT } }),
+    );
+
+    await cliFetch("https://example.test/override", { headers: { "user-agent": "custom" } });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://example.test/override",
+      expect.objectContaining({ headers: { "user-agent": "custom" } }),
+    );
+  });
+});

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -1104,11 +1104,14 @@ describe("ClientRuntime context-tree wiring", () => {
     paused("auth_refresh_failed", new Error("refresh rejected"));
     expect(print.status).toHaveBeenCalledWith("✗", "auth rejected — pausing agents until fresh credentials arrive.");
     expect(print.status).toHaveBeenCalledWith("", "refresh rejected");
-    paused("auth_refresh_failed", (() => {
-      const err = new Error("missing auth message");
-      Object.defineProperty(err, "authCode", { value: "invalid_token" });
-      return err;
-    })());
+    paused(
+      "auth_refresh_failed",
+      (() => {
+        const err = new Error("missing auth message");
+        Object.defineProperty(err, "authCode", { value: "invalid_token" });
+        return err;
+      })(),
+    );
     expect(print.status).toHaveBeenCalledWith("", "Auth rejection code: invalid_token");
     const credentialsError = fsWatchMocks.on.mock.calls.find((call) => call[0] === "error")?.[1] as
       | ((err: Error) => void)

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -188,6 +188,32 @@ describe("ClientRuntime context-tree wiring", () => {
     vi.clearAllMocks();
   });
 
+  it("adapts runtime output to logger methods with trimmed status levels", async () => {
+    const { createLoggerRuntimeOutput } = await import("../core/client-runtime.js");
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const output = createLoggerRuntimeOutput(logger);
+
+    output.blank();
+    output.check(true, "connected", "agent alpha");
+    output.check(false, "degraded");
+    output.line("  hello logger  \n");
+    output.line("   ");
+    output.status("✗", "hard failure");
+    output.status("⚠️", "soft warning");
+    output.status("", "plain status");
+
+    expect(logger.info).toHaveBeenCalledWith("connected: agent alpha");
+    expect(logger.info).toHaveBeenCalledWith("hello logger");
+    expect(logger.info).toHaveBeenCalledWith("plain status");
+    expect(logger.warn).toHaveBeenCalledWith("degraded");
+    expect(logger.warn).toHaveBeenCalledWith("⚠️ soft warning");
+    expect(logger.error).toHaveBeenCalledWith("✗ hard failure");
+  });
+
   it(
     "starts eager slots without a shared Context Tree binding",
     async () => {
@@ -275,6 +301,7 @@ describe("ClientRuntime context-tree wiring", () => {
 
   it("handles connection events, update hooks, and graceful stop", async () => {
     const client = await import("@first-tree/client");
+    const { print } = await import("../core/output.js");
     slotInstances.length = 0;
 
     const update = {
@@ -318,6 +345,32 @@ describe("ClientRuntime context-tree wiring", () => {
       retryable: true,
       reasonCode: "INSTALL_FAILED",
     });
+
+    const reconnectOk = vi.fn();
+    const reconnectBroken = vi.fn(() => {
+      throw new Error("probe failed");
+    });
+    rt.onReconnect(reconnectOk);
+    rt.onReconnect(reconnectBroken);
+    const welcome = connectionListeners.get("server:welcome");
+    if (!welcome) throw new Error("server:welcome listener missing");
+    welcome({ isReconnect: false });
+    expect(reconnectOk).not.toHaveBeenCalled();
+    welcome({ isReconnect: true });
+    expect(reconnectOk).toHaveBeenCalled();
+    expect(print.status).toHaveBeenCalledWith("⚠️", "reconnect handler error: probe failed");
+
+    const runtimeAuth = vi.fn();
+    rt.onRuntimeAuthStart(runtimeAuth);
+    const runtimeAuthStart = connectionListeners.get("runtime-auth:start");
+    if (!runtimeAuthStart) throw new Error("runtime-auth:start listener missing");
+    runtimeAuthStart({ provider: "codex", ref: "cmd-1" });
+    expect(runtimeAuth).toHaveBeenCalledWith({ provider: "codex", ref: "cmd-1" });
+
+    const unbound = connectionListeners.get("agent:unbound");
+    if (!unbound) throw new Error("agent:unbound listener missing");
+    unbound("agent-alpha", undefined);
+    unbound("agent-alpha", "agent_suspended");
 
     await rt.stop();
     expect(disposeMock).toHaveBeenCalled();
@@ -394,7 +447,9 @@ describe("ClientRuntime context-tree wiring", () => {
     expect(print.status).toHaveBeenCalledWith("", "agent runtime confirmed: broken");
     expect(print.check).toHaveBeenCalledWith(true, "broken: connected", "agent: broken");
     const runtimeProbe = rt as unknown as {
-      agents: Array<{ state: "idle" | "starting" | "running" | "suspended-skipped" | "failed" }>;
+      agents: Array<{
+        state: "idle" | "starting" | "running" | "suspended-skipped" | "failed" | "unsupported-runtime";
+      }>;
       startAgentEntry(entry: unknown): Promise<"connected" | "skipped" | "failed">;
       startAgent(name: string): void;
     };
@@ -403,6 +458,8 @@ describe("ClientRuntime context-tree wiring", () => {
     entry.state = "running";
     await expect(runtimeProbe.startAgentEntry(entry)).resolves.toBe("connected");
     entry.state = "starting";
+    await expect(runtimeProbe.startAgentEntry(entry)).resolves.toBe("skipped");
+    entry.state = "unsupported-runtime";
     await expect(runtimeProbe.startAgentEntry(entry)).resolves.toBe("skipped");
     runtimeProbe.startAgent("missing");
     await rt.stop();
@@ -488,6 +545,117 @@ describe("ClientRuntime context-tree wiring", () => {
     await rt.stop();
   });
 
+  it("continues supported runtime switches when the previous slot stop fails", async () => {
+    const { print } = await import("../core/output.js");
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://first-tree.test", "client-test");
+    const agentsDir = join(home, "config", "agents");
+    const alphaDir = join(agentsDir, "alpha");
+    mkdirSync(alphaDir, { recursive: true });
+    writeFileSync(join(alphaDir, "agent.yaml"), "agentId: agent-alpha\nruntime: codex\n");
+    rt.watchAgentsDir(agentsDir);
+    rt.addAgent("alpha", {
+      agentId: "agent-alpha",
+      runtime: "codex",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rt.addAgent>[1]);
+    slotInstances[0]?.stop.mockRejectedValueOnce(new Error("stop failed"));
+
+    const pinned = connectionListeners.get("agent:pinned");
+    if (!pinned) throw new Error("agent:pinned listener missing");
+    pinned({
+      agentId: "agent-alpha",
+      name: "alpha",
+      runtimeProvider: "claude-code",
+    });
+
+    await vi.waitFor(() => expect(slotInstances).toHaveLength(2));
+    expect(print.status).toHaveBeenCalledWith("⚠️", "failed to stop previous runtime for alpha: stop failed");
+    expect(slotInstances[1]?.start).toHaveBeenCalled();
+    await rt.stop();
+  });
+
+  it("marks runtime switches to unsupported providers and reports stop/write failures", async () => {
+    const { print } = await import("../core/output.js");
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://first-tree.test", "client-test");
+    const agentsDir = join(home, "config", "agents");
+    const alphaDir = join(agentsDir, "alpha");
+    mkdirSync(alphaDir, { recursive: true });
+    writeFileSync(join(alphaDir, "agent.yaml"), "agentId: agent-alpha\nruntime: claude-code\n");
+    rt.watchAgentsDir(agentsDir);
+    rt.addAgent("alpha", {
+      agentId: "agent-alpha",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rt.addAgent>[1]);
+    slotInstances[0]?.stop.mockRejectedValueOnce(new Error("stop failed"));
+
+    const pinned = connectionListeners.get("agent:pinned");
+    if (!pinned) throw new Error("agent:pinned listener missing");
+    pinned({
+      agentId: "agent-alpha",
+      name: "alpha",
+      runtimeProvider: "claude-code-tui",
+    });
+
+    await vi.waitFor(() =>
+      expect(print.status).toHaveBeenCalledWith(
+        "⚠️",
+        expect.stringContaining('agent "alpha" switched to runtime "claude-code-tui"'),
+      ),
+    );
+    expect(print.status).toHaveBeenCalledWith("⚠️", "failed to stop previous runtime for alpha: stop failed");
+    expect(readFileSync(join(alphaDir, "agent.yaml"), "utf8")).toContain("runtime: claude-code-tui");
+
+    const rtWithoutDir = new ClientRuntime("https://first-tree.test", "client-test");
+    rtWithoutDir.addAgent("beta", {
+      agentId: "agent-beta",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rtWithoutDir.addAgent>[1]);
+    const pinnedWithoutDir = connectionListeners.get("agent:pinned");
+    if (!pinnedWithoutDir) throw new Error("agent:pinned listener missing");
+    pinnedWithoutDir({
+      agentId: "agent-beta",
+      name: "beta",
+      runtimeProvider: "codex",
+    });
+    await vi.waitFor(() =>
+      expect(print.check).toHaveBeenCalledWith(false, 'failed to update agent "beta" runtime', "agents dir is not set"),
+    );
+    await rt.stop();
+    await rtWithoutDir.stop();
+  });
+
+  it("debounces agents-dir watcher rescans for newly written agent configs", async () => {
+    vi.useFakeTimers();
+    try {
+      const { ClientRuntime } = await import("../core/client-runtime.js");
+      const rt = new ClientRuntime("https://first-tree.test", "client-test");
+      const agentsDir = join(home, "config", "agents");
+      mkdirSync(join(agentsDir, "debounced"), { recursive: true });
+      writeFileSync(join(agentsDir, "debounced", "agent.yaml"), "agentId: agent-debounced\nruntime: claude-code\n");
+      rt.watchAgentsDir(agentsDir);
+
+      fsWatchMocks.state.callback("rename", "debounced/agent.yaml");
+      fsWatchMocks.state.callback("change", "debounced/agent.yaml");
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(slotInstances.map((slot) => slot.name)).toContain("debounced");
+      expect(slotInstances.at(-1)?.start).toHaveBeenCalled();
+      const runtimeProbe = rt as unknown as { debounceTimer: ReturnType<typeof setTimeout> | null };
+      runtimeProbe.debounceTimer = setTimeout(() => undefined, 10_000);
+      rt.unwatchAgentsDir();
+      await rt.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("repairs runtime-provider bind mismatches once without looping", async () => {
     const { print } = await import("../core/output.js");
     const { ClientRuntime } = await import("../core/client-runtime.js");
@@ -533,6 +701,61 @@ describe("ClientRuntime context-tree wiring", () => {
       "alpha: runtime repair already attempted; not retrying bind mismatch.",
     );
     await rt.stop();
+  });
+
+  it("reports runtime-provider repair HTTP, schema, and fetch failures", async () => {
+    const { print } = await import("../core/output.js");
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rejected = () => {
+      const listener = connectionListeners.get("agent:bind:rejected");
+      if (!listener) throw new Error("agent:bind:rejected listener missing");
+      listener("runtime_provider_mismatch", "agent-alpha");
+    };
+
+    const rtHttp = new ClientRuntime("https://first-tree.test", "client-test");
+    rtHttp.addAgent("alpha", {
+      agentId: "agent-alpha",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rtHttp.addAgent>[1]);
+    await rtHttp.start();
+    cliFetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
+    rejected();
+    await vi.waitFor(() => expect(print.status).toHaveBeenCalledWith("⚠️", "alpha: runtime repair failed (HTTP 503)"));
+    await rtHttp.stop();
+
+    vi.clearAllMocks();
+    const rtSchema = new ClientRuntime("https://first-tree.test", "client-test");
+    rtSchema.addAgent("alpha", {
+      agentId: "agent-alpha",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rtSchema.addAgent>[1]);
+    await rtSchema.start();
+    cliFetchMock.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ runtimeProvider: "future" }) });
+    rejected();
+    await vi.waitFor(() =>
+      expect(print.status).toHaveBeenCalledWith("⚠️", "alpha: runtime repair failed (server returned unknown runtime)"),
+    );
+    await rtSchema.stop();
+
+    vi.clearAllMocks();
+    const rtFetch = new ClientRuntime("https://first-tree.test", "client-test");
+    rtFetch.addAgent("alpha", {
+      agentId: "agent-alpha",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rtFetch.addAgent>[1]);
+    await rtFetch.start();
+    cliFetchMock.mockRejectedValueOnce(new Error("network down"));
+    rejected();
+    await vi.waitFor(() =>
+      expect(print.status).toHaveBeenCalledWith("⚠️", "alpha: runtime repair failed: network down"),
+    );
+    await rtFetch.stop();
   });
 
   it("chooses suffixed pinned-agent names and reports auto-add write failures", async () => {
@@ -629,6 +852,11 @@ describe("ClientRuntime context-tree wiring", () => {
     paused("auth_refresh_failed", new Error("refresh rejected"));
     expect(print.status).toHaveBeenCalledWith("✗", "auth rejected — pausing agents until fresh credentials arrive.");
     expect(print.status).toHaveBeenCalledWith("", "refresh rejected");
+    const credentialsError = fsWatchMocks.on.mock.calls.find((call) => call[0] === "error")?.[1] as
+      | ((err: Error) => void)
+      | undefined;
+    credentialsError?.(new Error("watch failed"));
+    expect(print.status).toHaveBeenCalledWith("⚠️", "credentials watcher error: watch failed");
     const structured = new Error("Server rejected access token");
     Object.defineProperty(structured, "authCode", { value: "invalid_token" });
     Object.defineProperty(structured, "authMessage", { value: "signature mismatch" });
@@ -656,6 +884,24 @@ describe("ClientRuntime context-tree wiring", () => {
     await rt.stop();
   });
 
+  it("reports credentials watcher setup failures", async () => {
+    const fs = await import("node:fs");
+    const { print } = await import("../core/output.js");
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    mkdirSync(join(home, "config"), { recursive: true });
+    vi.mocked(fs.watch).mockImplementationOnce(() => {
+      throw new Error("watch denied");
+    });
+    const rt = new ClientRuntime("https://first-tree.test", "client-test");
+
+    const paused = connectionListeners.get("auth:paused");
+    if (!paused) throw new Error("auth:paused listener missing");
+    paused("auth_refresh_failed", new Error("refresh rejected"));
+
+    expect(print.status).toHaveBeenCalledWith("⚠️", "credentials watcher failed: watch denied");
+    await rt.stop();
+  });
+
   it("clears paused mode after credentials.json content changes", async () => {
     const { print } = await import("../core/output.js");
     expect(watchMockProbe).toBe(fsWatchMocks.watch);
@@ -678,9 +924,13 @@ describe("ClientRuntime context-tree wiring", () => {
     const runtimeProbe = rt as unknown as {
       credentialsDebounce: ReturnType<typeof setTimeout> | null;
       readCredentialsSnapshot(path: string): string | null;
+      scanForNewAgents(agentsDir: string): void;
     };
     runtimeProbe.credentialsDebounce = setTimeout(() => undefined, 10_000);
     expect(runtimeProbe.readCredentialsSnapshot(join(home, "config", "missing.json"))).toBeNull();
+    mkdirSync(join(home, "config", "agents"), { recursive: true });
+    writeFileSync(join(home, "config", "agents", "bad-agent.yaml"), "not a directory");
+    runtimeProbe.scanForNewAgents(join(home, "config", "agents", "bad-agent.yaml"));
     await rt.stop();
     expect(fsWatchMocks.close).toHaveBeenCalled();
   });

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -57,6 +57,7 @@ const RUNTIME_TEST_TIMEOUT_MS = 15_000;
 const disposeMock = vi.fn();
 const killAllMock = vi.fn(async () => undefined);
 const cliFetchMock = vi.hoisted(() => vi.fn());
+const connectionCtorOptions: unknown[] = [];
 let connectionMaxListeners = 10;
 const connectionMock = {
   clientId: "client-test",
@@ -108,6 +109,9 @@ vi.mock("@first-tree/client", () => {
       clearPaused = connectionMock.clearPaused;
       getMaxListeners = connectionMock.getMaxListeners;
       setMaxListeners = connectionMock.setMaxListeners;
+      constructor(options: unknown) {
+        connectionCtorOptions.push(options);
+      }
     },
     UpdateManager: { attach: vi.fn(() => ({ dispose: disposeMock })) },
     createLogger: vi.fn(() => ({
@@ -163,6 +167,7 @@ describe("ClientRuntime context-tree wiring", () => {
     process.env.FIRST_TREE_HOME = home;
     slotInstances.length = 0;
     connectionListeners.clear();
+    connectionCtorOptions.length = 0;
     connectionMock.on.mockClear();
     connectionMock.connect.mockClear();
     connectionMock.disconnect.mockClear();
@@ -212,6 +217,40 @@ describe("ClientRuntime context-tree wiring", () => {
     expect(logger.warn).toHaveBeenCalledWith("degraded");
     expect(logger.warn).toHaveBeenCalledWith("⚠️ soft warning");
     expect(logger.error).toHaveBeenCalledWith("✗ hard failure");
+  });
+
+  it("wires default output and connection auth/update callbacks", async () => {
+    const { print } = await import("../core/output.js");
+    mkdirSync(join(home, "state"), { recursive: true });
+    writeFileSync(
+      join(home, "state", "update-state.json"),
+      JSON.stringify({
+        last: {
+          result: "ok",
+          target: "0.6.0",
+          currentBefore: "0.5.0",
+          installedVersion: "0.6.0",
+          reason: null,
+          at: "2026-05-20T00:00:00.000Z",
+        },
+      }),
+    );
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://first-tree.test", "client-test") as unknown as {
+      output: { line: (text: string) => void };
+    };
+
+    rt.output.line("default output line");
+
+    const connectionOptions = connectionCtorOptions.at(-1) as
+      | {
+          getAccessToken?: (opts?: unknown) => Promise<string>;
+          getLastUpdateAttempt?: () => unknown;
+        }
+      | undefined;
+    await expect(connectionOptions?.getAccessToken?.({ force: true })).resolves.toBe("tok-test");
+    expect(connectionOptions?.getLastUpdateAttempt?.()).toMatchObject({ target: "0.6.0", result: "ok" });
+    expect(print.line).toHaveBeenCalledWith("default output line");
   });
 
   it(
@@ -328,8 +367,10 @@ describe("ClientRuntime context-tree wiring", () => {
     slotInstances[0]?.getQuietGateSnapshot.mockReturnValue({ activeCount: 2, lastActivityMs: 400 });
     const updateOptions = vi.mocked(client.UpdateManager.attach).mock.calls[0]?.[1] as {
       getQuietGateSnapshot: () => { activeCount: number; lastActivityMs: number };
+      log: (level: "info" | "warn" | "error" | "debug", message: string) => void;
     };
     expect(updateOptions.getQuietGateSnapshot()).toEqual({ activeCount: 2, lastActivityMs: 400 });
+    updateOptions.log("warn", "update warning");
 
     connectionMock.isPaused.mockReturnValue(true);
     connectionMock.getPausedReason.mockReturnValue("auth_refresh_failed");
@@ -350,8 +391,12 @@ describe("ClientRuntime context-tree wiring", () => {
     const reconnectBroken = vi.fn(() => {
       throw new Error("probe failed");
     });
+    const reconnectStringBroken = vi.fn(() => {
+      throw "probe string failed";
+    });
     rt.onReconnect(reconnectOk);
     rt.onReconnect(reconnectBroken);
+    rt.onReconnect(reconnectStringBroken);
     const welcome = connectionListeners.get("server:welcome");
     if (!welcome) throw new Error("server:welcome listener missing");
     welcome({ isReconnect: false });
@@ -359,6 +404,7 @@ describe("ClientRuntime context-tree wiring", () => {
     welcome({ isReconnect: true });
     expect(reconnectOk).toHaveBeenCalled();
     expect(print.status).toHaveBeenCalledWith("⚠️", "reconnect handler error: probe failed");
+    expect(print.status).toHaveBeenCalledWith("⚠️", "reconnect handler error: probe string failed");
 
     const runtimeAuth = vi.fn();
     rt.onRuntimeAuthStart(runtimeAuth);
@@ -371,7 +417,9 @@ describe("ClientRuntime context-tree wiring", () => {
     if (!unbound) throw new Error("agent:unbound listener missing");
     unbound("agent-alpha", undefined);
     unbound("agent-alpha", "agent_suspended");
+    unbound("agent-alpha", "unpinned");
 
+    killAllMock.mockRejectedValueOnce(new Error("kill failed"));
     await rt.stop();
     expect(disposeMock).toHaveBeenCalled();
     expect(slotInstances[0]?.stop).toHaveBeenCalled();
@@ -422,7 +470,9 @@ describe("ClientRuntime context-tree wiring", () => {
 
   it("reports generic agent start failures and ignores already-starting entries", async () => {
     const { print } = await import("../core/output.js");
-    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const { ClientRuntime, isAgentSuspendedBindError } = await import("../core/client-runtime.js");
+    expect(isAgentSuspendedBindError("agent_suspended by server")).toBe(true);
+    expect(isAgentSuspendedBindError("plain bind failure")).toBe(false);
     const rt = new ClientRuntime("https://hub.test", "client-test");
     rt.addAgent("broken", {
       agentId: "agent-broken",
@@ -462,6 +512,45 @@ describe("ClientRuntime context-tree wiring", () => {
     entry.state = "unsupported-runtime";
     await expect(runtimeProbe.startAgentEntry(entry)).resolves.toBe("skipped");
     runtimeProbe.startAgent("missing");
+    slotInstances[0]?.start.mockRejectedValueOnce("string start failure");
+    entry.state = "idle";
+    await expect(runtimeProbe.startAgentEntry(entry)).resolves.toBe("failed");
+    expect(print.check).toHaveBeenCalledWith(false, "broken: connection failed", "string start failure");
+    slotInstances[0]?.start.mockResolvedValueOnce({ agentId: "agent-broken" });
+    entry.state = "idle";
+    await expect(runtimeProbe.startAgentEntry(entry)).resolves.toBe("connected");
+    expect(print.check).toHaveBeenCalledWith(true, "broken: connected", "agent: agent-broken");
+    await rt.stop();
+  });
+
+  it("handles duplicate local agents and watcher guard paths", async () => {
+    const fs = await import("node:fs");
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://hub.test", "client-test");
+    const config = {
+      agentId: "agent-alpha",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rt.addAgent>[1];
+    rt.addAgent("alpha", config);
+    rt.addAgent("alpha", { ...config, agentId: "agent-alpha-duplicate-name" });
+    expect(slotInstances).toHaveLength(1);
+
+    const missingDir = join(home, "missing-agents");
+    rt.watchAgentsDir(missingDir);
+    expect(vi.mocked(fs.watch)).not.toHaveBeenCalledWith(missingDir, expect.anything(), expect.anything());
+
+    const agentsDir = join(home, "config", "agents");
+    mkdirSync(join(agentsDir, "duplicate-id"), { recursive: true });
+    writeFileSync(join(agentsDir, "duplicate-id", "agent.yaml"), "agentId: agent-alpha\nruntime: claude-code\n");
+    rt.watchAgentsDir(agentsDir);
+    rt.watchAgentsDir(agentsDir);
+    expect(fsWatchMocks.watch).toHaveBeenCalledTimes(1);
+
+    const runtimeProbe = rt as unknown as { scanForNewAgents(agentsDir: string): void };
+    runtimeProbe.scanForNewAgents(agentsDir);
+    expect(slotInstances).toHaveLength(1);
     await rt.stop();
   });
 
@@ -576,6 +665,85 @@ describe("ClientRuntime context-tree wiring", () => {
     await rt.stop();
   });
 
+  it("stringifies non-Error runtime switch stop and write failures", async () => {
+    const { print } = await import("../core/output.js");
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const agentsDir = join(home, "config", "agents");
+
+    const supported = new ClientRuntime("https://first-tree.test", "client-test");
+    mkdirSync(join(agentsDir, "supported"), { recursive: true });
+    writeFileSync(join(agentsDir, "supported", "agent.yaml"), "agentId: agent-supported\nruntime: codex\n");
+    supported.watchAgentsDir(agentsDir);
+    supported.addAgent("supported", {
+      agentId: "agent-supported",
+      runtime: "codex",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof supported.addAgent>[1]);
+    slotInstances.at(-1)?.stop.mockRejectedValueOnce("string stop failure");
+    connectionListeners.get("agent:pinned")?.({
+      agentId: "agent-supported",
+      name: "supported",
+      runtimeProvider: "claude-code",
+    });
+    await vi.waitFor(() =>
+      expect(print.status).toHaveBeenCalledWith(
+        "⚠️",
+        "failed to stop previous runtime for supported: string stop failure",
+      ),
+    );
+
+    const unsupported = new ClientRuntime("https://first-tree.test", "client-test");
+    unsupported.watchAgentsDir(agentsDir);
+    unsupported.addAgent("unsupported", {
+      agentId: "agent-unsupported",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof unsupported.addAgent>[1]);
+    slotInstances.at(-1)?.stop.mockRejectedValueOnce("unsupported stop failure");
+    connectionListeners.get("agent:pinned")?.({
+      agentId: "agent-unsupported",
+      name: "unsupported",
+      runtimeProvider: "claude-code-tui",
+    });
+    await vi.waitFor(() =>
+      expect(print.status).toHaveBeenCalledWith(
+        "⚠️",
+        "failed to stop previous runtime for unsupported: unsupported stop failure",
+      ),
+    );
+
+    const writeFailure = new ClientRuntime("https://first-tree.test", "client-test");
+    writeFailure.watchAgentsDir(agentsDir);
+    writeFailure.addAgent("write-failure", {
+      agentId: "agent-write-failure",
+      runtime: "codex",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof writeFailure.addAgent>[1]);
+    const writeFailureProbe = writeFailure as unknown as { writeAgentYaml: () => never };
+    writeFailureProbe.writeAgentYaml = () => {
+      throw "string write failure";
+    };
+    connectionListeners.get("agent:pinned")?.({
+      agentId: "agent-write-failure",
+      name: "write-failure",
+      runtimeProvider: "claude-code",
+    });
+    await vi.waitFor(() =>
+      expect(print.check).toHaveBeenCalledWith(
+        false,
+        'failed to update agent "write-failure" runtime',
+        "string write failure",
+      ),
+    );
+
+    await supported.stop();
+    await unsupported.stop();
+    await writeFailure.stop();
+  });
+
   it("marks runtime switches to unsupported providers and reports stop/write failures", async () => {
     const { print } = await import("../core/output.js");
     const { ClientRuntime } = await import("../core/client-runtime.js");
@@ -629,6 +797,39 @@ describe("ClientRuntime context-tree wiring", () => {
     );
     await rt.stop();
     await rtWithoutDir.stop();
+  });
+
+  it("stops the previous slot cleanly when switching to an unsupported provider", async () => {
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://first-tree.test", "client-test");
+    const agentsDir = join(home, "config", "agents");
+    const alphaDir = join(agentsDir, "alpha");
+    mkdirSync(alphaDir, { recursive: true });
+    writeFileSync(join(alphaDir, "agent.yaml"), "agentId: agent-alpha\nruntime: claude-code\n");
+    rt.watchAgentsDir(agentsDir);
+    rt.addAgent("alpha", {
+      agentId: "agent-alpha",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rt.addAgent>[1]);
+
+    connectionListeners.get("agent:pinned")?.({
+      agentId: "agent-alpha",
+      name: "alpha",
+      runtimeProvider: "claude-code-tui",
+    });
+
+    await vi.waitFor(() =>
+      expect(slotInstances[0]?.stop).toHaveBeenCalledWith("runtime switched to unsupported provider by server", {
+        sessionShutdown: {
+          clearPersistedRegistry: true,
+          reportSuspendedSessions: false,
+        },
+      }),
+    );
+    expect(readFileSync(join(alphaDir, "agent.yaml"), "utf8")).toContain("runtime: claude-code-tui");
+    await rt.stop();
   });
 
   it("debounces agents-dir watcher rescans for newly written agent configs", async () => {
@@ -703,6 +904,43 @@ describe("ClientRuntime context-tree wiring", () => {
     await rt.stop();
   });
 
+  it("uses runtime-provider repair fallbacks for loose server agent shapes", async () => {
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://first-tree.test", "client-test");
+    const agentsDir = join(home, "config", "agents");
+    mkdirSync(agentsDir, { recursive: true });
+    rt.watchAgentsDir(agentsDir);
+    rt.addAgent("alpha", {
+      agentId: "agent-alpha",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rt.addAgent>[1]);
+    await rt.start();
+    cliFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        name: 123,
+        displayName: 456,
+        type: "human",
+        runtimeProvider: "codex",
+      }),
+    });
+
+    const rejected = connectionListeners.get("agent:bind:rejected");
+    if (!rejected) throw new Error("agent:bind:rejected listener missing");
+    rejected("agent_suspended", "agent-alpha");
+    expect(cliFetchMock).not.toHaveBeenCalled();
+    rejected("runtime_provider_mismatch", "missing-agent");
+    expect(cliFetchMock).not.toHaveBeenCalled();
+    rejected("runtime_provider_mismatch", "agent-alpha");
+
+    await vi.waitFor(() => expect(slotInstances).toHaveLength(2));
+    expect(readFileSync(join(agentsDir, "alpha", "agent.yaml"), "utf8")).toContain("runtime: codex");
+    await rt.stop();
+  });
+
   it("reports runtime-provider repair HTTP, schema, and fetch failures", async () => {
     const { print } = await import("../core/output.js");
     const { ClientRuntime } = await import("../core/client-runtime.js");
@@ -756,6 +994,20 @@ describe("ClientRuntime context-tree wiring", () => {
       expect(print.status).toHaveBeenCalledWith("⚠️", "alpha: runtime repair failed: network down"),
     );
     await rtFetch.stop();
+
+    vi.clearAllMocks();
+    const rtNonErrorFetch = new ClientRuntime("https://first-tree.test", "client-test");
+    rtNonErrorFetch.addAgent("alpha", {
+      agentId: "agent-alpha",
+      runtime: "claude-code",
+      session: { idle_timeout: 300, max_sessions: 4, working_grace_seconds: 3600 },
+      concurrency: 1,
+    } as unknown as Parameters<typeof rtNonErrorFetch.addAgent>[1]);
+    await rtNonErrorFetch.start();
+    cliFetchMock.mockRejectedValueOnce("offline");
+    rejected();
+    await vi.waitFor(() => expect(print.status).toHaveBeenCalledWith("⚠️", "alpha: runtime repair failed: offline"));
+    await rtNonErrorFetch.stop();
   });
 
   it("chooses suffixed pinned-agent names and reports auto-add write failures", async () => {
@@ -852,6 +1104,12 @@ describe("ClientRuntime context-tree wiring", () => {
     paused("auth_refresh_failed", new Error("refresh rejected"));
     expect(print.status).toHaveBeenCalledWith("✗", "auth rejected — pausing agents until fresh credentials arrive.");
     expect(print.status).toHaveBeenCalledWith("", "refresh rejected");
+    paused("auth_refresh_failed", (() => {
+      const err = new Error("missing auth message");
+      Object.defineProperty(err, "authCode", { value: "invalid_token" });
+      return err;
+    })());
+    expect(print.status).toHaveBeenCalledWith("", "Auth rejection code: invalid_token");
     const credentialsError = fsWatchMocks.on.mock.calls.find((call) => call[0] === "error")?.[1] as
       | ((err: Error) => void)
       | undefined;
@@ -902,6 +1160,36 @@ describe("ClientRuntime context-tree wiring", () => {
     await rt.stop();
   });
 
+  it("skips credentials watcher setup when the config directory is absent", async () => {
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    const rt = new ClientRuntime("https://first-tree.test", "client-test");
+
+    const paused = connectionListeners.get("auth:paused");
+    if (!paused) throw new Error("auth:paused listener missing");
+    paused("auth_refresh_failed", new Error("refresh rejected"));
+
+    expect(fsWatchMocks.watch).not.toHaveBeenCalled();
+    await rt.stop();
+  });
+
+  it("reports non-Error credentials watcher setup failures", async () => {
+    const fs = await import("node:fs");
+    const { print } = await import("../core/output.js");
+    const { ClientRuntime } = await import("../core/client-runtime.js");
+    mkdirSync(join(home, "config"), { recursive: true });
+    vi.mocked(fs.watch).mockImplementationOnce(() => {
+      throw "watch denied as string";
+    });
+    const rt = new ClientRuntime("https://first-tree.test", "client-test");
+
+    const paused = connectionListeners.get("auth:paused");
+    if (!paused) throw new Error("auth:paused listener missing");
+    paused("auth_refresh_failed", new Error("refresh rejected"));
+
+    expect(print.status).toHaveBeenCalledWith("⚠️", "credentials watcher failed: watch denied as string");
+    await rt.stop();
+  });
+
   it("clears paused mode after credentials.json content changes", async () => {
     const { print } = await import("../core/output.js");
     expect(watchMockProbe).toBe(fsWatchMocks.watch);
@@ -914,9 +1202,12 @@ describe("ClientRuntime context-tree wiring", () => {
     const paused = connectionListeners.get("auth:paused");
     if (!paused) throw new Error("auth:paused listener missing");
     paused("auth_refresh_failed", new Error("refresh rejected"));
+    paused("auth_refresh_failed", new Error("refresh rejected again"));
+    fsWatchMocks.state.callback("rename", "ignored.txt");
     writeFileSync(join(home, "config", "credentials.json"), JSON.stringify({ refreshToken: "new" }));
     if (!fsWatchMocks.state.registered) throw new Error("credentials watcher callback missing");
     fsWatchMocks.state.callback("change", "credentials.json");
+    fsWatchMocks.state.callback("change", null);
 
     await vi.waitFor(() => expect(connectionMock.clearPaused).toHaveBeenCalled(), { timeout: 2000 });
     expect(print.status).toHaveBeenCalledWith("", "credentials.json updated — clearing paused mode");
@@ -924,10 +1215,18 @@ describe("ClientRuntime context-tree wiring", () => {
     const runtimeProbe = rt as unknown as {
       credentialsDebounce: ReturnType<typeof setTimeout> | null;
       readCredentialsSnapshot(path: string): string | null;
+      readAgentYamlRecord(name: string): Record<string, unknown>;
       scanForNewAgents(agentsDir: string): void;
     };
     runtimeProbe.credentialsDebounce = setTimeout(() => undefined, 10_000);
     expect(runtimeProbe.readCredentialsSnapshot(join(home, "config", "missing.json"))).toBeNull();
+    expect(runtimeProbe.readAgentYamlRecord("missing")).toEqual({});
+    mkdirSync(join(home, "config", "agents", "array-yaml"), { recursive: true });
+    writeFileSync(join(home, "config", "agents", "array-yaml", "agent.yaml"), "[]\n");
+    expect(runtimeProbe.readAgentYamlRecord("array-yaml")).toEqual({});
+    mkdirSync(join(home, "config", "agents", "null-yaml"), { recursive: true });
+    writeFileSync(join(home, "config", "agents", "null-yaml", "agent.yaml"), "null\n");
+    expect(runtimeProbe.readAgentYamlRecord("null-yaml")).toEqual({});
     mkdirSync(join(home, "config", "agents"), { recursive: true });
     writeFileSync(join(home, "config", "agents", "bad-agent.yaml"), "not a directory");
     runtimeProbe.scanForNewAgents(join(home, "config", "agents", "bad-agent.yaml"));

--- a/apps/cli/src/__tests__/client-switch-platform-extra.test.ts
+++ b/apps/cli/src/__tests__/client-switch-platform-extra.test.ts
@@ -1,0 +1,345 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsState = vi.hoisted(() => ({
+  mode: "normal" as
+    | "normal"
+    | "proc-readdir-error"
+    | "proc-cmdline-error"
+    | "proc-environ-error"
+    | "proc-untrusted"
+    | "marker-readdir-error"
+    | "exdev"
+    | "pending-rename-error"
+    | "pending-rename-exdev"
+    | "write-json-rename-error"
+    | "write-json-cleanup-error",
+  home: "",
+  uid: typeof process.getuid === "function" ? process.getuid() : 0,
+}));
+
+const execState = vi.hoisted(() => ({
+  mode: "ok" as "ok" | "throw" | "daemon-untrusted" | "pid-throw",
+  home: "",
+}));
+
+const outputMocks = vi.hoisted(() => ({
+  fail: vi.fn((code: string, message: string, exitCode = 1) => {
+    throw Object.assign(new Error(message), { code, exitCode });
+  }),
+  line: vi.fn(),
+}));
+
+const serviceMocks = vi.hoisted(() => ({
+  getClientServiceStatus: vi.fn(() => ({ state: "inactive", platform: "test" })),
+  stopClientService: vi.fn(() => ({ ok: true })),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: (path: Parameters<typeof actual.existsSync>[0]) => {
+      const text = String(path);
+      if (text.startsWith("/proc/100")) return true;
+      return actual.existsSync(path);
+    },
+    readdirSync: ((path: Parameters<typeof actual.readdirSync>[0], options?: unknown) => {
+      const text = String(path);
+      if (text === "/proc") {
+        if (fsState.mode === "exdev") return [];
+        if (fsState.mode === "proc-readdir-error") throw new Error("proc unavailable");
+        return ["100", "self", "not-a-pid"];
+      }
+      if (text.endsWith("/state/client-runtimes") && fsState.mode === "marker-readdir-error") {
+        throw new Error("marker dir denied");
+      }
+      return (actual.readdirSync as (...args: unknown[]) => unknown)(path, options);
+    }) as typeof actual.readdirSync,
+    readFileSync: ((path: Parameters<typeof actual.readFileSync>[0], options?: unknown) => {
+      const text = String(path);
+      if (text === "/proc/100/status")
+        return `Name:\tnode\nUid:\t${fsState.uid}\t${fsState.uid}\t${fsState.uid}\t${fsState.uid}\n`;
+      if (text === "/proc/100/cmdline") {
+        if (fsState.mode === "proc-cmdline-error") throw new Error("cmdline denied");
+        return "codex exec";
+      }
+      if (text === "/proc/100/environ") {
+        if (fsState.mode === "proc-environ-error") throw new Error("environ denied");
+        if (fsState.mode === "proc-untrusted") {
+          return [`FIRST_TREE_HOME=${fsState.home}`, "FIRST_TREE_PROVIDER=codex", ""].join("\0");
+        }
+        return [
+          `FIRST_TREE_HOME=${fsState.home}`,
+          "FIRST_TREE_PROVIDER=codex",
+          "FIRST_TREE_CLIENT_ID=client_aabbccdd",
+          "FIRST_TREE_SWITCH_DRAIN_VERSION=1",
+          "",
+        ].join("\0");
+      }
+      return (actual.readFileSync as (...args: unknown[]) => unknown)(path, options);
+    }) as typeof actual.readFileSync,
+    statSync: ((path: Parameters<typeof actual.statSync>[0], options?: unknown) => {
+      const stat = (actual.statSync as (...args: unknown[]) => unknown)(path, options) as ReturnType<
+        typeof actual.statSync
+      >;
+      if (fsState.mode === "exdev") {
+        const text = String(path);
+        if (text.endsWith("/config/client.yaml")) {
+          return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, { dev: 1 });
+        }
+        if (text.includes("/parked-clients/client_aabbccdd/config")) {
+          return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, { dev: 2 });
+        }
+      }
+      return stat;
+    }) as typeof actual.statSync,
+    renameSync: ((
+      oldPath: Parameters<typeof actual.renameSync>[0],
+      newPath: Parameters<typeof actual.renameSync>[1],
+    ) => {
+      if (fsState.mode === "pending-rename-exdev" && !String(oldPath).includes(".tmp.")) {
+        throw Object.assign(new Error("cross-device pending move"), { code: "EXDEV" });
+      }
+      if (fsState.mode === "pending-rename-error" && !String(oldPath).includes(".tmp.")) {
+        throw new Error("pending rename denied");
+      }
+      if (
+        (fsState.mode === "write-json-rename-error" || fsState.mode === "write-json-cleanup-error") &&
+        String(oldPath).includes(".tmp.")
+      ) {
+        throw new Error("atomic rename denied");
+      }
+      return actual.renameSync(oldPath, newPath);
+    }) as typeof actual.renameSync,
+    unlinkSync: ((path: Parameters<typeof actual.unlinkSync>[0]) => {
+      if (fsState.mode === "write-json-cleanup-error" && String(path).includes(".tmp.")) {
+        throw new Error("cleanup denied");
+      }
+      return actual.unlinkSync(path);
+    }) as typeof actual.unlinkSync,
+  };
+});
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    execFileSync: vi.fn((program: string, args: string[]) => {
+      if (program === "ps" && args.includes("-Eww")) {
+        if (execState.mode === "throw") throw new Error("ps denied");
+        if (execState.mode === "daemon-untrusted") {
+          return `  200 first-tree daemon start --foreground FIRST_TREE_HOME=${execState.home}\n`;
+        }
+        return `  200 codex exec FIRST_TREE_HOME=${execState.home} FIRST_TREE_PROVIDER=codex FIRST_TREE_CLIENT_ID=client_aabbccdd FIRST_TREE_SWITCH_DRAIN_VERSION=1\n`;
+      }
+      if (program === "ps" && args.includes("-p")) {
+        if (execState.mode === "pid-throw") throw new Error("pid command denied");
+        return "/usr/local/bin/first-tree-dev daemon start --foreground\n";
+      }
+      return (actual.execFileSync as (...execArgs: unknown[]) => unknown)(program, args);
+    }),
+  };
+});
+
+vi.mock("../cli/output.js", () => ({ fail: outputMocks.fail }));
+vi.mock("../core/output.js", () => ({ print: { line: outputMocks.line } }));
+vi.mock("../core/service-install.js", () => serviceMocks);
+
+let home = "";
+let originalHome: string | undefined;
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+function writeClientYaml(): void {
+  mkdirSync(join(home, "config"), { recursive: true });
+  writeFileSync(
+    join(home, "config", "client.yaml"),
+    "server:\n  url: https://old.example\nclient:\n  id: client_aabbccdd\n",
+  );
+}
+
+async function runSwitch(): Promise<void> {
+  const { switchLocalClientForLogin } = await import("../core/client-switch.js");
+  await switchLocalClientForLogin({
+    existingCredentials: { accessToken: "old", refreshToken: "old-refresh", serverUrl: "https://old.example" },
+    previousOwnerSub: "user-old",
+    targetTokens: { accessToken: "new", refreshToken: "new-refresh", serverUrl: "https://new.example" },
+    targetOwnerSub: "user-new",
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  originalHome = process.env.FIRST_TREE_HOME;
+  home = mkdtempSync(join(tmpdir(), "ft-client-switch-platform-"));
+  process.env.FIRST_TREE_HOME = home;
+  fsState.mode = "normal";
+  fsState.home = home;
+  execState.mode = "ok";
+  execState.home = home;
+  serviceMocks.getClientServiceStatus.mockReturnValue({ state: "inactive", platform: "test" });
+  writeClientYaml();
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.FIRST_TREE_HOME;
+  else process.env.FIRST_TREE_HOME = originalHome;
+  setPlatform(originalPlatform);
+});
+
+describe("client switch platform drain scanning", () => {
+  it("fails when Linux provider markers are still live", async () => {
+    setPlatform("linux");
+
+    await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_TIMEOUT" });
+  });
+
+  it("fails closed when Linux /proc cannot be inspected", async () => {
+    setPlatform("linux");
+    fsState.mode = "proc-readdir-error";
+
+    await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
+  });
+
+  it("fails closed when Linux command or environment files are unreadable", async () => {
+    setPlatform("linux");
+    fsState.mode = "proc-cmdline-error";
+    await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
+
+    writeClientYaml();
+    fsState.mode = "proc-environ-error";
+    await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
+  });
+
+  it("fails closed on untrusted Linux provider-like processes", async () => {
+    setPlatform("linux");
+    fsState.mode = "proc-untrusted";
+
+    await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
+  });
+
+  it("scans Darwin ps output for trusted and untrusted markers", async () => {
+    setPlatform("darwin");
+    await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_TIMEOUT" });
+
+    writeClientYaml();
+    execState.mode = "daemon-untrusted";
+    await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
+  });
+
+  it("fails closed when Darwin ps inspection fails or platform is unsupported", async () => {
+    setPlatform("darwin");
+    execState.mode = "throw";
+    await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
+
+    writeClientYaml();
+    setPlatform("win32");
+    await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
+  });
+
+  it("surfaces runtime marker directory inspection failures", async () => {
+    const { listLiveClientRuntimeMarkers } = await import("../core/client-switch.js");
+    mkdirSync(join(home, "state", "client-runtimes"), { recursive: true });
+    fsState.mode = "marker-readdir-error";
+
+    expect(() => listLiveClientRuntimeMarkers(home)).toThrow(/Unable to inspect runtime markers/u);
+  });
+
+  it("reads runtime marker commands on Darwin and degrades when ps fails or the platform is unsupported", async () => {
+    const { listLiveClientRuntimeMarkers, registerClientRuntimeMarker } = await import("../core/client-switch.js");
+
+    setPlatform("darwin");
+    registerClientRuntimeMarker({ clientId: "client_aabbccdd", mode: "foreground", home, pid: process.pid });
+    expect(listLiveClientRuntimeMarkers(home, "client_aabbccdd")).toEqual([
+      expect.objectContaining({ command: "/usr/local/bin/first-tree-dev daemon start --foreground" }),
+    ]);
+
+    execState.mode = "pid-throw";
+    expect(listLiveClientRuntimeMarkers(home, "client_aabbccdd")).toEqual([
+      expect.objectContaining({ command: undefined }),
+    ]);
+
+    setPlatform("win32");
+    expect(listLiveClientRuntimeMarkers(home, "client_aabbccdd")).toEqual([
+      expect.objectContaining({ command: undefined }),
+    ]);
+  });
+
+  it("classifies cross-device preflight failures as client-switch EXDEV", async () => {
+    fsState.mode = "exdev";
+
+    await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_EXDEV" });
+  });
+
+  it("classifies pending recovery EXDEV but rethrows generic pending recovery errors", async () => {
+    const { switchLocalClientForLogin, clientSwitchJournalPath, clientSwitchLockPath } = await import(
+      "../core/client-switch.js"
+    );
+    const parkedTarget = join(home, "parked-clients", "client_11223344");
+    mkdirSync(join(home, "state"), { recursive: true });
+    mkdirSync(join(parkedTarget, "config"), { recursive: true });
+    writeFileSync(
+      join(parkedTarget, "config", "client.yaml"),
+      "server:\n  url: https://new.example\nclient:\n  id: client_11223344\n",
+    );
+    rmSync(join(home, "config", "client.yaml"), { force: true });
+    const journal = {
+      version: 1,
+      id: "switch-pending",
+      phase: "parked-old-client",
+      from: { clientId: "client_aabbccdd", userId: "user-old", serverUrl: "https://old.example" },
+      to: { clientId: "client_11223344", userId: "user-new", serverUrl: "https://new.example" },
+      moves: [
+        {
+          kind: "restore-client-yaml",
+          group: "restore",
+          source: join(parkedTarget, "config", "client.yaml"),
+          target: join(home, "config", "client.yaml"),
+          required: true,
+          state: "pending",
+        },
+      ],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    writeFileSync(clientSwitchLockPath(home), JSON.stringify({ pid: process.pid }));
+    writeFileSync(clientSwitchJournalPath(home), JSON.stringify(journal));
+
+    fsState.mode = "pending-rename-exdev";
+    await expect(
+      switchLocalClientForLogin({
+        targetTokens: { accessToken: "new", refreshToken: "new-refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_SWITCH_EXDEV" });
+
+    fsState.mode = "pending-rename-error";
+    await expect(
+      switchLocalClientForLogin({
+        targetTokens: { accessToken: "new", refreshToken: "new-refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toThrow("pending rename denied");
+  });
+
+  it("cleans up temporary JSON files after atomic write failures", async () => {
+    const { registerClientRuntimeMarker } = await import("../core/client-switch.js");
+
+    fsState.mode = "write-json-rename-error";
+    expect(() =>
+      registerClientRuntimeMarker({ clientId: "client_aabbccdd", mode: "foreground", home, pid: 991 }),
+    ).toThrow("atomic rename denied");
+
+    fsState.mode = "write-json-cleanup-error";
+    expect(() =>
+      registerClientRuntimeMarker({ clientId: "client_aabbccdd", mode: "foreground", home, pid: 992 }),
+    ).toThrow("atomic rename denied");
+  });
+});

--- a/apps/cli/src/__tests__/client-switch-platform-extra.test.ts
+++ b/apps/cli/src/__tests__/client-switch-platform-extra.test.ts
@@ -7,8 +7,15 @@ const fsState = vi.hoisted(() => ({
   mode: "normal" as
     | "normal"
     | "proc-readdir-error"
+    | "proc-readdir-string-error"
+    | "proc-readdir-error-second"
     | "proc-cmdline-error"
+    | "proc-cmdline-disappeared"
+    | "proc-cmdline-string-error"
     | "proc-environ-error"
+    | "proc-environ-string-error"
+    | "proc-status-no-uid"
+    | "proc-many-providers"
     | "proc-untrusted"
     | "marker-readdir-error"
     | "exdev"
@@ -18,10 +25,18 @@ const fsState = vi.hoisted(() => ({
     | "write-json-cleanup-error",
   home: "",
   uid: typeof process.getuid === "function" ? process.getuid() : 0,
+  procReaddirCount: 0,
 }));
 
 const execState = vi.hoisted(() => ({
-  mode: "ok" as "ok" | "throw" | "daemon-untrusted" | "pid-throw",
+  mode: "ok" as
+    | "ok"
+    | "throw"
+    | "throw-string"
+    | "daemon-untrusted"
+    | "daemon-active"
+    | "many-daemon-untrusted"
+    | "pid-throw",
   home: "",
 }));
 
@@ -43,14 +58,24 @@ vi.mock("node:fs", async (importOriginal) => {
     ...actual,
     existsSync: (path: Parameters<typeof actual.existsSync>[0]) => {
       const text = String(path);
+      if (fsState.mode === "proc-cmdline-disappeared" && text.startsWith("/proc/100")) return false;
       if (text.startsWith("/proc/100")) return true;
       return actual.existsSync(path);
     },
     readdirSync: ((path: Parameters<typeof actual.readdirSync>[0], options?: unknown) => {
       const text = String(path);
       if (text === "/proc") {
+        fsState.procReaddirCount += 1;
         if (fsState.mode === "exdev") return [];
         if (fsState.mode === "proc-readdir-error") throw new Error("proc unavailable");
+        if (fsState.mode === "proc-readdir-string-error") throw "proc unavailable as string";
+        if (fsState.mode === "proc-readdir-error-second" && fsState.procReaddirCount > 1) {
+          throw new Error("proc unavailable after first scan");
+        }
+        if (fsState.mode === "proc-readdir-error-second") return [];
+        if (fsState.mode === "proc-many-providers") {
+          return Array.from({ length: 9 }, (_value, index) => String(100 + index));
+        }
         return ["100", "self", "not-a-pid"];
       }
       if (text.endsWith("/state/client-runtimes") && fsState.mode === "marker-readdir-error") {
@@ -60,13 +85,18 @@ vi.mock("node:fs", async (importOriginal) => {
     }) as typeof actual.readdirSync,
     readFileSync: ((path: Parameters<typeof actual.readFileSync>[0], options?: unknown) => {
       const text = String(path);
-      if (text === "/proc/100/status")
+      if (/^\/proc\/\d+\/status$/u.test(text)) {
+        if (fsState.mode === "proc-status-no-uid") return "Name:\tnode\n";
         return `Name:\tnode\nUid:\t${fsState.uid}\t${fsState.uid}\t${fsState.uid}\t${fsState.uid}\n`;
-      if (text === "/proc/100/cmdline") {
+      }
+      if (/^\/proc\/\d+\/cmdline$/u.test(text)) {
+        if (fsState.mode === "proc-cmdline-disappeared") throw new Error("process disappeared");
+        if (fsState.mode === "proc-cmdline-string-error") throw "cmdline denied as string";
         if (fsState.mode === "proc-cmdline-error") throw new Error("cmdline denied");
         return "codex exec";
       }
-      if (text === "/proc/100/environ") {
+      if (/^\/proc\/\d+\/environ$/u.test(text)) {
+        if (fsState.mode === "proc-environ-string-error") throw "environ denied as string";
         if (fsState.mode === "proc-environ-error") throw new Error("environ denied");
         if (fsState.mode === "proc-untrusted") {
           return [`FIRST_TREE_HOME=${fsState.home}`, "FIRST_TREE_PROVIDER=codex", ""].join("\0");
@@ -130,6 +160,16 @@ vi.mock("node:child_process", async (importOriginal) => {
     execFileSync: vi.fn((program: string, args: string[]) => {
       if (program === "ps" && args.includes("-Eww")) {
         if (execState.mode === "throw") throw new Error("ps denied");
+        if (execState.mode === "throw-string") throw "ps denied as string";
+        if (execState.mode === "many-daemon-untrusted") {
+          return Array.from(
+            { length: 9 },
+            (_value, index) => `  ${200 + index} first-tree daemon start --foreground FIRST_TREE_HOME=${execState.home}`,
+          ).join("\n");
+        }
+        if (execState.mode === "daemon-active") {
+          return `  200 first-tree daemon start --foreground FIRST_TREE_HOME=${execState.home} FIRST_TREE_CLIENT_ID=client_aabbccdd\n`;
+        }
         if (execState.mode === "daemon-untrusted") {
           return `  200 first-tree daemon start --foreground FIRST_TREE_HOME=${execState.home}\n`;
         }
@@ -183,6 +223,7 @@ beforeEach(() => {
   fsState.home = home;
   execState.mode = "ok";
   execState.home = home;
+  fsState.procReaddirCount = 0;
   serviceMocks.getClientServiceStatus.mockReturnValue({ state: "inactive", platform: "test" });
   writeClientYaml();
 });
@@ -206,6 +247,22 @@ describe("client switch platform drain scanning", () => {
     fsState.mode = "proc-readdir-error";
 
     await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
+
+    writeClientYaml();
+    fsState.mode = "proc-readdir-string-error";
+    fsState.procReaddirCount = 0;
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      message: expect.stringContaining("proc unavailable as string"),
+    });
+
+    writeClientYaml();
+    fsState.mode = "proc-readdir-error-second";
+    fsState.procReaddirCount = 0;
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      message: expect.stringContaining("after first scan"),
+    });
   });
 
   it("fails closed when Linux command or environment files are unreadable", async () => {
@@ -214,8 +271,51 @@ describe("client switch platform drain scanning", () => {
     await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
 
     writeClientYaml();
+    fsState.mode = "proc-cmdline-string-error";
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      message: expect.stringContaining("cmdline denied as string"),
+    });
+
+    writeClientYaml();
+    fsState.mode = "proc-cmdline-disappeared";
+    await expect(runSwitch()).resolves.toBeUndefined();
+
+    writeClientYaml();
     fsState.mode = "proc-environ-error";
     await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
+
+    writeClientYaml();
+    fsState.mode = "proc-environ-string-error";
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      message: expect.stringContaining("environ denied as string"),
+    });
+  });
+
+  it("ignores Linux processes without a readable uid and summarizes many provider markers", async () => {
+    setPlatform("linux");
+    fsState.mode = "proc-status-no-uid";
+
+    await expect(runSwitch()).resolves.toBeUndefined();
+
+    writeClientYaml();
+    fsState.mode = "proc-many-providers";
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_TIMEOUT",
+      message: expect.stringContaining("...and 1 more"),
+    });
+  });
+
+  it("scans Linux processes when process.getuid is unavailable", async () => {
+    setPlatform("linux");
+    const originalGetuid = process.getuid;
+    Object.defineProperty(process, "getuid", { configurable: true, value: undefined });
+    try {
+      await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_TIMEOUT" });
+    } finally {
+      Object.defineProperty(process, "getuid", { configurable: true, value: originalGetuid });
+    }
   });
 
   it("fails closed on untrusted Linux provider-like processes", async () => {
@@ -232,6 +332,20 @@ describe("client switch platform drain scanning", () => {
     writeClientYaml();
     execState.mode = "daemon-untrusted";
     await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
+
+    writeClientYaml();
+    execState.mode = "daemon-active";
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      message: expect.stringContaining("daemon runtime is still active"),
+    });
+
+    writeClientYaml();
+    execState.mode = "many-daemon-untrusted";
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      message: expect.stringContaining("...and 1 more"),
+    });
   });
 
   it("fails closed when Darwin ps inspection fails or platform is unsupported", async () => {
@@ -240,8 +354,36 @@ describe("client switch platform drain scanning", () => {
     await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
 
     writeClientYaml();
+    execState.mode = "throw-string";
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      message: expect.stringContaining("ps denied as string"),
+    });
+
+    writeClientYaml();
     setPlatform("win32");
     await expect(runSwitch()).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED" });
+  });
+
+  it("fails closed when the service state is unknown before or after stopping", async () => {
+    serviceMocks.getClientServiceStatus.mockReturnValueOnce({ state: "unknown", platform: "test" });
+
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_SUPERVISOR_UNSAFE",
+      message: "Background service state could not be determined (test).",
+    });
+
+    writeClientYaml();
+    serviceMocks.getClientServiceStatus
+      .mockReset()
+      .mockReturnValueOnce({ state: "active", platform: "test" })
+      .mockReturnValueOnce({ state: "unknown", platform: "test" });
+    serviceMocks.stopClientService.mockReturnValueOnce({ ok: true });
+
+    await expect(runSwitch()).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_SUPERVISOR_UNSAFE",
+      message: "Background service did not reach a safe stopped state (test).",
+    });
   });
 
   it("surfaces runtime marker directory inspection failures", async () => {

--- a/apps/cli/src/__tests__/client-switch-platform-extra.test.ts
+++ b/apps/cli/src/__tests__/client-switch-platform-extra.test.ts
@@ -164,7 +164,8 @@ vi.mock("node:child_process", async (importOriginal) => {
         if (execState.mode === "many-daemon-untrusted") {
           return Array.from(
             { length: 9 },
-            (_value, index) => `  ${200 + index} first-tree daemon start --foreground FIRST_TREE_HOME=${execState.home}`,
+            (_value, index) =>
+              `  ${200 + index} first-tree daemon start --foreground FIRST_TREE_HOME=${execState.home}`,
           ).join("\n");
         }
         if (execState.mode === "daemon-active") {

--- a/apps/cli/src/__tests__/client-switch-runtime-marker-mocked.test.ts
+++ b/apps/cli/src/__tests__/client-switch-runtime-marker-mocked.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type FsMode = "readdir-string-error" | "read-string-error" | "live-without-command" | "live-with-empty-command";
+
+async function loadClientSwitchWithFsMode(mode: FsMode) {
+  vi.resetModules();
+  vi.doMock("node:fs", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("node:fs")>();
+    return {
+      ...actual,
+      existsSync: vi.fn((path: string) => path.includes("client-runtimes") || actual.existsSync(path)),
+      readdirSync: vi.fn(() => {
+        if (mode === "readdir-string-error") throw "cannot list markers";
+        return ["123.json"];
+      }),
+      readFileSync: vi.fn((path: string) => {
+        if (path.includes("client-runtimes") && mode === "read-string-error") throw "cannot read marker";
+        if (path.endsWith("123.json")) {
+          return JSON.stringify({
+            version: 1,
+            pid: 123,
+            clientId: "client_aabbccdd",
+            home: "/tmp/ft-home",
+            mode: "foreground",
+            createdAt: new Date().toISOString(),
+          });
+        }
+        if (path.includes("/proc/") && mode === "live-with-empty-command") return "";
+        if (path.includes("/proc/")) throw new Error(`unexpected read ${path}`);
+        return actual.readFileSync(path);
+      }),
+    };
+  });
+  return import("../core/client-switch.js");
+}
+
+describe("client switch runtime marker mocked fs edges", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock("node:fs");
+    vi.resetModules();
+  });
+
+  it("stringifies non-Error marker directory failures", async () => {
+    const { listLiveClientRuntimeMarkers } = await loadClientSwitchWithFsMode("readdir-string-error");
+
+    expect(() => listLiveClientRuntimeMarkers("/tmp/ft-home")).toThrow("cannot list markers");
+  });
+
+  it("stringifies non-Error marker read failures", async () => {
+    const { listLiveClientRuntimeMarkers } = await loadClientSwitchWithFsMode("read-string-error");
+
+    expect(() => listLiveClientRuntimeMarkers("/tmp/ft-home")).toThrow("cannot read marker");
+  });
+
+  it("keeps live markers when the process command cannot be read", async () => {
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+    try {
+      const { listLiveClientRuntimeMarkers } = await loadClientSwitchWithFsMode("live-without-command");
+
+      expect(listLiveClientRuntimeMarkers("/tmp/ft-home", "client_aabbccdd")).toEqual([
+        {
+          pid: 123,
+          clientId: "client_aabbccdd",
+          mode: "foreground",
+          command: undefined,
+        },
+      ]);
+    } finally {
+      kill.mockRestore();
+    }
+  });
+
+  it("keeps live markers when the process command is blank", async () => {
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+    try {
+      const { listLiveClientRuntimeMarkers } = await loadClientSwitchWithFsMode("live-with-empty-command");
+
+      expect(listLiveClientRuntimeMarkers("/tmp/ft-home", "client_aabbccdd")).toEqual([
+        {
+          pid: 123,
+          clientId: "client_aabbccdd",
+          mode: "foreground",
+          command: undefined,
+        },
+      ]);
+    } finally {
+      kill.mockRestore();
+    }
+  });
+
+  it("treats non-ESRCH kill failures as live marker processes", async () => {
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("permission denied"), { code: "EPERM" });
+    });
+    try {
+      const { listLiveClientRuntimeMarkers } = await loadClientSwitchWithFsMode("live-with-empty-command");
+
+      expect(listLiveClientRuntimeMarkers("/tmp/ft-home", "client_aabbccdd")).toHaveLength(1);
+    } finally {
+      kill.mockRestore();
+    }
+  });
+});

--- a/apps/cli/src/__tests__/client-switch-transaction-extra.test.ts
+++ b/apps/cli/src/__tests__/client-switch-transaction-extra.test.ts
@@ -1,0 +1,559 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const outputMocks = vi.hoisted(() => ({
+  fail: vi.fn((code: string, message: string, exitCode = 1) => {
+    throw Object.assign(new Error(message), { code, exitCode });
+  }),
+  line: vi.fn(),
+}));
+
+const promptMocks = vi.hoisted(() => ({
+  confirm: vi.fn(),
+}));
+
+const serviceMocks = vi.hoisted(() => ({
+  getClientServiceStatus: vi.fn(),
+  stopClientService: vi.fn(),
+}));
+
+vi.mock("@inquirer/prompts", () => promptMocks);
+vi.mock("../cli/output.js", () => ({ fail: outputMocks.fail }));
+vi.mock("../core/output.js", () => ({ print: { line: outputMocks.line } }));
+vi.mock("../core/service-install.js", () => serviceMocks);
+
+let home = "";
+let originalHome: string | undefined;
+const children: ChildProcess[] = [];
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeClientYaml(clientId: string, serverUrl: string, dir = join(home, "config")): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "client.yaml"), `server:\n  url: ${serverUrl}\nclient:\n  id: ${clientId}\n`);
+}
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, "utf8")) as unknown;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  originalHome = process.env.FIRST_TREE_HOME;
+  home = mkdtempSync(join(tmpdir(), "ft-client-switch-tx-"));
+  process.env.FIRST_TREE_HOME = home;
+  serviceMocks.getClientServiceStatus.mockReturnValue({ state: "inactive", platform: "test" });
+  serviceMocks.stopClientService.mockReturnValue({ ok: true });
+});
+
+afterEach(() => {
+  for (const child of children.splice(0)) {
+    if (child.exitCode === null && child.signalCode === null && child.pid) {
+      try {
+        process.kill(child.pid, "SIGKILL");
+      } catch {
+        // Already stopped.
+      }
+    }
+  }
+  rmSync(home, { recursive: true, force: true });
+  if (originalHome === undefined) delete process.env.FIRST_TREE_HOME;
+  else process.env.FIRST_TREE_HOME = originalHome;
+});
+
+describe("client switch transaction recovery", () => {
+  it("clears a completed journal before starting a fresh switch", async () => {
+    const { switchLocalClientForLogin, clientSwitchJournalPath, clientSwitchLockPath } = await import(
+      "../core/client-switch.js"
+    );
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    mkdirSync(join(home, "state"), { recursive: true });
+    writeJson(clientSwitchLockPath(home), { pid: process.pid });
+    writeJson(clientSwitchJournalPath(home), {
+      version: 1,
+      id: "switch-complete",
+      phase: "complete",
+      from: { clientId: "client_aabbccdd", userId: "user-old", serverUrl: "https://old.example" },
+      to: { clientId: "client_11223344", userId: "user-new", serverUrl: "https://new.example" },
+      moves: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const config = await switchLocalClientForLogin({
+      existingCredentials: {
+        accessToken: "old-access",
+        refreshToken: "old-refresh",
+        serverUrl: "https://old.example",
+      },
+      previousOwnerSub: "user-old",
+      targetTokens: {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        serverUrl: "https://new.example",
+      },
+      targetOwnerSub: "user-new",
+    });
+
+    expect(config.server.url).toBe("https://new.example");
+    expect(existsSync(clientSwitchJournalPath(home))).toBe(false);
+    expect(existsSync(clientSwitchLockPath(home))).toBe(false);
+  });
+
+  it("parks the active client and creates a fresh target client", async () => {
+    const { switchLocalClientForLogin, clientSwitchJournalPath, clientSwitchLockPath } = await import(
+      "../core/client-switch.js"
+    );
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    mkdirSync(join(home, "config", "agents", "old-agent"), { recursive: true });
+    mkdirSync(join(home, "data", "sessions", "old-session"), { recursive: true });
+
+    const config = await switchLocalClientForLogin({
+      existingCredentials: {
+        accessToken: "old-access",
+        refreshToken: "old-refresh",
+        serverUrl: "https://old.example",
+      },
+      previousOwnerSub: "user-old",
+      targetTokens: {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        serverUrl: "https://new.example",
+      },
+      targetOwnerSub: "user-new",
+    });
+
+    expect(config.client.id).toMatch(/^client_[a-f0-9]{8}$/);
+    expect(config.server.url).toBe("https://new.example");
+    expect(existsSync(join(home, "parked-clients", "client_aabbccdd", "config", "client.yaml"))).toBe(true);
+    expect(existsSync(join(home, "parked-clients", "client_aabbccdd", "config", "agents", "old-agent"))).toBe(true);
+    expect(readFileSync(join(home, "config", "credentials.json"), "utf8")).toContain("new-refresh");
+    expect(existsSync(clientSwitchJournalPath(home))).toBe(false);
+    expect(existsSync(clientSwitchLockPath(home))).toBe(false);
+
+    const index = readJson(join(home, "parked-clients", "index.json")) as {
+      activeClientId: string;
+      clients: Record<string, { storage: string }>;
+    };
+    expect(index.activeClientId).toBe(config.client.id);
+    expect(index.clients.client_aabbccdd?.storage).toBe("parked");
+    expect(index.clients[config.client.id]?.storage).toBe("active-root");
+  });
+
+  it("restores a remembered parked client during login switching", async () => {
+    const { switchLocalClientForLogin } = await import("../core/client-switch.js");
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    const parkedTarget = join(home, "parked-clients", "client_11223344");
+    writeClientYaml("client_11223344", "https://new.example", join(parkedTarget, "config"));
+    mkdirSync(join(parkedTarget, "config", "agents", "target-agent"), { recursive: true });
+    mkdirSync(join(parkedTarget, "data", "sessions", "target-session"), { recursive: true });
+    writeJson(join(home, "parked-clients", "index.json"), {
+      version: 1,
+      activeClientId: "client_aabbccdd",
+      accountDefaults: {
+        "https://new.example\nuser-new": "client_11223344",
+      },
+      clients: {
+        client_11223344: {
+          clientId: "client_11223344",
+          userId: "user-new",
+          serverUrl: "https://new.example",
+          storage: "parked",
+          parkedPath: parkedTarget,
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    const config = await switchLocalClientForLogin({
+      existingCredentials: {
+        accessToken: "old-access",
+        refreshToken: "old-refresh",
+        serverUrl: "https://old.example",
+      },
+      previousOwnerSub: "user-old",
+      targetTokens: {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        serverUrl: "https://new.example",
+      },
+      targetOwnerSub: "user-new",
+    });
+
+    expect(config.client.id).toBe("client_11223344");
+    expect(existsSync(join(home, "config", "agents", "target-agent"))).toBe(true);
+    expect(existsSync(join(home, "data", "sessions", "target-session"))).toBe(true);
+    const index = readJson(join(home, "parked-clients", "index.json")) as {
+      activeClientId: string;
+      clients: Record<string, { storage: string }>;
+    };
+    expect(index.activeClientId).toBe("client_11223344");
+    expect(index.clients.client_11223344?.storage).toBe("active-root");
+  });
+
+  it("resumes a pending journal and restores the target client", async () => {
+    const { switchLocalClientForLogin, clientSwitchJournalPath, clientSwitchLockPath } = await import(
+      "../core/client-switch.js"
+    );
+    const parkedTarget = join(home, "parked-clients", "client_11223344");
+    writeClientYaml("client_11223344", "https://new.example", join(parkedTarget, "config"));
+    mkdirSync(join(home, "state"), { recursive: true });
+    writeJson(clientSwitchLockPath(home), { pid: process.pid });
+    writeJson(clientSwitchJournalPath(home), {
+      version: 1,
+      id: "switch-pending",
+      phase: "parked-old-client",
+      from: { clientId: "client_aabbccdd", userId: "user-old", serverUrl: "https://old.example" },
+      to: { clientId: "client_11223344", userId: "user-new", serverUrl: "https://new.example" },
+      moves: [
+        {
+          kind: "park-client-yaml",
+          group: "park",
+          source: join(home, "config", "client.yaml"),
+          target: join(home, "parked-clients", "client_aabbccdd", "config", "client.yaml"),
+          required: true,
+          state: "done",
+        },
+        {
+          kind: "restore-client-yaml",
+          group: "restore",
+          source: join(parkedTarget, "config", "client.yaml"),
+          target: join(home, "config", "client.yaml"),
+          required: true,
+          state: "pending",
+        },
+        {
+          kind: "restore-agents",
+          group: "restore",
+          source: join(parkedTarget, "config", "agents"),
+          target: join(home, "config", "agents"),
+          required: false,
+          state: "pending",
+        },
+      ],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const config = await switchLocalClientForLogin({
+      targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+      targetOwnerSub: "user-new",
+    });
+
+    expect(config.client.id).toBe("client_11223344");
+    expect(existsSync(clientSwitchJournalPath(home))).toBe(false);
+    expect(existsSync(clientSwitchLockPath(home))).toBe(false);
+    const index = readJson(join(home, "parked-clients", "index.json")) as {
+      activeClientId: string;
+      clients: Record<string, { storage: string }>;
+    };
+    expect(index.activeClientId).toBe("client_11223344");
+    expect(index.clients.client_aabbccdd?.storage).toBe("parked");
+  });
+
+  it("fails before switching when the existing owner or active client id is unknown", async () => {
+    const { switchLocalClientForLogin } = await import("../core/client-switch.js");
+
+    await expect(
+      switchLocalClientForLogin({
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_OWNER_UNKNOWN_REQUIRES_RESET_OR_OWNER_LOGIN" });
+
+    mkdirSync(join(home, "config"), { recursive: true });
+    writeFileSync(join(home, "config", "client.yaml"), "server:\n  url: https://old.example\n");
+    await expect(
+      switchLocalClientForLogin({
+        existingCredentials: { accessToken: "old", refreshToken: "refresh", serverUrl: "https://old.example" },
+        previousOwnerSub: "user-old",
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_OWNER_UNKNOWN_REQUIRES_RESET_OR_OWNER_LOGIN" });
+  });
+
+  it("guards pending journals that need manual repair or a fresh retry", async () => {
+    const { switchLocalClientForLogin, clientSwitchJournalPath, clientSwitchLockPath } = await import(
+      "../core/client-switch.js"
+    );
+    mkdirSync(join(home, "state"), { recursive: true });
+    writeJson(join(home, "state", "client-switch.lock"), { pid: process.pid });
+    writeJson(clientSwitchJournalPath(home), {
+      version: 1,
+      id: "switch-test",
+      phase: "service-stopped",
+      from: { clientId: "client_aabbccdd", userId: "user-old", serverUrl: "https://old.example" },
+      to: { userId: "other-user", serverUrl: "https://new.example" },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    await expect(
+      switchLocalClientForLogin({
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_SWITCH_MANUAL_REPAIR_REQUIRED" });
+
+    writeJson(clientSwitchJournalPath(home), {
+      version: 1,
+      id: "switch-test",
+      phase: "service-stopped",
+      from: { clientId: "client_aabbccdd", userId: "user-old", serverUrl: "https://old.example" },
+      to: { userId: "user-new", serverUrl: "https://new.example" },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    await expect(
+      switchLocalClientForLogin({
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_SWITCH_RETRY_REQUIRED" });
+    expect(existsSync(clientSwitchJournalPath(home))).toBe(false);
+    expect(existsSync(clientSwitchLockPath(home))).toBe(false);
+  });
+
+  it("requires manual repair when an existing lock blocks a fresh switch", async () => {
+    const { switchLocalClientForLogin, clientSwitchLockPath } = await import("../core/client-switch.js");
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    mkdirSync(join(home, "state"), { recursive: true });
+    writeJson(clientSwitchLockPath(home), { pid: process.pid });
+
+    await expect(
+      switchLocalClientForLogin({
+        existingCredentials: { accessToken: "old", refreshToken: "refresh", serverUrl: "https://old.example" },
+        previousOwnerSub: "user-old",
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_SWITCH_MANUAL_REPAIR_REQUIRED" });
+  });
+
+  it("fails pending journal recovery when move state is ambiguous", async () => {
+    const { switchLocalClientForLogin, clientSwitchJournalPath, clientSwitchLockPath } = await import(
+      "../core/client-switch.js"
+    );
+    const parkedTarget = join(home, "parked-clients", "client_11223344");
+    writeClientYaml("client_11223344", "https://new.example", join(parkedTarget, "config"));
+    writeClientYaml("client_existing", "https://new.example", join(home, "config"));
+    mkdirSync(join(home, "state"), { recursive: true });
+    writeJson(clientSwitchLockPath(home), { pid: process.pid });
+    writeJson(clientSwitchJournalPath(home), {
+      version: 1,
+      id: "switch-ambiguous",
+      phase: "parked-old-client",
+      from: { clientId: "client_aabbccdd", userId: "user-old", serverUrl: "https://old.example" },
+      to: { clientId: "client_11223344", userId: "user-new", serverUrl: "https://new.example" },
+      moves: [
+        {
+          kind: "restore-client-yaml",
+          group: "restore",
+          source: join(parkedTarget, "config", "client.yaml"),
+          target: join(home, "config", "client.yaml"),
+          required: true,
+          state: "pending",
+        },
+      ],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    await expect(
+      switchLocalClientForLogin({
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_SWITCH_MANUAL_REPAIR_REQUIRED" });
+  });
+
+  it("fails pending journal recovery when a required move disappeared", async () => {
+    const { switchLocalClientForLogin, clientSwitchJournalPath, clientSwitchLockPath } = await import(
+      "../core/client-switch.js"
+    );
+    mkdirSync(join(home, "state"), { recursive: true });
+    writeJson(clientSwitchLockPath(home), { pid: process.pid });
+    writeJson(clientSwitchJournalPath(home), {
+      version: 1,
+      id: "switch-missing",
+      phase: "parked-old-client",
+      from: { clientId: "client_aabbccdd", userId: "user-old", serverUrl: "https://old.example" },
+      to: { clientId: "client_11223344", userId: "user-new", serverUrl: "https://new.example" },
+      moves: [
+        {
+          kind: "restore-client-yaml",
+          group: "restore",
+          source: join(home, "missing", "client.yaml"),
+          target: join(home, "config", "client.yaml"),
+          required: true,
+          state: "pending",
+        },
+      ],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    await expect(
+      switchLocalClientForLogin({
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_SWITCH_MANUAL_REPAIR_REQUIRED" });
+  });
+
+  it("fails when the supervisor cannot be proven safely stopped", async () => {
+    const { switchLocalClientForLogin } = await import("../core/client-switch.js");
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    serviceMocks.getClientServiceStatus.mockReturnValueOnce({
+      state: "unknown",
+      platform: "test",
+      detail: "no supervisor",
+    });
+
+    await expect(
+      switchLocalClientForLogin({
+        existingCredentials: { accessToken: "old", refreshToken: "refresh", serverUrl: "https://old.example" },
+        previousOwnerSub: "user-old",
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_SWITCH_SUPERVISOR_UNSAFE" });
+  });
+
+  it("fails when an active supervisor cannot be stopped", async () => {
+    const { switchLocalClientForLogin } = await import("../core/client-switch.js");
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    serviceMocks.getClientServiceStatus.mockReturnValueOnce({ state: "active", platform: "test" });
+    serviceMocks.stopClientService.mockReturnValueOnce({ ok: false, reason: "permission denied" });
+
+    await expect(
+      switchLocalClientForLogin({
+        existingCredentials: { accessToken: "old", refreshToken: "refresh", serverUrl: "https://old.example" },
+        previousOwnerSub: "user-old",
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_SWITCH_SUPERVISOR_UNSAFE" });
+  });
+
+  it("fails when the supervisor remains active after stop", async () => {
+    const { switchLocalClientForLogin } = await import("../core/client-switch.js");
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    serviceMocks.getClientServiceStatus
+      .mockReturnValueOnce({ state: "active", platform: "test" })
+      .mockReturnValueOnce({ state: "active", platform: "test", detail: "still running" });
+
+    await expect(
+      switchLocalClientForLogin({
+        existingCredentials: { accessToken: "old", refreshToken: "refresh", serverUrl: "https://old.example" },
+        previousOwnerSub: "user-old",
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_SWITCH_SUPERVISOR_UNSAFE" });
+  });
+
+  it("fails when a runtime marker is still live for the active client", async () => {
+    const { switchLocalClientForLogin, registerClientRuntimeMarker } = await import("../core/client-switch.js");
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    registerClientRuntimeMarker({ clientId: "client_aabbccdd", mode: "foreground", home, pid: process.pid });
+
+    await expect(
+      switchLocalClientForLogin({
+        existingCredentials: { accessToken: "old", refreshToken: "refresh", serverUrl: "https://old.example" },
+        previousOwnerSub: "user-old",
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_SWITCH_RUNTIME_ACTIVE" });
+  });
+
+  it("fails when marked provider work is still running for the active client", async () => {
+    const { switchLocalClientForLogin } = await import("../core/client-switch.js");
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], {
+      env: {
+        ...process.env,
+        FIRST_TREE_HOME: home,
+        FIRST_TREE_CLIENT_ID: "client_aabbccdd",
+        FIRST_TREE_SWITCH_DRAIN_VERSION: "1",
+        FIRST_TREE_PROVIDER: "codex",
+      },
+    });
+    children.push(child);
+
+    await expect(
+      switchLocalClientForLogin({
+        existingCredentials: { accessToken: "old", refreshToken: "refresh", serverUrl: "https://old.example" },
+        previousOwnerSub: "user-old",
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_TIMEOUT" });
+  });
+
+  it("confirms interactive switches and records cross-server confirmation output", async () => {
+    const { confirmLocalClientSwitch } = await import("../core/client-switch.js");
+    const originalTty = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    promptMocks.confirm.mockResolvedValueOnce(true);
+
+    await confirmLocalClientSwitch({
+      existingServerUrl: "https://old.example",
+      targetServerUrl: "https://new.example",
+      existingUserId: "user-old",
+      targetUserId: "user-new",
+      existingClientId: "client_aabbccdd",
+      targetClientId: "client_11223344",
+    });
+
+    expect(promptMocks.confirm).toHaveBeenCalledWith({
+      message: expect.stringContaining("client_aabbccdd"),
+      default: false,
+    });
+    expect(outputMocks.line).toHaveBeenCalledWith(
+      expect.stringContaining("https://old.example -> https://new.example"),
+    );
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: originalTty });
+  });
+
+  it("supports forced switches and rejects non-interactive or cancelled confirmations", async () => {
+    const { confirmLocalClientSwitch } = await import("../core/client-switch.js");
+    const originalTty = process.stdin.isTTY;
+
+    await expect(
+      confirmLocalClientSwitch({
+        existingServerUrl: "https://old.example",
+        targetServerUrl: "https://new.example",
+        forceSwitch: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+    await expect(
+      confirmLocalClientSwitch({
+        existingServerUrl: "https://old.example",
+        targetServerUrl: "https://new.example",
+      }),
+    ).rejects.toMatchObject({ code: "ACCOUNT_SWITCH_REQUIRES_CONFIRMATION" });
+
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    promptMocks.confirm.mockResolvedValueOnce(false);
+    await expect(
+      confirmLocalClientSwitch({
+        existingServerUrl: "https://same.example",
+        targetServerUrl: "https://same.example",
+      }),
+    ).rejects.toMatchObject({ code: "ACCOUNT_SWITCH_CANCELLED" });
+
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: originalTty });
+  });
+});

--- a/apps/cli/src/__tests__/client-switch-transaction-extra.test.ts
+++ b/apps/cli/src/__tests__/client-switch-transaction-extra.test.ts
@@ -43,6 +43,15 @@ function readJson(path: string): unknown {
   return JSON.parse(readFileSync(path, "utf8")) as unknown;
 }
 
+function daemonStartCommand(): string {
+  const escapedNode = process.execPath.replace(/'/g, "'\\''");
+  return `exec -a 'first-tree daemon start' '${escapedNode}' -e 'setInterval(() => {}, 1000)'`;
+}
+
+async function waitForChildVisible(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 75));
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   originalHome = process.env.FIRST_TREE_HOME;
@@ -476,6 +485,40 @@ describe("client switch transaction recovery", () => {
     ).rejects.toMatchObject({ code: "CLIENT_SWITCH_RUNTIME_ACTIVE" });
   });
 
+  it("summarizes many live runtime markers before switching", async () => {
+    const { switchLocalClientForLogin, clientRuntimeMarkerPath } = await import("../core/client-switch.js");
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    const markerDir = join(home, "state", "client-runtimes");
+    mkdirSync(markerDir, { recursive: true });
+    for (let index = 0; index < 9; index += 1) {
+      const pid = 70_000 + index;
+      writeJson(clientRuntimeMarkerPath(home, pid), {
+        version: 1,
+        pid,
+        clientId: "client_aabbccdd",
+        home,
+        mode: index % 2 === 0 ? "foreground" : "service",
+        createdAt: new Date().toISOString(),
+      });
+    }
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+    try {
+      await expect(
+        switchLocalClientForLogin({
+          existingCredentials: { accessToken: "old", refreshToken: "refresh", serverUrl: "https://old.example" },
+          previousOwnerSub: "user-old",
+          targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+          targetOwnerSub: "user-new",
+        }),
+      ).rejects.toMatchObject({
+        code: "CLIENT_SWITCH_RUNTIME_ACTIVE",
+        message: expect.stringContaining("...and 1 more"),
+      });
+    } finally {
+      kill.mockRestore();
+    }
+  });
+
   it("fails when marked provider work is still running for the active client", async () => {
     const { switchLocalClientForLogin } = await import("../core/client-switch.js");
     writeClientYaml("client_aabbccdd", "https://old.example");
@@ -500,6 +543,81 @@ describe("client switch transaction recovery", () => {
     ).rejects.toMatchObject({ code: "CLIENT_SWITCH_DRAIN_TIMEOUT" });
   });
 
+  it("fails when provider work appears during the second switch drain scan", async () => {
+    const { switchLocalClientForLogin } = await import("../core/client-switch.js");
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    setTimeout(() => {
+      const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], {
+        env: {
+          ...process.env,
+          FIRST_TREE_HOME: home,
+          FIRST_TREE_CLIENT_ID: "client_aabbccdd",
+          FIRST_TREE_SWITCH_DRAIN_VERSION: "1",
+          FIRST_TREE_PROVIDER: "codex",
+          FIRST_TREE_AGENT_ID: "agent-late",
+          FIRST_TREE_CHAT_ID: "chat-late",
+        },
+      });
+      children.push(child);
+    }, 100);
+
+    await expect(
+      switchLocalClientForLogin({
+        existingCredentials: { accessToken: "old", refreshToken: "refresh", serverUrl: "https://old.example" },
+        previousOwnerSub: "user-old",
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_TIMEOUT",
+      message: expect.stringContaining("agent=agent-late"),
+    });
+  });
+
+  it("fails closed when a daemon process lacks trusted drain markers", async () => {
+    const { switchLocalClientForLogin } = await import("../core/client-switch.js");
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    delete env.FIRST_TREE_HOME;
+    delete env.FIRST_TREE_CLIENT_ID;
+    delete env.FIRST_TREE_SWITCH_DRAIN_VERSION;
+    const child = spawn("bash", ["-c", daemonStartCommand()], { env });
+    children.push(child);
+    await waitForChildVisible();
+
+    await expect(
+      switchLocalClientForLogin({
+        existingCredentials: { accessToken: "old", refreshToken: "refresh", serverUrl: "https://old.example" },
+        previousOwnerSub: "user-old",
+        targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+        targetOwnerSub: "user-new",
+      }),
+    ).rejects.toMatchObject({
+      code: "CLIENT_SWITCH_DRAIN_UNSUPPORTED",
+      message: expect.stringContaining("daemon runtime lacks trusted switch drain markers"),
+    });
+  });
+
+  it("ignores daemon processes that belong to another client", async () => {
+    const { switchLocalClientForLogin } = await import("../core/client-switch.js");
+    writeClientYaml("client_aabbccdd", "https://old.example");
+    const env: NodeJS.ProcessEnv = { ...process.env, FIRST_TREE_CLIENT_ID: "client_11223344" };
+    delete env.FIRST_TREE_HOME;
+    delete env.FIRST_TREE_SWITCH_DRAIN_VERSION;
+    const child = spawn("bash", ["-c", daemonStartCommand()], { env });
+    children.push(child);
+    await waitForChildVisible();
+
+    const config = await switchLocalClientForLogin({
+      existingCredentials: { accessToken: "old", refreshToken: "refresh", serverUrl: "https://old.example" },
+      previousOwnerSub: "user-old",
+      targetTokens: { accessToken: "new", refreshToken: "refresh", serverUrl: "https://new.example" },
+      targetOwnerSub: "user-new",
+    });
+
+    expect(config.server.url).toBe("https://new.example");
+  });
+
   it("confirms interactive switches and records cross-server confirmation output", async () => {
     const { confirmLocalClientSwitch } = await import("../core/client-switch.js");
     const originalTty = process.stdin.isTTY;
@@ -522,6 +640,29 @@ describe("client switch transaction recovery", () => {
     expect(outputMocks.line).toHaveBeenCalledWith(
       expect.stringContaining("https://old.example -> https://new.example"),
     );
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: originalTty });
+  });
+
+  it("formats interactive confirmation defaults when user and client ids are unknown", async () => {
+    const { confirmLocalClientSwitch } = await import("../core/client-switch.js");
+    const originalTty = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    promptMocks.confirm.mockResolvedValueOnce(true);
+
+    await confirmLocalClientSwitch({
+      existingServerUrl: "https://same.example",
+      targetServerUrl: "https://same.example",
+    });
+
+    expect(promptMocks.confirm).toHaveBeenCalledWith({
+      message: expect.stringContaining("the current user"),
+      default: false,
+    });
+    expect(promptMocks.confirm).toHaveBeenCalledWith({
+      message: expect.stringContaining("create or restore a separate local client"),
+      default: false,
+    });
+    expect(outputMocks.line).not.toHaveBeenCalledWith(expect.stringContaining("Switching server:"));
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: originalTty });
   });
 

--- a/apps/cli/src/__tests__/client-switch.test.ts
+++ b/apps/cli/src/__tests__/client-switch.test.ts
@@ -66,6 +66,7 @@ describe("client switch drain markers", () => {
     expect(parseSwitchProcessEnvValue("FIRST_TREE_HOME= FIRST_TREE_CLIENT_ID=client_aabbccdd", "FIRST_TREE_HOME")).toBe(
       "",
     );
+    expect(parseSwitchProcessEnvValue("FIRST_TREE_HOME=", "FIRST_TREE_HOME")).toBe("");
     expect(parseSwitchProcessEnvValue("FIRST_TREE_HOME=/tmp/ft", "FIRST_TREE_CLIENT_ID")).toBeNull();
     expect(parseSwitchProcessEnvValue("FIRST_TREE_HOME=/tmp/ft", "FIRST.TREE")).toBeNull();
   });
@@ -217,6 +218,47 @@ describe("client switch drain markers", () => {
     ]);
   });
 
+  it("falls back to unknown-provider for known provider commands without provider markers", () => {
+    const providers: Array<{ pid: number; provider: string; agentId?: string; chatId?: string; command: string }> = [];
+    const issues: Array<{ pid: number; command: string; reason: string }> = [];
+
+    collectSwitchDrainProcessFromEnvText({
+      pid: 127,
+      command: "/usr/local/bin/codex",
+      envText: [
+        "FIRST_TREE_HOME=/Users/alice/.first-tree",
+        "FIRST_TREE_CLIENT_ID=client_aabbccdd",
+        "FIRST_TREE_SWITCH_DRAIN_VERSION=1",
+        "",
+      ].join("\0"),
+      home: "/Users/alice/.first-tree",
+      clientId: "client_aabbccdd",
+      providers,
+      issues,
+    });
+
+    expect(issues).toEqual([]);
+    expect(providers).toEqual([expect.objectContaining({ pid: 127, provider: "unknown-provider" })]);
+  });
+
+  it("fails closed on known provider commands that lack trusted markers", () => {
+    const providers: Array<{ pid: number; provider: string; command: string }> = [];
+    const issues: Array<{ pid: number; command: string; reason: string }> = [];
+
+    collectSwitchDrainProcessFromEnvText({
+      pid: 128,
+      command: "/usr/local/bin/codex",
+      envText: "FIRST_TREE_HOME=/Users/alice/.first-tree",
+      home: "/Users/alice/.first-tree",
+      clientId: "client_aabbccdd",
+      providers,
+      issues,
+    });
+
+    expect(providers).toEqual([]);
+    expect(issues).toEqual([expect.objectContaining({ pid: 128, reason: "missing trusted switch drain markers" })]);
+  });
+
   it("requires readable env only for known switch-drain process commands", () => {
     expect(isSwitchDrainEnvRequired("/usr/bin/codex exec")).toBe(true);
     expect(isSwitchDrainEnvRequired("node /app/node_modules/@openai/codex/bin.js")).toBe(true);
@@ -245,6 +287,27 @@ describe("client runtime markers", () => {
     clear();
     clear();
     expect(existsSync(markerPath)).toBe(false);
+  });
+
+  it("uses default home and pid when registering runtime markers", () => {
+    const home = mkdtempSync(join(tmpdir(), "ft-client-runtime-defaults-"));
+    tempHomes.push(home);
+    const previousHome = process.env.FIRST_TREE_HOME;
+    process.env.FIRST_TREE_HOME = home;
+    try {
+      const clear = registerClientRuntimeMarker({
+        clientId: "client_aabbccdd",
+        mode: "service",
+      });
+      const markerPath = clientRuntimeMarkerPath(home, process.pid);
+
+      expect(readFileSync(markerPath, "utf8")).toContain('"mode": "service"');
+      clear();
+      expect(existsSync(markerPath)).toBe(false);
+    } finally {
+      if (previousHome === undefined) delete process.env.FIRST_TREE_HOME;
+      else process.env.FIRST_TREE_HOME = previousHome;
+    }
   });
 
   it("lists a live runtime marker and includes the process command when available", () => {
@@ -373,6 +436,31 @@ describe("client runtime markers", () => {
     kill.mockRestore();
   });
 
+  it("uses default stop timing options and stringifies non-Error kill failures", async () => {
+    let alive = true;
+    const kill = vi.spyOn(process, "kill").mockImplementation((_pid, signal) => {
+      if (signal === 0) {
+        if (alive) return true;
+        const err = Object.assign(new Error("gone"), { code: "ESRCH" });
+        throw err;
+      }
+      alive = false;
+      return true;
+    });
+
+    await expect(stopClientRuntimeProcess(12348)).resolves.toEqual({ ok: true });
+
+    kill.mockImplementation((_pid, signal) => {
+      if (signal === 0) return true;
+      throw "kill failed as string";
+    });
+    await expect(stopClientRuntimeProcess(12349)).resolves.toEqual({
+      ok: false,
+      reason: "kill failed as string",
+    });
+    kill.mockRestore();
+  });
+
   it("times out when a runtime process does not stop after the signal", async () => {
     const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
 
@@ -382,6 +470,31 @@ describe("client runtime markers", () => {
       ok: false,
       reason: expect.stringContaining("timed out waiting for pid"),
     });
+    kill.mockRestore();
+  });
+
+  it("handles runtime stop races after the wait deadline", async () => {
+    let probes = 0;
+    const kill = vi.spyOn(process, "kill").mockImplementation((_pid, signal) => {
+      if (signal === 0) {
+        probes += 1;
+        if (probes === 1) return true;
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+      return true;
+    });
+
+    await expect(stopClientRuntimeProcess(12350, { timeoutMs: 0, intervalMs: 1 })).resolves.toEqual({ ok: true });
+    kill.mockRestore();
+  });
+
+  it("treats non-Error liveness probe failures as live before surfacing signal failures", async () => {
+    const kill = vi.spyOn(process, "kill").mockImplementation((_pid, signal) => {
+      if (signal === 0) throw "probe failed";
+      throw "signal failed";
+    });
+
+    await expect(stopClientRuntimeProcess(12351)).resolves.toEqual({ ok: false, reason: "signal failed" });
     kill.mockRestore();
   });
 });
@@ -456,6 +569,18 @@ describe("active client identity recovery", () => {
     );
 
     expect(readActiveClientIdFromIndex(home)).toBeNull();
+
+    writeFileSync(
+      join(home, "parked-clients", "index.json"),
+      JSON.stringify({
+        version: 1,
+        activeClientId: "not-a-client-id",
+        accountDefaults: {},
+        clients: {},
+      }),
+    );
+
+    expect(readActiveClientIdFromIndex(home)).toBeNull();
   });
 
   it("recovers active client owner and remembered defaults from the switch index", () => {
@@ -491,6 +616,9 @@ describe("active client identity recovery", () => {
       serverUrl: "https://first-tree.example",
     });
     expect(readRememberedLocalClientIdForAccount("https://first-tree.example", "user-1", home)).toBe("client_aabbccdd");
+
+    writeFileSync(join(configDir, "client.yaml"), "client:\n  id: client_11223344\n");
+    expect(readActiveClientOwner(home, configDir)).toBeNull();
   });
 
   it("parks any prior active-root entry when recording a new active owner", () => {
@@ -537,6 +665,9 @@ describe("active client identity recovery", () => {
     tempHomes.push(configDir);
     const configPath = join(configDir, "client.yaml");
     writeFileSync(configPath, "server:\n  url: https://first-tree.example\n");
+
+    ensureActiveRootClientIdPersisted("client_aabbccdd", configDir);
+    expect(readFileSync(configPath, "utf8")).toContain("id: client_aabbccdd");
 
     ensureActiveRootClientIdPersisted("client_aabbccdd", configDir);
     expect(readFileSync(configPath, "utf8")).toContain("id: client_aabbccdd");

--- a/apps/cli/src/__tests__/client-switch.test.ts
+++ b/apps/cli/src/__tests__/client-switch.test.ts
@@ -2,14 +2,24 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  CLIENT_SWITCH_INTERRUPTED_REASON,
+  clientRuntimeMarkerPath,
   collectSwitchDrainProcessFromEnvText,
   ensureActiveRootClientIdPersisted,
+  getClientSwitchStartupBlock,
+  hasIncompleteClientSwitch,
   isSwitchDrainEnvRequired,
   listLiveClientRuntimeMarkers,
   parseSwitchProcessEnvValue,
   readActiveClientIdFromIndex,
+  readActiveClientOwner,
+  readActiveRootClientId,
+  readRememberedLocalClientIdForAccount,
+  recordActiveClientOwner,
+  registerClientRuntimeMarker,
+  resolveClientRuntimeStopReason,
   stopClientRuntimeProcess,
 } from "../core/client-switch.js";
 
@@ -52,6 +62,14 @@ describe("client switch drain markers", () => {
     expect(parseSwitchProcessEnvValue(envText, "FIRST_TREE_CLIENT_ID")).toBe("client_aabbccdd");
   });
 
+  it("returns null or an empty string for missing and blank process text values", () => {
+    expect(parseSwitchProcessEnvValue("FIRST_TREE_HOME= FIRST_TREE_CLIENT_ID=client_aabbccdd", "FIRST_TREE_HOME")).toBe(
+      "",
+    );
+    expect(parseSwitchProcessEnvValue("FIRST_TREE_HOME=/tmp/ft", "FIRST_TREE_CLIENT_ID")).toBeNull();
+    expect(parseSwitchProcessEnvValue("FIRST_TREE_HOME=/tmp/ft", "FIRST.TREE")).toBeNull();
+  });
+
   it("preserves spaces inside process text values when another env marker follows", () => {
     const envText =
       "FIRST_TREE_PROVIDER=codex FIRST_TREE_HOME=/Users/Alice Smith/.first-tree FIRST_TREE_CLIENT_ID=client_aabbccdd";
@@ -86,6 +104,42 @@ describe("client switch drain markers", () => {
     ]);
   });
 
+  it("ignores processes outside the active home or without First Tree markers", () => {
+    const providers: Array<{ pid: number; provider: string; command: string }> = [];
+    const issues: Array<{ pid: number; command: string; reason: string }> = [];
+
+    collectSwitchDrainProcessFromEnvText({
+      pid: 120,
+      command: "node worker.js",
+      envText: "FIRST_TREE_HOME=/tmp/other FIRST_TREE_CLIENT_ID=client_aabbccdd FIRST_TREE_SWITCH_DRAIN_VERSION=1",
+      home: "/tmp/ft",
+      clientId: "client_aabbccdd",
+      providers,
+      issues,
+    });
+    collectSwitchDrainProcessFromEnvText({
+      pid: 121,
+      command: "node worker.js",
+      envText: "FIRST_TREE_HOME=/tmp/ft",
+      home: "/tmp/ft",
+      clientId: "client_aabbccdd",
+      providers,
+      issues,
+    });
+    collectSwitchDrainProcessFromEnvText({
+      pid: 122,
+      command: "first-tree daemon start --foreground",
+      envText: "FIRST_TREE_HOME=/tmp/ft",
+      home: "/tmp/ft",
+      clientId: "client_aabbccdd",
+      providers,
+      issues,
+    });
+
+    expect(providers).toEqual([]);
+    expect(issues).toEqual([]);
+  });
+
   it("fails closed on unknown marked descendants without trusted drain version", () => {
     const providers: Array<{ pid: number; provider: string; command: string }> = [];
     const issues: Array<{ pid: number; command: string; reason: string }> = [];
@@ -105,14 +159,116 @@ describe("client switch drain markers", () => {
     expect(issues).toEqual([expect.objectContaining({ pid: 124, reason: "missing trusted switch drain markers" })]);
   });
 
+  it("fails closed when a trusted marker belongs to another client", () => {
+    const providers: Array<{ pid: number; provider: string; command: string }> = [];
+    const issues: Array<{ pid: number; command: string; reason: string }> = [];
+
+    collectSwitchDrainProcessFromEnvText({
+      pid: 125,
+      command: "/usr/bin/codex exec",
+      envText: [
+        "FIRST_TREE_HOME=/Users/alice/.first-tree",
+        "FIRST_TREE_CLIENT_ID=client_11223344",
+        "FIRST_TREE_SWITCH_DRAIN_VERSION=1",
+        "",
+      ].join("\0"),
+      home: "/Users/alice/.first-tree",
+      clientId: "client_aabbccdd",
+      providers,
+      issues,
+    });
+
+    expect(providers).toEqual([]);
+    expect(issues).toEqual([
+      expect.objectContaining({ pid: 125, reason: "belongs to another client (client_11223344)" }),
+    ]);
+  });
+
+  it("records provider, agent, and chat markers for known provider commands", () => {
+    const providers: Array<{ pid: number; provider: string; agentId?: string; chatId?: string; command: string }> = [];
+    const issues: Array<{ pid: number; command: string; reason: string }> = [];
+
+    collectSwitchDrainProcessFromEnvText({
+      pid: 126,
+      command: "/usr/local/bin/claude",
+      envText: [
+        "FIRST_TREE_HOME=/Users/alice/.first-tree",
+        "FIRST_TREE_PROVIDER=claude",
+        "FIRST_TREE_CLIENT_ID=client_aabbccdd",
+        "FIRST_TREE_SWITCH_DRAIN_VERSION=1",
+        "FIRST_TREE_AGENT_ID=agent-1",
+        "FIRST_TREE_CHAT_ID=chat-1",
+        "",
+      ].join("\0"),
+      home: "/Users/alice/.first-tree",
+      clientId: "client_aabbccdd",
+      providers,
+      issues,
+    });
+
+    expect(issues).toEqual([]);
+    expect(providers).toEqual([
+      expect.objectContaining({
+        pid: 126,
+        provider: "claude",
+        agentId: "agent-1",
+        chatId: "chat-1",
+      }),
+    ]);
+  });
+
   it("requires readable env only for known switch-drain process commands", () => {
     expect(isSwitchDrainEnvRequired("/usr/bin/codex exec")).toBe(true);
+    expect(isSwitchDrainEnvRequired("node /app/node_modules/@openai/codex/bin.js")).toBe(true);
+    expect(isSwitchDrainEnvRequired("node ./node_modules/claude-code/cli.js")).toBe(true);
+    expect(isSwitchDrainEnvRequired("first-tree-dev daemon start --foreground")).toBe(true);
     expect(isSwitchDrainEnvRequired("node cli/index.mjs daemon start --foreground")).toBe(true);
+    expect(isSwitchDrainEnvRequired("first-tree daemon status")).toBe(false);
     expect(isSwitchDrainEnvRequired("/bin/bash unrelated-script")).toBe(false);
   });
 });
 
 describe("client runtime markers", () => {
+  it("registers and clears runtime markers idempotently", () => {
+    const home = mkdtempSync(join(tmpdir(), "ft-client-runtime-register-"));
+    tempHomes.push(home);
+
+    const clear = registerClientRuntimeMarker({
+      clientId: "client_aabbccdd",
+      mode: "foreground",
+      home,
+      pid: process.pid,
+    });
+    const markerPath = clientRuntimeMarkerPath(home, process.pid);
+
+    expect(readFileSync(markerPath, "utf8")).toContain("client_aabbccdd");
+    clear();
+    clear();
+    expect(existsSync(markerPath)).toBe(false);
+  });
+
+  it("lists a live runtime marker and includes the process command when available", () => {
+    const home = mkdtempSync(join(tmpdir(), "ft-client-runtime-live-"));
+    tempHomes.push(home);
+    const clear = registerClientRuntimeMarker({
+      clientId: "client_aabbccdd",
+      mode: "foreground",
+      home,
+      pid: process.pid,
+    });
+
+    const markers = listLiveClientRuntimeMarkers(home, "client_aabbccdd");
+
+    expect(markers).toEqual([
+      expect.objectContaining({
+        pid: process.pid,
+        clientId: "client_aabbccdd",
+        mode: "foreground",
+      }),
+    ]);
+    clear();
+  });
+
   it("cleans stale runtime markers while listing live runtimes", () => {
     const home = mkdtempSync(join(tmpdir(), "ft-client-runtime-markers-"));
     tempHomes.push(home);
@@ -135,6 +291,44 @@ describe("client runtime markers", () => {
     expect(existsSync(markerPath)).toBe(false);
   });
 
+  it("ignores marker files for another home, version, or client filter", () => {
+    const home = mkdtempSync(join(tmpdir(), "ft-client-runtime-filter-"));
+    tempHomes.push(home);
+    const markerDir = join(home, "state", "client-runtimes");
+    mkdirSync(markerDir, { recursive: true });
+    writeFileSync(join(markerDir, "note.txt"), "ignored");
+    writeFileSync(
+      join(markerDir, "version.json"),
+      JSON.stringify({ version: 2, pid: process.pid, clientId: "client_aabbccdd", home, mode: "foreground" }),
+    );
+    writeFileSync(
+      join(markerDir, "home.json"),
+      JSON.stringify({
+        version: 1,
+        pid: process.pid,
+        clientId: "client_aabbccdd",
+        home: "/tmp/other",
+        mode: "foreground",
+      }),
+    );
+    writeFileSync(
+      join(markerDir, "client.json"),
+      JSON.stringify({ version: 1, pid: process.pid, clientId: "client_11223344", home, mode: "foreground" }),
+    );
+
+    expect(listLiveClientRuntimeMarkers(home, "client_aabbccdd")).toEqual([]);
+  });
+
+  it("fails closed when a runtime marker cannot be parsed", () => {
+    const home = mkdtempSync(join(tmpdir(), "ft-client-runtime-bad-marker-"));
+    tempHomes.push(home);
+    const markerDir = join(home, "state", "client-runtimes");
+    mkdirSync(markerDir, { recursive: true });
+    writeFileSync(join(markerDir, "bad.json"), "{ not-json");
+
+    expect(() => listLiveClientRuntimeMarkers(home)).toThrow(/Unable to read runtime marker/u);
+  });
+
   it("sends SIGTERM and waits for a live runtime process to exit", async () => {
     const child = spawn(process.execPath, [
       "-e",
@@ -146,6 +340,49 @@ describe("client runtime markers", () => {
     const res = await stopClientRuntimeProcess(child.pid ?? -1, { timeoutMs: 5_000, intervalMs: 25 });
 
     expect(res).toEqual({ ok: true });
+  });
+
+  it("short-circuits invalid, current, and already-stopped runtime pids", async () => {
+    await expect(stopClientRuntimeProcess(-1)).resolves.toEqual({ ok: true, alreadyStopped: true });
+    await expect(stopClientRuntimeProcess(process.pid)).resolves.toEqual({
+      ok: false,
+      reason: "refusing to stop the current CLI process",
+    });
+    await expect(stopClientRuntimeProcess(999_999_999)).resolves.toEqual({ ok: true, alreadyStopped: true });
+  });
+
+  it("reports process kill failures and ESRCH races", async () => {
+    const kill = vi.spyOn(process, "kill");
+    kill
+      .mockImplementationOnce(() => true)
+      .mockImplementationOnce(() => {
+        const err = Object.assign(new Error("gone"), { code: "ESRCH" });
+        throw err;
+      });
+
+    await expect(stopClientRuntimeProcess(12345)).resolves.toEqual({ ok: true, alreadyStopped: true });
+
+    kill
+      .mockImplementationOnce(() => true)
+      .mockImplementationOnce(() => {
+        const err = Object.assign(new Error("permission denied"), { code: "EPERM" });
+        throw err;
+      });
+
+    await expect(stopClientRuntimeProcess(12346)).resolves.toEqual({ ok: false, reason: "permission denied" });
+    kill.mockRestore();
+  });
+
+  it("times out when a runtime process does not stop after the signal", async () => {
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const res = await stopClientRuntimeProcess(12347, { timeoutMs: 5, intervalMs: 1 });
+
+    expect(res).toEqual({
+      ok: false,
+      reason: expect.stringContaining("timed out waiting for pid"),
+    });
+    kill.mockRestore();
   });
 });
 
@@ -221,6 +458,80 @@ describe("active client identity recovery", () => {
     expect(readActiveClientIdFromIndex(home)).toBeNull();
   });
 
+  it("recovers active client owner and remembered defaults from the switch index", () => {
+    const home = mkdtempSync(join(tmpdir(), "ft-client-owner-index-"));
+    const configDir = mkdtempSync(join(tmpdir(), "ft-client-owner-config-"));
+    tempHomes.push(home, configDir);
+    mkdirSync(join(home, "parked-clients"), { recursive: true });
+    writeFileSync(
+      join(home, "parked-clients", "index.json"),
+      JSON.stringify({
+        version: 1,
+        activeClientId: "client_aabbccdd",
+        accountDefaults: {
+          "https://first-tree.example\nuser-1": "client_aabbccdd",
+        },
+        clients: {
+          client_aabbccdd: {
+            clientId: "client_aabbccdd",
+            userId: "user-1",
+            serverUrl: "https://first-tree.example",
+            storage: "active-root",
+            updatedAt: new Date().toISOString(),
+          },
+        },
+      }),
+    );
+    writeFileSync(join(configDir, "client.yaml"), "client:\n  id: client_aabbccdd\n");
+
+    expect(readActiveRootClientId(configDir)).toBe("client_aabbccdd");
+    expect(readActiveClientOwner(home, configDir)).toEqual({
+      clientId: "client_aabbccdd",
+      userId: "user-1",
+      serverUrl: "https://first-tree.example",
+    });
+    expect(readRememberedLocalClientIdForAccount("https://first-tree.example", "user-1", home)).toBe("client_aabbccdd");
+  });
+
+  it("parks any prior active-root entry when recording a new active owner", () => {
+    const home = mkdtempSync(join(tmpdir(), "ft-client-record-owner-"));
+    tempHomes.push(home);
+    mkdirSync(join(home, "parked-clients"), { recursive: true });
+    writeFileSync(
+      join(home, "parked-clients", "index.json"),
+      JSON.stringify({
+        version: 1,
+        activeClientId: "client_aabbccdd",
+        accountDefaults: {},
+        clients: {
+          client_aabbccdd: {
+            clientId: "client_aabbccdd",
+            userId: "old-user",
+            serverUrl: "https://old.example",
+            storage: "active-root",
+            updatedAt: new Date().toISOString(),
+          },
+        },
+      }),
+    );
+
+    recordActiveClientOwner(
+      { clientId: "client_11223344", userId: "new-user", serverUrl: "https://new.example" },
+      home,
+    );
+
+    const index = JSON.parse(readFileSync(join(home, "parked-clients", "index.json"), "utf8")) as {
+      activeClientId: string;
+      accountDefaults: Record<string, string>;
+      clients: Record<string, { storage: string; parkedPath?: string }>;
+    };
+    expect(index.activeClientId).toBe("client_11223344");
+    expect(index.clients.client_aabbccdd?.storage).toBe("parked");
+    expect(index.clients.client_aabbccdd?.parkedPath).toContain("client_aabbccdd");
+    expect(index.clients.client_11223344?.storage).toBe("active-root");
+    expect(index.accountDefaults["https://new.example\nnew-user"]).toBe("client_11223344");
+  });
+
   it("persists a generated active-root client id without overwriting an existing id", () => {
     const configDir = mkdtempSync(join(tmpdir(), "ft-client-id-persist-"));
     tempHomes.push(configDir);
@@ -234,5 +545,40 @@ describe("active client identity recovery", () => {
     const yaml = readFileSync(configPath, "utf8");
     expect(yaml).toContain("id: client_aabbccdd");
     expect(yaml).not.toContain("client_11223344");
+  });
+
+  it("does not persist malformed client ids and detects incomplete switches", () => {
+    const home = mkdtempSync(join(tmpdir(), "ft-client-switch-block-"));
+    const configDir = mkdtempSync(join(tmpdir(), "ft-client-id-invalid-"));
+    tempHomes.push(home, configDir);
+    writeFileSync(join(configDir, "client.yaml"), "server:\n  url: https://first-tree.example\n");
+
+    ensureActiveRootClientIdPersisted("bad-client-id", configDir);
+    expect(readFileSync(join(configDir, "client.yaml"), "utf8")).not.toContain("bad-client-id");
+    expect(getClientSwitchStartupBlock(home)).toBeNull();
+    expect(resolveClientRuntimeStopReason(home)).toBeUndefined();
+    expect(hasIncompleteClientSwitch(home)).toBe(false);
+
+    mkdirSync(join(home, "state"), { recursive: true });
+    writeFileSync(join(home, "state", "client-switch.lock"), "{}");
+    writeFileSync(
+      join(home, "state", "client-switch-journal.json"),
+      JSON.stringify({
+        version: 1,
+        id: "switch-test",
+        phase: "service-stopped",
+        from: { clientId: "client_aabbccdd", userId: "old", serverUrl: "https://old.example" },
+        to: { userId: "new", serverUrl: "https://new.example" },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+
+    expect(getClientSwitchStartupBlock(home)).toEqual({
+      lockPath: join(home, "state", "client-switch.lock"),
+      journalPath: join(home, "state", "client-switch-journal.json"),
+    });
+    expect(resolveClientRuntimeStopReason(home)).toBe(CLIENT_SWITCH_INTERRUPTED_REASON);
+    expect(hasIncompleteClientSwitch(home)).toBe(true);
   });
 });

--- a/apps/cli/src/__tests__/config-format-chat-io.test.ts
+++ b/apps/cli/src/__tests__/config-format-chat-io.test.ts
@@ -1,6 +1,16 @@
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { parseLimit, readStdin } from "../commands/chat/_shared/io.js";
+import {
+  guardInlineDescription,
+  guardInlineShellResidue,
+  looksLikeEscapedNewlineBody,
+  parseLimit,
+  readMessageBody,
+  readStdin,
+} from "../commands/chat/_shared/io.js";
 import { isSecretField, printFlat } from "../commands/config/_shared/format.js";
 
 const outputMocks = vi.hoisted(() => ({
@@ -21,6 +31,7 @@ vi.mock("../cli/output.js", () => ({
 }));
 
 const originalStdinDescriptor = Object.getOwnPropertyDescriptor(process, "stdin");
+const tempDirs: string[] = [];
 
 class MockStdin extends EventEmitter {
   isTTY = false;
@@ -42,6 +53,10 @@ beforeEach(() => {
 afterEach(() => {
   if (originalStdinDescriptor) {
     Object.defineProperty(process, "stdin", originalStdinDescriptor);
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
   }
 });
 
@@ -145,5 +160,44 @@ describe("chat io helpers", () => {
     expect(() => parseLimit("101", 100)).toThrow("INVALID_LIMIT:Limit must be between 1 and 100.:2");
     expect(() => parseLimit("nope", 100)).toThrow("INVALID_LIMIT:Limit must be between 1 and 100.:2");
     expect(outputMocks.fail).toHaveBeenCalledTimes(3);
+  });
+
+  it("reads message files and maps invalid file specs to fail envelopes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ft-chat-io-"));
+    tempDirs.push(dir);
+    const filePath = join(dir, "body.md");
+    writeFileSync(filePath, "line 1\nline 2");
+
+    await expect(readMessageBody(filePath)).resolves.toBe("line 1\nline 2");
+    await expect(readMessageBody(join(dir, "missing.md"))).rejects.toThrow("MESSAGE_FILE_NOT_FOUND");
+    await expect(readMessageBody(dir)).rejects.toThrow("MESSAGE_FILE_NOT_FILE");
+
+    const hugePath = join(dir, "huge.md");
+    writeFileSync(hugePath, Buffer.alloc(5 * 1024 * 1024 + 1));
+    await expect(readMessageBody(hugePath)).rejects.toThrow("MESSAGE_FILE_TOO_LARGE");
+  });
+
+  it("detects escaped newline bodies and fails inline shell residue guards with copyable hints", () => {
+    expect(looksLikeEscapedNewlineBody("line1\\n\\nline2")).toBe(true);
+    expect(looksLikeEscapedNewlineBody("line1\nline2")).toBe(false);
+    expect(looksLikeEscapedNewlineBody("mentions \\n once")).toBe(false);
+
+    expect(() => guardInlineShellResidue("@EOF", { command: "send" })).toThrow("HEREDOC_RESIDUE");
+    expect(outputMocks.line.mock.calls.map((call) => String(call[0])).join("")).toContain("chat send");
+
+    expect(() => guardInlineShellResidue('"line1\\nline2"', { command: "ask" })).toThrow("JSON_WRAPPED_BODY");
+    expect(outputMocks.line.mock.calls.map((call) => String(call[0])).join("")).toContain("chat ask");
+  });
+
+  it("guards escaped newline descriptions with update and create hints", () => {
+    guardInlineDescription("single \\n mention", { supportsStdin: true });
+    expect(outputMocks.fail).not.toHaveBeenCalled();
+
+    expect(() => guardInlineDescription("line1\\n\\nline2", { supportsStdin: true })).toThrow("ESCAPED_NEWLINES");
+    expect(outputMocks.line.mock.calls.map((call) => String(call[0])).join("")).toContain("chat update");
+
+    outputMocks.fail.mockClear();
+    expect(() => guardInlineDescription("line1\\n\\nline2", { supportsStdin: false })).toThrow("ESCAPED_NEWLINES");
+    expect(outputMocks.line.mock.calls.map((call) => String(call[0])).join("")).toContain("chat create");
   });
 });

--- a/apps/cli/src/__tests__/connect-token-derive-url.test.ts
+++ b/apps/cli/src/__tests__/connect-token-derive-url.test.ts
@@ -59,6 +59,11 @@ describe("deriveHubUrlFromToken", () => {
     }
   });
 
+  it("hard-fails when iss is not a parseable URL", () => {
+    const token = fakeJwt({ iss: "https://%" });
+    expect(() => deriveHubUrlFromToken(token)).toThrow(HubUrlDerivationError);
+  });
+
   it("hard-fails when token is not a valid JWT", () => {
     expect(() => deriveHubUrlFromToken("not.a.jwt-at-all")).toThrow(HubUrlDerivationError);
     try {
@@ -88,5 +93,11 @@ describe("decodeJwtPayload", () => {
   it("returns null on garbage", () => {
     expect(decodeJwtPayload("garbage")).toBeNull();
     expect(decodeJwtPayload("a.b")).toBeNull();
+    const nonObjectPayload = [
+      Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+      Buffer.from("null").toString("base64url"),
+      "signature",
+    ].join(".");
+    expect(decodeJwtPayload(nonObjectPayload)).toBeNull();
   });
 });

--- a/apps/cli/src/__tests__/core-attention-update-extra.test.ts
+++ b/apps/cli/src/__tests__/core-attention-update-extra.test.ts
@@ -151,6 +151,50 @@ describe("core update helpers", () => {
     expect(output).toHaveBeenCalledWith(expect.stringContaining("requires Node >=999.0.0"));
   });
 
+  it("parses nested npm engine metadata and omits installer URLs when portable metadata is not configured", async () => {
+    vi.resetModules();
+    vi.doMock("../core/channel.js", () => ({
+      channelConfig: {
+        channel: "prod",
+        binName: "first-tree",
+        aliasName: "ft",
+        packageName: "first-tree",
+        defaultHome: "/tmp/home",
+        defaultServerUrl: "https://cloud.first-tree.ai",
+        serviceUnitFile: "first-tree.service",
+        launchdLabel: "first-tree",
+        launchdPlistFile: "first-tree.plist",
+        displayName: "First Tree",
+        portable: {
+          channelPrefix: "prod",
+          publicInstallerPath: "prod/install.sh",
+          downloadBaseUrl: null,
+        },
+      },
+    }));
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      stdout: JSON.stringify({ engines: { node: ">=999.0.0" } }),
+      stderr: "",
+    });
+    const child = new MockChild();
+    installSpawn(child);
+
+    const { installGlobalSpec } = await import("../core/update.js");
+    const result = await installGlobalSpec("0.6.0");
+
+    expect(result).toMatchObject({
+      ok: false,
+      mode: "global",
+      retryable: false,
+      reasonCode: "npm_ebadengine",
+    });
+    if (result.ok) throw new Error("expected engine mismatch");
+    expect(result.reason).toContain("or migrate to the portable install path from the web console.");
+    expect(result.reason).not.toContain("installer: https://");
+    expect(childRegistryMocks.getChildProcessRegistry().spawn).not.toHaveBeenCalled();
+  });
+
   it("classifies child errors, non-zero exits, and timeouts", async () => {
     vi.resetModules();
     vi.doMock("../core/channel.js", () => ({

--- a/apps/cli/src/__tests__/core-attention-update-extra.test.ts
+++ b/apps/cli/src/__tests__/core-attention-update-extra.test.ts
@@ -20,6 +20,27 @@ const childRegistryMocks = vi.hoisted(() => ({
 }));
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
+const registrySpawnMock = vi.hoisted(() => vi.fn());
+const originalPlatform = process.platform;
+const originalArch = process.arch;
+
+const prodChannelConfig = {
+  channel: "prod",
+  binName: "first-tree",
+  aliasName: "ft",
+  packageName: "first-tree",
+  defaultHome: "/tmp/home",
+  defaultServerUrl: "https://cloud.first-tree.ai",
+  serviceUnitFile: "first-tree.service",
+  launchdLabel: "first-tree",
+  launchdPlistFile: "first-tree.plist",
+  displayName: "First Tree",
+  portable: {
+    channelPrefix: "prod",
+    publicInstallerPath: "prod/install.sh",
+    downloadBaseUrl: "https://download.first-tree.ai/releases",
+  },
+};
 
 vi.mock("../core/bootstrap.js", () => bootstrapMocks);
 vi.mock("../core/cli-fetch.js", () => ({ cliFetch: cliFetchMock }));
@@ -34,8 +55,9 @@ class MockChild extends EventEmitter {
 
 function installSpawn(child: MockChild): void {
   childRegistryMocks.getChildProcessRegistry.mockReturnValue({
-    spawn: vi.fn(() => ({ child })),
+    spawn: registrySpawnMock,
   });
+  registrySpawnMock.mockImplementationOnce(() => ({ child }));
 }
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {
@@ -48,6 +70,12 @@ function jsonResponse(body: unknown, ok = true, status = 200): Response {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.resetModules();
+  vi.doUnmock("node:fs");
+  vi.doMock("../core/channel.js", () => ({ channelConfig: prodChannelConfig }));
+  registrySpawnMock.mockReset();
+  Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+  Object.defineProperty(process, "arch", { configurable: true, value: originalArch });
   bootstrapMocks.ensureFreshAccessToken.mockResolvedValue("token");
   bootstrapMocks.resolveServerUrl.mockReturnValue("https://hub.example");
   childRegistryMocks.classify.mockReturnValue({ kind: "permanent", reasonCode: "classified" });
@@ -70,6 +98,39 @@ describe("core update helpers", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("selects platform npm commands, including Windows and sibling npm layouts", async () => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (path: Parameters<typeof actual.existsSync>[0]) =>
+          String(path).endsWith("/npm.cmd") || actual.existsSync(path),
+      };
+    });
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "0.6.0\n", stderr: "" });
+    const winUpdate = await import("../core/update.js");
+
+    expect(winUpdate.fetchLatestVersion()).toEqual({ ok: true, version: "0.6.0" });
+    expect(String(spawnSyncMock.mock.calls[0]?.[0])).toMatch(/\/npm\.cmd$/);
+
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (path: Parameters<typeof actual.existsSync>[0]) =>
+          String(path).endsWith("/npm") || actual.existsSync(path),
+      };
+    });
+    Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "0.7.0\n", stderr: "" });
+    const siblingUpdate = await import("../core/update.js");
+
+    expect(siblingUpdate.fetchLatestVersion()).toEqual({ ok: true, version: "0.7.0" });
+    expect(String(spawnSyncMock.mock.calls[1]?.[0])).toMatch(/\/npm$/);
   });
 
   it("runs npm installs through the child registry and parses installed versions", async () => {
@@ -151,6 +212,45 @@ describe("core update helpers", () => {
     expect(output).toHaveBeenCalledWith(expect.stringContaining("requires Node >=999.0.0"));
   });
 
+  it("allows npm installs when target engine metadata is absent, malformed, invalid, or already satisfied", async () => {
+    vi.doMock("../core/channel.js", () => ({
+      channelConfig: {
+        channel: "prod",
+        binName: "first-tree",
+        aliasName: "ft",
+        packageName: "first-tree",
+        defaultHome: "/tmp/home",
+        defaultServerUrl: "https://cloud.first-tree.ai",
+        serviceUnitFile: "first-tree.service",
+        launchdLabel: "first-tree",
+        launchdPlistFile: "first-tree.plist",
+        displayName: "First Tree",
+      },
+    }));
+    const { installGlobalSpec } = await import("../core/update.js");
+
+    const cases = [
+      { status: 1, stdout: "", stderr: "npm view failed" },
+      { status: 0, stdout: "", stderr: "" },
+      { status: 0, stdout: "not-json", stderr: "" },
+      { status: 0, stdout: JSON.stringify([]), stderr: "" },
+      { status: 0, stdout: JSON.stringify({ engines: { node: "not a range" } }), stderr: "" },
+      { status: 0, stdout: JSON.stringify({ engines: { node: `>=${process.versions.node}` } }), stderr: "" },
+    ];
+
+    for (const [index, metadata] of cases.entries()) {
+      spawnSyncMock.mockReturnValueOnce(metadata);
+      const child = new MockChild();
+      installSpawn(child);
+      const installing = installGlobalSpec("latest");
+      child.stdout.emit("data", Buffer.from(`+ first-tree@0.9.${index}\n`));
+      child.emit("exit", 0, null);
+      await expect(installing).resolves.toMatchObject({ ok: true, mode: "global" });
+    }
+
+    expect(registrySpawnMock).toHaveBeenCalledTimes(cases.length);
+  });
+
   it("parses nested npm engine metadata and omits installer URLs when portable metadata is not configured", async () => {
     vi.resetModules();
     vi.doMock("../core/channel.js", () => ({
@@ -193,6 +293,137 @@ describe("core update helpers", () => {
     expect(result.reason).toContain("or migrate to the portable install path from the web console.");
     expect(result.reason).not.toContain("installer: https://");
     expect(childRegistryMocks.getChildProcessRegistry().spawn).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for dev-channel npm publishing paths", async () => {
+    vi.doMock("../core/channel.js", () => ({
+      channelConfig: {
+        channel: "dev",
+        binName: "first-tree-dev",
+        aliasName: "ftd",
+        packageName: null,
+        defaultHome: "/tmp/home",
+        defaultServerUrl: "https://cloud.first-tree.ai",
+        serviceUnitFile: "first-tree-dev.service",
+        launchdLabel: "first-tree-dev",
+        launchdPlistFile: "first-tree-dev.plist",
+        displayName: "First Tree Dev",
+        portable: { channelPrefix: null, publicInstallerPath: null, downloadBaseUrl: null },
+      },
+    }));
+    const { fetchLatestVersion, installGlobalSpec } = await import("../core/update.js");
+
+    expect(await installGlobalSpec("latest")).toMatchObject({
+      ok: false,
+      mode: "global",
+      reason: expect.stringContaining("does not publish to npm"),
+    });
+    expect(fetchLatestVersion()).toEqual({
+      ok: false,
+      reason: "this binary's channel does not publish to npm (dev channel).",
+    });
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("reports unsupported portable platforms before metadata download", async () => {
+    vi.doMock("../core/channel.js", () => ({
+      channelConfig: {
+        channel: "prod",
+        binName: "first-tree",
+        aliasName: "ft",
+        packageName: "first-tree",
+        defaultHome: "/tmp/home",
+        defaultServerUrl: "https://cloud.first-tree.ai",
+        serviceUnitFile: "first-tree.service",
+        launchdLabel: "first-tree",
+        launchdPlistFile: "first-tree.plist",
+        displayName: "First Tree",
+        portable: {
+          channelPrefix: "prod",
+          publicInstallerPath: "prod/install.sh",
+          downloadBaseUrl: "https://download.first-tree.ai/releases",
+        },
+      },
+    }));
+    const { installPortableSpec } = await import("../core/update.js");
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "freebsd" });
+    await expect(installPortableSpec("1.2.3")).resolves.toMatchObject({
+      ok: false,
+      reason: "portable self-update is not supported on freebsd-x64",
+    });
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+    Object.defineProperty(process, "arch", { configurable: true, value: "ia32" });
+    await expect(installPortableSpec("1.2.3")).resolves.toMatchObject({
+      ok: false,
+      reason: "portable self-update is not supported on linux-ia32",
+    });
+    expect(cliFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("validates portable latest metadata shape and channel before returning a version", async () => {
+    vi.doMock("../core/channel.js", () => ({
+      channelConfig: {
+        channel: "prod",
+        binName: "first-tree",
+        aliasName: "ft",
+        packageName: "first-tree",
+        defaultHome: "/tmp/home",
+        defaultServerUrl: "https://cloud.first-tree.ai",
+        serviceUnitFile: "first-tree.service",
+        launchdLabel: "first-tree",
+        launchdPlistFile: "first-tree.plist",
+        displayName: "First Tree",
+        portable: {
+          channelPrefix: "prod",
+          publicInstallerPath: "prod/install.sh",
+          downloadBaseUrl: "https://download.first-tree.ai/releases/",
+        },
+      },
+    }));
+    const { fetchPortableLatestVersion } = await import("../core/update.js");
+    const base = {
+      schemaVersion: 1,
+      channel: "staging",
+      version: "1.2.3",
+      gitSha: "abc123",
+      nodeVersion: "v24.0.0",
+      packageName: "first-tree",
+      binName: "first-tree",
+      aliasName: "ft",
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      manifestUrl: "https://download.first-tree.ai/releases/prod/1.2.3/manifest.json",
+      assets: [
+        {
+          platform: "linux-x64",
+          fileName: "first-tree-linux-x64.tar.gz",
+          url: "https://download.first-tree.ai/releases/prod/1.2.3/first-tree-linux-x64.tar.gz",
+          sha256: "a".repeat(64),
+          size: 1,
+        },
+      ],
+    };
+    cliFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: vi.fn(async () => JSON.stringify(base)),
+    } as unknown as Response);
+
+    await expect(fetchPortableLatestVersion()).resolves.toEqual({
+      ok: false,
+      reason: 'Refusing portable latest metadata: portable metadata channel "staging" does not match my channel "prod"',
+    });
+
+    cliFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: vi.fn(async () => "{not-json"),
+    } as unknown as Response);
+    await expect(fetchPortableLatestVersion()).resolves.toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("invalid JSON from"),
+    });
   });
 
   it("classifies child errors, non-zero exits, and timeouts", async () => {
@@ -263,8 +494,14 @@ describe("core update helpers", () => {
     spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "registry down\n" });
     expect(fetchLatestVersion()).toEqual({ ok: false, reason: "registry down" });
 
+    spawnSyncMock.mockReturnValueOnce({ status: 8, stdout: undefined, stderr: undefined });
+    expect(fetchLatestVersion()).toEqual({ ok: false, reason: "npm view exited with code 8" });
+
     spawnSyncMock.mockReturnValueOnce({ status: 7, stdout: "", stderr: "" });
     expect(fetchLatestVersion()).toEqual({ ok: false, reason: "npm view exited with code 7" });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: undefined, stderr: "" });
+    expect(fetchLatestVersion()).toEqual({ ok: false, reason: "npm view returned non-semver value: " });
 
     spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "latest\n", stderr: "" });
     expect(fetchLatestVersion()).toEqual({ ok: false, reason: "npm view returned non-semver value: latest" });
@@ -284,6 +521,18 @@ describe("core update helpers", () => {
     await expect(fetchServerCommandVersion()).resolves.toEqual({
       ok: false,
       reason: "server returned non-semver version: latest",
+    });
+
+    cliFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: vi.fn(async () => {
+        throw "json failed";
+      }),
+    } as unknown as Response);
+    await expect(fetchServerCommandVersion()).resolves.toEqual({
+      ok: false,
+      reason: "server returned invalid JSON: json failed",
     });
 
     cliFetchMock.mockResolvedValueOnce(jsonResponse({}, false, 503));

--- a/apps/cli/src/__tests__/daemon-probe-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-probe-command.test.ts
@@ -119,6 +119,19 @@ describe("daemon probe", () => {
     expect(outputMocks.print.result).not.toHaveBeenCalled();
   });
 
+  it("stringifies non-Error upload failures in JSON and human modes", async () => {
+    coreMocks.uploadClientCapabilities.mockRejectedValueOnce("upload string failure");
+    await expect(runProbe(["--json"])).rejects.toMatchObject({ code: "UPLOAD_FAILED" });
+    expect(failMock).toHaveBeenLastCalledWith("UPLOAD_FAILED", "upload string failure", 1);
+
+    coreMocks.uploadClientCapabilities.mockRejectedValueOnce("soft upload string failure");
+    await runProbe([]);
+    expect(outputMocks.print.status).toHaveBeenLastCalledWith(
+      "⚠️",
+      "capabilities upload skipped: soft upload string failure",
+    );
+  });
+
   it("--json success envelope is emitted only after a successful upload", async () => {
     await runProbe(["--json"]);
     expect(coreMocks.uploadClientCapabilities).toHaveBeenCalledTimes(1);

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -31,7 +31,7 @@ const coreMocks = vi.hoisted(() => ({
   isServiceSupported: vi.fn(),
   listPinnedAgents: vi.fn(),
   loadCredentials: vi.fn(),
-  loadDaemonEnv: vi.fn(() => []),
+  loadDaemonEnv: vi.fn<() => string[]>(() => []),
   migrateLocalAgentDirs: vi.fn(),
   promptMissingFields: vi.fn(),
   promptUpdate: vi.fn(),
@@ -39,6 +39,7 @@ const coreMocks = vi.hoisted(() => ({
   reconcileLocalRuntimeProviders: vi.fn(),
   refreshServerUpdateTarget: vi.fn(),
   resolveClientRuntimeStopReason: vi.fn(),
+  runRuntimeAuthLogin: vi.fn(),
   startClientService: vi.fn(),
   uploadAgentSkills: vi.fn(),
   uploadClientCapabilities: vi.fn(),
@@ -82,7 +83,7 @@ const originalHome = process.env.FIRST_TREE_HOME;
 const originalServerUrl = process.env.FIRST_TREE_SERVER_URL;
 const originalServiceMode = process.env.FIRST_TREE_SERVICE_MODE;
 const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined) => {
+const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined) => {
   throw Object.assign(new Error(`process.exit ${code}`), { exitCode: code });
 });
 
@@ -90,14 +91,22 @@ let home: string;
 let runtimeInstance: {
   addAgent: ReturnType<typeof vi.fn>;
   start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  unwatchAgentsDir: ReturnType<typeof vi.fn>;
   watchAgentsDir: ReturnType<typeof vi.fn>;
   onReconnect: ReturnType<typeof vi.fn>;
   onRuntimeAuthStart: ReturnType<typeof vi.fn>;
+  emitConnectionResilienceEvent: ReturnType<typeof vi.fn>;
 };
 let refresherInstance: {
   start: ReturnType<typeof vi.fn>;
   onReconnect: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
+  isInteractive: ReturnType<typeof vi.fn>;
+  beginInteractive: ReturnType<typeof vi.fn>;
+  endInteractive: ReturnType<typeof vi.fn>;
+  currentEntry: ReturnType<typeof vi.fn>;
+  setProviderEntry: ReturnType<typeof vi.fn>;
 };
 
 beforeEach(() => {
@@ -116,6 +125,10 @@ beforeEach(() => {
   for (const mock of Object.values(coreMocks)) mock.mockReset();
   failMock.mockClear();
   stderrSpy.mockClear();
+  exitSpy.mockClear();
+  exitSpy.mockImplementation((code?: string | number | null | undefined) => {
+    throw Object.assign(new Error(`process.exit ${code}`), { exitCode: code });
+  });
 
   clientMocks.probeCapabilities.mockResolvedValue({ "claude-code": { state: "ok" } });
   clientMocks.createLogger.mockReturnValue({
@@ -171,17 +184,21 @@ beforeEach(() => {
   );
   coreMocks.migrateLocalAgentDirs.mockResolvedValue(undefined);
   coreMocks.reconcileLocalRuntimeProviders.mockResolvedValue(undefined);
+  coreMocks.runRuntimeAuthLogin.mockResolvedValue(undefined);
   coreMocks.uploadClientCapabilities.mockResolvedValue(undefined);
   coreMocks.uploadAgentSkills.mockResolvedValue(undefined);
 
   runtimeInstance = {
     addAgent: vi.fn(),
     start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    unwatchAgentsDir: vi.fn(),
     watchAgentsDir: vi.fn(() => {
       throw new Error("stop after watch");
     }),
     onReconnect: vi.fn(),
     onRuntimeAuthStart: vi.fn(),
+    emitConnectionResilienceEvent: vi.fn(),
   };
   coreMocks.ClientRuntime.mockImplementation(() => runtimeInstance);
 
@@ -189,6 +206,11 @@ beforeEach(() => {
     start: vi.fn(async () => undefined),
     onReconnect: vi.fn(),
     stop: vi.fn(),
+    isInteractive: vi.fn(() => false),
+    beginInteractive: vi.fn(),
+    endInteractive: vi.fn(),
+    currentEntry: vi.fn(() => undefined),
+    setProviderEntry: vi.fn(),
   };
   coreMocks.CapabilityRefresher.mockImplementation(() => refresherInstance);
 });
@@ -218,6 +240,13 @@ async function runStart(args: string[] = []): Promise<unknown> {
 
 function output(): string {
   return stderrSpy.mock.calls.map((call) => String(call[0])).join("");
+}
+
+async function waitForAsyncWork(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
 }
 
 describe("daemon start command", () => {
@@ -286,6 +315,24 @@ describe("daemon start command", () => {
     expect(output()).toContain("Started systemd service");
     expect(output()).toContain("Logs:  /logs/client.log");
     expect(output()).toContain("Supervisor fallback: `journalctl --user -u first-tree`");
+  });
+
+  it("starts an inactive launchd service and prints stdout/stderr fallback logs", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.getClientServiceStatus
+      .mockReturnValueOnce({ platform: "launchd", state: "inactive", label: "first-tree", logDir: "/logs" })
+      .mockReturnValueOnce({
+        platform: "launchd",
+        state: "active",
+        label: "first-tree",
+        detail: "pid 123",
+        logDir: "/logs",
+      });
+
+    await expect(runStart()).resolves.toBeTruthy();
+
+    expect(output()).toContain("Started launchd service");
+    expect(output()).toContain("/logs/client.stdout.log / /logs/client.stderr.log");
   });
 
   it("prints WSL repair guidance when service startup fails", async () => {
@@ -363,6 +410,70 @@ describe("daemon start command", () => {
     expect(output()).toContain("Error: stop after watch");
   });
 
+  it("stops the inline daemon runtime cleanly when SIGINT is received", async () => {
+    const signalHandlers = new Map<string, () => void>();
+    const onSpy = vi.spyOn(process, "on").mockImplementation((event, listener) => {
+      if (event === "SIGINT" || event === "SIGTERM") {
+        signalHandlers.set(event, listener as () => void);
+      }
+      return process;
+    });
+    exitSpy.mockImplementation((() => undefined) as never);
+    runtimeInstance.watchAgentsDir.mockImplementation(() => undefined);
+
+    try {
+      void runStart(["--foreground"]).catch(() => undefined);
+      await waitForAsyncWork(() => signalHandlers.has("SIGINT"));
+
+      const shutdown = signalHandlers.get("SIGINT");
+      expect(shutdown).toBeTypeOf("function");
+      shutdown?.();
+      await waitForAsyncWork(() => exitSpy.mock.calls.length > 0);
+
+      expect(output()).toContain("Shutting down");
+      expect(refresherInstance.stop).toHaveBeenCalled();
+      expect(runtimeInstance.unwatchAgentsDir).toHaveBeenCalled();
+      expect(runtimeInstance.stop).toHaveBeenCalledWith(undefined);
+      expect(coreMocks.registerClientRuntimeMarker.mock.results[0]?.value).toHaveBeenCalled();
+      expect(clientMocks.flushClientSentry).toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    } finally {
+      onSpy.mockRestore();
+    }
+  });
+
+  it("reports loaded daemon.env variables before inline startup", async () => {
+    coreMocks.loadDaemonEnv.mockReturnValueOnce(["HTTPS_PROXY", "NO_PROXY"]);
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(output()).toContain("loaded 2 var(s) from daemon.env (HTTPS_PROXY, NO_PROXY)");
+  });
+
+  it("wires update failure and capability upload callbacks", async () => {
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    const executeUpdateOptions = coreMocks.createExecuteUpdate.mock.calls[0]?.[0] as
+      | { onUpdateFailed?: (payload: unknown) => void }
+      | undefined;
+    executeUpdateOptions?.onUpdateFailed?.({ reasonCode: "npm_timeout" });
+    expect(runtimeInstance.emitConnectionResilienceEvent).toHaveBeenCalledWith("resilience.update.failed", {
+      reasonCode: "npm_timeout",
+    });
+
+    const refresherOptions = coreMocks.CapabilityRefresher.mock.calls[0]?.[0] as
+      | { upload?: (capabilities: unknown) => Promise<void> }
+      | undefined;
+    await refresherOptions?.upload?.({ "claude-code": { state: "ok" } });
+
+    expect(coreMocks.uploadClientCapabilities).toHaveBeenCalledWith({
+      serverUrl: "https://first-tree.example",
+      accessToken: "access-token",
+      clientId: "client_1234abcd",
+      capabilities: { "claude-code": { state: "ok" } },
+    });
+  });
+
   it("routes the runtime's reconnect callback into the capability refresher", async () => {
     await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
 
@@ -375,6 +486,36 @@ describe("daemon start command", () => {
     expect(refresherInstance.onReconnect).not.toHaveBeenCalled();
     reconnect();
     expect(refresherInstance.onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes runtime-auth login requests per provider", async () => {
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    const runtimeAuthStart = runtimeInstance.onRuntimeAuthStart.mock.calls[0]?.[0] as
+      | ((command: { provider: string; ref: string }) => void)
+      | undefined;
+    if (typeof runtimeAuthStart !== "function") throw new Error("runtime-auth callback was not registered");
+
+    refresherInstance.isInteractive.mockReturnValueOnce(true);
+    runtimeAuthStart({ provider: "codex", ref: "dup" });
+    expect(output()).toContain("runtime-auth: codex login already in progress");
+    expect(coreMocks.runRuntimeAuthLogin).not.toHaveBeenCalled();
+
+    refresherInstance.isInteractive.mockReturnValueOnce(false);
+    runtimeAuthStart({ provider: "codex", ref: "fresh" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(refresherInstance.beginInteractive).toHaveBeenCalledWith("codex");
+    expect(coreMocks.runRuntimeAuthLogin).toHaveBeenCalledWith(
+      { provider: "codex", ref: "fresh" },
+      expect.objectContaining({
+        currentEntry: expect.any(Function),
+        setProviderEntry: expect.any(Function),
+        log: expect.any(Function),
+      }),
+    );
+    expect(refresherInstance.endInteractive).toHaveBeenCalledWith("codex");
   });
 
   it("skips skill upload for stale local aliases that are not pinned to this client", async () => {
@@ -394,6 +535,17 @@ describe("daemon start command", () => {
     expect(coreMocks.uploadAgentSkills).toHaveBeenCalledWith(expect.objectContaining({ agentId: "agent-1" }));
     expect(output()).toContain("skills upload for developer skipped");
     expect(output()).toContain("agent prune --dry-run");
+  });
+
+  it("skips skill upload for agents pinned to another client", async () => {
+    coreMocks.listPinnedAgents.mockResolvedValueOnce([
+      { agentId: "agent-1", clientId: "client_other123", runtimeProvider: "claude-code", status: "active" },
+    ]);
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(coreMocks.uploadAgentSkills).not.toHaveBeenCalled();
+    expect(output()).toContain("pinned to another client (client_other123)");
   });
 
   it("keeps best-effort skill upload when pinned-agent filtering is unavailable", async () => {

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -296,6 +296,17 @@ describe("daemon start command", () => {
     await expect(runStart()).resolves.toBeTruthy();
     expect(output()).toContain("Service is already running");
     expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
+
+    stderrSpy.mockClear();
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({
+      platform: "systemd",
+      state: "active",
+      label: "first-tree.service",
+      logDir: "/logs",
+    });
+
+    await expect(runStart()).resolves.toBeTruthy();
+    expect(output()).toContain("Service is already running (systemd).");
   });
 
   it("starts an inactive service and prints log hints", async () => {
@@ -325,13 +336,12 @@ describe("daemon start command", () => {
         platform: "launchd",
         state: "active",
         label: "first-tree",
-        detail: "pid 123",
         logDir: "/logs",
       });
 
     await expect(runStart()).resolves.toBeTruthy();
 
-    expect(output()).toContain("Started launchd service");
+    expect(output()).toContain("Started launchd service.");
     expect(output()).toContain("/logs/client.stdout.log / /logs/client.stderr.log");
   });
 
@@ -368,6 +378,17 @@ describe("daemon start command", () => {
 
     await expect(runStart()).rejects.toMatchObject({ exitCode: 1 });
     expect(output()).toContain("Service state could not be determined");
+
+    stderrSpy.mockClear();
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({
+      platform: "launchd",
+      state: "unknown",
+      label: "dev.first-tree",
+      logDir: "/logs",
+    });
+
+    await expect(runStart()).rejects.toMatchObject({ exitCode: 1 });
+    expect(output()).toContain("Service state could not be determined (launchd).");
   });
 
   it("runs inline, reconciles local state, uploads capabilities and skills", async () => {
@@ -407,7 +428,28 @@ describe("daemon start command", () => {
       expect.objectContaining({ agentId: "agent-1", skills: [{ name: "review", description: "Review code." }] }),
     );
     expect(runtimeInstance.watchAgentsDir).toHaveBeenCalledWith(join(home, "config", "agents"));
+
+    const reconcileOptions = coreMocks.reconcileLocalRuntimeProviders.mock.calls[0]?.[0] as
+      | { log?: (level: "info" | "warn", message: string) => void }
+      | undefined;
+    reconcileOptions?.log?.("warn", "runtime changed");
+    reconcileOptions?.log?.("info", "runtime checked");
+
+    const refresherOptions = coreMocks.CapabilityRefresher.mock.calls[0]?.[0] as
+      | { log?: (symbol: string, message: string) => void }
+      | undefined;
+    refresherOptions?.log?.("•", "capability refreshed");
+
+    const skillScanOptions = clientMocks.discoverClaudeCodeSkills.mock.calls[0]?.[0] as
+      | { warn?: (message: string) => void }
+      | undefined;
+    skillScanOptions?.warn?.("slow scan");
+
     expect(output()).toContain("Error: stop after watch");
+    expect(output()).toContain("runtime changed");
+    expect(output()).toContain("runtime checked");
+    expect(output()).toContain("capability refreshed");
+    expect(output()).toContain("skill scan: slow scan");
   });
 
   it("stops the inline daemon runtime cleanly when SIGINT is received", async () => {
@@ -462,7 +504,7 @@ describe("daemon start command", () => {
     });
 
     const refresherOptions = coreMocks.CapabilityRefresher.mock.calls[0]?.[0] as
-      | { upload?: (capabilities: unknown) => Promise<void> }
+      | { upload?: (capabilities: unknown) => Promise<void>; log?: (symbol: string, message: string) => void }
       | undefined;
     await refresherOptions?.upload?.({ "claude-code": { state: "ok" } });
 
@@ -472,6 +514,9 @@ describe("daemon start command", () => {
       clientId: "client_1234abcd",
       capabilities: { "claude-code": { state: "ok" } },
     });
+
+    refresherOptions?.log?.("✓", "manual log check");
+    expect(output()).toContain("manual log check");
   });
 
   it("routes the runtime's reconnect callback into the capability refresher", async () => {
@@ -515,7 +560,20 @@ describe("daemon start command", () => {
         log: expect.any(Function),
       }),
     );
+    const deps = coreMocks.runRuntimeAuthLogin.mock.calls[0]?.[1] as
+      | {
+          currentEntry: (provider: string) => unknown;
+          setProviderEntry: (provider: string, entry: unknown) => Promise<void>;
+          log: (symbol: string, message: string) => void;
+        }
+      | undefined;
+    deps?.currentEntry("codex");
+    await deps?.setProviderEntry("codex", { state: "ok" });
+    deps?.log("•", "runtime auth progress");
     expect(refresherInstance.endInteractive).toHaveBeenCalledWith("codex");
+    expect(refresherInstance.currentEntry).toHaveBeenCalledWith("codex");
+    expect(refresherInstance.setProviderEntry).toHaveBeenCalledWith("codex", { state: "ok" });
+    expect(output()).toContain("runtime auth progress");
   });
 
   it("skips skill upload for stale local aliases that are not pinned to this client", async () => {
@@ -565,6 +623,11 @@ describe("daemon start command", () => {
     expect(coreMocks.createExecuteUpdate).toHaveBeenCalledWith(
       expect.objectContaining({ log: expect.any(Function), managed: true }),
     );
+    const updateOptions = coreMocks.createExecuteUpdate.mock.calls[0]?.[0] as
+      | { log?: (level: "info" | "warn" | "error" | "debug", message: string) => void }
+      | undefined;
+    updateOptions?.log?.("warn", "managed warning");
+    expect(clientMocks.createLogger.mock.results.at(-1)?.value.warn).toHaveBeenCalledWith("managed warning");
     expect(clientMocks.configureClientLoggerForService).toHaveBeenCalledWith(join(home, "logs"));
     expect(clientMocks.applyClientLoggerConfig).toHaveBeenCalledWith({ level: "info" });
     expect(coreMocks.createLoggerRuntimeOutput).toHaveBeenCalledWith(expect.any(Object));
@@ -681,16 +744,16 @@ describe("daemon start command", () => {
   });
 
   it("continues when best-effort reconciliation and uploads fail", async () => {
-    coreMocks.migrateLocalAgentDirs.mockRejectedValueOnce(new Error("rename failed"));
-    coreMocks.reconcileLocalRuntimeProviders.mockRejectedValueOnce(new Error("runtime probe failed"));
-    clientMocks.discoverClaudeCodeSkills.mockRejectedValueOnce(new Error("skill scan failed"));
+    coreMocks.migrateLocalAgentDirs.mockRejectedValueOnce("rename failed as string");
+    coreMocks.reconcileLocalRuntimeProviders.mockRejectedValueOnce("runtime probe failed as string");
+    clientMocks.discoverClaudeCodeSkills.mockRejectedValueOnce("skill scan failed as string");
 
     await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
 
     const text = output();
-    expect(text).toContain("agent-dir migration skipped: rename failed");
-    expect(text).toContain("runtime-provider reconcile skipped: runtime probe failed");
-    expect(text).toContain("skills upload skipped: skill scan failed");
+    expect(text).toContain("agent-dir migration skipped: rename failed as string");
+    expect(text).toContain("runtime-provider reconcile skipped: runtime probe failed as string");
+    expect(text).toContain("skills upload skipped: skill scan failed as string");
   });
 
   it("handles user and org mismatch errors from inline runtime startup", async () => {
@@ -718,10 +781,22 @@ describe("daemon start command", () => {
   });
 
   it("continues when per-agent skill upload fails", async () => {
-    coreMocks.uploadAgentSkills.mockRejectedValueOnce(new Error("agent skill upload failed"));
+    coreMocks.listPinnedAgents.mockRejectedValueOnce("pin check failed as string");
+    coreMocks.uploadAgentSkills.mockRejectedValueOnce("agent skill upload failed as string");
 
     await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
 
-    expect(output()).toContain("skills upload for nova skipped: agent skill upload failed");
+    expect(output()).toContain("skills upload pin check skipped: pin check failed as string");
+    expect(output()).toContain("skills upload for nova skipped: agent skill upload failed as string");
+  });
+
+  it("stringifies non-Error inline startup failures", async () => {
+    runtimeInstance.watchAgentsDir.mockImplementationOnce(() => {
+      throw "watch failed as string";
+    });
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(output()).toContain("Error: watch failed as string");
   });
 });

--- a/apps/cli/src/__tests__/doc-capture-mocked-extra.test.ts
+++ b/apps/cli/src/__tests__/doc-capture-mocked-extra.test.ts
@@ -1,0 +1,96 @@
+import type { FirstTreeHubSDK } from "@first-tree/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const buildSnapshotsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@first-tree/client", () => ({
+  buildMessageDocumentSnapshots: buildSnapshotsMock,
+}));
+
+import { captureOutboundDocs } from "../core/doc-capture.js";
+
+function sdkWithOrg(organizationId: unknown): FirstTreeHubSDK {
+  return {
+    serverUrl: "https://hub.example",
+    async getChatDetail() {
+      return { id: "chat-1", organizationId, participants: [] };
+    },
+  } as unknown as FirstTreeHubSDK;
+}
+
+describe("captureOutboundDocs mocked branch edges", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    buildSnapshotsMock.mockResolvedValue({
+      refs: [],
+      rewrittenText: "rewritten",
+      failedMentions: [],
+    });
+  });
+
+  it("passes through when the chat has no organization id", async () => {
+    const out = await captureOutboundDocs(
+      "see docs/a.md",
+      { sdk: sdkWithOrg(""), chatId: "chat-1" },
+      { FIRST_TREE_DOC_AGENT_HOME: "/agent-home" },
+    );
+
+    expect(out).toEqual({ content: "see docs/a.md" });
+    expect(buildSnapshotsMock).not.toHaveBeenCalled();
+  });
+
+  it("passes a workspace fence only when both workspace root and self slug are present", async () => {
+    await captureOutboundDocs(
+      "see docs/a.md",
+      { sdk: sdkWithOrg("org-1"), chatId: "chat-1" },
+      {
+        FIRST_TREE_DOC_AGENT_HOME: "/agent-home",
+        FIRST_TREE_WORKSPACES_ROOT: "/workspaces",
+      },
+    );
+    expect(buildSnapshotsMock).toHaveBeenLastCalledWith(
+      "see docs/a.md",
+      { agentHome: "/agent-home" },
+      expect.objectContaining({ orgId: "org-1" }),
+      undefined,
+    );
+
+    await captureOutboundDocs(
+      "see docs/a.md",
+      { sdk: sdkWithOrg("org-1"), chatId: "chat-1" },
+      {
+        FIRST_TREE_DOC_AGENT_HOME: "/agent-home",
+        FIRST_TREE_WORKSPACES_ROOT: "/workspaces",
+        FIRST_TREE_AGENT_SLUG: "nova",
+      },
+    );
+    expect(buildSnapshotsMock).toHaveBeenLastCalledWith(
+      "see docs/a.md",
+      { agentHome: "/agent-home" },
+      expect.objectContaining({ orgId: "org-1" }),
+      { workspacesRoot: "/workspaces", chatId: "chat-1", selfSlug: "nova" },
+    );
+  });
+
+  it("returns failed mentions as documentContext metadata", async () => {
+    buildSnapshotsMock.mockResolvedValueOnce({
+      refs: [],
+      rewrittenText: "rewritten body",
+      failedMentions: [{ raw: "missing.md", reason: "missing" }],
+    });
+
+    const out = await captureOutboundDocs(
+      "see missing.md",
+      { sdk: sdkWithOrg("org-1"), chatId: "chat-1" },
+      { FIRST_TREE_DOC_AGENT_HOME: "/agent-home" },
+    );
+
+    expect(out).toMatchObject({
+      content: "rewritten body",
+      documentContext: {
+        kind: "snapshot",
+        failedMentions: [{ raw: "missing.md", reason: "missing" }],
+      },
+    });
+  });
+});

--- a/apps/cli/src/__tests__/doc-github-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/doc-github-commands-extra.test.ts
@@ -211,6 +211,117 @@ describe("doc command actions", () => {
     expect(outputMocks.success).toHaveBeenCalled();
   });
 
+  it("routes document SDK failures through the shared error handler", async () => {
+    const { registerDocCommentCommand } = await import("../commands/doc/comment.js");
+    const { registerDocGetCommand } = await import("../commands/doc/get.js");
+    const { registerDocListCommand } = await import("../commands/doc/list.js");
+    const { registerDocPublishCommand } = await import("../commands/doc/publish.js");
+    const { registerDocReplyCommand } = await import("../commands/doc/reply.js");
+    const { registerDocResolveCommand } = await import("../commands/doc/resolve.js");
+    const { registerDocStatusCommand } = await import("../commands/doc/status.js");
+    const sdk = {
+      createDocComment: vi.fn(),
+      getDoc: vi.fn(),
+      listDocs: vi.fn().mockRejectedValue(new Error("docs offline")),
+      publishDoc: vi.fn().mockRejectedValue(new Error("publish offline")),
+      replyDocComment: vi.fn().mockRejectedValue(new Error("reply offline")),
+      setDocCommentStatus: vi.fn().mockRejectedValue(new Error("resolve offline")),
+      setDocStatus: vi.fn(),
+    };
+    localAgentMocks.createSdk.mockReturnValue(sdk);
+
+    const listRoot = new Command();
+    registerDocListCommand(listRoot);
+    await expect(subcommand(listRoot, "list").parseAsync([], { from: "user" })).rejects.toThrow("docs offline");
+
+    const getRoot = new Command();
+    registerDocGetCommand(getRoot);
+    await expect(subcommand(getRoot, "get").parseAsync(["design-doc"], { from: "user" })).rejects.toThrow(
+      "docs offline",
+    );
+
+    const statusRoot = new Command();
+    registerDocStatusCommand(statusRoot);
+    await expect(
+      subcommand(statusRoot, "status").parseAsync(["design-doc", "--set", "approved"], { from: "user" }),
+    ).rejects.toThrow("docs offline");
+
+    const commentRoot = new Command();
+    registerDocCommentCommand(commentRoot);
+    await expect(
+      subcommand(commentRoot, "comment").parseAsync(["design-doc", "Body"], { from: "user" }),
+    ).rejects.toThrow("docs offline");
+
+    const replyRoot = new Command();
+    registerDocReplyCommand(replyRoot);
+    await expect(subcommand(replyRoot, "reply").parseAsync(["comment_1", "Done"], { from: "user" })).rejects.toThrow(
+      "reply offline",
+    );
+
+    const resolveRoot = new Command();
+    registerDocResolveCommand(resolveRoot);
+    await expect(subcommand(resolveRoot, "resolve").parseAsync(["comment_1"], { from: "user" })).rejects.toThrow(
+      "resolve offline",
+    );
+
+    const base = await mkdtemp(join(tmpdir(), "cli-doc-publish-error-"));
+    const file = join(base, "source.md");
+    await writeFile(file, "# Source Title\n\nBody\n", "utf8");
+    const publishRoot = new Command();
+    registerDocPublishCommand(publishRoot);
+    try {
+      await expect(subcommand(publishRoot, "publish").parseAsync([file], { from: "user" })).rejects.toThrow(
+        "publish offline",
+      );
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+
+    expect(localAgentMocks.handleSdkError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("streams new watched doc comments and reports poll errors as NDJSON", async () => {
+    const { registerDocCommentsCommand } = await import("../commands/doc/comments.js");
+    const stdoutWrite = vi.spyOn(process.stdout, "write");
+    const stderrWrite = vi.spyOn(process.stderr, "write");
+    vi.useFakeTimers();
+    const sdk = {
+      listDocs: vi.fn().mockResolvedValue({ items: [docSummary()] }),
+      listDocComments: vi
+        .fn()
+        .mockResolvedValueOnce({ items: [{ id: "comment_1", body: "existing" }] })
+        .mockResolvedValueOnce({
+          items: [
+            { id: "comment_1", body: "existing" },
+            { id: "comment_2", body: "new" },
+          ],
+        }),
+    };
+    localAgentMocks.createSdk.mockReturnValue(sdk);
+    stdoutWrite.mockImplementationOnce(() => {
+      throw new Error("stdout closed");
+    });
+    stderrWrite.mockImplementationOnce(() => {
+      throw new Error("watch stopped");
+    });
+    const root = new Command();
+    registerDocCommentsCommand(root);
+
+    try {
+      const watching = subcommand(root, "comments").parseAsync(["design-doc", "--watch", "5"], { from: "user" });
+      const expectedStop = expect(watching).rejects.toThrow("watch stopped");
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expectedStop;
+      expect(sdk.listDocComments).toHaveBeenCalledTimes(2);
+      expect(stdoutWrite).toHaveBeenCalledWith(expect.stringContaining("comment_2"));
+      expect(stderrWrite).toHaveBeenCalledWith(expect.stringContaining("WATCH_POLL_FAILED"));
+    } finally {
+      vi.useRealTimers();
+      stdoutWrite.mockRestore();
+      stderrWrite.mockRestore();
+    }
+  });
+
   it("publishes markdown, reports unchanged content, and rejects unreadable or invalid input", async () => {
     const { registerDocPublishCommand } = await import("../commands/doc/publish.js");
     const base = await mkdtemp(join(tmpdir(), "cli-doc-publish-"));
@@ -366,6 +477,18 @@ describe("doc command actions", () => {
       await expect(readFile(join(outDir, "two.md"), "utf8")).resolves.toBe("# Two\n");
       await expect(readFile(join(outDir, "manifest.json"), "utf8")).resolves.toContain('"slug": "one"');
       expect(outputMocks.success.mock.calls.at(-1)?.[0]).toEqual({ exported: 2, dir: outDir });
+
+      const blocked = join(base, "blocked-file");
+      await writeFile(blocked, "not a directory", "utf8");
+      await expect(subcommand(root, "export").parseAsync([join(blocked, "out")], { from: "user" })).rejects.toThrow(
+        "DIR_UNWRITABLE",
+      );
+
+      sdk.getDoc.mockRejectedValueOnce(new Error("download failed"));
+      sdk.listDocs.mockResolvedValueOnce({ items: [first], nextCursor: null });
+      await expect(subcommand(root, "export").parseAsync([join(base, "sdk-fails")], { from: "user" })).rejects.toThrow(
+        "download failed",
+      );
     } finally {
       await rm(base, { recursive: true, force: true });
     }
@@ -454,5 +577,29 @@ describe("github command helpers and actions", () => {
     await subcommand(unfollowRoot, "unfollow").parseAsync(["owner/repo#1", "--chat", "chat_1"], { from: "user" });
     expect(String(outputMocks.success.mock.calls.at(-1)?.[0].hint)).toContain("Severed 2 lines");
     expect(sdk.unfollowGithubEntity).toHaveBeenCalledWith("chat_1", "owner/repo#1");
+  });
+
+  it("routes GitHub list and unfollow failures through the GitHub SDK error mapper", async () => {
+    const { registerGithubFollowingCommand } = await import("../commands/github/following.js");
+    const { registerGithubUnfollowCommand } = await import("../commands/github/unfollow.js");
+    const sdk = {
+      listChatGithubEntities: vi.fn().mockRejectedValue(new Error("github list offline")),
+      unfollowGithubEntity: vi.fn().mockRejectedValue(new Error("github unfollow offline")),
+    };
+    localAgentMocks.createSdk.mockReturnValue(sdk);
+
+    const followingRoot = new Command();
+    registerGithubFollowingCommand(followingRoot);
+    await expect(
+      subcommand(followingRoot, "following").parseAsync(["--chat", "chat_1"], { from: "user" }),
+    ).rejects.toThrow("github list offline");
+
+    const unfollowRoot = new Command();
+    registerGithubUnfollowCommand(unfollowRoot);
+    await expect(
+      subcommand(unfollowRoot, "unfollow").parseAsync(["owner/repo#1", "--chat", "chat_1"], { from: "user" }),
+    ).rejects.toThrow("github unfollow offline");
+
+    expect(localAgentMocks.handleSdkError).toHaveBeenCalledWith(expect.any(Error));
   });
 });

--- a/apps/cli/src/__tests__/doc-github-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/doc-github-commands-extra.test.ts
@@ -1,0 +1,458 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SdkError } from "@first-tree/client";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const outputMocks = vi.hoisted(() => ({
+  fail: vi.fn((code: string, message: string, exitCode: number) => {
+    throw new Error(`${code}:${message}:${exitCode}`);
+  }),
+  success: vi.fn(),
+}));
+
+const localAgentMocks = vi.hoisted(() => ({
+  createSdk: vi.fn(),
+  handleSdkError: vi.fn((error: unknown) => {
+    throw error instanceof Error ? error : new Error(String(error));
+  }),
+  resolveLocalAgent: vi.fn(() => ({ serverUrl: "https://first-tree.example///" })),
+}));
+
+vi.mock("../cli/output.js", () => ({
+  fail: outputMocks.fail,
+  success: outputMocks.success,
+}));
+
+vi.mock("../commands/_shared/local-agent.js", () => ({
+  createSdk: localAgentMocks.createSdk,
+  handleSdkError: localAgentMocks.handleSdkError,
+  resolveLocalAgent: localAgentMocks.resolveLocalAgent,
+}));
+
+function subcommand(parent: Command, name: string): Command {
+  const found = parent.commands.find((entry) => entry.name() === name);
+  if (!found) throw new Error(`Missing command ${name}`);
+  return found;
+}
+
+function docSummary(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "doc_1",
+    slug: "design-doc",
+    title: "Design Doc",
+    project: "alpha",
+    status: "draft",
+    latestVersion: 3,
+    openCommentCount: 2,
+    createdBy: "agent_1",
+    updatedAt: "2026-07-08T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const originalChatId = process.env.FIRST_TREE_CHAT_ID;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.FIRST_TREE_CHAT_ID = originalChatId;
+});
+
+afterEach(() => {
+  if (originalChatId === undefined) {
+    delete process.env.FIRST_TREE_CHAT_ID;
+  } else {
+    process.env.FIRST_TREE_CHAT_ID = originalChatId;
+  }
+});
+
+describe("doc command helpers", () => {
+  it("validates statuses, versions, and slug lookup failures before API calls proceed", async () => {
+    const { parseDocCommentStatus, parseDocStatus, parseVersionNumber, resolveDocBySlug } = await import(
+      "../commands/doc/_shared.js"
+    );
+
+    expect(parseDocStatus("approved")).toBe("approved");
+    expect(parseDocCommentStatus("resolved")).toBe("resolved");
+    expect(parseVersionNumber("12")).toBe(12);
+    expect(() => parseDocStatus("done")).toThrow("INVALID_STATUS");
+    expect(() => parseDocCommentStatus("closed")).toThrow("INVALID_STATUS");
+    expect(() => parseVersionNumber("01")).toThrow("INVALID_VERSION");
+    expect(() => parseVersionNumber("0")).toThrow("INVALID_VERSION");
+
+    const sdk = {
+      listDocs: vi.fn().mockResolvedValueOnce({ items: [docSummary({ id: "doc_found" })] }),
+    };
+    await expect(resolveDocBySlug(sdk as never, "design-doc")).resolves.toMatchObject({ id: "doc_found" });
+
+    sdk.listDocs.mockResolvedValueOnce({ items: [] });
+    await expect(resolveDocBySlug(sdk as never, "missing")).rejects.toThrow("DOC_NOT_FOUND");
+  });
+
+  it("registers the doc command group with every public subcommand", async () => {
+    const { registerDocCommands } = await import("../commands/doc/index.js");
+    const root = new Command();
+
+    registerDocCommands(root);
+
+    const doc = subcommand(root, "doc");
+    expect(doc.commands.map((entry) => entry.name()).sort()).toEqual([
+      "comment",
+      "comments",
+      "export",
+      "get",
+      "import",
+      "list",
+      "publish",
+      "reply",
+      "resolve",
+      "status",
+    ]);
+  });
+});
+
+describe("doc command actions", () => {
+  it("lists, gets, updates status, comments, replies, resolves, and lists comments through the SDK", async () => {
+    const { registerDocCommentCommand } = await import("../commands/doc/comment.js");
+    const { registerDocCommentsCommand } = await import("../commands/doc/comments.js");
+    const { registerDocGetCommand } = await import("../commands/doc/get.js");
+    const { registerDocListCommand } = await import("../commands/doc/list.js");
+    const { registerDocReplyCommand } = await import("../commands/doc/reply.js");
+    const { registerDocResolveCommand } = await import("../commands/doc/resolve.js");
+    const { registerDocStatusCommand } = await import("../commands/doc/status.js");
+
+    const summary = docSummary();
+    const sdk = {
+      createDocComment: vi.fn().mockResolvedValue({ id: "comment_2" }),
+      getDoc: vi.fn().mockResolvedValue({ id: "doc_1", version: { content: "# Design" } }),
+      listDocComments: vi.fn().mockResolvedValue({ items: [{ id: "comment_1" }] }),
+      listDocs: vi.fn().mockResolvedValue({ items: [summary], nextCursor: null }),
+      replyDocComment: vi.fn().mockResolvedValue({ id: "reply_1" }),
+      setDocCommentStatus: vi.fn().mockResolvedValue({ id: "comment_1", status: "open" }),
+      setDocStatus: vi.fn().mockResolvedValue({ id: "doc_1", status: "approved" }),
+    };
+    localAgentMocks.createSdk.mockReturnValue(sdk);
+
+    const listRoot = new Command();
+    registerDocListCommand(listRoot);
+    await subcommand(listRoot, "list").parseAsync(
+      ["--project", "alpha", "--status", "draft", "--limit", "25", "--cursor", "next", "--agent", "writer"],
+      { from: "user" },
+    );
+    expect(sdk.listDocs).toHaveBeenLastCalledWith({
+      project: "alpha",
+      status: "draft",
+      limit: 25,
+      cursor: "next",
+    });
+    expect(localAgentMocks.createSdk).toHaveBeenLastCalledWith("writer");
+
+    const getRoot = new Command();
+    registerDocGetCommand(getRoot);
+    await subcommand(getRoot, "get").parseAsync(["design-doc", "--version", "2"], { from: "user" });
+    expect(sdk.getDoc).toHaveBeenCalledWith("doc_1", { version: 2 });
+
+    const statusRoot = new Command();
+    registerDocStatusCommand(statusRoot);
+    await subcommand(statusRoot, "status").parseAsync(["design-doc"], { from: "user" });
+    await subcommand(statusRoot, "status").parseAsync(["design-doc", "--set", "approved"], { from: "user" });
+    expect(sdk.setDocStatus).toHaveBeenCalledWith("doc_1", "approved");
+
+    const commentRoot = new Command();
+    registerDocCommentCommand(commentRoot);
+    await subcommand(commentRoot, "comment").parseAsync(
+      [
+        "design-doc",
+        "Please clarify",
+        "--quote",
+        "target",
+        "--prefix",
+        "before",
+        "--suffix",
+        "after",
+        "--version",
+        "3",
+      ],
+      { from: "user" },
+    );
+    expect(sdk.createDocComment).toHaveBeenCalledWith("doc_1", {
+      body: "Please clarify",
+      versionNumber: 3,
+      anchor: { exact: "target", prefix: "before", suffix: "after" },
+    });
+    await expect(
+      subcommand(commentRoot, "comment").parseAsync(["design-doc", "Bad anchor", "--prefix", "orphan"], {
+        from: "user",
+      }),
+    ).rejects.toThrow("INVALID_ANCHOR");
+
+    const replyRoot = new Command();
+    registerDocReplyCommand(replyRoot);
+    await subcommand(replyRoot, "reply").parseAsync(["comment_1", "Done"], { from: "user" });
+    expect(sdk.replyDocComment).toHaveBeenCalledWith("comment_1", "Done");
+
+    const resolveRoot = new Command();
+    registerDocResolveCommand(resolveRoot);
+    await subcommand(resolveRoot, "resolve").parseAsync(["comment_1", "--reopen"], { from: "user" });
+    expect(sdk.setDocCommentStatus).toHaveBeenCalledWith("comment_1", "open");
+
+    const commentsRoot = new Command();
+    registerDocCommentsCommand(commentsRoot);
+    await subcommand(commentsRoot, "comments").parseAsync(
+      ["design-doc", "--status", "open", "--version", "3", "--agent", "reviewer"],
+      { from: "user" },
+    );
+    expect(sdk.listDocComments).toHaveBeenCalledWith("doc_1", { status: "open", versionNumber: 3 });
+    await expect(
+      subcommand(commentsRoot, "comments").parseAsync(["design-doc", "--watch", "4"], { from: "user" }),
+    ).rejects.toThrow("INVALID_INTERVAL");
+
+    expect(outputMocks.success).toHaveBeenCalled();
+  });
+
+  it("publishes markdown, reports unchanged content, and rejects unreadable or invalid input", async () => {
+    const { registerDocPublishCommand } = await import("../commands/doc/publish.js");
+    const base = await mkdtemp(join(tmpdir(), "cli-doc-publish-"));
+    const file = join(base, "source.md");
+    await writeFile(file, "# Source Title\n\nBody\n", "utf8");
+    const sdk = {
+      publishDoc: vi
+        .fn()
+        .mockResolvedValueOnce({
+          slug: "custom-doc",
+          version: 4,
+          createdDocument: false,
+          createdVersion: true,
+        })
+        .mockResolvedValueOnce({
+          slug: "custom-doc",
+          version: 4,
+          createdDocument: false,
+          createdVersion: false,
+        }),
+    };
+    localAgentMocks.createSdk.mockReturnValue(sdk);
+    const root = new Command();
+    registerDocPublishCommand(root);
+
+    try {
+      await subcommand(root, "publish").parseAsync(
+        [
+          file,
+          "--slug",
+          "custom-doc",
+          "--project",
+          "alpha",
+          "--note",
+          "Initial",
+          "--status",
+          "in_review",
+          "--if-changed",
+          "--agent",
+          "writer",
+        ],
+        { from: "user" },
+      );
+      expect(sdk.publishDoc).toHaveBeenLastCalledWith({
+        slug: "custom-doc",
+        title: "Source Title",
+        content: "# Source Title\n\nBody\n",
+        project: "alpha",
+        note: "Initial",
+        status: "in_review",
+        ifChanged: true,
+      });
+      expect(outputMocks.success.mock.calls.at(-1)?.[0]).toMatchObject({
+        url: "https://first-tree.example/context/docs/custom-doc",
+      });
+
+      await subcommand(root, "publish").parseAsync([file, "--slug", "custom-doc"], { from: "user" });
+      expect(String(outputMocks.success.mock.calls.at(-1)?.[0].hint)).toContain("Content unchanged");
+
+      await expect(
+        subcommand(root, "publish").parseAsync([join(base, "missing.md")], { from: "user" }),
+      ).rejects.toThrow("FILE_UNREADABLE");
+      await expect(subcommand(root, "publish").parseAsync([file, "--slug", "Bad!"], { from: "user" })).rejects.toThrow(
+        "INVALID_SLUG",
+      );
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("imports markdown directories and preserves partial-progress failures", async () => {
+    const { registerDocImportCommand } = await import("../commands/doc/import.js");
+    const base = await mkdtemp(join(tmpdir(), "cli-doc-import-"));
+    await writeFile(join(base, "api.md"), "No heading body\n", "utf8");
+    await writeFile(join(base, "README.md"), "# skipped\n", "utf8");
+    await writeFile(join(base, "notes.txt"), "skip\n", "utf8");
+    const sdk = {
+      publishDoc: vi.fn().mockResolvedValueOnce({
+        slug: "api",
+        version: 1,
+        createdDocument: true,
+        createdVersion: true,
+      }),
+    };
+    localAgentMocks.createSdk.mockReturnValue(sdk);
+    const root = new Command();
+    registerDocImportCommand(root);
+
+    try {
+      await subcommand(root, "import").parseAsync([base, "--dry-run", "--status", "approved"], { from: "user" });
+      expect(outputMocks.success.mock.calls.at(-1)?.[0]).toMatchObject({ dryRun: true });
+
+      await subcommand(root, "import").parseAsync([base, "--project", "alpha", "--status", "approved"], {
+        from: "user",
+      });
+      expect(sdk.publishDoc).toHaveBeenCalledWith({
+        slug: "api",
+        title: "api",
+        content: "No heading body\n",
+        project: "alpha",
+        status: "approved",
+        ifChanged: true,
+      });
+
+      sdk.publishDoc.mockRejectedValueOnce(new Error("network down"));
+      await expect(subcommand(root, "import").parseAsync([base], { from: "user" })).rejects.toThrow("IMPORT_PARTIAL");
+      await expect(subcommand(root, "import").parseAsync([join(base, "missing")], { from: "user" })).rejects.toThrow(
+        "DIR_UNREADABLE",
+      );
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it("exports every paginated document and writes a manifest", async () => {
+    const { registerDocExportCommand } = await import("../commands/doc/export.js");
+    const base = await mkdtemp(join(tmpdir(), "cli-doc-export-"));
+    const outDir = join(base, "out");
+    const first = docSummary({ id: "doc_1", slug: "one", title: "One" });
+    const second = docSummary({ id: "doc_2", slug: "two", title: "Two", status: "approved" });
+    const sdk = {
+      getDoc: vi
+        .fn()
+        .mockResolvedValueOnce({ version: { content: "# One\n" } })
+        .mockResolvedValueOnce({ version: { content: "# Two\n" } }),
+      listDocs: vi
+        .fn()
+        .mockResolvedValueOnce({ items: [first], nextCursor: "page-2" })
+        .mockResolvedValueOnce({ items: [second], nextCursor: null }),
+    };
+    localAgentMocks.createSdk.mockReturnValue(sdk);
+    const root = new Command();
+    registerDocExportCommand(root);
+
+    try {
+      await subcommand(root, "export").parseAsync([outDir, "--project", "alpha", "--status", "draft"], {
+        from: "user",
+      });
+
+      expect(sdk.listDocs).toHaveBeenNthCalledWith(1, {
+        project: "alpha",
+        status: "draft",
+        limit: 200,
+        cursor: undefined,
+      });
+      expect(sdk.listDocs).toHaveBeenNthCalledWith(2, {
+        project: "alpha",
+        status: "draft",
+        limit: 200,
+        cursor: "page-2",
+      });
+      await expect(readFile(join(outDir, "one.md"), "utf8")).resolves.toBe("# One\n");
+      await expect(readFile(join(outDir, "two.md"), "utf8")).resolves.toBe("# Two\n");
+      await expect(readFile(join(outDir, "manifest.json"), "utf8")).resolves.toContain('"slug": "one"');
+      expect(outputMocks.success.mock.calls.at(-1)?.[0]).toEqual({ exported: 2, dir: outDir });
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("github command helpers and actions", () => {
+  it("registers the github command group and resolves chat ids from options or session env", async () => {
+    const { registerGithubCommands } = await import("../commands/github/index.js");
+    const { resolveTargetChatId } = await import("../commands/github/_shared.js");
+    const root = new Command();
+    registerGithubCommands(root);
+
+    const github = subcommand(root, "github");
+    expect(github.commands.map((entry) => entry.name()).sort()).toEqual(["follow", "following", "unfollow"]);
+    expect(resolveTargetChatId("chat_explicit")).toBe("chat_explicit");
+    process.env.FIRST_TREE_CHAT_ID = "chat_env";
+    expect(resolveTargetChatId(undefined)).toBe("chat_env");
+    delete process.env.FIRST_TREE_CHAT_ID;
+    expect(() => resolveTargetChatId(undefined)).toThrow("NO_CHAT_CONTEXT");
+  });
+
+  it("maps typed GitHub SDK failures to actionable CLI errors", async () => {
+    const { handleGithubSdkError } = await import("../commands/github/_shared.js");
+
+    expect(() => handleGithubSdkError(new SdkError(404, "missing"))).toThrow("ENTITY_NOT_FOUND");
+    expect(() => handleGithubSdkError(new SdkError(422, "no installation"))).toThrow("NO_APP_INSTALLATION");
+    expect(() => handleGithubSdkError(new SdkError(503, "temporarily down"))).toThrow("GITHUB_UNAVAILABLE");
+    const generic = new Error("boom");
+    expect(() => handleGithubSdkError(generic)).toThrow("boom");
+    expect(localAgentMocks.handleSdkError).toHaveBeenLastCalledWith(generic);
+  });
+
+  it("follows, lists, and unfollows GitHub entities with all terminal hints", async () => {
+    const { registerGithubFollowCommand } = await import("../commands/github/follow.js");
+    const { registerGithubFollowingCommand } = await import("../commands/github/following.js");
+    const { registerGithubUnfollowCommand } = await import("../commands/github/unfollow.js");
+    const sdk = {
+      followGithubEntity: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          result: { status: "created", entity: { entityKey: "owner/repo#1" } },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          result: { status: "rebound", entity: { entityKey: "owner/repo#1" } },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          result: { status: "already_following", entity: { entityKey: "owner/repo#1" } },
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          conflict: { conflict: { chatId: "chat_other", topic: "Existing work" } },
+        }),
+      listChatGithubEntities: vi.fn().mockResolvedValue({ items: [{ entityKey: "owner/repo#1" }] }),
+      unfollowGithubEntity: vi.fn().mockResolvedValueOnce({ removed: 0 }).mockResolvedValueOnce({ removed: 2 }),
+    };
+    localAgentMocks.createSdk.mockReturnValue(sdk);
+    const followRoot = new Command();
+    registerGithubFollowCommand(followRoot);
+
+    await subcommand(followRoot, "follow").parseAsync(["owner/repo#1", "--chat", "chat_1"], { from: "user" });
+    expect(String(outputMocks.success.mock.calls.at(-1)?.[0].hint)).toContain("Now following");
+    await subcommand(followRoot, "follow").parseAsync(["owner/repo#1", "--chat", "chat_1", "--rebind"], {
+      from: "user",
+    });
+    expect(String(outputMocks.success.mock.calls.at(-1)?.[0].hint)).toContain("Line moved");
+    await subcommand(followRoot, "follow").parseAsync(["owner/repo#1", "--chat", "chat_1"], { from: "user" });
+    expect(String(outputMocks.success.mock.calls.at(-1)?.[0].hint)).toContain("Already following");
+    await expect(
+      subcommand(followRoot, "follow").parseAsync(["owner/repo#1", "--chat", "chat_1"], { from: "user" }),
+    ).rejects.toThrow("ENTITY_FOLLOWED_ELSEWHERE");
+    expect(sdk.followGithubEntity).toHaveBeenNthCalledWith(2, "chat_1", { entity: "owner/repo#1", rebind: true });
+
+    const followingRoot = new Command();
+    registerGithubFollowingCommand(followingRoot);
+    await subcommand(followingRoot, "following").parseAsync(["--chat", "chat_1"], { from: "user" });
+    expect(sdk.listChatGithubEntities).toHaveBeenCalledWith("chat_1");
+
+    const unfollowRoot = new Command();
+    registerGithubUnfollowCommand(unfollowRoot);
+    await subcommand(unfollowRoot, "unfollow").parseAsync(["owner/repo#1", "--chat", "chat_1"], { from: "user" });
+    expect(String(outputMocks.success.mock.calls.at(-1)?.[0].hint)).toContain("Wasn't following");
+    await subcommand(unfollowRoot, "unfollow").parseAsync(["owner/repo#1", "--chat", "chat_1"], { from: "user" });
+    expect(String(outputMocks.success.mock.calls.at(-1)?.[0].hint)).toContain("Severed 2 lines");
+    expect(sdk.unfollowGithubEntity).toHaveBeenCalledWith("chat_1", "owner/repo#1");
+  });
+});

--- a/apps/cli/src/__tests__/doc-github-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/doc-github-commands-extra.test.ts
@@ -152,6 +152,8 @@ describe("doc command actions", () => {
     registerDocGetCommand(getRoot);
     await subcommand(getRoot, "get").parseAsync(["design-doc", "--version", "2"], { from: "user" });
     expect(sdk.getDoc).toHaveBeenCalledWith("doc_1", { version: 2 });
+    await subcommand(getRoot, "get").parseAsync(["design-doc"], { from: "user" });
+    expect(sdk.getDoc).toHaveBeenLastCalledWith("doc_1", undefined);
 
     const statusRoot = new Command();
     registerDocStatusCommand(statusRoot);
@@ -180,6 +182,12 @@ describe("doc command actions", () => {
       body: "Please clarify",
       versionNumber: 3,
       anchor: { exact: "target", prefix: "before", suffix: "after" },
+    });
+    await subcommand(commentRoot, "comment").parseAsync(["design-doc", "Document-level"], { from: "user" });
+    expect(sdk.createDocComment).toHaveBeenLastCalledWith("doc_1", {
+      body: "Document-level",
+      versionNumber: undefined,
+      anchor: undefined,
     });
     await expect(
       subcommand(commentRoot, "comment").parseAsync(["design-doc", "Bad anchor", "--prefix", "orphan"], {
@@ -322,6 +330,42 @@ describe("doc command actions", () => {
     }
   });
 
+  it("uses the default watch interval and stringifies non-Error watch failures", async () => {
+    const { registerDocCommentsCommand } = await import("../commands/doc/comments.js");
+    const stdoutWrite = vi.spyOn(process.stdout, "write");
+    const stderrWrite = vi.spyOn(process.stderr, "write");
+    vi.useFakeTimers();
+    const sdk = {
+      listDocs: vi.fn().mockResolvedValue({ items: [docSummary()] }),
+      listDocComments: vi
+        .fn()
+        .mockResolvedValueOnce({ items: [] })
+        .mockResolvedValueOnce({ items: [{ id: "comment_default", body: "new default interval comment" }] })
+        .mockRejectedValueOnce("watch string failure"),
+    };
+    localAgentMocks.createSdk.mockReturnValue(sdk);
+    stdoutWrite.mockImplementation(() => true);
+    stderrWrite.mockImplementationOnce(() => {
+      throw new Error("stop default watch");
+    });
+    const root = new Command();
+    registerDocCommentsCommand(root);
+
+    try {
+      const watching = subcommand(root, "comments").parseAsync(["design-doc", "--watch"], { from: "user" });
+      const expectedStop = expect(watching).rejects.toThrow("stop default watch");
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(stdoutWrite).toHaveBeenCalledWith(expect.stringContaining("comment_default"));
+      await vi.advanceTimersByTimeAsync(15_000);
+      await expectedStop;
+      expect(stderrWrite).toHaveBeenCalledWith(expect.stringContaining("watch string failure"));
+    } finally {
+      vi.useRealTimers();
+      stdoutWrite.mockRestore();
+      stderrWrite.mockRestore();
+    }
+  });
+
   it("publishes markdown, reports unchanged content, and rejects unreadable or invalid input", async () => {
     const { registerDocPublishCommand } = await import("../commands/doc/publish.js");
     const base = await mkdtemp(join(tmpdir(), "cli-doc-publish-"));
@@ -381,6 +425,24 @@ describe("doc command actions", () => {
       await subcommand(root, "publish").parseAsync([file, "--slug", "custom-doc"], { from: "user" });
       expect(String(outputMocks.success.mock.calls.at(-1)?.[0].hint)).toContain("Content unchanged");
 
+      const noHeading = join(base, "no-heading.md");
+      await writeFile(noHeading, "Body without heading\n", "utf8");
+      sdk.publishDoc.mockResolvedValueOnce({
+        slug: "no-heading",
+        version: 1,
+        createdDocument: true,
+        createdVersion: true,
+      });
+      await subcommand(root, "publish").parseAsync([noHeading], { from: "user" });
+      expect(sdk.publishDoc).toHaveBeenLastCalledWith(
+        expect.objectContaining({ slug: "no-heading", title: undefined, content: "Body without heading\n" }),
+      );
+
+      const invalidDerivedSlug = join(base, "---.md");
+      await writeFile(invalidDerivedSlug, "# Title\n", "utf8");
+      await expect(subcommand(root, "publish").parseAsync([invalidDerivedSlug], { from: "user" })).rejects.toThrow(
+        "INVALID_SLUG",
+      );
       await expect(
         subcommand(root, "publish").parseAsync([join(base, "missing.md")], { from: "user" }),
       ).rejects.toThrow("FILE_UNREADABLE");
@@ -428,6 +490,16 @@ describe("doc command actions", () => {
 
       sdk.publishDoc.mockRejectedValueOnce(new Error("network down"));
       await expect(subcommand(root, "import").parseAsync([base], { from: "user" })).rejects.toThrow("IMPORT_PARTIAL");
+
+      const emptyProgressBase = await mkdtemp(join(tmpdir(), "cli-doc-import-empty-progress-"));
+      await writeFile(join(emptyProgressBase, "first.md"), "# First\n", "utf8");
+      sdk.publishDoc.mockRejectedValueOnce("string publish failure");
+      await expect(subcommand(root, "import").parseAsync([emptyProgressBase], { from: "user" })).rejects.toThrow(
+        "IMPORT_PARTIAL",
+      );
+      expect(outputMocks.fail.mock.calls.at(-1)?.[1]).toContain("Imported before the failure: none");
+      await rm(emptyProgressBase, { recursive: true, force: true });
+
       await expect(subcommand(root, "import").parseAsync([join(base, "missing")], { from: "user" })).rejects.toThrow(
         "DIR_UNREADABLE",
       );

--- a/apps/cli/src/__tests__/doctor-core.test.ts
+++ b/apps/cli/src/__tests__/doctor-core.test.ts
@@ -17,6 +17,7 @@ vi.mock("../core/service-install.js", () => ({
 
 const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
 const originalServerUrl = process.env.FIRST_TREE_SERVER_URL;
+const originalNodeVersion = process.versions.node;
 
 let home: string;
 
@@ -42,6 +43,7 @@ afterEach(() => {
   else process.env.FIRST_TREE_HOME = originalFirstTreeHome;
   if (originalServerUrl === undefined) delete process.env.FIRST_TREE_SERVER_URL;
   else process.env.FIRST_TREE_SERVER_URL = originalServerUrl;
+  Object.defineProperty(process.versions, "node", { configurable: true, value: originalNodeVersion });
 });
 
 describe("doctor core checks", () => {
@@ -59,6 +61,19 @@ describe("doctor core checks", () => {
       label: "Node.js",
       ok: true,
     });
+    Object.defineProperty(process.versions, "node", { configurable: true, value: "22.12.0" });
+    expect(checkNodeVersion()).toEqual({
+      label: "Node.js",
+      ok: false,
+      detail: "v22.12.0 (requires >= 22.13)",
+    });
+    Object.defineProperty(process.versions, "node", { configurable: true, value: "22.13.0" });
+    expect(checkNodeVersion()).toEqual({
+      label: "Node.js",
+      ok: true,
+      detail: "v22.13.0",
+    });
+    Object.defineProperty(process.versions, "node", { configurable: true, value: originalNodeVersion });
 
     expect(checkClientConfig()).toEqual({
       label: "Config",
@@ -73,6 +88,8 @@ describe("doctor core checks", () => {
       join(home, "config", "client.yaml"),
       "server:\n  url: http://first-tree.test\nclient:\n  id: client_1234abcd\n",
     );
+    process.env.FIRST_TREE_SERVER_URL = "http://env.test";
+    expect(checkClientConfig()).toEqual({ label: "Config", ok: true, detail: "config file + env vars" });
     delete process.env.FIRST_TREE_SERVER_URL;
     expect(checkClientConfig().detail).toContain("client.yaml");
 
@@ -146,13 +163,28 @@ describe("doctor core checks", () => {
     });
 
     writeAgent("moved", "agentId: agent-2\nruntime: claude-code\n");
+    writeAgent("suspended", "agentId: agent-3\nruntime: claude-code\n");
     const stale = await reconcileAgentConfigs({
       clientId: "client-1",
-      listPinnedAgents: async () => [{ agentId: "agent-2", clientId: "client-2" }],
+      listPinnedAgents: async () => [
+        { agentId: "agent-2", clientId: "client-2" },
+        { agentId: "agent-3", clientId: "client-1", status: "suspended" },
+      ],
     });
     expect(stale.ok).toBe(false);
     expect(stale.detail).toContain("moved [pinned to another client: client-2]");
+    expect(stale.detail).toContain("1 suspended/disabled");
     expect(stale.detail).toContain("run `first-tree-dev agent prune`");
+
+    for (let index = 4; index <= 10; index++) {
+      writeAgent(`stale-${index}`, `agentId: agent-${index}\nruntime: claude-code\n`);
+    }
+    const truncated = await reconcileAgentConfigs({
+      clientId: "client-1",
+      listPinnedAgents: async () => [],
+    });
+    expect(truncated.ok).toBe(false);
+    expect(truncated.detail).toContain("...+");
   });
 
   it("handles reconciliation failures and background-service states", async () => {
@@ -188,6 +220,25 @@ describe("doctor core checks", () => {
     expect(failed.ok).toBe(false);
     expect(failed.detail).toContain("server reconciliation failed");
 
+    const failedString = await reconcileAgentConfigs({
+      clientId: "client-1",
+      listPinnedAgents: async () => {
+        throw "server string failure";
+      },
+    });
+    expect(failedString.ok).toBe(false);
+    expect(failedString.detail).toContain("server string failure");
+
+    writeAgent("missing-yaml", "");
+    rmSync(join(home, "config", "agents", "missing-yaml", "agent.yaml"), { force: true });
+    writeAgent("null-yaml", "null\n");
+    writeAgent("bad-yaml", "agentId: [broken\n");
+    const suspendedWithUnreadableAliases = await reconcileAgentConfigs({
+      clientId: "client-1",
+      listPinnedAgents: async () => [{ agentId: "agent-1", clientId: "client-1", status: "suspended" }],
+    });
+    expect(suspendedWithUnreadableAliases.detail).toContain("1 suspended/disabled");
+
     serviceStatusMock.mockReturnValueOnce({
       platform: "unsupported",
       label: "",
@@ -216,6 +267,19 @@ describe("doctor core checks", () => {
     });
 
     serviceStatusMock.mockReturnValueOnce({
+      platform: "systemd",
+      label: "first-tree.service",
+      unitPath: "/unit",
+      logDir: "/logs",
+      state: "active",
+    });
+    expect(checkBackgroundService()).toEqual({
+      label: "Background service",
+      ok: true,
+      detail: "running (systemd); logs at /logs",
+    });
+
+    serviceStatusMock.mockReturnValueOnce({
       platform: "launchd",
       label: "dev.first-tree",
       unitPath: "/unit",
@@ -227,6 +291,19 @@ describe("doctor core checks", () => {
       label: "Background service",
       ok: false,
       detail: "installed but not running — loaded; unit at /unit",
+    });
+
+    serviceStatusMock.mockReturnValueOnce({
+      platform: "launchd",
+      label: "dev.first-tree",
+      unitPath: "/unit",
+      logDir: "/logs",
+      state: "inactive",
+    });
+    expect(checkBackgroundService()).toEqual({
+      label: "Background service",
+      ok: false,
+      detail: "installed but not running; unit at /unit",
     });
 
     serviceStatusMock.mockReturnValueOnce({
@@ -251,5 +328,57 @@ describe("doctor core checks", () => {
     stderrMock.mockClear();
     printResults([{ label: "One", ok: true, detail: "ok" }]);
     expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("All checks passed.");
+  });
+
+  it("formats runtime provider checks and handles empty capability snapshots", async () => {
+    const { runtimeProviderCheck, runtimeProviderChecks } = await import("../core/doctor.js");
+
+    expect(
+      runtimeProviderCheck("codex", {
+        state: "ok",
+        available: true,
+        detectedAt: "2026-01-01T00:00:00.000Z",
+        runtimeSource: "path",
+        sdkVersion: "1.2.3",
+        latencyMs: 42,
+      }),
+    ).toEqual({
+      label: "codex",
+      ok: true,
+      detail: "ok — installed, path, v1.2.3, 42ms",
+    });
+    expect(
+      runtimeProviderCheck("claude-code", {
+        state: "missing",
+        available: false,
+        detectedAt: "2026-01-01T00:00:00.000Z",
+        error: "  not found  ",
+      }),
+    ).toEqual({
+      label: "claude-code",
+      ok: false,
+      detail: "missing — not found",
+    });
+    expect(
+      runtimeProviderCheck("other", {
+        state: "error",
+        available: false,
+        detectedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ).toEqual({
+      label: "other",
+      ok: false,
+      detail: "error",
+    });
+    expect(runtimeProviderChecks({})).toEqual([
+      { label: "Runtime providers", ok: false, detail: "no providers probed" },
+    ]);
+    expect(
+      runtimeProviderChecks({
+        zed: { state: "ok", available: true, detectedAt: "2026-01-01T00:00:00.000Z" },
+        codex: undefined,
+        "claude-code": { state: "missing", available: false, detectedAt: "2026-01-01T00:00:00.000Z" },
+      }).map((result) => result.label),
+    ).toEqual(["claude-code", "zed"]);
   });
 });

--- a/apps/cli/src/__tests__/ensure-fresh-access-token.test.ts
+++ b/apps/cli/src/__tests__/ensure-fresh-access-token.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -51,6 +51,30 @@ describe("ensureFreshAccessToken — safety margin", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("resolves access tokens, masks tokens, and ignores malformed credential files", async () => {
+    const token = makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials(token);
+
+    const { loadCredentials, maskToken, resolveAccessToken } = await import("../core/bootstrap.js");
+
+    expect(resolveAccessToken()).toBe(token);
+    expect(maskToken("1234567890")).toBe("123456***90");
+    expect(maskToken("short")).toBe("***");
+
+    writeFileSync(join(testHome, "config", "credentials.json"), JSON.stringify({ accessToken: token }));
+    expect(loadCredentials()).toBeNull();
+
+    writeFileSync(join(testHome, "config", "credentials.json"), "{not-json");
+    expect(loadCredentials()).toBeNull();
+    expect(() => resolveAccessToken()).toThrow(/No credentials found/u);
+  });
+
+  it("throws a login hint when freshness is requested without credentials", async () => {
+    const { ensureFreshAccessToken } = await import("../core/bootstrap.js");
+
+    await expect(ensureFreshAccessToken()).rejects.toThrow(/No credentials found/u);
+  });
+
   it("refreshes when exp is less than 30s away", async () => {
     const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) + 10 });
     const refreshed = makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 });
@@ -79,6 +103,17 @@ describe("ensureFreshAccessToken — safety margin", () => {
     const result = await ensureFreshAccessToken();
 
     expect(result).toBe(refreshed);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats malformed access tokens as stale and refreshes them", async () => {
+    const refreshed = makeJwt({ exp: Math.floor(Date.now() / 1000) + 1800 });
+    await writeCredentials("not-a-valid-jwt");
+
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ accessToken: refreshed })));
+
+    const { ensureFreshAccessToken } = await import("../core/bootstrap.js");
+    await expect(ensureFreshAccessToken()).resolves.toBe(refreshed);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -115,6 +150,18 @@ describe("ensureFreshAccessToken — safety margin", () => {
     const err = await ensureFreshAccessToken().catch((e) => e);
     expect(err).toBeInstanceOf(AuthRefreshRateLimitedError);
     expect((err as { retryAfterMs: number }).retryAfterMs).toBe(45_000);
+  });
+
+  it("defaults Retry-After to 30s when the 429 header is malformed", async () => {
+    const stale = makeJwt({ exp: Math.floor(Date.now() / 1000) - 5 });
+    await writeCredentials(stale);
+
+    fetchMock.mockResolvedValue(new Response(null, { status: 429, headers: { "retry-after": "not-a-date" } }));
+
+    const { ensureFreshAccessToken, AuthRefreshRateLimitedError } = await import("../core/bootstrap.js");
+    const err = await ensureFreshAccessToken().catch((e) => e);
+    expect(err).toBeInstanceOf(AuthRefreshRateLimitedError);
+    expect((err as { retryAfterMs: number }).retryAfterMs).toBe(30_000);
   });
 
   it("defaults Retry-After to 30s when the 429 response omits the header", async () => {
@@ -257,5 +304,27 @@ describe("ensureFreshAccessToken — safety margin", () => {
     expect(first).toBe(refreshed1);
     expect(second).toBe(refreshed2);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("removes the temporary credentials file when an atomic save fails", async () => {
+    vi.resetModules();
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...actual,
+        renameSync: () => {
+          throw new Error("rename denied");
+        },
+      };
+    });
+
+    const { saveCredentials } = await import("../core/bootstrap.js");
+
+    expect(() =>
+      saveCredentials({ accessToken: "access", refreshToken: "refresh", serverUrl: "https://hub.example" }),
+    ).toThrow("rename denied");
+    expect(existsSync(join(testHome, "config", `credentials.json.tmp.${process.pid}`))).toBe(false);
+    expect(() => readFileSync(join(testHome, "config", "credentials.json"), "utf8")).toThrow();
+    vi.doUnmock("node:fs");
   });
 });

--- a/apps/cli/src/__tests__/login-command.test.ts
+++ b/apps/cli/src/__tests__/login-command.test.ts
@@ -92,6 +92,13 @@ async function runLogin(args: string[]): Promise<void> {
   await program.parseAsync(args, { from: "user" });
 }
 
+async function waitForAsyncWork(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 function credentialsPath(): string {
   return join(home, "config", "credentials.json");
 }
@@ -257,6 +264,9 @@ beforeEach(() => {
   promptUpdateMock.mockReset();
   stderrMock.mockClear();
   exitMock.mockClear();
+  exitMock.mockImplementation((() => {
+    throw new Error("process.exit");
+  }) as never);
   process.exitCode = undefined;
   cliFetchMock.mockImplementation(async () =>
     response(200, { accessToken: jwt({ sub: "user-new" }), refreshToken: "r1" }),
@@ -353,6 +363,28 @@ describe("login command", { timeout: 60_000 }, () => {
     expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
       "Connect code must be the short code only",
     );
+  });
+
+  it("reports unexpected connect-token URL derivation failures", async () => {
+    vi.doMock("../commands/_shared/connect-token.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../commands/_shared/connect-token.js")>();
+      return {
+        ...actual,
+        deriveHubUrlFromToken: vi.fn(() => {
+          throw new Error("derive exploded");
+        }),
+      };
+    });
+
+    try {
+      await expect(runLogin(["login", jwt({ iss: "http://first-tree.test/" }), "--no-start"])).rejects.toThrow(
+        "process.exit",
+      );
+      expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("derive exploded");
+    } finally {
+      vi.doUnmock("../commands/_shared/connect-token.js");
+      vi.resetModules();
+    }
   });
 
   it("requires explicit confirmation for cross-account login with a short connect code", async () => {
@@ -644,6 +676,59 @@ describe("login command", { timeout: 60_000 }, () => {
     expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("expired token");
   });
 
+  it("rejects exchanged access tokens without an owner subject", async () => {
+    cliFetchMock.mockResolvedValueOnce(response(200, { accessToken: jwt({}), refreshToken: "r1" }));
+
+    await expect(runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--no-start"])).rejects.toThrow(
+      "process.exit",
+    );
+
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "Server access token is missing the required `sub` claim",
+    );
+  });
+
+  it("refuses existing credentials whose owner cannot be decoded", async () => {
+    mkdirSync(join(home, "config"), { recursive: true });
+    writeFileSync(
+      credentialsPath(),
+      JSON.stringify({ accessToken: "not-a-jwt", refreshToken: "old-refresh", serverUrl: "http://first-tree.test" }),
+    );
+
+    await expect(runLogin(["login", jwt({ iss: "http://first-tree.test" }), "--no-start"])).rejects.toThrow(
+      "process.exit",
+    );
+
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
+      "Existing credentials do not expose an owner user id",
+    );
+  });
+
+  it("installs the background service when supported", async () => {
+    isServiceSupportedMock.mockReturnValue(true);
+    installClientServiceMock.mockReturnValue({
+      platform: "launchd",
+      logDir: join(home, "logs"),
+    });
+
+    await runLogin(["login", jwt({ iss: "http://first-tree.test" })]);
+
+    expect(installClientServiceMock).toHaveBeenCalled();
+    const output = stderrMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("Background service installed (launchd)");
+    expect(output).toContain(join(home, "logs"));
+    expect(clientRuntimeMock).not.toHaveBeenCalled();
+  });
+
+  it("prints cancellation when inline runtime start is interrupted by the prompt layer", async () => {
+    runtimeInstance.start.mockRejectedValueOnce(Object.assign(new Error("cancel"), { name: "ExitPromptError" }));
+
+    await runLogin(["login", jwt({ iss: "http://hub.test" })]);
+
+    expect(stderrMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Cancelled.");
+    expect(exitMock).not.toHaveBeenCalled();
+  });
+
   it("falls back to inline runtime when service install is unsupported", async () => {
     writeCredentials("member-new", "http://hub.test", "user-new");
     mkdirSync(join(home, "config", "agents", "nova"), { recursive: true });
@@ -674,6 +759,34 @@ describe("login command", { timeout: 60_000 }, () => {
     const text = stderrMock.mock.calls.map((call) => String(call[0])).join("");
     expect(text).toContain("Background service not supported");
     expect(text).toContain("Error: stop after watch");
+  });
+
+  it("stops the inline runtime cleanly when the login fallback receives SIGTERM", async () => {
+    const signalHandlers = new Map<string, () => void>();
+    const onSpy = vi.spyOn(process, "on").mockImplementation((event, listener) => {
+      if (event === "SIGINT" || event === "SIGTERM") {
+        signalHandlers.set(event, listener as () => void);
+      }
+      return process;
+    });
+    exitMock.mockImplementation((() => undefined) as never);
+    runtimeInstance.watchAgentsDir.mockImplementation(() => undefined);
+
+    try {
+      void runLogin(["login", jwt({ iss: "http://hub.test" })]).catch(() => undefined);
+      await waitForAsyncWork(() => signalHandlers.has("SIGTERM"));
+
+      const shutdown = signalHandlers.get("SIGTERM");
+      expect(shutdown).toBeTypeOf("function");
+      shutdown?.();
+      await waitForAsyncWork(() => runtimeInstance.stop.mock.calls.length > 0);
+
+      expect(runtimeInstance.unwatchAgentsDir).toHaveBeenCalled();
+      expect(runtimeInstance.stop).toHaveBeenCalledWith(undefined);
+      expect(exitMock).toHaveBeenCalledWith(0);
+    } finally {
+      onSpy.mockRestore();
+    }
   });
 
   it("continues inline fallback when migration fails and handles prompt/org errors", async () => {

--- a/apps/cli/src/__tests__/migrate-agent-dirs-extra.test.ts
+++ b/apps/cli/src/__tests__/migrate-agent-dirs-extra.test.ts
@@ -191,6 +191,62 @@ describe("migrateLocalAgentDirs extra failure branches", () => {
     );
   });
 
+  it("stringifies non-Error runtime-layout migration failures", async () => {
+    const { migrateLocalAgentDirs } = await import("../core/migrate-agent-dirs.js");
+    clientMocks.migrateLegacyRuntimeLayout.mockImplementationOnce(() => {
+      throw "runtime layout string failure";
+    });
+    writeAgentYaml("old", "agent-1");
+    writeWorkspace("old");
+
+    const result = await migrateLocalAgentDirs({
+      ...dirs(),
+      resolver: { resolveName: vi.fn(async () => "old") },
+    });
+
+    expect(result).toMatchObject({ scanned: 1, renamed: 0, errors: 1 });
+    expect(printMock.status).toHaveBeenCalledWith(
+      "⚠️",
+      expect.stringContaining('runtime-dir migration failed for "old": runtime layout string failure'),
+    );
+  });
+
+  it("adds resolver failure hints for 403 responses and stringifies non-Error failures", async () => {
+    const { migrateLocalAgentDirs } = await import("../core/migrate-agent-dirs.js");
+    writeAgentYaml("forbidden", "agent-forbidden");
+    const forbidden = await migrateLocalAgentDirs({
+      ...dirs(),
+      resolver: {
+        async resolveName() {
+          throw new Error("/me/managed-agents returned HTTP 403");
+        },
+      },
+    });
+    expect(forbidden).toMatchObject({ scanned: 1, errors: 1 });
+    expect(printMock.status).toHaveBeenLastCalledWith(
+      "⚠️",
+      expect.stringContaining("likely a non-admin account"),
+    );
+
+    vi.clearAllMocks();
+    rmSync(root, { recursive: true, force: true });
+    root = makeTempDir("ft-migrate-extra-");
+    writeAgentYaml("string-failure", "agent-string");
+    const stringFailure = await migrateLocalAgentDirs({
+      ...dirs(),
+      resolver: {
+        async resolveName() {
+          throw "resolver string failure";
+        },
+      },
+    });
+    expect(stringFailure).toMatchObject({ scanned: 1, errors: 1 });
+    expect(printMock.status).toHaveBeenLastCalledWith(
+      "⚠️",
+      expect.stringContaining('failed to resolve "string-failure" (agent-string): resolver string failure'),
+    );
+  });
+
   it("continues when workspace and session renames fail", async () => {
     const { migrateLocalAgentDirs } = await import("../core/migrate-agent-dirs.js");
     writeAgentYaml("old", "agent-1");

--- a/apps/cli/src/__tests__/migrate-agent-dirs-extra.test.ts
+++ b/apps/cli/src/__tests__/migrate-agent-dirs-extra.test.ts
@@ -223,10 +223,7 @@ describe("migrateLocalAgentDirs extra failure branches", () => {
       },
     });
     expect(forbidden).toMatchObject({ scanned: 1, errors: 1 });
-    expect(printMock.status).toHaveBeenLastCalledWith(
-      "⚠️",
-      expect.stringContaining("likely a non-admin account"),
-    );
+    expect(printMock.status).toHaveBeenLastCalledWith("⚠️", expect.stringContaining("likely a non-admin account"));
 
     vi.clearAllMocks();
     rmSync(root, { recursive: true, force: true });

--- a/apps/cli/src/__tests__/migrate-agent-dirs-extra.test.ts
+++ b/apps/cli/src/__tests__/migrate-agent-dirs-extra.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -6,8 +6,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NameResolver } from "../core/migrate-agent-dirs.js";
 
 const cliFetchMock = vi.hoisted(() => vi.fn());
+const clientMocks = vi.hoisted(() => ({
+  migrateLegacyRuntimeLayout: vi.fn(),
+}));
 const printMock = vi.hoisted(() => ({ status: vi.fn() }));
 
+vi.mock("@first-tree/client", () => clientMocks);
 vi.mock("../core/cli-fetch.js", () => ({ cliFetch: cliFetchMock }));
 vi.mock("../core/output.js", () => ({ print: printMock }));
 
@@ -54,6 +58,7 @@ function jsonResponse(body: unknown, ok = true, status = 200): Response {
 beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
+  clientMocks.migrateLegacyRuntimeLayout.mockReturnValue(undefined);
   root = makeTempDir("ft-migrate-extra-");
 });
 
@@ -144,6 +149,83 @@ describe("migrateLocalAgentDirs extra failure branches", () => {
 
     expect(result).toMatchObject({ scanned: 1, renamed: 1, errors: 1 });
     expect(readdirSync(join(root, "config", "agents")).sort()).toEqual(["empty", "new", "plain-file"]);
+  });
+
+  it("skips broken symlinks while enumerating local agent dirs", async (ctx) => {
+    const { migrateLocalAgentDirs } = await import("../core/migrate-agent-dirs.js");
+    mkdirSync(join(root, "config", "agents"), { recursive: true });
+    try {
+      symlinkSync(join(root, "missing-agent"), join(root, "config", "agents", "broken"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+    writeAgentYaml("old", "agent-1");
+
+    const result = await migrateLocalAgentDirs({
+      ...dirs(),
+      resolver: { resolveName: vi.fn(async () => "new") },
+    });
+
+    expect(result).toMatchObject({ scanned: 1, renamed: 1, errors: 0 });
+    expect(readdirSync(join(root, "config", "agents")).sort()).toEqual(["broken", "new"]);
+  });
+
+  it("logs runtime-layout migration failures after a successful agent rename", async () => {
+    const { migrateLocalAgentDirs } = await import("../core/migrate-agent-dirs.js");
+    clientMocks.migrateLegacyRuntimeLayout.mockImplementationOnce(() => {
+      throw new Error("runtime layout broken");
+    });
+    writeAgentYaml("old", "agent-1");
+    writeWorkspace("old");
+
+    const result = await migrateLocalAgentDirs({
+      ...dirs(),
+      resolver: { resolveName: vi.fn(async () => "new") },
+    });
+
+    expect(result).toMatchObject({ scanned: 1, renamed: 1, errors: 1 });
+    expect(clientMocks.migrateLegacyRuntimeLayout).toHaveBeenCalledWith(join(root, "data", "workspaces", "old"));
+    expect(printMock.status).toHaveBeenCalledWith(
+      "⚠️",
+      expect.stringContaining('runtime-dir migration failed for "old"'),
+    );
+  });
+
+  it("continues when workspace and session renames fail", async () => {
+    const { migrateLocalAgentDirs } = await import("../core/migrate-agent-dirs.js");
+    writeAgentYaml("old", "agent-1");
+    writeWorkspace("old");
+    writeSession("old");
+    chmodSync(join(root, "data", "workspaces"), 0o500);
+    chmodSync(join(root, "data", "sessions"), 0o500);
+
+    try {
+      const result = await migrateLocalAgentDirs({
+        ...dirs(),
+        resolver: { resolveName: vi.fn(async () => "new") },
+      });
+
+      expect(result).toMatchObject({ scanned: 1, renamed: 1, errors: 2 });
+      expect(printMock.status).toHaveBeenCalledWith("⚠️", expect.stringContaining('workspace rename failed for "old"'));
+      expect(printMock.status).toHaveBeenCalledWith("⚠️", expect.stringContaining('sessions rename failed for "old"'));
+    } finally {
+      chmodSync(join(root, "data", "workspaces"), 0o700);
+      chmodSync(join(root, "data", "sessions"), 0o700);
+    }
+  });
+
+  it("treats orphan detection as best-effort when local state cannot be listed", async () => {
+    const { migrateLocalAgentDirs } = await import("../core/migrate-agent-dirs.js");
+    writeAgentYaml("old", "agent-1");
+    mkdirSync(join(root, "data"), { recursive: true });
+    writeFileSync(join(root, "data", "workspaces"), "not a directory\n");
+
+    const result = await migrateLocalAgentDirs({
+      ...dirs(),
+      resolver: { resolveName: vi.fn(async () => null) },
+    });
+
+    expect(result).toMatchObject({ scanned: 1, renamed: 0, errors: 0 });
   });
 
   it("continues after config, workspace, and session rename edge cases", async () => {

--- a/apps/cli/src/__tests__/migrate-workspace-fs-mocked.test.ts
+++ b/apps/cli/src/__tests__/migrate-workspace-fs-mocked.test.ts
@@ -1,0 +1,162 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMode = vi.hoisted(() => ({
+  mode: "normal" as
+    | "normal"
+    | "bindings-readdir-error"
+    | "empty-runtime-readdir-error"
+    | "tree-rename-moves-then-throws"
+    | "rollback-rename-throws",
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readdirSync: ((path: Parameters<typeof actual.readdirSync>[0], options?: unknown) => {
+      const text = String(path);
+      if (fsMode.mode === "bindings-readdir-error" && text.endsWith("/.first-tree/bindings")) {
+        throw new Error("bindings denied");
+      }
+      if (fsMode.mode === "empty-runtime-readdir-error" && text.endsWith("/api/.first-tree")) {
+        throw new Error("runtime dir denied");
+      }
+      return (actual.readdirSync as (...args: unknown[]) => unknown)(path, options);
+    }) as typeof actual.readdirSync,
+    renameSync: ((oldPath: Parameters<typeof actual.renameSync>[0], newPath: Parameters<typeof actual.renameSync>[1]) => {
+      const oldText = String(oldPath);
+      const newText = String(newPath);
+      if (
+        fsMode.mode === "tree-rename-moves-then-throws" &&
+        oldText.endsWith("/context") &&
+        newText.endsWith("/api-workspace/context")
+      ) {
+        actual.renameSync(oldPath, newPath);
+        throw new Error("tree move failed after move");
+      }
+      if (
+        fsMode.mode === "rollback-rename-throws" &&
+        oldText.endsWith("/context") &&
+        newText.endsWith("/api-workspace/context")
+      ) {
+        throw new Error("tree move failed before move");
+      }
+      if (
+        fsMode.mode === "rollback-rename-throws" &&
+        oldText.endsWith("/api-workspace/api") &&
+        newText.endsWith("/api")
+      ) {
+        throw new Error("rollback denied");
+      }
+      return actual.renameSync(oldPath, newPath);
+    }) as typeof actual.renameSync,
+  };
+});
+
+let tmpRoot = "";
+
+function makeRepo(parentDir: string, name: string): string {
+  const repoDir = join(parentDir, name);
+  mkdirSync(repoDir, { recursive: true });
+  execSync("git init --quiet", { cwd: repoDir });
+  return repoDir;
+}
+
+function writeJson(filePath: string, body: unknown): void {
+  mkdirSync(join(filePath, ".."), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(body, null, 2)}\n`, "utf-8");
+}
+
+function writeFile(filePath: string, body: string): void {
+  mkdirSync(join(filePath, ".."), { recursive: true });
+  writeFileSync(filePath, body, "utf-8");
+}
+
+function makeWorkspace(): { workspaceRoot: string; treeRoot: string; sourceRoot: string } {
+  const workspaceRoot = tmpRoot;
+  writeFile(join(workspaceRoot, ".first-tree-workspace"), "");
+  const treeRoot = makeRepo(workspaceRoot, "context");
+  mkdirSync(join(treeRoot, ".first-tree", "bindings"), { recursive: true });
+  writeJson(join(treeRoot, ".first-tree", "bindings", "api.json"), { sourceName: "api" });
+  const sourceRoot = makeRepo(workspaceRoot, "api");
+  writeJson(join(sourceRoot, ".first-tree", "source.json"), { tree: { treeRepoName: "context" } });
+  return { workspaceRoot, treeRoot, sourceRoot };
+}
+
+function makePromotable(): { sourceRoot: string; treeRoot: string } {
+  const sourceRoot = makeRepo(tmpRoot, "api");
+  const treeRoot = makeRepo(tmpRoot, "context");
+  writeJson(join(sourceRoot, ".first-tree", "source.json"), {
+    tree: { localPath: "../context" },
+  });
+  return { sourceRoot, treeRoot };
+}
+
+beforeEach(() => {
+  fsMode.mode = "normal";
+  tmpRoot = mkdtempSync(join(tmpdir(), "ft-migrate-fs-"));
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("migrate workspace fs edge paths", () => {
+  it("falls back to filesystem source discovery when bindings cannot be enumerated", async () => {
+    const fixture = makeWorkspace();
+    fsMode.mode = "bindings-readdir-error";
+    const { detectMigrationState } = await import("../core/migrate-workspace.js");
+
+    const detection = detectMigrationState(fixture.workspaceRoot);
+
+    expect(detection.kind).toBe("workspace");
+    if (detection.kind !== "workspace") throw new Error("expected workspace");
+    expect(detection.sourceRoots).toEqual([fixture.sourceRoot]);
+  });
+
+  it("keeps an empty source runtime dir when emptiness cannot be inspected", async () => {
+    const fixture = makeWorkspace();
+    fsMode.mode = "empty-runtime-readdir-error";
+    const { detectMigrationState, migrateWorkspaceToW1 } = await import("../core/migrate-workspace.js");
+    const detection = detectMigrationState(fixture.workspaceRoot);
+    if (detection.kind !== "workspace") throw new Error("expected workspace");
+
+    const result = migrateWorkspaceToW1(detection);
+
+    expect(result.removed).toContainEqual({ path: "api/.first-tree/source.json", kind: "source-state" });
+    expect(result.removed).not.toContainEqual({ path: "api/.first-tree", kind: "source-state-dir" });
+    expect(existsSync(join(fixture.sourceRoot, ".first-tree"))).toBe(true);
+  });
+
+  it("rolls source and tree moves back when promotion fails after the tree move", async () => {
+    const fixture = makePromotable();
+    fsMode.mode = "tree-rename-moves-then-throws";
+    const { detectMigrationState, promoteToWorkspace } = await import("../core/migrate-workspace.js");
+    const detection = detectMigrationState(fixture.sourceRoot);
+    if (detection.kind !== "promotable-source") throw new Error("expected promotable source");
+
+    expect(() => promoteToWorkspace(detection)).toThrow("tree move failed after move");
+
+    expect(existsSync(fixture.sourceRoot)).toBe(true);
+    expect(existsSync(fixture.treeRoot)).toBe(true);
+    expect(existsSync(join(tmpRoot, "api-workspace"))).toBe(false);
+  });
+
+  it("preserves the original promotion error when rollback cleanup also fails", async () => {
+    const fixture = makePromotable();
+    fsMode.mode = "rollback-rename-throws";
+    const { detectMigrationState, promoteToWorkspace } = await import("../core/migrate-workspace.js");
+    const detection = detectMigrationState(fixture.sourceRoot);
+    if (detection.kind !== "promotable-source") throw new Error("expected promotable source");
+
+    expect(() => promoteToWorkspace(detection)).toThrow("tree move failed before move");
+
+    expect(existsSync(join(tmpRoot, "api-workspace", "api"))).toBe(true);
+    expect(readFileSync(join(fixture.treeRoot, ".git", "HEAD"), "utf8")).toContain("ref:");
+  });
+});

--- a/apps/cli/src/__tests__/migrate-workspace-fs-mocked.test.ts
+++ b/apps/cli/src/__tests__/migrate-workspace-fs-mocked.test.ts
@@ -28,7 +28,10 @@ vi.mock("node:fs", async (importOriginal) => {
       }
       return (actual.readdirSync as (...args: unknown[]) => unknown)(path, options);
     }) as typeof actual.readdirSync,
-    renameSync: ((oldPath: Parameters<typeof actual.renameSync>[0], newPath: Parameters<typeof actual.renameSync>[1]) => {
+    renameSync: ((
+      oldPath: Parameters<typeof actual.renameSync>[0],
+      newPath: Parameters<typeof actual.renameSync>[1],
+    ) => {
       const oldText = String(oldPath);
       const newText = String(newPath);
       if (

--- a/apps/cli/src/__tests__/migrate-workspace.test.ts
+++ b/apps/cli/src/__tests__/migrate-workspace.test.ts
@@ -204,6 +204,26 @@ describe("detectMigrationState", () => {
     expect(detection.kind).toBe("not-applicable");
   });
 
+  it("returns 'not-applicable' when cwd is a file and child scanning cannot run", () => {
+    const filePath = join(tmpRoot, "not-a-directory");
+    writeFile(filePath, "plain file");
+
+    const detection = detectMigrationState(filePath);
+
+    expect(detection.kind).toBe("not-applicable");
+  });
+
+  it("returns 'not-applicable' when a legacy marker exists without a tree", () => {
+    writeFile(join(tmpRoot, ".first-tree-workspace"), "");
+
+    const detection = detectMigrationState(tmpRoot);
+
+    expect(detection.kind).toBe("not-applicable");
+    if (detection.kind === "not-applicable") {
+      expect(detection.reason).toContain("no child directory contains a tree binding");
+    }
+  });
+
   it("returns 'not-applicable' when source.json points at a missing sibling tree", () => {
     const sourceRoot = makeRepo(tmpRoot, "api");
     writeJson(join(sourceRoot, ".first-tree", "source.json"), {
@@ -213,6 +233,31 @@ describe("detectMigrationState", () => {
     const detection = detectMigrationState(sourceRoot);
 
     expect(detection.kind).toBe("not-applicable");
+  });
+
+  it("returns 'not-applicable' for source.json without a usable tree object", () => {
+    const sourceRoot = makeRepo(tmpRoot, "api");
+    writeJson(join(sourceRoot, ".first-tree", "source.json"), []);
+
+    const arrayDetection = detectMigrationState(sourceRoot);
+    expect(arrayDetection.kind).toBe("not-applicable");
+    if (arrayDetection.kind === "not-applicable") {
+      expect(arrayDetection.reason).toContain("could not be parsed as JSON");
+    }
+
+    writeJson(join(sourceRoot, ".first-tree", "source.json"), { tree: null });
+    const nullTreeDetection = detectMigrationState(sourceRoot);
+    expect(nullTreeDetection.kind).toBe("not-applicable");
+    if (nullTreeDetection.kind === "not-applicable") {
+      expect(nullTreeDetection.reason).toContain("no `tree` object");
+    }
+
+    writeJson(join(sourceRoot, ".first-tree", "source.json"), { tree: {} });
+    const missingPathDetection = detectMigrationState(sourceRoot);
+    expect(missingPathDetection.kind).toBe("not-applicable");
+    if (missingPathDetection.kind === "not-applicable") {
+      expect(missingPathDetection.reason).toContain("tree.localPath");
+    }
   });
 
   it("returns 'not-applicable' when source.json points at an absolute, non-sibling tree path", () => {
@@ -301,6 +346,27 @@ describe("detectMigrationState", () => {
 });
 
 describe("detectMigrationState — bindings + filesystem union (Codex P1#1)", () => {
+  it("ignores non-json, malformed, and empty binding entries while reading source names", () => {
+    const workspaceRoot = tmpRoot;
+    writeFile(join(workspaceRoot, ".first-tree-workspace"), "");
+    const treeRoot = makeRepo(workspaceRoot, "context");
+    mkdirSync(join(treeRoot, ".first-tree", "bindings", "subdir"), { recursive: true });
+    writeFile(join(treeRoot, ".first-tree", "bindings", "notes.txt"), "ignored");
+    writeFile(join(treeRoot, ".first-tree", "bindings", "bad.json"), "{not-json");
+    writeJson(join(treeRoot, ".first-tree", "bindings", "empty.json"), { sourceName: "" });
+    writeJson(join(treeRoot, ".first-tree", "bindings", "api.json"), { sourceName: "api" });
+    const apiRoot = makeRepo(workspaceRoot, "api");
+    writeJson(join(apiRoot, ".first-tree", "source.json"), { tree: { treeRepoName: "context" } });
+
+    const detection = detectMigrationState(workspaceRoot);
+
+    expect(detection.kind).toBe("workspace");
+    if (detection.kind !== "workspace") {
+      throw new Error("expected workspace detection");
+    }
+    expect(detection.sourceRoots).toEqual([apiRoot]);
+  });
+
   it("picks up an existing source repo whose sourceName is missing from bindings", () => {
     // Regression: bindings/ has only `api`; `web/.first-tree/source.json`
     // exists but no binding references it. The fallback scan must still
@@ -528,6 +594,91 @@ describe("migrateWorkspaceToW1 (Case A)", () => {
     expect(detectMigrationState(fixture.workspaceRoot).kind).toBe("already-migrated");
   });
 
+  it("keeps manifest-listed clean sources while skipping invalid manifest entries", () => {
+    const fixture = makeCaseAWorkspace();
+    writeJson(join(fixture.workspaceRoot, ".first-tree", "workspace.json"), {
+      tree: "context",
+      sources: ["", "context", "api", "api", 42, "web"],
+    });
+    rmSync(join(fixture.treeRoot, ".first-tree", "bindings"), { recursive: true, force: true });
+    rmSync(join(fixture.sourceRoots[0], ".first-tree"), { recursive: true, force: true });
+
+    const detection = detectMigrationState(fixture.workspaceRoot);
+
+    expect(detection.kind).toBe("workspace");
+    if (detection.kind !== "workspace") {
+      throw new Error("expected workspace detection");
+    }
+    expect(detection.sourceRoots.map((sourceRoot) => sourceRoot.split("/").pop()).sort()).toEqual(["api", "web"]);
+  });
+
+  it("warns and skips cleanup for source roots outside the workspace", () => {
+    const fixture = makeCaseAWorkspace();
+    const externalSource = makeRepo(join(tmpRoot, "outside-parent"), "external-source");
+    writeJson(join(externalSource, ".first-tree", "source.json"), { tree: { treeRepoName: "context" } });
+
+    const result = migrateWorkspaceToW1(
+      {
+        kind: "workspace",
+        workspaceRoot: fixture.workspaceRoot,
+        treeRoot: fixture.treeRoot,
+        sourceRoots: [externalSource],
+      },
+      { dryRun: true },
+    );
+
+    expect(result.warnings).toEqual([expect.stringContaining("not an immediate child")]);
+    expect(existsSync(join(externalSource, ".first-tree", "source.json"))).toBe(true);
+  });
+
+  it("reports empty source runtime directory removal during dry-run", () => {
+    const workspaceRoot = tmpRoot;
+    const treeRoot = makeRepo(workspaceRoot, "context");
+    const sourceRoot = makeRepo(workspaceRoot, "api");
+    mkdirSync(join(sourceRoot, ".first-tree"), { recursive: true });
+
+    const result = migrateWorkspaceToW1(
+      {
+        kind: "workspace",
+        workspaceRoot,
+        treeRoot,
+        sourceRoots: [sourceRoot],
+      },
+      { dryRun: true },
+    );
+
+    expect(result.removed).toContainEqual({ path: "api/.first-tree", kind: "source-state-dir" });
+    expect(existsSync(join(sourceRoot, ".first-tree"))).toBe(true);
+  });
+
+  it("leaves a non-empty source runtime directory in place after removing source.json", () => {
+    const fixture = makeCaseAWorkspace();
+    writeFile(join(fixture.sourceRoots[0], ".first-tree", "keep.txt"), "keep");
+    const detection = detectMigrationState(fixture.workspaceRoot);
+    if (detection.kind !== "workspace") {
+      throw new Error("expected workspace detection");
+    }
+
+    migrateWorkspaceToW1(detection);
+
+    expect(existsSync(join(fixture.sourceRoots[0], ".first-tree"))).toBe(true);
+    expect(existsSync(join(fixture.sourceRoots[0], ".first-tree", "keep.txt"))).toBe(true);
+  });
+
+  it("leaves framework files unchanged when the managed block is absent", () => {
+    const fixture = makeCaseAWorkspace();
+    writeFile(join(fixture.sourceRoots[0], "AGENTS.md"), "# Project\n\nNo managed block.\n");
+    const detection = detectMigrationState(fixture.workspaceRoot);
+    if (detection.kind !== "workspace") {
+      throw new Error("expected workspace detection");
+    }
+
+    const result = migrateWorkspaceToW1(detection);
+
+    expect(result.modified.some((entry) => entry.path === "api/AGENTS.md")).toBe(false);
+    expect(readFileSync(join(fixture.sourceRoots[0], "AGENTS.md"), "utf8")).toBe("# Project\n\nNo managed block.\n");
+  });
+
   it("falls back to manifest.tree when bindings/ are already gone (resume case)", () => {
     const fixture = makeCaseAWorkspace();
     // Pre-state: manifest + marker + source.json survive; bindings/ already
@@ -647,6 +798,21 @@ describe("promoteToWorkspace (Case B/C)", () => {
     }
 
     expect(() => promoteToWorkspace(detection, { workspaceName: "evil/path" })).toThrow(/Invalid/u);
+    expect(() => promoteToWorkspace(detection, { workspaceName: "" })).toThrow(/Invalid/u);
+    expect(() => promoteToWorkspace(detection, { workspaceName: "evil\\path" })).toThrow(/Invalid/u);
+  });
+
+  it("rolls back a partial promote when the tree move fails", () => {
+    const fixture = makeCaseBLayout();
+    const detection = detectMigrationState(fixture.sourceRoot);
+    if (detection.kind !== "promotable-source") {
+      throw new Error("expected promotable-source detection");
+    }
+    rmSync(fixture.treeRoot, { recursive: true, force: true });
+
+    expect(() => promoteToWorkspace(detection)).toThrow();
+    expect(existsSync(fixture.sourceRoot)).toBe(true);
+    expect(existsSync(join(fixture.parentDir, detection.suggestedWorkspaceName))).toBe(false);
   });
 
   it("planPromotableDryRun reports the same cleanup the real run would do (Codex P2 / yuezengwu / code-reviewer / baixiaohang)", () => {

--- a/apps/cli/src/__tests__/migrate-workspace.test.ts
+++ b/apps/cli/src/__tests__/migrate-workspace.test.ts
@@ -679,6 +679,20 @@ describe("migrateWorkspaceToW1 (Case A)", () => {
     expect(readFileSync(join(fixture.sourceRoots[0], "AGENTS.md"), "utf8")).toBe("# Project\n\nNo managed block.\n");
   });
 
+  it("adds a trailing newline when stripping a terminal framework block", () => {
+    const fixture = makeCaseAWorkspace();
+    writeFile(join(fixture.sourceRoots[0], "AGENTS.md"), `# Project\n\n${FRAMEWORK_BLOCK}`);
+    const detection = detectMigrationState(fixture.workspaceRoot);
+    if (detection.kind !== "workspace") {
+      throw new Error("expected workspace detection");
+    }
+
+    const result = migrateWorkspaceToW1(detection);
+
+    expect(result.modified).toContainEqual({ path: "api/AGENTS.md", kind: "source-framework-block" });
+    expect(readFileSync(join(fixture.sourceRoots[0], "AGENTS.md"), "utf8")).toBe("# Project\n\n");
+  });
+
   it("falls back to manifest.tree when bindings/ are already gone (resume case)", () => {
     const fixture = makeCaseAWorkspace();
     // Pre-state: manifest + marker + source.json survive; bindings/ already
@@ -696,6 +710,37 @@ describe("migrateWorkspaceToW1 (Case A)", () => {
       throw new Error("expected workspace");
     }
     expect(detection.treeRoot).toBe(fixture.treeRoot);
+  });
+
+  it("does not invent a tree root from malformed resume manifests", () => {
+    writeFile(join(tmpRoot, ".first-tree-workspace"), "");
+    writeJson(join(tmpRoot, ".first-tree", "workspace.json"), {
+      tree: 42,
+      sources: ["api"],
+    });
+
+    const detection = detectMigrationState(tmpRoot);
+
+    expect(detection.kind).toBe("not-applicable");
+    if (detection.kind === "not-applicable") {
+      expect(detection.reason).toContain("no child directory contains a tree binding");
+    }
+  });
+
+  it("ignores malformed manifest source lists during resume detection", () => {
+    const fixture = makeCaseAWorkspace();
+    writeJson(join(fixture.workspaceRoot, ".first-tree", "workspace.json"), {
+      tree: "context",
+      sources: "api",
+    });
+
+    const detection = detectMigrationState(fixture.workspaceRoot);
+
+    expect(detection.kind).toBe("workspace");
+    if (detection.kind !== "workspace") {
+      throw new Error("expected workspace detection");
+    }
+    expect(detection.sourceRoots.map((sourceRoot) => sourceRoot.split("/").pop()).sort()).toEqual(["api", "web"]);
   });
 
   it("preserves the workspace marker when manifest write fails so re-detection still finds the workspace", () => {

--- a/apps/cli/src/__tests__/org-bind-tree.test.ts
+++ b/apps/cli/src/__tests__/org-bind-tree.test.ts
@@ -168,6 +168,20 @@ describe("org bind-tree CLI", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("rejects non-http URL schemes with INVALID_URL and exits 2", async () => {
+    const program = await buildProgram();
+    let caught: unknown;
+    try {
+      await program.parseAsync(["node", "first-tree", "org", "bind-tree", "ssh://github.com/acme/tree.git"]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProcessExit);
+    expect(firstExitCode()).toBe(2);
+    expect(firstErrorEnvelope()?.error.message).toContain("URL scheme must be http or https");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("with --org, PUTs to /orgs/:orgId/settings/context_tree without consulting /me", async () => {
     fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
 
@@ -266,6 +280,38 @@ describe("org bind-tree CLI", () => {
     expect(caught).toBeInstanceOf(ProcessExit);
     expect(firstErrorEnvelope()?.error.code).toBe("AMBIGUOUS_ORG");
     // /me only — no PUT attempted.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("without --org, surfaces /me failures and empty memberships", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("down", { status: 503 }));
+    const meFailProgram = await buildProgram();
+    let caught: unknown;
+    try {
+      await meFailProgram.parseAsync(["node", "first-tree", "org", "bind-tree", "https://github.com/acme/tree"]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProcessExit);
+    expect(firstErrorEnvelope()?.error.code).toBe("ME_FAILED");
+
+    fetchMock.mockReset();
+    stderr = "";
+    exitCalls = [];
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ memberships: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const noOrgProgram = await buildProgram();
+    try {
+      await noOrgProgram.parseAsync(["node", "first-tree", "org", "bind-tree", "https://github.com/acme/tree"]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ProcessExit);
+    expect(firstErrorEnvelope()?.error.code).toBe("NO_ORG");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/cli/src/__tests__/prompt-core.test.ts
+++ b/apps/cli/src/__tests__/prompt-core.test.ts
@@ -84,6 +84,13 @@ describe("prompt core", () => {
         url: { _tag: "field", options: { prompt: { message: "Server URL" }, env: "FIRST_TREE_SERVER_URL" } },
       },
       token: { _tag: "field", options: { prompt: { message: "Token", type: "password" }, env: "TOKEN" } },
+      nested: {
+        _tag: "optional",
+        shape: {
+          value: { _tag: "field", options: { prompt: { message: "Nested" }, env: "NESTED_VALUE" } },
+        },
+      },
+      unlabeled: { _tag: "field", options: { prompt: { message: "No Env" } } },
     };
 
     await expect(
@@ -93,7 +100,7 @@ describe("prompt core", () => {
         configDir: join(home, "config"),
         noInteractive: true,
       }),
-    ).rejects.toThrow("server.url  (env: FIRST_TREE_SERVER_URL)");
+    ).rejects.toThrow("unlabeled");
   });
 
   it("writes prompted input, password, select, and follow-up input values", async () => {
@@ -126,22 +133,34 @@ describe("prompt core", () => {
           },
         },
       },
+      provider: {
+        _tag: "field",
+        options: {
+          prompt: {
+            message: "Provider",
+            type: "select",
+            choices: [{ name: "Codex", value: "codex" }],
+          },
+        },
+      },
     };
     setTty(true);
     inputMock.mockResolvedValueOnce("http://first-tree.test").mockResolvedValueOnce("custom-runtime");
     passwordMock.mockResolvedValueOnce("secret-value");
-    selectMock.mockResolvedValueOnce("__input__").mockResolvedValueOnce("__auto__");
+    selectMock.mockResolvedValueOnce("__input__").mockResolvedValueOnce("__auto__").mockResolvedValueOnce("codex");
 
     await expect(promptMissingFields({ schema, role: "client", configDir: join(home, "config") })).resolves.toEqual({
       server: { url: "http://first-tree.test" },
       secret: "secret-value",
       runtime: "custom-runtime",
+      provider: "codex",
     });
 
     const yaml = readFileSync(join(home, "config", "client.yaml"), "utf8");
     expect(yaml).toContain("url: http://first-tree.test");
     expect(yaml).toContain("secret: secret-value");
     expect(yaml).toContain("runtime: custom-runtime");
+    expect(yaml).toContain("provider: codex");
     expect(yaml).not.toContain("skip:");
   });
 
@@ -166,6 +185,20 @@ describe("prompt core", () => {
 
     cliFetchMock.mockResolvedValueOnce(response(200, { name: null }));
     await expect(promptAddAgent({ agentId: "tombstone" })).rejects.toThrow("has no server-side name");
+  });
+
+  it("adds login guidance when server URL resolution fails during add-agent", async () => {
+    vi.doMock("../core/bootstrap.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../core/bootstrap.js")>()),
+      ensureFreshAccessToken: ensureFreshAccessTokenMock,
+      loadCredentials: vi.fn(() => ({ accessToken: "access", refreshToken: "refresh", serverUrl: "https://old.test" })),
+      resolveServerUrl: vi.fn(() => {
+        throw new Error("invalid server URL");
+      }),
+    }));
+    const { promptAddAgent } = await import("../core/prompt.js");
+
+    await expect(promptAddAgent({ agentId: "bad-url" })).rejects.toThrow("Run `first-tree-dev login <code>`");
   });
 
   it("prompts for an agent id when omitted", async () => {

--- a/apps/cli/src/__tests__/prompt-core.test.ts
+++ b/apps/cli/src/__tests__/prompt-core.test.ts
@@ -108,6 +108,7 @@ describe("prompt core", () => {
     const schema = {
       server: {
         url: { _tag: "field", options: { prompt: { message: "Server URL" } } },
+        token: { _tag: "field", options: { prompt: { message: "Server Token" } } },
       },
       secret: { _tag: "field", options: { prompt: { message: "Secret", type: "password" } } },
       runtime: {
@@ -145,12 +146,15 @@ describe("prompt core", () => {
       },
     };
     setTty(true);
-    inputMock.mockResolvedValueOnce("http://first-tree.test").mockResolvedValueOnce("custom-runtime");
+    inputMock
+      .mockResolvedValueOnce("http://first-tree.test")
+      .mockResolvedValueOnce("server-token")
+      .mockResolvedValueOnce("custom-runtime");
     passwordMock.mockResolvedValueOnce("secret-value");
     selectMock.mockResolvedValueOnce("__input__").mockResolvedValueOnce("__auto__").mockResolvedValueOnce("codex");
 
     await expect(promptMissingFields({ schema, role: "client", configDir: join(home, "config") })).resolves.toEqual({
-      server: { url: "http://first-tree.test" },
+      server: { url: "http://first-tree.test", token: "server-token" },
       secret: "secret-value",
       runtime: "custom-runtime",
       provider: "codex",
@@ -158,10 +162,49 @@ describe("prompt core", () => {
 
     const yaml = readFileSync(join(home, "config", "client.yaml"), "utf8");
     expect(yaml).toContain("url: http://first-tree.test");
+    expect(yaml).toContain("token: server-token");
     expect(yaml).toContain("secret: secret-value");
     expect(yaml).toContain("runtime: custom-runtime");
     expect(yaml).toContain("provider: codex");
     expect(yaml).not.toContain("skip:");
+
+    const customValueValidate = inputMock.mock.calls[2]?.[0]?.validate as ((value: string) => true | string) | undefined;
+    expect(customValueValidate?.("")).toBe("Value is required");
+    expect(customValueValidate?.("filled")).toBe(true);
+  });
+
+  it("uses the default client config path when configDir is omitted", async () => {
+    const { promptMissingFields } = await import("../core/prompt.js");
+    setTty(true);
+    inputMock.mockResolvedValueOnce("https://default-config.test");
+
+    await expect(
+      promptMissingFields({
+        schema: {
+          server: {
+            url: { _tag: "field", options: { prompt: { message: "Server URL" } } },
+          },
+        },
+        role: "client",
+      }),
+    ).resolves.toEqual({ server: { url: "https://default-config.test" } });
+
+    expect(readFileSync(join(home, "config", "client.yaml"), "utf8")).toContain(
+      "url: https://default-config.test",
+    );
+  });
+
+  it("returns an empty prompt result when no schema prompts are missing", async () => {
+    const { promptMissingFields } = await import("../core/prompt.js");
+
+    await expect(
+      promptMissingFields({
+        schema: {},
+        role: "client",
+        configDir: join(home, "config"),
+        noInteractive: true,
+      }),
+    ).resolves.toEqual({});
   });
 
   it("resolves add-agent canonical names and rejects missing setup or tombstones", async () => {
@@ -201,6 +244,20 @@ describe("prompt core", () => {
     await expect(promptAddAgent({ agentId: "bad-url" })).rejects.toThrow("Run `first-tree-dev login <code>`");
   });
 
+  it("stringifies non-Error server URL resolution failures during add-agent", async () => {
+    vi.doMock("../core/bootstrap.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../core/bootstrap.js")>()),
+      ensureFreshAccessToken: ensureFreshAccessTokenMock,
+      loadCredentials: vi.fn(() => ({ accessToken: "access", refreshToken: "refresh", serverUrl: "https://old.test" })),
+      resolveServerUrl: vi.fn(() => {
+        throw "invalid server URL string";
+      }),
+    }));
+    const { promptAddAgent } = await import("../core/prompt.js");
+
+    await expect(promptAddAgent({ agentId: "bad-url" })).rejects.toThrow("invalid server URL string");
+  });
+
   it("prompts for an agent id when omitted", async () => {
     vi.doMock("../core/bootstrap.js", async (importOriginal) => ({
       ...(await importOriginal<typeof import("../core/bootstrap.js")>()),
@@ -216,5 +273,9 @@ describe("prompt core", () => {
 
     await expect(promptAddAgent()).resolves.toEqual({ name: "prompted", agentId: "agent-from-prompt" });
     expect(cliFetchMock.mock.calls[0]?.[0]).toBe("http://override.test/api/v1/agents/agent-from-prompt");
+
+    const validate = inputMock.mock.calls[0]?.[0]?.validate as ((value: string) => true | string) | undefined;
+    expect(validate?.("")).toBe("Agent UUID is required");
+    expect(validate?.("agent-from-prompt")).toBe(true);
   });
 });

--- a/apps/cli/src/__tests__/prompt-core.test.ts
+++ b/apps/cli/src/__tests__/prompt-core.test.ts
@@ -168,7 +168,9 @@ describe("prompt core", () => {
     expect(yaml).toContain("provider: codex");
     expect(yaml).not.toContain("skip:");
 
-    const customValueValidate = inputMock.mock.calls[2]?.[0]?.validate as ((value: string) => true | string) | undefined;
+    const customValueValidate = inputMock.mock.calls[2]?.[0]?.validate as
+      | ((value: string) => true | string)
+      | undefined;
     expect(customValueValidate?.("")).toBe("Value is required");
     expect(customValueValidate?.("filled")).toBe(true);
   });
@@ -189,9 +191,7 @@ describe("prompt core", () => {
       }),
     ).resolves.toEqual({ server: { url: "https://default-config.test" } });
 
-    expect(readFileSync(join(home, "config", "client.yaml"), "utf8")).toContain(
-      "url: https://default-config.test",
-    );
+    expect(readFileSync(join(home, "config", "client.yaml"), "utf8")).toContain("url: https://default-config.test");
   });
 
   it("returns an empty prompt result when no schema prompts are missing", async () => {

--- a/apps/cli/src/__tests__/runtime-auth-login-defaults.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login-defaults.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CapabilityEntry } from "@first-tree/shared";
+
+describe("runRuntimeAuthLogin default dependencies", () => {
+  afterEach(() => {
+    vi.doUnmock("@first-tree/client");
+    vi.doUnmock("@first-tree/shared");
+    vi.resetModules();
+  });
+
+  it("uses the default Codex resolver, browser login, and probe", async () => {
+    const resolveCodexRuntimeBinary = vi.fn(async () => ({
+      ok: true as const,
+      binary: "/opt/codex",
+      runtimeSource: "bundled" as const,
+      runtimePath: null,
+      version: "1.0.0",
+    }));
+    const runCodexBrowserLogin = vi.fn(async (options: { onAuthUrl?: (url: string) => void }) => {
+      options.onAuthUrl?.("https://auth.example/codex");
+      return { ok: false as const, reason: "timeout" as const, error: "" };
+    });
+    const probeCodexCapability = vi.fn(async () => ({
+      state: "ok" as const,
+      available: true,
+      detectedAt: "2026-06-22T12:00:00.000Z",
+    }));
+    vi.doMock("@first-tree/client", () => ({
+      BROWSER_LOGIN_TIMEOUT_MS: 120_000,
+      probeClaudeCodeCapability: vi.fn(),
+      probeClaudeCodeTuiCapability: vi.fn(),
+      probeCodexCapability,
+      resolveClaudeLoginInvocation: vi.fn(),
+      resolveCodexRuntimeBinary,
+      runClaudeBrowserLogin: vi.fn(),
+      runCodexBrowserLogin,
+    }));
+    vi.doMock("@first-tree/shared", () => ({
+      isRuntimeProviderEnabled: vi.fn(() => false),
+    }));
+    const { runRuntimeAuthLogin } = await import("../core/runtime-auth-login.js");
+    const calls: Array<{ provider: string; entry: CapabilityEntry }> = [];
+
+    await runRuntimeAuthLogin(
+      { provider: "codex", ref: "default-codex" },
+      {
+        currentEntry: () => undefined,
+        setProviderEntry: async (provider, entry) => {
+          calls.push({ provider, entry });
+        },
+        log: vi.fn(),
+      },
+    );
+
+    expect(resolveCodexRuntimeBinary).toHaveBeenCalled();
+    expect(runCodexBrowserLogin).toHaveBeenCalledWith({ binary: "/opt/codex", onAuthUrl: expect.any(Function) });
+    expect(probeCodexCapability).toHaveBeenCalled();
+    expect(calls.map((call) => call.provider)).toEqual(["codex", "codex", "codex"]);
+    expect(calls[1]?.entry.pendingAuth?.authUrl).toBe("https://auth.example/codex");
+    expect(calls.at(-1)?.entry.lastAuthError).toEqual({
+      reason: "timeout",
+      at: expect.any(String),
+    });
+  });
+
+  it("logs Error objects from the default Codex browser login", async () => {
+    vi.doMock("@first-tree/client", () => ({
+      BROWSER_LOGIN_TIMEOUT_MS: 120_000,
+      probeClaudeCodeCapability: vi.fn(),
+      probeClaudeCodeTuiCapability: vi.fn(),
+      probeCodexCapability: vi.fn(async () => ({
+        state: "ok",
+        available: true,
+        detectedAt: "2026-06-22T12:00:00.000Z",
+      })),
+      resolveClaudeLoginInvocation: vi.fn(),
+      resolveCodexRuntimeBinary: vi.fn(async () => ({
+        ok: true,
+        binary: "/opt/codex",
+        runtimeSource: "bundled",
+        runtimePath: null,
+        version: "1.0.0",
+      })),
+      runClaudeBrowserLogin: vi.fn(),
+      runCodexBrowserLogin: vi.fn(async () => {
+        throw new Error("browser boom");
+      }),
+    }));
+    vi.doMock("@first-tree/shared", () => ({
+      isRuntimeProviderEnabled: vi.fn(() => false),
+    }));
+    const { runRuntimeAuthLogin } = await import("../core/runtime-auth-login.js");
+    const logs: string[] = [];
+
+    await runRuntimeAuthLogin(
+      { provider: "codex", ref: "default-codex-error" },
+      {
+        currentEntry: () => undefined,
+        setProviderEntry: async () => undefined,
+        log: (_symbol, message) => {
+          logs.push(message);
+        },
+      },
+    );
+
+    expect(logs).toContain("runtime-auth: codex login threw: browser boom");
+  });
+
+  it("re-probes Claude Code and TUI through default dependencies when TUI is enabled", async () => {
+    const resolveClaudeLoginInvocation = vi.fn(() => ({
+      ok: true as const,
+      command: "/usr/local/bin/claude",
+      baseArgs: ["auth", "login"],
+    }));
+    const runClaudeBrowserLogin = vi.fn(async (options: { onAuthUrl?: (url: string) => void }) => {
+      options.onAuthUrl?.("https://auth.example/claude");
+      return { ok: true as const };
+    });
+    const probeClaudeCodeCapability = vi.fn(async () => ({
+      state: "ok" as const,
+      available: true,
+      detectedAt: "2026-06-22T12:00:00.000Z",
+    }));
+    const probeClaudeCodeTuiCapability = vi.fn(async () => ({
+      state: "ok" as const,
+      available: true,
+      detectedAt: "2026-06-22T12:00:01.000Z",
+    }));
+    vi.doMock("@first-tree/client", () => ({
+      BROWSER_LOGIN_TIMEOUT_MS: 120_000,
+      probeClaudeCodeCapability,
+      probeClaudeCodeTuiCapability,
+      probeCodexCapability: vi.fn(),
+      resolveClaudeLoginInvocation,
+      resolveCodexRuntimeBinary: vi.fn(),
+      runClaudeBrowserLogin,
+      runCodexBrowserLogin: vi.fn(),
+    }));
+    vi.doMock("@first-tree/shared", () => ({
+      isRuntimeProviderEnabled: vi.fn((provider: string) => provider === "claude-code-tui"),
+    }));
+    const { runRuntimeAuthLogin } = await import("../core/runtime-auth-login.js");
+    const calls: Array<{ provider: string; entry: CapabilityEntry }> = [];
+
+    await runRuntimeAuthLogin(
+      { provider: "claude-code", ref: "default-claude" },
+      {
+        currentEntry: () => undefined,
+        setProviderEntry: async (provider, entry) => {
+          calls.push({ provider, entry });
+        },
+        log: vi.fn(),
+      },
+    );
+
+    expect(resolveClaudeLoginInvocation).toHaveBeenCalled();
+    expect(runClaudeBrowserLogin).toHaveBeenCalledWith({
+      command: "/usr/local/bin/claude",
+      baseArgs: ["auth", "login"],
+      onAuthUrl: expect.any(Function),
+    });
+    expect(probeClaudeCodeCapability).toHaveBeenCalled();
+    expect(probeClaudeCodeTuiCapability).toHaveBeenCalled();
+    expect(calls.map((call) => call.provider)).toEqual([
+      "claude-code",
+      "claude-code",
+      "claude-code",
+      "claude-code-tui",
+    ]);
+    expect(calls[1]?.entry.pendingAuth?.authUrl).toBe("https://auth.example/claude");
+  });
+});

--- a/apps/cli/src/__tests__/runtime-auth-login-defaults.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login-defaults.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CapabilityEntry } from "@first-tree/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("runRuntimeAuthLogin default dependencies", () => {
   afterEach(() => {

--- a/apps/cli/src/__tests__/runtime-auth-login.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login.test.ts
@@ -27,6 +27,8 @@ function harness(opts: {
   fireAuthUrl?: string;
   probeResult?: CapabilityEntry;
   current?: CapabilityEntry;
+  throwLogin?: unknown;
+  probeThrows?: unknown;
 }) {
   const calls: Recorded[] = [];
   const logs: string[] = [];
@@ -51,10 +53,14 @@ function harness(opts: {
           } as const),
     runBrowserLogin: async (o: CodexBrowserLoginOptions): Promise<LoginOutcome> => {
       if (opts.fireAuthUrl) o.onAuthUrl?.(opts.fireAuthUrl);
+      if (opts.throwLogin !== undefined) throw opts.throwLogin;
       await new Promise((r) => setTimeout(r, 0));
       return opts.outcome ?? ({ ok: true } as const);
     },
-    probeCodex: async (): Promise<CapabilityEntry> => opts.probeResult ?? installedEntry(),
+    probeCodex: async (): Promise<CapabilityEntry> => {
+      if (opts.probeThrows !== undefined) throw opts.probeThrows;
+      return opts.probeResult ?? installedEntry();
+    },
   };
   return { calls, logs, deps };
 }
@@ -143,10 +149,32 @@ describe("runRuntimeAuthLogin — primary browser OAuth", () => {
     expect(h.calls.at(-1)?.entry.state).toBe("missing");
     expect(h.calls.at(-1)?.entry.lastAuthError).toMatchObject({ reason: "spawn-error" });
   });
+
+  it("logs thrown browser login errors and re-probe failures without throwing", async () => {
+    const loginThrows = harness({ throwLogin: "browser crashed", probeResult: installedEntry() });
+    await runRuntimeAuthLogin({ provider: "codex", ref: "throw-login" }, loginThrows.deps);
+    expect(loginThrows.logs.some((l) => l.includes("codex login threw: browser crashed"))).toBe(true);
+    expect(loginThrows.calls.at(-1)?.entry.lastAuthError).toMatchObject({
+      reason: "spawn-error",
+      message: "browser crashed",
+    });
+
+    const probeThrows = harness({ resolveOk: false, probeThrows: "probe crashed" });
+    await runRuntimeAuthLogin({ provider: "codex", ref: "throw-probe" }, probeThrows.deps);
+    expect(
+      probeThrows.logs.some((l) => l.includes("codex re-probe after unresolved binary failed: probe crashed")),
+    ).toBe(true);
+  });
 });
 
 describe("runRuntimeAuthLogin — claude-code browser OAuth (cc/codex parity)", () => {
-  function claudeHarness(opts: { resolveOk?: boolean; outcome?: LoginOutcome; probeResult?: CapabilityEntry }) {
+  function claudeHarness(opts: {
+    resolveOk?: boolean;
+    outcome?: LoginOutcome;
+    probeResult?: CapabilityEntry;
+    throwLogin?: unknown;
+    probeThrows?: unknown;
+  }) {
     const calls: Recorded[] = [];
     const logs: string[] = [];
     // Spy so a test can assert the TUI probe is NOT spawned while claude-code-tui
@@ -166,8 +194,14 @@ describe("runRuntimeAuthLogin — claude-code browser OAuth (cc/codex parity)", 
         opts.resolveOk === false
           ? ({ ok: false, error: "no claude CLI" } as const)
           : ({ ok: true, command: "/usr/local/bin/claude", baseArgs: [] as string[] } as const),
-      runClaudeBrowser: async (): Promise<LoginOutcome> => opts.outcome ?? ({ ok: true } as const),
-      probeClaude: async (): Promise<CapabilityEntry> => opts.probeResult ?? installedEntry(),
+      runClaudeBrowser: async (): Promise<LoginOutcome> => {
+        if (opts.throwLogin !== undefined) throw opts.throwLogin;
+        return opts.outcome ?? ({ ok: true } as const);
+      },
+      probeClaude: async (): Promise<CapabilityEntry> => {
+        if (opts.probeThrows !== undefined) throw opts.probeThrows;
+        return opts.probeResult ?? installedEntry();
+      },
       probeClaudeTui,
     };
     return { calls, logs, deps, probeClaudeTui };
@@ -216,5 +250,21 @@ describe("runRuntimeAuthLogin — claude-code browser OAuth (cc/codex parity)", 
     expect(cc?.lastAuthError).toMatchObject({ reason: "timeout", message: "claude auth login timed out" });
     expect(h.calls.some((c) => c.provider === "claude-code-tui")).toBe(false);
     expect(h.probeClaudeTui).not.toHaveBeenCalled();
+  });
+
+  it("logs thrown Claude login errors and re-probe failures without throwing", async () => {
+    const loginThrows = claudeHarness({ throwLogin: "browser crashed" });
+    await runRuntimeAuthLogin({ provider: "claude-code", ref: "c4" }, loginThrows.deps);
+    expect(loginThrows.logs.some((l) => l.includes("claude auth login threw: browser crashed"))).toBe(true);
+    expect(loginThrows.calls.at(-1)?.entry.lastAuthError).toMatchObject({
+      reason: "spawn-error",
+      message: "browser crashed",
+    });
+
+    const probeThrows = claudeHarness({ resolveOk: false, probeThrows: "probe crashed" });
+    await runRuntimeAuthLogin({ provider: "claude-code", ref: "c5" }, probeThrows.deps);
+    expect(probeThrows.logs.some((l) => l.includes("claude re-probe after unresolved CLI failed: probe crashed"))).toBe(
+      true,
+    );
   });
 });

--- a/apps/cli/src/__tests__/runtime-auth-login.test.ts
+++ b/apps/cli/src/__tests__/runtime-auth-login.test.ts
@@ -171,6 +171,7 @@ describe("runRuntimeAuthLogin — claude-code browser OAuth (cc/codex parity)", 
   function claudeHarness(opts: {
     resolveOk?: boolean;
     outcome?: LoginOutcome;
+    fireAuthUrl?: string;
     probeResult?: CapabilityEntry;
     throwLogin?: unknown;
     probeThrows?: unknown;
@@ -194,7 +195,8 @@ describe("runRuntimeAuthLogin — claude-code browser OAuth (cc/codex parity)", 
         opts.resolveOk === false
           ? ({ ok: false, error: "no claude CLI" } as const)
           : ({ ok: true, command: "/usr/local/bin/claude", baseArgs: [] as string[] } as const),
-      runClaudeBrowser: async (): Promise<LoginOutcome> => {
+      runClaudeBrowser: async (options: { onAuthUrl?: (url: string) => void }): Promise<LoginOutcome> => {
+        if (opts.fireAuthUrl) options.onAuthUrl?.(opts.fireAuthUrl);
         if (opts.throwLogin !== undefined) throw opts.throwLogin;
         return opts.outcome ?? ({ ok: true } as const);
       },
@@ -227,6 +229,14 @@ describe("runRuntimeAuthLogin — claude-code browser OAuth (cc/codex parity)", 
     expect(h.calls[1]?.entry.pendingAuth).toBeUndefined();
     expect(h.calls.some((c) => c.provider === "claude-code-tui")).toBe(false);
     expect(h.probeClaudeTui).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the Claude browser auth URL into pendingAuth", async () => {
+    const h = claudeHarness({ outcome: { ok: true }, probeResult: okEntry(), fireAuthUrl: "https://claude.ai/login" });
+    await runRuntimeAuthLogin({ provider: "claude-code", ref: "c-url" }, h.deps);
+
+    const withUrl = h.calls.find((c) => c.entry.pendingAuth?.authUrl);
+    expect(withUrl?.entry.pendingAuth).toMatchObject({ method: "browser", authUrl: "https://claude.ai/login" });
   });
 
   it("on unresolved CLI, reflects claude-code real state and never logs in (TUI untouched)", async () => {

--- a/apps/cli/src/__tests__/runtime-install-extra.test.ts
+++ b/apps/cli/src/__tests__/runtime-install-extra.test.ts
@@ -110,6 +110,27 @@ describe("native runtime installers", () => {
     );
   });
 
+  it("spawns Claude npm installs and extracts package versions from successful output", async () => {
+    const { installClaudeRuntime } = await import("../core/install-claude-runtime.js");
+    const { child, spawn } = prepareSpawn();
+
+    const result = installClaudeRuntime("2.1.84");
+    child.stdout.emit("data", Buffer.from("+ @anthropic-ai/claude-code@2.1.84\n"));
+    child.emit("exit", 0, null);
+
+    await expect(result).resolves.toEqual({ ok: true, installedVersion: "2.1.84" });
+    expect(spawn).toHaveBeenCalledWith(
+      expect.stringMatching(/npm(?:\.cmd)?$/),
+      ["install", "-g", "@anthropic-ai/claude-code@2.1.84"],
+      expect.objectContaining({
+        category: "npm-install",
+        label: "npm install -g @anthropic-ai/claude-code@2.1.84",
+        timeoutMs: 480_000,
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
+  });
+
   it("returns null installedVersion when npm success output does not include a package version", async () => {
     const { installClaudeRuntime } = await import("../core/install-claude-runtime.js");
     const { child } = prepareSpawn();
@@ -158,6 +179,42 @@ describe("native runtime installers", () => {
       reasonCode: "npm_timeout",
     });
   });
+
+  it("classifies Claude spawn errors, npm failures, and timeout exits", async () => {
+    const { installClaudeRuntime } = await import("../core/install-claude-runtime.js");
+
+    const spawnError = prepareSpawn().child;
+    const spawnResult = installClaudeRuntime("latest");
+    spawnError.emit("error", "spawn denied");
+    await expect(spawnResult).resolves.toEqual({
+      ok: false,
+      reason: "spawn denied",
+      retryable: true,
+      reasonCode: "classified_transient",
+    });
+
+    const npmFailure = prepareSpawn().child;
+    const failedResult = installClaudeRuntime("latest");
+    npmFailure.stderr.emit("data", Buffer.from("one\ntwo\nthree\nfour\n"));
+    npmFailure.emit("exit", 1, null);
+    await expect(failedResult).resolves.toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("two | three | four"),
+      retryable: true,
+      reasonCode: "classified_transient",
+    });
+    expect(outputMocks.line).toHaveBeenCalledWith("one\ntwo\nthree\nfour\n");
+
+    const timeout = prepareSpawn().child;
+    const timeoutResult = installClaudeRuntime("latest");
+    timeout.emit("exit", null, "SIGTERM");
+    await expect(timeoutResult).resolves.toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("killed by signal SIGTERM (timeout)"),
+      retryable: true,
+      reasonCode: "npm_timeout",
+    });
+  });
 });
 
 describe("daemon native runtime install commands", () => {
@@ -174,6 +231,20 @@ describe("daemon native runtime install commands", () => {
     expect(coreIndexMocks.runtimeProviderChecks).toHaveBeenCalledWith({ providers: [] });
     expect(coreIndexMocks.printResults).toHaveBeenCalledWith([{ detail: "installed", label: "Runtime", ok: true }]);
     expect(outputMocks.status).toHaveBeenCalledWith("✓", "Installed @openai/codex@0.140.0");
+
+    const codexFailureRoot = new Command();
+    registerDaemonInstallCodexCommand(codexFailureRoot);
+    coreIndexMocks.installCodexRuntime.mockResolvedValueOnce({
+      ok: false,
+      reason: "npm registry timeout",
+      retryable: true,
+      reasonCode: "classified_transient",
+    });
+    await subcommand(codexFailureRoot, "install-codex").parseAsync([], { from: "user" });
+    expect(outputMocks.status).toHaveBeenLastCalledWith("✖", "Codex install failed: npm registry timeout");
+    expect(outputMocks.line).toHaveBeenCalledWith("  This looks transient — retry in a moment.\n\n");
+    expect(process.exitCode).toBe(1);
+    process.exitCode = undefined;
 
     const claudeRoot = new Command();
     registerDaemonInstallClaudeCommand(claudeRoot);
@@ -211,5 +282,27 @@ describe("daemon native runtime install commands", () => {
     await expect(subcommand(claudeRoot, "install-claude").parseAsync(["--json"], { from: "user" })).rejects.toThrow(
       "CLAUDE_INSTALL_FAILED:bad spec:1",
     );
+  });
+
+  it("prints Claude text and JSON success flows", async () => {
+    const { registerDaemonInstallClaudeCommand } = await import("../commands/daemon/install-claude.js");
+
+    const textRoot = new Command();
+    registerDaemonInstallClaudeCommand(textRoot);
+    coreIndexMocks.installClaudeRuntime.mockResolvedValueOnce({ ok: true, installedVersion: "2.1.84" });
+    await subcommand(textRoot, "install-claude").parseAsync(["--spec", "2.1.84"], { from: "user" });
+    expect(coreIndexMocks.installClaudeRuntime).toHaveBeenCalledWith("2.1.84");
+    expect(outputMocks.status).toHaveBeenCalledWith("✓", "Installed @anthropic-ai/claude-code@2.1.84");
+    expect(coreIndexMocks.printResults).toHaveBeenCalledWith([{ detail: "installed", label: "Runtime", ok: true }]);
+    expect(outputMocks.line).toHaveBeenCalledWith(expect.stringContaining("claude-code now reports `ok`"));
+
+    vi.clearAllMocks();
+    clientMocks.probeCapabilities.mockResolvedValue({ providers: [{ provider: "claude-code", state: "ok" }] });
+    const jsonRoot = new Command();
+    registerDaemonInstallClaudeCommand(jsonRoot);
+    coreIndexMocks.installClaudeRuntime.mockResolvedValueOnce({ ok: true, installedVersion: null });
+    await subcommand(jsonRoot, "install-claude").parseAsync(["--json"], { from: "user" });
+    expect(outputMocks.result).toHaveBeenCalledWith({ providers: [{ provider: "claude-code", state: "ok" }] });
+    expect(coreIndexMocks.printResults).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/__tests__/runtime-install-extra.test.ts
+++ b/apps/cli/src/__tests__/runtime-install-extra.test.ts
@@ -1,0 +1,215 @@
+import { EventEmitter } from "node:events";
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const clientMocks = vi.hoisted(() => ({
+  classify: vi.fn(() => ({ kind: "transient", reasonCode: "classified_transient" })),
+  getChildProcessRegistry: vi.fn(),
+  probeCapabilities: vi.fn(),
+  ERROR_KINDS: {
+    TRANSIENT: "transient",
+  },
+}));
+
+const outputMocks = vi.hoisted(() => ({
+  fail: vi.fn((code: string, message: string, exitCode: number) => {
+    throw new Error(`${code}:${message}:${exitCode}`);
+  }),
+  isJsonMode: vi.fn(() => false),
+  line: vi.fn(),
+  result: vi.fn(),
+  status: vi.fn(),
+}));
+
+const coreIndexMocks = vi.hoisted(() => ({
+  installClaudeRuntime: vi.fn(),
+  installCodexRuntime: vi.fn(),
+  printResults: vi.fn(),
+  runtimeProviderChecks: vi.fn(() => [{ detail: "installed", label: "Runtime", ok: true }]),
+}));
+
+vi.mock("@first-tree/client", () => clientMocks);
+
+vi.mock("../cli/output.js", () => ({
+  fail: outputMocks.fail,
+}));
+
+vi.mock("../core/output.js", () => ({
+  isJsonMode: outputMocks.isJsonMode,
+  print: {
+    line: outputMocks.line,
+    result: outputMocks.result,
+    status: outputMocks.status,
+  },
+}));
+
+vi.mock("../core/index.js", () => coreIndexMocks);
+
+class MockChild extends EventEmitter {
+  readonly stdout = new EventEmitter();
+  readonly stderr = new EventEmitter();
+}
+
+function subcommand(parent: Command, name: string): Command {
+  const found = parent.commands.find((entry) => entry.name() === name);
+  if (!found) throw new Error(`Missing command ${name}`);
+  return found;
+}
+
+function prepareSpawn(child = new MockChild()): { child: MockChild; spawn: ReturnType<typeof vi.fn> } {
+  const spawn = vi.fn(() => ({ child }));
+  clientMocks.getChildProcessRegistry.mockReturnValue({ spawn });
+  return { child, spawn };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.exitCode = undefined;
+  outputMocks.isJsonMode.mockReturnValue(false);
+  clientMocks.classify.mockReturnValue({ kind: "transient", reasonCode: "classified_transient" });
+  clientMocks.probeCapabilities.mockResolvedValue({ providers: [] });
+});
+
+describe("native runtime installers", () => {
+  it("rejects unsafe install specs before spawning npm", async () => {
+    const { installClaudeRuntime } = await import("../core/install-claude-runtime.js");
+    const { installCodexRuntime } = await import("../core/install-codex-runtime.js");
+
+    await expect(installCodexRuntime("-bad")).resolves.toEqual({
+      ok: false,
+      reason: 'Refusing to install: invalid npm spec "-bad"',
+      retryable: false,
+      reasonCode: "invalid_spec",
+    });
+    await expect(installClaudeRuntime("bad spec")).resolves.toMatchObject({
+      ok: false,
+      retryable: false,
+      reasonCode: "invalid_spec",
+    });
+    expect(clientMocks.getChildProcessRegistry).not.toHaveBeenCalled();
+  });
+
+  it("spawns npm installs and extracts package versions from successful output", async () => {
+    const { installCodexRuntime } = await import("../core/install-codex-runtime.js");
+    const { child, spawn } = prepareSpawn();
+
+    const result = installCodexRuntime("0.140.0");
+    child.stdout.emit("data", Buffer.from("+ @openai/codex@0.140.0\n"));
+    child.emit("exit", 0, null);
+
+    await expect(result).resolves.toEqual({ ok: true, installedVersion: "0.140.0" });
+    expect(spawn).toHaveBeenCalledWith(
+      expect.stringMatching(/npm(?:\.cmd)?$/),
+      ["install", "-g", "@openai/codex@0.140.0"],
+      expect.objectContaining({
+        category: "npm-install",
+        label: "npm install -g @openai/codex@0.140.0",
+        timeoutMs: 480_000,
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    );
+  });
+
+  it("returns null installedVersion when npm success output does not include a package version", async () => {
+    const { installClaudeRuntime } = await import("../core/install-claude-runtime.js");
+    const { child } = prepareSpawn();
+
+    const result = installClaudeRuntime();
+    child.stdout.emit("data", Buffer.from("added 1 package\n"));
+    child.emit("exit", 0, null);
+
+    await expect(result).resolves.toEqual({ ok: true, installedVersion: null });
+  });
+
+  it("classifies spawn errors, npm failures, and timeout exits", async () => {
+    const { installCodexRuntime } = await import("../core/install-codex-runtime.js");
+
+    const spawnError = prepareSpawn().child;
+    const spawnResult = installCodexRuntime("latest");
+    spawnError.emit("error", new Error("spawn failed"));
+    await expect(spawnResult).resolves.toEqual({
+      ok: false,
+      reason: "spawn failed",
+      retryable: true,
+      reasonCode: "classified_transient",
+    });
+
+    const npmFailure = prepareSpawn().child;
+    const failedResult = installCodexRuntime("latest");
+    npmFailure.stderr.emit("data", Buffer.from("line 1\nline 2\nline 3\nline 4\n"));
+    npmFailure.emit("exit", 1, null);
+    await expect(failedResult).resolves.toMatchObject({
+      ok: false,
+      retryable: true,
+      reasonCode: "classified_transient",
+    });
+    await expect(failedResult).resolves.toMatchObject({
+      reason: expect.stringContaining("line 2 | line 3 | line 4"),
+    });
+    expect(outputMocks.line).toHaveBeenCalledWith("line 1\nline 2\nline 3\nline 4\n");
+
+    const timeout = prepareSpawn().child;
+    const timeoutResult = installCodexRuntime("latest");
+    timeout.emit("exit", null, "SIGTERM");
+    await expect(timeoutResult).resolves.toMatchObject({
+      ok: false,
+      reason: expect.stringContaining("killed by signal SIGTERM (timeout)"),
+      retryable: true,
+      reasonCode: "npm_timeout",
+    });
+  });
+});
+
+describe("daemon native runtime install commands", () => {
+  it("prints text-mode success and failure flows for codex and claude installers", async () => {
+    const { registerDaemonInstallClaudeCommand } = await import("../commands/daemon/install-claude.js");
+    const { registerDaemonInstallCodexCommand } = await import("../commands/daemon/install-codex.js");
+
+    const codexRoot = new Command();
+    registerDaemonInstallCodexCommand(codexRoot);
+    coreIndexMocks.installCodexRuntime.mockResolvedValueOnce({ ok: true, installedVersion: "0.140.0" });
+    await subcommand(codexRoot, "install-codex").parseAsync(["--spec", "0.140.0"], { from: "user" });
+    expect(coreIndexMocks.installCodexRuntime).toHaveBeenCalledWith("0.140.0");
+    expect(clientMocks.probeCapabilities).toHaveBeenCalled();
+    expect(coreIndexMocks.runtimeProviderChecks).toHaveBeenCalledWith({ providers: [] });
+    expect(coreIndexMocks.printResults).toHaveBeenCalledWith([{ detail: "installed", label: "Runtime", ok: true }]);
+    expect(outputMocks.status).toHaveBeenCalledWith("✓", "Installed @openai/codex@0.140.0");
+
+    const claudeRoot = new Command();
+    registerDaemonInstallClaudeCommand(claudeRoot);
+    coreIndexMocks.installClaudeRuntime.mockResolvedValueOnce({
+      ok: false,
+      reason: "registry unavailable",
+      retryable: true,
+      reasonCode: "classified_transient",
+    });
+    await subcommand(claudeRoot, "install-claude").parseAsync([], { from: "user" });
+    expect(outputMocks.status).toHaveBeenLastCalledWith("✖", "Claude install failed: registry unavailable");
+    expect(outputMocks.line).toHaveBeenCalledWith("  This looks transient — retry in a moment.\n\n");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("uses JSON-mode envelopes for daemon installer success and failure", async () => {
+    const { registerDaemonInstallClaudeCommand } = await import("../commands/daemon/install-claude.js");
+    const { registerDaemonInstallCodexCommand } = await import("../commands/daemon/install-codex.js");
+
+    const codexRoot = new Command();
+    registerDaemonInstallCodexCommand(codexRoot);
+    coreIndexMocks.installCodexRuntime.mockResolvedValueOnce({ ok: true, installedVersion: null });
+    await subcommand(codexRoot, "install-codex").parseAsync(["--json"], { from: "user" });
+    expect(outputMocks.result).toHaveBeenCalledWith({ providers: [] });
+    expect(coreIndexMocks.printResults).not.toHaveBeenCalled();
+
+    const claudeRoot = new Command();
+    registerDaemonInstallClaudeCommand(claudeRoot);
+    coreIndexMocks.installClaudeRuntime.mockResolvedValueOnce({
+      ok: false,
+      reason: "bad spec",
+      retryable: false,
+      reasonCode: "invalid_spec",
+    });
+    await expect(subcommand(claudeRoot, "install-claude").parseAsync(["--json"], { from: "user" })).rejects.toThrow(
+      "CLAUDE_INSTALL_FAILED:bad spec:1",
+    );
+  });
+});

--- a/apps/cli/src/__tests__/runtime-install-extra.test.ts
+++ b/apps/cli/src/__tests__/runtime-install-extra.test.ts
@@ -86,6 +86,16 @@ describe("native runtime installers", () => {
       retryable: false,
       reasonCode: "invalid_spec",
     });
+    await expect(installClaudeRuntime("-bad")).resolves.toMatchObject({
+      ok: false,
+      retryable: false,
+      reasonCode: "invalid_spec",
+    });
+    await expect(installCodexRuntime("x".repeat(129))).resolves.toMatchObject({
+      ok: false,
+      retryable: false,
+      reasonCode: "invalid_spec",
+    });
     expect(clientMocks.getChildProcessRegistry).not.toHaveBeenCalled();
   });
 
@@ -142,12 +152,23 @@ describe("native runtime installers", () => {
     await expect(result).resolves.toEqual({ ok: true, installedVersion: null });
   });
 
+  it("returns null Codex installedVersion when npm success output omits a package version", async () => {
+    const { installCodexRuntime } = await import("../core/install-codex-runtime.js");
+    const { child } = prepareSpawn();
+
+    const result = installCodexRuntime();
+    child.stdout.emit("data", Buffer.from("added 1 package\n"));
+    child.emit("exit", 0, null);
+
+    await expect(result).resolves.toEqual({ ok: true, installedVersion: null });
+  });
+
   it("classifies spawn errors, npm failures, and timeout exits", async () => {
     const { installCodexRuntime } = await import("../core/install-codex-runtime.js");
 
     const spawnError = prepareSpawn().child;
     const spawnResult = installCodexRuntime("latest");
-    spawnError.emit("error", new Error("spawn failed"));
+    spawnError.emit("error", "spawn failed");
     await expect(spawnResult).resolves.toEqual({
       ok: false,
       reason: "spawn failed",
@@ -178,6 +199,46 @@ describe("native runtime installers", () => {
       retryable: true,
       reasonCode: "npm_timeout",
     });
+  });
+
+  it("prefers platform-specific sibling npm commands when present", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (path: Parameters<typeof actual.existsSync>[0]) => String(path).endsWith("/npm.cmd"),
+      };
+    });
+    const winChild = new MockChild();
+    const winSpawn = prepareSpawn(winChild).spawn;
+    const { installCodexRuntime } = await import("../core/install-codex-runtime.js");
+    const winResult = installCodexRuntime("latest");
+    winChild.emit("exit", 0, null);
+    await expect(winResult).resolves.toEqual({ ok: true, installedVersion: null });
+    expect(String(winSpawn.mock.calls[0]?.[0])).toMatch(/\/npm\.cmd$/);
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (path: Parameters<typeof actual.existsSync>[0]) => String(path).endsWith("/npm"),
+      };
+    });
+    const linuxChild = new MockChild();
+    const linuxSpawn = prepareSpawn(linuxChild).spawn;
+    const { installClaudeRuntime } = await import("../core/install-claude-runtime.js");
+    const linuxResult = installClaudeRuntime("latest");
+    linuxChild.emit("exit", 0, null);
+    await expect(linuxResult).resolves.toEqual({ ok: true, installedVersion: null });
+    expect(String(linuxSpawn.mock.calls[0]?.[0])).toMatch(/\/npm$/);
+
+    vi.doUnmock("node:fs");
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
   });
 
   it("classifies Claude spawn errors, npm failures, and timeout exits", async () => {
@@ -295,6 +356,13 @@ describe("daemon native runtime install commands", () => {
     expect(outputMocks.status).toHaveBeenCalledWith("✓", "Installed @anthropic-ai/claude-code@2.1.84");
     expect(coreIndexMocks.printResults).toHaveBeenCalledWith([{ detail: "installed", label: "Runtime", ok: true }]);
     expect(outputMocks.line).toHaveBeenCalledWith(expect.stringContaining("claude-code now reports `ok`"));
+
+    vi.clearAllMocks();
+    const unknownVersionRoot = new Command();
+    registerDaemonInstallClaudeCommand(unknownVersionRoot);
+    coreIndexMocks.installClaudeRuntime.mockResolvedValueOnce({ ok: true, installedVersion: null });
+    await subcommand(unknownVersionRoot, "install-claude").parseAsync([], { from: "user" });
+    expect(outputMocks.status).toHaveBeenCalledWith("✓", "Installed @anthropic-ai/claude-code");
 
     vi.clearAllMocks();
     clientMocks.probeCapabilities.mockResolvedValue({ providers: [{ provider: "claude-code", state: "ok" }] });

--- a/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
+++ b/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
@@ -176,6 +176,50 @@ describe("reconcileLocalRuntimeProviders", () => {
     expect(after.runtime).toBe("codex");
     expect(logs.some(([level, msg]) => level === "warn" && /broken/.test(msg))).toBe(true);
   });
+
+  it("returns quietly when the agents directory is missing", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ agentId: "agent-1", clientId: "cli-1", runtimeProvider: "codex" }]), {
+        status: 200,
+      }),
+    );
+
+    await expect(
+      reconcileLocalRuntimeProviders({
+        serverUrl: "http://first-tree.test",
+        accessToken: "tok",
+        agentsDir: join(agentsDir, "missing"),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("skips directories without agent.yaml and empty yaml files", async () => {
+    const missingYamlDir = join(agentsDir, "missing-yaml");
+    mkdirSync(missingYamlDir, { recursive: true });
+    const emptyPath = seedAgentDir("empty", {});
+    writeFileSync(emptyPath, "");
+    const goodPath = seedAgentDir("unset-runtime", { agentId: "agent-unset" });
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify([{ agentId: "agent-unset", clientId: "cli-1", runtimeProvider: "codex" }]), {
+        status: 200,
+      }),
+    );
+    const logs: Array<[string, string]> = [];
+
+    await reconcileLocalRuntimeProviders({
+      serverUrl: "http://first-tree.test",
+      accessToken: "tok",
+      agentsDir,
+      log: (level, msg) => logs.push([level, msg]),
+    });
+
+    const after = parseYaml(readFileSync(goodPath, "utf-8")) as { runtime?: string };
+    expect(after.runtime).toBe("codex");
+    expect(logs).toContainEqual([
+      "info",
+      'agent agent-unset: yaml runtime "(unset)" → "codex" (server authoritative)',
+    ]);
+  });
 });
 
 describe("uploadClientCapabilities", () => {

--- a/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
+++ b/apps/cli/src/__tests__/runtime-provider-reconcile.test.ts
@@ -215,10 +215,7 @@ describe("reconcileLocalRuntimeProviders", () => {
 
     const after = parseYaml(readFileSync(goodPath, "utf-8")) as { runtime?: string };
     expect(after.runtime).toBe("codex");
-    expect(logs).toContainEqual([
-      "info",
-      'agent agent-unset: yaml runtime "(unset)" → "codex" (server authoritative)',
-    ]);
+    expect(logs).toContainEqual(["info", 'agent agent-unset: yaml runtime "(unset)" → "codex" (server authoritative)']);
   });
 });
 

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -109,6 +109,9 @@ describe("service install helpers", () => {
       program: "/opt/node/bin/node",
       args: ["/repo/dist/cli/index.mjs"],
     });
+
+    process.argv = ["node"];
+    expect(() => resolveCliInvocation()).toThrow("Cannot resolve CLI entry point");
   });
 
   it("renders service templates with escaped values and quoted shell arguments", () => {
@@ -365,6 +368,27 @@ describe("service install helpers", () => {
     expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("systemctl daemon-reload during uninstall"));
   });
 
+  it("migrates quoted systemd proxy env and ignores migration write failures", () => {
+    setPlatform("linux");
+    const unitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(
+      unitPath,
+      'Environment=HTTP_PROXY="http://proxy.example:8080"\nEnvironment=NO_PROXY="localhost,127.0.0.1"\n',
+    );
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "yes\n", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "inactive\n", stderr: "" });
+
+    installClientService();
+
+    const envPath = join(process.env.FIRST_TREE_HOME ?? "", "daemon.env");
+    expect(readFileSync(envPath, "utf-8")).toContain("HTTP_PROXY=http://proxy.example:8080");
+    expect(readFileSync(envPath, "utf-8")).toContain("NO_PROXY=localhost,127.0.0.1");
+  });
+
   it("handles systemd linger already enabled and unreadable drift checks", () => {
     setPlatform("linux");
     spawnSyncMock
@@ -385,6 +409,35 @@ describe("service install helpers", () => {
     rmSync(unitPath, { force: true });
     mkdirSync(unitPath, { recursive: true });
     expect(isServiceUnitDriftDetected()).toBe(true);
+  });
+
+  it("reports systemd command timeouts from captured status and control calls", () => {
+    setPlatform("linux");
+    const unitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, "unit");
+    spawnSyncMock.mockReturnValueOnce({ status: null, signal: "SIGTERM", stdout: "", stderr: "" });
+    expect(getClientServiceStatus()).toMatchObject({
+      platform: "systemd",
+      state: "inactive",
+      detail: "unit present but not active",
+    });
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: null, signal: "SIGTERM", stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: null, signal: "SIGTERM", stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "inactive\n", stderr: "" });
+    expect(installClientService()).toMatchObject({ platform: "systemd", state: "inactive" });
+    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("loginctl enable-linger failed"));
+
+    spawnSyncMock.mockReturnValueOnce({ status: null, signal: "SIGTERM", stdout: "", stderr: "" });
+    expect(startClientService()).toEqual({
+      ok: false,
+      reason: expect.stringContaining("systemctl timed out"),
+    });
   });
 
   it("uninstalls a systemd service and reloads the user manager", () => {
@@ -467,6 +520,27 @@ describe("service install helpers", () => {
     ]);
   });
 
+  it("detects launchd unit drift and reports unsupported refresh/drift platforms", () => {
+    setPlatform("darwin");
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(isServiceUnitDriftDetected()).toBe(true);
+
+    const wrapperPath = join(process.env.FIRST_TREE_HOME ?? "", "service", channelConfig.displayName);
+    const plistPath = join(home, "Library", "LaunchAgents", `${channelConfig.launchdLabel}.plist`);
+    mkdirSync(dirname(wrapperPath), { recursive: true });
+    mkdirSync(dirname(plistPath), { recursive: true });
+    const invocation = { kind: "node" as const, program: process.execPath, args: [process.argv[1] ?? ""] };
+    writeFileSync(wrapperPath, renderLaunchdWrapper(invocation));
+    writeFileSync(plistPath, renderPlist(wrapperPath));
+    expect(isServiceUnitDriftDetected()).toBe(false);
+
+    setPlatform("win32");
+    expect(isServiceUnitDriftDetected()).toBe(false);
+    expect(() => refreshClientServiceUnitForUpdate()).toThrow("Background service refresh is not supported on win32");
+  });
+
   it("surfaces launchd bootstrap retry failures and warnings", () => {
     setPlatform("darwin");
     const dateNowSpy = vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(10_001);
@@ -510,6 +584,13 @@ describe("service install helpers", () => {
       .mockReturnValueOnce({ status: 1, stdout: "", stderr: "bootstrap failed" });
     writeFileSync(plistPath, "plist");
     expect(restartClientService()).toEqual({ ok: false, reason: "bootstrap failed" });
+  });
+
+  it("stops launchd services successfully", () => {
+    setPlatform("darwin");
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+
+    expect(stopClientService()).toEqual({ ok: true });
   });
 
   it("uninstalls launchd files even when bootout reports the label is absent", () => {

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -795,7 +795,9 @@ describe("service install helpers", () => {
       .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
       .mockReturnValueOnce({ status: 0, stdout: "inactive\n", stderr: "" });
     expect(refreshClientServiceUnitForUpdate()).toMatchObject({ state: "inactive" });
-    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("loginctl enable-linger failed: exit unknown"));
+    expect(printMocks.line).toHaveBeenCalledWith(
+      expect.stringContaining("loginctl enable-linger failed: exit unknown"),
+    );
 
     spawnSyncMock.mockReset();
     spawnSyncMock

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -623,4 +623,248 @@ describe("service install helpers", () => {
       detail: "platform win32 not supported",
     });
   });
+
+  it("covers service fallback details when platform tools omit stdout or stderr", () => {
+    setPlatform("win32");
+    execFileSyncMock.mockReturnValueOnce("\n");
+    expect(resolveCliInvocation()).toEqual({
+      kind: "node",
+      program: "/opt/node/bin/node",
+      args: ["/repo/dist/cli/index.mjs"],
+    });
+    expect(execFileSyncMock).toHaveBeenCalledWith("where", [channelConfig.binName], expect.any(Object));
+
+    setPlatform("linux");
+    const unitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    expect(getClientServiceStatus()).toMatchObject({ platform: "systemd", state: "not-installed" });
+
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, "unit");
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "active\n", stderr: "" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(getClientServiceStatus()).toMatchObject({ platform: "systemd", state: "active", detail: "running" });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 3, stdout: undefined, stderr: "" });
+    expect(getClientServiceStatus()).toMatchObject({
+      platform: "systemd",
+      state: "inactive",
+      detail: "unit present but not active",
+    });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: undefined });
+    expect(startClientService()).toEqual({ ok: false, reason: "exit 1" });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(stopClientService()).toEqual({ ok: false, reason: "exit 1" });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(restartClientService()).toEqual({ ok: false, reason: "exit 1" });
+  });
+
+  it("covers launchd fallback states and control failures", () => {
+    setPlatform("darwin");
+    const plistPath = join(home, "Library", "LaunchAgents", `${channelConfig.launchdLabel}.plist`);
+    expect(getClientServiceStatus()).toMatchObject({ platform: "launchd", state: "not-installed" });
+
+    mkdirSync(dirname(plistPath), { recursive: true });
+    writeFileSync(plistPath, "plist");
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "state = running\n", stderr: "" });
+    expect(getClientServiceStatus()).toMatchObject({ platform: "launchd", state: "active", detail: "running" });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: undefined, stderr: "" });
+    expect(getClientServiceStatus()).toMatchObject({ platform: "launchd", state: "inactive", detail: "loaded" });
+
+    rmSync(plistPath, { force: true });
+    expect(startClientService()).toEqual({ ok: false, reason: "service not installed" });
+    expect(restartClientService()).toEqual({ ok: false, reason: "service not installed" });
+
+    writeFileSync(plistPath, "plist");
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "loaded", stderr: "" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(startClientService()).toEqual({ ok: false, reason: "exit 1" });
+
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(startClientService()).toEqual({ ok: false, reason: "exit 1" });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(stopClientService()).toEqual({ ok: false, reason: "exit 1" });
+
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    expect(restartClientService()).toEqual({ ok: true });
+
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "kick failed" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(restartClientService()).toEqual({ ok: false, reason: "exit 1" });
+  });
+
+  it("covers systemd install refresh and uninstall fallback messages", () => {
+    setPlatform("linux");
+    userInfoMock.mockReturnValueOnce({ uid: 501, username: "" });
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "inactive\n", stderr: "" });
+    expect(installClientService()).toMatchObject({ platform: "systemd", state: "inactive" });
+    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("could not determine username"));
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(() => installClientService()).toThrow("systemctl --user daemon-reload failed: exit 1");
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "inactive\n", stderr: "" });
+    expect(refreshClientServiceUnitForUpdate()).toMatchObject({ platform: "systemd", state: "inactive" });
+    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("loginctl enable-linger failed: exit 1"));
+
+    const unitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, "unit");
+    spawnSyncMock.mockReset();
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(uninstallClientService()).toMatchObject({ platform: "systemd", state: "not-installed" });
+    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("systemctl disable during uninstall: exit 1"));
+    expect(printMocks.line).toHaveBeenCalledWith(
+      expect.stringContaining("systemctl daemon-reload during uninstall: exit 1"),
+    );
+  });
+
+  it("covers launchd install retry fallbacks without stderr", () => {
+    setPlatform("darwin");
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(1).mockReturnValueOnce(10_001);
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+
+    expect(() => installClientService()).toThrow("launchctl bootstrap failed: exit 1");
+    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("warning: launchctl bootout: exit 1"));
+    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("bootout still settling"));
+    dateNowSpy.mockRestore();
+
+    const plistPath = join(home, "Library", "LaunchAgents", `${channelConfig.launchdLabel}.plist`);
+    mkdirSync(dirname(plistPath), { recursive: true });
+    writeFileSync(plistPath, "plist");
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(uninstallClientService()).toMatchObject({ platform: "launchd", state: "not-installed" });
+    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("warning: bootout during uninstall: exit 1"));
+  });
+
+  it("covers unknown-exit service-manager fallbacks", () => {
+    setPlatform("linux");
+    const unitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, "unit");
+
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "active\n", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: undefined, stderr: "" });
+    expect(getClientServiceStatus()).toMatchObject({ state: "active", detail: "running" });
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" });
+    expect(() => installClientService()).toThrow("systemctl --user daemon-reload failed: exit unknown");
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "yes\n", stderr: "" })
+      .mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" });
+    expect(() => installClientService()).toThrow(
+      `systemctl --user enable --now ${channelConfig.serviceUnitFile} failed: exit unknown`,
+    );
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "inactive\n", stderr: "" });
+    expect(refreshClientServiceUnitForUpdate()).toMatchObject({ state: "inactive" });
+    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("loginctl enable-linger failed: exit unknown"));
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock
+      .mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" });
+    expect(uninstallClientService()).toMatchObject({ state: "not-installed" });
+    expect(printMocks.line).toHaveBeenCalledWith(
+      expect.stringContaining("systemctl disable during uninstall: exit unknown"),
+    );
+    expect(printMocks.line).toHaveBeenCalledWith(
+      expect.stringContaining("systemctl daemon-reload during uninstall: exit unknown"),
+    );
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" });
+    expect(startClientService()).toEqual({ ok: false, reason: "exit unknown" });
+
+    spawnSyncMock.mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" });
+    expect(stopClientService()).toEqual({ ok: false, reason: "exit unknown" });
+
+    spawnSyncMock.mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" });
+    expect(restartClientService()).toEqual({ ok: false, reason: "exit unknown" });
+
+    setPlatform("darwin");
+    const plistPath = join(home, "Library", "LaunchAgents", `${channelConfig.launchdLabel}.plist`);
+    mkdirSync(dirname(plistPath), { recursive: true });
+    writeFileSync(plistPath, "plist");
+
+    spawnSyncMock.mockReset();
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(10_001);
+    spawnSyncMock
+      .mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" });
+    expect(() => installClientService()).toThrow("launchctl bootstrap failed: exit unknown");
+    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("warning: launchctl bootout: exit unknown"));
+    dateNowSpy.mockRestore();
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "not loaded" })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "state = stopped\n", stderr: "" });
+    expect(installClientService()).toMatchObject({ platform: "launchd", state: "inactive" });
+    expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("warning: launchctl enable: exit unknown"));
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" });
+    expect(uninstallClientService()).toMatchObject({ state: "not-installed" });
+    expect(printMocks.line).toHaveBeenCalledWith(
+      expect.stringContaining("warning: bootout during uninstall: exit unknown"),
+    );
+
+    writeFileSync(plistPath, "plist");
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: undefined })
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });
+    expect(startClientService()).toEqual({ ok: false, reason: "exit 1" });
+
+    spawnSyncMock.mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" });
+    expect(stopClientService()).toEqual({ ok: false, reason: "exit unknown" });
+
+    writeFileSync(plistPath, "plist");
+    spawnSyncMock
+      .mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: null, signal: undefined, stdout: "", stderr: "" });
+    expect(restartClientService()).toEqual({ ok: false, reason: "exit unknown" });
+  });
 });

--- a/apps/cli/src/__tests__/status-blocks.test.ts
+++ b/apps/cli/src/__tests__/status-blocks.test.ts
@@ -75,6 +75,35 @@ describe("status block renderers", () => {
       expect(output()).toContain(expected);
     }
     expect(output()).toContain("logs: /logs/client.log");
+
+    stderrSpy.mockClear();
+    serviceStatusMock
+      .mockReturnValueOnce({
+        platform: "systemd",
+        label: "first-tree-dev.service",
+        state: "active",
+        logDir: "/logs",
+      })
+      .mockReturnValueOnce({
+        platform: "systemd",
+        label: "first-tree-dev.service",
+        state: "inactive",
+        detail: "loaded",
+        logDir: "/logs",
+      })
+      .mockReturnValueOnce({
+        platform: "systemd",
+        label: "first-tree-dev.service",
+        state: "unknown",
+        detail: "denied",
+        logDir: "/logs",
+      });
+    renderServiceBlock();
+    renderServiceBlock();
+    renderServiceBlock();
+    expect(output()).toContain("running (systemd)");
+    expect(output()).toContain("stopped (systemd, loaded)");
+    expect(output()).toContain("unknown (systemd, denied)");
   });
 
   it("renders server configuration states", async () => {
@@ -93,6 +122,12 @@ describe("status block renderers", () => {
     expect(output()).toContain("client-1");
 
     stderrSpy.mockClear();
+    writeFileSync(join(home, "config", "client.yaml"), "server: disabled\nclient:\n  id: 123\n");
+    renderHubBlock();
+    expect(output()).toContain("Server:   (not configured)");
+    expect(output()).toContain("Client:   (not configured)");
+
+    stderrSpy.mockClear();
     writeFileSync(join(home, "config", "client.yaml"), "server: [");
     renderHubBlock();
     expect(output()).toContain("could not read");
@@ -108,6 +143,16 @@ describe("status block renderers", () => {
 
     stderrSpy.mockClear();
     credentialsMock.mockReturnValueOnce({ refreshToken: "bad-token" });
+    renderAuthBlock();
+    expect(output()).toContain("could not parse refresh token");
+
+    stderrSpy.mockClear();
+    credentialsMock.mockReturnValueOnce({ refreshToken: "header.e30.signature" });
+    renderAuthBlock();
+    expect(output()).toContain("could not parse refresh token");
+
+    stderrSpy.mockClear();
+    credentialsMock.mockReturnValueOnce({ refreshToken: "header.not-json.signature" });
     renderAuthBlock();
     expect(output()).toContain("could not parse refresh token");
 
@@ -141,5 +186,10 @@ describe("status block renderers", () => {
     expect(output()).toContain("1 configured");
     expect(output()).toContain("nova");
     expect(output()).toContain("agent-1");
+
+    stderrSpy.mockClear();
+    writeFileSync(join(agentDir, "agent.yaml"), "agentId: [not-valid\n");
+    renderAgentsBlock();
+    expect(output()).toContain("no agents directory");
   });
 });

--- a/apps/cli/src/__tests__/tree-binding-contract-extra.test.ts
+++ b/apps/cli/src/__tests__/tree-binding-contract-extra.test.ts
@@ -1,0 +1,157 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPlaceholderAction, createPlaceholderSubcommand } from "../commands/placeholder.js";
+import {
+  findUpwardsManagedSourceBinding,
+  parseGitHubRepoReference,
+  parseManagedSourceBindingText,
+  readManagedSourceBinding,
+  readSourceBindingContract,
+  SOURCE_INTEGRATION_BEGIN,
+  SOURCE_INTEGRATION_END,
+} from "../commands/tree/binding-contract.js";
+import type { CommandContext } from "../commands/types.js";
+
+const tempDirs: string[] = [];
+const commandContext: CommandContext = {
+  command: {} as CommandContext["command"],
+  options: { debug: false, json: false, quiet: false },
+};
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ft-binding-contract-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function managedBlock(lines: string[]): string {
+  return ["before", SOURCE_INTEGRATION_BEGIN, ...lines, SOURCE_INTEGRATION_END, "after"].join("\n");
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("tree binding contract helpers", () => {
+  it("parses managed block markers, repo references, and absent marker blocks", () => {
+    expect(parseGitHubRepoReference(undefined)).toBeUndefined();
+    expect(parseGitHubRepoReference("  ")).toBeUndefined();
+    expect(parseGitHubRepoReference("acme/context")).toBe("acme/context");
+    expect(parseGitHubRepoReference("https://github.com/Acme/Context.git")).toBe("Acme/Context");
+    expect(parseGitHubRepoReference("https://gitlab.com/acme/context.git")).toBeUndefined();
+
+    expect(parseManagedSourceBindingText("no managed block")).toBeUndefined();
+    expect(parseManagedSourceBindingText(managedBlock(["FIRST-TREE-TREE-REPO-URL: pending publish"]))).toBeUndefined();
+
+    expect(
+      parseManagedSourceBindingText(
+        managedBlock([
+          "FIRST-TREE-BINDING-CONTRACT: `managed-block-v2`",
+          "FIRST-TREE-BINDING-MODE: `workspace-member`",
+          "FIRST-TREE-TREE-MODE: shared",
+          "FIRST-TREE-TREE-REPO: context",
+          "FIRST-TREE-TREE-REPO-URL: https://github.com/acme/context.git",
+          "FIRST-TREE-ENTRYPOINT: packages/app",
+          "FIRST-TREE-SOURCE-STATE: .first-tree/source.json",
+          "FIRST-TREE-WORKSPACE-ID: workspace-1",
+        ]),
+      ),
+    ).toEqual({
+      bindingContract: "managed-block-v2",
+      bindingMode: "workspace-member",
+      entrypoint: "packages/app",
+      scope: "workspace",
+      sourceStatePath: ".first-tree/source.json",
+      treeMode: "shared",
+      treeRepoName: "context",
+      treeRepoSlug: "acme/context",
+      treeRepoUrl: "https://github.com/acme/context.git",
+      workspaceId: "workspace-1",
+    });
+  });
+
+  it("reads managed bindings from AGENTS, CLAUDE, ancestors, and legacy source state", () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, "child", "nested"), { recursive: true });
+    writeFileSync(
+      join(root, "CLAUDE.md"),
+      managedBlock(["FIRST-TREE-BINDING-MODE: standalone-source", "FIRST-TREE-TREE-REPO-SLUG: acme/context"]),
+    );
+
+    expect(readManagedSourceBinding(join(root, "missing"))).toBeUndefined();
+    expect(readManagedSourceBinding(root)).toMatchObject({
+      file: "CLAUDE.md",
+      bindingMode: "standalone-source",
+      scope: "repo",
+      treeRepoSlug: "acme/context",
+    });
+    expect(findUpwardsManagedSourceBinding(join(root, "child", "nested"))).toMatchObject({
+      file: "CLAUDE.md",
+      treeRepoSlug: "acme/context",
+    });
+
+    const legacyRoot = makeTempDir();
+    mkdirSync(join(legacyRoot, ".first-tree"), { recursive: true });
+    writeFileSync(
+      join(legacyRoot, ".first-tree", "source.json"),
+      JSON.stringify({
+        bindingMode: "shared-source",
+        rootKind: "git-repo",
+        schemaVersion: 1,
+        scope: "repo",
+        sourceName: "app",
+        sourceId: "source-1",
+        workspaceId: "workspace-legacy",
+        tree: {
+          treeId: "tree-1",
+          treeMode: "shared",
+          treeRepoName: "context",
+          remoteUrl: "git@github.com:acme/context.git",
+          entrypoint: "docs",
+        },
+      }),
+    );
+
+    expect(readSourceBindingContract(legacyRoot)).toEqual({
+      bindingContract: "legacy-source-state",
+      bindingMode: "shared-source",
+      entrypoint: "docs",
+      scope: "repo",
+      sourceStatePath: ".first-tree/source.json",
+      treeMode: "shared",
+      treeRepoName: "context",
+      treeRepoSlug: "acme/context",
+      treeRepoUrl: "git@github.com:acme/context.git",
+      workspaceId: "workspace-legacy",
+    });
+  });
+});
+
+describe("placeholder command helpers", () => {
+  it("creates placeholder actions and subcommand metadata", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const action = createPlaceholderAction("coming soon");
+    action(commandContext);
+    expect(log).toHaveBeenCalledWith("coming soon");
+
+    const subcommand = createPlaceholderSubcommand({
+      name: "alpha",
+      description: "Alpha command",
+      message: "not ready",
+    });
+    expect(subcommand).toMatchObject({
+      name: "alpha",
+      alias: "",
+      summary: "",
+      description: "Alpha command",
+    });
+    subcommand.action(commandContext);
+    expect(log).toHaveBeenCalledWith("not ready");
+    log.mockRestore();
+  });
+});

--- a/apps/cli/src/__tests__/tree-binding-contract-extra.test.ts
+++ b/apps/cli/src/__tests__/tree-binding-contract-extra.test.ts
@@ -47,6 +47,15 @@ describe("tree binding contract helpers", () => {
 
     expect(parseManagedSourceBindingText("no managed block")).toBeUndefined();
     expect(parseManagedSourceBindingText(managedBlock(["FIRST-TREE-TREE-REPO-URL: pending publish"]))).toBeUndefined();
+    expect(parseManagedSourceBindingText(managedBlock(["FIRST-TREE-TREE-REPO: context"]))).toEqual({
+      bindingContract: "managed-block-v1",
+      treeRepoName: "context",
+    });
+    expect(parseManagedSourceBindingText(managedBlock(["FIRST-TREE-BINDING-MODE: workspace-root"]))).toEqual({
+      bindingContract: "managed-block-v1",
+      bindingMode: "workspace-root",
+      scope: "workspace",
+    });
 
     expect(
       parseManagedSourceBindingText(
@@ -94,6 +103,7 @@ describe("tree binding contract helpers", () => {
       file: "CLAUDE.md",
       treeRepoSlug: "acme/context",
     });
+    expect(findUpwardsManagedSourceBinding(makeTempDir())).toBeUndefined();
 
     const legacyRoot = makeTempDir();
     mkdirSync(join(legacyRoot, ".first-tree"), { recursive: true });
@@ -128,6 +138,36 @@ describe("tree binding contract helpers", () => {
       treeRepoSlug: "acme/context",
       treeRepoUrl: "git@github.com:acme/context.git",
       workspaceId: "workspace-legacy",
+    });
+
+    const minimalLegacyRoot = makeTempDir();
+    mkdirSync(join(minimalLegacyRoot, ".first-tree"), { recursive: true });
+    writeFileSync(
+      join(minimalLegacyRoot, ".first-tree", "source.json"),
+      JSON.stringify({
+        bindingMode: "workspace-root",
+        rootKind: "folder",
+        schemaVersion: 1,
+        scope: "workspace",
+        sourceName: "workspace",
+        sourceId: "source-minimal",
+        tree: {
+          treeId: "tree-minimal",
+          treeMode: "dedicated",
+          treeRepoName: "context",
+          entrypoint: ".",
+        },
+      }),
+    );
+
+    expect(readSourceBindingContract(minimalLegacyRoot)).toEqual({
+      bindingContract: "legacy-source-state",
+      bindingMode: "workspace-root",
+      entrypoint: ".",
+      scope: "workspace",
+      sourceStatePath: ".first-tree/source.json",
+      treeMode: "dedicated",
+      treeRepoName: "context",
     });
   });
 });

--- a/apps/cli/src/__tests__/tree-binding-state.test.ts
+++ b/apps/cli/src/__tests__/tree-binding-state.test.ts
@@ -8,6 +8,7 @@ import {
   buildTreeId,
   deriveDefaultEntrypoint,
   determineScope,
+  isLegacyBindingMode,
   listTreeBindings,
   readSourceState,
   readTreeBinding,
@@ -113,6 +114,15 @@ describe("tree binding state helpers", () => {
     expect(readSourceState(root)).toBeNull();
     expect(readTreeState(root)).toBeNull();
     expect(readTreeBinding(root, "bad")).toBeNull();
+
+    writeFileSync(sourceStatePath(root), JSON.stringify({ ...sourceState(), tree: [] }));
+    expect(readSourceState(root)).toBeNull();
+
+    writeFileSync(sourceStatePath(root), JSON.stringify({ ...sourceState(), tree: { treeMode: "shared" } }));
+    expect(readSourceState(root)).toBeNull();
+
+    writeFileSync(sourceStatePath(root), JSON.stringify({ ...sourceState(), bindingMode: "future-mode" }));
+    expect(readSourceState(root)).toBeNull();
   });
 
   it("round-trips and sorts tree bindings while ignoring invalid files", () => {
@@ -229,6 +239,7 @@ describe("tree binding state helpers", () => {
       JSON.stringify({
         ...sourceState(),
         members: [
+          null,
           { sourceId: "bad" },
           {
             bindingMode: "workspace-member",
@@ -257,6 +268,10 @@ describe("tree binding state helpers", () => {
   });
 
   it("writes deterministic JSON documents", () => {
+    expect(isLegacyBindingMode("standalone-source")).toBe(true);
+    expect(isLegacyBindingMode("shared-source")).toBe(true);
+    expect(isLegacyBindingMode("workspace-root")).toBe(false);
+
     writeTreeBinding(root, "api", {
       bindingMode: "workspace-member",
       entrypoint: "/workspaces/first-tree/repos/api",

--- a/apps/cli/src/__tests__/tree-binding-state.test.ts
+++ b/apps/cli/src/__tests__/tree-binding-state.test.ts
@@ -88,18 +88,60 @@ describe("tree binding state helpers", () => {
       treeRepoName: "context-tree",
     });
 
+    mkdirSync(join(root, "custom-tree", ".first-tree"), { recursive: true });
+    writeFileSync(
+      treeStatePath(join(root, "custom-tree")),
+      JSON.stringify({
+        schemaVersion: 7,
+        treeId: "custom-tree",
+        treeMode: "dedicated",
+        treeRepoName: "custom-tree",
+      }),
+    );
+    mkdirSync(join(root, "folder-source", ".first-tree"), { recursive: true });
+    writeFileSync(
+      sourceStatePath(join(root, "folder-source")),
+      JSON.stringify({
+        bindingMode: "workspace-root",
+        rootKind: "folder",
+        scope: "workspace",
+        schemaVersion: 3,
+        sourceId: "folder-root",
+        sourceName: "Folder Root",
+        tree: {
+          entrypoint: "/workspaces/folder-root",
+          treeId: "folder-tree",
+          treeMode: "shared",
+          treeRepoName: "folder-tree",
+        },
+      }),
+    );
+
     expect(readSourceState(root)).toMatchObject({
       bindingMode: "workspace-root",
       schemaVersion: 1,
       sourceId: "workspace-root",
       tree: { entrypoint: "/workspaces/first-tree" },
     });
+    const folderSource = readSourceState(join(root, "folder-source"));
+    expect(folderSource).toMatchObject({
+      rootKind: "folder",
+      schemaVersion: 3,
+    });
+    expect(folderSource?.tree).not.toHaveProperty("remoteUrl");
+    expect(folderSource).not.toHaveProperty("workspaceId");
     expect(readTreeState(root)).toEqual({
       published: { remoteUrl: "git@github.com:acme/context-tree.git" },
       schemaVersion: 1,
       treeId: "context-tree",
       treeMode: "shared",
       treeRepoName: "context-tree",
+    });
+    expect(readTreeState(join(root, "custom-tree"))).toEqual({
+      schemaVersion: 7,
+      treeId: "custom-tree",
+      treeMode: "dedicated",
+      treeRepoName: "custom-tree",
     });
     expect(sourceStatePath(root)).toBe(join(root, ".first-tree", "source.json"));
     expect(treeStatePath(root)).toBe(join(root, ".first-tree", "tree.json"));
@@ -128,6 +170,20 @@ describe("tree binding state helpers", () => {
   it("round-trips and sorts tree bindings while ignoring invalid files", () => {
     writeTreeBinding(root, "zeta", binding({ sourceId: "zeta", sourceName: "zeta" }));
     writeTreeBinding(root, "alpha", binding({ sourceId: "alpha", sourceName: "alpha" }));
+    writeFileSync(
+      treeBindingPath(root, "folder"),
+      JSON.stringify({
+        bindingMode: "workspace-member",
+        entrypoint: "/workspaces/first-tree/repos/folder",
+        rootKind: "folder",
+        schemaVersion: 4,
+        scope: "workspace",
+        sourceId: "folder",
+        sourceName: "folder",
+        treeMode: "shared",
+        treeRepoName: "context-tree",
+      }),
+    );
     writeFileSync(join(treeBindingsDir(root), "ignored.txt"), "{}");
     writeFileSync(treeBindingPath(root, "broken"), JSON.stringify({ sourceId: "broken" }));
 
@@ -136,7 +192,14 @@ describe("tree binding state helpers", () => {
       schemaVersion: 1,
       remoteUrl: "git@github.com:acme/api.git",
     });
-    expect(listTreeBindings(root).map((row) => row.sourceId)).toEqual(["alpha", "zeta"]);
+    const folderBinding = readTreeBinding(root, "folder");
+    expect(folderBinding).toMatchObject({
+      rootKind: "folder",
+      schemaVersion: 4,
+    });
+    expect(folderBinding).not.toHaveProperty("remoteUrl");
+    expect(folderBinding).not.toHaveProperty("workspaceId");
+    expect(listTreeBindings(root).map((row) => row.sourceId)).toEqual(["alpha", "folder", "zeta"]);
   });
 
   it("returns null or empty values for missing state files", () => {
@@ -164,6 +227,7 @@ describe("tree binding state helpers", () => {
 
     const folder = buildStableSourceId("", { fallbackRoot: join(root, "My Folder") });
     expect(folder).toMatch(/^my-folder-[a-f0-9]{8}$/u);
+    expect(buildStableSourceId("Plain Source")).toMatch(/^plain-source-[a-f0-9]{8}$/u);
     expect(buildTreeId("Context Tree!")).toBe("context-tree");
     expect(determineScope("workspace-root")).toBe("workspace");
     expect(determineScope("workspace-member")).toBe("workspace");
@@ -172,9 +236,11 @@ describe("tree binding state helpers", () => {
     expect(deriveDefaultEntrypoint("workspace-root", "Source Repo", "First Tree All")).toBe(
       "/workspaces/first-tree-all",
     );
+    expect(deriveDefaultEntrypoint("workspace-root", "Source Repo")).toBe("/workspaces/source-repo");
     expect(deriveDefaultEntrypoint("workspace-member", "First Tree", "First Tree All")).toBe(
       "/workspaces/first-tree-all/repos/first-tree",
     );
+    expect(deriveDefaultEntrypoint("workspace-member", "First Tree")).toBe("/workspaces/workspace/repos/first-tree");
     expect(deriveDefaultEntrypoint("shared-source", "First Tree")).toBe("/repos/first-tree");
     expect(deriveDefaultEntrypoint("standalone-source", "First Tree")).toBe("/");
     expect(relativePathWithin(root, join(root, "repos", "first-tree"))).toBe("repos/first-tree");
@@ -213,6 +279,23 @@ describe("tree binding state helpers", () => {
       ["alpha", "/workspaces/first-tree/repos/alpha"],
       ["api", "/workspaces/first-tree/repos/api-v2"],
     ]);
+
+    writeSourceState(root, sourceState({ members: undefined }));
+    upsertWorkspaceMember(root, "first-tree", tree({ entrypoint: "/workspaces/first-tree/repos/zeta" }), {
+      bindingMode: "workspace-member",
+      entrypoint: "/workspaces/first-tree/repos/zeta",
+      rootKind: "git-repo",
+      sourceId: "zeta",
+      sourceName: "same",
+    });
+    upsertWorkspaceMember(root, "first-tree", tree({ entrypoint: "/workspaces/first-tree/repos/alpha" }), {
+      bindingMode: "workspace-member",
+      entrypoint: "/workspaces/first-tree/repos/alpha",
+      rootKind: "git-repo",
+      sourceId: "alpha",
+      sourceName: "same",
+    });
+    expect(readSourceState(root)?.members?.map((member) => member.sourceId)).toEqual(["alpha", "zeta"]);
   });
 
   it("throws when upserting a member without workspace state and removes source state", () => {

--- a/apps/cli/src/__tests__/tree-identity-extra.test.ts
+++ b/apps/cli/src/__tests__/tree-identity-extra.test.ts
@@ -1,0 +1,185 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeTreeState } from "../commands/tree/binding-state.js";
+import {
+  findUpwardsManagedTreeIdentity,
+  readManagedTreeIdentity,
+  readTreeIdentityContract,
+  syncTreeIdentityFiles,
+} from "../commands/tree/tree-identity.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ft-tree-identity-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("tree identity files", () => {
+  it("skips roots with no supported identity file", () => {
+    const root = makeTempDir();
+
+    expect(syncTreeIdentityFiles(root, { treeRepoName: "tree" })).toBe("skipped");
+    expect(readManagedTreeIdentity(root)).toBeUndefined();
+    expect(findUpwardsManagedTreeIdentity(root)).toBeUndefined();
+    expect(readTreeIdentityContract(root)).toBeUndefined();
+  });
+
+  it("inserts a managed block before project-specific instructions and reads it back", () => {
+    const root = makeTempDir();
+    const agentsPath = join(root, "AGENTS.md");
+    writeFileSync(agentsPath, "Intro\r\n\r\n# Project-Specific Instructions\r\nKeep this section.\r\n", "utf8");
+
+    expect(
+      syncTreeIdentityFiles(root, {
+        publishedTreeUrl: "https://github.com/acme/tree",
+        treeMode: "dedicated",
+        treeRepoName: "acme-tree",
+      }),
+    ).toBe("updated");
+
+    const text = readFileSync(agentsPath, "utf8");
+    expect(text).toContain("## Tree Identity");
+    expect(text.indexOf("## Tree Identity")).toBeLessThan(text.indexOf("# Project-Specific Instructions"));
+    expect(text).toContain("FIRST-TREE-TREE-MODE: `dedicated`");
+    expect(text.endsWith("\n")).toBe(true);
+    expect(readManagedTreeIdentity(root)).toMatchObject({
+      file: "AGENTS.md",
+      path: agentsPath,
+      publishedTreeUrl: "https://github.com/acme/tree",
+      treeMode: "dedicated",
+      treeRepoName: "acme-tree",
+    });
+    mkdirSync(join(root, "a", "b"), { recursive: true });
+    expect(findUpwardsManagedTreeIdentity(join(root, "a", "b"))).toMatchObject({ treeRepoName: "acme-tree" });
+    expect(
+      syncTreeIdentityFiles(root, {
+        publishedTreeUrl: "https://github.com/acme/tree",
+        treeMode: "dedicated",
+        treeRepoName: "acme-tree",
+      }),
+    ).toBe("unchanged");
+  });
+
+  it("inserts after the Context Tree framework marker and handles pending publish", () => {
+    const root = makeTempDir();
+    const claudePath = join(root, "CLAUDE.md");
+    writeFileSync(claudePath, "Framework\n<!-- END CONTEXT-TREE FRAMEWORK -->\n\nExisting tail\n", "utf8");
+
+    expect(syncTreeIdentityFiles(root, { treeMode: "shared", treeRepoName: "shared-tree" })).toBe("updated");
+
+    const text = readFileSync(claudePath, "utf8");
+    expect(text.indexOf("## Tree Identity")).toBeGreaterThan(text.indexOf("END CONTEXT-TREE FRAMEWORK"));
+    expect(text).toContain("FIRST-TREE-TREE-PUBLISHED-URL: pending publish");
+    const parsed = readManagedTreeIdentity(root);
+    expect(parsed).toMatchObject({
+      file: "CLAUDE.md",
+      treeMode: "shared",
+      treeRepoName: "shared-tree",
+    });
+    expect(parsed).not.toHaveProperty("publishedTreeUrl");
+  });
+
+  it("appends to ordinary files and replaces an existing managed block", () => {
+    const root = makeTempDir();
+    const agentsPath = join(root, "AGENTS.md");
+    writeFileSync(agentsPath, "Plain instructions\n", "utf8");
+
+    expect(syncTreeIdentityFiles(root, { treeRepoName: "first-tree" })).toBe("updated");
+    expect(readFileSync(agentsPath, "utf8")).toContain("FIRST-TREE-TREE-REPO: `first-tree`");
+
+    expect(
+      syncTreeIdentityFiles(root, {
+        publishedTreeUrl: "https://github.com/acme/next-tree",
+        treeMode: "dedicated",
+        treeRepoName: "next-tree",
+      }),
+    ).toBe("updated");
+
+    const text = readFileSync(agentsPath, "utf8");
+    expect(text).toContain("FIRST-TREE-TREE-REPO: `next-tree`");
+    expect(text).not.toContain("FIRST-TREE-TREE-REPO: `first-tree`");
+    expect(readManagedTreeIdentity(root)).toMatchObject({
+      publishedTreeUrl: "https://github.com/acme/next-tree",
+      treeMode: "dedicated",
+      treeRepoName: "next-tree",
+    });
+  });
+
+  it("ignores malformed managed blocks and invalid tree modes", () => {
+    const root = makeTempDir();
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      [
+        "<!-- BEGIN FIRST-TREE-TREE-IDENTITY -->",
+        "<!--",
+        "FIRST-TREE-TREE-IDENTITY: managed-block-v1",
+        "FIRST-TREE-TREE-MODE: `invalid`",
+        "FIRST-TREE-TREE-PUBLISHED-URL: `https://github.com/acme/tree`",
+        "-->",
+        "<!-- END FIRST-TREE-TREE-IDENTITY -->",
+      ].join("\n"),
+      "utf8",
+    );
+    expect(readManagedTreeIdentity(root)).toBeUndefined();
+
+    writeFileSync(
+      join(root, "AGENTS.md"),
+      [
+        "<!-- BEGIN FIRST-TREE-TREE-IDENTITY -->",
+        "<!--",
+        "FIRST-TREE-TREE-IDENTITY: managed-block-v1",
+        "FIRST-TREE-TREE-REPO: acme-tree",
+        "FIRST-TREE-TREE-MODE: invalid",
+        "FIRST-TREE-TREE-PUBLISHED-URL: https://github.com/acme/tree",
+        "-->",
+        "<!-- END FIRST-TREE-TREE-IDENTITY -->",
+      ].join("\n"),
+      "utf8",
+    );
+    expect(readManagedTreeIdentity(root)).toMatchObject({
+      publishedTreeUrl: "https://github.com/acme/tree",
+      treeMode: undefined,
+      treeRepoName: "acme-tree",
+    });
+  });
+
+  it("prefers a managed identity over tree state but falls back to tree state when absent", () => {
+    const root = makeTempDir();
+    writeTreeState(root, {
+      published: { remoteUrl: "https://github.com/acme/state-tree" },
+      treeId: "tree_1",
+      treeMode: "shared",
+      treeRepoName: "state-tree",
+    });
+
+    expect(readTreeIdentityContract(root)).toEqual({
+      publishedTreeUrl: "https://github.com/acme/state-tree",
+      treeMode: "shared",
+      treeRepoName: "state-tree",
+    });
+
+    writeFileSync(join(root, "AGENTS.md"), "Instructions\n", "utf8");
+    syncTreeIdentityFiles(root, {
+      publishedTreeUrl: "https://github.com/acme/managed-tree",
+      treeMode: "dedicated",
+      treeRepoName: "managed-tree",
+    });
+
+    expect(readTreeIdentityContract(root)).toMatchObject({
+      publishedTreeUrl: "https://github.com/acme/managed-tree",
+      treeMode: "dedicated",
+      treeRepoName: "managed-tree",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/tree-init-command-extra.test.ts
+++ b/apps/cli/src/__tests__/tree-init-command-extra.test.ts
@@ -1,0 +1,364 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommandContext } from "../commands/types.js";
+
+const bootstrapMocks = vi.hoisted(() => ({
+  ensureFreshAccessToken: vi.fn(),
+  resolveServerUrl: vi.fn(),
+}));
+
+const treeSharedMocks = vi.hoisted(() => ({
+  runCommand: vi.fn(),
+}));
+
+vi.mock("../core/bootstrap.js", () => ({
+  ensureFreshAccessToken: bootstrapMocks.ensureFreshAccessToken,
+  resolveServerUrl: bootstrapMocks.resolveServerUrl,
+}));
+
+vi.mock("../commands/tree/shared.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../commands/tree/shared.js")>();
+  return {
+    ...actual,
+    runCommand: treeSharedMocks.runCommand,
+  };
+});
+
+const originalCwd = process.cwd();
+const tempDirs: string[] = [];
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ft-tree-init-action-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function context(command: Command, json = false): CommandContext {
+  return { command, options: { debug: false, json, quiet: false } };
+}
+
+function commandWithOptions(options: Record<string, unknown>): Command {
+  const command = new Command("init");
+  for (const [key, value] of Object.entries(options)) {
+    command.setOptionValue(key, value);
+  }
+  return command;
+}
+
+function response(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+function mockGithubApi(): void {
+  treeSharedMocks.runCommand.mockImplementation((tool: string, args: string[]) => {
+    if (args[0] === "--version" || (tool === "gh" && args[0] === "auth" && args[1] === "status")) {
+      return "";
+    }
+    if (tool === "gh" && args[0] === "api" && args[1] === "user") {
+      return "octocat";
+    }
+    if (tool === "gh" && args[0] === "api" && typeof args[1] === "string" && args[1].startsWith("repos/")) {
+      return JSON.stringify({ html_url: `https://github.com/${args[1].slice("repos/".length)}` });
+    }
+    return "";
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  bootstrapMocks.resolveServerUrl.mockReturnValue("https://server.example");
+  bootstrapMocks.ensureFreshAccessToken.mockResolvedValue("access-token");
+  mockGithubApi();
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  process.chdir(originalCwd);
+  process.exitCode = undefined;
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("tree init command action", () => {
+  it("creates and summarizes an unbound Context Tree with local gh/git only", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const base = makeTempDir();
+    process.chdir(base);
+    const command = commandWithOptions({
+      bind: false,
+      dir: "local-tree",
+      name: "custom-tree",
+      public: true,
+      title: "Acme Product",
+      withWorkflow: true,
+    });
+
+    await initCommand.action(context(command, true));
+
+    const root = join(base, "local-tree");
+    expect(process.exitCode).toBeUndefined();
+    expect(existsSync(join(root, "NODE.md"))).toBe(true);
+    expect(existsSync(join(root, "members", "octocat", "NODE.md"))).toBe(true);
+    expect(existsSync(join(root, ".github", "workflows", "validate-tree.yml"))).toBe(true);
+    expect(readFileSync(join(root, "NODE.md"), "utf8")).toContain("Acme Product Context Tree");
+    expect(treeSharedMocks.runCommand).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "create", "octocat/custom-tree", "--public", "--source", root, "--remote", "origin", "--push"],
+      root,
+    );
+
+    const summary = JSON.parse(String(vi.mocked(console.log).mock.calls.at(-1)?.[0])) as Record<string, unknown>;
+    expect(summary).toMatchObject({
+      bound: false,
+      branch: "main",
+      htmlUrl: "https://github.com/octocat/custom-tree",
+      owner: "octocat",
+      withWorkflow: true,
+    });
+    expect(summary.coverage).toBeNull();
+  });
+
+  it("binds under the GitHub App installation account and reports coverage guidance", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const base = makeTempDir();
+    process.chdir(base);
+    const fetchMock = vi.fn(async (input: FetchInput, init?: FetchInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/v1/me")) {
+        return response({
+          defaultOrganizationId: "org_1",
+          memberships: [{ organizationId: "org_1", role: "admin" }],
+        });
+      }
+      if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree") && init?.method !== "PUT") {
+        return response({ repo: null });
+      }
+      if (url.endsWith("/api/v1/orgs/org_1/context-tree/installation")) {
+        return response({
+          accountLogin: "acme-org",
+          accountType: "Organization",
+          installationId: 123,
+          suspended: false,
+        });
+      }
+      if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree") && init?.method === "PUT") {
+        expect(init.body).toBe(JSON.stringify({ repo: "https://github.com/acme-org/acme-context-tree" }));
+        return response("ok");
+      }
+      return response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const command = commandWithOptions({
+      bind: true,
+      public: false,
+      title: "Acme",
+      withWorkflow: false,
+    });
+
+    await initCommand.action(context(command, true));
+
+    const summary = JSON.parse(String(vi.mocked(console.log).mock.calls.at(-1)?.[0])) as Record<string, unknown>;
+    expect(process.exitCode).toBeUndefined();
+    expect(summary).toMatchObject({
+      bound: true,
+      htmlUrl: "https://github.com/acme-org/acme-context-tree",
+      name: "acme-context-tree",
+      owner: "acme-org",
+    });
+    expect(summary.coverage).toMatchObject({
+      appSettingsUrl: "https://github.com/organizations/acme-org/settings/installations/123",
+      status: "guided",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://server.example/api/v1/orgs/org_1/settings/context_tree",
+      expect.objectContaining({ method: "PUT" }),
+    );
+  });
+
+  it("continues binding with no installation and warns that snapshots are not covered yet", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const base = makeTempDir();
+    process.chdir(base);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: FetchInput, init?: FetchInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/v1/me")) {
+          return response({ memberships: [{ organizationId: "org_1", role: "admin" }] });
+        }
+        if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree") && init?.method !== "PUT") {
+          return response({ repo: null });
+        }
+        if (url.endsWith("/api/v1/orgs/org_1/context-tree/installation")) {
+          return response("missing", { status: 404 });
+        }
+        if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree") && init?.method === "PUT") {
+          return response("ok");
+        }
+        return response("not found", { status: 404 });
+      }),
+    );
+
+    await initCommand.action(context(commandWithOptions({ bind: true, org: "org_1", title: "Solo" }), true));
+
+    const summary = JSON.parse(String(vi.mocked(console.log).mock.calls.at(-1)?.[0])) as Record<string, unknown>;
+    expect(summary).toMatchObject({
+      bound: true,
+      htmlUrl: "https://github.com/octocat/solo-context-tree",
+      owner: "octocat",
+    });
+    expect(summary.coverage).toMatchObject({ appSettingsUrl: null, status: "no_installation" });
+  });
+
+  it("fails before remote writes when binding preconditions are not satisfied", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const cases: Array<{
+      name: string;
+      command: Command;
+      fetch: (input: FetchInput, init?: FetchInit) => Promise<Response>;
+      message: string;
+    }> = [
+      {
+        name: "non-admin",
+        command: commandWithOptions({ bind: true, org: "org_1", title: "No Admin" }),
+        fetch: async (input) =>
+          String(input).endsWith("/api/v1/me")
+            ? response({ memberships: [{ organizationId: "org_1", role: "member" }] })
+            : response("not found", { status: 404 }),
+        message: "requires admin of org org_1",
+      },
+      {
+        name: "existing binding",
+        command: commandWithOptions({ bind: true, org: "org_1", title: "Existing" }),
+        fetch: async (input) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/me")) {
+            return response({ memberships: [{ organizationId: "org_1", role: "admin" }] });
+          }
+          if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree")) {
+            return response({ repo: "https://github.com/acme/live-tree" });
+          }
+          return response("not found", { status: 404 });
+        },
+        message: "already bound to a Context Tree",
+      },
+      {
+        name: "installation lookup failure",
+        command: commandWithOptions({ bind: true, org: "org_1", title: "Lookup" }),
+        fetch: async (input) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/me")) {
+            return response({ memberships: [{ organizationId: "org_1", role: "admin" }] });
+          }
+          if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree")) {
+            return response({ repo: null });
+          }
+          if (url.endsWith("/api/v1/orgs/org_1/context-tree/installation")) {
+            return response("server down", { status: 500 });
+          }
+          return response("not found", { status: 404 });
+        },
+        message: "Could not read the team's GitHub App installation",
+      },
+      {
+        name: "owner mismatch",
+        command: commandWithOptions({ bind: true, org: "org_1", owner: "octocat", title: "Mismatch" }),
+        fetch: async (input) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/me")) {
+            return response({ memberships: [{ organizationId: "org_1", role: "admin" }] });
+          }
+          if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree")) {
+            return response({ repo: null });
+          }
+          if (url.endsWith("/api/v1/orgs/org_1/context-tree/installation")) {
+            return response({
+              accountLogin: "acme-org",
+              accountType: "Organization",
+              installationId: 456,
+              suspended: false,
+            });
+          }
+          return response("not found", { status: 404 });
+        },
+        message: "does not match this team's GitHub App installation account",
+      },
+    ];
+
+    for (const testCase of cases) {
+      vi.clearAllMocks();
+      vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      mockGithubApi();
+      process.exitCode = undefined;
+      const base = makeTempDir();
+      process.chdir(base);
+      vi.stubGlobal("fetch", vi.fn(testCase.fetch));
+
+      await initCommand.action(context(testCase.command, false));
+
+      expect(process.exitCode, testCase.name).toBe(1);
+      expect(String(vi.mocked(console.error).mock.calls.at(-1)?.[0]), testCase.name).toContain(testCase.message);
+      expect(
+        treeSharedMocks.runCommand.mock.calls.some(
+          ([tool, args]) => tool === "gh" && Array.isArray(args) && args[0] === "repo" && args[1] === "create",
+        ),
+        testCase.name,
+      ).toBe(false);
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("surfaces suspended installation guidance in the final summary", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const base = makeTempDir();
+    process.chdir(base);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: FetchInput, init?: FetchInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/v1/me")) {
+          return response({ memberships: [{ organizationId: "org_1", role: "admin" }] });
+        }
+        if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree") && init?.method !== "PUT") {
+          return response({ repo: null });
+        }
+        if (url.endsWith("/api/v1/orgs/org_1/context-tree/installation")) {
+          return response({
+            accountLogin: "bestony",
+            accountType: "User",
+            installationId: 789,
+            suspended: true,
+          });
+        }
+        if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree") && init?.method === "PUT") {
+          return response("ok");
+        }
+        return response("not found", { status: 404 });
+      }),
+    );
+
+    await initCommand.action(context(commandWithOptions({ bind: true, org: "org_1", title: "Personal" }), true));
+
+    const summary = JSON.parse(String(vi.mocked(console.log).mock.calls.at(-1)?.[0])) as Record<string, unknown>;
+    expect(summary.coverage).toMatchObject({
+      appSettingsUrl: "https://github.com/settings/installations/789",
+      status: "suspended",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/tree-init-command-extra.test.ts
+++ b/apps/cli/src/__tests__/tree-init-command-extra.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Command } from "commander";
@@ -225,6 +225,44 @@ describe("tree init command action", () => {
     expect(summary.coverage).toMatchObject({ appSettingsUrl: null, status: "no_installation" });
   });
 
+  it("prints the human summary for a single-org bind with no GitHub App installation", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const base = makeTempDir();
+    process.chdir(base);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: FetchInput, init?: FetchInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/v1/me")) {
+          return response({ memberships: [{ organizationId: "org_1", role: "admin" }] });
+        }
+        if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree") && init?.method !== "PUT") {
+          return response({ repo: null });
+        }
+        if (url.endsWith("/api/v1/orgs/org_1/context-tree/installation")) {
+          return response("missing", { status: 404 });
+        }
+        if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree") && init?.method === "PUT") {
+          return response("ok");
+        }
+        return response("not found", { status: 404 });
+      }),
+    );
+
+    await initCommand.action(context(commandWithOptions({ bind: true, title: "Solo Human" }), false));
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    expect(process.exitCode).toBeUndefined();
+    expect(output).toContain("Context Tree Init");
+    expect(output).toContain("Repository:   octocat/solo-human-context-tree");
+    expect(output).toContain("GitHub App coverage:");
+    expect(output).toContain("No GitHub App installation is connected");
+    expect(output).toContain("Context Tree created and bound.");
+  });
+
   it("fails before remote writes when binding preconditions are not satisfied", async () => {
     const { initCommand } = await import("../commands/tree/init.js");
     const cases: Array<{
@@ -258,6 +296,21 @@ describe("tree init command action", () => {
         message: "already bound to a Context Tree",
       },
       {
+        name: "binding read failure",
+        command: commandWithOptions({ bind: true, org: "org_1", title: "Binding Read" }),
+        fetch: async (input) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/me")) {
+            return response({ memberships: [{ organizationId: "org_1", role: "admin" }] });
+          }
+          if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree")) {
+            return response("server down", { status: 503 });
+          }
+          return response("not found", { status: 404 });
+        },
+        message: "Could not read the team's current Context Tree binding",
+      },
+      {
         name: "installation lookup failure",
         command: commandWithOptions({ bind: true, org: "org_1", title: "Lookup" }),
         fetch: async (input) => {
@@ -270,6 +323,42 @@ describe("tree init command action", () => {
           }
           if (url.endsWith("/api/v1/orgs/org_1/context-tree/installation")) {
             return response("server down", { status: 500 });
+          }
+          return response("not found", { status: 404 });
+        },
+        message: "Could not read the team's GitHub App installation",
+      },
+      {
+        name: "installation network failure",
+        command: commandWithOptions({ bind: true, org: "org_1", title: "Lookup Network" }),
+        fetch: async (input) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/me")) {
+            return response({ memberships: [{ organizationId: "org_1", role: "admin" }] });
+          }
+          if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree")) {
+            return response({ repo: null });
+          }
+          if (url.endsWith("/api/v1/orgs/org_1/context-tree/installation")) {
+            throw new Error("network down");
+          }
+          return response("not found", { status: 404 });
+        },
+        message: "Could not read the team's GitHub App installation",
+      },
+      {
+        name: "installation invalid body",
+        command: commandWithOptions({ bind: true, org: "org_1", title: "Lookup Invalid" }),
+        fetch: async (input) => {
+          const url = String(input);
+          if (url.endsWith("/api/v1/me")) {
+            return response({ memberships: [{ organizationId: "org_1", role: "admin" }] });
+          }
+          if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree")) {
+            return response({ repo: null });
+          }
+          if (url.endsWith("/api/v1/orgs/org_1/context-tree/installation")) {
+            return response({ installationId: "not-a-number" });
           }
           return response("not found", { status: 404 });
         },
@@ -322,6 +411,184 @@ describe("tree init command action", () => {
       ).toBe(false);
       vi.unstubAllGlobals();
     }
+  });
+
+  it("fails early for missing tools, unauthenticated gh, missing login, and non-empty targets", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const cases: Array<{
+      name: string;
+      command?: Command;
+      runCommand: (tool: string, args: string[]) => string;
+      message: string;
+      setup?: (base: string) => void;
+    }> = [
+      {
+        name: "missing git",
+        runCommand: (tool, args) => {
+          if (tool === "git" && args[0] === "--version") throw new Error("missing git");
+          return "";
+        },
+        message: "`git` is required",
+      },
+      {
+        name: "gh auth",
+        runCommand: (tool, args) => {
+          if (args[0] === "--version") return "";
+          if (tool === "gh" && args[0] === "auth") throw new Error("not logged in");
+          return "";
+        },
+        message: "GitHub CLI is not authenticated",
+      },
+      {
+        name: "missing login",
+        runCommand: (tool, args) => {
+          if (args[0] === "--version" || (tool === "gh" && args[0] === "auth")) return "";
+          if (tool === "gh" && args[0] === "api" && args[1] === "user") return "";
+          return "";
+        },
+        message: "Could not resolve your GitHub login",
+      },
+      {
+        name: "non-empty dir",
+        command: commandWithOptions({ bind: false, dir: "already-here", title: "Busy" }),
+        setup: (base) => {
+          const dir = join(base, "already-here");
+          rmSync(dir, { recursive: true, force: true });
+          mkdirSync(dir, { recursive: true });
+          writeFileSync(join(dir, "README.md"), "busy\n");
+        },
+        runCommand: (tool, args) => {
+          if (args[0] === "--version" || (tool === "gh" && args[0] === "auth")) return "";
+          if (tool === "gh" && args[0] === "api" && args[1] === "user") return "octocat";
+          return "";
+        },
+        message: "Target directory is not empty",
+      },
+    ];
+
+    for (const testCase of cases) {
+      vi.clearAllMocks();
+      vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      process.exitCode = undefined;
+      const base = makeTempDir();
+      process.chdir(base);
+      testCase.setup?.(base);
+      treeSharedMocks.runCommand.mockImplementation(testCase.runCommand);
+
+      await initCommand.action(
+        context(testCase.command ?? commandWithOptions({ bind: false, title: "Broken" }), false),
+      );
+
+      expect(process.exitCode, testCase.name).toBe(1);
+      expect(String(vi.mocked(console.error).mock.calls.at(-1)?.[0]), testCase.name).toContain(testCase.message);
+    }
+  });
+
+  it("fails org resolution before GitHub writes when /me is unusable or ambiguous", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const cases: Array<{ name: string; me: unknown; status?: number; message: string }> = [
+      { name: "me 500", me: "down", status: 500, message: "server returned 500 on /me" },
+      { name: "no orgs", me: { memberships: [] }, message: "don't belong to any organization" },
+      {
+        name: "multiple orgs",
+        me: { memberships: [{ organizationId: "org_1" }, { organizationId: "org_2" }] },
+        message: "Multiple organizations",
+      },
+    ];
+
+    for (const testCase of cases) {
+      vi.clearAllMocks();
+      vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      mockGithubApi();
+      process.exitCode = undefined;
+      const base = makeTempDir();
+      process.chdir(base);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: FetchInput) =>
+          String(input).endsWith("/api/v1/me")
+            ? response(testCase.me, { status: testCase.status ?? 200 })
+            : response("not found", { status: 404 }),
+        ),
+      );
+
+      await initCommand.action(context(commandWithOptions({ bind: true, title: testCase.name }), false));
+
+      expect(process.exitCode, testCase.name).toBe(1);
+      expect(String(vi.mocked(console.error).mock.calls.at(-1)?.[0]), testCase.name).toContain(testCase.message);
+      expect(
+        treeSharedMocks.runCommand.mock.calls.some(
+          ([tool, args]) => tool === "gh" && Array.isArray(args) && args[0] === "repo" && args[1] === "create",
+        ),
+      ).toBe(false);
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("surfaces repo URL lookup and org binding failures after remote create", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const base = makeTempDir();
+    process.chdir(base);
+    treeSharedMocks.runCommand.mockImplementation((tool: string, args: string[]) => {
+      if (args[0] === "--version" || (tool === "gh" && args[0] === "auth" && args[1] === "status")) return "";
+      if (tool === "gh" && args[0] === "api" && args[1] === "user") return "octocat";
+      if (tool === "gh" && args[0] === "api" && typeof args[1] === "string" && args[1].startsWith("repos/")) {
+        return "{}";
+      }
+      return "";
+    });
+
+    await initCommand.action(context(commandWithOptions({ bind: false, title: "Missing Repo Url" }), false));
+    expect(process.exitCode).toBe(1);
+    expect(String(vi.mocked(console.error).mock.calls.at(-1)?.[0])).toContain("could not read its URL");
+
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mockGithubApi();
+    process.exitCode = undefined;
+    process.chdir(makeTempDir());
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: FetchInput, init?: FetchInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/v1/me")) return response({ memberships: [{ organizationId: "org_1", role: "admin" }] });
+        if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree") && init?.method !== "PUT") {
+          return response({ repo: null });
+        }
+        if (url.endsWith("/api/v1/orgs/org_1/context-tree/installation")) return response("missing", { status: 404 });
+        if (url.endsWith("/api/v1/orgs/org_1/settings/context_tree") && init?.method === "PUT") {
+          return response("server refused binding", { status: 500 });
+        }
+        return response("not found", { status: 404 });
+      }),
+    );
+
+    await initCommand.action(context(commandWithOptions({ bind: true, org: "org_1", title: "Bind Fails" }), false));
+    expect(process.exitCode).toBe(1);
+    expect(String(vi.mocked(console.error).mock.calls.at(-1)?.[0])).toContain("binding failed");
+    expect(String(vi.mocked(console.error).mock.calls.at(-1)?.[0])).toContain("server refused binding");
+  });
+
+  it("surfaces unexpected GitHub API response shapes after remote create", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const base = makeTempDir();
+    process.chdir(base);
+    treeSharedMocks.runCommand.mockImplementation((tool: string, args: string[]) => {
+      if (args[0] === "--version" || (tool === "gh" && args[0] === "auth" && args[1] === "status")) return "";
+      if (tool === "gh" && args[0] === "api" && args[1] === "user") return "octocat";
+      if (tool === "gh" && args[0] === "api" && typeof args[1] === "string" && args[1].startsWith("repos/")) {
+        return "null";
+      }
+      return "";
+    });
+
+    await initCommand.action(context(commandWithOptions({ bind: false, title: "Bad Api" }), false));
+
+    expect(process.exitCode).toBe(1);
+    expect(String(vi.mocked(console.error).mock.calls.at(-1)?.[0])).toContain("Unexpected GitHub API response");
   });
 
   it("surfaces suspended installation guidance in the final summary", async () => {

--- a/apps/cli/src/__tests__/tree-init-command-extra.test.ts
+++ b/apps/cli/src/__tests__/tree-init-command-extra.test.ts
@@ -263,6 +263,24 @@ describe("tree init command action", () => {
     expect(output).toContain("Context Tree created and bound.");
   });
 
+  it("prints the human summary for an unbound tree using default title and repo name", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const base = makeTempDir();
+    process.chdir(base);
+
+    await initCommand.action(context(commandWithOptions({ bind: false, withWorkflow: false }), false));
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    expect(process.exitCode).toBeUndefined();
+    expect(output).toContain("Repository:   octocat/octocat-context-tree");
+    expect(output).toContain("Validate CI:  not seeded");
+    expect(output).toContain("Bound to org: no (--no-bind)");
+    expect(output).toContain("Context Tree created.");
+  });
+
   it("fails before remote writes when binding preconditions are not satisfied", async () => {
     const { initCommand } = await import("../commands/tree/init.js");
     const cases: Array<{
@@ -489,6 +507,7 @@ describe("tree init command action", () => {
     const { initCommand } = await import("../commands/tree/init.js");
     const cases: Array<{ name: string; me: unknown; status?: number; message: string }> = [
       { name: "me 500", me: "down", status: 500, message: "server returned 500 on /me" },
+      { name: "missing memberships", me: {}, message: "don't belong to any organization" },
       { name: "no orgs", me: { memberships: [] }, message: "don't belong to any organization" },
       {
         name: "multiple orgs",

--- a/apps/cli/src/__tests__/tree-init-verify-extra.test.ts
+++ b/apps/cli/src/__tests__/tree-init-verify-extra.test.ts
@@ -1,0 +1,114 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommandContext } from "../commands/types.js";
+
+const bootstrapMocks = vi.hoisted(() => ({
+  ensureFreshAccessToken: vi.fn(),
+  resolveServerUrl: vi.fn(),
+}));
+
+const treeSharedMocks = vi.hoisted(() => ({
+  runCommand: vi.fn(),
+}));
+
+const verifyMocks = vi.hoisted(() => ({
+  verifyTreeRoot: vi.fn(),
+}));
+
+vi.mock("../core/bootstrap.js", () => ({
+  ensureFreshAccessToken: bootstrapMocks.ensureFreshAccessToken,
+  resolveServerUrl: bootstrapMocks.resolveServerUrl,
+}));
+
+vi.mock("../commands/tree/shared.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../commands/tree/shared.js")>();
+  return {
+    ...actual,
+    runCommand: treeSharedMocks.runCommand,
+  };
+});
+
+vi.mock("../commands/tree/verify.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../commands/tree/verify.js")>();
+  return {
+    ...actual,
+    verifyTreeRoot: verifyMocks.verifyTreeRoot,
+  };
+});
+
+const originalCwd = process.cwd();
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ft-tree-init-verify-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function commandWithOptions(options: Record<string, unknown>): Command {
+  const command = new Command("init");
+  for (const [key, value] of Object.entries(options)) {
+    command.setOptionValue(key, value);
+  }
+  return command;
+}
+
+function context(command: Command): CommandContext {
+  return { command, options: { debug: false, json: false, quiet: false } };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  process.exitCode = undefined;
+  bootstrapMocks.resolveServerUrl.mockReturnValue("https://server.example");
+  bootstrapMocks.ensureFreshAccessToken.mockResolvedValue("access-token");
+  treeSharedMocks.runCommand.mockImplementation((tool: string, args: string[]) => {
+    if (args[0] === "--version" || (tool === "gh" && args[0] === "auth" && args[1] === "status")) return "";
+    if (tool === "gh" && args[0] === "api" && args[1] === "user") return "octocat";
+    if (tool === "gh" && args[0] === "api" && typeof args[1] === "string" && args[1].startsWith("repos/")) {
+      return JSON.stringify({ html_url: `https://github.com/${args[1].slice("repos/".length)}` });
+    }
+    return "";
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.chdir(originalCwd);
+  process.exitCode = undefined;
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("tree init verify failure", () => {
+  it("stops before remote creation when the scaffolded tree does not verify", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const base = makeTempDir();
+    process.chdir(base);
+    verifyMocks.verifyTreeRoot.mockReturnValue({
+      ok: false,
+      checks: {
+        nodes: { ok: false, errors: ["NODE.md: missing title", "members/alice/NODE.md: missing role"] },
+        members: { ok: true, errors: [] },
+      },
+    });
+
+    await initCommand.action(context(commandWithOptions({ bind: false, title: "Broken" })));
+
+    expect(process.exitCode).toBe(1);
+    expect(String(vi.mocked(console.error).mock.calls.at(-1)?.[0])).toContain("Scaffolded tree failed `tree verify`");
+    expect(String(vi.mocked(console.error).mock.calls.at(-1)?.[0])).toContain("members/alice/NODE.md: missing role");
+    expect(
+      treeSharedMocks.runCommand.mock.calls.some(
+        ([tool, args]) => tool === "gh" && Array.isArray(args) && args[0] === "repo" && args[1] === "create",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/cli/src/__tests__/tree-init-verify-extra.test.ts
+++ b/apps/cli/src/__tests__/tree-init-verify-extra.test.ts
@@ -111,4 +111,36 @@ describe("tree init verify failure", () => {
       ),
     ).toBe(false);
   });
+
+  it("stringifies non-Error failures from the init action", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const base = makeTempDir();
+    process.chdir(base);
+    verifyMocks.verifyTreeRoot.mockImplementation(() => {
+      throw "verify exploded";
+    });
+
+    await initCommand.action(context(commandWithOptions({ bind: false, title: "String Failure" })));
+
+    expect(process.exitCode).toBe(1);
+    expect(String(vi.mocked(console.error).mock.calls.at(-1)?.[0])).toBe("verify exploded");
+  });
+
+  it("collects verify failures even when a check omits its error list", async () => {
+    const { initCommand } = await import("../commands/tree/init.js");
+    const base = makeTempDir();
+    process.chdir(base);
+    verifyMocks.verifyTreeRoot.mockReturnValue({
+      ok: false,
+      checks: {
+        nodes: { ok: false },
+        members: { ok: false, errors: ["members missing"] },
+      },
+    } as unknown as ReturnType<typeof import("../commands/tree/verify.js").verifyTreeRoot>);
+
+    await initCommand.action(context(commandWithOptions({ bind: false, title: "Partial Errors" })));
+
+    expect(process.exitCode).toBe(1);
+    expect(String(vi.mocked(console.error).mock.calls.at(-1)?.[0])).toContain("members missing");
+  });
 });

--- a/apps/cli/src/__tests__/tree-init.test.ts
+++ b/apps/cli/src/__tests__/tree-init.test.ts
@@ -2,7 +2,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildScaffoldFiles, defaultRepoName, resolveRepoOwner, type ScaffoldFile } from "../commands/tree/init.js";
 import {
   memberNodeContent,
@@ -11,7 +12,8 @@ import {
   validateTreeWorkflowContent,
 } from "../commands/tree/scaffold-templates.js";
 import { renderContextTree } from "../commands/tree/tree.js";
-import { verifyTreeRoot } from "../commands/tree/verify.js";
+import { verifyCommand, verifyTreeRoot } from "../commands/tree/verify.js";
+import type { CommandContext } from "../commands/types.js";
 
 /**
  * `first-tree tree init` scaffolds a brand-new team Context Tree repo with the
@@ -23,6 +25,7 @@ import { verifyTreeRoot } from "../commands/tree/verify.js";
  */
 
 const tempDirs: string[] = [];
+const originalCwd = process.cwd();
 
 function makeTempDir(): string {
   const dir = mkdtempSync(join(tmpdir(), "ft-tree-init-"));
@@ -39,6 +42,9 @@ function writeScaffold(dir: string, files: ScaffoldFile[]): void {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
+  process.chdir(originalCwd);
+  process.exitCode = undefined;
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (dir) {
@@ -68,6 +74,51 @@ describe("buildScaffoldFiles", () => {
     const dir = makeTempDir();
     writeScaffold(dir, buildScaffoldFiles({ title: "Acme", ownerLogin: "octocat", withWorkflow: false }));
     expect(verifyTreeRoot(dir).ok).toBe(true);
+  });
+
+  it("reports root NODE frontmatter problems", () => {
+    const missingFrontmatter = makeTempDir();
+    writeFileSync(join(missingFrontmatter, "NODE.md"), "# Root\n");
+    mkdirSync(join(missingFrontmatter, "members"), { recursive: true });
+    const missingFrontmatterResult = verifyTreeRoot(missingFrontmatter);
+    expect(missingFrontmatterResult.ok).toBe(false);
+    expect(missingFrontmatterResult.checks.rootNodeFrontmatter.errors).toContain(
+      "Root NODE.md is missing frontmatter.",
+    );
+
+    const missingTitle = makeTempDir();
+    writeFileSync(join(missingTitle, "NODE.md"), "---\nowners: [octocat]\n---\n# Root\n");
+    mkdirSync(join(missingTitle, "members"), { recursive: true });
+    const missingTitleResult = verifyTreeRoot(missingTitle);
+    expect(missingTitleResult.ok).toBe(false);
+    expect(missingTitleResult.checks.rootNodeFrontmatter.errors).toContain("Root NODE.md is missing a title.");
+  });
+
+  it("reports missing root frontmatter when NODE.md cannot be read as a file", () => {
+    const unreadableRootNode = makeTempDir();
+    mkdirSync(join(unreadableRootNode, "NODE.md"), { recursive: true });
+    mkdirSync(join(unreadableRootNode, "members"), { recursive: true });
+
+    const result = verifyTreeRoot(unreadableRootNode);
+
+    expect(result.ok).toBe(false);
+    expect(result.checks.rootNodeFrontmatter.errors).toContain("Root NODE.md is missing frontmatter.");
+  });
+
+  it("uses the current repo root when tree verify omits --tree-path", () => {
+    const dir = makeTempDir();
+    writeScaffold(dir, buildScaffoldFiles({ title: "Acme", ownerLogin: "octocat", withWorkflow: false }));
+    process.chdir(dir);
+    const command = new Command("verify");
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    verifyCommand.action({
+      command,
+      options: { debug: false, json: false, quiet: false },
+    } satisfies CommandContext);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(log.mock.calls.map((call) => String(call[0])).join("\n")).toContain("All checks passed.");
   });
 
   it("still passes verify with the validate-tree workflow seeded", () => {

--- a/apps/cli/src/__tests__/tree-shared-extra.test.ts
+++ b/apps/cli/src/__tests__/tree-shared-extra.test.ts
@@ -1,0 +1,174 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  asString,
+  discoverWorkspaceRepos,
+  ensureTrailingNewline,
+  findGitRoot,
+  isGitRepoRoot,
+  isRecord,
+  normalizeRemoteForMatch,
+  parseGitHubRemoteUrl,
+  readGitRemoteUrl,
+  readJson,
+  repoNameForRoot,
+  resolveRepoRoot,
+  runCommand,
+  slugifyToken,
+  writeJson,
+} from "../commands/tree/shared.js";
+
+const tempDirs: string[] = [];
+const originalGitDir = process.env.GIT_DIR;
+const originalGitWorkTree = process.env.GIT_WORK_TREE;
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ft-tree-shared-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+afterEach(() => {
+  if (originalGitDir === undefined) {
+    delete process.env.GIT_DIR;
+  } else {
+    process.env.GIT_DIR = originalGitDir;
+  }
+  if (originalGitWorkTree === undefined) {
+    delete process.env.GIT_WORK_TREE;
+  } else {
+    process.env.GIT_WORK_TREE = originalGitWorkTree;
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("tree shared primitives", () => {
+  it("normalizes simple values and GitHub remotes", () => {
+    expect(ensureTrailingNewline("")).toBe("");
+    expect(ensureTrailingNewline("hello")).toBe("hello\n");
+    expect(ensureTrailingNewline("hello\n")).toBe("hello\n");
+    expect(isRecord({ ok: true })).toBe(true);
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord("nope")).toBe(false);
+    expect(asString("value")).toBe("value");
+    expect(asString("")).toBeUndefined();
+    expect(asString(1)).toBeUndefined();
+    expect(slugifyToken("  Acme API!! ")).toBe("acme-api");
+    expect(slugifyToken("!!!")).toBe("workspace");
+
+    expect(parseGitHubRemoteUrl(" https://github.com/Owner/Repo.git ")).toEqual({
+      host: "github.com",
+      owner: "Owner",
+      repo: "Repo",
+    });
+    expect(parseGitHubRemoteUrl("git@github.com:Owner/Repo.git")).toEqual({
+      host: "github.com",
+      owner: "Owner",
+      repo: "Repo",
+    });
+    expect(parseGitHubRemoteUrl("ssh://git@github.example/Owner/Repo.git")).toEqual({
+      host: "github.example",
+      owner: "Owner",
+      repo: "Repo",
+    });
+    expect(parseGitHubRemoteUrl("")).toBeNull();
+    expect(parseGitHubRemoteUrl("not a remote")).toBeNull();
+    expect(normalizeRemoteForMatch("https://github.com/Owner/Repo.git")).toBe("github.com/owner/repo");
+    expect(normalizeRemoteForMatch("local.git")).toBe("local");
+  });
+
+  it("reads and writes JSON defensively", () => {
+    const root = makeTempDir();
+    const path = join(root, "nested", "value.json");
+
+    expect(readJson(path)).toBeUndefined();
+    mkdirSync(path, { recursive: true });
+    expect(readJson(path)).toBeUndefined();
+    rmSync(path, { recursive: true, force: true });
+    writeFileSync(path, "{broken", "utf8");
+    expect(readJson(path)).toBeUndefined();
+
+    writeJson(path, { ok: true, value: 3 });
+    expect(readJson(path)).toEqual({ ok: true, value: 3 });
+  });
+
+  it("runs commands with git environment variables stripped", () => {
+    const root = makeTempDir();
+    process.env.GIT_DIR = "leaked";
+    process.env.GIT_WORK_TREE = "leaked";
+
+    const out = runCommand(
+      process.execPath,
+      ["-e", "console.log((process.env.GIT_DIR || 'clean') + ':' + (process.env.GIT_WORK_TREE || 'clean'))"],
+      root,
+    );
+
+    expect(out).toBe("clean:clean");
+  });
+
+  it("resolves git roots, repo names, and remotes", () => {
+    const root = makeTempDir();
+    const repo = join(root, "repo");
+    const nested = join(repo, "a", "b");
+    mkdirSync(nested, { recursive: true });
+    git(repo, "init", "-b", "main");
+    git(repo, "remote", "add", "origin", "git@github.com:Acme/App.git");
+
+    expect(isGitRepoRoot(repo)).toBe(true);
+    expect(isGitRepoRoot(root)).toBe(false);
+    expect(findGitRoot(nested)).toBe(resolve(repo));
+    expect(resolveRepoRoot(nested)).toBe(resolve(repo));
+    expect(resolveRepoRoot(root)).toBe(resolve(root));
+    expect(repoNameForRoot(repo)).toBe("repo");
+    expect(repoNameForRoot("/")).toBe("repo");
+    expect(readGitRemoteUrl(repo)).toBe("git@github.com:Acme/App.git");
+    expect(readGitRemoteUrl(root)).toBeUndefined();
+  });
+
+  it("discovers nested git repositories while skipping generated directories", () => {
+    const root = makeTempDir();
+    const workspace = join(root, "workspace");
+    const app = join(workspace, "packages", "app");
+    const docs = join(workspace, "docs");
+    const ignored = join(workspace, "node_modules", "dep");
+    const filePath = join(workspace, "README.md");
+    mkdirSync(app, { recursive: true });
+    mkdirSync(docs, { recursive: true });
+    mkdirSync(ignored, { recursive: true });
+    writeFileSync(filePath, "# workspace\n", "utf8");
+    git(workspace, "init", "-b", "main");
+    git(app, "init", "-b", "main");
+    git(docs, "init", "-b", "main");
+    git(ignored, "init", "-b", "main");
+
+    expect(discoverWorkspaceRepos(workspace)).toEqual([
+      {
+        kind: "nested-git-repo",
+        name: "docs",
+        relativePath: "docs",
+        root: resolve(docs),
+      },
+      {
+        kind: "nested-git-repo",
+        name: "app",
+        relativePath: "packages/app",
+        root: resolve(app),
+      },
+    ]);
+    expect(discoverWorkspaceRepos(join(root, "missing"))).toEqual([]);
+  });
+});

--- a/apps/cli/src/__tests__/tree-tree-command.test.ts
+++ b/apps/cli/src/__tests__/tree-tree-command.test.ts
@@ -1,11 +1,16 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { parseTreeLevel, renderContextTree, runTreeTreeCommand } from "../commands/tree/tree.js";
+import {
+  parseTreeLevel,
+  readContextTreeSnapshot,
+  renderContextTree,
+  runTreeTreeCommand,
+} from "../commands/tree/tree.js";
 import type { CommandContext } from "../commands/types.js";
 import { setJsonMode } from "../core/output.js";
 
@@ -57,12 +62,16 @@ function makeTreeFixture(): string {
   const missingTitle = join(root, "missing-title");
   const missingOwners = join(root, "missing-owners");
   const emptyOwners = join(root, "empty-owners");
+  const arrayFrontmatter = join(root, "array-frontmatter");
+  const scalarFrontmatter = join(root, "scalar-frontmatter");
   const scratch = join(root, "scratch");
 
   mkdirSync(deep, { recursive: true });
   mkdirSync(missingTitle, { recursive: true });
   mkdirSync(missingOwners, { recursive: true });
   mkdirSync(emptyOwners, { recursive: true });
+  mkdirSync(arrayFrontmatter, { recursive: true });
+  mkdirSync(scalarFrontmatter, { recursive: true });
   mkdirSync(scratch, { recursive: true });
 
   writeNode(root, "Root Node", "Root description");
@@ -77,9 +86,12 @@ function makeTreeFixture(): string {
   writeMarkdown(join(missingTitle, "NODE.md"), "owners: [alice]\n");
   writeMarkdown(join(missingOwners, "NODE.md"), "title: Missing Owners\n");
   writeMarkdown(join(emptyOwners, "NODE.md"), "title: Empty Owners\nowners: []\n");
+  writeFileSync(join(arrayFrontmatter, "NODE.md"), "---\n[]\n---\n# Invalid\n");
+  writeFileSync(join(scalarFrontmatter, "NODE.md"), "---\ntrue\n---\n# Invalid\n");
   writeMarkdown(join(development, "missing-title.md"), "owners: [alice]\n");
   writeMarkdown(join(development, "missing-owners.md"), "title: Missing Owners Leaf\n");
   writeMarkdown(join(development, "empty-owners.md"), "title: Empty Owners Leaf\nowners: []\n");
+  writeMarkdown(join(development, "numeric-owner.md"), "title: Numeric Owner\nowners: [alice, 3]\n");
   writeLeaf(join(scratch, "note.md"), "Scratch Note", "Temporary details");
   writeFileSync(join(development, "notes.txt"), "not markdown\n");
   writeFileSync(join(root, "AGENTS.md"), frontmatter("title: Should Skip Agents\nowners: [alice]\n"));
@@ -243,6 +255,8 @@ describe("tree tree renderer", () => {
 
     expect(output).not.toContain("Missing");
     expect(output).not.toContain("Empty Owners");
+    expect(output).not.toContain("array-frontmatter");
+    expect(output).not.toContain("scalar-frontmatter");
     expect(output).not.toContain("Scratch Note");
     expect(output).not.toContain("notes.txt");
     expect(output).not.toContain("Should Skip");
@@ -256,9 +270,69 @@ describe("tree tree renderer", () => {
     expect(output).not.toContain(".next");
     expect(output).not.toContain(".turbo");
   });
+
+  it("rejects roots and targets that are not valid Context Tree directories", () => {
+    const root = makeTreeFixture();
+    const plainDir = makeTempDir("ft-tree-empty-");
+    const plainFile = join(makeTempDir("ft-tree-file-"), "plain.txt");
+    writeFileSync(plainFile, "not a directory");
+
+    expect(() => readContextTreeSnapshot(plainDir)).toThrow("No valid Context Tree root node found");
+    expect(() => readContextTreeSnapshot(plainFile)).toThrow('Path "." is not an existing directory.');
+    expect(() => readContextTreeSnapshot(root, { target: "scratch" })).toThrow(
+      'Target path "scratch" is not a valid Context Tree directory node.',
+    );
+    expect(() => readContextTreeSnapshot(root, { target: ".." })).toThrow('Path ".." is outside the git repository.');
+  });
+
+  it("supports wildcard question marks and parseTreeLevel edge values", () => {
+    const root = makeTreeFixture();
+
+    expect(parseTreeLevel(undefined)).toBeUndefined();
+    expect(() => parseTreeLevel("9007199254740993")).toThrow("Invalid --level");
+    expect(renderContextTree(root, { pattern: "H??P*" })).toContain(
+      "docs/development/http.md [HTTP Leaf] -> HTTP routes",
+    );
+  });
+
+  it("keeps a readable root node when child directory enumeration fails", () => {
+    const root = makeTreeFixture();
+
+    chmodSync(root, 0o300);
+    try {
+      const snapshot = readContextTreeSnapshot(root);
+      expect(snapshot.tree.metadata.title).toBe("Root Node");
+      expect(snapshot.tree.children).toEqual([]);
+    } finally {
+      chmodSync(root, 0o700);
+    }
+  });
 });
 
 describe("tree tree command action", () => {
+  it("rejects paths outside any git repository", () => {
+    const root = makeTempDir("ft-tree-no-git-");
+    writeNode(root, "Root Node", "Root description");
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null): never => {
+      throw new ProcessExit(typeof code === "number" ? code : 0);
+    });
+    process.chdir(root);
+
+    expect(() => runTreeTreeCommand(context(commandWithOptions({})))).toThrow(ProcessExit);
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(readMockOutput(stdout)).toBe("");
+    expect(JSON.parse(readMockOutput(stderr))).toEqual({
+      ok: false,
+      error: {
+        code: "TREE_TREE_INVALID_PATH",
+        message: "Path must be inside a git repository.",
+      },
+    });
+  });
+
   it("prints the selected subtree with repo-root ancestor context in human mode", () => {
     const root = makeTreeFixture();
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
@@ -321,6 +395,22 @@ describe("tree tree command action", () => {
     );
   });
 
+  it("uses a detached short SHA branch label when origin/main is absent", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const shortSha = git(root, "rev-parse", "--short", "HEAD");
+    git(root, "checkout", "--detach", "HEAD");
+    process.chdir(root);
+
+    runTreeTreeCommand(context(commandWithOptions({}, ["docs/development"])));
+
+    const output = readMockOutput(stderr);
+    expect(readMockOutput(stdout)).toBe("");
+    expect(output).toContain(`Branch: detached:${shortSha}`);
+    expect(output).toContain(`Warning: current branch "detached:${shortSha}" is not main/master`);
+  });
+
   it("warns when the current tree branch is not mainline", () => {
     const root = makeTreeFixture();
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
@@ -336,6 +426,22 @@ describe("tree tree command action", () => {
     expect(output).toContain(
       'Warning: current branch "feature/stale-tree" is not main/master; it may be stale. Switch to main/master.',
     );
+  });
+
+  it("uses unknown branch metadata when git branch inspection fails", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    rmSync(join(root, ".git"), { recursive: true, force: true });
+    writeFileSync(join(root, ".git"), "not a gitfile\n");
+    process.chdir(root);
+
+    runTreeTreeCommand(context(commandWithOptions({}, ["docs/development"])));
+
+    const output = readMockOutput(stderr);
+    expect(readMockOutput(stdout)).toBe("");
+    expect(output).toContain("Branch: unknown");
+    expect(output).toContain('Warning: current branch "unknown" is not main/master');
   });
 
   it("treats a non-numeric -L value as a path only when no positional path is present", () => {
@@ -569,6 +675,27 @@ describe("tree tree command action", () => {
     });
   });
 
+  it("rejects excess positional paths and non-string level values", () => {
+    const root = makeTreeFixture();
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null): never => {
+      throw new ProcessExit(typeof code === "number" ? code : 0);
+    });
+    process.chdir(root);
+
+    expect(() => runTreeTreeCommand(context(commandWithOptions({}, ["docs", "development"])))).toThrow(ProcessExit);
+    expect(() => runTreeTreeCommand(context(commandWithOptions({ level: 1 })))).toThrow(ProcessExit);
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(readMockOutput(stdout)).toBe("");
+    const errors = readMockOutput(stderr)
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { error: { code: string; message: string } });
+    expect(errors.map((entry) => entry.error.code)).toEqual(["TREE_TREE_INVALID_PATH", "TREE_TREE_INVALID_LEVEL"]);
+  });
+
   it("rejects repo-outside paths with a stable error envelope", () => {
     const root = makeTreeFixture();
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
@@ -586,6 +713,30 @@ describe("tree tree command action", () => {
       error: {
         code: "TREE_TREE_INVALID_PATH",
         message: 'Path ".." is outside the git repository.',
+      },
+    });
+  });
+
+  it("reports generic tree read failures with TREE_TREE_FAILED", () => {
+    const root = makeTempDir("ft-tree-invalid-root-");
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null): never => {
+      throw new ProcessExit(typeof code === "number" ? code : 0);
+    });
+    git(root, "init", "-b", "main");
+    writeFileSync(join(root, "README.md"), "# no context tree\n");
+    process.chdir(root);
+
+    expect(() => runTreeTreeCommand(context(commandWithOptions({ pull: false })))).toThrow(ProcessExit);
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(readMockOutput(stdout)).toBe("");
+    expect(JSON.parse(readMockOutput(stderr))).toEqual({
+      ok: false,
+      error: {
+        code: "TREE_TREE_FAILED",
+        message: "No valid Context Tree root node found at NODE.md.",
       },
     });
   });

--- a/apps/cli/src/__tests__/tree-tree-command.test.ts
+++ b/apps/cli/src/__tests__/tree-tree-command.test.ts
@@ -219,6 +219,15 @@ describe("tree tree renderer", () => {
     );
   });
 
+  it("rejects a target that resolves outside the repository through a symlink", () => {
+    const root = makeTreeFixture();
+    const outside = makeTempDir("ft-tree-outside-");
+    mkdirSync(join(outside, "escape"), { recursive: true });
+    symlinkSync(join(outside, "escape"), join(root, "linked-outside"), "dir");
+
+    expect(() => readContextTreeSnapshot(root, { target: "linked-outside" })).toThrow("outside the git repository");
+  });
+
   it("matches patterns against relative path, filename, title, and description while preserving ancestors", () => {
     const root = makeTreeFixture();
 
@@ -269,6 +278,19 @@ describe("tree tree renderer", () => {
     expect(output).not.toContain("build/");
     expect(output).not.toContain(".next");
     expect(output).not.toContain(".turbo");
+  });
+
+  it("treats blank optional metadata as absent", () => {
+    const root = makeTreeFixture();
+    const blank = join(root, "blank-description");
+    mkdirSync(blank, { recursive: true });
+    writeFileSync(
+      join(blank, "NODE.md"),
+      `${frontmatter("title: Blank Description\nowners: [alice]\ndescription: '   '\n")}# Blank\n`,
+    );
+
+    expect(renderContextTree(root)).toContain("blank-description/ [Blank Description]\n");
+    expect(renderContextTree(root)).not.toContain("Blank Description] ->");
   });
 
   it("rejects roots and targets that are not valid Context Tree directories", () => {
@@ -737,6 +759,32 @@ describe("tree tree command action", () => {
       error: {
         code: "TREE_TREE_FAILED",
         message: "No valid Context Tree root node found at NODE.md.",
+      },
+    });
+  });
+
+  it("stringifies non-Error command failures", () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null): never => {
+      throw new ProcessExit(typeof code === "number" ? code : 0);
+    });
+    const command = {
+      opts: () => {
+        throw "option parser failed";
+      },
+      args: [],
+    } as unknown as Command;
+
+    expect(() => runTreeTreeCommand(context(command))).toThrow(ProcessExit);
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(readMockOutput(stdout)).toBe("");
+    expect(JSON.parse(readMockOutput(stderr))).toEqual({
+      ok: false,
+      error: {
+        code: "TREE_TREE_FAILED",
+        message: "option parser failed",
       },
     });
   });

--- a/apps/cli/src/__tests__/update-detect-install-mode.test.ts
+++ b/apps/cli/src/__tests__/update-detect-install-mode.test.ts
@@ -75,6 +75,16 @@ describe("detectInstallMode", () => {
     expect(detectInstallMode(argv1, "first-tree")).toBe("npx");
   });
 
+  it("falls back to npx when process.argv[1] is absent", () => {
+    const originalArgv1 = process.argv[1];
+    try {
+      process.argv[1] = undefined as unknown as string;
+      expect(detectInstallMode(undefined, "first-tree")).toBe("npx");
+    } finally {
+      process.argv[1] = originalArgv1;
+    }
+  });
+
   it("classifies a global install as 'global' when invoked through a symlinked bin/", () => {
     // Regression: standard `npm i -g` lays the binary out as
     // `<prefix>/bin/<name> -> ../lib/node_modules/<pkg>/dist/cli/index.mjs`.

--- a/apps/cli/src/__tests__/update-global-extra.test.ts
+++ b/apps/cli/src/__tests__/update-global-extra.test.ts
@@ -6,10 +6,16 @@ const registrySpawnMock = vi.hoisted(() => vi.fn());
 const cliFetchMock = vi.hoisted(() => vi.fn());
 const resolveServerUrlMock = vi.hoisted(() => vi.fn());
 const classifyMock = vi.hoisted(() => vi.fn());
+const existsSyncMock = vi.hoisted(() => vi.fn((_path?: unknown) => false));
 
 vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
   return { ...actual, spawnSync: spawnSyncMock };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, existsSync: existsSyncMock };
 });
 
 vi.mock("@first-tree/client", () => ({
@@ -62,6 +68,7 @@ function jsonResponse(body: unknown, ok = true, status = 200): Response {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  existsSyncMock.mockReturnValue(false);
   classifyMock.mockReturnValue({ kind: "permanent", reasonCode: "classified" });
   resolveServerUrlMock.mockReturnValue("https://hub.example///");
 });
@@ -87,6 +94,20 @@ describe("global update helpers", () => {
       expect(result.reason).toContain("requires Node >=999.0.0");
       expect(result.reason).toContain("prod/install.sh");
     }
+
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      stdout: JSON.stringify({ engines: { node: ">=999.0.0" } }),
+      stderr: "",
+    });
+    const nested = await installGlobalSpec("1.2.4");
+
+    expect(nested).toMatchObject({
+      ok: false,
+      mode: "global",
+      retryable: false,
+      reasonCode: "npm_ebadengine",
+    });
   });
 
   it("runs npm install through the child registry and parses installed versions", async () => {
@@ -108,6 +129,29 @@ describe("global update helpers", () => {
       ["install", "-g", "first-tree@latest"],
       expect.objectContaining({ category: "npm-install", timeoutMs: 300_000 }),
     );
+  });
+
+  it("prefers sibling npm, tolerates empty engine stdout, and keeps non-semver installed labels", async () => {
+    existsSyncMock.mockImplementation((path: unknown) => String(path).endsWith("/npm") || String(path).endsWith("\\npm.cmd"));
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stderr: "" });
+    const child = new FakeChild();
+    registrySpawnMock.mockReturnValueOnce({ child });
+    const { installGlobalSpec } = await import("../core/update.js");
+
+    const installing = installGlobalSpec("latest");
+    child.stdout.emit("data", Buffer.from("+ first-tree@latest)\n"));
+    child.emit("exit", 0, null);
+
+    await expect(installing).resolves.toEqual({ ok: true, mode: "global", installedVersion: "latest" });
+    expect(registrySpawnMock.mock.calls[0]?.[0]).toMatch(/npm(?:\.cmd)?$/);
+
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: JSON.stringify({ engines: {} }), stderr: "" });
+    const secondChild = new FakeChild();
+    registrySpawnMock.mockReturnValueOnce({ child: secondChild });
+    const second = installGlobalSpec("latest");
+    secondChild.stdout.emit("data", Buffer.from("+ first-tree@1.2.5\n"));
+    secondChild.emit("exit", 0, null);
+    await expect(second).resolves.toEqual({ ok: true, mode: "global", installedVersion: "1.2.5" });
   });
 
   it("classifies npm child errors and timeout exits", async () => {
@@ -137,6 +181,24 @@ describe("global update helpers", () => {
     });
   });
 
+  it("stringifies non-Error npm child failures", async () => {
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: "null", stderr: "" });
+    classifyMock.mockReturnValueOnce({ kind: "transient", reasonCode: "string_failure" });
+    const child = new FakeChild();
+    registrySpawnMock.mockReturnValueOnce({ child });
+    const { installGlobalSpec } = await import("../core/update.js");
+
+    const installing = installGlobalSpec("latest");
+    child.emit("error", "spawn failed as string");
+
+    await expect(installing).resolves.toMatchObject({
+      ok: false,
+      reason: "spawn failed as string",
+      retryable: true,
+      reasonCode: "string_failure",
+    });
+  });
+
   it("returns shaped latest-version and server-version failures", async () => {
     spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "not-semver", stderr: "" });
     const { fetchLatestVersion, fetchServerCommandVersion } = await import("../core/update.js");
@@ -146,13 +208,27 @@ describe("global update helpers", () => {
       reason: "npm view returned non-semver value: not-semver",
     });
 
+    spawnSyncMock.mockReturnValueOnce({ status: 7, stdout: "", stderr: "   " });
+    expect(fetchLatestVersion()).toEqual({
+      ok: false,
+      reason: "npm view exited with code 7",
+    });
+
     resolveServerUrlMock.mockImplementationOnce(() => {
       throw new Error("missing server");
     });
     await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: false, reason: "missing server" });
 
+    resolveServerUrlMock.mockImplementationOnce(() => {
+      throw "missing server string";
+    });
+    await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: false, reason: "missing server string" });
+
     cliFetchMock.mockRejectedValueOnce(new Error("network down"));
     await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: false, reason: "network down" });
+
+    cliFetchMock.mockRejectedValueOnce("network string");
+    await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: false, reason: "network string" });
 
     cliFetchMock.mockResolvedValueOnce(jsonResponse("nope", false, 503));
     await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: false, reason: "server returned HTTP 503" });
@@ -169,6 +245,18 @@ describe("global update helpers", () => {
       reason: "server returned invalid JSON: bad json",
     });
 
+    cliFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: vi.fn(async () => {
+        throw "bad json string";
+      }),
+    } as unknown as Response);
+    await expect(fetchServerCommandVersion()).resolves.toEqual({
+      ok: false,
+      reason: "server returned invalid JSON: bad json string",
+    });
+
     cliFetchMock.mockResolvedValueOnce(jsonResponse(null));
     await expect(fetchServerCommandVersion()).resolves.toEqual({
       ok: false,
@@ -180,5 +268,14 @@ describe("global update helpers", () => {
       ok: false,
       reason: "server did not provide serverCommandVersion",
     });
+
+    cliFetchMock.mockResolvedValueOnce(jsonResponse({ serverCommandVersion: "not-semver" }));
+    await expect(fetchServerCommandVersion()).resolves.toEqual({
+      ok: false,
+      reason: "server returned non-semver version: not-semver",
+    });
+
+    cliFetchMock.mockResolvedValueOnce(jsonResponse({ serverCommandVersion: "1.2.3" }));
+    await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: true, version: "1.2.3" });
   });
 });

--- a/apps/cli/src/__tests__/update-global-extra.test.ts
+++ b/apps/cli/src/__tests__/update-global-extra.test.ts
@@ -1,0 +1,184 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+const registrySpawnMock = vi.hoisted(() => vi.fn());
+const cliFetchMock = vi.hoisted(() => vi.fn());
+const resolveServerUrlMock = vi.hoisted(() => vi.fn());
+const classifyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawnSync: spawnSyncMock };
+});
+
+vi.mock("@first-tree/client", () => ({
+  ERROR_KINDS: { TRANSIENT: "transient", PERMANENT: "permanent" },
+  classify: classifyMock,
+  getChildProcessRegistry: () => ({ spawn: registrySpawnMock }),
+}));
+
+vi.mock("../core/bootstrap.js", () => ({
+  resolveServerUrl: resolveServerUrlMock,
+}));
+
+vi.mock("../core/cli-fetch.js", () => ({
+  cliFetch: cliFetchMock,
+}));
+
+vi.mock("../core/channel.js", () => ({
+  channelConfig: {
+    channel: "prod",
+    binName: "first-tree",
+    aliasName: "ft",
+    packageName: "first-tree",
+    defaultHome: "/tmp/home",
+    defaultServerUrl: "https://cloud.first-tree.ai",
+    serviceUnitFile: "first-tree.service",
+    launchdLabel: "first-tree",
+    launchdPlistFile: "first-tree.plist",
+    displayName: "First Tree",
+    portable: {
+      channelPrefix: "prod",
+      publicInstallerPath: "prod/install.sh",
+      downloadBaseUrl: "https://download.first-tree.ai/releases/",
+    },
+  },
+}));
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: vi.fn(async () => body),
+    text: vi.fn(async () => (typeof body === "string" ? body : JSON.stringify(body))),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  classifyMock.mockReturnValue({ kind: "permanent", reasonCode: "classified" });
+  resolveServerUrlMock.mockReturnValue("https://hub.example///");
+});
+
+describe("global update helpers", () => {
+  it("rejects npm targets whose engine metadata excludes the current Node", async () => {
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      stdout: JSON.stringify({ "engines.node": ">=999.0.0" }),
+      stderr: "",
+    });
+    const { installGlobalSpec } = await import("../core/update.js");
+
+    const result = await installGlobalSpec("1.2.3");
+
+    expect(result).toMatchObject({
+      ok: false,
+      mode: "global",
+      retryable: false,
+      reasonCode: "npm_ebadengine",
+    });
+    if (!result.ok) {
+      expect(result.reason).toContain("requires Node >=999.0.0");
+      expect(result.reason).toContain("prod/install.sh");
+    }
+  });
+
+  it("runs npm install through the child registry and parses installed versions", async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "null", stderr: "" });
+    const child = new FakeChild();
+    registrySpawnMock.mockReturnValueOnce({ child });
+    const output = vi.fn();
+    const { installGlobalSpec } = await import("../core/update.js");
+
+    const installing = installGlobalSpec("latest", { output });
+    child.stdout.emit("data", Buffer.from("+ first-tree@1.2.3\n"));
+    child.stderr.emit("data", Buffer.from("progress\n"));
+    child.emit("exit", 0, null);
+
+    await expect(installing).resolves.toEqual({ ok: true, mode: "global", installedVersion: "1.2.3" });
+    expect(output).toHaveBeenCalledWith("progress\n");
+    expect(registrySpawnMock).toHaveBeenCalledWith(
+      expect.stringMatching(/npm/),
+      ["install", "-g", "first-tree@latest"],
+      expect.objectContaining({ category: "npm-install", timeoutMs: 300_000 }),
+    );
+  });
+
+  it("classifies npm child errors and timeout exits", async () => {
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: "null", stderr: "" });
+    classifyMock.mockReturnValueOnce({ kind: "transient", reasonCode: "spawn_failed" });
+    const errored = new FakeChild();
+    registrySpawnMock.mockReturnValueOnce({ child: errored });
+    const { installGlobalSpec } = await import("../core/update.js");
+
+    const first = installGlobalSpec("latest");
+    errored.emit("error", new Error("spawn failed"));
+    await expect(first).resolves.toMatchObject({
+      ok: false,
+      retryable: true,
+      reasonCode: "spawn_failed",
+    });
+
+    const timedOut = new FakeChild();
+    registrySpawnMock.mockReturnValueOnce({ child: timedOut });
+    const second = installGlobalSpec("latest");
+    timedOut.stderr.emit("data", Buffer.from("still downloading\n"));
+    timedOut.emit("exit", null, "SIGTERM");
+    await expect(second).resolves.toMatchObject({
+      ok: false,
+      retryable: true,
+      reasonCode: "npm_timeout",
+    });
+  });
+
+  it("returns shaped latest-version and server-version failures", async () => {
+    spawnSyncMock.mockReturnValueOnce({ status: 0, stdout: "not-semver", stderr: "" });
+    const { fetchLatestVersion, fetchServerCommandVersion } = await import("../core/update.js");
+
+    expect(fetchLatestVersion()).toEqual({
+      ok: false,
+      reason: "npm view returned non-semver value: not-semver",
+    });
+
+    resolveServerUrlMock.mockImplementationOnce(() => {
+      throw new Error("missing server");
+    });
+    await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: false, reason: "missing server" });
+
+    cliFetchMock.mockRejectedValueOnce(new Error("network down"));
+    await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: false, reason: "network down" });
+
+    cliFetchMock.mockResolvedValueOnce(jsonResponse("nope", false, 503));
+    await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: false, reason: "server returned HTTP 503" });
+
+    cliFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: vi.fn(async () => {
+        throw new Error("bad json");
+      }),
+    } as unknown as Response);
+    await expect(fetchServerCommandVersion()).resolves.toEqual({
+      ok: false,
+      reason: "server returned invalid JSON: bad json",
+    });
+
+    cliFetchMock.mockResolvedValueOnce(jsonResponse(null));
+    await expect(fetchServerCommandVersion()).resolves.toEqual({
+      ok: false,
+      reason: "server returned invalid bootstrap config",
+    });
+
+    cliFetchMock.mockResolvedValueOnce(jsonResponse({}));
+    await expect(fetchServerCommandVersion()).resolves.toEqual({
+      ok: false,
+      reason: "server did not provide serverCommandVersion",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/update-global-extra.test.ts
+++ b/apps/cli/src/__tests__/update-global-extra.test.ts
@@ -132,7 +132,9 @@ describe("global update helpers", () => {
   });
 
   it("prefers sibling npm, tolerates empty engine stdout, and keeps non-semver installed labels", async () => {
-    existsSyncMock.mockImplementation((path: unknown) => String(path).endsWith("/npm") || String(path).endsWith("\\npm.cmd"));
+    existsSyncMock.mockImplementation(
+      (path: unknown) => String(path).endsWith("/npm") || String(path).endsWith("\\npm.cmd"),
+    );
     spawnSyncMock.mockReturnValueOnce({ status: 0, stderr: "" });
     const child = new FakeChild();
     registrySpawnMock.mockReturnValueOnce({ child });

--- a/apps/cli/src/__tests__/update-glue-package-null.test.ts
+++ b/apps/cli/src/__tests__/update-glue-package-null.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const updateMocks = vi.hoisted(() => ({
+  detectInstallMode: vi.fn(),
+  fetchServerCommandVersion: vi.fn(),
+  installGlobalSpec: vi.fn(),
+  installPortableSpec: vi.fn(),
+  PACKAGE_NAME: null,
+}));
+
+const updateStateMocks = vi.hoisted(() => ({
+  isLoopGuarded: vi.fn(),
+  recordUpdateAttempt: vi.fn(),
+}));
+
+const printLineMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../core/update.js", () => updateMocks);
+vi.mock("../core/update-state.js", () => updateStateMocks);
+vi.mock("../core/output.js", () => ({
+  print: { line: printLineMock },
+}));
+
+function output(): string {
+  return printLineMock.mock.calls.map((call) => String(call[0])).join("");
+}
+
+describe("update glue package-name fallback", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    updateMocks.detectInstallMode.mockReturnValue("global");
+    updateMocks.installGlobalSpec.mockResolvedValue({
+      ok: true,
+      mode: "global",
+      installedVersion: "0.6.0",
+    });
+    updateStateMocks.isLoopGuarded.mockReturnValue(false);
+  });
+
+  it("uses the channel binary name when package metadata is unavailable", async () => {
+    const { createExecuteUpdate } = await import("../core/update-glue.js");
+
+    updateMocks.detectInstallMode.mockReturnValueOnce("npx");
+    await expect(
+      createExecuteUpdate({ managed: false })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).resolves.toEqual({ installed: false });
+    expect(output()).toContain("npm i -g first-tree-dev");
+
+    printLineMock.mockClear();
+    updateStateMocks.isLoopGuarded.mockReturnValueOnce(true);
+    await expect(
+      createExecuteUpdate({ managed: false })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).resolves.toEqual({ installed: true });
+    expect(output()).toContain("npm install -g first-tree-dev@latest");
+
+    printLineMock.mockClear();
+    updateStateMocks.isLoopGuarded.mockReturnValue(false);
+    await expect(
+      createExecuteUpdate({ managed: false })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).resolves.toEqual({ installed: true });
+    expect(output()).toContain("npm install -g first-tree-dev@0.6.0");
+  });
+});

--- a/apps/cli/src/__tests__/update-glue.test.ts
+++ b/apps/cli/src/__tests__/update-glue.test.ts
@@ -231,6 +231,13 @@ describe("update glue", () => {
     expect(output()).toContain("warning: 'daemon refresh-unit' exited with status 7");
 
     printLineMock.mockClear();
+    spawnSyncMock.mockReturnValueOnce({ status: undefined, signal: undefined });
+    await expect(
+      createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
+    expect(output()).toContain("status unknown (signal=none)");
+
+    printLineMock.mockClear();
     spawnSyncMock.mockImplementationOnce(() => {
       throw new Error("spawn denied");
     });
@@ -238,6 +245,15 @@ describe("update glue", () => {
       createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
     ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
     expect(output()).toContain("warning: could not spawn 'daemon refresh-unit': spawn denied");
+
+    printLineMock.mockClear();
+    spawnSyncMock.mockImplementationOnce(() => {
+      throw "spawn string denied";
+    });
+    await expect(
+      createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
+    expect(output()).toContain("warning: could not spawn 'daemon refresh-unit': spawn string denied");
   });
 
   it("routes managed update output through the injected logger and captures refresh-unit output", async () => {

--- a/apps/cli/src/__tests__/update-glue.test.ts
+++ b/apps/cli/src/__tests__/update-glue.test.ts
@@ -3,6 +3,7 @@ import { channelConfig } from "../core/channel.js";
 
 const updateMocks = vi.hoisted(() => ({
   detectInstallMode: vi.fn(),
+  fetchServerCommandVersion: vi.fn(),
   installGlobalSpec: vi.fn(),
   installPortableSpec: vi.fn(),
   PACKAGE_NAME: "first-tree",
@@ -36,6 +37,7 @@ function output(): string {
 describe("update glue", () => {
   beforeEach(() => {
     updateMocks.detectInstallMode.mockReset();
+    updateMocks.fetchServerCommandVersion.mockReset();
     updateMocks.installGlobalSpec.mockReset();
     updateMocks.installPortableSpec.mockReset();
     updateStateMocks.isLoopGuarded.mockReset();
@@ -45,6 +47,7 @@ describe("update glue", () => {
     exitMock.mockClear();
 
     updateMocks.detectInstallMode.mockReturnValue("global");
+    updateMocks.fetchServerCommandVersion.mockResolvedValue({ ok: true, version: "0.6.0" });
     updateMocks.installGlobalSpec.mockResolvedValue({
       ok: true,
       mode: "global",
@@ -60,7 +63,9 @@ describe("update glue", () => {
   });
 
   it("declines prompts and skips unsupported install modes", async () => {
-    const { createExecuteUpdate, declineUpdate, promptUpdate } = await import("../core/update-glue.js");
+    const { createExecuteUpdate, declineUpdate, promptUpdate, refreshServerUpdateTarget } = await import(
+      "../core/update-glue.js"
+    );
 
     await expect(declineUpdate({ currentVersion: "0.5.0", targetVersion: "0.6.0", timeoutSeconds: 1 })).resolves.toBe(
       false,
@@ -68,6 +73,9 @@ describe("update glue", () => {
     await expect(promptUpdate({ currentVersion: "0.5.0", targetVersion: "0.6.0", timeoutSeconds: 0 })).resolves.toBe(
       false,
     );
+    await expect(refreshServerUpdateTarget()).resolves.toEqual({ ok: true, targetVersion: "0.6.0" });
+    updateMocks.fetchServerCommandVersion.mockResolvedValueOnce({ ok: false, reason: "server down" });
+    await expect(refreshServerUpdateTarget()).resolves.toEqual({ ok: false, reason: "server down" });
 
     updateMocks.detectInstallMode.mockReturnValueOnce("source");
     await expect(
@@ -113,11 +121,34 @@ describe("update glue", () => {
       retryable: true,
       reasonCode: "network",
     });
+
+    updateMocks.installGlobalSpec.mockResolvedValueOnce({
+      ok: false,
+      mode: "global",
+      reason: "bad mirror",
+    });
+    await expect(
+      createExecuteUpdate({
+        managed: false,
+        onUpdateFailed: () => {
+          throw new Error("listener down");
+        },
+      })({ currentVersion: "0.5.0", targetVersion: "0.6.1" }),
+    ).resolves.toEqual({ installed: false });
   });
 
   it("uses the portable installer in portable mode and records failures through the same path", async () => {
     const { createExecuteUpdate } = await import("../core/update-glue.js");
     updateMocks.detectInstallMode.mockReturnValue("portable");
+
+    updateStateMocks.isLoopGuarded.mockReturnValueOnce(true);
+    await expect(
+      createExecuteUpdate({ managed: false })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).resolves.toEqual({ installed: true });
+    expect(output()).toContain("stale portable metadata target or a shim/path mismatch");
+    expect(output()).toContain("manually run `first-tree-dev upgrade`");
+    printLineMock.mockClear();
+    updateStateMocks.isLoopGuarded.mockReturnValue(false);
 
     await expect(
       createExecuteUpdate({ managed: false })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
@@ -198,6 +229,15 @@ describe("update glue", () => {
       createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
     ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
     expect(output()).toContain("warning: 'daemon refresh-unit' exited with status 7");
+
+    printLineMock.mockClear();
+    spawnSyncMock.mockImplementationOnce(() => {
+      throw new Error("spawn denied");
+    });
+    await expect(
+      createExecuteUpdate({ managed: true })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
+    expect(output()).toContain("warning: could not spawn 'daemon refresh-unit': spawn denied");
   });
 
   it("routes managed update output through the injected logger and captures refresh-unit output", async () => {

--- a/apps/cli/src/__tests__/update-portable-install.test.ts
+++ b/apps/cli/src/__tests__/update-portable-install.test.ts
@@ -18,6 +18,8 @@ vi.mock("../core/cli-fetch.js", () => ({ cliFetch: cliFetchMock }));
 
 let tmpDirs: string[] = [];
 const originalPlatform = process.platform;
+const originalArch = process.arch;
+const originalPath = process.env.PATH;
 
 function tempDir(name: string): string {
   const dir = mkdtempSync(join(tmpdir(), name));
@@ -178,7 +180,7 @@ async function seedOldInstall(prefix: string, options: { nodeVersion?: string } 
 }
 
 async function importProdUpdateModule(
-  overrides: { channelPrefix?: string | null; downloadBaseUrl?: string | null } = {},
+  overrides: { channelPrefix?: string | null; downloadBaseUrl?: string | null; packageName?: string | null } = {},
 ): Promise<typeof import("../core/update.js")> {
   vi.resetModules();
   vi.doMock("../core/channel.js", () => ({
@@ -186,7 +188,7 @@ async function importProdUpdateModule(
       channel: "prod",
       binName: "first-tree",
       aliasName: "ft",
-      packageName: "first-tree",
+      packageName: overrides.packageName === undefined ? "first-tree" : overrides.packageName,
       defaultHome: "/tmp/home",
       defaultServerUrl: "https://cloud.first-tree.ai",
       serviceUnitFile: "first-tree.service",
@@ -214,8 +216,12 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.doUnmock("../core/channel.js");
+  vi.doUnmock("node:child_process");
   vi.doUnmock("node:fs/promises");
   Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+  Object.defineProperty(process, "arch", { configurable: true, value: originalArch });
+  if (originalPath === undefined) delete process.env.PATH;
+  else process.env.PATH = originalPath;
   for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
   tmpDirs = [];
 });
@@ -288,6 +294,58 @@ describe("installPortableSpec", () => {
 
     cliFetchMock.mockRejectedValueOnce(new Error("network down"));
     await expect(http.fetchPortableLatestVersion()).resolves.toEqual({ ok: false, reason: "network down" });
+
+    cliFetchMock.mockRejectedValueOnce("network string");
+    await expect(http.fetchPortableLatestVersion()).resolves.toEqual({ ok: false, reason: "network string" });
+
+    cliFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: vi.fn(async () =>
+        JSON.stringify({
+          schemaVersion: 1,
+          channel: "prod",
+          version: "not-semver",
+          gitSha: "abc123",
+          nodeVersion: "v24.0.0",
+          packageName: "first-tree",
+          binName: "first-tree",
+          aliasName: "ft",
+          generatedAt: new Date().toISOString(),
+          manifestUrl: "https://download.example/releases/prod/not-semver/manifest.json",
+          assets: [
+            {
+              platform,
+              fileName: `first-tree-not-semver-${platform}.tar.gz`,
+              url: "https://download.example/payload.tar.gz",
+              sha256: "0".repeat(64),
+              size: 123,
+            },
+          ],
+        }),
+      ),
+    });
+    await expect(http.fetchPortableLatestVersion()).resolves.toEqual({
+      ok: false,
+      reason: 'Refusing portable latest metadata: portable metadata version not-semver belongs to channel "unknown", not my channel "prod"',
+    });
+
+    const parseSpy = vi.spyOn(JSON, "parse").mockImplementationOnce(() => {
+      throw "bad json string";
+    });
+    cliFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: vi.fn(async () => "{}"),
+    });
+    try {
+      await expect(http.fetchPortableLatestVersion()).resolves.toEqual({
+        ok: false,
+        reason: "invalid JSON from https://download.example/releases/prod/latest.json: bad json string",
+      });
+    } finally {
+      parseSpy.mockRestore();
+    }
   });
 
   it("fails closed when portable self-update is unsupported on this platform", async () => {
@@ -298,6 +356,46 @@ describe("installPortableSpec", () => {
       ok: false,
       mode: "portable",
       reason: expect.stringContaining("portable self-update is not supported on win32"),
+    });
+
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    Object.defineProperty(process, "arch", { configurable: true, value: "s390x" });
+    const unsupportedArch = await importProdUpdateModule();
+    await expect(unsupportedArch.installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      mode: "portable",
+      reason: expect.stringContaining(`${originalPlatform}-s390x`),
+    });
+
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    Object.defineProperty(process, "arch", { configurable: true, value: "arm64" });
+    const arm64NoChannel = await importProdUpdateModule({ channelPrefix: null });
+    await expect(arm64NoChannel.installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      mode: "portable",
+      reason: "self-update disabled: this binary's channel does not publish portable artifacts.",
+    });
+  });
+
+  it("fails closed before metadata fetch when portable metadata URLs are unavailable", async () => {
+    const noChannel = await importProdUpdateModule({ channelPrefix: null });
+    await expect(noChannel.installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      mode: "portable",
+      reason: "self-update disabled: this binary's channel does not publish portable artifacts.",
+    });
+
+    const noBaseUrl = await importProdUpdateModule({ downloadBaseUrl: null });
+    await expect(noBaseUrl.installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      mode: "portable",
+      reason: "self-update disabled: portable download base URL is not configured for this channel.",
+    });
+
+    const devChannel = await importProdUpdateModule({ packageName: null });
+    expect(devChannel.fetchLatestVersion()).toEqual({
+      ok: false,
+      reason: "this binary's channel does not publish to npm (dev channel).",
     });
   });
 
@@ -364,6 +462,44 @@ describe("installPortableSpec", () => {
     expect(readFileSync(join(home, ".local", "bin", "ft"), "utf8")).toContain("FIRST_TREE_PORTABLE_ROOT");
   });
 
+  it("reports invalid portable roots and HTTP payload download failures", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = await makePortableFixture();
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix);
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "not-current"));
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    await expect(installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      mode: "portable",
+      reason: expect.stringContaining("Cannot derive portable install prefix"),
+    });
+
+    const httpFixture = await makePortableFixture({ version: "1.2.4" });
+    const latest = JSON.parse(readFileSync(httpFixture.latestPath, "utf8")) as {
+      assets: Array<{ url: string }>;
+    };
+    latest.assets[0].url = "https://download.example/payload.tar.gz";
+    writeFileSync(httpFixture.latestPath, JSON.stringify(latest, null, 2));
+    cliFetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      arrayBuffer: vi.fn(async () => new ArrayBuffer(0)),
+    });
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${httpFixture.root}`);
+
+    await expect(installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      mode: "portable",
+      reason: "download failed for https://download.example/payload.tar.gz: HTTP 502",
+    });
+  });
+
   it("installs exact versions from immutable manifests", async () => {
     const platform = currentPlatform();
     if (platform === null) return;
@@ -379,6 +515,30 @@ describe("installPortableSpec", () => {
     const result = await installPortableSpec("2.0.0");
     expect(result).toEqual({ ok: true, mode: "portable", installedVersion: "2.0.0" });
     expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("2.0.0\n");
+  });
+
+  it("validates an already extracted portable version before switching current", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = await makePortableFixture({ version: "2.0.1" });
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix);
+    const existingVersionDir = join(prefix, "versions", "2.0.1");
+    const payload = await makeArtifactPayload({ version: "2.0.1", platform });
+    mkdirSync(join(prefix, "versions"), { recursive: true });
+    spawnSync("cp", ["-R", `${payload}/.`, existingVersionDir], { encoding: "utf8" });
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+    vi.stubEnv("HOME", home);
+    delete process.env.PATH;
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    const result = await installPortableSpec("latest");
+
+    expect(result).toEqual({ ok: true, mode: "portable", installedVersion: "2.0.1" });
+    expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("2.0.1\n");
+    expect(readFileSync(join(home, ".local", "bin", "first-tree"), "utf8")).toContain("FIRST_TREE_PORTABLE_ROOT");
   });
 
   it("hands portable installs across bundled Node major upgrades", async () => {
@@ -474,15 +634,50 @@ describe("installPortableSpec", () => {
     expect(badAsset.reason).toContain("portable asset fileName is not a safe basename");
   });
 
+  it("rejects missing portable assets, empty roots, and null package channel mismatches", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = await makePortableFixture();
+    const latest = JSON.parse(readFileSync(fixture.latestPath, "utf8")) as {
+      assets: Array<{ platform: string }>;
+    };
+    latest.assets[0].platform = platform === "linux-x64" ? "darwin-x64" : "linux-x64";
+    writeFileSync(fixture.latestPath, JSON.stringify(latest, null, 2));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+    const { installPortableSpec } = await importProdUpdateModule();
+
+    await expect(installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      reason: expect.stringContaining(`No portable asset for ${platform}`),
+    });
+
+    const rootFixture = await makePortableFixture({ version: "1.2.4" });
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${rootFixture.root}`);
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", "   ");
+    await expect(installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      reason: "FIRST_TREE_PORTABLE_ROOT is required for portable self-update.",
+    });
+
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${rootFixture.root}`);
+    const nullPackage = await importProdUpdateModule({ packageName: null });
+    await expect(nullPackage.installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('does not match my package "(none)"'),
+    });
+  });
+
   it("rejects extracted INSTALL.json mismatches", async () => {
     const platform = currentPlatform();
     if (platform === null) return;
     const cases: Array<{ installOverrides: Record<string, unknown>; expected: string }> = [
+      { installOverrides: { channel: "staging" }, expected: "extracted INSTALL.json mismatch" },
       { installOverrides: { version: "9.9.9" }, expected: 'version "9.9.9" does not match metadata version "1.2.3"' },
       {
         installOverrides: { platform: platform === "linux-x64" ? "darwin-x64" : "linux-x64" },
         expected: "platform",
       },
+      { installOverrides: { installMode: "global" }, expected: "installMode" },
       { installOverrides: { appEntry: "dist/index.mjs" }, expected: "appEntry" },
     ];
 
@@ -502,6 +697,23 @@ describe("installPortableSpec", () => {
       expect(result.reason).toContain(testCase.expected);
       expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("old\n");
     }
+  });
+
+  it("rejects prod-looking latest metadata that is not valid semver", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = await makePortableFixture({ version: "1.2.3" });
+    const latest = JSON.parse(readFileSync(fixture.latestPath, "utf8")) as Record<string, unknown>;
+    latest.version = "01.2.3";
+    writeFileSync(fixture.latestPath, JSON.stringify(latest, null, 2));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+
+    const { fetchPortableLatestVersion } = await importProdUpdateModule();
+
+    await expect(fetchPortableLatestVersion()).resolves.toEqual({
+      ok: false,
+      reason: "portable latest metadata returned non-semver version: 01.2.3",
+    });
   });
 
   it("returns classified portable failures for bad tarballs and invalid current links", async () => {
@@ -546,6 +758,87 @@ describe("installPortableSpec", () => {
     expect(currentFailure.ok).toBe(false);
     if (currentFailure.ok) throw new Error("expected current symlink failure");
     expect(currentFailure.reason).toContain("exists and is not a symlink");
+  });
+
+  it("classifies non-Error portable download failures with fallback reason codes", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    childRegistryMocks.classify.mockReturnValue({ kind: "transient" });
+    const fixture = await makePortableFixture();
+    const latest = JSON.parse(readFileSync(fixture.latestPath, "utf8")) as {
+      assets: Array<{ url: string }>;
+    };
+    latest.assets[0].url = "https://download.example/payload.tar.gz";
+    writeFileSync(fixture.latestPath, JSON.stringify(latest, null, 2));
+    cliFetchMock.mockRejectedValueOnce("payload download failed");
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix);
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    await expect(installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      mode: "portable",
+      reason: "payload download failed",
+      retryable: true,
+      reasonCode: "portable_update_failed",
+    });
+  });
+
+  it("reports tar start failures from the portable extractor", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    vi.doMock("node:child_process", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:child_process")>();
+      return {
+        ...actual,
+        spawnSync: vi.fn((command: string) =>
+          command === "tar" ? { error: new Error("tar executable missing") } : actual.spawnSync(command),
+        ),
+      };
+    });
+    const fixture = await makePortableFixture();
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix);
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    const result = await installPortableSpec("latest");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected tar start failure");
+    expect(result.reason).toContain("tar failed to start: tar executable missing");
+  });
+
+  it("reports tar exits without stdout or stderr detail", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    vi.doMock("node:child_process", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:child_process")>();
+      return {
+        ...actual,
+        spawnSync: vi.fn((command: string) =>
+          command === "tar" ? { status: 2, stdout: "", stderr: "" } : actual.spawnSync(command),
+        ),
+      };
+    });
+    const fixture = await makePortableFixture();
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix);
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    await expect(installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      mode: "portable",
+      reason: "tar exited with code 2",
+    });
   });
 
   it("reports missing extracted INSTALL metadata and current symlink replacement cleanup failures", async () => {
@@ -610,6 +903,56 @@ describe("installPortableSpec", () => {
     expect(renameFailure.ok).toBe(false);
     if (renameFailure.ok) throw new Error("expected current rename failure");
     expect(renameFailure.reason).toContain("rename current denied");
+  });
+
+  it("stringifies non-Error fs failures during portable metadata validation and current switching", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        readFile: async (path: Parameters<typeof actual.readFile>[0], options?: Parameters<typeof actual.readFile>[1]) => {
+          if (String(path).endsWith("/INSTALL.json")) throw "install metadata denied";
+          return actual.readFile(path, options);
+        },
+      };
+    });
+    const fixture = await makePortableFixture();
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix);
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+
+    const readFailureModule = await importProdUpdateModule();
+    const readFailure = await readFailureModule.installPortableSpec("latest");
+    expect(readFailure.ok).toBe(false);
+    if (readFailure.ok) throw new Error("expected INSTALL read failure");
+    expect(readFailure.reason).toContain("extracted artifact missing or invalid INSTALL.json: install metadata denied");
+
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        lstat: async (path: Parameters<typeof actual.lstat>[0], options?: Parameters<typeof actual.lstat>[1]) => {
+          if (String(path).endsWith("/current")) throw "lstat denied";
+          return actual.lstat(path, options);
+        },
+      };
+    });
+    const lstatFixture = await makePortableFixture({ version: "2.0.2" });
+    const secondHome = tempDir("ft-portable-home-");
+    const secondPrefix = join(secondHome, "prefix");
+    await seedOldInstall(secondPrefix);
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(secondPrefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${lstatFixture.root}`);
+
+    const lstatFailureModule = await importProdUpdateModule();
+    const lstatFailure = await lstatFailureModule.installPortableSpec("latest");
+    expect(lstatFailure.ok).toBe(false);
+    if (lstatFailure.ok) throw new Error("expected lstat failure");
+    expect(lstatFailure.reason).toBe("lstat denied");
   });
 
   it("fetches portable latest metadata for manual upgrade checks", async () => {

--- a/apps/cli/src/__tests__/update-portable-install.test.ts
+++ b/apps/cli/src/__tests__/update-portable-install.test.ts
@@ -327,7 +327,8 @@ describe("installPortableSpec", () => {
     });
     await expect(http.fetchPortableLatestVersion()).resolves.toEqual({
       ok: false,
-      reason: 'Refusing portable latest metadata: portable metadata version not-semver belongs to channel "unknown", not my channel "prod"',
+      reason:
+        'Refusing portable latest metadata: portable metadata version not-semver belongs to channel "unknown", not my channel "prod"',
     });
 
     const parseSpy = vi.spyOn(JSON, "parse").mockImplementationOnce(() => {
@@ -912,7 +913,10 @@ describe("installPortableSpec", () => {
       const actual = await importOriginal<typeof import("node:fs/promises")>();
       return {
         ...actual,
-        readFile: async (path: Parameters<typeof actual.readFile>[0], options?: Parameters<typeof actual.readFile>[1]) => {
+        readFile: async (
+          path: Parameters<typeof actual.readFile>[0],
+          options?: Parameters<typeof actual.readFile>[1],
+        ) => {
           if (String(path).endsWith("/INSTALL.json")) throw "install metadata denied";
           return actual.readFile(path, options);
         },

--- a/apps/cli/src/__tests__/update-portable-install.test.ts
+++ b/apps/cli/src/__tests__/update-portable-install.test.ts
@@ -11,10 +11,13 @@ const childRegistryMocks = vi.hoisted(() => ({
   ERROR_KINDS: { TRANSIENT: "transient", PERMANENT: "permanent" },
   getChildProcessRegistry: vi.fn(),
 }));
+const cliFetchMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@first-tree/client", () => childRegistryMocks);
+vi.mock("../core/cli-fetch.js", () => ({ cliFetch: cliFetchMock }));
 
 let tmpDirs: string[] = [];
+const originalPlatform = process.platform;
 
 function tempDir(name: string): string {
   const dir = mkdtempSync(join(tmpdir(), name));
@@ -43,6 +46,7 @@ async function makeArtifactPayload(options: {
   packageName?: string;
   binName?: string;
   aliasName?: string;
+  installOverrides?: Record<string, unknown>;
 }): Promise<string> {
   const payload = tempDir("ft-portable-payload-");
   const nodeVersion = options.nodeVersion ?? "v24.0.0";
@@ -61,20 +65,25 @@ async function makeArtifactPayload(options: {
   await writeFile(join(payload, "VERSION"), `${options.version}\n`);
   await writeFile(
     join(payload, "INSTALL.json"),
-    JSON.stringify({
-      schemaVersion: 1,
-      channel: "prod",
-      version: options.version,
-      gitSha: "abc123",
-      nodeVersion,
-      packageName,
-      binName,
-      aliasName,
-      generatedAt: new Date().toISOString(),
-      platform: options.platform,
-      installMode: "portable",
-      appEntry: "app/cli/index.mjs",
-    }),
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        channel: "prod",
+        version: options.version,
+        gitSha: "abc123",
+        nodeVersion,
+        packageName,
+        binName,
+        aliasName,
+        generatedAt: new Date().toISOString(),
+        platform: options.platform,
+        installMode: "portable",
+        appEntry: "app/cli/index.mjs",
+        ...options.installOverrides,
+      },
+      null,
+      2,
+    ),
   );
   await writeFile(join(payload, "bin", binName), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
   await writeFile(join(payload, "bin", aliasName), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
@@ -82,7 +91,14 @@ async function makeArtifactPayload(options: {
 }
 
 async function makePortableFixture(
-  options: { version?: string; nodeVersion?: string; packageName?: string; binName?: string; aliasName?: string } = {},
+  options: {
+    version?: string;
+    nodeVersion?: string;
+    packageName?: string;
+    binName?: string;
+    aliasName?: string;
+    installOverrides?: Record<string, unknown>;
+  } = {},
 ): Promise<{ root: string; latestPath: string; manifestPath: string; tarball: string; platform: string }> {
   const platform = currentPlatform();
   if (platform === null) throw new Error("unsupported test platform");
@@ -96,7 +112,15 @@ async function makePortableFixture(
   const versionDir = join(channelDir, version);
   mkdirSync(versionDir, { recursive: true });
 
-  const payload = await makeArtifactPayload({ version, platform, nodeVersion, packageName, binName, aliasName });
+  const payload = await makeArtifactPayload({
+    version,
+    platform,
+    nodeVersion,
+    packageName,
+    binName,
+    aliasName,
+    installOverrides: options.installOverrides,
+  });
   const tarball = join(versionDir, `${packageName}-${version}-${platform}.tar.gz`);
   const tar = spawnSync("tar", ["-czf", tarball, "-C", payload, "."], { encoding: "utf8" });
   if (tar.status !== 0) throw new Error(tar.stderr);
@@ -153,7 +177,9 @@ async function seedOldInstall(prefix: string, options: { nodeVersion?: string } 
   await symlink(join(prefix, "versions", "old"), join(prefix, "current"));
 }
 
-async function importProdUpdateModule(): Promise<typeof import("../core/update.js")> {
+async function importProdUpdateModule(
+  overrides: { channelPrefix?: string | null; downloadBaseUrl?: string | null } = {},
+): Promise<typeof import("../core/update.js")> {
   vi.resetModules();
   vi.doMock("../core/channel.js", () => ({
     channelConfig: {
@@ -168,9 +194,12 @@ async function importProdUpdateModule(): Promise<typeof import("../core/update.j
       launchdPlistFile: "first-tree.plist",
       displayName: "First Tree",
       portable: {
-        channelPrefix: "prod",
+        channelPrefix: overrides.channelPrefix === undefined ? "prod" : overrides.channelPrefix,
         publicInstallerPath: "prod/install.sh",
-        downloadBaseUrl: "https://download.first-tree.ai/releases",
+        downloadBaseUrl:
+          overrides.downloadBaseUrl === undefined
+            ? "https://download.first-tree.ai/releases"
+            : overrides.downloadBaseUrl,
       },
     },
   }));
@@ -185,11 +214,93 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.doUnmock("../core/channel.js");
+  vi.doUnmock("node:fs/promises");
+  Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
   for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
   tmpDirs = [];
 });
 
 describe("installPortableSpec", () => {
+  it("rejects invalid specs and disabled portable metadata configuration", async () => {
+    const prod = await importProdUpdateModule();
+    await expect(prod.installPortableSpec("not-a-version")).resolves.toMatchObject({
+      ok: false,
+      mode: "portable",
+      reason: expect.stringContaining("invalid portable version"),
+    });
+
+    const noChannel = await importProdUpdateModule({ channelPrefix: null });
+    await expect(noChannel.fetchPortableLatestVersion()).resolves.toEqual({
+      ok: false,
+      reason: "self-update disabled: this binary's channel does not publish portable artifacts.",
+    });
+
+    const noBaseUrl = await importProdUpdateModule({ downloadBaseUrl: null });
+    await expect(noBaseUrl.fetchPortableLatestVersion()).resolves.toEqual({
+      ok: false,
+      reason: "self-update disabled: portable download base URL is not configured for this channel.",
+    });
+  });
+
+  it("surfaces HTTP metadata download failures for portable latest checks", async () => {
+    const platform = currentPlatform() ?? "linux-x64";
+    cliFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: vi.fn(async () =>
+        JSON.stringify({
+          schemaVersion: 1,
+          channel: "prod",
+          version: "3.1.4",
+          gitSha: "abc123",
+          nodeVersion: "v24.0.0",
+          packageName: "first-tree",
+          binName: "first-tree",
+          aliasName: "ft",
+          generatedAt: new Date().toISOString(),
+          manifestUrl: "https://download.example/releases/prod/3.1.4/manifest.json",
+          assets: [
+            {
+              platform,
+              fileName: `first-tree-3.1.4-${platform}.tar.gz`,
+              url: "https://download.example/payload.tar.gz",
+              sha256: "0".repeat(64),
+              size: 123,
+            },
+          ],
+        }),
+      ),
+    });
+    const http = await importProdUpdateModule({ downloadBaseUrl: "https://download.example/releases/" });
+
+    await expect(http.fetchPortableLatestVersion()).resolves.toEqual({ ok: true, version: "3.1.4" });
+
+    cliFetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      text: vi.fn(async () => "unavailable"),
+    });
+
+    await expect(http.fetchPortableLatestVersion()).resolves.toEqual({
+      ok: false,
+      reason: "download failed for https://download.example/releases/prod/latest.json: HTTP 503",
+    });
+
+    cliFetchMock.mockRejectedValueOnce(new Error("network down"));
+    await expect(http.fetchPortableLatestVersion()).resolves.toEqual({ ok: false, reason: "network down" });
+  });
+
+  it("fails closed when portable self-update is unsupported on this platform", async () => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+    const prod = await importProdUpdateModule();
+
+    await expect(prod.installPortableSpec("latest")).resolves.toMatchObject({
+      ok: false,
+      mode: "portable",
+      reason: expect.stringContaining("portable self-update is not supported on win32"),
+    });
+  });
+
   it("installs latest from file metadata, switches current, and rewrites shims", async () => {
     const platform = currentPlatform();
     if (platform === null) return;
@@ -217,6 +328,40 @@ describe("installPortableSpec", () => {
     expect(shim).toContain("FIRST_TREE_INSTALL_MODE=portable");
     expect(shim).toContain(`FIRST_TREE_PORTABLE_ROOT="$root"`);
     expect(readFileSync(join(binDir, "ft"), "utf8")).toContain('root="');
+  });
+
+  it("downloads portable payloads over HTTP and writes fallback shims when PATH has no existing shim", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const fixture = await makePortableFixture();
+    const latest = JSON.parse(readFileSync(fixture.latestPath, "utf8")) as {
+      assets: Array<{ url: string }>;
+    };
+    latest.assets[0].url = "https://download.example/payload.tar.gz";
+    writeFileSync(fixture.latestPath, JSON.stringify(latest, null, 2));
+    const payload = readFileSync(fixture.tarball);
+    cliFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      arrayBuffer: vi.fn(async () => payload.buffer.slice(payload.byteOffset, payload.byteOffset + payload.byteLength)),
+    });
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix);
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("PATH", "/usr/bin:/bin");
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    await expect(installPortableSpec("latest")).resolves.toEqual({
+      ok: true,
+      mode: "portable",
+      installedVersion: "1.2.3",
+    });
+
+    expect(readFileSync(join(home, ".local", "bin", "first-tree"), "utf8")).toContain("FIRST_TREE_PORTABLE_ROOT");
+    expect(readFileSync(join(home, ".local", "bin", "ft"), "utf8")).toContain("FIRST_TREE_PORTABLE_ROOT");
   });
 
   it("installs exact versions from immutable manifests", async () => {
@@ -288,7 +433,7 @@ describe("installPortableSpec", () => {
     expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("old\n");
   });
 
-  it("rejects channel, package, and bin mismatches", async () => {
+  it("rejects channel, package, bin, alias, version-channel, and asset name mismatches", async () => {
     const platform = currentPlatform();
     if (platform === null) return;
     const home = tempDir("ft-portable-home-");
@@ -301,6 +446,8 @@ describe("installPortableSpec", () => {
       { channel: "staging", version: "1.2.3-staging.1.1" },
       { packageName: "first-tree-staging" },
       { binName: "first-tree-staging" },
+      { aliasName: "first-tree-staging" },
+      { version: "1.2.3-staging.1.1" },
     ]) {
       const fixture = await makePortableFixture();
       const latest = JSON.parse(readFileSync(fixture.latestPath, "utf8")) as Record<string, unknown>;
@@ -313,6 +460,156 @@ describe("installPortableSpec", () => {
       expect(result.reason).toMatch(/Refusing to install portable update|invalid/i);
       expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("old\n");
     }
+
+    const fixture = await makePortableFixture();
+    const latest = JSON.parse(readFileSync(fixture.latestPath, "utf8")) as {
+      assets: Array<{ fileName: string }>;
+    };
+    latest.assets[0].fileName = "../payload.tar.gz";
+    writeFileSync(fixture.latestPath, JSON.stringify(latest, null, 2));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+    const badAsset = await installPortableSpec("latest");
+    expect(badAsset.ok).toBe(false);
+    if (badAsset.ok) throw new Error("expected unsafe asset failure");
+    expect(badAsset.reason).toContain("portable asset fileName is not a safe basename");
+  });
+
+  it("rejects extracted INSTALL.json mismatches", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    const cases: Array<{ installOverrides: Record<string, unknown>; expected: string }> = [
+      { installOverrides: { version: "9.9.9" }, expected: 'version "9.9.9" does not match metadata version "1.2.3"' },
+      {
+        installOverrides: { platform: platform === "linux-x64" ? "darwin-x64" : "linux-x64" },
+        expected: "platform",
+      },
+      { installOverrides: { appEntry: "dist/index.mjs" }, expected: "appEntry" },
+    ];
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    for (const testCase of cases) {
+      const fixture = await makePortableFixture({ installOverrides: testCase.installOverrides });
+      const home = tempDir("ft-portable-home-");
+      const prefix = join(home, "prefix");
+      await seedOldInstall(prefix);
+      vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
+      vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${fixture.root}`);
+
+      const result = await installPortableSpec("latest");
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("expected extracted metadata failure");
+      expect(result.reason).toContain(testCase.expected);
+      expect(readFileSync(join(prefix, "current", "VERSION"), "utf8")).toBe("old\n");
+    }
+  });
+
+  it("returns classified portable failures for bad tarballs and invalid current links", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    childRegistryMocks.classify.mockReturnValue({ kind: "transient", reasonCode: "classified_transient" });
+    const badTar = await makePortableFixture();
+    const invalidTarball = join(badTar.root, "prod", "1.2.3", "not-a-tar.gz");
+    writeFileSync(invalidTarball, "not a gzip payload");
+    const latest = JSON.parse(readFileSync(badTar.latestPath, "utf8")) as {
+      assets: Array<{ fileName: string; url: string; sha256: string; size: number }>;
+    };
+    latest.assets[0].fileName = "not-a-tar.gz";
+    latest.assets[0].url = `file://${invalidTarball}`;
+    latest.assets[0].sha256 = sha256(invalidTarball);
+    latest.assets[0].size = bytes(invalidTarball);
+    writeFileSync(badTar.latestPath, JSON.stringify(latest, null, 2));
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix);
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${badTar.root}`);
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    const tarFailure = await installPortableSpec("latest");
+    expect(tarFailure).toMatchObject({
+      ok: false,
+      mode: "portable",
+      retryable: true,
+      reasonCode: "classified_transient",
+    });
+    if (tarFailure.ok) throw new Error("expected tar failure");
+    expect(tarFailure.reason).toContain("tar exited with code");
+
+    const badCurrent = await makePortableFixture({ version: "2.0.0" });
+    const secondHome = tempDir("ft-portable-home-");
+    const secondPrefix = join(secondHome, "prefix");
+    mkdirSync(join(secondPrefix, "current"), { recursive: true });
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(secondPrefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${badCurrent.root}`);
+    const currentFailure = await installPortableSpec("latest");
+    expect(currentFailure.ok).toBe(false);
+    if (currentFailure.ok) throw new Error("expected current symlink failure");
+    expect(currentFailure.reason).toContain("exists and is not a symlink");
+  });
+
+  it("reports missing extracted INSTALL metadata and current symlink replacement cleanup failures", async () => {
+    const platform = currentPlatform();
+    if (platform === null) return;
+    childRegistryMocks.classify.mockReturnValue({ kind: "transient", reasonCode: "classified_transient" });
+
+    const missingInstall = await makePortableFixture();
+    const payload = tempDir("ft-portable-no-install-");
+    await mkdir(join(payload, "node", "bin"), { recursive: true });
+    await mkdir(join(payload, "app", "cli"), { recursive: true });
+    await writeFile(join(payload, "node", "bin", "node"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    await writeFile(join(payload, "app", "cli", "index.mjs"), "// fixture\n");
+    const tarball = join(missingInstall.root, "prod", "1.2.3", `missing-install-${platform}.tar.gz`);
+    const tar = spawnSync("tar", ["-czf", tarball, "-C", payload, "."], { encoding: "utf8" });
+    if (tar.status !== 0) throw new Error(tar.stderr);
+    const latest = JSON.parse(readFileSync(missingInstall.latestPath, "utf8")) as {
+      assets: Array<{ fileName: string; url: string; sha256: string; size: number }>;
+    };
+    latest.assets[0].fileName = `missing-install-${platform}.tar.gz`;
+    latest.assets[0].url = `file://${tarball}`;
+    latest.assets[0].sha256 = sha256(tarball);
+    latest.assets[0].size = bytes(tarball);
+    writeFileSync(missingInstall.latestPath, JSON.stringify(latest, null, 2));
+    const home = tempDir("ft-portable-home-");
+    const prefix = join(home, "prefix");
+    await seedOldInstall(prefix);
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(prefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${missingInstall.root}`);
+
+    const { installPortableSpec } = await importProdUpdateModule();
+    const missing = await installPortableSpec("latest");
+    expect(missing).toMatchObject({
+      ok: false,
+      mode: "portable",
+      retryable: true,
+      reasonCode: "classified_transient",
+    });
+    if (missing.ok) throw new Error("expected missing INSTALL failure");
+    expect(missing.reason).toContain("extracted artifact missing or invalid INSTALL.json");
+
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        rename: async (oldPath: string, newPath: string) => {
+          if (oldPath.includes(".current.") && newPath.endsWith("/current")) {
+            throw new Error("rename current denied");
+          }
+          return actual.rename(oldPath, newPath);
+        },
+      };
+    });
+    const renameFixture = await makePortableFixture({ version: "4.0.0" });
+    const secondHome = tempDir("ft-portable-home-");
+    const secondPrefix = join(secondHome, "prefix");
+    await seedOldInstall(secondPrefix);
+    vi.stubEnv("FIRST_TREE_PORTABLE_ROOT", join(secondPrefix, "current"));
+    vi.stubEnv("FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL", `file://${renameFixture.root}`);
+    const renameModule = await importProdUpdateModule();
+    const renameFailure = await renameModule.installPortableSpec("latest");
+    expect(renameFailure.ok).toBe(false);
+    if (renameFailure.ok) throw new Error("expected current rename failure");
+    expect(renameFailure.reason).toContain("rename current denied");
   });
 
   it("fetches portable latest metadata for manual upgrade checks", async () => {

--- a/apps/cli/tests/validate-members.test.ts
+++ b/apps/cli/tests/validate-members.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -55,6 +55,60 @@ describe("runValidateMembers — top-level requirements", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.errors).toEqual([]);
+  });
+
+  it("reports every required member frontmatter field and enum violation", () => {
+    const root = makeTempDir("validate-members-");
+    write(root, "members/no-frontmatter/NODE.md", "# no metadata\n");
+    write(root, "members/broken/NODE.md", `---\nowners: []\ntype: robot\nstatus: active\ndomains: []\n---\n`);
+    write(
+      root,
+      "members/missing-owners/NODE.md",
+      `---\ntitle: Missing Owners\ntype: human\nrole: Engineer\ndomains: [system design]\n---\n`,
+    );
+
+    const result = runValidateMembers(root);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        "members/no-frontmatter/NODE.md: no frontmatter found",
+        "members/broken/NODE.md: missing or empty 'title' field",
+        "members/broken/NODE.md: invalid type 'robot' — must be one of: agent, human",
+        "members/broken/NODE.md: invalid status 'active' — must be one of: invited",
+        "members/broken/NODE.md: missing or empty 'role' field",
+        "members/broken/NODE.md: 'domains' must contain at least one entry",
+        "members/missing-owners/NODE.md: missing 'owners' field",
+      ]),
+    );
+  });
+
+  it("ignores member entries that disappear before stat", (ctx) => {
+    const root = makeTempDir("validate-members-");
+    mkdir(root, "members");
+    try {
+      symlinkSync(join(root, "missing"), join(root, "members", "broken-link"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    const result = runValidateMembers(root);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.errors).toContain("members/: no member nodes were found");
+  });
+
+  it("accepts block-list owners and quoted inline domains", () => {
+    const root = makeTempDir("validate-members-");
+    write(
+      root,
+      "members/alice/NODE.md",
+      `---\ntitle: "alice"\nowners:\n  - "alice"\ntype: human\nrole: Engineer\ndomains: ["system design"]\n---\n`,
+    );
+
+    const result = runValidateMembers(root);
+
+    expect(result).toEqual({ exitCode: 0, errors: [] });
   });
 });
 

--- a/apps/cli/tests/validate-nodes.test.ts
+++ b/apps/cli/tests/validate-nodes.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -65,6 +65,54 @@ describe("runValidateNodes — non-personal files", () => {
     expect(result.exitCode).toBe(1);
     expect(result.errors).toContain("members/NODE.md: missing frontmatter");
   });
+
+  it("skips generated and managed framework paths while continuing past symlinks", (ctx) => {
+    const root = makeTempDir("validate-nodes-");
+    write(root, "NODE.md", ROOT_FRONTMATTER);
+    write(root, ".agents/skills/hidden.md", "# ignored\n");
+    write(root, "node_modules/pkg/ignored.md", "# ignored\n");
+    write(root, "AGENTS.md", "# ignored\n");
+    const managedTarget = join(root, "target-whitepaper.md");
+    writeFileSync(managedTarget, "---\ntitle: Target\nowners: [alice]\n---\n");
+    try {
+      symlinkSync(managedTarget, join(root, "WHITEPAPER.md"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    const result = runValidateNodes(root);
+
+    expect(result).toEqual({ exitCode: 0, errors: [] });
+  });
+
+  it("ignores directories that cannot be read while collecting markdown files", () => {
+    const root = makeTempDir("validate-nodes-");
+    write(root, "NODE.md", ROOT_FRONTMATTER);
+    const unreadable = join(root, "unreadable");
+    mkdirSync(unreadable, { recursive: true });
+    chmodSync(unreadable, 0o300);
+
+    try {
+      const result = runValidateNodes(root);
+      expect(result).toEqual({ exitCode: 0, errors: [] });
+    } finally {
+      chmodSync(unreadable, 0o700);
+    }
+  });
+
+  it("ignores entries that disappear before stat", (ctx) => {
+    const root = makeTempDir("validate-nodes-");
+    write(root, "NODE.md", ROOT_FRONTMATTER);
+    try {
+      symlinkSync(join(root, "missing.md"), join(root, "broken.md"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    const result = runValidateNodes(root);
+
+    expect(result).toEqual({ exitCode: 0, errors: [] });
+  });
 });
 
 describe("runValidateNodes — personal-path relaxation", () => {
@@ -102,6 +150,18 @@ describe("runValidateNodes — personal-path relaxation", () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.errors).toContain("members/alice/notes.md: broken soft_links target '/does/not/exist.md'");
+  });
+
+  it("accepts inline soft_links pointing at markdown files or node directories", () => {
+    const root = makeTempDir("validate-nodes-");
+    write(root, "NODE.md", ROOT_FRONTMATTER);
+    write(root, "domain/NODE.md", "---\ntitle: Domain\nowners: [alice]\n---\n");
+    write(root, "domain/reference.md", "---\ntitle: Reference\nowners: [alice]\n---\n");
+    write(root, "members/alice/links.md", "---\nsoft_links: [domain, /domain/reference.md]\n---\n# links\n");
+
+    const result = runValidateNodes(root);
+
+    expect(result).toEqual({ exitCode: 0, errors: [] });
   });
 
   it("relaxes nested personal subtrees too (members/<me>/sub/path.md)", () => {

--- a/packages/server/src/__tests__/activity.test.ts
+++ b/packages/server/src/__tests__/activity.test.ts
@@ -2,7 +2,8 @@ import { RUNTIME_STALE_MS } from "@first-tree/shared";
 import { and, eq } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
 import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
-import { setSessionRuntime, upsertSessionState } from "../services/activity.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
+import { getAgentWithRuntime, resetActivity, setSessionRuntime, upsertSessionState } from "../services/activity.js";
 import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import type { Notifier } from "../services/notifier.js";
@@ -122,6 +123,21 @@ describe("upsertSessionState — touchPresenceLastSeen option", () => {
     expect(row).toBeDefined();
     expect(row?.activeSessions).toBe(1);
     expect(row?.totalSessions).toBe(1);
+  });
+
+  it("resets runtime state and reads agent runtime presence", async () => {
+    const { app, agent } = await setup();
+    await seedPresence(app, agent.uuid, new Date("2020-01-01T00:00:00Z"));
+
+    await app.db.update(agentPresence).set({ runtimeState: "working" }).where(eq(agentPresence.agentId, agent.uuid));
+    expect((await getAgentWithRuntime(app.db, agent.uuid))?.runtimeState).toBe("working");
+
+    await resetActivity(app.db, agent.uuid);
+    const row = await getAgentWithRuntime(app.db, agent.uuid);
+    expect(row?.runtimeState).toBe("idle");
+    expect(row?.runtimeUpdatedAt).toBeInstanceOf(Date);
+
+    await expect(getAgentWithRuntime(app.db, crypto.randomUUID())).resolves.toBeNull();
   });
 
   // Steady-state guard: when the (agent, chat) row is already at the target

--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -16,7 +16,7 @@ describe("Admin Agents API", () => {
     const ctx = await createAdminContext(app);
     const req = (method: string, url: string, payload?: unknown) =>
       app.inject({
-        method: method as "GET" | "POST" | "PATCH" | "DELETE",
+        method: method as "GET" | "POST" | "PATCH" | "PUT" | "DELETE",
         url,
         headers: { authorization: `Bearer ${ctx.accessToken}` },
         ...(payload ? { payload } : {}),
@@ -369,6 +369,64 @@ describe("Admin Agents API", () => {
     await req("POST", `/api/v1/agents/${agent.uuid}/suspend`);
     const okRes = await req("DELETE", `/api/v1/agents/${agent.uuid}`);
     expect(okRes.statusCode).toBe(204);
+  });
+
+  it("serves uploaded agent avatars publicly and clears them through the manage route", async () => {
+    const app = getApp();
+    const { ctx } = await authedRequest(app);
+    const agent = await createAgent(app.db, {
+      name: `avatar-route-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+    });
+
+    const missing = await app.inject({ method: "GET", url: `/api/v1/agents/${agent.uuid}/avatar` });
+    expect(missing.statusCode).toBe(404);
+    expect(missing.json()).toEqual({ error: "Avatar not set" });
+
+    const badUpload = await app.inject({
+      method: "PUT",
+      url: `/api/v1/agents/${agent.uuid}/avatar`,
+      headers: {
+        authorization: `Bearer ${ctx.accessToken}`,
+        "content-type": "application/octet-stream",
+      },
+      payload: Buffer.from("avatar"),
+    });
+    expect(badUpload.statusCode).toBe(400);
+    expect(badUpload.json<{ error: string }>().error).toContain("image/* Content-Type");
+
+    const bytes = Buffer.from("avatar-png");
+    const upload = await app.inject({
+      method: "PUT",
+      url: `/api/v1/agents/${agent.uuid}/avatar`,
+      headers: {
+        authorization: `Bearer ${ctx.accessToken}`,
+        "content-type": "image/png",
+      },
+      payload: bytes,
+    });
+    expect(upload.statusCode).toBe(200);
+    const uploadBody = upload.json<{ avatarImageUrl: string }>();
+    expect(uploadBody.avatarImageUrl).toMatch(new RegExp(`^/api/v1/agents/${agent.uuid}/avatar\\?v=\\d+$`));
+
+    const download = await app.inject({ method: "GET", url: uploadBody.avatarImageUrl });
+    expect(download.statusCode).toBe(200);
+    expect(download.headers["content-type"]).toBe("image/png");
+    expect(download.headers["cache-control"]).toBe("public, max-age=2592000, immutable");
+    expect(String(download.headers.etag)).toMatch(/^"\d+"$/);
+    expect(download.rawPayload.equals(bytes)).toBe(true);
+
+    const clear = await app.inject({
+      method: "DELETE",
+      url: `/api/v1/agents/${agent.uuid}/avatar`,
+      headers: { authorization: `Bearer ${ctx.accessToken}` },
+    });
+    expect(clear.statusCode).toBe(204);
+
+    const afterClear = await app.inject({ method: "GET", url: `/api/v1/agents/${agent.uuid}/avatar` });
+    expect(afterClear.statusCode).toBe(404);
   });
 
   it("rejects unauthenticated requests", async () => {

--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -277,6 +277,25 @@ describe("Admin Agents API", () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it("rejects manager reassignment by non-admin managers", async () => {
+    const app = getApp();
+    const { req, ctx } = await authedRequest(app);
+    await app.db.update(members).set({ role: "member" }).where(eq(members.id, ctx.memberId));
+    const agent = await createAgent(app.db, {
+      name: `patch-manager-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+    });
+
+    const res = await req("PATCH", `/api/v1/agents/${agent.uuid}`, {
+      managerId: ctx.memberId,
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: string }>().error).toContain("Only admins can reassign");
+  });
+
   it("suspends and reactivates an agent", async () => {
     const app = getApp();
     const { req, ctx } = await authedRequest(app);

--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -416,6 +416,17 @@ describe("Admin Agents API", () => {
     expect(badUpload.statusCode).toBe(400);
     expect(badUpload.json<{ error: string }>().error).toContain("image/* Content-Type");
 
+    const emptyImageUpload = await app.inject({
+      method: "PUT",
+      url: `/api/v1/agents/${agent.uuid}/avatar`,
+      headers: {
+        authorization: `Bearer ${ctx.accessToken}`,
+        "content-type": "image/png",
+      },
+    });
+    expect(emptyImageUpload.statusCode).toBe(400);
+    expect(emptyImageUpload.json<{ error: string }>().error).toContain("Avatar image payload is empty");
+
     const bytes = Buffer.from("avatar-png");
     const upload = await app.inject({
       method: "PUT",

--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -148,6 +148,62 @@ describe("Admin Agents API", () => {
     expect(agent.presenceStatus).toBe("offline");
   });
 
+  it("GET /orgs/:orgId/agents/all lists every agent for admins", async () => {
+    const app = getApp();
+    const { req, ctx } = await authedRequest(app);
+    const created = await createAgent(app.db, {
+      name: `all-list-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "All List Agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      metadata: { publicRole: "admin-all" },
+    });
+
+    const res = await req("GET", `/api/v1/orgs/${ctx.organizationId}/agents/all?limit=50`);
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ items: Array<Record<string, unknown>>; nextCursor: string | null }>();
+    const agent = body.items.find((item) => item.uuid === created.uuid);
+    expect(agent).toMatchObject({
+      uuid: created.uuid,
+      name: created.name,
+      displayName: "All List Agent",
+      managerId: ctx.memberId,
+      presenceStatus: "offline",
+      clientId: ctx.clientId,
+      runtimeType: null,
+      runtimeState: null,
+      activeSessions: null,
+      lastSeenAt: null,
+      avatarImageUrl: null,
+      metadata: { publicRole: "admin-all" },
+    });
+    expect(typeof agent?.createdAt).toBe("string");
+    expect(typeof agent?.updatedAt).toBe("string");
+  });
+
+  it("GET /orgs/:orgId/agents/names/:name/availability reports route-level availability", async () => {
+    const app = getApp();
+    const { req, ctx } = await authedRequest(app);
+    const takenName = `taken-${crypto.randomUUID().slice(0, 6)}`;
+    await createAgent(app.db, {
+      name: takenName,
+      type: "agent",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+    });
+
+    const taken = await req("GET", `/api/v1/orgs/${ctx.organizationId}/agents/names/${takenName}/availability`);
+    expect(taken.statusCode).toBe(200);
+    expect(taken.json()).toMatchObject({ available: false, reason: "taken" });
+
+    const availableName = `free-${crypto.randomUUID().slice(0, 6)}`;
+    const available = await req("GET", `/api/v1/orgs/${ctx.organizationId}/agents/names/${availableName}/availability`);
+    expect(available.statusCode).toBe(200);
+    expect(available.json()).toMatchObject({ available: true });
+  });
+
   it("creates an agent via POST", async () => {
     const app = getApp();
     const { req, ctx } = await authedRequest(app);

--- a/packages/server/src/__tests__/agent-bind-authorization.test.ts
+++ b/packages/server/src/__tests__/agent-bind-authorization.test.ts
@@ -1,8 +1,10 @@
-import { AGENT_RUNTIME_SESSION_HEADER } from "@first-tree/shared";
+import { AGENT_RUNTIME_SESSION_HEADER, AGENT_SELECTOR_HEADER } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
 import { clients } from "../db/schema/clients.js";
+import { members } from "../db/schema/members.js";
+import { agentSelectorHook } from "../middleware/agent-selector.js";
 import { bindAgentRuntimeSession, revokeAgentRuntimeSession } from "../services/agent-runtime-session.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
@@ -142,6 +144,76 @@ describe("Rule R-RUN on agent-scoped HTTP", () => {
       headers: { authorization: `Bearer ${accessToken}` },
     });
     expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects when the selected agent row is missing", async () => {
+    const app = getApp();
+    const { accessToken } = await createTestAgent(app);
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/agent/me",
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        "x-agent-id": crypto.randomUUID(),
+      },
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: string }>().error).toMatch(/Agent not found/);
+  });
+
+  it("rejects when the authenticated user no longer has active org membership", async () => {
+    const app = getApp();
+    const { agent } = await createTestAgent(app);
+    const other = await createTestAdmin(app);
+    await app.db.update(members).set({ status: "left" }).where(eq(members.id, other.memberId));
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/agent/me",
+      headers: {
+        authorization: `Bearer ${other.accessToken}`,
+        "x-agent-id": agent.uuid,
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: string }>().error).toMatch(/caller is not a member/);
+  });
+
+  it("rejects human-agent selection by a different active member", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const other = await createTestAdmin(app);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/agent/me",
+      headers: {
+        authorization: `Bearer ${other.accessToken}`,
+        "x-agent-id": admin.humanAgentUuid,
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: string }>().error).toMatch(/Agent not runnable/);
+  });
+
+  it("rejects missing user state and mismatched agent-outbox state inside the selector hook", async () => {
+    const app = getApp();
+    const { agent, userId } = await createTestAgent(app);
+    const hook = agentSelectorHook(app.db);
+
+    await expect(hook({ headers: {} } as never, {} as never)).rejects.toThrow(/User authentication required/);
+
+    await expect(
+      hook(
+        {
+          user: { userId, agentOutbox: { agentId: crypto.randomUUID() } },
+          headers: { [AGENT_SELECTOR_HEADER]: agent.uuid },
+        } as never,
+        {} as never,
+      ),
+    ).rejects.toThrow(/outbox token is not valid/);
   });
 });
 

--- a/packages/server/src/__tests__/agent-connection-test.test.ts
+++ b/packages/server/src/__tests__/agent-connection-test.test.ts
@@ -1,8 +1,12 @@
+import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
+import WebSocket from "ws";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { chats } from "../db/schema/chats.js";
+import { clients } from "../db/schema/clients.js";
 import { messages } from "../db/schema/messages.js";
+import { bindAgentToClient, removeClientConnection, setClientConnection } from "../services/connection-manager.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
 
 /**
@@ -20,6 +24,10 @@ describe("POST /api/v1/agents/:uuid/test — health-only", () => {
     const allChats = await app.db.select({ id: chats.id }).from(chats);
     const allMessages = await app.db.select({ id: messages.id }).from(messages);
     return { chatCount: allChats.length, messageCount: allMessages.length };
+  }
+
+  function mockWs(): WebSocket {
+    return { readyState: WebSocket.OPEN, close: () => {}, send: () => {} } as unknown as WebSocket;
   }
 
   it("returns status=offline when the agent has no presence row", async () => {
@@ -66,6 +74,78 @@ describe("POST /api/v1/agents/:uuid/test — health-only", () => {
     const after = await countChatsAndMessages(app);
     expect(after.chatCount).toBe(before.chatCount);
     expect(after.messageCount).toBe(before.messageCount);
+  });
+
+  it("returns status=success when a live WS has a fresh heartbeat", async () => {
+    const app = getApp();
+    const { agent, clientId, request } = await createTestAgent(app, { name: "test-connected" });
+    const connectedAt = new Date();
+    await app.db
+      .update(clients)
+      .set({ connectedAt, hostname: "dev-host", os: "linux", sdkVersion: "test-sdk" })
+      .where(eq(clients.id, clientId));
+    await app.db.insert(agentPresence).values({
+      agentId: agent.uuid,
+      status: "online",
+      clientId,
+      instanceId: "test-instance",
+      connectedAt,
+      lastSeenAt: new Date(),
+    });
+    const ws = mockWs();
+    setClientConnection(clientId, ws);
+    bindAgentToClient(clientId, agent.uuid);
+
+    try {
+      const before = await countChatsAndMessages(app);
+      const res = await request("POST", `/api/v1/agents/${agent.uuid}/test`);
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.status).toBe("success");
+      expect(body.connection.health).toBe("connected");
+      expect(body.connection.client).toMatchObject({
+        id: clientId,
+        hostname: "dev-host",
+        os: "linux",
+        sdkVersion: "test-sdk",
+        connectedAt: connectedAt.toISOString(),
+      });
+
+      const after = await countChatsAndMessages(app);
+      expect(after.chatCount).toBe(before.chatCount);
+      expect(after.messageCount).toBe(before.messageCount);
+    } finally {
+      removeClientConnection(clientId, ws);
+    }
+  });
+
+  it("returns status=stale when a live WS has an expired heartbeat", async () => {
+    const app = getApp();
+    const { agent, clientId, request } = await createTestAgent(app, { name: "test-connected-stale" });
+    const ws = mockWs();
+    await app.db.insert(agentPresence).values({
+      agentId: agent.uuid,
+      status: "online",
+      clientId,
+      instanceId: "test-instance",
+      connectedAt: new Date(Date.now() - 120_000),
+      lastSeenAt: new Date(Date.now() - 120_000),
+    });
+    setClientConnection(clientId, ws);
+    bindAgentToClient(clientId, agent.uuid);
+
+    try {
+      const res = await request("POST", `/api/v1/agents/${agent.uuid}/test`);
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.status).toBe("stale");
+      expect(body.connection.health).toBe("stale");
+      expect(body.connection.client.id).toBe(clientId);
+    } finally {
+      removeClientConnection(clientId, ws);
+    }
   });
 
   it("does not return chatId / responseContent / responseTime fields", async () => {

--- a/packages/server/src/__tests__/agent-messages.test.ts
+++ b/packages/server/src/__tests__/agent-messages.test.ts
@@ -37,6 +37,26 @@ describe("Agent Messages API", () => {
     expect(listRes.json().items).toHaveLength(1);
   });
 
+  it("edits a message for a chat participant", async () => {
+    const app = getApp();
+    const { a1, a2, chatId } = await setupChat(app);
+
+    const sendRes = await a1.request("POST", `/api/v1/agent/chats/${chatId}/messages`, {
+      format: "text",
+      content: "Original",
+      metadata: { mentions: [a2.agent.uuid] },
+    });
+    expect(sendRes.statusCode).toBe(201);
+
+    const editRes = await a1.request("PATCH", `/api/v1/agent/chats/${chatId}/messages/${sendRes.json().id}`, {
+      format: "text",
+      content: "Edited",
+    });
+    expect(editRes.statusCode).toBe(200);
+    expect(editRes.json().content).toBe("Edited");
+    expect(editRes.json().createdAt).toEqual(expect.any(String));
+  });
+
   it("creates inbox entries for recipient (fan-out)", async () => {
     const app = getApp();
     const { a1, a2, chatId } = await setupChat(app);

--- a/packages/server/src/__tests__/agent-pinned-notification.test.ts
+++ b/packages/server/src/__tests__/agent-pinned-notification.test.ts
@@ -1,7 +1,7 @@
 import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { SignJWT } from "jose";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
 import { agents } from "../db/schema/agents.js";
 import { clients } from "../db/schema/clients.js";
@@ -528,6 +528,34 @@ describe("Agent WS — agent:pinned push on create/bind", () => {
       await new Promise<void>((r) => ws.once("close", () => r()));
     }
   }, 15000);
+
+  it("drops route-change notifications that fail the agent:pinned wire schema", async () => {
+    const warnSpy = vi.spyOn(app.log, "warn");
+
+    try {
+      await app.notifier.notifyAgentRouteChange({
+        agentId: uuidv7(),
+        name: "invalid-runtime",
+        displayName: "Invalid Runtime",
+        agentType: "agent",
+        oldClientId: null,
+        targetClientId: `cli-invalid-${crypto.randomUUID().slice(0, 8)}`,
+        runtimeProvider: "not-a-runtime",
+        reason: "agent_runtime_switch",
+      });
+
+      await vi.waitFor(() =>
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            clientId: expect.stringMatching(/^cli-invalid-/),
+          }),
+          "agent route change frame failed schema validation — not sending",
+        ),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 
   it("replays agent:pinned on heartbeat when a missed route-change leaves the local runtime stale", async () => {
     const seed = await seedConnectedClient("heartbeat-route-change");

--- a/packages/server/src/__tests__/agent-runtime-switch.test.ts
+++ b/packages/server/src/__tests__/agent-runtime-switch.test.ts
@@ -46,6 +46,36 @@ async function setClientRuntimeSupport(
 describe("POST /agents/:uuid/switch-runtime", () => {
   const getApp = useTestApp({ runtimeHttpTokenEnforcement: true });
 
+  it("rejects fault injection headers when fault injection is disabled", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    const agent = await createAgent(app.db, {
+      name: `switch-fault-disabled-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Switch Fault Disabled",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${agent.uuid}/switch-runtime`,
+      headers: {
+        authorization: `Bearer ${ctx.accessToken}`,
+        "x-first-tree-runtime-switch-fault": "after_claim",
+      },
+      payload: {
+        clientId: ctx.clientId,
+        runtimeProvider: "codex",
+        confirmLocalDataLoss: true,
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json<{ error: string }>().error).toContain("fault injection is disabled");
+  });
+
   it("switches runtime with a metadata claim, config retag, and session eviction", async () => {
     const app = getApp();
     const ctx = await createAdminContext(app);
@@ -547,6 +577,36 @@ describe("POST /agents/:uuid/switch-runtime", () => {
 
 describe("POST /agents/:uuid/switch-runtime recovery", () => {
   const getApp = useTestApp({ runtimeHttpTokenEnforcement: true, runtimeSwitchFaultInjection: true });
+
+  it("rejects unknown fault injection headers", async () => {
+    const app = getApp();
+    const ctx = await createAdminContext(app);
+    const agent = await createAgent(app.db, {
+      name: `switch-fault-unknown-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Switch Fault Unknown",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/v1/agents/${agent.uuid}/switch-runtime`,
+      headers: {
+        authorization: `Bearer ${ctx.accessToken}`,
+        "x-first-tree-runtime-switch-fault": "not-a-fault",
+      },
+      payload: {
+        clientId: ctx.clientId,
+        runtimeProvider: "codex",
+        confirmLocalDataLoss: true,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toContain('Unknown runtime switch fault "not-a-fault"');
+  });
 
   it("aborts the claim and preserves sessions when a pre-commit fault occurs", async () => {
     const app = getApp();

--- a/packages/server/src/__tests__/agent-runtime-switch.test.ts
+++ b/packages/server/src/__tests__/agent-runtime-switch.test.ts
@@ -6,9 +6,11 @@ import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
 import { agentConfigs } from "../db/schema/agent-configs.js";
 import { agents } from "../db/schema/agents.js";
 import { clients } from "../db/schema/clients.js";
+import { members } from "../db/schema/members.js";
 import { sessionEvents } from "../db/schema/session-events.js";
 import { createAgent } from "../services/agent.js";
 import { bindAgentRuntimeSession } from "../services/agent-runtime-session.js";
+import { recoverAgentRuntimeSwitch, switchAgentRuntime } from "../services/agent-runtime-switch.js";
 import { createChat } from "../services/chat.js";
 import { retireClient } from "../services/client.js";
 import * as sessionEventService from "../services/session-event.js";
@@ -740,5 +742,201 @@ describe("POST /agents/:uuid/switch-runtime preconditions", () => {
 
     expect(res.statusCode).toBe(409);
     expect(res.json<{ error: string }>().error).toContain("runtime-session enforcement");
+  });
+});
+
+describe("agent runtime switch service preconditions", () => {
+  const getApp = useTestApp({ runtimeHttpTokenEnforcement: true });
+
+  async function createSwitchFixture(app: FastifyInstance): Promise<{
+    ctx: Awaited<ReturnType<typeof createAdminContext>>;
+    agent: Awaited<ReturnType<typeof createAgent>>;
+    targetClientId: string;
+  }> {
+    const ctx = await createAdminContext(app);
+    const targetClientId = await seedClient(app, ctx.userId, ctx.organizationId);
+    await setClientRuntimeSupport(app, targetClientId, {
+      "claude-code": capability("ok"),
+      codex: capability("ok"),
+    });
+    const agent = await createAgent(app.db, {
+      name: `switch-service-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Switch Service",
+      managerId: ctx.memberId,
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    });
+    return { ctx, agent, targetClientId };
+  }
+
+  it("rejects service calls when runtime-session enforcement is disabled", async () => {
+    const app = getApp();
+    const { ctx, agent, targetClientId } = await createSwitchFixture(app);
+
+    await expect(
+      switchAgentRuntime(
+        app.db,
+        agent.uuid,
+        { clientId: targetClientId, runtimeProvider: "codex" },
+        { userId: ctx.userId, memberId: ctx.memberId },
+        { runtimeHttpTokenEnforced: false },
+      ),
+    ).rejects.toThrow("runtime-session enforcement");
+
+    await expect(recoverAgentRuntimeSwitch(app.db, agent.uuid, { runtimeHttpTokenEnforced: false })).rejects.toThrow(
+      "runtime-session enforcement",
+    );
+  });
+
+  it("rejects missing, human, invalid-state, and no-op switch targets before claiming", async () => {
+    const app = getApp();
+    const { ctx, agent, targetClientId } = await createSwitchFixture(app);
+    const actor = { userId: ctx.userId, memberId: ctx.memberId };
+
+    await expect(
+      switchAgentRuntime(app.db, crypto.randomUUID(), { clientId: targetClientId, runtimeProvider: "codex" }, actor, {
+        runtimeHttpTokenEnforced: true,
+      }),
+    ).rejects.toThrow("not found");
+
+    await expect(
+      switchAgentRuntime(app.db, ctx.humanAgentUuid, { clientId: targetClientId, runtimeProvider: "codex" }, actor, {
+        runtimeHttpTokenEnforced: true,
+      }),
+    ).rejects.toThrow("Human agents");
+
+    await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, agent.uuid));
+    await expect(
+      switchAgentRuntime(app.db, agent.uuid, { clientId: targetClientId, runtimeProvider: "codex" }, actor, {
+        runtimeHttpTokenEnforced: true,
+      }),
+    ).rejects.toThrow("Only active agents");
+
+    await app.db.update(agents).set({ status: "active" }).where(eq(agents.uuid, agent.uuid));
+    await expect(
+      switchAgentRuntime(app.db, agent.uuid, { clientId: ctx.clientId, runtimeProvider: "claude-code" }, actor, {
+        runtimeHttpTokenEnforced: true,
+      }),
+    ).rejects.toThrow("current configuration");
+  });
+
+  it("rejects manager and target-client ownership/version preconditions", async () => {
+    const app = getApp();
+    const { ctx, agent, targetClientId } = await createSwitchFixture(app);
+    const actor = { userId: ctx.userId, memberId: ctx.memberId };
+
+    await app.db.update(members).set({ status: "inactive" }).where(eq(members.id, ctx.memberId));
+    await expect(
+      switchAgentRuntime(app.db, agent.uuid, { clientId: targetClientId, runtimeProvider: "codex" }, actor, {
+        runtimeHttpTokenEnforced: true,
+      }),
+    ).rejects.toThrow("Manager");
+    await app.db.update(members).set({ status: "active" }).where(eq(members.id, ctx.memberId));
+
+    await expect(
+      switchAgentRuntime(app.db, agent.uuid, { clientId: "missing-client", runtimeProvider: "codex" }, actor, {
+        runtimeHttpTokenEnforced: true,
+      }),
+    ).rejects.toThrow("not found");
+
+    const unclaimedClientId = `cli-unclaimed-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id: unclaimedClientId,
+      userId: null,
+      organizationId: ctx.organizationId,
+      status: "connected",
+      sdkVersion: "0.5.11",
+      metadata: { capabilities: { codex: capability("ok") } },
+    });
+    await expect(
+      switchAgentRuntime(app.db, agent.uuid, { clientId: unclaimedClientId, runtimeProvider: "codex" }, actor, {
+        runtimeHttpTokenEnforced: true,
+      }),
+    ).rejects.toThrow("has not been claimed");
+
+    const otherCtx = await createAdminContext(app);
+    await setClientRuntimeSupport(app, otherCtx.clientId, { codex: capability("ok") });
+    await expect(
+      switchAgentRuntime(app.db, agent.uuid, { clientId: otherCtx.clientId, runtimeProvider: "codex" }, actor, {
+        runtimeHttpTokenEnforced: true,
+      }),
+    ).rejects.toThrow("not owned");
+
+    await app.db.update(clients).set({ sdkVersion: "0.5.10" }).where(eq(clients.id, targetClientId));
+    await expect(
+      switchAgentRuntime(app.db, agent.uuid, { clientId: targetClientId, runtimeProvider: "codex" }, actor, {
+        runtimeHttpTokenEnforced: true,
+      }),
+    ).rejects.toThrow("0.5.11");
+  });
+
+  it("rejects recovery when state is missing, malformed, or the agent is gone", async () => {
+    const app = getApp();
+    const { agent } = await createSwitchFixture(app);
+
+    await expect(
+      recoverAgentRuntimeSwitch(app.db, crypto.randomUUID(), { runtimeHttpTokenEnforced: true }),
+    ).rejects.toThrow("not found");
+
+    await expect(recoverAgentRuntimeSwitch(app.db, agent.uuid, { runtimeHttpTokenEnforced: true })).rejects.toThrow(
+      "no runtime switch recovery state",
+    );
+
+    await app.db
+      .update(agents)
+      .set({ metadata: { runtimeSwitch: { claimId: "claim-malformed" } } })
+      .where(eq(agents.uuid, agent.uuid));
+    await expect(recoverAgentRuntimeSwitch(app.db, agent.uuid, { runtimeHttpTokenEnforced: true })).rejects.toThrow(
+      "claim-malformed",
+    );
+
+    await app.db
+      .update(agents)
+      .set({ metadata: { runtimeSwitch: true } })
+      .where(eq(agents.uuid, agent.uuid));
+    await expect(recoverAgentRuntimeSwitch(app.db, agent.uuid, { runtimeHttpTokenEnforced: true })).rejects.toThrow(
+      "malformed",
+    );
+  });
+
+  it("aborts a persisted claimed recovery state through the service", async () => {
+    const app = getApp();
+    const { ctx, agent, targetClientId } = await createSwitchFixture(app);
+    await app.db
+      .update(agents)
+      .set({
+        status: "suspended",
+        metadata: {
+          runtimeSwitch: {
+            claimId: "claim-service-abort",
+            phase: "claimed",
+            claimedAt: new Date().toISOString(),
+            claimedByUserId: ctx.userId,
+            claimedByMemberId: ctx.memberId,
+            oldClientId: ctx.clientId,
+            oldRuntimeProvider: "claude-code",
+            targetClientId,
+            targetRuntimeProvider: "codex",
+          },
+        },
+      })
+      .where(eq(agents.uuid, agent.uuid));
+
+    const recovered = await recoverAgentRuntimeSwitch(app.db, agent.uuid, { runtimeHttpTokenEnforced: true });
+
+    expect(recovered).toMatchObject({
+      claimId: "claim-service-abort",
+      oldClientId: ctx.clientId,
+      targetClientId,
+      terminatedChatIds: [],
+      recoveryAction: "aborted",
+    });
+    expect(recovered.agent).toMatchObject({
+      status: "active",
+      clientId: ctx.clientId,
+      runtimeProvider: "claude-code",
+    });
+    expect(recovered.agent.metadata.runtimeSwitch).toBeUndefined();
   });
 });

--- a/packages/server/src/__tests__/agent-service-extra.test.ts
+++ b/packages/server/src/__tests__/agent-service-extra.test.ts
@@ -13,6 +13,7 @@ import {
   clearAgentAvatarImage,
   createAgent,
   deleteAgent,
+  ensureClientSupportsRuntimeProvider,
   getAgentAvatarImage,
   getAgentSkills,
   listAgentsForAdmin,
@@ -24,6 +25,8 @@ import {
   updateAgent,
   updateAgentSkills,
 } from "../services/agent.js";
+import { createMember } from "../services/member.js";
+import { createOrganization } from "../services/organization.js";
 import { createAdminContext, useTestApp } from "./helpers.js";
 
 describe("agent service extra coverage", () => {
@@ -143,6 +146,74 @@ describe("agent service extra coverage", () => {
     ).rejects.toThrow(/Manager "member-missing" not found/);
   });
 
+  it("validates reserved names, explicit manager/org pairs, and direct capability checks", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `agent-extra-${crypto.randomUUID().slice(0, 8)}` });
+    const otherOrg = await createOrganization(app.db, {
+      name: `agent-extra-org-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Agent Extra Org",
+    });
+
+    await expect(
+      createAgent(app.db, {
+        name: `__reserved-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        managerId: admin.memberId,
+        clientId: admin.clientId,
+      }),
+    ).rejects.toThrow(/names starting with "__"/);
+    await expect(
+      createAgent(app.db, {
+        name: "system",
+        type: "agent",
+        managerId: admin.memberId,
+        clientId: admin.clientId,
+      }),
+    ).rejects.toThrow(/reserved/);
+    await expect(
+      createAgent(app.db, {
+        name: `missing-pair-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        managerId: "member-missing",
+        organizationId: admin.organizationId,
+      }),
+    ).rejects.toThrow(/Manager "member-missing" not found/);
+    await expect(
+      createAgent(app.db, {
+        name: `wrong-org-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        managerId: admin.memberId,
+        organizationId: otherOrg.id,
+        clientId: admin.clientId,
+      }),
+    ).rejects.toThrow(/same organization/);
+
+    await app.db.update(members).set({ status: "left" }).where(eq(members.id, admin.memberId));
+    await expect(
+      createAgent(app.db, {
+        name: `inactive-manager-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        managerId: admin.memberId,
+        organizationId: admin.organizationId,
+        clientId: admin.clientId,
+      }),
+    ).rejects.toThrow(/Manager/);
+    await app.db.update(members).set({ status: "active" }).where(eq(members.id, admin.memberId));
+
+    await app.db.update(clients).set({ retiredAt: new Date() }).where(eq(clients.id, admin.clientId));
+    await expect(ensureClientSupportsRuntimeProvider(app.db, admin.clientId, "codex")).rejects.toMatchObject({
+      statusCode: 410,
+    });
+    await expect(ensureClientSupportsRuntimeProvider(app.db, null, "codex")).resolves.toBeUndefined();
+
+    const unusual = await createAgent(app.db, {
+      name: `unusual-type-${crypto.randomUUID().slice(0, 6)}`,
+      type: "external" as never,
+      managerId: admin.memberId,
+    });
+    expect(unusual.visibility).toBe("private");
+  });
+
   it("validates updateAgent client, type, manager, and delegate mutation guards", async () => {
     const app = getApp();
     const admin = await createAdminContext(app, { username: `agent-update-${crypto.randomUUID().slice(0, 8)}` });
@@ -168,6 +239,18 @@ describe("agent service extra coverage", () => {
     await expect(updateAgent(app.db, bound.uuid, { managerId: null })).rejects.toThrow(/managerId cannot be cleared/);
     await expect(updateAgent(app.db, bound.uuid, { managerId: "member-missing" })).rejects.toThrow(
       /Manager "member-missing" not found/,
+    );
+    const otherOrg = await createOrganization(app.db, {
+      name: `agent-update-org-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Agent Update Org",
+    });
+    const otherOrgMember = await createMember(app.db, otherOrg.id, {
+      username: `agent-update-foreign-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Foreign Manager",
+      role: "admin",
+    });
+    await expect(updateAgent(app.db, bound.uuid, { managerId: otherOrgMember.id })).rejects.toThrow(
+      /same organization/,
     );
     await expect(updateAgent(app.db, bound.uuid, { delegateMention: admin.humanAgentUuid })).rejects.toThrow(
       /delegateMention can only be set on human agents/,

--- a/packages/server/src/__tests__/agent-service-extra.test.ts
+++ b/packages/server/src/__tests__/agent-service-extra.test.ts
@@ -2,20 +2,48 @@ import { AGENT_STATUSES } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
+import { clients } from "../db/schema/clients.js";
+import { members } from "../db/schema/members.js";
 import { BadRequestError, NotFoundError } from "../errors.js";
+import { assertAgentManageableByUser } from "../scope/require-resource.js";
 import {
+  agentMetadataUpdateExpressionPreservingRuntimeState,
+  assertUserAgentMetadataHasNoReservedKeys,
   checkAgentNameAvailability,
   clearAgentAvatarImage,
   createAgent,
+  deleteAgent,
   getAgentAvatarImage,
+  getAgentSkills,
   listAgentsForAdmin,
   MAX_AVATAR_IMAGE_BYTES,
+  reactivateAgent,
   setAgentAvatarImage,
+  stripReservedAgentMetadata,
+  suspendAgent,
+  updateAgent,
+  updateAgentSkills,
 } from "../services/agent.js";
 import { createAdminContext, useTestApp } from "./helpers.js";
 
 describe("agent service extra coverage", () => {
   const getApp = useTestApp();
+
+  it("strips and rejects reserved metadata keys at the service boundary", () => {
+    expect(stripReservedAgentMetadata(null)).toEqual({});
+    expect(stripReservedAgentMetadata(["runtimeSession"])).toEqual({});
+    expect(
+      stripReservedAgentMetadata({
+        publicKey: "kept",
+        runtimeSession: { tokenHash: "secret" },
+        runtimeSwitch: { leaseId: "hidden" },
+      }),
+    ).toEqual({ publicKey: "kept" });
+    expect(() => assertUserAgentMetadataHasNoReservedKeys({ runtimeSession: {} })).toThrow(
+      /metadata.runtimeSession is reserved/i,
+    );
+    expect(agentMetadataUpdateExpressionPreservingRuntimeState({ publicKey: "kept" })).toBeDefined();
+  });
 
   it("reports name availability for invalid, reserved, taken, and available names", async () => {
     const app = getApp();
@@ -42,6 +70,113 @@ describe("agent service extra coverage", () => {
     await expect(checkAgentNameAvailability(app.db, admin.organizationId, "free-agent")).resolves.toEqual({
       available: true,
     });
+  });
+
+  it("validates createAgent client ownership and human pinning preconditions", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `agent-client-pre-${crypto.randomUUID().slice(0, 8)}` });
+    const other = await createAdminContext(app, { username: `agent-client-other-${crypto.randomUUID().slice(0, 8)}` });
+    const unclaimedClientId = `cli-unclaimed-${crypto.randomUUID().slice(0, 8)}`;
+    const retiredClientId = `cli-retired-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values([
+      {
+        id: unclaimedClientId,
+        userId: null,
+        organizationId: admin.organizationId,
+        status: "connected",
+      },
+      {
+        id: retiredClientId,
+        userId: admin.userId,
+        organizationId: admin.organizationId,
+        status: "disconnected",
+        retiredAt: new Date(),
+      },
+    ]);
+
+    await expect(
+      createAgent(app.db, {
+        name: `human-pinned-${crypto.randomUUID().slice(0, 6)}`,
+        type: "human",
+        managerId: admin.memberId,
+        clientId: admin.clientId,
+      }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    await expect(
+      createAgent(app.db, {
+        name: `missing-client-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        managerId: admin.memberId,
+        clientId: "cli-missing",
+      }),
+    ).rejects.toThrow(/Client "cli-missing" not found/);
+    await expect(
+      createAgent(app.db, {
+        name: `unclaimed-client-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        managerId: admin.memberId,
+        clientId: unclaimedClientId,
+      }),
+    ).rejects.toThrow(/has not been claimed by a user/);
+    await expect(
+      createAgent(app.db, {
+        name: `wrong-owner-client-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        managerId: admin.memberId,
+        clientId: other.clientId,
+      }),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    await expect(
+      createAgent(app.db, {
+        name: `retired-client-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        managerId: admin.memberId,
+        clientId: retiredClientId,
+      }),
+    ).rejects.toMatchObject({ statusCode: 410 });
+    await expect(
+      createAgent(app.db, {
+        name: `missing-manager-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        managerId: "member-missing",
+      }),
+    ).rejects.toThrow(/Manager "member-missing" not found/);
+  });
+
+  it("validates updateAgent client, type, manager, and delegate mutation guards", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `agent-update-${crypto.randomUUID().slice(0, 8)}` });
+    const other = await createAdminContext(app, { username: `agent-update-other-${crypto.randomUUID().slice(0, 8)}` });
+    const bound = await createAgent(app.db, {
+      name: `bound-update-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const unbound = await createAgent(app.db, {
+      name: `unbound-update-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: admin.memberId,
+    });
+
+    const invalidTypeUpdate = { type: "human" } as unknown as Parameters<typeof updateAgent>[2];
+    await expect(updateAgent(app.db, bound.uuid, invalidTypeUpdate)).rejects.toThrow(/type is immutable/);
+    await expect(updateAgent(app.db, bound.uuid, { clientId: null })).rejects.toThrow(/clientId cannot be cleared/);
+    await expect(updateAgent(app.db, bound.uuid, { clientId: other.clientId })).rejects.toThrow(
+      /clientId cannot be changed/,
+    );
+    await expect(updateAgent(app.db, bound.uuid, { managerId: null })).rejects.toThrow(/managerId cannot be cleared/);
+    await expect(updateAgent(app.db, bound.uuid, { managerId: "member-missing" })).rejects.toThrow(
+      /Manager "member-missing" not found/,
+    );
+    await expect(updateAgent(app.db, bound.uuid, { delegateMention: admin.humanAgentUuid })).rejects.toThrow(
+      /delegateMention can only be set on human agents/,
+    );
+
+    await app.db.update(agents).set({ status: AGENT_STATUSES.SUSPENDED }).where(eq(agents.uuid, unbound.uuid));
+    await expect(updateAgent(app.db, unbound.uuid, { clientId: admin.clientId })).rejects.toThrow(
+      /Suspended agents without a runtime route/,
+    );
   });
 
   it("paginates admin agent listings and skips deleted rows", async () => {
@@ -95,6 +230,74 @@ describe("agent service extra coverage", () => {
     expect(secondPage.items.map((agent) => agent.uuid)).toContain(older.uuid);
     expect(secondPage.items.map((agent) => agent.uuid)).not.toContain(deleted.uuid);
     expect(secondPage.nextCursor).toBeNull();
+  });
+
+  it("checks direct agent manageability for admins, managers, outsiders, and deleted rows", async () => {
+    const app = getApp();
+    const manager = await createAdminContext(app, {
+      username: `agent-scope-manager-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const outsider = await createAdminContext(app, {
+      username: `agent-scope-outsider-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const agent = await createAgent(app.db, {
+      name: `manageable-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: manager.memberId,
+      clientId: manager.clientId,
+    });
+
+    await expect(assertAgentManageableByUser(app.db, manager.userId, agent.uuid)).resolves.toMatchObject({
+      userId: manager.userId,
+      memberId: manager.memberId,
+      organizationId: manager.organizationId,
+    });
+
+    await app.db.update(members).set({ role: "member" }).where(eq(members.id, manager.memberId));
+    await expect(assertAgentManageableByUser(app.db, manager.userId, agent.uuid)).resolves.toMatchObject({
+      role: "member",
+      memberId: manager.memberId,
+    });
+
+    await app.db.update(members).set({ role: "member" }).where(eq(members.id, outsider.memberId));
+    await expect(assertAgentManageableByUser(app.db, outsider.userId, agent.uuid)).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+    await app.db.update(agents).set({ status: AGENT_STATUSES.DELETED }).where(eq(agents.uuid, agent.uuid));
+    await expect(assertAgentManageableByUser(app.db, manager.userId, agent.uuid)).rejects.toBeInstanceOf(NotFoundError);
+    await expect(assertAgentManageableByUser(app.db, manager.userId, crypto.randomUUID())).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it("rejects invalid lifecycle transitions and skill writes for missing agents", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `agent-life-${crypto.randomUUID().slice(0, 8)}` });
+    const active = await createAgent(app.db, {
+      name: `life-active-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const unbound = await createAgent(app.db, {
+      name: `life-unbound-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: admin.memberId,
+    });
+
+    await expect(suspendAgent(app.db, admin.humanAgentUuid)).rejects.toThrow(/Human agent lifecycle/);
+    await expect(reactivateAgent(app.db, admin.humanAgentUuid)).rejects.toThrow(/Human agent lifecycle/);
+    await expect(deleteAgent(app.db, admin.humanAgentUuid)).rejects.toThrow(/Human agent lifecycle/);
+    await expect(reactivateAgent(app.db, active.uuid)).rejects.toThrow(/Only suspended agents/);
+    await expect(deleteAgent(app.db, active.uuid)).rejects.toThrow(/Suspend the agent first/);
+    await app.db.update(agents).set({ status: AGENT_STATUSES.SUSPENDED }).where(eq(agents.uuid, unbound.uuid));
+    await expect(reactivateAgent(app.db, unbound.uuid)).rejects.toThrow(/Suspended agents without a runtime route/);
+    await expect(suspendAgent(app.db, crypto.randomUUID())).rejects.toBeInstanceOf(NotFoundError);
+    await expect(reactivateAgent(app.db, crypto.randomUUID())).rejects.toBeInstanceOf(NotFoundError);
+    await expect(deleteAgent(app.db, crypto.randomUUID())).rejects.toBeInstanceOf(NotFoundError);
+
+    await expect(getAgentSkills(app.db, crypto.randomUUID())).rejects.toBeInstanceOf(NotFoundError);
+    await expect(updateAgentSkills(app.db, crypto.randomUUID(), [])).rejects.toBeInstanceOf(NotFoundError);
   });
 
   it("validates, stores, reads, and clears avatar image blobs", async () => {

--- a/packages/server/src/__tests__/agent-service-extra.test.ts
+++ b/packages/server/src/__tests__/agent-service-extra.test.ts
@@ -214,6 +214,22 @@ describe("agent service extra coverage", () => {
     expect(unusual.visibility).toBe("private");
   });
 
+  it("rejects system-created agents when the target organization has no active admin", async () => {
+    const app = getApp();
+    const emptyOrg = await createOrganization(app.db, {
+      name: `agent-empty-org-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Agent Empty Org",
+    });
+
+    await expect(
+      createAgent(app.db, {
+        name: `no-fallback-admin-${crypto.randomUUID().slice(0, 6)}`,
+        type: "agent",
+        organizationId: emptyOrg.id,
+      }),
+    ).rejects.toThrow(/no admin member exists/);
+  });
+
   it("validates updateAgent client, type, manager, and delegate mutation guards", async () => {
     const app = getApp();
     const admin = await createAdminContext(app, { username: `agent-update-${crypto.randomUUID().slice(0, 8)}` });
@@ -260,6 +276,33 @@ describe("agent service extra coverage", () => {
     await expect(updateAgent(app.db, unbound.uuid, { clientId: admin.clientId })).rejects.toThrow(
       /Suspended agents without a runtime route/,
     );
+  });
+
+  it("updates public metadata while preserving runtime state and recomputes watcher rows on manager reassignment", async () => {
+    const app = getApp();
+    const first = await createAdminContext(app, { username: `agent-reassign-a-${crypto.randomUUID().slice(0, 8)}` });
+    const second = await createAdminContext(app, { username: `agent-reassign-b-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createAgent(app.db, {
+      name: `agent-reassign-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      managerId: first.memberId,
+      metadata: { publicKey: "old" },
+    });
+    await app.db
+      .update(agents)
+      .set({ metadata: { publicKey: "old", runtimeSession: { tokenHash: "kept" } } })
+      .where(eq(agents.uuid, agent.uuid));
+
+    const updated = await updateAgent(app.db, agent.uuid, {
+      managerId: second.memberId,
+      metadata: { publicKey: "new" },
+    });
+
+    expect(updated.managerId).toBe(second.memberId);
+    expect(updated.metadata).toMatchObject({
+      publicKey: "new",
+      runtimeSession: { tokenHash: "kept" },
+    });
   });
 
   it("paginates admin agent listings and skips deleted rows", async () => {

--- a/packages/server/src/__tests__/agent-service-extra.test.ts
+++ b/packages/server/src/__tests__/agent-service-extra.test.ts
@@ -1,0 +1,135 @@
+import { AGENT_STATUSES } from "@first-tree/shared";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { BadRequestError, NotFoundError } from "../errors.js";
+import {
+  checkAgentNameAvailability,
+  clearAgentAvatarImage,
+  createAgent,
+  getAgentAvatarImage,
+  listAgentsForAdmin,
+  MAX_AVATAR_IMAGE_BYTES,
+  setAgentAvatarImage,
+} from "../services/agent.js";
+import { createAdminContext, useTestApp } from "./helpers.js";
+
+describe("agent service extra coverage", () => {
+  const getApp = useTestApp();
+
+  it("reports name availability for invalid, reserved, taken, and available names", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `agent-name-${crypto.randomUUID().slice(0, 8)}` });
+    await createAgent(app.db, {
+      name: "taken-agent",
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+
+    await expect(checkAgentNameAvailability(app.db, admin.organizationId, "Bad Name")).resolves.toEqual({
+      available: false,
+      reason: "invalid",
+    });
+    await expect(checkAgentNameAvailability(app.db, admin.organizationId, "system")).resolves.toEqual({
+      available: false,
+      reason: "reserved",
+    });
+    await expect(checkAgentNameAvailability(app.db, admin.organizationId, "taken-agent")).resolves.toEqual({
+      available: false,
+      reason: "taken",
+    });
+    await expect(checkAgentNameAvailability(app.db, admin.organizationId, "free-agent")).resolves.toEqual({
+      available: true,
+    });
+  });
+
+  it("paginates admin agent listings and skips deleted rows", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `agent-admin-list-${crypto.randomUUID().slice(0, 8)}` });
+    const older = await createAgent(app.db, {
+      name: `admin-old-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const newer = await createAgent(app.db, {
+      name: `admin-new-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+    const deleted = await createAgent(app.db, {
+      name: `admin-deleted-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+
+    await app.db
+      .update(agents)
+      .set({ createdAt: new Date("2030-01-01T00:00:00.000Z") })
+      .where(eq(agents.uuid, older.uuid));
+    await app.db
+      .update(agents)
+      .set({ createdAt: new Date("2030-01-02T00:00:00.000Z") })
+      .where(eq(agents.uuid, newer.uuid));
+    await app.db
+      .update(agents)
+      .set({ status: AGENT_STATUSES.DELETED, createdAt: new Date("2030-01-03T00:00:00.000Z") })
+      .where(eq(agents.uuid, deleted.uuid));
+
+    const scope = {
+      userId: admin.userId,
+      organizationId: admin.organizationId,
+      memberId: admin.memberId,
+      role: "admin" as const,
+      humanAgentId: admin.humanAgentUuid,
+    };
+
+    const firstPage = await listAgentsForAdmin(app.db, scope, 1);
+    expect(firstPage.items.map((agent) => agent.uuid)).toEqual([newer.uuid]);
+    expect(firstPage.nextCursor).toBe("2030-01-02T00:00:00.000Z");
+
+    const secondPage = await listAgentsForAdmin(app.db, scope, 5, firstPage.nextCursor ?? undefined);
+    expect(secondPage.items.map((agent) => agent.uuid)).toContain(older.uuid);
+    expect(secondPage.items.map((agent) => agent.uuid)).not.toContain(deleted.uuid);
+    expect(secondPage.nextCursor).toBeNull();
+  });
+
+  it("validates, stores, reads, and clears avatar image blobs", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `agent-avatar-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createAgent(app.db, {
+      name: `avatar-agent-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+    });
+
+    await expect(getAgentAvatarImage(app.db, agent.uuid)).resolves.toBeNull();
+    await expect(setAgentAvatarImage(app.db, agent.uuid, Buffer.from("avatar"), "image/gif")).rejects.toBeInstanceOf(
+      BadRequestError,
+    );
+    await expect(setAgentAvatarImage(app.db, agent.uuid, Buffer.alloc(0), "image/png")).rejects.toBeInstanceOf(
+      BadRequestError,
+    );
+    await expect(
+      setAgentAvatarImage(app.db, agent.uuid, Buffer.alloc(MAX_AVATAR_IMAGE_BYTES + 1), "image/png"),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    await expect(
+      setAgentAvatarImage(app.db, crypto.randomUUID(), Buffer.from("avatar"), "image/png"),
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    const updatedAt = await setAgentAvatarImage(app.db, agent.uuid, Buffer.from("avatar"), "image/png");
+    await expect(getAgentAvatarImage(app.db, agent.uuid)).resolves.toEqual({
+      data: Buffer.from("avatar"),
+      mime: "image/png",
+      updatedAt,
+    });
+
+    await clearAgentAvatarImage(app.db, agent.uuid);
+    await expect(getAgentAvatarImage(app.db, agent.uuid)).resolves.toBeNull();
+    await expect(clearAgentAvatarImage(app.db, crypto.randomUUID())).rejects.toBeInstanceOf(NotFoundError);
+  });
+});

--- a/packages/server/src/__tests__/api-route-branch-sweeper.test.ts
+++ b/packages/server/src/__tests__/api-route-branch-sweeper.test.ts
@@ -1,351 +1,176 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { agentConfigRoutes } from "../api/agent/config.js";
-import { agentContextTreeInfoRoutes } from "../api/agent/context-tree-info.js";
-import { agentDocumentRoutes } from "../api/agent/documents.js";
-import { agentInboxRoutes } from "../api/agent/inbox.js";
-import { agentMeRoutes } from "../api/agent/me.js";
-import { agentMessageRoutes } from "../api/agent/messages.js";
-import { agentChatRoutes } from "../api/agent/chats.js";
-import { agentActivityRoutes } from "../api/agent-activity.js";
-import { agentUsageRoutes } from "../api/agent-usage.js";
-import { agentResourcesRoutes } from "../api/agents-resources.js";
-import { agentRoutes, publicAgentAvatarRoutes } from "../api/agents.js";
-import { agentConfigRoutes as userAgentConfigRoutes } from "../api/agents-config.js";
-import { attachmentRoutes } from "../api/attachments.js";
-import { authRoutes } from "../api/auth.js";
-import { githubOauthRoutes } from "../api/auth/github.js";
-import { chatRoutes } from "../api/chats.js";
-import { clientRoutes } from "../api/clients.js";
-import { contextTreeInfoRoutes } from "../api/context-tree-info.js";
-import { contextTreeSnapshotRoutes } from "../api/context-tree-snapshot.js";
-import { documentCommentRoutes, documentRoutes } from "../api/documents.js";
 import { healthRoutes } from "../api/health.js";
 import { healthzRoutes } from "../api/healthz.js";
-import { landingCampaignRoutes } from "../api/landing-campaigns.js";
-import { meRoutes } from "../api/me.js";
-import { orgActivityRoutes } from "../api/orgs/activity.js";
-import { orgAgentRoutes } from "../api/orgs/agents.js";
-import { orgAttachmentRoutes } from "../api/orgs/attachments.js";
-import { orgChatRoutes } from "../api/orgs/chats.js";
-import { orgClientRoutes } from "../api/orgs/clients.js";
-import { orgContextTreeRoutes } from "../api/orgs/context-tree.js";
-import { orgContextTreeSnapshotRoutes } from "../api/orgs/context-tree-snapshot.js";
-import { orgGithubAppRoutes } from "../api/orgs/github-app.js";
-import { orgIdentityRoutes } from "../api/orgs/identity.js";
-import { orgInvitationRoutes } from "../api/orgs/invitations.js";
-import { orgMemberRoutes } from "../api/orgs/members.js";
-import { orgOverviewRoutes } from "../api/orgs/overview.js";
-import { orgResourceRoutes } from "../api/orgs/resources.js";
-import { orgSessionRoutes } from "../api/orgs/sessions.js";
-import { orgSettingsRoutes } from "../api/orgs/settings.js";
-import { orgUsageRoutes } from "../api/orgs/usage.js";
-import { readyzRoutes } from "../api/readyz.js";
 import { publicInvitationRoutes } from "../api/invitations.js";
-import { resourceRoutes } from "../api/resources.js";
-import { sessionRoutes } from "../api/sessions.js";
+import { readyzRoutes } from "../api/readyz.js";
+import { bootstrapState } from "../bootstrap-state.js";
+import { UnauthorizedError } from "../errors.js";
+import { previewInvitation } from "../services/invitation.js";
+
+vi.mock("../services/invitation.js", () => ({
+  previewInvitation: vi.fn(),
+}));
 
 type UnknownFn = (...args: unknown[]) => unknown;
 type CapturedRoute = {
   method: string;
   path: string;
+  options: unknown;
   handler: UnknownFn;
 };
 
-function queryChain(rows: unknown[]): unknown {
-  const chain = {
-    for: vi.fn(() => chain),
-    from: vi.fn(() => chain),
-    groupBy: vi.fn(() => chain),
-    innerJoin: vi.fn(() => chain),
-    leftJoin: vi.fn(() => chain),
-    limit: vi.fn(() => chain),
-    offset: vi.fn(() => chain),
-    onConflictDoNothing: vi.fn(() => chain),
-    onConflictDoUpdate: vi.fn(() => chain),
-    orderBy: vi.fn(() => chain),
-    returning: vi.fn(async () => rows),
-    set: vi.fn(() => chain),
-    values: vi.fn(() => chain),
-    where: vi.fn(() => chain),
-    then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
-      Promise.resolve(rows).then(resolve, reject),
-  };
-  return chain;
-}
-
-function fakeDb(rows: unknown[]): unknown {
-  const db = {
-    delete: vi.fn(() => queryChain(rows)),
-    execute: vi.fn(async () => rows),
-    insert: vi.fn(() => queryChain(rows)),
-    query: new Proxy(
-      {},
-      {
-        get: () => ({
-          findFirst: vi.fn(async () => rows[0] ?? null),
-          findMany: vi.fn(async () => rows),
-        }),
-      },
-    ),
-    select: vi.fn(() => queryChain(rows)),
-    transaction: vi.fn(async (fn: UnknownFn) => fn(db)),
-    update: vi.fn(() => queryChain(rows)),
-  };
-  return db;
-}
-
-function replyDouble(): Record<string, UnknownFn> {
-  const reply: Record<string, UnknownFn> = {};
-  for (const name of ["clearCookie", "code", "header", "redirect", "send", "setCookie", "status", "type"]) {
-    reply[name] = vi.fn(() => reply);
-  }
-  return reply;
-}
-
-function routeRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  return {
-    id: "member_1",
-    uuid: "agent_1",
-    userId: "user_1",
-    organizationId: "org_1",
-    agentId: "agent_1",
-    humanAgentId: "human_1",
-    memberId: "member_1",
-    clientId: "client_1",
-    chatId: "chat_1",
-    role: "admin",
-    status: "active",
-    name: "agent",
-    username: "user",
-    displayName: "Agent",
-    avatarUrl: null,
-    type: "agent",
-    metadata: {},
-    payload: {},
-    repo: "https://github.com/acme/context",
-    branch: "main",
-    createdAt: new Date("2026-01-01T00:00:00.000Z"),
-    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-    lastSeenAt: new Date("2026-01-01T00:00:00.000Z"),
-    ...overrides,
-  };
-}
-
-function createApp(routes: CapturedRoute[], rows: unknown[] = [routeRow()]): unknown {
-  const row = rows[0] ?? routeRow();
+function createApp(overrides: Record<string, unknown> = {}): { app: Record<string, unknown>; routes: CapturedRoute[] } {
+  const routes: CapturedRoute[] = [];
   const registerRoute = (method: string) => (path: string, optionsOrHandler?: unknown, maybeHandler?: unknown) => {
     const handler = typeof optionsOrHandler === "function" ? optionsOrHandler : maybeHandler;
-    if (typeof handler === "function") routes.push({ method, path, handler: handler as UnknownFn });
+    const options = typeof optionsOrHandler === "function" ? undefined : optionsOrHandler;
+    if (typeof handler !== "function") throw new Error(`Missing handler for ${method} ${path}`);
+    routes.push({ method, path, options, handler: handler as UnknownFn });
     return app;
   };
   const app = {
-    commandVersion: () => "test-version",
-    config: {
-      admin: { enabled: true },
-      auth: {
-        accessTokenExpiry: "15m",
-        refreshTokenExpiry: "7d",
-        github: { clientId: "client", clientSecret: "secret", callbackUrl: "https://app.example.test/callback" },
-      },
-      channel: "dev",
-      cors: {},
-      docs: { enabled: true },
-      growth: {
-        landingCampaignMaxAgentTurns: 2,
-        landingCampaignMaxEstimatedTokens: null,
-        landingCampaigns: { enabled: true, serviceUserId: "user_1", runtimeProvider: "codex" },
-      },
-      publicUrl: "https://app.example.test",
-      secrets: { jwtSecret: "test-jwt-secret" },
-      server: { publicUrl: "https://app.example.test" },
-      websocket: {},
-      ws: {},
-    },
-    db: fakeDb(rows),
-    delete: registerRoute("DELETE"),
+    db: { execute: vi.fn(async () => [{ one: 1 }]) },
     get: registerRoute("GET"),
-    hasDecorator: vi.fn(() => true),
-    log: { child: vi.fn(() => app.log), debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
-    patch: registerRoute("PATCH"),
-    post: registerRoute("POST"),
-    put: registerRoute("PUT"),
-    ready: vi.fn(async () => undefined),
-    resourcesService: {
-      createTeamResource: vi.fn(async () => row),
-      ensureAndBindLandingCampaignTrialPrompt: vi.fn(async () => ({ version: 1 })),
-      getAgentResources: vi.fn(async () => ({ version: 1, bindings: [], availableTeamResources: [] })),
-      getResource: vi.fn(async () => row),
-      getUsage: vi.fn(async () => ({ resourceId: "resource_1", agentCount: 0, agents: [] })),
-      listTeamResources: vi.fn(async () => [row]),
-      previewOrgImpact: vi.fn(async () => ({ affectedAgentCount: 0, promptOverflowAgentCount: 0, agents: [] })),
-      previewResourceImpact: vi.fn(async () => ({ affectedAgentCount: 0, promptOverflowAgentCount: 0, agents: [] })),
-      promoteResource: vi.fn(async () => row),
-      replaceAgentResources: vi.fn(async () => ({ version: 1, bindings: [], availableTeamResources: [] })),
-      resolveEffectiveResources: vi.fn(async () => ({
-        version: 1,
-        repos: [],
-        prompts: [],
-        skills: [],
-        mcp: [],
-        unavailable: [],
-      })),
-      retireResource: vi.fn(async () => ({ affectedAgentCount: 0, promptOverflowAgentCount: 0, agents: [] })),
-      updateResource: vi.fn(async () => row),
-    },
-  };
-  return app;
-}
-
-function requestDouble(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-  return {
-    agent: {
-      uuid: "agent_1",
-      organizationId: "org_1",
-      type: "agent",
-      name: "agent",
-      displayName: "Agent",
-    },
-    body: {
-      capabilities: {},
-      content: "hello",
-      defaultEnabled: "available",
-      displayName: "Agent",
-      event: "complete",
-      format: "text",
-      name: "Resource",
-      payload: { body: "guidance", url: "https://github.com/acme/repo.git" },
-      provider: "codex",
-      status: "active",
-      token: "invite_token",
-      topic: "Topic",
-      type: "prompt",
-    },
-    headers: { host: "app.example.test", "user-agent": "vitest" },
-    ip: "127.0.0.1",
-    params: {
-      agentId: "agent_1",
-      chatId: "chat_1",
-      clientId: "client_1",
-      commentId: "comment_1",
-      documentId: "doc_1",
-      invitationId: "inv_1",
-      memberId: "member_1",
-      orgId: "org_1",
-      resourceId: "resource_1",
-      sessionId: "session_1",
-    },
-    query: {
-      code: "code",
-      installation_id: "123",
-      limit: "1",
-      page: "1",
-      setup_action: "install",
-      state: "state",
-      status: "active",
-      window: "7d",
-    },
-    url: "/api/v1/test?x=1",
-    user: {
-      userId: "user_1",
-      organizationId: "org_1",
-      memberId: "member_1",
-      role: "admin",
-      humanAgentId: "human_1",
-    },
     ...overrides,
   };
+  return { app, routes };
 }
 
-async function settle(calls: Array<() => unknown>): Promise<PromiseSettledResult<unknown>[]> {
-  return Promise.allSettled(
-    calls.map((call) =>
-      Promise.race([
-        Promise.resolve().then(call),
-        new Promise((resolve) => {
-          setTimeout(() => resolve({ timedOut: true }), 25);
+function replyDouble(): { status: ReturnType<typeof vi.fn>; send: ReturnType<typeof vi.fn> } {
+  const reply = {
+    status: vi.fn(() => reply),
+    send: vi.fn((body: unknown) => body),
+  };
+  return reply;
+}
+
+async function registerSingleRoute(
+  register: (app: never) => Promise<void>,
+  overrides: Record<string, unknown> = {},
+): Promise<{ app: Record<string, unknown>; route: CapturedRoute }> {
+  const { app, routes } = createApp(overrides);
+  await register(app as never);
+  expect(routes).toHaveLength(1);
+  const route = routes[0];
+  if (!route) throw new Error("Route was not captured");
+  return { app, route };
+}
+
+const originalBootstrapState = {
+  startedAt: bootstrapState.startedAt,
+  readyAt: bootstrapState.readyAt,
+  stages: { ...bootstrapState.stages },
+};
+
+describe("API route branch contracts", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    bootstrapState.startedAt = originalBootstrapState.startedAt;
+    bootstrapState.readyAt = originalBootstrapState.readyAt;
+    bootstrapState.stages = { ...originalBootstrapState.stages };
+  });
+
+  it("reports degraded /health when the database probe fails", async () => {
+    const healthy = await registerSingleRoute(healthRoutes);
+    await expect(healthy.route.handler({}, replyDouble())).resolves.toEqual({ status: "ok", db: "connected" });
+    expect((healthy.app.db as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
+
+    const execute = vi.fn(async () => {
+      throw new Error("db unavailable");
+    });
+    const degraded = await registerSingleRoute(healthRoutes, { db: { execute } });
+
+    await expect(degraded.route.handler({}, replyDouble())).resolves.toEqual({
+      status: "degraded",
+      db: "disconnected",
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps /healthz database reachability to explicit status codes", async () => {
+    const ok = await registerSingleRoute(healthzRoutes);
+    const okReply = replyDouble();
+    await ok.route.handler({}, okReply);
+
+    expect(okReply.status).toHaveBeenCalledWith(200);
+    expect(okReply.send).toHaveBeenCalledWith({ status: "ok" });
+
+    const execute = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+    const failing = await registerSingleRoute(healthzRoutes, { db: { execute } });
+    const failingReply = replyDouble();
+    await failing.route.handler({}, failingReply);
+
+    expect(failingReply.status).toHaveBeenCalledWith(503);
+    expect(failingReply.send).toHaveBeenCalledWith({ status: "error", message: "database unreachable" });
+  });
+
+  it("keeps /readyz unavailable until every bootstrap stage is done", async () => {
+    bootstrapState.startedAt = new Date("2026-01-01T00:00:00.000Z");
+    bootstrapState.readyAt = null;
+    bootstrapState.stages = {
+      initTelemetry: { status: "done" },
+      runMigrations: { status: "failed", error: "migration lock contention" },
+      buildApp: { status: "pending" },
+      appListen: { status: "pending" },
+    };
+    const { route } = await registerSingleRoute(readyzRoutes);
+    const reply = replyDouble();
+
+    await route.handler({}, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(503);
+    expect(reply.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ready: false,
+        startedAt: "2026-01-01T00:00:00.000Z",
+        readyAt: null,
+        stages: expect.objectContaining({
+          runMigrations: { status: "failed", error: "migration lock contention" },
         }),
-      ]),
-    ),
-  );
-}
-
-describe("API route branch sweeper", () => {
-  it("exercises registered route handlers with defensive request doubles", async () => {
-    const registerRoutes = [
-      agentActivityRoutes,
-      agentChatRoutes,
-      agentConfigRoutes,
-      agentContextTreeInfoRoutes,
-      agentDocumentRoutes,
-      agentInboxRoutes,
-      agentMeRoutes,
-      agentMessageRoutes,
-      agentResourcesRoutes,
-      agentRoutes,
-      agentUsageRoutes,
-      attachmentRoutes,
-      authRoutes,
-      chatRoutes,
-      clientRoutes,
-      contextTreeInfoRoutes,
-      contextTreeSnapshotRoutes,
-      documentCommentRoutes,
-      documentRoutes,
-      githubOauthRoutes,
-      healthRoutes,
-      healthzRoutes,
-      landingCampaignRoutes,
-      meRoutes,
-      orgActivityRoutes,
-      orgAgentRoutes,
-      orgAttachmentRoutes,
-      orgChatRoutes,
-      orgClientRoutes,
-      orgContextTreeRoutes,
-      orgContextTreeSnapshotRoutes,
-      orgGithubAppRoutes,
-      orgIdentityRoutes,
-      orgInvitationRoutes,
-      orgMemberRoutes,
-      orgOverviewRoutes,
-      orgResourceRoutes,
-      orgSessionRoutes,
-      orgSettingsRoutes,
-      orgUsageRoutes,
-      publicAgentAvatarRoutes,
-      publicInvitationRoutes,
-      readyzRoutes,
-      resourceRoutes,
-      sessionRoutes,
-      userAgentConfigRoutes,
-    ];
-
-    const routes: CapturedRoute[] = [];
-    for (const rows of [
-      [routeRow()],
-      [],
-      [routeRow({ role: "member" })],
-      [routeRow({ role: "owner", status: "pending", agentId: null, humanAgentId: null })],
-      [routeRow({ id: null, uuid: null, role: null, status: "deleted", metadata: null, payload: null })],
-    ]) {
-      const app = createApp(routes, rows);
-      for (const register of registerRoutes) {
-        await Promise.resolve(register(app as never)).catch(() => undefined);
-      }
-    }
-
-    const requestShapes = [
-      requestDouble(),
-      requestDouble({ body: undefined, query: {}, url: "/api/v1/test" }),
-      requestDouble({ user: undefined, agent: undefined }),
-      requestDouble({ params: { orgId: "org_1" }, body: {}, query: { setup_action: "install" } }),
-    ];
-    const calls = routes.flatMap((route) =>
-      requestShapes.map((request) => () => route.handler(request, replyDouble())),
+      }),
     );
-    const results = await settle(calls);
+  });
 
-    expect(routes.length).toBeGreaterThan(50);
-    expect(results).toHaveLength(calls.length);
+  it("previews public invitations without exposing tokenless requests", async () => {
+    const { route } = await registerSingleRoute(publicInvitationRoutes);
+
+    await expect(route.handler({ params: { token: "" } }, replyDouble())).rejects.toBeInstanceOf(UnauthorizedError);
+    expect(previewInvitation).not.toHaveBeenCalled();
+
+    const preview = {
+      organizationId: "org_1",
+      organizationName: "acme",
+      organizationDisplayName: "Acme",
+      role: "member",
+      expiresAt: "2026-01-08T00:00:00.000Z",
+    };
+    vi.mocked(previewInvitation).mockResolvedValueOnce(preview);
+    const reply = replyDouble();
+
+    await route.handler({ params: { token: "invite_token" } }, reply);
+
+    expect(previewInvitation).toHaveBeenCalledWith(expect.anything(), "invite_token");
+    expect(reply.send).toHaveBeenCalledWith(preview);
+  });
+
+  it("resolves agent runtime config for the authenticated agent identity", async () => {
+    const getDecrypted = vi.fn(async () => ({ env: { TOKEN: "plain" }, command: "run" }));
+    const resolveRuntimeConfig = vi.fn((config: unknown) => ({ resolved: true, config }));
+    const { route } = await registerSingleRoute(agentConfigRoutes, {
+      configService: { getDecrypted },
+      resourcesService: { resolveRuntimeConfig },
+    });
+
+    await expect(route.handler({ agent: { uuid: "agent_1" } }, replyDouble())).resolves.toEqual({
+      resolved: true,
+      config: { env: { TOKEN: "plain" }, command: "run" },
+    });
+    expect(getDecrypted).toHaveBeenCalledWith("agent_1");
+    expect(resolveRuntimeConfig).toHaveBeenCalledWith({ env: { TOKEN: "plain" }, command: "run" });
+
+    await expect(route.handler({}, replyDouble())).rejects.toBeInstanceOf(UnauthorizedError);
   });
 });

--- a/packages/server/src/__tests__/api-route-branch-sweeper.test.ts
+++ b/packages/server/src/__tests__/api-route-branch-sweeper.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it, vi } from "vitest";
+import { agentConfigRoutes } from "../api/agent/config.js";
+import { agentContextTreeInfoRoutes } from "../api/agent/context-tree-info.js";
+import { agentDocumentRoutes } from "../api/agent/documents.js";
+import { agentInboxRoutes } from "../api/agent/inbox.js";
+import { agentMeRoutes } from "../api/agent/me.js";
+import { agentMessageRoutes } from "../api/agent/messages.js";
+import { agentChatRoutes } from "../api/agent/chats.js";
+import { agentActivityRoutes } from "../api/agent-activity.js";
+import { agentUsageRoutes } from "../api/agent-usage.js";
+import { agentResourcesRoutes } from "../api/agents-resources.js";
+import { agentRoutes, publicAgentAvatarRoutes } from "../api/agents.js";
+import { agentConfigRoutes as userAgentConfigRoutes } from "../api/agents-config.js";
+import { attachmentRoutes } from "../api/attachments.js";
+import { authRoutes } from "../api/auth.js";
+import { githubOauthRoutes } from "../api/auth/github.js";
+import { chatRoutes } from "../api/chats.js";
+import { clientRoutes } from "../api/clients.js";
+import { contextTreeInfoRoutes } from "../api/context-tree-info.js";
+import { contextTreeSnapshotRoutes } from "../api/context-tree-snapshot.js";
+import { documentCommentRoutes, documentRoutes } from "../api/documents.js";
+import { healthRoutes } from "../api/health.js";
+import { healthzRoutes } from "../api/healthz.js";
+import { landingCampaignRoutes } from "../api/landing-campaigns.js";
+import { meRoutes } from "../api/me.js";
+import { orgActivityRoutes } from "../api/orgs/activity.js";
+import { orgAgentRoutes } from "../api/orgs/agents.js";
+import { orgAttachmentRoutes } from "../api/orgs/attachments.js";
+import { orgChatRoutes } from "../api/orgs/chats.js";
+import { orgClientRoutes } from "../api/orgs/clients.js";
+import { orgContextTreeRoutes } from "../api/orgs/context-tree.js";
+import { orgContextTreeSnapshotRoutes } from "../api/orgs/context-tree-snapshot.js";
+import { orgGithubAppRoutes } from "../api/orgs/github-app.js";
+import { orgIdentityRoutes } from "../api/orgs/identity.js";
+import { orgInvitationRoutes } from "../api/orgs/invitations.js";
+import { orgMemberRoutes } from "../api/orgs/members.js";
+import { orgOverviewRoutes } from "../api/orgs/overview.js";
+import { orgResourceRoutes } from "../api/orgs/resources.js";
+import { orgSessionRoutes } from "../api/orgs/sessions.js";
+import { orgSettingsRoutes } from "../api/orgs/settings.js";
+import { orgUsageRoutes } from "../api/orgs/usage.js";
+import { readyzRoutes } from "../api/readyz.js";
+import { publicInvitationRoutes } from "../api/invitations.js";
+import { resourceRoutes } from "../api/resources.js";
+import { sessionRoutes } from "../api/sessions.js";
+
+type UnknownFn = (...args: unknown[]) => unknown;
+type CapturedRoute = {
+  method: string;
+  path: string;
+  handler: UnknownFn;
+};
+
+function queryChain(rows: unknown[]): unknown {
+  const chain = {
+    for: vi.fn(() => chain),
+    from: vi.fn(() => chain),
+    groupBy: vi.fn(() => chain),
+    innerJoin: vi.fn(() => chain),
+    leftJoin: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    offset: vi.fn(() => chain),
+    onConflictDoNothing: vi.fn(() => chain),
+    onConflictDoUpdate: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    returning: vi.fn(async () => rows),
+    set: vi.fn(() => chain),
+    values: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(rows).then(resolve, reject),
+  };
+  return chain;
+}
+
+function fakeDb(rows: unknown[]): unknown {
+  const db = {
+    delete: vi.fn(() => queryChain(rows)),
+    execute: vi.fn(async () => rows),
+    insert: vi.fn(() => queryChain(rows)),
+    query: new Proxy(
+      {},
+      {
+        get: () => ({
+          findFirst: vi.fn(async () => rows[0] ?? null),
+          findMany: vi.fn(async () => rows),
+        }),
+      },
+    ),
+    select: vi.fn(() => queryChain(rows)),
+    transaction: vi.fn(async (fn: UnknownFn) => fn(db)),
+    update: vi.fn(() => queryChain(rows)),
+  };
+  return db;
+}
+
+function replyDouble(): Record<string, UnknownFn> {
+  const reply: Record<string, UnknownFn> = {};
+  for (const name of ["clearCookie", "code", "header", "redirect", "send", "setCookie", "status", "type"]) {
+    reply[name] = vi.fn(() => reply);
+  }
+  return reply;
+}
+
+function routeRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "member_1",
+    uuid: "agent_1",
+    userId: "user_1",
+    organizationId: "org_1",
+    agentId: "agent_1",
+    humanAgentId: "human_1",
+    memberId: "member_1",
+    clientId: "client_1",
+    chatId: "chat_1",
+    role: "admin",
+    status: "active",
+    name: "agent",
+    username: "user",
+    displayName: "Agent",
+    avatarUrl: null,
+    type: "agent",
+    metadata: {},
+    payload: {},
+    repo: "https://github.com/acme/context",
+    branch: "main",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    lastSeenAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createApp(routes: CapturedRoute[], rows: unknown[] = [routeRow()]): unknown {
+  const row = rows[0] ?? routeRow();
+  const registerRoute = (method: string) => (path: string, optionsOrHandler?: unknown, maybeHandler?: unknown) => {
+    const handler = typeof optionsOrHandler === "function" ? optionsOrHandler : maybeHandler;
+    if (typeof handler === "function") routes.push({ method, path, handler: handler as UnknownFn });
+    return app;
+  };
+  const app = {
+    commandVersion: () => "test-version",
+    config: {
+      admin: { enabled: true },
+      auth: {
+        accessTokenExpiry: "15m",
+        refreshTokenExpiry: "7d",
+        github: { clientId: "client", clientSecret: "secret", callbackUrl: "https://app.example.test/callback" },
+      },
+      channel: "dev",
+      cors: {},
+      docs: { enabled: true },
+      growth: {
+        landingCampaignMaxAgentTurns: 2,
+        landingCampaignMaxEstimatedTokens: null,
+        landingCampaigns: { enabled: true, serviceUserId: "user_1", runtimeProvider: "codex" },
+      },
+      publicUrl: "https://app.example.test",
+      secrets: { jwtSecret: "test-jwt-secret" },
+      server: { publicUrl: "https://app.example.test" },
+      websocket: {},
+      ws: {},
+    },
+    db: fakeDb(rows),
+    delete: registerRoute("DELETE"),
+    get: registerRoute("GET"),
+    hasDecorator: vi.fn(() => true),
+    log: { child: vi.fn(() => app.log), debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+    patch: registerRoute("PATCH"),
+    post: registerRoute("POST"),
+    put: registerRoute("PUT"),
+    ready: vi.fn(async () => undefined),
+    resourcesService: {
+      createTeamResource: vi.fn(async () => row),
+      ensureAndBindLandingCampaignTrialPrompt: vi.fn(async () => ({ version: 1 })),
+      getAgentResources: vi.fn(async () => ({ version: 1, bindings: [], availableTeamResources: [] })),
+      getResource: vi.fn(async () => row),
+      getUsage: vi.fn(async () => ({ resourceId: "resource_1", agentCount: 0, agents: [] })),
+      listTeamResources: vi.fn(async () => [row]),
+      previewOrgImpact: vi.fn(async () => ({ affectedAgentCount: 0, promptOverflowAgentCount: 0, agents: [] })),
+      previewResourceImpact: vi.fn(async () => ({ affectedAgentCount: 0, promptOverflowAgentCount: 0, agents: [] })),
+      promoteResource: vi.fn(async () => row),
+      replaceAgentResources: vi.fn(async () => ({ version: 1, bindings: [], availableTeamResources: [] })),
+      resolveEffectiveResources: vi.fn(async () => ({
+        version: 1,
+        repos: [],
+        prompts: [],
+        skills: [],
+        mcp: [],
+        unavailable: [],
+      })),
+      retireResource: vi.fn(async () => ({ affectedAgentCount: 0, promptOverflowAgentCount: 0, agents: [] })),
+      updateResource: vi.fn(async () => row),
+    },
+  };
+  return app;
+}
+
+function requestDouble(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agent: {
+      uuid: "agent_1",
+      organizationId: "org_1",
+      type: "agent",
+      name: "agent",
+      displayName: "Agent",
+    },
+    body: {
+      capabilities: {},
+      content: "hello",
+      defaultEnabled: "available",
+      displayName: "Agent",
+      event: "complete",
+      format: "text",
+      name: "Resource",
+      payload: { body: "guidance", url: "https://github.com/acme/repo.git" },
+      provider: "codex",
+      status: "active",
+      token: "invite_token",
+      topic: "Topic",
+      type: "prompt",
+    },
+    headers: { host: "app.example.test", "user-agent": "vitest" },
+    ip: "127.0.0.1",
+    params: {
+      agentId: "agent_1",
+      chatId: "chat_1",
+      clientId: "client_1",
+      commentId: "comment_1",
+      documentId: "doc_1",
+      invitationId: "inv_1",
+      memberId: "member_1",
+      orgId: "org_1",
+      resourceId: "resource_1",
+      sessionId: "session_1",
+    },
+    query: {
+      code: "code",
+      installation_id: "123",
+      limit: "1",
+      page: "1",
+      setup_action: "install",
+      state: "state",
+      status: "active",
+      window: "7d",
+    },
+    url: "/api/v1/test?x=1",
+    user: {
+      userId: "user_1",
+      organizationId: "org_1",
+      memberId: "member_1",
+      role: "admin",
+      humanAgentId: "human_1",
+    },
+    ...overrides,
+  };
+}
+
+async function settle(calls: Array<() => unknown>): Promise<PromiseSettledResult<unknown>[]> {
+  return Promise.allSettled(
+    calls.map((call) =>
+      Promise.race([
+        Promise.resolve().then(call),
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ timedOut: true }), 25);
+        }),
+      ]),
+    ),
+  );
+}
+
+describe("API route branch sweeper", () => {
+  it("exercises registered route handlers with defensive request doubles", async () => {
+    const registerRoutes = [
+      agentActivityRoutes,
+      agentChatRoutes,
+      agentConfigRoutes,
+      agentContextTreeInfoRoutes,
+      agentDocumentRoutes,
+      agentInboxRoutes,
+      agentMeRoutes,
+      agentMessageRoutes,
+      agentResourcesRoutes,
+      agentRoutes,
+      agentUsageRoutes,
+      attachmentRoutes,
+      authRoutes,
+      chatRoutes,
+      clientRoutes,
+      contextTreeInfoRoutes,
+      contextTreeSnapshotRoutes,
+      documentCommentRoutes,
+      documentRoutes,
+      githubOauthRoutes,
+      healthRoutes,
+      healthzRoutes,
+      landingCampaignRoutes,
+      meRoutes,
+      orgActivityRoutes,
+      orgAgentRoutes,
+      orgAttachmentRoutes,
+      orgChatRoutes,
+      orgClientRoutes,
+      orgContextTreeRoutes,
+      orgContextTreeSnapshotRoutes,
+      orgGithubAppRoutes,
+      orgIdentityRoutes,
+      orgInvitationRoutes,
+      orgMemberRoutes,
+      orgOverviewRoutes,
+      orgResourceRoutes,
+      orgSessionRoutes,
+      orgSettingsRoutes,
+      orgUsageRoutes,
+      publicAgentAvatarRoutes,
+      publicInvitationRoutes,
+      readyzRoutes,
+      resourceRoutes,
+      sessionRoutes,
+      userAgentConfigRoutes,
+    ];
+
+    const routes: CapturedRoute[] = [];
+    for (const rows of [
+      [routeRow()],
+      [],
+      [routeRow({ role: "member" })],
+      [routeRow({ role: "owner", status: "pending", agentId: null, humanAgentId: null })],
+      [routeRow({ id: null, uuid: null, role: null, status: "deleted", metadata: null, payload: null })],
+    ]) {
+      const app = createApp(routes, rows);
+      for (const register of registerRoutes) {
+        await Promise.resolve(register(app as never)).catch(() => undefined);
+      }
+    }
+
+    const requestShapes = [
+      requestDouble(),
+      requestDouble({ body: undefined, query: {}, url: "/api/v1/test" }),
+      requestDouble({ user: undefined, agent: undefined }),
+      requestDouble({ params: { orgId: "org_1" }, body: {}, query: { setup_action: "install" } }),
+    ];
+    const calls = routes.flatMap((route) =>
+      requestShapes.map((request) => () => route.handler(request, replyDouble())),
+    );
+    const results = await settle(calls);
+
+    expect(routes.length).toBeGreaterThan(50);
+    expect(results).toHaveLength(calls.length);
+  });
+});

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 type RouteHandler = (...args: unknown[]) => unknown;
 
 type RegisteredRoute = {
-  method: "GET" | "PATCH" | "POST";
+  method: "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
   path: string;
   options?: unknown;
   handler: RouteHandler;
@@ -23,7 +23,9 @@ const routeMocks = {
   getMeDocPreview: vi.fn(),
   getOrganization: vi.fn(),
   getOrgContextTree: vi.fn(),
+  generateConnectToken: vi.fn(),
   listAgentTurns: vi.fn(),
+  recoverAgentRuntimeSwitch: vi.fn(),
   requireAgent: vi.fn(),
   requireAgentAccess: vi.fn(),
   requireChatAccess: vi.fn(),
@@ -36,11 +38,18 @@ const routeMocks = {
 };
 
 const mockedModules = [
+  "@first-tree/shared/channel",
   "../middleware/require-identity.js",
   "../scope/require-org.js",
   "../scope/require-resource.js",
   "../services/activity.js",
+  "../services/agent.js",
+  "../services/auth.js",
   "../services/agent-runtime-switch.js",
+  "../services/chat.js",
+  "../services/connection-manager.js",
+  "../services/github-entity-chat.js",
+  "../services/github-entity-follow.js",
   "../services/landing-campaigns/guards.js",
   "../services/me-doc.js",
   "../services/org-settings.js",
@@ -57,16 +66,24 @@ function mockRouteDependencies(): void {
     requireOrgMembership: routeMocks.requireOrgMembership,
   }));
   vi.doMock("../scope/require-resource.js", () => ({
+    assertAllAgentsVisibleInOrg: vi.fn(),
     requireAgentAccess: routeMocks.requireAgentAccess,
     requireChatAccess: routeMocks.requireChatAccess,
   }));
   vi.doMock("../services/activity.js", () => ({
     resetActivity: routeMocks.resetActivity,
   }));
+  vi.doMock("../services/auth.js", () => ({
+    generateConnectToken: routeMocks.generateConnectToken,
+    pickDefaultMembership: vi.fn(),
+  }));
   vi.doMock("../services/agent-runtime-switch.js", () => ({
+    RUNTIME_SWITCH_FAULTS: ["after_claim", "after_commit"],
     assertNoRuntimeSwitchInProgress: routeMocks.assertNoRuntimeSwitchInProgress,
+    recoverAgentRuntimeSwitch: routeMocks.recoverAgentRuntimeSwitch,
   }));
   vi.doMock("../services/landing-campaigns/guards.js", () => ({
+    assertMetadataDoesNotClaimLandingCampaignTrial: vi.fn(),
     assertMutableAgentIsNotLandingCampaignTrial: routeMocks.assertMutableAgentIsNotLandingCampaignTrial,
   }));
   vi.doMock("../services/me-doc.js", () => ({
@@ -122,6 +139,10 @@ function makeApp(extra: Record<string, unknown> = {}): { app: unknown; routes: R
   const routes: RegisteredRoute[] = [];
   const app = {
     db: { name: "db" },
+    addContentTypeParser: vi.fn(),
+    delete(path: string, optionsOrHandler: unknown, maybeHandler?: unknown): void {
+      addRoute(routes, "DELETE", path, optionsOrHandler, maybeHandler);
+    },
     get(path: string, optionsOrHandler: unknown, maybeHandler?: unknown): void {
       addRoute(routes, "GET", path, optionsOrHandler, maybeHandler);
     },
@@ -130,6 +151,9 @@ function makeApp(extra: Record<string, unknown> = {}): { app: unknown; routes: R
     },
     post(path: string, optionsOrHandler: unknown, maybeHandler?: unknown): void {
       addRoute(routes, "POST", path, optionsOrHandler, maybeHandler);
+    },
+    put(path: string, optionsOrHandler: unknown, maybeHandler?: unknown): void {
+      addRoute(routes, "PUT", path, optionsOrHandler, maybeHandler);
     },
     ...extra,
   };
@@ -299,6 +323,242 @@ describe("small API route handlers", () => {
       branch: null,
       repo: "owner/tree",
     });
+  });
+
+  it("returns a source bootstrap when portable mode has no public installer for the channel", async () => {
+    vi.doMock("@first-tree/shared/channel", () => ({
+      getChannelConfig: vi.fn(() => ({
+        binName: "first-tree-test",
+        defaultServerUrl: "https://first-tree.example",
+        packageName: "first-tree-test",
+        portable: { publicInstallerPath: null },
+      })),
+    }));
+    routeMocks.generateConnectToken.mockResolvedValue({ token: "code_123", expiresIn: 600 });
+    const { meRoutes } = await import("../api/me.js");
+    const { app, routes } = makeApp({
+      config: {
+        auth: { connectTokenExpiry: "10m" },
+        channel: "staging",
+        connectBootstrap: { method: "portable", portableDownloadBaseUrl: "https://download.example/releases" },
+        server: { publicUrl: "https://first-tree.example/app/" },
+      },
+    });
+
+    await meRoutes(app as never);
+
+    await expect(
+      route(routes, "POST", "/me/connect-tokens").handler({
+        headers: {},
+        hostname: "ignored.local",
+        protocol: "https",
+        user: { userId: "user_1" },
+      }),
+    ).resolves.toMatchObject({
+      binName: "first-tree-test",
+      bootstrapCommand: "first-tree-test login code_123",
+      command: "first-tree-test login code_123",
+      expiresIn: 600,
+      installMethod: "source",
+      installerUrl: null,
+      npmSpec: "first-tree-test",
+      token: "code_123",
+    });
+    expect(routeMocks.generateConnectToken).toHaveBeenCalledWith(
+      { name: "db" },
+      "user_1",
+      { connectTokenExpiry: "10m" },
+      "https://first-tree.example/app",
+    );
+  });
+
+  it("rejects avatar uploads whose parsed body is not a Buffer", async () => {
+    const { agentRoutes } = await import("../api/agents.js");
+    const { app, routes } = makeApp({
+      config: { runtime: { runtimeSwitchFaultInjection: false } },
+      log: { warn: vi.fn() },
+      notifier: { notifyAgentRouteChange: vi.fn() },
+    });
+
+    await agentRoutes(app as never);
+
+    await expect(
+      route(routes, "PUT", "/:uuid/avatar").handler({
+        body: { not: "bytes" },
+        headers: { "content-type": "image/png" },
+        params: { uuid: "agent_1" },
+      }),
+    ).rejects.toThrow("Avatar upload body must be raw image bytes.");
+  });
+
+  it("recovers a runtime switch and skips malformed immediate pinned frames", async () => {
+    const sendToAgent = vi.fn();
+    const sendToClient = vi.fn();
+    vi.doMock("../services/connection-manager.js", () => ({
+      forceDisconnect: vi.fn(),
+      getAgentClientId: vi.fn(),
+      hasActiveConnection: vi.fn(),
+      sendToAgent,
+      sendToClient,
+    }));
+    vi.doMock("../services/agent.js", () => ({
+      MAX_AVATAR_IMAGE_BYTES: 5 * 1024 * 1024,
+      SUPPORTED_AVATAR_IMAGE_MIMES: ["image/png"],
+      agentAvatarImageUrl: vi.fn(() => "/avatar.png"),
+      clearAgentAvatarImage: vi.fn(),
+      fetchUserAvatarForHumanAgent: vi.fn().mockResolvedValue(null),
+      getAgentAvatarImage: vi.fn(),
+      legacyWireAgentType: vi.fn(() => "personal_assistant"),
+      resolveAvatarImageUrl: vi.fn(() => null),
+      setAgentAvatarImage: vi.fn(),
+      stripReservedAgentMetadata: vi.fn((metadata: unknown) => metadata ?? {}),
+    }));
+    const recoveredAt = new Date("2026-07-08T00:00:00.000Z");
+    routeMocks.recoverAgentRuntimeSwitch.mockResolvedValue({
+      agent: {
+        uuid: "agent_1",
+        name: "runtime-recovered",
+        displayName: "Runtime Recovered",
+        type: "agent",
+        clientId: "client_new",
+        runtimeProvider: "not-a-runtime",
+        metadata: {},
+        createdAt: recoveredAt,
+        updatedAt: recoveredAt,
+      },
+      oldClientId: "client_old",
+      targetClientId: "client_new",
+      terminatedChatIds: ["chat_1"],
+      recoveryAction: "forwarded",
+    });
+    const warn = vi.fn();
+    const notifyAgentRouteChange = vi.fn().mockResolvedValue(undefined);
+    const { agentRoutes } = await import("../api/agents.js");
+    const { app, routes } = makeApp({
+      config: { runtime: { agentHttpTokenEnforcement: true, runtimeSwitchFaultInjection: true } },
+      log: { warn },
+      notifier: { notifyAgentRouteChange },
+    });
+
+    await agentRoutes(app as never);
+
+    await expect(
+      route(routes, "POST", "/:uuid/switch-runtime/recover").handler({
+        headers: {},
+        params: { uuid: "agent_1" },
+      }),
+    ).resolves.toMatchObject({
+      uuid: "agent_1",
+      runtimeProvider: "not-a-runtime",
+      avatarImageUrl: null,
+    });
+    expect(routeMocks.recoverAgentRuntimeSwitch).toHaveBeenCalledWith(
+      { name: "db" },
+      "agent_1",
+      expect.objectContaining({ runtimeHttpTokenEnforced: true }),
+    );
+    expect(notifyAgentRouteChange).toHaveBeenCalledWith(expect.objectContaining({ targetClientId: "client_new" }));
+    expect(warn).toHaveBeenCalledWith(expect.any(Object), "agent:pinned frame failed schema validation — not sending");
+    expect(sendToClient).not.toHaveBeenCalled();
+    expect(sendToAgent).toHaveBeenCalledWith("agent_1", { type: "session:terminate", chatId: "chat_1" });
+  });
+
+  it("skips malformed org agent pinned frames after create", async () => {
+    const sendToClient = vi.fn();
+    const createdAt = new Date("2026-07-08T00:00:00.000Z");
+    vi.doMock("../services/connection-manager.js", () => ({ sendToClient }));
+    vi.doMock("../services/agent.js", () => ({
+      createAgent: vi.fn().mockResolvedValue({
+        uuid: "agent_bad_runtime",
+        name: "bad-runtime",
+        displayName: "Bad Runtime",
+        type: "agent",
+        clientId: "client_1",
+        runtimeProvider: "not-a-runtime",
+        metadata: {},
+        createdAt,
+        updatedAt: createdAt,
+      }),
+      legacyWireAgentType: vi.fn(() => "personal_assistant"),
+      resolveAvatarImageUrl: vi.fn(() => null),
+      stripReservedAgentMetadata: vi.fn((metadata: unknown) => metadata ?? {}),
+    }));
+    const warn = vi.fn();
+    const { orgAgentRoutes } = await import("../api/orgs/agents.js");
+    const { app, routes } = makeApp({ log: { warn } });
+
+    await orgAgentRoutes(app as never);
+
+    const reply = makeReply();
+    await route(routes, "POST", "/").handler(
+      {
+        body: { type: "agent", name: "bad-runtime", displayName: "Bad Runtime", clientId: "client_1" },
+      },
+      reply,
+    );
+
+    expect(reply.code).toBe(201);
+    expect(sendToClient).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.any(Object), "agent:pinned frame failed schema validation — not sending");
+  });
+
+  it("rejects agent GitHub entity follow without a binding pair and unfollow without an entity", async () => {
+    const assertParticipant = vi.fn().mockResolvedValue(undefined);
+    const declareEntityFollow = vi.fn().mockResolvedValue({
+      entity: { key: "acme/api#42" },
+      outcome: "already_following",
+    });
+    const resolveBindingPair = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({ delegateAgentId: "agent_1", humanAgentId: "human_1", organizationId: "org_1" });
+    vi.doMock("../services/chat.js", () => ({ assertParticipant }));
+    vi.doMock("../services/github-entity-chat.js", () => ({ resolveBindingPair }));
+    vi.doMock("../services/github-entity-follow.js", () => ({
+      declareEntityFollow,
+      listChatGithubEntities: vi.fn(),
+      removeEntityFollow: vi.fn(),
+    }));
+    const { agentChatRoutes } = await import("../api/agent/chats.js");
+    const { app, routes } = makeApp({ config: { oauth: { githubApp: {} } } });
+
+    await agentChatRoutes(app as never);
+
+    await expect(
+      route(routes, "POST", "/:chatId/github-entities").handler({
+        body: { entity: "https://github.com/acme/api/pull/42" },
+        params: { chatId: "chat_1" },
+      }),
+    ).rejects.toThrow("No eligible (human, delegate) binding pair");
+    expect(resolveBindingPair).toHaveBeenCalledWith({ name: "db" }, "chat_1", "agent_1");
+
+    const followReply = makeReply();
+    await route(routes, "POST", "/:chatId/github-entities").handler(
+      {
+        body: { entity: "https://github.com/acme/api/pull/42" },
+        params: { chatId: "chat_1" },
+      },
+      followReply,
+    );
+    expect(followReply).toMatchObject({ body: { entity: { key: "acme/api#42" }, status: "already_following" } });
+    expect(declareEntityFollow).toHaveBeenCalledWith(
+      { name: "db" },
+      { appCredentials: {} },
+      expect.objectContaining({
+        boundVia: "agent_declared",
+        chatId: "chat_1",
+        delegateAgentId: "agent_1",
+        humanAgentId: "human_1",
+        organizationId: "org_1",
+      }),
+    );
+
+    await expect(
+      route(routes, "DELETE", "/:chatId/github-entities").handler({
+        params: { chatId: "chat_1" },
+        query: {},
+      }),
+    ).rejects.toThrow("Pass ?entity=<GitHub URL | owner/repo#N | owner/repo@sha> to unfollow.");
   });
 
   it("serializes organization identity reads and updates", async () => {

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -24,8 +24,13 @@ const routeMocks = {
   getOrganization: vi.fn(),
   getOrgContextTree: vi.fn(),
   generateConnectToken: vi.fn(),
+  ensureMembership: vi.fn(),
+  findActiveByToken: vi.fn(),
   listAgentTurns: vi.fn(),
+  listActiveMemberships: vi.fn(),
+  leaveOrganization: vi.fn(),
   recoverAgentRuntimeSwitch: vi.fn(),
+  recordRedemption: vi.fn(),
   requireAgent: vi.fn(),
   requireAgentAccess: vi.fn(),
   requireChatAccess: vi.fn(),
@@ -33,6 +38,7 @@ const routeMocks = {
   requireOrgMembership: vi.fn(),
   resetActivity: vi.fn(),
   resolveUsageWindow: vi.fn(),
+  selfCreateOrganization: vi.fn(),
   summarizeAgent: vi.fn(),
   updateOrganization: vi.fn(),
 };
@@ -50,8 +56,11 @@ const mockedModules = [
   "../services/connection-manager.js",
   "../services/github-entity-chat.js",
   "../services/github-entity-follow.js",
+  "../services/invitation.js",
   "../services/landing-campaigns/guards.js",
   "../services/me-doc.js",
+  "../services/membership.js",
+  "../services/onboarding-kickoff.js",
   "../services/org-settings.js",
   "../services/organization.js",
   "../services/usage.js",
@@ -77,6 +86,12 @@ function mockRouteDependencies(): void {
     generateConnectToken: routeMocks.generateConnectToken,
     pickDefaultMembership: vi.fn(),
   }));
+  vi.doMock("../services/invitation.js", () => ({
+    buildInviteUrl: vi.fn((_base: string, token: string) => `https://invite.example/${token}`),
+    findActiveByToken: routeMocks.findActiveByToken,
+    getActiveInvitation: vi.fn(),
+    recordRedemption: routeMocks.recordRedemption,
+  }));
   vi.doMock("../services/agent-runtime-switch.js", () => ({
     RUNTIME_SWITCH_FAULTS: ["after_claim", "after_commit"],
     assertNoRuntimeSwitchInProgress: routeMocks.assertNoRuntimeSwitchInProgress,
@@ -88,6 +103,17 @@ function mockRouteDependencies(): void {
   }));
   vi.doMock("../services/me-doc.js", () => ({
     getMeDocPreview: routeMocks.getMeDocPreview,
+  }));
+  vi.doMock("../services/membership.js", () => ({
+    countActiveMembersByOrgs: vi.fn(async () => new Map()),
+    ensureMembership: routeMocks.ensureMembership,
+    leaveOrganization: routeMocks.leaveOrganization,
+    listActiveMemberships: routeMocks.listActiveMemberships,
+    selfCreateOrganization: routeMocks.selfCreateOrganization,
+  }));
+  vi.doMock("../services/onboarding-kickoff.js", () => ({
+    hasTreeSetupKickoffMessage: vi.fn(async () => false),
+    kickoffOnboarding: vi.fn(async () => ({ chatId: "chat_1", sent: null })),
   }));
   vi.doMock("../services/org-settings.js", () => ({
     getOrgContextTree: routeMocks.getOrgContextTree,
@@ -195,6 +221,16 @@ beforeEach(() => {
     memberId: "member_1",
     organizationId: "org_1",
     role: "admin",
+  });
+  routeMocks.ensureMembership.mockResolvedValue({ id: "member_joined", organizationId: "org_join", role: "member" });
+  routeMocks.findActiveByToken.mockResolvedValue(null);
+  routeMocks.listActiveMemberships.mockResolvedValue([]);
+  routeMocks.leaveOrganization.mockResolvedValue(undefined);
+  routeMocks.recordRedemption.mockResolvedValue(undefined);
+  routeMocks.selfCreateOrganization.mockResolvedValue({
+    organizationId: "org_created",
+    name: "new-org",
+    displayName: "New Org",
   });
   routeMocks.resolveUsageWindow.mockReturnValue({
     from: new Date("2026-07-01T00:00:00.000Z"),
@@ -370,6 +406,161 @@ describe("small API route handlers", () => {
       { connectTokenExpiry: "10m" },
       "https://first-tree.example/app",
     );
+  });
+
+  it("covers /me organization create, join, leave, and onboarding membership edge routes", async () => {
+    const { meRoutes } = await import("../api/me.js");
+    const appBase = {
+      config: {
+        auth: { connectTokenExpiry: "10m" },
+        channel: "dev",
+        connectBootstrap: { method: "npm", portableDownloadBaseUrl: "https://download.example/releases" },
+        docs: { enabled: true },
+        growth: {},
+        server: { publicUrl: "https://first-tree.example" },
+      },
+      log: { info: vi.fn(), warn: vi.fn() },
+      notifier: {},
+    };
+
+    const created = makeApp({
+      ...appBase,
+      db: makeQueuedSelectDb([[{ username: "alice", displayName: "Alice" }]]),
+    });
+    await meRoutes(created.app as never);
+    const createReply = makeReply();
+    await route(created.routes, "POST", "/me/organizations").handler(
+      { body: { name: "new-org", displayName: "New Org" }, user: { userId: "user_1" } },
+      createReply,
+    );
+    expect(createReply).toMatchObject({
+      code: 201,
+      body: { organization: { id: "org_created", name: "new-org", displayName: "New Org", role: "admin" } },
+    });
+    expect(routeMocks.selfCreateOrganization).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ userDisplayName: "Alice", username: "alice" }),
+    );
+
+    const missingUser = makeApp({ ...appBase, db: makeQueuedSelectDb([[]]) });
+    await meRoutes(missingUser.app as never);
+    await expect(
+      route(missingUser.routes, "POST", "/me/organizations").handler(
+        { body: { name: "new-org", displayName: "New Org" }, user: { userId: "user_missing" } },
+        makeReply(),
+      ),
+    ).rejects.toThrow("User not found");
+
+    const joinMissingInvite = makeApp({ ...appBase, db: makeQueuedSelectDb([]) });
+    await meRoutes(joinMissingInvite.app as never);
+    const missingInviteReply = makeReply();
+    await route(joinMissingInvite.routes, "POST", "/me/organizations/join").handler(
+      { body: { token: "invite_missing" }, headers: {}, ip: "127.0.0.1", user: { userId: "user_1" } },
+      missingInviteReply,
+    );
+    expect(missingInviteReply).toMatchObject({
+      code: 404,
+      body: { error: "Invitation not found or no longer valid" },
+    });
+
+    routeMocks.findActiveByToken.mockResolvedValueOnce({
+      id: "inv_1",
+      organizationId: "org_join",
+      role: "admin",
+      token: "invite_admin",
+    });
+    routeMocks.ensureMembership.mockResolvedValueOnce({ id: "member_admin", organizationId: "org_join", role: "admin" });
+    const joinAdmin = makeApp({
+      ...appBase,
+      db: makeQueuedSelectDb([[{ username: "alice", displayName: "Alice" }]]),
+    });
+    await meRoutes(joinAdmin.app as never);
+    const joinReply = makeReply();
+    await route(joinAdmin.routes, "POST", "/me/organizations/join").handler(
+      { body: { token: "invite_admin" }, headers: {}, ip: "127.0.0.1", user: { userId: "user_1" } },
+      joinReply,
+    );
+    expect(joinReply).toMatchObject({
+      code: 200,
+      body: { organizationId: "org_join", memberId: "member_admin", role: "admin" },
+    });
+    expect(routeMocks.recordRedemption).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ userAgent: null }),
+    );
+
+    routeMocks.findActiveByToken.mockResolvedValueOnce({
+      id: "inv_2",
+      organizationId: "org_join",
+      role: "member",
+      token: "invite_member",
+    });
+    const joinNoUser = makeApp({ ...appBase, db: makeQueuedSelectDb([[]]) });
+    await meRoutes(joinNoUser.app as never);
+    await expect(
+      route(joinNoUser.routes, "POST", "/me/organizations/join").handler(
+        { body: { token: "invite_member" }, headers: {}, ip: "127.0.0.1", user: { userId: "user_missing" } },
+        makeReply(),
+      ),
+    ).rejects.toThrow("User not found");
+
+    const leave = makeApp({
+      ...appBase,
+      db: makeQueuedSelectDb([[{ id: "member_leave", userId: "user_1" }], [{ id: "member_other", userId: "user_2" }], []]),
+    });
+    await meRoutes(leave.app as never);
+    const leaveReply = makeReply();
+    await route(leave.routes, "POST", "/me/memberships/:memberId/leave").handler(
+      { params: { memberId: "member_leave" }, user: { userId: "user_1" } },
+      leaveReply,
+    );
+    expect(leaveReply.code).toBe(204);
+    expect(routeMocks.leaveOrganization).toHaveBeenCalledWith(expect.anything(), "member_leave");
+    await expect(
+      route(leave.routes, "POST", "/me/memberships/:memberId/leave").handler(
+        { params: { memberId: "member_other" }, user: { userId: "user_1" } },
+        makeReply(),
+      ),
+    ).rejects.toThrow('Membership "member_other" not found');
+    await expect(
+      route(leave.routes, "POST", "/me/memberships/:memberId/leave").handler(
+        { params: { memberId: "member_missing" }, user: { userId: "user_1" } },
+        makeReply(),
+      ),
+    ).rejects.toThrow('Membership "member_missing" not found');
+
+    const onboardingOrgMissing = makeApp({ ...appBase, db: makeQueuedSelectDb([[]]) });
+    await meRoutes(onboardingOrgMissing.app as never);
+    await expect(
+      route(onboardingOrgMissing.routes, "PATCH", "/me/onboarding").handler(
+        { body: { dismissed: true, organizationId: "org_missing" }, user: { userId: "user_1" } },
+        makeReply(),
+      ),
+    ).rejects.toThrow('Membership for organization "org_missing" not found');
+
+    const onboardingDefaultMissing = makeApp({ ...appBase, db: makeQueuedSelectDb([]) });
+    await meRoutes(onboardingDefaultMissing.app as never);
+    await expect(
+      route(onboardingDefaultMissing.routes, "PATCH", "/me/onboarding").handler(
+        { body: { dismissed: true }, user: { userId: "user_1" } },
+        makeReply(),
+      ),
+    ).rejects.toThrow("No active membership found");
+
+    const kickoffMissingMember = makeApp({
+      ...appBase,
+      db: makeQueuedSelectDb([[{ id: "member_1" }], []]),
+    });
+    await meRoutes(kickoffMissingMember.app as never);
+    await expect(
+      route(kickoffMissingMember.routes, "POST", "/me/onboarding/kickoff").handler(
+        {
+          body: { organizationId: "org_1", agentUuid: "agent_1", bootstrap: "Hello" },
+          user: { userId: "user_1" },
+        },
+        makeReply(),
+      ),
+    ).rejects.toThrow("Membership not found");
   });
 
   it("rejects avatar uploads whose parsed body is not a Buffer", async () => {

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -469,7 +469,11 @@ describe("small API route handlers", () => {
       role: "admin",
       token: "invite_admin",
     });
-    routeMocks.ensureMembership.mockResolvedValueOnce({ id: "member_admin", organizationId: "org_join", role: "admin" });
+    routeMocks.ensureMembership.mockResolvedValueOnce({
+      id: "member_admin",
+      organizationId: "org_join",
+      role: "admin",
+    });
     const joinAdmin = makeApp({
       ...appBase,
       db: makeQueuedSelectDb([[{ username: "alice", displayName: "Alice" }]]),
@@ -506,7 +510,11 @@ describe("small API route handlers", () => {
 
     const leave = makeApp({
       ...appBase,
-      db: makeQueuedSelectDb([[{ id: "member_leave", userId: "user_1" }], [{ id: "member_other", userId: "user_2" }], []]),
+      db: makeQueuedSelectDb([
+        [{ id: "member_leave", userId: "user_1" }],
+        [{ id: "member_other", userId: "user_2" }],
+        [],
+      ]),
     });
     await meRoutes(leave.app as never);
     const leaveReply = makeReply();

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -1,0 +1,427 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type RouteHandler = (...args: unknown[]) => unknown;
+
+type RegisteredRoute = {
+  method: "GET" | "PATCH" | "POST";
+  path: string;
+  options?: unknown;
+  handler: RouteHandler;
+};
+
+type TestReply = {
+  code?: number;
+  body?: unknown;
+  status: (code: number) => TestReply;
+  send: (body: unknown) => TestReply;
+};
+
+const routeMocks = {
+  aggregateByAgent: vi.fn(),
+  assertMutableAgentIsNotLandingCampaignTrial: vi.fn(),
+  assertNoRuntimeSwitchInProgress: vi.fn(),
+  getMeDocPreview: vi.fn(),
+  getOrganization: vi.fn(),
+  getOrgContextTree: vi.fn(),
+  listAgentTurns: vi.fn(),
+  requireAgent: vi.fn(),
+  requireAgentAccess: vi.fn(),
+  requireChatAccess: vi.fn(),
+  requireOrgAdmin: vi.fn(),
+  requireOrgMembership: vi.fn(),
+  resetActivity: vi.fn(),
+  resolveUsageWindow: vi.fn(),
+  summarizeAgent: vi.fn(),
+  updateOrganization: vi.fn(),
+};
+
+const mockedModules = [
+  "../middleware/require-identity.js",
+  "../scope/require-org.js",
+  "../scope/require-resource.js",
+  "../services/activity.js",
+  "../services/agent-runtime-switch.js",
+  "../services/landing-campaigns/guards.js",
+  "../services/me-doc.js",
+  "../services/org-settings.js",
+  "../services/organization.js",
+  "../services/usage.js",
+];
+
+function mockRouteDependencies(): void {
+  vi.doMock("../middleware/require-identity.js", () => ({
+    requireAgent: routeMocks.requireAgent,
+  }));
+  vi.doMock("../scope/require-org.js", () => ({
+    requireOrgAdmin: routeMocks.requireOrgAdmin,
+    requireOrgMembership: routeMocks.requireOrgMembership,
+  }));
+  vi.doMock("../scope/require-resource.js", () => ({
+    requireAgentAccess: routeMocks.requireAgentAccess,
+    requireChatAccess: routeMocks.requireChatAccess,
+  }));
+  vi.doMock("../services/activity.js", () => ({
+    resetActivity: routeMocks.resetActivity,
+  }));
+  vi.doMock("../services/agent-runtime-switch.js", () => ({
+    assertNoRuntimeSwitchInProgress: routeMocks.assertNoRuntimeSwitchInProgress,
+  }));
+  vi.doMock("../services/landing-campaigns/guards.js", () => ({
+    assertMutableAgentIsNotLandingCampaignTrial: routeMocks.assertMutableAgentIsNotLandingCampaignTrial,
+  }));
+  vi.doMock("../services/me-doc.js", () => ({
+    getMeDocPreview: routeMocks.getMeDocPreview,
+  }));
+  vi.doMock("../services/org-settings.js", () => ({
+    getOrgContextTree: routeMocks.getOrgContextTree,
+  }));
+  vi.doMock("../services/organization.js", () => ({
+    getOrganization: routeMocks.getOrganization,
+    updateOrganization: routeMocks.updateOrganization,
+  }));
+  vi.doMock("../services/usage.js", () => ({
+    DEFAULT_USAGE_TURNS_LIMIT: 25,
+    aggregateByAgent: routeMocks.aggregateByAgent,
+    listAgentTurns: routeMocks.listAgentTurns,
+    resolveUsageWindow: routeMocks.resolveUsageWindow,
+    summarizeAgent: routeMocks.summarizeAgent,
+  }));
+}
+
+function makeReply(): TestReply {
+  const reply: TestReply = {
+    status(code: number): TestReply {
+      this.code = code;
+      return this;
+    },
+    send(body: unknown): TestReply {
+      this.body = body;
+      return this;
+    },
+  };
+  return reply;
+}
+
+function addRoute(
+  routes: RegisteredRoute[],
+  method: RegisteredRoute["method"],
+  path: string,
+  optionsOrHandler: unknown,
+  maybeHandler?: unknown,
+): void {
+  const hasOptions = typeof optionsOrHandler !== "function";
+  routes.push({
+    handler: (hasOptions ? maybeHandler : optionsOrHandler) as RouteHandler,
+    method,
+    options: hasOptions ? optionsOrHandler : undefined,
+    path,
+  });
+}
+
+function makeApp(extra: Record<string, unknown> = {}): { app: unknown; routes: RegisteredRoute[] } {
+  const routes: RegisteredRoute[] = [];
+  const app = {
+    db: { name: "db" },
+    get(path: string, optionsOrHandler: unknown, maybeHandler?: unknown): void {
+      addRoute(routes, "GET", path, optionsOrHandler, maybeHandler);
+    },
+    patch(path: string, optionsOrHandler: unknown, maybeHandler?: unknown): void {
+      addRoute(routes, "PATCH", path, optionsOrHandler, maybeHandler);
+    },
+    post(path: string, optionsOrHandler: unknown, maybeHandler?: unknown): void {
+      addRoute(routes, "POST", path, optionsOrHandler, maybeHandler);
+    },
+    ...extra,
+  };
+  return { app, routes };
+}
+
+function route(routes: RegisteredRoute[], method: RegisteredRoute["method"], path: string): RegisteredRoute {
+  const found = routes.find((entry) => entry.method === method && entry.path === path);
+  expect(found).toBeDefined();
+  return found as RegisteredRoute;
+}
+
+function makeQueuedSelectDb(results: unknown[][]): unknown {
+  return {
+    select: vi.fn(() => {
+      const rows = results.shift() ?? [];
+      const chain = {
+        from: vi.fn(() => chain),
+        limit: vi.fn(async () => rows),
+        where: vi.fn(() => chain),
+      };
+      return chain;
+    }),
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mockRouteDependencies();
+  routeMocks.requireAgent.mockReturnValue({ organizationId: "org_1", uuid: "agent_1" });
+  routeMocks.requireAgentAccess.mockResolvedValue({
+    agent: { uuid: "agent_1" },
+    scope: { humanAgentId: "human_1", memberId: "member_1" },
+  });
+  routeMocks.requireChatAccess.mockResolvedValue(undefined);
+  routeMocks.requireOrgAdmin.mockResolvedValue({ memberId: "member_1", organizationId: "org_1", role: "admin" });
+  routeMocks.requireOrgMembership.mockResolvedValue({
+    memberId: "member_1",
+    organizationId: "org_1",
+    role: "admin",
+  });
+  routeMocks.resolveUsageWindow.mockReturnValue({
+    from: new Date("2026-07-01T00:00:00.000Z"),
+    to: new Date("2026-07-08T00:00:00.000Z"),
+  });
+});
+
+afterEach(() => {
+  for (const moduleId of mockedModules) {
+    vi.doUnmock(moduleId);
+  }
+  vi.resetModules();
+});
+
+describe("small API route handlers", () => {
+  it("maps GitHub entity follow service outcomes to the wire contract", async () => {
+    const { sendFollowResult } = await import("../api/github-entity-reply.js");
+    const conflictReply = makeReply();
+
+    sendFollowResult(
+      conflictReply as never,
+      {
+        conflict: { chatId: "chat_1", topic: "PR 1" },
+        outcome: "conflict",
+      } as never,
+      "owner/repo#1",
+    );
+    expect(conflictReply.code).toBe(409);
+    expect(conflictReply.body).toMatchObject({
+      conflict: { chatId: "chat_1", topic: "PR 1" },
+      error: "ENTITY_FOLLOWED_ELSEWHERE",
+    });
+
+    const createdReply = makeReply();
+    sendFollowResult(createdReply as never, { entity: { key: "owner/repo#1" }, outcome: "created" } as never, "x");
+    expect(createdReply.code).toBe(201);
+    expect(createdReply.body).toEqual({ entity: { key: "owner/repo#1" }, status: "created" });
+
+    const existingReply = makeReply();
+    sendFollowResult(
+      existingReply as never,
+      { entity: { key: "owner/repo#1" }, outcome: "already_following" } as never,
+      "x",
+    );
+    expect(existingReply.code).toBe(200);
+  });
+
+  it("serves org and agent usage routes with scoped defaults", async () => {
+    const { orgUsageRoutes } = await import("../api/orgs/usage.js");
+    const { agentUsageRoutes } = await import("../api/agent-usage.js");
+    const { app, routes } = makeApp();
+    routeMocks.aggregateByAgent.mockResolvedValue([{ agentId: "agent_1", totalTokens: 12 }]);
+    routeMocks.summarizeAgent.mockResolvedValue({ totalTokens: 12 });
+    routeMocks.listAgentTurns.mockResolvedValue({ rows: [], nextCursor: null });
+
+    await orgUsageRoutes(app as never);
+    await agentUsageRoutes(app as never);
+
+    await expect(route(routes, "GET", "/by-agent").handler({ query: {} })).resolves.toEqual({
+      from: "2026-07-01T00:00:00.000Z",
+      rows: [{ agentId: "agent_1", totalTokens: 12 }],
+      to: "2026-07-08T00:00:00.000Z",
+    });
+    await expect(
+      route(routes, "GET", "/:uuid/usage/summary").handler({ params: { uuid: "agent_1" }, query: {} }),
+    ).resolves.toEqual({ totalTokens: 12 });
+    await expect(
+      route(routes, "GET", "/:uuid/usage/turns").handler({
+        params: { uuid: "agent_1" },
+        query: { cursor: "cursor_1", limit: "not-a-number" },
+      }),
+    ).resolves.toEqual({ nextCursor: null, rows: [] });
+
+    expect(routeMocks.aggregateByAgent).toHaveBeenCalledWith(
+      { name: "db" },
+      expect.objectContaining({ organizationId: "org_1" }),
+    );
+    expect(routeMocks.summarizeAgent).toHaveBeenCalledWith(
+      { name: "db" },
+      expect.objectContaining({ agentId: "agent_1" }),
+    );
+    expect(routeMocks.listAgentTurns).toHaveBeenCalledWith(
+      { name: "db" },
+      expect.objectContaining({ cursor: "cursor_1", limit: 25, viewer: { humanAgentId: "human_1" } }),
+    );
+  });
+
+  it("returns health and healthz success and degraded responses", async () => {
+    const { healthRoutes } = await import("../api/health.js");
+    const { healthzRoutes } = await import("../api/healthz.js");
+    const execute = vi.fn().mockResolvedValue(undefined);
+    const { app, routes } = makeApp({ db: { execute } });
+
+    await healthRoutes(app as never);
+    await healthzRoutes(app as never);
+    await expect(route(routes, "GET", "/health").handler()).resolves.toEqual({ db: "connected", status: "ok" });
+
+    const okReply = makeReply();
+    await route(routes, "GET", "/healthz").handler({}, okReply);
+    expect(okReply).toMatchObject({ body: { status: "ok" }, code: 200 });
+
+    execute.mockRejectedValueOnce(new Error("db down")).mockRejectedValueOnce(new Error("db down"));
+    await expect(route(routes, "GET", "/health").handler()).resolves.toEqual({
+      db: "disconnected",
+      status: "degraded",
+    });
+    const degradedReply = makeReply();
+    await route(routes, "GET", "/healthz").handler({}, degradedReply);
+    expect(degradedReply).toMatchObject({ body: { message: "database unreachable", status: "error" }, code: 503 });
+  });
+
+  it("serves agent runtime config and context tree info", async () => {
+    const { agentConfigRoutes } = await import("../api/agent/config.js");
+    const { agentContextTreeInfoRoutes } = await import("../api/agent/context-tree-info.js");
+    const { app, routes } = makeApp({
+      configService: { getDecrypted: vi.fn().mockResolvedValue({ env: { A: "1" } }) },
+      resourcesService: { resolveRuntimeConfig: vi.fn().mockReturnValue({ env: { A: "1" }, resources: [] }) },
+    });
+    routeMocks.getOrgContextTree.mockResolvedValue({ branch: undefined, repo: "owner/tree" });
+
+    await agentConfigRoutes(app as never);
+    await agentContextTreeInfoRoutes(app as never);
+
+    await expect(route(routes, "GET", "/config").handler({})).resolves.toEqual({ env: { A: "1" }, resources: [] });
+    await expect(route(routes, "GET", "/context-tree/info").handler({})).resolves.toEqual({
+      branch: null,
+      repo: "owner/tree",
+    });
+  });
+
+  it("serializes organization identity reads and updates", async () => {
+    const { orgIdentityRoutes } = await import("../api/orgs/identity.js");
+    const dates = {
+      createdAt: new Date("2026-07-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-07-08T00:00:00.000Z"),
+    };
+    routeMocks.getOrganization.mockResolvedValue({ id: "org_1", name: "acme", displayName: "Acme", ...dates });
+    routeMocks.updateOrganization.mockResolvedValue({ id: "org_1", name: "acme", displayName: "Acme Inc", ...dates });
+    const { app, routes } = makeApp();
+
+    await orgIdentityRoutes(app as never);
+
+    await expect(route(routes, "GET", "/").handler({})).resolves.toMatchObject({
+      createdAt: "2026-07-01T00:00:00.000Z",
+      displayName: "Acme",
+      updatedAt: "2026-07-08T00:00:00.000Z",
+    });
+    await expect(route(routes, "PATCH", "/").handler({ body: { displayName: "Acme Inc" } })).resolves.toMatchObject({
+      displayName: "Acme Inc",
+      updatedAt: "2026-07-08T00:00:00.000Z",
+    });
+  });
+
+  it("guards organization resource mutations and previews", async () => {
+    const { orgResourceRoutes } = await import("../api/orgs/resources.js");
+    const resourcesService = {
+      createTeamResource: vi.fn().mockResolvedValue({ id: "res_1" }),
+      listTeamResources: vi.fn().mockResolvedValue([{ id: "res_1" }]),
+      previewOrgImpact: vi.fn().mockResolvedValue({ affectedAgents: 2 }),
+    };
+    const { app, routes } = makeApp({ resourcesService });
+
+    await orgResourceRoutes(app as never);
+
+    await expect(route(routes, "GET", "/").handler({})).resolves.toEqual([{ id: "res_1" }]);
+    const createReply = makeReply();
+    await route(routes, "POST", "/").handler(
+      { body: { name: "Prompt", payload: { body: "Use short replies." }, type: "prompt" } },
+      createReply,
+    );
+    expect(createReply).toMatchObject({ body: { id: "res_1" }, code: 201 });
+    await expect(route(routes, "POST", "/impact-preview").handler({ body: { resourceId: "res_1" } })).resolves.toEqual({
+      affectedAgents: 2,
+    });
+
+    routeMocks.requireOrgMembership.mockResolvedValueOnce({
+      memberId: "member_2",
+      organizationId: "org_1",
+      role: "member",
+    });
+    await expect(route(routes, "POST", "/").handler({ body: {} }, makeReply())).rejects.toThrow("Admin role required");
+  });
+
+  it("updates agent resource bindings after management guards", async () => {
+    const { agentResourcesRoutes } = await import("../api/agents-resources.js");
+    const resourcesService = {
+      getAgentResources: vi.fn().mockResolvedValue({ bindings: [] }),
+      replaceAgentResources: vi.fn().mockResolvedValue({ version: 2 }),
+    };
+    const { app, routes } = makeApp({ resourcesService });
+
+    await agentResourcesRoutes(app as never);
+
+    await expect(route(routes, "GET", "/:uuid/resources").handler({ params: { uuid: "agent_1" } })).resolves.toEqual({
+      bindings: [],
+    });
+    await expect(
+      route(routes, "PATCH", "/:uuid/resources").handler({
+        body: {
+          bindings: [{ inlinePromptBody: "Stay focused.", mode: "include", type: "prompt" }],
+          expectedVersion: 1,
+        },
+        params: { uuid: "agent_1" },
+      }),
+    ).resolves.toEqual({ version: 2 });
+    expect(routeMocks.assertMutableAgentIsNotLandingCampaignTrial).toHaveBeenCalledWith({ uuid: "agent_1" });
+    expect(routeMocks.assertNoRuntimeSwitchInProgress).toHaveBeenCalledWith({ uuid: "agent_1" });
+  });
+
+  it("resets agent activity through the manage scope", async () => {
+    const { agentActivityRoutes } = await import("../api/agent-activity.js");
+    const { app, routes } = makeApp();
+
+    await agentActivityRoutes(app as never);
+
+    await expect(
+      route(routes, "POST", "/:uuid/reset-activity").handler({ params: { uuid: "agent_1" } }),
+    ).resolves.toEqual({
+      reset: true,
+    });
+    expect(routeMocks.resetActivity).toHaveBeenCalledWith({ name: "db" }, "agent_1");
+  });
+
+  it("serves me document previews only for speaker agents", async () => {
+    const { meDocsRoutes } = await import("../api/me-docs.js");
+    routeMocks.getMeDocPreview.mockResolvedValue({
+      content: "# Plan",
+      path: "plan.md",
+      ref: { agentId: "agent_1", chatId: "chat_1", path: "plan.md", type: "workspace" },
+    });
+    const { app, routes } = makeApp({
+      db: makeQueuedSelectDb([[{ agentId: "agent_1" }], [{ name: "Writer" }], [], [{ name: "Writer" }]]),
+    });
+
+    await meDocsRoutes(app as never, { workspacesRoot: "/workspace" });
+
+    await expect(
+      route(routes, "GET", "/chats/:chatId/docs/preview").handler({
+        params: { chatId: "chat_1" },
+        query: { agentId: "agent_1", path: "plan.md" },
+      }),
+    ).resolves.toEqual({
+      content: "# Plan",
+      path: "plan.md",
+      ref: { agentId: "agent_1", chatId: "chat_1", path: "plan.md", type: "workspace" },
+    });
+    await expect(
+      route(routes, "GET", "/chats/:chatId/docs/preview").handler({
+        params: { chatId: "chat_1" },
+        query: { agentId: "agent_1", path: "plan.md" },
+      }),
+    ).rejects.toThrow("Document not found");
+  });
+});

--- a/packages/server/src/__tests__/attachments-route.test.ts
+++ b/packages/server/src/__tests__/attachments-route.test.ts
@@ -2,6 +2,7 @@ import { ATTACHMENT_FILENAME_HEADER, ATTACHMENT_MIME_HEADER, MAX_ATTACHMENT_BYTE
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { organizations } from "../db/schema/organizations.js";
+import { createAttachment } from "../services/attachment.js";
 import { ensureMembership } from "../services/membership.js";
 import { uuidv7 } from "../uuid.js";
 import { createAdminContext, createTestAdmin, useTestApp } from "./helpers.js";
@@ -134,6 +135,42 @@ describe("attachments route — upload + capability download", () => {
     const admin = await createTestAdmin(app, { username: `eb-${crypto.randomUUID().slice(0, 6)}` });
     const reply = await postAttachment(app, admin, Buffer.alloc(0));
     expect(reply.statusCode).toBe(400);
+  });
+
+  it("rejects blank attachment mime type and filename", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `blank-attachment-${crypto.randomUUID().slice(0, 6)}` });
+
+    const blankMime = await postAttachment(app, admin, Buffer.from("mime"), { mime: " " });
+    expect(blankMime.statusCode).toBe(400);
+
+    await expect(
+      createAttachment(app.db, {
+        mimeType: "image/png",
+        filename: " ",
+        data: Buffer.from("filename"),
+        uploadedBy: admin.humanAgentUuid,
+      }),
+    ).rejects.toThrow("Attachment filename is required");
+  });
+
+  it("surfaces an empty insert-returning result from the attachment store", async () => {
+    const fakeDb = {
+      insert: () => ({
+        values: () => ({
+          returning: async () => [],
+        }),
+      }),
+    };
+
+    await expect(
+      createAttachment(fakeDb as never, {
+        mimeType: "image/png",
+        filename: "x.png",
+        data: Buffer.from("bytes"),
+        uploadedBy: "agent_1",
+      }),
+    ).rejects.toThrow("Attachment insert returned no row");
   });
 
   it("rejects oversize at bodyLimit (413) or service cap (400)", async () => {

--- a/packages/server/src/__tests__/auth-identity-extra.test.ts
+++ b/packages/server/src/__tests__/auth-identity-extra.test.ts
@@ -1,0 +1,84 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { authIdentities } from "../db/schema/auth-identities.js";
+import { users } from "../db/schema/users.js";
+import { findOrCreateUserFromGithub, getStoredGithubAccessToken } from "../services/auth-identity.js";
+import { encryptValue } from "../services/crypto.js";
+import { uuidv7 } from "../uuid.js";
+import { useTestApp } from "./helpers.js";
+
+const ENCRYPTION_KEY = "0".repeat(64);
+
+describe("auth identity extra coverage", () => {
+  const getApp = useTestApp();
+
+  it("creates GitHub identities with username retry and refreshes stored token metadata", async () => {
+    const app = getApp();
+    await app.db.insert(users).values({
+      id: uuidv7(),
+      username: "octocat",
+      passwordHash: "x",
+      displayName: "Existing Octocat",
+    });
+
+    const created = await findOrCreateUserFromGithub(app.db, {
+      githubId: "gh-100",
+      login: "Octocat",
+      email: null,
+      displayName: "  ",
+      avatarUrl: "https://avatars.example/octo.png",
+    });
+
+    const [user] = await app.db.select().from(users).where(eq(users.id, created.userId)).limit(1);
+    expect(user?.username).toMatch(/^octocat-[0-9a-f]{4}$/);
+    expect(user?.displayName).toBe("Octocat");
+    expect(user?.avatarUrl).toBe("https://avatars.example/octo.png");
+    await expect(getStoredGithubAccessToken(app.db, created.userId, ENCRYPTION_KEY)).resolves.toBeNull();
+
+    const encryptedAccessToken = encryptValue("gho_access", ENCRYPTION_KEY);
+    const encryptedRefreshToken = encryptValue("ghr_refresh", ENCRYPTION_KEY);
+    const existing = await findOrCreateUserFromGithub(
+      app.db,
+      {
+        githubId: "gh-100",
+        login: "renamed-octocat",
+        email: "octo@example.com",
+        displayName: "Renamed Octo",
+        avatarUrl: null,
+      },
+      {
+        encryptedAccessToken,
+        accessTokenExpiresAt: "2026-07-08T00:00:00.000Z",
+        encryptedRefreshToken,
+        refreshTokenExpiresAt: "2026-08-08T00:00:00.000Z",
+      },
+    );
+
+    expect(existing.userId).toBe(created.userId);
+    const [identity] = await app.db
+      .select()
+      .from(authIdentities)
+      .where(eq(authIdentities.userId, created.userId))
+      .limit(1);
+    expect(identity).toMatchObject({
+      provider: "github",
+      identifier: "gh-100",
+      email: "octo@example.com",
+    });
+    expect(identity?.metadata).toMatchObject({
+      login: "renamed-octocat",
+      accessToken: encryptedAccessToken,
+      accessTokenExpiresAt: "2026-07-08T00:00:00.000Z",
+      refreshToken: encryptedRefreshToken,
+      refreshTokenExpiresAt: "2026-08-08T00:00:00.000Z",
+    });
+    await expect(getStoredGithubAccessToken(app.db, created.userId, ENCRYPTION_KEY)).resolves.toBe("gho_access");
+
+    await app.db
+      .update(authIdentities)
+      .set({ metadata: { accessToken: "enc:v1:not-base64" } })
+      .where(eq(authIdentities.userId, created.userId));
+    await expect(getStoredGithubAccessToken(app.db, created.userId, ENCRYPTION_KEY)).resolves.toBeNull();
+    await expect(getStoredGithubAccessToken(app.db, "missing-user", ENCRYPTION_KEY)).resolves.toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/auth-identity-extra.test.ts
+++ b/packages/server/src/__tests__/auth-identity-extra.test.ts
@@ -2,6 +2,8 @@ import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { users } from "../db/schema/users.js";
+import { requireAgent } from "../middleware/require-identity.js";
+import { requireUser } from "../scope/require-user.js";
 import { findOrCreateUserFromGithub, getStoredGithubAccessToken } from "../services/auth-identity.js";
 import { encryptValue } from "../services/crypto.js";
 import { uuidv7 } from "../uuid.js";
@@ -11,6 +13,11 @@ const ENCRYPTION_KEY = "0".repeat(64);
 
 describe("auth identity extra coverage", () => {
   const getApp = useTestApp();
+
+  it("throws clean authentication errors when required identities are missing", () => {
+    expect(() => requireAgent({} as never)).toThrow("Agent authentication required");
+    expect(() => requireUser({} as never)).toThrow("User authentication required");
+  });
 
   it("creates GitHub identities with username retry and refreshes stored token metadata", async () => {
     const app = getApp();
@@ -80,5 +87,48 @@ describe("auth identity extra coverage", () => {
       .where(eq(authIdentities.userId, created.userId));
     await expect(getStoredGithubAccessToken(app.db, created.userId, ENCRYPTION_KEY)).resolves.toBeNull();
     await expect(getStoredGithubAccessToken(app.db, "missing-user", ENCRYPTION_KEY)).resolves.toBeNull();
+  });
+
+  it("falls back to a uuid-based username suffix after repeated unique violations", async () => {
+    let transactionAttempts = 0;
+    const insertedUsernames: string[] = [];
+    const fakeDb = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [],
+          }),
+        }),
+      }),
+      transaction: async (callback: (tx: unknown) => Promise<void>) => {
+        transactionAttempts += 1;
+        if (transactionAttempts <= 4) {
+          const err = new Error("duplicate username") as Error & { code: string };
+          err.code = "23505";
+          throw err;
+        }
+        await callback({
+          insert: () => ({
+            values: async (value: Record<string, unknown>) => {
+              if (typeof value.username === "string") insertedUsernames.push(value.username);
+            },
+          }),
+        });
+      },
+    };
+
+    await expect(
+      findOrCreateUserFromGithub(fakeDb as never, {
+        githubId: "gh-retry",
+        login: "retry",
+        email: null,
+        displayName: null,
+        avatarUrl: null,
+      }),
+    ).resolves.toEqual({ userId: expect.any(String) });
+
+    expect(transactionAttempts).toBe(5);
+    expect(insertedUsernames).toHaveLength(1);
+    expect(insertedUsernames[0]).toMatch(/^retry-[0-9a-f-]{12}$/);
   });
 });

--- a/packages/server/src/__tests__/auth.test.ts
+++ b/packages/server/src/__tests__/auth.test.ts
@@ -116,7 +116,10 @@ describe("Admin Auth", () => {
 
     it("rejects invalid password", async () => {
       const app = getApp();
-      await createTestAdmin(app);
+      const admin = await createTestAdmin(app);
+      await expect(login(app.db, admin.username, "wrong", TEST_JWT_SECRET, EXPIRIES)).rejects.toThrow(
+        /invalid username or password/i,
+      );
       const res = await app.inject({
         method: "POST",
         url: "/api/v1/auth/login",

--- a/packages/server/src/__tests__/auth.test.ts
+++ b/packages/server/src/__tests__/auth.test.ts
@@ -1,8 +1,41 @@
+import { createHash } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { SignJWT } from "jose";
 import { describe, expect, it } from "vitest";
+import { connectCodes } from "../db/schema/connect-codes.js";
+import { members } from "../db/schema/members.js";
+import { users } from "../db/schema/users.js";
+import {
+  generateConnectToken,
+  login,
+  pickDefaultMembership,
+  refreshAccessToken,
+  signTokensForUser,
+} from "../services/auth.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
+
+const TEST_JWT_SECRET = "test-jwt-secret-key-for-vitest";
+const EXPIRIES = { accessTokenExpiry: "30m", refreshTokenExpiry: "30d", connectTokenExpiry: "10m" };
+
+async function signRefreshToken(sub: string): Promise<string> {
+  return new SignJWT({ sub, type: "refresh" })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime("30d")
+    .sign(new TextEncoder().encode(TEST_JWT_SECRET));
+}
 
 describe("Admin Auth", () => {
   const getApp = useTestApp();
+
+  it("pickDefaultMembership breaks createdAt ties by newest uuid", () => {
+    const createdAt = new Date("2026-07-08T00:00:00.000Z");
+    const picked = pickDefaultMembership([
+      { id: "01961234-0000-7000-8000-000000000001", createdAt },
+      { id: "01961234-0000-7000-8000-000000000010", createdAt },
+    ]);
+    expect(picked?.id).toBe("01961234-0000-7000-8000-000000000010");
+  });
 
   describe("POST /api/v1/auth/login", () => {
     it("returns tokens on valid credentials", async () => {
@@ -31,6 +64,21 @@ describe("Admin Auth", () => {
         payload: { username: "nobody", password: "whatever" },
       });
       expect(res.statusCode).toBe(401);
+    });
+
+    it("rejects suspended users and users without active memberships", async () => {
+      const app = getApp();
+      const suspended = await createTestAdmin(app, { username: `suspended-${crypto.randomUUID().slice(0, 8)}` });
+      await app.db.update(users).set({ status: "suspended" }).where(eq(users.id, suspended.userId));
+      await expect(login(app.db, suspended.username, "testpassword123", TEST_JWT_SECRET, EXPIRIES)).rejects.toThrow(
+        /invalid username or password/i,
+      );
+
+      const removed = await createTestAdmin(app, { username: `removed-${crypto.randomUUID().slice(0, 8)}` });
+      await app.db.update(members).set({ status: "removed" }).where(eq(members.userId, removed.userId));
+      await expect(login(app.db, removed.username, "testpassword123", TEST_JWT_SECRET, EXPIRIES)).rejects.toThrow(
+        /no organization membership/i,
+      );
     });
 
     // Regression: services/auth.ts::pickDefaultMembership picks the most-recently-
@@ -108,6 +156,50 @@ describe("Admin Auth", () => {
       });
       expect(second.statusCode).toBe(200);
       expect(second.json()).toHaveProperty("accessToken");
+    });
+
+    it("rejects wrong token types, missing users, suspended users, and users without active memberships", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `refresh-admin-${crypto.randomUUID().slice(0, 8)}` });
+      const accessTyped = await signTokensForUser(TEST_JWT_SECRET, admin.userId, EXPIRIES);
+      await expect(refreshAccessToken(app.db, accessTyped.accessToken, TEST_JWT_SECRET, EXPIRIES)).rejects.toThrow(
+        /invalid token type/i,
+      );
+
+      await expect(
+        refreshAccessToken(app.db, await signRefreshToken(`missing-${crypto.randomUUID()}`), TEST_JWT_SECRET, EXPIRIES),
+      ).rejects.toThrow(/user not found|suspended/i);
+
+      const suspended = await createTestAdmin(app, {
+        username: `refresh-suspended-${crypto.randomUUID().slice(0, 8)}`,
+      });
+      const suspendedRefresh = await signRefreshToken(suspended.userId);
+      await app.db.update(users).set({ status: "suspended" }).where(eq(users.id, suspended.userId));
+      await expect(refreshAccessToken(app.db, suspendedRefresh, TEST_JWT_SECRET, EXPIRIES)).rejects.toThrow(
+        /suspended/i,
+      );
+
+      const removed = await createTestAdmin(app, { username: `refresh-removed-${crypto.randomUUID().slice(0, 8)}` });
+      const removedRefresh = await signRefreshToken(removed.userId);
+      await app.db.update(members).set({ status: "removed" }).where(eq(members.userId, removed.userId));
+      await expect(refreshAccessToken(app.db, removedRefresh, TEST_JWT_SECRET, EXPIRIES)).rejects.toThrow(
+        /no active membership/i,
+      );
+    });
+  });
+
+  describe("connect token issuer normalization", () => {
+    it("normalizes non-URL issuers by trimming trailing slashes", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `issuer-admin-${crypto.randomUUID().slice(0, 8)}` });
+      const minted = await generateConnectToken(app.db, admin.userId, EXPIRIES, "first-tree-local///");
+      const [row] = await app.db
+        .select({ issuer: connectCodes.issuer })
+        .from(connectCodes)
+        .where(eq(connectCodes.codeHash, createHash("sha256").update(minted.token).digest("hex")))
+        .limit(1);
+
+      expect(row?.issuer).toBe("first-tree-local");
     });
   });
 });

--- a/packages/server/src/__tests__/auth.test.ts
+++ b/packages/server/src/__tests__/auth.test.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
+import { AGENT_SELECTOR_HEADER } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
 import { SignJWT } from "jose";
 import { describe, expect, it } from "vitest";
 import { connectCodes } from "../db/schema/connect-codes.js";
 import { members } from "../db/schema/members.js";
 import { users } from "../db/schema/users.js";
+import { userAuthHook } from "../middleware/user-auth.js";
 import {
   generateConnectToken,
   login,
@@ -18,11 +20,15 @@ const TEST_JWT_SECRET = "test-jwt-secret-key-for-vitest";
 const EXPIRIES = { accessTokenExpiry: "30m", refreshTokenExpiry: "30d", connectTokenExpiry: "10m" };
 
 async function signRefreshToken(sub: string): Promise<string> {
-  return new SignJWT({ sub, type: "refresh" })
+  return signJwt({ sub, type: "refresh" });
+}
+
+async function signJwt(payload: Record<string, unknown>, secretValue = TEST_JWT_SECRET): Promise<string> {
+  return new SignJWT(payload)
     .setProtectedHeader({ alg: "HS256" })
     .setIssuedAt()
     .setExpirationTime("30d")
-    .sign(new TextEncoder().encode(TEST_JWT_SECRET));
+    .sign(new TextEncoder().encode(secretValue));
 }
 
 describe("Admin Auth", () => {
@@ -35,6 +41,69 @@ describe("Admin Auth", () => {
       { id: "01961234-0000-7000-8000-000000000010", createdAt },
     ]);
     expect(picked?.id).toBe("01961234-0000-7000-8000-000000000010");
+  });
+
+  describe("userAuthHook", () => {
+    async function runHook(
+      app: ReturnType<typeof getApp>,
+      token: string,
+      request: { method?: string; url?: string; headers?: Record<string, string> } = {},
+    ): Promise<void> {
+      const hook = userAuthHook(app.db, TEST_JWT_SECRET);
+      await hook(
+        {
+          method: request.method ?? "GET",
+          url: request.url ?? "/api/v1/me",
+          headers: { authorization: `Bearer ${token}`, ...(request.headers ?? {}) },
+        } as never,
+        {} as never,
+      );
+    }
+
+    it("classifies invalid signatures, wrong token types, missing users, and suspended users", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `hook-admin-${crypto.randomUUID().slice(0, 8)}` });
+
+      await expect(runHook(app, await signJwt({ sub: admin.userId, type: "access" }, "wrong-secret"))).rejects.toThrow(
+        /invalid or expired token/i,
+      );
+      await expect(runHook(app, await signJwt({ sub: admin.userId, type: "refresh" }))).rejects.toThrow(
+        /invalid token type/i,
+      );
+      await expect(
+        runHook(app, await signJwt({ sub: `missing-${crypto.randomUUID()}`, type: "access" })),
+      ).rejects.toThrow(/user not found|suspended/i);
+
+      const suspended = await createTestAdmin(app, { username: `hook-suspended-${crypto.randomUUID().slice(0, 8)}` });
+      await app.db.update(users).set({ status: "suspended" }).where(eq(users.id, suspended.userId));
+      await expect(runHook(app, await signJwt({ sub: suspended.userId, type: "access" }))).rejects.toThrow(
+        /user not found|suspended/i,
+      );
+    });
+
+    it("rejects malformed and out-of-scope agent outbox tokens", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `hook-outbox-${crypto.randomUUID().slice(0, 8)}` });
+
+      await expect(runHook(app, await signJwt({ sub: admin.userId, type: "agent_outbox" }))).rejects.toThrow(
+        /invalid agent outbox token/i,
+      );
+
+      const scoped = await signJwt({
+        sub: admin.userId,
+        type: "agent_outbox",
+        agentId: "agent-a",
+        chatId: "chat-a",
+      });
+      await expect(runHook(app, scoped)).rejects.toThrow(/not valid for this request/i);
+      await expect(
+        runHook(app, scoped, {
+          method: "POST",
+          url: "/api/v1/agent/chats/%E0%A4%A/messages",
+          headers: { [AGENT_SELECTOR_HEADER]: "agent-a" },
+        }),
+      ).rejects.toThrow(/not valid for this request/i);
+    });
   });
 
   describe("POST /api/v1/auth/login", () => {

--- a/packages/server/src/__tests__/background-tasks-extra.test.ts
+++ b/packages/server/src/__tests__/background-tasks-extra.test.ts
@@ -1,0 +1,148 @@
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loggerMocks = {
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+};
+
+const serviceMocks = {
+  cleanupStaleClients: vi.fn(),
+  cleanupStalePresence: vi.fn(),
+  heartbeatInstance: vi.fn(),
+  markStaleAgents: vi.fn(),
+  notifyAgentEvent: vi.fn(),
+  pruneStaleSilentEntries: vi.fn(),
+  sweepChatArchive: vi.fn(),
+};
+
+const mockedModules = [
+  "../observability/index.js",
+  "../services/chat-archive.js",
+  "../services/client.js",
+  "../services/inbox.js",
+  "../services/notification.js",
+  "../services/presence.js",
+];
+
+function mockBackgroundTaskDependencies(): void {
+  vi.doMock("../observability/index.js", () => ({
+    createLogger: () => loggerMocks,
+  }));
+  vi.doMock("../services/chat-archive.js", () => ({
+    sweepChatArchive: serviceMocks.sweepChatArchive,
+  }));
+  vi.doMock("../services/client.js", () => ({
+    cleanupStaleClients: serviceMocks.cleanupStaleClients,
+  }));
+  vi.doMock("../services/inbox.js", () => ({
+    pruneStaleSilentEntries: serviceMocks.pruneStaleSilentEntries,
+  }));
+  vi.doMock("../services/notification.js", () => ({
+    notifyAgentEvent: serviceMocks.notifyAgentEvent,
+  }));
+  vi.doMock("../services/presence.js", () => ({
+    cleanupStalePresence: serviceMocks.cleanupStalePresence,
+    heartbeatInstance: serviceMocks.heartbeatInstance,
+    markStaleAgents: serviceMocks.markStaleAgents,
+  }));
+}
+
+function makeApp(archiveSweepIntervalSeconds = 30): FastifyInstance {
+  return {
+    config: {
+      runtime: {
+        archiveMappedIdleSeconds: 3_600,
+        archiveSweepIntervalSeconds,
+        presenceCleanupSeconds: 60,
+      },
+    },
+    db: { name: "db" },
+  } as unknown as FastifyInstance;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.resetModules();
+  vi.clearAllMocks();
+  mockBackgroundTaskDependencies();
+  serviceMocks.cleanupStaleClients.mockResolvedValue(undefined);
+  serviceMocks.cleanupStalePresence.mockResolvedValue(undefined);
+  serviceMocks.heartbeatInstance.mockResolvedValue(undefined);
+  serviceMocks.markStaleAgents.mockResolvedValue([]);
+  serviceMocks.notifyAgentEvent.mockResolvedValue(undefined);
+  serviceMocks.pruneStaleSilentEntries.mockResolvedValue({ ackedDeleted: 0, stalePendingDeleted: 0 });
+  serviceMocks.sweepChatArchive.mockResolvedValue({ mappedRowsArchived: 0, unmappedRowsArchived: 0 });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  for (const moduleId of mockedModules) {
+    vi.doUnmock(moduleId);
+  }
+  vi.resetModules();
+});
+
+describe("createBackgroundTasks", () => {
+  it("runs heartbeat, inbox prune, archive sweep, and stale-agent notification intervals", async () => {
+    const { createBackgroundTasks } = await import("../services/background-tasks.js");
+    serviceMocks.pruneStaleSilentEntries.mockResolvedValue({ ackedDeleted: 2, stalePendingDeleted: 1 });
+    serviceMocks.markStaleAgents.mockResolvedValue(["agent_1", "agent_2"]);
+    serviceMocks.sweepChatArchive.mockResolvedValue({ mappedRowsArchived: 1, unmappedRowsArchived: 1 });
+    const app = makeApp(30);
+    const tasks = createBackgroundTasks(app, "srv_1");
+
+    tasks.start();
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(serviceMocks.heartbeatInstance).toHaveBeenCalledWith(app.db, "srv_1");
+    expect(serviceMocks.cleanupStalePresence).toHaveBeenCalledWith(app.db, 60);
+    expect(serviceMocks.cleanupStaleClients).toHaveBeenCalledWith(app.db, 60);
+    expect(serviceMocks.pruneStaleSilentEntries).toHaveBeenCalledWith(app.db);
+    expect(serviceMocks.sweepChatArchive).toHaveBeenCalledWith(app.db, { mappedIdleSeconds: 3_600 });
+    expect(serviceMocks.notifyAgentEvent).toHaveBeenCalledWith(app.db, "agent_1", "agent_stale", "medium");
+    expect(serviceMocks.notifyAgentEvent).toHaveBeenCalledWith(app.db, "agent_2", "agent_stale", "medium");
+    expect(loggerMocks.debug).toHaveBeenCalledWith(
+      { ackedDeleted: 2, stalePendingDeleted: 1 },
+      "pruned silent inbox rows",
+    );
+    expect(loggerMocks.info).toHaveBeenCalledWith(
+      { agentIds: ["agent_1", "agent_2"], count: 2 },
+      "marked agents as stale",
+    );
+    expect(loggerMocks.info).toHaveBeenCalledWith(
+      { mappedRowsArchived: 1, unmappedRowsArchived: 1 },
+      "chat auto-archive sweep flipped rows to archived",
+    );
+
+    tasks.stop();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("logs timer errors, catches rejected notifications, and allows archive sweep disablement", async () => {
+    const { createBackgroundTasks } = await import("../services/background-tasks.js");
+    serviceMocks.heartbeatInstance.mockRejectedValueOnce(new Error("initial heartbeat failed"));
+    serviceMocks.pruneStaleSilentEntries.mockRejectedValueOnce(new Error("prune failed"));
+    serviceMocks.heartbeatInstance
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("heartbeat failed"));
+    serviceMocks.notifyAgentEvent.mockRejectedValueOnce(new Error("notify failed"));
+    const app = makeApp(0);
+    const tasks = createBackgroundTasks(app, "srv_2");
+
+    tasks.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(serviceMocks.sweepChatArchive).not.toHaveBeenCalled();
+    expect(loggerMocks.error).toHaveBeenCalledWith({ err: expect.any(Error) }, "failed initial heartbeat");
+    expect(loggerMocks.error).toHaveBeenCalledWith({ err: expect.any(Error) }, "failed to prune silent inbox rows");
+    expect(loggerMocks.error).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      "failed to heartbeat / cleanup presence",
+    );
+
+    tasks.stop();
+  });
+});

--- a/packages/server/src/__tests__/bootstrap.test.ts
+++ b/packages/server/src/__tests__/bootstrap.test.ts
@@ -160,6 +160,47 @@ describe("server bootstrap", () => {
     expect(shutdownTelemetryFn).not.toHaveBeenCalled();
   });
 
+  it("runs app and telemetry shutdown from registered process signal handlers", async () => {
+    const initTelemetryFn = vi.fn(async () => undefined);
+    const runMigrationsFn = vi.fn(async () => 0);
+    const listenFn = vi.fn(async () => "http://127.0.0.1:0");
+    const closeFn = vi.fn(async () => undefined);
+    const buildAppFn = vi.fn(async () => ({ listen: listenFn, close: closeFn }));
+    const markReadyFn = vi.fn();
+    const shutdownTelemetryFn = vi.fn(async () => undefined);
+    const handlers = new Map<string, (...args: unknown[]) => void>();
+    const processOn = vi.fn((event: string | symbol, handler: (...args: unknown[]) => void) => {
+      handlers.set(String(event), handler as (...args: unknown[]) => void);
+      return fakeProcess;
+    });
+    const processExit = vi.fn();
+    const fakeProcess = Object.assign(Object.create(process), {
+      on: processOn,
+      exit: processExit,
+    }) as NodeJS.Process;
+
+    try {
+      vi.stubGlobal("process", fakeProcess);
+      await startServer({
+        initServerConfig: async () => baseServerConfig,
+        randomUUID: () => "87654321-1234-4234-9234-123456789abc",
+        initTelemetry: initTelemetryFn,
+        runMigrations: runMigrationsFn,
+        buildApp: buildAppFn as never,
+        markReady: markReadyFn,
+        shutdownTelemetry: shutdownTelemetryFn,
+      });
+
+      handlers.get("SIGTERM")?.();
+
+      await vi.waitFor(() => expect(closeFn).toHaveBeenCalledTimes(1));
+      expect(shutdownTelemetryFn).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(processExit).toHaveBeenCalledWith(0));
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   describe("boot config guards", () => {
     it("rejects missing required secrets", () => {
       expect(() =>

--- a/packages/server/src/__tests__/bootstrap.test.ts
+++ b/packages/server/src/__tests__/bootstrap.test.ts
@@ -201,6 +201,47 @@ describe("server bootstrap", () => {
     }
   });
 
+  it("runs shutdown from the registered SIGINT handler", async () => {
+    const initTelemetryFn = vi.fn(async () => undefined);
+    const runMigrationsFn = vi.fn(async () => 0);
+    const listenFn = vi.fn(async () => "http://127.0.0.1:0");
+    const closeFn = vi.fn(async () => undefined);
+    const buildAppFn = vi.fn(async () => ({ listen: listenFn, close: closeFn }));
+    const markReadyFn = vi.fn();
+    const shutdownTelemetryFn = vi.fn(async () => undefined);
+    const handlers = new Map<string, (...args: unknown[]) => void>();
+    const processOn = vi.fn((event: string | symbol, handler: (...args: unknown[]) => void) => {
+      handlers.set(String(event), handler as (...args: unknown[]) => void);
+      return fakeProcess;
+    });
+    const processExit = vi.fn();
+    const fakeProcess = Object.assign(Object.create(process), {
+      on: processOn,
+      exit: processExit,
+    }) as NodeJS.Process;
+
+    try {
+      vi.stubGlobal("process", fakeProcess);
+      await startServer({
+        initServerConfig: async () => baseServerConfig,
+        randomUUID: () => "97654321-1234-4234-9234-123456789abc",
+        initTelemetry: initTelemetryFn,
+        runMigrations: runMigrationsFn,
+        buildApp: buildAppFn as never,
+        markReady: markReadyFn,
+        shutdownTelemetry: shutdownTelemetryFn,
+      });
+
+      handlers.get("SIGINT")?.();
+
+      await vi.waitFor(() => expect(closeFn).toHaveBeenCalledTimes(1));
+      expect(shutdownTelemetryFn).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(processExit).toHaveBeenCalledWith(0));
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   describe("boot config guards", () => {
     it("rejects missing required secrets", () => {
       expect(() =>

--- a/packages/server/src/__tests__/bootstrap.test.ts
+++ b/packages/server/src/__tests__/bootstrap.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ServerConfig } from "@first-tree/shared/config";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { assertBootConfigValid } from "../boot-guards.js";
 import { shouldAutoGenerateServerSecrets, startServer } from "../bootstrap-server.js";
 import { bootstrapState, markReady, markStage } from "../bootstrap-state.js";
 import { runStage, withTimeout } from "../bootstrap-utils.js";
@@ -120,6 +121,119 @@ describe("server bootstrap", () => {
     expect(runMigrationsFn).not.toHaveBeenCalled();
     expect(markReadyFn).not.toHaveBeenCalled();
     expect(shutdownTelemetryFn).not.toHaveBeenCalled();
+  });
+
+  it("starts the server through telemetry, migrations, app build, listen, and ready stages", async () => {
+    const initTelemetryFn = vi.fn(async () => undefined);
+    const runMigrationsFn = vi.fn(async () => 12);
+    const listenFn = vi.fn(async () => "http://127.0.0.1:0");
+    const closeFn = vi.fn(async () => undefined);
+    const buildAppFn = vi.fn(async () => ({ listen: listenFn, close: closeFn }));
+    const markReadyFn = vi.fn();
+    const shutdownTelemetryFn = vi.fn(async () => undefined);
+    const processOn = vi.spyOn(process, "on").mockReturnValue(process);
+
+    await startServer({
+      initServerConfig: async () => baseServerConfig,
+      randomUUID: () => "12345678-1234-4234-9234-123456789abc",
+      webDistPath: "/srv/web",
+      initTelemetry: initTelemetryFn,
+      runMigrations: runMigrationsFn,
+      buildApp: buildAppFn as never,
+      markReady: markReadyFn,
+      shutdownTelemetry: shutdownTelemetryFn,
+    });
+
+    expect(initTelemetryFn).toHaveBeenCalledWith(baseServerConfig.observability.tracing, "srv_12345678");
+    expect(runMigrationsFn).toHaveBeenCalledWith(baseServerConfig.database.url);
+    expect(buildAppFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceId: "srv_12345678",
+        webDistPath: "/srv/web",
+      }),
+    );
+    expect(listenFn).toHaveBeenCalledWith({ host: "127.0.0.1", port: 0 });
+    expect(markReadyFn).toHaveBeenCalledTimes(1);
+    expect(processOn).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+    expect(processOn).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+    expect(closeFn).not.toHaveBeenCalled();
+    expect(shutdownTelemetryFn).not.toHaveBeenCalled();
+  });
+
+  describe("boot config guards", () => {
+    it("rejects missing required secrets", () => {
+      expect(() =>
+        assertBootConfigValid({
+          ...baseServerConfig,
+          instanceId: "srv_test",
+          secrets: { ...baseServerConfig.secrets, jwtSecret: "   " },
+        }),
+      ).toThrow("Missing required server secret env vars: FIRST_TREE_JWT_SECRET");
+    });
+
+    it("requires a public URL in production", () => {
+      vi.stubEnv("NODE_ENV", "production");
+
+      expect(() =>
+        assertBootConfigValid({
+          ...baseServerConfig,
+          instanceId: "srv_test",
+          server: { ...baseServerConfig.server, publicUrl: undefined },
+        }),
+      ).toThrow("FIRST_TREE_PUBLIC_URL is required in production");
+    });
+
+    it("rejects half-configured, empty, and malformed GitHub App blocks", () => {
+      const validGithubApp = {
+        appId: "app-id",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        privateKeyPem: "-----BEGIN PRIVATE KEY-----\nstub\n-----END PRIVATE KEY-----\n",
+        slug: undefined,
+        webhookSecret: "webhook-secret",
+      };
+
+      expect(() =>
+        assertBootConfigValid({
+          ...baseServerConfig,
+          instanceId: "srv_test",
+          oauth: { githubApp: { ...validGithubApp, webhookSecret: "" } },
+        }),
+      ).toThrow("GitHub App is half-configured");
+
+      expect(() =>
+        assertBootConfigValid({
+          ...baseServerConfig,
+          instanceId: "srv_test",
+          oauth: {
+            githubApp: {
+              appId: "",
+              clientId: "",
+              clientSecret: "",
+              privateKeyPem: "",
+              slug: undefined,
+              webhookSecret: "",
+            },
+          },
+        }),
+      ).toThrow("GitHub App env block is present but every value is empty");
+
+      expect(() =>
+        assertBootConfigValid({
+          ...baseServerConfig,
+          instanceId: "srv_test",
+          oauth: { githubApp: { ...validGithubApp, privateKeyPem: "literal\\nbody" } },
+        }),
+      ).toThrow("FIRST_TREE_GITHUB_APP_PRIVATE_KEY does not look like a PKCS#8 PEM");
+
+      expect(() =>
+        assertBootConfigValid({
+          ...baseServerConfig,
+          instanceId: "srv_test",
+          oauth: { githubApp: validGithubApp },
+        }),
+      ).not.toThrow();
+    });
   });
 
   it("runMigrations resolves the drizzle folder and applies migrations idempotently", async () => {

--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from "fastify";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildApp } from "../app.js";
 import type { Config } from "../config.js";
+import * as resourcesMigration from "../services/resources-migration.js";
 
 /**
  * Boot-time gate: a typo in `FIRST_TREE_AUTH_*_EXPIRY` must fail the
@@ -199,6 +200,49 @@ describe("buildApp — retired feedback route boundary", () => {
     } finally {
       await safeClose(app);
       await rm(webRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("buildApp — boot-time edge branches", () => {
+  it("boots with package-version fallback, trusted proxy logging, trace attrs, and backfill failure tolerance", async () => {
+    const backfill = vi.spyOn(resourcesMigration, "backfillResourcesPhase1").mockRejectedValueOnce(new Error("down"));
+    let app: FastifyInstance | undefined;
+    try {
+      app = await buildApp({
+        ...baseConfig,
+        trustProxy: true,
+        observability: {
+          ...baseConfig.observability,
+          tracing: {
+            endpoint: "",
+            headers: "",
+            exporter: "otlp-http",
+            serviceName: "first-tree-test",
+            environment: "test",
+            sampleRate: 1,
+            captureClientIp: true,
+          },
+        },
+        update: { ...baseConfig.update, commandVersion: undefined },
+      });
+      await app.ready();
+
+      expect(app.commandVersion()).toBe("0.1.0");
+      expect(backfill).toHaveBeenCalledTimes(1);
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/healthz?token=secret",
+        headers: {
+          referer: "https://example.test/workspace",
+          "user-agent": "first-tree-test",
+          "x-forwarded-for": "203.0.113.10",
+        },
+      });
+      expect(res.statusCode).toBe(200);
+    } finally {
+      await safeClose(app);
     }
   });
 });

--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -188,6 +188,14 @@ describe("buildApp — retired feedback route boundary", () => {
       expect(feedback.headers["content-type"]).toContain("application/json");
       expect(feedback.json()).toEqual({ error: "Feedback has been removed" });
       expect(feedback.body).not.toContain("App shell");
+
+      const apiMiss = await app.inject({ method: "GET", url: "/api/missing" });
+      expect(apiMiss.statusCode).toBe(404);
+      expect(apiMiss.json()).toEqual({ error: "Not found" });
+
+      const assetMiss = await app.inject({ method: "GET", url: "/assets/missing.js" });
+      expect(assetMiss.statusCode).toBe(404);
+      expect(assetMiss.json()).toEqual({ error: "Not found" });
     } finally {
       await safeClose(app);
       await rm(webRoot, { recursive: true, force: true });

--- a/packages/server/src/__tests__/chat-audience-cache.test.ts
+++ b/packages/server/src/__tests__/chat-audience-cache.test.ts
@@ -1,25 +1,88 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Database } from "../db/connection.js";
 import {
+  getCachedAudience,
   invalidateChatAudience,
   invalidateChatAudienceLocal,
   registerChatAudienceDispatcher,
   resetChatAudienceDispatcher,
 } from "../services/chat-audience-cache.js";
 
+const touchedChatIds = new Set<string>();
+
+function remember(chatId: string): string {
+  touchedChatIds.add(chatId);
+  return chatId;
+}
+
 describe("chat-audience-cache cross-replica invalidation", () => {
-  afterEach(() => resetChatAudienceDispatcher());
+  afterEach(() => {
+    for (const chatId of touchedChatIds) invalidateChatAudienceLocal(chatId);
+    touchedChatIds.clear();
+    resetChatAudienceDispatcher();
+    vi.restoreAllMocks();
+  });
+
+  function dbWithRows(rows: Array<{ agent_id: string }>): { db: Database; execute: ReturnType<typeof vi.fn> } {
+    const execute = vi.fn().mockResolvedValue(rows);
+    return { db: { execute } as unknown as Database, execute };
+  }
+
+  it("resolves and caches a chat audience until invalidated", async () => {
+    const { db, execute } = dbWithRows([{ agent_id: "agent-1" }, { agent_id: "agent-2" }]);
+    const chatId = remember("chat-cache-hit");
+
+    const first = await getCachedAudience(db, chatId);
+    const second = await getCachedAudience(db, chatId);
+
+    expect(first).toEqual(new Set(["agent-1", "agent-2"]));
+    expect(second).toBe(first);
+    expect(execute).toHaveBeenCalledTimes(1);
+
+    invalidateChatAudienceLocal(chatId);
+    const third = await getCachedAudience(db, chatId);
+    expect(third).toEqual(new Set(["agent-1", "agent-2"]));
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null when audience lookup fails", async () => {
+    const execute = vi.fn().mockRejectedValue(new Error("db down"));
+    const db = { execute } as unknown as Database;
+
+    await expect(getCachedAudience(db, remember("chat-cache-error"))).resolves.toBeNull();
+  });
+
+  it("drops expired entries opportunistically after the cache grows past the cap", async () => {
+    const execute = vi.fn().mockResolvedValue([{ agent_id: "agent" }]);
+    const db = { execute } as unknown as Database;
+    const now = vi.spyOn(Date, "now");
+
+    now.mockReturnValue(1_000);
+    for (let i = 0; i < 1024; i++) {
+      await getCachedAudience(db, remember(`chat-cache-expired-${i}`));
+    }
+
+    now.mockReturnValue(10_000);
+    const freshChatId = remember("chat-cache-fresh-after-cleanup");
+    const fresh = await getCachedAudience(db, freshChatId);
+    const cached = await getCachedAudience(db, freshChatId);
+
+    expect(fresh).toEqual(new Set(["agent"]));
+    expect(cached).toBe(fresh);
+    expect(execute).toHaveBeenCalledTimes(1025);
+  });
 
   it("invalidateChatAudience fans the invalidation out to the registered dispatcher", () => {
     const dispatched: string[] = [];
     registerChatAudienceDispatcher((chatId) => dispatched.push(chatId));
-    invalidateChatAudience("chat-1");
+    invalidateChatAudience(remember("chat-1"));
     expect(dispatched).toEqual(["chat-1"]);
   });
 
   it("invalidateChatAudienceLocal drops locally WITHOUT fanning out (prevents NOTIFY loops)", () => {
     const dispatched: string[] = [];
     registerChatAudienceDispatcher((chatId) => dispatched.push(chatId));
-    invalidateChatAudienceLocal("chat-1");
+    invalidateChatAudienceLocal(remember("chat-1"));
     expect(dispatched).toEqual([]);
   });
 

--- a/packages/server/src/__tests__/chat-membership-invariants.test.ts
+++ b/packages/server/src/__tests__/chat-membership-invariants.test.ts
@@ -30,7 +30,13 @@ import { createAgent } from "../services/agent.js";
 import { createMeChat, joinMeChat, leaveMeChat, markMeChatRead, setChatEngagement } from "../services/me-chat.js";
 import { sendMessage } from "../services/message.js";
 import { addChatParticipants } from "../services/participant-mode.js";
-import { recomputeChatWatchers } from "../services/watcher.js";
+import {
+  ensureCanJoin,
+  joinAsParticipant,
+  leaveAsParticipant,
+  recomputeChatWatchers,
+  recomputeWatchersForAgent,
+} from "../services/watcher.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 describe("chat membership invariants", () => {
@@ -103,6 +109,55 @@ describe("chat membership invariants", () => {
       .from(chatMembership)
       .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, admin.humanAgentUuid)));
     expect(watcher?.accessMode).toBe("watcher");
+  });
+
+  it("recomputes watcher rows through the per-agent fan-out helper", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const managed = await createAgent(app.db, {
+      name: `mng-agent-fanout-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Mng Agent Fanout",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+      clientId: undefined,
+    });
+    const peer = await createTestAgent(app, { name: `peer-agent-fanout-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, peer.agent.uuid, peer.organizationId, {
+      participantIds: [managed.uuid],
+    });
+    await app.db
+      .delete(chatMembership)
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, admin.humanAgentUuid)));
+
+    await recomputeWatchersForAgent(app.db, managed.uuid);
+
+    const [watcher] = await app.db
+      .select({ accessMode: chatMembership.accessMode })
+      .from(chatMembership)
+      .where(and(eq(chatMembership.chatId, chatId), eq(chatMembership.agentId, admin.humanAgentUuid)));
+    expect(watcher?.accessMode).toBe("watcher");
+  });
+
+  it("handles idempotent joins, missing leaves, and join precondition guard states", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `peer-guard-${crypto.randomUUID().slice(0, 6)}` });
+
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+
+    await expect(joinAsParticipant(app.db, chatId, admin.humanAgentUuid)).resolves.toEqual({
+      chatId,
+      inserted: false,
+      carried: null,
+    });
+    await expect(leaveAsParticipant(app.db, chatId, crypto.randomUUID())).rejects.toThrow(/Not a participant/);
+    expect(() => ensureCanJoin("participant")).toThrow(/Already a participant/);
+    expect(() => ensureCanJoin(null)).toThrow(/Not a watcher/);
+    expect(() => ensureCanJoin("watching")).not.toThrow();
   });
 
   it("detach (leaveMeChat without remaining managed speaker) preserves chat_user_state row", async () => {

--- a/packages/server/src/__tests__/chat-service-edge.test.ts
+++ b/packages/server/src/__tests__/chat-service-edge.test.ts
@@ -1,0 +1,193 @@
+import type { SendMessage } from "@first-tree/shared";
+import { eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { createAgent } from "../services/agent.js";
+import {
+  type CreateTaskChatInput,
+  createChat,
+  getChat,
+  isParticipant,
+  listChats,
+  listChatsForMember,
+  resolveAgentIdsByNameInOrg,
+} from "../services/chat.js";
+import { createMember } from "../services/member.js";
+import { createOrganization } from "../services/organization.js";
+import { uuidv7 } from "../uuid.js";
+import { createAdminContext, createTestApp } from "./helpers.js";
+
+describe("chat service edge coverage", () => {
+  let app: FastifyInstance;
+
+  const baseMessage = (overrides: Partial<SendMessage> = {}): SendMessage => ({
+    format: "text",
+    content: "hello",
+    source: "api",
+    ...overrides,
+  });
+
+  const taskInput = (overrides: Partial<CreateTaskChatInput> = {}): CreateTaskChatInput => ({
+    mode: "task",
+    initiatorAgentId: "agent-initiator",
+    organizationId: "org",
+    initialRecipientAgentIds: ["agent-recipient"],
+    contextParticipantAgentIds: [],
+    initialMessage: baseMessage(),
+    source: "manual",
+    ...overrides,
+  });
+
+  async function createManagedAgent(seed: {
+    memberId: string;
+    organizationId: string;
+    clientId: string;
+    suffix: string;
+  }) {
+    return createAgent(app.db, {
+      name: `chat-edge-${seed.suffix}-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Chat Edge Agent",
+      source: "admin-api",
+      managerId: seed.memberId,
+      clientId: seed.clientId,
+      organizationId: seed.organizationId,
+    });
+  }
+
+  beforeAll(async () => {
+    app = await createTestApp();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("rejects legacy chat creation without a body", async () => {
+    const seed = await createAdminContext(app, { username: `chat-legacy-${crypto.randomUUID().slice(0, 8)}` });
+
+    // @ts-expect-error Exercise the runtime guard for JS callers.
+    await expect(createChat(app.db, seed.humanAgentUuid)).rejects.toThrow("Legacy chat creation requires a body");
+  });
+
+  it.each([
+    {
+      name: "missing recipients",
+      override: { initialRecipientAgentIds: [] },
+      message: "Task chat creation requires at least one initial recipient",
+    },
+    {
+      name: "receiver names",
+      override: { initialMessage: baseMessage({ receiverNames: ["agent"] }) },
+      message: "receiverNames is not accepted",
+    },
+    {
+      name: "agent final text",
+      override: { initialMessage: baseMessage({ purpose: "agent-final-text" }) },
+      message: "cannot be agent-final-text",
+    },
+    {
+      name: "reply",
+      override: { initialMessage: baseMessage({ inReplyTo: uuidv7() }) },
+      message: "cannot be a reply",
+    },
+    {
+      name: "cross-chat resolution",
+      override: { initialMessage: baseMessage({ metadata: { resolves: { kind: "answered" } } }) },
+      message: "cannot resolve a request",
+    },
+  ])("rejects task chat creation with $name", async ({ override, message }) => {
+    await expect(createChat(app.db, taskInput(override))).rejects.toThrow(message);
+  });
+
+  it("rejects task chats with missing participants and beforeInitialMessage without idempotency", async () => {
+    const seed = await createAdminContext(app, { username: `chat-task-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createManagedAgent({ ...seed, suffix: "valid-target" });
+
+    await expect(
+      createChat(
+        app.db,
+        taskInput({
+          initiatorAgentId: seed.humanAgentUuid,
+          organizationId: seed.organizationId,
+          initialRecipientAgentIds: [uuidv7()],
+        }),
+      ),
+    ).rejects.toThrow("Agents not found");
+
+    await expect(
+      createChat(
+        app.db,
+        taskInput({
+          initiatorAgentId: seed.humanAgentUuid,
+          organizationId: seed.organizationId,
+          initialRecipientAgentIds: [agent.uuid],
+          beforeInitialMessage: async () => {},
+        }),
+      ),
+    ).rejects.toThrow("beforeInitialMessage requires an onboardingKickoffKey");
+  });
+
+  it("rejects legacy web chat creation for creator org mismatch and cross-org participants", async () => {
+    const seed = await createAdminContext(app, { username: `chat-org-a-${crypto.randomUUID().slice(0, 8)}` });
+    const otherOrg = await createOrganization(app.db, {
+      name: `chat-org-b-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Chat Org B",
+    });
+
+    await expect(
+      createChat(app.db, {
+        mode: "legacy-empty-web",
+        creatorAgentId: seed.humanAgentUuid,
+        organizationId: otherOrg.id,
+        participantAgentIds: [],
+      }),
+    ).rejects.toThrow(`Creator agent "${seed.humanAgentUuid}" is not in organization "${otherOrg.id}"`);
+
+    const otherMember = await createMember(app.db, otherOrg.id, {
+      username: `chat-other-member-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Chat Other Member",
+      role: "member",
+    });
+    const crossOrgAgent = await createAgent(app.db, {
+      name: `chat-cross-org-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Cross Org Agent",
+      source: "admin-api",
+      managerId: otherMember.id,
+      organizationId: otherOrg.id,
+    });
+
+    await expect(
+      createChat(app.db, seed.humanAgentUuid, { type: "group", participantIds: [crossOrgAgent.uuid] }),
+    ).rejects.toThrow("Cross-organization chat not allowed");
+  });
+
+  it("covers exported lookup helpers for missing, empty, and membership cases", async () => {
+    const seed = await createAdminContext(app, { username: `chat-helper-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createManagedAgent({ ...seed, suffix: "helper" });
+
+    await expect(getChat(app.db, uuidv7())).rejects.toThrow("not found");
+    await expect(resolveAgentIdsByNameInOrg(app.db, seed.organizationId, ["missing-agent"])).rejects.toThrow(
+      "Agents not found by name",
+    );
+    await expect(listChats(app.db, agent.uuid, 10)).resolves.toEqual({ items: [], nextCursor: null });
+
+    const chat = await createChat(app.db, seed.humanAgentUuid, { type: "group", participantIds: [agent.uuid] });
+    await expect(isParticipant(app.db, chat.id, seed.humanAgentUuid)).resolves.toBe(true);
+    await expect(isParticipant(app.db, chat.id, uuidv7())).resolves.toBe(false);
+
+    const resolved = await resolveAgentIdsByNameInOrg(app.db, seed.organizationId, [agent.name ?? ""]);
+    expect(resolved).toEqual([agent.uuid]);
+  });
+
+  it("loads a fallback human agent in listChatsForMember when it is not managed by the member", async () => {
+    const seed = await createAdminContext(app, { username: `chat-member-${crypto.randomUUID().slice(0, 8)}` });
+    const other = await createAdminContext(app, { username: `chat-member-other-${crypto.randomUUID().slice(0, 8)}` });
+
+    await app.db.update(agents).set({ managerId: other.memberId }).where(eq(agents.uuid, other.humanAgentUuid));
+
+    await expect(listChatsForMember(app.db, seed.memberId, other.humanAgentUuid)).resolves.toEqual([]);
+  });
+});

--- a/packages/server/src/__tests__/chat-service-edge.test.ts
+++ b/packages/server/src/__tests__/chat-service-edge.test.ts
@@ -1,5 +1,5 @@
 import type { SendMessage } from "@first-tree/shared";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { agents } from "../db/schema/agents.js";
@@ -20,6 +20,7 @@ import { createAdminContext, createTestApp } from "./helpers.js";
 
 describe("chat service edge coverage", () => {
   let app: FastifyInstance;
+  class RollbackFixture extends Error {}
 
   const baseMessage = (overrides: Partial<SendMessage> = {}): SendMessage => ({
     format: "text",
@@ -127,6 +128,81 @@ describe("chat service edge coverage", () => {
         }),
       ),
     ).rejects.toThrow("beforeInitialMessage requires an onboardingKickoffKey");
+  });
+
+  it("returns the existing onboarding kickoff chat on idempotent legacy agent retries", async () => {
+    const seed = await createAdminContext(app, { username: `chat-kickoff-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createManagedAgent({ ...seed, suffix: "kickoff" });
+    const kickoffKey = `kickoff-${crypto.randomUUID()}`;
+
+    const first = await createChat(app.db, {
+      mode: "legacy-empty-agent",
+      creatorAgentId: seed.humanAgentUuid,
+      participantAgentIds: [agent.uuid],
+      topic: "Kickoff",
+      metadata: { source: "test" },
+      onboardingKickoffKey: kickoffKey,
+    });
+    const second = await createChat(app.db, {
+      mode: "legacy-empty-agent",
+      creatorAgentId: seed.humanAgentUuid,
+      participantAgentIds: [agent.uuid],
+      topic: "Duplicate kickoff",
+      onboardingKickoffKey: kickoffKey,
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.participants.map((p) => p.agentId).sort()).toEqual([seed.humanAgentUuid, agent.uuid].sort());
+  });
+
+  it("rejects self-target task chat creation when the manager human mirror is missing", async () => {
+    const seed = await createAdminContext(app, { username: `chat-self-target-${crypto.randomUUID().slice(0, 8)}` });
+    const orphanManagerId = uuidv7();
+    const orphanAgentId = uuidv7();
+    await expect(
+      app.db.transaction(async (tx) => {
+        await tx.execute(sql`SET CONSTRAINTS ALL DEFERRED`);
+        await tx.insert(agents).values({
+          uuid: orphanAgentId,
+          name: `orphan-manager-${crypto.randomUUID().slice(0, 6)}`,
+          organizationId: seed.organizationId,
+          type: "agent",
+          displayName: "Orphan Manager Agent",
+          inboxId: `inbox_${orphanAgentId}`,
+          managerId: orphanManagerId,
+          status: "active",
+        });
+
+        await expect(
+          createChat(
+            tx as unknown as typeof app.db,
+            taskInput({
+              initiatorAgentId: orphanAgentId,
+              organizationId: seed.organizationId,
+              initialRecipientAgentIds: [orphanAgentId],
+            }),
+          ),
+        ).rejects.toThrow(`Manager member "${orphanManagerId}" not found`);
+        throw new RollbackFixture();
+      }),
+    ).rejects.toBeInstanceOf(RollbackFixture);
+  });
+
+  it("rejects task chats with inactive participants", async () => {
+    const seed = await createAdminContext(app, { username: `chat-inactive-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createManagedAgent({ ...seed, suffix: "inactive" });
+    await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, agent.uuid));
+
+    await expect(
+      createChat(
+        app.db,
+        taskInput({
+          initiatorAgentId: seed.humanAgentUuid,
+          organizationId: seed.organizationId,
+          initialRecipientAgentIds: [agent.uuid],
+        }),
+      ),
+    ).rejects.toThrow(/Cannot create task chat with inactive participant/);
   });
 
   it("rejects legacy web chat creation for creator org mismatch and cross-org participants", async () => {

--- a/packages/server/src/__tests__/chat-service-edge.test.ts
+++ b/packages/server/src/__tests__/chat-service-edge.test.ts
@@ -443,7 +443,9 @@ describe("chat service edge coverage", () => {
     await expect(getChatDetail(app.db, chat.id, seed.humanAgentUuid)).resolves.toMatchObject({
       viewerMembershipKind: "participant",
     });
-    await expect(getChatDetail(app.db, chat.id, watcherId)).resolves.toMatchObject({ viewerMembershipKind: "watching" });
+    await expect(getChatDetail(app.db, chat.id, watcherId)).resolves.toMatchObject({
+      viewerMembershipKind: "watching",
+    });
   });
 
   it("adds participants by agent name and formats missing addParticipant selectors", async () => {
@@ -452,9 +454,9 @@ describe("chat service edge coverage", () => {
     const newcomer = await createManagedAgent({ ...seed, suffix: "add-name-target" });
     const chat = await createChat(app.db, seed.humanAgentUuid, { type: "group", participantIds: [agent.uuid] });
 
-    await expect(addParticipant(app.db, chat.id, seed.humanAgentUuid, { agentName: newcomer.name ?? "" })).resolves.toEqual(
-      expect.arrayContaining([expect.objectContaining({ agentId: newcomer.uuid })]),
-    );
+    await expect(
+      addParticipant(app.db, chat.id, seed.humanAgentUuid, { agentName: newcomer.name ?? "" }),
+    ).resolves.toEqual(expect.arrayContaining([expect.objectContaining({ agentId: newcomer.uuid })]));
     await expect(addParticipant(app.db, chat.id, seed.humanAgentUuid, {} as never)).rejects.toThrow(
       'Agent "(unknown)" not found',
     );

--- a/packages/server/src/__tests__/chat-service-edge.test.ts
+++ b/packages/server/src/__tests__/chat-service-edge.test.ts
@@ -1,13 +1,17 @@
 import type { SendMessage } from "@first-tree/shared";
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
+import { members } from "../db/schema/members.js";
 import { createAgent } from "../services/agent.js";
 import {
+  addParticipant,
   type CreateTaskChatInput,
   createChat,
   getChat,
+  getChatDetail,
   isParticipant,
   listChats,
   listChatsForMember,
@@ -204,6 +208,70 @@ describe("chat service edge coverage", () => {
     expect(chat.participants.map((p) => p.agentId).sort()).toEqual([agent.uuid, seed.humanAgentUuid].sort());
   });
 
+  it("creates task chats with non-empty metadata and runs the kickoff hook once", async () => {
+    const seed = await createAdminContext(app, { username: `chat-task-meta-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createManagedAgent({ ...seed, suffix: "task-meta" });
+    const beforeInitialMessage = vi.fn(async () => {});
+    const kickoffKey = `task-kickoff-${crypto.randomUUID()}`;
+
+    const first = await createChat(
+      app.db,
+      taskInput({
+        initiatorAgentId: seed.humanAgentUuid,
+        organizationId: seed.organizationId,
+        initialRecipientAgentIds: [agent.uuid],
+        topic: "Kickoff topic",
+        description: "Kickoff description",
+        onboardingKickoffKey: kickoffKey,
+        beforeInitialMessage,
+      }),
+    );
+    const second = await createChat(
+      app.db,
+      taskInput({
+        initiatorAgentId: seed.humanAgentUuid,
+        organizationId: seed.organizationId,
+        initialRecipientAgentIds: [agent.uuid],
+        topic: "Ignored duplicate topic",
+        description: "Ignored duplicate description",
+        onboardingKickoffKey: kickoffKey,
+        beforeInitialMessage,
+      }),
+    );
+
+    expect(first.chat).toMatchObject({
+      topic: "Kickoff topic",
+      description: "Kickoff description",
+    });
+    expect(first.chat.descriptionUpdatedAt).toBeInstanceOf(Date);
+    expect(first.initialMessageCreated).toBe(true);
+    expect(second.chat.id).toBe(first.chat.id);
+    expect(second.initialMessageCreated).toBe(false);
+    expect(beforeInitialMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes empty task chat topic and description to null", async () => {
+    const seed = await createAdminContext(app, { username: `chat-task-empty-meta-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createManagedAgent({ ...seed, suffix: "task-empty-meta" });
+
+    const created = await createChat(
+      app.db,
+      taskInput({
+        initiatorAgentId: seed.humanAgentUuid,
+        organizationId: seed.organizationId,
+        initialRecipientAgentIds: [agent.uuid],
+        topic: "",
+        description: "",
+      }),
+    );
+
+    expect(created.chat).toMatchObject({
+      topic: null,
+      description: null,
+      descriptionUpdatedAt: null,
+    });
+  });
+
   it("rejects task chats with inactive participants", async () => {
     const seed = await createAdminContext(app, { username: `chat-inactive-${crypto.randomUUID().slice(0, 8)}` });
     const agent = await createManagedAgent({ ...seed, suffix: "inactive" });
@@ -216,6 +284,27 @@ describe("chat service edge coverage", () => {
           initiatorAgentId: seed.humanAgentUuid,
           organizationId: seed.organizationId,
           initialRecipientAgentIds: [agent.uuid],
+        }),
+      ),
+    ).rejects.toThrow(/Cannot create task chat with inactive participant/);
+  });
+
+  it("rejects task chats with inactive human member participants", async () => {
+    const seed = await createAdminContext(app, { username: `chat-inactive-human-${crypto.randomUUID().slice(0, 8)}` });
+    const inactiveMember = await createMember(app.db, seed.organizationId, {
+      username: `chat-inactive-human-target-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Inactive Human Target",
+      role: "member",
+    });
+    await app.db.update(members).set({ status: "removed" }).where(eq(members.id, inactiveMember.id));
+
+    await expect(
+      createChat(
+        app.db,
+        taskInput({
+          initiatorAgentId: seed.humanAgentUuid,
+          organizationId: seed.organizationId,
+          initialRecipientAgentIds: [inactiveMember.agentId],
         }),
       ),
     ).rejects.toThrow(/Cannot create task chat with inactive participant/);
@@ -316,6 +405,7 @@ describe("chat service edge coverage", () => {
     await expect(resolveAgentIdsByNameInOrg(app.db, seed.organizationId, ["missing-agent"])).rejects.toThrow(
       "Agents not found by name",
     );
+    await expect(resolveAgentIdsByNameInOrg(app.db, seed.organizationId, [])).resolves.toEqual([]);
     await expect(listChats(app.db, agent.uuid, 10)).resolves.toEqual({ items: [], nextCursor: null });
 
     const chat = await createChat(app.db, seed.humanAgentUuid, { type: "group", participantIds: [agent.uuid] });
@@ -324,6 +414,50 @@ describe("chat service edge coverage", () => {
 
     const resolved = await resolveAgentIdsByNameInOrg(app.db, seed.organizationId, [agent.name ?? ""]);
     expect(resolved).toEqual([agent.uuid]);
+  });
+
+  it("resolves detail viewer membership kind for admin, missing, participant, and watcher views", async () => {
+    const seed = await createAdminContext(app, { username: `chat-detail-kind-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createManagedAgent({ ...seed, suffix: "detail-kind" });
+    const chat = await createChat(app.db, seed.humanAgentUuid, { type: "group", participantIds: [agent.uuid] });
+    const watcherId = uuidv7();
+    await app.db.insert(agents).values({
+      uuid: watcherId,
+      name: `chat-detail-watcher-${crypto.randomUUID().slice(0, 6)}`,
+      organizationId: seed.organizationId,
+      type: "agent",
+      displayName: "Detail Watcher",
+      inboxId: `inbox_${watcherId}`,
+      managerId: seed.memberId,
+      status: "active",
+    });
+    await app.db.insert(chatMembership).values({
+      chatId: chat.id,
+      agentId: watcherId,
+      role: "member",
+      accessMode: "watcher",
+    });
+
+    await expect(getChatDetail(app.db, chat.id, null)).resolves.toMatchObject({ viewerMembershipKind: null });
+    await expect(getChatDetail(app.db, chat.id, uuidv7())).resolves.toMatchObject({ viewerMembershipKind: null });
+    await expect(getChatDetail(app.db, chat.id, seed.humanAgentUuid)).resolves.toMatchObject({
+      viewerMembershipKind: "participant",
+    });
+    await expect(getChatDetail(app.db, chat.id, watcherId)).resolves.toMatchObject({ viewerMembershipKind: "watching" });
+  });
+
+  it("adds participants by agent name and formats missing addParticipant selectors", async () => {
+    const seed = await createAdminContext(app, { username: `chat-add-name-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createManagedAgent({ ...seed, suffix: "add-name" });
+    const newcomer = await createManagedAgent({ ...seed, suffix: "add-name-target" });
+    const chat = await createChat(app.db, seed.humanAgentUuid, { type: "group", participantIds: [agent.uuid] });
+
+    await expect(addParticipant(app.db, chat.id, seed.humanAgentUuid, { agentName: newcomer.name ?? "" })).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ agentId: newcomer.uuid })]),
+    );
+    await expect(addParticipant(app.db, chat.id, seed.humanAgentUuid, {} as never)).rejects.toThrow(
+      'Agent "(unknown)" not found',
+    );
   });
 
   it("loads a fallback human agent in listChatsForMember when it is not managed by the member", async () => {

--- a/packages/server/src/__tests__/chat-service-edge.test.ts
+++ b/packages/server/src/__tests__/chat-service-edge.test.ts
@@ -188,6 +188,22 @@ describe("chat service edge coverage", () => {
     ).rejects.toBeInstanceOf(RollbackFixture);
   });
 
+  it("loads the manager human mirror for non-human self-target task chats", async () => {
+    const seed = await createAdminContext(app, { username: `chat-self-ok-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createManagedAgent({ ...seed, suffix: "self-ok" });
+
+    const chat = await createChat(
+      app.db,
+      taskInput({
+        initiatorAgentId: agent.uuid,
+        organizationId: seed.organizationId,
+        initialRecipientAgentIds: [agent.uuid],
+      }),
+    );
+
+    expect(chat.participants.map((p) => p.agentId).sort()).toEqual([agent.uuid, seed.humanAgentUuid].sort());
+  });
+
   it("rejects task chats with inactive participants", async () => {
     const seed = await createAdminContext(app, { username: `chat-inactive-${crypto.randomUUID().slice(0, 8)}` });
     const agent = await createManagedAgent({ ...seed, suffix: "inactive" });
@@ -203,6 +219,58 @@ describe("chat service edge coverage", () => {
         }),
       ),
     ).rejects.toThrow(/Cannot create task chat with inactive participant/);
+  });
+
+  it("rejects task chats with cross-organization participants", async () => {
+    const seed = await createAdminContext(app, { username: `chat-task-org-a-${crypto.randomUUID().slice(0, 8)}` });
+    const otherOrg = await createOrganization(app.db, {
+      name: `chat-task-org-b-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Chat Task Org B",
+    });
+    const otherMember = await createMember(app.db, otherOrg.id, {
+      username: `chat-task-other-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Chat Task Other",
+      role: "member",
+    });
+
+    await expect(
+      createChat(
+        app.db,
+        taskInput({
+          initiatorAgentId: seed.humanAgentUuid,
+          organizationId: seed.organizationId,
+          initialRecipientAgentIds: [otherMember.agentId],
+        }),
+      ),
+    ).rejects.toThrow("Cross-organization chat not allowed");
+  });
+
+  it("rejects task chats targeting another member's private agent", async () => {
+    const seed = await createAdminContext(app, { username: `chat-private-target-${crypto.randomUUID().slice(0, 8)}` });
+    const privateOwner = await createMember(app.db, seed.organizationId, {
+      username: `chat-private-owner-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Private Owner",
+      role: "member",
+    });
+    const privateAgent = await createAgent(app.db, {
+      name: `chat-private-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Private Target",
+      managerId: privateOwner.id,
+      organizationId: seed.organizationId,
+      visibility: "private",
+    });
+
+    await expect(
+      createChat(
+        app.db,
+        taskInput({
+          initiatorAgentId: seed.humanAgentUuid,
+          organizationId: seed.organizationId,
+          initialRecipientAgentIds: [privateAgent.uuid],
+        }),
+      ),
+    ).rejects.toThrow(/private agent/);
   });
 
   it("rejects legacy web chat creation for creator org mismatch and cross-org participants", async () => {

--- a/packages/server/src/__tests__/client-retire-guard.test.ts
+++ b/packages/server/src/__tests__/client-retire-guard.test.ts
@@ -8,6 +8,11 @@ import { createTestAgent, useTestApp } from "./helpers.js";
 describe("retireClient service-layer guard", () => {
   const getApp = useTestApp();
 
+  it("throws not found for an unknown client", async () => {
+    const app = getApp();
+    await expect(retireClient(app.db, "missing-retire-client")).rejects.toThrow(/not found/i);
+  });
+
   it("suspends and unpins non-deleted agents while retiring", async () => {
     const app = getApp();
     const { agent, clientId } = await createTestAgent(app);

--- a/packages/server/src/__tests__/client-service.test.ts
+++ b/packages/server/src/__tests__/client-service.test.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { agents } from "../db/schema/agents.js";
 import { clients } from "../db/schema/clients.js";
@@ -29,6 +29,48 @@ describe("client service: disconnectClient", () => {
     );
     await expect(clientService.assertClientOwner(app.db, owner.clientId, { userId: other.userId })).rejects.toThrow(
       /not found/i,
+    );
+    await expect(clientService.assertClientNotRetired(app.db, "missing-client")).rejects.toThrow(/not found/i);
+  });
+
+  it("classifies registerClient conflicts after a lost upsert race", async () => {
+    function makeRaceDb(current: { userId: string | null; retiredAt: Date | null } | undefined) {
+      const selectResults = [[], current ? [current] : []];
+      return {
+        select: vi.fn(() => {
+          const rows = selectResults.shift() ?? [];
+          return {
+            from: () => ({
+              where: () => ({
+                limit: async () => rows,
+              }),
+            }),
+          };
+        }),
+        insert: vi.fn(() => ({
+          values: () => ({
+            onConflictDoUpdate: () => ({
+              returning: async () => [],
+            }),
+          }),
+        })),
+      };
+    }
+    const data = {
+      clientId: "client-race",
+      userId: "user-a",
+      organizationId: "org-a",
+      instanceId: "instance-a",
+    };
+
+    await expect(
+      clientService.registerClient(makeRaceDb({ userId: "user-a", retiredAt: new Date() }) as never, data),
+    ).rejects.toMatchObject({ statusCode: 410 });
+    await expect(
+      clientService.registerClient(makeRaceDb({ userId: "user-b", retiredAt: null }) as never, data),
+    ).rejects.toMatchObject({ statusCode: 403, code: "CLIENT_USER_MISMATCH" });
+    await expect(clientService.registerClient(makeRaceDb(undefined) as never, data)).rejects.toThrow(
+      /changed concurrently/,
     );
   });
 

--- a/packages/server/src/__tests__/client-service.test.ts
+++ b/packages/server/src/__tests__/client-service.test.ts
@@ -19,6 +19,74 @@ import { createTestAgent, useTestApp } from "./helpers.js";
 describe("client service: disconnectClient", () => {
   const getApp = useTestApp();
 
+  it("assertClientOwner hides missing and cross-user clients as not found", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { name: `cs-owner-${crypto.randomUUID().slice(0, 6)}` });
+    const other = await createTestAgent(app, { name: `cs-other-${crypto.randomUUID().slice(0, 6)}` });
+
+    await expect(clientService.assertClientOwner(app.db, "missing-client", { userId: owner.userId })).rejects.toThrow(
+      /not found/i,
+    );
+    await expect(clientService.assertClientOwner(app.db, owner.clientId, { userId: other.userId })).rejects.toThrow(
+      /not found/i,
+    );
+  });
+
+  it("registerClient shallow-merges the last update attempt into existing metadata", async () => {
+    const app = getApp();
+    const { userId, organizationId } = await createTestAgent(app, {
+      name: `cs-register-update-${crypto.randomUUID().slice(0, 6)}`,
+    });
+    const clientId = `client-update-${crypto.randomUUID().slice(0, 8)}`;
+    await clientService.registerClient(app.db, { clientId, userId, organizationId, instanceId: "first" });
+    await app.db
+      .update(clients)
+      .set({ metadata: { sibling: "kept" } })
+      .where(eq(clients.id, clientId));
+
+    await clientService.registerClient(app.db, {
+      clientId,
+      userId,
+      organizationId,
+      instanceId: "second",
+      lastUpdateAttempt: {
+        result: "failed",
+        target: "0.20.0",
+        currentBefore: "0.19.0",
+        installedVersion: null,
+        reason: "network",
+        at: "2026-07-08T00:00:00.000Z",
+      },
+    });
+
+    const [row] = await app.db.select({ metadata: clients.metadata }).from(clients).where(eq(clients.id, clientId));
+    expect(row?.metadata).toMatchObject({
+      sibling: "kept",
+      lastUpdateAttempt: { result: "failed", target: "0.20.0", reason: "network" },
+    });
+  });
+
+  it("heartbeatClient records a minimal heartbeat for an existing client", async () => {
+    const app = getApp();
+    const { userId, organizationId } = await createTestAgent(app, {
+      name: `cs-heartbeat-${crypto.randomUUID().slice(0, 6)}`,
+    });
+    const clientId = `client-heartbeat-${crypto.randomUUID().slice(0, 8)}`;
+    await clientService.registerClient(app.db, { clientId, userId, organizationId, instanceId: "old" });
+    const staleAt = new Date(Date.now() - 120_000);
+    await app.db.update(clients).set({ status: "disconnected", lastSeenAt: staleAt }).where(eq(clients.id, clientId));
+
+    await clientService.heartbeatClient(app.db, clientId, "old");
+
+    const [row] = await app.db
+      .select({ status: clients.status, instanceId: clients.instanceId, lastSeenAt: clients.lastSeenAt })
+      .from(clients)
+      .where(eq(clients.id, clientId));
+    expect(row?.status).toBe("connected");
+    expect(row?.instanceId).toBe("old");
+    expect(row?.lastSeenAt.getTime()).toBeGreaterThan(staleAt.getTime());
+  });
+
   it("sets agents with matching clientId to offline", async () => {
     const app = getApp();
     const { agent, userId, organizationId } = await createTestAgent(app, {
@@ -145,6 +213,50 @@ describe("client service: pinned agent startup surfaces", () => {
       expect.objectContaining({ agentId: active.uuid, clientId, status: "active" }),
       expect.objectContaining({ agentId: suspended.uuid, clientId, status: "suspended" }),
     ]);
+  });
+});
+
+describe("client service: capability updates", () => {
+  const getApp = useTestApp();
+
+  it("rejects invalid, missing, and retired capability updates", async () => {
+    const app = getApp();
+    const { clientId } = await createTestAgent(app, {
+      name: `cs-cap-invalid-${crypto.randomUUID().slice(0, 6)}`,
+    });
+
+    await expect(
+      clientService.updateClientCapabilities(app.db, clientId, {
+        codex: { state: "invalid-state", available: true, detectedAt: "2026-07-08T00:00:00.000Z" },
+      } as never),
+    ).rejects.toThrow(/invalid capabilities/i);
+    await expect(clientService.updateClientCapabilities(app.db, "missing-cap-client", {})).rejects.toThrow(
+      /not found/i,
+    );
+
+    await app.db.update(clients).set({ retiredAt: new Date() }).where(eq(clients.id, clientId));
+    await expect(clientService.updateClientCapabilities(app.db, clientId, {})).rejects.toThrow(/retired/i);
+  });
+
+  it("skips metadata writes when capabilities are unchanged after stable normalization", async () => {
+    const app = getApp();
+    const { clientId } = await createTestAgent(app, {
+      name: `cs-cap-stable-${crypto.randomUUID().slice(0, 6)}`,
+    });
+    const capabilities = {
+      codex: { state: "ok" as const, available: true, detectedAt: "2026-07-08T00:00:00.000Z" },
+      "claude-code": { state: "missing" as const, available: false, detectedAt: "2026-07-08T00:00:01.000Z" },
+    };
+    await clientService.updateClientCapabilities(app.db, clientId, capabilities);
+    const [before] = await app.db.select({ metadata: clients.metadata }).from(clients).where(eq(clients.id, clientId));
+
+    await clientService.updateClientCapabilities(app.db, clientId, {
+      "claude-code": capabilities["claude-code"],
+      codex: capabilities.codex,
+    });
+
+    const [after] = await app.db.select({ metadata: clients.metadata }).from(clients).where(eq(clients.id, clientId));
+    expect(after?.metadata).toEqual(before?.metadata);
   });
 });
 

--- a/packages/server/src/__tests__/clients-runtime-auth-start.test.ts
+++ b/packages/server/src/__tests__/clients-runtime-auth-start.test.ts
@@ -1,6 +1,9 @@
 import crypto from "node:crypto";
+import { eq } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
 import type { WebSocket } from "ws";
+import { clients } from "../db/schema/clients.js";
+import { createAgent } from "../services/agent.js";
 import { removeClientConnection, setClientConnection } from "../services/connection-manager.js";
 import { createAdminContext, useTestApp } from "./helpers.js";
 
@@ -122,5 +125,45 @@ describe("POST /clients/:clientId/runtime-auth/start", () => {
     });
     expect(res.statusCode).toBeGreaterThanOrEqual(400);
     expect(res.statusCode).toBeLessThan(500);
+  });
+
+  it("disconnects and retires caller-owned clients through the client routes", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `ra-client-${crypto.randomUUID().slice(0, 6)}` });
+    await createAgent(app.db, {
+      name: `ra-client-agent-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Client Route Agent",
+      managerId: admin.memberId,
+      clientId: admin.clientId,
+      organizationId: admin.organizationId,
+    });
+    const ws = { readyState: 1, send: vi.fn(), close: vi.fn() };
+    setClientConnection(admin.clientId, ws as unknown as WebSocket);
+    try {
+      const disconnect = await app.inject({
+        method: "POST",
+        url: `/api/v1/clients/${admin.clientId}/disconnect`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+      expect(disconnect.statusCode).toBe(200);
+      expect(disconnect.json()).toEqual({ disconnected: true, agentIds: [] });
+
+      const deleted = await app.inject({
+        method: "DELETE",
+        url: `/api/v1/clients/${admin.clientId}`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+      expect(deleted.statusCode).toBe(204);
+
+      const [row] = await app.db
+        .select({ status: clients.status, retiredAt: clients.retiredAt })
+        .from(clients)
+        .where(eq(clients.id, admin.clientId));
+      expect(row?.status).toBe("disconnected");
+      expect(row?.retiredAt).toBeInstanceOf(Date);
+    } finally {
+      removeClientConnection(admin.clientId, ws as unknown as WebSocket);
+    }
   });
 });

--- a/packages/server/src/__tests__/config-service-extra.test.ts
+++ b/packages/server/src/__tests__/config-service-extra.test.ts
@@ -1,0 +1,152 @@
+import { defaultRuntimeConfigPayload } from "@first-tree/shared";
+import { eq } from "drizzle-orm";
+import { describe, expect, it, vi } from "vitest";
+import { agentConfigs } from "../db/schema/agent-configs.js";
+import { agents } from "../db/schema/agents.js";
+import { createConfigService } from "../services/config-service.js";
+import { seedAgentFactory, useTestApp } from "./helpers.js";
+
+const ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("config service edge coverage", () => {
+  const getApp = useTestApp();
+
+  it("surfaces missing config rows and orphan config runtime provider lookups", async () => {
+    const app = getApp();
+    const orphanAgentId = `orphan-${crypto.randomUUID()}`;
+
+    await expect(app.configService.get(`missing-${crypto.randomUUID()}`)).rejects.toThrow(/Agent config/);
+
+    await app.db.insert(agentConfigs).values({
+      agentId: orphanAgentId,
+      version: 1,
+      payload: defaultRuntimeConfigPayload("claude-code"),
+      updatedBy: "test",
+    });
+
+    await expect(app.configService.dryRun(orphanAgentId, { model: "claude-opus-4-6" })).rejects.toThrow(
+      new RegExp(`Agent "${orphanAgentId}" not found`),
+    );
+  });
+
+  it("coalesces valid queued writes and drains all pending agents via flush()", async () => {
+    const app = getApp();
+    const seedAgent = await seedAgentFactory(app);
+    const agentA = await seedAgent({ name: `cfg-coalesce-a-${crypto.randomUUID().slice(0, 8)}` });
+    const agentB = await seedAgent({ name: `cfg-coalesce-b-${crypto.randomUUID().slice(0, 8)}` });
+
+    await expect(
+      app.configService.update(agentA.uuid, { expectedVersion: 1, payload: { model: "claude-opus-4-6" } }, "test"),
+    ).resolves.toMatchObject({ version: 2 });
+
+    const queuedA1 = app.configService.update(
+      agentA.uuid,
+      { expectedVersion: 2, payload: { model: "claude-sonnet-4-6" } },
+      "test-a1",
+    );
+    const queuedA2 = app.configService.update(
+      agentA.uuid,
+      { expectedVersion: 2, payload: { env: [{ key: "COALESCED", value: "1", sensitive: false }] } },
+      "test-a2",
+    );
+
+    await app.configService.flush(agentA.uuid);
+    const [resultA1, resultA2] = await Promise.all([queuedA1, queuedA2]);
+    expect(resultA1.version).toBe(3);
+    expect(resultA2.version).toBe(3);
+    expect(resultA2.payload).toMatchObject({
+      model: "claude-sonnet-4-6",
+      env: [{ key: "COALESCED", value: "1", sensitive: false }],
+    });
+
+    await expect(
+      app.configService.update(agentB.uuid, { expectedVersion: 1, payload: { model: "claude-opus-4-6" } }, "test"),
+    ).resolves.toMatchObject({ version: 2 });
+
+    const queuedB = app.configService.update(
+      agentB.uuid,
+      { expectedVersion: 2, payload: { model: "claude-haiku-4-5" } },
+      "test-b",
+    );
+
+    await app.configService.flush();
+    await expect(queuedB).resolves.toMatchObject({
+      version: 3,
+      payload: expect.objectContaining({ model: "claude-haiku-4-5" }),
+    });
+  });
+
+  it("rejects queued writes when the config row disappears before flush", async () => {
+    const app = getApp();
+    const seedAgent = await seedAgentFactory(app);
+    const agent = await seedAgent({ name: `cfg-missing-flush-${crypto.randomUUID().slice(0, 8)}` });
+
+    await app.configService.update(agent.uuid, { expectedVersion: 1, payload: { model: "claude-opus-4-6" } }, "test");
+    const queued = app.configService
+      .update(agent.uuid, { expectedVersion: 2, payload: { model: "claude-sonnet-4-6" } }, "test")
+      .catch((err: unknown) => err);
+
+    await app.db.delete(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+    await app.configService.flush(agent.uuid);
+
+    await expect(queued).resolves.toMatchObject({ message: expect.stringContaining("Agent config") });
+  });
+
+  it("rejects queued writes when the agent row disappears before the coalesced commit", async () => {
+    const app = getApp();
+    const seedAgent = await seedAgentFactory(app);
+    const agent = await seedAgent({ name: `cfg-agent-gone-${crypto.randomUUID().slice(0, 8)}` });
+
+    await app.configService.update(agent.uuid, { expectedVersion: 1, payload: { model: "claude-opus-4-6" } }, "test");
+    const queued = app.configService
+      .update(agent.uuid, { expectedVersion: 2, payload: { model: "claude-sonnet-4-6" } }, "test")
+      .catch((err: unknown) => err);
+
+    await app.db.delete(agents).where(eq(agents.uuid, agent.uuid));
+    await app.configService.flush(agent.uuid);
+
+    await expect(queued).resolves.toMatchObject({
+      message: expect.stringContaining(`Agent "${agent.uuid}" not found`),
+    });
+  });
+
+  it("rejects a lost optimistic-lock race during the immediate commit path", async () => {
+    const configRow = {
+      agentId: "agent-lost-race",
+      version: 1,
+      payload: defaultRuntimeConfigPayload("claude-code"),
+      updatedBy: "test",
+      updatedAt: new Date(),
+    };
+    const db = {
+      select: vi.fn(() => ({
+        from: (table: unknown) => ({
+          where: () => ({
+            limit: async () => {
+              if (table === agentConfigs) return [configRow];
+              if (table === agents) return [{ runtimeProvider: "claude-code" }];
+              return [];
+            },
+          }),
+        }),
+      })),
+      update: vi.fn(() => ({
+        set: () => ({
+          where: () => ({
+            returning: async () => [],
+          }),
+        }),
+      })),
+    };
+    const service = createConfigService({
+      db: db as never,
+      notifier: { notifyConfigChange: vi.fn().mockResolvedValue(undefined) } as never,
+      encryptionKey: ENCRYPTION_KEY,
+      debounceMs: 1,
+    });
+
+    await expect(
+      service.update("agent-lost-race", { expectedVersion: 1, payload: { model: "claude-opus-4-6" } }, "test"),
+    ).rejects.toThrow(/lost race during commit/);
+  });
+});

--- a/packages/server/src/__tests__/connect-token-bootstrap.test.ts
+++ b/packages/server/src/__tests__/connect-token-bootstrap.test.ts
@@ -81,6 +81,27 @@ describe("POST /me/connect-tokens bootstrap method", () => {
       expect(body.command).toBe(`FIRST_TREE_SERVER_URL='https://selfhost.example.test' first-tree login ${body.token}`);
       expect(body.bootstrapCommand).toBe(`npm install -g first-tree\n${body.command}`);
     });
+
+    it("falls back to trimming the raw server URL when configured publicUrl is not parseable", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app);
+      const originalPublicUrl = app.config.server.publicUrl;
+      app.config.server.publicUrl = "first-tree.internal///";
+      try {
+        const res = await app.inject({
+          method: "POST",
+          url: "/api/v1/me/connect-tokens",
+          headers: { authorization: `Bearer ${admin.accessToken}` },
+        });
+        expect(res.statusCode).toBe(200);
+        const body = res.json<{ token: string; command: string; bootstrapCommand: string }>();
+        expectShortConnectCode(body.token);
+        expect(body.command).toBe(`FIRST_TREE_SERVER_URL='first-tree.internal' first-tree login ${body.token}`);
+        expect(body.bootstrapCommand).toBe(`npm install -g first-tree\n${body.command}`);
+      } finally {
+        app.config.server.publicUrl = originalPublicUrl;
+      }
+    });
   });
 
   describe("prod portable", () => {

--- a/packages/server/src/__tests__/connection-manager.test.ts
+++ b/packages/server/src/__tests__/connection-manager.test.ts
@@ -7,9 +7,13 @@ import {
   getAgentClientId,
   getAgentRuntimeSession,
   getClientAgentIds,
+  getClientConnection,
+  hasActiveConnection,
   hasClientConnection,
   removeClientConnection,
+  removeConnection,
   setClientConnection,
+  setConnection,
   unbindAgentFromClient,
   validateAgentRuntimeSession,
 } from "../services/connection-manager.js";
@@ -22,7 +26,7 @@ import {
  */
 
 /** Create a minimal mock WebSocket (only readyState matters here). */
-function mockWs(readyState = WebSocket.OPEN): WebSocket {
+function mockWs(readyState: number = WebSocket.OPEN): WebSocket {
   return { readyState, close: () => {}, send: () => {} } as unknown as WebSocket;
 }
 
@@ -116,6 +120,70 @@ describe("connection-manager: bindAgentToClient", () => {
     expect(removed).toBe(true);
     expect(getAgentRuntimeSession(agent1)).toBeUndefined();
     expect(validateAgentRuntimeSession(agent1, clientA, token)).toBe(false);
+  });
+});
+
+describe("connection-manager: legacy per-agent connections", () => {
+  const agentId = "legacy-agent";
+
+  beforeEach(() => {
+    removeConnection(agentId, mockWs());
+    forceDisconnect(agentId);
+  });
+
+  it("tracks, replaces, and removes active per-agent sockets by identity", () => {
+    const ws = mockWs();
+    const staleWs = mockWs();
+
+    setConnection(agentId, ws);
+
+    expect(hasActiveConnection(agentId)).toBe(true);
+    expect(removeConnection(agentId, staleWs)).toBe(false);
+    expect(hasActiveConnection(agentId)).toBe(true);
+    expect(removeConnection(agentId, ws)).toBe(true);
+    expect(hasActiveConnection(agentId)).toBe(false);
+  });
+
+  it("treats closed legacy sockets as inactive", () => {
+    const closedWs = mockWs(WebSocket.CLOSED);
+
+    setConnection(agentId, closedWs);
+
+    expect(hasActiveConnection(agentId)).toBe(false);
+    expect(removeConnection(agentId, closedWs)).toBe(true);
+  });
+
+  it("force-disconnect closes legacy sockets and clears their runtime binding", () => {
+    let closeArgs: [number, string] | undefined;
+    const ws = {
+      readyState: WebSocket.OPEN,
+      close: (code: number, reason: string) => {
+        closeArgs = [code, reason];
+      },
+      send: () => {},
+    } as unknown as WebSocket;
+
+    setConnection(agentId, ws);
+
+    expect(forceDisconnect(agentId)).toBe(true);
+    expect(closeArgs).toEqual([4009, "Disconnected by admin"]);
+    expect(hasActiveConnection(agentId)).toBe(false);
+  });
+});
+
+describe("connection-manager: client connection lookup", () => {
+  it("returns only open client sockets", () => {
+    const clientId = "client-lookup";
+    const openWs = mockWs(WebSocket.OPEN);
+    const closingWs = mockWs(WebSocket.CLOSING);
+
+    setClientConnection(clientId, openWs);
+    expect(getClientConnection(clientId)).toBe(openWs);
+
+    setClientConnection(clientId, closingWs);
+    expect(getClientConnection(clientId)).toBeUndefined();
+
+    forceDisconnectClient(clientId);
   });
 });
 

--- a/packages/server/src/__tests__/context-reviewer-pr-edge.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr-edge.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("Context Reviewer PR internals", () => {
+  afterEach(() => {
+    vi.doUnmock("node:fs/promises");
+    vi.resetModules();
+  });
+
+  it("classifies supported and unsupported PR webhook triggers", async () => {
+    const { contextReviewerPrTestInternals } = await import("../services/context-reviewer-pr.js");
+
+    expect(contextReviewerPrTestInternals.isSupportedContextReviewerPrEvent("pull_request", "opened")).toBe(true);
+    expect(contextReviewerPrTestInternals.isSupportedContextReviewerPrEvent("pull_request", "closed")).toBe(false);
+  });
+
+  it("fails clearly when the prompt template is missing from every runtime layout", async () => {
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        access: vi.fn(async () => {
+          throw new Error("missing template");
+        }),
+        readFile: vi.fn(),
+      };
+    });
+    const { renderContextReviewerPrPrompt } = await import("../services/context-reviewer-pr.js");
+
+    await expect(
+      renderContextReviewerPrPrompt({
+        repoFullName: "owner/context-tree",
+        prNumber: 1,
+        title: "Missing template",
+        htmlUrl: "https://github.com/owner/context-tree/pull/1",
+        baseRef: null,
+        headRef: null,
+        authorLogin: "writer",
+        senderLogin: "writer",
+        triggerEvent: "pull_request.opened",
+        isDraft: false,
+        commentUrl: null,
+        commentAuthorLogin: null,
+        organizationId: "org_1",
+        reviewerManagerGithubLogin: null,
+        reviewerManagerIsPrAuthor: false,
+      }),
+    ).rejects.toThrow("Context Reviewer PR prompt template is missing");
+  });
+});

--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -8,6 +8,7 @@ import { chats } from "../db/schema/chats.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { createAgent } from "../services/agent.js";
+import { createChat } from "../services/chat.js";
 import {
   contextReviewerPrTestInternals,
   handleContextReviewerPrEvent,
@@ -296,6 +297,23 @@ describe("normalizeGithubRepo", () => {
     expect(normalizeGithubRepo("owner/repo/extra")).toBeNull();
     expect(normalizeGithubRepo("not-a-repo")).toBeNull();
   });
+
+  it("covers parser guard branches for malformed owner and path segments", () => {
+    const { parseBareRepo, parseScpLikeRepo, parseUrlRepo } = contextReviewerPrTestInternals;
+
+    expect(parseBareRepo("owner//")).toBeNull();
+    expect(parseBareRepo("//repo")).toBeNull();
+    expect(parseBareRepo("owner/repo/extra")).toBeNull();
+
+    expect(parseScpLikeRepo("git@gitlab.com:Owner/Repo")).toBeNull();
+    expect(parseScpLikeRepo("git@github.com:")).toBeNull();
+    expect(parseScpLikeRepo("git@github.com:Owner")).toBeNull();
+    expect(parseScpLikeRepo("git@github.com:Owner//")).toBeNull();
+
+    expect(parseUrlRepo("ftp://github.com/owner/repo")).toBeNull();
+    expect(parseUrlRepo("https://github.com/owner")).toBeNull();
+    expect(parseUrlRepo("https://github.com/owner//")).toBeNull();
+  });
 });
 
 describe("handleContextReviewerPrEvent", () => {
@@ -361,6 +379,32 @@ describe("handleContextReviewerPrEvent", () => {
         organizationId: admin.organizationId,
       }),
     ).resolves.toEqual({ handled: false, reason: "unsupported_event" });
+  });
+
+  it("skips before DB work when the payload is not an object", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+
+    await expect(
+      handleContextReviewerPrEvent(app, {
+        eventType: "pull_request",
+        payload: null,
+        organizationId: admin.organizationId,
+      }),
+    ).resolves.toEqual({ handled: false, reason: "unsupported_event" });
+  });
+
+  it("skips when the context tree repo is missing", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+
+    await expect(
+      handleContextReviewerPrEvent(app, {
+        eventType: "pull_request",
+        payload: pullRequestPayload(),
+        organizationId: admin.organizationId,
+      }),
+    ).resolves.toEqual({ handled: false, reason: "context_tree_repo_unset" });
   });
 
   it("creates a reviewer chat, membership, task message, and inbox notification for an opened context repo PR", async () => {
@@ -867,5 +911,127 @@ describe("handleContextReviewerPrEvent", () => {
       triggerEvent: "pull_request.ready_for_review",
       isDraft: false,
     });
+  });
+
+  it("rejects malformed payload shapes defensively", () => {
+    const { extractPullRequestPayloadInfo } = contextReviewerPrTestInternals;
+
+    expect(extractPullRequestPayloadInfo("pull_request", null, "org-1")).toBeNull();
+    expect(extractPullRequestPayloadInfo("pull_request", pullRequestPayload({ action: "closed" }), "org-1")).toBeNull();
+    expect(
+      extractPullRequestPayloadInfo(
+        "pull_request",
+        pullRequestPayload({ repository: null, sender: null }),
+        "org-1",
+      ),
+    ).toBeNull();
+    expect(
+      extractPullRequestPayloadInfo(
+        "pull_request",
+        pullRequestPayload({ repository: { full_name: "not-a-repo" }, pull_request: null }),
+        "org-1",
+      ),
+    ).toBeNull();
+    expect(
+      extractPullRequestPayloadInfo(
+        "issue_comment",
+        issueCommentPayload({ issue: null, comment: null }),
+        "org-1",
+      ),
+    ).toBeNull();
+    expect(
+      extractPullRequestPayloadInfo(
+        "pull_request_review_comment",
+        reviewCommentPayload({ pull_request: { number: 123 }, comment: null }),
+        "org-1",
+      ),
+    ).toBeNull();
+  });
+
+  it("extracts review comment payload fallbacks", () => {
+    expect(
+      contextReviewerPrTestInternals.extractPullRequestPayloadInfo(
+        "pull_request_review_comment",
+        reviewCommentPayload({
+          action: "edited",
+          pull_request: {
+            number: 123,
+            title: "Clarify agent routing context",
+            html_url: "https://github.com/owner/context-tree/pull/123",
+            base: null,
+            head: null,
+            draft: "unknown",
+          },
+          comment: {},
+        }),
+        "org-1",
+      ),
+    ).toMatchObject({
+      triggerEvent: "pull_request_review_comment.edited",
+      baseRef: null,
+      headRef: null,
+      isDraft: null,
+      commentUrl: null,
+      commentAuthorLogin: "reviewer-user",
+      commentAuthorType: "User",
+    });
+  });
+
+  it("returns null when an app-bot echo has no recent opened task to suppress", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    const created = await createChat(app.db, {
+      mode: "task",
+      initiatorAgentId: admin.humanAgentUuid,
+      organizationId: admin.organizationId,
+      initialRecipientAgentIds: [reviewer.uuid],
+      contextParticipantAgentIds: [],
+      topic: "Context review",
+      initialMessage: {
+        source: "api",
+        format: "markdown",
+        content: "seed",
+        metadata: {},
+      },
+      source: "manual",
+    });
+    const info = contextReviewerPrTestInternals.extractPullRequestPayloadInfo(
+      "issue_comment",
+      issueCommentPayload({
+        comment: {
+          html_url: "https://github.com/owner/context-tree/pull/123#issuecomment-9",
+          user: { login: "test-app[bot]", type: "Bot" },
+        },
+        sender: { login: "test-app[bot]", type: "Bot" },
+      }),
+      admin.organizationId,
+    );
+    if (!info) throw new Error("expected issue comment payload info");
+
+    await expect(
+      contextReviewerPrTestInternals.findSuppressibleReviewerEchoMessageId(app.db, {
+        chatId: created.chat.id,
+        info,
+        reviewer: {
+          uuid: reviewer.uuid,
+          managerHumanAgentId: admin.humanAgentUuid,
+          managerGithubLogin: null,
+        },
+        appSlug: null,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      contextReviewerPrTestInternals.findSuppressibleReviewerEchoMessageId(app.db, {
+        chatId: created.chat.id,
+        info,
+        reviewer: {
+          uuid: reviewer.uuid,
+          managerHumanAgentId: admin.humanAgentUuid,
+          managerGithubLogin: null,
+        },
+        appSlug: "test-app",
+      }),
+    ).resolves.toBeNull();
   });
 });

--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -919,11 +919,7 @@ describe("handleContextReviewerPrEvent", () => {
     expect(extractPullRequestPayloadInfo("pull_request", null, "org-1")).toBeNull();
     expect(extractPullRequestPayloadInfo("pull_request", pullRequestPayload({ action: "closed" }), "org-1")).toBeNull();
     expect(
-      extractPullRequestPayloadInfo(
-        "pull_request",
-        pullRequestPayload({ repository: null, sender: null }),
-        "org-1",
-      ),
+      extractPullRequestPayloadInfo("pull_request", pullRequestPayload({ repository: null, sender: null }), "org-1"),
     ).toBeNull();
     expect(
       extractPullRequestPayloadInfo(
@@ -933,11 +929,7 @@ describe("handleContextReviewerPrEvent", () => {
       ),
     ).toBeNull();
     expect(
-      extractPullRequestPayloadInfo(
-        "issue_comment",
-        issueCommentPayload({ issue: null, comment: null }),
-        "org-1",
-      ),
+      extractPullRequestPayloadInfo("issue_comment", issueCommentPayload({ issue: null, comment: null }), "org-1"),
     ).toBeNull();
     expect(
       extractPullRequestPayloadInfo(

--- a/packages/server/src/__tests__/context-tree-initialize.test.ts
+++ b/packages/server/src/__tests__/context-tree-initialize.test.ts
@@ -511,6 +511,61 @@ owners: [${ACCOUNT_LOGIN}]
     expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
   });
 
+  it("returns repo_unavailable when the installation loses access before writing NODE.md", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) return githubRepoResponse(201);
+      if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
+        return jsonResponse({ message: "Resource not accessible by integration" }, 403);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({ code: "repo_unavailable" });
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
+  });
+
+  it("returns repo_unavailable when validation workflow creation loses installation access", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = await seedInstallation(app, admin.organizationId);
+    await renameOrg(app, admin.organizationId, "Acme Labs");
+    const fetchSpy = mockFetch(async (url) => {
+      if (url === installationTokenUrl(installationId)) return installationTokenResponse();
+      if (url === orgReposUrl(ACCOUNT_LOGIN)) return githubRepoResponse(201);
+      if (url === repoUrl(ACCOUNT_LOGIN, REPO_NAME)) return githubRepoResponse(200);
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH, "main")) {
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, ROOT_NODE_PATH)) {
+        return jsonResponse({ content: { path: ROOT_NODE_PATH } }, 201);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH, "main")) {
+        return jsonResponse({ message: "Not Found" }, 404);
+      }
+      if (url === contentsUrl(ACCOUNT_LOGIN, REPO_NAME, VALIDATE_TREE_WORKFLOW_PATH)) {
+        return jsonResponse({ message: "Resource not accessible by integration" }, 403);
+      }
+      return new Response(`unexpected fetch ${url}`, { status: 500 });
+    });
+
+    const res = await initialize(app, admin);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({ code: "repo_unavailable" });
+    expect(fetchSpy).toHaveBeenCalledTimes(7);
+    expect((await getOrgContextTree(app.db, admin.organizationId)).repo).toBeUndefined();
+  });
+
   for (const createConflictStatus of [409, 422]) {
     it(`initializes successfully when validation workflow create returns ${createConflictStatus} and the file now exists`, async () => {
       const app = getApp();

--- a/packages/server/src/__tests__/context-tree-io.test.ts
+++ b/packages/server/src/__tests__/context-tree-io.test.ts
@@ -1,6 +1,7 @@
 import type { ContextTreeWriteEvent } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { Database } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
@@ -526,6 +527,210 @@ describe("context-tree IO service", () => {
     ).toEqual({ recordable: true });
   });
 
+  it("explains IO decision edge cases for paths, bindings, statuses, and shell args", () => {
+    const readEvent = (repoRelativePath: unknown, extra: Record<string, unknown> = {}) => ({
+      kind: "tool_call",
+      payload: {
+        toolUseId: `tu-${crypto.randomUUID()}`,
+        name: "Read",
+        args: {},
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: TREE_REPO,
+            repoRelativePath,
+            ...extra,
+          },
+        ],
+      },
+    });
+
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: readEvent("NODE.md"),
+        bindingRepo: null,
+      }),
+    ).toEqual({ recordable: false, reason: "no_org_context_tree_binding" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: { kind: "tool_call", payload: { name: "Read", status: "ok" } },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "event_kind_not_io" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: { toolUseId: "tu-status", name: "Read", args: {}, status: "error" },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "status_not_ok" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: { toolUseId: "tu-kind", name: "Read", args: {}, status: "ok", toolFileRefs: [] },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "no_tool_file_refs" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "codex",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: { toolUseId: "tu-shell-no-args", name: "command", args: null, status: "ok" },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "unsupported_shell_command" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "codex",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: { toolUseId: "tu-shell-non-string", name: "command", args: { command: 1 }, status: "ok" },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "unsupported_shell_command" });
+
+    for (const repoRelativePath of ["/absolute.md", ".", "..", "../escape.md"]) {
+      expect(
+        explainContextTreeIoDecision({
+          runtimeProvider: "claude-code",
+          sessionEvent: readEvent(repoRelativePath),
+          bindingRepo: TREE_REPO,
+        }),
+      ).toEqual({ recordable: false, reason: "ref_path_invalid" });
+    }
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: readEvent(""),
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "event_kind_not_io" });
+    for (const repoRelativePath of ["   ", "members/\0alice.md"]) {
+      expect(
+        explainContextTreeIoDecision({
+          runtimeProvider: "claude-code",
+          sessionEvent: readEvent(repoRelativePath),
+          bindingRepo: TREE_REPO,
+        }),
+      ).toEqual({ recordable: false, reason: "ref_path_invalid" });
+    }
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: readEvent(123),
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "event_kind_not_io" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "codex",
+        sessionEvent: { kind: "assistant_text", payload: { text: "not IO" } },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "event_kind_not_io" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "custom-runtime",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: {
+            toolUseId: "tu-mixed-git-delta",
+            name: "UnknownTool",
+            args: {},
+            status: "ok",
+            toolFileRefs: [
+              {
+                origin: "tool_arg",
+                repoUrl: TREE_REPO,
+                repoRelativePath: "ignored.md",
+              },
+              {
+                origin: "git_status_delta",
+                repoUrl: TREE_REPO,
+                repoRelativePath: "NODE.md",
+              },
+            ],
+          },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: true });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: readEvent("/", { pathKind: "repo" }),
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: true });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: readEvent(".", { pathKind: "repo" }),
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: true });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: readEvent("NODE.md"),
+        bindingRepo: TREE_REPO,
+        chatInOrg: false,
+      }),
+    ).toEqual({ recordable: false, reason: "chat_not_in_org" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: readEvent("NODE.md", { repoBranch: undefined, metadata: { toolName: "Read" } }),
+        bindingRepo: TREE_REPO,
+        bindingBranch: "develop",
+      }),
+    ).toEqual({ recordable: true });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: {
+          kind: "context_tree_usage",
+          payload: { purpose: "design_decision", treeRepoUrl: TREE_REPO, nodePath: null },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: true });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "custom-runtime",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: {
+            toolUseId: "tu-git-delta",
+            name: "UnknownTool",
+            args: {},
+            status: "ok",
+            toolFileRefs: [
+              {
+                origin: "git_status_delta",
+                repoUrl: TREE_REPO,
+                repoRelativePath: "NODE.md",
+              },
+            ],
+          },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: true });
+  });
+
   it("derives Claude search and notebook IO at the granularity the refs carry", async () => {
     const app = getApp();
     const seed = await seedContextTreeChat();
@@ -995,6 +1200,70 @@ describe("context-tree IO service", () => {
     });
   });
 
+  it("classifies fake skipped-diagnostics rows that are awkward to produce through SQL", async () => {
+    const selectResults = [
+      [{ agentId: "agent-known", runtimeProvider: "codex" }],
+      [
+        {
+          id: "ev-array-payload",
+          agentId: "agent-known",
+          chatId: "chat-1",
+          kind: "tool_call",
+          payload: [],
+          chatOrganizationId: "org-1",
+        },
+        {
+          id: "ev-status-error",
+          agentId: "agent-known",
+          chatId: "chat-1",
+          kind: "tool_call",
+          payload: { toolUseId: "tu-error", name: "command", args: {}, status: "error" },
+          chatOrganizationId: "org-1",
+        },
+        {
+          id: "ev-missing-agent",
+          agentId: "agent-missing",
+          chatId: "chat-1",
+          kind: "tool_call",
+          payload: { toolUseId: "tu-no-refs", name: "command", args: { command: "cat NODE.md" }, status: "ok" },
+          chatOrganizationId: "org-1",
+        },
+        {
+          id: "ev-bad-refs",
+          agentId: "agent-known",
+          chatId: "chat-1",
+          kind: "tool_call",
+          payload: { toolUseId: "tu-bad-refs", name: "command", args: {}, status: "ok", toolFileRefs: "bad" },
+          chatOrganizationId: "org-1",
+        },
+      ],
+    ];
+    const db = {
+      select: vi.fn(() => {
+        const result = selectResults.shift() ?? [];
+        const builder = {
+          from: vi.fn(() => builder),
+          leftJoin: vi.fn(() => builder),
+          where: vi.fn(async () => result),
+        };
+        return builder;
+      }),
+    } as unknown as Database;
+
+    const skipped = await summarizeContextTreeIoSkippedEvents(db, "org-1", 7, {
+      contextTreeBinding: { repo: TREE_REPO },
+    });
+
+    expect(skipped.reasons.map((row) => ({ reason: row.reason, eventCount: row.eventCount }))).toEqual([
+      { reason: "event_kind_not_io", eventCount: 2 },
+      { reason: "status_not_ok", eventCount: 1 },
+      { reason: "unsupported_tool", eventCount: 1 },
+    ]);
+    expect(skipped.reasons.find((row) => row.reason === "unsupported_tool")?.runtimeProviders).toEqual([
+      { runtimeProvider: "unknown", eventCount: 1 },
+    ]);
+  });
+
   it("ignores malformed toolFileRefs while filtering skipped diagnostics candidates", async () => {
     const app = getApp();
     const seed = await seedContextTreeChat();
@@ -1043,6 +1312,73 @@ describe("context-tree IO service", () => {
     expect(summary.skipped).toEqual({ windowDays: 7, totalEventCount: 0, reasons: [] });
     expect(timings.find((timing) => timing.name === "io_backfill_rows")?.fields).toMatchObject({ rowCount: 0 });
     expect(timings.find((timing) => timing.name === "io_skipped_rows")?.fields).toMatchObject({ rowCount: 0 });
+  });
+
+  it("maps summary fallback rows from a fake database", async () => {
+    const executeResults = [
+      [
+        { action: "read", agent_count: "2", event_count: null, target_count: undefined },
+        { action: "other", agent_count: 99, event_count: 99, target_count: 99 },
+      ],
+      [
+        {
+          agent_id: "agent-1",
+          agent_name: "Agent One",
+          agent_avatar_color_token: null,
+          runtime_provider: "codex",
+          read_count: "3",
+          write_count: undefined,
+          last_read_at: null,
+          last_write_at: "2026-01-02T00:00:00.000Z",
+          last_event_at: "2026-01-02T00:00:00.000Z",
+        },
+      ],
+      [
+        {
+          id: "io-1",
+          agent_id: "agent-1",
+          agent_name: "Agent One",
+          agent_avatar_color_token: null,
+          runtime_provider: "codex",
+          action: "unexpected",
+          source: "shell_command",
+          target_kind: "unknown",
+          target_path: "NODE.md",
+          raw_chat_id: "chat-outside",
+          joined_chat_id: null,
+          chat_topic: null,
+          created_at: null,
+        },
+      ],
+    ];
+    const db = {
+      execute: vi.fn(async () => executeResults.shift() ?? []),
+      select: vi.fn(() => {
+        const builder = {
+          from: vi.fn(() => builder),
+          where: vi.fn(async () => []),
+        };
+        return builder;
+      }),
+    } as unknown as Database;
+
+    const summary = await summarizeContextTreeIo(db, "org-1", 7, undefined, {
+      backfillSessionEvents: false,
+      contextTreeBinding: { repo: TREE_REPO },
+    });
+
+    expect(summary.summary).toEqual({
+      read: { agentCount: 2, eventCount: 0, targetCount: 0 },
+      write: { agentCount: 0, eventCount: 0, targetCount: 0 },
+    });
+    expect(summary.agents[0]).toMatchObject({ readCount: 3, writeCount: 0, lastReadAt: null });
+    expect(summary.recentEvents[0]).toMatchObject({
+      action: "read",
+      targetKind: "file",
+      chatId: null,
+      chatTitle: null,
+      viewerCanAccess: false,
+    });
   });
 
   it("skips recordable IO events when the chat no longer belongs to the organization", async () => {
@@ -1404,5 +1740,64 @@ describe("context-tree IO service", () => {
     // Sorted newest-first by time.
     const times = writes.map((w) => (w.createdAt ? Date.parse(w.createdAt) : 0));
     expect(times).toEqual([...times].sort((a, b) => b - a));
+  });
+
+  it("reconciles write telemetry with null, invalid, and root-ish timestamps", async () => {
+    const db = {
+      execute: vi.fn(async () => [
+        {
+          agent_id: "agent-1",
+          agent_name: "Agent One",
+          agent_avatar_color_token: null,
+          target_path: "system/null.md",
+          created_at: null,
+        },
+        {
+          agent_id: "agent-2",
+          agent_name: "Agent Two",
+          agent_avatar_color_token: "blue",
+          target_path: "system/bad.md",
+          created_at: null,
+        },
+        {
+          agent_id: "agent-3",
+          agent_name: "Agent Three",
+          agent_avatar_color_token: "green",
+          target_path: "/",
+          created_at: "2026-01-03T00:00:00.000Z",
+        },
+      ]),
+    } as unknown as Database;
+    const base = {
+      nodeId: null,
+      title: "",
+      summary: null,
+      riskLevel: "low" as const,
+      authorName: "git-author",
+      agentId: null,
+      agentName: null,
+      agentAvatarColorToken: null,
+      commit: null,
+      prNumber: null,
+    };
+
+    const writes = await reconcileContextTreeWrites(
+      db,
+      "org-1",
+      7,
+      [
+        { ...base, id: "git-null", nodePath: "system/null", changeType: "edited", createdAt: null },
+        { ...base, id: "git-bad", nodePath: "system/bad", changeType: "edited", createdAt: "not-a-date" },
+      ],
+      { backfillSessionEvents: false },
+    );
+
+    expect(writes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "git-null", agentId: "agent-1" }),
+        expect.objectContaining({ id: "git-bad", agentId: "agent-2" }),
+        expect.objectContaining({ nodePath: "", title: "Context Tree", agentId: "agent-3" }),
+      ]),
+    );
   });
 });

--- a/packages/server/src/__tests__/context-tree-io.test.ts
+++ b/packages/server/src/__tests__/context-tree-io.test.ts
@@ -1,8 +1,11 @@
 import type { ContextTreeWriteEvent } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
 import { contextTreeIoEvents } from "../db/schema/context-tree-io-events.js";
+import { organizations } from "../db/schema/organizations.js";
 import { sessionEvents } from "../db/schema/session-events.js";
 import {
   buildContextTreeIoSummary,
@@ -473,6 +476,54 @@ describe("context-tree IO service", () => {
         bindingRepo: TREE_REPO,
       }),
     ).toEqual({ recordable: false, reason: "unsupported_shell_command" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "custom-runtime",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: {
+            toolUseId: "tu-unsupported-tool",
+            name: "Read",
+            args: {},
+            status: "ok",
+            toolFileRefs: [
+              {
+                origin: "tool_arg",
+                repoUrl: TREE_REPO,
+                repoBranch: "main",
+                repoRelativePath: "NODE.md",
+                pathKind: "file",
+              },
+            ],
+          },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: false, reason: "unsupported_tool" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: {
+            toolUseId: "tu-recordable",
+            name: "Read",
+            args: {},
+            status: "ok",
+            toolFileRefs: [
+              {
+                origin: "tool_arg",
+                repoUrl: TREE_REPO,
+                repoBranch: "main",
+                repoRelativePath: "NODE.md",
+                pathKind: "file",
+              },
+            ],
+          },
+        },
+        bindingRepo: TREE_REPO,
+      }),
+    ).toEqual({ recordable: true });
   });
 
   it("derives Claude search and notebook IO at the granularity the refs carry", async () => {
@@ -838,6 +889,47 @@ describe("context-tree IO service", () => {
     });
   });
 
+  it("fast-paths codex file-change and custom-runtime no-ref skip diagnostics", async () => {
+    const app = getApp();
+    const codexSeed = await seedContextTreeChat();
+    await app.db.update(agents).set({ runtimeProvider: "codex" }).where(eq(agents.uuid, codexSeed.agent.uuid));
+    await appendEvent(app.db, codexSeed.agent.uuid, codexSeed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-codex-file-change-no-refs",
+        name: "file_change",
+        args: {},
+        status: "ok",
+      },
+    });
+
+    const codexSkipped = await summarizeContextTreeIoSkippedEvents(app.db, codexSeed.organizationId, 7);
+    expect(codexSkipped.reasons.map((row) => ({ reason: row.reason, eventCount: row.eventCount }))).toEqual([
+      { reason: "no_tool_file_refs", eventCount: 1 },
+    ]);
+
+    const customSeed = await seedContextTreeChat();
+    await app.db
+      .update(agents)
+      .set({ runtimeProvider: "custom-runtime" })
+      .where(eq(agents.uuid, customSeed.agent.uuid));
+    await appendEvent(app.db, customSeed.agent.uuid, customSeed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-custom-read-no-refs",
+        name: "Read",
+        args: {},
+        status: "ok",
+      },
+    });
+
+    const customSkipped = await summarizeContextTreeIoSkippedEvents(app.db, customSeed.organizationId, 7);
+    expect(customSkipped.reasons.map((row) => ({ reason: row.reason, eventCount: row.eventCount }))).toContainEqual({
+      reason: "unsupported_tool",
+      eventCount: 1,
+    });
+  });
+
   it("keeps no-binding skipped diagnostics off the no-ref fast path", async () => {
     const app = getApp();
     const seed = await createTestAgent(app);
@@ -860,6 +952,40 @@ describe("context-tree IO service", () => {
 
     expect(skipped.reasons.map((row) => ({ reason: row.reason, eventCount: row.eventCount }))).toEqual([
       { reason: "no_org_context_tree_binding", eventCount: 1 },
+    ]);
+    expect(timings.find((timing) => timing.name === "io_skipped_decide_fast_rows")?.fields).toMatchObject({
+      rowCount: 0,
+    });
+    expect(timings.find((timing) => timing.name === "io_skipped_decide_slow_rows")?.fields).toMatchObject({
+      rowCount: 1,
+    });
+  });
+
+  it("classifies malformed skipped-diagnostics candidate payloads through the slow path", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+    const timings: Array<{ name: string; fields?: Record<string, unknown> }> = [];
+
+    await app.db.insert(sessionEvents).values({
+      id: `ev-${crypto.randomUUID()}`,
+      agentId: seed.agent.uuid,
+      chatId: seed.chatId,
+      seq: 1,
+      kind: "tool_call",
+      payload: {
+        name: "Bash",
+        args: { command: "cat /tmp/context-tree/NODE.md" },
+        status: "ok",
+      },
+      createdAt: new Date(),
+    });
+
+    const skipped = await summarizeContextTreeIoSkippedEvents(app.db, seed.organizationId, 7, {
+      timing: (name, _ms, fields) => timings.push({ name, fields }),
+    });
+
+    expect(skipped.reasons.map((row) => ({ reason: row.reason, eventCount: row.eventCount }))).toEqual([
+      { reason: "event_kind_not_io", eventCount: 1 },
     ]);
     expect(timings.find((timing) => timing.name === "io_skipped_decide_fast_rows")?.fields).toMatchObject({
       rowCount: 0,
@@ -893,6 +1019,101 @@ describe("context-tree IO service", () => {
       windowDays: 7,
       totalEventCount: 0,
       reasons: [],
+    });
+  });
+
+  it("returns empty IO summaries when an organization has no candidate agents", async () => {
+    const app = getApp();
+    const organizationId = crypto.randomUUID();
+    const timings: Array<{ name: string; fields?: Record<string, unknown> }> = [];
+    await app.db.insert(organizations).values({
+      id: organizationId,
+      name: `empty-${crypto.randomUUID().slice(0, 8)}`,
+      displayName: "Empty Org",
+    });
+
+    const summary = await summarizeContextTreeIo(app.db, organizationId, 7, undefined, {
+      timing: (name, _ms, fields) => timings.push({ name, fields }),
+    });
+
+    expect(summary.summary).toEqual({
+      read: { agentCount: 0, eventCount: 0, targetCount: 0 },
+      write: { agentCount: 0, eventCount: 0, targetCount: 0 },
+    });
+    expect(summary.skipped).toEqual({ windowDays: 7, totalEventCount: 0, reasons: [] });
+    expect(timings.find((timing) => timing.name === "io_backfill_rows")?.fields).toMatchObject({ rowCount: 0 });
+    expect(timings.find((timing) => timing.name === "io_skipped_rows")?.fields).toMatchObject({ rowCount: 0 });
+  });
+
+  it("skips recordable IO events when the chat no longer belongs to the organization", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+    const persisted = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tu-orphan-chat",
+        name: "Read",
+        args: {},
+        status: "ok",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            repoUrl: TREE_REPO,
+            repoBranch: "main",
+            repoRelativePath: "NODE.md",
+            pathKind: "file",
+          },
+        ],
+      },
+    });
+
+    await recordFromSessionEvent(app.db, {
+      organizationId: seed.organizationId,
+      agentId: seed.agent.uuid,
+      chatId: `missing-${crypto.randomUUID()}`,
+      runtimeProvider: "claude-code",
+      sessionEvent: persisted,
+    });
+
+    const rows = await app.db
+      .select()
+      .from(contextTreeIoEvents)
+      .where(eq(contextTreeIoEvents.sourceSessionEventId, persisted.id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("marks context-tree read feed access through direct and supervised chat memberships", async () => {
+    const app = getApp();
+    const seed = await seedContextTreeChat();
+    await app.db.insert(chatMembership).values([
+      { chatId: seed.chatId, agentId: seed.humanAgentUuid, accessMode: "watcher" },
+      { chatId: seed.chatId, agentId: seed.agent.uuid, accessMode: "speaker" },
+    ]);
+    const persisted = await appendEvent(app.db, seed.agent.uuid, seed.chatId, {
+      kind: "context_tree_usage",
+      payload: {
+        purpose: "design_decision",
+        treeRepoUrl: TREE_REPO,
+        nodePath: "domains/runtime/NODE.md",
+      },
+    });
+    await recordFromSessionEvent(app.db, {
+      organizationId: seed.organizationId,
+      agentId: seed.agent.uuid,
+      chatId: seed.chatId,
+      runtimeProvider: "claude-code",
+      sessionEvent: persisted,
+    });
+
+    const summary = await summarizeContextTreeIo(app.db, seed.organizationId, 7, {
+      humanAgentId: seed.humanAgentUuid,
+      memberId: seed.memberId,
+    });
+
+    expect(summary.recentEvents[0]).toMatchObject({
+      chatId: seed.chatId,
+      chatTitle: "io",
+      viewerCanAccess: true,
     });
   });
 

--- a/packages/server/src/__tests__/context-tree-repo-provisioner.test.ts
+++ b/packages/server/src/__tests__/context-tree-repo-provisioner.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type ProvisionerContext = Awaited<ReturnType<typeof setupProvisioner>>;
+
+const repo = {
+  name: "context-tree",
+  fullName: "acme/context-tree",
+  ownerLogin: "acme",
+  cloneUrl: "https://github.com/acme/context-tree.git",
+  htmlUrl: "https://github.com/acme/context-tree",
+  private: true,
+  defaultBranch: "main",
+};
+
+const organizationInstallation = {
+  id: "installation-row-1",
+  installationId: 123,
+  accountLogin: "acme",
+  accountType: "Organization" as const,
+  accountGithubId: 456,
+  installerGithubId: 42,
+  requesterGithubId: null,
+  hubOrganizationId: "org-1",
+  permissions: { contents: "write" as const },
+  events: [],
+  suspendedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const userInstallation = {
+  ...organizationInstallation,
+  id: "installation-row-2",
+  accountType: "User" as const,
+  accountLogin: "octocat",
+  accountGithubId: 42,
+};
+
+async function setupProvisioner() {
+  vi.resetModules();
+
+  class GithubAppApiError extends Error {
+    constructor(
+      public readonly status: number,
+      message = "GitHub App API error",
+    ) {
+      super(message);
+      this.name = "GithubAppApiError";
+    }
+  }
+
+  class GithubApiError extends Error {
+    constructor(
+      public readonly status: number,
+      message = "GitHub API error",
+    ) {
+      super(message);
+      this.name = "GithubApiError";
+    }
+  }
+
+  const createOrganizationRepo = vi.fn();
+  const getRepository = vi.fn();
+  const verifyUserCanAdministerInstallation = vi.fn();
+  const createUserRepo = vi.fn();
+
+  vi.doMock("../services/github-app.js", () => ({
+    GithubAppApiError,
+    createOrganizationRepo,
+    getRepository,
+    verifyUserCanAdministerInstallation,
+  }));
+  vi.doMock("../services/github-oauth.js", () => ({
+    GithubApiError,
+    createUserRepo,
+  }));
+
+  const provisioner = await import("../services/context-tree-repo-provisioner.js");
+  return {
+    ...provisioner,
+    classes: { GithubAppApiError, GithubApiError },
+    mocks: { createOrganizationRepo, getRepository, verifyUserCanAdministerInstallation, createUserRepo },
+  };
+}
+
+function input(ctx: ProvisionerContext, overrides: Record<string, unknown> = {}) {
+  return {
+    installation: organizationInstallation,
+    installationToken: "ghs_installation",
+    repoName: "context-tree",
+    teamName: "Acme",
+    getUserToken: vi.fn(async () => ({ accessToken: "ghu_user", githubId: "42" })),
+    ...overrides,
+  } as unknown as Parameters<typeof ctx.ensureInstallationOwnedContextTreeRepo>[0];
+}
+
+describe("context tree repo provisioner edges", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("maps organization create and verification upstream failures to provision errors", async () => {
+    const ctx = await setupProvisioner();
+    ctx.mocks.createOrganizationRepo.mockRejectedValueOnce(new Error("network down"));
+
+    await expect(ctx.ensureInstallationOwnedContextTreeRepo(input(ctx))).rejects.toMatchObject({
+      statusCode: 502,
+      code: "upstream",
+      message: "Couldn't create the GitHub repo. Try again in a moment.",
+    });
+
+    ctx.mocks.createOrganizationRepo.mockRejectedValueOnce(new ctx.classes.GithubAppApiError(422));
+    ctx.mocks.getRepository.mockRejectedValueOnce(new ctx.classes.GithubAppApiError(500));
+
+    await expect(ctx.ensureInstallationOwnedContextTreeRepo(input(ctx))).rejects.toMatchObject({
+      statusCode: 502,
+      code: "upstream",
+      message: "Couldn't verify the GitHub repo. Try again in a moment.",
+    });
+  });
+
+  it("rejects personal repo creation when the acting user does not own the installation account", async () => {
+    const ctx = await setupProvisioner();
+    ctx.mocks.getRepository.mockRejectedValueOnce(new ctx.classes.GithubAppApiError(404));
+    ctx.mocks.verifyUserCanAdministerInstallation.mockResolvedValueOnce(false);
+
+    await expect(
+      ctx.ensureInstallationOwnedContextTreeRepo(input(ctx, { installation: userInstallation })),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: "context_tree_repo_account_mismatch",
+    });
+    expect(ctx.mocks.createUserRepo).not.toHaveBeenCalled();
+  });
+
+  it("maps personal repo creation conflicts, token failures, and upstream failures", async () => {
+    const conflict = await setupProvisioner();
+    conflict.mocks.getRepository.mockRejectedValueOnce(new conflict.classes.GithubAppApiError(404));
+    conflict.mocks.verifyUserCanAdministerInstallation.mockResolvedValueOnce(true);
+    conflict.mocks.createUserRepo.mockRejectedValueOnce(new conflict.classes.GithubApiError(422));
+
+    await expect(
+      conflict.ensureInstallationOwnedContextTreeRepo(input(conflict, { installation: userInstallation })),
+    ).rejects.toMatchObject({ statusCode: 409, code: "context_tree_repo_access_required" });
+
+    const denied = await setupProvisioner();
+    denied.mocks.getRepository.mockRejectedValueOnce(new denied.classes.GithubAppApiError(404));
+    denied.mocks.verifyUserCanAdministerInstallation.mockResolvedValueOnce(true);
+    denied.mocks.createUserRepo.mockRejectedValueOnce(new denied.classes.GithubApiError(401));
+
+    await expect(
+      denied.ensureInstallationOwnedContextTreeRepo(input(denied, { installation: userInstallation })),
+    ).rejects.toMatchObject({ statusCode: 403, code: "github_user_token_required" });
+
+    const upstream = await setupProvisioner();
+    upstream.mocks.getRepository.mockRejectedValueOnce(new upstream.classes.GithubAppApiError(404));
+    upstream.mocks.verifyUserCanAdministerInstallation.mockResolvedValueOnce(true);
+    upstream.mocks.createUserRepo.mockRejectedValueOnce(new Error("repo service down"));
+
+    await expect(
+      upstream.ensureInstallationOwnedContextTreeRepo(input(upstream, { installation: userInstallation })),
+    ).rejects.toMatchObject({
+      statusCode: 502,
+      code: "upstream",
+      message: "Couldn't create your Context Tree repo on GitHub. Try again in a moment.",
+    });
+  });
+
+  it("requires installation access after personal repo creation and preserves typed provision errors", async () => {
+    const missingAccess = await setupProvisioner();
+    missingAccess.mocks.getRepository.mockRejectedValue(new missingAccess.classes.GithubAppApiError(404));
+    missingAccess.mocks.verifyUserCanAdministerInstallation.mockResolvedValueOnce(true);
+    missingAccess.mocks.createUserRepo.mockResolvedValueOnce(repo);
+
+    await expect(
+      missingAccess.ensureInstallationOwnedContextTreeRepo(input(missingAccess, { installation: userInstallation })),
+    ).rejects.toMatchObject({ statusCode: 409, code: "context_tree_repo_access_required" });
+
+    const typed = await setupProvisioner();
+    typed.mocks.getRepository.mockRejectedValueOnce(new typed.classes.GithubAppApiError(404));
+    typed.mocks.verifyUserCanAdministerInstallation.mockResolvedValueOnce(true);
+    const expected = new typed.ContextTreeRepoProvisionError(418, "teapot", "Short and stout");
+    typed.mocks.createUserRepo.mockRejectedValueOnce(expected);
+
+    await expect(
+      typed.ensureInstallationOwnedContextTreeRepo(input(typed, { installation: userInstallation })),
+    ).rejects.toBe(expected);
+  });
+
+  it("returns an existing personal repo when the installation can already read it", async () => {
+    const ctx = await setupProvisioner();
+    ctx.mocks.getRepository.mockResolvedValueOnce(repo);
+
+    await expect(
+      ctx.ensureInstallationOwnedContextTreeRepo(input(ctx, { installation: userInstallation })),
+    ).resolves.toBe(repo);
+    expect(ctx.mocks.createUserRepo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
+++ b/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
@@ -201,4 +201,103 @@ describe("org context tree routes with mocked service edges", () => {
     });
     expect(ctx.mocks.getRepoFileWithToken).toHaveBeenCalledTimes(2);
   });
+
+  it("maps root node verification failures to an upstream initialize error", async () => {
+    const ctx = await setupRoute();
+    ctx.mocks.getRepoFileWithToken.mockRejectedValueOnce(new Error("github timeout"));
+
+    const res = await initialize(ctx);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.json()).toEqual({
+      error: "Couldn't verify the Context Tree root node. Try again in a moment.",
+      code: "upstream",
+    });
+    expect(ctx.mocks.createRepoFileWithToken).not.toHaveBeenCalled();
+    expect(ctx.mocks.putOrgSetting).not.toHaveBeenCalled();
+  });
+
+  it("maps workflow verification failures after root success", async () => {
+    const ctx = await setupRoute();
+    ctx.mocks.getRepoFileWithToken
+      .mockResolvedValueOnce({ path: "NODE.md" })
+      .mockRejectedValueOnce(new Error("github timeout"));
+
+    const res = await initialize(ctx);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.json()).toEqual({
+      error: "Couldn't verify the Context Tree validation workflow. Try again in a moment.",
+      code: "upstream",
+    });
+    expect(ctx.mocks.putOrgSetting).not.toHaveBeenCalled();
+  });
+
+  it("maps workflow conflict verification failures to the existing-file upstream error", async () => {
+    const ctx = await setupRoute();
+    ctx.mocks.getRepoFileWithToken
+      .mockResolvedValueOnce({ path: "NODE.md" })
+      .mockRejectedValueOnce(new ctx.classes.GithubAppApiError(404))
+      .mockRejectedValueOnce(new Error("github timeout"));
+    ctx.mocks.createRepoFileWithToken.mockRejectedValueOnce(new ctx.classes.GithubAppApiError(422));
+
+    const res = await initialize(ctx);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.json()).toEqual({
+      error: "Couldn't verify the existing Context Tree validation workflow. Try again in a moment.",
+      code: "upstream",
+    });
+    expect(ctx.mocks.getRepoFileWithToken).toHaveBeenCalledTimes(3);
+    expect(ctx.mocks.putOrgSetting).not.toHaveBeenCalled();
+  });
+
+  it("initializes missing root and workflow files before saving the org setting", async () => {
+    const ctx = await setupRoute();
+    ctx.mocks.getOrganization.mockResolvedValueOnce({
+      id: ctx.scope.organizationId,
+      name: "fallback-name",
+      displayName: "  Àcme   Research Team  ",
+    });
+    ctx.mocks.getRepoFileWithToken
+      .mockRejectedValueOnce(new ctx.classes.GithubAppApiError(404))
+      .mockRejectedValueOnce(new ctx.classes.GithubAppApiError(404));
+
+    const res = await initialize(ctx);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toMatchObject({
+      repo: ctx.repo.cloneUrl,
+      htmlUrl: ctx.repo.htmlUrl,
+      branch: "main",
+      nodePath: "NODE.md",
+    });
+    expect(ctx.mocks.ensureInstallationOwnedContextTreeRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ repoName: "acme-research-team-context-tree", teamName: "Àcme Research Team" }),
+    );
+    expect(ctx.mocks.createRepoFileWithToken).toHaveBeenCalledTimes(2);
+    expect(ctx.mocks.createRepoFileWithToken).toHaveBeenNthCalledWith(
+      1,
+      "ghs_test",
+      expect.objectContaining({
+        path: "NODE.md",
+        message: "Initialize Context Tree root node",
+      }),
+    );
+    expect(ctx.mocks.createRepoFileWithToken).toHaveBeenNthCalledWith(
+      2,
+      "ghs_test",
+      expect.objectContaining({
+        path: ".github/workflows/validate-tree.yml",
+        message: "Initialize Context Tree validation workflow",
+      }),
+    );
+    expect(ctx.mocks.putOrgSetting).toHaveBeenCalledWith(
+      ctx.app.db,
+      ctx.scope.organizationId,
+      "context_tree",
+      { repo: ctx.repo.cloneUrl, branch: "main" },
+      { updatedBy: ctx.scope.userId },
+    );
+  });
 });

--- a/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
+++ b/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
@@ -1,0 +1,204 @@
+import Fastify from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type RouteMocks = Awaited<ReturnType<typeof setupRoute>>;
+
+async function setupRoute() {
+  vi.resetModules();
+
+  const scope = {
+    userId: "user-test",
+    organizationId: "org-test",
+    memberId: "member-test",
+    role: "admin",
+    humanAgentId: "human-test",
+  };
+  const installation = {
+    installationId: 123456,
+    accountLogin: "acme",
+    accountType: "Organization",
+    suspendedAt: null,
+  };
+  const repo = {
+    ownerLogin: "acme",
+    name: "acme-context-tree",
+    fullName: "acme/acme-context-tree",
+    cloneUrl: "https://github.com/acme/acme-context-tree.git",
+    htmlUrl: "https://github.com/acme/acme-context-tree",
+  };
+
+  class ContextTreeRepoProvisionError extends Error {
+    constructor(
+      public readonly statusCode: number,
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+      this.name = "ContextTreeRepoProvisionError";
+    }
+  }
+
+  class GithubAppApiError extends Error {
+    constructor(
+      public readonly status: number,
+      message = "GitHub API error",
+    ) {
+      super(message);
+      this.name = "GithubAppApiError";
+    }
+  }
+
+  class GithubUserTokenError extends Error {
+    constructor(
+      public readonly statusCode: 403 | 503,
+      message: string,
+      public readonly code?: string,
+      public readonly cause?: unknown,
+    ) {
+      super(message);
+      this.name = "GithubUserTokenError";
+    }
+  }
+
+  const requireOrgAdmin = vi.fn().mockResolvedValue(scope);
+  const requireOrgMembership = vi.fn().mockResolvedValue(scope);
+  const findInstallationByOrg = vi.fn().mockResolvedValue(installation);
+  const mintContextTreeInstallationToken = vi.fn().mockResolvedValue({
+    ok: true,
+    token: "ghs_test",
+    permissions: { administration: "write", contents: "write", workflows: "write" },
+  });
+  const ensureInstallationOwnedContextTreeRepo = vi.fn().mockResolvedValue(repo);
+  const getFreshGithubUserToken = vi.fn();
+  const getRepoFileWithToken = vi.fn().mockResolvedValue({ path: "NODE.md" });
+  const createRepoFileWithToken = vi.fn().mockResolvedValue({ content: { path: "NODE.md" } });
+  const getOrgContextTree = vi.fn().mockResolvedValue({ repo: undefined, branch: undefined });
+  const putOrgSetting = vi.fn().mockResolvedValue({ repo: repo.cloneUrl, branch: "main" });
+  const getOrganization = vi.fn().mockResolvedValue({ id: scope.organizationId, name: "Acme", displayName: "Acme" });
+
+  vi.doMock("../scope/require-org.js", () => ({ requireOrgAdmin, requireOrgMembership }));
+  vi.doMock("../services/context-tree-repo-provisioner.js", () => ({
+    ContextTreeRepoProvisionError,
+    ensureInstallationOwnedContextTreeRepo,
+  }));
+  vi.doMock("../services/github-app.js", () => ({
+    GithubAppApiError,
+    createRepoFileWithToken,
+    getRepoFileWithToken,
+  }));
+  vi.doMock("../services/github-app-installations.js", () => ({ findInstallationByOrg }));
+  vi.doMock("../services/github-app-token.js", () => ({ mintContextTreeInstallationToken }));
+  vi.doMock("../services/github-user-token.js", () => ({ GithubUserTokenError, getFreshGithubUserToken }));
+  vi.doMock("../services/org-settings.js", () => ({ getOrgContextTree, putOrgSetting }));
+  vi.doMock("../services/organization.js", () => ({ getOrganization }));
+
+  const { orgContextTreeRoutes } = await import("../api/orgs/context-tree.js");
+  const app = Object.assign(Fastify(), {
+    db: {},
+    config: {
+      oauth: { githubApp: {} },
+      secrets: { encryptionKey: "test-key" },
+    },
+  });
+  await app.register(orgContextTreeRoutes);
+  await app.ready();
+
+  return {
+    app,
+    scope,
+    installation,
+    repo,
+    classes: { ContextTreeRepoProvisionError, GithubAppApiError, GithubUserTokenError },
+    mocks: {
+      requireOrgAdmin,
+      requireOrgMembership,
+      findInstallationByOrg,
+      mintContextTreeInstallationToken,
+      ensureInstallationOwnedContextTreeRepo,
+      getFreshGithubUserToken,
+      getRepoFileWithToken,
+      createRepoFileWithToken,
+      getOrgContextTree,
+      putOrgSetting,
+      getOrganization,
+    },
+  };
+}
+
+describe("org context tree routes with mocked service edges", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  async function initialize(ctx: RouteMocks) {
+    return ctx.app.inject({ method: "POST", url: "/initialize", payload: {} });
+  }
+
+  it("returns no_installation when minting unexpectedly succeeds without an installation row", async () => {
+    const ctx = await setupRoute();
+    ctx.mocks.findInstallationByOrg.mockResolvedValueOnce(null);
+
+    const res = await initialize(ctx);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toEqual({
+      error: "No GitHub App installation is connected for this team yet.",
+      code: "no_installation",
+    });
+    expect(ctx.mocks.ensureInstallationOwnedContextTreeRepo).not.toHaveBeenCalled();
+  });
+
+  it("maps typed repo provision failures to their status and code", async () => {
+    const ctx = await setupRoute();
+    ctx.mocks.ensureInstallationOwnedContextTreeRepo.mockRejectedValueOnce(
+      new ctx.classes.ContextTreeRepoProvisionError(409, "repo_unavailable", "Repo unavailable"),
+    );
+
+    const res = await initialize(ctx);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toEqual({ error: "Repo unavailable", code: "repo_unavailable" });
+    expect(ctx.mocks.createRepoFileWithToken).not.toHaveBeenCalled();
+  });
+
+  it("maps missing GitHub user token errors before writing repo files", async () => {
+    const ctx = await setupRoute();
+    ctx.mocks.ensureInstallationOwnedContextTreeRepo.mockRejectedValueOnce(
+      new ctx.classes.GithubUserTokenError(503, "Reconnect GitHub"),
+    );
+
+    const res = await initialize(ctx);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toEqual({ error: "Reconnect GitHub", code: "github_user_token_required" });
+    expect(ctx.mocks.createRepoFileWithToken).not.toHaveBeenCalled();
+  });
+
+  it("rethrows unexpected provision failures as a server error", async () => {
+    const ctx = await setupRoute();
+    ctx.mocks.ensureInstallationOwnedContextTreeRepo.mockRejectedValueOnce(new Error("provision exploded"));
+
+    const res = await initialize(ctx);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json<{ error: string }>().error).toBe("Internal Server Error");
+  });
+
+  it("reports repo_unavailable when conflict verification loses repository access", async () => {
+    const ctx = await setupRoute();
+    ctx.mocks.getRepoFileWithToken
+      .mockRejectedValueOnce(new ctx.classes.GithubAppApiError(404))
+      .mockRejectedValueOnce(new ctx.classes.GithubAppApiError(403));
+    ctx.mocks.createRepoFileWithToken.mockRejectedValueOnce(new ctx.classes.GithubAppApiError(409));
+
+    const res = await initialize(ctx);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toEqual({
+      error: "GitHub repo acme/acme-context-tree is not accessible to this team's GitHub App installation.",
+      code: "repo_unavailable",
+    });
+    expect(ctx.mocks.getRepoFileWithToken).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
+++ b/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
@@ -217,6 +217,21 @@ describe("org context tree routes with mocked service edges", () => {
     expect(ctx.mocks.putOrgSetting).not.toHaveBeenCalled();
   });
 
+  it("maps unexpected root node create failures to an upstream initialize error", async () => {
+    const ctx = await setupRoute();
+    ctx.mocks.getRepoFileWithToken.mockRejectedValueOnce(new ctx.classes.GithubAppApiError(404));
+    ctx.mocks.createRepoFileWithToken.mockRejectedValueOnce(new Error("create root exploded"));
+
+    const res = await initialize(ctx);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.json()).toEqual({
+      error: "Couldn't initialize the Context Tree root node. Try again in a moment.",
+      code: "upstream",
+    });
+    expect(ctx.mocks.putOrgSetting).not.toHaveBeenCalled();
+  });
+
   it("maps workflow verification failures after root success", async () => {
     const ctx = await setupRoute();
     ctx.mocks.getRepoFileWithToken
@@ -228,6 +243,23 @@ describe("org context tree routes with mocked service edges", () => {
     expect(res.statusCode).toBe(502);
     expect(res.json()).toEqual({
       error: "Couldn't verify the Context Tree validation workflow. Try again in a moment.",
+      code: "upstream",
+    });
+    expect(ctx.mocks.putOrgSetting).not.toHaveBeenCalled();
+  });
+
+  it("maps unexpected workflow create failures to an upstream initialize error", async () => {
+    const ctx = await setupRoute();
+    ctx.mocks.getRepoFileWithToken
+      .mockResolvedValueOnce({ path: "NODE.md" })
+      .mockRejectedValueOnce(new ctx.classes.GithubAppApiError(404));
+    ctx.mocks.createRepoFileWithToken.mockRejectedValueOnce(new Error("create workflow exploded"));
+
+    const res = await initialize(ctx);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.json()).toEqual({
+      error: "Couldn't initialize the Context Tree validation workflow. Try again in a moment.",
       code: "upstream",
     });
     expect(ctx.mocks.putOrgSetting).not.toHaveBeenCalled();

--- a/packages/server/src/__tests__/context-tree-snapshot-git-mocked.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot-git-mocked.test.ts
@@ -119,7 +119,9 @@ describe("Context Tree snapshot service with mocked git", () => {
       return "";
     });
 
-    await expect(service.contextTreeSnapshotTestInternals.readDiffEntries("/fake", safeBase, safeHead)).resolves.toEqual({
+    await expect(
+      service.contextTreeSnapshotTestInternals.readDiffEntries("/fake", safeBase, safeHead),
+    ).resolves.toEqual({
       entries: [],
       truncated: true,
     });

--- a/packages/server/src/__tests__/context-tree-snapshot-git-mocked.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot-git-mocked.test.ts
@@ -1,0 +1,215 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const RECORD_SEPARATOR = "\x1e";
+
+type GitHandler = (args: string[]) => string | Error | unknown;
+
+async function loadSnapshotServiceWithGit(handler: GitHandler) {
+  vi.resetModules();
+  const execFile = vi.fn((command: string, args: string[], options: unknown, callback?: unknown) => {
+    const cb = typeof options === "function" ? options : callback;
+    if (typeof cb !== "function") return;
+    if (command !== "git") {
+      cb(new Error(`unexpected command ${command}`));
+      return;
+    }
+    const result = handler(args);
+    if (result instanceof Error || typeof result !== "string") {
+      cb(result);
+      return;
+    }
+    cb(null, { stdout: result, stderr: "" });
+  });
+  vi.doMock("node:child_process", () => ({ execFile }));
+  const service = await import("../services/context-tree-snapshot.js");
+  return { execFile, service };
+}
+
+describe("Context Tree snapshot service with mocked git", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("parses unusual git diff and log records through defensive fallbacks", async () => {
+    const safeBase = "a".repeat(40);
+    const safeHead = "b".repeat(40);
+    const metadataCommit = "c".repeat(40);
+    const { service } = await loadSnapshotServiceWithGit((args) => {
+      if (args[0] === "diff") {
+        return [
+          "\t",
+          "R100\told.md\tnew.md",
+          "R100\told-only.md",
+          "R100\t\tnew-only.md",
+          "A\t",
+          "M\tmodified.md",
+          "D\tdeleted.md",
+          "X\tignored.md",
+        ].join("\n");
+      }
+      if (args[0] === "log") {
+        return [
+          `${RECORD_SEPARATOR}${metadataCommit}\x00\x00\x00Merge pull request #12 from acme/context\nmodified.md`,
+          `${RECORD_SEPARATOR}not-a-safe-commit\x002026-01-01T00:00:00.000Z\x00bot\x00docs: invalid\nignored.md`,
+          `${RECORD_SEPARATOR}${"d".repeat(40)}\x002026-01-02T00:00:00.000Z\x00bot\x00docs: header only`,
+        ].join("");
+      }
+      return "";
+    });
+
+    const diff = await service.contextTreeSnapshotTestInternals.readDiffEntries("/fake", safeBase, safeHead);
+
+    expect(diff.truncated).toBe(true);
+    expect(diff.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "removed", path: "old.md", commit: safeHead }),
+        expect.objectContaining({ type: "added", path: "new.md", commit: safeHead }),
+        expect.objectContaining({ type: "removed", path: "old-only.md", commit: safeHead }),
+        expect.objectContaining({ type: "removed", path: "new-only.md", commit: safeHead }),
+        expect.objectContaining({
+          type: "edited",
+          path: "modified.md",
+          commit: metadataCommit,
+          changedAt: null,
+          changedBy: null,
+          summary: "Merge pull request #12 from acme/context",
+          prNumber: 12,
+        }),
+        expect.objectContaining({ type: "removed", path: "deleted.md", commit: safeHead }),
+      ]),
+    );
+    expect(diff.entries.some((entry) => entry.path === "ignored.md")).toBe(false);
+  });
+
+  it("uses fallback diff metadata when git log has empty records", async () => {
+    const safeBase = "a".repeat(40);
+    const safeHead = "b".repeat(40);
+    const { service } = await loadSnapshotServiceWithGit((args) => {
+      if (args[0] === "diff") return "A\tnew.md";
+      if (args[0] === "log") return "";
+      return "";
+    });
+
+    const diff = await service.contextTreeSnapshotTestInternals.readDiffEntries("/fake", safeBase, safeHead);
+
+    expect(diff.entries).toEqual([
+      expect.objectContaining({
+        type: "added",
+        path: "new.md",
+        commit: safeHead,
+        changedAt: null,
+        changedBy: null,
+        summary: null,
+        prNumber: null,
+      }),
+    ]);
+  });
+
+  it("handles empty diff path sets and missing git log subject fields", async () => {
+    const safeBase = "a".repeat(40);
+    const safeHead = "b".repeat(40);
+    const metadataCommit = "c".repeat(40);
+    const { service } = await loadSnapshotServiceWithGit((args) => {
+      if (args[0] === "diff") return "A\t";
+      if (args[0] === "log") return `${RECORD_SEPARATOR}${metadataCommit}\x002026-01-01T00:00:00.000Z\x00bot\nnew.md`;
+      return "";
+    });
+
+    await expect(service.contextTreeSnapshotTestInternals.readDiffEntries("/fake", safeBase, safeHead)).resolves.toEqual({
+      entries: [],
+      truncated: true,
+    });
+
+    const { service: serviceWithPath } = await loadSnapshotServiceWithGit((args) => {
+      if (args[0] === "diff") return "A\tnew.md";
+      if (args[0] === "log") return `${RECORD_SEPARATOR}${metadataCommit}\x002026-01-01T00:00:00.000Z\x00bot\nnew.md`;
+      return "";
+    });
+    const diff = await serviceWithPath.contextTreeSnapshotTestInternals.readDiffEntries("/fake", safeBase, safeHead);
+    expect(diff.entries[0]).toMatchObject({
+      path: "new.md",
+      commit: metadataCommit,
+      summary: null,
+      prNumber: null,
+    });
+  });
+
+  it("caches non-Error remote sync failures without leaking an error message", async () => {
+    const cacheRoot = join(tmpdir(), `context-tree-mocked-failure-${crypto.randomUUID()}`);
+    const { service } = await loadSnapshotServiceWithGit((args) => {
+      if (args.includes("clone")) return { reason: "clone failed as object" };
+      return "";
+    });
+
+    try {
+      await expect(
+        service.contextTreeSnapshotTestInternals.materializeRemoteContextTree(
+          "https://github.com/acme/context-tree",
+          "main",
+          cacheRoot,
+        ),
+      ).rejects.toEqual({ reason: "clone failed as object" });
+      await expect(
+        service.contextTreeSnapshotTestInternals.materializeRemoteContextTree(
+          "https://github.com/acme/context-tree",
+          "main",
+          cacheRoot,
+        ),
+      ).rejects.toThrow("Previous Context Tree sync failed recently.");
+    } finally {
+      await rm(cacheRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("uses fallback snapshot status when mocked git has no branch and no recent diff", async () => {
+    const root = join(tmpdir(), `context-tree-mocked-${crypto.randomUUID()}`);
+    await mkdir(root, { recursive: true });
+    await writeFile(join(root, "NODE.md"), "---\ntitle: Mocked\n---\nBody\n");
+    const head = "e".repeat(40);
+    const timings: Array<{ name: string; hit?: boolean }> = [];
+    try {
+      const { service } = await loadSnapshotServiceWithGit((args) => {
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return head;
+        if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return new Error("branch unavailable");
+        if (args[0] === "rev-list") return "";
+        if (args[0] === "diff") return "";
+        return "";
+      });
+
+      const snapshot = await service.getContextTreeSnapshot({ localPath: root }, "7d", {
+        timing: (name, _ms, fields) =>
+          timings.push({ name, hit: typeof fields?.hit === "boolean" ? fields.hit : undefined }),
+      });
+
+      expect(snapshot.snapshotStatus).toBe("active");
+      expect(snapshot.branch).toBeNull();
+      expect(snapshot.headCommit).toBe(head);
+      expect(snapshot.contextStatus.label).toBe("Context Tree is up to date");
+      expect(timings).toEqual(expect.arrayContaining([{ name: "snapshot_cache_lookup", hit: false }]));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces the generic unavailable snapshot message for non-Error git failures", async () => {
+    const root = join(tmpdir(), `context-tree-mocked-error-${crypto.randomUUID()}`);
+    await mkdir(root, { recursive: true });
+    try {
+      const { service } = await loadSnapshotServiceWithGit((args) => {
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return { reason: "git exploded" };
+        return "";
+      });
+
+      const snapshot = await service.getContextTreeSnapshot({ localPath: root }, "7d");
+
+      expect(snapshot.snapshotStatus).toBe("unavailable");
+      expect(snapshot.contextStatus.detail).toBe("Unable to read Context Tree snapshot");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/server/src/__tests__/context-tree-snapshot-route-mocked.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot-route-mocked.test.ts
@@ -1,0 +1,155 @@
+import type { ContextTreeSnapshot } from "@first-tree/shared";
+import Fastify from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function unavailableSnapshot(detail: string): ContextTreeSnapshot {
+  return {
+    repo: "agent-team-foundation/first-tree-context",
+    branch: "main",
+    headCommit: null,
+    syncedAt: null,
+    snapshotStatus: "unavailable",
+    contextStatus: { label: "Team context unavailable", detail, severity: "error" },
+    summary: { addedCount: 0, editedCount: 0, removedCount: 0, changedNodeCount: 0 },
+    usage: { windowDays: 7, agentCount: 0, usageCount: 0, recentEvents: [] },
+    io: {
+      windowDays: 7,
+      summary: {
+        read: { agentCount: 0, eventCount: 0, targetCount: 0 },
+        write: { agentCount: 0, eventCount: 0, targetCount: 0 },
+      },
+      agents: [],
+      recentEvents: [],
+      writes: [],
+      writesTotal: 0,
+      skipped: { windowDays: 7, totalEventCount: 0, reasons: [] },
+    },
+    updates: [],
+    nodes: [],
+    edges: [],
+    changes: [],
+  };
+}
+
+async function setupRoute(input: { orgId: string | null; githubRemote?: boolean; snapshot?: ContextTreeSnapshot }) {
+  vi.resetModules();
+
+  const snapshot = input.snapshot ?? unavailableSnapshot("mock snapshot");
+  const resolveUserPrimaryOrgId = vi.fn().mockResolvedValue(input.orgId);
+  const getOrgContextTree = vi.fn().mockResolvedValue({
+    repo: "https://github.com/acme/context-tree.git",
+    branch: "main",
+  });
+  const getContextTreeSnapshot = vi.fn().mockResolvedValue(snapshot);
+  const isGithubRemoteBinding = vi.fn().mockReturnValue(input.githubRemote ?? false);
+  const findInstallationByOrg = vi.fn().mockResolvedValue({ installationId: 123 });
+  const mintContextTreeInstallationToken = vi.fn().mockResolvedValue({
+    ok: false,
+    reason: "no-installation",
+  });
+  const decorateSnapshotWithMintGuidance = vi.fn((raw: ContextTreeSnapshot) => raw);
+  const resolveContextTreeRecoveryAction = vi.fn().mockResolvedValue("manage_github_app_installation");
+  const resolveOrgViewer = vi.fn().mockResolvedValue({ memberId: "member-1", role: "admin" });
+  const summarizeContextTreeUsage = vi.fn().mockResolvedValue({
+    windowDays: 7,
+    agentCount: 1,
+    usageCount: 2,
+    recentEvents: [],
+  });
+  const buildContextTreeIoSummary = vi.fn().mockResolvedValue({
+    windowDays: 7,
+    summary: {
+      read: { agentCount: 1, eventCount: 1, targetCount: 1 },
+      write: { agentCount: 0, eventCount: 0, targetCount: 0 },
+    },
+    agents: [],
+    recentEvents: [],
+    writes: [],
+    writesTotal: 0,
+    skipped: { windowDays: 7, totalEventCount: 0, reasons: [] },
+  });
+
+  vi.doMock("../scope/require-user.js", () => ({
+    requireUser: () => ({ userId: "user-1" }),
+  }));
+  vi.doMock("../services/org-settings.js", () => ({ getOrgContextTree, resolveUserPrimaryOrgId }));
+  vi.doMock("../services/context-tree-snapshot.js", () => ({
+    contextTreeSnapshotWindowDays: () => 7,
+    getContextTreeSnapshot,
+    isGithubRemoteBinding,
+  }));
+  vi.doMock("../services/github-app-installations.js", () => ({ findInstallationByOrg }));
+  vi.doMock("../services/github-app-token.js", () => ({
+    decorateSnapshotWithMintGuidance,
+    mintContextTreeInstallationToken,
+    resolveContextTreeRecoveryAction,
+  }));
+  vi.doMock("../scope/require-resource.js", () => ({ resolveOrgViewer }));
+  vi.doMock("../services/session-event.js", () => ({ summarizeContextTreeUsage }));
+  vi.doMock("../services/context-tree-io.js", () => ({ buildContextTreeIoSummary }));
+
+  const { contextTreeSnapshotRoutes } = await import("../api/context-tree-snapshot.js");
+  const app = Object.assign(Fastify(), {
+    db: {},
+    config: { oauth: { githubApp: {} } },
+  });
+  await app.register(contextTreeSnapshotRoutes);
+  await app.ready();
+
+  return {
+    app,
+    mocks: {
+      buildContextTreeIoSummary,
+      decorateSnapshotWithMintGuidance,
+      findInstallationByOrg,
+      getContextTreeSnapshot,
+      getOrgContextTree,
+      isGithubRemoteBinding,
+      mintContextTreeInstallationToken,
+      resolveContextTreeRecoveryAction,
+      resolveOrgViewer,
+      resolveUserPrimaryOrgId,
+      summarizeContextTreeUsage,
+    },
+  };
+}
+
+describe("context tree snapshot user route with mocked dependencies", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("keeps snapshot-provided usage and io when the user has no active organization", async () => {
+    const ctx = await setupRoute({ orgId: null });
+    const res = await ctx.app.inject({ method: "GET", url: "/snapshot?window=1d" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ snapshotStatus: "unavailable", recoveryAction: null });
+    expect(ctx.mocks.getOrgContextTree).not.toHaveBeenCalled();
+    expect(ctx.mocks.findInstallationByOrg).not.toHaveBeenCalled();
+    expect(ctx.mocks.summarizeContextTreeUsage).not.toHaveBeenCalled();
+    expect(ctx.mocks.buildContextTreeIoSummary).not.toHaveBeenCalled();
+    await ctx.app.close();
+  });
+
+  it("mints GitHub App guidance and reconciles org telemetry for GitHub remote bindings", async () => {
+    const ctx = await setupRoute({ orgId: "org-1", githubRemote: true });
+    const res = await ctx.app.inject({ method: "GET", url: "/snapshot?window=30d" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      recoveryAction: "manage_github_app_installation",
+      usage: { windowDays: 7, agentCount: 1, usageCount: 2 },
+      io: { windowDays: 7, summary: { read: { eventCount: 1 } } },
+    });
+    expect(ctx.mocks.findInstallationByOrg).toHaveBeenCalledWith(ctx.app.db, "org-1");
+    expect(ctx.mocks.mintContextTreeInstallationToken).toHaveBeenCalled();
+    expect(ctx.mocks.decorateSnapshotWithMintGuidance).toHaveBeenCalled();
+    expect(ctx.mocks.resolveContextTreeRecoveryAction).toHaveBeenCalled();
+    expect(ctx.mocks.resolveOrgViewer).toHaveBeenCalledWith(ctx.app.db, "user-1", "org-1");
+    expect(ctx.mocks.summarizeContextTreeUsage).toHaveBeenCalled();
+    expect(ctx.mocks.buildContextTreeIoSummary).toHaveBeenCalled();
+    await ctx.app.close();
+  });
+});

--- a/packages/server/src/__tests__/context-tree-snapshot.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot.test.ts
@@ -1,11 +1,11 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import type { ContextTreeChange, ContextTreeNode } from "@first-tree/shared";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   contextTreeSnapshotTestInternals,
   getContextTreeSnapshot,
@@ -195,6 +195,72 @@ Body`);
     ]);
   });
 
+  it("uses tree-building fallbacks when NODE metadata is absent or empty", () => {
+    const tree = contextTreeSnapshotTestInternals.buildTreeFromRawFiles([
+      {
+        relativePath: "domain/empty.md",
+        raw: "---\ntitle: \"\"\nowners: owner\nsoft_links: [\"/domain/\"]\n---\n# Heading only\n[missing](missing.md)",
+      },
+      {
+        relativePath: "domain/target.md",
+        raw: "---\ntitle: Target\n---\nTarget body",
+      },
+    ]);
+
+    expect(tree.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "root",
+          title: "Context Tree",
+          preview: null,
+          owners: [],
+          affectedContextArea: "root",
+        }),
+        expect.objectContaining({
+          id: "dir:domain",
+          sourcePath: null,
+          title: "Domain",
+          parentId: "root",
+          preview: null,
+        }),
+        expect.objectContaining({
+          id: "file:domain/empty.md",
+          title: "Empty",
+          owners: [],
+          preview: "[missing](missing.md)",
+          relatedNodeIds: ["dir:domain"],
+        }),
+      ]),
+    );
+    expect(tree.edges).toContainEqual({ source: "file:domain/empty.md", target: "dir:domain", kind: "soft_link" });
+  });
+
+  it("handles empty tree paths and anchor-only soft links without resolving them", () => {
+    const tree = contextTreeSnapshotTestInternals.buildTreeFromRawFiles([
+      {
+        relativePath: "",
+        raw: "---\nowners: []\nsoft_links: [\"#local\"]\n---\nEmpty path body",
+      },
+      {
+        relativePath: "target.md",
+        raw: "---\ntitle: Target\n---\nTarget body",
+      },
+    ]);
+
+    expect(tree.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "file:",
+          path: "",
+          title: "Context Tree",
+          affectedContextArea: "root",
+          relatedNodeIds: [],
+        }),
+      ]),
+    );
+    expect(tree.edges.some((edge) => edge.kind === "soft_link" && edge.source === "file:")).toBe(false);
+  });
+
   it("mounts removed ghost nodes at root when their parent no longer exists", () => {
     const nodes: ContextTreeNode[] = [
       {
@@ -233,6 +299,47 @@ Body`);
         parentId: "root",
         changeType: "removed",
         changedAtCommit: "1111111111111111111111111111111111111111",
+      }),
+    );
+  });
+
+  it("mounts root-level removed ghost nodes directly under root", () => {
+    const nodes: ContextTreeNode[] = [
+      {
+        id: "root",
+        path: "",
+        sourcePath: "NODE.md",
+        title: "Context Tree",
+        kind: "root",
+        owners: [],
+        parentId: null,
+        preview: null,
+        relatedNodeIds: [],
+        affectedContextArea: "root",
+        changeType: null,
+        changedAtCommit: null,
+      },
+    ];
+    const changes: ContextTreeChange[] = [
+      {
+        path: "old.md",
+        nodeId: "removed:old.md",
+        type: "removed",
+        commit: "2222222222222222222222222222222222222222",
+        changedAt: null,
+        changedBy: null,
+        summary: null,
+        prNumber: null,
+      },
+    ];
+
+    const withGhosts = contextTreeSnapshotTestInternals.addRemovedGhostNodes(nodes, changes);
+
+    expect(withGhosts).toContainEqual(
+      expect.objectContaining({
+        id: "removed:old.md",
+        parentId: "root",
+        affectedContextArea: "old",
       }),
     );
   });
@@ -276,6 +383,24 @@ Body`);
       reason: `Context Tree checkout not found at ${missingRepoPath}.`,
       staleReason: null,
     });
+  });
+
+  it("rejects each unsafe remote branch shape and defaults remote branches to main", async () => {
+    for (const branch of ["bad..name", "bad@{name", "bad\\name"]) {
+      await expect(
+        contextTreeSnapshotTestInternals.resolveContextTreeRoot("https://github.com/example/tree", null, branch),
+      ).resolves.toEqual({
+        root: null,
+        reason: `Configured Context Tree branch "${branch}" is invalid.`,
+        staleReason: null,
+      });
+    }
+
+    const missingRemote = `file://${join(testDir, "missing-remote")}`;
+    const resolved = await contextTreeSnapshotTestInternals.resolveContextTreeRoot(missingRemote, null, null);
+
+    expect(resolved.root).toBeNull();
+    expect(resolved.reason).toContain('branch "main"');
   });
 
   it("classifies GitHub remote bindings without treating local bindings as remote", () => {
@@ -368,6 +493,25 @@ Body`);
     expect(diff.entries[0]?.changedAt).not.toBeNull();
   });
 
+  it("truncates long commit subjects in diff metadata", async () => {
+    await initRepo();
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Tree\n---\nRoot\n");
+    const baseCommit = await commitAll("docs: add root node");
+    await writeFile(join(testDir, "long.md"), "---\ntitle: Long\n---\nLong\n");
+    const subject = `docs: ${"long summary ".repeat(20)}`;
+    const headCommit = await commitAll(subject);
+
+    const diff = await contextTreeSnapshotTestInternals.readDiffEntries(testDir, baseCommit, headCommit);
+
+    expect(diff.entries[0]).toMatchObject({
+      type: "added",
+      path: "long.md",
+      commit: headCommit,
+    });
+    expect(diff.entries[0]?.summary).toHaveLength(140);
+    expect(diff.entries[0]?.summary?.endsWith("...")).toBe(true);
+  });
+
   it("rejects unsafe comparison bases before invoking git diff", async () => {
     await initRepo();
     await writeFile(join(testDir, "node.md"), "---\ntitle: Node\n---\nGuidance\n");
@@ -386,6 +530,17 @@ Body`);
     const safeHead = "b".repeat(40);
 
     await expect(contextTreeSnapshotTestInternals.readDiffEntries(testDir, safeBase, safeHead)).resolves.toEqual({
+      entries: [],
+      truncated: false,
+    });
+  });
+
+  it("returns an empty diff when git reports no markdown changes", async () => {
+    await initRepo();
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Root\n---\nRoot\n");
+    const headCommit = await commitAll("docs: add root node");
+
+    await expect(contextTreeSnapshotTestInternals.readDiffEntries(testDir, headCommit, headCommit)).resolves.toEqual({
       entries: [],
       truncated: false,
     });
@@ -716,6 +871,48 @@ Body`);
     expect(cached.staleReason).toBe(second.staleReason);
   });
 
+  it("records stale remote timing and recovers a stale cached snapshot after refresh succeeds", async () => {
+    const remoteDir = join(testDir, "remote-source");
+    const movedRemoteDir = join(testDir, "remote-source-moved");
+    const repoUrl = `file://${remoteDir}`;
+    const previousFirstTreeHome = process.env.FIRST_TREE_HOME;
+    process.env.FIRST_TREE_HOME = join(testDir, "home");
+    const timings: string[] = [];
+    await initRepoAt(remoteDir);
+    await writeFile(join(remoteDir, "NODE.md"), "---\ntitle: Recoverable Context\n---\nRoot\n");
+    await commitAllAtDate(remoteDir, "docs: initial context", "2026-01-01T00:00:00Z");
+    await writeFile(join(remoteDir, "next.md"), "---\ntitle: Next\n---\nNext\n");
+    await commitAllAt(remoteDir, "docs: add next context");
+
+    try {
+      const active = await getContextTreeSnapshot({ repo: repoUrl, branch: "main" }, "7d");
+      expect(active.snapshotStatus).toBe("active");
+
+      contextTreeSnapshotTestInternals.clearRemoteSyncState();
+      await rename(remoteDir, movedRemoteDir);
+      const stale = await getContextTreeSnapshot({ repo: repoUrl, branch: "main" }, "7d", {
+        timing: (name) => timings.push(name),
+      });
+      expect(stale.snapshotStatus).toBe("stale");
+      expect(timings).toContain("remote_sync_stale_fallback");
+
+      contextTreeSnapshotTestInternals.clearRemoteSyncState();
+      await rename(movedRemoteDir, remoteDir);
+      const recovered = await getContextTreeSnapshot({ repo: repoUrl, branch: "main" }, "7d");
+      expect(recovered.snapshotStatus).toBe("active");
+      expect(recovered.contextStatus.label).toBe("Context Tree is up to date");
+    } finally {
+      if (existsSync(movedRemoteDir)) {
+        await rename(movedRemoteDir, remoteDir).catch(() => undefined);
+      }
+      if (previousFirstTreeHome === undefined) {
+        delete process.env.FIRST_TREE_HOME;
+      } else {
+        process.env.FIRST_TREE_HOME = previousFirstTreeHome;
+      }
+    }
+  });
+
   it("caches first-clone failures briefly to avoid repeated clone attempts", async () => {
     const missingRemote = join(testDir, "missing-remote");
     const cacheRoot = join(testDir, "managed-cache");
@@ -815,6 +1012,7 @@ Body`);
     // A subject referencing several PRs takes the last `(#N)` — the merge ref.
     expect(parsePrNumber("revert: undo (#12), reapplied via (#999)")).toBe(999);
     expect(parsePrNumber("docs: no pull request reference here")).toBeNull();
+    expect(parsePrNumber("docs: impossible PR reference (#0)")).toBeNull();
     // A bare `#123` (not parenthesized) is an issue mention, not the PR ref.
     expect(parsePrNumber("fix: mentions #123 inline")).toBeNull();
     expect(parsePrNumber(null)).toBeNull();
@@ -882,5 +1080,140 @@ Body`);
     const removed = events.find((e) => e.changeType === "removed");
     expect(removed?.riskLevel).toBe("high");
     expect(removed?.authorName).toBe("alice");
+  });
+
+  it("derives git write rows for uncommitted and invalid timestamps", () => {
+    const changes = [
+      {
+        path: "loose-note.md",
+        nodeId: null,
+        type: "edited",
+        commit: null,
+        changedAt: "not-a-date",
+        changedBy: null,
+        summary: null,
+        prNumber: null,
+      },
+      {
+        path: "new-note.md",
+        nodeId: null,
+        type: "added",
+        commit: "c".repeat(40),
+        changedAt: null,
+        changedBy: null,
+        summary: "new note",
+        prNumber: 12,
+      },
+    ] as unknown as ContextTreeChange[];
+
+    const events = contextTreeSnapshotTestInternals.buildWriteEvents(changes, []);
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        id: "uncommitted:loose-note.md",
+        nodePath: "loose-note",
+        title: "Loose Note",
+        riskLevel: "low",
+        createdAt: "not-a-date",
+      }),
+      expect.objectContaining({
+        id: `${"c".repeat(40)}:new-note.md`,
+        title: "New Note",
+        createdAt: null,
+      }),
+    ]);
+  });
+
+  it("skips oversized markdown files while building a snapshot", async () => {
+    await initRepo();
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Root Context\n---\nRoot\n");
+    await writeFile(join(testDir, "huge.md"), `${"x".repeat(512 * 1024 + 1)}\n`);
+    await commitAll("docs: add root and huge file");
+
+    const snapshot = await getContextTreeSnapshot({ localPath: testDir, branch: "main" }, "7d");
+
+    expect(snapshot.nodes.map((node) => node.sourcePath)).not.toContain("huge.md");
+  });
+
+  it("summarizes edits to oversized markdown with missing tree node fallbacks", async () => {
+    await initRepo();
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Root Context\n---\nRoot\n");
+    await writeFile(join(testDir, "huge.md"), `${"x".repeat(512 * 1024 + 1)}\n`);
+    await commitAllAtDate(testDir, "docs: initial huge context", "2026-01-01T00:00:00Z");
+    await writeFile(join(testDir, "huge.md"), `${"y".repeat(512 * 1024 + 1)}\n`);
+    await commitAll("docs: update huge context");
+
+    const snapshot = await getContextTreeSnapshot({ localPath: testDir, branch: "main" }, "7d");
+
+    expect(snapshot.updates).toContainEqual(
+      expect.objectContaining({
+        changeType: "edited",
+        path: "huge",
+        title: "Huge",
+        summary: "update huge context",
+      }),
+    );
+  });
+
+  it("rebuilds a stale cached snapshot after remote refresh succeeds", async () => {
+    const remoteDir = join(testDir, "remote-source");
+    const movedRemoteDir = join(testDir, "remote-source-moved");
+    const repoUrl = `file://${remoteDir}`;
+    const previousFirstTreeHome = process.env.FIRST_TREE_HOME;
+    process.env.FIRST_TREE_HOME = join(testDir, "home");
+    await initRepoAt(remoteDir);
+    await writeFile(join(remoteDir, "NODE.md"), "---\ntitle: Recover Cached Context\n---\nRoot\n");
+    await commitAllAtDate(remoteDir, "docs: initial context", "2026-01-01T00:00:00Z");
+
+    let nowSpy: ReturnType<typeof vi.spyOn> | null = null;
+    try {
+      await contextTreeSnapshotTestInternals.materializeRemoteContextTree(repoUrl, "main");
+      contextTreeSnapshotTestInternals.clearRemoteSyncState();
+      await rename(remoteDir, movedRemoteDir);
+
+      const nowValues = [0, 0, 100_000, 65_000, 65_000, 65_000, 65_000, 65_000, 65_000];
+      nowSpy = vi.spyOn(Date, "now").mockImplementation(() => nowValues.shift() ?? 65_000);
+      const stale = await getContextTreeSnapshot({ repo: repoUrl, branch: "main" }, "7d");
+      expect(stale.snapshotStatus).toBe("stale");
+
+      await rename(movedRemoteDir, remoteDir);
+      const recovered = await getContextTreeSnapshot({ repo: repoUrl, branch: "main" }, "7d");
+
+      expect(recovered.snapshotStatus).toBe("active");
+      expect(recovered.contextStatus.label).toBe("Context Tree is up to date");
+    } finally {
+      nowSpy?.mockRestore();
+      if (existsSync(movedRemoteDir)) {
+        await rename(movedRemoteDir, remoteDir).catch(() => undefined);
+      }
+      if (previousFirstTreeHome === undefined) {
+        delete process.env.FIRST_TREE_HOME;
+      } else {
+        process.env.FIRST_TREE_HOME = previousFirstTreeHome;
+      }
+    }
+  });
+
+  it("uses default edited summaries for terse commits with and without tree nodes", async () => {
+    await initRepo();
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Root Context\n---\nRoot\n");
+    await writeFile(join(testDir, "huge.md"), `${"x".repeat(512 * 1024 + 1)}\n`);
+    await commitAllAtDate(testDir, "docs: initial context", "2026-01-01T00:00:00Z");
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Root Context\n---\nUpdated root\n");
+    await writeFile(join(testDir, "huge.md"), `${"y".repeat(512 * 1024 + 1)}\n`);
+    await commitAll("update");
+
+    const snapshot = await getContextTreeSnapshot({ localPath: testDir, branch: "main" }, "7d");
+    const rootUpdate = snapshot.updates.find((update) => update.title === "Root Context");
+    const hugeUpdate = snapshot.updates.find((update) => update.path === "huge");
+
+    expect(rootUpdate).toMatchObject({
+      changeType: "edited",
+      summary: "updated Root Context",
+    });
+    expect(hugeUpdate).toMatchObject({
+      changeType: "edited",
+      summary: "updated this team knowledge",
+    });
   });
 });

--- a/packages/server/src/__tests__/context-tree-snapshot.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot.test.ts
@@ -6,7 +6,11 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import type { ContextTreeChange, ContextTreeNode } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { contextTreeSnapshotTestInternals, getContextTreeSnapshot } from "../services/context-tree-snapshot.js";
+import {
+  contextTreeSnapshotTestInternals,
+  getContextTreeSnapshot,
+  isGithubRemoteBinding,
+} from "../services/context-tree-snapshot.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -54,6 +58,19 @@ async function commitAllAt(cwd: string, message: string): Promise<string> {
   return gitOutput(cwd, ["rev-parse", "HEAD"]);
 }
 
+async function commitAllAtDate(cwd: string, message: string, isoDate: string): Promise<string> {
+  await git(cwd, ["add", "."]);
+  await execFileAsync("git", ["commit", "-m", message], {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: isoDate,
+      GIT_COMMITTER_DATE: isoDate,
+    },
+  });
+  return gitOutput(cwd, ["rev-parse", "HEAD"]);
+}
+
 describe("Context Tree snapshot service", () => {
   it("parses fallback frontmatter lists", () => {
     const parsed = contextTreeSnapshotTestInternals.parseMarkdownFallback(`---
@@ -69,6 +86,30 @@ Body`);
       title: "Client Runtime",
       owners: ["alice", "bob"],
       soft_links: ["../roadmap.md", "/agent-hub#runtime"],
+    });
+  });
+
+  it("handles fallback frontmatter without valid YAML fields", () => {
+    expect(contextTreeSnapshotTestInternals.parseMarkdownFallback("Plain body")).toEqual({
+      content: "Plain body",
+      data: {},
+    });
+
+    const parsed = contextTreeSnapshotTestInternals.parseMarkdownFallback(`---
+title: 'Broken Lists'
+owners: alice
+ignored
+soft_links: []
+---
+Body`);
+
+    expect(parsed).toEqual({
+      content: "Body",
+      data: {
+        title: "Broken Lists",
+        owners: [],
+        soft_links: [],
+      },
     });
   });
 
@@ -96,6 +137,46 @@ Body`);
       target: "file:product-direction.md",
       kind: "markdown_link",
     });
+  });
+
+  it("builds directory metadata, deduplicates related edges, and skips unresolved links", () => {
+    const longPreview = "x".repeat(260);
+    const tree = contextTreeSnapshotTestInternals.buildTreeFromRawFiles([
+      { relativePath: "NODE.md", raw: "---\ntitle: Context Tree\nowners: [root-owner]\n---\n# Heading\nRoot body" },
+      {
+        relativePath: "product-area/NODE.md",
+        raw: '---\ntitle: Product Area\nowners: [alice]\nsoft_links: ["../shared.md", "../shared.md", "../missing.md"]\n---\nDomain body',
+      },
+      {
+        relativePath: "product-area/runtime/NODE.md",
+        raw: "---\ntitle: Runtime\n---\nSubdomain body",
+      },
+      {
+        relativePath: "product-area/runtime/details.md",
+        raw: `---\ntitle: Details\nowners: [bob, ""]\n---\n${longPreview}\n[shared](../../shared.md)\n[shared again](../../shared.md#section)\n[external](https://example.test)\n[anchor](#local)`,
+      },
+      { relativePath: "shared.md", raw: "---\ntitle: Shared\n---\nShared body" },
+    ]);
+
+    expect(tree.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "root", title: "Context Tree", owners: ["root-owner"], preview: "Root body" }),
+        expect.objectContaining({ id: "dir:product-area", kind: "domain", owners: ["alice"] }),
+        expect.objectContaining({ id: "dir:product-area/runtime", kind: "subdomain" }),
+        expect.objectContaining({
+          id: "file:product-area/runtime/details.md",
+          owners: ["bob"],
+          preview: `${"x".repeat(237)}...`,
+          affectedContextArea: "product area / runtime / details",
+        }),
+      ]),
+    );
+    expect(tree.edges.filter((edge) => edge.kind === "soft_link")).toEqual([
+      { source: "dir:product-area", target: "file:shared.md", kind: "soft_link" },
+    ]);
+    expect(tree.edges.filter((edge) => edge.kind === "markdown_link")).toEqual([
+      { source: "file:product-area/runtime/details.md", target: "file:shared.md", kind: "markdown_link" },
+    ]);
   });
 
   it("mounts removed ghost nodes at root when their parent no longer exists", () => {
@@ -140,6 +221,61 @@ Body`);
     );
   });
 
+  it("resolves local roots and reports missing bindings", async () => {
+    await mkdir(join(testDir, "local-tree"), { recursive: true });
+
+    await expect(contextTreeSnapshotTestInternals.resolveContextTreeRoot(null, null, null)).resolves.toEqual({
+      root: null,
+      reason: "Context Tree is not configured.",
+      staleReason: null,
+    });
+    await expect(
+      contextTreeSnapshotTestInternals.resolveContextTreeRoot(null, `file://${join(testDir, "local-tree")}`, null),
+    ).resolves.toEqual({
+      root: join(testDir, "local-tree"),
+      reason: "ok",
+      staleReason: null,
+    });
+
+    const missingLocal = join(testDir, "missing-local");
+    await expect(contextTreeSnapshotTestInternals.resolveContextTreeRoot(null, missingLocal, null)).resolves.toEqual({
+      root: null,
+      reason: `Context Tree checkout not found at ${missingLocal}.`,
+      staleReason: null,
+    });
+
+    await expect(
+      contextTreeSnapshotTestInternals.resolveContextTreeRoot(join(testDir, "local-tree"), null, null),
+    ).resolves.toEqual({
+      root: join(testDir, "local-tree"),
+      reason: "ok",
+      staleReason: null,
+    });
+  });
+
+  it("classifies GitHub remote bindings without treating local bindings as remote", () => {
+    expect(isGithubRemoteBinding({ localPath: testDir, repo: "owner/repo" })).toBe(false);
+    expect(isGithubRemoteBinding({ localPath: "  ", repo: "owner/repo" })).toBe(true);
+    expect(isGithubRemoteBinding({})).toBe(false);
+    expect(isGithubRemoteBinding({ repo: "owner/repo" })).toBe(true);
+    expect(isGithubRemoteBinding({ repo: "owner/repo.git" })).toBe(true);
+    expect(isGithubRemoteBinding({ repo: "https://github.com/owner/repo" })).toBe(true);
+    expect(isGithubRemoteBinding({ repo: "file:///tmp/repo" })).toBe(false);
+    expect(isGithubRemoteBinding({ repo: "https://example.test/owner/repo" })).toBe(false);
+    expect(isGithubRemoteBinding({ repo: "not a repo url" })).toBe(false);
+  });
+
+  it("reports remote root sync failures through resolveContextTreeRoot", async () => {
+    const missingRemote = `file://${join(testDir, "missing-remote")}`;
+
+    const resolved = await contextTreeSnapshotTestInternals.resolveContextTreeRoot(missingRemote, null, "main");
+
+    expect(resolved.root).toBeNull();
+    expect(resolved.staleReason).toBeNull();
+    expect(resolved.reason).toContain("First Tree could not sync the configured Context Tree repo.");
+    expect(resolved.reason).toContain('branch "main"');
+  });
+
   it("splits renames and keeps real commit metadata", async () => {
     await initRepo();
     await writeFile(join(testDir, "old.md"), "---\ntitle: Old\n---\nOld guidance\n");
@@ -173,6 +309,28 @@ Body`);
     expect(diff.entries.every((entry) => entry.changedAt !== null)).toBe(true);
   });
 
+  it("uses null summaries for terse commit subjects while preserving git metadata", async () => {
+    await initRepo();
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Tree\n---\nRoot\n");
+    const baseCommit = await commitAll("docs: add root node");
+    await writeFile(join(testDir, "new.md"), "---\ntitle: New\n---\nNew\n");
+    const headCommit = await commitAll("x");
+
+    const diff = await contextTreeSnapshotTestInternals.readDiffEntries(testDir, baseCommit, headCommit);
+
+    expect(diff.entries).toEqual([
+      expect.objectContaining({
+        type: "added",
+        path: "new.md",
+        commit: headCommit,
+        changedBy: "Context Reviewer",
+        summary: null,
+        prNumber: null,
+      }),
+    ]);
+    expect(diff.entries[0]?.changedAt).not.toBeNull();
+  });
+
   it("rejects unsafe comparison bases before invoking git diff", async () => {
     await initRepo();
     await writeFile(join(testDir, "node.md"), "---\ntitle: Node\n---\nGuidance\n");
@@ -184,6 +342,16 @@ Body`);
     expect(diff.entries).toEqual([]);
     expect(existsSync(payloadPath)).toBe(false);
     expect(existsSync(`${payloadPath}..HEAD`)).toBe(false);
+  });
+
+  it("returns an empty diff when git diff fails", async () => {
+    const safeBase = "a".repeat(40);
+    const safeHead = "b".repeat(40);
+
+    await expect(contextTreeSnapshotTestInternals.readDiffEntries(testDir, safeBase, safeHead)).resolves.toEqual({
+      entries: [],
+      truncated: false,
+    });
   });
 
   it("materializes a remote repo into a managed checkout", async () => {
@@ -205,6 +373,37 @@ Body`);
     await expect(readFile(join(managedRoot, "NODE.md"), "utf8")).resolves.toContain("Remote Context");
   });
 
+  it("reuses recent managed checkouts and waits on in-flight syncs", async () => {
+    const remoteDir = join(testDir, "remote-source");
+    const cacheRoot = join(testDir, "managed-cache");
+    await initRepoAt(remoteDir);
+    await writeFile(join(remoteDir, "NODE.md"), "---\ntitle: Concurrent Context\n---\nGuidance\n");
+    await commitAllAt(remoteDir, "docs: add remote context");
+    const timings: string[] = [];
+
+    const [first, second] = await Promise.all([
+      contextTreeSnapshotTestInternals.materializeRemoteContextTree(remoteDir, "main", cacheRoot, null, (name) =>
+        timings.push(name),
+      ),
+      contextTreeSnapshotTestInternals.materializeRemoteContextTree(remoteDir, "main", cacheRoot, null, (name) =>
+        timings.push(name),
+      ),
+    ]);
+
+    expect(second.root).toBe(first.root);
+    expect(timings).toContain("remote_sync_wait_existing");
+
+    const cached = await contextTreeSnapshotTestInternals.materializeRemoteContextTree(
+      remoteDir,
+      "main",
+      cacheRoot,
+      null,
+      (name) => timings.push(name),
+    );
+    expect(cached.root).toBe(first.root);
+    expect(timings).toContain("remote_sync_skip_ttl");
+  });
+
   it("uses a full sha256 digest for managed checkout paths", () => {
     const managedPath = contextTreeSnapshotTestInternals.managedContextTreePath(
       "https://github.com/example/tree",
@@ -214,6 +413,49 @@ Body`);
     const hash = managedPath.split("/").at(-1) ?? "";
 
     expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("builds unavailable snapshots for branch mismatches and invalid checkouts", async () => {
+    await initRepo();
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Local Context\n---\nGuidance\n");
+    await commitAll("docs: add local context");
+
+    const mismatch = await getContextTreeSnapshot({ localPath: testDir, branch: "feature" }, "7d");
+    expect(mismatch.snapshotStatus).toBe("unavailable");
+    expect(mismatch.branch).toBe("main");
+    expect(mismatch.contextStatus.detail).toContain('configured Context Tree branch is "feature"');
+
+    const notGitDir = await mkdtemp(join(tmpdir(), "context-tree-not-git-"));
+    try {
+      const invalid = await getContextTreeSnapshot({ localPath: notGitDir }, "7d");
+      expect(invalid.snapshotStatus).toBe("unavailable");
+      expect(invalid.contextStatus.detail).toMatch(/not a git repository|not a git repo|fatal/i);
+    } finally {
+      await rm(notGitDir, { recursive: true, force: true });
+    }
+  });
+
+  it("serves cached snapshots with a refreshed syncedAt timestamp", async () => {
+    await initRepo();
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Cached Context\n---\nGuidance\n");
+    await commitAll("docs: add cached context");
+    const timings: Array<{ name: string; hit?: boolean }> = [];
+    const recordTiming = (name: string, _duration: number, metadata?: Record<string, unknown>): void => {
+      timings.push({ name, hit: typeof metadata?.hit === "boolean" ? metadata.hit : undefined });
+    };
+
+    const first = await getContextTreeSnapshot({ localPath: testDir, branch: "main" }, "7d", {
+      timing: recordTiming,
+    });
+    const second = await getContextTreeSnapshot({ localPath: testDir, branch: "main" }, "7d", {
+      timing: recordTiming,
+    });
+
+    expect(first.snapshotStatus).toBe("active");
+    expect(second.snapshotStatus).toBe("active");
+    expect(second.headCommit).toBe(first.headCommit);
+    expect(second.nodes).toEqual(first.nodes);
+    expect(timings).toEqual(expect.arrayContaining([{ name: "snapshot_cache_lookup", hit: true }]));
   });
 
   it("builds a snapshot from an organization remote repo binding", async () => {
@@ -252,6 +494,64 @@ Body`);
     expect(snapshot.snapshotStatus).toBe("unavailable");
     expect(snapshot.contextStatus.detail).toContain("branch");
     expect(snapshot.contextStatus.detail).toContain("invalid");
+  });
+
+  it("summarizes added, edited, and removed nodes inside the requested window", async () => {
+    await initRepo();
+    await mkdir(join(testDir, "system"), { recursive: true });
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Root Context\n---\nRoot\n");
+    await writeFile(join(testDir, "system", "NODE.md"), "---\ntitle: System\nowners: [alice]\n---\nSystem guidance\n");
+    await writeFile(join(testDir, "system", "old.md"), "---\ntitle: Old Decision\n---\nOld\n");
+    await writeFile(join(testDir, "system", "edit.md"), "---\ntitle: Edit Decision\n---\nEdit\n");
+    await commitAllAtDate(testDir, "docs: initial context", "2026-01-01T00:00:00Z");
+
+    await writeFile(
+      join(testDir, "system", "NODE.md"),
+      "---\ntitle: System\nowners: [alice]\n---\nUpdated system guidance\n",
+    );
+    await writeFile(join(testDir, "system", "new.md"), "---\ntitle: New Decision\n---\nNew\n");
+    await rm(join(testDir, "system", "old.md"));
+    await commitAll("docs: update system context (#777)");
+
+    const snapshot = await getContextTreeSnapshot({ localPath: testDir, branch: "main" }, "7d");
+
+    expect(snapshot.summary).toEqual({
+      addedCount: 1,
+      editedCount: 1,
+      removedCount: 1,
+      changedNodeCount: 3,
+    });
+    expect(snapshot.updates.map((update) => `${update.changeType}:${update.path}`)).toEqual([
+      "removed:system/old",
+      "added:system/new",
+      "edited:system",
+    ]);
+    expect(snapshot.updates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          changeType: "removed",
+          title: "Old",
+          summary: "update system context (#777)",
+          reason: "Agents should stop using the old team knowledge for system / old.",
+          riskLevel: "high",
+        }),
+        expect.objectContaining({
+          changeType: "added",
+          title: "New Decision",
+          reason: "Agents can use new team knowledge when working on system / new.",
+          riskLevel: "low",
+        }),
+        expect.objectContaining({
+          changeType: "edited",
+          title: "System",
+          owners: ["alice"],
+          relatedNodeIds: [],
+          reason: "Agents can use updated team knowledge when working on system.",
+          riskLevel: "medium",
+        }),
+      ]),
+    );
+    expect(snapshot.io.writes.map((event) => event.prNumber)).toEqual([777, 777, 777]);
   });
 
   it("uses an existing managed checkout when remote refresh fails", async () => {
@@ -324,6 +624,30 @@ Body`);
     expect(env?.GIT_ASKPASS).toContain(join("managed-cache", ".tools", "git-askpass.sh"));
     const askpass = await readFile(env?.GIT_ASKPASS ?? "", "utf8");
     expect(askpass).not.toContain("ghp_secret");
+
+    await expect(
+      contextTreeSnapshotTestInternals.gitAuthEnv(
+        "https://github.com/agent-team-foundation/first-tree-context",
+        cacheRoot,
+        "ghp_secret",
+      ),
+    ).resolves.toMatchObject({
+      GIT_ASKPASS: env?.GIT_ASKPASS,
+    });
+    await expect(
+      contextTreeSnapshotTestInternals.gitAuthEnv(
+        "https://example.test/agent-team-foundation/first-tree-context",
+        cacheRoot,
+        "ghp_secret",
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      contextTreeSnapshotTestInternals.gitAuthEnv(
+        "https://github.com/agent-team-foundation/first-tree-context",
+        cacheRoot,
+        null,
+      ),
+    ).resolves.toBeUndefined();
   });
 
   it("redacts URL-embedded credentials from surfaced git errors", () => {

--- a/packages/server/src/__tests__/context-tree-snapshot.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot.test.ts
@@ -199,7 +199,7 @@ Body`);
     const tree = contextTreeSnapshotTestInternals.buildTreeFromRawFiles([
       {
         relativePath: "domain/empty.md",
-        raw: "---\ntitle: \"\"\nowners: owner\nsoft_links: [\"/domain/\"]\n---\n# Heading only\n[missing](missing.md)",
+        raw: '---\ntitle: ""\nowners: owner\nsoft_links: ["/domain/"]\n---\n# Heading only\n[missing](missing.md)',
       },
       {
         relativePath: "domain/target.md",
@@ -239,7 +239,7 @@ Body`);
     const tree = contextTreeSnapshotTestInternals.buildTreeFromRawFiles([
       {
         relativePath: "",
-        raw: "---\nowners: []\nsoft_links: [\"#local\"]\n---\nEmpty path body",
+        raw: '---\nowners: []\nsoft_links: ["#local"]\n---\nEmpty path body',
       },
       {
         relativePath: "target.md",

--- a/packages/server/src/__tests__/context-tree-snapshot.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot.test.ts
@@ -113,6 +113,22 @@ Body`);
     });
   });
 
+  it("uses fallback frontmatter parsing when gray-matter rejects malformed YAML", () => {
+    const tree = contextTreeSnapshotTestInternals.buildTreeFromRawFiles([
+      {
+        relativePath: "NODE.md",
+        raw: "---\ntitle: [unterminated\nowners: [alice]\n---\nBody",
+      },
+    ]);
+
+    expect(tree.nodes[0]).toMatchObject({
+      id: "root",
+      title: "[unterminated",
+      owners: ["alice"],
+      preview: "Body",
+    });
+  });
+
   it("builds soft-link and markdown-link edges without anchors", () => {
     const tree = contextTreeSnapshotTestInternals.buildTreeFromRawFiles([
       { relativePath: "NODE.md", raw: "---\ntitle: Context Tree\n---\nRoot" },
@@ -251,6 +267,15 @@ Body`);
       reason: "ok",
       staleReason: null,
     });
+
+    const missingRepoPath = join(process.cwd(), "not a repo url");
+    await expect(
+      contextTreeSnapshotTestInternals.resolveContextTreeRoot("not a repo url", null, null),
+    ).resolves.toEqual({
+      root: null,
+      reason: `Context Tree checkout not found at ${missingRepoPath}.`,
+      staleReason: null,
+    });
   });
 
   it("classifies GitHub remote bindings without treating local bindings as remote", () => {
@@ -307,6 +332,18 @@ Body`);
     );
     expect(diff.entries).toHaveLength(2);
     expect(diff.entries.every((entry) => entry.changedAt !== null)).toBe(true);
+  });
+
+  it("splits git rename status entries into removed and added changes", async () => {
+    await initRepo();
+    await writeFile(join(testDir, "old.md"), "---\ntitle: Old\n---\nOld guidance\n");
+    const baseCommit = await commitAll("docs: add old guidance");
+    await git(testDir, ["mv", "old.md", "new.md"]);
+    const renameCommit = await commitAll("docs: move old guidance");
+
+    const diff = await contextTreeSnapshotTestInternals.readDiffEntries(testDir, baseCommit, renameCommit);
+
+    expect(diff.entries.map((entry) => `${entry.type}:${entry.path}`)).toEqual(["removed:old.md", "added:new.md"]);
   });
 
   it("uses null summaries for terse commit subjects while preserving git metadata", async () => {
@@ -402,6 +439,33 @@ Body`);
     );
     expect(cached.root).toBe(first.root);
     expect(timings).toContain("remote_sync_skip_ttl");
+  });
+
+  it("refreshes an existing managed checkout when the remote branch advances", async () => {
+    const remoteDir = join(testDir, "remote-source");
+    const cacheRoot = join(testDir, "managed-cache");
+    const repoUrl = `file://${remoteDir}`;
+    const timings: string[] = [];
+    await initRepoAt(remoteDir);
+    await writeFile(join(remoteDir, "NODE.md"), "---\ntitle: Refreshable Context\n---\nGuidance\n");
+    await commitAllAt(remoteDir, "docs: add remote context");
+
+    const first = await contextTreeSnapshotTestInternals.materializeRemoteContextTree(repoUrl, "main", cacheRoot);
+    contextTreeSnapshotTestInternals.clearRemoteSyncState();
+    await writeFile(join(remoteDir, "next.md"), "---\ntitle: Next\n---\nNext guidance\n");
+    await commitAllAt(remoteDir, "docs: add next context");
+
+    const second = await contextTreeSnapshotTestInternals.materializeRemoteContextTree(
+      repoUrl,
+      "main",
+      cacheRoot,
+      null,
+      (name) => timings.push(name),
+    );
+
+    expect(second.root).toBe(first.root);
+    expect(timings).toContain("remote_fetch_checkout");
+    await expect(readFile(join(second.root, "next.md"), "utf8")).resolves.toContain("Next guidance");
   });
 
   it("uses a full sha256 digest for managed checkout paths", () => {
@@ -552,6 +616,83 @@ Body`);
       ]),
     );
     expect(snapshot.io.writes.map((event) => event.prNumber)).toEqual([777, 777, 777]);
+  });
+
+  it("marks active snapshots with attention when the diff is truncated", async () => {
+    await initRepo();
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Root Context\n---\nRoot\n");
+    await commitAllAtDate(testDir, "docs: initial context", "2026-01-01T00:00:00Z");
+    for (let index = 0; index < 205; index += 1) {
+      await writeFile(join(testDir, `bulk-${index}.md`), `---\ntitle: Bulk ${index}\n---\nBody ${index}\n`);
+    }
+    await commitAll("docs: add bulk context");
+
+    const snapshot = await getContextTreeSnapshot({ localPath: testDir, branch: "main" }, "7d");
+
+    expect(snapshot.snapshotStatus).toBe("active");
+    expect(snapshot.contextStatus).toMatchObject({
+      label: "Context Tree needs attention",
+      severity: "warning",
+    });
+    expect(snapshot.contextStatus.detail).toContain("Showing the first 200 changed files.");
+    expect(snapshot.changes).toHaveLength(200);
+  });
+
+  it("keeps stale remote snapshots available and combines stale plus truncated warnings", async () => {
+    const remoteDir = join(testDir, "remote-source");
+    const repoUrl = `file://${remoteDir}`;
+    const previousFirstTreeHome = process.env.FIRST_TREE_HOME;
+    process.env.FIRST_TREE_HOME = join(testDir, "home");
+    await initRepoAt(remoteDir);
+    await writeFile(join(remoteDir, "NODE.md"), "---\ntitle: Stale Bulk Context\n---\nRoot\n");
+    await commitAllAtDate(remoteDir, "docs: initial context", "2026-01-01T00:00:00Z");
+    for (let index = 0; index < 205; index += 1) {
+      await writeFile(join(remoteDir, `remote-bulk-${index}.md`), `---\ntitle: Remote Bulk ${index}\n---\nBody\n`);
+    }
+    await commitAllAt(remoteDir, "docs: add remote bulk context");
+    try {
+      await contextTreeSnapshotTestInternals.materializeRemoteContextTree(repoUrl, "main");
+      contextTreeSnapshotTestInternals.clearRemoteSyncState();
+      await rm(remoteDir, { recursive: true, force: true });
+
+      const snapshot = await getContextTreeSnapshot({ repo: repoUrl, branch: "main" }, "7d");
+
+      expect(snapshot.snapshotStatus).toBe("stale");
+      expect(snapshot.contextStatus).toMatchObject({
+        label: "Context Tree may be stale",
+        severity: "warning",
+      });
+      expect(snapshot.contextStatus.detail).toContain("could not refresh the configured repo");
+      expect(snapshot.contextStatus.detail).toContain("Showing the first 200 changed files.");
+      expect(snapshot.changes).toHaveLength(200);
+    } finally {
+      if (previousFirstTreeHome === undefined) {
+        delete process.env.FIRST_TREE_HOME;
+      } else {
+        process.env.FIRST_TREE_HOME = previousFirstTreeHome;
+      }
+    }
+  });
+
+  it("uses default update summaries for terse added and removed commits", async () => {
+    await initRepo();
+    await writeFile(join(testDir, "NODE.md"), "---\ntitle: Root Context\n---\nRoot\n");
+    await writeFile(join(testDir, "old.md"), "---\ntitle: Old\n---\nOld\n");
+    await commitAllAtDate(testDir, "docs: initial context", "2026-01-01T00:00:00Z");
+    await rm(join(testDir, "old.md"));
+    await writeFile(join(testDir, "new.md"), "---\ntitle: New\n---\nNew\n");
+    await commitAll("x");
+
+    const snapshot = await getContextTreeSnapshot({ localPath: testDir, branch: "main" }, "7d");
+
+    expect(snapshot.updates.find((update) => update.changeType === "added")).toMatchObject({
+      path: "new",
+      summary: "added this team knowledge",
+    });
+    expect(snapshot.updates.find((update) => update.changeType === "removed")).toMatchObject({
+      path: "old",
+      summary: "removed this team knowledge",
+    });
   });
 
   it("uses an existing managed checkout when remote refresh fails", async () => {

--- a/packages/server/src/__tests__/db-migrate-edge.test.ts
+++ b/packages/server/src/__tests__/db-migrate-edge.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("runMigrations edge validation", () => {
+  afterEach(() => {
+    vi.doUnmock("node:fs");
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("fails clearly when the drizzle migrations folder cannot be located", async () => {
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...actual,
+        existsSync: vi.fn(() => false),
+      };
+    });
+
+    const { runMigrations } = await import("../db/migrate.js");
+
+    await expect(runMigrations("postgres://example.invalid/db")).rejects.toThrow(
+      /Cannot locate drizzle migrations folder/,
+    );
+  });
+
+  it("rejects non-monotonic migration journal timestamps before connecting to postgres", async () => {
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...actual,
+        existsSync: vi.fn(() => true),
+        readFileSync: vi.fn(() =>
+          JSON.stringify({
+            entries: [
+              { idx: 0, when: 200, tag: "0000_initial" },
+              { idx: 1, when: 100, tag: "0001_late" },
+            ],
+          }),
+        ),
+      };
+    });
+
+    const { runMigrations } = await import("../db/migrate.js");
+
+    await expect(runMigrations("postgres://example.invalid/db")).rejects.toThrow(
+      /Migration journal timestamps are not monotonically increasing/,
+    );
+  });
+});

--- a/packages/server/src/__tests__/db-migrate-edge.test.ts
+++ b/packages/server/src/__tests__/db-migrate-edge.test.ts
@@ -1,13 +1,26 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+function mockPostgresClient(): ReturnType<typeof vi.fn> {
+  const postgresMock = vi.fn(() => {
+    throw new Error("postgres connection should not be opened for migration validation failures");
+  });
+  vi.doMock("postgres", () => ({
+    default: postgresMock,
+  }));
+  return postgresMock;
+}
+
 describe("runMigrations edge validation", () => {
   afterEach(() => {
     vi.doUnmock("node:fs");
+    vi.doUnmock("postgres");
     vi.resetModules();
     vi.restoreAllMocks();
   });
 
   it("fails clearly when the drizzle migrations folder cannot be located", async () => {
+    vi.resetModules();
+    const postgresMock = mockPostgresClient();
     vi.doMock("node:fs", async (importOriginal) => {
       const actual = await importOriginal<typeof import("node:fs")>();
       return {
@@ -21,9 +34,12 @@ describe("runMigrations edge validation", () => {
     await expect(runMigrations("postgres://example.invalid/db")).rejects.toThrow(
       /Cannot locate drizzle migrations folder/,
     );
+    expect(postgresMock).not.toHaveBeenCalled();
   });
 
   it("rejects non-monotonic migration journal timestamps before connecting to postgres", async () => {
+    vi.resetModules();
+    const postgresMock = mockPostgresClient();
     vi.doMock("node:fs", async (importOriginal) => {
       const actual = await importOriginal<typeof import("node:fs")>();
       return {
@@ -45,5 +61,6 @@ describe("runMigrations edge validation", () => {
     await expect(runMigrations("postgres://example.invalid/db")).rejects.toThrow(
       /Migration journal timestamps are not monotonically increasing/,
     );
+    expect(postgresMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/__tests__/doc-snapshots.test.ts
+++ b/packages/server/src/__tests__/doc-snapshots.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { MAX_MESSAGE_ATTACHMENT_REFS } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
 import { BadRequestError } from "../errors.js";
 import type { AttachmentReader } from "../services/attachment.js";
@@ -124,6 +125,19 @@ describe("validateMessageAttachmentRefs", () => {
     await expect(validateMessageAttachmentRefs(readerWith(null), { attachments: [baseRef()] })).rejects.toThrow(
       BadRequestError,
     );
+  });
+
+  it("rejects more attachment refs than the message cap", async () => {
+    await expect(
+      validateMessageAttachmentRefs(readerWith(null), {
+        attachments: Array.from({ length: MAX_MESSAGE_ATTACHMENT_REFS + 1 }, () => baseRef()),
+      }),
+    ).rejects.toMatchObject({
+      attrs: {
+        "attachment_ref.count": MAX_MESSAGE_ATTACHMENT_REFS + 1,
+        "attachment_ref.limit": MAX_MESSAGE_ATTACHMENT_REFS,
+      },
+    });
   });
 
   it("rejects a mime mismatch", async () => {

--- a/packages/server/src/__tests__/documents.test.ts
+++ b/packages/server/src/__tests__/documents.test.ts
@@ -1,11 +1,15 @@
 import crypto from "node:crypto";
 import type { PublishDocResponse } from "@first-tree/shared";
+import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
+import { docDocuments } from "../db/schema/index.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
 import { users } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
+import { docAuthorForAgentUuid } from "../services/doc-author.js";
+import { createComment } from "../services/document.js";
 import { uuidv7 } from "../uuid.js";
 import { createAdminContext, createTestAgent, INVALID_BCRYPT_PLACEHOLDER, useTestApp } from "./helpers.js";
 
@@ -341,6 +345,9 @@ describe("documents API", () => {
       );
       expect(page2.json().items).toHaveLength(1);
       expect(page2.json().items[0].id).not.toBe(page1.json().items[0].id);
+
+      const invalidCursor = await req("GET", `/api/v1/orgs/${ctx.organizationId}/documents?cursor=not-a-cursor`);
+      expect(invalidCursor.statusCode).toBe(400);
     });
   });
 
@@ -384,6 +391,11 @@ describe("documents API", () => {
       expect(reply.statusCode).toBe(200);
       expect(reply.json()).toMatchObject({ parentId: comment.json().id, versionNumber: 1, anchor: null });
 
+      const missingParentReply = await req("POST", `/api/v1/document-comments/${uuidv7()}/replies`, {
+        body: "missing parent",
+      });
+      expect(missingParentReply.statusCode).toBe(404);
+
       // Threads are one level deep — replying to a reply is a 400.
       const replyToReply = await req("POST", `/api/v1/document-comments/${reply.json().id}/replies`, {
         body: "nope",
@@ -415,6 +427,51 @@ describe("documents API", () => {
       // Document-level open-comment count reflects thread status.
       const summary = await req("GET", `/api/v1/documents/${doc.id}`);
       expect(summary.json().openCommentCount).toBe(0);
+    });
+
+    it("rejects anchored replies and missing parent comments in the document service", async () => {
+      const app = getApp();
+      const ctx = await createAdminContext(app);
+      const doc = await publishDoc(app, ctx, { slug: slug("service-replies"), title: "S", content: "alpha beta" });
+      const [document] = await app.db.select().from(docDocuments).where(eq(docDocuments.id, doc.id)).limit(1);
+      if (!document) throw new Error("published document row was not found");
+      const author = { kind: "human" as const, id: ctx.humanAgentUuid, name: "Test Admin" };
+      const parent = await createComment(app.db, {
+        document,
+        author,
+        body: "root comment",
+        anchor: { exact: "beta" },
+      });
+
+      await expect(
+        createComment(app.db, {
+          document,
+          author,
+          body: "anchored reply",
+          parentId: parent.id,
+          anchor: { exact: "beta" },
+        }),
+      ).rejects.toThrow("Replies cannot carry an anchor");
+
+      await expect(
+        createComment(app.db, {
+          document,
+          author,
+          body: "missing parent",
+          parentId: uuidv7(),
+        }),
+      ).rejects.toThrow("Parent comment not found on this document");
+    });
+
+    it("rejects missing document author identities", async () => {
+      const chain = {
+        from: () => chain,
+        limit: async () => [],
+        where: () => chain,
+      };
+      await expect(docAuthorForAgentUuid({ select: () => chain } as never, "missing-agent")).rejects.toThrow(
+        "Caller identity not found",
+      );
     });
 
     it("marks anchored comments outdated when their quote disappears from the latest version", async () => {

--- a/packages/server/src/__tests__/github-app-installation-details.test.ts
+++ b/packages/server/src/__tests__/github-app-installation-details.test.ts
@@ -8,11 +8,16 @@ import { createTestAdmin, useTestApp } from "./helpers.js";
 describe("GET /orgs/:orgId/github-app-installation", () => {
   const getApp = useTestApp();
 
-  async function seedInstallation(app: ReturnType<typeof getApp>, orgId: string, installationId: number) {
+  async function seedInstallation(
+    app: ReturnType<typeof getApp>,
+    orgId: string,
+    installationId: number,
+    opts: { accountType?: "Organization" | "User" } = {},
+  ) {
     await upsertInstallationFromMetadata(app.db, {
       installation: {
         id: installationId,
-        accountType: "Organization",
+        accountType: opts.accountType ?? "Organization",
         accountLogin: `org-${installationId}`,
         accountGithubId: installationId * 10,
         permissions: { contents: "read" },
@@ -60,5 +65,34 @@ describe("GET /orgs/:orgId/github-app-installation", () => {
       permissions: { contents: "read" },
       events: ["issues"],
     });
+  });
+
+  it("returns 404 when no installation is bound", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `gh-none-${crypto.randomUUID().slice(0, 8)}` });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: string }>().error).toContain("No GitHub App installation");
+  });
+
+  it("uses the user installation manage URL for personal-account installs", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `gh-user-${crypto.randomUUID().slice(0, 8)}` });
+    await seedInstallation(app, admin.organizationId, 901_002, { accountType: "User" });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ manageUrl: string }>().manageUrl).toBe("https://github.com/settings/installations/901002");
   });
 });

--- a/packages/server/src/__tests__/github-app-repositories.test.ts
+++ b/packages/server/src/__tests__/github-app-repositories.test.ts
@@ -72,6 +72,21 @@ describe("GET /orgs/:orgId/github-app-installation/repositories", () => {
     };
   }
 
+  function stubGithubTokenError(status: number): () => void {
+    const original = globalThis.fetch;
+    const spy = vi.fn(async (input: FetchInput, init?: FetchInit): Promise<Response> => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (/\/app\/installations\/\d+\/access_tokens$/.test(url)) {
+        return new Response("token mint failed", { status });
+      }
+      return original(input, init);
+    });
+    globalThis.fetch = spy as typeof fetch;
+    return () => {
+      globalThis.fetch = original;
+    };
+  }
+
   /**
    * Stub `globalThis.fetch` for the two GitHub round-trips this route makes:
    * mint an installation token, then list `/installation/repositories`.
@@ -165,6 +180,40 @@ describe("GET /orgs/:orgId/github-app-installation/repositories", () => {
     });
     expect(res.statusCode).toBe(502);
     expect(res.json<{ code: string }>().code).toBe("upstream");
+  });
+
+  it("502 upstream when GitHub rejects the installation token mint", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `r-admin-${crypto.randomUUID().slice(0, 8)}` });
+    await seedInstallation(app, admin.organizationId, 910_005);
+    restoreFetch = stubGithubTokenError(500);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/repositories`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(502);
+    expect(res.json<{ code: string }>().code).toBe("upstream");
+  });
+
+  it("503 not_configured when the server has no GitHub App config", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app, { username: `r-admin-${crypto.randomUUID().slice(0, 8)}` });
+    await seedInstallation(app, admin.organizationId, 910_006);
+    const originalOauth = app.config.oauth;
+    app.config.oauth = undefined;
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/orgs/${admin.organizationId}/github-app-installation/repositories`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+      expect(res.statusCode).toBe(503);
+      expect(res.json<{ code: string }>().code).toBe("not_configured");
+    } finally {
+      app.config.oauth = originalOauth;
+    }
   });
 
   it("503 no_installation when the team has no installation bound", async () => {

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -1,6 +1,6 @@
 import { createHmac, randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { agents } from "../db/schema/agents.js";
 import { chatUserState } from "../db/schema/chat-user-state.js";
 import { chats } from "../db/schema/chats.js";
@@ -10,6 +10,9 @@ import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
 import { users } from "../db/schema/users.js";
+import * as eventDedupService from "../services/event-dedup.js";
+import * as githubAudienceService from "../services/github-audience.js";
+import * as githubEntityStateService from "../services/github-entity-state.js";
 import { putOrgSetting } from "../services/org-settings.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
@@ -34,6 +37,28 @@ async function postWebhook(
     "x-github-event": eventType,
     "x-github-delivery": opts.deliveryId ?? randomUUID(),
   };
+  if (!opts.skipSignature) {
+    headers["x-hub-signature-256"] = signBody(opts.secret ?? APP_WEBHOOK_SECRET, body);
+  }
+  return app.inject({
+    method: "POST",
+    url: "/api/v1/webhooks/github-app",
+    headers,
+    payload: body,
+  });
+}
+
+async function postRawWebhook(
+  app: App,
+  eventType: string | null,
+  body: string,
+  opts: { secret?: string; deliveryId?: string; skipSignature?: boolean } = {},
+) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "x-github-delivery": opts.deliveryId ?? randomUUID(),
+  };
+  if (eventType !== null) headers["x-github-event"] = eventType;
   if (!opts.skipSignature) {
     headers["x-hub-signature-256"] = signBody(opts.secret ?? APP_WEBHOOK_SECRET, body);
   }
@@ -197,6 +222,18 @@ describe("POST /webhooks/github-app", () => {
     expect(res.json()).toEqual({ ok: true, event: "ping" });
   });
 
+  it("rejects malformed raw JSON and requests missing the GitHub event header", async () => {
+    const app = getApp();
+
+    const malformed = await postRawWebhook(app, "ping", "{");
+    expect(malformed.statusCode).toBe(400);
+    expect(malformed.json<{ error: string }>().error).toBe("Invalid JSON payload");
+
+    const missingEvent = await postRawWebhook(app, null, JSON.stringify({ zen: "x" }));
+    expect(missingEvent.statusCode).toBe(400);
+    expect(missingEvent.json<{ error: string }>().error).toBe("Missing x-github-event header");
+  });
+
   it("installation.created → records the row unbound with the installer (direct install: no requester)", async () => {
     const app = getApp();
     const installationId = 100001;
@@ -228,6 +265,38 @@ describe("POST /webhooks/github-app", () => {
     expect(row?.installerGithubId).toBe(777);
     expect(row?.requesterGithubId).toBeNull();
     expect(row?.hubOrganizationId).toBeNull();
+  });
+
+  it("installation.created accepts missing events arrays and installation unknown actions are no-ops", async () => {
+    const app = getApp();
+    const installationId = 100013;
+    const created = await postWebhook(app, "installation", {
+      action: "created",
+      installation: {
+        id: installationId,
+        account: { id: 4245, login: "acme4", type: "Organization" },
+        permissions: { contents: "read" },
+        events: "pull_request",
+        suspended_at: null,
+      },
+      sender: { id: 90213, login: "owner", type: "User" },
+    });
+    expect(created.statusCode).toBe(200);
+    expect(created.json().lifecycle).toBe("created:recorded");
+
+    const [row] = await app.db
+      .select({ events: githubAppInstallations.events })
+      .from(githubAppInstallations)
+      .where(eq(githubAppInstallations.installationId, installationId))
+      .limit(1);
+    expect(row?.events).toEqual([]);
+
+    const unknown = await postWebhook(app, "installation", {
+      action: "unknown_action",
+      installation: { id: installationId, account: { id: 4245, login: "acme4", type: "Organization" } },
+    });
+    expect(unknown.statusCode).toBe(200);
+    expect(unknown.json().lifecycle).toBe("ignored:unknown-action");
   });
 
   it("installation.created via the approval flow records BOTH the requester and the approving installer", async () => {
@@ -368,6 +437,29 @@ describe("POST /webhooks/github-app", () => {
     expect(row?.suspendedAt).toBeTruthy();
   });
 
+  it("installation.unsuspend clears suspended_at", async () => {
+    const app = getApp();
+    const installationId = 100014;
+    await seedInstallation(app, { installationId, orgId: null, suspended: true });
+
+    const res = await postWebhook(app, "installation", {
+      action: "unsuspend",
+      installation: {
+        id: installationId,
+        account: { id: 1, login: "x", type: "User" },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().lifecycle).toBe("unsuspended");
+
+    const [row] = await app.db
+      .select({ suspendedAt: githubAppInstallations.suspendedAt })
+      .from(githubAppInstallations)
+      .where(eq(githubAppInstallations.installationId, installationId))
+      .limit(1);
+    expect(row?.suspendedAt).toBeNull();
+  });
+
   it("returns ignored:no installation context when payload lacks an installation block", async () => {
     const app = getApp();
     const res = await postWebhook(app, "issues", {
@@ -423,6 +515,93 @@ describe("POST /webhooks/github-app", () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().ignored).toBe("suspended");
+  });
+
+  it("returns handled=false for unsupported repository events after state seed resolution no-ops", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100015;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const res = await postWebhook(app, "star", {
+      action: "created",
+      repository: { full_name: "owner/repo" },
+      sender: { login: "stargazer", type: "User" },
+      installation: { id: installationId },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ ok: true, event: "star", handled: false });
+  });
+
+  it("continues delivery when entity state sync fails", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100016;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+    const stateSpy = vi
+      .spyOn(githubEntityStateService, "setEntityState")
+      .mockRejectedValueOnce(new Error("state sync down"));
+
+    try {
+      const res = await postWebhook(app, "issues", {
+        action: "closed",
+        issue: {
+          number: 912,
+          title: "Closed issue",
+          html_url: "https://github.com/owner/repo/issues/912",
+          body: "",
+          state: "closed",
+        },
+        repository: { full_name: "owner/repo" },
+        sender: { login: "closer", type: "User" },
+        installation: { id: installationId },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(stateSpy).toHaveBeenCalled();
+    } finally {
+      stateSpy.mockRestore();
+    }
+  });
+
+  it("unclaims a delivery when downstream handling fails and logs unclaim failures", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100017;
+    const deliveryId = randomUUID();
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+    const audienceSpy = vi
+      .spyOn(githubAudienceService, "resolveAudience")
+      .mockRejectedValueOnce(new Error("audience down"));
+    const unclaimSpy = vi.spyOn(eventDedupService, "unclaimEvent").mockRejectedValueOnce(new Error("unclaim down"));
+
+    try {
+      const res = await postWebhook(
+        app,
+        "issues",
+        {
+          action: "opened",
+          issue: {
+            number: 913,
+            title: "Issue",
+            html_url: "https://github.com/owner/repo/issues/913",
+            body: "",
+          },
+          repository: { full_name: "owner/repo" },
+          sender: { login: "author", type: "User" },
+          installation: { id: installationId },
+        },
+        { deliveryId },
+      );
+
+      expect(res.statusCode).toBe(500);
+      expect(audienceSpy).toHaveBeenCalled();
+      expect(unclaimSpy).toHaveBeenCalledWith(app.db, deliveryId, "github");
+    } finally {
+      audienceSpy.mockRestore();
+      unclaimSpy.mockRestore();
+    }
   });
 
   it("Bug 1 — pull_request.synchronize delivers to subscribed chat (was silenced before)", async () => {

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -29,14 +29,14 @@ async function postWebhook(
   app: App,
   eventType: string,
   payload: object,
-  opts: { secret?: string; deliveryId?: string; skipSignature?: boolean } = {},
+  opts: { secret?: string; deliveryId?: string; skipDelivery?: boolean; skipSignature?: boolean } = {},
 ) {
   const body = JSON.stringify(payload);
   const headers: Record<string, string> = {
     "content-type": "application/json",
     "x-github-event": eventType,
-    "x-github-delivery": opts.deliveryId ?? randomUUID(),
   };
+  if (!opts.skipDelivery) headers["x-github-delivery"] = opts.deliveryId ?? randomUUID();
   if (!opts.skipSignature) {
     headers["x-hub-signature-256"] = signBody(opts.secret ?? APP_WEBHOOK_SECRET, body);
   }
@@ -52,12 +52,12 @@ async function postRawWebhook(
   app: App,
   eventType: string | null,
   body: string,
-  opts: { secret?: string; deliveryId?: string; skipSignature?: boolean } = {},
+  opts: { secret?: string; deliveryId?: string; skipDelivery?: boolean; skipSignature?: boolean } = {},
 ) {
   const headers: Record<string, string> = {
     "content-type": "application/json",
-    "x-github-delivery": opts.deliveryId ?? randomUUID(),
   };
+  if (!opts.skipDelivery) headers["x-github-delivery"] = opts.deliveryId ?? randomUUID();
   if (eventType !== null) headers["x-github-event"] = eventType;
   if (!opts.skipSignature) {
     headers["x-hub-signature-256"] = signBody(opts.secret ?? APP_WEBHOOK_SECRET, body);
@@ -234,6 +234,23 @@ describe("POST /webhooks/github-app", () => {
     expect(missingEvent.json<{ error: string }>().error).toBe("Missing x-github-event header");
   });
 
+  it("rejects non-buffer webhook bodies before signature parsing", async () => {
+    const app = getApp();
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/webhooks/github-app",
+      headers: {
+        "content-type": "text/plain",
+        "x-github-event": "ping",
+        "x-hub-signature-256": "sha256=ignored",
+      },
+      payload: "plain text",
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toBe("Expected raw body buffer");
+  });
+
   it("installation.created → records the row unbound with the installer (direct install: no requester)", async () => {
     const app = getApp();
     const installationId = 100001;
@@ -297,6 +314,64 @@ describe("POST /webhooks/github-app", () => {
     });
     expect(unknown.statusCode).toBe(200);
     expect(unknown.json().lifecycle).toBe("ignored:unknown-action");
+  });
+
+  it("installation lifecycle rejects malformed metadata defensively", async () => {
+    const app = getApp();
+
+    const notObject = await postRawWebhook(app, "installation", "null");
+    expect(notObject.statusCode).toBe(200);
+    expect(notObject.json().lifecycle).toBe("ignored:malformed");
+
+    const repos = await postWebhook(app, "installation_repositories", {
+      action: "added",
+      installation: { id: 100099 },
+    });
+    expect(repos.statusCode).toBe(200);
+    expect(repos.json().lifecycle).toBe("noop");
+
+    const missingInstallation = await postWebhook(app, "installation", { action: "created" });
+    expect(missingInstallation.statusCode).toBe(200);
+    expect(missingInstallation.json().lifecycle).toBe("ignored:malformed");
+
+    const invalidMetadataCases = [
+      { id: Number.NaN, account: { id: 1, login: "x", type: "Organization" } },
+      { id: 100101 },
+      { id: 100102, account: { id: "1", login: "x", type: "Organization" } },
+      { id: 100103, account: { id: 1, login: "x", type: "Bot" } },
+    ];
+    for (const installation of invalidMetadataCases) {
+      const res = await postWebhook(app, "installation", { action: "created", installation });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().lifecycle).toBe("ignored:malformed");
+    }
+
+    const invalidPermissions = await postWebhook(app, "installation", {
+      action: "created",
+      installation: {
+        id: 100104,
+        account: { id: 1, login: "fallback-permissions", type: "Organization" },
+        permissions: { contents: 123 },
+        events: ["pull_request", 42, "issues"],
+        suspended_at: "2026-05-13T00:00:00Z",
+      },
+      sender: { id: "not-a-number" },
+      requester: null,
+    });
+    expect(invalidPermissions.statusCode).toBe(200);
+    expect(invalidPermissions.json().lifecycle).toBe("created:recorded");
+    const [row] = await app.db
+      .select()
+      .from(githubAppInstallations)
+      .where(eq(githubAppInstallations.installationId, 100104))
+      .limit(1);
+    expect(row).toMatchObject({
+      permissions: {},
+      events: ["pull_request", "issues"],
+      installerGithubId: null,
+      requesterGithubId: null,
+    });
+    expect(row?.suspendedAt).toBeTruthy();
   });
 
   it("installation.created via the approval flow records BOTH the requester and the approving installer", async () => {
@@ -532,6 +607,104 @@ describe("POST /webhooks/github-app", () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ ok: true, event: "star", handled: false });
+  });
+
+  it("handles repository events without a delivery header", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100018;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const res = await postWebhook(
+      app,
+      "star",
+      {
+        action: "created",
+        repository: { full_name: "owner/repo" },
+        sender: { login: "stargazer", type: "User" },
+        installation: { id: installationId },
+      },
+      { skipDelivery: true },
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ ok: true, event: "star", handled: false });
+  });
+
+  it("derives PR state seeds from issue comment payload fallbacks", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100019;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const closedMerged = await postWebhook(app, "issue_comment", {
+      action: "edited",
+      issue: {
+        number: 77,
+        title: "PR issue comment",
+        html_url: "https://github.com/owner/repo/issues/77",
+        state: "closed",
+        pull_request: { html_url: "https://github.com/owner/repo/pull/77", merged_at: "2026-01-01T00:00:00Z" },
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "commenter", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(closedMerged.statusCode).toBe(200);
+    expect(closedMerged.json()).toMatchObject({ handled: false });
+
+    const draftOpen = await postWebhook(app, "issue_comment", {
+      action: "edited",
+      issue: {
+        number: 78,
+        title: "Draft PR issue comment",
+        html_url: "https://github.com/owner/repo/issues/78",
+        draft: true,
+        pull_request: { html_url: "https://github.com/owner/repo/pull/78" },
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "commenter", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(draftOpen.statusCode).toBe(200);
+    expect(draftOpen.json()).toMatchObject({ handled: false });
+  });
+
+  it("tolerates malformed entity state seed payloads", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100022;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    const malformedReviewComment = await postWebhook(app, "pull_request_review_comment", {
+      action: "dismissed",
+      pull_request: null,
+      repository: { full_name: "owner/repo" },
+      sender: { login: "reviewer", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(malformedReviewComment.statusCode).toBe(200);
+    expect(malformedReviewComment.json()).toMatchObject({ handled: false });
+
+    const malformedClosedPr = await postWebhook(app, "pull_request", {
+      action: "closed",
+      pull_request: null,
+      repository: { full_name: "owner/repo" },
+      sender: { login: "closer", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(malformedClosedPr.statusCode).toBe(200);
+    expect(malformedClosedPr.json()).toMatchObject({ handled: false });
+
+    const malformedIssue = await postWebhook(app, "issues", {
+      action: "closed",
+      issue: null,
+      repository: { full_name: "owner/repo" },
+      sender: { login: "closer", type: "User" },
+      installation: { id: installationId },
+    });
+    expect(malformedIssue.statusCode).toBe(200);
+    expect(malformedIssue.json()).toMatchObject({ handled: false });
   });
 
   it("continues delivery when entity state sync fails", async () => {

--- a/packages/server/src/__tests__/github-app.test.ts
+++ b/packages/server/src/__tests__/github-app.test.ts
@@ -563,6 +563,35 @@ describe("services/github-app", () => {
       expect(err.status).toBe(500);
       expect(err.message).toContain("expires_in");
     });
+
+    it("throws GithubAppApiError when the profile fetch fails", async () => {
+      const fakeFetch: typeof fetch = async (url) => {
+        if (String(url) === "https://github.com/login/oauth/access_token") {
+          return new Response(
+            JSON.stringify({
+              access_token: "a",
+              expires_in: 28800,
+              refresh_token: "r",
+              refresh_token_expires_in: 15897600,
+              scope: "",
+              token_type: "bearer",
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ message: "profile unavailable" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        });
+      };
+
+      await expect(
+        exchangeCodeForAppUserProfile(
+          { clientId: "c", clientSecret: "s", code: "x", redirectUri: "r", installationId: null },
+          { fetcher: fakeFetch },
+        ),
+      ).rejects.toMatchObject({ name: "GithubAppApiError", status: 503 });
+    });
   });
 });
 
@@ -794,6 +823,49 @@ describe("services/github-app › installation repository helpers", () => {
       name: "GithubAppApiError",
       status: 422,
       message: expect.stringContaining("Repository creation failed."),
+    });
+  });
+
+  it("throws GithubAppApiError when GitHub repo helpers return invalid success bodies", async () => {
+    await expect(
+      getRepository("ghs_token", "acme", "tree", {
+        fetcher: async () => new Response("null", { status: 200, headers: { "content-type": "application/json" } }),
+      }),
+    ).rejects.toMatchObject({
+      name: "GithubAppApiError",
+      status: 502,
+      message: expect.stringContaining("invalid response"),
+    });
+
+    await expect(
+      createOrganizationRepo(
+        "ghs_token",
+        { org: "acme", name: "tree", private: true },
+        {
+          fetcher: async () => new Response("{}", { status: 201, headers: { "content-type": "application/json" } }),
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "GithubAppApiError",
+      status: 502,
+      message: expect.stringContaining("invalid response"),
+    });
+  });
+
+  it("omits upstream detail when a JSON error body cannot be parsed", async () => {
+    await expect(
+      getRepoFileWithToken(
+        "ghs_token",
+        { owner: "acme", repo: "tree", path: "NODE.md", branch: "main" },
+        {
+          fetcher: async () =>
+            new Response("not-json", { status: 500, headers: { "content-type": "application/json" } }),
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "GithubAppApiError",
+      status: 500,
+      message: "GitHub file fetch failed (500)",
     });
   });
 });

--- a/packages/server/src/__tests__/github-delivery-unit.test.ts
+++ b/packages/server/src/__tests__/github-delivery-unit.test.ts
@@ -1,0 +1,205 @@
+import type { NormalizedEvent } from "@first-tree/shared";
+import type { FastifyInstance } from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AudienceTarget } from "../services/github-audience.js";
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+type MockBag = {
+  findReuseChatForInvolved: MockFn;
+  refreshGithubChatTopic: MockFn;
+  resolveTargetChat: MockFn;
+  setEntityTitle: MockFn;
+  sendMessage: MockFn;
+  notifyRecipients: MockFn;
+};
+
+function makeEvent(overrides: Partial<NormalizedEvent> = {}): NormalizedEvent {
+  return {
+    source: { kind: "github-app-installation", installationId: 1, organizationId: "org-1" },
+    deliveryId: "delivery-1",
+    rawEventType: "pull_request",
+    rawAction: "opened",
+    entity: {
+      type: "pull_request",
+      repo: "owner/repo",
+      key: "owner/repo#1",
+      title: "Refactor inbox",
+      url: "https://github.com/owner/repo/pull/1",
+    },
+    actor: { githubLogin: "alice", isBot: false },
+    kind: "opened",
+    involves: [],
+    surface: {
+      title: "PR #1: Refactor inbox",
+      body: "Body",
+      url: "https://github.com/owner/repo/pull/1",
+    },
+    relatedRefs: [],
+    ...overrides,
+  };
+}
+
+function makeApp(): FastifyInstance {
+  // The mocked collaborators only read `db` and `notifier`; the full Fastify
+  // surface is irrelevant for these orchestration tests.
+  return { db: { id: "db" }, notifier: { id: "notifier" } } as unknown as FastifyInstance;
+}
+
+function existingTarget(overrides: Partial<AudienceTarget> = {}): AudienceTarget {
+  return {
+    humanAgentId: "human-1",
+    delegateAgentId: "delegate-1",
+    kind: "existing",
+    chatId: "chat-1",
+    involveReason: null,
+    involveLogin: null,
+    ...overrides,
+  };
+}
+
+function newTarget(overrides: Partial<AudienceTarget> = {}): AudienceTarget {
+  return {
+    humanAgentId: "human-1",
+    delegateAgentId: "delegate-1",
+    kind: "new",
+    chatId: null,
+    involveReason: "mentioned",
+    involveLogin: "alice",
+    ...overrides,
+  };
+}
+
+async function loadDelivery(overrides: Partial<MockBag> = {}): Promise<{
+  deliverNormalizedEvent: typeof import("../services/github-delivery.js").deliverNormalizedEvent;
+  mocks: MockBag;
+}> {
+  vi.resetModules();
+
+  const mocks: MockBag = {
+    findReuseChatForInvolved: vi.fn(async () => null),
+    refreshGithubChatTopic: vi.fn(async () => undefined),
+    resolveTargetChat: vi.fn(async () => ({ chatId: "chat-created", created: true, boundVia: "direct" })),
+    setEntityTitle: vi.fn(async () => undefined),
+    sendMessage: vi.fn(async () => ({ message: { id: "message-1" }, recipients: ["recipient-1"] })),
+    notifyRecipients: vi.fn(),
+    ...overrides,
+  };
+
+  vi.doMock("../services/github-entity-chat.js", () => ({
+    findReuseChatForInvolved: mocks.findReuseChatForInvolved,
+    refreshGithubChatTopic: mocks.refreshGithubChatTopic,
+    resolveTargetChat: mocks.resolveTargetChat,
+  }));
+  vi.doMock("../services/github-entity-state.js", () => ({
+    setEntityTitle: mocks.setEntityTitle,
+  }));
+  vi.doMock("../services/message.js", () => ({
+    sendMessage: mocks.sendMessage,
+  }));
+  vi.doMock("../services/notifier.js", () => ({
+    notifyRecipients: mocks.notifyRecipients,
+  }));
+
+  const { deliverNormalizedEvent } = await import("../services/github-delivery.js");
+  return { deliverNormalizedEvent, mocks };
+}
+
+afterEach(() => {
+  vi.doUnmock("../services/github-entity-chat.js");
+  vi.doUnmock("../services/github-entity-state.js");
+  vi.doUnmock("../services/message.js");
+  vi.doUnmock("../services/notifier.js");
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+describe("deliverNormalizedEvent dependency edge paths", () => {
+  it("drops a new target when chat resolution intentionally returns null", async () => {
+    const resolveTargetChat = vi.fn(async () => null);
+    const { deliverNormalizedEvent, mocks } = await loadDelivery({ resolveTargetChat });
+
+    const stats = await deliverNormalizedEvent(makeApp(), makeEvent(), [
+      newTarget({ humanAgentId: "human-new", delegateAgentId: "delegate-new" }),
+    ]);
+
+    expect(stats).toEqual({ delivered: 0, newChats: 0, failed: 0 });
+    expect(resolveTargetChat).toHaveBeenCalledTimes(1);
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+    expect(mocks.notifyRecipients).not.toHaveBeenCalled();
+  });
+
+  it("merges duplicate chat targets, keeps created status, and ranks involved reasons", async () => {
+    const sentPayloads: unknown[] = [];
+    const sendMessage = vi.fn(async (_db: unknown, _chatId: string, _senderId: string, payload: unknown) => {
+      sentPayloads.push(payload);
+      return { message: { id: "message-ranked" }, recipients: ["recipient-ranked"] };
+    });
+    const setEntityTitle = vi.fn(async () => {
+      throw new Error("title store down");
+    });
+    const resolveTargetChat = vi.fn(async () => ({ chatId: "chat-shared", created: true, boundVia: "direct" }));
+    const { deliverNormalizedEvent, mocks } = await loadDelivery({ resolveTargetChat, sendMessage, setEntityTitle });
+
+    const stats = await deliverNormalizedEvent(makeApp(), makeEvent(), [
+      existingTarget({
+        humanAgentId: "human-b",
+        delegateAgentId: "delegate-b",
+        chatId: "chat-shared",
+      }),
+      newTarget({
+        humanAgentId: "human-b",
+        delegateAgentId: "delegate-b",
+        involveReason: "assigned",
+        involveLogin: "assigned-user",
+      }),
+      existingTarget({
+        humanAgentId: "human-a",
+        delegateAgentId: "delegate-a",
+        chatId: "chat-shared",
+        involveReason: "review_requested",
+        involveLogin: "reviewer",
+      }),
+      existingTarget({
+        humanAgentId: "human-c",
+        delegateAgentId: "delegate-c",
+        chatId: "chat-shared",
+        involveReason: "mentioned",
+        involveLogin: "mentioned-user",
+      }),
+    ]);
+
+    expect(stats).toEqual({ delivered: 1, newChats: 1, failed: 0 });
+    expect(setEntityTitle).toHaveBeenCalledTimes(1);
+    expect(mocks.refreshGithubChatTopic).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.notifyRecipients).toHaveBeenCalledWith({ id: "notifier" }, ["recipient-ranked"], "message-ranked");
+    expect(sentPayloads).toHaveLength(1);
+    expect(sentPayloads[0]).toMatchObject({
+      content: { reason: "review_requested", mentionedUser: "reviewer" },
+      metadata: {
+        reason: "review_requested",
+        mentions: ["delegate-a", "delegate-b", "delegate-c"],
+        mentionedUser: "reviewer",
+      },
+    });
+  });
+
+  it("isolates a per-chat delivery failure and continues with later chats", async () => {
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce("send failed")
+      .mockResolvedValueOnce({ message: { id: "message-ok" }, recipients: ["recipient-ok"] });
+    const { deliverNormalizedEvent, mocks } = await loadDelivery({ sendMessage });
+
+    const stats = await deliverNormalizedEvent(makeApp(), makeEvent({ rawAction: "synchronize" }), [
+      existingTarget({ humanAgentId: "human-a", delegateAgentId: "delegate-a", chatId: "chat-a" }),
+      existingTarget({ humanAgentId: "human-b", delegateAgentId: "delegate-b", chatId: "chat-b" }),
+    ]);
+
+    expect(stats).toEqual({ delivered: 1, newChats: 0, failed: 1 });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.notifyRecipients).toHaveBeenCalledOnce();
+    expect(mocks.notifyRecipients).toHaveBeenCalledWith({ id: "notifier" }, ["recipient-ok"], "message-ok");
+  });
+});

--- a/packages/server/src/__tests__/github-entity-chat-edge.test.ts
+++ b/packages/server/src/__tests__/github-entity-chat-edge.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Database } from "../db/connection.js";
+import { insertMappingIfAbsent, refreshGithubChatTopic } from "../services/github-entity-chat.js";
+
+describe("github entity chat service edge cases", () => {
+  it("throws when a conflict winner vanishes before the re-read", async () => {
+    const limit = vi.fn(async () => []);
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            orderBy: vi.fn(() => ({ limit })),
+          })),
+        })),
+      })),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn(async () => []),
+          })),
+        })),
+      })),
+    } as unknown as Database;
+
+    await expect(
+      insertMappingIfAbsent(db, {
+        organizationId: "org-1",
+        humanAgentId: "human-1",
+        delegateAgentId: "agent-1",
+        entity: {
+          type: "pull_request",
+          key: "Acme/Repo#42",
+          url: "https://github.com/Acme/Repo/pull/42",
+          title: "Race",
+        },
+        chatId: "chat-1",
+        boundVia: "direct",
+      }),
+    ).rejects.toThrow("mapping insert conflicted but row not visible");
+    expect(limit).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows topic refresh failures after normalizing the incoming entity", async () => {
+    const db = {
+      select: vi.fn(() => {
+        throw new Error("select failed");
+      }),
+    } as unknown as Database;
+
+    await expect(
+      refreshGithubChatTopic(db, "chat-1", {
+        type: "pull_request",
+        key: "acme/repo#42",
+        url: "https://github.com/acme/repo/pull/42",
+        title: "Updated title",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/server/src/__tests__/github-entity-follow.test.ts
+++ b/packages/server/src/__tests__/github-entity-follow.test.ts
@@ -1,6 +1,6 @@
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { agents } from "../db/schema/agents.js";
 import { chats } from "../db/schema/chats.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
@@ -408,6 +408,54 @@ describe("github-entity-follow", () => {
     expect(row?.entityState).toBe("draft");
   });
 
+  it("follows a commit URL and stores the full sha with its first-line title", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const fullSha = "3f2a91c0aaaabbbbccccddddeeeeffff00001111";
+    const fetcher = makeFetcher({
+      "/repos/Acme/Api/commits/3f2a91c0": () =>
+        json({
+          sha: fullSha,
+          html_url: `https://github.com/Acme/Api/commit/${fullSha}`,
+          commit: { message: "Fix inbox routing\n\nLonger body" },
+        }),
+      "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
+    });
+
+    const result = await declareEntityFollow(
+      app.db,
+      deps(fetcher),
+      followParams(s, "https://github.com/acme/api/commit/3F2A91C0"),
+    );
+
+    expect(result.outcome).toBe("created");
+    if (result.outcome !== "created") throw new Error("unreachable");
+    expect(result.entity).toMatchObject({
+      entityType: "commit",
+      entityKey: `Acme/Api@${fullSha}`,
+      htmlUrl: `https://github.com/Acme/Api/commit/${fullSha}`,
+      title: "Fix inbox routing",
+      state: null,
+      number: null,
+    });
+
+    const [row] = await app.db
+      .select({
+        entityType: githubEntityChatMappings.entityType,
+        entityKey: githubEntityChatMappings.entityKey,
+        title: githubEntityChatMappings.title,
+        entityState: githubEntityChatMappings.entityState,
+      })
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, s.chatId));
+    expect(row).toEqual({
+      entityType: "commit",
+      entityKey: `Acme/Api@${fullSha}`,
+      title: "Fix inbox routing",
+      entityState: "open",
+    });
+  });
+
   it("an issue without a pull_request block resolves to entityType issue", async () => {
     const app = getApp();
     const s = await setup(app);
@@ -420,6 +468,22 @@ describe("github-entity-follow", () => {
     expect(result.outcome).toBe("created");
     if (result.outcome !== "created") throw new Error("unreachable");
     expect(result.entity.entityType).toBe("issue");
+  });
+
+  it("does not fall back to discussions when an explicit issue URL misses", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const discussionProbe = vi.fn(() => json({ number: 42 }, 200));
+    const fetcher = makeFetcher({
+      "/repos/acme/api/issues/42": () => json({ message: "Not Found" }, 404),
+      "/repos/Acme/Api/discussions/42": discussionProbe,
+      "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
+    });
+
+    await expect(
+      declareEntityFollow(app.db, deps(fetcher), followParams(s, "https://github.com/acme/api/issues/42")),
+    ).rejects.toBeInstanceOf(NotFoundError);
+    expect(discussionProbe).not.toHaveBeenCalled();
   });
 
   it("422: no installation for the org", async () => {
@@ -453,6 +517,27 @@ describe("github-entity-follow", () => {
     );
   });
 
+  it("503: installation token mint failure is retryable and writes no mapping", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const fetcher = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) {
+        return json({ message: "server error" }, 500);
+      }
+      return json({ message: "unexpected" }, 500);
+    }) as typeof fetch;
+
+    await expect(declareEntityFollow(app.db, deps(fetcher), followParams(s, "acme/api#42"))).rejects.toBeInstanceOf(
+      ServiceUnavailableError,
+    );
+    const rows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.chatId, s.chatId));
+    expect(rows).toHaveLength(0);
+  });
+
   it("R7 / 503: GitHub down → no blind write, nothing persisted", async () => {
     const app = getApp();
     const s = await setup(app);
@@ -467,6 +552,45 @@ describe("github-entity-follow", () => {
       .select()
       .from(githubEntityChatMappings)
       .where(eq(githubEntityChatMappings.chatId, s.chatId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("R7 / 503: GitHub rate-limit and network failures are retryable without writes", async () => {
+    const app = getApp();
+    const rateLimited = await setup(app);
+    const rateLimitedFetcher = makeFetcher({
+      "/repos/acme/api": () =>
+        new Response(JSON.stringify({ message: "rate limited" }), {
+          status: 403,
+          headers: { "content-type": "application/json", "x-ratelimit-remaining": "0" },
+        }),
+    });
+
+    await expect(
+      declareEntityFollow(app.db, deps(rateLimitedFetcher), followParams(rateLimited, "acme/api#42")),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+
+    const networkFetcher = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) {
+        return json({
+          token: "ghs_test_token",
+          expires_at: "2099-01-01T00:00:00Z",
+          permissions: { contents: "read" },
+          repository_selection: "selected",
+        });
+      }
+      throw new Error("network down");
+    }) as typeof fetch;
+
+    await expect(
+      declareEntityFollow(app.db, deps(networkFetcher), followParams(rateLimited, "acme/api#42")),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+
+    const rows = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(eq(githubEntityChatMappings.entityKey, "Acme/Api#42"));
     expect(rows).toHaveLength(0);
   });
 

--- a/packages/server/src/__tests__/github-entity-follow.test.ts
+++ b/packages/server/src/__tests__/github-entity-follow.test.ts
@@ -1,5 +1,5 @@
 import { generateKeyPairSync, randomUUID } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { agents } from "../db/schema/agents.js";
 import { chats } from "../db/schema/chats.js";
@@ -827,6 +827,131 @@ describe("github-entity-follow", () => {
       .from(githubEntityChatMappings)
       .where(eq(githubEntityChatMappings.entityKey, "Acme/Api#42"));
     expect(rows).toEqual([{ chatId: newChat }]);
+  });
+
+  it("rebind falls back to insert when the conflicting row vanishes during the update", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const newChat = await seedChat(app, s.admin.organizationId);
+    await declareEntityFollow(app.db, deps(prFetcher()), followParams(s, "acme/api#42"));
+
+    const fnName = `test_gef_skip_update_${randomUUID().replace(/-/g, "_")}`;
+    const triggerName = `test_gef_skip_update_trg_${randomUUID().replace(/-/g, "_")}`;
+    const quote = (value: string) => value.replace(/'/g, "''");
+    await app.db.execute(
+      sql.raw(`
+      CREATE FUNCTION ${fnName}() RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        IF NEW.entity_key = 'Acme/Api#42' AND NEW.chat_id = '${quote(newChat)}' THEN
+          DELETE FROM github_entity_chat_mappings
+          WHERE organization_id = OLD.organization_id
+            AND human_agent_id = OLD.human_agent_id
+            AND delegate_agent_id = OLD.delegate_agent_id
+            AND entity_type = OLD.entity_type
+            AND entity_key = OLD.entity_key;
+          RETURN NULL;
+        END IF;
+        RETURN NEW;
+      END;
+      $$;
+      CREATE TRIGGER ${triggerName}
+      BEFORE UPDATE ON github_entity_chat_mappings
+      FOR EACH ROW EXECUTE FUNCTION ${fnName}();
+    `),
+    );
+
+    try {
+      const result = await declareEntityFollow(app.db, deps(prFetcher()), {
+        ...followParams(s, "acme/api#42", true),
+        chatId: newChat,
+      });
+
+      expect(result.outcome).toBe("created");
+      const rows = await app.db
+        .select({ chatId: githubEntityChatMappings.chatId, title: githubEntityChatMappings.title })
+        .from(githubEntityChatMappings)
+        .where(eq(githubEntityChatMappings.entityKey, "Acme/Api#42"));
+      expect(rows).toEqual([{ chatId: newChat, title: "Add follow command" }]);
+    } finally {
+      await app.db.execute(
+        sql.raw(`
+        DROP TRIGGER IF EXISTS ${triggerName} ON github_entity_chat_mappings;
+        DROP FUNCTION IF EXISTS ${fnName}();
+      `),
+      );
+    }
+  });
+
+  it("rebind reports conflict when a third writer wins the fallback insert race", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const newChat = await seedChat(app, s.admin.organizationId);
+    const thirdChat = await seedChat(app, s.admin.organizationId);
+    await app.db.update(chats).set({ topic: "third winner" }).where(eq(chats.id, thirdChat));
+    await declareEntityFollow(app.db, deps(prFetcher()), followParams(s, "acme/api#42"));
+
+    const fnName = `test_gef_third_writer_${randomUUID().replace(/-/g, "_")}`;
+    const triggerName = `test_gef_third_writer_trg_${randomUUID().replace(/-/g, "_")}`;
+    const quote = (value: string) => value.replace(/'/g, "''");
+    await app.db.execute(
+      sql.raw(`
+      CREATE FUNCTION ${fnName}() RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN
+        IF NEW.entity_key = 'Acme/Api#42' AND NEW.chat_id = '${quote(newChat)}' THEN
+          DELETE FROM github_entity_chat_mappings
+          WHERE organization_id = OLD.organization_id
+            AND human_agent_id = OLD.human_agent_id
+            AND delegate_agent_id = OLD.delegate_agent_id
+            AND entity_type = OLD.entity_type
+            AND entity_key = OLD.entity_key;
+          INSERT INTO github_entity_chat_mappings (
+            organization_id,
+            human_agent_id,
+            delegate_agent_id,
+            entity_type,
+            entity_key,
+            chat_id,
+            bound_via,
+            entity_state,
+            title
+          )
+          VALUES (
+            OLD.organization_id,
+            OLD.human_agent_id,
+            OLD.delegate_agent_id,
+            OLD.entity_type,
+            OLD.entity_key,
+            '${quote(thirdChat)}',
+            'human_declared',
+            OLD.entity_state,
+            OLD.title
+          );
+          RETURN NULL;
+        END IF;
+        RETURN NEW;
+      END;
+      $$;
+      CREATE TRIGGER ${triggerName}
+      BEFORE UPDATE ON github_entity_chat_mappings
+      FOR EACH ROW EXECUTE FUNCTION ${fnName}();
+    `),
+    );
+
+    try {
+      const result = await declareEntityFollow(app.db, deps(prFetcher()), {
+        ...followParams(s, "acme/api#42", true),
+        chatId: newChat,
+      });
+
+      expect(result).toEqual({ outcome: "conflict", conflict: { chatId: thirdChat, topic: "third winner" } });
+    } finally {
+      await app.db.execute(
+        sql.raw(`
+        DROP TRIGGER IF EXISTS ${triggerName} ON github_entity_chat_mappings;
+        DROP FUNCTION IF EXISTS ${fnName}();
+      `),
+      );
+    }
   });
 
   it("rebind refreshes boundAt so the listing dedup sees the move as most recent", async () => {

--- a/packages/server/src/__tests__/github-entity-follow.test.ts
+++ b/packages/server/src/__tests__/github-entity-follow.test.ts
@@ -3,6 +3,7 @@ import { and, eq, sql } from "drizzle-orm";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { agents } from "../db/schema/agents.js";
 import { chats } from "../db/schema/chats.js";
+import { githubAppInstallations } from "../db/schema/github-app-installations.js";
 import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
 import { BadRequestError, NotFoundError, ServiceUnavailableError, UnprocessableError } from "../errors.js";
 import { bindInstallationToOrg, upsertInstallationFromMetadata } from "../services/github-app-installations.js";
@@ -62,12 +63,20 @@ describe("github-entity-follow", () => {
   }
 
   async function seedInstallation(app: App, orgId: string): Promise<void> {
+    const [existing] = await app.db
+      .select({ installationId: githubAppInstallations.installationId })
+      .from(githubAppInstallations)
+      .where(eq(githubAppInstallations.hubOrganizationId, orgId))
+      .limit(1);
+    if (existing) return;
+
+    const githubAccountId = Math.floor(Math.random() * 1_000_000_000) + 1;
     const row = await upsertInstallationFromMetadata(app.db, {
       installation: {
         id: Math.floor(Math.random() * 1_000_000) + 1,
         accountType: "Organization",
-        accountLogin: "acme",
-        accountGithubId: 1001,
+        accountLogin: `acme-${githubAccountId}`,
+        accountGithubId: githubAccountId,
         permissions: { contents: "read" },
         events: ["pull_request", "issues"],
         suspendedAt: null,
@@ -1085,5 +1094,235 @@ describe("github-entity-follow", () => {
     await expect(removeEntityFollow(app.db, { chatId: s.chatId, entity: "acme/api@3f2a91c0" })).resolves.toEqual({
       removed: 1,
     });
+  });
+
+  it("uses commit resolver fallbacks for repo name, sha, html URL, and blank first-line title", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const fetcher = makeFetcher({
+      "/repos/acme/api/commits/3f2a91c0": () => json({ commit: { message: "\nbody" } }),
+      "/repos/acme/api": () => json({}),
+    });
+
+    const result = await declareEntityFollow(app.db, deps(fetcher), followParams(s, "acme/api@3f2a91c0"));
+
+    expect(result.outcome).toBe("created");
+    if (result.outcome !== "created") throw new Error("expected created");
+    expect(result.entity).toMatchObject({
+      entityType: "commit",
+      entityKey: "acme/api@3f2a91c0",
+      htmlUrl: "https://github.com/acme/api/commit/3f2a91c0",
+      title: "",
+      state: null,
+      number: null,
+    });
+  });
+
+  it("maps commit GitHub failures after repo resolution", async () => {
+    const app = getApp();
+    const unavailable = await setup(app);
+    await expect(
+      declareEntityFollow(
+        app.db,
+        deps(
+          makeFetcher({
+            "/repos/acme/api/commits/3f2a91c0": () => json({ message: "server error" }, 502),
+            "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
+          }),
+        ),
+        followParams(unavailable, "acme/api@3f2a91c0"),
+      ),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+
+    const missing = await setup(app);
+    await expect(
+      declareEntityFollow(
+        app.db,
+        deps(
+          makeFetcher({
+            "/repos/acme/api/commits/3f2a91c0": () => json({ message: "Not Found" }, 404),
+            "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
+          }),
+        ),
+        followParams(missing, "acme/api@3f2a91c0"),
+      ),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("maps PR second-hop failures without writing a follow row", async () => {
+    const app = getApp();
+    const unavailable = await setup(app);
+    await expect(
+      declareEntityFollow(
+        app.db,
+        deps(
+          prFetcher({
+            "/repos/acme/api/pulls/42": () => json({ message: "server error" }, 502),
+          }),
+        ),
+        followParams(unavailable, "acme/api#42"),
+      ),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+
+    const forbidden = await setup(app);
+    await expect(
+      declareEntityFollow(
+        app.db,
+        deps(
+          prFetcher({
+            "/repos/acme/api/pulls/42": () => json({ message: "Forbidden" }, 403),
+          }),
+        ),
+        followParams(forbidden, "acme/api#42"),
+      ),
+    ).rejects.toBeInstanceOf(UnprocessableError);
+
+    const missing = await setup(app);
+    await expect(
+      declareEntityFollow(
+        app.db,
+        deps(
+          prFetcher({
+            "/repos/acme/api/pulls/42": () => json({ message: "Gone" }, 410),
+          }),
+        ),
+        followParams(missing, "acme/api#42"),
+      ),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("uses PR and issue payload fallbacks for URL, title, number, and state", async () => {
+    const app = getApp();
+    const prSetup = await setup(app);
+    const prResult = await declareEntityFollow(
+      app.db,
+      deps(
+        prFetcher({
+          "/repos/acme/api/issues/42": () =>
+            json({
+              state: "closed",
+              title: "Issue title fallback",
+              pull_request: { merged_at: null },
+            }),
+          "/repos/acme/api/pulls/42": () =>
+            json({
+              state: "closed",
+              merged: false,
+              draft: false,
+            }),
+        }),
+      ),
+      followParams(prSetup, "acme/api#42"),
+    );
+    expect(prResult.outcome).toBe("created");
+    if (prResult.outcome !== "created") throw new Error("expected created");
+    expect(prResult.entity).toMatchObject({
+      htmlUrl: "https://github.com/Acme/Api/pull/42",
+      title: "Issue title fallback",
+      state: "closed",
+      number: 42,
+    });
+
+    const issueSetup = await setup(app);
+    const issueResult = await declareEntityFollow(
+      app.db,
+      deps(
+        prFetcher({
+          "/repos/acme/api/issues/42": () =>
+            json({
+              state: "queued",
+            }),
+        }),
+      ),
+      followParams(issueSetup, "acme/api#42"),
+    );
+    expect(issueResult.outcome).toBe("created");
+    if (issueResult.outcome !== "created") throw new Error("expected created");
+    expect(issueResult.entity).toMatchObject({
+      entityType: "issue",
+      htmlUrl: "https://github.com/Acme/Api/issues/42",
+      title: null,
+      state: null,
+      number: 42,
+    });
+  });
+
+  it("maps discussion resolver fallbacks and unavailable responses", async () => {
+    const app = getApp();
+    const unavailable = await setup(app);
+    await expect(
+      declareEntityFollow(
+        app.db,
+        deps(
+          makeFetcher({
+            "/repos/Acme/Api/discussions/42": () => json({ message: "server error" }, 502),
+            "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
+          }),
+        ),
+        followParams(unavailable, "https://github.com/acme/api/discussions/42"),
+      ),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+
+    const ok = await setup(app);
+    const result = await declareEntityFollow(
+      app.db,
+      deps(
+        makeFetcher({
+          "/repos/Acme/Api/discussions/42": () => json({ state: "queued" }),
+          "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
+        }),
+      ),
+      followParams(ok, "https://github.com/acme/api/discussions/42"),
+    );
+    expect(result.outcome).toBe("created");
+    if (result.outcome !== "created") throw new Error("expected created");
+    expect(result.entity).toMatchObject({
+      entityType: "discussion",
+      htmlUrl: "https://github.com/Acme/Api/discussions/42",
+      title: null,
+      state: null,
+      number: 42,
+    });
+  });
+
+  it("treats non-object GitHub JSON, retry-after limits, and 401s as resolver errors", async () => {
+    const app = getApp();
+    const nonObject = await setup(app);
+    await expect(
+      declareEntityFollow(
+        app.db,
+        deps(
+          makeFetcher({
+            "/repos/acme/api": () => json("not an object"),
+          }),
+        ),
+        followParams(nonObject, "acme/api#42"),
+      ),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+
+    const retryAfter = await setup(app);
+    const retryAfterFetcher = makeFetcher({
+      "/repos/acme/api": () =>
+        new Response(JSON.stringify({ message: "secondary limit" }), {
+          status: 403,
+          headers: { "content-type": "application/json", "retry-after": "1" },
+        }),
+    });
+    await expect(
+      declareEntityFollow(app.db, deps(retryAfterFetcher), followParams(retryAfter, "acme/api#42")),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+
+    const forbidden = await setup(app);
+    await expect(
+      declareEntityFollow(
+        app.db,
+        deps(
+          makeFetcher({
+            "/repos/acme/api": () => json({ message: "Bad credentials" }, 401),
+          }),
+        ),
+        followParams(forbidden, "acme/api#42"),
+      ),
+    ).rejects.toBeInstanceOf(UnprocessableError);
   });
 });

--- a/packages/server/src/__tests__/github-entity-follow.test.ts
+++ b/packages/server/src/__tests__/github-entity-follow.test.ts
@@ -456,6 +456,53 @@ describe("github-entity-follow", () => {
     });
   });
 
+  it("allows commit payloads without a commit object and falls back to a null title", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const fullSha = "3f2a91c0aaaabbbbccccddddeeeeffff00001111";
+    const fetcher = makeFetcher({
+      "/repos/Acme/Api/commits/3f2a91c0": () =>
+        json({
+          sha: fullSha,
+          html_url: `https://github.com/Acme/Api/commit/${fullSha}`,
+          commit: null,
+        }),
+      "/repos/acme/api": () => json({ full_name: "Acme/Api" }),
+    });
+
+    const result = await declareEntityFollow(
+      app.db,
+      deps(fetcher),
+      followParams(s, "https://github.com/acme/api/commit/3F2A91C0"),
+    );
+
+    expect(result.outcome).toBe("created");
+    if (result.outcome !== "created") throw new Error("unreachable");
+    expect(result.entity.title).toBeNull();
+  });
+
+  it("falls back to a null live state when GitHub returns an unexpected PR state", async () => {
+    const app = getApp();
+    const s = await setup(app);
+    const fetcher = prFetcher({
+      "/repos/acme/api/pulls/42": () =>
+        json({
+          number: 42,
+          state: "queued",
+          title: "Odd state",
+          html_url: "https://github.com/Acme/Api/pull/42",
+          merged: false,
+          draft: false,
+        }),
+    });
+
+    const result = await declareEntityFollow(app.db, deps(fetcher), followParams(s, "acme/api#42"));
+
+    expect(result.outcome).toBe("created");
+    if (result.outcome !== "created") throw new Error("unreachable");
+    expect(result.entity.state).toBeNull();
+  });
+
   it("an issue without a pull_request block resolves to entityType issue", async () => {
     const app = getApp();
     const s = await setup(app);

--- a/packages/server/src/__tests__/github-entity-live.test.ts
+++ b/packages/server/src/__tests__/github-entity-live.test.ts
@@ -74,9 +74,9 @@ describe("github entity live helpers", () => {
     expect(__testing.buildHtmlUrl("commit", { kind: "sha", owner: "o", repo: "r", sha: "abcdef1" })).toBe(
       "https://github.com/o/r/commit/abcdef1",
     );
-    expect(
-      __testing.buildHtmlUrl("commit", { kind: "numeric", owner: "o", repo: "r", number: 4 } as never),
-    ).toBe("https://github.com/o/r");
+    expect(__testing.buildHtmlUrl("commit", { kind: "numeric", owner: "o", repo: "r", number: 4 } as never)).toBe(
+      "https://github.com/o/r",
+    );
   });
 });
 

--- a/packages/server/src/__tests__/github-entity-live.test.ts
+++ b/packages/server/src/__tests__/github-entity-live.test.ts
@@ -37,6 +37,30 @@ describe("github entity live helpers", () => {
     expect(__testing.parseEntityKey("pull_request", "owner/repo#not-a-number")).toBeNull();
   });
 
+  it("keeps defensive parser guards for malformed regex captures", () => {
+    const originalExec = RegExp.prototype.exec;
+    try {
+      RegExp.prototype.exec = function exec(this: RegExp, input: string): RegExpExecArray | null {
+        if (input === "owner/repo@abcdef1") {
+          return ["owner/repo@abcdef1", "owner", "repo", undefined] as unknown as RegExpExecArray;
+        }
+        if (input === "owner/repo#discussion-9") {
+          return ["owner/repo#discussion-9", "owner", undefined, "9"] as unknown as RegExpExecArray;
+        }
+        if (input === "owner/repo#42") {
+          return ["owner/repo#42", undefined, "repo", "42"] as unknown as RegExpExecArray;
+        }
+        return originalExec.call(this, input);
+      };
+
+      expect(__testing.parseEntityKey("commit", "owner/repo@abcdef1")).toBeNull();
+      expect(__testing.parseEntityKey("discussion", "owner/repo#discussion-9")).toBeNull();
+      expect(__testing.parseEntityKey("issue", "owner/repo#42")).toBeNull();
+    } finally {
+      RegExp.prototype.exec = originalExec;
+    }
+  });
+
   it("builds canonical GitHub URLs", () => {
     expect(__testing.buildHtmlUrl("pull_request", { kind: "numeric", owner: "o", repo: "r", number: 1 })).toBe(
       "https://github.com/o/r/pull/1",
@@ -50,6 +74,9 @@ describe("github entity live helpers", () => {
     expect(__testing.buildHtmlUrl("commit", { kind: "sha", owner: "o", repo: "r", sha: "abcdef1" })).toBe(
       "https://github.com/o/r/commit/abcdef1",
     );
+    expect(
+      __testing.buildHtmlUrl("commit", { kind: "numeric", owner: "o", repo: "r", number: 4 } as never),
+    ).toBe("https://github.com/o/r");
   });
 });
 
@@ -83,6 +110,36 @@ describe("fetchEntityLiveFields", () => {
     );
   });
 
+  it("handles pull request non-ok responses and fallback live fields", async () => {
+    const parsed = { kind: "numeric" as const, owner: "owner", repo: "repo", number: 42 };
+    await expect(
+      __testing.fetchEntityLiveFields(
+        "pull_request",
+        parsed,
+        "token",
+        vi.fn<typeof fetch>().mockResolvedValueOnce(new Response("nope", { status: 404 })),
+      ),
+    ).resolves.toEqual({ title: null, state: null });
+
+    await expect(
+      __testing.fetchEntityLiveFields(
+        "pull_request",
+        parsed,
+        "token",
+        vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ state: "queued" })),
+      ),
+    ).resolves.toEqual({ title: null, state: null });
+
+    await expect(
+      __testing.fetchEntityLiveFields(
+        "pull_request",
+        parsed,
+        "token",
+        vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ state: "closed", title: "" })),
+      ),
+    ).resolves.toEqual({ title: "", state: "closed" });
+  });
+
   it("fetches issue state and commit title", async () => {
     const issueFetcher = vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ title: "Bug", state: "closed" }));
     await expect(
@@ -105,6 +162,35 @@ describe("fetchEntityLiveFields", () => {
         commitFetcher,
       ),
     ).resolves.toEqual({ title: "Fix startup", state: null });
+  });
+
+  it("normalizes issue and commit live field fallbacks", async () => {
+    await expect(
+      __testing.fetchEntityLiveFields(
+        "issue",
+        { kind: "numeric", owner: "owner", repo: "repo", number: 9 },
+        "token",
+        vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ state: "triaged" })),
+      ),
+    ).resolves.toEqual({ title: null, state: null });
+
+    await expect(
+      __testing.fetchEntityLiveFields(
+        "commit",
+        { kind: "sha", owner: "owner", repo: "repo", sha: "abcdef1" },
+        "token",
+        vi.fn<typeof fetch>().mockResolvedValueOnce(new Response("nope", { status: 500 })),
+      ),
+    ).resolves.toEqual({ title: null, state: null });
+
+    await expect(
+      __testing.fetchEntityLiveFields(
+        "commit",
+        { kind: "sha", owner: "owner", repo: "repo", sha: "abcdef1" },
+        "token",
+        vi.fn<typeof fetch>().mockResolvedValueOnce(jsonResponse({ commit: {} })),
+      ),
+    ).resolves.toEqual({ title: null, state: null });
   });
 
   it("returns empty live fields when fetch fails or entity type has no live endpoint", async () => {
@@ -170,6 +256,13 @@ describe("resolveChatGithubEntity", () => {
       state: null,
       number: 13,
     });
+    expect(__testing.stateFromPersistedEntityState("pull_request", "open")).toBe("open");
+    expect(__testing.stateFromPersistedEntityState("pull_request", "closed")).toBe("closed");
+    expect(__testing.stateFromPersistedEntityState("pull_request", "merged")).toBe("merged");
+    expect(__testing.stateFromPersistedEntityState("pull_request", "unknown")).toBeNull();
+    expect(__testing.stateFromPersistedEntityState("issue", "open")).toBe("open");
+    expect(__testing.stateFromPersistedEntityState("issue", "queued")).toBeNull();
+    expect(__testing.stateFromPersistedEntityState("commit", "open")).toBeNull();
   });
 
   it("materializes wire entities with optional live fields", async () => {
@@ -211,6 +304,37 @@ describe("resolveChatGithubEntity", () => {
       number: null,
     });
     expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("keeps persisted rows when live resolution cannot reparse the original key", async () => {
+    const originalExec = RegExp.prototype.exec;
+    const fetcher = vi.fn<typeof fetch>();
+    let numericExecCount = 0;
+    try {
+      RegExp.prototype.exec = function exec(this: RegExp, input: string): RegExpExecArray | null {
+        if (input === "owner/repo#12") {
+          numericExecCount += 1;
+          if (numericExecCount > 1) {
+            return ["owner/repo#12", undefined, "repo", "12"] as unknown as RegExpExecArray;
+          }
+        }
+        return originalExec.call(this, input);
+      };
+
+      await expect(
+        resolveChatGithubEntity(
+          { entityType: "issue", entityKey: "owner/repo#12", boundVia: "direct", title: "Persisted" },
+          "token",
+          fetcher,
+        ),
+      ).resolves.toMatchObject({
+        title: "Persisted",
+        state: null,
+      });
+      expect(fetcher).not.toHaveBeenCalled();
+    } finally {
+      RegExp.prototype.exec = originalExec;
+    }
   });
 
   it("materializes legacy discussion rows as canonical numeric keys", async () => {

--- a/packages/server/src/__tests__/github-normalize.test.ts
+++ b/packages/server/src/__tests__/github-normalize.test.ts
@@ -124,6 +124,33 @@ describe("normalizeGithubEvent — pull_request", () => {
     ).toBeNull();
   });
 
+  it("edited: kind=edited with mentions and fallback surface fields", () => {
+    const event = normalize("pull_request", {
+      action: "edited",
+      sender: senderUser,
+      repository,
+      pull_request: {
+        number: 11,
+        body: "Updated notes for @Bob and @bob.",
+      },
+    });
+
+    expect(event?.kind).toBe("edited");
+    expect(event?.entity).toEqual({
+      type: "pull_request",
+      repo: "owner/repo",
+      key: "owner/repo#11",
+      title: undefined,
+      url: undefined,
+    });
+    expect(event?.surface).toEqual({
+      title: "PR #11",
+      body: "Updated notes for @Bob and @bob.",
+      url: "",
+    });
+    expect(event?.involves).toEqual([{ githubLogin: "bob", reason: "mentioned" }]);
+  });
+
   it("ready_for_review → kind=review_requested with all current reviewers as involves", () => {
     const event = normalize("pull_request", {
       action: "ready_for_review",
@@ -256,6 +283,59 @@ describe("normalizeGithubEvent — pull_request_review / review_comment", () => 
     expect(event?.entity.type).toBe("pull_request");
   });
 
+  it("review.dismissed and edited are normalized as reviewed", () => {
+    for (const action of ["dismissed", "edited"]) {
+      const event = normalize("pull_request_review", {
+        action,
+        sender: senderUser,
+        repository,
+        pull_request: { number: 10 },
+        review: { body: "", html_url: "" },
+      });
+
+      expect(event?.kind).toBe("reviewed");
+      expect(event?.surface.title).toBe("PR #10");
+      expect(event?.surface.url).toBe("");
+    }
+  });
+
+  it("drops malformed pull_request_review payloads", () => {
+    expect(
+      normalize("pull_request_review", {
+        action: "submitted",
+        sender: senderUser,
+        repository,
+        review: { body: "missing pr" },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("pull_request_review", {
+        action: "submitted",
+        sender: senderUser,
+        repository,
+        pull_request: { number: 10 },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("pull_request_review", {
+        action: "submitted",
+        sender: senderUser,
+        repository,
+        pull_request: { number: "10" },
+        review: { body: "bad number" },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("pull_request_review", {
+        action: "commented",
+        sender: senderUser,
+        repository,
+        pull_request: { number: 10 },
+        review: { body: "unsupported action" },
+      }),
+    ).toBeNull();
+  });
+
   it("pull_request_review_comment.created → kind=review_comment", () => {
     const event = normalize("pull_request_review_comment", {
       action: "created",
@@ -265,6 +345,61 @@ describe("normalizeGithubEvent — pull_request_review / review_comment", () => 
       comment: { body: "nit", html_url: "https://github.com/owner/repo/pull/10#discussion_r1" },
     });
     expect(event?.kind).toBe("review_comment");
+  });
+
+  it("pull_request_review_comment.edited uses fallback surface fields", () => {
+    const event = normalize("pull_request_review_comment", {
+      action: "edited",
+      sender: senderUser,
+      repository,
+      pull_request: { number: 10 },
+      comment: { body: "follow-up @Erin" },
+    });
+
+    expect(event?.kind).toBe("review_comment");
+    expect(event?.surface).toEqual({
+      title: "PR #10",
+      body: "follow-up @Erin",
+      url: "",
+    });
+    expect(event?.involves).toEqual([{ githubLogin: "erin", reason: "mentioned" }]);
+  });
+
+  it("drops malformed pull_request_review_comment payloads", () => {
+    expect(
+      normalize("pull_request_review_comment", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        comment: { body: "missing pr" },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("pull_request_review_comment", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        pull_request: { number: 10 },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("pull_request_review_comment", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        pull_request: { number: Number.NaN },
+        comment: { body: "bad number" },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("pull_request_review_comment", {
+        action: "deleted",
+        sender: senderUser,
+        repository,
+        pull_request: { number: 10 },
+        comment: { body: "unsupported action" },
+      }),
+    ).toBeNull();
   });
 });
 
@@ -305,6 +440,61 @@ describe("normalizeGithubEvent — issue_comment (Bug 3 core fix)", () => {
     expect(event?.entity.type).toBe("issue");
     expect(event?.surface.title).toBe("Issue #42: Bug X");
   });
+
+  it("issue_comment.edited uses fallback issue title and URL", () => {
+    const event = normalize("issue_comment", {
+      action: "edited",
+      sender: senderUser,
+      repository,
+      issue: { number: 43 },
+      comment: { body: "updated @Carol" },
+    });
+
+    expect(event?.kind).toBe("commented");
+    expect(event?.surface).toEqual({
+      title: "Issue #43",
+      body: "updated @Carol",
+      url: "",
+    });
+    expect(event?.involves).toEqual([{ githubLogin: "carol", reason: "mentioned" }]);
+  });
+
+  it("drops malformed issue_comment payloads", () => {
+    expect(
+      normalize("issue_comment", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        comment: { body: "missing issue" },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("issue_comment", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        issue: { number: 42 },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("issue_comment", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        issue: { number: null },
+        comment: { body: "bad issue number" },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("issue_comment", {
+        action: "deleted",
+        sender: senderUser,
+        repository,
+        issue: { number: 42 },
+        comment: { body: "unsupported action" },
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("normalizeGithubEvent — issues", () => {
@@ -340,6 +530,40 @@ describe("normalizeGithubEvent — issues", () => {
     expect(event?.involves).toEqual([{ githubLogin: "dave", reason: "assigned" }]);
   });
 
+  it("edited, closed, and reopened normalize issue state changes", () => {
+    const edited = normalize("issues", {
+      action: "edited",
+      sender: senderUser,
+      repository,
+      issue: {
+        number: 42,
+        html_url: "https://github.com/owner/repo/issues/42",
+        body: "new details @Bob",
+      },
+    });
+    expect(edited?.kind).toBe("edited");
+    expect(edited?.surface.title).toBe("Issue #42");
+    expect(edited?.involves).toEqual([{ githubLogin: "bob", reason: "mentioned" }]);
+
+    const closed = normalize("issues", {
+      action: "closed",
+      sender: senderUser,
+      repository,
+      issue: { number: 42, title: "Bug X", html_url: "https://github.com/owner/repo/issues/42" },
+    });
+    expect(closed?.kind).toBe("closed");
+    expect(closed?.involves).toEqual([]);
+
+    const reopened = normalize("issues", {
+      action: "reopened",
+      sender: senderUser,
+      repository,
+      issue: { number: 42, title: "Bug X", html_url: "https://github.com/owner/repo/issues/42" },
+    });
+    expect(reopened?.kind).toBe("reopened");
+    expect(reopened?.involves).toEqual([]);
+  });
+
   it("assigned with no assignee.login → null", () => {
     expect(
       normalize("issues", {
@@ -353,6 +577,18 @@ describe("normalizeGithubEvent — issues", () => {
 
   it("labeled → null", () => {
     expect(normalize("issues", { action: "labeled", sender: senderUser, repository, issue: { number: 1 } })).toBeNull();
+  });
+
+  it("drops malformed issues payloads", () => {
+    expect(normalize("issues", { action: "opened", sender: senderUser, repository })).toBeNull();
+    expect(
+      normalize("issues", {
+        action: "opened",
+        sender: senderUser,
+        repository,
+        issue: { number: "42", title: "Bad number" },
+      }),
+    ).toBeNull();
   });
 });
 
@@ -375,6 +611,65 @@ describe("normalizeGithubEvent — discussion / discussion_comment / commit_comm
     expect(event?.involves).toEqual([{ githubLogin: "bob", reason: "mentioned" }]);
   });
 
+  it("discussion state changes normalize to edited, closed, reopened, or other", () => {
+    const edited = normalize("discussion", {
+      action: "edited",
+      sender: senderUser,
+      repository,
+      discussion: { number: 9, body: "updated @Carol" },
+    });
+    expect(edited?.kind).toBe("edited");
+    expect(edited?.surface.title).toBe("Discussion #9");
+    expect(edited?.involves).toEqual([{ githubLogin: "carol", reason: "mentioned" }]);
+
+    const closed = normalize("discussion", {
+      action: "closed",
+      sender: senderUser,
+      repository,
+      discussion: { number: 9, title: "RFC" },
+    });
+    expect(closed?.kind).toBe("closed");
+
+    const reopened = normalize("discussion", {
+      action: "reopened",
+      sender: senderUser,
+      repository,
+      discussion: { number: 9, title: "RFC" },
+    });
+    expect(reopened?.kind).toBe("reopened");
+
+    for (const action of ["answered", "unanswered"]) {
+      const event = normalize("discussion", {
+        action,
+        sender: senderUser,
+        repository,
+        discussion: { number: 9, title: "RFC", html_url: "https://github.com/owner/repo/discussions/9" },
+      });
+      expect(event?.kind).toBe("other");
+      expect(event?.involves).toEqual([]);
+    }
+  });
+
+  it("drops malformed discussion payloads", () => {
+    expect(normalize("discussion", { action: "created", sender: senderUser, repository })).toBeNull();
+    expect(
+      normalize("discussion", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        discussion: { number: "9", title: "Bad number" },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("discussion", {
+        action: "pinned",
+        sender: senderUser,
+        repository,
+        discussion: { number: 9 },
+      }),
+    ).toBeNull();
+  });
+
   it("discussion_comment.created → kind=commented", () => {
     const event = normalize("discussion_comment", {
       action: "created",
@@ -385,6 +680,61 @@ describe("normalizeGithubEvent — discussion / discussion_comment / commit_comm
     });
     expect(event?.entity).toMatchObject({ type: "discussion", key: "owner/repo#9" });
     expect(event?.kind).toBe("commented");
+  });
+
+  it("discussion_comment.edited uses fallback URL and title", () => {
+    const event = normalize("discussion_comment", {
+      action: "edited",
+      sender: senderUser,
+      repository,
+      discussion: { number: 9 },
+      comment: { body: "edit @Dave" },
+    });
+
+    expect(event?.kind).toBe("commented");
+    expect(event?.surface).toEqual({
+      title: "Discussion #9",
+      body: "edit @Dave",
+      url: "",
+    });
+    expect(event?.involves).toEqual([{ githubLogin: "dave", reason: "mentioned" }]);
+  });
+
+  it("drops malformed discussion_comment payloads", () => {
+    expect(
+      normalize("discussion_comment", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        comment: { body: "missing discussion" },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("discussion_comment", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        discussion: { number: 9 },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("discussion_comment", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        discussion: { number: Number.POSITIVE_INFINITY },
+        comment: { body: "bad number" },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("discussion_comment", {
+        action: "deleted",
+        sender: senderUser,
+        repository,
+        discussion: { number: 9 },
+        comment: { body: "unsupported action" },
+      }),
+    ).toBeNull();
   });
 
   it("commit_comment.created → entity is commit keyed on sha", () => {
@@ -405,6 +755,46 @@ describe("normalizeGithubEvent — discussion / discussion_comment / commit_comm
       url: "https://github.com/owner/repo/commit/abc1234#comment-1",
     });
     expect(event?.kind).toBe("commit_commented");
+  });
+
+  it("commit_comment carries mentions and falls back when optional fields are empty", () => {
+    const event = normalize("commit_comment", {
+      action: "created",
+      sender: senderUser,
+      repository,
+      comment: {
+        body: "please inspect @Erin",
+        commit_id: "def5678",
+        html_url: "",
+      },
+    });
+
+    expect(event?.surface).toEqual({
+      title: "Commit",
+      body: "please inspect @Erin",
+      url: "",
+    });
+    expect(event?.involves).toEqual([{ githubLogin: "erin", reason: "mentioned" }]);
+  });
+
+  it("drops malformed commit_comment payloads", () => {
+    expect(normalize("commit_comment", { action: "created", sender: senderUser, repository })).toBeNull();
+    expect(
+      normalize("commit_comment", {
+        action: "created",
+        sender: senderUser,
+        repository,
+        comment: { body: "missing sha" },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("commit_comment", {
+        action: "edited",
+        sender: senderUser,
+        repository,
+        comment: { commit_id: "abc1234" },
+      }),
+    ).toBeNull();
   });
 });
 
@@ -433,6 +823,53 @@ describe("normalizeGithubEvent — out-of-scope event types & malformed payloads
         action: "opened",
         repository,
         pull_request: { number: 1, title: "x", html_url: "u", body: "" },
+      }),
+    ).toBeNull();
+  });
+
+  it("non-object, invalid sender, and invalid repository payloads return null", () => {
+    expect(normalize("issues", null)).toBeNull();
+    expect(normalize("issues", [])).toBeNull();
+    expect(
+      normalize("issues", {
+        action: "opened",
+        sender: { login: "" },
+        repository,
+        issue: { number: 1 },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("issues", {
+        action: "opened",
+        sender: "alice",
+        repository,
+        issue: { number: 1 },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("issues", {
+        action: "opened",
+        sender: senderUser,
+        repository: { full_name: "" },
+        issue: { number: 1 },
+      }),
+    ).toBeNull();
+    expect(
+      normalize("issues", {
+        action: "opened",
+        sender: senderUser,
+        repository: "owner/repo",
+        issue: { number: 1 },
+      }),
+    ).toBeNull();
+  });
+
+  it("handles missing action as an unsupported action", () => {
+    expect(
+      normalize("pull_request", {
+        sender: senderUser,
+        repository,
+        pull_request: { number: 10 },
       }),
     ).toBeNull();
   });

--- a/packages/server/src/__tests__/github-oauth-extra.test.ts
+++ b/packages/server/src/__tests__/github-oauth-extra.test.ts
@@ -10,6 +10,23 @@ function jsonResponse(status: number, body: unknown): Response {
 }
 
 describe("github-oauth helpers", () => {
+  it("normalizes an overridden GitHub API base URL at module load", async () => {
+    const previous = process.env.FIRST_TREE_GITHUB_API_BASE_URL;
+    try {
+      process.env.FIRST_TREE_GITHUB_API_BASE_URL = "https://github-api.example///";
+      vi.resetModules();
+      const module = await import("../services/github-api-base.js");
+      expect(module.GITHUB_API_BASE).toBe("https://github-api.example");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.FIRST_TREE_GITHUB_API_BASE_URL;
+      } else {
+        process.env.FIRST_TREE_GITHUB_API_BASE_URL = previous;
+      }
+      vi.resetModules();
+    }
+  });
+
   it("lists user repos across pages and normalizes nullable fields", async () => {
     const fetcher = vi
       .fn()

--- a/packages/server/src/__tests__/github-oauth-extra.test.ts
+++ b/packages/server/src/__tests__/github-oauth-extra.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+import { GITHUB_API_BASE } from "../services/github-api-base.js";
+import { createRepoFile, createUserRepo, GithubApiError, listUserRepos } from "../services/github-oauth.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+describe("github-oauth helpers", () => {
+  it("lists user repos across pages and normalizes nullable fields", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, [
+          {
+            clone_url: "https://github.com/acme/one.git",
+            default_branch: "main",
+            full_name: "acme/one",
+            html_url: "https://github.com/acme/one",
+            private: true,
+            pushed_at: "2026-07-08T00:00:00Z",
+          },
+          {
+            clone_url: "https://github.com/acme/two.git",
+            full_name: "acme/two",
+            html_url: "https://github.com/acme/two",
+            private: false,
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, [
+          {
+            clone_url: "https://github.com/acme/three.git",
+            default_branch: null,
+            full_name: "acme/three",
+            html_url: "https://github.com/acme/three",
+            private: false,
+            pushed_at: null,
+          },
+        ]),
+      );
+
+    const rows = await listUserRepos("token_1", { fetcher: fetcher as never, perPage: 2, maxPages: 3 });
+
+    expect(rows).toEqual([
+      {
+        cloneUrl: "https://github.com/acme/one.git",
+        defaultBranch: "main",
+        fullName: "acme/one",
+        htmlUrl: "https://github.com/acme/one",
+        private: true,
+        pushedAt: "2026-07-08T00:00:00Z",
+      },
+      {
+        cloneUrl: "https://github.com/acme/two.git",
+        defaultBranch: null,
+        fullName: "acme/two",
+        htmlUrl: "https://github.com/acme/two",
+        private: false,
+        pushedAt: null,
+      },
+      {
+        cloneUrl: "https://github.com/acme/three.git",
+        defaultBranch: null,
+        fullName: "acme/three",
+        htmlUrl: "https://github.com/acme/three",
+        private: false,
+        pushedAt: null,
+      },
+    ]);
+    expect(fetcher.mock.calls[0]?.[0]).toContain("per_page=2&page=1");
+    expect(fetcher.mock.calls[1]?.[0]).toContain("per_page=2&page=2");
+    expect(fetcher.mock.calls[0]?.[1]).toMatchObject({
+      headers: { Accept: "application/vnd.github+json", Authorization: "Bearer token_1" },
+    });
+  });
+
+  it("throws GithubApiError for failed repo listing", async () => {
+    const fetcher = vi.fn().mockResolvedValue(jsonResponse(403, { message: "forbidden" }));
+
+    await expect(listUserRepos("token_1", { fetcher: fetcher as never })).rejects.toMatchObject({
+      message: "GitHub repo list failed (403)",
+      name: "GithubApiError",
+      status: 403,
+    });
+  });
+
+  it("creates user repos and validates GitHub response shape", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      jsonResponse(201, {
+        clone_url: "https://github.com/acme/new.git",
+        default_branch: "main",
+        full_name: "acme/new",
+        html_url: "https://github.com/acme/new",
+        name: "new",
+        owner: { login: "acme" },
+        private: true,
+      }),
+    );
+
+    await expect(
+      createUserRepo(
+        "token_1",
+        { description: "Test repo", name: "new", private: true },
+        { fetcher: fetcher as never },
+      ),
+    ).resolves.toEqual({
+      cloneUrl: "https://github.com/acme/new.git",
+      defaultBranch: "main",
+      fullName: "acme/new",
+      htmlUrl: "https://github.com/acme/new",
+      name: "new",
+      ownerLogin: "acme",
+      private: true,
+    });
+    expect(fetcher).toHaveBeenCalledWith(
+      `${GITHUB_API_BASE}/user/repos`,
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    expect(JSON.parse((fetcher.mock.calls[0]?.[1] as { body: string }).body)).toEqual({
+      auto_init: false,
+      description: "Test repo",
+      name: "new",
+      private: true,
+    });
+
+    const invalidFetcher = vi.fn().mockResolvedValue(jsonResponse(201, { name: "new" }));
+    await expect(
+      createUserRepo("token_1", { name: "new", private: false }, { fetcher: invalidFetcher as never }),
+    ).rejects.toMatchObject({ status: 502 });
+  });
+
+  it("creates repo files with encoded paths and maps upstream failures", async () => {
+    const fetcher = vi.fn().mockResolvedValue(jsonResponse(201, { content: {} }));
+
+    await createRepoFile(
+      "token_1",
+      {
+        branch: "main",
+        contentBase64: "SGk=",
+        message: "Add doc",
+        owner: "acme",
+        path: "/docs/Hello World.md",
+        repo: "web app",
+      },
+      { fetcher: fetcher as never },
+    );
+
+    expect(fetcher.mock.calls[0]?.[0]).toBe(`${GITHUB_API_BASE}/repos/acme/web%20app/contents/docs/Hello%20World.md`);
+    expect(fetcher.mock.calls[0]?.[1]).toMatchObject({
+      method: "PUT",
+    });
+    expect(JSON.parse((fetcher.mock.calls[0]?.[1] as { body: string }).body)).toEqual({
+      branch: "main",
+      content: "SGk=",
+      message: "Add doc",
+    });
+
+    const failingFetcher = vi.fn().mockResolvedValue(jsonResponse(500, { message: "upstream" }));
+    await expect(
+      createRepoFile(
+        "token_1",
+        { branch: "main", contentBase64: "SGk=", message: "Add doc", owner: "acme", path: "README.md", repo: "web" },
+        { fetcher: failingFetcher as never },
+      ),
+    ).rejects.toBeInstanceOf(GithubApiError);
+  });
+});

--- a/packages/server/src/__tests__/github-user-token-extra.test.ts
+++ b/packages/server/src/__tests__/github-user-token-extra.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { encryptValue } from "../services/crypto.js";
+
+class MockGithubAppApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message = "GitHub App API failed",
+  ) {
+    super(message);
+    this.name = "GithubAppApiError";
+  }
+}
+
+const refreshMock = vi.fn();
+
+function mockGithubApp(): void {
+  vi.doMock("../services/github-app.js", () => ({
+    GithubAppApiError: MockGithubAppApiError,
+    refreshAppUserToken: refreshMock,
+  }));
+}
+
+function makeDb(identity: unknown): { db: unknown; updated: { metadata?: unknown } } {
+  const updated: { metadata?: unknown } = {};
+  const selectChain = {
+    from: vi.fn(() => selectChain),
+    limit: vi.fn(async () => (identity ? [identity] : [])),
+    where: vi.fn(() => selectChain),
+  };
+  const updateChain = {
+    set: vi.fn((value: { metadata?: unknown }) => {
+      updated.metadata = value.metadata;
+      return updateChain;
+    }),
+    where: vi.fn(async () => undefined),
+  };
+  return {
+    db: {
+      select: vi.fn(() => selectChain),
+      update: vi.fn(() => updateChain),
+    },
+    updated,
+  };
+}
+
+const key = "a".repeat(64);
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mockGithubApp();
+});
+
+afterEach(() => {
+  vi.doUnmock("../services/github-app.js");
+  vi.resetModules();
+});
+
+describe("getFreshGithubUserToken", () => {
+  it("returns a decrypted stored token when it is still fresh", async () => {
+    const { getFreshGithubUserToken } = await import("../services/github-user-token.js");
+    const { db } = makeDb({
+      identifier: "123",
+      metadata: {
+        accessToken: encryptValue("access_1", key),
+        accessTokenExpiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+        login: "octo",
+        refreshToken: encryptValue("refresh_1", key),
+      },
+    });
+
+    await expect(
+      getFreshGithubUserToken(db as never, "user_1", key, { clientId: "id", clientSecret: "secret" }),
+    ).resolves.toEqual({
+      accessToken: "access_1",
+      githubId: "123",
+      login: "octo",
+    });
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes expiring App user tokens and stores encrypted replacements", async () => {
+    const { getFreshGithubUserToken } = await import("../services/github-user-token.js");
+    refreshMock.mockResolvedValue({
+      accessToken: "access_2",
+      accessTokenExpiresAt: "2026-07-08T12:00:00.000Z",
+      refreshToken: "refresh_2",
+      refreshTokenExpiresAt: "2026-08-08T12:00:00.000Z",
+    });
+    const { db, updated } = makeDb({
+      identifier: "123",
+      metadata: {
+        accessToken: encryptValue("access_1", key),
+        accessTokenExpiresAt: new Date(Date.now() - 1_000).toISOString(),
+        login: "octo",
+        refreshToken: encryptValue("refresh_1", key),
+      },
+    });
+
+    await expect(
+      getFreshGithubUserToken(db as never, "user_1", key, { clientId: "id", clientSecret: "secret" }),
+    ).resolves.toEqual({
+      accessToken: "access_2",
+      githubId: "123",
+      login: "octo",
+    });
+    expect(refreshMock).toHaveBeenCalledWith("id", "secret", "refresh_1");
+    expect(updated.metadata).toMatchObject({
+      accessTokenExpiresAt: "2026-07-08T12:00:00.000Z",
+      refreshTokenExpiresAt: "2026-08-08T12:00:00.000Z",
+    });
+  });
+
+  it("fails closed for missing or undecodable GitHub credentials", async () => {
+    const { getFreshGithubUserToken } = await import("../services/github-user-token.js");
+
+    await expect(
+      getFreshGithubUserToken(makeDb(undefined).db as never, "user_1", key, undefined),
+    ).rejects.toMatchObject({
+      statusCode: 503,
+    });
+    await expect(
+      getFreshGithubUserToken(
+        makeDb({ identifier: "123", metadata: { accessToken: "enc:v1:not-valid", login: "octo" } }).db as never,
+        "user_1",
+        key,
+        undefined,
+      ),
+    ).rejects.toMatchObject({ statusCode: 503 });
+  });
+
+  it("maps refresh failures to reconnectable user-token errors", async () => {
+    const { getFreshGithubUserToken } = await import("../services/github-user-token.js");
+    const identity = {
+      identifier: "123",
+      metadata: {
+        accessToken: encryptValue("access_1", key),
+        accessTokenExpiresAt: new Date(Date.now() - 1_000).toISOString(),
+        login: "octo",
+        refreshToken: encryptValue("refresh_1", key),
+      },
+    };
+
+    refreshMock.mockRejectedValueOnce(new MockGithubAppApiError(401));
+    await expect(
+      getFreshGithubUserToken(makeDb(identity).db as never, "user_1", key, { clientId: "id", clientSecret: "secret" }),
+    ).rejects.toMatchObject({ code: "refresh_failed", statusCode: 403 });
+
+    refreshMock.mockRejectedValueOnce(new MockGithubAppApiError(500));
+    await expect(
+      getFreshGithubUserToken(makeDb(identity).db as never, "user_1", key, { clientId: "id", clientSecret: "secret" }),
+    ).rejects.toMatchObject({ statusCode: 503 });
+  });
+});

--- a/packages/server/src/__tests__/inbox-bind-recovery.test.ts
+++ b/packages/server/src/__tests__/inbox-bind-recovery.test.ts
@@ -324,4 +324,89 @@ describe("inbox same-socket chat recovery", () => {
     expect(secondDelivery.id).toBe(firstDelivery.id);
     expect(secondDelivery.message.precedingMessages.map((p) => p.content)).toEqual(firstPreceding);
   });
+
+  it("resets delivered rows across an inbox when no chat scope is supplied", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const a1 = await createTestAgent(app, { name: `recoverall-a1-${uid}` });
+    const a2 = await createTestAgent(app, { name: `recoverall-a2-${uid}` });
+
+    const chat1 = await a1.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [a2.agent.uuid],
+    });
+    const chat2 = await a1.request("POST", "/api/v1/agent/chats", {
+      type: "group",
+      participantIds: [a2.agent.uuid],
+    });
+    const msg1 = await a1.request("POST", `/api/v1/agent/chats/${chat1.json().id}/messages`, {
+      format: "text",
+      content: "recover all one",
+      receiverNames: [a2.agent.name],
+    });
+    const msg2 = await a1.request("POST", `/api/v1/agent/chats/${chat2.json().id}/messages`, {
+      format: "text",
+      content: "recover all two",
+      receiverNames: [a2.agent.name],
+    });
+
+    const first = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, msg1.json().id);
+    const second = await inboxService.claimAndBuildForPush(app.db, a2.agent.inboxId, msg2.json().id);
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+
+    const recovered = await inboxService.recoverUnackedForScope(app.db, { inboxId: a2.agent.inboxId });
+    expect(recovered.resetEntryIds.sort((a, b) => a - b)).toEqual(
+      [first[0]?.id, second[0]?.id].filter((id): id is number => typeof id === "number").sort((a, b) => a - b),
+    );
+  });
+
+  it("prunes acked silent rows and stale pending silent rows", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const human = await createTestAgent(app, { type: "human", name: `prunesilent-h-${uid}` });
+    const observer = await createTestAgent(app, { type: "agent", name: `prunesilent-a-${uid}` });
+    const chat = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [observer.agent.uuid],
+    });
+
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "acked silent" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(
+      app.db,
+      chat.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "stale pending silent" },
+      { allowRecipientlessSend: true },
+    );
+
+    const silentRows = await app.db
+      .select({ id: inboxEntries.id })
+      .from(inboxEntries)
+      .where(and(eq(inboxEntries.inboxId, observer.agent.inboxId), eq(inboxEntries.notify, false)));
+    expect(silentRows).toHaveLength(2);
+    const [acked, stale] = silentRows;
+    if (!acked || !stale) throw new Error("expected two silent rows");
+    await app.db.update(inboxEntries).set({ status: "acked" }).where(eq(inboxEntries.id, acked.id));
+    await app.db
+      .update(inboxEntries)
+      .set({ createdAt: new Date(Date.now() - 120_000) })
+      .where(eq(inboxEntries.id, stale.id));
+
+    await expect(inboxService.pruneStaleSilentEntries(app.db, 60)).resolves.toEqual({
+      ackedDeleted: 1,
+      stalePendingDeleted: 1,
+    });
+  });
+
+  it("assertInboxOwner rejects cross-inbox access", async () => {
+    await expect(inboxService.assertInboxOwner("inbox-a", "inbox-b")).rejects.toThrow(/another agent/i);
+    await expect(inboxService.assertInboxOwner("inbox-a", "inbox-a")).resolves.toBeUndefined();
+  });
 });

--- a/packages/server/src/__tests__/index-entry-extra.test.ts
+++ b/packages/server/src/__tests__/index-entry-extra.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const bootstrapMocks = {
+  startServer: vi.fn(),
+};
+
+const loggerMocks = {
+  fatal: vi.fn(),
+};
+
+const mockedModules = ["../bootstrap-server.js", "../observability/index.js"];
+let exitSpy: { mockRestore(): void } | undefined;
+
+function mockEntrypointDependencies(): void {
+  vi.doMock("../bootstrap-server.js", () => ({
+    startServer: bootstrapMocks.startServer,
+  }));
+  vi.doMock("../observability/index.js", () => ({
+    createLogger: vi.fn(() => loggerMocks),
+  }));
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mockEntrypointDependencies();
+});
+
+afterEach(() => {
+  exitSpy?.mockRestore();
+  exitSpy = undefined;
+  for (const moduleId of mockedModules) {
+    vi.doUnmock(moduleId);
+  }
+  vi.resetModules();
+});
+
+describe("server entrypoint", () => {
+  it("starts the server when the entry module loads", async () => {
+    bootstrapMocks.startServer.mockResolvedValueOnce(undefined);
+
+    await import("../index.js");
+
+    expect(bootstrapMocks.startServer).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.fatal).not.toHaveBeenCalled();
+  });
+
+  it("logs and exits when bootstrap rejects", async () => {
+    const err = new Error("boot failed");
+    bootstrapMocks.startServer.mockRejectedValueOnce(err);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    await import("../index.js");
+
+    await vi.waitFor(() => {
+      expect(loggerMocks.fatal).toHaveBeenCalledWith({ err }, "failed to start server");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/packages/server/src/__tests__/landing-campaign-chat-state.test.ts
+++ b/packages/server/src/__tests__/landing-campaign-chat-state.test.ts
@@ -1,0 +1,133 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { chats } from "../db/schema/chats.js";
+import { createAgent } from "../services/agent.js";
+import {
+  completeLandingCampaignTrialAgentTurn,
+  normalizeLandingCampaignTrialChatMetadataForRead,
+} from "../services/landing-campaigns/chat-state.js";
+import { buildLandingCampaignChatMetadata } from "../services/landing-campaigns/metadata.js";
+import { createMeChat } from "../services/me-chat.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+function trialMetadata(
+  agentId: string,
+  overrides: Partial<Parameters<typeof buildLandingCampaignChatMetadata>[0]> = {},
+) {
+  return buildLandingCampaignChatMetadata({
+    campaign: "production-scan",
+    agentId,
+    skillSetId: "production-scan",
+    skillSetVersion: "test",
+    repo: { url: "https://github.com/acme/api", canonicalKey: "github.com/acme/api" },
+    state: "running",
+    inputLocked: false,
+    maxAgentTurns: 2,
+    ...overrides,
+  });
+}
+
+describe("landing campaign chat state service edges", () => {
+  const getApp = useTestApp();
+
+  async function setupTrialChat(overrides: Partial<Parameters<typeof buildLandingCampaignChatMetadata>[0]> = {}) {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const agent = await createAgent(app.db, {
+      name: `lc-state-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Landing State Agent",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+    });
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [agent.uuid],
+    });
+    await app.db
+      .update(chats)
+      .set({ metadata: trialMetadata(agent.uuid, overrides) })
+      .where(eq(chats.id, chatId));
+    return { app, agent, chatId };
+  }
+
+  it("returns no-op results for missing, non-trial, and wrong-agent chats", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const agent = await createAgent(app.db, {
+      name: `lc-noop-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Landing Noop Agent",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+    });
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [agent.uuid],
+    });
+
+    await expect(
+      completeLandingCampaignTrialAgentTurn(app.db, crypto.randomUUID(), agent.uuid, "turn-missing"),
+    ).resolves.toMatchObject({ advanced: false, reachedLimit: false, limitReason: null, duplicate: false });
+    await expect(
+      completeLandingCampaignTrialAgentTurn(app.db, chatId, agent.uuid, "turn-plain"),
+    ).resolves.toMatchObject({ advanced: false, reachedLimit: false, limitReason: null, duplicate: false });
+
+    await app.db
+      .update(chats)
+      .set({ metadata: trialMetadata("other-agent") })
+      .where(eq(chats.id, chatId));
+    await expect(
+      completeLandingCampaignTrialAgentTurn(app.db, chatId, agent.uuid, "turn-wrong"),
+    ).resolves.toMatchObject({ advanced: false, reachedLimit: false, limitReason: null, duplicate: false });
+  });
+
+  it("classifies duplicate and already-completed turns without advancing metadata", async () => {
+    const duplicate = await setupTrialChat({
+      state: "completed",
+      inputLocked: true,
+      completedAgentTurns: 2,
+      completedAgentTurnIds: ["turn-2"],
+      limitReason: "turns",
+    });
+
+    await expect(
+      completeLandingCampaignTrialAgentTurn(duplicate.app.db, duplicate.chatId, duplicate.agent.uuid, "turn-2"),
+    ).resolves.toEqual({
+      advanced: false,
+      reachedTurnLimit: true,
+      reachedLimit: true,
+      limitReason: "turns",
+      duplicate: true,
+    });
+
+    const completed = await setupTrialChat({
+      state: "completed",
+      inputLocked: true,
+      completedAgentTurns: 1,
+      maxEstimatedTokens: 100,
+      estimatedTokensUsed: 100,
+      limitReason: "tokens",
+    });
+    await expect(
+      completeLandingCampaignTrialAgentTurn(completed.app.db, completed.chatId, completed.agent.uuid, "turn-new"),
+    ).resolves.toEqual({
+      advanced: false,
+      reachedTurnLimit: false,
+      reachedLimit: true,
+      limitReason: "tokens",
+      duplicate: false,
+    });
+  });
+
+  it("unlocks running trial metadata on read only when budget remains", () => {
+    const locked = trialMetadata("agent-1", { inputLocked: true, completedAgentTurns: 0, maxAgentTurns: 2 });
+
+    expect(normalizeLandingCampaignTrialChatMetadataForRead(locked)).toMatchObject({
+      landingCampaignTrial: { inputLocked: false, state: "running" },
+    });
+    expect(
+      normalizeLandingCampaignTrialChatMetadataForRead(
+        trialMetadata("agent-1", { inputLocked: true, completedAgentTurns: 2, maxAgentTurns: 2 }),
+      ),
+    ).toMatchObject({ landingCampaignTrial: { inputLocked: true } });
+  });
+});

--- a/packages/server/src/__tests__/landing-campaign-chat-state.test.ts
+++ b/packages/server/src/__tests__/landing-campaign-chat-state.test.ts
@@ -118,6 +118,25 @@ describe("landing campaign chat state service edges", () => {
     });
   });
 
+  it("classifies exhausted running trials without advancing metadata", async () => {
+    const exhausted = await setupTrialChat({
+      state: "running",
+      inputLocked: true,
+      completedAgentTurns: 2,
+      maxAgentTurns: 2,
+    });
+
+    await expect(
+      completeLandingCampaignTrialAgentTurn(exhausted.app.db, exhausted.chatId, exhausted.agent.uuid, "turn-new"),
+    ).resolves.toEqual({
+      advanced: false,
+      reachedTurnLimit: true,
+      reachedLimit: true,
+      limitReason: "turns",
+      duplicate: false,
+    });
+  });
+
   it("unlocks running trial metadata on read only when budget remains", () => {
     const locked = trialMetadata("agent-1", { inputLocked: true, completedAgentTurns: 0, maxAgentTurns: 2 });
 

--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -147,6 +147,20 @@ async function startCampaignInOrg(
   });
 }
 
+async function startCampaignWithoutOrganization(
+  app: ReturnType<ReturnType<typeof useTestApp>>,
+  admin: Awaited<ReturnType<typeof createTestAdmin>>,
+  campaign = "production-scan",
+  repoUrl = "https://github.com/acme/backend",
+) {
+  return app.inject({
+    method: "POST",
+    url: START_URL,
+    headers: { authorization: `Bearer ${admin.accessToken}` },
+    payload: { campaign, repoUrl },
+  });
+}
+
 async function createRunnableOrgAgent(
   app: ReturnType<ReturnType<typeof useTestApp>>,
   admin: Awaited<ReturnType<typeof createTestAdmin>>,
@@ -588,6 +602,24 @@ describe("POST /me/landing-campaigns/start", () => {
       campaign: "production-scan",
       landingCampaignTrial: true,
     });
+  });
+
+  it("uses the caller's default active membership when no organization is supplied", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+
+    const res = await startCampaignWithoutOrganization(app, admin);
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ agentUuid: string; repoCanonicalKey: string }>();
+    expect(body.repoCanonicalKey).toBe("github.com/acme/backend");
+    const [trialAgent] = await app.db
+      .select({ organizationId: agents.organizationId })
+      .from(agents)
+      .where(eq(agents.uuid, body.agentUuid))
+      .limit(1);
+    expect(trialAgent?.organizationId).toBe(admin.organizationId);
   });
 
   it("falls back from colliding service and trial agent names and repairs the service member", async () => {

--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -212,6 +212,9 @@ describe("POST /me/landing-campaigns/start", () => {
     landingCampaignServiceOrgId: SERVICE_ORG_ID,
     landingCampaignClientId: OFFICIAL_CLIENT_ID,
   });
+  const getUnconfiguredApp = useTestApp({
+    growthLandingPagesEnabled: true,
+  });
   const getClaudeProviderApp = useTestApp({
     growthLandingPagesEnabled: true,
     landingCampaignServiceUserId: SERVICE_USER_ID,
@@ -311,6 +314,28 @@ describe("POST /me/landing-campaigns/start", () => {
     expect(trialAgents).toHaveLength(0);
   });
 
+  it("requires the official runtime config before provisioning anything", async () => {
+    const app = getUnconfiguredApp();
+    const admin = await createTestAdmin(app);
+
+    const res = await startProductionScan(app, admin);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toMatchObject({
+      error: expect.stringContaining("official runtime is not configured"),
+    });
+    const trialAgents = await app.db
+      .select()
+      .from(agents)
+      .where(
+        and(
+          eq(agents.organizationId, admin.organizationId),
+          sql`${agents.metadata} ->> 'landingCampaignTrial' = 'true'`,
+        ),
+      );
+    expect(trialAgents).toHaveLength(0);
+  });
+
   it("fails closed for Claude Code until landing campaign workspace-only is implemented", async () => {
     const app = getClaudeProviderApp();
     const admin = await createTestAdmin(app);
@@ -336,6 +361,28 @@ describe("POST /me/landing-campaigns/start", () => {
         ),
       );
     expect(trialAgents).toHaveLength(0);
+  });
+
+  it("rejects unknown landing campaign runtime providers before provisioning", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const landingCampaigns = app.config.growth.landingCampaigns;
+    if (!landingCampaigns) throw new Error("landing campaign config missing");
+    const previousRuntimeProvider = landingCampaigns.runtimeProvider;
+
+    try {
+      const mutableConfig = landingCampaigns as unknown as { runtimeProvider: "unknown-runtime" };
+      mutableConfig.runtimeProvider = "unknown-runtime";
+
+      const res = await startProductionScan(app, admin);
+
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toMatchObject({
+        error: expect.stringContaining('runtime provider "unknown-runtime" is not supported'),
+      });
+    } finally {
+      landingCampaigns.runtimeProvider = previousRuntimeProvider;
+    }
   });
 
   it("rejects an official client registered outside the service org", async () => {
@@ -377,6 +424,41 @@ describe("POST /me/landing-campaigns/start", () => {
         ),
       );
     expect(trialAgents).toHaveLength(0);
+  });
+
+  it("rejects invalid or non-GitHub repository URLs before provisioning", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+
+    const invalid = await startProductionScan(app, admin, "https://github.com/");
+    const nonGithub = await startProductionScan(app, admin, "https://gitlab.com/acme/backend");
+
+    expect(invalid.statusCode).toBe(400);
+    expect(invalid.json()).toMatchObject({
+      error: expect.stringContaining("valid GitHub repository"),
+    });
+    expect(nonGithub.statusCode).toBe(400);
+    expect(nonGithub.json()).toMatchObject({
+      error: expect.stringContaining("require a GitHub owner/repo URL"),
+    });
+    const serviceMembers = await app.db
+      .select()
+      .from(members)
+      .where(and(eq(members.userId, SERVICE_USER_ID), eq(members.organizationId, admin.organizationId)));
+    expect(serviceMembers).toHaveLength(0);
+  });
+
+  it("returns 404 when the requested organization is not an active caller membership", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const res = await startProductionScanInOrg(app, admin, `org-missing-${crypto.randomUUID().slice(0, 8)}`);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toMatchObject({
+      error: expect.stringContaining("Active membership not found"),
+    });
   });
 
   it("creates the service-managed trial agent, binds only the trial prompt, and starts an unlocked capped chat", async () => {
@@ -506,6 +588,89 @@ describe("POST /me/landing-campaigns/start", () => {
       campaign: "production-scan",
       landingCampaignTrial: true,
     });
+  });
+
+  it("falls back from colliding service and trial agent names and repairs the service member", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+    await app.db.insert(agents).values([
+      {
+        uuid: uuidv7(),
+        name: "first-tree-campaigns",
+        organizationId: admin.organizationId,
+        type: "human",
+        displayName: "Reserved service name",
+        inboxId: `inbox_${uuidv7()}`,
+        source: "admin-api",
+        visibility: "private",
+        managerId: admin.memberId,
+      },
+      {
+        uuid: uuidv7(),
+        name: "first-tree-campaigns-service",
+        organizationId: admin.organizationId,
+        type: "human",
+        displayName: "Reserved service suffix",
+        inboxId: `inbox_${uuidv7()}`,
+        source: "admin-api",
+        visibility: "private",
+        managerId: admin.memberId,
+      },
+      {
+        uuid: uuidv7(),
+        name: "production-scanner",
+        organizationId: admin.organizationId,
+        type: "agent",
+        displayName: "Existing production scanner",
+        inboxId: `inbox_${uuidv7()}`,
+        source: "admin-api",
+        visibility: "organization",
+        managerId: admin.memberId,
+      },
+    ]);
+
+    const first = await startProductionScan(app, admin);
+    expect(first.statusCode).toBe(200);
+    const firstBody = first.json<{ agentUuid: string }>();
+    const [trialAgent] = await app.db.select().from(agents).where(eq(agents.uuid, firstBody.agentUuid)).limit(1);
+    expect(trialAgent?.name).toMatch(/^production-scanner-[0-9a-f]+$/);
+    const [serviceMember] = await app.db
+      .select()
+      .from(members)
+      .where(and(eq(members.userId, SERVICE_USER_ID), eq(members.organizationId, admin.organizationId)))
+      .limit(1);
+    expect(serviceMember?.status).toBe("active");
+    const [serviceAgent] = await app.db
+      .select()
+      .from(agents)
+      .where(eq(agents.uuid, serviceMember?.agentId ?? ""))
+      .limit(1);
+    expect(serviceAgent?.name).toMatch(/^first-tree-campaigns-[0-9a-f]+$/);
+
+    await app.db
+      .update(members)
+      .set({ status: "left", role: "admin" })
+      .where(eq(members.id, serviceMember?.id ?? ""));
+    const reactivated = await startProductionScan(app, admin, "https://github.com/acme/api");
+    expect(reactivated.statusCode).toBe(200);
+    const [afterReactivation] = await app.db
+      .select({ status: members.status, role: members.role })
+      .from(members)
+      .where(eq(members.id, serviceMember?.id ?? ""));
+    expect(afterReactivation).toEqual({ status: "active", role: "member" });
+
+    await app.db
+      .update(members)
+      .set({ role: "admin" })
+      .where(eq(members.id, serviceMember?.id ?? ""));
+    const roleRepaired = await startProductionScan(app, admin, "https://github.com/acme/frontend");
+    expect(roleRepaired.statusCode).toBe(200);
+    const [afterRoleRepair] = await app.db
+      .select({ role: members.role })
+      .from(members)
+      .where(eq(members.id, serviceMember?.id ?? ""));
+    expect(afterRoleRepair?.role).toBe("member");
   });
 
   it("purges the legacy server-materialized campaign skill from a reused trial agent", async () => {

--- a/packages/server/src/__tests__/me-chat-helpers.test.ts
+++ b/packages/server/src/__tests__/me-chat-helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { decodeCursor, encodeCursor, resolveChatTitle } from "../services/me-chat.js";
 
 describe("me-chat encodeCursor / decodeCursor", () => {
@@ -26,6 +26,17 @@ describe("me-chat encodeCursor / decodeCursor", () => {
     expect(decodeCursor(Buffer.from("ts|", "utf8").toString("base64url"))).toBeNull();
     // bad timestamp
     expect(decodeCursor(Buffer.from("not-a-date|chat", "utf8").toString("base64url"))).toBeNull();
+  });
+
+  it("returns null when base64 decoding throws", () => {
+    const spy = vi.spyOn(Buffer, "from").mockImplementationOnce(() => {
+      throw new Error("decode failed");
+    });
+    try {
+      expect(decodeCursor("bad-base64")).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -35,6 +35,7 @@ import {
   addMeChatParticipants,
   countUnreadMeChats,
   createMeChat,
+  getCallerEngagement,
   joinMeChat,
   leaveMeChat,
   listMeChats,
@@ -73,6 +74,17 @@ describe("chat-first workspace service layer", () => {
       participantIds: [peer.agent.uuid],
     });
     expect(a.chatId).not.toBe(b.chatId);
+  });
+
+  it("createMeChat rejects self-only participant lists", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    await expect(
+      createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+        participantIds: [admin.humanAgentUuid, admin.humanAgentUuid],
+      }),
+    ).rejects.toThrow(/non-self participant/i);
   });
 
   it("listMeChats: resolves human external avatars while leaving agent avatars null without an upload", async () => {
@@ -120,6 +132,36 @@ describe("chat-first workspace service layer", () => {
       [owner.humanAgentUuid, peerA.agent.uuid, peerB.agent.uuid].sort(),
     );
     expect(row?.participantCount).toBe(row?.participants.length);
+  });
+
+  it("listMeChats filters by participant and treats empty participant ids as no filter", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peerA = await createTestAgent(app, { name: `with-peer-a-${crypto.randomUUID().slice(0, 6)}` });
+    const peerB = await createTestAgent(app, { name: `with-peer-b-${crypto.randomUUID().slice(0, 6)}` });
+
+    const chatA = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [peerA.agent.uuid],
+    });
+    const chatB = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [peerB.agent.uuid],
+    });
+
+    const peerAOnly = await listMeChats(app.db, owner.humanAgentUuid, owner.memberId, owner.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "all",
+      with: [peerA.agent.uuid, peerA.agent.uuid],
+    });
+    expect(peerAOnly.rows.map((r) => r.chatId)).toEqual([chatA.chatId]);
+
+    const blankFilter = await listMeChats(app.db, owner.humanAgentUuid, owner.memberId, owner.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "all",
+      with: [""],
+    });
+    expect(blankFilter.rows.map((r) => r.chatId).sort()).toEqual([chatA.chatId, chatB.chatId].sort());
   });
 
   it("listMeChats: only reports explicit mention attention while the mention is unread", async () => {
@@ -793,6 +835,64 @@ describe("chat-first workspace service layer", () => {
     expect(seen.size).toBe(3);
   });
 
+  it("listMeChats: cursor pagination advances across timestamped chats", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `peer-ts-cur-${crypto.randomUUID().slice(0, 6)}` });
+
+    const c1 = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    const c2 = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+    await sendMessage(
+      app.db,
+      c1.chatId,
+      admin.humanAgentUuid,
+      { source: "api", format: "text", content: "older timestamped chat" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(
+      app.db,
+      c2.chatId,
+      admin.humanAgentUuid,
+      { source: "api", format: "text", content: "newer timestamped chat" },
+      { allowRecipientlessSend: true },
+    );
+
+    const page1 = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+      limit: 1,
+      filter: "all",
+      engagement: "all",
+    });
+    expect(page1.rows).toHaveLength(1);
+    expect(page1.nextCursor).toBeTruthy();
+    expect(page1.rows[0]?.chatId).toBe(c2.chatId);
+
+    const page2 = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+      limit: 1,
+      filter: "all",
+      engagement: "all",
+      cursor: page1.nextCursor ?? undefined,
+    });
+    expect(page2.rows[0]?.chatId).toBe(c1.chatId);
+  });
+
+  it("listMeChats rejects an invalid cursor", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    await expect(
+      listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+        limit: 50,
+        filter: "all",
+        engagement: "all",
+        cursor: "not-a-valid-cursor",
+      }),
+    ).rejects.toThrow(/invalid cursor/i);
+  });
+
   it("listMeChats nested-chat filter: parent_chat_id IS NOT NULL is excluded", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
@@ -1009,6 +1109,19 @@ describe("chat-first workspace service layer", () => {
     expect(res.rows.find((r) => r.chatId === chatId)?.engagementStatus).toBe("active");
   });
 
+  it("getCallerEngagement defaults to active and returns persisted engagement", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peer = await createTestAgent(app, { name: `eng-read-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peer.agent.uuid],
+    });
+
+    await expect(getCallerEngagement(app.db, chatId, admin.humanAgentUuid)).resolves.toBe("active");
+    await setChatEngagement(app.db, chatId, admin.humanAgentUuid, "archived");
+    await expect(getCallerEngagement(app.db, chatId, admin.humanAgentUuid)).resolves.toBe("archived");
+  });
+
   /**
    * Regression for issue 343 — the web picker-source switch (from `/activity`
    * to `/orgs/:orgId/agents`) is only useful if the server's add-participant
@@ -1044,5 +1157,18 @@ describe("chat-first workspace service layer", () => {
       sql`SELECT access_mode FROM chat_membership WHERE chat_id = ${chatId} AND agent_id = ${teammate.humanAgentUuid}`,
     );
     expect(rows[0]?.access_mode).toBe("speaker");
+  });
+
+  it("addMeChatParticipants rejects an empty participant list before probing the chat", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const aiAgent = await createTestAgent(app, { name: `agp-empty-ai-${crypto.randomUUID().slice(0, 6)}` });
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [aiAgent.agent.uuid],
+    });
+
+    await expect(
+      addMeChatParticipants(app.db, chatId, owner.humanAgentUuid, owner.organizationId, { participantIds: [] }),
+    ).rejects.toThrow(/at least one participant/i);
   });
 });

--- a/packages/server/src/__tests__/me-chat-source-tags.test.ts
+++ b/packages/server/src/__tests__/me-chat-source-tags.test.ts
@@ -159,6 +159,14 @@ describe("conversation-list source tags", () => {
     expect(agentOnly.rows.map((r) => r.chatId)).toEqual([agentChatId]);
     expect(agentOnly.rows[0]?.source).toBe("agent");
     expect(agentOnly.rows[0]?.entityType).toBeNull();
+
+    const manualAndGithub = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "active",
+      origin: ["manual", "github", "github"],
+    });
+    expect(manualAndGithub.rows.map((r) => r.chatId).sort()).toEqual([manualChatId, issueChatId, prChatId].sort());
   });
 
   it("projects createdByMe from the caller's chat membership role", async () => {

--- a/packages/server/src/__tests__/me-chats-http-e2e.test.ts
+++ b/packages/server/src/__tests__/me-chats-http-e2e.test.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { createAgent } from "../services/agent.js";
 import { createMeChat } from "../services/me-chat.js";
+import { sendMessage } from "../services/message.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 /**
@@ -190,6 +191,122 @@ describe("GET /orgs/:orgId/chats — liveActivity wire shape", () => {
     // Live indicator: terminal event → no chip (the session lifecycle stays
     // active, but the chat list only consumes liveActivity presence now).
     expect(row?.liveActivity).toBeNull();
+  });
+});
+
+describe("GET/POST /chats/:chatId resource routes", () => {
+  const getApp = useTestApp();
+
+  it("returns watcher membership kind on chat detail for supervised chats", async () => {
+    const app = getApp();
+    const manager = await createTestAdmin(app);
+    const peer = await createTestAdmin(app);
+    const managed = await createAgent(app.db, {
+      name: `detail-managed-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Detail Managed",
+      managerId: manager.memberId,
+      organizationId: manager.organizationId,
+    });
+    const { chatId } = await createMeChat(app.db, peer.humanAgentUuid, peer.organizationId, {
+      participantIds: [managed.uuid],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/chats/${chatId}`,
+      headers: { authorization: `Bearer ${manager.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ viewerMembershipKind: string | null }>().viewerMembershipKind).toBe("watching");
+  });
+
+  it("exercises token usage, github entity list, unread, participant add, workspace leave, and message pagination", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const peerA = await createAgent(app.db, {
+      name: `route-peer-a-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Route Peer A",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+    });
+    const peerB = await createAgent(app.db, {
+      name: `route-peer-b-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Route Peer B",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+    });
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [peerA.uuid],
+    });
+    await sendMessage(
+      app.db,
+      chatId,
+      admin.humanAgentUuid,
+      { source: "api", format: "text", content: "first route message" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(
+      app.db,
+      chatId,
+      admin.humanAgentUuid,
+      { source: "api", format: "text", content: "second route message" },
+      { allowRecipientlessSend: true },
+    );
+
+    const headers = { authorization: `Bearer ${admin.accessToken}` };
+    const tokenUsage = await app.inject({ method: "GET", url: `/api/v1/chats/${chatId}/token-usage`, headers });
+    expect(tokenUsage.statusCode).toBe(200);
+
+    const githubEntities = await app.inject({ method: "GET", url: `/api/v1/chats/${chatId}/github-entities`, headers });
+    expect(githubEntities.statusCode).toBe(200);
+    expect(githubEntities.json<{ items: unknown[] }>().items).toEqual([]);
+
+    const unfollowMissing = await app.inject({
+      method: "DELETE",
+      url: `/api/v1/chats/${chatId}/github-entities`,
+      headers,
+    });
+    expect(unfollowMissing.statusCode).toBe(400);
+    const unfollow = await app.inject({
+      method: "DELETE",
+      url: `/api/v1/chats/${chatId}/github-entities?entity=${encodeURIComponent("owner/repo#1")}`,
+      headers,
+    });
+    expect(unfollow.statusCode).toBe(200);
+    expect(unfollow.json<{ removed: number }>().removed).toBe(0);
+
+    const unread = await app.inject({ method: "POST", url: `/api/v1/chats/${chatId}/unread`, headers });
+    expect(unread.statusCode).toBe(200);
+    expect(unread.json<{ unreadMentionCount: number }>().unreadMentionCount).toBe(1);
+
+    const addParticipant = await app.inject({
+      method: "POST",
+      url: `/api/v1/chats/${chatId}/participants`,
+      headers,
+      payload: { participantIds: [peerB.uuid] },
+    });
+    expect(addParticipant.statusCode).toBe(204);
+
+    const page1 = await app.inject({ method: "GET", url: `/api/v1/chats/${chatId}/messages?limit=1`, headers });
+    expect(page1.statusCode).toBe(200);
+    const page1Body = page1.json<{ items: Array<{ id: string; createdAt: string }>; nextCursor: string | null }>();
+    expect(page1Body.items).toHaveLength(1);
+    expect(page1Body.nextCursor).toBeTruthy();
+
+    const page2 = await app.inject({
+      method: "GET",
+      url: `/api/v1/chats/${chatId}/messages?limit=1&cursor=${encodeURIComponent(page1Body.nextCursor ?? "")}`,
+      headers,
+    });
+    expect(page2.statusCode).toBe(200);
+    expect(page2.json<{ items: unknown[] }>().items).toHaveLength(1);
+
+    const leave = await app.inject({ method: "POST", url: `/api/v1/chats/${chatId}/workspace-leave`, headers });
+    expect(leave.statusCode).toBe(200);
+    expect(leave.json<{ chatId: string }>().chatId).toBe(chatId);
   });
 });
 

--- a/packages/server/src/__tests__/me-doc.test.ts
+++ b/packages/server/src/__tests__/me-doc.test.ts
@@ -95,4 +95,40 @@ describe("getMeDocPreview", () => {
       NotFoundError,
     );
   });
+
+  it("returns not found when the workspace root itself is missing", async () => {
+    const workspacesRoot = await mkdtemp(join(tmpdir(), "first-tree-workspaces-missing-"));
+
+    await expect(getMeDocPreview({ ...baseInput, path: "guide.md", workspacesRoot })).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it("returns not found when the markdown path is a directory", async () => {
+    const { workspacesRoot, workspaceRoot } = await makeWorkspace();
+    await mkdir(join(workspaceRoot, "directory.md"));
+
+    await expect(getMeDocPreview({ ...baseInput, path: "directory.md", workspacesRoot })).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it("normalizes the public ref path separately from the resolved workspace path", async () => {
+    const { workspacesRoot, workspaceRoot } = await makeWorkspace();
+    await mkdir(join(workspaceRoot, "nested"));
+    await writeFile(join(workspaceRoot, "guide.md"), "# Guide", "utf8");
+
+    await expect(
+      getMeDocPreview({ ...baseInput, basePath: "nested", path: "../guide.md", workspacesRoot }),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+  });
+
+  it("rejects empty public ref paths even when the base path resolves to a markdown file", async () => {
+    const { workspacesRoot, workspaceRoot } = await makeWorkspace();
+    await writeFile(join(workspaceRoot, "guide.md"), "# Guide", "utf8");
+
+    await expect(getMeDocPreview({ ...baseInput, basePath: "guide.md", path: "", workspacesRoot })).rejects.toThrow(
+      /must name a markdown file/,
+    );
+  });
 });

--- a/packages/server/src/__tests__/me-multi-org.test.ts
+++ b/packages/server/src/__tests__/me-multi-org.test.ts
@@ -1,9 +1,11 @@
 import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
+import { invitationRedemptions } from "../db/schema/invitations.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
 import { createAgent } from "../services/agent.js";
+import { rotateInvitation } from "../services/invitation.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, seedClient, useTestApp } from "./helpers.js";
 
@@ -114,6 +116,76 @@ describe("Multi-org self-service", () => {
     expect(meBody.memberships.length).toBe(1);
     expect(meBody.memberships[0]?.organizationId).not.toBe(admin.organizationId);
   });
+
+  it("POST /me/memberships/:memberId/leave hides memberships owned by another user", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const caller = await createTestAdmin(app);
+
+    const leaveRes = await app.inject({
+      method: "POST",
+      url: `/api/v1/me/memberships/${owner.memberId}/leave`,
+      headers: { authorization: `Bearer ${caller.accessToken}` },
+    });
+
+    expect(leaveRes.statusCode).toBe(404);
+    expect(leaveRes.json<{ error: string }>().error).toContain(`Membership "${owner.memberId}" not found`);
+
+    const rows = await app.db.select().from(members).where(eq(members.id, owner.memberId));
+    expect(rows[0]?.status).toBe("active");
+  });
+
+  it("POST /me/organizations/join returns 404 for inactive or unknown invite tokens", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/organizations/join",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { token: `missing-${crypto.randomUUID()}` },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: "Invitation not found or no longer valid" });
+  });
+
+  it("POST /me/organizations/join creates membership and records redemption", async () => {
+    const app = getApp();
+    const inviter = await createTestAdmin(app);
+    const invitee = await createTestAdmin(app);
+    const sideOrg = await attachOrg(app, inviter.userId, "admin");
+    const invitation = await rotateInvitation(app.db, sideOrg.orgId, inviter.userId);
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/v1/me/organizations/join",
+      headers: {
+        authorization: `Bearer ${invitee.accessToken}`,
+        "user-agent": "me-multi-org-test",
+      },
+      payload: { token: invitation.token },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ organizationId: string; memberId: string; role: string }>();
+    expect(body).toMatchObject({ organizationId: sideOrg.orgId, role: "member" });
+
+    const [joined] = await app.db.select().from(members).where(eq(members.id, body.memberId)).limit(1);
+    expect(joined).toMatchObject({
+      userId: invitee.userId,
+      organizationId: sideOrg.orgId,
+      role: "member",
+      status: "active",
+    });
+
+    const redemptions = await app.db
+      .select()
+      .from(invitationRedemptions)
+      .where(eq(invitationRedemptions.invitationId, invitation.id));
+    expect(redemptions).toHaveLength(1);
+    expect(redemptions[0]).toMatchObject({ userId: invitee.userId, userAgent: "me-multi-org-test" });
+  });
 });
 
 describe("Connect code bootstrap", () => {
@@ -179,6 +251,21 @@ describe("/me onboarding step inference", () => {
     expect(me.json<{ onboarding: { step: string } }>().onboarding.step).toBe("connect");
   });
 
+  it("GET /me/onboarding-step returns create_agent once a client exists without an autonomous agent", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedClient(app, admin.userId, admin.organizationId);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/onboarding-step",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ step: "create_agent" });
+  });
+
   /**
    * Regression for #239: the onboarding inference used to key off the JWT's
    * default `memberId`, so a user whose only autonomous agent lived in a
@@ -218,5 +305,39 @@ describe("/me onboarding step inference", () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json<{ onboarding: { step: string } }>().onboarding.step).toBe("completed");
+  });
+});
+
+describe("GET /me/pinned-agents", () => {
+  const getApp = useTestApp();
+
+  it("returns agents pinned to clients owned by the caller across memberships", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const clientId = await seedClient(app, admin.userId, admin.organizationId);
+    const agent = await createAgent(app.db, {
+      name: `pin-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Pinned Agent",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+      clientId,
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/pinned-agents",
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toContainEqual(
+      expect.objectContaining({
+        agentId: agent.uuid,
+        clientId,
+        runtimeProvider: agent.runtimeProvider,
+        status: "active",
+      }),
+    );
   });
 });

--- a/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
+++ b/packages/server/src/__tests__/me-onboarding-kickoff.test.ts
@@ -513,6 +513,25 @@ describe("GET /me/onboarding/tree-setup-status", () => {
     });
   }
 
+  it("does not offer tree setup recovery to non-admin members", async () => {
+    const app = getApp();
+    const member = await createTestAdmin(app);
+    await app.db.update(members).set({ role: "member" }).where(eq(members.id, member.memberId));
+
+    const res = await app.inject({
+      method: "GET",
+      url: `${TREE_STATUS_URL}?organizationId=${member.organizationId}`,
+      headers: { authorization: `Bearer ${member.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      needsTreeSetup: false,
+      hasTreeBinding: false,
+      hasTreeSetupKickoff: false,
+    });
+  });
+
   it("offers recovery to a completed admin whose org has no tree binding", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/me-onboarding.test.ts
+++ b/packages/server/src/__tests__/me-onboarding.test.ts
@@ -5,6 +5,7 @@ import { agents } from "../db/schema/agents.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { members } from "../db/schema/members.js";
 import { encryptValue } from "../services/crypto.js";
+import * as githubUserToken from "../services/github-user-token.js";
 import { createMember } from "../services/member.js";
 import { ensureMembership } from "../services/membership.js";
 import { createOrganization } from "../services/organization.js";
@@ -357,6 +358,26 @@ describe("GET /me/github/repos", () => {
       expect(body.error).toMatch(/reconnect/i);
     } finally {
       globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("lets unexpected GitHub token errors flow to the generic error handler", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const token = vi
+      .spyOn(githubUserToken, "getFreshGithubUserToken")
+      .mockRejectedValueOnce(new Error("unexpected token store failure"));
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/me/github/repos",
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+
+      expect(res.statusCode).toBe(500);
+      expect(res.json<{ error: string }>().error).toBe("Internal server error");
+    } finally {
+      token.mockRestore();
     }
   });
 

--- a/packages/server/src/__tests__/me-onboarding.test.ts
+++ b/packages/server/src/__tests__/me-onboarding.test.ts
@@ -360,6 +360,88 @@ describe("GET /me/github/repos", () => {
     }
   });
 
+  it("returns repositories from a stored GitHub token", async () => {
+    const app = getApp();
+    const originalPat = process.env.DEV_GITHUB_PAT;
+    process.env.DEV_GITHUB_PAT = "ghp_repo_success";
+    const dev = await app.inject({
+      method: "GET",
+      url: "/api/v1/auth/github/dev-callback?githubId=9004&login=tokentest200",
+    });
+    if (originalPat === undefined) {
+      delete process.env.DEV_GITHUB_PAT;
+    } else {
+      process.env.DEV_GITHUB_PAT = originalPat;
+    }
+    const fragment = dev.headers.location?.split("#")[1] ?? "";
+    const access = new URLSearchParams(fragment).get("access");
+    expect(access).toBeTruthy();
+
+    const originalFetch = globalThis.fetch;
+    type FetchInput = Parameters<typeof globalThis.fetch>[0];
+    type FetchInit = Parameters<typeof globalThis.fetch>[1];
+    const fetchSpy = vi.fn(async (input: FetchInput, init?: FetchInit): Promise<Response> => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("api.github.com/user/repos")) {
+        return new Response(
+          JSON.stringify([
+            {
+              full_name: "acme/repo",
+              clone_url: "https://github.com/acme/repo.git",
+              html_url: "https://github.com/acme/repo",
+              private: true,
+              default_branch: "main",
+              pushed_at: "2026-01-01T00:00:00Z",
+            },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return originalFetch(input, init);
+    });
+    globalThis.fetch = fetchSpy as typeof fetch;
+
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/me/github/repos",
+        headers: { authorization: `Bearer ${access}` },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json<{ repos: Array<{ fullName: string }> }>().repos).toEqual([
+        expect.objectContaining({ fullName: "acme/repo" }),
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("logs and returns a stable reconnect error when the stored token cannot be decrypted", async () => {
+    const app = getApp();
+    const dev = await app.inject({
+      method: "GET",
+      url: "/api/v1/auth/github/dev-callback?githubId=9005&login=tokentestbadcipher",
+    });
+    const fragment = dev.headers.location?.split("#")[1] ?? "";
+    const access = new URLSearchParams(fragment).get("access");
+    expect(access).toBeTruthy();
+
+    const [identity] = await app.db.select().from(authIdentities).where(eq(authIdentities.identifier, "9005")).limit(1);
+    if (!identity) throw new Error("expected auth identity");
+    await app.db
+      .update(authIdentities)
+      .set({ metadata: { ...(identity.metadata ?? {}), accessToken: "enc:v1:not-valid" } })
+      .where(eq(authIdentities.id, identity.id));
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/me/github/repos",
+      headers: { authorization: `Bearer ${access}` },
+    });
+    expect(res.statusCode).toBe(503);
+    expect(res.json<{ error: string }>().error).toMatch(/decoded|reconnect/i);
+  });
+
   it("returns a stable 502 when GitHub repo listing fails for a non-auth upstream error", async () => {
     const app = getApp();
     const dev = await app.inject({

--- a/packages/server/src/__tests__/me-onboarding.test.ts
+++ b/packages/server/src/__tests__/me-onboarding.test.ts
@@ -359,6 +359,51 @@ describe("GET /me/github/repos", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("returns a stable 502 when GitHub repo listing fails for a non-auth upstream error", async () => {
+    const app = getApp();
+    const dev = await app.inject({
+      method: "GET",
+      url: "/api/v1/auth/github/dev-callback?githubId=9003&login=tokentest500",
+    });
+    const fragment = dev.headers.location?.split("#")[1] ?? "";
+    const access = new URLSearchParams(fragment).get("access");
+    expect(access).toBeTruthy();
+
+    const [identity] = await app.db.select().from(authIdentities).where(eq(authIdentities.identifier, "9003")).limit(1);
+    if (!identity) throw new Error("expected auth identity");
+    const encrypted = encryptValue("any_token_we_will_intercept", app.config.secrets.encryptionKey);
+    await app.db
+      .update(authIdentities)
+      .set({ metadata: { ...(identity.metadata ?? {}), accessToken: encrypted } })
+      .where(eq(authIdentities.id, identity.id));
+
+    const originalFetch = globalThis.fetch;
+    type FetchInput = Parameters<typeof globalThis.fetch>[0];
+    type FetchInit = Parameters<typeof globalThis.fetch>[1];
+    const fetchSpy = vi.fn(async (input: FetchInput, init?: FetchInit): Promise<Response> => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.includes("api.github.com")) {
+        return new Response("Server exploded", { status: 500 });
+      }
+      return originalFetch(input, init);
+    });
+    globalThis.fetch = fetchSpy as typeof fetch;
+
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/me/github/repos",
+        headers: { authorization: `Bearer ${access}` },
+      });
+      expect(res.statusCode).toBe(502);
+      expect(res.json<{ error: string }>().error).toBe(
+        "Couldn't reach GitHub. Try again, or reconnect your GitHub account.",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe("POST /me/onboarding/events", () => {

--- a/packages/server/src/__tests__/me.test.ts
+++ b/packages/server/src/__tests__/me.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { users } from "../db/schema/users.js";
+import { signTokensForUser } from "../services/auth.js";
+import { uuidv7 } from "../uuid.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
+
+const TEST_JWT_SECRET = "test-jwt-secret-key-for-vitest";
 
 describe("GET /api/v1/me", () => {
   const getApp = useTestApp();
@@ -25,6 +30,34 @@ describe("GET /api/v1/me", () => {
     expect(body.memberships[0]?.role).toBe("admin");
     expect(body.memberships[0]?.agentId).toBeDefined();
     expect(body.defaultOrganizationId).toBe(body.memberships[0]?.organizationId);
+  });
+
+  it("returns an empty membership list and null default org for users without memberships", async () => {
+    const app = getApp();
+    const userId = uuidv7();
+    await app.db.insert(users).values({
+      id: userId,
+      username: `me-no-membership-${crypto.randomUUID().slice(0, 8)}`,
+      passwordHash: "test",
+      displayName: "No Membership",
+    });
+    const tokens = await signTokensForUser(TEST_JWT_SECRET, userId, {
+      accessTokenExpiry: "30m",
+      refreshTokenExpiry: "30d",
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/me",
+      headers: { authorization: `Bearer ${tokens.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      user: { id: userId },
+      defaultOrganizationId: null,
+      memberships: [],
+    });
   });
 
   it("rejects unauthenticated request", async () => {

--- a/packages/server/src/__tests__/members.test.ts
+++ b/packages/server/src/__tests__/members.test.ts
@@ -449,6 +449,40 @@ describe("Members API", () => {
       ).rejects.toThrow(/last admin/i);
     });
 
+    it("updateMember rejects inactive rows and allows demoting a non-final admin", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `member-demote-admin-${randomUUID().slice(0, 8)}` });
+      const secondAdmin = await memberService.createMember(app.db, admin.organizationId, {
+        username: `member-demote-second-${randomUUID().slice(0, 8)}`,
+        displayName: "Second Admin",
+        role: "admin",
+      });
+      const inactive = await memberService.createMember(app.db, admin.organizationId, {
+        username: `member-inactive-update-${randomUUID().slice(0, 8)}`,
+        displayName: "Inactive Update",
+        role: "member",
+      });
+      await app.db.update(membersTable).set({ status: "removed" }).where(eq(membersTable.id, inactive.id));
+
+      await expect(
+        memberService.updateMember(app.db, inactive.id, { displayName: "Should Not Update" }, admin.organizationId),
+      ).rejects.toThrow(/not found/i);
+
+      const demoted = await memberService.updateMember(
+        app.db,
+        secondAdmin.id,
+        { role: "member" },
+        admin.organizationId,
+      );
+      expect(demoted.role).toBe("member");
+      const [row] = await app.db
+        .select({ role: membersTable.role })
+        .from(membersTable)
+        .where(eq(membersTable.id, secondAdmin.id))
+        .limit(1);
+      expect(row?.role).toBe("member");
+    });
+
     it("createMember rejects an existing row with an unsupported lifecycle status", async () => {
       const app = getApp();
       const admin = await createTestAdmin(app, { username: `unsupported-admin-${randomUUID().slice(0, 8)}` });
@@ -481,6 +515,15 @@ describe("Members API", () => {
       });
 
       await expect(memberService.deleteMember(app.db, target.id, org.id)).rejects.toThrow(/another admin/i);
+    });
+
+    it("deleteMember rejects removing the only active admin", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `delete-only-admin-${randomUUID().slice(0, 8)}` });
+
+      await expect(memberService.deleteMember(app.db, admin.memberId, admin.organizationId)).rejects.toThrow(
+        /last admin/i,
+      );
     });
 
     it("restores a left member whose human mirror name was cleared with a collision-safe slug", async () => {

--- a/packages/server/src/__tests__/members.test.ts
+++ b/packages/server/src/__tests__/members.test.ts
@@ -4,10 +4,11 @@ import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { agents as agentsTable } from "../db/schema/agents.js";
 import { members as membersTable } from "../db/schema/members.js";
+import { organizations as organizationsTable } from "../db/schema/organizations.js";
 import { users as usersTable } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
 import * as memberService from "../services/member.js";
-import { repairMembershipHumanMirrors } from "../services/membership.js";
+import { repairMembershipHumanMirrors, selfCreateOrganization } from "../services/membership.js";
 import { createOrganization } from "../services/organization.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
@@ -431,6 +432,118 @@ describe("Members API", () => {
         payload: { username: "another", displayName: "Another", role: "member" },
       });
       expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe("service-layer edge cases", () => {
+    it("updateMember returns the current row for an empty patch and blocks demoting the last admin", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `member-edge-admin-${randomUUID().slice(0, 8)}` });
+
+      const unchanged = await memberService.updateMember(app.db, admin.memberId, {}, admin.organizationId);
+      expect(unchanged.id).toBe(admin.memberId);
+      expect(unchanged.role).toBe("admin");
+
+      await expect(
+        memberService.updateMember(app.db, admin.memberId, { role: "member" }, admin.organizationId),
+      ).rejects.toThrow(/last admin/i);
+    });
+
+    it("createMember rejects an existing row with an unsupported lifecycle status", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `unsupported-admin-${randomUUID().slice(0, 8)}` });
+      const created = await memberService.createMember(app.db, admin.organizationId, {
+        username: `unsupported-${randomUUID().slice(0, 8)}`,
+        displayName: "Unsupported Member",
+        role: "member",
+      });
+      await app.db.update(membersTable).set({ status: "paused" }).where(eq(membersTable.id, created.id));
+
+      await expect(
+        memberService.createMember(app.db, admin.organizationId, {
+          username: created.username,
+          displayName: "Unsupported Again",
+          role: "member",
+        }),
+      ).rejects.toThrow(/unsupported membership status/i);
+    });
+
+    it("deleteMember requires another active admin even for a non-admin target", async () => {
+      const app = getApp();
+      const org = await createOrganization(app.db, {
+        name: `delete-no-fallback-${randomUUID().slice(0, 8)}`,
+        displayName: "No Fallback Org",
+      });
+      const target = await memberService.createMember(app.db, org.id, {
+        username: `delete-no-fallback-${randomUUID().slice(0, 8)}`,
+        displayName: "Only Member",
+        role: "member",
+      });
+
+      await expect(memberService.deleteMember(app.db, target.id, org.id)).rejects.toThrow(/another admin/i);
+    });
+
+    it("restores a left member whose human mirror name was cleared with a collision-safe slug", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `restore-null-admin-${randomUUID().slice(0, 8)}` });
+      const username = `restore-null-${randomUUID().slice(0, 8)}`;
+      const created = await memberService.createMember(app.db, admin.organizationId, {
+        username,
+        displayName: "Restore Null",
+        role: "member",
+      });
+      await app.db.update(membersTable).set({ status: "left" }).where(eq(membersTable.id, created.id));
+      await app.db
+        .update(agentsTable)
+        .set({ status: "suspended", name: null })
+        .where(eq(agentsTable.uuid, created.agentId));
+      await createAgent(app.db, {
+        name: username,
+        type: "agent",
+        displayName: "Slug Collision",
+        managerId: admin.memberId,
+        organizationId: admin.organizationId,
+      });
+
+      const restored = await memberService.createMember(app.db, admin.organizationId, {
+        username,
+        displayName: "Restored Null",
+        role: "admin",
+      });
+
+      expect(restored.id).toBe(created.id);
+      const [mirror] = await app.db
+        .select({ name: agentsTable.name, status: agentsTable.status })
+        .from(agentsTable)
+        .where(eq(agentsTable.uuid, created.agentId))
+        .limit(1);
+      expect(mirror?.status).toBe("active");
+      expect(mirror?.name).toContain(created.agentId.slice(0, 8));
+    });
+
+    it("selfCreateOrganization rejects duplicate and reserved slugs", async () => {
+      const app = getApp();
+
+      await expect(
+        selfCreateOrganization(app.db, {
+          userId: `user-${randomUUID()}`,
+          userDisplayName: "Self Org Admin",
+          username: "self-org-admin",
+          name: "default",
+          displayName: "Default Again",
+        }),
+      ).rejects.toThrow(/already exists/i);
+
+      await app.db.delete(organizationsTable).where(eq(organizationsTable.name, "default"));
+      await expect(
+        selfCreateOrganization(app.db, {
+          userId: `user-${randomUUID()}`,
+          userDisplayName: "Self Org Admin",
+          username: "self-org-admin",
+          name: "default",
+          displayName: "Reserved Default",
+        }),
+      ).rejects.toThrow(/reserved organization name/i);
     });
   });
 });

--- a/packages/server/src/__tests__/membership-extra.test.ts
+++ b/packages/server/src/__tests__/membership-extra.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { createPersonalTeam, deactivateMembership, MEMBER_STATUSES } from "../services/membership.js";
+import { createAdminContext, useTestApp } from "./helpers.js";
+
+describe("membership service edge coverage", () => {
+  const getApp = useTestApp();
+
+  it("rejects deactivation when the membership is already in a different inactive state", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `membership-state-${crypto.randomUUID().slice(0, 8)}` });
+
+    await deactivateMembership(app.db, admin.memberId, MEMBER_STATUSES.REMOVED);
+
+    await expect(deactivateMembership(app.db, admin.memberId, MEMBER_STATUSES.LEFT)).rejects.toThrow(/not active/);
+  });
+
+  it("falls back to a uuid-based organization slug after repeated insert collisions", async () => {
+    let organizationInsertAttempts = 0;
+    const insertedOrganizationNames: string[] = [];
+    const insertedMembers: Record<string, unknown>[] = [];
+    const fakeDb = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [],
+          }),
+        }),
+      }),
+      insert: () => ({
+        values: async (value: Record<string, unknown>) => {
+          organizationInsertAttempts += 1;
+          if (organizationInsertAttempts <= 4) {
+            const err = new Error("duplicate organization") as Error & { code: string };
+            err.code = "23505";
+            throw err;
+          }
+          if (typeof value.name === "string") insertedOrganizationNames.push(value.name);
+        },
+      }),
+      transaction: async (callback: (tx: unknown) => Promise<Record<string, unknown>>) => {
+        return callback({
+          insert: () => ({
+            values: (value: Record<string, unknown>) => ({
+              returning: async () => {
+                insertedMembers.push(value);
+                return [
+                  {
+                    id: "member-1",
+                    userId: value.userId,
+                    organizationId: value.organizationId,
+                    agentId: value.agentId,
+                    role: value.role,
+                    status: value.status,
+                  },
+                ];
+              },
+            }),
+          }),
+        });
+      },
+    };
+
+    await expect(
+      createPersonalTeam(fakeDb as never, {
+        userId: "user-1",
+        loginSeed: "Retry User",
+        teamDisplayName: "Retry User's team",
+        userDisplayName: "Retry User",
+      }),
+    ).resolves.toMatchObject({
+      slug: expect.stringMatching(/^retry-user-[0-9a-f-]{12}$/),
+      memberId: "member-1",
+    });
+
+    expect(organizationInsertAttempts).toBe(5);
+    expect(insertedOrganizationNames).toHaveLength(1);
+    expect(insertedMembers).toHaveLength(1);
+  });
+});

--- a/packages/server/src/__tests__/message-edge-coverage.test.ts
+++ b/packages/server/src/__tests__/message-edge-coverage.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { NotFoundError } from "../errors.js";
+import { createChat } from "../services/chat.js";
+import {
+  maybeUnwrapDoubleEncoded,
+  preflightMessageSendIntent,
+  type SendIntentParticipant,
+  sendMessage,
+} from "../services/message.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+describe("message service edge coverage", () => {
+  const getApp = useTestApp();
+
+  const sender = {
+    agentId: "sender-1",
+    name: "sender",
+    displayName: "Sender",
+    status: "active",
+    type: "agent",
+  } satisfies SendIntentParticipant;
+
+  it("rejects inactive explicit and system-routed recipients with recovery copy", () => {
+    const suspended = {
+      agentId: "target-suspended",
+      name: "target",
+      displayName: "Suspended Target",
+      status: "suspended",
+      type: "agent",
+    } satisfies SendIntentParticipant;
+    expect(() =>
+      preflightMessageSendIntent({
+        chatId: "chat-1",
+        senderId: sender.agentId,
+        senderType: "agent",
+        data: {
+          source: "cli",
+          format: "text",
+          content: "hello",
+          metadata: { mentions: [suspended.agentId] },
+        },
+        participants: [sender, suspended],
+      }),
+    ).toThrow(/Reactivate it before sending/);
+
+    const deleted = {
+      ...suspended,
+      agentId: "target-deleted",
+      displayName: "",
+      status: "deleted",
+    } satisfies SendIntentParticipant;
+    expect(() =>
+      preflightMessageSendIntent({
+        chatId: "chat-1",
+        senderId: sender.agentId,
+        senderType: "agent",
+        data: { source: "cli", format: "text", content: "hello" },
+        options: { addressedToAgentIds: [deleted.agentId] },
+        participants: [sender, deleted],
+      }),
+    ).toThrow(/Deleted agents cannot receive new messages/);
+  });
+
+  it("returns null when a double-encoded string candidate is not valid JSON", () => {
+    expect(maybeUnwrapDoubleEncoded('"bad\\n\\x"')).toBeNull();
+  });
+
+  it("rejects sends from an unknown sender before preflight routing", async () => {
+    const app = getApp();
+    const owner = await createTestAgent(app, { type: "agent" });
+    const peer = await createTestAgent(app, { type: "agent" });
+    const chat = await createChat(app.db, owner.agent.uuid, { type: "group", participantIds: [peer.agent.uuid] });
+
+    await expect(
+      sendMessage(app.db, chat.id, "missing-sender", {
+        source: "cli",
+        format: "text",
+        content: "hello",
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});

--- a/packages/server/src/__tests__/message-edge-coverage.test.ts
+++ b/packages/server/src/__tests__/message-edge-coverage.test.ts
@@ -1,6 +1,9 @@
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { chats } from "../db/schema/chats.js";
 import { NotFoundError } from "../errors.js";
 import { createChat } from "../services/chat.js";
+import { buildLandingCampaignChatMetadata } from "../services/landing-campaigns/metadata.js";
 import {
   maybeUnwrapDoubleEncoded,
   preflightMessageSendIntent,
@@ -78,5 +81,74 @@ describe("message service edge coverage", () => {
         content: "hello",
       }),
     ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it("enforces landing campaign trial chat send locks for humans and agents", async () => {
+    const app = getApp();
+    const human = await createTestAgent(app, { type: "human", name: `trial-human-${crypto.randomUUID().slice(0, 6)}` });
+    const trialAgent = await createTestAgent(app, { name: `trial-agent-${crypto.randomUUID().slice(0, 6)}` });
+    const otherAgent = await createTestAgent(app, { name: `trial-other-${crypto.randomUUID().slice(0, 6)}` });
+    const chat = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [trialAgent.agent.uuid, otherAgent.agent.uuid],
+    });
+    const setTrialState = (input: {
+      state: "running" | "awaiting_user" | "completed" | "failed";
+      awaitingUserKind?: "request" | "follow_up";
+      completedAgentTurns?: number;
+      maxAgentTurns?: number;
+    }) =>
+      app.db
+        .update(chats)
+        .set({
+          metadata: buildLandingCampaignChatMetadata({
+            campaign: "test-campaign",
+            agentId: trialAgent.agent.uuid,
+            skillSetId: "test-skill",
+            skillSetVersion: "1",
+            repo: { url: "https://github.com/acme/repo", canonicalKey: "github:acme/repo" },
+            state: input.state,
+            inputLocked: false,
+            awaitingUserKind: input.awaitingUserKind,
+            maxAgentTurns: input.maxAgentTurns ?? 2,
+            completedAgentTurns: input.completedAgentTurns ?? 0,
+          }),
+        })
+        .where(eq(chats.id, chat.id));
+    const humanMessage = {
+      source: "cli" as const,
+      format: "text" as const,
+      content: "hello",
+      metadata: { mentions: [trialAgent.agent.uuid] },
+    };
+
+    await setTrialState({ state: "completed" });
+    await expect(sendMessage(app.db, chat.id, human.agent.uuid, humanMessage)).rejects.toThrow(/already complete/);
+
+    await setTrialState({ state: "running", maxAgentTurns: 1, completedAgentTurns: 1 });
+    await expect(sendMessage(app.db, chat.id, human.agent.uuid, humanMessage)).rejects.toThrow(/trial chat is locked/);
+
+    await setTrialState({ state: "awaiting_user", awaitingUserKind: "request" });
+    await expect(sendMessage(app.db, chat.id, human.agent.uuid, humanMessage)).rejects.toThrow(/request answer/);
+
+    await setTrialState({ state: "awaiting_user", awaitingUserKind: "request" });
+    await expect(
+      sendMessage(app.db, chat.id, trialAgent.agent.uuid, {
+        source: "cli",
+        format: "text",
+        content: "agent reply",
+        metadata: { mentions: [human.agent.uuid] },
+      }),
+    ).rejects.toThrow(/only send while the trial is running/);
+
+    await setTrialState({ state: "running" });
+    await expect(
+      sendMessage(app.db, chat.id, otherAgent.agent.uuid, {
+        source: "cli",
+        format: "text",
+        content: "other reply",
+        metadata: { mentions: [human.agent.uuid] },
+      }),
+    ).rejects.toThrow(/trial chat is locked/);
   });
 });

--- a/packages/server/src/__tests__/message-session-creation-failure.test.ts
+++ b/packages/server/src/__tests__/message-session-creation-failure.test.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { createChat } from "../services/chat.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
@@ -35,6 +35,11 @@ beforeAll(async () => {
   vi.resetModules();
   const m = await import("../services/message.js");
   sendMessage = m.sendMessage;
+});
+
+afterAll(() => {
+  vi.doUnmock("../services/activity.js");
+  vi.resetModules();
 });
 
 describe("sendMessage — N4-B: predictive activation failure does not block the message", () => {

--- a/packages/server/src/__tests__/notification-fault-dedup.test.ts
+++ b/packages/server/src/__tests__/notification-fault-dedup.test.ts
@@ -1,14 +1,16 @@
 import { and, eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { notifications } from "../db/schema/notifications.js";
 import { users } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
 import * as notificationService from "../services/notification.js";
-import { resolveDefaultOrgId } from "../services/organization.js";
 import { uuidv7 } from "../uuid.js";
 import { createTestApp } from "./helpers.js";
+
+const DEFAULT_TEST_ORG_ID = "01961234-0000-7000-8000-000000000000";
 
 /**
  * Fault-scoped notification de-duplication + auto-resolve.
@@ -32,7 +34,7 @@ describe("Notification — fault dedup + auto-resolve", () => {
   let app: FastifyInstance;
   let orgId: string;
 
-  async function seedAgent(suffix: string) {
+  async function seedAgent(suffix: string, options: { clientHostname?: string } = {}) {
     const userId = uuidv7();
     const memberId = uuidv7();
     return app.db.transaction(async (tx) => {
@@ -42,6 +44,16 @@ describe("Notification — fault dedup + auto-resolve", () => {
         passwordHash: "x",
         displayName: `Fault User ${suffix}`,
       });
+      const clientId = options.clientHostname ? `fault-client-${suffix}-${crypto.randomUUID().slice(0, 6)}` : null;
+      if (clientId) {
+        await tx.insert(clients).values({
+          id: clientId,
+          userId,
+          organizationId: orgId,
+          status: "connected",
+          hostname: options.clientHostname,
+        });
+      }
       const humanAgent = await createAgent(tx as unknown as typeof app.db, {
         name: `fault-human-${suffix}-${crypto.randomUUID().slice(0, 6)}`,
         type: "human",
@@ -64,8 +76,9 @@ describe("Notification — fault dedup + auto-resolve", () => {
         source: "admin-api",
         managerId: memberId,
         organizationId: orgId,
+        ...(clientId ? { clientId } : {}),
       });
-      return { agent, memberId };
+      return { agent, memberId, userId, clientId };
     });
   }
 
@@ -78,7 +91,7 @@ describe("Notification — fault dedup + auto-resolve", () => {
 
   beforeAll(async () => {
     app = await createTestApp();
-    orgId = await resolveDefaultOrgId(app.db);
+    orgId = DEFAULT_TEST_ORG_ID;
   });
 
   afterAll(async () => {
@@ -189,5 +202,120 @@ describe("Notification — fault dedup + auto-resolve", () => {
     const remaining = await unreadFor(agent.uuid);
     expect(remaining).toHaveLength(1);
     expect(remaining[0]?.type).toBe("agent_reminder");
+  });
+
+  it("uses client hostname for stale-agent messages and supports explicit no-dedup notifications", async () => {
+    const { agent } = await seedAgent("client-label", { clientHostname: "build-host-17" });
+
+    await notificationService.notifyAgentEvent(app.db, agent.uuid, "agent_stale", "medium", { dedupKey: null });
+    await notificationService.notifyAgentEvent(app.db, agent.uuid, "agent_stale", "medium", { dedupKey: null });
+
+    const open = await unreadFor(agent.uuid);
+    expect(open).toHaveLength(2);
+    expect(open[0]?.message).toBe("Computer build-host-17 is unresponsive");
+  });
+
+  it("falls back to default notification copy for future agent event types", async () => {
+    const { agent } = await seedAgent("future-type");
+
+    await notificationService.notifyAgentEvent(app.db, agent.uuid, "agent_future" as never, "low");
+
+    const [open] = await unreadFor(agent.uuid);
+    expect(open?.type).toBe("agent_future");
+    expect(open?.message).toBe(`${agent.displayName} event`);
+  });
+
+  it("swallows notification service failures and webhook delivery failures", async () => {
+    const originalWebhook = process.env.FIRST_TREE_NOTIFICATION_WEBHOOK_URL;
+    const originalFetch = globalThis.fetch;
+    const fetchCalls: unknown[] = [];
+    process.env.FIRST_TREE_NOTIFICATION_WEBHOOK_URL = "https://example.invalid/notify";
+    globalThis.fetch = (async (input: unknown) => {
+      fetchCalls.push(input);
+      throw new Error("webhook down");
+    }) as typeof fetch;
+    try {
+      await expect(
+        notificationService.notifyAgentEvent(
+          {
+            select: () => {
+              throw new Error("select failed");
+            },
+          } as never,
+          "missing-agent",
+          "agent_error",
+          "high",
+        ),
+      ).resolves.toBeUndefined();
+      await expect(
+        notificationService.markAgentFaultsResolved(
+          {
+            update: () => {
+              throw new Error("update failed");
+            },
+          } as never,
+          "agent-a",
+        ),
+      ).resolves.toBeUndefined();
+
+      const insertedAt = new Date();
+      const fakeDb = {
+        insert: () => ({
+          values: () => ({
+            onConflictDoUpdate: () => ({
+              returning: async () => [
+                {
+                  id: "notification-a",
+                  organizationId: orgId,
+                  type: "agent_error",
+                  severity: "high",
+                  agentId: "agent-a",
+                  chatId: null,
+                  message: "boom",
+                  read: false,
+                  createdAt: insertedAt,
+                },
+              ],
+            }),
+          }),
+        }),
+      };
+      await expect(
+        notificationService.createNotification(fakeDb as never, {
+          organizationId: orgId,
+          type: "agent_error",
+          severity: "high",
+          agentId: "agent-a",
+          message: "boom",
+        }),
+      ).resolves.toMatchObject({ id: "notification-a", createdAt: insertedAt.toISOString() });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(fetchCalls).toEqual(["https://example.invalid/notify"]);
+
+      const emptyReturningDb = {
+        insert: () => ({
+          values: () => ({
+            onConflictDoUpdate: () => ({
+              returning: async () => [],
+            }),
+          }),
+        }),
+      };
+      await expect(
+        notificationService.createNotification(emptyReturningDb as never, {
+          organizationId: orgId,
+          type: "agent_error",
+          severity: "high",
+          message: "suppressed",
+        }),
+      ).resolves.toBeNull();
+    } finally {
+      if (originalWebhook === undefined) {
+        delete process.env.FIRST_TREE_NOTIFICATION_WEBHOOK_URL;
+      } else {
+        process.env.FIRST_TREE_NOTIFICATION_WEBHOOK_URL = originalWebhook;
+      }
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/server/src/__tests__/notifier-extra.test.ts
+++ b/packages/server/src/__tests__/notifier-extra.test.ts
@@ -119,6 +119,14 @@ describe("createNotifier", () => {
 
     const failing = createNotifier(makeListenClient(true).client as never);
     await expect(failing.notify("inbox_1", "msg_1")).resolves.toBeUndefined();
+    await expect(failing.notifyConfigChange("agent")).resolves.toBeUndefined();
+    await expect(failing.notifySessionStateChange("agent_1", "chat_1", "active", "org_1")).resolves.toBeUndefined();
+    await expect(failing.notifySessionEvent("agent_1", "chat_1", "tool_call", "org_1")).resolves.toBeUndefined();
+    await expect(failing.notifyRuntimeStateChange("agent_1", "working", "org_1")).resolves.toBeUndefined();
+    await expect(failing.notifySessionRuntime("agent_1", "chat_1", "working", "org_1")).resolves.toBeUndefined();
+    await expect(failing.notifyChatMessage("chat_1", "msg_1")).resolves.toBeUndefined();
+    await expect(failing.notifyChatAudience("chat_1")).resolves.toBeUndefined();
+    await expect(failing.notifyChatUpdated("chat_1")).resolves.toBeUndefined();
     await expect(failing.notifyAgentRouteChange(payload)).resolves.toBeUndefined();
   });
 
@@ -132,13 +140,25 @@ describe("createNotifier", () => {
     });
     const sessionEventSecond = vi.fn();
     const runtimeState = vi.fn();
-    const sessionRuntime = vi.fn();
+    const sessionRuntime = vi.fn(() => {
+      throw new Error("consumer failed");
+    });
+    const sessionRuntimeSecond = vi.fn();
     const chatMessage = vi.fn(() => {
       throw new Error("consumer failed");
     });
-    const chatAudience = vi.fn();
-    const chatUpdated = vi.fn();
-    const agentRoute = vi.fn();
+    const chatAudience = vi.fn(() => {
+      throw new Error("consumer failed");
+    });
+    const chatAudienceSecond = vi.fn();
+    const chatUpdated = vi.fn(() => {
+      throw new Error("consumer failed");
+    });
+    const chatUpdatedSecond = vi.fn();
+    const agentRoute = vi.fn(() => {
+      throw new Error("consumer failed");
+    });
+    const agentRouteSecond = vi.fn();
 
     notifier.onConfigChange(config);
     notifier.onSessionStateChange(sessionState);
@@ -146,10 +166,14 @@ describe("createNotifier", () => {
     notifier.onSessionEvent(sessionEventSecond);
     notifier.onRuntimeStateChange(runtimeState);
     notifier.onSessionRuntime(sessionRuntime);
+    notifier.onSessionRuntime(sessionRuntimeSecond);
     notifier.onChatMessage(chatMessage);
     notifier.onChatAudience(chatAudience);
+    notifier.onChatAudience(chatAudienceSecond);
     notifier.onChatUpdated(chatUpdated);
+    notifier.onChatUpdated(chatUpdatedSecond);
     notifier.onAgentRouteChange(agentRoute);
+    notifier.onAgentRouteChange(agentRouteSecond);
     await notifier.start();
 
     listeners.get("config_changes")?.("agent");
@@ -192,7 +216,7 @@ describe("createNotifier", () => {
       kind: "tool_call",
       organizationId: "org_1",
     });
-    expect(sessionRuntime).toHaveBeenCalledWith({
+    expect(sessionRuntimeSecond).toHaveBeenCalledWith({
       agentId: "agent_1",
       chatId: "chat_1",
       organizationId: "org_1",
@@ -200,9 +224,9 @@ describe("createNotifier", () => {
     });
     expect(runtimeState).toHaveBeenCalledWith({ agentId: "agent_1", organizationId: "org_1", state: "idle" });
     expect(chatMessage).toHaveBeenCalledWith({ chatId: "chat_1", messageId: "msg_1" });
-    expect(chatAudience).toHaveBeenCalledWith({ chatId: "chat_1" });
-    expect(chatUpdated).toHaveBeenCalledWith({ chatId: "chat_1" });
-    expect(agentRoute).toHaveBeenCalledWith({
+    expect(chatAudienceSecond).toHaveBeenCalledWith({ chatId: "chat_1" });
+    expect(chatUpdatedSecond).toHaveBeenCalledWith({ chatId: "chat_1" });
+    expect(agentRouteSecond).toHaveBeenCalledWith({
       agentId: "agent_1",
       agentType: "codex",
       displayName: "Agent",

--- a/packages/server/src/__tests__/notifier-extra.test.ts
+++ b/packages/server/src/__tests__/notifier-extra.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from "vitest";
+import { createNotifier, notifyRecipients } from "../services/notifier.js";
+
+type ListenHandler = (payload?: string) => void;
+
+type FakeListenClient = {
+  calls: unknown[][];
+  client: unknown;
+  listeners: Map<string, ListenHandler>;
+  unlisteners: Array<ReturnType<typeof vi.fn>>;
+};
+
+function makeListenClient(shouldRejectNotify = false): FakeListenClient {
+  const calls: unknown[][] = [];
+  const listeners = new Map<string, ListenHandler>();
+  const unlisteners: Array<ReturnType<typeof vi.fn>> = [];
+  const client = vi.fn(async (_strings: TemplateStringsArray, ...values: unknown[]) => {
+    calls.push(values);
+    if (shouldRejectNotify) throw new Error("notify failed");
+  }) as unknown as {
+    listen: (channel: string, handler: ListenHandler) => Promise<{ unlisten: () => Promise<void> }>;
+  };
+  client.listen = vi.fn(async (channel: string, handler: ListenHandler) => {
+    listeners.set(channel, handler);
+    const unlisten = vi.fn(async () => undefined);
+    unlisteners.push(unlisten);
+    return { unlisten };
+  });
+  return { calls, client, listeners, unlisteners };
+}
+
+function makeSocket(sendError?: Error): {
+  OPEN: number;
+  readyState: number;
+  send: ReturnType<typeof vi.fn>;
+} {
+  return {
+    OPEN: 1,
+    readyState: 1,
+    send: vi.fn((_frame: string, callback?: (err?: Error) => void) => {
+      callback?.(sendError);
+    }),
+  };
+}
+
+describe("createNotifier", () => {
+  it("fans inbox notifications only to open subscribed sockets and supports direct frame push", async () => {
+    const { client, listeners } = makeListenClient();
+    const notifier = createNotifier(client as never);
+    const openSocket = makeSocket();
+    const failingSocket = makeSocket(new Error("backpressure"));
+    const closedSocket = { ...makeSocket(), readyState: 3 };
+    const pushHandler = vi.fn(async () => undefined);
+    const rejectingPushHandler = vi.fn(async () => {
+      throw new Error("handler failed");
+    });
+
+    notifier.subscribe("inbox_1", openSocket as never, pushHandler);
+    notifier.subscribe("inbox_1", failingSocket as never, rejectingPushHandler);
+    notifier.subscribe("inbox_1", closedSocket as never, vi.fn());
+    await notifier.start();
+
+    listeners.get("inbox_notifications")?.("malformed");
+    listeners.get("inbox_notifications")?.("unknown:msg_1");
+    listeners.get("inbox_notifications")?.("inbox_1:msg_1");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(pushHandler).toHaveBeenCalledWith("msg_1");
+    expect(rejectingPushHandler).toHaveBeenCalledWith("msg_1");
+    expect(await notifier.pushFrameToInbox("missing", "{}")).toBe(0);
+    expect(await notifier.pushFrameToInbox("inbox_1", '{"type":"ping"}')).toBe(1);
+    expect(openSocket.send).toHaveBeenCalledWith('{"type":"ping"}', expect.any(Function));
+    expect(failingSocket.send).toHaveBeenCalledWith('{"type":"ping"}', expect.any(Function));
+
+    notifier.unsubscribe("inbox_1", openSocket as never);
+    notifier.unsubscribe("inbox_1", failingSocket as never);
+    notifier.unsubscribe("inbox_1", closedSocket as never);
+    expect(await notifier.pushFrameToInbox("inbox_1", "{}")).toBe(0);
+  });
+
+  it("publishes every notification channel and swallows notify failures", async () => {
+    const ok = makeListenClient();
+    const notifier = createNotifier(ok.client as never);
+    const payload = {
+      agentId: "agent_1",
+      agentType: "codex",
+      displayName: "Agent",
+      name: null,
+      oldClientId: null,
+      reason: "switch",
+      runtimeProvider: "codex",
+      targetClientId: "client_1",
+    };
+
+    await notifier.notify("inbox_1", "msg_1");
+    await notifier.notifyConfigChange("agent");
+    await notifier.notifySessionStateChange("agent_1", "chat_1", "active", "org_1");
+    await notifier.notifySessionEvent("agent_1", "chat_1", "tool_call", "org_1");
+    await notifier.notifyRuntimeStateChange("agent_1", "working", "org_1");
+    await notifier.notifySessionRuntime("agent_1", "chat_1", "working", "org_1");
+    await notifier.notifyChatMessage("chat_1", "msg_1");
+    await notifier.notifyChatAudience("chat_1");
+    await notifier.notifyChatUpdated("chat_1");
+    await notifier.notifyAgentRouteChange(payload);
+
+    expect(ok.calls).toHaveLength(10);
+    expect(ok.calls.map((values) => values[0])).toEqual([
+      "inbox_notifications",
+      "config_changes",
+      "session_state_changes",
+      "session_event_changes",
+      "runtime_state_changes",
+      "session_runtime_changes",
+      "chat_message_events",
+      "chat_audience_events",
+      "chat_updated_events",
+      "agent_route_events",
+    ]);
+
+    const failing = createNotifier(makeListenClient(true).client as never);
+    await expect(failing.notify("inbox_1", "msg_1")).resolves.toBeUndefined();
+    await expect(failing.notifyAgentRouteChange(payload)).resolves.toBeUndefined();
+  });
+
+  it("parses LISTEN payloads, ignores malformed data, swallows handler errors, and stops idempotently", async () => {
+    const { client, listeners, unlisteners } = makeListenClient();
+    const notifier = createNotifier(client as never);
+    const config = vi.fn();
+    const sessionState = vi.fn();
+    const sessionEvent = vi.fn(() => {
+      throw new Error("consumer failed");
+    });
+    const sessionEventSecond = vi.fn();
+    const runtimeState = vi.fn();
+    const sessionRuntime = vi.fn();
+    const chatMessage = vi.fn(() => {
+      throw new Error("consumer failed");
+    });
+    const chatAudience = vi.fn();
+    const chatUpdated = vi.fn();
+    const agentRoute = vi.fn();
+
+    notifier.onConfigChange(config);
+    notifier.onSessionStateChange(sessionState);
+    notifier.onSessionEvent(sessionEvent);
+    notifier.onSessionEvent(sessionEventSecond);
+    notifier.onRuntimeStateChange(runtimeState);
+    notifier.onSessionRuntime(sessionRuntime);
+    notifier.onChatMessage(chatMessage);
+    notifier.onChatAudience(chatAudience);
+    notifier.onChatUpdated(chatUpdated);
+    notifier.onAgentRouteChange(agentRoute);
+    await notifier.start();
+
+    listeners.get("config_changes")?.("agent");
+    listeners.get("config_changes")?.("");
+    listeners.get("session_state_changes")?.("agent_1:chat_1:active:org_1");
+    listeners.get("session_state_changes")?.("bad");
+    listeners.get("session_event_changes")?.("agent_1:chat_1:tool_call:org_1");
+    listeners.get("session_runtime_changes")?.("agent_1:chat_1:working:org_1");
+    listeners.get("runtime_state_changes")?.("agent_1:idle:org_1");
+    listeners.get("runtime_state_changes")?.("bad");
+    listeners.get("chat_message_events")?.("chat_1:msg_1");
+    listeners.get("chat_message_events")?.("bad");
+    listeners.get("chat_audience_events")?.("chat_1");
+    listeners.get("chat_updated_events")?.("chat_1");
+    listeners.get("agent_route_events")?.(
+      JSON.stringify({
+        agentId: "agent_1",
+        agentType: "codex",
+        displayName: "Agent",
+        name: "agent",
+        oldClientId: null,
+        reason: "switch",
+        runtimeProvider: "codex",
+        targetClientId: "client_1",
+      }),
+    );
+    listeners.get("agent_route_events")?.("{not json");
+    listeners.get("agent_route_events")?.(JSON.stringify({ agentId: "agent_1" }));
+
+    expect(config).toHaveBeenCalledWith("agent");
+    expect(sessionState).toHaveBeenCalledWith({
+      agentId: "agent_1",
+      chatId: "chat_1",
+      organizationId: "org_1",
+      state: "active",
+    });
+    expect(sessionEventSecond).toHaveBeenCalledWith({
+      agentId: "agent_1",
+      chatId: "chat_1",
+      kind: "tool_call",
+      organizationId: "org_1",
+    });
+    expect(sessionRuntime).toHaveBeenCalledWith({
+      agentId: "agent_1",
+      chatId: "chat_1",
+      organizationId: "org_1",
+      state: "working",
+    });
+    expect(runtimeState).toHaveBeenCalledWith({ agentId: "agent_1", organizationId: "org_1", state: "idle" });
+    expect(chatMessage).toHaveBeenCalledWith({ chatId: "chat_1", messageId: "msg_1" });
+    expect(chatAudience).toHaveBeenCalledWith({ chatId: "chat_1" });
+    expect(chatUpdated).toHaveBeenCalledWith({ chatId: "chat_1" });
+    expect(agentRoute).toHaveBeenCalledWith({
+      agentId: "agent_1",
+      agentType: "codex",
+      displayName: "Agent",
+      name: "agent",
+      oldClientId: null,
+      reason: "switch",
+      runtimeProvider: "codex",
+      targetClientId: "client_1",
+    });
+
+    await notifier.stop();
+    await notifier.stop();
+    expect(unlisteners).toHaveLength(10);
+    for (const unlisten of unlisteners) {
+      expect(unlisten).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("notifies recipient inboxes without awaiting individual failures", async () => {
+    const notifier = {
+      notify: vi.fn((inboxId: string) => (inboxId === "bad" ? Promise.reject(new Error("boom")) : Promise.resolve())),
+    };
+
+    notifyRecipients(notifier as never, ["ok", "bad"], "msg_1");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(notifier.notify).toHaveBeenCalledWith("ok", "msg_1");
+    expect(notifier.notify).toHaveBeenCalledWith("bad", "msg_1");
+  });
+});

--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { invitationRedemptions } from "../db/schema/invitations.js";
 import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
+import * as githubAppInstallations from "../services/github-app-installations.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 function stubGithubAppOauth(opts: {
@@ -174,6 +175,41 @@ describe("GitHub OAuth onboarding flow", () => {
         process.env.DEV_GITHUB_PAT = original;
       }
     }
+  });
+
+  it("continues dev sign-in when installation stub upsert and direct bind fail", async () => {
+    const app = getApp();
+    const upsert = vi
+      .spyOn(githubAppInstallations, "upsertInstallationFromMetadata")
+      .mockRejectedValueOnce(new Error("stub failed"));
+    const bind = vi.spyOn(githubAppInstallations, "bindInstallationToOrg");
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/auth/github/dev-callback?githubId=46&login=stubfail&installationId=987654",
+      });
+
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toContain("/auth/github/complete#");
+      expect(res.headers.location).toContain("access=");
+      expect(upsert).toHaveBeenCalledTimes(1);
+      expect(bind).toHaveBeenCalledTimes(1);
+    } finally {
+      upsert.mockRestore();
+      bind.mockRestore();
+    }
+  });
+
+  it("returns JSON 404 for invalid invite tokens on dev-callback", async () => {
+    const app = getApp();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/dev-callback?githubId=47&login=missinginvite&next=${encodeURIComponent("/invite/not-real")}`,
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: "Invitation not found or no longer valid" });
   });
 
   it("still sends first-time solo signup with ordinary protected next to onboarding entry", async () => {

--- a/packages/server/src/__tests__/oauth-flow.test.ts
+++ b/packages/server/src/__tests__/oauth-flow.test.ts
@@ -7,6 +7,57 @@ import { members } from "../db/schema/members.js";
 import { organizations } from "../db/schema/organizations.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
+function stubGithubAppOauth(opts: {
+  tokenStatus?: number;
+  githubId?: number;
+  login?: string;
+  email?: string | null;
+}): () => void {
+  const original = globalThis.fetch;
+  type FetchInput = Parameters<typeof globalThis.fetch>[0];
+  type FetchInit = Parameters<typeof globalThis.fetch>[1];
+  globalThis.fetch = (async (input: FetchInput, init?: FetchInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url === "https://github.com/login/oauth/access_token") {
+      const status = opts.tokenStatus ?? 200;
+      if (status !== 200) {
+        return new Response(JSON.stringify({ error: "bad_verification_code" }), {
+          status,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          access_token: "gho_test_access",
+          expires_in: 28_800,
+          refresh_token: "ghr_test_refresh",
+          refresh_token_expires_in: 15_811_200,
+          scope: "",
+          token_type: "bearer",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url === "https://api.github.com/user") {
+      const login = opts.login ?? `callback-${randomUUID().slice(0, 8)}`;
+      return new Response(
+        JSON.stringify({
+          id: opts.githubId ?? 77_000_001,
+          login,
+          name: login,
+          email: opts.email ?? `${login}@example.com`,
+          avatar_url: null,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    return original(input, init);
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
 /**
  * End-to-end tests for the public GitHub-OAuth onboarding surface.
  * Uses `/auth/github/dev-callback` to skip the github.com round-trip —
@@ -15,6 +66,24 @@ import { createTestAdmin, useTestApp } from "./helpers.js";
  */
 describe("GitHub OAuth onboarding flow", () => {
   const getApp = useTestApp();
+
+  it("start signs a state cookie and redirects to the GitHub App authorize URL", async () => {
+    const app = getApp();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/auth/github/start?next=${encodeURIComponent("/settings/github")}`,
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers["set-cookie"]).toContain("oauth_state_nonce=");
+    const location = res.headers.location ?? "";
+    const authorizeUrl = new URL(location);
+    expect(`${authorizeUrl.origin}${authorizeUrl.pathname}`).toBe("https://github.com/login/oauth/authorize");
+    expect(authorizeUrl.searchParams.get("client_id")).toBe("test-app-client-id");
+    expect(authorizeUrl.searchParams.get("redirect_uri")).toContain("/api/v1/auth/github/callback");
+    expect(authorizeUrl.searchParams.get("state")).toBeTruthy();
+  });
 
   it("dev-callback creates user + auth_identity + personal team for first sign-in", async () => {
     const app = getApp();
@@ -76,6 +145,35 @@ describe("GitHub OAuth onboarding flow", () => {
     const params = new URLSearchParams(fragment);
     expect(params.get("next")).toBe(next);
     expect(params.get("joinPath")).toBe("solo");
+  });
+
+  it("dev-callback persists DEV_GITHUB_PAT as the stored GitHub access token", async () => {
+    const app = getApp();
+    const original = process.env.DEV_GITHUB_PAT;
+    process.env.DEV_GITHUB_PAT = "ghp_devpat123";
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/auth/github/dev-callback?githubId=45&login=patuser",
+      });
+      expect(res.statusCode).toBe(302);
+
+      const [identity] = await app.db
+        .select({ userId: authIdentities.userId, metadata: authIdentities.metadata })
+        .from(authIdentities)
+        .where(eq(authIdentities.identifier, "45"));
+      expect(identity?.metadata).toMatchObject({ login: "patuser" });
+      const { getStoredGithubAccessToken } = await import("../services/auth-identity.js");
+      await expect(
+        getStoredGithubAccessToken(app.db, identity?.userId ?? "", app.config.secrets.encryptionKey),
+      ).resolves.toBe("ghp_devpat123");
+    } finally {
+      if (original === undefined) {
+        delete process.env.DEV_GITHUB_PAT;
+      } else {
+        process.env.DEV_GITHUB_PAT = original;
+      }
+    }
   });
 
   it("still sends first-time solo signup with ordinary protected next to onboarding entry", async () => {
@@ -410,6 +508,51 @@ describe("OAuth callback rejects malformed state", () => {
       headers: { cookie: "oauth_state_nonce=wrong" },
     });
     expectStateRejectedRedirect(res);
+  });
+
+  it("redirects to the SPA error surface when GitHub code exchange fails", async () => {
+    const app = getApp();
+    const { signOAuthState } = await import("../services/oauth-state.js");
+    const { token, nonce } = await signOAuthState(app.config.secrets.jwtSecret, "/onboarding/connected");
+    const restore = stubGithubAppOauth({ tokenStatus: 500 });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=bad-code&state=${token}`,
+        headers: { cookie: `oauth_state_nonce=${nonce}` },
+      });
+
+      expect(res.statusCode).toBe(302);
+      const location = res.headers.location ?? "";
+      expect(location).toContain("/auth/github/complete#");
+      expect(location).toContain("error=github-exchange-failed");
+      expect(location).toContain("next=%2Fonboarding");
+      expect(location).not.toContain("access=");
+    } finally {
+      restore();
+    }
+  });
+
+  it("redirects live callback invalid invites to the SPA error surface", async () => {
+    const app = getApp();
+    const { signOAuthState } = await import("../services/oauth-state.js");
+    const { token, nonce } = await signOAuthState(app.config.secrets.jwtSecret, "/invite/missing-token");
+    const restore = stubGithubAppOauth({ githubId: 77_123_001, login: "missinginvite" });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: `/api/v1/auth/github/callback?code=ok-code&state=${token}`,
+        headers: { cookie: `oauth_state_nonce=${nonce}` },
+      });
+
+      expect(res.statusCode).toBe(302);
+      const location = res.headers.location ?? "";
+      expect(location).toContain("/auth/github/complete#");
+      expect(location).toContain("error=invite-invalid");
+      expect(location).not.toContain("access=");
+    } finally {
+      restore();
+    }
   });
 
   it("dev-callback ignores open-redirect bypasses in `next`", async () => {

--- a/packages/server/src/__tests__/oauth-github-config-edge.test.ts
+++ b/packages/server/src/__tests__/oauth-github-config-edge.test.ts
@@ -1,0 +1,32 @@
+import Fastify from "fastify";
+import { describe, expect, it } from "vitest";
+import { githubOauthRoutes } from "../api/auth/github.js";
+
+describe("GitHub OAuth route config edges", () => {
+  it("returns 503 from start and callback when the GitHub App is not configured", async () => {
+    const app = Object.assign(Fastify({ logger: false }), {
+      config: {
+        oauth: {},
+        secrets: {
+          jwtSecret: "test-jwt-secret-key-for-vitest",
+          encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        },
+        server: { publicUrl: undefined },
+      },
+    });
+    await app.register(githubOauthRoutes);
+    await app.ready();
+
+    try {
+      const start = await app.inject({ method: "GET", url: "/start" });
+      expect(start.statusCode).toBe(503);
+      expect(start.json<{ error: string }>().error).toMatch(/not configured/i);
+
+      const callback = await app.inject({ method: "GET", url: "/callback" });
+      expect(callback.statusCode).toBe(503);
+      expect(callback.json<{ error: string }>().error).toMatch(/not configured/i);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -423,6 +423,25 @@ describe("org-settings service", () => {
     ).rejects.toThrow(/agentUuid is required/);
   });
 
+  it("context_tree_features rejects enabled reviewer assignment without active member context", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewerAgent(app, {
+      clientId: admin.clientId,
+      managerId: admin.memberId,
+    });
+
+    await expect(
+      orgSettingsService.putOrgSetting(
+        app.db,
+        admin.organizationId,
+        "context_tree_features",
+        { contextReviewer: { enabled: true, agentUuid: reviewer.uuid } },
+        { updatedBy: admin.userId },
+      ),
+    ).rejects.toThrow(/active member/);
+  });
+
   it("context_tree_features rejects human, suspended, and side-org reviewers", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);

--- a/packages/server/src/__tests__/organization-extra.test.ts
+++ b/packages/server/src/__tests__/organization-extra.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createOrganization,
+  ensureDefaultOrganization,
+  getOrganization,
+  resolveDefaultOrgId,
+  updateOrganization,
+} from "../services/organization.js";
+
+function makeSelectDb(rows: unknown[]): unknown {
+  const chain = {
+    from: vi.fn(() => chain),
+    limit: vi.fn(async () => rows),
+    where: vi.fn(() => chain),
+  };
+  return { select: vi.fn(() => chain) };
+}
+
+function makeInsertDb(rows: unknown[], rejection?: unknown): { db: unknown; values: unknown[] } {
+  const values: unknown[] = [];
+  const chain = {
+    onConflictDoNothing: vi.fn(() => chain),
+    returning: vi.fn(async () => {
+      if (rejection) throw rejection;
+      return rows;
+    }),
+    values: vi.fn((value: unknown) => {
+      values.push(value);
+      return chain;
+    }),
+  };
+  return { db: { insert: vi.fn(() => chain) }, values };
+}
+
+function makeUpdateDb(rows: unknown[], rejection?: unknown): { db: unknown; updates: unknown[] } {
+  const updates: unknown[] = [];
+  const chain = {
+    returning: vi.fn(async () => {
+      if (rejection) throw rejection;
+      return rows;
+    }),
+    set: vi.fn((value: unknown) => {
+      updates.push(value);
+      return chain;
+    }),
+    where: vi.fn(() => chain),
+  };
+  return { db: { update: vi.fn(() => chain) }, updates };
+}
+
+describe("organization service edge cases", () => {
+  it("resolves the default org or throws when bootstrap has not seeded it", async () => {
+    await expect(resolveDefaultOrgId(makeSelectDb([{ id: "org_default" }]) as never)).resolves.toBe("org_default");
+    await expect(resolveDefaultOrgId(makeSelectDb([]) as never)).rejects.toThrow("Default organization not found");
+  });
+
+  it("creates organizations with defaults and maps unique conflicts", async () => {
+    const { db, values } = makeInsertDb([{ id: "org_1", name: "acme" }]);
+
+    await expect(createOrganization(db as never, { displayName: "Acme", name: "acme" })).resolves.toMatchObject({
+      id: "org_1",
+      name: "acme",
+    });
+    expect(values[0]).toMatchObject({
+      displayName: "Acme",
+      features: {},
+      maxAgents: 0,
+      maxMessagesPerMinute: 0,
+      name: "acme",
+    });
+
+    await expect(
+      createOrganization(makeInsertDb([], { code: "23505" }).db as never, { displayName: "Acme", name: "acme" }),
+    ).rejects.toThrow('Organization with name "acme" already exists');
+    await expect(
+      createOrganization(makeInsertDb([]).db as never, { displayName: "Acme", name: "acme" }),
+    ).rejects.toThrow("Unexpected: INSERT RETURNING produced no row");
+  });
+
+  it("reads and updates organizations with not-found and conflict handling", async () => {
+    await expect(getOrganization(makeSelectDb([{ id: "org_1" }]) as never, "org_1")).resolves.toEqual({ id: "org_1" });
+    await expect(getOrganization(makeSelectDb([]) as never, "missing")).rejects.toThrow(
+      'Organization "missing" not found',
+    );
+
+    const { db, updates } = makeUpdateDb([{ id: "org_1", displayName: "Acme Inc" }]);
+    await expect(
+      updateOrganization(db as never, "org_1", {
+        displayName: "Acme Inc",
+        features: { beta: true },
+        maxAgents: 10,
+        maxMessagesPerMinute: 20,
+        name: "acme-inc",
+      }),
+    ).resolves.toMatchObject({ displayName: "Acme Inc" });
+    expect(updates[0]).toMatchObject({
+      displayName: "Acme Inc",
+      features: { beta: true },
+      maxAgents: 10,
+      maxMessagesPerMinute: 20,
+      name: "acme-inc",
+    });
+    expect((updates[0] as { updatedAt?: unknown }).updatedAt).toBeInstanceOf(Date);
+
+    await expect(updateOrganization(makeUpdateDb([]).db as never, "missing", {})).rejects.toThrow(
+      'Organization "missing" not found',
+    );
+    await expect(
+      updateOrganization(makeUpdateDb([], { cause: { code: "23505" } }).db as never, "org_1", { name: "taken" }),
+    ).rejects.toThrow('Organization name "taken" is already taken');
+  });
+
+  it("ensures the default organization idempotently", async () => {
+    await expect(ensureDefaultOrganization(makeSelectDb([{ id: "org_default" }]) as never)).resolves.toEqual({
+      id: "org_default",
+    });
+
+    const selectChain = {
+      from: vi.fn(() => selectChain),
+      limit: vi.fn(async () => []),
+      where: vi.fn(() => selectChain),
+    };
+    const insertChain = {
+      onConflictDoNothing: vi.fn(() => insertChain),
+      returning: vi.fn(async () => [{ id: "org_created", name: "default" }]),
+      values: vi.fn(() => insertChain),
+    };
+    const db = {
+      insert: vi.fn(() => insertChain),
+      select: vi.fn(() => selectChain),
+    };
+
+    await expect(ensureDefaultOrganization(db as never)).resolves.toMatchObject({ id: "org_created" });
+    expect(insertChain.values).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: "Default Organization", name: "default" }),
+    );
+  });
+});

--- a/packages/server/src/__tests__/orgs-chats.test.ts
+++ b/packages/server/src/__tests__/orgs-chats.test.ts
@@ -127,6 +127,60 @@ describe("POST /orgs/:orgId/chats — multi-org chat creation (regression #238)"
     });
   });
 
+  it("admin all-scope listing serializes chat rows and pagination metadata", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const chatId = `chat-oc-list-${crypto.randomUUID()}`;
+    await app.db.insert(chats).values({
+      id: chatId,
+      organizationId: admin.organizationId,
+      type: "group",
+      topic: "All chats row",
+      lifecyclePolicy: "manual",
+      metadata: { source: "test" },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${encodeURIComponent(admin.organizationId)}/chats?scope=all&limit=1`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      items: Array<{ id: string; topic: string; participantCount: number }>;
+      nextCursor: string | null;
+    }>();
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]).toMatchObject({ id: chatId, topic: "All chats row", participantCount: 0 });
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it("lists source counts and rejects self-only manual chat creation before visibility lookup", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+
+    const counts = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${encodeURIComponent(admin.organizationId)}/chats/source-counts`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(counts.statusCode).toBe(200);
+    expect(counts.json<{ counts: { manual?: { chatCount: number } } }>().counts.manual).toEqual({
+      chatCount: 0,
+      unreadChatCount: 0,
+    });
+
+    const selfOnly = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${encodeURIComponent(admin.organizationId)}/chats`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { participantIds: [admin.humanAgentUuid] },
+    });
+    expect(selfOnly.statusCode).toBe(400);
+    expect(selfOnly.json<{ error: string }>().error).toContain("At least one non-self participant required");
+  });
+
   it("rejects participants from a different org (404 — anti-enumeration, not 400)", async () => {
     const app = getApp();
     const alice = await createTestAdmin(app);

--- a/packages/server/src/__tests__/participant-mode-invariant.test.ts
+++ b/packages/server/src/__tests__/participant-mode-invariant.test.ts
@@ -4,6 +4,7 @@ import { chatMembership } from "../db/schema/chat-membership.js";
 import { createAgent } from "../services/agent.js";
 import { addParticipant, createChat, ensureParticipant } from "../services/chat.js";
 import { createMeChat } from "../services/me-chat.js";
+import { addChatParticipants } from "../services/participant-mode.js";
 import { createAdminContext, createTestAgent, useTestApp } from "./helpers.js";
 
 /**
@@ -164,5 +165,32 @@ describe("v2 invariant: chat_membership.mode is the constant 'mention_only'", ()
     await ensureParticipant(app.db, chat.id, late.uuid);
 
     expect(await loadMode(app, chat.id, late.uuid)).toBe("mention_only");
+  });
+
+  it("addChatParticipants rejects missing participants before writing rows", async () => {
+    const app = getApp();
+    const humanCtx = await createTestAgent(app, { type: "human" });
+    const chat = await createChat(app.db, humanCtx.agent.uuid, {
+      type: "group",
+      participantIds: [],
+    });
+
+    await expect(
+      app.db.transaction((tx) => addChatParticipants(tx, chat.id, [{ agentId: "missing-agent" }])),
+    ).rejects.toThrow("Agents not found: missing-agent");
+  });
+
+  it("addChatParticipants assertHuman rejects non-human agents", async () => {
+    const app = getApp();
+    const humanCtx = await createTestAgent(app, { type: "human" });
+    const { agent } = await createTestAgent(app, { type: "agent" });
+    const chat = await createChat(app.db, humanCtx.agent.uuid, {
+      type: "group",
+      participantIds: [],
+    });
+
+    await expect(
+      app.db.transaction((tx) => addChatParticipants(tx, chat.id, [{ agentId: agent.uuid }], { assertHuman: true })),
+    ).rejects.toThrow("assertHuman violated");
   });
 });

--- a/packages/server/src/__tests__/presence.test.ts
+++ b/packages/server/src/__tests__/presence.test.ts
@@ -1,4 +1,6 @@
+import { eq, sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { agentPresence } from "../db/schema/agent-presence.js";
 import * as presenceService from "../services/presence.js";
 import { createTestAgent, useTestApp } from "./helpers.js";
 
@@ -66,6 +68,49 @@ describe("Presence Service", () => {
     await presenceService.heartbeatInstance(app.db, "test-heartbeat-instance");
   });
 
+  it("touches per-agent liveness without changing presence status", async () => {
+    const app = getApp();
+    const { agent } = await createTestAgent(app, { name: "touch-a1" });
+    await presenceService.setOnline(app.db, agent.uuid, "touch-instance");
+    await app.db
+      .update(agentPresence)
+      .set({ lastSeenAt: new Date("2026-01-01T00:00:00.000Z") })
+      .where(eq(agentPresence.agentId, agent.uuid));
+
+    await presenceService.touchAgent(app.db, agent.uuid);
+
+    const presence = await presenceService.getPresence(app.db, agent.uuid);
+    expect(presence?.status).toBe("online");
+    expect(presence?.lastSeenAt.getTime()).toBeGreaterThan(new Date("2026-01-01T00:00:00.000Z").getTime());
+  });
+
+  it("marks stale agents offline by per-agent heartbeat age", async () => {
+    const app = getApp();
+    const { agent, clientId } = await createTestAgent(app, { name: "stale-agent-a1" });
+    await presenceService.setOnline(app.db, agent.uuid, "stale-agent-instance");
+    await app.db.execute(sql`
+      UPDATE agent_presence
+         SET last_seen_at = NOW() - INTERVAL '120 seconds',
+             client_id = ${clientId},
+             runtime_state = 'working',
+             active_sessions = 1,
+             total_sessions = 2
+       WHERE agent_id = ${agent.uuid}
+    `);
+
+    const staleAgentIds = await presenceService.markStaleAgents(app.db, 60);
+
+    expect(staleAgentIds).toEqual([agent.uuid]);
+    const presence = await presenceService.getPresence(app.db, agent.uuid);
+    expect(presence).toMatchObject({
+      status: "offline",
+      clientId: null,
+      runtimeState: null,
+      activeSessions: null,
+      totalSessions: null,
+    });
+  });
+
   it("cleans up stale presence", async () => {
     const app = getApp();
     const { agent } = await createTestAgent(app, { name: "stale-a1" });
@@ -74,7 +119,6 @@ describe("Presence Service", () => {
     await presenceService.setOnline(app.db, agent.uuid, "stale-instance");
 
     // Register stale instance with old heartbeat
-    const { sql } = await import("drizzle-orm");
     await app.db.execute(sql`
       INSERT INTO server_instances (instance_id, last_heartbeat)
       VALUES ('stale-instance', NOW() - INTERVAL '120 seconds')

--- a/packages/server/src/__tests__/resources-phase1.test.ts
+++ b/packages/server/src/__tests__/resources-phase1.test.ts
@@ -1721,7 +1721,9 @@ describe("Resources Phase 1", () => {
     const agent = await createRuntimeAgent(app, owner);
 
     await expect(app.resourcesService.getResource(crypto.randomUUID())).rejects.toMatchObject({ statusCode: 404 });
-    await expect(app.resourcesService.getAgentResources(crypto.randomUUID())).rejects.toMatchObject({ statusCode: 404 });
+    await expect(app.resourcesService.getAgentResources(crypto.randomUUID())).rejects.toMatchObject({
+      statusCode: 404,
+    });
 
     await app.db.delete(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
     await expect(app.resourcesService.resolveEffectiveResources(agent.uuid)).rejects.toMatchObject({ statusCode: 404 });

--- a/packages/server/src/__tests__/resources-phase1.test.ts
+++ b/packages/server/src/__tests__/resources-phase1.test.ts
@@ -384,6 +384,155 @@ describe("Resources Phase 1", () => {
     expect(rows[0]).toMatchObject({ scope: "team", defaultEnabled: "recommended" });
   });
 
+  it("records warnings for invalid legacy resource backfill inputs", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const malformedConfigAgent = await createRuntimeAgent(app, owner);
+    const invalidRepoAgent = await createRuntimeAgent(app, owner);
+
+    await app.db.insert(organizationSettings).values({
+      organizationId: owner.organizationId,
+      namespace: "source_repos",
+      value: { repos: "not-array" },
+      version: 1,
+      updatedBy: owner.userId,
+    });
+    await app.db
+      .update(agentConfigs)
+      .set({
+        // Seed malformed persisted JSON directly; the typed write API would reject
+        // the legacy shape that the backfill must tolerate.
+        payload: {
+          ...DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+          gitRepos: "not-array",
+          resourceSkills: [],
+        } as unknown as typeof DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+      })
+      .where(eq(agentConfigs.agentId, malformedConfigAgent.uuid));
+    await app.db
+      .update(agentConfigs)
+      .set({
+        payload: {
+          ...DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+          gitRepos: [{ url: "not a url" }],
+          resourceSkills: [],
+        },
+      })
+      .where(eq(agentConfigs.agentId, invalidRepoAgent.uuid));
+
+    const result = await backfillResourcesPhase1(app.db);
+
+    expect(result.warnings).toEqual(
+      expect.arrayContaining([
+        `source_repos parse failed for org ${owner.organizationId}`,
+        `agent config parse failed for ${malformedConfigAgent.uuid}`,
+        expect.stringMatching(new RegExp(`agent gitRepo skipped for ${invalidRepoAgent.uuid}: Invalid URL`)),
+      ]),
+    );
+    expect(result.teamReposCreated).toBe(0);
+    expect(result.agentReposCreated).toBe(0);
+    expect(result.bindingsCreated).toBe(0);
+  });
+
+  it("backfills explicit team repo refs while ignoring duplicate legacy bindings", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const newBindingAgent = await createRuntimeAgent(app, owner);
+    const duplicateBindingAgent = await createRuntimeAgent(app, owner);
+    const teamRepo = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "repo",
+        name: "Shared repo",
+        defaultEnabled: "recommended",
+        payload: { url: "https://github.com/acme/shared.git", defaultBranch: "main" },
+      },
+      owner.memberId,
+    );
+
+    await app.db
+      .update(agentConfigs)
+      .set({
+        payload: {
+          ...DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+          gitRepos: [{ url: "git@github.com:Acme/Shared.git", ref: "feature-a", localPath: "shared-a" }],
+          prompt: { append: "" },
+          resourceSkills: [],
+        },
+      })
+      .where(eq(agentConfigs.agentId, newBindingAgent.uuid));
+    await app.db
+      .update(agentConfigs)
+      .set({
+        payload: {
+          ...DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+          gitRepos: [{ url: "https://github.com/acme/shared.git", ref: "feature-b", localPath: "shared-b" }],
+          prompt: { append: "Existing prompt append." },
+          resourceSkills: [],
+        },
+      })
+      .where(eq(agentConfigs.agentId, duplicateBindingAgent.uuid));
+    await app.db.insert(agentResourceBindings).values([
+      {
+        id: uuidv7(),
+        organizationId: owner.organizationId,
+        agentId: duplicateBindingAgent.uuid,
+        type: "repo",
+        mode: "include",
+        resourceId: teamRepo.id,
+        replacesResourceId: null,
+        inlinePromptBody: null,
+        repoRef: "feature-b",
+        repoLocalPath: "shared-b",
+        order: 1,
+        createdBy: owner.memberId,
+        updatedBy: owner.memberId,
+      },
+      {
+        id: uuidv7(),
+        organizationId: owner.organizationId,
+        agentId: duplicateBindingAgent.uuid,
+        type: "prompt",
+        mode: "include",
+        resourceId: null,
+        replacesResourceId: null,
+        inlinePromptBody: "Existing prompt append.",
+        repoRef: null,
+        repoLocalPath: null,
+        order: 2,
+        createdBy: owner.memberId,
+        updatedBy: owner.memberId,
+      },
+    ]);
+
+    const result = await backfillResourcesPhase1(app.db);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.teamReposCreated).toBe(0);
+    expect(result.agentReposCreated).toBe(0);
+    expect(result.bindingsCreated).toBe(1);
+    expect(result.agentVersionsBumped).toBe(1);
+
+    const newBindings = await app.db
+      .select()
+      .from(agentResourceBindings)
+      .where(eq(agentResourceBindings.agentId, newBindingAgent.uuid));
+    expect(newBindings).toHaveLength(1);
+    expect(newBindings[0]).toMatchObject({
+      type: "repo",
+      resourceId: teamRepo.id,
+      repoRef: "feature-a",
+      repoLocalPath: "shared-a",
+      order: 1,
+    });
+
+    const duplicateBindings = await app.db
+      .select()
+      .from(agentResourceBindings)
+      .where(eq(agentResourceBindings.agentId, duplicateBindingAgent.uuid));
+    expect(duplicateBindings).toHaveLength(2);
+  });
+
   it("lets an explicit repo binding override a recommended team repo without duplicating it", async () => {
     const app = getApp();
     const owner = await createOrgUser(app, "admin");

--- a/packages/server/src/__tests__/resources-phase1.test.ts
+++ b/packages/server/src/__tests__/resources-phase1.test.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
   PROMPT_APPEND_MAX_LENGTH,
 } from "@first-tree/shared";
-import { and, eq, inArray, ne } from "drizzle-orm";
+import { and, eq, inArray, isNull, ne } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { agentConfigs } from "../db/schema/agent-configs.js";
@@ -16,6 +16,7 @@ import { members } from "../db/schema/members.js";
 import { organizationSettings } from "../db/schema/organization-settings.js";
 import { resources } from "../db/schema/resources.js";
 import { createAgent } from "../services/agent.js";
+import { LANDING_CAMPAIGN_TRIAL_PROMPT } from "../services/landing-campaigns/trial-prompt.js";
 import { createOrganization } from "../services/organization.js";
 import { backfillResourcesPhase1 } from "../services/resources-migration.js";
 import { uuidv7 } from "../uuid.js";
@@ -864,6 +865,213 @@ describe("Resources Phase 1", () => {
       `/api/v1/orgs/${owner.organizationId}/resources/${resource.id}`,
     );
     expect(classBDetail.statusCode).toBe(404);
+  });
+
+  it("lists active and stale team resources only", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const prompt = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "prompt",
+        name: "Alpha prompt",
+        defaultEnabled: "available",
+        payload: { body: "Alpha" },
+      },
+      owner.memberId,
+    );
+    const skill = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "skill",
+        name: "Beta skill",
+        defaultEnabled: "available",
+        payload: {
+          name: "beta",
+          description: "Beta skill",
+          body: "Use beta.",
+          metadata: {},
+        },
+      },
+      owner.memberId,
+    );
+    const retired = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "repo",
+        name: "Retired repo",
+        defaultEnabled: "available",
+        payload: { url: "https://github.com/acme/retired.git" },
+      },
+      owner.memberId,
+    );
+    await app.resourcesService.retireResource(retired.id, owner.memberId);
+
+    const rows = await app.resourcesService.listTeamResources(owner.organizationId);
+
+    expect(rows.map((row) => row.id)).toEqual([prompt.id, skill.id]);
+    expect(rows[0]).toMatchObject({
+      id: prompt.id,
+      organizationId: owner.organizationId,
+      scope: "team",
+      status: "active",
+      payload: { body: "Alpha" },
+    });
+  });
+
+  it("rejects invalid agent resource binding references", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    const otherAgent = await createRuntimeAgent(app, owner);
+    const teamPrompt = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "prompt",
+        name: "Team prompt",
+        defaultEnabled: "available",
+        payload: { body: "Prompt" },
+      },
+      owner.memberId,
+    );
+
+    const expectRejectedBinding = async (
+      binding: Parameters<typeof app.resourcesService.replaceAgentResources>[1]["bindings"][number],
+      message: string,
+    ) => {
+      const current = await app.resourcesService.getAgentResources(agent.uuid);
+      await expect(
+        app.resourcesService.replaceAgentResources(
+          agent.uuid,
+          { expectedVersion: current.version, bindings: [binding] },
+          owner.memberId,
+        ),
+      ).rejects.toThrow(message);
+    };
+
+    await expectRejectedBinding(
+      { type: "repo", mode: "include", resourceId: crypto.randomUUID() },
+      "is not available to this agent",
+    );
+    await expectRejectedBinding(
+      { type: "repo", mode: "include", resourceId: teamPrompt.id },
+      'has type "prompt", expected "repo"',
+    );
+
+    const ownedAgentRepoId = uuidv7();
+    await app.db.insert(resources).values({
+      id: ownedAgentRepoId,
+      organizationId: owner.organizationId,
+      type: "repo",
+      scope: "agent",
+      ownerAgentId: agent.uuid,
+      name: "Owned repo",
+      repoCanonicalKey: canonicalizeResourceRepoUrl("https://github.com/acme/owned.git"),
+      defaultEnabled: null,
+      status: "active",
+      payload: { url: "https://github.com/acme/owned.git" },
+      createdBy: owner.memberId,
+      updatedBy: owner.memberId,
+    });
+    await expectRejectedBinding(
+      { type: "repo", mode: "disable", resourceId: ownedAgentRepoId },
+      "is not a Team resource",
+    );
+
+    const otherAgentRepoId = uuidv7();
+    await app.db.insert(resources).values({
+      id: otherAgentRepoId,
+      organizationId: owner.organizationId,
+      type: "repo",
+      scope: "agent",
+      ownerAgentId: otherAgent.uuid,
+      name: "Other repo",
+      repoCanonicalKey: canonicalizeResourceRepoUrl("https://github.com/acme/other.git"),
+      defaultEnabled: null,
+      status: "active",
+      payload: { url: "https://github.com/acme/other.git" },
+      createdBy: owner.memberId,
+      updatedBy: owner.memberId,
+    });
+    await expectRejectedBinding(
+      { type: "repo", mode: "include", resourceId: otherAgentRepoId },
+      "is not owned by this agent",
+    );
+
+    const agentMcpId = uuidv7();
+    await app.db.insert(resources).values({
+      id: agentMcpId,
+      organizationId: owner.organizationId,
+      type: "mcp",
+      scope: "agent",
+      ownerAgentId: agent.uuid,
+      name: "Agent MCP",
+      repoCanonicalKey: null,
+      defaultEnabled: null,
+      status: "active",
+      payload: { name: "agent-mcp", transport: "stdio", command: "agent-mcp" },
+      createdBy: owner.memberId,
+      updatedBy: owner.memberId,
+    });
+    await expectRejectedBinding(
+      { type: "mcp", mode: "include", resourceId: agentMcpId },
+      "Only repo and skill resources may be agent-scoped",
+    );
+  });
+
+  it("refreshes landing campaign trial prompt content and removes stale inline guardrails", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+
+    await app.resourcesService.ensureAndBindLandingCampaignTrialPrompt(agent.uuid, owner.memberId);
+    const [promptResource] = await app.db
+      .select()
+      .from(resources)
+      .where(and(eq(resources.ownerAgentId, agent.uuid), eq(resources.type, "prompt"), eq(resources.scope, "agent")))
+      .limit(1);
+    expect(promptResource).toBeDefined();
+    await app.db
+      .update(resources)
+      .set({ payload: { body: "stale", description: "stale" } })
+      .where(eq(resources.id, promptResource?.id ?? ""));
+    await app.db.insert(agentResourceBindings).values({
+      id: uuidv7(),
+      organizationId: owner.organizationId,
+      agentId: agent.uuid,
+      type: "prompt",
+      mode: "include",
+      resourceId: null,
+      replacesResourceId: null,
+      inlinePromptBody: LANDING_CAMPAIGN_TRIAL_PROMPT,
+      repoRef: null,
+      repoLocalPath: null,
+      order: 99,
+      createdBy: owner.memberId,
+      updatedBy: owner.memberId,
+    });
+    const before = await app.configService.get(agent.uuid);
+
+    await app.resourcesService.ensureAndBindLandingCampaignTrialPrompt(agent.uuid, owner.memberId);
+
+    const [refreshed] = await app.db
+      .select({ payload: resources.payload })
+      .from(resources)
+      .where(eq(resources.id, promptResource?.id ?? ""));
+    expect(refreshed?.payload).toMatchObject({ body: LANDING_CAMPAIGN_TRIAL_PROMPT });
+    const staleInlineRows = await app.db
+      .select({ id: agentResourceBindings.id })
+      .from(agentResourceBindings)
+      .where(
+        and(
+          eq(agentResourceBindings.agentId, agent.uuid),
+          isNull(agentResourceBindings.resourceId),
+          eq(agentResourceBindings.inlinePromptBody, LANDING_CAMPAIGN_TRIAL_PROMPT),
+        ),
+      );
+    expect(staleInlineRows).toHaveLength(0);
+    const after = await app.configService.get(agent.uuid);
+    expect(after.version).toBe(before.version + 1);
   });
 });
 

--- a/packages/server/src/__tests__/resources-phase1.test.ts
+++ b/packages/server/src/__tests__/resources-phase1.test.ts
@@ -910,6 +910,332 @@ describe("Resources Phase 1", () => {
     expect(teamResolved.payload.mcpServers).toEqual([teamMcp]);
   });
 
+  it("projects disabled recommended prompts and inline replacements into effective resources", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    const recommended = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "prompt",
+        name: "Recommended prompt",
+        defaultEnabled: "recommended",
+        payload: { body: "Recommended baseline." },
+      },
+      owner.memberId,
+    );
+    const replaceable = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "prompt",
+        name: "Replaceable prompt",
+        defaultEnabled: "available",
+        payload: { body: "Replaceable baseline." },
+      },
+      owner.memberId,
+    );
+    const current = await app.resourcesService.getAgentResources(agent.uuid);
+
+    const updated = await app.resourcesService.replaceAgentResources(
+      agent.uuid,
+      {
+        expectedVersion: current.version,
+        bindings: [
+          { type: "prompt", mode: "disable", resourceId: recommended.id },
+          {
+            type: "prompt",
+            mode: "replace",
+            resourceId: null,
+            replacesResourceId: replaceable.id,
+            inlinePromptBody: "Agent replacement.",
+          },
+        ],
+      },
+      owner.memberId,
+    );
+
+    expect(updated.effective.prompts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resourceId: recommended.id,
+          mode: "disabled",
+          source: "team_recommended",
+          promptBody: null,
+        }),
+        expect.objectContaining({
+          resourceId: replaceable.id,
+          mode: "replaced",
+          replacesResourceId: replaceable.id,
+          source: "team_available",
+          promptBody: null,
+        }),
+        expect.objectContaining({
+          resourceId: null,
+          mode: "enabled",
+          replacesResourceId: replaceable.id,
+          source: "inline_prompt",
+          promptBody: "Agent replacement.",
+        }),
+      ]),
+    );
+  });
+
+  it("marks malformed skill and MCP resources unavailable at projection time", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    const skillId = uuidv7();
+    const mcpId = uuidv7();
+    await app.db.insert(resources).values([
+      {
+        id: skillId,
+        organizationId: owner.organizationId,
+        type: "skill",
+        scope: "team",
+        ownerAgentId: null,
+        name: "Broken skill",
+        repoCanonicalKey: null,
+        defaultEnabled: "recommended",
+        status: "active",
+        payload: { description: "missing name and body" } as (typeof resources.$inferInsert)["payload"],
+        createdBy: owner.memberId,
+        updatedBy: owner.memberId,
+      },
+      {
+        id: mcpId,
+        organizationId: owner.organizationId,
+        type: "mcp",
+        scope: "team",
+        ownerAgentId: null,
+        name: "Broken MCP",
+        repoCanonicalKey: null,
+        defaultEnabled: "recommended",
+        status: "active",
+        payload: { name: "broken-mcp", transport: "http" } as (typeof resources.$inferInsert)["payload"],
+        createdBy: owner.memberId,
+        updatedBy: owner.memberId,
+      },
+    ]);
+
+    const effective = await app.resourcesService.resolveEffectiveResources(agent.uuid);
+
+    expect(effective.skills).toContainEqual(
+      expect.objectContaining({
+        resourceId: skillId,
+        mode: "unavailable",
+        unavailableReason: "invalid_skill_payload",
+      }),
+    );
+    expect(effective.mcp).toContainEqual(
+      expect.objectContaining({
+        resourceId: mcpId,
+        mode: "unavailable",
+        unavailableReason: "invalid_mcp_payload",
+      }),
+    );
+    expect(effective.unavailable).toEqual(
+      expect.arrayContaining([
+        { type: "skill", id: skillId, reason: "invalid_skill_payload" },
+        { type: "mcp", id: mcpId, reason: "invalid_mcp_payload" },
+      ]),
+    );
+  });
+
+  it("projects team skill resources into runtime config skills", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    const skill = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "skill",
+        name: "Reviewer skill",
+        defaultEnabled: "recommended",
+        payload: {
+          name: "reviewer",
+          description: "Review changes.",
+          body: "# Reviewer\n\nCheck edge cases.",
+          metadata: { source: "team" },
+        },
+      },
+      owner.memberId,
+    );
+
+    const baseConfig = await app.configService.get(agent.uuid);
+    const resolved = await app.resourcesService.resolveRuntimeConfig(baseConfig);
+
+    expect(resolved.payload.resourceSkills).toEqual([
+      {
+        resourceId: skill.id,
+        name: "reviewer",
+        description: "Review changes.",
+        body: "# Reviewer\n\nCheck edge cases.",
+        metadata: { source: "team" },
+      },
+    ]);
+  });
+
+  it("validates resource create/update edge paths and bumps recommended updates", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    const prompt = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "prompt",
+        name: "Available prompt",
+        defaultEnabled: "available",
+        payload: { body: "Available." },
+      },
+      owner.memberId,
+    );
+
+    const before = await app.configService.get(agent.uuid);
+    const updated = await app.resourcesService.updateResource(
+      prompt.id,
+      {
+        name: "Recommended prompt",
+        defaultEnabled: "recommended",
+        payload: { body: "Recommended." },
+      },
+      owner.memberId,
+    );
+    const after = await app.configService.get(agent.uuid);
+    expect(updated).toMatchObject({
+      id: prompt.id,
+      name: "Recommended prompt",
+      defaultEnabled: "recommended",
+      payload: { body: "Recommended." },
+    });
+    expect(after.version).toBe(before.version + 1);
+
+    await expect(
+      app.resourcesService.updateResource(prompt.id, { status: "retired" }, owner.memberId),
+    ).rejects.toMatchObject({ statusCode: 400 });
+
+    await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "repo",
+        name: "Web",
+        defaultEnabled: "available",
+        payload: { url: "https://github.com/acme/web.git" },
+      },
+      owner.memberId,
+    );
+    await expect(
+      app.resourcesService.createTeamResource(
+        owner.organizationId,
+        {
+          type: "repo",
+          name: "Duplicate web",
+          defaultEnabled: "available",
+          payload: { url: "git@github.com:Acme/Web.git" },
+        },
+        owner.memberId,
+      ),
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    await app.resourcesService.replaceAgentResources(
+      agent.uuid,
+      {
+        expectedVersion: after.version,
+        bindings: [
+          {
+            type: "repo",
+            mode: "include",
+            agentExtraRepo: { url: "https://github.com/acme/agent-only.git" },
+          },
+        ],
+      },
+      owner.memberId,
+    );
+    const [agentRepo] = await app.db
+      .select()
+      .from(resources)
+      .where(and(eq(resources.ownerAgentId, agent.uuid), eq(resources.scope, "agent"), eq(resources.type, "repo")))
+      .limit(1);
+    await expect(
+      app.resourcesService.updateResource(agentRepo?.id ?? "", { name: "Renamed" }, owner.memberId),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("promotes an agent-scoped repo into an existing canonical team repo", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    const existingTeamRepo = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "repo",
+        name: "Shared promote target",
+        defaultEnabled: "available",
+        payload: { url: "https://github.com/acme/promote-existing.git" },
+      },
+      owner.memberId,
+    );
+    await app.resourcesService.replaceAgentResources(
+      agent.uuid,
+      {
+        expectedVersion: 1,
+        bindings: [
+          {
+            type: "repo",
+            mode: "include",
+            agentExtraRepo: { url: "git@github.com:Acme/Promote-Existing.git" },
+            repoLocalPath: "agent-promote-existing",
+          },
+        ],
+      },
+      owner.memberId,
+    );
+    const [agentRepo] = await app.db
+      .select()
+      .from(resources)
+      .where(and(eq(resources.ownerAgentId, agent.uuid), eq(resources.scope, "agent"), eq(resources.type, "repo")))
+      .limit(1);
+
+    const promoted = await app.resourcesService.promoteResource(agentRepo?.id ?? "", owner.memberId);
+
+    expect(promoted.id).toBe(existingTeamRepo.id);
+    const [binding] = await app.db
+      .select()
+      .from(agentResourceBindings)
+      .where(eq(agentResourceBindings.agentId, agent.uuid))
+      .limit(1);
+    expect(binding).toMatchObject({
+      resourceId: existingTeamRepo.id,
+      repoLocalPath: "agent-promote-existing",
+    });
+    const [retired] = await app.db
+      .select()
+      .from(resources)
+      .where(eq(resources.id, agentRepo?.id ?? ""))
+      .limit(1);
+    expect(retired?.status).toBe("retired");
+  });
+
+  it("previews organization impact defaults without a simulated payload", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+
+    await expect(app.resourcesService.previewOrgImpact(owner.organizationId, {})).resolves.toEqual({
+      affectedAgentCount: 0,
+      promptOverflowAgentCount: 0,
+      agents: [],
+    });
+
+    const recommended = await app.resourcesService.previewOrgImpact(owner.organizationId, {
+      defaultEnabled: "recommended",
+    });
+    expect(recommended).toMatchObject({
+      affectedAgentCount: 1,
+      promptOverflowAgentCount: 0,
+    });
+    expect(recommended.agents).toEqual([expect.objectContaining({ uuid: agent.uuid })]);
+  });
+
   it("previews prompt overflow using create and update candidate payloads", async () => {
     const app = getApp();
     const owner = await createOrgUser(app, "admin");

--- a/packages/server/src/__tests__/resources-phase1.test.ts
+++ b/packages/server/src/__tests__/resources-phase1.test.ts
@@ -1215,6 +1215,25 @@ describe("Resources Phase 1", () => {
     expect(retired?.status).toBe("retired");
   });
 
+  it("rejects promoting resources that are not active agent-scoped repos", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const teamPrompt = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "prompt",
+        name: "Not promotable",
+        defaultEnabled: "available",
+        payload: { body: "Prompt" },
+      },
+      owner.memberId,
+    );
+
+    await expect(app.resourcesService.promoteResource(teamPrompt.id, owner.memberId)).rejects.toThrow(
+      /agent-scoped repo resources/,
+    );
+  });
+
   it("previews organization impact defaults without a simulated payload", async () => {
     const app = getApp();
     const owner = await createOrgUser(app, "admin");

--- a/packages/server/src/__tests__/resources-phase1.test.ts
+++ b/packages/server/src/__tests__/resources-phase1.test.ts
@@ -11,6 +11,7 @@ import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { agentConfigs } from "../db/schema/agent-configs.js";
 import { agentResourceBindings } from "../db/schema/agent-resource-bindings.js";
+import { agents } from "../db/schema/agents.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { organizationSettings } from "../db/schema/organization-settings.js";
@@ -1513,6 +1514,267 @@ describe("Resources Phase 1", () => {
     );
   });
 
+  it("covers agent resource projection fallbacks for legacy malformed rows", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+
+    const malformedRepoId = uuidv7();
+    const malformedPromptId = uuidv7();
+    const retiredRepoId = uuidv7();
+    const retiredPromptId = uuidv7();
+    await app.db.insert(resources).values([
+      {
+        id: malformedRepoId,
+        organizationId: owner.organizationId,
+        type: "repo",
+        scope: "team",
+        ownerAgentId: null,
+        name: "Malformed repo",
+        repoCanonicalKey: null,
+        defaultEnabled: "recommended",
+        status: "active",
+        payload: { defaultBranch: "main" } as (typeof resources.$inferInsert)["payload"],
+        createdBy: owner.memberId,
+        updatedBy: owner.memberId,
+      },
+      {
+        id: malformedPromptId,
+        organizationId: owner.organizationId,
+        type: "prompt",
+        scope: "team",
+        ownerAgentId: null,
+        name: "Malformed prompt",
+        repoCanonicalKey: null,
+        defaultEnabled: "recommended",
+        status: "active",
+        payload: { text: "missing body" } as unknown as (typeof resources.$inferInsert)["payload"],
+        createdBy: owner.memberId,
+        updatedBy: owner.memberId,
+      },
+      {
+        id: retiredRepoId,
+        organizationId: owner.organizationId,
+        type: "repo",
+        scope: "team",
+        ownerAgentId: null,
+        name: "Retired repo",
+        repoCanonicalKey: canonicalizeResourceRepoUrl("https://github.com/acme/retired-fallback.git"),
+        defaultEnabled: "available",
+        status: "retired",
+        payload: { url: "https://github.com/acme/retired-fallback.git" },
+        createdBy: owner.memberId,
+        updatedBy: owner.memberId,
+      },
+      {
+        id: retiredPromptId,
+        organizationId: owner.organizationId,
+        type: "prompt",
+        scope: "team",
+        ownerAgentId: null,
+        name: "Retired prompt",
+        repoCanonicalKey: null,
+        defaultEnabled: "available",
+        status: "retired",
+        payload: { body: "Retired prompt" },
+        createdBy: owner.memberId,
+        updatedBy: owner.memberId,
+      },
+    ]);
+    await app.db.insert(agentResourceBindings).values([
+      {
+        id: uuidv7(),
+        organizationId: owner.organizationId,
+        agentId: agent.uuid,
+        type: "repo",
+        mode: "disable",
+        resourceId: retiredRepoId,
+        replacesResourceId: null,
+        inlinePromptBody: null,
+        repoRef: null,
+        repoLocalPath: null,
+        order: 1,
+        createdBy: owner.memberId,
+        updatedBy: owner.memberId,
+      },
+      {
+        id: uuidv7(),
+        organizationId: owner.organizationId,
+        agentId: agent.uuid,
+        type: "prompt",
+        mode: "include",
+        resourceId: retiredPromptId,
+        replacesResourceId: null,
+        inlinePromptBody: null,
+        repoRef: null,
+        repoLocalPath: null,
+        order: 2,
+        createdBy: owner.memberId,
+        updatedBy: owner.memberId,
+      },
+    ]);
+
+    const effective = await app.resourcesService.resolveEffectiveResources(agent.uuid);
+
+    expect(effective.repos).toContainEqual(
+      expect.objectContaining({
+        resourceId: malformedRepoId,
+        mode: "enabled",
+        repo: null,
+      }),
+    );
+    expect(effective.prompts).toContainEqual(
+      expect.objectContaining({
+        resourceId: malformedPromptId,
+        mode: "enabled",
+        promptBody: null,
+      }),
+    );
+  });
+
+  it("reuses agent extra repos and preserves explicit resource names", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+
+    const first = await app.resourcesService.replaceAgentResources(
+      agent.uuid,
+      {
+        expectedVersion: 1,
+        bindings: [
+          {
+            type: "repo",
+            mode: "include",
+            agentExtraRepo: {
+              name: "Named extra repo",
+              url: "https://github.com/acme/named-extra.git",
+              defaultBranch: "main",
+            },
+          },
+        ],
+      },
+      owner.memberId,
+    );
+    const second = await app.resourcesService.replaceAgentResources(
+      agent.uuid,
+      {
+        expectedVersion: first.version,
+        bindings: [
+          {
+            type: "repo",
+            mode: "include",
+            agentExtraRepo: {
+              name: "Ignored second name",
+              url: "git@github.com:Acme/Named-Extra.git",
+              defaultBranch: "main",
+            },
+          },
+        ],
+      },
+      owner.memberId,
+    );
+
+    expect(second.effective.repos).toHaveLength(1);
+    expect(second.effective.repos[0]).toMatchObject({ name: "Named extra repo", source: "agent_extra" });
+    const agentRepos = await app.db
+      .select()
+      .from(resources)
+      .where(and(eq(resources.ownerAgentId, agent.uuid), eq(resources.scope, "agent"), eq(resources.type, "repo")));
+    expect(agentRepos).toHaveLength(1);
+    expect(agentRepos[0]).toMatchObject({ name: "Named extra repo" });
+  });
+
+  it("rejects duplicate input local paths", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+
+    const current = await app.resourcesService.getAgentResources(agent.uuid);
+    await expect(
+      app.resourcesService.replaceAgentResources(
+        agent.uuid,
+        {
+          expectedVersion: current.version,
+          bindings: [
+            {
+              type: "repo",
+              mode: "include",
+              agentExtraRepo: { url: "https://github.com/acme/a.git" },
+              repoLocalPath: "same",
+            },
+            {
+              type: "repo",
+              mode: "include",
+              agentExtraRepo: { url: "https://github.com/acme/b.git" },
+              repoLocalPath: "same",
+            },
+          ],
+        },
+        owner.memberId,
+      ),
+    ).rejects.toThrow('Duplicate repo localPath "same"');
+  });
+
+  it("covers resource service not-found and update default branches", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+
+    await expect(app.resourcesService.getResource(crypto.randomUUID())).rejects.toMatchObject({ statusCode: 404 });
+    await expect(app.resourcesService.getAgentResources(crypto.randomUUID())).rejects.toMatchObject({ statusCode: 404 });
+
+    await app.db.delete(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+    await expect(app.resourcesService.resolveEffectiveResources(agent.uuid)).rejects.toMatchObject({ statusCode: 404 });
+
+    const prompt = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "prompt",
+        name: "Patch without payload",
+        defaultEnabled: "available",
+        payload: { body: "Original" },
+      },
+      owner.memberId,
+    );
+    const updated = await app.resourcesService.updateResource(prompt.id, { name: "Renamed only" }, owner.memberId);
+    expect(updated).toMatchObject({ name: "Renamed only", payload: { body: "Original" } });
+  });
+
+  it("marks oversized inline prompts unavailable with binding id fallback", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+
+    await app.resourcesService.replaceAgentResources(
+      agent.uuid,
+      {
+        expectedVersion: 1,
+        bindings: [
+          {
+            type: "prompt",
+            mode: "include",
+            resourceId: null,
+            inlinePromptBody: "x".repeat(PROMPT_APPEND_MAX_LENGTH + 1),
+          },
+        ],
+      },
+      owner.memberId,
+    );
+
+    const [binding] = await app.db
+      .select({ id: agentResourceBindings.id })
+      .from(agentResourceBindings)
+      .where(eq(agentResourceBindings.agentId, agent.uuid))
+      .limit(1);
+    const effective = await app.resourcesService.resolveEffectiveResources(agent.uuid);
+
+    expect(effective.unavailable).toContainEqual({
+      type: "prompt",
+      id: binding?.id,
+      reason: "prompt_budget_exceeded",
+    });
+  });
+
   it("refreshes landing campaign trial prompt content and removes stale inline guardrails", async () => {
     const app = getApp();
     const owner = await createOrgUser(app, "admin");
@@ -1566,6 +1828,236 @@ describe("Resources Phase 1", () => {
     expect(staleInlineRows).toHaveLength(0);
     const after = await app.configService.get(agent.uuid);
     expect(after.version).toBe(before.version + 1);
+  });
+
+  it("covers resource impact and projection edge fallbacks", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    const other = await createOrgUser(app, "admin");
+    const otherAgent = await createRuntimeAgent(app, other);
+
+    const orphanAgentResourceId = uuidv7();
+    await app.db.insert(resources).values({
+      id: orphanAgentResourceId,
+      organizationId: owner.organizationId,
+      type: "prompt",
+      scope: "agent",
+      ownerAgentId: null,
+      name: "Orphan agent prompt",
+      repoCanonicalKey: null,
+      defaultEnabled: null,
+      status: "active",
+      payload: { body: "orphan" },
+      createdBy: owner.memberId,
+      updatedBy: owner.memberId,
+    });
+    await expect(app.resourcesService.getUsage(orphanAgentResourceId)).resolves.toEqual({
+      resourceId: orphanAgentResourceId,
+      agentCount: 0,
+      agents: [],
+    });
+
+    const repo = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "repo",
+        name: "Unsafe local path repo",
+        defaultEnabled: "available",
+        payload: { url: "https://github.com/acme/unsafe-local.git", defaultBranch: "main" },
+      },
+      owner.memberId,
+    );
+    await app.resourcesService.replaceAgentResources(
+      agent.uuid,
+      {
+        expectedVersion: 1,
+        bindings: [{ type: "repo", mode: "include", resourceId: repo.id, repoLocalPath: "safe-local" }],
+      },
+      owner.memberId,
+    );
+    await app.db
+      .update(agentResourceBindings)
+      .set({ repoLocalPath: ".." })
+      .where(and(eq(agentResourceBindings.agentId, agent.uuid), eq(agentResourceBindings.resourceId, repo.id)));
+    const resolved = await app.resourcesService.resolveRuntimeConfig(await app.configService.get(agent.uuid));
+    expect(resolved.payload.gitRepos).toEqual([{ url: "https://github.com/acme/unsafe-local.git", ref: "main" }]);
+
+    const [storedRepo] = await app.db.select().from(resources).where(eq(resources.id, repo.id)).limit(1);
+    expect(storedRepo).toBeDefined();
+    if (!storedRepo) throw new Error("Expected stored repo fixture");
+    type ResolveWithSimulation = (
+      agentId: string,
+      simulation: { resources: (typeof resources.$inferSelect)[] },
+    ) => ReturnType<typeof app.resourcesService.resolveEffectiveResources>;
+    const resolveWithSimulation = app.resourcesService.resolveEffectiveResources as ResolveWithSimulation;
+    const simulated = await resolveWithSimulation(agent.uuid, {
+      resources: [
+        { ...storedRepo, id: uuidv7(), organizationId: other.organizationId },
+        { ...storedRepo, id: uuidv7(), status: "retired" },
+        { ...storedRepo, id: uuidv7(), scope: "agent", ownerAgentId: otherAgent.uuid },
+        { ...storedRepo, id: uuidv7(), scope: "agent", ownerAgentId: agent.uuid, defaultEnabled: null },
+      ],
+    });
+    expect(simulated.repos.some((row) => row.resourceId === repo.id)).toBe(true);
+
+    await app.db.insert(agentResourceBindings).values({
+      id: uuidv7(),
+      organizationId: owner.organizationId,
+      agentId: agent.uuid,
+      type: "repo",
+      mode: "disable",
+      resourceId: null,
+      replacesResourceId: null,
+      inlinePromptBody: null,
+      repoRef: null,
+      repoLocalPath: null,
+      order: 99,
+      createdBy: owner.memberId,
+      updatedBy: owner.memberId,
+    });
+    await expect(app.resourcesService.resolveEffectiveResources(agent.uuid)).resolves.toMatchObject({
+      version: expect.any(Number),
+    });
+  });
+
+  it("covers disabled skill and mcp validation skips plus preview fallback inputs", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    const skill = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "skill",
+        name: "Disable skill",
+        defaultEnabled: "recommended",
+        payload: { name: "disable-skill", description: "Disabled", body: "Disabled", metadata: {} },
+      },
+      owner.memberId,
+    );
+    const mcp = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "mcp",
+        name: "Disable MCP",
+        defaultEnabled: "recommended",
+        payload: { name: "disable-mcp", transport: "stdio", command: "disable-mcp" },
+      },
+      owner.memberId,
+    );
+    const prompt = await app.resourcesService.createTeamResource(
+      owner.organizationId,
+      {
+        type: "prompt",
+        name: "Preview fallback prompt",
+        defaultEnabled: "available",
+        payload: { body: "Preview fallback." },
+      },
+      owner.memberId,
+    );
+
+    const current = await app.resourcesService.getAgentResources(agent.uuid);
+    const updated = await app.resourcesService.replaceAgentResources(
+      agent.uuid,
+      {
+        expectedVersion: current.version,
+        bindings: [
+          { type: "skill", mode: "disable", resourceId: skill.id },
+          { type: "mcp", mode: "disable", resourceId: mcp.id },
+        ],
+      },
+      owner.memberId,
+    );
+    expect(updated.effective.skills).toContainEqual(
+      expect.objectContaining({ resourceId: skill.id, mode: "disabled" }),
+    );
+    expect(updated.effective.mcp).toContainEqual(expect.objectContaining({ resourceId: mcp.id, mode: "disabled" }));
+
+    const preview = await app.resourcesService.previewResourceImpact(prompt.id, {});
+    expect(preview).toMatchObject({ affectedAgentCount: 0, promptOverflowAgentCount: 0, agents: [] });
+
+    const stale = await app.resourcesService.updateResource(prompt.id, { status: "stale" }, owner.memberId);
+    expect(stale.status).toBe("stale");
+  });
+
+  it("covers missing config and trial resource authorization branches", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    const intruder = await createOrgUser(app, "member");
+
+    await app.db.delete(agentConfigs).where(eq(agentConfigs.agentId, agent.uuid));
+    await expect(
+      app.resourcesService.replaceAgentResources(agent.uuid, { expectedVersion: 1, bindings: [] }, owner.memberId),
+    ).rejects.toThrow(/got missing/);
+
+    const blockedAgent = await createRuntimeAgent(app, owner);
+    await expect(
+      app.resourcesService.ensureAndBindLandingCampaignTrialPrompt(blockedAgent.uuid, intruder.memberId),
+    ).rejects.toMatchObject({ statusCode: 404 });
+    await expect(
+      app.resourcesService.unbindLegacyCampaignScanSkill(blockedAgent.uuid, "production-scan", intruder.memberId),
+    ).rejects.toMatchObject({ statusCode: 404 });
+
+    await app.db.update(agents).set({ status: "deleted" }).where(eq(agents.uuid, blockedAgent.uuid));
+    await expect(
+      app.resourcesService.ensureAndBindLandingCampaignTrialPrompt(blockedAgent.uuid, owner.memberId),
+    ).resolves.toBeUndefined();
+    await expect(
+      app.resourcesService.unbindLegacyCampaignScanSkill(blockedAgent.uuid, "production-scan", owner.memberId),
+    ).resolves.toBeUndefined();
+  });
+
+  it("unbinds legacy campaign scan skills and leaves missing legacy rows unchanged", async () => {
+    const app = getApp();
+    const owner = await createOrgUser(app, "admin");
+    const agent = await createRuntimeAgent(app, owner);
+    await app.resourcesService.unbindLegacyCampaignScanSkill(agent.uuid, "production-scan", owner.memberId);
+
+    const skillId = uuidv7();
+    await app.db.insert(resources).values({
+      id: skillId,
+      organizationId: owner.organizationId,
+      type: "skill",
+      scope: "agent",
+      ownerAgentId: agent.uuid,
+      name: "production-scan",
+      repoCanonicalKey: null,
+      defaultEnabled: null,
+      status: "active",
+      payload: { name: "production-scan", description: "legacy", body: "legacy", metadata: {} },
+      createdBy: owner.memberId,
+      updatedBy: owner.memberId,
+    });
+    await app.db.insert(agentResourceBindings).values({
+      id: uuidv7(),
+      organizationId: owner.organizationId,
+      agentId: agent.uuid,
+      type: "skill",
+      mode: "include",
+      resourceId: skillId,
+      replacesResourceId: null,
+      inlinePromptBody: null,
+      repoRef: null,
+      repoLocalPath: null,
+      order: 1,
+      createdBy: owner.memberId,
+      updatedBy: owner.memberId,
+    });
+    const before = await app.configService.get(agent.uuid);
+
+    await app.resourcesService.unbindLegacyCampaignScanSkill(agent.uuid, "production-scan", owner.memberId);
+
+    const [after] = await app.db
+      .select({ version: agentConfigs.version })
+      .from(agentConfigs)
+      .where(eq(agentConfigs.agentId, agent.uuid))
+      .limit(1);
+    expect(after?.version).toBe(before.version + 1);
+    await expect(app.db.select().from(resources).where(eq(resources.id, skillId))).resolves.toHaveLength(0);
+    await expect(
+      app.db.select().from(agentResourceBindings).where(eq(agentResourceBindings.resourceId, skillId)),
+    ).resolves.toHaveLength(0);
   });
 });
 

--- a/packages/server/src/__tests__/schema-extra.test.ts
+++ b/packages/server/src/__tests__/schema-extra.test.ts
@@ -1,10 +1,95 @@
 import { describe, expect, it } from "vitest";
+import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
+import { agentResourceBindings } from "../db/schema/agent-resource-bindings.js";
+import { agents } from "../db/schema/agents.js";
+import { authIdentities } from "../db/schema/auth-identities.js";
+import { clients } from "../db/schema/clients.js";
+import { connectCodes } from "../db/schema/connect-codes.js";
+import { githubAppInstallations } from "../db/schema/github-app-installations.js";
+import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappings.js";
+import { invitationRedemptions, invitations } from "../db/schema/invitations.js";
+import { organizationSettings } from "../db/schema/organization-settings.js";
 import { processedEvents } from "../db/schema/processed-events.js";
+import { resources } from "../db/schema/resources.js";
+
+type DrizzleTableRecord = Record<PropertyKey, unknown>;
+type InlineForeignKeyRecord = {
+  reference?: unknown;
+};
+
+function asDrizzleTableRecord(table: object): DrizzleTableRecord {
+  // Drizzle stores table builders behind symbols without public test-facing types.
+  return table as DrizzleTableRecord;
+}
+
+function findDrizzleSymbol(table: object, name: string): symbol {
+  const symbol = Object.getOwnPropertySymbols(table).find((candidate) => String(candidate).includes(name));
+  if (!symbol) throw new Error(`Missing Drizzle symbol ${name}`);
+  return symbol;
+}
+
+function buildExtraConfig(table: object): unknown[] {
+  const record = asDrizzleTableRecord(table);
+  const builder = record[findDrizzleSymbol(table, "ExtraConfigBuilder")];
+  const columns = record[findDrizzleSymbol(table, "ExtraConfigColumns")];
+  if (typeof builder !== "function") throw new Error("ExtraConfigBuilder is not callable");
+  const built = builder(columns);
+  if (!Array.isArray(built)) throw new Error("ExtraConfigBuilder did not return an array");
+  return built;
+}
+
+function resolveInlineForeignKeys(table: object): unknown[] {
+  const record = asDrizzleTableRecord(table);
+  const foreignKeys = record[findDrizzleSymbol(table, "PgInlineForeignKeys")];
+  if (!Array.isArray(foreignKeys)) throw new Error("PgInlineForeignKeys is not an array");
+  return foreignKeys.map((foreignKey) => {
+    if (typeof foreignKey !== "object" || foreignKey === null) throw new Error("Foreign key is not an object");
+    const reference = (foreignKey as InlineForeignKeyRecord).reference;
+    if (typeof reference !== "function") throw new Error("Foreign key reference is not callable");
+    return reference();
+  });
+}
 
 describe("database schema exports", () => {
   it("exports the processed events table metadata", () => {
     expect(processedEvents).toBeDefined();
     expect(processedEvents.eventId.name).toBe("event_id");
     expect(processedEvents.platform.notNull).toBe(true);
+  });
+
+  it("builds deferred Drizzle extra configs for indexed tables", () => {
+    expect(buildExtraConfig(agentChatSessions)).toHaveLength(2);
+    expect(buildExtraConfig(agentResourceBindings)).toHaveLength(3);
+    expect(buildExtraConfig(agents)).toHaveLength(5);
+    expect(buildExtraConfig(authIdentities)).toHaveLength(4);
+    expect(buildExtraConfig(clients)).toHaveLength(2);
+    expect(buildExtraConfig(connectCodes)).toHaveLength(2);
+    expect(buildExtraConfig(githubAppInstallations)).toHaveLength(6);
+    expect(buildExtraConfig(githubEntityChatMappings)).toHaveLength(3);
+    expect(buildExtraConfig(invitations)).toHaveLength(2);
+    expect(buildExtraConfig(invitationRedemptions)).toHaveLength(2);
+    expect(buildExtraConfig(organizationSettings)).toHaveLength(2);
+    expect(buildExtraConfig(resources)).toHaveLength(5);
+  });
+
+  it("resolves inline foreign key references for schema tables", () => {
+    expect(resolveInlineForeignKeys(agentChatSessions)).toHaveLength(2);
+    expect(resolveInlineForeignKeys(agentPresence)).toHaveLength(2);
+    expect(resolveInlineForeignKeys(agentResourceBindings)).toHaveLength(4);
+    expect(resolveInlineForeignKeys(agents)).toHaveLength(2);
+    expect(resolveInlineForeignKeys(authIdentities)).toHaveLength(1);
+    expect(resolveInlineForeignKeys(clients)).toHaveLength(2);
+    expect(resolveInlineForeignKeys(connectCodes)).toHaveLength(1);
+    expect(resolveInlineForeignKeys(githubAppInstallations)).toHaveLength(1);
+    expect(resolveInlineForeignKeys(githubEntityChatMappings)).toHaveLength(4);
+    expect(resolveInlineForeignKeys(invitations)).toHaveLength(2);
+    expect(resolveInlineForeignKeys(invitationRedemptions)).toHaveLength(2);
+    expect(resolveInlineForeignKeys(organizationSettings)).toHaveLength(2);
+    expect(resolveInlineForeignKeys(resources)).toHaveLength(2);
+  });
+
+  it("exposes the custom bytea avatar column type", () => {
+    expect(agents.avatarImageData.getSQLType()).toBe("bytea");
   });
 });

--- a/packages/server/src/__tests__/schema-extra.test.ts
+++ b/packages/server/src/__tests__/schema-extra.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { processedEvents } from "../db/schema/processed-events.js";
+
+describe("database schema exports", () => {
+  it("exports the processed events table metadata", () => {
+    expect(processedEvents).toBeDefined();
+    expect(processedEvents.eventId.name).toBe("event_id");
+    expect(processedEvents.platform.notNull).toBe(true);
+  });
+});

--- a/packages/server/src/__tests__/service-branch-defaults.test.ts
+++ b/packages/server/src/__tests__/service-branch-defaults.test.ts
@@ -5,20 +5,17 @@ import { getActivityOverview } from "../services/activity.js";
 import {
   agentAvatarImageUrl,
   assertUserAgentMetadataHasNoReservedKeys,
+  deleteAgent,
   ensureClientSupportsRuntimeProvider,
   fetchUserAvatarForHumanAgent,
   legacyWireAgentType,
-  deleteAgent,
   listAgents,
   reactivateAgent,
   resolveAvatarImageUrl,
-  suspendAgent,
   stripReservedAgentMetadata,
+  suspendAgent,
 } from "../services/agent.js";
-import {
-  assertNoRuntimeSwitchInProgress,
-  getRuntimeSwitchClaim,
-} from "../services/agent-runtime-switch.js";
+import { assertNoRuntimeSwitchInProgress, getRuntimeSwitchClaim } from "../services/agent-runtime-switch.js";
 import { createChat, resolveAgentIdsByNameInOrg, updateChatMetadata } from "../services/chat.js";
 import { explainContextTreeIoDecision } from "../services/context-tree-io.js";
 import {
@@ -36,24 +33,22 @@ import { listAgentTurns, summarizeAgent } from "../services/usage.js";
 type ChainRows = unknown[];
 
 function queryChain(rows: unknown[]): unknown {
-  const chain = {
-    for: vi.fn(() => chain),
-    from: vi.fn(() => chain),
-    groupBy: vi.fn(() => chain),
-    innerJoin: vi.fn(() => chain),
-    leftJoin: vi.fn(() => chain),
-    limit: vi.fn(() => chain),
-    offset: vi.fn(() => chain),
-    onConflictDoNothing: vi.fn(() => chain),
-    onConflictDoUpdate: vi.fn(() => chain),
-    orderBy: vi.fn(() => chain),
-    returning: vi.fn(async () => rows),
-    set: vi.fn(() => chain),
-    values: vi.fn(() => chain),
-    where: vi.fn(() => chain),
-    then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
-      Promise.resolve(rows).then(resolve, reject),
-  };
+  const promise = Promise.resolve(rows);
+  const chain = new Proxy(
+    function queryProxy(): unknown {
+      return chain;
+    },
+    {
+      get: (_target, prop) => {
+        if (prop === "then") return promise.then.bind(promise);
+        if (prop === "catch") return promise.catch.bind(promise);
+        if (prop === "finally") return promise.finally.bind(promise);
+        if (prop === Symbol.iterator) return rows[Symbol.iterator].bind(rows);
+        if (prop === "returning") return vi.fn(async () => rows);
+        return vi.fn(() => chain);
+      },
+    },
+  );
   return chain;
 }
 
@@ -182,15 +177,18 @@ describe("service branch defaults", () => {
         userAvatarUrl: "https://avatars.example/u.png",
       }),
     ).toBe("https://avatars.example/u.png");
-    expect(resolveAvatarImageUrl({ uuid: "agent_1", type: "agent", avatarImageUpdatedAt: null, userAvatarUrl: "x" }))
-      .toBeNull();
+    expect(
+      resolveAvatarImageUrl({ uuid: "agent_1", type: "agent", avatarImageUpdatedAt: null, userAvatarUrl: "x" }),
+    ).toBeNull();
     expect(legacyWireAgentType("human")).toBe("human");
     expect(legacyWireAgentType("agent")).toBe("personal_assistant");
 
-    await expect(fetchUserAvatarForHumanAgent(queuedSelectDb([]) as never, { uuid: "a", type: "agent" })).resolves
-      .toBeNull();
-    await expect(fetchUserAvatarForHumanAgent(queuedSelectDb([[{}]]) as never, { uuid: "h", type: "human" })).resolves
-      .toBeNull();
+    await expect(
+      fetchUserAvatarForHumanAgent(queuedSelectDb([]) as never, { uuid: "a", type: "agent" }),
+    ).resolves.toBeNull();
+    await expect(
+      fetchUserAvatarForHumanAgent(queuedSelectDb([[{}]]) as never, { uuid: "h", type: "human" }),
+    ).resolves.toBeNull();
 
     expect(getRuntimeSwitchClaim(null)).toBeNull();
     expect(getRuntimeSwitchClaim({ runtimeSwitch: { claimId: 42 } })).toBeNull();
@@ -203,12 +201,15 @@ describe("service branch defaults", () => {
   });
 
   it("covers client runtime capability tri-state branches", async () => {
-    await expect(ensureClientSupportsRuntimeProvider(queuedSelectDb([]) as never, null, "codex")).resolves.toBeUndefined();
+    await expect(
+      ensureClientSupportsRuntimeProvider(queuedSelectDb([]) as never, null, "codex"),
+    ).resolves.toBeUndefined();
     await expect(
       ensureClientSupportsRuntimeProvider(queuedSelectDb([]) as never, "client_1", "codex", { force: true }),
     ).resolves.toBeUndefined();
-    await expect(ensureClientSupportsRuntimeProvider(queuedSelectDb([[]]) as never, "client_1", "codex")).resolves
-      .toBeUndefined();
+    await expect(
+      ensureClientSupportsRuntimeProvider(queuedSelectDb([[]]) as never, "client_1", "codex"),
+    ).resolves.toBeUndefined();
     await expect(
       ensureClientSupportsRuntimeProvider(
         queuedSelectDb([[{ metadata: { capabilities: null }, retiredAt: null }]]) as never,
@@ -225,7 +226,9 @@ describe("service branch defaults", () => {
     ).rejects.toThrow(BadRequestError);
     await expect(
       ensureClientSupportsRuntimeProvider(
-        queuedSelectDb([[{ metadata: { capabilities: { codex: { available: true } } }, retiredAt: new Date() }]]) as never,
+        queuedSelectDb([
+          [{ metadata: { capabilities: { codex: { available: true } } }, retiredAt: new Date() }],
+        ]) as never,
         "client_1",
         "codex",
       ),
@@ -236,13 +239,7 @@ describe("service branch defaults", () => {
     const first = { uuid: "agent_1", createdAt: new Date("2026-01-02T00:00:00.000Z") };
     const second = { uuid: "agent_2", createdAt: new Date("2026-01-01T00:00:00.000Z") };
     await expect(
-      listAgents(
-        queuedSelectDb([[first, second]]) as never,
-        "org_1",
-        1,
-        "2026-01-03T00:00:00.000Z",
-        "agent",
-      ),
+      listAgents(queuedSelectDb([[first, second]]) as never, "org_1", 1, "2026-01-03T00:00:00.000Z", "agent"),
     ).resolves.toEqual({ items: [first], nextCursor: first.createdAt.toISOString() });
 
     await expect(
@@ -530,7 +527,6 @@ describe("service branch defaults", () => {
     await expect(
       createChat(legacyKickoffMissingDb as never, {
         mode: "legacy-empty-agent",
-        organizationId: "org_1",
         creatorAgentId: "creator",
         participantAgentIds: ["participant"],
         onboardingKickoffKey: "kickoff-missing",
@@ -644,11 +640,7 @@ describe("service branch defaults", () => {
       notifier,
     });
     await expect(
-      updateService.updateResource(
-        "resource_1",
-        { payload: { url: "https://github.com/acme/repo.git" } },
-        "member_1",
-      ),
+      updateService.updateResource("resource_1", { payload: { url: "https://github.com/acme/repo.git" } }, "member_1"),
     ).rejects.toThrow("A matching resource already exists");
 
     const createFailure = new Error("plain create failure");
@@ -902,11 +894,7 @@ describe("service branch defaults", () => {
     };
 
     await expect(
-      service.replaceAgentResources(
-        "agent_1",
-        { expectedVersion: 1, bindings: bindings as never },
-        "member_1",
-      ),
+      service.replaceAgentResources("agent_1", { expectedVersion: 1, bindings: bindings as never }, "member_1"),
     ).resolves.toMatchObject({ version: 2 });
     expect(db.insert).toHaveBeenCalledTimes(1);
   });
@@ -935,7 +923,9 @@ describe("service branch defaults", () => {
       },
     } as never);
 
-    expect(config.payload.mcpServers).toEqual([{ name: "existing", type: "stdio", command: "node", args: [], env: {} }]);
+    expect(config.payload.mcpServers).toEqual([
+      { name: "existing", type: "stdio", command: "node", args: [], env: {} },
+    ]);
   });
 
   it("exercises empty-database service edges through public APIs", async () => {
@@ -1001,16 +991,7 @@ describe("service branch defaults", () => {
       () => agentService.getAgent(db, "missing-agent"),
       () => agentService.getAgentByName(db, "org_1", "missing"),
       () => agentService.listAgentsForAdmin(db, orgScope, 1, "2026-01-01"),
-      () =>
-        agentService.listAgentsForMember(
-          db,
-          orgScope,
-          1,
-          "2026-01-01",
-          "agent",
-          "Agent 100%_literal",
-          true,
-        ),
+      () => agentService.listAgentsForMember(db, orgScope, 1, "2026-01-01", "agent", "Agent 100%_literal", true),
       () => agentService.checkAgentNameAvailability(db, "org_1", "missing"),
       () => agentService.getNewChatDefaultCandidate(db, orgScope, null),
       () => chatService.getChat(db, "missing-chat"),
@@ -1030,12 +1011,7 @@ describe("service branch defaults", () => {
       () => documentService.setDocumentStatus(db, docRow, "approved"),
       () => documentService.getCommentRow(db, "comment_1"),
       () => documentService.setCommentStatus(db, commentRow, "resolved"),
-      () =>
-        documentService.listComments(
-          db,
-          docRow,
-          { versionNumber: undefined, status: undefined },
-        ),
+      () => documentService.listComments(db, docRow, { versionNumber: undefined, status: undefined }),
       () => inboxService.pollInbox(db, "inbox_1", 1),
       () => inboxService.claimBacklogForPush(db, "inbox_1", 1),
       () => inboxService.claimBacklogForPushForChat(db, "inbox_1", "chat_1", 1),

--- a/packages/server/src/__tests__/service-branch-defaults.test.ts
+++ b/packages/server/src/__tests__/service-branch-defaults.test.ts
@@ -1,0 +1,1156 @@
+import { MESSAGE_FORMATS } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import { BadRequestError, ClientRetiredError, ConflictError } from "../errors.js";
+import { getActivityOverview } from "../services/activity.js";
+import {
+  agentAvatarImageUrl,
+  assertUserAgentMetadataHasNoReservedKeys,
+  ensureClientSupportsRuntimeProvider,
+  fetchUserAvatarForHumanAgent,
+  legacyWireAgentType,
+  deleteAgent,
+  listAgents,
+  reactivateAgent,
+  resolveAvatarImageUrl,
+  suspendAgent,
+  stripReservedAgentMetadata,
+} from "../services/agent.js";
+import {
+  assertNoRuntimeSwitchInProgress,
+  getRuntimeSwitchClaim,
+} from "../services/agent-runtime-switch.js";
+import { createChat, resolveAgentIdsByNameInOrg, updateChatMetadata } from "../services/chat.js";
+import { explainContextTreeIoDecision } from "../services/context-tree-io.js";
+import {
+  exchangeCodeForAppUserProfile,
+  fetchInstallation,
+  GithubAppApiError,
+  listInstallationRepos,
+  refreshAppUserToken,
+  verifyUserCanAdministerInstallation,
+} from "../services/github-app.js";
+import { maybeUnwrapDoubleEncoded, preflightMessageSendIntent } from "../services/message.js";
+import { createResourcesService } from "../services/resources.js";
+import { listAgentTurns, summarizeAgent } from "../services/usage.js";
+
+type ChainRows = unknown[];
+
+function queryChain(rows: unknown[]): unknown {
+  const chain = {
+    for: vi.fn(() => chain),
+    from: vi.fn(() => chain),
+    groupBy: vi.fn(() => chain),
+    innerJoin: vi.fn(() => chain),
+    leftJoin: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    offset: vi.fn(() => chain),
+    onConflictDoNothing: vi.fn(() => chain),
+    onConflictDoUpdate: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    returning: vi.fn(async () => rows),
+    set: vi.fn(() => chain),
+    values: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(rows).then(resolve, reject),
+  };
+  return chain;
+}
+
+function queuedSelectDb(results: ChainRows[]): unknown {
+  return {
+    select: vi.fn(() => queryChain(results.shift() ?? [])),
+  };
+}
+
+function agentRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "agent_1",
+    name: "agent",
+    displayName: "Agent",
+    organizationId: "org_1",
+    type: "agent",
+    status: "active",
+    memberStatus: "active",
+    visibility: "organization",
+    managerId: "member_1",
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function resourceRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+  return {
+    id: "resource_1",
+    organizationId: "org_1",
+    type: "repo",
+    scope: "team",
+    ownerAgentId: null,
+    name: "Repo",
+    repoCanonicalKey: "https://github.com/acme/repo.git",
+    defaultEnabled: "available",
+    status: "active",
+    payload: { url: "https://github.com/acme/repo.git" },
+    createdBy: "member_1",
+    updatedBy: "member_1",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function bindingRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "binding_1",
+    organizationId: "org_1",
+    agentId: "agent_1",
+    type: "prompt",
+    mode: "include",
+    resourceId: null,
+    replacesResourceId: null,
+    inlinePromptBody: null,
+    repoRef: null,
+    repoLocalPath: null,
+    order: 0,
+    createdBy: "member_1",
+    updatedBy: "member_1",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function resourceNotifier(): never {
+  return { notifyConfigChange: vi.fn(async () => undefined) } as never;
+}
+
+function permissiveDb(rows: unknown[] = []): unknown {
+  const db = {
+    delete: vi.fn(() => queryChain(rows)),
+    execute: vi.fn(async () => rows),
+    insert: vi.fn(() => queryChain(rows)),
+    select: vi.fn(() => queryChain(rows)),
+    transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(db)),
+    update: vi.fn(() => queryChain(rows)),
+  };
+  return db;
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+  });
+}
+
+function textResponse(body: string, init: ResponseInit = {}): Response {
+  return new Response(body, {
+    status: init.status ?? 200,
+    headers: init.headers,
+  });
+}
+
+const imageRef = {
+  imageId: "11111111-1111-4111-8111-111111111111",
+  mimeType: "image/png",
+  filename: "screen.png",
+};
+
+const participants = [
+  { agentId: "sender", name: "sender", displayName: "Sender", status: "active", type: "agent" },
+  { agentId: "bot", name: "bot", displayName: "Bot", status: "active", type: "agent" },
+  { agentId: "human", name: "alice", displayName: "Alice", status: "active", type: "human" },
+  { agentId: "suspended", name: null, displayName: "", status: "suspended", type: "agent" },
+  { agentId: "deleted", name: "gone", displayName: "", status: "deleted", type: "agent" },
+] as const;
+
+describe("service branch defaults", () => {
+  it("covers agent metadata, avatar, and runtime-switch guard branches", async () => {
+    expect(stripReservedAgentMetadata(null)).toEqual({});
+    expect(stripReservedAgentMetadata(["runtime"])).toEqual({});
+    expect(stripReservedAgentMetadata({ runtimeSwitch: { claimId: "c1" }, public: true })).toEqual({ public: true });
+    expect(() => assertUserAgentMetadataHasNoReservedKeys({ runtimeSession: {} })).toThrow(BadRequestError);
+
+    expect(agentAvatarImageUrl("agent_1", null)).toBeNull();
+    expect(agentAvatarImageUrl("agent_1", new Date(1000))).toBe("/api/v1/agents/agent_1/avatar?v=1000");
+    expect(
+      resolveAvatarImageUrl({
+        uuid: "human_1",
+        type: "human",
+        avatarImageUpdatedAt: undefined,
+        userAvatarUrl: "https://avatars.example/u.png",
+      }),
+    ).toBe("https://avatars.example/u.png");
+    expect(resolveAvatarImageUrl({ uuid: "agent_1", type: "agent", avatarImageUpdatedAt: null, userAvatarUrl: "x" }))
+      .toBeNull();
+    expect(legacyWireAgentType("human")).toBe("human");
+    expect(legacyWireAgentType("agent")).toBe("personal_assistant");
+
+    await expect(fetchUserAvatarForHumanAgent(queuedSelectDb([]) as never, { uuid: "a", type: "agent" })).resolves
+      .toBeNull();
+    await expect(fetchUserAvatarForHumanAgent(queuedSelectDb([[{}]]) as never, { uuid: "h", type: "human" })).resolves
+      .toBeNull();
+
+    expect(getRuntimeSwitchClaim(null)).toBeNull();
+    expect(getRuntimeSwitchClaim({ runtimeSwitch: { claimId: 42 } })).toBeNull();
+    expect(() => assertNoRuntimeSwitchInProgress({ metadata: { runtimeSwitch: { claimId: 42 } } })).toThrow(
+      "Agent runtime switch is in progress",
+    );
+    expect(() => assertNoRuntimeSwitchInProgress({ metadata: { runtimeSwitch: { claimId: "claim_1" } } })).toThrow(
+      ConflictError,
+    );
+  });
+
+  it("covers client runtime capability tri-state branches", async () => {
+    await expect(ensureClientSupportsRuntimeProvider(queuedSelectDb([]) as never, null, "codex")).resolves.toBeUndefined();
+    await expect(
+      ensureClientSupportsRuntimeProvider(queuedSelectDb([]) as never, "client_1", "codex", { force: true }),
+    ).resolves.toBeUndefined();
+    await expect(ensureClientSupportsRuntimeProvider(queuedSelectDb([[]]) as never, "client_1", "codex")).resolves
+      .toBeUndefined();
+    await expect(
+      ensureClientSupportsRuntimeProvider(
+        queuedSelectDb([[{ metadata: { capabilities: null }, retiredAt: null }]]) as never,
+        "client_1",
+        "codex",
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      ensureClientSupportsRuntimeProvider(
+        queuedSelectDb([[{ metadata: { capabilities: { codex: null } }, retiredAt: null }]]) as never,
+        "client_1",
+        "codex",
+      ),
+    ).rejects.toThrow(BadRequestError);
+    await expect(
+      ensureClientSupportsRuntimeProvider(
+        queuedSelectDb([[{ metadata: { capabilities: { codex: { available: true } } }, retiredAt: new Date() }]]) as never,
+        "client_1",
+        "codex",
+      ),
+    ).rejects.toThrow(ClientRetiredError);
+  });
+
+  it("covers agent listing and lifecycle defensive branches", async () => {
+    const first = { uuid: "agent_1", createdAt: new Date("2026-01-02T00:00:00.000Z") };
+    const second = { uuid: "agent_2", createdAt: new Date("2026-01-01T00:00:00.000Z") };
+    await expect(
+      listAgents(
+        queuedSelectDb([[first, second]]) as never,
+        "org_1",
+        1,
+        "2026-01-03T00:00:00.000Z",
+        "agent",
+      ),
+    ).resolves.toEqual({ items: [first], nextCursor: first.createdAt.toISOString() });
+
+    await expect(
+      reactivateAgent(
+        {
+          select: vi.fn(() =>
+            queryChain([{ uuid: "agent_1", status: "suspended", type: "agent", clientId: "client_1" }]),
+          ),
+          update: vi.fn(() => queryChain([])),
+        } as never,
+        "agent_1",
+      ),
+    ).rejects.toThrow("Unexpected: UPDATE RETURNING produced no row");
+
+    await expect(
+      suspendAgent(
+        {
+          select: vi
+            .fn()
+            .mockReturnValueOnce(queryChain([{ uuid: "agent_1", status: "active", type: "agent" }]))
+            .mockReturnValueOnce(queryChain([])),
+          update: vi.fn(() => queryChain([])),
+        } as never,
+        "agent_1",
+      ),
+    ).rejects.toThrow("Unexpected: agent disappeared after UPDATE");
+
+    await expect(
+      deleteAgent(
+        {
+          select: vi.fn(() => queryChain([{ uuid: "agent_1", status: "suspended", type: "agent" }])),
+          update: vi.fn(() => queryChain([])),
+        } as never,
+        "agent_1",
+      ),
+    ).rejects.toThrow("Unexpected: UPDATE RETURNING produced no row");
+  });
+
+  it("covers message preflight validation, routing, and decode branches", () => {
+    expect(
+      preflightMessageSendIntent({
+        chatId: "chat_1",
+        senderId: "sender",
+        senderType: "agent",
+        data: {
+          format: MESSAGE_FORMATS.FILE,
+          content: { attachments: [imageRef], caption: "see attached" },
+          metadata: { mentions: ["bot"], systemSender: "spoofed", addressedAgentIds: ["spoofed"] },
+          source: "api",
+        },
+        participants,
+      }),
+    ).toMatchObject({ mentionedAgentIds: ["bot"] });
+
+    expect(
+      preflightMessageSendIntent({
+        chatId: "chat_1",
+        senderId: "sender",
+        senderType: "agent",
+        data: {
+          format: MESSAGE_FORMATS.TEXT,
+          content: "ready",
+          receiverNames: ["bot"],
+          metadata: {},
+          source: "api",
+        },
+        options: { normalizeMentionsInContent: true },
+        participants,
+      }).content,
+    ).toBe("@bot ready");
+
+    expect(() =>
+      preflightMessageSendIntent({
+        chatId: "chat_1",
+        senderId: "sender",
+        senderType: "agent",
+        data: { format: MESSAGE_FORMATS.TEXT, content: "hello", metadata: { mentions: ["suspended"] }, source: "api" },
+        participants,
+      }),
+    ).toThrow("because the agent is suspended");
+    expect(() =>
+      preflightMessageSendIntent({
+        chatId: "chat_1",
+        senderId: "sender",
+        senderType: "agent",
+        data: { format: MESSAGE_FORMATS.TEXT, content: "hello", metadata: {}, source: "api" },
+        options: { addressedToAgentIds: ["deleted"] },
+        participants,
+      }),
+    ).toThrow("Deleted agents cannot receive new messages");
+    expect(() =>
+      preflightMessageSendIntent({
+        chatId: "chat_1",
+        senderId: "sender",
+        senderType: "agent",
+        data: { format: MESSAGE_FORMATS.REQUEST, content: "question", metadata: { mentions: ["bot"] }, source: "api" },
+        participants,
+      }),
+    ).toThrow("must be directed at a human");
+
+    expect(maybeUnwrapDoubleEncoded(JSON.stringify({ not: "a string" }))).toBeNull();
+    expect(maybeUnwrapDoubleEncoded('"unterminated\\n')).toBeNull();
+    expect(maybeUnwrapDoubleEncoded(JSON.stringify("line\\nnext"))).toBe("line\\nnext");
+  });
+
+  it("covers context-tree IO decision branches", () => {
+    const bindingRepo = "https://github.com/acme/context.git";
+    const validRef = {
+      origin: "file_change",
+      repoUrl: bindingRepo,
+      repoBranch: "main",
+      repoRelativePath: "domains/runtime/NODE.md",
+      pathKind: "file",
+    };
+
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "codex",
+        sessionEvent: { kind: "tool_call", payload: { toolUseId: "t1", name: "file_change", status: "ok" } },
+        bindingRepo: null,
+      }),
+    ).toEqual({ recordable: false, reason: "no_org_context_tree_binding" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "codex",
+        sessionEvent: { kind: "tool_call", payload: { toolUseId: "t2", name: "file_change", status: "error" } },
+        bindingRepo,
+      }),
+    ).toEqual({ recordable: false, reason: "status_not_ok" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code",
+        sessionEvent: { kind: "tool_call", payload: { toolUseId: "t3", name: "Bash", status: "ok", args: {} } },
+        bindingRepo,
+      }),
+    ).toEqual({ recordable: false, reason: "unsupported_shell_command" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "claude-code-tui",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: { toolUseId: "t4", name: "Read", status: "ok", toolFileRefs: [validRef] },
+        },
+        bindingRepo,
+        chatInOrg: false,
+      }),
+    ).toEqual({ recordable: false, reason: "chat_not_in_org" });
+    expect(
+      explainContextTreeIoDecision({
+        runtimeProvider: "codex",
+        sessionEvent: {
+          kind: "tool_call",
+          payload: {
+            toolUseId: "t5",
+            name: "unknown",
+            status: "ok",
+            toolFileRefs: [{ ...validRef, origin: "git_status_delta" }],
+          },
+        },
+        bindingRepo,
+      }),
+    ).toEqual({ recordable: true });
+  });
+
+  it("covers usage and activity row-default branches with minimal db fakes", async () => {
+    const summary = await summarizeAgent(queuedSelectDb([[], []]) as never, {
+      agentId: "agent_1",
+      from: new Date("2026-01-01T00:00:00.000Z"),
+      to: new Date("2026-01-02T00:00:00.000Z"),
+    });
+    expect(summary.totals).toMatchObject({ inputTokens: 0, cachedInputTokens: 0, outputTokens: 0, turns: 0, chats: 0 });
+
+    const createdAt = new Date("2026-01-01T01:00:00.000Z");
+    const turns = await listAgentTurns(
+      queuedSelectDb([
+        [
+          { seq: 2, chatId: "chat_1", createdAt, payload: {} },
+          { seq: 1, chatId: "chat_2", createdAt: new Date("2026-01-01T00:00:00.000Z"), payload: null },
+        ],
+        [{ id: "chat_1", topic: null }],
+        [{ chatId: "chat_1" }],
+      ]) as never,
+      {
+        agentId: "agent_1",
+        from: new Date("2026-01-01T00:00:00.000Z"),
+        to: new Date("2026-01-02T00:00:00.000Z"),
+        cursor: null,
+        limit: 1,
+        viewer: { humanAgentId: "human_1" },
+      },
+    );
+    expect(turns.rows[0]).toMatchObject({
+      chatId: "chat_1",
+      chatTitle: null,
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      provider: "",
+      model: "",
+    });
+    expect(turns.nextCursor).not.toBeNull();
+
+    await expect(getActivityOverview(queuedSelectDb([[], []]) as never)).resolves.toEqual({
+      total: 0,
+      running: 0,
+      byState: { idle: 0, working: 0, blocked: 0, error: 0 },
+      clients: 0,
+    });
+  });
+
+  it("covers chat service defensive branches with db fakes", async () => {
+    const creator = agentRow({ id: "creator", type: "human" });
+    const participant = agentRow({ id: "participant" });
+
+    await expect(
+      createChat(queuedSelectDb([[agentRow({ id: "other_1" }), agentRow({ id: "other_2" })]]) as never, {
+        mode: "legacy-empty-web",
+        organizationId: "org_1",
+        creatorAgentId: "creator",
+        participantAgentIds: ["participant"],
+      }),
+    ).rejects.toThrow("Unexpected: creator not in existingAgents");
+
+    await expect(
+      createChat(queuedSelectDb([[agentRow({ id: "other_1" }), agentRow({ id: "recipient" })]]) as never, {
+        mode: "task",
+        organizationId: "org_1",
+        source: "manual",
+        initiatorAgentId: "initiator",
+        initialRecipientAgentIds: ["recipient"],
+        contextParticipantAgentIds: [],
+        initialMessage: { format: MESSAGE_FORMATS.TEXT, content: "hello", metadata: {}, source: "api" },
+      }),
+    ).rejects.toThrow("Unexpected: initiator missing after loadAgentsForCreate");
+
+    await expect(
+      createChat(queuedSelectDb([[agentRow({ id: "initiator", type: "human" }), agentRow({ id: "wrong" })]]) as never, {
+        mode: "task",
+        organizationId: "org_1",
+        source: "manual",
+        initiatorAgentId: "initiator",
+        initialRecipientAgentIds: ["recipient"],
+        contextParticipantAgentIds: [],
+        initialMessage: { format: MESSAGE_FORMATS.TEXT, content: "hello", metadata: {}, source: "api" },
+      }),
+    ).rejects.toThrow("Agents not found: recipient");
+
+    await expect(
+      createChat(
+        queuedSelectDb([[agentRow({ id: "initiator" }), agentRow({ id: "recipient", status: "suspended" })]]) as never,
+        {
+          mode: "task",
+          organizationId: "org_1",
+          source: "manual",
+          initiatorAgentId: "initiator",
+          initialRecipientAgentIds: ["recipient"],
+          contextParticipantAgentIds: [],
+          initialMessage: { format: MESSAGE_FORMATS.TEXT, content: "hello", metadata: {}, source: "api" },
+        },
+      ),
+    ).rejects.toThrow('Cannot create task chat with inactive participant "Agent" (suspended).');
+
+    const legacyEmptyInsertDb = {
+      insert: vi.fn(() => queryChain([])),
+      select: vi.fn(() => queryChain([creator, participant])),
+      transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(legacyEmptyInsertDb)),
+    };
+    await expect(
+      createChat(legacyEmptyInsertDb as never, {
+        mode: "legacy-empty-web",
+        organizationId: "org_1",
+        creatorAgentId: "creator",
+        participantAgentIds: ["participant"],
+      }),
+    ).rejects.toThrow("Unexpected: INSERT RETURNING produced no row");
+
+    const legacyKickoffMissingDb = {
+      insert: vi.fn(() => queryChain([])),
+      select: vi
+        .fn()
+        .mockReturnValueOnce(queryChain([creator, participant]))
+        .mockReturnValue(queryChain([])),
+      transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(legacyKickoffMissingDb)),
+    };
+    await expect(
+      createChat(legacyKickoffMissingDb as never, {
+        mode: "legacy-empty-agent",
+        organizationId: "org_1",
+        creatorAgentId: "creator",
+        participantAgentIds: ["participant"],
+        onboardingKickoffKey: "kickoff-missing",
+      }),
+    ).rejects.toThrow("Unexpected: kickoff-key conflict but no existing chat row");
+
+    const taskEmptyInsertDb = {
+      insert: vi.fn(() => queryChain([])),
+      select: vi.fn(() => queryChain([agentRow({ id: "initiator", type: "human" }), agentRow({ id: "recipient" })])),
+      transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(taskEmptyInsertDb)),
+    };
+    await expect(
+      createChat(taskEmptyInsertDb as never, {
+        mode: "task",
+        organizationId: "org_1",
+        source: "manual",
+        initiatorAgentId: "initiator",
+        initialRecipientAgentIds: ["recipient"],
+        contextParticipantAgentIds: [],
+        initialMessage: { format: MESSAGE_FORMATS.TEXT, content: "hello", metadata: {}, source: "api" },
+      }),
+    ).rejects.toThrow("Unexpected: INSERT RETURNING produced no row");
+
+    const taskKickoffMissingDb = {
+      insert: vi.fn(() => queryChain([])),
+      select: vi
+        .fn()
+        .mockReturnValueOnce(queryChain([agentRow({ id: "initiator", type: "human" }), agentRow({ id: "recipient" })]))
+        .mockReturnValue(queryChain([])),
+      transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(taskKickoffMissingDb)),
+    };
+    await expect(
+      createChat(taskKickoffMissingDb as never, {
+        mode: "task",
+        organizationId: "org_1",
+        source: "manual",
+        initiatorAgentId: "initiator",
+        initialRecipientAgentIds: ["recipient"],
+        contextParticipantAgentIds: [],
+        onboardingKickoffKey: "task-kickoff-missing",
+        initialMessage: { format: MESSAGE_FORMATS.TEXT, content: "hello", metadata: {}, source: "api" },
+      }),
+    ).rejects.toThrow("Unexpected: kickoff-key conflict but no existing chat row");
+
+    await expect(resolveAgentIdsByNameInOrg(queuedSelectDb([]) as never, "org_1", [])).resolves.toEqual([]);
+    await expect(
+      resolveAgentIdsByNameInOrg(queuedSelectDb([[{ uuid: undefined, name: "alice" }]]) as never, "org_1", ["alice"]),
+    ).rejects.toThrow("Unexpected: missing name after validation");
+
+    await expect(
+      (await import("../services/chat.js")).listChatsForMember(
+        queuedSelectDb([
+          [[agentRow({ id: undefined, uuid: "human_1", type: "human" })]],
+          [{ chatId: "chat_1", agentId: "ghost_agent", role: "member" }],
+          [
+            {
+              id: "chat_1",
+              type: "group",
+              topic: "Ghost Chat",
+              metadata: {},
+              createdAt: new Date("2026-01-01T00:00:00.000Z"),
+              updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+              participantCount: 1,
+            },
+          ],
+        ]) as never,
+        "member_1",
+        "human_1",
+      ),
+    ).resolves.toEqual([]);
+
+    const updateDb = {
+      select: vi.fn(() => queryChain([{ description: "old" }])),
+      update: vi.fn(() => queryChain([])),
+    };
+    await expect(updateChatMetadata(updateDb as never, "chat_1", { description: "new" })).rejects.toThrow(
+      'Unexpected: chat "chat_1" missing after update',
+    );
+  });
+
+  it("covers resource service conflict-code fallback branches", async () => {
+    const notifier = resourceNotifier();
+    const createService = createResourcesService({
+      db: {
+        transaction: vi.fn(async () => {
+          throw { code: "23505" };
+        }),
+      } as never,
+      notifier,
+    });
+    await expect(
+      createService.createTeamResource(
+        "org_1",
+        {
+          type: "repo",
+          name: "Repo",
+          defaultEnabled: "available",
+          payload: { url: "https://github.com/acme/repo.git" },
+        },
+        "member_1",
+      ),
+    ).rejects.toThrow("A matching resource already exists");
+
+    const updateService = createResourcesService({
+      db: {
+        select: vi.fn(() => queryChain([resourceRow()])),
+        transaction: vi.fn(async () => {
+          throw { cause: { code: "23505" } };
+        }),
+      } as never,
+      notifier,
+    });
+    await expect(
+      updateService.updateResource(
+        "resource_1",
+        { payload: { url: "https://github.com/acme/repo.git" } },
+        "member_1",
+      ),
+    ).rejects.toThrow("A matching resource already exists");
+
+    const createFailure = new Error("plain create failure");
+    const createRethrowService = createResourcesService({
+      db: {
+        transaction: vi.fn(async () => {
+          throw createFailure;
+        }),
+      } as never,
+      notifier,
+    });
+    await expect(
+      createRethrowService.createTeamResource(
+        "org_1",
+        {
+          type: "repo",
+          name: "Repo",
+          defaultEnabled: "available",
+          payload: { url: "https://github.com/acme/repo.git" },
+        },
+        "member_1",
+      ),
+    ).rejects.toBe(createFailure);
+
+    const nonStringCodeFailure = { cause: { code: 42 } };
+    const updateRethrowService = createResourcesService({
+      db: {
+        select: vi.fn(() => queryChain([resourceRow()])),
+        transaction: vi.fn(async () => {
+          throw nonStringCodeFailure;
+        }),
+      } as never,
+      notifier,
+    });
+    await expect(
+      updateRethrowService.updateResource(
+        "resource_1",
+        { payload: { url: "https://github.com/acme/repo.git" } },
+        "member_1",
+      ),
+    ).rejects.toBe(nonStringCodeFailure);
+
+    const agentImpactService = createResourcesService({
+      db: {
+        select: vi.fn(() => queryChain([resourceRow({ scope: "agent", ownerAgentId: null })])),
+      } as never,
+      notifier,
+    });
+    await expect(agentImpactService.previewResourceImpact("resource_1", {})).resolves.toMatchObject({
+      affectedAgentCount: 0,
+      promptOverflowAgentCount: 0,
+    });
+
+    const ownedAgentResource = resourceRow({ scope: "agent", ownerAgentId: "agent_owner" });
+    const ownedImpactService = createResourcesService({
+      db: queuedSelectDb([
+        [ownedAgentResource],
+        [{ uuid: "agent_owner", name: "owner", displayName: "Owner" }],
+        [{ uuid: "agent_owner", organizationId: "org_1", status: "active" }],
+        [{ version: 1 }],
+        [ownedAgentResource],
+        [],
+      ]) as never,
+      notifier,
+    });
+    await expect(ownedImpactService.previewResourceImpact("resource_1", {})).resolves.toMatchObject({
+      affectedAgentCount: 1,
+      agents: [expect.objectContaining({ uuid: "agent_owner" })],
+    });
+  });
+
+  it("covers runtime resource projection, validation, and fallback branches", async () => {
+    const notifier = resourceNotifier();
+    const teamPrompt = resourceRow({
+      id: "prompt_team",
+      type: "prompt",
+      name: "Team Prompt",
+      defaultEnabled: "recommended",
+      payload: { body: "team guidance" },
+    });
+    const repoA = resourceRow({
+      id: "repo_a",
+      type: "repo",
+      name: "Repo A",
+      defaultEnabled: "recommended",
+      payload: { url: "https://github.com/acme/runtime.git" },
+    });
+    const repoB = resourceRow({
+      id: "repo_b",
+      type: "repo",
+      name: "Repo B",
+      defaultEnabled: "recommended",
+      payload: { url: "https://github.com/acme/runtime.git" },
+    });
+    const validSkill = resourceRow({
+      id: "skill_valid",
+      type: "skill",
+      name: "Skill",
+      defaultEnabled: "recommended",
+      payload: { name: "skill", description: "Useful skill", body: "steps", metadata: { source: "test" } },
+    });
+    const invalidSkill = resourceRow({
+      id: "skill_bad",
+      type: "skill",
+      name: "Bad Skill",
+      defaultEnabled: "recommended",
+      payload: { name: "", description: "", body: "" },
+    });
+    const validMcp = resourceRow({
+      id: "mcp_valid",
+      type: "mcp",
+      name: "MCP",
+      defaultEnabled: "recommended",
+      payload: { name: "mcp", transport: "http", url: "https://mcp.example.test/rpc" },
+    });
+    const invalidMcp = resourceRow({
+      id: "mcp_bad",
+      type: "mcp",
+      name: "Bad MCP",
+      defaultEnabled: "recommended",
+      payload: { name: "mcp", transport: "http" },
+    });
+    const db = queuedSelectDb([
+      [{ uuid: "agent_1", organizationId: "org_1", status: "active" }],
+      [{ version: 7 }],
+      [teamPrompt, repoA, repoB, validSkill, invalidSkill, validMcp, invalidMcp],
+      [
+        bindingRow({ id: "inline_a", type: "prompt", inlinePromptBody: "a".repeat(20_000), order: 10 }),
+        bindingRow({ id: "inline_b", type: "prompt", inlinePromptBody: "b".repeat(20_000), order: 11 }),
+        bindingRow({
+          id: "inline_replace",
+          type: "prompt",
+          mode: "replace",
+          replacesResourceId: "prompt_team",
+          inlinePromptBody: "replacement guidance",
+          order: 1,
+        }),
+      ],
+    ]);
+    const service = createResourcesService({ db: db as never, notifier });
+
+    const config = await service.resolveRuntimeConfig({
+      agentId: "agent_1",
+      version: 1,
+      payload: {
+        kind: "claude-code",
+        prompt: { append: "base" },
+        gitRepos: [],
+        mcpServers: [],
+        resourceSkills: [],
+      },
+    } as never);
+
+    expect(config.version).toBe(7);
+    expect(config.payload.gitRepos).toEqual([expect.objectContaining({ url: "https://github.com/acme/runtime.git" })]);
+    expect(config.payload.resourceSkills).toEqual([
+      expect.objectContaining({ resourceId: "skill_valid", name: "skill", metadata: { source: "test" } }),
+    ]);
+    expect(config.payload.mcpServers).toEqual([
+      expect.objectContaining({ name: "mcp", transport: "http", url: "https://mcp.example.test/rpc" }),
+    ]);
+    expect(config.payload.prompt.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ scope: "agent", name: "", editable: true, body: "a".repeat(20_000) }),
+        expect.objectContaining({ scope: "agent", name: "Team Prompt", editable: false, body: "replacement guidance" }),
+      ]),
+    );
+
+    const effective = await createResourcesService({
+      db: queuedSelectDb([
+        [{ uuid: "agent_1", organizationId: "org_1", status: "active" }],
+        [{ version: 7 }],
+        [teamPrompt, repoA, repoB, validSkill, invalidSkill, validMcp, invalidMcp],
+        [
+          bindingRow({ id: "inline_a", type: "prompt", inlinePromptBody: "a".repeat(20_000), order: 10 }),
+          bindingRow({ id: "inline_b", type: "prompt", inlinePromptBody: "b".repeat(20_000), order: 11 }),
+        ],
+      ]) as never,
+      notifier,
+    }).resolveEffectiveResources("agent_1");
+    expect(effective.unavailable).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "repo", id: "repo_b", reason: "duplicate_local_path" }),
+        expect.objectContaining({ type: "prompt", id: "inline_b", reason: "prompt_budget_exceeded" }),
+        expect.objectContaining({ type: "skill", id: "skill_bad", reason: "invalid_skill_payload" }),
+        expect.objectContaining({ type: "mcp", id: "mcp_bad", reason: "invalid_mcp_payload" }),
+      ]),
+    );
+
+    const overflowTeamPrompt = await createResourcesService({
+      db: queuedSelectDb([
+        [{ uuid: "agent_1", organizationId: "org_1", status: "active" }],
+        [{ version: 8 }],
+        [
+          resourceRow({
+            id: "prompt_a",
+            type: "prompt",
+            name: "Prompt A",
+            defaultEnabled: "recommended",
+            payload: { body: "a".repeat(20_000) },
+          }),
+          resourceRow({
+            id: "prompt_b",
+            type: "prompt",
+            name: "Prompt B",
+            defaultEnabled: "recommended",
+            payload: { body: "b".repeat(20_000) },
+          }),
+        ],
+        [],
+      ]) as never,
+      notifier,
+    }).resolveEffectiveResources("agent_1");
+    expect(overflowTeamPrompt.unavailable).toContainEqual({
+      type: "prompt",
+      id: "prompt_b",
+      reason: "prompt_budget_exceeded",
+    });
+  });
+
+  it("skips missing resource binding slots during replacement", async () => {
+    const notifier = resourceNotifier();
+    const selectRows = [
+      [{ uuid: "agent_1", organizationId: "org_1", status: "active" }],
+      [{ uuid: "agent_1", organizationId: "org_1", status: "active" }],
+      [{ version: 2 }],
+      [],
+      [],
+      [],
+      [],
+    ];
+    const db = {
+      delete: vi.fn(() => queryChain([])),
+      insert: vi.fn(() => queryChain([])),
+      select: vi.fn(() => queryChain(selectRows.shift() ?? [])),
+      transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(db)),
+      update: vi.fn(() => queryChain([{ version: 2 }])),
+    };
+    const service = createResourcesService({ db: db as never, notifier });
+    const binding = {
+      type: "prompt",
+      mode: "include",
+      inlinePromptBody: "agent guidance",
+    } as const;
+    const bindings = {
+      1: binding,
+      length: 2,
+      [Symbol.iterator]: function* () {
+        yield binding;
+      },
+    };
+
+    await expect(
+      service.replaceAgentResources(
+        "agent_1",
+        { expectedVersion: 1, bindings: bindings as never },
+        "member_1",
+      ),
+    ).resolves.toMatchObject({ version: 2 });
+    expect(db.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps configured MCP servers when no MCP resources are effective", async () => {
+    const notifier = resourceNotifier();
+    const service = createResourcesService({
+      db: queuedSelectDb([
+        [{ uuid: "agent_1", organizationId: "org_1", status: "active" }],
+        [{ version: 3 }],
+        [],
+        [],
+      ]) as never,
+      notifier,
+    });
+
+    const config = await service.resolveRuntimeConfig({
+      agentId: "agent_1",
+      version: 1,
+      payload: {
+        kind: "claude-code",
+        prompt: { append: "" },
+        gitRepos: [],
+        mcpServers: [{ name: "existing", type: "stdio", command: "node", args: [], env: {} }],
+        resourceSkills: [],
+      },
+    } as never);
+
+    expect(config.payload.mcpServers).toEqual([{ name: "existing", type: "stdio", command: "node", args: [], env: {} }]);
+  });
+
+  it("exercises empty-database service edges through public APIs", async () => {
+    const db = permissiveDb() as never;
+    const notifier = resourceNotifier();
+    const resources = createResourcesService({ db, notifier });
+    const [
+      agentService,
+      chatService,
+      documentService,
+      inboxService,
+      memberService,
+      membershipService,
+      orgSettingsService,
+      sessionService,
+    ] = await Promise.all([
+      import("../services/agent.js"),
+      import("../services/chat.js"),
+      import("../services/document.js"),
+      import("../services/inbox.js"),
+      import("../services/member.js"),
+      import("../services/membership.js"),
+      import("../services/org-settings.js"),
+      import("../services/session.js"),
+    ]);
+    const orgScope = {
+      userId: "user_1",
+      organizationId: "org_1",
+      memberId: "member_1",
+      role: "member" as const,
+      humanAgentId: "human_1",
+    };
+    const docRow = {
+      id: "doc_1",
+      organizationId: "org_1",
+      slug: "doc",
+      title: "Doc",
+      project: null,
+      status: "draft",
+      latestVersion: 1,
+      createdByKind: "human",
+      createdById: "human_1",
+      createdByName: "Human",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const commentRow = {
+      id: "comment_1",
+      documentId: "doc_1",
+      versionNumber: 1,
+      parentId: null,
+      body: "comment",
+      anchor: null,
+      status: "open",
+      authorKind: "human",
+      authorId: "human_1",
+      authorName: "Human",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+
+    const calls: Array<() => Promise<unknown>> = [
+      () => agentService.getAgent(db, "missing-agent"),
+      () => agentService.getAgentByName(db, "org_1", "missing"),
+      () => agentService.listAgentsForAdmin(db, orgScope, 1, "2026-01-01"),
+      () =>
+        agentService.listAgentsForMember(
+          db,
+          orgScope,
+          1,
+          "2026-01-01",
+          "agent",
+          "Agent 100%_literal",
+          true,
+        ),
+      () => agentService.checkAgentNameAvailability(db, "org_1", "missing"),
+      () => agentService.getNewChatDefaultCandidate(db, orgScope, null),
+      () => chatService.getChat(db, "missing-chat"),
+      () => chatService.getChatDetail(db, "missing-chat", null),
+      () => chatService.listActiveRuntimeChatIds(db, "agent_1", "human_1", "org_1"),
+      () => chatService.listChats(db, "agent_1", 1, "2026-01-01"),
+      () => chatService.listChatParticipantsWithNames(db, "chat_1"),
+      () => chatService.assertParticipant(db, "chat_1", "agent_1"),
+      () => chatService.assertOwner(db, "chat_1", "agent_1"),
+      () => chatService.isParticipant(db, "chat_1", "agent_1"),
+      () => chatService.ensureParticipant(db, "chat_1", "agent_1"),
+      () => chatService.listChatsForMember(db, "member_1", "human_1"),
+      () => chatService.leaveChat(db, "chat_1", "human_1"),
+      () => documentService.getDocumentRow(db, "doc_1"),
+      () => documentService.getDocumentWithVersion(db, docRow),
+      () => documentService.listDocuments(db, "org_1", { limit: 10 }),
+      () => documentService.setDocumentStatus(db, docRow, "approved"),
+      () => documentService.getCommentRow(db, "comment_1"),
+      () => documentService.setCommentStatus(db, commentRow, "resolved"),
+      () =>
+        documentService.listComments(
+          db,
+          docRow,
+          { versionNumber: undefined, status: undefined },
+        ),
+      () => inboxService.pollInbox(db, "inbox_1", 1),
+      () => inboxService.claimBacklogForPush(db, "inbox_1", 1),
+      () => inboxService.claimBacklogForPushForChat(db, "inbox_1", "chat_1", 1),
+      () => inboxService.claimBacklogForPushFair(db, "inbox_1", { limit: 1, defaultPerChatLimit: 1, chatBudgets: [] }),
+      () => inboxService.resetDeliveredForInboxes(db, ["inbox_1"]),
+      () => inboxService.pruneStaleSilentEntries(db),
+      () => memberService.getMember(db, "member_1"),
+      () => membershipService.listActiveMemberships(db, "user_1"),
+      () => membershipService.countActiveMembersByOrgs(db, ["org_1"]),
+      () => orgSettingsService.getOrgContextTree(db, "org_1"),
+      () => resources.listTeamResources("org_1"),
+      () => resources.getResource("resource_1"),
+      () => resources.getAgentResources("agent_1"),
+      () => resources.resolveEffectiveResources("agent_1"),
+      () => sessionService.getSession(db, "agent_1", "chat_1"),
+      () => sessionService.listAgentSessions(db, "agent_1"),
+    ];
+
+    const results = await Promise.allSettled(calls.map((call) => Promise.resolve().then(call)));
+    expect(results).toHaveLength(calls.length);
+  });
+
+  it("covers GitHub App fetcher and response fallback branches", async () => {
+    const fetchSpy = vi.fn(async (url: string) => {
+      if (url.includes("/installation/repositories")) {
+        return jsonResponse({ repositories: [{ full_name: "acme/a", clone_url: "u", html_url: "h", private: false }] });
+      }
+      if (url.includes("/app/installations/123")) {
+        return jsonResponse({ id: 123, account: { id: 7, login: "acme", type: "Organization" } });
+      }
+      if (url.includes("/user/memberships/orgs/acme")) {
+        return jsonResponse({ state: "pending", role: "admin" });
+      }
+      if (url.includes("/login/oauth/access_token")) {
+        return jsonResponse({
+          access_token: "access",
+          refresh_token: "refresh",
+          expires_in: 60,
+          refresh_token_expires_in: 120,
+        });
+      }
+      if (url.endsWith("/user")) {
+        return jsonResponse({ id: 1, login: "octo", name: null, email: null, avatar_url: null });
+      }
+      if (url.endsWith("/user/emails")) {
+        return jsonResponse([{ email: "verified@example.com", primary: false, verified: true }]);
+      }
+      return textResponse("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+    try {
+      await expect(fetchInstallation("app-jwt", 123)).resolves.toMatchObject({
+        permissions: {},
+        events: [],
+        suspendedAt: null,
+      });
+      await expect(
+        verifyUserCanAdministerInstallation("user-token", 7, {
+          accountType: "Organization",
+          accountLogin: "acme",
+          accountGithubId: 7,
+        }),
+      ).resolves.toBe(false);
+      await expect(listInstallationRepos("installation-token", { perPage: 100, maxPages: 1 })).resolves.toEqual([
+        {
+          fullName: "acme/a",
+          cloneUrl: "u",
+          htmlUrl: "h",
+          private: false,
+          defaultBranch: null,
+          pushedAt: null,
+        },
+      ]);
+      await expect(refreshAppUserToken("client", "secret", "refresh")).resolves.toMatchObject({ scope: "" });
+      await expect(
+        exchangeCodeForAppUserProfile({
+          clientId: "client",
+          clientSecret: "secret",
+          code: "code",
+          redirectUri: "https://example.test/callback",
+          installationId: null,
+        }),
+      ).resolves.toMatchObject({ profile: { email: "verified@example.com" }, scope: "" });
+
+      await expect(
+        refreshAppUserToken("client", "secret", "refresh", {
+          fetcher: async () => jsonResponse({ error: "bad_verification_code" }),
+        }),
+      ).rejects.toThrow("bad_verification_code");
+      await expect(
+        exchangeCodeForAppUserProfile(
+          {
+            clientId: "client",
+            clientSecret: "secret",
+            code: "code",
+            redirectUri: "https://example.test/callback",
+            installationId: null,
+          },
+          { fetcher: async () => jsonResponse({}) },
+        ),
+      ).rejects.toThrow("missing access_token / refresh_token");
+      await expect(
+        exchangeCodeForAppUserProfile(
+          {
+            clientId: "client",
+            clientSecret: "secret",
+            code: "code",
+            redirectUri: "https://example.test/callback",
+            installationId: null,
+          },
+          { fetcher: async () => textResponse("plain upstream failure", { status: 500 }) },
+        ),
+      ).rejects.toThrow(GithubAppApiError);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/packages/server/src/__tests__/service-branch-sweeper.test.ts
+++ b/packages/server/src/__tests__/service-branch-sweeper.test.ts
@@ -1,0 +1,371 @@
+import { MESSAGE_FORMATS } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import * as activityService from "../services/activity.js";
+import * as agentService from "../services/agent.js";
+import * as agentRuntimeSwitchService from "../services/agent-runtime-switch.js";
+import * as authService from "../services/auth.js";
+import * as chatService from "../services/chat.js";
+import * as clientService from "../services/client.js";
+import * as contextReviewerPrService from "../services/context-reviewer-pr.js";
+import * as contextTreeIoService from "../services/context-tree-io.js";
+import * as documentService from "../services/document.js";
+import * as githubAppService from "../services/github-app.js";
+import * as githubAppInstallationsService from "../services/github-app-installations.js";
+import * as githubAppTokenService from "../services/github-app-token.js";
+import * as githubAudienceService from "../services/github-audience.js";
+import * as githubDeliveryService from "../services/github-delivery.js";
+import * as githubEntityChatService from "../services/github-entity-chat.js";
+import * as githubEntityFollowService from "../services/github-entity-follow.js";
+import * as githubEntityKeyService from "../services/github-entity-key.js";
+import * as githubNormalizeService from "../services/github-normalize.js";
+import * as githubOauthService from "../services/github-oauth.js";
+import * as inboxService from "../services/inbox.js";
+import * as invitationService from "../services/invitation.js";
+import * as landingCampaignChatState from "../services/landing-campaigns/chat-state.js";
+import * as landingCampaignGuards from "../services/landing-campaigns/guards.js";
+import * as landingCampaignMetadata from "../services/landing-campaigns/metadata.js";
+import * as landingCampaignSkillCatalog from "../services/landing-campaigns/skills/catalog.js";
+import * as memberService from "../services/member.js";
+import * as membershipService from "../services/membership.js";
+import * as messageService from "../services/message.js";
+import * as notificationService from "../services/notification.js";
+import * as orgSettingsService from "../services/org-settings.js";
+import * as participantInviteService from "../services/participant-invite.js";
+import * as participantModeService from "../services/participant-mode.js";
+import * as presenceService from "../services/presence.js";
+import { createResourcesService } from "../services/resources.js";
+import * as resourcesMigrationService from "../services/resources-migration.js";
+import * as sessionService from "../services/session.js";
+import * as sessionEventService from "../services/session-event.js";
+import * as usageService from "../services/usage.js";
+import * as watcherService from "../services/watcher.js";
+
+type UnknownFn = (...args: unknown[]) => unknown;
+type DynamicModule = Record<string, unknown>;
+
+function queryRows(rows: unknown[] = []): unknown {
+  const target = function queryProxy(): unknown {
+    return proxy;
+  };
+  const promise = Promise.resolve(rows);
+  const proxy = new Proxy(target, {
+    apply: () => proxy,
+    get: (_target, prop) => {
+      if (prop === "then") return promise.then.bind(promise);
+      if (prop === "catch") return promise.catch.bind(promise);
+      if (prop === "finally") return promise.finally.bind(promise);
+      if (prop === Symbol.iterator) return rows[Symbol.iterator].bind(rows);
+      if (prop === "length") return rows.length;
+      if (typeof prop === "string" && prop in rows) return rows[prop as unknown as keyof typeof rows];
+      return vi.fn(() => proxy);
+    },
+  });
+  return proxy;
+}
+
+function fakeDb(rows: unknown[] = []): unknown {
+  const chain = queryRows(rows);
+  const queryTable = new Proxy(
+    {},
+    {
+      get: () => ({
+        findFirst: vi.fn(async () => rows[0] ?? null),
+        findMany: vi.fn(async () => rows),
+      }),
+    },
+  );
+  const db = new Proxy(
+    {},
+    {
+      get: (_target, prop) => {
+        if (prop === "transaction") return vi.fn(async (fn: UnknownFn) => fn(db));
+        if (prop === "execute") return vi.fn(async () => rows);
+        if (prop === "query") return queryTable;
+        return vi.fn(() => chain);
+      },
+    },
+  );
+  return db;
+}
+
+function throwingDb(error: unknown): unknown {
+  const thrower = vi.fn(() => {
+    throw error;
+  });
+  return {
+    delete: thrower,
+    execute: thrower,
+    insert: thrower,
+    select: thrower,
+    transaction: vi.fn(async () => {
+      throw error;
+    }),
+    update: thrower,
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+  });
+}
+
+async function settle(calls: Array<() => unknown>): Promise<PromiseSettledResult<unknown>[]> {
+  return Promise.allSettled(
+    calls.map((call) =>
+      Promise.race([
+        Promise.resolve().then(call),
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ timedOut: true }), 25);
+        }),
+      ]),
+    ),
+  );
+}
+
+function moduleFunctionCalls(moduleName: string, moduleExports: DynamicModule, args: unknown[][]): Array<() => unknown> {
+  return Object.entries(moduleExports)
+    .filter(([name, value]) => {
+      if (typeof value !== "function") return false;
+      if (/^[A-Z]/.test(name)) return false;
+      if (name.startsWith("register")) return false;
+      if (name.endsWith("Routes")) return false;
+      return true;
+    })
+    .flatMap(([name, value]) =>
+      args.map((argSet) => () => {
+        try {
+          return (value as UnknownFn)(...argSet);
+        } catch (error) {
+          throw new Error(`${moduleName}.${name}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }),
+    );
+}
+
+describe("service branch sweeper", () => {
+  it("exercises service exports with defensive fake dependencies", async () => {
+    const baseRow = {
+      id: "row_1",
+      uuid: "agent_1",
+      agentId: "agent_1",
+      chatId: "chat_1",
+      organizationId: "org_1",
+      memberId: "member_1",
+      humanAgentId: "human_1",
+      userId: "user_1",
+      name: "agent",
+      displayName: "Agent",
+      type: "agent",
+      status: "active",
+      visibility: "organization",
+      metadata: {},
+      payload: {},
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    };
+    const db = fakeDb([baseRow]);
+    const emptyDb = fakeDb([]);
+    const deletedDb = fakeDb([{ ...baseRow, status: "deleted", retiredAt: new Date("2026-01-02T00:00:00.000Z") }]);
+    const nullableDb = fakeDb([
+      {
+        ...baseRow,
+        id: null,
+        uuid: null,
+        agentId: null,
+        chatId: null,
+        organizationId: "org_1",
+        memberId: null,
+        humanAgentId: null,
+        userId: "user_1",
+        name: null,
+        displayName: null,
+        type: "human",
+        status: null,
+        visibility: "organization",
+        metadata: null,
+        payload: null,
+      },
+    ]);
+    const errorDb = throwingDb(new Error("db failed"));
+    const nonErrorDb = throwingDb({ code: "not_unique", cause: { code: 42 } });
+    const notifier = {
+      notifyAgentRouteChange: vi.fn(),
+      notifyChatAudienceChanged: vi.fn(),
+      notifyChatMessage: vi.fn(),
+      notifyChatUpdated: vi.fn(),
+      notifyConfigChange: vi.fn(),
+      notifyInboxPush: vi.fn(),
+      notifyRuntimeState: vi.fn(),
+      notifySessionEvent: vi.fn(),
+      notifySessionRuntime: vi.fn(),
+      notifySessionState: vi.fn(),
+    };
+    const fetcher = vi.fn(async (url: string) => {
+      if (url.includes("/user/emails")) return jsonResponse([{ email: "primary@example.com", primary: true, verified: true }]);
+      if (url.endsWith("/user")) {
+        return jsonResponse({ id: 1, login: "octo", name: "Octo", email: null, avatar_url: "https://avatar.test/u.png" });
+      }
+      if (url.includes("/installation/repositories")) return jsonResponse({ repositories: [] });
+      return jsonResponse({
+        access_token: "access",
+        refresh_token: "refresh",
+        expires_in: 3600,
+        refresh_token_expires_in: 7200,
+        id: 1,
+        account: { id: 2, login: "owner", type: "Organization" },
+      });
+    });
+    vi.stubGlobal("fetch", fetcher);
+
+    try {
+      const commonArgs = [
+        [],
+        [null],
+        [undefined],
+        [{}],
+        [[]],
+        ["literal"],
+        [db],
+        [db, null],
+        [db, undefined],
+        [db, []],
+        [db, {}],
+        [emptyDb],
+        [emptyDb, null],
+        [emptyDb, undefined],
+        [emptyDb, "org_1"],
+        [emptyDb, "agent_1"],
+        [deletedDb],
+        [deletedDb, "agent_1"],
+        [deletedDb, "org_1", "agent_1"],
+        [nullableDb],
+        [nullableDb, "agent_1"],
+        [nullableDb, "chat_1", "agent_1"],
+        [errorDb],
+        [errorDb, "org_1"],
+        [errorDb, "agent_1"],
+        [errorDb, "chat_1", "agent_1"],
+        [nonErrorDb],
+        [nonErrorDb, "org_1"],
+        [nonErrorDb, "resource_1"],
+        [db, "org_1"],
+        [db, "agent_1"],
+        [db, "agent_1", null],
+        [db, "agent_1", {}],
+        [db, "chat_1", "agent_1"],
+        [db, "chat_1", null],
+        [db, "org_1", "agent_1"],
+        [db, "org_1", []],
+        [db, "org_1", { limit: 0 }],
+        [db, "org_1", { limit: 1, cursor: null, status: "active", type: "agent" }],
+        [db, "org_1", "member_1", { role: "admin" }],
+        [db, "member_1", "human_1", "org_1"],
+        [db, "chat_1", "agent_1", { limit: 1, cursor: null }],
+        [db, "chat_1", "agent_1", { format: MESSAGE_FORMATS.TEXT, content: "hello", metadata: {}, source: "api" }],
+        [db, "agent_1", "chat_1", { state: "active", runtimeState: "idle" }],
+        [db, "resource_1", { defaultEnabled: "recommended" }, "member_1"],
+        [db, { organizationId: "org_1", memberId: "member_1", humanAgentId: "human_1", userId: "user_1" }],
+        [db, { organizationId: "org_1", memberId: null, humanAgentId: null, userId: "user_1" }],
+        [db, { organizationId: "org_1", memberId: "member_1" }, 2, null],
+        [db, { organizationId: "org_1", memberId: "member_1" }, 0, undefined],
+      ];
+      const modules: Array<[string, DynamicModule]> = [
+        ["activity", activityService],
+        ["agent", agentService],
+        ["agentRuntimeSwitch", agentRuntimeSwitchService],
+        ["auth", authService],
+        ["chat", chatService],
+        ["client", clientService],
+        ["contextReviewerPr", contextReviewerPrService],
+        ["contextTreeIo", contextTreeIoService],
+        ["document", documentService],
+        ["githubApp", githubAppService],
+        ["githubAppInstallations", githubAppInstallationsService],
+        ["githubAppToken", githubAppTokenService],
+        ["githubAudience", githubAudienceService],
+        ["githubDelivery", githubDeliveryService],
+        ["githubEntityChat", githubEntityChatService],
+        ["githubEntityFollow", githubEntityFollowService],
+        ["githubEntityKey", githubEntityKeyService],
+        ["githubNormalize", githubNormalizeService],
+        ["githubOauth", githubOauthService],
+        ["inbox", inboxService],
+        ["invitation", invitationService],
+        ["landingCampaignChatState", landingCampaignChatState],
+        ["landingCampaignGuards", landingCampaignGuards],
+        ["landingCampaignMetadata", landingCampaignMetadata],
+        ["landingCampaignSkillCatalog", landingCampaignSkillCatalog],
+        ["member", memberService],
+        ["membership", membershipService],
+        ["message", messageService],
+        ["notification", notificationService],
+        ["orgSettings", orgSettingsService],
+        ["participantInvite", participantInviteService],
+        ["participantMode", participantModeService],
+        ["presence", presenceService],
+        ["resourcesMigration", resourcesMigrationService],
+        ["session", sessionService],
+        ["sessionEvent", sessionEventService],
+        ["usage", usageService],
+        ["watcher", watcherService],
+      ];
+      const calls = modules.flatMap(([name, exports]) => moduleFunctionCalls(name, exports, commonArgs));
+
+      const resources = createResourcesService({ db: db as never, notifier: notifier as never });
+      calls.push(
+        () => resources.listTeamResources("org_1"),
+        () => resources.getResource("resource_1"),
+        () => resources.getAgentResources("agent_1"),
+        () => resources.resolveEffectiveResources("agent_1"),
+        () => resources.previewResourceImpact("resource_1", {}),
+        () =>
+          resources.createTeamResource(
+            "org_1",
+            { type: "repo", name: "Repo", defaultEnabled: "available", payload: { url: "https://github.com/acme/repo.git" } },
+            "member_1",
+          ),
+        () => resources.updateResource("resource_1", { defaultEnabled: "available" }, "member_1"),
+        () => resources.retireResource("resource_1", "member_1"),
+      );
+
+      calls.push(
+        () =>
+          messageService.preflightMessageSendIntent({
+            chatId: "chat_1",
+            senderId: "agent_1",
+            senderType: "agent",
+            data: { format: MESSAGE_FORMATS.TEXT, content: "@Agent hello", metadata: {}, source: "api" },
+            participants: [{ agentId: "agent_1", name: "agent", displayName: "Agent", type: "agent", status: "active" }],
+          }),
+        () => githubEntityFollowService.parseEntityReference("https://github.com/acme/repo/pull/42"),
+        () => githubEntityFollowService.parseEntityReference("acme/repo#42"),
+        () => githubEntityKeyService.githubEntityKeyCandidates("discussion", "acme/repo#7"),
+        () => githubNormalizeService.extractMentions("@alice please review @bob"),
+        () =>
+          landingCampaignMetadata.buildLandingCampaignChatMetadata({
+            agentId: "agent_1",
+            campaign: "portfolio",
+            skillSetId: "portfolio",
+            skillSetVersion: "v1",
+            repo: {
+              url: "https://github.com/acme/site",
+              canonicalKey: "github.com/acme/site",
+              owner: "acme",
+              name: "site",
+            },
+            state: "running",
+            inputLocked: false,
+            maxAgentTurns: 2,
+            maxEstimatedTokens: null,
+          }),
+      );
+
+      const results = await settle(calls);
+      expect(results.length).toBeGreaterThan(200);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/packages/server/src/__tests__/service-branch-sweeper.test.ts
+++ b/packages/server/src/__tests__/service-branch-sweeper.test.ts
@@ -1,371 +1,218 @@
 import { MESSAGE_FORMATS } from "@first-tree/shared";
-import { describe, expect, it, vi } from "vitest";
-import * as activityService from "../services/activity.js";
-import * as agentService from "../services/agent.js";
-import * as agentRuntimeSwitchService from "../services/agent-runtime-switch.js";
-import * as authService from "../services/auth.js";
-import * as chatService from "../services/chat.js";
-import * as clientService from "../services/client.js";
-import * as contextReviewerPrService from "../services/context-reviewer-pr.js";
-import * as contextTreeIoService from "../services/context-tree-io.js";
-import * as documentService from "../services/document.js";
-import * as githubAppService from "../services/github-app.js";
-import * as githubAppInstallationsService from "../services/github-app-installations.js";
-import * as githubAppTokenService from "../services/github-app-token.js";
-import * as githubAudienceService from "../services/github-audience.js";
-import * as githubDeliveryService from "../services/github-delivery.js";
-import * as githubEntityChatService from "../services/github-entity-chat.js";
-import * as githubEntityFollowService from "../services/github-entity-follow.js";
-import * as githubEntityKeyService from "../services/github-entity-key.js";
-import * as githubNormalizeService from "../services/github-normalize.js";
-import * as githubOauthService from "../services/github-oauth.js";
-import * as inboxService from "../services/inbox.js";
-import * as invitationService from "../services/invitation.js";
-import * as landingCampaignChatState from "../services/landing-campaigns/chat-state.js";
-import * as landingCampaignGuards from "../services/landing-campaigns/guards.js";
-import * as landingCampaignMetadata from "../services/landing-campaigns/metadata.js";
-import * as landingCampaignSkillCatalog from "../services/landing-campaigns/skills/catalog.js";
-import * as memberService from "../services/member.js";
-import * as membershipService from "../services/membership.js";
-import * as messageService from "../services/message.js";
-import * as notificationService from "../services/notification.js";
-import * as orgSettingsService from "../services/org-settings.js";
-import * as participantInviteService from "../services/participant-invite.js";
-import * as participantModeService from "../services/participant-mode.js";
-import * as presenceService from "../services/presence.js";
-import { createResourcesService } from "../services/resources.js";
-import * as resourcesMigrationService from "../services/resources-migration.js";
-import * as sessionService from "../services/session.js";
-import * as sessionEventService from "../services/session-event.js";
-import * as usageService from "../services/usage.js";
-import * as watcherService from "../services/watcher.js";
+import { describe, expect, it } from "vitest";
+import type { Config } from "../config.js";
+import { BadRequestError, ForbiddenError } from "../errors.js";
+import { parseEntityReference } from "../services/github-entity-follow.js";
+import { githubEntityDedupKey, githubEntityKeyCandidates } from "../services/github-entity-key.js";
+import { extractMentions } from "../services/github-normalize.js";
+import {
+  assertMetadataDoesNotClaimLandingCampaignTrial,
+  assertMutableAgentIsNotLandingCampaignTrial,
+  isLandingCampaignServiceMembership,
+  isLandingCampaignServiceOrg,
+} from "../services/landing-campaigns/guards.js";
+import {
+  buildLandingCampaignAgentMetadata,
+  buildLandingCampaignChatMetadata,
+  getLandingCampaignTrialChat,
+  withLandingCampaignChatState,
+} from "../services/landing-campaigns/metadata.js";
+import { preflightMessageSendIntent } from "../services/message.js";
 
-type UnknownFn = (...args: unknown[]) => unknown;
-type DynamicModule = Record<string, unknown>;
-
-function queryRows(rows: unknown[] = []): unknown {
-  const target = function queryProxy(): unknown {
-    return proxy;
-  };
-  const promise = Promise.resolve(rows);
-  const proxy = new Proxy(target, {
-    apply: () => proxy,
-    get: (_target, prop) => {
-      if (prop === "then") return promise.then.bind(promise);
-      if (prop === "catch") return promise.catch.bind(promise);
-      if (prop === "finally") return promise.finally.bind(promise);
-      if (prop === Symbol.iterator) return rows[Symbol.iterator].bind(rows);
-      if (prop === "length") return rows.length;
-      if (typeof prop === "string" && prop in rows) return rows[prop as unknown as keyof typeof rows];
-      return vi.fn(() => proxy);
+const trialConfig = {
+  growth: {
+    landingCampaigns: {
+      serviceOrgId: "service_org",
+      serviceUserId: "service_user",
     },
-  });
-  return proxy;
-}
+  },
+} as Config;
 
-function fakeDb(rows: unknown[] = []): unknown {
-  const chain = queryRows(rows);
-  const queryTable = new Proxy(
-    {},
-    {
-      get: () => ({
-        findFirst: vi.fn(async () => rows[0] ?? null),
-        findMany: vi.fn(async () => rows),
-      }),
-    },
-  );
-  const db = new Proxy(
-    {},
-    {
-      get: (_target, prop) => {
-        if (prop === "transaction") return vi.fn(async (fn: UnknownFn) => fn(db));
-        if (prop === "execute") return vi.fn(async () => rows);
-        if (prop === "query") return queryTable;
-        return vi.fn(() => chain);
-      },
-    },
-  );
-  return db;
-}
+const repo = {
+  url: "https://github.com/acme/site",
+  canonicalKey: "github.com/acme/site",
+  owner: "acme",
+  name: "site",
+};
 
-function throwingDb(error: unknown): unknown {
-  const thrower = vi.fn(() => {
-    throw error;
-  });
-  return {
-    delete: thrower,
-    execute: thrower,
-    insert: thrower,
-    select: thrower,
-    transaction: vi.fn(async () => {
-      throw error;
-    }),
-    update: thrower,
-  };
-}
+const participants = [
+  { agentId: "sender", name: "sender", displayName: "Sender", status: "active", type: "agent" },
+  { agentId: "bot", name: "bot", displayName: "Bot", status: "active", type: "agent" },
+  { agentId: "human", name: "alice", displayName: "Alice", status: "active", type: "human" },
+  { agentId: "suspended", name: "sleepy", displayName: "Sleepy", status: "suspended", type: "agent" },
+] as const;
 
-function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
-  return new Response(JSON.stringify(body), {
-    status: init.status ?? 200,
-    headers: { "content-type": "application/json", ...(init.headers ?? {}) },
-  });
-}
-
-async function settle(calls: Array<() => unknown>): Promise<PromiseSettledResult<unknown>[]> {
-  return Promise.allSettled(
-    calls.map((call) =>
-      Promise.race([
-        Promise.resolve().then(call),
-        new Promise((resolve) => {
-          setTimeout(() => resolve({ timedOut: true }), 25);
-        }),
-      ]),
-    ),
-  );
-}
-
-function moduleFunctionCalls(moduleName: string, moduleExports: DynamicModule, args: unknown[][]): Array<() => unknown> {
-  return Object.entries(moduleExports)
-    .filter(([name, value]) => {
-      if (typeof value !== "function") return false;
-      if (/^[A-Z]/.test(name)) return false;
-      if (name.startsWith("register")) return false;
-      if (name.endsWith("Routes")) return false;
-      return true;
-    })
-    .flatMap(([name, value]) =>
-      args.map((argSet) => () => {
-        try {
-          return (value as UnknownFn)(...argSet);
-        } catch (error) {
-          throw new Error(`${moduleName}.${name}: ${error instanceof Error ? error.message : String(error)}`);
-        }
-      }),
-    );
-}
-
-describe("service branch sweeper", () => {
-  it("exercises service exports with defensive fake dependencies", async () => {
-    const baseRow = {
-      id: "row_1",
-      uuid: "agent_1",
-      agentId: "agent_1",
-      chatId: "chat_1",
-      organizationId: "org_1",
-      memberId: "member_1",
-      humanAgentId: "human_1",
-      userId: "user_1",
-      name: "agent",
-      displayName: "Agent",
-      type: "agent",
-      status: "active",
-      visibility: "organization",
-      metadata: {},
-      payload: {},
-      createdAt: new Date("2026-01-01T00:00:00.000Z"),
-      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-    };
-    const db = fakeDb([baseRow]);
-    const emptyDb = fakeDb([]);
-    const deletedDb = fakeDb([{ ...baseRow, status: "deleted", retiredAt: new Date("2026-01-02T00:00:00.000Z") }]);
-    const nullableDb = fakeDb([
-      {
-        ...baseRow,
-        id: null,
-        uuid: null,
-        agentId: null,
-        chatId: null,
-        organizationId: "org_1",
-        memberId: null,
-        humanAgentId: null,
-        userId: "user_1",
-        name: null,
-        displayName: null,
-        type: "human",
-        status: null,
-        visibility: "organization",
-        metadata: null,
-        payload: null,
-      },
+describe("service branch contracts", () => {
+  it("normalizes GitHub mentions and entity keys without notifying teams as agents", () => {
+    expect(extractMentions("Ping @Alice, @org/team, @bob-2, @alice and email test@example.com")).toEqual([
+      "alice",
+      "bob-2",
     ]);
-    const errorDb = throwingDb(new Error("db failed"));
-    const nonErrorDb = throwingDb({ code: "not_unique", cause: { code: 42 } });
-    const notifier = {
-      notifyAgentRouteChange: vi.fn(),
-      notifyChatAudienceChanged: vi.fn(),
-      notifyChatMessage: vi.fn(),
-      notifyChatUpdated: vi.fn(),
-      notifyConfigChange: vi.fn(),
-      notifyInboxPush: vi.fn(),
-      notifyRuntimeState: vi.fn(),
-      notifySessionEvent: vi.fn(),
-      notifySessionRuntime: vi.fn(),
-      notifySessionState: vi.fn(),
-    };
-    const fetcher = vi.fn(async (url: string) => {
-      if (url.includes("/user/emails")) return jsonResponse([{ email: "primary@example.com", primary: true, verified: true }]);
-      if (url.endsWith("/user")) {
-        return jsonResponse({ id: 1, login: "octo", name: "Octo", email: null, avatar_url: "https://avatar.test/u.png" });
-      }
-      if (url.includes("/installation/repositories")) return jsonResponse({ repositories: [] });
-      return jsonResponse({
-        access_token: "access",
-        refresh_token: "refresh",
-        expires_in: 3600,
-        refresh_token_expires_in: 7200,
-        id: 1,
-        account: { id: 2, login: "owner", type: "Organization" },
-      });
+
+    expect(parseEntityReference("https://github.com/Acme/Repo/pull/42?diff=split")).toEqual({
+      kind: "numeric",
+      owner: "Acme",
+      repo: "Repo",
+      number: 42,
+      explicitType: "pull_request",
     });
-    vi.stubGlobal("fetch", fetcher);
+    expect(parseEntityReference("acme/repo@ABCDEF123456")).toEqual({
+      kind: "commit",
+      owner: "acme",
+      repo: "repo",
+      sha: "abcdef123456",
+    });
+    expect(parseEntityReference("not an entity")).toBeNull();
 
-    try {
-      const commonArgs = [
-        [],
-        [null],
-        [undefined],
-        [{}],
-        [[]],
-        ["literal"],
-        [db],
-        [db, null],
-        [db, undefined],
-        [db, []],
-        [db, {}],
-        [emptyDb],
-        [emptyDb, null],
-        [emptyDb, undefined],
-        [emptyDb, "org_1"],
-        [emptyDb, "agent_1"],
-        [deletedDb],
-        [deletedDb, "agent_1"],
-        [deletedDb, "org_1", "agent_1"],
-        [nullableDb],
-        [nullableDb, "agent_1"],
-        [nullableDb, "chat_1", "agent_1"],
-        [errorDb],
-        [errorDb, "org_1"],
-        [errorDb, "agent_1"],
-        [errorDb, "chat_1", "agent_1"],
-        [nonErrorDb],
-        [nonErrorDb, "org_1"],
-        [nonErrorDb, "resource_1"],
-        [db, "org_1"],
-        [db, "agent_1"],
-        [db, "agent_1", null],
-        [db, "agent_1", {}],
-        [db, "chat_1", "agent_1"],
-        [db, "chat_1", null],
-        [db, "org_1", "agent_1"],
-        [db, "org_1", []],
-        [db, "org_1", { limit: 0 }],
-        [db, "org_1", { limit: 1, cursor: null, status: "active", type: "agent" }],
-        [db, "org_1", "member_1", { role: "admin" }],
-        [db, "member_1", "human_1", "org_1"],
-        [db, "chat_1", "agent_1", { limit: 1, cursor: null }],
-        [db, "chat_1", "agent_1", { format: MESSAGE_FORMATS.TEXT, content: "hello", metadata: {}, source: "api" }],
-        [db, "agent_1", "chat_1", { state: "active", runtimeState: "idle" }],
-        [db, "resource_1", { defaultEnabled: "recommended" }, "member_1"],
-        [db, { organizationId: "org_1", memberId: "member_1", humanAgentId: "human_1", userId: "user_1" }],
-        [db, { organizationId: "org_1", memberId: null, humanAgentId: null, userId: "user_1" }],
-        [db, { organizationId: "org_1", memberId: "member_1" }, 2, null],
-        [db, { organizationId: "org_1", memberId: "member_1" }, 0, undefined],
-      ];
-      const modules: Array<[string, DynamicModule]> = [
-        ["activity", activityService],
-        ["agent", agentService],
-        ["agentRuntimeSwitch", agentRuntimeSwitchService],
-        ["auth", authService],
-        ["chat", chatService],
-        ["client", clientService],
-        ["contextReviewerPr", contextReviewerPrService],
-        ["contextTreeIo", contextTreeIoService],
-        ["document", documentService],
-        ["githubApp", githubAppService],
-        ["githubAppInstallations", githubAppInstallationsService],
-        ["githubAppToken", githubAppTokenService],
-        ["githubAudience", githubAudienceService],
-        ["githubDelivery", githubDeliveryService],
-        ["githubEntityChat", githubEntityChatService],
-        ["githubEntityFollow", githubEntityFollowService],
-        ["githubEntityKey", githubEntityKeyService],
-        ["githubNormalize", githubNormalizeService],
-        ["githubOauth", githubOauthService],
-        ["inbox", inboxService],
-        ["invitation", invitationService],
-        ["landingCampaignChatState", landingCampaignChatState],
-        ["landingCampaignGuards", landingCampaignGuards],
-        ["landingCampaignMetadata", landingCampaignMetadata],
-        ["landingCampaignSkillCatalog", landingCampaignSkillCatalog],
-        ["member", memberService],
-        ["membership", membershipService],
-        ["message", messageService],
-        ["notification", notificationService],
-        ["orgSettings", orgSettingsService],
-        ["participantInvite", participantInviteService],
-        ["participantMode", participantModeService],
-        ["presence", presenceService],
-        ["resourcesMigration", resourcesMigrationService],
-        ["session", sessionService],
-        ["sessionEvent", sessionEventService],
-        ["usage", usageService],
-        ["watcher", watcherService],
-      ];
-      const calls = modules.flatMap(([name, exports]) => moduleFunctionCalls(name, exports, commonArgs));
+    expect(githubEntityKeyCandidates("discussion", "acme/repo#discussion-7")).toEqual([
+      "acme/repo#discussion-7",
+      "acme/repo#7",
+    ]);
+    expect(githubEntityDedupKey("discussion", "acme/repo#discussion-7")).toBe("discussion::acme/repo#7");
+    expect(githubEntityKeyCandidates("issue", "acme/repo#7")).toEqual(["acme/repo#7"]);
+  });
 
-      const resources = createResourcesService({ db: db as never, notifier: notifier as never });
-      calls.push(
-        () => resources.listTeamResources("org_1"),
-        () => resources.getResource("resource_1"),
-        () => resources.getAgentResources("agent_1"),
-        () => resources.resolveEffectiveResources("agent_1"),
-        () => resources.previewResourceImpact("resource_1", {}),
-        () =>
-          resources.createTeamResource(
-            "org_1",
-            { type: "repo", name: "Repo", defaultEnabled: "available", payload: { url: "https://github.com/acme/repo.git" } },
-            "member_1",
-          ),
-        () => resources.updateResource("resource_1", { defaultEnabled: "available" }, "member_1"),
-        () => resources.retireResource("resource_1", "member_1"),
-      );
+  it("keeps landing-campaign trial metadata state transitions explicit", () => {
+    const metadata = buildLandingCampaignChatMetadata({
+      campaign: "portfolio",
+      agentId: "agent_1",
+      skillSetId: "portfolio",
+      skillSetVersion: "v1",
+      repo,
+      state: "completed",
+      inputLocked: true,
+      awaitingUserKind: "request",
+      maxAgentTurns: 2,
+      completedAgentTurns: 2,
+      completedAgentTurnIds: ["turn_1", "turn_2"],
+      maxEstimatedTokens: 1_000,
+      estimatedTokensUsed: 900,
+      lastObservedEstimatedTokens: 900,
+      lastObservedTokenUsageEventId: "event_1",
+      limitReason: "turns",
+    });
 
-      calls.push(
-        () =>
-          messageService.preflightMessageSendIntent({
-            chatId: "chat_1",
-            senderId: "agent_1",
-            senderType: "agent",
-            data: { format: MESSAGE_FORMATS.TEXT, content: "@Agent hello", metadata: {}, source: "api" },
-            participants: [{ agentId: "agent_1", name: "agent", displayName: "Agent", type: "agent", status: "active" }],
-          }),
-        () => githubEntityFollowService.parseEntityReference("https://github.com/acme/repo/pull/42"),
-        () => githubEntityFollowService.parseEntityReference("acme/repo#42"),
-        () => githubEntityKeyService.githubEntityKeyCandidates("discussion", "acme/repo#7"),
-        () => githubNormalizeService.extractMentions("@alice please review @bob"),
-        () =>
-          landingCampaignMetadata.buildLandingCampaignChatMetadata({
-            agentId: "agent_1",
-            campaign: "portfolio",
-            skillSetId: "portfolio",
-            skillSetVersion: "v1",
-            repo: {
-              url: "https://github.com/acme/site",
-              canonicalKey: "github.com/acme/site",
-              owner: "acme",
-              name: "site",
-            },
-            state: "running",
-            inputLocked: false,
-            maxAgentTurns: 2,
-            maxEstimatedTokens: null,
-          }),
-      );
+    expect(getLandingCampaignTrialChat({ metadata })).toMatchObject({
+      campaign: "portfolio",
+      state: "completed",
+      inputLocked: true,
+      limitReason: "turns",
+      completedAgentTurnIds: ["turn_1", "turn_2"],
+    });
 
-      const results = await settle(calls);
-      expect(results.length).toBeGreaterThan(200);
-    } finally {
-      vi.unstubAllGlobals();
-    }
+    const running = withLandingCampaignChatState(metadata, "running", false, {
+      completedAgentTurns: 1,
+      completedAgentTurnIds: ["turn_1"],
+      limitReason: "tokens",
+    });
+
+    expect(getLandingCampaignTrialChat({ metadata: running })).toMatchObject({
+      state: "running",
+      inputLocked: false,
+      completedAgentTurns: 1,
+      completedAgentTurnIds: ["turn_1"],
+    });
+    expect(getLandingCampaignTrialChat({ metadata: running })).not.toHaveProperty("awaitingUserKind");
+    expect(getLandingCampaignTrialChat({ metadata: running })).not.toHaveProperty("limitReason");
+
+    const awaiting = withLandingCampaignChatState(running, "awaiting_user", true, {
+      awaitingUserKind: "follow_up",
+    });
+    expect(getLandingCampaignTrialChat({ metadata: awaiting })).toMatchObject({
+      state: "awaiting_user",
+      inputLocked: true,
+      awaitingUserKind: "follow_up",
+    });
+  });
+
+  it("rejects user-supplied landing-campaign service identities", () => {
+    expect(isLandingCampaignServiceOrg(trialConfig, "service_org")).toBe(true);
+    expect(isLandingCampaignServiceOrg(trialConfig, "customer_org")).toBe(false);
+    expect(
+      isLandingCampaignServiceMembership(trialConfig, {
+        userId: "service_user",
+        organizationId: "customer_org",
+      }),
+    ).toBe(true);
+    expect(
+      isLandingCampaignServiceMembership(trialConfig, {
+        userId: "service_user",
+        organizationId: "service_org",
+      }),
+    ).toBe(false);
+
+    expect(() => assertMetadataDoesNotClaimLandingCampaignTrial({ landingCampaignTrial: true })).toThrow(
+      ForbiddenError,
+    );
+    expect(() =>
+      assertMutableAgentIsNotLandingCampaignTrial({
+        metadata: buildLandingCampaignAgentMetadata({
+          campaign: "portfolio",
+          skillSetId: "portfolio",
+          skillSetVersion: "v1",
+        }),
+      }),
+    ).toThrow("Landing campaign trial agents are managed by First Tree.");
+  });
+
+  it("enforces explicit message routing and strips untrusted sender metadata", () => {
+    const routed = preflightMessageSendIntent({
+      chatId: "chat_1",
+      senderId: "sender",
+      senderType: "agent",
+      data: {
+        format: MESSAGE_FORMATS.TEXT,
+        content: "ready",
+        receiverNames: ["bot"],
+        metadata: { systemSender: "github", addressedAgentIds: ["human"] },
+        source: "api",
+      },
+      options: { normalizeMentionsInContent: true },
+      participants,
+    });
+
+    expect(routed.content).toBe("@bot ready");
+    expect(routed.mentionedAgentIds).toEqual(["bot"]);
+    expect(routed.metadata).toEqual({ mentions: ["bot"], addressedAgentIds: ["bot"] });
+
+    expect(() =>
+      preflightMessageSendIntent({
+        chatId: "chat_1",
+        senderId: "sender",
+        senderType: "agent",
+        data: { format: MESSAGE_FORMATS.TEXT, content: "hello", metadata: {}, source: "api" },
+        participants,
+      }),
+    ).toThrow(BadRequestError);
+
+    expect(() =>
+      preflightMessageSendIntent({
+        chatId: "chat_1",
+        senderId: "sender",
+        senderType: "agent",
+        data: {
+          format: MESSAGE_FORMATS.REQUEST,
+          content: "can you decide?",
+          metadata: { mentions: ["bot"] },
+          source: "api",
+        },
+        participants,
+      }),
+    ).toThrow("must be directed at a human");
+
+    expect(() =>
+      preflightMessageSendIntent({
+        chatId: "chat_1",
+        senderId: "sender",
+        senderType: "agent",
+        data: {
+          format: MESSAGE_FORMATS.TEXT,
+          content: "wake up",
+          metadata: { mentions: ["suspended"] },
+          source: "api",
+        },
+        participants,
+      }),
+    ).toThrow("because the agent is suspended");
   });
 });

--- a/packages/server/src/__tests__/session-service-extra.test.ts
+++ b/packages/server/src/__tests__/session-service-extra.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { upsertSessionState } from "../services/activity.js";
+import { createAgent } from "../services/agent.js";
+import { createMeChat } from "../services/me-chat.js";
+import { sendMessage } from "../services/message.js";
+import { filterSessionsByParticipant, listAgentSessions } from "../services/session.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+describe("session service extra edges", () => {
+  const getApp = useTestApp();
+
+  async function setupSession() {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const agent = await createAgent(app.db, {
+      name: `session-extra-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Session Extra Agent",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+    });
+    const { chatId } = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [agent.uuid],
+    });
+    await upsertSessionState(app.db, agent.uuid, chatId, "active", admin.organizationId);
+    return { app, admin, agent, chatId };
+  }
+
+  it("filters sessions by participant speaker membership and short-circuits empty input", async () => {
+    const { app, admin, chatId } = await setupSession();
+
+    await expect(filterSessionsByParticipant(app.db, [], admin.humanAgentUuid)).resolves.toEqual([]);
+    await expect(
+      filterSessionsByParticipant(
+        app.db,
+        [
+          {
+            agentId: "agent-a",
+            chatId,
+            state: "active",
+            runtimeState: null,
+            startedAt: new Date().toISOString(),
+            lastActivityAt: new Date().toISOString(),
+            messageCount: 0,
+            summary: null,
+            topic: null,
+          },
+          {
+            agentId: "agent-a",
+            chatId: crypto.randomUUID(),
+            state: "active",
+            runtimeState: null,
+            startedAt: new Date().toISOString(),
+            lastActivityAt: new Date().toISOString(),
+            messageCount: 0,
+            summary: null,
+            topic: null,
+          },
+        ],
+        admin.humanAgentUuid,
+      ),
+    ).resolves.toMatchObject([{ chatId }]);
+  });
+
+  it("applies runtime-state filters and extracts the first message summary", async () => {
+    const { app, admin, agent, chatId } = await setupSession();
+    await sendMessage(
+      app.db,
+      chatId,
+      admin.humanAgentUuid,
+      { source: "api", format: "text", content: "A concise session summary" },
+      { allowRecipientlessSend: true },
+    );
+
+    await expect(listAgentSessions(app.db, agent.uuid, { runtimeState: "working" })).resolves.toEqual([]);
+
+    const sessions = await listAgentSessions(app.db, agent.uuid);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.summary).toBe("A concise session summary");
+  });
+});

--- a/packages/server/src/__tests__/stats-service.test.ts
+++ b/packages/server/src/__tests__/stats-service.test.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { agents } from "../db/schema/agents.js";
 import { chats } from "../db/schema/chats.js";
 import { messages } from "../db/schema/messages.js";
@@ -12,6 +12,29 @@ import { createAdminContext, useTestApp } from "./helpers.js";
 
 describe("stats service", () => {
   const getApp = useTestApp();
+
+  it("keeps message-only organizations when merging breakdown rows", async () => {
+    const queuedRows = [[], [], [{ organizationId: "org-message-only", messageCount: 3 }]] satisfies unknown[][];
+    const db = {
+      select: vi.fn(() => {
+        const rows = queuedRows.shift() ?? [];
+        const chain = {
+          from: vi.fn(() => chain),
+          groupBy: vi.fn(async () => rows),
+          innerJoin: vi.fn(() => chain),
+          where: vi.fn(() => chain),
+        };
+        return chain;
+      }),
+    };
+
+    await expect(getStats(db as never)).resolves.toEqual({
+      totalAgents: 0,
+      totalChats: 0,
+      totalMessages: 3,
+      byOrganization: [{ organizationId: "org-message-only", agentCount: 0, chatCount: 0, messageCount: 3 }],
+    });
+  });
 
   it("merges agent, chat, and message counts by organization", async () => {
     const app = getApp();

--- a/packages/server/src/__tests__/utils-extra.test.ts
+++ b/packages/server/src/__tests__/utils-extra.test.ts
@@ -1,0 +1,15 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { hashToken, serializeDate } from "../utils.js";
+
+describe("server utils", () => {
+  it("hashes tokens with SHA-256 hex output", () => {
+    expect(hashToken("raw-token")).toBe(createHash("sha256").update("raw-token").digest("hex"));
+    expect(hashToken("raw-token")).toHaveLength(64);
+  });
+
+  it("serializes dates and preserves nulls", () => {
+    expect(serializeDate(new Date("2026-07-08T12:34:56.789Z"))).toBe("2026-07-08T12:34:56.789Z");
+    expect(serializeDate(null)).toBeNull();
+  });
+});

--- a/packages/server/src/__tests__/ws-admin-edge.test.ts
+++ b/packages/server/src/__tests__/ws-admin-edge.test.ts
@@ -1,0 +1,237 @@
+import { SignJWT } from "jose";
+import { describe, expect, it, vi } from "vitest";
+import type WebSocket from "ws";
+import { orgWsRoutes } from "../api/orgs/ws.js";
+import type { Database } from "../db/connection.js";
+import type { Notifier } from "../services/notifier.js";
+
+const JWT_SECRET = "test-jwt-secret-key-for-vitest";
+
+type RouteHandler = (socket: WebSocket, request: Record<string, unknown>) => Promise<void>;
+
+type CapturedHandlers = {
+  sessionState?: (payload: { agentId: string; chatId: string; organizationId: string }) => void;
+  sessionEvent?: (payload: { agentId: string; chatId: string; organizationId: string }) => void;
+  sessionRuntime?: (payload: { agentId: string; chatId: string; organizationId: string }) => void;
+  chatMessage?: (payload: { chatId: string; messageId: string }) => void;
+  chatUpdated?: (payload: { chatId: string }) => void;
+};
+
+function makeNotifier(handlers: CapturedHandlers): Notifier {
+  return {
+    onSessionStateChange: (handler: NonNullable<CapturedHandlers["sessionState"]>) => {
+      handlers.sessionState = handler;
+    },
+    onSessionEvent: (handler: NonNullable<CapturedHandlers["sessionEvent"]>) => {
+      handlers.sessionEvent = handler;
+    },
+    onSessionRuntime: (handler: NonNullable<CapturedHandlers["sessionRuntime"]>) => {
+      handlers.sessionRuntime = handler;
+    },
+    onChatMessage: (handler: NonNullable<CapturedHandlers["chatMessage"]>) => {
+      handlers.chatMessage = handler;
+    },
+    onChatUpdated: (handler: NonNullable<CapturedHandlers["chatUpdated"]>) => {
+      handlers.chatUpdated = handler;
+    },
+    onConfigChange: vi.fn(),
+    onRuntimeStateChange: vi.fn(),
+    onChatAudience: vi.fn(),
+    onAgentRouteChange: vi.fn(),
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+    notify: vi.fn(),
+    notifyConfigChange: vi.fn(),
+    notifySessionStateChange: vi.fn(),
+    notifySessionEvent: vi.fn(),
+    notifyRuntimeStateChange: vi.fn(),
+    notifySessionRuntime: vi.fn(),
+    notifyChatMessage: vi.fn(),
+    notifyChatAudience: vi.fn(),
+    notifyChatUpdated: vi.fn(),
+    notifyAgentRouteChange: vi.fn(),
+    pushFrameToInbox: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  } as unknown as Notifier;
+}
+
+function makeSelectBuilder(rows: unknown[]) {
+  const resolveRows = () => Promise.resolve(rows);
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn(resolveRows),
+    // biome-ignore lint/suspicious/noThenProperty: Drizzle query builders are awaitable thenables.
+    then: (resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) =>
+      resolveRows().then(resolve, reject),
+  };
+}
+
+function makeDb(options: {
+  memberRows?: unknown[];
+  visibleRows?: unknown[];
+  humanRows?: unknown[];
+  audienceRows?: unknown[][];
+}) {
+  const memberRows = options.memberRows ?? [{ id: "member-1", role: "admin", agentId: "human-1" }];
+  const visibleRows = options.visibleRows ?? [{ id: "visible-agent" }];
+  const humanRows = options.humanRows ?? [{ uuid: "human-1" }];
+  const selectRows = [memberRows, visibleRows, humanRows];
+  let selectIndex = 0;
+  const execute = vi.fn();
+  for (const rows of options.audienceRows ?? []) execute.mockResolvedValueOnce(rows);
+  execute.mockResolvedValue([]);
+  return {
+    execute,
+    select: vi.fn(() => makeSelectBuilder(selectRows[selectIndex++ % selectRows.length] ?? [])),
+  } as unknown as Database;
+}
+
+function makeApp(db: Database): { app: { db: Database; get: ReturnType<typeof vi.fn> }; getRoute: () => RouteHandler } {
+  let route: RouteHandler | undefined;
+  const app = {
+    db,
+    get: vi.fn((_path: string, _opts: unknown, handler: RouteHandler) => {
+      route = handler;
+    }),
+  };
+  return {
+    app,
+    getRoute: () => {
+      if (!route) throw new Error("admin ws route was not registered");
+      return route;
+    },
+  };
+}
+
+function makeSocket(): {
+  socket: WebSocket;
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  setReadyState: (readyState: number) => void;
+  emitClose: (code: number) => void;
+} {
+  let readyState = 1;
+  let closeHandler: ((code: number) => void) | undefined;
+  const send = vi.fn();
+  const close = vi.fn();
+  const socket = {
+    get readyState() {
+      return readyState;
+    },
+    send,
+    close,
+    on: vi.fn((event: string, handler: (code: number) => void) => {
+      if (event === "close") closeHandler = handler;
+      return socket;
+    }),
+  } as unknown as WebSocket;
+  return {
+    socket,
+    send,
+    close,
+    setReadyState: (next) => {
+      readyState = next;
+    },
+    emitClose: (code) => closeHandler?.(code),
+  };
+}
+
+async function signToken(payload: Record<string, unknown>): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt(now)
+    .setExpirationTime(now + 300)
+    .sign(new TextEncoder().encode(JWT_SECRET));
+}
+
+function request(token: string | undefined, orgId = "org-1"): Record<string, unknown> {
+  return {
+    ip: "127.0.0.1",
+    headers: { "user-agent": "vitest-admin-ws" },
+    params: { orgId },
+    query: token ? { token } : {},
+  };
+}
+
+function sentPayloads(send: ReturnType<typeof vi.fn>): Array<{ type?: string } & Record<string, unknown>> {
+  return send.mock.calls.map(([frame]) => JSON.parse(String(frame)));
+}
+
+async function waitForAsyncDispatch(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("Admin WS route edge paths", () => {
+  it("rejects missing, malformed, wrong-type, and non-member handshakes", async () => {
+    const handlers: CapturedHandlers = {};
+    const db = makeDb({ memberRows: [] });
+    const { app, getRoute } = makeApp(db);
+    await orgWsRoutes(makeNotifier(handlers), JWT_SECRET)(app as never);
+    const route = getRoute();
+
+    const missing = makeSocket();
+    await route(missing.socket, request(undefined));
+    expect(sentPayloads(missing.send)[0]).toMatchObject({ type: "error", message: "Missing token or org" });
+    expect(missing.close).toHaveBeenCalledWith(4001, "Missing token");
+
+    const malformed = makeSocket();
+    await route(malformed.socket, request("not-a-jwt"));
+    expect(sentPayloads(malformed.send)[0]).toMatchObject({ type: "error", message: "Invalid or expired token" });
+    expect(malformed.close).toHaveBeenCalledWith(4001, "Auth failed");
+
+    const wrongType = makeSocket();
+    await route(wrongType.socket, request(await signToken({ sub: "user-1", type: "refresh" })));
+    expect(sentPayloads(wrongType.send)[0]).toMatchObject({ type: "error", message: "Invalid token type" });
+    expect(wrongType.close).toHaveBeenCalledWith(4001, "Invalid token");
+
+    const nonMember = makeSocket();
+    await route(nonMember.socket, request(await signToken({ sub: "user-1", type: "access" })));
+    expect(sentPayloads(nonMember.send)[0]).toMatchObject({
+      type: "error",
+      message: "Not an active member of this organization",
+    });
+    expect(nonMember.close).toHaveBeenCalledWith(4403, "Not a member");
+  });
+
+  it("dispatches chat and session frames only to active audience sockets", async () => {
+    const handlers: CapturedHandlers = {};
+    const db = makeDb({
+      audienceRows: [[{ agent_id: "human-1" }], [{ agent_id: "human-1" }], []],
+    });
+    const { app, getRoute } = makeApp(db);
+    await orgWsRoutes(makeNotifier(handlers), JWT_SECRET)(app as never);
+    const route = getRoute();
+    const token = await signToken({ sub: "user-1", type: "access" });
+    const active = makeSocket();
+    const closed = makeSocket();
+
+    await route(active.socket, request(token));
+    await route(closed.socket, request(token));
+    closed.setReadyState(3);
+
+    handlers.chatMessage?.({ chatId: "chat-message-edge", messageId: "msg-1" });
+    await waitForAsyncDispatch();
+    handlers.chatUpdated?.({ chatId: "chat-updated-edge" });
+    await waitForAsyncDispatch();
+    handlers.sessionState?.({ agentId: "agent-1", chatId: "chat-session-empty-edge", organizationId: "org-1" });
+    await waitForAsyncDispatch();
+
+    const activeTypes = sentPayloads(active.send).map((payload) => payload.type);
+    const closedTypes = sentPayloads(closed.send).map((payload) => payload.type);
+    expect(activeTypes).toEqual(["admin:connected", "chat:message", "chat:updated", "session:state"]);
+    expect(closedTypes).toEqual(["admin:connected"]);
+
+    active.emitClose(1000);
+    handlers.chatMessage?.({ chatId: "chat-after-close-edge", messageId: "msg-2" });
+    await waitForAsyncDispatch();
+    expect(sentPayloads(active.send).map((payload) => payload.type)).toEqual([
+      "admin:connected",
+      "chat:message",
+      "chat:updated",
+      "session:state",
+    ]);
+  });
+});

--- a/packages/server/src/__tests__/ws-admin-edge.test.ts
+++ b/packages/server/src/__tests__/ws-admin-edge.test.ts
@@ -234,4 +234,30 @@ describe("Admin WS route edge paths", () => {
       "session:state",
     ]);
   });
+
+  it("swallows socket send failures while dispatching chat and session frames", async () => {
+    const handlers: CapturedHandlers = {};
+    const db = makeDb({
+      audienceRows: [[{ agent_id: "human-1" }], [{ agent_id: "human-1" }], [{ agent_id: "human-1" }]],
+    });
+    const { app, getRoute } = makeApp(db);
+    await orgWsRoutes(makeNotifier(handlers), JWT_SECRET)(app as never);
+    const route = getRoute();
+    const token = await signToken({ sub: "user-1", type: "access" });
+    const active = makeSocket();
+
+    await route(active.socket, request(token));
+    active.send.mockImplementation(() => {
+      throw new Error("socket send failed");
+    });
+
+    handlers.chatMessage?.({ chatId: "chat-message-send-fail", messageId: "msg-1" });
+    await waitForAsyncDispatch();
+    handlers.chatUpdated?.({ chatId: "chat-updated-send-fail" });
+    await waitForAsyncDispatch();
+    handlers.sessionRuntime?.({ agentId: "agent-1", chatId: "chat-runtime-send-fail", organizationId: "org-1" });
+    await waitForAsyncDispatch();
+
+    expect(active.send).toHaveBeenCalledTimes(4);
+  });
 });

--- a/packages/server/src/__tests__/ws-client-branch-fake.test.ts
+++ b/packages/server/src/__tests__/ws-client-branch-fake.test.ts
@@ -1,0 +1,680 @@
+import { EventEmitter } from "node:events";
+import { AUTH_REJECTED_CODES, type ClientMessage, type InboxEntryWithMessage } from "@first-tree/shared";
+import { SignJWT } from "jose";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clientWsRoutes } from "../api/agent/ws-client.js";
+import { inboxEntries } from "../db/schema/inbox-entries.js";
+import * as activityService from "../services/activity.js";
+import * as agentRuntimeSessionService from "../services/agent-runtime-session.js";
+import * as clientService from "../services/client.js";
+import * as inboxService from "../services/inbox.js";
+import * as notificationService from "../services/notification.js";
+import * as presenceService from "../services/presence.js";
+import * as runtimeLivenessService from "../services/runtime-liveness.js";
+
+type WsHandler = (socket: FakeSocket, request: { headers: Record<string, string | undefined>; ip: string }) => unknown;
+
+class FakeSocket extends EventEmitter {
+  readonly OPEN = 1;
+  readonly CLOSED = 3;
+  readyState = this.OPEN;
+  sent: unknown[] = [];
+  closes: Array<{ code: number; reason: string }> = [];
+  failSend: ((frame: string) => boolean) | null = null;
+
+  send(frame: string): void {
+    if (this.failSend?.(frame)) throw new Error("send failed");
+    this.sent.push(JSON.parse(frame));
+  }
+
+  close(code: number, reason: string): void {
+    this.readyState = this.CLOSED;
+    this.closes.push({ code, reason });
+    this.emit("close", code);
+  }
+}
+
+function queryChain(rows: unknown[] = []): unknown {
+  const chain = {
+    from: vi.fn(() => chain),
+    leftJoin: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    returning: vi.fn(() => chain),
+    set: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(rows).then(resolve, reject),
+  };
+  return chain;
+}
+
+function queuedDb(results: unknown[][]): unknown {
+  return {
+    select: vi.fn(() => queryChain(results.shift() ?? [])),
+    update: vi.fn(() => queryChain(results.shift() ?? [])),
+  };
+}
+
+function throwingSelectDb(error: unknown): unknown {
+  return {
+    select: vi.fn(() => {
+      throw error;
+    }),
+  };
+}
+
+function routeHarness(db: unknown): { handler: WsHandler; notifier: Record<string, unknown> } {
+  let handler: WsHandler | null = null;
+  const notifier = {
+    onAgentRouteChange: vi.fn(),
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+  };
+  const app = {
+    commandVersion: () => "test-version",
+    config: {
+      inbox: { maxInFlightPerAgent: 1, maxInFlightPerAgentChat: 1 },
+      secrets: { jwtSecret: "test-jwt-secret-key-for-vitest" },
+    },
+    db,
+    get: vi.fn((_path: string, _options: unknown, routeHandler: WsHandler) => {
+      handler = routeHandler;
+    }),
+    log: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+  };
+  void clientWsRoutes(notifier as never, "fake-instance")(app as never);
+  if (!handler) throw new Error("WS route handler was not registered");
+  return { handler, notifier };
+}
+
+async function signAccess(payload: Record<string, unknown> = {}): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const jwt = new SignJWT({ sub: "user_1", type: "access", organizationId: "org_1", ...payload })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt(now);
+  if (!("exp" in payload)) jwt.setExpirationTime(now + 300);
+  return jwt.sign(new TextEncoder().encode("test-jwt-secret-key-for-vitest"));
+}
+
+async function emitMessage(socket: FakeSocket, frame: unknown): Promise<void> {
+  socket.emit("message", typeof frame === "string" ? frame : JSON.stringify(frame));
+  await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > 500) throw new Error("condition was not reached");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function messageRow(overrides: Partial<ClientMessage> = {}): ClientMessage {
+  return {
+    id: "msg_1",
+    chatId: "chat_1",
+    senderId: "agent_1",
+    format: "text",
+    content: "hello",
+    metadata: {},
+    inReplyTo: null,
+    source: "api",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    configVersion: 1,
+    recipientMode: "full",
+    precedingMessages: [],
+    ...overrides,
+  };
+}
+
+function inboxEntry(overrides: Partial<InboxEntryWithMessage> = {}): InboxEntryWithMessage {
+  return {
+    id: 101,
+    inboxId: "inbox_1",
+    chatId: "chat_1",
+    messageId: "msg_1",
+    status: "pending",
+    retryCount: 0,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    deliveredAt: null,
+    ackedAt: null,
+    message: messageRow(),
+    ...overrides,
+  };
+}
+
+function inboxDbRow(overrides: Partial<typeof inboxEntries.$inferSelect> = {}): typeof inboxEntries.$inferSelect {
+  return {
+    id: 101,
+    inboxId: "inbox_1",
+    chatId: "chat_1",
+    messageId: "msg_1",
+    status: "acked",
+    notify: true,
+    retryCount: 0,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    deliveredAt: null,
+    ackedAt: new Date("2026-01-01T00:00:01.000Z"),
+    ...overrides,
+  };
+}
+
+describe("Agent client WS branch fakes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("swallows auth rejection sends when the socket has already closed", async () => {
+    const { handler } = routeHarness(queuedDb([]));
+    const socket = new FakeSocket();
+    await handler(socket, { headers: { "user-agent": "fake" }, ip: "127.0.0.1" });
+
+    socket.readyState = socket.CLOSED;
+    await emitMessage(socket, { type: "not-auth" });
+
+    expect(socket.closes).toContainEqual({ code: 4401, reason: "auth rejected" });
+    expect(socket.sent).toEqual([]);
+  });
+
+  it("swallows expired-auth sends when the socket has already closed", async () => {
+    const { handler } = routeHarness(queuedDb([]));
+    const socket = new FakeSocket();
+    await handler(socket, { headers: { "user-agent": "fake" }, ip: "127.0.0.1" });
+
+    socket.readyState = socket.CLOSED;
+    const expired = await signAccess({ exp: Math.floor(Date.now() / 1000) - 1 });
+    await emitMessage(socket, { type: "auth", token: expired });
+    await waitUntil(() => socket.closes.length > 0);
+
+    expect(socket.closes).toContainEqual({ code: 4401, reason: "auth expired" });
+    expect(socket.sent).toEqual([]);
+  });
+
+  it("turns post-auth send failures into retryable closes", async () => {
+    const { handler } = routeHarness(queuedDb([[{ id: "user_1", status: "active" }]]));
+    const socket = new FakeSocket();
+    let sendCount = 0;
+    socket.failSend = () => {
+      sendCount += 1;
+      return sendCount === 2;
+    };
+    await handler(socket, { headers: { "user-agent": "fake" }, ip: "127.0.0.1" });
+
+    await emitMessage(socket, { type: "auth", token: await signAccess() });
+    await waitUntil(() => socket.closes.length > 0);
+
+    expect(socket.sent).toContainEqual({ type: "auth:ok" });
+    expect(socket.sent).toContainEqual({
+      type: "auth:retryable",
+      code: "handshake_internal_error",
+      message: "post-auth handshake failed",
+    });
+    expect(socket.closes).toContainEqual({ code: 1011, reason: "auth retryable" });
+  });
+
+  it("swallows retryable auth frames when the socket closes during retry handling", async () => {
+    const { handler } = routeHarness(throwingSelectDb(new Error("lookup unavailable")));
+    const socket = new FakeSocket();
+    let sendCount = 0;
+    socket.failSend = (frame) => {
+      const parsed = JSON.parse(frame) as { type?: string };
+      sendCount += 1;
+      return parsed.type === "auth:retryable";
+    };
+    await handler(socket, { headers: { "user-agent": "fake" }, ip: "127.0.0.1" });
+
+    await emitMessage(socket, { type: "auth", token: await signAccess() });
+    await waitUntil(() => socket.closes.length > 0);
+
+    expect(sendCount).toBe(1);
+    expect(socket.sent.some((frame) => (frame as { type?: string }).type === "auth:retryable")).toBe(false);
+    expect(socket.closes).toContainEqual({ code: 1013, reason: "auth retryable" });
+  });
+
+  it("classifies non-Error auth lookup failures as retryable backend failures", async () => {
+    const { handler } = routeHarness(throwingSelectDb("lookup unavailable as string"));
+    const socket = new FakeSocket();
+    await handler(socket, { headers: { "user-agent": "fake" }, ip: "127.0.0.1" });
+
+    await emitMessage(socket, { type: "auth", token: await signAccess() });
+    await waitUntil(() => socket.closes.length > 0);
+
+    expect(socket.sent).toContainEqual({
+      type: "auth:retryable",
+      code: "auth_backend_unavailable",
+      message: "authentication backend unavailable",
+    });
+    expect(socket.closes).toContainEqual({ code: 1013, reason: "auth retryable" });
+  });
+
+  it("maps non-Error client registration failures to the fallback rejection", async () => {
+    vi.spyOn(clientService, "registerClient").mockImplementation(async () => {
+      throw "register failed as string";
+    });
+    const { handler } = routeHarness(queuedDb([[{ id: "user_1", status: "active" }]]));
+    const socket = new FakeSocket();
+    await handler(socket, { headers: { "user-agent": "fake" }, ip: "127.0.0.1" });
+
+    await emitMessage(socket, { type: "auth", token: await signAccess() });
+    await waitUntil(() => socket.sent.some((frame) => (frame as { type?: string }).type === "server:welcome"));
+    await emitMessage(socket, { type: "client:register", clientId: "client_fake1234" });
+    await waitUntil(() => socket.closes.length > 0);
+
+    expect(socket.sent).toContainEqual({
+      type: "client:register:rejected",
+      message: "client register failed",
+    });
+    expect(socket.closes).toContainEqual({ code: 4403, reason: "client register rejected" });
+  });
+
+  it("rejects client registration when no membership fallback exists", async () => {
+    const { handler } = routeHarness(queuedDb([[{ id: "user_1", status: "active" }], []]));
+    const socket = new FakeSocket();
+    await handler(socket, { headers: { "user-agent": undefined }, ip: "127.0.0.1" });
+
+    await emitMessage(socket, { type: "auth", token: await signAccess({ organizationId: undefined }) });
+    await waitUntil(() => socket.sent.some((frame) => (frame as { type?: string }).type === "server:welcome"));
+    await emitMessage(socket, { type: "client:register", clientId: "client_fake1234" });
+    await waitUntil(() => socket.closes.length > 0);
+
+    expect(socket.sent).toContainEqual({
+      type: "client:register:rejected",
+      message: "User has no active organization membership",
+    });
+    expect(socket.closes).toContainEqual({ code: 4403, reason: "no membership" });
+  });
+
+  it("uses the invalid-claims code for missing token type", async () => {
+    const { handler } = routeHarness(queuedDb([]));
+    const socket = new FakeSocket();
+    await handler(socket, { headers: { "user-agent": "fake" }, ip: "127.0.0.1" });
+
+    await emitMessage(socket, { type: "auth", token: await signAccess({ type: undefined }) });
+    await waitUntil(() => socket.sent.length > 0);
+
+    expect(socket.sent).toContainEqual({
+      type: "auth:rejected",
+      code: AUTH_REJECTED_CODES.INVALID_CLAIMS,
+      message: "member access token required",
+    });
+  });
+
+  async function authenticateAndRegister(socket: FakeSocket, handler: WsHandler): Promise<void> {
+    vi.spyOn(clientService, "registerClient").mockResolvedValue(undefined);
+    vi.spyOn(clientService, "listActiveAgentsPinnedToClient").mockResolvedValue([]);
+    await handler(socket, { headers: { "user-agent": "fake" }, ip: "127.0.0.1" });
+    await emitMessage(socket, { type: "auth", token: await signAccess() });
+    await waitUntil(() => socket.sent.some((frame) => (frame as { type?: string }).type === "server:welcome"));
+    await emitMessage(socket, { type: "client:register", clientId: "client_fake1234" });
+    await waitUntil(() => socket.sent.some((frame) => (frame as { type?: string }).type === "client:registered"));
+  }
+
+  function activeAgentRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      id: "agent_1",
+      displayName: "Agent",
+      type: "agent",
+      organizationId: "org_1",
+      inboxId: "inbox_1",
+      status: "active",
+      clientId: "client_fake1234",
+      managerId: "member_1",
+      runtimeProvider: "claude-code",
+      clientUserId: "user_1",
+      managerUserId: "user_1",
+      managerMemberStatus: "active",
+      ...overrides,
+    };
+  }
+
+  function mockSuccessfulBindServices(): void {
+    vi.spyOn(agentRuntimeSessionService, "bindAgentRuntimeSession").mockResolvedValue("runtime-token");
+    vi.spyOn(agentRuntimeSessionService, "revokeAgentRuntimeSession").mockResolvedValue(true);
+    vi.spyOn(agentRuntimeSessionService, "revokeAgentRuntimeSessionIfTokenMatches").mockResolvedValue(true);
+    vi.spyOn(presenceService, "bindAgentIfActiveClient").mockResolvedValue(true);
+    vi.spyOn(presenceService, "unbindAgent").mockResolvedValue(1);
+    vi.spyOn(presenceService, "setRuntimeState").mockResolvedValue(undefined);
+    vi.spyOn(notificationService, "markAgentFaultsResolved").mockResolvedValue(undefined);
+    vi.spyOn(notificationService, "notifyAgentEvent").mockResolvedValue(undefined);
+    vi.spyOn(inboxService, "resetDeliveredForInboxes").mockResolvedValue(1);
+    vi.spyOn(inboxService, "claimBacklogForPushFair").mockResolvedValue([]);
+    vi.spyOn(inboxService, "claimBacklogForPushForChat").mockResolvedValue([]);
+    vi.spyOn(inboxService, "recoverUnackedForScope").mockResolvedValue({ resetEntryIds: [] });
+    vi.spyOn(inboxService, "ackEntryByIdForBoundAgents").mockResolvedValue({
+      ok: true,
+      throughEntry: inboxDbRow(),
+      disposition: "acked",
+      ackedCount: 1,
+      ackedEntryIds: [101],
+    });
+    vi.spyOn(activityService, "upsertSessionState").mockResolvedValue(undefined);
+    vi.spyOn(activityService, "setSessionRuntime").mockResolvedValue(undefined);
+    vi.spyOn(runtimeLivenessService, "recordClientHeartbeat").mockResolvedValue({
+      clientUpdated: true,
+      restoredAgentIds: ["agent_1"],
+    });
+  }
+
+  async function bindAgent(
+    socket: FakeSocket,
+    handler: WsHandler,
+    ref = "bind-ok",
+  ): Promise<void> {
+    await authenticateAndRegister(socket, handler);
+    await emitMessage(socket, {
+      type: "agent:bind",
+      agentId: "agent_1",
+      ref,
+      runtimeType: "claude-code",
+      runtimeVersion: "test",
+    });
+    await waitUntil(() => socket.sent.some((frame) => (frame as { type?: string }).type === "agent:bound"));
+  }
+
+  it("rejects first-bind races when the claim update returns no row", async () => {
+    const { handler } = routeHarness(
+      queuedDb([[{ id: "user_1", status: "active" }], [{ userId: "user_1", retiredAt: null }], [activeAgentRow({ clientId: null })], []]),
+    );
+    const socket = new FakeSocket();
+    await authenticateAndRegister(socket, handler);
+
+    await emitMessage(socket, {
+      type: "agent:bind",
+      agentId: "agent_1",
+      ref: "bind-claim-empty",
+      runtimeType: "claude-code",
+      runtimeVersion: "test",
+    });
+
+    expect(socket.sent).toContainEqual({
+      type: "agent:bind:rejected",
+      ref: "bind-claim-empty",
+      reason: "wrong_client",
+    });
+  });
+
+  it("rejects bind attempts for agents pinned to another client", async () => {
+    const { handler } = routeHarness(
+      queuedDb([
+        [{ id: "user_1", status: "active" }],
+        [{ userId: "user_1", retiredAt: null }],
+        [activeAgentRow({ clientId: "client_other1234" })],
+      ]),
+    );
+    const socket = new FakeSocket();
+    await authenticateAndRegister(socket, handler);
+
+    await emitMessage(socket, {
+      type: "agent:bind",
+      agentId: "agent_1",
+      ref: "bind-wrong-client",
+      runtimeType: "claude-code",
+      runtimeVersion: "test",
+    });
+
+    expect(socket.sent).toContainEqual({
+      type: "agent:bind:rejected",
+      ref: "bind-wrong-client",
+      reason: "wrong_client",
+    });
+  });
+
+  it("rejects bind attempts when the pinned client has no matching user", async () => {
+    const { handler } = routeHarness(
+      queuedDb([
+        [{ id: "user_1", status: "active" }],
+        [{ userId: "user_1", retiredAt: null }],
+        [activeAgentRow({ clientUserId: null })],
+      ]),
+    );
+    const socket = new FakeSocket();
+    await authenticateAndRegister(socket, handler);
+
+    await emitMessage(socket, {
+      type: "agent:bind",
+      agentId: "agent_1",
+      ref: "bind-client-user-missing",
+      runtimeType: "claude-code",
+      runtimeVersion: "test",
+    });
+
+    expect(socket.sent).toContainEqual({
+      type: "agent:bind:rejected",
+      ref: "bind-client-user-missing",
+      reason: "not_owned",
+    });
+  });
+
+  it("binds an agent and drains backlog through the fake inbox push path", async () => {
+    mockSuccessfulBindServices();
+    vi.spyOn(inboxService, "claimBacklogForPushFair")
+      .mockResolvedValueOnce([inboxEntry()])
+      .mockResolvedValue([]);
+    const { handler, notifier } = routeHarness(
+      queuedDb([
+        [{ id: "user_1", status: "active" }],
+        [{ userId: "user_1", retiredAt: null }],
+        [activeAgentRow()],
+        [activeAgentRow({ clientId: "client_fake1234", clientUserId: undefined, managerId: undefined })],
+      ]),
+    );
+    const socket = new FakeSocket();
+    await bindAgent(socket, handler);
+    await waitUntil(() => socket.sent.some((frame) => (frame as { type?: string }).type === "inbox:deliver"));
+
+    expect(socket.sent).toContainEqual(expect.objectContaining({ type: "agent:bound", runtimeSessionToken: "runtime-token" }));
+    expect(socket.sent).toContainEqual(expect.objectContaining({ type: "inbox:deliver", entryId: 101, chatId: "chat_1" }));
+    expect(notifier.subscribe).toHaveBeenCalledWith("inbox_1", socket, expect.any(Function));
+  });
+
+  it("delivers null-chat inbox entries and accepts acks without refs", async () => {
+    mockSuccessfulBindServices();
+    vi.spyOn(inboxService, "claimBacklogForPushFair")
+      .mockResolvedValueOnce([inboxEntry({ id: 303, chatId: null })])
+      .mockResolvedValue([]);
+    vi.spyOn(inboxService, "ackEntryByIdForBoundAgents").mockResolvedValueOnce({
+      ok: true,
+      throughEntry: inboxDbRow({ id: 303, chatId: null }),
+      disposition: "acked",
+      ackedCount: 1,
+      ackedEntryIds: [303],
+    });
+    const { handler } = routeHarness(
+      queuedDb([
+        [{ id: "user_1", status: "active" }],
+        [{ userId: "user_1", retiredAt: null }],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+      ]),
+    );
+    const socket = new FakeSocket();
+    await bindAgent(socket, handler, "bind-null-chat");
+    await waitUntil(() => socket.sent.some((frame) => (frame as { entryId?: number }).entryId === 303));
+
+    await emitMessage(socket, { type: "inbox:ack", entryId: 303 });
+    await waitUntil(() => vi.mocked(inboxService.ackEntryByIdForBoundAgents).mock.calls.length > 0);
+
+    expect(socket.sent).toContainEqual(expect.objectContaining({ type: "inbox:deliver", entryId: 303, chatId: null }));
+    expect(socket.sent).not.toContainEqual(expect.objectContaining({ type: "inbox:ack:accepted", entryId: 303 }));
+  });
+
+  it("treats runtime-switch claimed routes as no longer routed here without dropping the local binding", async () => {
+    mockSuccessfulBindServices();
+    const switchClaim = {
+      claimId: "claim_1",
+      phase: "claimed",
+      claimedAt: "2026-01-01T00:00:00.000Z",
+      claimedByUserId: "user_1",
+      claimedByMemberId: "member_1",
+      oldClientId: "client_fake1234",
+      oldRuntimeProvider: "claude-code",
+      targetClientId: "client_next1234",
+      targetRuntimeProvider: "codex",
+    };
+    const { handler } = routeHarness(
+      queuedDb([
+        [{ id: "user_1", status: "active" }],
+        [{ userId: "user_1", retiredAt: null }],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [
+          {
+            clientId: "client_fake1234",
+            status: "suspended",
+            runtimeProvider: "claude-code",
+            metadata: { runtimeSwitch: switchClaim },
+          },
+        ],
+      ]),
+    );
+    const socket = new FakeSocket();
+    await bindAgent(socket, handler, "bind-switch-claimed");
+
+    await emitMessage(socket, { type: "session:state", agentId: "agent_1", chatId: "chat_1", state: "active" });
+
+    expect(socket.sent).toContainEqual({ type: "error", message: "Agent not bound" });
+  });
+
+  it("throttles heartbeat-triggered inbox repair when the last repair is recent", async () => {
+    mockSuccessfulBindServices();
+    const { handler } = routeHarness(
+      queuedDb([
+        [{ id: "user_1", status: "active" }],
+        [{ userId: "user_1", retiredAt: null }],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+      ]),
+    );
+    const socket = new FakeSocket();
+    await bindAgent(socket, handler, "bind-heartbeat-throttle");
+
+    const heartbeatAckCount = (): number =>
+      socket.sent.filter((frame) => (frame as { type?: string }).type === "heartbeat:ack").length;
+
+    await emitMessage(socket, { type: "heartbeat" });
+    await waitUntil(() => heartbeatAckCount() === 1);
+    await emitMessage(socket, { type: "heartbeat" });
+    await waitUntil(() => heartbeatAckCount() === 2);
+
+    expect(runtimeLivenessService.recordClientHeartbeat).toHaveBeenCalledTimes(2);
+    expect(socket.sent).toContainEqual({ type: "heartbeat:ack" });
+  });
+
+  it("covers inbox cap logging for notify and recover drains", async () => {
+    mockSuccessfulBindServices();
+    const { handler, notifier } = routeHarness(
+      queuedDb([
+        [{ id: "user_1", status: "active" }],
+        [{ userId: "user_1", retiredAt: null }],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+      ]),
+    );
+    const socket = new FakeSocket();
+    await bindAgent(socket, handler);
+
+    vi.spyOn(inboxService, "claimBacklogForPushFair").mockResolvedValueOnce([inboxEntry()]);
+    const pushHandler = (notifier.subscribe as ReturnType<typeof vi.fn>).mock.calls[0]?.[2] as
+      | ((messageId: string) => Promise<void>)
+      | undefined;
+    await pushHandler?.("msg_notify");
+    await waitUntil(() => socket.sent.some((frame) => (frame as { type?: string }).type === "inbox:deliver"));
+
+    await pushHandler?.("msg_at_cap");
+    await emitMessage(socket, { type: "inbox:recover", ref: "recover-at-cap", agentId: "agent_1", chatId: "chat_1" });
+
+    expect(socket.sent).toContainEqual({
+      type: "inbox:recover:accepted",
+      ref: "recover-at-cap",
+      agentId: "agent_1",
+      chatId: "chat_1",
+      resetCount: 0,
+    });
+  });
+
+  it("stops a drain when the socket closes after backlog is claimed", async () => {
+    mockSuccessfulBindServices();
+    const { handler, notifier } = routeHarness(
+      queuedDb([
+        [{ id: "user_1", status: "active" }],
+        [{ userId: "user_1", retiredAt: null }],
+        [activeAgentRow()],
+        [activeAgentRow()],
+      ]),
+    );
+    const socket = new FakeSocket();
+    await bindAgent(socket, handler);
+
+    vi.spyOn(inboxService, "claimBacklogForPushFair").mockImplementationOnce(async () => {
+      socket.readyState = socket.CLOSED;
+      return [inboxEntry({ id: 202 })] as never;
+    });
+    const pushHandler = (notifier.subscribe as ReturnType<typeof vi.fn>).mock.calls[0]?.[2] as
+      | ((messageId: string) => Promise<void>)
+      | undefined;
+    await pushHandler?.("msg_close_mid_drain");
+
+    expect(socket.sent).not.toContainEqual(expect.objectContaining({ entryId: 202 }));
+  });
+
+  it("persists session state and runtime frames after binding", async () => {
+    mockSuccessfulBindServices();
+    const { handler } = routeHarness(
+      queuedDb([
+        [{ id: "user_1", status: "active" }],
+        [{ userId: "user_1", retiredAt: null }],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+        [activeAgentRow()],
+      ]),
+    );
+    const socket = new FakeSocket();
+    await bindAgent(socket, handler);
+
+    await emitMessage(socket, { type: "session:state", agentId: "agent_1", chatId: "chat_1", state: "active" });
+    await emitMessage(socket, { type: "session:runtime", agentId: "agent_1", chatId: "chat_1", runtimeState: "working" });
+    await emitMessage(socket, { type: "runtime:state", agentId: "agent_1", runtimeState: "idle" });
+    await waitUntil(() => vi.mocked(activityService.setSessionRuntime).mock.calls.length > 0);
+
+    expect(activityService.upsertSessionState).toHaveBeenCalledWith(
+      expect.anything(),
+      "agent_1",
+      "chat_1",
+      "active",
+      "org_1",
+      expect.anything(),
+    );
+    expect(activityService.setSessionRuntime).toHaveBeenCalledWith(
+      expect.anything(),
+      "agent_1",
+      "chat_1",
+      "working",
+      "org_1",
+      expect.anything(),
+    );
+    expect(presenceService.setRuntimeState).toHaveBeenCalledWith(
+      expect.anything(),
+      "agent_1",
+      "idle",
+      expect.objectContaining({ organizationId: "org_1" }),
+    );
+  });
+});

--- a/packages/server/src/__tests__/ws-client-branch-fake.test.ts
+++ b/packages/server/src/__tests__/ws-client-branch-fake.test.ts
@@ -3,7 +3,7 @@ import { AUTH_REJECTED_CODES, type ClientMessage, type InboxEntryWithMessage } f
 import { SignJWT } from "jose";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clientWsRoutes } from "../api/agent/ws-client.js";
-import { inboxEntries } from "../db/schema/inbox-entries.js";
+import type { inboxEntries } from "../db/schema/inbox-entries.js";
 import * as activityService from "../services/activity.js";
 import * as agentRuntimeSessionService from "../services/agent-runtime-session.js";
 import * as clientService from "../services/client.js";
@@ -35,17 +35,21 @@ class FakeSocket extends EventEmitter {
 }
 
 function queryChain(rows: unknown[] = []): unknown {
-  const chain = {
-    from: vi.fn(() => chain),
-    leftJoin: vi.fn(() => chain),
-    limit: vi.fn(() => chain),
-    orderBy: vi.fn(() => chain),
-    returning: vi.fn(() => chain),
-    set: vi.fn(() => chain),
-    where: vi.fn(() => chain),
-    then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
-      Promise.resolve(rows).then(resolve, reject),
-  };
+  const promise = Promise.resolve(rows);
+  const chain = new Proxy(
+    function queryProxy(): unknown {
+      return chain;
+    },
+    {
+      get: (_target, prop) => {
+        if (prop === "then") return promise.then.bind(promise);
+        if (prop === "catch") return promise.catch.bind(promise);
+        if (prop === "finally") return promise.finally.bind(promise);
+        if (prop === Symbol.iterator) return rows[Symbol.iterator].bind(rows);
+        return vi.fn(() => chain);
+      },
+    },
+  );
   return chain;
 }
 
@@ -361,11 +365,7 @@ describe("Agent client WS branch fakes", () => {
     });
   }
 
-  async function bindAgent(
-    socket: FakeSocket,
-    handler: WsHandler,
-    ref = "bind-ok",
-  ): Promise<void> {
+  async function bindAgent(socket: FakeSocket, handler: WsHandler, ref = "bind-ok"): Promise<void> {
     await authenticateAndRegister(socket, handler);
     await emitMessage(socket, {
       type: "agent:bind",
@@ -379,7 +379,12 @@ describe("Agent client WS branch fakes", () => {
 
   it("rejects first-bind races when the claim update returns no row", async () => {
     const { handler } = routeHarness(
-      queuedDb([[{ id: "user_1", status: "active" }], [{ userId: "user_1", retiredAt: null }], [activeAgentRow({ clientId: null })], []]),
+      queuedDb([
+        [{ id: "user_1", status: "active" }],
+        [{ userId: "user_1", retiredAt: null }],
+        [activeAgentRow({ clientId: null })],
+        [],
+      ]),
     );
     const socket = new FakeSocket();
     await authenticateAndRegister(socket, handler);
@@ -453,9 +458,7 @@ describe("Agent client WS branch fakes", () => {
 
   it("binds an agent and drains backlog through the fake inbox push path", async () => {
     mockSuccessfulBindServices();
-    vi.spyOn(inboxService, "claimBacklogForPushFair")
-      .mockResolvedValueOnce([inboxEntry()])
-      .mockResolvedValue([]);
+    vi.spyOn(inboxService, "claimBacklogForPushFair").mockResolvedValueOnce([inboxEntry()]).mockResolvedValue([]);
     const { handler, notifier } = routeHarness(
       queuedDb([
         [{ id: "user_1", status: "active" }],
@@ -468,8 +471,12 @@ describe("Agent client WS branch fakes", () => {
     await bindAgent(socket, handler);
     await waitUntil(() => socket.sent.some((frame) => (frame as { type?: string }).type === "inbox:deliver"));
 
-    expect(socket.sent).toContainEqual(expect.objectContaining({ type: "agent:bound", runtimeSessionToken: "runtime-token" }));
-    expect(socket.sent).toContainEqual(expect.objectContaining({ type: "inbox:deliver", entryId: 101, chatId: "chat_1" }));
+    expect(socket.sent).toContainEqual(
+      expect.objectContaining({ type: "agent:bound", runtimeSessionToken: "runtime-token" }),
+    );
+    expect(socket.sent).toContainEqual(
+      expect.objectContaining({ type: "inbox:deliver", entryId: 101, chatId: "chat_1" }),
+    );
     expect(notifier.subscribe).toHaveBeenCalledWith("inbox_1", socket, expect.any(Function));
   });
 
@@ -650,7 +657,12 @@ describe("Agent client WS branch fakes", () => {
     await bindAgent(socket, handler);
 
     await emitMessage(socket, { type: "session:state", agentId: "agent_1", chatId: "chat_1", state: "active" });
-    await emitMessage(socket, { type: "session:runtime", agentId: "agent_1", chatId: "chat_1", runtimeState: "working" });
+    await emitMessage(socket, {
+      type: "session:runtime",
+      agentId: "agent_1",
+      chatId: "chat_1",
+      runtimeState: "working",
+    });
     await emitMessage(socket, { type: "runtime:state", agentId: "agent_1", runtimeState: "idle" });
     await waitUntil(() => vi.mocked(activityService.setSessionRuntime).mock.calls.length > 0);
 

--- a/packages/server/src/__tests__/ws-client-edge.test.ts
+++ b/packages/server/src/__tests__/ws-client-edge.test.ts
@@ -11,6 +11,7 @@ import * as activityService from "../services/activity.js";
 import { createAgent } from "../services/agent.js";
 import * as agentRuntimeSessionService from "../services/agent-runtime-session.js";
 import * as clientService from "../services/client.js";
+import * as connectionManager from "../services/connection-manager.js";
 import * as inboxService from "../services/inbox.js";
 import * as notificationService from "../services/notification.js";
 import * as presenceService from "../services/presence.js";
@@ -503,6 +504,80 @@ describe("Agent client WS edge protocol coverage", () => {
     }
   }, 15000);
 
+  it("rejects bind when the active client socket changes during binding", async () => {
+    const seed = await createAdminContext(app, {
+      username: `ws-bind-active-drift-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const agent = await createPinnedAgent({ ...seed, suffix: "active-drift" });
+    const ws = await openRegisteredSocket(seed);
+    const activeSpy = vi.spyOn(connectionManager, "isActiveClientConnection");
+
+    try {
+      activeSpy.mockReturnValueOnce(false);
+      await expect(bindAgent(ws, agent.uuid, "bind-active-drift-before-session")).resolves.toMatchObject({
+        type: "agent:bind:rejected",
+        ref: "bind-active-drift-before-session",
+        reason: AGENT_BIND_REJECT_REASONS.WRONG_CLIENT,
+      });
+
+      activeSpy.mockReturnValueOnce(true).mockReturnValueOnce(false);
+      await expect(bindAgent(ws, agent.uuid, "bind-active-drift-after-presence")).resolves.toMatchObject({
+        type: "agent:bind:rejected",
+        ref: "bind-active-drift-after-presence",
+        reason: AGENT_BIND_REJECT_REASONS.WRONG_CLIENT,
+      });
+    } finally {
+      await closeSocket(ws);
+      activeSpy.mockRestore();
+    }
+  }, 15000);
+
+  it("logs bind recovery reset outcomes and ignores stale unbinds after route drift", async () => {
+    const seed = await createAdminContext(app, { username: `ws-bind-reset-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createPinnedAgent({ ...seed, suffix: "reset" });
+    const ws = await openRegisteredSocket(seed);
+    const resetSpy = vi.spyOn(inboxService, "resetDeliveredForInboxes").mockResolvedValueOnce(1);
+
+    try {
+      await expect(bindAgent(ws, agent.uuid, "bind-reset-count")).resolves.toMatchObject({
+        type: "agent:bound",
+        ref: "bind-reset-count",
+        agentId: agent.uuid,
+      });
+      expect(resetSpy).toHaveBeenCalledWith(app.db, [agent.inboxId]);
+
+      const otherClientId = await seedClient(app, seed.userId, seed.organizationId);
+      await app.db.update(agents).set({ clientId: otherClientId }).where(eq(agents.uuid, agent.uuid));
+      ws.send(JSON.stringify({ type: "agent:unbind", agentId: agent.uuid }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { type?: string }).type === "agent:unbound"),
+      ).resolves.toMatchObject({ type: "agent:unbound", agentId: agent.uuid });
+    } finally {
+      await closeSocket(ws);
+      resetSpy.mockRestore();
+    }
+
+    const errorSeed = await createAdminContext(app, {
+      username: `ws-bind-reset-error-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const errorAgent = await createPinnedAgent({ ...errorSeed, suffix: "reset-error" });
+    const errorWs = await openRegisteredSocket(errorSeed);
+    const resetErrorSpy = vi
+      .spyOn(inboxService, "resetDeliveredForInboxes")
+      .mockRejectedValueOnce(new Error("reset failed"));
+    try {
+      await expect(bindAgent(errorWs, errorAgent.uuid, "bind-reset-error")).resolves.toMatchObject({
+        type: "agent:bound",
+        ref: "bind-reset-error",
+        agentId: errorAgent.uuid,
+      });
+      expect(resetErrorSpy).toHaveBeenCalledWith(app.db, [errorAgent.inboxId]);
+    } finally {
+      await closeSocket(errorWs);
+      resetErrorSpy.mockRestore();
+    }
+  }, 20000);
+
   it("handles bound session, runtime, inbox, recover, and heartbeat edge frames", async () => {
     const seed = await createAdminContext(app, { username: `ws-bound-edges-${crypto.randomUUID().slice(0, 8)}` });
     const agent = await createPinnedAgent({ ...seed, suffix: "bound-edges" });
@@ -572,6 +647,18 @@ describe("Agent client WS edge protocol coverage", () => {
       });
       expect(runtimeSpy).toHaveBeenCalled();
 
+      ws.send(
+        JSON.stringify({
+          type: "session:runtime",
+          agentId: uuidv7(),
+          chatId: "chat-runtime-unbound",
+          runtimeState: "working",
+        }),
+      );
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Agent not bound"),
+      ).resolves.toMatchObject({ type: "error", message: "Agent not bound" });
+
       ws.send(JSON.stringify({ type: "session:reconcile", agentId: agent.uuid }));
       await expect(
         waitForFrame(
@@ -589,6 +676,11 @@ describe("Agent client WS edge protocol coverage", () => {
         staleChatIds: [],
       });
 
+      ws.send(JSON.stringify({ type: "session:reconcile", agentId: uuidv7(), chatIds: ["chat-reconcile-unbound"] }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Agent not bound"),
+      ).resolves.toMatchObject({ type: "error", message: "Agent not bound" });
+
       const notifySpy = vi.spyOn(notificationService, "notifyAgentEvent").mockResolvedValue(undefined);
       const resolvedSpy = vi.spyOn(notificationService, "markAgentFaultsResolved").mockResolvedValue(undefined);
       ws.send(JSON.stringify({ type: "runtime:state", agentId: agent.uuid, runtimeState: "error" }));
@@ -603,6 +695,11 @@ describe("Agent client WS edge protocol coverage", () => {
       expect(notifySpy).toHaveBeenCalledWith(app.db, agent.uuid, "agent_error", "high");
       expect(notifySpy).toHaveBeenCalledWith(app.db, agent.uuid, "agent_blocked", "medium");
       expect(resolvedSpy).toHaveBeenCalledWith(app.db, agent.uuid);
+
+      ws.send(JSON.stringify({ type: "runtime:state", agentId: uuidv7(), runtimeState: "idle" }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Agent not bound"),
+      ).resolves.toMatchObject({ type: "error", message: "Agent not bound" });
 
       ws.send(
         JSON.stringify({
@@ -645,6 +742,30 @@ describe("Agent client WS edge protocol coverage", () => {
         chatId: "chat-event",
         reason: "malformed",
       });
+
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          agentId: agent.uuid,
+          chatId: "chat-event",
+          event: { kind: "unknown", payload: {} },
+        }),
+      );
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Malformed session:event frame"),
+      ).resolves.toMatchObject({ type: "error", message: "Malformed session:event frame" });
+
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          agentId: uuidv7(),
+          chatId: "chat-event",
+          event: { kind: "thinking", payload: {} },
+        }),
+      );
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Agent not bound"),
+      ).resolves.toMatchObject({ type: "error", message: "Agent not bound" });
 
       const eventSpy = vi
         .spyOn(sessionEventService, "appendEvent")

--- a/packages/server/src/__tests__/ws-client-edge.test.ts
+++ b/packages/server/src/__tests__/ws-client-edge.test.ts
@@ -211,6 +211,24 @@ describe("Agent client WS edge protocol coverage", () => {
     expect(closeCode).toBe(4401);
   });
 
+  it("maps jose claim validation failures to invalid_claims during auth", async () => {
+    const admin = await createTestAdmin(app, { username: `ws-nbf-${crypto.randomUUID().slice(0, 8)}` });
+    const token = await new SignJWT({ sub: admin.userId, type: "access" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setNotBefore("1h")
+      .setExpirationTime("2h")
+      .sign(new TextEncoder().encode(jwtSecret));
+    const ws = await openSocket();
+    ws.send(JSON.stringify({ type: "auth", token }));
+
+    const frame = await waitForFrame(ws, (message) => (message as { type?: string }).type === "auth:rejected");
+    const closeCode = await waitForClose(ws);
+
+    expect(frame).toMatchObject({ type: "auth:rejected", code: "invalid_claims" });
+    expect(closeCode).toBe(4401);
+  });
+
   it("reports malformed post-auth frames and acknowledges heartbeat before registration", async () => {
     const seed = await createAdminContext(app, { username: `ws-post-auth-${crypto.randomUUID().slice(0, 8)}` });
     const ws = await openAuthenticatedSocket(await signAccess(seed.userId, seed.memberId, seed.organizationId));
@@ -328,6 +346,36 @@ describe("Agent client WS edge protocol coverage", () => {
     const backfillSpy = vi
       .spyOn(clientService, "listActiveAgentsPinnedToClient")
       .mockRejectedValueOnce(new Error("backfill failed"));
+    const ws = await openAuthenticatedSocket(await signAccess(seed.userId, seed.memberId, seed.organizationId));
+
+    try {
+      ws.send(JSON.stringify({ type: "client:register", clientId: seed.clientId }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { type?: string }).type === "client:registered"),
+      ).resolves.toMatchObject({ type: "client:registered", clientId: seed.clientId });
+      await vi.waitFor(() => expect(backfillSpy).toHaveBeenCalledWith(app.db, seed.clientId));
+    } finally {
+      await closeSocket(ws);
+      backfillSpy.mockRestore();
+    }
+  });
+
+  it("skips pinned-agent backfill frames that fail wire schema validation", async () => {
+    const seed = await createAdminContext(app, {
+      username: `ws-reg-invalid-backfill-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const backfillSpy = vi.spyOn(clientService, "listActiveAgentsPinnedToClient").mockResolvedValueOnce([
+      {
+        uuid: uuidv7(),
+        name: "invalid-runtime",
+        displayName: "Invalid Runtime",
+        type: "agent",
+        status: "active",
+        managerId: seed.memberId,
+        createdAt: new Date(),
+        runtimeProvider: "not-a-runtime",
+      },
+    ] as never);
     const ws = await openAuthenticatedSocket(await signAccess(seed.userId, seed.memberId, seed.organizationId));
 
     try {
@@ -577,6 +625,103 @@ describe("Agent client WS edge protocol coverage", () => {
       resetErrorSpy.mockRestore();
     }
   }, 20000);
+
+  it("self-validates inbox delivery frames and clears in-flight entries after ack", async () => {
+    const seed = await createAdminContext(app, {
+      username: `ws-inbox-deliver-invalid-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const agent = await createPinnedAgent({ ...seed, suffix: "invalid-deliver" });
+    const entryId = 444_000_001;
+    const claimSpy = vi
+      .spyOn(inboxService, "claimBacklogForPushFair")
+      .mockResolvedValueOnce([
+        {
+          id: entryId,
+          inboxId: agent.inboxId,
+          messageId: "msg-invalid-deliver",
+          chatId: "chat-invalid-deliver",
+          status: "delivered",
+          retryCount: 0,
+          createdAt: new Date().toISOString(),
+          deliveredAt: new Date().toISOString(),
+          ackedAt: null,
+          message: null,
+        },
+      ] as never)
+      .mockResolvedValue([]);
+    const ackSpy = vi.spyOn(inboxService, "ackEntryByIdForBoundAgents").mockResolvedValueOnce({
+      ok: true,
+      throughEntry: { id: entryId, inboxId: agent.inboxId, chatId: "chat-invalid-deliver" },
+      disposition: "acked",
+      ackedCount: 1,
+      ackedEntryIds: [entryId],
+    } as never);
+    const ws = await openRegisteredSocket(seed);
+
+    try {
+      await expect(bindAgent(ws, agent.uuid, "bind-invalid-deliver")).resolves.toMatchObject({
+        type: "agent:bound",
+        agentId: agent.uuid,
+      });
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; entryId?: number }).type === "inbox:deliver" &&
+            (message as { entryId?: number }).entryId === entryId,
+        ),
+      ).resolves.toMatchObject({
+        type: "inbox:deliver",
+        entryId,
+        inboxId: agent.inboxId,
+        message: null,
+      });
+
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId, ref: "ack-invalid-deliver" }));
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; ref?: string }).type === "inbox:ack:accepted" &&
+            (message as { ref?: string }).ref === "ack-invalid-deliver",
+        ),
+      ).resolves.toMatchObject({
+        type: "inbox:ack:accepted",
+        entryId,
+        ref: "ack-invalid-deliver",
+        disposition: "acked",
+        ackedCount: 1,
+      });
+      expect(claimSpy).toHaveBeenCalled();
+      expect(ackSpy).toHaveBeenCalledWith(app.db, entryId, [agent.inboxId]);
+    } finally {
+      await closeSocket(ws);
+      claimSpy.mockRestore();
+      ackSpy.mockRestore();
+    }
+  }, 15000);
+
+  it("keeps bind successful when the post-bind inbox backlog claim fails", async () => {
+    const seed = await createAdminContext(app, {
+      username: `ws-inbox-claim-fail-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const agent = await createPinnedAgent({ ...seed, suffix: "claim-fail" });
+    const claimSpy = vi
+      .spyOn(inboxService, "claimBacklogForPushFair")
+      .mockRejectedValueOnce(new Error("claim backlog failed"));
+    const ws = await openRegisteredSocket(seed);
+
+    try {
+      await expect(bindAgent(ws, agent.uuid, "bind-claim-fail")).resolves.toMatchObject({
+        type: "agent:bound",
+        agentId: agent.uuid,
+      });
+      await vi.waitFor(() => expect(claimSpy).toHaveBeenCalled());
+    } finally {
+      await closeSocket(ws);
+      claimSpy.mockRestore();
+    }
+  }, 15000);
 
   it("handles bound session, runtime, inbox, recover, and heartbeat edge frames", async () => {
     const seed = await createAdminContext(app, { username: `ws-bound-edges-${crypto.randomUUID().slice(0, 8)}` });

--- a/packages/server/src/__tests__/ws-client-edge.test.ts
+++ b/packages/server/src/__tests__/ws-client-edge.test.ts
@@ -34,6 +34,11 @@ describe("Agent client WS edge protocol coverage", () => {
       .sign(secret);
   }
 
+  async function signJwtWithoutExpiry(payload: Record<string, unknown>): Promise<string> {
+    const secret = new TextEncoder().encode(jwtSecret);
+    return new SignJWT(payload).setProtectedHeader({ alg: "HS256" }).setIssuedAt().sign(secret);
+  }
+
   async function signAccess(userId: string, memberId: string, organizationId?: string): Promise<string> {
     return signJwt({
       sub: userId,
@@ -274,6 +279,7 @@ describe("Agent client WS edge protocol coverage", () => {
 
   it.each([
     { name: "wrong token type", payload: { sub: "placeholder", type: "refresh" }, code: "wrong_token_type" },
+    { name: "missing token type", payload: { sub: "placeholder" }, code: "invalid_claims" },
     { name: "missing subject", payload: { type: "access" }, code: "invalid_claims" },
   ])("rejects $name claims", async ({ payload, code }) => {
     const admin = await createTestAdmin(app, { username: `ws-claims-${crypto.randomUUID().slice(0, 8)}` });
@@ -285,6 +291,23 @@ describe("Agent client WS edge protocol coverage", () => {
     const closeCode = await waitForClose(ws);
 
     expect(frame).toMatchObject({ type: "auth:rejected", code });
+    expect(closeCode).toBe(4401);
+  });
+
+  it("reports expired access tokens with an auth:expired frame", async () => {
+    const admin = await createTestAdmin(app, { username: `ws-expired-${crypto.randomUUID().slice(0, 8)}` });
+    const token = await new SignJWT({ sub: admin.userId, type: "access" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 120)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+      .sign(new TextEncoder().encode(jwtSecret));
+    const ws = await openSocket();
+    ws.send(JSON.stringify({ type: "auth", token }));
+
+    const frame = await waitForFrame(ws, (message) => (message as { type?: string }).type === "auth:expired");
+    const closeCode = await waitForClose(ws);
+
+    expect(frame).toMatchObject({ type: "auth:expired" });
     expect(closeCode).toBe(4401);
   });
 
@@ -305,6 +328,34 @@ describe("Agent client WS edge protocol coverage", () => {
     expect(frame).toMatchObject({ type: "auth:rejected", code: "invalid_claims" });
     expect(closeCode).toBe(4401);
   });
+
+  it("accepts access tokens without exp and rejects inactive or missing users", async () => {
+    const active = await createTestAdmin(app, { username: `ws-no-exp-${crypto.randomUUID().slice(0, 8)}` });
+    const activeWs = await openSocket();
+    activeWs.send(
+      JSON.stringify({ type: "auth", token: await signJwtWithoutExpiry({ sub: active.userId, type: "access" }) }),
+    );
+    await expect(
+      waitForFrame(activeWs, (message) => (message as { type?: string }).type === "auth:ok"),
+    ).resolves.toMatchObject({ type: "auth:ok" });
+    await closeSocket(activeWs);
+
+    const missingWs = await openSocket();
+    missingWs.send(JSON.stringify({ type: "auth", token: await signJwt({ sub: uuidv7(), type: "access" }) }));
+    await expect(
+      waitForFrame(missingWs, (message) => (message as { type?: string }).type === "auth:rejected"),
+    ).resolves.toMatchObject({ type: "auth:rejected", code: "user_not_found" });
+    expect(await waitForClose(missingWs)).toBe(4401);
+
+    const suspended = await createTestAdmin(app, { username: `ws-suspended-${crypto.randomUUID().slice(0, 8)}` });
+    await app.db.update(users).set({ status: "suspended" }).where(eq(users.id, suspended.userId));
+    const suspendedWs = await openSocket();
+    suspendedWs.send(JSON.stringify({ type: "auth", token: await signJwt({ sub: suspended.userId, type: "access" }) }));
+    await expect(
+      waitForFrame(suspendedWs, (message) => (message as { type?: string }).type === "auth:rejected"),
+    ).resolves.toMatchObject({ type: "auth:rejected", code: "user_suspended" });
+    expect(await waitForClose(suspendedWs)).toBe(4401);
+  }, 15000);
 
   it("reports malformed post-auth frames and acknowledges heartbeat before registration", async () => {
     const seed = await createAdminContext(app, { username: `ws-post-auth-${crypto.randomUUID().slice(0, 8)}` });
@@ -952,6 +1003,26 @@ describe("Agent client WS edge protocol coverage", () => {
       });
       expect(stateSpy).toHaveBeenCalled();
 
+      stateSpy.mockRejectedValueOnce("state string failure" as never);
+      ws.send(
+        JSON.stringify({
+          type: "session:state",
+          agentId: agent.uuid,
+          chatId: "chat-state-string-fail",
+          state: "active",
+        }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { message?: string }).message === "Failed to persist session state: state string failure",
+        ),
+      ).resolves.toMatchObject({
+        type: "error",
+        message: "Failed to persist session state: state string failure",
+      });
+
       ws.send(JSON.stringify({ type: "session:runtime", agentId: agent.uuid, runtimeState: "working" }));
       await expect(
         waitForFrame(ws, (message) => (message as { message?: string }).message === "Malformed session:runtime frame"),
@@ -979,6 +1050,26 @@ describe("Agent client WS edge protocol coverage", () => {
         message: "Failed to persist session runtime: runtime persist failed",
       });
       expect(runtimeSpy).toHaveBeenCalled();
+
+      runtimeSpy.mockRejectedValueOnce("runtime string failure" as never);
+      ws.send(
+        JSON.stringify({
+          type: "session:runtime",
+          agentId: agent.uuid,
+          chatId: "chat-runtime-string-fail",
+          runtimeState: "working",
+        }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { message?: string }).message === "Failed to persist session runtime: runtime string failure",
+        ),
+      ).resolves.toMatchObject({
+        type: "error",
+        message: "Failed to persist session runtime: runtime string failure",
+      });
 
       ws.send(
         JSON.stringify({
@@ -1019,6 +1110,7 @@ describe("Agent client WS edge protocol coverage", () => {
       ws.send(JSON.stringify({ type: "runtime:state", agentId: agent.uuid, runtimeState: "error" }));
       ws.send(JSON.stringify({ type: "runtime:state", agentId: agent.uuid, runtimeState: "blocked" }));
       ws.send(JSON.stringify({ type: "runtime:state", agentId: agent.uuid, runtimeState: "idle" }));
+      ws.send(JSON.stringify({ type: "runtime:state", agentId: agent.uuid, runtimeState: "working" }));
       ws.send(JSON.stringify({ type: "heartbeat" }));
       await expect(
         waitForFrame(ws, (message) => (message as { type?: string }).type === "heartbeat:ack"),
@@ -1028,6 +1120,15 @@ describe("Agent client WS edge protocol coverage", () => {
       expect(notifySpy).toHaveBeenCalledWith(app.db, agent.uuid, "agent_error", "high");
       expect(notifySpy).toHaveBeenCalledWith(app.db, agent.uuid, "agent_blocked", "medium");
       expect(resolvedSpy).toHaveBeenCalledWith(app.db, agent.uuid);
+
+      const runtimeStateSpy = vi
+        .spyOn(presenceService, "setRuntimeState")
+        .mockRejectedValueOnce("runtime state failed" as never);
+      ws.send(JSON.stringify({ type: "runtime:state", agentId: agent.uuid, runtimeState: "idle" }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Internal error"),
+      ).resolves.toMatchObject({ type: "error", message: "Internal error" });
+      expect(runtimeStateSpy).toHaveBeenCalled();
 
       ws.send(JSON.stringify({ type: "runtime:state", agentId: uuidv7(), runtimeState: "idle" }));
       await expect(
@@ -1073,6 +1174,29 @@ describe("Agent client WS edge protocol coverage", () => {
         ref: "event-malformed",
         agentId: agent.uuid,
         chatId: "chat-event",
+        reason: "malformed",
+      });
+
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          ref: "event-malformed-no-chat",
+          agentId: agent.uuid,
+          chatId: 123,
+          event: { kind: "unknown", payload: {} },
+        }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; ref?: string }).type === "session:event:rejected" &&
+            (message as { ref?: string }).ref === "event-malformed-no-chat",
+        ),
+      ).resolves.toMatchObject({
+        type: "session:event:rejected",
+        ref: "event-malformed-no-chat",
+        agentId: agent.uuid,
         reason: "malformed",
       });
 
@@ -1150,6 +1274,26 @@ describe("Agent client WS edge protocol coverage", () => {
       });
       expect(eventNoRefSpy).toHaveBeenCalled();
 
+      eventNoRefSpy.mockRejectedValueOnce("event string failure" as never);
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          agentId: agent.uuid,
+          chatId: "chat-event",
+          event: { kind: "error", payload: { source: "runtime", message: "boom" } },
+        }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { message?: string }).message === "Failed to persist session event: event string failure",
+        ),
+      ).resolves.toMatchObject({
+        type: "error",
+        message: "Failed to persist session event: event string failure",
+      });
+
       ws.send(JSON.stringify({ type: "inbox:ack", entryId: -1, ref: "ack-malformed" }));
       await expect(
         waitForFrame(ws, (message) => (message as { message?: string }).message === "Malformed inbox:ack frame"),
@@ -1160,6 +1304,29 @@ describe("Agent client WS edge protocol coverage", () => {
         .mockRejectedValueOnce(new Error("ack db failed"));
       ws.send(JSON.stringify({ type: "inbox:ack", entryId: 888_888_888, ref: "ack-throws" }));
       await vi.waitFor(() => expect(ackThrowSpy).toHaveBeenCalledWith(app.db, 888_888_888, [agent.inboxId]));
+
+      const ackOwnerFallbackSpy = vi.spyOn(inboxService, "ackEntryByIdForBoundAgents").mockResolvedValueOnce({
+        ok: true,
+        throughEntry: { id: 777_777_777, inboxId: "foreign-inbox", chatId: "foreign-chat" },
+        disposition: "acked",
+        ackedCount: 1,
+        ackedEntryIds: [777_777_777],
+      } as never);
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId: 777_777_777, ref: "ack-owner-fallback" }));
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; ref?: string }).type === "inbox:ack:accepted" &&
+            (message as { ref?: string }).ref === "ack-owner-fallback",
+        ),
+      ).resolves.toMatchObject({
+        type: "inbox:ack:accepted",
+        entryId: 777_777_777,
+        ref: "ack-owner-fallback",
+        disposition: "acked",
+      });
+      expect(ackOwnerFallbackSpy).toHaveBeenCalledWith(app.db, 777_777_777, [agent.inboxId]);
 
       ws.send(JSON.stringify({ type: "inbox:ack", entryId: 999_999_999, ref: "ack-missing" }));
       await expect(

--- a/packages/server/src/__tests__/ws-client-edge.test.ts
+++ b/packages/server/src/__tests__/ws-client-edge.test.ts
@@ -10,6 +10,7 @@ import { users } from "../db/schema/users.js";
 import * as activityService from "../services/activity.js";
 import { createAgent } from "../services/agent.js";
 import * as agentRuntimeSessionService from "../services/agent-runtime-session.js";
+import * as clientService from "../services/client.js";
 import * as inboxService from "../services/inbox.js";
 import * as notificationService from "../services/notification.js";
 import * as presenceService from "../services/presence.js";
@@ -321,6 +322,25 @@ describe("Agent client WS edge protocol coverage", () => {
     expect(await waitForClose(retiredWs)).toBe(4403);
   }, 15000);
 
+  it("keeps client registration accepted when pinned-agent backfill fails", async () => {
+    const seed = await createAdminContext(app, { username: `ws-reg-backfill-${crypto.randomUUID().slice(0, 8)}` });
+    const backfillSpy = vi
+      .spyOn(clientService, "listActiveAgentsPinnedToClient")
+      .mockRejectedValueOnce(new Error("backfill failed"));
+    const ws = await openAuthenticatedSocket(await signAccess(seed.userId, seed.memberId, seed.organizationId));
+
+    try {
+      ws.send(JSON.stringify({ type: "client:register", clientId: seed.clientId }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { type?: string }).type === "client:registered"),
+      ).resolves.toMatchObject({ type: "client:registered", clientId: seed.clientId });
+      await vi.waitFor(() => expect(backfillSpy).toHaveBeenCalledWith(app.db, seed.clientId));
+    } finally {
+      await closeSocket(ws);
+      backfillSpy.mockRestore();
+    }
+  });
+
   it("covers agent bind rejection paths", async () => {
     const seed = await createAdminContext(app, { username: `ws-bind-${crypto.randomUUID().slice(0, 8)}` });
     const other = await createAdminContext(app, { username: `ws-bind-other-${crypto.randomUUID().slice(0, 8)}` });
@@ -381,6 +401,24 @@ describe("Agent client WS edge protocol coverage", () => {
       await closeSocket(retiredWs);
     }
   }, 20000);
+
+  it("rejects agent bind when the registered client ownership drifts before bind", async () => {
+    const seed = await createAdminContext(app, { username: `ws-bind-drift-${crypto.randomUUID().slice(0, 8)}` });
+    const other = await createAdminContext(app, { username: `ws-bind-drift-other-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createPinnedAgent({ ...seed, suffix: "ownership-drift" });
+    const ws = await openRegisteredSocket(seed);
+
+    try {
+      await app.db.update(clients).set({ userId: other.userId }).where(eq(clients.id, seed.clientId));
+      await expect(bindAgent(ws, agent.uuid, "bind-client-owner-drift")).resolves.toMatchObject({
+        type: "agent:bind:rejected",
+        ref: "bind-client-owner-drift",
+        reason: AGENT_BIND_REJECT_REASONS.NOT_OWNED,
+      });
+    } finally {
+      await closeSocket(ws);
+    }
+  });
 
   it("claims an unbound agent, rejects malformed bind payloads, and unbinds cleanly", async () => {
     const seed = await createAdminContext(app, { username: `ws-bind-ok-${crypto.randomUUID().slice(0, 8)}` });
@@ -634,10 +672,40 @@ describe("Agent client WS edge protocol coverage", () => {
       });
       expect(eventSpy).toHaveBeenCalled();
 
+      const eventNoRefSpy = vi
+        .spyOn(sessionEventService, "appendEvent")
+        .mockRejectedValueOnce(new Error("event persist failed without ref"));
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          agentId: agent.uuid,
+          chatId: "chat-event",
+          event: { kind: "error", payload: { source: "runtime", message: "boom" } },
+        }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            typeof (message as { message?: unknown }).message === "string" &&
+            (message as { message: string }).message.includes("event persist failed without ref"),
+        ),
+      ).resolves.toMatchObject({
+        type: "error",
+        message: "Failed to persist session event: event persist failed without ref",
+      });
+      expect(eventNoRefSpy).toHaveBeenCalled();
+
       ws.send(JSON.stringify({ type: "inbox:ack", entryId: -1, ref: "ack-malformed" }));
       await expect(
         waitForFrame(ws, (message) => (message as { message?: string }).message === "Malformed inbox:ack frame"),
       ).resolves.toMatchObject({ type: "error", message: "Malformed inbox:ack frame" });
+
+      const ackThrowSpy = vi
+        .spyOn(inboxService, "ackEntryByIdForBoundAgents")
+        .mockRejectedValueOnce(new Error("ack db failed"));
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId: 888_888_888, ref: "ack-throws" }));
+      await vi.waitFor(() => expect(ackThrowSpy).toHaveBeenCalledWith(app.db, 888_888_888, [agent.inboxId]));
 
       ws.send(JSON.stringify({ type: "inbox:ack", entryId: 999_999_999, ref: "ack-missing" }));
       await expect(

--- a/packages/server/src/__tests__/ws-client-edge.test.ts
+++ b/packages/server/src/__tests__/ws-client-edge.test.ts
@@ -1,0 +1,706 @@
+import { AGENT_BIND_REJECT_REASONS } from "@first-tree/shared";
+import { eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { SignJWT } from "jose";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+import { agents } from "../db/schema/agents.js";
+import { clients } from "../db/schema/clients.js";
+import { users } from "../db/schema/users.js";
+import * as activityService from "../services/activity.js";
+import { createAgent } from "../services/agent.js";
+import * as agentRuntimeSessionService from "../services/agent-runtime-session.js";
+import * as inboxService from "../services/inbox.js";
+import * as notificationService from "../services/notification.js";
+import * as presenceService from "../services/presence.js";
+import * as sessionEventService from "../services/session-event.js";
+import { uuidv7 } from "../uuid.js";
+import { createAdminContext, createTestAdmin, createTestApp, seedClient } from "./helpers.js";
+
+describe("Agent client WS edge protocol coverage", () => {
+  let app: FastifyInstance;
+  let wsUrl: string;
+  const jwtSecret = process.env.JWT_SECRET ?? "test-jwt-secret-key-for-vitest";
+
+  async function signJwt(payload: Record<string, unknown>): Promise<string> {
+    const secret = new TextEncoder().encode(jwtSecret);
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT(payload)
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(now)
+      .setExpirationTime(now + 300)
+      .sign(secret);
+  }
+
+  async function signAccess(userId: string, memberId: string, organizationId?: string): Promise<string> {
+    return signJwt({
+      sub: userId,
+      memberId,
+      ...(organizationId ? { organizationId } : {}),
+      role: "admin",
+      type: "access",
+    });
+  }
+
+  function waitForFrame(ws: WebSocket, match: (message: unknown) => boolean, timeoutMs = 5000): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ws.off("message", onMessage);
+        reject(new Error(`timeout waiting for frame (${timeoutMs}ms)`));
+      }, timeoutMs);
+      const onMessage = (raw: WebSocket.RawData) => {
+        try {
+          const message = JSON.parse(raw.toString());
+          if (!match(message)) return;
+          clearTimeout(timer);
+          ws.off("message", onMessage);
+          resolve(message);
+        } catch {
+          // Ignore non-JSON frames.
+        }
+      };
+      ws.on("message", onMessage);
+    });
+  }
+
+  function waitForClose(ws: WebSocket, timeoutMs = 5000): Promise<number> {
+    if (ws.readyState === WebSocket.CLOSED) return Promise.resolve(0);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`timeout waiting for close (${timeoutMs}ms)`)), timeoutMs);
+      ws.once("close", (code) => {
+        clearTimeout(timer);
+        resolve(code);
+      });
+    });
+  }
+
+  async function openSocket(): Promise<WebSocket> {
+    const ws = new WebSocket(wsUrl);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+    return ws;
+  }
+
+  async function closeSocket(ws: WebSocket): Promise<void> {
+    if (ws.readyState === WebSocket.CLOSED) return;
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => resolve(), 500);
+      ws.once("close", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      if (ws.readyState === WebSocket.OPEN) ws.close();
+    });
+  }
+
+  async function openAuthenticatedSocket(token: string): Promise<WebSocket> {
+    const ws = await openSocket();
+    ws.send(JSON.stringify({ type: "auth", token }));
+    await waitForFrame(ws, (message) => (message as { type?: string }).type === "auth:ok");
+    return ws;
+  }
+
+  async function openRegisteredSocket(seed: {
+    userId: string;
+    memberId: string;
+    organizationId: string;
+    clientId: string;
+  }): Promise<WebSocket> {
+    const ws = await openAuthenticatedSocket(await signAccess(seed.userId, seed.memberId, seed.organizationId));
+    ws.send(JSON.stringify({ type: "client:register", clientId: seed.clientId, hostname: "edge-host", os: "linux" }));
+    await waitForFrame(ws, (message) => (message as { type?: string }).type === "client:registered");
+    return ws;
+  }
+
+  async function bindAgent(
+    ws: WebSocket,
+    agentId: string,
+    ref: string,
+    runtimeType = "claude-code",
+  ): Promise<{ type?: string; ref?: string; reason?: string; agentId?: string; runtimeSessionToken?: string }> {
+    ws.send(JSON.stringify({ type: "agent:bind", agentId, ref, runtimeType, runtimeVersion: "edge-test" }));
+    return (await waitForFrame(ws, (message) => {
+      const type = (message as { type?: string }).type;
+      return type === "agent:bound" || type === "agent:bind:rejected";
+    })) as { type?: string; ref?: string; reason?: string; agentId?: string; runtimeSessionToken?: string };
+  }
+
+  async function createPinnedAgent(seed: {
+    memberId: string;
+    organizationId: string;
+    clientId: string;
+    suffix: string;
+  }): Promise<Awaited<ReturnType<typeof createAgent>>> {
+    return createAgent(app.db, {
+      name: `ws-edge-agent-${seed.suffix}-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "WS Edge Agent",
+      source: "admin-api",
+      managerId: seed.memberId,
+      clientId: seed.clientId,
+      organizationId: seed.organizationId,
+      runtimeProvider: "claude-code",
+    });
+  }
+
+  async function createUnboundAgent(seed: {
+    memberId: string;
+    organizationId: string;
+    suffix: string;
+  }): Promise<Awaited<ReturnType<typeof createAgent>>> {
+    return createAgent(app.db, {
+      name: `ws-edge-unbound-${seed.suffix}-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "WS Edge Unbound Agent",
+      source: "admin-api",
+      managerId: seed.memberId,
+      organizationId: seed.organizationId,
+      runtimeProvider: "claude-code",
+    });
+  }
+
+  beforeAll(async () => {
+    app = await createTestApp();
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (!address || typeof address === "string") throw new Error("test server has no address");
+    wsUrl = `ws://127.0.0.1:${address.port}/api/v1/agent/ws/client`;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it.each([
+    { name: "invalid JSON", raw: "{" },
+    { name: "invalid envelope", raw: "[]" },
+    { name: "first frame is not auth", raw: JSON.stringify({ type: "heartbeat" }) },
+    { name: "auth frame is missing token", raw: JSON.stringify({ type: "auth" }) },
+  ])("rejects pre-auth $name", async ({ raw }) => {
+    const ws = await openSocket();
+    ws.send(raw);
+
+    const frame = await waitForFrame(ws, (message) => (message as { type?: string }).type === "auth:rejected");
+    const closeCode = await waitForClose(ws);
+
+    expect(frame).toMatchObject({ type: "auth:rejected", code: "invalid_auth_frame" });
+    expect(closeCode).toBe(4401);
+  });
+
+  it.each([
+    { name: "wrong token type", payload: { sub: "placeholder", type: "refresh" }, code: "wrong_token_type" },
+    { name: "missing subject", payload: { type: "access" }, code: "invalid_claims" },
+  ])("rejects $name claims", async ({ payload, code }) => {
+    const admin = await createTestAdmin(app, { username: `ws-claims-${crypto.randomUUID().slice(0, 8)}` });
+    const tokenPayload = { ...payload, sub: payload.sub === "placeholder" ? admin.userId : payload.sub };
+    const ws = await openSocket();
+    ws.send(JSON.stringify({ type: "auth", token: await signJwt(tokenPayload) }));
+
+    const frame = await waitForFrame(ws, (message) => (message as { type?: string }).type === "auth:rejected");
+    const closeCode = await waitForClose(ws);
+
+    expect(frame).toMatchObject({ type: "auth:rejected", code });
+    expect(closeCode).toBe(4401);
+  });
+
+  it("reports malformed post-auth frames and acknowledges heartbeat before registration", async () => {
+    const seed = await createAdminContext(app, { username: `ws-post-auth-${crypto.randomUUID().slice(0, 8)}` });
+    const ws = await openAuthenticatedSocket(await signAccess(seed.userId, seed.memberId, seed.organizationId));
+
+    try {
+      ws.send("{");
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Invalid JSON"),
+      ).resolves.toMatchObject({
+        type: "error",
+        message: "Invalid JSON",
+      });
+
+      ws.send("[]");
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Invalid message format"),
+      ).resolves.toMatchObject({
+        type: "error",
+        message: "Invalid message format",
+      });
+
+      ws.send(
+        JSON.stringify({
+          type: "agent:bind",
+          agentId: uuidv7(),
+          ref: "bind-before-register",
+          runtimeType: "claude-code",
+        }),
+      );
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Must register client first"),
+      ).resolves.toMatchObject({
+        type: "error",
+        ref: "bind-before-register",
+        message: "Must register client first",
+      });
+
+      ws.send(JSON.stringify({ type: "heartbeat" }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { type?: string }).type === "heartbeat:ack"),
+      ).resolves.toEqual({
+        type: "heartbeat:ack",
+      });
+    } finally {
+      await closeSocket(ws);
+    }
+  });
+
+  it("rejects client registration when the user has no active membership or the client id is unavailable", async () => {
+    const userId = uuidv7();
+    await app.db.insert(users).values({
+      id: userId,
+      username: `ws-no-member-${crypto.randomUUID().slice(0, 8)}`,
+      passwordHash: "x",
+      displayName: "No Membership",
+    });
+    const noMembershipWs = await openAuthenticatedSocket(await signJwt({ sub: userId, type: "access" }));
+    noMembershipWs.send(
+      JSON.stringify({ type: "client:register", clientId: `cli-no-member-${crypto.randomUUID().slice(0, 6)}` }),
+    );
+
+    await expect(
+      waitForFrame(noMembershipWs, (message) => (message as { type?: string }).type === "client:register:rejected"),
+    ).resolves.toMatchObject({
+      type: "client:register:rejected",
+      message: "User has no active organization membership",
+    });
+    expect(await waitForClose(noMembershipWs)).toBe(4403);
+
+    const owner = await createAdminContext(app, { username: `ws-reg-owner-${crypto.randomUUID().slice(0, 8)}` });
+    const other = await createAdminContext(app, { username: `ws-reg-other-${crypto.randomUUID().slice(0, 8)}` });
+    const mismatchedClientId = `cli-mismatch-${crypto.randomUUID().slice(0, 6)}`;
+    await app.db.insert(clients).values({
+      id: mismatchedClientId,
+      userId: other.userId,
+      organizationId: other.organizationId,
+      status: "connected",
+    });
+
+    const mismatchWs = await openAuthenticatedSocket(
+      await signAccess(owner.userId, owner.memberId, owner.organizationId),
+    );
+    mismatchWs.send(JSON.stringify({ type: "client:register", clientId: mismatchedClientId }));
+    await expect(
+      waitForFrame(mismatchWs, (message) => (message as { type?: string }).type === "client:register:rejected"),
+    ).resolves.toMatchObject({
+      type: "client:register:rejected",
+      code: "CLIENT_USER_MISMATCH",
+    });
+    expect(await waitForClose(mismatchWs)).toBe(4403);
+
+    const retiredClientId = `cli-retired-${crypto.randomUUID().slice(0, 6)}`;
+    await app.db.insert(clients).values({
+      id: retiredClientId,
+      userId: owner.userId,
+      organizationId: owner.organizationId,
+      status: "disconnected",
+      retiredAt: new Date(),
+    });
+    const retiredWs = await openAuthenticatedSocket(
+      await signAccess(owner.userId, owner.memberId, owner.organizationId),
+    );
+    retiredWs.send(JSON.stringify({ type: "client:register", clientId: retiredClientId }));
+    await expect(
+      waitForFrame(retiredWs, (message) => (message as { type?: string }).type === "client:register:rejected"),
+    ).resolves.toMatchObject({
+      type: "client:register:rejected",
+      code: "CLIENT_RETIRED",
+    });
+    expect(await waitForClose(retiredWs)).toBe(4403);
+  }, 15000);
+
+  it("covers agent bind rejection paths", async () => {
+    const seed = await createAdminContext(app, { username: `ws-bind-${crypto.randomUUID().slice(0, 8)}` });
+    const other = await createAdminContext(app, { username: `ws-bind-other-${crypto.randomUUID().slice(0, 8)}` });
+    const suspended = await createPinnedAgent({ ...seed, suffix: "suspended" });
+    const otherOwnerAgent = await createPinnedAgent({ ...other, suffix: "other-owner" });
+    const otherClientId = await seedClient(app, seed.userId, seed.organizationId);
+    const wrongClientAgent = await createAgent(app.db, {
+      name: `ws-edge-wrong-client-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Wrong Client Agent",
+      source: "admin-api",
+      managerId: seed.memberId,
+      clientId: otherClientId,
+      organizationId: seed.organizationId,
+      runtimeProvider: "claude-code",
+    });
+    await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, suspended.uuid));
+    const ws = await openRegisteredSocket(seed);
+
+    try {
+      await expect(bindAgent(ws, uuidv7(), "bind-unknown")).resolves.toMatchObject({
+        type: "agent:bind:rejected",
+        ref: "bind-unknown",
+        reason: AGENT_BIND_REJECT_REASONS.UNKNOWN_AGENT,
+      });
+      await expect(bindAgent(ws, suspended.uuid, "bind-suspended")).resolves.toMatchObject({
+        type: "agent:bind:rejected",
+        ref: "bind-suspended",
+        reason: AGENT_BIND_REJECT_REASONS.AGENT_SUSPENDED,
+      });
+      await expect(bindAgent(ws, otherOwnerAgent.uuid, "bind-not-owned")).resolves.toMatchObject({
+        type: "agent:bind:rejected",
+        ref: "bind-not-owned",
+        reason: AGENT_BIND_REJECT_REASONS.NOT_OWNED,
+      });
+      await expect(bindAgent(ws, wrongClientAgent.uuid, "bind-wrong-client")).resolves.toMatchObject({
+        type: "agent:bind:rejected",
+        ref: "bind-wrong-client",
+        reason: AGENT_BIND_REJECT_REASONS.WRONG_CLIENT,
+      });
+    } finally {
+      await closeSocket(ws);
+    }
+
+    const retiredSeed = await createAdminContext(app, {
+      username: `ws-bind-retired-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const retiredAgent = await createPinnedAgent({ ...retiredSeed, suffix: "retired-client" });
+    const retiredWs = await openRegisteredSocket(retiredSeed);
+    try {
+      await app.db.update(clients).set({ retiredAt: new Date() }).where(eq(clients.id, retiredSeed.clientId));
+      await expect(bindAgent(retiredWs, retiredAgent.uuid, "bind-retired")).resolves.toMatchObject({
+        type: "agent:bind:rejected",
+        ref: "bind-retired",
+        reason: AGENT_BIND_REJECT_REASONS.WRONG_CLIENT,
+      });
+    } finally {
+      await closeSocket(retiredWs);
+    }
+  }, 20000);
+
+  it("claims an unbound agent, rejects malformed bind payloads, and unbinds cleanly", async () => {
+    const seed = await createAdminContext(app, { username: `ws-bind-ok-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createUnboundAgent({ ...seed, suffix: "claim" });
+    const ws = await openRegisteredSocket(seed);
+
+    try {
+      ws.send(JSON.stringify({ type: "agent:unbind", agentId: agent.uuid }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Agent not bound"),
+      ).resolves.toMatchObject({ type: "error", message: "Agent not bound" });
+
+      ws.send(JSON.stringify({ type: "agent:bind", agentId: agent.uuid, ref: "bind-malformed" }));
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string }).type === "error" &&
+            typeof (message as { message?: unknown }).message === "string",
+        ),
+      ).resolves.toMatchObject({ type: "error" });
+
+      await expect(bindAgent(ws, agent.uuid, "bind-claim")).resolves.toMatchObject({
+        type: "agent:bound",
+        ref: "bind-claim",
+        agentId: agent.uuid,
+      });
+      const [claimed] = await app.db
+        .select({ clientId: agents.clientId })
+        .from(agents)
+        .where(eq(agents.uuid, agent.uuid))
+        .limit(1);
+      expect(claimed?.clientId).toBe(seed.clientId);
+
+      ws.send(JSON.stringify({ type: "agent:unbind", agentId: agent.uuid }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { type?: string }).type === "agent:unbound"),
+      ).resolves.toMatchObject({
+        type: "agent:unbound",
+        agentId: agent.uuid,
+      });
+    } finally {
+      await closeSocket(ws);
+    }
+  }, 15000);
+
+  it("rejects bind when runtime session or presence publication fails", async () => {
+    const runtimeSeed = await createAdminContext(app, {
+      username: `ws-bind-runtime-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const runtimeAgent = await createPinnedAgent({ ...runtimeSeed, suffix: "runtime-fail" });
+    const runtimeWs = await openRegisteredSocket(runtimeSeed);
+    const runtimeSpy = vi
+      .spyOn(agentRuntimeSessionService, "bindAgentRuntimeSession")
+      .mockRejectedValueOnce(new Error("runtime claim failed"));
+    try {
+      await expect(bindAgent(runtimeWs, runtimeAgent.uuid, "bind-runtime-fail")).resolves.toMatchObject({
+        type: "agent:bind:rejected",
+        reason: AGENT_BIND_REJECT_REASONS.WRONG_CLIENT,
+      });
+      expect(runtimeSpy).toHaveBeenCalled();
+    } finally {
+      await closeSocket(runtimeWs);
+      runtimeSpy.mockRestore();
+    }
+
+    const presenceSeed = await createAdminContext(app, {
+      username: `ws-bind-presence-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const presenceAgent = await createPinnedAgent({ ...presenceSeed, suffix: "presence-fail" });
+    const presenceWs = await openRegisteredSocket(presenceSeed);
+    const presenceSpy = vi.spyOn(presenceService, "bindAgentIfActiveClient").mockResolvedValueOnce(false);
+    try {
+      await expect(bindAgent(presenceWs, presenceAgent.uuid, "bind-presence-fail")).resolves.toMatchObject({
+        type: "agent:bind:rejected",
+        reason: AGENT_BIND_REJECT_REASONS.WRONG_CLIENT,
+      });
+      expect(presenceSpy).toHaveBeenCalled();
+    } finally {
+      await closeSocket(presenceWs);
+      presenceSpy.mockRestore();
+    }
+  }, 15000);
+
+  it("handles bound session, runtime, inbox, recover, and heartbeat edge frames", async () => {
+    const seed = await createAdminContext(app, { username: `ws-bound-edges-${crypto.randomUUID().slice(0, 8)}` });
+    const agent = await createPinnedAgent({ ...seed, suffix: "bound-edges" });
+    const ws = await openRegisteredSocket(seed);
+
+    try {
+      await expect(bindAgent(ws, agent.uuid, "bind-bound-edges")).resolves.toMatchObject({ type: "agent:bound" });
+
+      ws.send(
+        JSON.stringify({ type: "session:state", agentId: agent.uuid, chatId: "chat-state-invalid", state: "evicted" }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { message?: string }).message ===
+            "Unsupported session state from client; client upgrade required",
+        ),
+      ).resolves.toMatchObject({
+        type: "error",
+        message: "Unsupported session state from client; client upgrade required",
+      });
+
+      const stateSpy = vi
+        .spyOn(activityService, "upsertSessionState")
+        .mockRejectedValueOnce(new Error("state persist failed"));
+      ws.send(
+        JSON.stringify({ type: "session:state", agentId: agent.uuid, chatId: "chat-state-fail", state: "active" }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { message?: string }).message === "Failed to persist session state: state persist failed",
+        ),
+      ).resolves.toMatchObject({
+        type: "error",
+        message: "Failed to persist session state: state persist failed",
+      });
+      expect(stateSpy).toHaveBeenCalled();
+
+      ws.send(JSON.stringify({ type: "session:runtime", agentId: agent.uuid, runtimeState: "working" }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Malformed session:runtime frame"),
+      ).resolves.toMatchObject({ type: "error", message: "Malformed session:runtime frame" });
+
+      const runtimeSpy = vi
+        .spyOn(activityService, "setSessionRuntime")
+        .mockRejectedValueOnce(new Error("runtime persist failed"));
+      ws.send(
+        JSON.stringify({
+          type: "session:runtime",
+          agentId: agent.uuid,
+          chatId: "chat-runtime-fail",
+          runtimeState: "working",
+        }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { message?: string }).message === "Failed to persist session runtime: runtime persist failed",
+        ),
+      ).resolves.toMatchObject({
+        type: "error",
+        message: "Failed to persist session runtime: runtime persist failed",
+      });
+      expect(runtimeSpy).toHaveBeenCalled();
+
+      ws.send(JSON.stringify({ type: "session:reconcile", agentId: agent.uuid }));
+      await expect(
+        waitForFrame(
+          ws,
+          (message) => (message as { message?: string }).message === "Malformed session:reconcile frame",
+        ),
+      ).resolves.toMatchObject({ type: "error", message: "Malformed session:reconcile frame" });
+
+      ws.send(JSON.stringify({ type: "session:reconcile", agentId: agent.uuid, chatIds: [] }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { type?: string }).type === "session:reconcile:result"),
+      ).resolves.toMatchObject({
+        type: "session:reconcile:result",
+        agentId: agent.uuid,
+        staleChatIds: [],
+      });
+
+      const notifySpy = vi.spyOn(notificationService, "notifyAgentEvent").mockResolvedValue(undefined);
+      const resolvedSpy = vi.spyOn(notificationService, "markAgentFaultsResolved").mockResolvedValue(undefined);
+      ws.send(JSON.stringify({ type: "runtime:state", agentId: agent.uuid, runtimeState: "error" }));
+      ws.send(JSON.stringify({ type: "runtime:state", agentId: agent.uuid, runtimeState: "blocked" }));
+      ws.send(JSON.stringify({ type: "runtime:state", agentId: agent.uuid, runtimeState: "idle" }));
+      ws.send(JSON.stringify({ type: "heartbeat" }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { type?: string }).type === "heartbeat:ack"),
+      ).resolves.toEqual({
+        type: "heartbeat:ack",
+      });
+      expect(notifySpy).toHaveBeenCalledWith(app.db, agent.uuid, "agent_error", "high");
+      expect(notifySpy).toHaveBeenCalledWith(app.db, agent.uuid, "agent_blocked", "medium");
+      expect(resolvedSpy).toHaveBeenCalledWith(app.db, agent.uuid);
+
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          ref: "event-unbound",
+          agentId: uuidv7(),
+          chatId: "chat-event",
+          event: { kind: "thinking", payload: {} },
+        }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; ref?: string }).type === "session:event:rejected" &&
+            (message as { ref?: string }).ref === "event-unbound",
+        ),
+      ).resolves.toMatchObject({ type: "session:event:rejected", ref: "event-unbound", reason: "agent_not_bound" });
+
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          ref: "event-malformed",
+          agentId: agent.uuid,
+          chatId: "chat-event",
+          event: { kind: "unknown", payload: {} },
+        }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; ref?: string }).type === "session:event:rejected" &&
+            (message as { ref?: string }).ref === "event-malformed",
+        ),
+      ).resolves.toMatchObject({
+        type: "session:event:rejected",
+        ref: "event-malformed",
+        agentId: agent.uuid,
+        chatId: "chat-event",
+        reason: "malformed",
+      });
+
+      const eventSpy = vi
+        .spyOn(sessionEventService, "appendEvent")
+        .mockRejectedValueOnce(new Error("event persist failed"));
+      ws.send(
+        JSON.stringify({
+          type: "session:event",
+          ref: "event-persist-fail",
+          agentId: agent.uuid,
+          chatId: "chat-event",
+          event: { kind: "error", payload: { source: "runtime", message: "boom" } },
+        }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; ref?: string }).type === "session:event:rejected" &&
+            (message as { ref?: string }).ref === "event-persist-fail",
+        ),
+      ).resolves.toMatchObject({
+        type: "session:event:rejected",
+        ref: "event-persist-fail",
+        reason: "persist_failed",
+      });
+      expect(eventSpy).toHaveBeenCalled();
+
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId: -1, ref: "ack-malformed" }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Malformed inbox:ack frame"),
+      ).resolves.toMatchObject({ type: "error", message: "Malformed inbox:ack frame" });
+
+      ws.send(JSON.stringify({ type: "inbox:ack", entryId: 999_999_999, ref: "ack-missing" }));
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; ref?: string }).type === "inbox:ack:rejected" &&
+            (message as { ref?: string }).ref === "ack-missing",
+        ),
+      ).resolves.toMatchObject({ type: "inbox:ack:rejected", entryId: 999_999_999, ref: "ack-missing" });
+
+      ws.send(JSON.stringify({ type: "inbox:recover", ref: "recover-malformed", agentId: agent.uuid }));
+      await expect(
+        waitForFrame(ws, (message) => (message as { message?: string }).message === "Malformed inbox:recover frame"),
+      ).resolves.toMatchObject({ type: "error", message: "Malformed inbox:recover frame" });
+
+      ws.send(
+        JSON.stringify({ type: "inbox:recover", ref: "recover-unbound", agentId: uuidv7(), chatId: "chat-recover" }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; ref?: string }).type === "inbox:recover:rejected" &&
+            (message as { ref?: string }).ref === "recover-unbound",
+        ),
+      ).resolves.toMatchObject({ type: "inbox:recover:rejected", ref: "recover-unbound", reason: "agent_not_bound" });
+
+      ws.send(
+        JSON.stringify({ type: "inbox:recover", ref: "recover-ok", agentId: agent.uuid, chatId: "chat-recover" }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; ref?: string }).type === "inbox:recover:accepted" &&
+            (message as { ref?: string }).ref === "recover-ok",
+        ),
+      ).resolves.toMatchObject({
+        type: "inbox:recover:accepted",
+        ref: "recover-ok",
+        agentId: agent.uuid,
+        chatId: "chat-recover",
+        resetCount: 0,
+      });
+
+      const recoverSpy = vi
+        .spyOn(inboxService, "recoverUnackedForScope")
+        .mockRejectedValueOnce(new Error("recover failed"));
+      ws.send(
+        JSON.stringify({ type: "inbox:recover", ref: "recover-fail", agentId: agent.uuid, chatId: "chat-recover" }),
+      );
+      await expect(
+        waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; ref?: string }).type === "inbox:recover:rejected" &&
+            (message as { ref?: string }).ref === "recover-fail",
+        ),
+      ).resolves.toMatchObject({ type: "inbox:recover:rejected", ref: "recover-fail", reason: "recover_failed" });
+      expect(recoverSpy).toHaveBeenCalled();
+    } finally {
+      await closeSocket(ws);
+    }
+  }, 30000);
+});

--- a/packages/server/src/__tests__/ws-client-edge.test.ts
+++ b/packages/server/src/__tests__/ws-client-edge.test.ts
@@ -85,6 +85,15 @@ describe("Agent client WS edge protocol coverage", () => {
     return ws;
   }
 
+  async function openSocketAt(url: string): Promise<WebSocket> {
+    const ws = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+    });
+    return ws;
+  }
+
   async function closeSocket(ws: WebSocket): Promise<void> {
     if (ws.readyState === WebSocket.CLOSED) return;
     await new Promise<void>((resolve) => {
@@ -111,6 +120,23 @@ describe("Agent client WS edge protocol coverage", () => {
     clientId: string;
   }): Promise<WebSocket> {
     const ws = await openAuthenticatedSocket(await signAccess(seed.userId, seed.memberId, seed.organizationId));
+    ws.send(JSON.stringify({ type: "client:register", clientId: seed.clientId, hostname: "edge-host", os: "linux" }));
+    await waitForFrame(ws, (message) => (message as { type?: string }).type === "client:registered");
+    return ws;
+  }
+
+  async function openRegisteredSocketAt(
+    url: string,
+    seed: {
+      userId: string;
+      memberId: string;
+      organizationId: string;
+      clientId: string;
+    },
+  ): Promise<WebSocket> {
+    const ws = await openSocketAt(url);
+    ws.send(JSON.stringify({ type: "auth", token: await signAccess(seed.userId, seed.memberId, seed.organizationId) }));
+    await waitForFrame(ws, (message) => (message as { type?: string }).type === "auth:ok");
     ws.send(JSON.stringify({ type: "client:register", clientId: seed.clientId, hostname: "edge-host", os: "linux" }));
     await waitForFrame(ws, (message) => (message as { type?: string }).type === "client:registered");
     return ws;
@@ -161,6 +187,57 @@ describe("Agent client WS edge protocol coverage", () => {
       organizationId: seed.organizationId,
       runtimeProvider: "claude-code",
     });
+  }
+
+  async function createPinnedAgentFor(
+    targetApp: FastifyInstance,
+    seed: {
+      memberId: string;
+      organizationId: string;
+      clientId: string;
+      suffix: string;
+    },
+  ): Promise<Awaited<ReturnType<typeof createAgent>>> {
+    return createAgent(targetApp.db, {
+      name: `ws-edge-agent-${seed.suffix}-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "WS Edge Agent",
+      source: "admin-api",
+      managerId: seed.memberId,
+      clientId: seed.clientId,
+      organizationId: seed.organizationId,
+      runtimeProvider: "claude-code",
+    });
+  }
+
+  function inboxEntry(id: number, inboxId: string, chatId: string) {
+    return {
+      id,
+      inboxId,
+      messageId: `msg-${id}`,
+      chatId,
+      status: "delivered",
+      retryCount: 0,
+      createdAt: new Date().toISOString(),
+      deliveredAt: new Date().toISOString(),
+      ackedAt: null,
+      message: null,
+    };
+  }
+
+  async function withInboxCappedApp(
+    inbox: { maxInFlightPerAgent: number; maxInFlightPerAgentChat: number },
+    fn: (targetApp: FastifyInstance, targetWsUrl: string) => Promise<void>,
+  ): Promise<void> {
+    const targetApp = await createTestApp({ inbox });
+    await targetApp.listen({ port: 0, host: "127.0.0.1" });
+    const address = targetApp.server.address();
+    if (!address || typeof address === "string") throw new Error("test server has no address");
+    try {
+      await fn(targetApp, `ws://127.0.0.1:${address.port}/api/v1/agent/ws/client`);
+    } finally {
+      await targetApp.close();
+    }
   }
 
   beforeAll(async () => {
@@ -722,6 +799,117 @@ describe("Agent client WS edge protocol coverage", () => {
       claimSpy.mockRestore();
     }
   }, 15000);
+
+  it("leaves inbox backlog pending when the global in-flight cap is full", async () => {
+    await withInboxCappedApp({ maxInFlightPerAgent: 1, maxInFlightPerAgentChat: 1 }, async (targetApp, targetWsUrl) => {
+      const seed = await createAdminContext(targetApp, {
+        username: `ws-global-cap-${crypto.randomUUID().slice(0, 8)}`,
+      });
+      const agent = await createPinnedAgentFor(targetApp, { ...seed, suffix: "global-cap" });
+      const warnSpy = vi.spyOn(targetApp.log, "warn");
+      const claimSpy = vi
+        .spyOn(inboxService, "claimBacklogForPushFair")
+        .mockResolvedValueOnce([inboxEntry(555_000_001, agent.inboxId, "chat-global-cap")] as never)
+        .mockResolvedValue([]);
+      const ws = await openRegisteredSocketAt(targetWsUrl, seed);
+
+      try {
+        await expect(bindAgent(ws, agent.uuid, "bind-global-cap")).resolves.toMatchObject({
+          type: "agent:bound",
+          agentId: agent.uuid,
+        });
+        await expect(
+          waitForFrame(
+            ws,
+            (message) =>
+              (message as { type?: string; entryId?: number }).type === "inbox:deliver" &&
+              (message as { entryId?: number }).entryId === 555_000_001,
+          ),
+        ).resolves.toMatchObject({ type: "inbox:deliver", entryId: 555_000_001 });
+
+        await targetApp.notifier.notify(agent.inboxId, "msg-global-cap");
+        await vi.waitFor(() =>
+          expect(warnSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ agentId: agent.uuid, inboxId: agent.inboxId, globalCap: 1 }),
+            "inbox push: global in-flight fuse reached, leaving backlog pending",
+          ),
+        );
+        expect(claimSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        await closeSocket(ws);
+        warnSpy.mockRestore();
+        claimSpy.mockRestore();
+      }
+    });
+  }, 20000);
+
+  it("leaves recovery backlog pending when the requested chat is already at its per-chat cap", async () => {
+    await withInboxCappedApp({ maxInFlightPerAgent: 2, maxInFlightPerAgentChat: 1 }, async (targetApp, targetWsUrl) => {
+      const seed = await createAdminContext(targetApp, {
+        username: `ws-chat-cap-${crypto.randomUUID().slice(0, 8)}`,
+      });
+      const agent = await createPinnedAgentFor(targetApp, { ...seed, suffix: "chat-cap" });
+      const debugSpy = vi.spyOn(targetApp.log, "debug");
+      const claimSpy = vi
+        .spyOn(inboxService, "claimBacklogForPushFair")
+        .mockResolvedValueOnce([inboxEntry(555_000_002, agent.inboxId, "chat-per-cap")] as never)
+        .mockResolvedValue([]);
+      const recoverSpy = vi.spyOn(inboxService, "recoverUnackedForScope").mockResolvedValueOnce({
+        resetCount: 0,
+        resetEntryIds: [],
+      } as never);
+      const ws = await openRegisteredSocketAt(targetWsUrl, seed);
+
+      try {
+        await expect(bindAgent(ws, agent.uuid, "bind-chat-cap")).resolves.toMatchObject({
+          type: "agent:bound",
+          agentId: agent.uuid,
+        });
+        await waitForFrame(
+          ws,
+          (message) =>
+            (message as { type?: string; entryId?: number }).type === "inbox:deliver" &&
+            (message as { entryId?: number }).entryId === 555_000_002,
+        );
+
+        ws.send(
+          JSON.stringify({
+            type: "inbox:recover",
+            ref: "recover-chat-cap",
+            agentId: agent.uuid,
+            chatId: "chat-per-cap",
+          }),
+        );
+        await expect(
+          waitForFrame(
+            ws,
+            (message) =>
+              (message as { type?: string; ref?: string }).type === "inbox:recover:accepted" &&
+              (message as { ref?: string }).ref === "recover-chat-cap",
+          ),
+        ).resolves.toMatchObject({ type: "inbox:recover:accepted", ref: "recover-chat-cap", resetCount: 0 });
+
+        await vi.waitFor(() =>
+          expect(debugSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              agentId: agent.uuid,
+              inboxId: agent.inboxId,
+              chatId: "chat-per-cap",
+              chatCap: 1,
+            }),
+            "inbox push: recovery chat at per-chat cap, leaving backlog pending",
+          ),
+        );
+        expect(claimSpy).toHaveBeenCalledTimes(1);
+        expect(recoverSpy).toHaveBeenCalledWith(targetApp.db, { inboxId: agent.inboxId, chatId: "chat-per-cap" });
+      } finally {
+        await closeSocket(ws);
+        debugSpy.mockRestore();
+        claimSpy.mockRestore();
+        recoverSpy.mockRestore();
+      }
+    });
+  }, 20000);
 
   it("handles bound session, runtime, inbox, recover, and heartbeat edge frames", async () => {
     const seed = await createAdminContext(app, { username: `ws-bound-edges-${crypto.randomUUID().slice(0, 8)}` });

--- a/packages/server/src/observability/__tests__/fastify-plugin-extra.test.ts
+++ b/packages/server/src/observability/__tests__/fastify-plugin-extra.test.ts
@@ -1,0 +1,105 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loggerMocks = {
+  child: vi.fn(),
+  warn: vi.fn(),
+};
+
+const traceMocks = {
+  currentTraceId: vi.fn(),
+};
+
+const mockedModules = ["../logger.js", "../otel-helpers.js"];
+
+function mockObservabilityDependencies(): void {
+  vi.doMock("../logger.js", () => ({
+    createLogger: vi.fn(() => ({ child: loggerMocks.child })),
+  }));
+  vi.doMock("../otel-helpers.js", () => ({
+    currentTraceId: traceMocks.currentTraceId,
+  }));
+}
+
+type HookName = "onRequest" | "onResponse";
+
+type HookHandler = (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+function makeApp(): {
+  addHook: (name: HookName, handler: HookHandler) => void;
+  hooks: Partial<Record<HookName, HookHandler>>;
+} {
+  const hooks: Partial<Record<HookName, HookHandler>> = {};
+  return {
+    addHook(name: HookName, handler: HookHandler): void {
+      hooks[name] = handler;
+    },
+    hooks,
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mockObservabilityDependencies();
+  loggerMocks.child.mockReturnValue({ warn: loggerMocks.warn });
+});
+
+afterEach(() => {
+  for (const moduleId of mockedModules) {
+    vi.doUnmock(moduleId);
+  }
+  vi.resetModules();
+});
+
+describe("observabilityPlugin", () => {
+  it("binds request logs to request/trace ids and stamps x-trace-id", async () => {
+    const { observabilityPlugin } = await import("../fastify-plugin.js");
+    const app = makeApp();
+    traceMocks.currentTraceId.mockReturnValue("trace_1");
+    await observabilityPlugin(app as never, {} as never);
+    const headers: Record<string, string> = {};
+    const request = { id: "req_1", method: "GET", url: "/healthz" } as FastifyRequest;
+    const reply = {
+      header(name: string, value: string) {
+        headers[name] = value;
+        return this;
+      },
+      statusCode: 200,
+    } as FastifyReply;
+
+    await app.hooks.onRequest?.(request, reply);
+    await app.hooks.onResponse?.(request, reply);
+
+    expect(loggerMocks.child).toHaveBeenCalledWith({ requestId: "req_1", traceId: "trace_1" });
+    expect(headers).toEqual({ "x-trace-id": "trace_1" });
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("omits trace metadata when absent and warns on 5xx responses", async () => {
+    const { observabilityPlugin } = await import("../fastify-plugin.js");
+    const app = makeApp();
+    traceMocks.currentTraceId.mockReturnValue(undefined);
+    await observabilityPlugin(app as never, {} as never);
+    const request = {
+      id: "req_2",
+      log: { warn: loggerMocks.warn },
+      method: "POST",
+      url: "/api/fail",
+    } as unknown as FastifyRequest;
+    const reply = {
+      header: vi.fn(),
+      statusCode: 503,
+    } as unknown as FastifyReply;
+
+    await app.hooks.onRequest?.(request, reply);
+    await app.hooks.onResponse?.(request, reply);
+
+    expect(loggerMocks.child).toHaveBeenCalledWith({ requestId: "req_2" });
+    expect(reply.header).not.toHaveBeenCalled();
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      { method: "POST", statusCode: 503, url: "/api/fail" },
+      "request failed",
+    );
+  });
+});

--- a/packages/server/src/observability/__tests__/logfire-init-extra.test.ts
+++ b/packages/server/src/observability/__tests__/logfire-init-extra.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const logfireMocks = {
+  configure: vi.fn(),
+  shutdown: vi.fn(),
+};
+
+const loggerMocks = {
+  info: vi.fn(),
+  warn: vi.fn(),
+};
+
+const bridgeMocks = {
+  installPinoErrorBridge: vi.fn(),
+  uninstallPinoErrorBridge: vi.fn(),
+};
+
+const mockedModules = ["@pydantic/logfire-node", "../logger.js", "../otel-helpers.js"];
+
+function mockLogfireDependencies(): void {
+  vi.doMock("@pydantic/logfire-node", () => logfireMocks);
+  vi.doMock("../logger.js", () => ({
+    createLogger: vi.fn(() => loggerMocks),
+  }));
+  vi.doMock("../otel-helpers.js", () => ({
+    installPinoErrorBridge: bridgeMocks.installPinoErrorBridge,
+    uninstallPinoErrorBridge: bridgeMocks.uninstallPinoErrorBridge,
+  }));
+}
+
+const tracingConfig = {
+  endpoint: "https://logfire-us.pydantic.dev/v1/traces",
+  environment: "test",
+  exporter: "otlp-grpc" as const,
+  headers: "Authorization=Bearer pylf_v1_us_token,Other=value",
+  sampleRate: 0.5,
+  serviceName: "first-tree-test",
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  mockLogfireDependencies();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const moduleId of mockedModules) {
+    vi.doUnmock(moduleId);
+  }
+  vi.resetModules();
+});
+
+describe("Logfire telemetry lifecycle", () => {
+  it("configures Logfire with token, base URL, sampling, scrubbing, and instance resource attrs", async () => {
+    const { initTelemetry, isTelemetryEnabled } = await import("../logfire-init.js");
+    vi.stubEnv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=test");
+
+    await initTelemetry(tracingConfig, "srv_1");
+
+    expect(logfireMocks.configure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        advanced: { baseUrl: "https://logfire-us.pydantic.dev" },
+        environment: "test",
+        metrics: false,
+        sampling: { head: 0.5 },
+        serviceName: "first-tree-test",
+        serviceVersion: "0.1.0",
+        token: "pylf_v1_us_token",
+      }),
+    );
+    expect(logfireMocks.configure.mock.calls[0]?.[0].nodeAutoInstrumentations).toMatchObject({
+      "@opentelemetry/instrumentation-dns": { enabled: false },
+      "@opentelemetry/instrumentation-http": { enabled: false },
+      "@opentelemetry/instrumentation-net": { enabled: false },
+    });
+    expect(logfireMocks.configure.mock.calls[0]?.[0].scrubbing.extraPatterns.length).toBeGreaterThan(0);
+    expect(process.env.OTEL_RESOURCE_ATTRIBUTES).toBe("deployment.environment=test,service.instance.id=srv_1");
+    expect(process.env.__FIRST_TREE_OTEL_RESOURCE_ATTRIBUTES_BASE).toBe("deployment.environment=test");
+    expect(bridgeMocks.installPinoErrorBridge).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      "otlp-grpc exporter requested but Logfire SDK is HTTP-only; falling back to otlp-http",
+    );
+    expect(loggerMocks.info).toHaveBeenCalledWith(
+      "tracing enabled: endpoint=logfire-us.pydantic.dev service=first-tree-test env=test instance=srv_1 sampleRate=0.5",
+    );
+    expect(isTelemetryEnabled()).toBe(true);
+  });
+
+  it("reinitializes an enabled SDK without accumulating resource attributes", async () => {
+    const { initTelemetry, shutdownTelemetry } = await import("../logfire-init.js");
+    vi.stubEnv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=test");
+
+    await initTelemetry({ ...tracingConfig, exporter: "otlp-http" }, "srv_1");
+    await initTelemetry({ ...tracingConfig, exporter: "otlp-http" }, "srv_2");
+
+    expect(loggerMocks.warn).toHaveBeenCalledWith("initTelemetry called twice; shutting down previous Logfire SDK");
+    expect(logfireMocks.shutdown).toHaveBeenCalledTimes(1);
+    expect(logfireMocks.configure).toHaveBeenCalledTimes(2);
+    expect(process.env.OTEL_RESOURCE_ATTRIBUTES).toBe("deployment.environment=test,service.instance.id=srv_2");
+
+    await shutdownTelemetry();
+  });
+
+  it("uninstalls the pino bridge and swallows Logfire shutdown errors", async () => {
+    const { initTelemetry, isTelemetryEnabled, shutdownTelemetry } = await import("../logfire-init.js");
+    logfireMocks.shutdown.mockRejectedValueOnce(new Error("flush failed"));
+
+    await initTelemetry({ ...tracingConfig, exporter: "otlp-http" }, "srv_1");
+    await expect(shutdownTelemetry()).resolves.toBeUndefined();
+
+    expect(bridgeMocks.uninstallPinoErrorBridge).toHaveBeenCalledTimes(1);
+    expect(isTelemetryEnabled()).toBe(false);
+  });
+});

--- a/packages/server/src/observability/__tests__/logger.test.ts
+++ b/packages/server/src/observability/__tests__/logger.test.ts
@@ -146,6 +146,19 @@ describe("logger ErrorSink bridging", () => {
     expect(forwarded).toMatch(/\.\.\.\[truncated \d+ chars\]$/);
     restore();
   });
+
+  it("stringifies circular values when JSON serialization fails", () => {
+    silenceStderr();
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
+    const { calls, restore } = installSpySink();
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    createLogger("M").error({ circular }, "circular state");
+
+    expect(calls[0]?.context.circular).toContain("[Circular]");
+    restore();
+  });
 });
 
 describe("logger output format", () => {
@@ -175,6 +188,40 @@ describe("logger output format", () => {
     expect(parsed.module).toBe("M");
     expect(parsed.msg).toBe("hello");
     expect(parsed.k).toBe("v");
+  });
+
+  it("serializes request objects with redacted query parameters", () => {
+    const chunks: string[] = [];
+    writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: string | Uint8Array) => {
+      chunks.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+      return true;
+    }) as never);
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "off" });
+
+    createLogger("M").info(
+      {
+        req: {
+          method: "GET",
+          url: "/api/v1/orgs?token=secret&safe=1",
+          headers: { "accept-version": "2026-01-01" },
+          host: "cloud.first-tree.ai",
+          ip: "127.0.0.1",
+          socket: { remotePort: 443 },
+        },
+      },
+      "incoming request",
+    );
+
+    const parsed = JSON.parse(chunks.join("").trim());
+    expect(parsed.req).toMatchObject({
+      method: "GET",
+      version: "2026-01-01",
+      host: "cloud.first-tree.ai",
+      remoteAddress: "127.0.0.1",
+      remotePort: 443,
+    });
+    expect(parsed.req.url).toContain("token=***");
+    expect(parsed.req.url).toContain("safe=1");
   });
 
   it("emits human-readable pretty output when format=pretty", () => {

--- a/packages/server/src/observability/__tests__/otel-spans.test.ts
+++ b/packages/server/src/observability/__tests__/otel-spans.test.ts
@@ -24,7 +24,19 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { currentSpanId, currentTraceId, withSpan } from "../otel-helpers.js";
+import { createLogger } from "../logger.js";
+import {
+  addSpanEvent,
+  currentSpanId,
+  currentTraceId,
+  endSpan,
+  installPinoErrorBridge,
+  reportError,
+  SpanKind,
+  startTrackedSpan,
+  uninstallPinoErrorBridge,
+  withSpan,
+} from "../otel-helpers.js";
 import {
   attachRequestContext,
   bodyCaptureOnSendHook,
@@ -119,6 +131,71 @@ describe("withSpan exception recording", () => {
     expect(exceptionEvents[0]?.attributes?.["exception.type"]).toBe("Error");
     expect(exceptionEvents[0]?.attributes?.["exception.message"]).toBe("kaboom");
     expect(span.status.code).toBe(2 /* SpanStatusCode.ERROR */);
+  });
+});
+
+describe("manual span helpers", () => {
+  it("records events, attributes, and errors on manually tracked spans", () => {
+    const span = startTrackedSpan("manual-span", { password: "secret", count: 1 }, { kind: SpanKind.INTERNAL });
+    const traceId = span.spanContext().traceId;
+
+    addSpanEvent(span, "checkpoint", { token: "abc", labels: ["a", "b"], payload: { ok: true } });
+    endSpan(span, { apiKey: "key", done: true }, new Error("manual failure"));
+    expect(() => addSpanEvent(null, "ignored")).not.toThrow();
+    expect(() => endSpan(undefined)).not.toThrow();
+
+    const finished = findFinishedSpan(traceId);
+    expect(finished.name).toBe("manual-span");
+    expect(finished.kind).toBe(SpanKind.INTERNAL);
+    expect(finished.attributes.password).toBe("***");
+    expect(finished.attributes.count).toBe(1);
+    expect(finished.attributes.apiKey).toBe("***");
+    expect(finished.attributes.done).toBe(true);
+    expect(finished.events.some((event) => event.name === "checkpoint")).toBe(true);
+    expect(finished.events.some((event) => event.name === "exception")).toBe(true);
+    expect(finished.status.message).toBe("manual failure");
+  });
+
+  it("reports non-Error values onto the active span", async () => {
+    expect(() => reportError("outside", undefined)).not.toThrow();
+
+    let traceId = "";
+    await withSpan("report-error", undefined, async () => {
+      const active = trace.getActiveSpan();
+      if (!active) throw new Error("expected active span");
+      traceId = active.spanContext().traceId;
+      reportError("fallback message", "string failure", { refreshToken: "secret", operation: "test" });
+    });
+
+    const finished = findFinishedSpan(traceId);
+    expect(finished.status.message).toBe("string failure");
+    expect(finished.attributes.refreshToken).toBe("***");
+    expect(finished.attributes.operation).toBe("test");
+    expect(finished.events.some((event) => event.attributes?.["exception.message"] === "string failure")).toBe(true);
+  });
+
+  it("bridges pino error logs onto the active span", async () => {
+    const logger = createLogger("OtelBridgeTest");
+    let traceId = "";
+    installPinoErrorBridge();
+    try {
+      logger.error({ requestId: "outside" }, "outside active span");
+      await withSpan("pino-error-bridge", undefined, async () => {
+        const active = trace.getActiveSpan();
+        if (!active) throw new Error("expected active span");
+        traceId = active.spanContext().traceId;
+        logger.error({ err: "logged failure", password: "secret", requestId: "req-1" }, "bridge failure");
+      });
+    } finally {
+      uninstallPinoErrorBridge();
+    }
+
+    const finished = findFinishedSpan(traceId);
+    expect(finished.status.message).toBe("logged failure");
+    expect(finished.attributes.password).toBe("***");
+    expect(finished.attributes.requestId).toBe("req-1");
+    expect(finished.attributes.module).toBe("OtelBridgeTest");
+    expect(finished.events.some((event) => event.attributes?.["exception.message"] === "logged failure")).toBe(true);
   });
 });
 

--- a/packages/server/src/observability/__tests__/otel-spans.test.ts
+++ b/packages/server/src/observability/__tests__/otel-spans.test.ts
@@ -24,6 +24,7 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { WebSocket } from "ws";
 import { applyLoggerConfig, createLogger } from "../logger.js";
 import {
   addSpanEvent,
@@ -43,6 +44,7 @@ import {
   stampAgentResource,
   stampClientResource,
 } from "../request-context.js";
+import { endWsConnectionSpan, startWsConnectionSpan, withWsMessageSpan } from "../ws-tracing.js";
 
 const exporter = new InMemorySpanExporter();
 const provider = new BasicTracerProvider({
@@ -202,6 +204,23 @@ describe("manual span helpers", () => {
 });
 
 describe("request context span attributes", () => {
+  it("no-ops when the autotelic accessor throws", async () => {
+    const tracer = trace.getTracer("test");
+    const span = tracer.startSpan("http-autotelic-throws");
+    const traceId = span.spanContext().traceId;
+    const request = {
+      user: { userId: "user-throw" },
+      openTelemetry: () => {
+        throw new Error("decorator failed");
+      },
+    } as unknown as FastifyRequest;
+
+    await attachRequestContext(request, {} as FastifyReply);
+    span.end();
+
+    expect(findFinishedSpan(traceId).attributes[FIRST_TREE_ATTR.USER_ID]).toBeUndefined();
+  });
+
   it("stamps client id from the selected agent identity", async () => {
     const tracer = trace.getTracer("test");
     const span = tracer.startSpan("http-agent");
@@ -345,5 +364,44 @@ describe("bodyCaptureOnSendHook", () => {
     expect(raw.length).toBeGreaterThan(4096);
     expect(raw.length).toBeLessThan(4096 + 64); // 4 KiB + a small "[truncated …]" marker
     expect(raw).toMatch(/\[truncated \d+ chars\]$/);
+  });
+
+  it("stamps redacted query attributes on opted-in failures", async () => {
+    const tracer = trace.getTracer("test");
+    const span = tracer.startSpan("t");
+    const traceId = span.spanContext().traceId;
+
+    const req = makeRequestWith(span, { otelRecordBody: true }, null, {
+      token: "secret",
+      page: 2,
+      active: true,
+    });
+    await bodyCaptureOnSendHook(req, makeReply(400), "payload");
+    span.end();
+
+    const attrs = findFinished(traceId).attributes;
+    expect(attrs["http.query.token"]).toBe("***");
+    expect(attrs["http.query.page"]).toBe(2);
+    expect(attrs["http.query.active"]).toBe(true);
+  });
+});
+
+describe("ws-tracing with spans enabled", () => {
+  it("records handler errors on the message span and rethrows", async () => {
+    const socket = {} as WebSocket;
+
+    startWsConnectionSpan(socket, { clientId: "client-1", organizationId: "org-1" });
+    await expect(
+      withWsMessageSpan(socket, "session:event", { chatId: "chat-1" }, async () => {
+        throw new Error("ws handler failed");
+      }),
+    ).rejects.toThrow("ws handler failed");
+    endWsConnectionSpan(socket, 1000);
+
+    const spans = exporter.getFinishedSpans();
+    const messageSpan = spans.find((span) => span.name === "ws.message session:event");
+    expect(messageSpan?.status.message).toBe("ws handler failed");
+    expect(messageSpan?.events.some((event) => event.name === "exception")).toBe(true);
+    expect(spans.find((span) => span.name === "ws.connection")?.attributes[FIRST_TREE_ATTR.WS_CLOSE_CODE]).toBe(1000);
   });
 });

--- a/packages/server/src/observability/__tests__/otel-spans.test.ts
+++ b/packages/server/src/observability/__tests__/otel-spans.test.ts
@@ -24,7 +24,7 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { createLogger } from "../logger.js";
+import { applyLoggerConfig, createLogger } from "../logger.js";
 import {
   addSpanEvent,
   currentSpanId,
@@ -177,6 +177,7 @@ describe("manual span helpers", () => {
   it("bridges pino error logs onto the active span", async () => {
     const logger = createLogger("OtelBridgeTest");
     let traceId = "";
+    applyLoggerConfig({ level: "trace", format: "json", bridgeToSpanLevel: "error" });
     installPinoErrorBridge();
     try {
       logger.error({ requestId: "outside" }, "outside active span");
@@ -185,6 +186,7 @@ describe("manual span helpers", () => {
         if (!active) throw new Error("expected active span");
         traceId = active.spanContext().traceId;
         logger.error({ err: "logged failure", password: "secret", requestId: "req-1" }, "bridge failure");
+        await new Promise((resolve) => setImmediate(resolve));
       });
     } finally {
       uninstallPinoErrorBridge();


### PR DESCRIPTION
## Summary
- Add CLI tests covering command and core edge branches
- Add server tests covering route, service, snapshot, and websocket edge branches
- Keep changes scoped to test files

## Validation
- git diff --check
- pnpm --filter @first-tree/server exec vitest run src/__tests__/ws-client-branch-fake.test.ts