### PR TITLE
Reject escaped newline agent messages

### DIFF
--- a/packages/server/src/__tests__/message-escaped-newline-guard.test.ts
+++ b/packages/server/src/__tests__/message-escaped-newline-guard.test.ts
@@ -1,0 +1,87 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { messages } from "../db/schema/messages.js";
+import { createChat } from "../services/chat.js";
+import { sendMessage } from "../services/message.js";
+import { createTestAgent, useTestApp } from "./helpers.js";
+
+describe("sendMessage escaped-newline guard", () => {
+  const getApp = useTestApp();
+
+  async function setupAgentChat(uid: string) {
+    const app = getApp();
+    const sender = await createTestAgent(app, { name: `esc-s-${uid}` });
+    const peer = await createTestAgent(app, { name: `esc-p-${uid}` });
+    const chat = await createChat(app.db, sender.agent.uuid, {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+    return { app, sender, peer, chat };
+  }
+
+  it("rejects agent-authored escaped multiline bodies before they are persisted", async () => {
+    const { app, sender, peer, chat } = await setupAgentChat(crypto.randomUUID().slice(0, 6));
+
+    await expect(
+      sendMessage(app.db, chat.id, sender.agent.uuid, {
+        source: "api",
+        format: "markdown",
+        content: "PR 提好了，是 draft：\\n\\nhttps://github.com/example/repo/pull/1\\n\\n验证通过",
+        receiverNames: [peer.agent.name ?? ""],
+      }),
+    ).rejects.toThrow(/literal "\\n" escapes/i);
+
+    const rows = await app.db.select({ id: messages.id }).from(messages).where(eq(messages.chatId, chat.id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("rejects escaped multiline agent final text before the silent-send bypass can write history", async () => {
+    const { app, sender, chat } = await setupAgentChat(crypto.randomUUID().slice(0, 6));
+
+    await expect(
+      sendMessage(app.db, chat.id, sender.agent.uuid, {
+        source: "api",
+        format: "markdown",
+        content: "完成了：\\n\\n- commit: abc123\\n- branch: main",
+        purpose: "agent-final-text",
+      }),
+    ).rejects.toThrow(/literal "\\n" escapes/i);
+
+    const rows = await app.db.select({ id: messages.id }).from(messages).where(eq(messages.chatId, chat.id));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("accepts agent-authored markdown bodies that contain real newlines", async () => {
+    const { app, sender, peer, chat } = await setupAgentChat(crypto.randomUUID().slice(0, 6));
+    const body = "PR 提好了，是 draft：\n\nhttps://github.com/example/repo/pull/1\n\n验证通过";
+
+    const result = await sendMessage(app.db, chat.id, sender.agent.uuid, {
+      source: "api",
+      format: "markdown",
+      content: body,
+      receiverNames: [peer.agent.name ?? ""],
+    });
+
+    expect(result.message.content).toBe(body);
+  });
+
+  it("leaves human-authored literal backslash-n prose alone", async () => {
+    const app = getApp();
+    const human = await createTestAgent(app, { type: "human", name: `esc-human-${crypto.randomUUID().slice(0, 6)}` });
+    const peer = await createTestAgent(app, { name: `esc-human-peer-${crypto.randomUUID().slice(0, 6)}` });
+    const chat = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [peer.agent.uuid],
+    });
+    const body = "I literally want to discuss \\n\\n in this message.";
+
+    const result = await sendMessage(app.db, chat.id, human.agent.uuid, {
+      source: "web",
+      format: "text",
+      content: body,
+      metadata: { mentions: [peer.agent.uuid] },
+    });
+
+    expect(result.message.content).toBe(body);
+  });
+});

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -108,6 +108,27 @@ function validateTextBody(content: string, isRequest: boolean): void {
   }
 }
 
+/**
+ * Detect an agent-authored body whose intended markdown line structure arrived
+ * as literal `\n` tokens. CLI inline sends already reject this shape, but
+ * agent outbox/API callers can bypass the CLI and write directly through the
+ * server boundary; fail here before the row becomes durable.
+ */
+function looksLikeEscapedNewlineBody(content: string): boolean {
+  if (content.includes("\n")) return false;
+  const escapes = content.match(/\\n/g);
+  return (escapes?.length ?? 0) >= 2;
+}
+
+function validateAgentTextEncoding(content: string): void {
+  if (!looksLikeEscapedNewlineBody(content)) return;
+  throw new BadRequestError(
+    'Message content contains literal "\\n" escapes and no real newlines — this looks like a multi-line ' +
+      "markdown body that was shell-escaped or JSON-escaped before sending. Send the body with real newlines " +
+      "via stdin, a message file, or an unescaped API string before retrying.",
+  );
+}
+
 // Structural param (not `SendMessage`) so the edit path can reuse it against
 // the effective post-edit `{ format, content }`, where `format` is a plain
 // string off the stored row.
@@ -284,14 +305,17 @@ export function preflightMessageSendIntent(input: {
 
   let effectiveContent: SendMessage["content"] = data.content;
   if (senderType !== "human" && typeof effectiveContent === "string") {
-    const unwrapped = maybeUnwrapDoubleEncoded(effectiveContent);
+    let textContent = effectiveContent;
+    const unwrapped = maybeUnwrapDoubleEncoded(textContent);
     if (unwrapped !== null) {
       log.warn(
         { metric: "double_encoded_content_unwrapped_total", chatId, senderId },
         "agent sent JSON-encoded string content — unwrapping to restore markdown rendering",
       );
-      effectiveContent = unwrapped;
+      textContent = unwrapped;
+      effectiveContent = textContent;
     }
+    validateAgentTextEncoding(textContent);
   }
 
   // Re-validate the UNWRAPPED body. `validateMessageContent(data)` above checked


### PR DESCRIPTION
## Summary

- Add a server-side preflight guard for non-human string message bodies that contain multiple literal `\n` escapes and no real newlines.
- Keep existing JSON double-encoded recovery intact: confidently JSON-stringified agent content is still unwrapped first, then the guard evaluates the effective body.
- Add service tests for agent normal sends, agent final-text silent sends, valid real-newline markdown, and human-authored literal backslash-n prose.

## Verification

- `pnpm --filter @first-tree/server typecheck`
- `pnpm exec biome check packages/server/src/services/message.ts packages/server/src/__tests__/message-escaped-newline-guard.test.ts`
- `pnpm --dir apps/cli exec vitest run src/__tests__/chat-send-escaped-newline-guard.test.ts --reporter=dot`

Not run: `packages/server` DB-backed Vitest execution; this local machine has Docker CLI installed but the Docker daemon is not running, so Testcontainers fails before collection with "Could not find a working container runtime strategy".
