### PR TITLE
chore: bump CLI version to 0.5.12

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump the source CLI package version from `0.5.11` to `0.5.12`
- keep the source package identity as `first-tree-dev`; the production tag workflow rewrites package identity/bin/channel in CI

## Release gate
This is the stable release prep PR. Do not create `v0.5.12` until this PR is merged to `main`; the tag workflow requires the tag version to match `apps/cli/package.json` and the tagged commit to be on `origin/main`.

## Verification
- `node -e 'const p=require("./apps/cli/package.json"); if (p.name!=="first-tree-dev"||p.version!=="0.5.12") throw new Error(JSON.stringify({name:p.name,version:p.version})); console.log(`${p.name}@${p.version}`)'`
- `git rev-parse --verify v0.5.12` failed as expected: tag does not exist yet
- `npm view first-tree@0.5.12 version gitHead --json` returned `E404` as expected: production version is not published yet
- `git diff --check`
- `node -e 'JSON.parse(require("fs").readFileSync("apps/cli/package.json", "utf8")); console.log("apps/cli/package.json JSON ok")'`

## Replaces
- Closes/replaces #1534, which used a branch name rejected by the CI branch-name gate.
