### PR TITLE
[jeremy] Auto-invite mentioned chat agents

### DIFF
--- a/packages/web/src/components/__tests__/mention-autocomplete.test.ts
+++ b/packages/web/src/components/__tests__/mention-autocomplete.test.ts
@@ -288,6 +288,17 @@ describe("rankCandidates", () => {
     ]);
   });
 
+  it("empty query: joined chat agents stay above inviteable agents, with normal grouping inside each bucket", () => {
+    const input = [
+      cand({ agentId: "invite-mine", displayName: "Alpha Invite", managedByMe: true, inChat: false }),
+      cand({ agentId: "joined-other", displayName: "Zulu Joined", managedByMe: false, inChat: true }),
+      cand({ agentId: "joined-mine", displayName: "Bravo Joined", managedByMe: true, inChat: true }),
+      cand({ agentId: "invite-other", displayName: "Able Invite", managedByMe: false, inChat: false }),
+    ];
+    const result = rankCandidates(input, "");
+    expect(result.map((c) => c.agentId)).toEqual(["joined-mine", "joined-other", "invite-mine", "invite-other"]);
+  });
+
   it("non-empty query: returns every match, uncapped", () => {
     // Same no-cap guarantee on the typed path: a substring shared by more
     // than eight agents must surface them all, not silently truncate at 8.
@@ -296,6 +307,15 @@ describe("rankCandidates", () => {
     );
     const result = rankCandidates(input, "team");
     expect(result).toHaveLength(12);
+  });
+
+  it("non-empty query: equal-score joined matches stay above inviteable matches", () => {
+    const input = [
+      cand({ agentId: "invite", name: "alpha-invite", displayName: "Alpha Invite", inChat: false }),
+      cand({ agentId: "joined", name: "alpha-joined", displayName: "Zulu Joined", inChat: true }),
+    ];
+    const result = rankCandidates(input, "alpha");
+    expect(result.map((c) => c.agentId)).toEqual(["joined", "invite"]);
   });
 });
 

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -20,8 +20,9 @@
  *     open" path — skip is an answer, not a deferral.
  *
  * The free-text answer surface mirrors the chat composer: it supports `@mention`
- * autocomplete (against the chat's members) and image attachments (paste / drop /
- * file-picker), so answering an ask is as expressive as a normal message. The
+ * autocomplete (against chat speakers plus host-supplied inviteable agents) and
+ * image attachments (paste / drop / file-picker), so answering an ask is as
+ * expressive as a normal message. The
  * readable answer is still plain text (`buildResolveAnswer`: selected option
  * labels join on one line, any typed note follows); the host turns the assembled
  * {content, mentions, images} into the resolving reply. This is the ONLY way to
@@ -34,7 +35,12 @@ import { AtSign, Paperclip, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { usePendingImages } from "../../lib/use-pending-images.js";
-import { MentionAutocompletePopover, type MentionCandidate, useMentionAutocomplete } from "../mention-autocomplete.js";
+import {
+  detectMentionTrigger,
+  MentionAutocompletePopover,
+  type MentionCandidate,
+  useMentionAutocomplete,
+} from "../mention-autocomplete.js";
 import { MentionHighlightOverlay } from "../mention-highlight-overlay.js";
 import { Markdown } from "../ui/markdown.js";
 import { allRequiredAnswered, buildResolveAnswer } from "./request-state.js";
@@ -95,6 +101,9 @@ export function AskTakeover({
   sending = false,
   mentionCandidates = [],
   error,
+  onMentionQueryChange,
+  onMentionTextChange,
+  onMentionSelect,
   onReply,
   onSkip,
   isTrial = false,
@@ -107,13 +116,23 @@ export function AskTakeover({
   payload: AskRequest;
   askerName?: string;
   sending?: boolean;
-  /** Chat members the free-text `@` autocomplete suggests + resolves against
-   *  (self-excluded, same source as the composer). Empty → no autocomplete and
-   *  every `@<token>` stays plain text. */
+  /** Candidates the free-text `@` autocomplete suggests + resolves against
+   *  (self-excluded chat speakers plus host-supplied inviteable agents, same
+   *  source as the composer). Empty → no autocomplete and every `@<token>`
+   *  stays plain text. */
   mentionCandidates?: MentionCandidate[];
   /** A host-side send failure to surface in the card (the composer is covered,
    *  so a failed resolve must show here or it looks like nothing happened). */
   error?: string;
+  /** Reports the active `@query` so the host can fetch addressable agents that
+   *  are not already chat speakers. */
+  onMentionQueryChange?: (query: string | null) => void;
+  /** Reports the answer draft so the host can retain selected inviteable
+   *  candidates while their `@name` remains in the answer text. */
+  onMentionTextChange?: (text: string) => void;
+  /** Reports the picked candidate so the host can retain search-only
+   *  inviteable agents before the search result cache changes. */
+  onMentionSelect?: (candidate: MentionCandidate) => void;
   /** Resolve the question with the composed answer. */
   onReply: (answer: AskAnswer) => void;
   /** Resolve the question with a "skipped" answer (caller sends the reply). */
@@ -140,7 +159,7 @@ export function AskTakeover({
     onChange: () => setImageError(null),
   });
 
-  // Self-excluded membership projection for `@` resolution + the mirror overlay.
+  // Self-excluded mention projection for `@` resolution + the mirror overlay.
   const mentionParticipants = useMemo<MentionParticipant[]>(
     () => mentionCandidates.map((c) => ({ agentId: c.agentId, name: c.name })),
     [mentionCandidates],
@@ -148,13 +167,33 @@ export function AskTakeover({
 
   const taRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const activeMentionTrigger = useMemo(
+    () => (isTrial || sending ? null : detectMentionTrigger(freeText, cursor)),
+    [freeText, cursor, isTrial, sending],
+  );
+
+  useEffect(() => {
+    onMentionTextChange?.(freeText);
+  }, [freeText, onMentionTextChange]);
+
+  useEffect(() => {
+    onMentionQueryChange?.(activeMentionTrigger?.query ?? null);
+  }, [activeMentionTrigger?.query, onMentionQueryChange]);
+
+  useEffect(() => {
+    return () => {
+      onMentionQueryChange?.(null);
+      onMentionTextChange?.("");
+    };
+  }, [onMentionQueryChange, onMentionTextChange]);
 
   const mention = useMentionAutocomplete({
     value: freeText,
     cursor,
     candidates: mentionCandidates,
     disabled: sending,
-    onSelect: (update) => {
+    onSelect: (update, picked) => {
+      onMentionSelect?.(picked);
       setFreeText(update.text);
       setCursor(update.cursor);
       // Defer so React commits the new value before we move the selection —

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -28,6 +28,12 @@ export type MentionCandidate = {
   agentId: string;
   name: string | null;
   displayName: string | null;
+  /** False when the candidate is addressable but not yet a speaker in
+   *  the current chat. The existing-chat composer uses this to show
+   *  joined agents first, then inviteable agents under a divider. Omitted
+   *  means "not relevant to this surface" and is treated as joined for
+   *  ordering/rendering so existing pickers keep their behaviour. */
+  inChat?: boolean;
   /** True iff the caller's member is this agent's `managerId`. Drives
    *  participant-picker grouping (mine first, then teammates') and the
    *  empty-query branch of mention autocomplete so the user's own agents
@@ -243,7 +249,9 @@ export function buildPickerSections(
  */
 export function rankCandidates(candidates: MentionCandidate[], query: string): MentionCandidate[] {
   if (!query) {
-    // Reuse the picker's grouping logic and strip the divider marker.
+    // Joined chat speakers stay above inviteable org agents. Within each
+    // membership bucket, reuse the picker's grouping logic and strip the
+    // divider marker.
     // Keeping the empty-query path in lockstep with the picker means
     // changing one (mine-first, alpha) tomorrow won't silently leave the
     // other behind — and that lockstep now includes "no cap": the `[+]`
@@ -253,7 +261,11 @@ export function rankCandidates(candidates: MentionCandidate[], query: string): M
     // cut. A prior hard `.slice(0, 8)` dropped the 9th+ addressable agent
     // from the empty-`@` view with no "more" affordance, so the list read
     // as broken/incomplete the moment an org had more than eight.
-    return groupAndSortCandidates(candidates).filter((item): item is MentionCandidate => !("divider" in item));
+    const inChat = candidates.filter((c) => c.inChat !== false);
+    const notInChat = candidates.filter((c) => c.inChat === false);
+    const sortBucket = (bucket: MentionCandidate[]) =>
+      groupAndSortCandidates(bucket).filter((item): item is MentionCandidate => !("divider" in item));
+    return [...sortBucket(inChat), ...sortBucket(notInChat)];
   }
   const scored: Array<{ c: MentionCandidate; score: number }> = [];
   for (const c of candidates) {
@@ -266,7 +278,13 @@ export function rankCandidates(candidates: MentionCandidate[], query: string): M
     else if (lowerName.includes(query)) score = 3;
     if (score !== Infinity) scored.push({ c, score });
   }
-  scored.sort((a, b) => a.score - b.score || (a.c.displayName ?? "").localeCompare(b.c.displayName ?? ""));
+  scored.sort((a, b) => {
+    if (a.score !== b.score) return a.score - b.score;
+    const aInChat = a.c.inChat !== false;
+    const bInChat = b.c.inChat !== false;
+    if (aInChat !== bInChat) return aInChat ? -1 : 1;
+    return (a.c.displayName ?? "").localeCompare(b.c.displayName ?? "");
+  });
   // No cap here either: every scored match surfaces, scrolling inside the
   // popover. Capping the typed path would hide later matches behind a
   // query the user can't refine further (the substring is already as
@@ -333,7 +351,7 @@ export function useMentionAutocomplete({
   value: string;
   cursor: number;
   candidates: MentionCandidate[];
-  onSelect: (update: MentionInsert) => void;
+  onSelect: (update: MentionInsert, picked: MentionCandidate) => void;
   disabled?: boolean;
 }): {
   trigger: ActiveTrigger | null;
@@ -385,7 +403,7 @@ export function useMentionAutocomplete({
     if (!trigger) return;
     const insert = buildMentionInsert(value, trigger, cursor, candidate);
     if (!insert) return;
-    onSelect(insert);
+    onSelect(insert, candidate);
   }
 
   const handleKey: MentionKeyHandler = (e) => {
@@ -474,9 +492,10 @@ export function MentionAutocompletePopover({
     >
       {(() => {
         const ambiguous = ambiguousDisplayNames(results);
-        return results.map((c, i) => {
+        return results.flatMap((c, i) => {
           const active = i === highlightIndex;
-          return (
+          const needsMembershipDivider = i > 0 && c.inChat === false && results[i - 1]?.inChat !== false;
+          const row = (
             <button
               key={c.agentId}
               type="button"
@@ -502,6 +521,19 @@ export function MentionAutocompletePopover({
               <MentionLabel candidate={c} ambiguous={ambiguous} />
             </button>
           );
+          if (!needsMembershipDivider) return [row];
+          return [
+            <div
+              key="__not-in-chat-divider"
+              role="presentation"
+              style={{
+                height: "var(--hairline)",
+                background: "var(--border-faint)",
+                margin: "var(--sp-0_5) var(--sp-3)",
+              }}
+            />,
+            row,
+          ];
         });
       })()}
     </div>

--- a/packages/web/src/lib/use-org-agents.ts
+++ b/packages/web/src/lib/use-org-agents.ts
@@ -64,11 +64,12 @@ export function useOrgAgents(options?: {
  */
 export function useOrgAgentsSearch(
   query: string,
-  options?: { addressableOnly?: boolean },
+  options?: { addressableOnly?: boolean; enabled?: boolean },
 ): UseQueryResult<PaginatedAgents> {
   const trimmed = query.trim();
   const addressableOnly = options?.addressableOnly ?? false;
-  const unfiltered = useOrgAgents({ addressableOnly });
+  const enabled = options?.enabled ?? true;
+  const unfiltered = useOrgAgents({ addressableOnly, enabled });
   const search = useQuery({
     queryKey: ["agents", "org-list", { addressableOnly }, "search", trimmed],
     queryFn: () => listAgents({ limit: 100, query: trimmed, addressableOnly }),
@@ -76,7 +77,7 @@ export function useOrgAgentsSearch(
     // same term doesn't re-hit the server; expire fast enough that a newly
     // added agent shows up under search within a reasonable window.
     staleTime: 10_000,
-    enabled: trimmed.length > 0,
+    enabled: enabled && trimmed.length > 0,
   });
   return trimmed.length > 0 ? search : unfiltered;
 }

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -38,6 +38,10 @@ const agentMocks = vi.hoisted(() => ({
   listAgents: vi.fn(),
 }));
 
+const orgAgentsHookMocks = vi.hoisted(() => ({
+  searchOnlyItems: [] as Agent[],
+}));
+
 const attachmentMocks = vi.hoisted(() => ({
   fetchAttachmentBase64: vi.fn(),
   uploadImageAttachment: vi.fn(),
@@ -160,7 +164,21 @@ vi.mock("../../../../lib/use-agent-name-map.js", () => ({
 
 vi.mock("../../../../lib/use-org-agents.js", () => ({
   useOrgAgents: () => ({ data: { items: ORG_AGENTS, nextCursor: null } }),
-  useOrgAgentsSearch: () => ({ data: { items: ORG_AGENTS, nextCursor: null }, isFetching: false }),
+  useOrgAgentsSearch: (query: string, options?: { enabled?: boolean }) => {
+    const enabled = options?.enabled ?? true;
+    return {
+      data: enabled
+        ? {
+            items:
+              query.trim().length > 0 && orgAgentsHookMocks.searchOnlyItems.length > 0
+                ? orgAgentsHookMocks.searchOnlyItems
+                : ORG_AGENTS,
+            nextCursor: null,
+          }
+        : undefined,
+      isFetching: false,
+    };
+  },
 }));
 
 vi.mock("../../../../lib/visibility-interval.js", () => ({
@@ -588,6 +606,15 @@ async function click(element: Element | null): Promise<void> {
   await flush();
 }
 
+async function pickMentionCandidate(container: ParentNode, title: string): Promise<void> {
+  const candidateButton = container.querySelector<HTMLButtonElement>(`button[title="${title}"]`);
+  if (!candidateButton) throw new Error(`Expected mention candidate ${title}`);
+  await act(async () => {
+    candidateButton.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
 async function setValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): Promise<void> {
   await act(async () => {
     const proto = element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
@@ -635,6 +662,7 @@ beforeEach(() => {
   installBrowserStubs();
   document.body.innerHTML = "";
   vi.clearAllMocks();
+  orgAgentsHookMocks.searchOnlyItems = [];
   authMock.value = { agentId: "human-agent-self", memberId: "member-self", role: "admin" };
   activityMocks.listClients.mockResolvedValue([
     {
@@ -1409,6 +1437,108 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("invites a mentioned non-participant before sending the message", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, undefined, "/");
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Composer textarea missing");
+
+    await setValue(textarea, "Please help @teammate");
+    await click(container.querySelector('button[aria-label="Send"]'));
+
+    await waitForCondition(
+      () => meChatMocks.addMeChatParticipants.mock.calls.length > 0,
+      "Expected mentioned non-participant invite",
+    );
+    await waitForCondition(() => chatMocks.sendChatMessage.mock.calls.length > 0, "Expected message send");
+
+    expect(meChatMocks.addMeChatParticipants).toHaveBeenCalledWith("chat-1", { participantIds: ["agent-teammate"] });
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "Please help @teammate", ["agent-teammate"]);
+    expect(meChatMocks.addMeChatParticipants.mock.invocationCallOrder[0]).toBeLessThan(
+      chatMocks.sendChatMessage.mock.invocationCallOrder[0] ?? 0,
+    );
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps a search-only inviteable mention resolvable after the autocomplete trigger closes", async () => {
+    const deepAgent = agent({
+      uuid: "agent-deep",
+      name: "deep-agent",
+      displayName: "Deep Agent",
+      managerId: "member-alice",
+    });
+    orgAgentsHookMocks.searchOnlyItems = [deepAgent];
+
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, undefined, "/");
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Composer textarea missing");
+
+    await setValue(textarea, "Please help @deep");
+    await waitForCondition(
+      () => container.querySelector<HTMLButtonElement>('button[title="@deep-agent"]') !== null,
+      "Expected search-only inviteable mention candidate",
+    );
+    await pickMentionCandidate(container, "@deep-agent");
+    await waitForCondition(
+      () => textarea.value === "Please help @deep-agent ",
+      "Expected selected mention to be inserted",
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+    await flush();
+
+    await click(container.querySelector('button[aria-label="Send"]'));
+    await waitForCondition(
+      () => meChatMocks.addMeChatParticipants.mock.calls.length > 0,
+      "Expected retained search-only mention to invite",
+    );
+    await waitForCondition(() => chatMocks.sendChatMessage.mock.calls.length > 0, "Expected message send");
+
+    expect(meChatMocks.addMeChatParticipants).toHaveBeenCalledWith("chat-1", { participantIds: ["agent-deep"] });
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "Please help @deep-agent", ["agent-deep"]);
+
+    await act(async () => root.unmount());
+  });
+
+  it("shows and selects an inviteable non-participant from a bare @ trigger", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, undefined, "/");
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Composer textarea missing");
+
+    await setValue(textarea, "Please @");
+    await waitForCondition(
+      () => container.querySelector<HTMLButtonElement>('button[title="@teammate"]') !== null,
+      "Expected bare @ to show inviteable non-participant",
+    );
+    await pickMentionCandidate(container, "@teammate");
+    await waitForCondition(
+      () => textarea.value === "Please @teammate ",
+      "Expected bare @ inviteable mention to be inserted",
+    );
+
+    await click(container.querySelector('button[aria-label="Send"]'));
+    await waitForCondition(
+      () => meChatMocks.addMeChatParticipants.mock.calls.length > 0,
+      "Expected bare @ mention to invite",
+    );
+    await waitForCondition(() => chatMocks.sendChatMessage.mock.calls.length > 0, "Expected message send");
+
+    expect(meChatMocks.addMeChatParticipants).toHaveBeenCalledWith("chat-1", {
+      participantIds: ["agent-teammate"],
+    });
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "Please @teammate", ["agent-teammate"]);
+
+    await act(async () => root.unmount());
+  });
+
   it("clears the mention tip when switching to another group chat", async () => {
     const { ChatView } = await import("../chat-view.js");
     const { container, queryClient, root } = await renderDom(
@@ -1786,6 +1916,56 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("invites a search-only inviteable mention before resolving a blocking text answer", async () => {
+    const deepAgent = agent({
+      uuid: "agent-deep",
+      name: "deep-agent",
+      displayName: "Deep Agent",
+      managerId: "member-alice",
+    });
+    orgAgentsHookMocks.searchOnlyItems = [deepAgent];
+
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), freeTextDockMessages()),
+      "/",
+    );
+
+    await waitForText(container, "Reply");
+    const answerBox = askTextarea(container);
+    if (!answerBox) throw new Error("Overlay free-text input missing");
+    await setValue(answerBox, "Loop in @deep");
+    await waitForCondition(
+      () => container.querySelector<HTMLButtonElement>('button[title="@deep-agent"]') !== null,
+      "Expected ask answer search-only inviteable mention candidate",
+    );
+    await pickMentionCandidate(container, "@deep-agent");
+    await waitForCondition(
+      () => answerBox.value === "Loop in @deep-agent ",
+      "Expected ask answer mention to be inserted",
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+    await flush();
+
+    await click(buttonByText(container, "Reply"));
+    await waitForCondition(
+      () => meChatMocks.addMeChatParticipants.mock.calls.length > 0,
+      "Expected ask answer mention to invite",
+    );
+    await waitForCondition(() => chatMocks.sendChatMessage.mock.calls.length > 0, "Expected text resolve send");
+    expect(meChatMocks.addMeChatParticipants).toHaveBeenCalledWith("chat-1", { participantIds: ["agent-deep"] });
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "Loop in @deep-agent", ["agent-1", "agent-deep"], {
+      inReplyTo: "req-file",
+      resolves: { request: "req-file", kind: "answered" },
+    });
+
+    await act(async () => root.unmount());
+  });
+
   it("resolves a blocking free-text question with an attached image via a file-batch resolve", async () => {
     const { ChatView } = await import("../chat-view.js");
     const { container, root } = await renderDom(
@@ -1822,6 +2002,68 @@ describe("ChatView", () => {
       { inReplyTo: "req-file", resolves: { request: "req-file", kind: "answered" } },
     );
     expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("invites a search-only inviteable mention before resolving a blocking image answer", async () => {
+    const deepAgent = agent({
+      uuid: "agent-deep",
+      name: "deep-agent",
+      displayName: "Deep Agent",
+      managerId: "member-alice",
+    });
+    orgAgentsHookMocks.searchOnlyItems = [deepAgent];
+
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, chatDetail(), freeTextDockMessages()),
+      "/",
+    );
+
+    await waitForText(container, "Reply");
+    const answerBox = askTextarea(container);
+    if (!answerBox) throw new Error("Overlay free-text input missing");
+    await setValue(answerBox, "Screenshot for @deep");
+    await waitForCondition(
+      () => container.querySelector<HTMLButtonElement>('button[title="@deep-agent"]') !== null,
+      "Expected image answer search-only inviteable mention candidate",
+    );
+    await pickMentionCandidate(container, "@deep-agent");
+    await waitForCondition(
+      () => answerBox.value === "Screenshot for @deep-agent ",
+      "Expected image answer mention to be inserted",
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+    await flush();
+
+    const file = new File(["abc"], "evidence.png", { type: "image/png" });
+    const fileInput = container.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) throw new Error("File input missing");
+    await changeFiles(fileInput, [file]);
+    await click(buttonByText(container, "Reply"));
+    await waitForCondition(
+      () => meChatMocks.addMeChatParticipants.mock.calls.length > 0,
+      "Expected image answer mention to invite",
+    );
+    await waitForCondition(
+      () => chatMocks.sendFileMessageBatch.mock.calls.length > 0,
+      "Expected image file-batch resolve",
+    );
+    expect(meChatMocks.addMeChatParticipants).toHaveBeenCalledWith("chat-1", { participantIds: ["agent-deep"] });
+    expect(chatMocks.sendFileMessageBatch).toHaveBeenCalledWith(
+      "chat-1",
+      {
+        caption: "Screenshot for @deep-agent",
+        attachments: [{ imageId: "uploaded-image", mimeType: "image/png", filename: "evidence.png", size: 3 }],
+      },
+      { mentions: ["agent-1", "agent-deep"] },
+      { inReplyTo: "req-file", resolves: { request: "req-file", kind: "answered" } },
+    );
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1,4 +1,5 @@
 import {
+  type Agent,
   type AttachmentRef,
   attachmentRefsFromMetadata,
   type CapabilityEntry,
@@ -15,6 +16,7 @@ import {
   parseProviderRetryEventMessage,
   type RequestResolution,
   type RuntimeProvider,
+  scanMentionTokens,
   statusReasonFromProviderRetryEvent,
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -66,6 +68,7 @@ import {
   sendFileMessageBatch,
 } from "../../../api/chats.js";
 import { getImage, putImage } from "../../../api/image-store.js";
+import { addMeChatParticipants } from "../../../api/me-chats.js";
 import { cacheMessages, getCachedMessages } from "../../../api/message-store.js";
 import { getReadState, type ReadState, setReadState } from "../../../api/read-state-store.js";
 import {
@@ -97,6 +100,7 @@ import {
 import { WorkingTurn } from "../../../components/chat/working-turn.js";
 import { HistoryGapBanner } from "../../../components/history-gap-banner.js";
 import {
+  detectMentionTrigger,
   MentionAutocompletePopover,
   type MentionCandidate,
   useMentionAutocomplete,
@@ -126,7 +130,8 @@ import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-nam
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { useChatDraftText } from "../../../lib/use-chat-draft-text.js";
 import { useClientMap } from "../../../lib/use-client-map.js";
-import { useOrgAgents } from "../../../lib/use-org-agents.js";
+import { useDebouncedValue } from "../../../lib/use-debounced-value.js";
+import { useOrgAgents, useOrgAgentsSearch } from "../../../lib/use-org-agents.js";
 import { usePendingImages } from "../../../lib/use-pending-images.js";
 import { cn } from "../../../lib/utils.js";
 import { selectVisibleMessages } from "../../../utils/agent-final-text-filter.js";
@@ -1429,6 +1434,8 @@ export function ChatView({
   // `askError` surfaces a send failure IN the card (the composer is covered).
   const [askBusy, setAskBusy] = useState(false);
   const [askError, setAskError] = useState<string | null>(null);
+  const [askMentionQuery, setAskMentionQuery] = useState<string | null>(null);
+  const [askMentionText, setAskMentionText] = useState("");
   const { pendingImages, addImages, removeImage, clearImages } = usePendingImages({
     onError: setUploadError,
     // Dismiss a stale upload error (e.g. "image too large") the moment the
@@ -1722,15 +1729,22 @@ export function ChatView({
 
   /** Org-wide agent list, consumed by `managedByMeMap` for picker
    *  grouping and by the identity-map hooks (`useAgentIdentityMap` etc.)
-   *  that drive chip / avatar rendering. The `@` autocomplete is
-   *  membership-scoped (`mentionCandidates` below) and does NOT read
-   *  from this list — inviting a new agent goes through the `[+]`
-   *  button, which owns its own server-search via `useOrgAgentsSearch`
-   *  (issue 494) and is therefore not capped at the 100-row first page.
+   *  that drive chip / avatar rendering. The composer `@` autocomplete
+   *  uses a separate addressable search below so unjoined agents can be
+   *  invited by mention without being capped at the 100-row first page.
    *
    *  Shared single React Query cache, one HTTP fetch per refetch tick.
    *  See issue 495. */
   const { data: orgAgentsPage } = useOrgAgents();
+
+  const activeMentionTrigger = useMemo(() => detectMentionTrigger(draft, cursor), [draft, cursor]);
+  const activeMentionSurface = askMentionQuery !== null || activeMentionTrigger !== null;
+  const activeMentionQuery = askMentionQuery ?? activeMentionTrigger?.query ?? "";
+  const debouncedMentionQuery = useDebouncedValue(activeMentionQuery ?? "", 200);
+  const { data: mentionAgentsPage } = useOrgAgentsSearch(debouncedMentionQuery, {
+    addressableOnly: true,
+    enabled: activeMentionSurface && !readOnly,
+  });
 
   /**
    * Optimistic-update helpers for the messages cache. Wrap setQueryData so
@@ -1997,6 +2011,13 @@ export function ChatView({
     // by the target human's answer in the AskTakeover (an agent cannot resolve).
     const threadedRequestId = findThreadableRequestId(mergedMessages, myAgentId, routedMentions) ?? undefined;
 
+    try {
+      await ensureMentionedAgentsInvited(routedMentions);
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : "Failed to invite mentioned agents");
+      return;
+    }
+
     if (images.length > 0) {
       setUploading(true);
       setUploadError(null);
@@ -2165,6 +2186,7 @@ export function ChatView({
     const routedMentions = [...new Set([request.senderId, ...answer.mentions])];
     const resolves: RequestResolution = { request: request.id, kind: "answered" };
     try {
+      await ensureMentionedAgentsInvited(routedMentions);
       if (answer.images.length > 0) {
         const refs: ImageRefContent[] = [];
         for (const file of answer.images) {
@@ -3069,16 +3091,21 @@ export function ChatView({
     return m;
   }, [orgAgentsPage?.items, myMemberId]);
 
-  // Mention autocomplete candidates: strictly the agents currently in
-  // THIS chat (minus self). Driving the `@` popover and `extractMentions`
-  // off membership — instead of org-wide discovery — keeps the picker
-  // focused on the people who'll actually receive the message. To pull
-  // a new agent into the conversation, use the ParticipantsHeader `[+]`
-  // button (`AddParticipantDropdown` — owns its own search). Any
-  // participant without a slug (`name`) is skipped — mentions need one.
-  // Private agents in the chat surface here because membership, not
-  // discovery, is the source of truth.
-  const mentionCandidates = useMemo<MentionCandidate[]>(() => {
+  const chatParticipantIdSet = useMemo(
+    () => new Set((chatDetail?.participants ?? []).map((p) => p.agentId)),
+    [chatDetail?.participants],
+  );
+  const activeMentionTokenSet = useMemo(() => {
+    const tokens = new Set(scanMentionTokens(draft));
+    for (const token of scanMentionTokens(askMentionText)) tokens.add(token);
+    return tokens;
+  }, [draft, askMentionText]);
+
+  // In-chat mention candidates: agents currently in THIS chat (minus
+  // self). This stays the authoritative source for rendering historical
+  // mention chips, because chat membership is the scoped disclosure
+  // boundary for private agents and message rendering.
+  const inChatMentionCandidates = useMemo<MentionCandidate[]>(() => {
     const out: MentionCandidate[] = [];
     for (const p of chatDetail?.participants ?? []) {
       if (p.agentId === myAgentId) continue;
@@ -3088,18 +3115,104 @@ export function ChatView({
         agentId: p.agentId,
         name: ident.name,
         displayName: ident.displayName,
+        inChat: true,
         managedByMe: managedByMeMap.get(p.agentId) ?? false,
       });
     }
     return out;
   }, [chatDetail?.participants, chatScopedAgentIdentity, myAgentId, managedByMeMap]);
 
-  // The `[+]` participant picker (chat header + right-sidebar) owns its
-  // search input and fetches candidates directly via
-  // `useOrgAgentsSearch`, so this view no longer composes a union of
-  // chat participants + org-list for it. Pre-issue 494 the picker
-  // sourced an in-memory list capped at 100 rows; the server-side search
-  // model bypasses that cap, which is the whole point of issue 494.
+  const toInviteableMentionCandidate = useCallback(
+    (a: Agent): MentionCandidate | null => {
+      if (a.status === "suspended") return null;
+      if (myAgentId && a.uuid === myAgentId) return null;
+      if (chatParticipantIdSet.has(a.uuid)) return null;
+      if (!a.name) return null;
+      return {
+        agentId: a.uuid,
+        name: a.name,
+        displayName: a.displayName,
+        inChat: false,
+        managedByMe: Boolean(myMemberId && a.managerId === myMemberId),
+      };
+    },
+    [chatParticipantIdSet, myAgentId, myMemberId],
+  );
+
+  const [retainedInviteableMentionCandidates, setRetainedInviteableMentionCandidates] = useState<MentionCandidate[]>(
+    [],
+  );
+
+  const retainInviteableMentionCandidate = useCallback(
+    (candidate: MentionCandidate) => {
+      if (candidate.inChat !== false || chatParticipantIdSet.has(candidate.agentId)) return;
+      setRetainedInviteableMentionCandidates((prev) => {
+        const nextById = new Map(prev.map((c) => [c.agentId, c]));
+        nextById.set(candidate.agentId, candidate);
+        return [...nextById.values()];
+      });
+    },
+    [chatParticipantIdSet],
+  );
+
+  useEffect(() => {
+    setRetainedInviteableMentionCandidates((prev) => {
+      const nextById = new Map<string, MentionCandidate>();
+      for (const c of prev) {
+        if (!c.name) continue;
+        if (chatParticipantIdSet.has(c.agentId)) continue;
+        if (activeMentionTokenSet.has(c.name.toLowerCase())) nextById.set(c.agentId, c);
+      }
+      for (const a of mentionAgentsPage?.items ?? []) {
+        const c = toInviteableMentionCandidate(a);
+        if (!c?.name) continue;
+        if (activeMentionTokenSet.has(c.name.toLowerCase())) nextById.set(c.agentId, c);
+      }
+      const next = [...nextById.values()];
+      if (
+        next.length === prev.length &&
+        next.every((candidate, index) => {
+          const old = prev[index];
+          return (
+            old?.agentId === candidate.agentId &&
+            old.name === candidate.name &&
+            old.displayName === candidate.displayName &&
+            old.managedByMe === candidate.managedByMe
+          );
+        })
+      ) {
+        return prev;
+      }
+      return next;
+    });
+  }, [chatParticipantIdSet, activeMentionTokenSet, mentionAgentsPage?.items, toInviteableMentionCandidate]);
+
+  // Inviteable mention candidates: visible/addressable org agents that
+  // are not yet speakers in this chat. Picking one inserts the same
+  // `@name` literal as an in-chat mention; handleSend invites them before
+  // delivering the message so the server's speaker-only routing contract
+  // remains intact.
+  const inviteableMentionCandidates = useMemo<MentionCandidate[]>(() => {
+    const byId = new Map<string, MentionCandidate>();
+    for (const a of mentionAgentsPage?.items ?? []) {
+      const c = toInviteableMentionCandidate(a);
+      if (c) byId.set(c.agentId, c);
+    }
+    for (const c of retainedInviteableMentionCandidates) {
+      if (!chatParticipantIdSet.has(c.agentId)) byId.set(c.agentId, c);
+    }
+    return [...byId.values()];
+  }, [
+    chatParticipantIdSet,
+    mentionAgentsPage?.items,
+    retainedInviteableMentionCandidates,
+    toInviteableMentionCandidate,
+  ]);
+
+  const mentionCandidates = useMemo<MentionCandidate[]>(
+    () => [...inChatMentionCandidates, ...inviteableMentionCandidates],
+    [inChatMentionCandidates, inviteableMentionCandidates],
+  );
 
   /**
    * "Needs explicit @mention" guard: a real group (3+ speakers), OR a 1-on-1
@@ -3193,24 +3306,23 @@ export function ChatView({
     [mentionCandidates],
   );
   // Rendered-message variant of the projection above: the rehype plugin
-  // resolves `@<name>` tokens against this list, and it MUST include the
-  // viewer themselves so chips that target them flip to the
-  // `.mention-chip.is-self` attention tone. `mentionCandidates` deliberately
-  // excludes self (the composer's `@` autocomplete should not suggest you
-  // `@` yourself, and `draftMentions` / `MentionHighlightOverlay` keep
-  // that self-exclusive semantics), so we append the viewer here in a
-  // separate projection used only by rendered messages. Source the viewer's
-  // slug from the speaker-only `chatParticipantById` map — NOT from the
-  // org-identity fallback in `chatScopedAgentIdentity` — so a non-speaker
-  // watcher viewing the chat doesn't get their org-wide name pushed into
-  // the resolver, which would paint chips that the server would never
+  // resolves `@<name>` tokens only against in-chat membership, and it MUST
+  // include the viewer themselves so chips that target them flip to the
+  // `.mention-chip.is-self` attention tone. `mentionCandidates` now also
+  // includes inviteable org agents for the composer, so rendering derives
+  // from `inChatMentionCandidates` instead. Source the viewer's slug from
+  // the speaker-only `chatParticipantById` map — NOT from the org-identity
+  // fallback in `chatScopedAgentIdentity` — so a non-speaker watcher
+  // viewing the chat doesn't get their org-wide name pushed into the
+  // resolver, which would paint chips that the server would never
   // actually route to them.
   const renderMentionParticipants = useMemo<MentionParticipant[]>(() => {
-    if (!myAgentId) return mentionParticipants;
+    const inChatParticipants = inChatMentionCandidates.map((c) => ({ agentId: c.agentId, name: c.name }));
+    if (!myAgentId) return inChatParticipants;
     const selfParticipant = chatParticipantById.get(myAgentId);
-    if (!selfParticipant?.name) return mentionParticipants;
-    return [...mentionParticipants, { agentId: myAgentId, name: selfParticipant.name }];
-  }, [mentionParticipants, myAgentId, chatParticipantById]);
+    if (!selfParticipant?.name) return inChatParticipants;
+    return [...inChatParticipants, { agentId: myAgentId, name: selfParticipant.name }];
+  }, [inChatMentionCandidates, myAgentId, chatParticipantById]);
   const draftMentions = useMemo(() => extractMentions(draft, mentionParticipants), [draft, mentionParticipants]);
 
   /**
@@ -3239,6 +3351,16 @@ export function ChatView({
   const effectiveSendMentions = useMemo(
     () => (peerAgentId ? [...new Set([...draftMentions, peerAgentId])] : draftMentions),
     [draftMentions, peerAgentId],
+  );
+
+  const ensureMentionedAgentsInvited = useCallback(
+    async (mentions: string[]): Promise<void> => {
+      const missingParticipantIds = [...new Set(mentions)].filter((id) => !chatParticipantIdSet.has(id));
+      if (missingParticipantIds.length === 0) return;
+      await addMeChatParticipants(chatId, { participantIds: missingParticipantIds });
+      void queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] });
+    },
+    [chatId, chatParticipantIdSet, queryClient],
   );
 
   // Group-chat mention gate, shared by the send button (dimming / title) and
@@ -3270,8 +3392,9 @@ export function ChatView({
     cursor,
     candidates: mentionCandidates,
     disabled: landingCampaignChatLocked || sendMut.isPending || uploading,
-    onSelect: (update) => {
+    onSelect: (update, picked) => {
       autoPrimedDraftRef.current = false;
+      retainInviteableMentionCandidate(picked);
       setDraft(update.text);
       setCursor(update.cursor);
       // Defer so React has committed the new value before we move the
@@ -3407,6 +3530,9 @@ export function ChatView({
                 error={askError ?? undefined}
                 mentionCandidates={mentionCandidates}
                 isTrial={isTrial}
+                onMentionQueryChange={setAskMentionQuery}
+                onMentionTextChange={setAskMentionText}
+                onMentionSelect={retainInviteableMentionCandidate}
                 onReply={(answer) => {
                   void submitAskAnswer(dockRequest, answer);
                 }}


### PR DESCRIPTION
## Summary

- Expands the existing chat composer `@` picker to include current chat participants plus visible/addressable org agents that are not yet in the chat.
- Keeps joined agents above inviteable agents with a divider between the two groups.
- Invites mentioned non-participants before sending text messages, image batches, or blocking-ask answers so the server's speaker-only routing contract still holds.
- Keeps historical message rendering scoped to chat membership so org-wide candidates do not change old `@name` rendering.

## Validation

- `pnpm --filter @first-tree/web exec vitest run src/components/__tests__/mention-autocomplete.test.ts src/pages/workspace/center/__tests__/chat-view-dom.test.tsx`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check packages/web/src/components/mention-autocomplete.tsx packages/web/src/components/__tests__/mention-autocomplete.test.ts packages/web/src/lib/use-org-agents.ts packages/web/src/pages/workspace/center/chat-view.tsx packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx`

## Notes

Full-repo `pnpm check` is currently blocked by pre-existing unrelated lint findings outside this change set; the changed files pass Biome.
