### PR TITLE
test: expand client and web coverage

### DIFF
--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -177,6 +177,23 @@ describe("probeClaudeCodeCapability (install-only)", () => {
     expect(entry.error).toContain("not found in any parent node_modules");
   });
 
+  it("prefixes a bad CLAUDE_CODE_EXECUTABLE override when no fallback binary resolves", async () => {
+    const entry = await probeClaudeCodeCapability({
+      resolveExecutable: () => ({
+        path: undefined,
+        source: "default",
+        overrideError: "CLAUDE_CODE_EXECUTABLE points at a non-executable file",
+      }),
+      resolveBundled: () => {
+        throw new Error("SDK bundle missing");
+      },
+      exists: () => false,
+    });
+    expect(entry.state).toBe("missing");
+    expect(entry.error).toContain("CLAUDE_CODE_EXECUTABLE points at a non-executable file");
+    expect(entry.error).toContain("SDK bundle missing");
+  });
+
   it("a thrown resolveExecutable becomes state=error (never throws)", async () => {
     const entry = await probeClaudeCodeCapability({
       resolveExecutable: () => {
@@ -255,6 +272,33 @@ describe("resolveBundledClaudeBinary (hermetic — covers the SDK layout change)
       ).toThrow(/no installed Claude native binary|no bundled Claude binary/);
     } finally {
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when a native package resolves but does not contain the expected binary", () => {
+    const root = mkdtempSync(join(tmpdir(), "claude-bundle-"));
+    try {
+      const sdkDir = join(root, "sdk");
+      const nativeDir = join(root, "native-without-binary");
+      mkdirSync(sdkDir);
+      mkdirSync(nativeDir);
+      expect(() =>
+        resolveBundledClaudeBinary({ locateSdkDir: () => sdkDir, resolvePlatformPackageRoot: () => nativeDir }),
+      ).toThrow(/no installed Claude native binary/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("default resolver either reports the host SDK bundle or a descriptive missing-bundle error", () => {
+    try {
+      const res = resolveBundledClaudeBinary();
+      expect(["cli-js", "native"]).toContain(res.kind);
+      expect(res.path).toBeTruthy();
+    } catch (err) {
+      expect(err instanceof Error ? err.message : String(err)).toMatch(
+        /Claude native binary|Claude binary|claude-agent-sdk|no bundled Claude binary/,
+      );
     }
   });
 });
@@ -502,6 +546,21 @@ describe("resolveCodexRuntimeBinary (handler-contract parity)", () => {
       binary: "/usr/local/bin/codex",
       runtimePath: "/usr/local/bin/codex",
       version: "0.140.0",
+    });
+  });
+
+  it("keeps a validated PATH codex available when its version output has no semantic version", async () => {
+    const verifyPath = (): CodexExecutableVerification => ({ ok: true, output: "codex dev build" });
+    const res = await resolveCodexRuntimeBinary(
+      {},
+      { resolveBundled: notFound, findOnPath: () => "/usr/local/bin/codex", verifyPath },
+    );
+    expect(res).toMatchObject({
+      ok: true,
+      runtimeSource: "path",
+      binary: "/usr/local/bin/codex",
+      runtimePath: "/usr/local/bin/codex",
+      version: null,
     });
   });
 

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -117,6 +117,21 @@ function makeMessage(id: string, content: string): SessionMessage {
   };
 }
 
+function makeFileMessage(
+  id: string,
+  content: Record<string, unknown>,
+  chatId = "chat-claude-startup-race",
+): SessionMessage {
+  return {
+    id,
+    chatId,
+    senderId: "sender-1",
+    format: "file",
+    content,
+    metadata: {},
+  };
+}
+
 function makeContext(
   onFinishTurn: (count?: number) => void,
   opts: { formatInboundContent?: SessionContext["formatInboundContent"] } = {},
@@ -174,6 +189,68 @@ afterEach(() => {
 });
 
 describe("claude-code handler startup inject queue", () => {
+  it("materializes legacy inline images and describes unavailable image batches", async () => {
+    const completedCounts: Array<number | undefined> = [];
+    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const ctx = makeContext((count) => {
+      completedCounts.push(count);
+    });
+    state.resolveChatContext?.({
+      chatId: "chat-claude-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    await handler.start(
+      makeFileMessage(
+        "legacy-image",
+        {
+          data: Buffer.from("fake image bytes").toString("base64"),
+          mimeType: "image/png",
+          filename: "legacy.png",
+        },
+        "../unsafe/chat",
+      ),
+      ctx,
+    );
+
+    handler.inject(
+      makeFileMessage("batch-images", {
+        caption: "Compare these screenshots",
+        attachments: [
+          {
+            imageId: "00000000-0000-4000-8000-000000000001",
+            mimeType: "image/png",
+            filename: "one.png",
+            size: 12,
+          },
+          {
+            imageId: "00000000-0000-4000-8000-000000000002",
+            mimeType: "image/jpeg",
+            filename: "two.jpg",
+            size: 34,
+          },
+        ],
+      }),
+    );
+
+    await waitFor(() => state.observedInputs.length === 2);
+    expect(state.observedInputs[0]).toContain("Filename: legacy.png");
+    expect(state.observedInputs[0]).toContain(join("first-tree", "images", "unknown"));
+    expect(state.observedInputs[0]).toContain(".png");
+    expect(state.observedInputs[1]).toContain("Compare these screenshots");
+    expect(state.observedInputs[1]).toContain(
+      "2 images were shared in this chat. Please use the Read tool to read each one",
+    );
+    expect(state.observedInputs[1]).toContain('[Image "one.png" not available on this device]');
+    expect(state.observedInputs[1]).toContain('[Image "two.jpg" not available on this device]');
+    expect(completedCounts).toEqual([undefined, undefined]);
+
+    await handler.shutdown();
+  });
+
   it("queues injects received before the InputController exists so their inbox entries stay aligned with acks", async () => {
     const completedCounts: Array<number | undefined> = [];
     const handler = createClaudeCodeHandler({ workspaceRoot });

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -13,6 +13,8 @@ const state = vi.hoisted(() => ({
   pendingResults: [] as unknown[],
   waiters: [] as Array<() => void>,
   coalesceFirstResultAfterInputs: null as number | null,
+  resultMessagesForInput: null as ((turn: number) => unknown[]) | null,
+  closeAfterInput: false,
 }));
 
 function wakeQuery(): void {
@@ -36,12 +38,20 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
           if (turn < state.coalesceFirstResultAfterInputs) continue;
           state.coalesceFirstResultAfterInputs = null;
         }
-        state.pendingResults.push({
-          type: "result",
-          subtype: "success",
-          result: `reply ${turn}`,
-        });
+        const messages = state.resultMessagesForInput?.(turn) ?? [
+          {
+            type: "result",
+            subtype: "success",
+            result: `reply ${turn}`,
+          },
+        ];
+        state.pendingResults.push(...messages);
         wakeQuery();
+        if (state.closeAfterInput) {
+          closed = true;
+          wakeQuery();
+          return;
+        }
       }
       closed = true;
       wakeQuery();
@@ -174,6 +184,8 @@ beforeEach(() => {
   state.pendingResults.length = 0;
   state.waiters.length = 0;
   state.coalesceFirstResultAfterInputs = null;
+  state.resultMessagesForInput = null;
+  state.closeAfterInput = false;
   state.chatContextPromise = new Promise((resolve) => {
     state.resolveChatContext = resolve;
   });
@@ -185,6 +197,8 @@ afterEach(() => {
   state.resolveChatContext = null;
   state.pendingResults.length = 0;
   state.coalesceFirstResultAfterInputs = null;
+  state.resultMessagesForInput = null;
+  state.closeAfterInput = false;
   wakeQuery();
 });
 
@@ -403,6 +417,184 @@ describe("claude-code handler startup inject queue", () => {
     expect(state.observedInputs).toHaveLength(1);
     expect(completedCounts).toEqual([undefined]);
     expect(retryTurn).toHaveBeenCalledWith(makeMessage("m2", "bad"), "claude_inject_format_failed");
+
+    await handler.shutdown();
+  });
+
+  it("logs token usage emit failures without blocking successful turn close", async () => {
+    const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
+    const logs: string[] = [];
+    const outcomes: unknown[] = [];
+    state.resultMessagesForInput = () => [
+      {
+        type: "result",
+        subtype: "success",
+        result: "reply with usage",
+        modelUsage: {
+          "claude-sonnet-4-5": {
+            inputTokens: 3,
+            cacheCreationInputTokens: 2,
+            cacheReadInputTokens: 5,
+            outputTokens: 7,
+          },
+          "empty-model": {
+            inputTokens: 0,
+            cacheReadInputTokens: 0,
+            outputTokens: 0,
+          },
+          missing: null,
+        },
+      },
+    ];
+    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const ctx = makeContext(() => {});
+    ctx.log = (message) => {
+      logs.push(message);
+    };
+    ctx.emitEvent = (event) => {
+      events.push(event);
+      if (event.kind === "token_usage") throw new Error("event store down");
+    };
+    ctx.finishTurn = async (_messages, outcome) => {
+      outcomes.push(outcome);
+    };
+    state.resolveChatContext?.({
+      chatId: "chat-claude-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "usage"), ctx);
+
+    await waitFor(() => events.some((event) => event.kind === "turn_end"));
+    expect(events.find((event) => event.kind === "token_usage")).toMatchObject({
+      kind: "token_usage",
+      payload: {
+        provider: "claude-code",
+        model: "claude-sonnet-4-5",
+        inputTokens: 5,
+        cachedInputTokens: 5,
+        outputTokens: 7,
+      },
+    });
+    expect(logs).toContain("Failed to emit token_usage: event store down");
+    expect(events.filter((event) => event.kind === "turn_end")).toEqual([
+      { kind: "turn_end", payload: { status: "success" } },
+    ]);
+    expect(outcomes).toEqual([{ status: "success", terminal: true }]);
+
+    await handler.shutdown();
+  });
+
+  it("reports forwardResult failures as terminal runtime turn errors", async () => {
+    const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
+    const logs: string[] = [];
+    const outcomes: unknown[] = [];
+    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const ctx = makeContext(() => {});
+    ctx.forwardResult = vi.fn(async () => {
+      throw new Error("completion sink down");
+    });
+    ctx.log = (message) => {
+      logs.push(message);
+    };
+    ctx.emitEvent = (event) => {
+      events.push(event);
+    };
+    ctx.finishTurn = async (_messages, outcome) => {
+      outcomes.push(outcome);
+    };
+    state.resolveChatContext?.({
+      chatId: "chat-claude-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "forward"), ctx);
+
+    await waitFor(() => events.some((event) => event.kind === "turn_end"));
+    expect(ctx.forwardResult).toHaveBeenCalledWith("reply 1");
+    expect(logs).toContain("Failed to forward result: completion sink down");
+    expect(events).toContainEqual({
+      kind: "error",
+      payload: {
+        source: "runtime",
+        message: "Result forward failed: completion sink down\n---\nreply 1",
+      },
+    });
+    expect(events).toContainEqual({ kind: "turn_end", payload: { status: "error" } });
+    expect(outcomes).toEqual([
+      {
+        status: "error",
+        terminal: true,
+        completion: "consumed",
+        reason: "forward_failed",
+      },
+    ]);
+
+    await handler.shutdown();
+  });
+
+  it("closes successful turns when the SDK result has no result text", async () => {
+    const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
+    const outcomes: unknown[] = [];
+    state.resultMessagesForInput = () => [{ type: "result", subtype: "success" }];
+    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const ctx = makeContext(() => {});
+    ctx.forwardResult = vi.fn(async () => {});
+    ctx.emitEvent = (event) => {
+      events.push(event);
+    };
+    ctx.finishTurn = async (_messages, outcome) => {
+      outcomes.push(outcome);
+    };
+    state.resolveChatContext?.({
+      chatId: "chat-claude-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "empty result"), ctx);
+
+    await waitFor(() => events.some((event) => event.kind === "turn_end"));
+    expect(ctx.forwardResult).not.toHaveBeenCalled();
+    expect(events).toContainEqual({ kind: "turn_end", payload: { status: "success" } });
+    expect(outcomes).toEqual([{ status: "success", terminal: true }]);
+
+    await handler.shutdown();
+  });
+
+  it("flushes deferred auth hints when the stream closes before a result", async () => {
+    const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
+    state.resultMessagesForInput = () => [{ type: "auth_status", error: "authentication_failed" }];
+    state.closeAfterInput = true;
+    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const ctx = makeContext(() => {});
+    ctx.emitEvent = (event) => {
+      events.push(event);
+    };
+    state.resolveChatContext?.({
+      chatId: "chat-claude-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "auth"), ctx);
+
+    await waitFor(() => events.some((event) => event.kind === "error"));
+    const errorEvent = events.find((event) => event.kind === "error");
+    if (errorEvent?.kind !== "error") throw new Error("expected sdk error event");
+    expect(errorEvent.payload.source).toBe("sdk");
+    expect(errorEvent.payload.message).toContain("`claude auth login`");
+    expect(errorEvent.payload.message).toContain("Original SDK error: authentication_failed");
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/claude-code-tui-path.test.ts
+++ b/packages/client/src/__tests__/claude-code-tui-path.test.ts
@@ -1,0 +1,39 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { tmuxOnPath } from "../runtime/capabilities/claude-code-tui.js";
+
+describe("tmuxOnPath", () => {
+  let tmpBase: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "ft-tmux-path-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("finds an executable tmux binary on PATH", () => {
+    const binDir = join(tmpBase, "bin");
+    mkdirSync(binDir);
+    const binary = join(binDir, process.platform === "win32" ? "tmux.exe" : "tmux");
+    writeFileSync(binary, "#!/bin/sh\n");
+    if (process.platform !== "win32") chmodSync(binary, 0o755);
+
+    expect(tmuxOnPath({ PATH: `${binDir}${delimiter}` })).toBe(true);
+  });
+
+  it("rejects missing, empty, and non-executable tmux PATH entries", () => {
+    const emptyDir = join(tmpBase, "empty");
+    const directoryCandidate = join(tmpBase, "dir-candidate");
+    mkdirSync(emptyDir);
+    mkdirSync(directoryCandidate);
+    mkdirSync(join(directoryCandidate, process.platform === "win32" ? "tmux.exe" : "tmux"));
+
+    expect(tmuxOnPath({})).toBe(false);
+    expect(tmuxOnPath({ PATH: "" })).toBe(false);
+    expect(tmuxOnPath({ PATH: `${emptyDir}${delimiter}${directoryCandidate}` })).toBe(false);
+  });
+});

--- a/packages/client/src/__tests__/client-connection-more-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-more-coverage.test.ts
@@ -1,0 +1,416 @@
+import { EventEmitter } from "node:events";
+import type { ClientPausedReason, SessionEvent } from "@first-tree/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BoundAgent } from "../client-connection.js";
+
+type ClientConnectionModule = typeof import("../client-connection.js");
+type ClientConnectionInstance = InstanceType<ClientConnectionModule["ClientConnection"]>;
+type ClientConnectionConfig = ConstructorParameters<ClientConnectionModule["ClientConnection"]>[0];
+
+type PendingBind = {
+  agentId: string;
+  runtimeType: string;
+  runtimeVersion?: string;
+  resolve: (agent: BoundAgent) => void;
+  reject: (err: Error) => void;
+};
+
+type BindRetryRecord = {
+  attempts: number;
+  nextAllowedAt: number;
+  lastReason: string | null;
+};
+
+type ClientConnectionPrivate = {
+  ws: FakeWebSocket | null;
+  closing: boolean;
+  registered: boolean;
+  pausedReason: ClientPausedReason | null;
+  authRefreshTimer: ReturnType<typeof setTimeout> | null;
+  desiredBindings: Map<string, { agentId: string; runtimeType: string; runtimeVersion?: string }>;
+  boundAgents: Map<string, BoundAgent>;
+  bindRetryRecords: Map<string, BindRetryRecord>;
+  pendingBinds: Map<string, PendingBind>;
+  openWebSocket(): Promise<void>;
+  handleMessage(msg: Record<string, unknown>, connectResolve?: () => void): void;
+  sendBind(agentId: string, runtimeType: string, runtimeVersion?: string): Promise<BoundAgent>;
+  rebindAgents(): void;
+  runProactiveAuthRefresh(): Promise<void>;
+  clearTimers(): void;
+};
+
+type FakeWebSocketOptions = {
+  headers?: Record<string, string>;
+};
+
+class FakeWebSocket extends EventEmitter {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readonly url: string;
+  readonly options?: FakeWebSocketOptions;
+  readyState = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+  closeCalls: Array<{ code?: number; reason?: string }> = [];
+  terminate = vi.fn(() => {
+    this.readyState = FakeWebSocket.CLOSED;
+  });
+  ping = vi.fn();
+
+  constructor(url: string, options?: FakeWebSocketOptions) {
+    super();
+    this.url = url;
+    this.options = options;
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(raw: string): void {
+    this.sent.push(raw);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.closeCalls.push({ code, reason });
+    this.emit("close", code ?? 1000);
+  }
+
+  removeAllListeners(eventName?: string | symbol): this {
+    super.removeAllListeners(eventName);
+    return this;
+  }
+
+  emitOpen(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.emit("open");
+  }
+
+  emitMessage(frame: string | Record<string, unknown>): void {
+    this.emit("message", typeof frame === "string" ? frame : JSON.stringify(frame));
+  }
+
+  emitPong(): void {
+    this.emit("pong");
+  }
+}
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
+function priv(connection: ClientConnectionInstance): ClientConnectionPrivate {
+  return connection as unknown as ClientConnectionPrivate;
+}
+
+async function loadClientConnection(): Promise<ClientConnectionModule> {
+  vi.resetModules();
+  FakeWebSocket.instances = [];
+  vi.doMock("ws", () => ({ default: FakeWebSocket }));
+  return import("../client-connection.js");
+}
+
+async function makeConnection(overrides: Partial<ClientConnectionConfig> = {}): Promise<ClientConnectionInstance> {
+  const { ClientConnection } = await loadClientConnection();
+  return new ClientConnection({
+    serverUrl: "http://ws.test",
+    clientId: "client_more_coverage",
+    getAccessToken: async () => makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+    ...overrides,
+  });
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function parseSent(socket: FakeWebSocket, index: number): Record<string, unknown> {
+  return JSON.parse(socket.sent[index] ?? "{}") as Record<string, unknown>;
+}
+
+async function openRegisteredConnection(
+  connection: ClientConnectionInstance,
+  capabilities: Record<string, boolean> = {},
+): Promise<FakeWebSocket> {
+  const internal = priv(connection);
+  const openPromise = internal.openWebSocket();
+  const socket = FakeWebSocket.instances.at(-1);
+  if (!socket) throw new Error("missing fake socket");
+  socket.emitOpen();
+  await flushMicrotasks();
+  socket.emitMessage({ type: "auth:ok" });
+  socket.emitMessage({
+    type: "server:welcome",
+    serverCommandVersion: "1.0.0",
+    serverTimeMs: Date.now(),
+    capabilities,
+  });
+  socket.emitMessage({ type: "client:registered" });
+  await openPromise;
+  return socket;
+}
+
+async function bindAgent(
+  connection: ClientConnectionInstance,
+  socket: FakeWebSocket,
+  agentId = "agent-1",
+): Promise<BoundAgent> {
+  const bindPromise = priv(connection).sendBind(agentId, "codex");
+  const bindFrame = parseSent(socket, socket.sent.length - 1);
+  socket.emitMessage({
+    type: "agent:bound",
+    ref: bindFrame.ref,
+    agentId,
+    displayName: "Agent One",
+    agentType: "agent",
+    runtimeSessionToken: `runtime-token-${agentId}`,
+  });
+  return bindPromise;
+}
+
+function sessionEvent(message: string): SessionEvent {
+  return { kind: "error", payload: { source: "runtime", message } };
+}
+
+describe("ClientConnection — additional branch coverage", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.doUnmock("ws");
+    vi.resetModules();
+  });
+
+  it("swallows malformed and unknown frames without settling pending confirmations", async () => {
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection, {
+      wsInboxAckConfirm: true,
+      wsSessionEventConfirm: true,
+    });
+    await bindAgent(connection, socket);
+
+    const delivered: unknown[] = [];
+    const commands: unknown[] = [];
+    const pins: unknown[] = [];
+    const runtimeAuthStarts: unknown[] = [];
+    connection.on("inbox:deliver", (agentId, frame) => delivered.push({ agentId, frame }));
+    connection.on("session:command", (command) => commands.push(command));
+    connection.on("agent:pinned", (message) => pins.push(message));
+    connection.on("runtime-auth:start", (command) => runtimeAuthStarts.push(command));
+
+    const eventPromise = connection.reportSessionEventConfirmed("agent-1", "chat-1", sessionEvent("pending"));
+    const eventFrame = parseSent(socket, socket.sent.length - 1);
+    const ackPromise = connection.sendInboxAck(101);
+    const ackFrame = parseSent(socket, socket.sent.length - 1);
+    const recoverPromise = connection.sendInboxRecover("agent-1", "chat-1");
+    const recoverFrame = parseSent(socket, socket.sent.length - 1);
+
+    socket.emitMessage("{not json");
+    socket.emitMessage({ type: "unknown:frame", arbitrary: true });
+    socket.emitMessage({ type: "agent:pinned", agentId: 42 });
+    socket.emitMessage({ type: "runtime-auth:start", provider: "not-a-provider", ref: "bad" });
+    socket.emitMessage({ type: "session:suspend", agentId: "agent-1" });
+    socket.emitMessage({ type: "session:reconcile:result", agentId: "agent-1", staleChatIds: "chat-1" });
+    socket.emitMessage({ type: "session:event:accepted", ref: eventFrame.ref, agentId: "agent-1" });
+    socket.emitMessage({
+      type: "session:event:accepted",
+      ref: eventFrame.ref,
+      agentId: "agent-1",
+      chatId: "other-chat",
+    });
+    socket.emitMessage({ type: "inbox:ack:accepted", entryId: 101, ref: "wrong-ref", disposition: "acked" });
+    socket.emitMessage({
+      type: "inbox:recover:accepted",
+      ref: recoverFrame.ref,
+      agentId: "agent-1",
+      chatId: "other-chat",
+      resetCount: 1,
+    });
+    socket.emitMessage({ type: "inbox:deliver", entryId: "bad", message: { not: "valid" } });
+
+    expect(delivered).toEqual([]);
+    expect(commands).toEqual([]);
+    expect(pins).toEqual([]);
+    expect(runtimeAuthStarts).toEqual([]);
+
+    socket.emitMessage({
+      type: "session:event:accepted",
+      ref: eventFrame.ref,
+      agentId: "agent-1",
+      chatId: "chat-1",
+    });
+    socket.emitMessage({
+      type: "inbox:ack:accepted",
+      entryId: 101,
+      ref: ackFrame.ref,
+      disposition: "acked",
+    });
+    socket.emitMessage({
+      type: "inbox:recover:accepted",
+      ref: recoverFrame.ref,
+      agentId: "agent-1",
+      chatId: "chat-1",
+      resetCount: 2,
+    });
+
+    await expect(eventPromise).resolves.toBeUndefined();
+    await expect(ackPromise).resolves.toBeUndefined();
+    await expect(recoverPromise).resolves.toBeUndefined();
+  });
+
+  it("times out confirmed session events and keeps later rejection frames from double-settling", async () => {
+    vi.useFakeTimers();
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection, { wsSessionEventConfirm: true });
+    await bindAgent(connection, socket);
+
+    const pending = connection.reportSessionEventConfirmed("agent-1", "chat-timeout", sessionEvent("timeout"));
+    const frame = parseSent(socket, socket.sent.length - 1);
+    const rejection = expect(pending).rejects.toThrow("session:event rejected (timeout)");
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    socket.emitMessage({
+      type: "session:event:rejected",
+      ref: frame.ref,
+      agentId: "agent-1",
+      chatId: "chat-timeout",
+      reason: "late_rejection",
+    });
+
+    await rejection;
+  });
+
+  it("rejects agent-scoped recoveries and session events when a rebind is rejected or skipped", async () => {
+    const connection = await makeConnection();
+    const internal = priv(connection);
+    const socket = await openRegisteredConnection(connection, {
+      wsInboxAckConfirm: true,
+      wsSessionEventConfirm: true,
+    });
+    await bindAgent(connection, socket);
+
+    const recovering = connection.sendInboxRecover("agent-1", "chat-recover");
+    const reporting = connection.reportSessionEventConfirmed("agent-1", "chat-report", sessionEvent("reporting"));
+    const rebindPromise = internal.sendBind("agent-1", "codex");
+    const rebindFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "agent:bind:rejected",
+      ref: rebindFrame.ref,
+      reason: "wrong_client",
+    });
+
+    await expect(rebindPromise).rejects.toThrow("wrong_client");
+    await expect(recovering).rejects.toThrow("agent_bind_rejected:wrong_client");
+    await expect(reporting).rejects.toThrow("agent_bind_rejected:wrong_client");
+
+    const skippedRecover = connection.sendInboxRecover("agent-1", "chat-skipped-recover");
+    const skippedEvent = connection.reportSessionEventConfirmed(
+      "agent-1",
+      "chat-skipped-event",
+      sessionEvent("skipped"),
+    );
+    internal.desiredBindings.set("agent-1", { agentId: "agent-1", runtimeType: "codex" });
+    internal.bindRetryRecords.set("agent-1", {
+      attempts: 2,
+      nextAllowedAt: Date.now() + 60_000,
+      lastReason: "bind_wrong_client",
+    });
+    internal.rebindAgents();
+
+    await expect(skippedRecover).rejects.toThrow("agent_rebind_skipped");
+    await expect(skippedEvent).rejects.toThrow("agent_rebind_skipped");
+  });
+
+  it("handles auth and proactive refresh edges without source changes", async () => {
+    const pausedError = new Error("refresh token revoked");
+    pausedError.name = "AuthRefreshFailedError";
+    let tokenCalls = 0;
+    const pausedConnection = await makeConnection({
+      getAccessToken: async () => {
+        tokenCalls += 1;
+        if (tokenCalls === 1) return makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 });
+        throw pausedError;
+      },
+    });
+    const pausedSocket = await openRegisteredConnection(pausedConnection);
+    const paused: ClientPausedReason[] = [];
+    pausedConnection.on("auth:paused", (reason) => paused.push(reason));
+
+    await priv(pausedConnection).runProactiveAuthRefresh();
+
+    expect(pausedConnection.isPaused()).toBe(true);
+    expect(paused).toEqual(["auth_refresh_failed"]);
+    expect(pausedSocket.closeCalls).toEqual([]);
+
+    let genericCalls = 0;
+    const genericConnection = await makeConnection({
+      getAccessToken: async () => {
+        genericCalls += 1;
+        if (genericCalls === 1) return makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 });
+        throw "plain proactive failure";
+      },
+    });
+    const genericSocket = await openRegisteredConnection(genericConnection);
+
+    await priv(genericConnection).runProactiveAuthRefresh();
+
+    expect(genericSocket.closeCalls.at(-1)).toEqual({ code: 1000, reason: "proactive auth refresh" });
+  });
+
+  it("skips proactive timers for malformed, no-exp, and near-expiry tokens", async () => {
+    for (const token of ["not-a-jwt", makeJwt({ sub: "user-1" }), makeJwt({ exp: Math.floor(Date.now() / 1000) })]) {
+      const connection = await makeConnection({ getAccessToken: async () => token });
+      await openRegisteredConnection(connection);
+
+      expect(priv(connection).authRefreshTimer).toBeNull();
+      priv(connection).clearTimers();
+    }
+  });
+
+  it("continues registration when update metadata throws and surfaces socket errors", async () => {
+    const connection = await makeConnection({
+      getLastUpdateAttempt: () => {
+        throw "metadata read failed";
+      },
+    });
+    const errors: string[] = [];
+    connection.on("error", (err) => errors.push(err.message));
+
+    const socket = await openRegisteredConnection(connection);
+    const registerFrame = socket.sent
+      .map((raw) => JSON.parse(raw) as Record<string, unknown>)
+      .find((msg) => {
+        return msg.type === "client:register";
+      });
+    expect(registerFrame).toMatchObject({ type: "client:register", clientId: "client_more_coverage" });
+    expect(registerFrame).not.toHaveProperty("lastUpdateAttempt");
+
+    socket.emit("error", new Error("socket broke"));
+
+    expect(errors).toEqual(["socket broke"]);
+  });
+
+  it("rejects pending binds on error frames and terminates connecting sockets during disconnect", async () => {
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection);
+
+    const bindPromise = priv(connection).sendBind("agent-error", "codex");
+    const bindFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({ type: "error", ref: bindFrame.ref, message: "bind failed remotely" });
+    await expect(bindPromise).rejects.toThrow("bind failed remotely");
+
+    const unhandledErrors: string[] = [];
+    connection.on("error", (err) => unhandledErrors.push(err.message));
+    socket.emitMessage({ type: "error", message: "unscoped server error" });
+    expect(unhandledErrors).toEqual(["unscoped server error"]);
+
+    const connectingConnection = await makeConnection();
+    const connectingSocket = new FakeWebSocket("ws://ws.test/api/v1/agent/ws/client");
+    priv(connectingConnection).ws = connectingSocket;
+    await connectingConnection.disconnect();
+
+    expect(connectingSocket.terminate).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
@@ -230,6 +230,20 @@ function makeDeliveryToken(): DeliveryToken {
   };
 }
 
+function sentMessageResponse() {
+  return {
+    id: "msg-runtime-notice",
+    chatId: "chat-app-server-extra",
+    senderId: AGENT_ID,
+    format: "text",
+    content: "notice",
+    metadata: {},
+    inReplyTo: null,
+    source: "api" as const,
+    createdAt: new Date(0).toISOString(),
+  };
+}
+
 function makeContext(
   opts: {
     emitEvent?: ReturnType<typeof vi.fn<(event: SessionEvent) => void>>;
@@ -682,6 +696,213 @@ describe("codex app-server handler extra branches", () => {
     );
 
     await handler.shutdown();
+  });
+
+  it("posts and consumes usage-limit turns, or retries when the notice cannot be delivered", async () => {
+    const successFake = new FakeAppServerClient();
+    const successToken = makeDeliveryToken();
+    const successHandler = makeHandler(successFake);
+    const successCtx = makeContext();
+    const successSendMessage = vi.fn<SessionContext["sdk"]["sendMessage"]>().mockResolvedValue(sentMessageResponse());
+    successCtx.sdk.sendMessage = successSendMessage;
+
+    const successStart = successHandler.start(makeMessage("m1", "first"), successCtx, successToken);
+    await waitFor(() => successFake.requests.some((request) => request.method === "turn/start"), "usage turn/start");
+    successFake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "failed",
+        error: { message: "usage exhausted", codexErrorInfo: "usageLimitExceeded" },
+        items: [],
+      },
+    });
+    await successStart;
+
+    expect(successSendMessage).toHaveBeenCalledWith(
+      "chat-app-server-extra",
+      expect.objectContaining({
+        source: "api",
+        format: "text",
+        purpose: "agent-final-text",
+        metadata: { runtimeNotice: true },
+      }),
+    );
+    expect(successToken.complete).toHaveBeenCalledWith([makeMessage("m1", "first")], {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "usage_limit_notice_posted",
+    });
+    await successHandler.shutdown();
+
+    const failureFake = new FakeAppServerClient();
+    const failureToken = makeDeliveryToken();
+    const failureHandler = makeHandler(failureFake);
+    const failureCtx = makeContext();
+    failureCtx.sdk.sendMessage = vi.fn<SessionContext["sdk"]["sendMessage"]>(async () => {
+      throw new Error("chat write failed");
+    });
+
+    const failureStart = failureHandler.start(makeMessage("m2", "second"), failureCtx, failureToken);
+    await waitFor(
+      () => failureFake.requests.some((request) => request.method === "turn/start"),
+      "failed notice turn/start",
+    );
+    failureFake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "failed",
+        error: { message: "usage exhausted", codexErrorInfo: "usageLimitExceeded" },
+        items: [],
+      },
+    });
+    await failureStart;
+
+    expect(failureToken.retry).toHaveBeenCalledWith(
+      [makeMessage("m2", "second")],
+      "codex_usage_limit_notice_delivery_failed",
+    );
+    await failureHandler.shutdown();
+  });
+
+  it("consumes a turn when forwarding final text fails", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ emitEvent });
+    ctx.forwardResult = vi.fn(async () => {
+      throw new Error("forward sink failed");
+    });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "forward failure turn/start");
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        error: null,
+        items: [{ type: "agentMessage", id: "agent-1", text: "final answer" }],
+      },
+    });
+    await startPromise;
+
+    expect(emitEvent).toHaveBeenCalledWith({
+      kind: "error",
+      payload: { source: "runtime", message: "forwardResult failed: forward sink failed" },
+    });
+    expect(token.complete).toHaveBeenCalledWith([makeMessage("m1", "first")], {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "forward_failed",
+    });
+    await handler.shutdown();
+  });
+
+  it("retries turn/start responses that do not include a turn id", async () => {
+    const fake = new FakeAppServerClient();
+    fake.responders.set("turn/start", () => ({ turn: { status: "inProgress" } }));
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+
+    await expect(handler.start(makeMessage("m1", "first"), makeContext(), token)).resolves.toEqual({
+      sessionId: "thread-app-server",
+      route: { kind: "owned", mode: "processing" },
+    });
+
+    expect(token.retry).toHaveBeenCalledWith(
+      [makeMessage("m1", "first")],
+      "codex_app_server_turn_start_missing_id_unknown_custody",
+    );
+    expect(fake.shutdownCalls).toBe(1);
+    await handler.shutdown();
+  });
+
+  it("handles failed and interrupted terminal turns without structured errors", async () => {
+    const failedFake = new FakeAppServerClient();
+    const failedToken = makeDeliveryToken();
+    const failedLog = vi.fn<(message: string) => void>();
+    const failedHandler = makeHandler(failedFake);
+    const failedStart = failedHandler.start(makeMessage("m1", "first"), makeContext({ log: failedLog }), failedToken);
+    await waitFor(() => failedFake.requests.some((request) => request.method === "turn/start"), "failed turn/start");
+    failedFake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "failed",
+        error: null,
+        items: [
+          {
+            type: "mcpToolCall",
+            id: "mcp-ok",
+            status: "completed",
+            result: { structuredContent: { answer: 42 } },
+          },
+          { type: "mcpToolCall", id: "mcp-unknown", status: "completed", result: { content: ["raw"] } },
+          { type: "webSearch", id: "web-empty", query: 42 },
+          { type: "plan", id: "plan-empty", text: null },
+          { type: "unknownTool", id: "ignored" },
+        ],
+      },
+    });
+    await failedStart;
+
+    expect(failedToken.complete).toHaveBeenCalledWith([makeMessage("m1", "first")], {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "unsafe_replay",
+    });
+    expect(failedLog.mock.calls.some(([entry]) => entry.includes("consuming provider stop"))).toBe(true);
+    await failedHandler.shutdown();
+
+    const interruptedFake = new FakeAppServerClient();
+    const interruptedToken = makeDeliveryToken();
+    const interruptedHandler = makeHandler(interruptedFake);
+    const interruptedStart = interruptedHandler.start(makeMessage("m2", "second"), makeContext(), interruptedToken);
+    await waitFor(
+      () => interruptedFake.requests.some((request) => request.method === "turn/start"),
+      "interrupted turn/start",
+    );
+    interruptedFake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: { id: "turn-1", status: "interrupted", error: null, items: [] },
+    });
+    await interruptedStart;
+
+    expect(interruptedToken.retry).toHaveBeenCalledWith([makeMessage("m2", "second")], "codex_unknown_failure");
+    await interruptedHandler.shutdown();
+  });
+
+  it("suspends by retrying queued input, interrupting the active turn, and clearing app-server state", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const queuedToken = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "suspend turn/start");
+    handler.inject(makeMessage("m2", "queued"), queuedToken);
+
+    await handler.suspend();
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: { id: "turn-1", status: "interrupted", error: null, items: [] },
+    });
+    await startPromise;
+
+    expect(queuedToken.retry).toHaveBeenCalledWith(makeMessage("m2", "queued"), "codex_suspend_before_terminal");
+    expect(fake.requests.find((request) => request.method === "turn/interrupt")).toMatchObject({
+      method: "turn/interrupt",
+      params: { threadId: "thread-app-server", turnId: "turn-1" },
+      timeoutMs: 2_000,
+    });
+    expect(fake.shutdownCalls).toBe(1);
   });
 
   it("retries queued work, aborts the active turn, and still shuts down when interrupt fails", async () => {

--- a/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
@@ -965,6 +965,176 @@ describe("codex app-server handler extra branches", () => {
     await interruptedHandler.shutdown();
   });
 
+  it("closes the session and retries the accepted prefix when active inject formatting fails", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const injectToken = makeDeliveryToken();
+    const log = vi.fn<(message: string) => void>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({
+      log,
+      formatInboundContent: async (message) => {
+        if (message.id === "m2") throw new Error("format m2 failed");
+        return `body:${message.id}`;
+      },
+    });
+    const first = makeMessage("m1", "first");
+    const second = makeMessage("m2", "second");
+
+    const startPromise = handler.start(first, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "active format turn/start");
+    handler.inject(second, injectToken);
+
+    await waitFor(() => fake.shutdownCalls === 1, "format failure shutdown");
+    await startPromise;
+    expect(token.retry).toHaveBeenCalledWith([first, second], "codex_queued_turn_format_failed");
+    expect(log.mock.calls.some(([entry]) => entry.includes("inject formatInboundContent failed"))).toBe(true);
+    expect(fake.isClosed).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  it("retries post-turn queued input when formatting fails before a new turn starts", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const queuedToken = makeDeliveryToken();
+    const failSessionForRecovery = vi.fn<NonNullable<SessionContext["failSessionForRecovery"]>>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({
+      failSessionForRecovery,
+      formatInboundContent: async (message) => {
+        if (message.id === "m2") throw new Error("queued formatter down");
+        return `body:${message.id}`;
+      },
+    });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "post-turn first start");
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        error: null,
+        items: [{ type: "agentMessage", id: "agent-1", text: "done" }],
+      },
+    });
+    await startPromise;
+
+    const second = makeMessage("m2", "second");
+    handler.inject(second, queuedToken);
+
+    await waitFor(() => vi.mocked(queuedToken.retry).mock.calls.length === 1, "queued formatter retry");
+    expect(queuedToken.retry).toHaveBeenCalledWith(second, "codex_queued_turn_format_failed");
+    expect(failSessionForRecovery).toHaveBeenCalledWith("codex_queued_turn_format_failed", "thread-app-server");
+    expect(fake.shutdownCalls).toBe(1);
+
+    await handler.shutdown();
+  });
+
+  it("retries a turn when the app-server stream ends without a terminal turn payload", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const failSessionForRecovery = vi.fn<NonNullable<SessionContext["failSessionForRecovery"]>>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ emitEvent, failSessionForRecovery });
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "stream-end turn/start");
+    fake.emit("turn/completed", { threadId: "thread-app-server", turnId: "turn-1" });
+    await startPromise;
+
+    expect(emitEvent).toHaveBeenCalledWith({ kind: "turn_end", payload: { status: "error" } });
+    expect(token.retry).toHaveBeenCalledWith([message], "codex_app_server_stream_ended_without_completion");
+    expect(failSessionForRecovery).toHaveBeenCalledWith(
+      "codex_app_server_stream_ended_without_completion",
+      "thread-app-server",
+    );
+
+    await handler.shutdown();
+  });
+
+  it("returns a queued resume route when resume message formatting fails", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const log = vi.fn<(message: string) => void>();
+    const handler = makeHandler(fake);
+    const message = makeMessage("m1", "resume");
+    const ctx = makeContext({
+      log,
+      formatInboundContent: async () => {
+        throw new Error("resume formatter down");
+      },
+    });
+
+    await expect(handler.resume(message, "thread-existing", ctx, token)).resolves.toEqual({
+      sessionId: "thread-existing",
+      route: { kind: "owned", mode: "queued" },
+    });
+
+    expect(fake.requests.some((request) => request.method === "thread/resume")).toBe(true);
+    expect(fake.requests.some((request) => request.method === "turn/start")).toBe(false);
+    expect(token.retry).toHaveBeenCalledWith(message, "codex_app_server_initial_format_failed");
+    expect(log.mock.calls.some(([entry]) => entry.includes("resume formatInboundContent failed"))).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  it("falls nested activeTurnNotSteerable RPC errors back to the next turn", async () => {
+    const fake = new FakeAppServerClient();
+    fake.errors.set(
+      "turn/steer",
+      new CodexAppServerRpcError("turn/steer", {
+        code: -32602,
+        message: "cannot steer this turn",
+        data: { detail: [{ nested: { activeTurnNotSteerable: true } }] },
+      }),
+    );
+    const firstToken = makeDeliveryToken();
+    const secondToken = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+    const first = makeMessage("m1", "first");
+    const second = makeMessage("m2", "second");
+
+    const startPromise = handler.start(first, ctx, firstToken);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "nested steer first start");
+    handler.inject(second, secondToken);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"), "nested steer attempt");
+
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        error: null,
+        items: [{ type: "agentMessage", id: "agent-1", text: "first done" }],
+      },
+    });
+    await startPromise;
+    await waitFor(
+      () => fake.requests.filter((request) => request.method === "turn/start").length === 2,
+      "fallback second turn",
+    );
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-2",
+        status: "completed",
+        error: null,
+        items: [{ type: "agentMessage", id: "agent-2", text: "second done" }],
+      },
+    });
+
+    await waitFor(() => vi.mocked(secondToken.complete).mock.calls.length === 1, "fallback second complete");
+    expect(firstToken.complete).toHaveBeenCalledWith([first], { status: "success", terminal: true });
+    expect(secondToken.complete).toHaveBeenCalledWith([second], { status: "success", terminal: true });
+
+    await handler.shutdown();
+  });
+
   it("suspends by retrying queued input, interrupting the active turn, and clearing app-server state", async () => {
     const fake = new FakeAppServerClient();
     const token = makeDeliveryToken();

--- a/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
@@ -1,0 +1,720 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { PassThrough } from "node:stream";
+import type { SessionEvent } from "@first-tree/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CodexAppServerClient,
+  type CodexAppServerClientOptions,
+  CodexAppServerRpcError,
+  CodexAppServerTransportError,
+  isCodexAppServerTransientError,
+} from "../handlers/codex/app-server/client.js";
+import { CodexAppServerStartupError, createCodexAppServerHandler } from "../handlers/codex/app-server/index.js";
+import {
+  buildWorkspaceOnlyAppServerEnvironment,
+  buildWorkspaceOnlyBubblewrapArgs,
+  createWorkspaceOnlySpawnProcess,
+  landingCodexDenyPaths,
+} from "../handlers/codex/app-server/workspace-sandbox.js";
+import { setCliBinding } from "../runtime/cli-binding.js";
+import type { DeliveryToken, SessionContext, SessionMessage } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+vi.mock("../runtime/bootstrap.js", () => ({
+  FIRST_TREE_RUNTIME_DIR: ".first-tree-workspace",
+  FIRST_TREE_WORKSPACE_MARKER: ".first-tree-workspace",
+  IDENTITY_JSON_REL: join(".first-tree-workspace", "identity.json"),
+  bootstrapWorkspace: vi.fn(),
+  deepEqualIdentity: vi.fn(() => true),
+  ensureWorkspaceRuntimeDir: vi.fn((workspacePath: string) => {
+    const dir = join(workspacePath, ".first-tree-workspace");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }),
+  installCoreSkills: vi.fn(),
+  installFirstTreeIntegration: vi.fn(() => true),
+  isHubWorktreeMarker: vi.fn(() => false),
+  readCachedBundledCliVersion: vi.fn(() => null),
+  readCachedContextTreeHead: vi.fn(() => null),
+  readContextTreeHead: vi.fn(() => null),
+  resolveBundledCliVersion: vi.fn(() => "0.0.0-test"),
+  writeAgentBriefing: vi.fn(),
+  writeBundledCliVersion: vi.fn(),
+  writeContextTreeHead: vi.fn(),
+}));
+
+vi.mock("../runtime/chat-context.js", () => ({
+  fetchChatContext: vi.fn(async () => ({
+    chatId: "chat-app-server-extra",
+    title: "extra app-server coverage",
+    topic: null,
+    description: null,
+    participants: [],
+  })),
+}));
+
+const AGENT_ID = "019e71c9-88d2-70be-be67-fdb033b2ef0b";
+const RESPONSE_OK_TIMEOUT_MS = 2_000;
+
+type JsonRecord = Record<string, unknown>;
+type RequestRecord = {
+  method: string;
+  params: unknown;
+  timeoutMs?: number;
+};
+type NotificationHandler = (notification: { method: string; params?: unknown }) => void;
+type CloseHandler = (error: CodexAppServerTransportError) => void;
+type RequestResponder = (params: unknown, timeoutMs?: number) => unknown | Promise<unknown>;
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : null;
+}
+
+function makeChild(exitOnSignals: readonly NodeJS.Signals[] = ["SIGTERM"]) {
+  const child = new EventEmitter() as ChildProcessWithoutNullStreams & {
+    killed: boolean;
+    kill: ReturnType<typeof vi.fn<(signal?: NodeJS.Signals | number) => boolean>>;
+  };
+  const signals: Array<NodeJS.Signals | number | undefined> = [];
+  const writes: string[] = [];
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough();
+
+  stdin.on("data", (chunk: Buffer | string) => {
+    writes.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+  });
+
+  child.stdin = stdin as ChildProcessWithoutNullStreams["stdin"];
+  child.stdout = stdout as ChildProcessWithoutNullStreams["stdout"];
+  child.stderr = stderr as ChildProcessWithoutNullStreams["stderr"];
+  child.killed = false;
+  child.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+    signals.push(signal);
+    child.killed = true;
+    if (typeof signal === "string" && exitOnSignals.includes(signal)) {
+      setImmediate(() => child.emit("exit", null, signal));
+    }
+    return true;
+  });
+
+  return { child, signals, stderr, stdout, writes };
+}
+
+function writtenMessages(writes: readonly string[]): JsonRecord[] {
+  return writes
+    .join("")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => asRecord(JSON.parse(line)))
+    .filter((record): record is JsonRecord => record !== null);
+}
+
+async function waitFor(assertion: () => boolean, label = "assertion"): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!assertion()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${label}`);
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function startInitializedClient(options: Partial<CodexAppServerClientOptions> = {}): Promise<
+  {
+    client: CodexAppServerClient;
+  } & ReturnType<typeof makeChild>
+> {
+  const childState = makeChild();
+  const startPromise = CodexAppServerClient.start({
+    binary: "/tmp/fake-codex",
+    requestTimeoutMs: RESPONSE_OK_TIMEOUT_MS,
+    spawnProcess: () => childState.child,
+    ...options,
+  });
+  await waitFor(
+    () => writtenMessages(childState.writes).some((message) => message.method === "initialize"),
+    "initialize request",
+  );
+  childState.stdout.write(`${JSON.stringify({ id: 1, result: { ok: true } })}\n`);
+  const client = await startPromise;
+  return { client, ...childState };
+}
+
+class FakeAppServerClient {
+  readonly requests: RequestRecord[] = [];
+  readonly responders = new Map<string, RequestResponder>();
+  readonly errors = new Map<string, Error>();
+  stderr = "";
+  isClosed = false;
+  shutdownCalls = 0;
+  onNotification: NotificationHandler | null = null;
+  onClose: CloseHandler | null = null;
+  threadStartResult: unknown = { thread: { id: "thread-app-server" } };
+  turnCounter = 0;
+
+  async request(method: string, params?: unknown, timeoutMs?: number): Promise<unknown> {
+    this.requests.push({ method, params, ...(timeoutMs === undefined ? {} : { timeoutMs }) });
+    const responder = this.responders.get(method);
+    if (responder) return responder(params, timeoutMs);
+    const error = this.errors.get(method);
+    if (error) throw error;
+    if (method === "thread/start") return this.threadStartResult;
+    if (method === "thread/resume") return { thread: { id: "thread-app-server" } };
+    if (method === "turn/start") {
+      this.turnCounter += 1;
+      return {
+        turn: {
+          id: `turn-${this.turnCounter}`,
+          status: "inProgress",
+          items: [],
+          error: null,
+        },
+      };
+    }
+    if (method === "turn/steer") return { turnId: `turn-${this.turnCounter}` };
+    if (method === "turn/interrupt") return {};
+    return {};
+  }
+
+  notify(): void {}
+
+  shutdown(): void {
+    this.shutdownCalls += 1;
+    this.isClosed = true;
+  }
+
+  emit(method: string, params?: unknown): void {
+    this.onNotification?.({ method, params });
+  }
+
+  close(message = "app-server died"): void {
+    this.onClose?.(new CodexAppServerTransportError(message));
+  }
+}
+
+let workspaceRoot: string;
+const extraTempRoots: string[] = [];
+
+function makeOutsideTempRoot(prefix: string): string {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  extraTempRoots.push(root);
+  return root;
+}
+
+function makeMessage(id: string, content: string, inboxEntryId?: number): SessionMessage {
+  return {
+    ...(inboxEntryId === undefined ? {} : { inboxEntryId }),
+    id,
+    chatId: "chat-app-server-extra",
+    senderId: "sender-1",
+    format: "text",
+    content,
+    metadata: {},
+  };
+}
+
+function makeDeliveryToken(): DeliveryToken {
+  return {
+    processingStarted: vi.fn<DeliveryToken["processingStarted"]>(),
+    complete: vi.fn<DeliveryToken["complete"]>().mockResolvedValue(undefined),
+    retry: vi.fn<DeliveryToken["retry"]>(),
+    terminalRejected: vi.fn<DeliveryToken["terminalRejected"]>().mockResolvedValue(undefined),
+  };
+}
+
+function makeContext(
+  opts: {
+    emitEvent?: ReturnType<typeof vi.fn<(event: SessionEvent) => void>>;
+    failSessionForRecovery?: NonNullable<SessionContext["failSessionForRecovery"]>;
+    formatInboundContent?: SessionContext["formatInboundContent"];
+    log?: ReturnType<typeof vi.fn<(message: string) => void>>;
+  } = {},
+): SessionContext {
+  const sendMessage = vi
+    .fn<(chatId: string, body: Record<string, unknown>) => Promise<unknown>>()
+    .mockResolvedValue(undefined);
+  const createAgentOutboxToken = vi
+    .fn<(chatId: string) => Promise<{ accessToken: string; expiresIn: number }>>()
+    .mockResolvedValue({ accessToken: "scoped-outbox-token", expiresIn: 900 });
+
+  return {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: `inbox_${AGENT_ID}`,
+      displayName: "codex-assistant",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage, createAgentOutboxToken } as unknown as SessionContext["sdk"],
+    chatId: "chat-app-server-extra",
+    log: opts.log ?? (() => {}),
+    recordProviderActivity: () => {},
+    emitEvent: opts.emitEvent ?? (() => {}),
+    ...mockCtxPlumbing({ sendMessage }, "chat-app-server-extra"),
+    ...(opts.failSessionForRecovery ? { failSessionForRecovery: opts.failSessionForRecovery } : {}),
+    ...(opts.formatInboundContent ? { formatInboundContent: opts.formatInboundContent } : {}),
+  };
+}
+
+function makeHandler(fake: FakeAppServerClient, extraConfig: Record<string, unknown> = {}) {
+  return createCodexAppServerHandler({
+    workspaceRoot,
+    codexRuntimeBinaryResolver: async () => ({
+      ok: true,
+      binary: "/tmp/fake-codex",
+      runtimeSource: "path",
+      runtimePath: "/tmp/fake-codex",
+      version: "0.0.0-test",
+    }),
+    codexAppServerClientFactory: async (options: { onNotification?: NotificationHandler; onClose?: CloseHandler }) => {
+      fake.onNotification = options.onNotification ?? null;
+      fake.onClose = options.onClose ?? null;
+      return fake;
+    },
+    ...extraConfig,
+  });
+}
+
+function makeCliBin(root: string): string {
+  const cliBinDir = join(root, "first-tree-cli-bin");
+  mkdirSync(cliBinDir, { recursive: true });
+  writeFileSync(join(cliBinDir, "first-tree-test"), "#!/bin/sh\n", { mode: 0o755 });
+  return cliBinDir;
+}
+
+beforeEach(() => {
+  workspaceRoot = realpathSync(mkdtempSync(join(tmpdir(), "ft-codex-app-server-extra-")));
+  setCliBinding({ binName: "first-tree-test", packageName: null });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  rmSync(workspaceRoot, { recursive: true, force: true });
+  for (const root of extraTempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("CodexAppServerClient extra JSON-RPC coverage", () => {
+  it("logs malformed stdout, rejects unsupported server requests, and dispatches notifications", async () => {
+    const onLog = vi.fn<(message: string) => void>();
+    const onNotification = vi.fn<(notification: { method: string; params?: unknown }) => void>();
+    const { client, signals, stdout, writes } = await startInitializedClient({ onLog, onNotification });
+
+    stdout.write("\nnot-json\n[]\n");
+    stdout.write(`${JSON.stringify({ id: 999, result: "late unknown response" })}\n`);
+    stdout.write(`${JSON.stringify({ id: "srv-1", method: "workspace/read", params: { path: "README.md" } })}\n`);
+    stdout.write(`${JSON.stringify({ method: "turn/completed", params: { turnId: "turn-1" } })}\n`);
+
+    await waitFor(
+      () => onNotification.mock.calls.length === 1 && writtenMessages(writes).some((message) => message.id === "srv-1"),
+      "server request rejection and notification",
+    );
+
+    expect(onLog.mock.calls.some(([message]) => message.includes("emitted malformed JSON"))).toBe(true);
+    expect(onNotification).toHaveBeenCalledWith({ method: "turn/completed", params: { turnId: "turn-1" } });
+    expect(writtenMessages(writes).find((message) => message.id === "srv-1")).toMatchObject({
+      id: "srv-1",
+      error: {
+        code: -32601,
+        message: "First Tree does not handle app-server request workspace/read",
+      },
+    });
+
+    await client.shutdown();
+    expect(signals).toEqual(["SIGTERM"]);
+  });
+
+  it("surfaces rpc error payloads, timeout rejections, and closed transports", async () => {
+    const { client, stdout, writes } = await startInitializedClient();
+
+    const rpcPromise = client.request("turn/start", { input: [] });
+    await waitFor(() => writtenMessages(writes).some((message) => message.id === 2), "turn/start write");
+    stdout.write(
+      `${JSON.stringify({
+        id: 2,
+        error: { code: -32001, message: "server overloaded", data: { retryAfter: 2 } },
+      })}\n`,
+    );
+    const rpcError = await rpcPromise.catch((err: unknown) => err);
+    expect(rpcError).toBeInstanceOf(CodexAppServerRpcError);
+    expect(rpcError).toMatchObject({ code: -32001, data: { retryAfter: 2 } });
+    expect(isCodexAppServerTransientError(rpcError)).toBe(true);
+
+    const plainErrorPromise = client.request("bad/rpc");
+    await waitFor(() => writtenMessages(writes).some((message) => message.id === 3), "bad/rpc write");
+    stdout.write(`${JSON.stringify({ id: 3, error: "plain failure" })}\n`);
+    await expect(plainErrorPromise).rejects.toThrow("plain failure");
+
+    await expect(client.request("never/responds", undefined, 5)).rejects.toThrow(
+      "codex app-server request timed out: never/responds",
+    );
+
+    await client.shutdown();
+    await expect(client.request("after/shutdown")).rejects.toThrow("codex app-server transport is closed");
+  });
+});
+
+describe("workspace-only app-server sandbox extra edges", () => {
+  it("requires app-server state inside the workspace and omits missing optional host integrations", () => {
+    const cliBinDir = makeCliBin(workspaceRoot);
+    const hostHome = join(workspaceRoot, "host-home");
+    const firstTreeHome = join(workspaceRoot, ".first-tree-workspace", "outbox-home");
+    const outsideFirstTreeHome = makeOutsideTempRoot("ft-outside-first-tree-home-");
+    mkdirSync(hostHome, { recursive: true });
+    mkdirSync(firstTreeHome, { recursive: true });
+    mkdirSync(outsideFirstTreeHome, { recursive: true });
+
+    expect(() => buildWorkspaceOnlyAppServerEnvironment({ FIRST_TREE_CLI_BIN_DIR: cliBinDir }, workspaceRoot)).toThrow(
+      "workspace-only app-server requires FIRST_TREE_HOME",
+    );
+    expect(() =>
+      buildWorkspaceOnlyAppServerEnvironment(
+        {
+          HOME: hostHome,
+          FIRST_TREE_HOME: outsideFirstTreeHome,
+          FIRST_TREE_CLI_BIN_DIR: cliBinDir,
+        },
+        workspaceRoot,
+      ),
+    ).toThrow("FIRST_TREE_HOME escapes workspace-only sandbox");
+
+    const {
+      env,
+      codexHome,
+      hostHome: resolvedHostHome,
+    } = buildWorkspaceOnlyAppServerEnvironment(
+      {
+        HOME: hostHome,
+        CODEX_HOME: "relative-codex",
+        FIRST_TREE_HOME: firstTreeHome,
+        FIRST_TREE_CLI_BIN_DIR: cliBinDir,
+        FIRST_TREE_SERVER_URL: "https://first-tree.test",
+        OPENAI_API_KEY: "secret",
+        PATH: "/sensitive/bin:/usr/bin",
+      },
+      workspaceRoot,
+    );
+
+    expect(resolvedHostHome).toBe(hostHome);
+    expect(codexHome).toBe(resolve(hostHome, "relative-codex"));
+    expect(env).toMatchObject({
+      HOME: workspaceRoot,
+      CODEX_HOME: resolve(hostHome, "relative-codex"),
+      FIRST_TREE_HOME: firstTreeHome,
+      FIRST_TREE_SERVER_URL: "https://first-tree.test",
+      TMPDIR: "/tmp",
+    });
+    expect(env.GH_CONFIG_DIR).toBeUndefined();
+    expect(env.GIT_SSH_COMMAND).toBeUndefined();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.PATH).not.toContain("/sensitive/bin");
+  });
+
+  it("denies both lexical and real Codex home paths when the auth dir is a symlink", () => {
+    const hostHome = join(workspaceRoot, "host-home");
+    const realCodexHome = join(workspaceRoot, "real-codex-home");
+    const linkedCodexHome = join(hostHome, ".codex-link");
+    mkdirSync(hostHome, { recursive: true });
+    mkdirSync(realCodexHome, { recursive: true });
+    symlinkSync(realCodexHome, linkedCodexHome, "dir");
+
+    expect(landingCodexDenyPaths(linkedCodexHome, hostHome)).toEqual(
+      expect.arrayContaining([linkedCodexHome, realCodexHome, join(hostHome, ".first-tree")]),
+    );
+  });
+
+  it("fails closed for bad bubblewrap paths and missing sandbox binaries", () => {
+    const commandDir = join(workspaceRoot, "command-dir");
+    const outside = makeOutsideTempRoot("ft-bwrap-outside-");
+    mkdirSync(commandDir);
+
+    expect(() =>
+      buildWorkspaceOnlyBubblewrapArgs({
+        command: "missing-codex",
+        args: [],
+        workspaceRoot,
+        env: { PATH: "" },
+      }),
+    ).toThrow("workspace-only sandbox could not resolve executable: missing-codex");
+    expect(() =>
+      buildWorkspaceOnlyBubblewrapArgs({
+        command: commandDir,
+        args: [],
+        workspaceRoot,
+      }),
+    ).toThrow("workspace-only sandbox executable is not a file");
+    expect(() =>
+      buildWorkspaceOnlyBubblewrapArgs({
+        command: "/bin/sh",
+        args: [],
+        workspaceRoot,
+        cwd: outside,
+      }),
+    ).toThrow("cwd escapes workspace-only sandbox");
+
+    const spawnProcess = createWorkspaceOnlySpawnProcess({
+      workspaceRoot,
+      sandboxBinary: "definitely-missing-bwrap",
+    });
+    expect(() =>
+      spawnProcess("/bin/sh", ["-c", "true"], {
+        cwd: workspaceRoot,
+        env: {
+          FIRST_TREE_HOME: join(workspaceRoot, ".first-tree-workspace"),
+          FIRST_TREE_CLI_BIN_DIR: makeCliBin(workspaceRoot),
+          PATH: "/usr/bin:/bin",
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      }),
+    ).toThrow(process.platform === "linux" ? "workspace-only sandbox requires bubblewrap" : "requires Linux");
+  });
+});
+
+describe("codex app-server handler extra branches", () => {
+  it("wraps startup failures from binary resolution, initialization, and thread/start responses", async () => {
+    const resolveFailure = makeHandler(new FakeAppServerClient(), {
+      codexRuntimeBinaryResolver: async () => ({ ok: false, error: "missing codex binary" }),
+    });
+    await expect(resolveFailure.start(makeMessage("m1", "first"), makeContext())).rejects.toMatchObject({
+      stage: "resolve-binary",
+      message: expect.stringContaining("missing codex binary"),
+    });
+
+    const initializeFailure = makeHandler(new FakeAppServerClient(), {
+      codexAppServerClientFactory: async () => {
+        throw new Error("initialize rpc failed");
+      },
+    });
+    await expect(initializeFailure.start(makeMessage("m2", "first"), makeContext())).rejects.toMatchObject({
+      stage: "initialize",
+      message: expect.stringContaining("initialize rpc failed"),
+    });
+
+    const malformedThread = new FakeAppServerClient();
+    malformedThread.threadStartResult = { thread: {} };
+    const malformedHandler = makeHandler(malformedThread);
+    await expect(malformedHandler.start(makeMessage("m3", "first"), makeContext())).rejects.toMatchObject({
+      stage: "thread-start",
+      message: expect.stringContaining("missing thread id"),
+    });
+    await malformedHandler.shutdown();
+
+    const failedThread = new FakeAppServerClient();
+    failedThread.errors.set("thread/start", new Error("thread start rpc failed"));
+    const failedThreadHandler = makeHandler(failedThread);
+    const failedThreadError = await failedThreadHandler
+      .start(makeMessage("m4", "first"), makeContext())
+      .catch((err) => err);
+    expect(failedThreadError).toBeInstanceOf(CodexAppServerStartupError);
+    expect(failedThreadError).toMatchObject({
+      stage: "thread-start",
+      message: expect.stringContaining("thread start rpc failed"),
+    });
+    await failedThreadHandler.shutdown();
+  });
+
+  it("returns a queued route and retries when initial inbound formatting fails", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const log = vi.fn<(message: string) => void>();
+    const handler = makeHandler(fake);
+    const message = makeMessage("m1", "first");
+    const ctx = makeContext({
+      log,
+      formatInboundContent: async () => {
+        throw new Error("formatter down");
+      },
+    });
+
+    await expect(handler.start(message, ctx, token)).resolves.toEqual({
+      sessionId: "thread-app-server",
+      route: { kind: "owned", mode: "queued" },
+    });
+
+    expect(token.retry).toHaveBeenCalledWith(message, "codex_app_server_initial_format_failed");
+    expect(log.mock.calls.some(([entry]) => entry.includes("initial formatInboundContent failed"))).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  it("formats grouped injected bodies and emits app-server terminal item events with path metadata", async () => {
+    const contextTreePath = join(workspaceRoot, "context-tree");
+    const treeDoc = join(contextTreePath, "docs", "NODE.md");
+    mkdirSync(dirname(treeDoc), { recursive: true });
+    writeFileSync(treeDoc, "tree node\n");
+
+    const fake = new FakeAppServerClient();
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake, {
+      contextTreePath,
+      contextTreeRepoUrl: "https://github.com/acme/context-tree.git",
+      contextTreeBranch: "main",
+    });
+    const ctx = makeContext({
+      emitEvent,
+      formatInboundContent: async (message) => `body:${message.id}:${message.content}`,
+    });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "initial turn/start");
+
+    const injectTokenA = makeDeliveryToken();
+    const injectTokenB = makeDeliveryToken();
+    handler.inject(makeMessage("m2", "second"), injectTokenA);
+    handler.inject(makeMessage("m3", "third"), injectTokenB);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"), "turn/steer");
+
+    const steer = fake.requests.find((request) => request.method === "turn/steer");
+    const steerParams = asRecord(steer?.params);
+    const rawSteerInput = Array.isArray(steerParams?.input) ? steerParams.input[0] : null;
+    const steerInput = asRecord(rawSteerInput);
+    expect(steerInput?.text).toBe("body:m2:second\n\nbody:m3:third");
+
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        error: null,
+        items: [
+          { type: "reasoning", id: "think-1" },
+          {
+            type: "commandExecution",
+            id: "cmd-1",
+            status: "completed",
+            command: `cat ${treeDoc}`,
+            cwd: workspaceRoot,
+            aggregatedOutput: "x".repeat(450),
+          },
+          {
+            type: "fileChange",
+            id: "file-1",
+            status: "completed",
+            changes: [{ path: treeDoc }, { path: treeDoc }, { filePath: "src/local.ts" }],
+          },
+          {
+            type: "mcpToolCall",
+            id: "mcp-1",
+            status: "failed",
+            server: "docs",
+            tool: "lookup",
+            arguments: { query: "first-tree" },
+            error: { message: "missing document" },
+          },
+          { type: "webSearch", id: "web-1", query: "first tree" },
+          { type: "plan", id: "plan-1", text: "ship tests" },
+          { type: "agentMessage", id: "agent-1", text: "done", phase: null, memoryCitation: null },
+        ],
+      },
+    });
+
+    await startPromise;
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+    const toolCalls = events.filter(
+      (event): event is Extract<SessionEvent, { kind: "tool_call" }> => event.kind === "tool_call",
+    );
+    const commandEvent = toolCalls.find((event) => event.payload.name === "command");
+    const fileEvent = toolCalls.find((event) => event.payload.name === "file_change");
+    const mcpEvent = toolCalls.find((event) => event.payload.name === "mcp:docs/lookup");
+
+    expect(events.some((event) => event.kind === "thinking")).toBe(true);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "assistant_text", payload: { text: "done" } }),
+        expect.objectContaining({
+          kind: "tool_call",
+          payload: expect.objectContaining({ name: "web_search", args: { query: "first tree" }, status: "ok" }),
+        }),
+        expect.objectContaining({
+          kind: "tool_call",
+          payload: expect.objectContaining({ name: "todo_list", args: { text: "ship tests" }, status: "ok" }),
+        }),
+      ]),
+    );
+    expect(commandEvent?.payload.resultPreview).toHaveLength(400);
+    expect(commandEvent?.payload.toolFileRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          origin: "tool_arg",
+          localPath: treeDoc,
+          repoUrl: "https://github.com/acme/context-tree.git",
+          repoBranch: "main",
+          repoRelativePath: "docs/NODE.md",
+          pathKind: "file",
+        }),
+      ]),
+    );
+    expect(fileEvent?.payload.toolFileRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          origin: "file_change",
+          localPath: treeDoc,
+          repoUrl: "https://github.com/acme/context-tree.git",
+          repoBranch: "main",
+          repoRelativePath: "docs/NODE.md",
+          pathKind: "file",
+        }),
+        expect.objectContaining({ origin: "file_change", localPath: "src/local.ts", pathKind: "file" }),
+      ]),
+    );
+    expect(mcpEvent?.payload).toMatchObject({
+      args: { query: "first-tree" },
+      resultPreview: "error: missing document",
+      status: "error",
+    });
+    expect(token.complete).toHaveBeenCalledWith(
+      [makeMessage("m1", "first"), makeMessage("m2", "second"), makeMessage("m3", "third")],
+      { status: "success", terminal: true },
+    );
+
+    await handler.shutdown();
+  });
+
+  it("retries queued work, aborts the active turn, and still shuts down when interrupt fails", async () => {
+    const fake = new FakeAppServerClient();
+    fake.responders.set("turn/interrupt", () => {
+      throw new Error("interrupt rpc failed");
+    });
+    const log = vi.fn<(message: string) => void>();
+    const token = makeDeliveryToken();
+    const queuedToken = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({ log });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "active turn/start");
+
+    handler.inject(makeMessage("m2", "queued"), queuedToken);
+    await handler.shutdown("manual_shutdown");
+    await startPromise;
+    await flushAsync();
+
+    expect(queuedToken.retry).toHaveBeenCalledWith(makeMessage("m2", "queued"), "manual_shutdown");
+    expect(fake.requests.find((request) => request.method === "turn/interrupt")).toMatchObject({
+      method: "turn/interrupt",
+      params: { threadId: "thread-app-server", turnId: "turn-1" },
+      timeoutMs: 2_000,
+    });
+    expect(log.mock.calls.some(([entry]) => entry.includes("turn interrupt failed: interrupt rpc failed"))).toBe(true);
+    expect(fake.shutdownCalls).toBe(1);
+    expect(handler.inject(makeMessage("m3", "late"))).toEqual({
+      kind: "rejected",
+      reason: "no_active_context",
+      retryable: true,
+    });
+  });
+});

--- a/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSyn
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { PassThrough } from "node:stream";
-import type { SessionEvent } from "@first-tree/shared";
+import type { AgentRuntimeConfig, AgentRuntimeConfigPayload, SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CodexAppServerClient,
@@ -20,6 +20,7 @@ import {
   createWorkspaceOnlySpawnProcess,
   landingCodexDenyPaths,
 } from "../handlers/codex/app-server/workspace-sandbox.js";
+import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
 import { setCliBinding } from "../runtime/cli-binding.js";
 import type { DeliveryToken, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
@@ -299,6 +300,16 @@ function makeHandler(fake: FakeAppServerClient, extraConfig: Record<string, unkn
   });
 }
 
+function runtimeConfig(payload: AgentRuntimeConfigPayload): AgentRuntimeConfig {
+  return {
+    agentId: AGENT_ID,
+    version: 7,
+    payload,
+    updatedAt: "2026-06-01T00:00:00.000Z",
+    updatedBy: "member-self",
+  };
+}
+
 function makeCliBin(root: string): string {
   const cliBinDir = join(root, "first-tree-cli-bin");
   mkdirSync(cliBinDir, { recursive: true });
@@ -537,6 +548,82 @@ describe("codex app-server handler extra branches", () => {
       message: expect.stringContaining("thread start rpc failed"),
     });
     await failedThreadHandler.shutdown();
+  });
+
+  it("passes cached MCP config and env while logging chat-context fetch failures", async () => {
+    const { fetchChatContext } = await import("../runtime/chat-context.js");
+    vi.mocked(fetchChatContext).mockRejectedValueOnce(new Error("chat context offline"));
+    const fake = new FakeAppServerClient();
+    const log = vi.fn<(message: string) => void>();
+    let capturedEnv: NodeJS.ProcessEnv | null = null;
+    const payload = {
+      kind: "codex",
+      prompt: { append: "Use the current runbook." },
+      model: "gpt-5-codex",
+      reasoningEffort: "medium",
+      mcpServers: [
+        { name: "stdio-docs", transport: "stdio", command: "node", args: ["server.js"] },
+        { name: "http-docs", transport: "http", url: "https://mcp.example/http", headers: { "x-api": "1" } },
+        { name: "sse-docs", transport: "sse", url: "https://mcp.example/sse" },
+      ],
+      env: [{ key: "EXTRA_FLAG", value: "enabled", sensitive: false }],
+      gitRepos: [],
+      resourceSkills: [],
+    } satisfies AgentRuntimeConfigPayload;
+    const cachedConfig = runtimeConfig(payload);
+    const agentConfigCache = {
+      refresh: vi.fn(async () => cachedConfig),
+      get: vi.fn(() => cachedConfig),
+    } as unknown as AgentConfigCache;
+    const handler = createCodexAppServerHandler({
+      workspaceRoot,
+      agentConfigCache,
+      codexRuntimeBinaryResolver: async () => ({
+        ok: true,
+        binary: "/tmp/fake-codex",
+        runtimeSource: "path",
+        runtimePath: "/tmp/fake-codex",
+        version: "0.0.0-test",
+      }),
+      codexAppServerClientFactory: async (options: {
+        env: NodeJS.ProcessEnv;
+        onNotification?: NotificationHandler;
+        onClose?: CloseHandler;
+      }) => {
+        capturedEnv = options.env;
+        fake.onNotification = options.onNotification ?? null;
+        fake.onClose = options.onClose ?? null;
+        return fake;
+      },
+    });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), makeContext({ log }));
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "cached config turn/start");
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: { id: "turn-1", status: "completed", error: null, items: [{ type: "agentMessage", text: "done" }] },
+    });
+    await startPromise;
+
+    const threadStart = fake.requests.find((request) => request.method === "thread/start");
+    const params = asRecord(threadStart?.params);
+    expect(params?.model).toBe("gpt-5-codex");
+    expect(params?.config).toMatchObject({
+      mcp_servers: {
+        "stdio-docs": { command: "node", args: ["server.js"] },
+        "http-docs": { url: "https://mcp.example/http", headers: { "x-api": "1" } },
+        "sse-docs": { url: "https://mcp.example/sse" },
+      },
+    });
+    const turnStart = fake.requests.find((request) => request.method === "turn/start");
+    expect(asRecord(turnStart?.params)?.effort).toBe("medium");
+    const envForAssert = capturedEnv as NodeJS.ProcessEnv | null;
+    expect(envForAssert?.EXTRA_FLAG).toBe("enabled");
+    expect(log.mock.calls.some(([entry]) => entry.includes("fetchChatContext failed: chat context offline"))).toBe(
+      true,
+    );
+
+    await handler.shutdown();
   });
 
   it("returns a queued route and retries when initial inbound formatting fails", async () => {

--- a/packages/client/src/__tests__/codex-handler-engine-extra.test.ts
+++ b/packages/client/src/__tests__/codex-handler-engine-extra.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentHandler, HandlerConfig, SessionContext, SessionMessage } from "../runtime/handler.js";
+
+const trialMetadata = {
+  landingCampaignTrial: true,
+  campaign: "production-scan",
+  skillSetId: "production-scan",
+  skillSetVersion: "2026.07.02.1",
+  repo: {
+    url: "https://github.com/acme/backend",
+    canonicalKey: "github.com/acme/backend",
+  },
+};
+
+type MockHandler = {
+  start: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
+  inject: ReturnType<typeof vi.fn>;
+  suspend: ReturnType<typeof vi.fn>;
+  shutdown: ReturnType<typeof vi.fn>;
+};
+
+function message(): SessionMessage {
+  return {
+    id: "m1",
+    chatId: "chat-1",
+    senderId: "human-1",
+    format: "text",
+    content: "start",
+    metadata: {},
+  };
+}
+
+function context(metadata: Record<string, unknown> = {}): SessionContext {
+  return {
+    log: vi.fn(),
+    agent: {
+      agentId: "agent-1",
+      inboxId: "inbox_agent-1",
+      displayName: "Trial Agent",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata,
+    },
+  } as unknown as SessionContext;
+}
+
+function makeMockHandler(overrides: Partial<MockHandler> = {}): MockHandler {
+  return {
+    start: vi.fn(async () => ({ providerSessionId: "started" })),
+    resume: vi.fn(async () => ({ providerSessionId: "resumed" })),
+    inject: vi.fn(async () => undefined),
+    suspend: vi.fn(async () => undefined),
+    shutdown: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+function handlerConfig(overrides: Partial<HandlerConfig> = {}): HandlerConfig {
+  return {
+    workspaceRoot: "/tmp/first-tree-codex-handler-test",
+    ...overrides,
+  };
+}
+
+async function importWithMocks(options: { app?: Partial<MockHandler>; sdk?: Partial<MockHandler> } = {}): Promise<{
+  createCodexHandler: (config: HandlerConfig) => AgentHandler;
+  appHandler: MockHandler;
+  sdkHandler: MockHandler;
+  StartupError: new (stage: string, message: string) => Error & { stage: string };
+}> {
+  vi.resetModules();
+
+  class StartupError extends Error {
+    stage: string;
+
+    constructor(stage: string, message: string) {
+      super(message);
+      this.name = "CodexAppServerStartupError";
+      this.stage = stage;
+    }
+  }
+
+  const appHandler = makeMockHandler(options.app);
+  const sdkHandler = makeMockHandler(options.sdk);
+
+  vi.doMock("../handlers/codex/app-server/index.js", () => ({
+    CodexAppServerStartupError: StartupError,
+    createCodexAppServerHandler: vi.fn(() => appHandler),
+  }));
+  vi.doMock("../handlers/codex/sdk.js", () => ({
+    appendGitStatusDeltaRefs: vi.fn(),
+    buildCodexAgentBriefing: vi.fn(),
+    buildCodexThreadOptions: vi.fn(),
+    collectCodexFileChangePaths: vi.fn(),
+    computePerTurnUsageDelta: vi.fn(),
+    createCodexSdkHandler: vi.fn(() => sdkHandler),
+    isTransientCodexErrorMessage: vi.fn(),
+    toolFileRefsForTerminalCodexTool: vi.fn(),
+    toolFileRefsFromCodexFileChange: vi.fn(),
+  }));
+
+  const mod = await import("../handlers/codex/index.js");
+  return { createCodexHandler: mod.createCodexHandler, appHandler, sdkHandler, StartupError };
+}
+
+describe("codex handler engine delegation branches", () => {
+  afterEach(() => {
+    vi.doUnmock("../handlers/codex/app-server/index.js");
+    vi.doUnmock("../handlers/codex/sdk.js");
+    vi.resetModules();
+  });
+
+  it("delegates all SDK-engine operations when workspace-only metadata is absent", async () => {
+    const { createCodexHandler, sdkHandler } = await importWithMocks();
+    const ctx = context();
+    const handler = createCodexHandler(handlerConfig({ codexHandlerEngine: "sdk" }));
+
+    await expect(handler.start(message(), ctx)).resolves.toEqual({ providerSessionId: "started" });
+    await expect(handler.resume(message(), "session-1", ctx)).resolves.toEqual({ providerSessionId: "resumed" });
+    await handler.inject(message());
+    await handler.suspend();
+    await handler.shutdown("done");
+
+    expect(sdkHandler.start).toHaveBeenCalledWith(message(), ctx, undefined);
+    expect(sdkHandler.resume).toHaveBeenCalledWith(message(), "session-1", ctx, undefined);
+    expect(sdkHandler.inject).toHaveBeenCalledWith(message(), undefined);
+    expect(sdkHandler.suspend).toHaveBeenCalledTimes(1);
+    expect(sdkHandler.shutdown).toHaveBeenCalledWith("done");
+  });
+
+  it("falls back from app-server start and logs shutdown failures", async () => {
+    const { createCodexHandler, appHandler, sdkHandler, StartupError } = await importWithMocks({
+      app: {
+        start: vi.fn(async () => {
+          throw new StartupError("launch", "app server failed");
+        }),
+        shutdown: vi.fn(async () => {
+          throw new Error("shutdown failed");
+        }),
+      },
+    });
+    const ctx = context();
+    const handler = createCodexHandler(handlerConfig({ codexHandlerEngine: "auto" }));
+
+    await expect(handler.start(message(), ctx)).resolves.toEqual({ providerSessionId: "started" });
+    await handler.suspend();
+    await handler.shutdown("fallback done");
+
+    expect(appHandler.shutdown).toHaveBeenCalledWith();
+    expect(ctx.log).toHaveBeenCalledWith(
+      "codex app-server shutdown before fallback failed after launch: shutdown failed",
+    );
+    expect(ctx.log).toHaveBeenCalledWith("app server failed; falling back to @openai/codex-sdk handler");
+    expect(sdkHandler.start).toHaveBeenCalledWith(message(), ctx, undefined);
+    expect(sdkHandler.suspend).toHaveBeenCalledTimes(1);
+    expect(sdkHandler.shutdown).toHaveBeenCalledWith("fallback done");
+  });
+
+  it("falls back from app-server resume and keeps app-server for workspace-only trials", async () => {
+    const { createCodexHandler, sdkHandler, StartupError } = await importWithMocks({
+      app: {
+        resume: vi.fn(async () => {
+          throw new StartupError("connect", "resume failed");
+        }),
+      },
+    });
+
+    const handler = createCodexHandler(handlerConfig({ codexHandlerEngine: "auto" }));
+    await expect(handler.resume(message(), "session-1", context())).resolves.toEqual({ providerSessionId: "resumed" });
+    expect(sdkHandler.resume).toHaveBeenCalledWith(message(), "session-1", expect.any(Object), undefined);
+
+    const trialHandler = createCodexHandler(handlerConfig({ codexHandlerEngine: "auto" }));
+    await expect(trialHandler.resume(message(), "session-2", context(trialMetadata))).rejects.toThrow("resume failed");
+  });
+
+  it("uses production auto mode when no explicit engine or test env fallback is present", async () => {
+    const previousEngine = process.env.FIRST_TREE_CODEX_HANDLER_ENGINE;
+    const previousVitest = process.env.VITEST;
+    const previousNodeEnv = process.env.NODE_ENV;
+    delete process.env.FIRST_TREE_CODEX_HANDLER_ENGINE;
+    delete process.env.VITEST;
+    delete process.env.NODE_ENV;
+    const { createCodexHandler, appHandler } = await importWithMocks();
+
+    try {
+      const handler = createCodexHandler(handlerConfig());
+      await handler.inject(message());
+      expect(appHandler.inject).toHaveBeenCalledWith(message(), undefined);
+    } finally {
+      if (previousEngine === undefined) delete process.env.FIRST_TREE_CODEX_HANDLER_ENGINE;
+      else process.env.FIRST_TREE_CODEX_HANDLER_ENGINE = previousEngine;
+      if (previousVitest === undefined) delete process.env.VITEST;
+      else process.env.VITEST = previousVitest;
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
+});

--- a/packages/client/src/__tests__/codex-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/codex-inject-startup-race.test.ts
@@ -11,6 +11,7 @@ const state = vi.hoisted(() => ({
   chatContextPromise: null as Promise<ChatContext> | null,
   resolveChatContext: null as ((value: ChatContext) => void) | null,
   runInputs: [] as unknown[],
+  itemsByTurn: new Map<number, unknown[]>(),
   agentMessagesByTurn: new Map<number, string[]>(),
   failureByTurn: new Map<number, string>(),
   streamErrorByTurn: new Map<number, string>(),
@@ -33,12 +34,19 @@ vi.mock("@openai/codex-sdk", () => {
       return {
         events: (async function* () {
           yield { type: "thread.started", thread_id: "thread-test" };
-          const messages = state.agentMessagesByTurn.get(turn) ?? [`reply ${turn}`];
-          const diagnosticAfterFirstMessage = state.diagnosticAfterFirstMessageByTurn.get(turn);
-          for (const [index, text] of messages.entries()) {
-            yield { type: "item.completed", item: { type: "agent_message", text } };
-            if (index === 0 && diagnosticAfterFirstMessage) {
-              yield { type: "error", message: diagnosticAfterFirstMessage };
+          const items = state.itemsByTurn.get(turn);
+          if (items) {
+            for (const item of items) {
+              yield { type: "item.completed", item };
+            }
+          } else {
+            const messages = state.agentMessagesByTurn.get(turn) ?? [`reply ${turn}`];
+            const diagnosticAfterFirstMessage = state.diagnosticAfterFirstMessageByTurn.get(turn);
+            for (const [index, text] of messages.entries()) {
+              yield { type: "item.completed", item: { type: "agent_message", text } };
+              if (index === 0 && diagnosticAfterFirstMessage) {
+                yield { type: "error", message: diagnosticAfterFirstMessage };
+              }
             }
           }
           const failure = state.failureByTurn.get(turn);
@@ -224,6 +232,7 @@ async function waitFor(assertion: () => boolean): Promise<void> {
 beforeEach(() => {
   workspaceRoot = mkdtempSync(join(tmpdir(), "ft-codex-startup-race-"));
   state.runInputs.length = 0;
+  state.itemsByTurn.clear();
   state.agentMessagesByTurn.clear();
   state.failureByTurn.clear();
   state.streamErrorByTurn.clear();
@@ -240,6 +249,136 @@ afterEach(() => {
 });
 
 describe("codex handler startup inject queue", () => {
+  it("emits runtime events for every Codex SDK terminal item shape", async () => {
+    const events: SessionEvent[] = [];
+    const completedCounts: Array<number | undefined> = [];
+    state.itemsByTurn.set(1, [
+      { type: "agent_message", text: "   " },
+      { type: "agent_message", text: "visible answer" },
+      {
+        type: "command_execution",
+        id: "cmd-ok",
+        status: "completed",
+        command: "echo ok",
+        aggregated_output: "x".repeat(450),
+      },
+      {
+        type: "command_execution",
+        id: "cmd-error",
+        status: "failed",
+        command: "exit 1",
+        aggregated_output: "failed",
+      },
+      {
+        type: "command_execution",
+        id: "cmd-pending",
+        status: "running",
+        command: "sleep 1",
+      },
+      {
+        type: "file_change",
+        id: "file-ok",
+        status: "completed",
+        changes: [{ path: "src/created.ts" }],
+      },
+      {
+        type: "file_change",
+        id: "file-error",
+        status: "failed",
+        changes: [{ path: "src/rejected.ts" }],
+      },
+      {
+        type: "mcp_tool_call",
+        id: "mcp-error",
+        status: "failed",
+        server: "docs",
+        tool: "lookup",
+        arguments: { query: "missing" },
+        error: { message: "not found" },
+      },
+      {
+        type: "mcp_tool_call",
+        id: "mcp-ok",
+        status: "completed",
+        server: "docs",
+        tool: "lookup",
+        arguments: { query: "present" },
+        result: { structured_content: { answer: 42 } },
+      },
+      {
+        type: "mcp_tool_call",
+        id: "mcp-pending",
+        status: "running",
+        server: "docs",
+        tool: "lookup",
+        arguments: {},
+        result: { content: ["raw"] },
+      },
+      { type: "web_search", id: "web-1", query: "first tree" },
+      { type: "todo_list", id: "todo-1", items: [{ text: "ship tests", completed: false }] },
+      { type: "reasoning" },
+      {
+        type: "error",
+        message:
+          "Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.",
+      },
+      { type: "unknown_future_item" },
+    ]);
+    const handler = createCodexHandler({ workspaceRoot });
+    const ctx = makeContext(
+      (count) => {
+        completedCounts.push(count);
+      },
+      { emitEvent: (event) => events.push(event) },
+    );
+
+    state.resolveChatContext?.({
+      chatId: "chat-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "first"), ctx);
+
+    const toolEvents = events.filter(
+      (event): event is Extract<SessionEvent, { kind: "tool_call" }> => event.kind === "tool_call",
+    );
+    expect(events).toEqual(
+      expect.arrayContaining([
+        { kind: "assistant_text", payload: { text: "visible answer" } },
+        { kind: "thinking", payload: {} },
+        expect.objectContaining({
+          kind: "error",
+          payload: expect.objectContaining({ source: "tool", message: expect.stringContaining("codex auth") }),
+        }),
+      ]),
+    );
+    expect(toolEvents.map((event) => `${event.payload.toolUseId}:${event.payload.status}`)).toEqual([
+      "cmd-ok:ok",
+      "cmd-error:error",
+      "cmd-pending:pending",
+      "file-ok:ok",
+      "file-error:error",
+      "mcp-error:error",
+      "mcp-ok:ok",
+      "mcp-pending:pending",
+      "web-1:ok",
+      "todo-1:ok",
+    ]);
+    expect(toolEvents.find((event) => event.payload.toolUseId === "cmd-ok")?.payload.resultPreview).toHaveLength(400);
+    expect(toolEvents.find((event) => event.payload.toolUseId === "mcp-error")?.payload.resultPreview).toBe(
+      "error: not found",
+    );
+    expect(toolEvents.find((event) => event.payload.toolUseId === "mcp-ok")?.payload.resultPreview).toBe(
+      JSON.stringify({ answer: 42 }),
+    );
+    expect(completedCounts).toEqual([1]);
+
+    await handler.shutdown();
+  });
+
   it("queues injects received before the Codex thread exists so their inbox entries stay aligned with acks", async () => {
     const completedCounts: Array<number | undefined> = [];
     const handler = createCodexHandler({ workspaceRoot });

--- a/packages/client/src/__tests__/codex-login.test.ts
+++ b/packages/client/src/__tests__/codex-login.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runCodexBrowserLogin, stripAnsi } from "../runtime/codex-login.js";
 import { extractAuthUrl } from "../runtime/runtime-login.js";
 
@@ -41,6 +41,12 @@ describe("extractAuthUrl", () => {
 
   it("returns null when there is no URL yet", () => {
     expect(extractAuthUrl("Starting local login server…\n")).toBeNull();
+  });
+
+  it("skips malformed URL tokens and continues scanning", () => {
+    expect(extractAuthUrl("open https://[broken\nthen https://auth.openai.com/ok\n")).toBe(
+      "https://auth.openai.com/ok",
+    );
   });
 });
 
@@ -84,9 +90,11 @@ describe("runCodexBrowserLogin", () => {
   it("resolves ok on exit 0 (codex wrote auth.json) and surfaces a fallback URL once", async () => {
     const child = new FakeChild();
     const urls: string[] = [];
+    const rawOutput: string[] = [];
     const run = runCodexBrowserLogin({
       binary: "/bundled/codex",
       onAuthUrl: (u) => urls.push(u),
+      onRawOutput: (chunk) => rawOutput.push(chunk),
       spawnFn: fakeSpawn(child),
     });
 
@@ -96,6 +104,7 @@ describe("runCodexBrowserLogin", () => {
 
     await expect(run).resolves.toEqual({ ok: true });
     expect(urls).toEqual(["https://auth.openai.com/auth?x=1"]);
+    expect(rawOutput.join("")).toContain("Starting local login server");
   });
 
   it("does NOT surface the loopback callback server as a fallback link (QA #1225 / redirect-404)", async () => {
@@ -144,6 +153,53 @@ describe("runCodexBrowserLogin", () => {
     expect(outcome.ok).toBe(false);
     if (!outcome.ok) expect(outcome.reason).toBe("aborted");
     expect(child.killed).toBe(true);
+  });
+
+  it("returns aborted without spawning when the signal is already cancelled", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const spawnFn = vi.fn() as unknown as typeof import("node:child_process").spawn;
+
+    const outcome = await runCodexBrowserLogin({
+      binary: "/bundled/codex",
+      signal: controller.signal,
+      spawnFn,
+    });
+
+    expect(outcome).toEqual({ ok: false, reason: "aborted", error: "codex login aborted before start" });
+    expect(spawnFn).not.toHaveBeenCalled();
+  });
+
+  it("maps child process error events to spawn-error and kills the child", async () => {
+    const child = new FakeChild();
+    const run = runCodexBrowserLogin({ binary: "/bundled/codex", spawnFn: fakeSpawn(child) });
+    child.emit("error", new Error("spawn crashed"));
+
+    await expect(run).resolves.toEqual({ ok: false, reason: "spawn-error", error: "spawn crashed" });
+    expect(child.killed).toBe(true);
+  });
+
+  it("times out the login subprocess and kills the child", async () => {
+    vi.useFakeTimers();
+    try {
+      const child = new FakeChild();
+      const run = runCodexBrowserLogin({
+        binary: "/bundled/codex",
+        timeoutMs: 25,
+        spawnFn: fakeSpawn(child),
+      });
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      await expect(run).resolves.toEqual({
+        ok: false,
+        reason: "timeout",
+        error: "codex login timed out after 25ms",
+      });
+      expect(child.killed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("maps a spawn throw to spawn-error", async () => {

--- a/packages/client/src/__tests__/handler-helper-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/handler-helper-extra-coverage.test.ts
@@ -1,0 +1,249 @@
+import type { AgentRuntimeConfigPayload, SessionEvent, ToolFileRef } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createToolCallProcessor,
+  detectClaudeSessionLimitResult,
+  detectStreamApiError,
+  isSameModelFamily,
+  mapMcpServers,
+  StreamApiTransientError,
+} from "../handlers/claude-code.js";
+import {
+  appendGitStatusDeltaRefs,
+  buildCodexThreadOptions,
+  collectCodexFileChangePaths,
+  toolFileRefsForTerminalCodexTool,
+  toolFileRefsFromCodexFileChange,
+} from "../handlers/codex/index.js";
+import type { ContextTreeGitWriteTracker } from "../runtime/context-tree-git-status.js";
+
+function claudePayload(overrides: Partial<Extract<AgentRuntimeConfigPayload, { kind: "claude-code" }>> = {}) {
+  return {
+    kind: "claude-code",
+    prompt: { append: "" },
+    model: "",
+    mcpServers: [],
+    env: [],
+    gitRepos: [],
+    resourceSkills: [],
+    reasoningEffort: "",
+    ...overrides,
+  } satisfies AgentRuntimeConfigPayload;
+}
+
+describe("additional Codex helper branches", () => {
+  it("handles nested file-change payload shapes and empty context-tree attribution", () => {
+    expect(
+      collectCodexFileChangePaths([
+        "direct/path.md",
+        null,
+        { file_path: "snake.md", filename: "name.md", nested: [{ path: "ignored-by-collector-value.md" }] },
+        { "windows\\path.md": true },
+        { plain: "not a path" },
+      ]),
+    ).toEqual(["direct/path.md", "snake.md", "name.md", "windows\\path.md"]);
+
+    expect(
+      toolFileRefsFromCodexFileChange({
+        changes: [{ path: "relative.md" }],
+        workspaceCwd: "/workspace",
+        contextTreePath: null,
+        contextTreeRepoUrl: null,
+      }),
+    ).toEqual([{ origin: "file_change", localPath: "relative.md", pathKind: "file" }]);
+  });
+
+  it("captures git baselines for failed terminal tools and returns undefined for empty deltas", () => {
+    const captureBaseline = vi.fn();
+    const gitWriteTracker: ContextTreeGitWriteTracker = {
+      captureBaseline,
+      refsForSuccessfulToolCall: vi.fn(() => []),
+    };
+
+    expect(
+      toolFileRefsForTerminalCodexTool({
+        status: "error",
+        gitWriteTracker,
+        toolName: "Bash",
+        toolUseId: "tool-1",
+      }),
+    ).toBeUndefined();
+    expect(captureBaseline).toHaveBeenCalledTimes(1);
+
+    expect(
+      toolFileRefsForTerminalCodexTool({
+        status: "pending",
+        gitWriteTracker,
+        toolName: "Bash",
+        toolUseId: "tool-2",
+      }),
+    ).toBeUndefined();
+
+    expect(appendGitStatusDeltaRefs({ toolName: "Bash", toolUseId: "tool-3" })).toBeUndefined();
+  });
+
+  it("uses the non-codex reasoning fallback when called with a different runtime payload", () => {
+    const opts = buildCodexThreadOptions(claudePayload(), "/workspace");
+    expect(opts.modelReasoningEffort).toBe("high");
+    expect(opts.additionalDirectories).toEqual([]);
+  });
+});
+
+describe("additional Claude helper branches", () => {
+  it("maps all MCP transports and compares model families defensively", () => {
+    expect(
+      mapMcpServers(
+        claudePayload({
+          mcpServers: [
+            { name: "stdio-server", transport: "stdio", command: "node", args: ["server.js"] },
+            { name: "http-server", transport: "http", url: "https://mcp.example/http", headers: { "x-api": "1" } },
+            { name: "sse-server", transport: "sse", url: "https://mcp.example/sse", headers: { "x-api": "2" } },
+          ],
+        }),
+      ),
+    ).toEqual({
+      "stdio-server": { type: "stdio", command: "node", args: ["server.js"] },
+      "http-server": { type: "http", url: "https://mcp.example/http", headers: { "x-api": "1" } },
+      "sse-server": { type: "sse", url: "https://mcp.example/sse", headers: { "x-api": "2" } },
+    });
+
+    expect(isSameModelFamily("claude-opus-4-5", "claude-opus-4-6")).toBe(true);
+    expect(isSameModelFamily("claude-opus-4-5", "claude-sonnet-4-5")).toBe(false);
+    expect(isSameModelFamily("", "claude-opus-4-5")).toBe(false);
+    expect(isSameModelFamily("short", "claude-opus-4-5")).toBe(false);
+  });
+
+  it("classifies stream API and session-limit result text without false positives", () => {
+    expect(new StreamApiTransientError("socket dropped").name).toBe("StreamApiTransientError");
+    expect(detectStreamApiError("Anthropic API error: socket connection was closed\nretry later")).toEqual({
+      message: "Anthropic API error: socket connection was closed",
+    });
+    expect(detectStreamApiError("API Error: how to handle API errors")).toBeNull();
+    expect(detectStreamApiError("x".repeat(500))).toBeNull();
+    expect(detectStreamApiError(42 as unknown as string)).toBeNull();
+
+    expect(detectClaudeSessionLimitResult("You've hit your session limit · resets tomorrow.")).toEqual({
+      message: "You've hit your session limit · resets tomorrow.",
+    });
+    expect(detectClaudeSessionLimitResult("You’ve hit your session limit")).toEqual({
+      message: "You’ve hit your session limit",
+    });
+    expect(detectClaudeSessionLimitResult("You've hit your session limit\nextra")).toBeNull();
+    expect(detectClaudeSessionLimitResult(null as unknown as string)).toBeNull();
+  });
+
+  it("emits pending, assistant text, thinking, ok/error tool calls, file refs, and flushes pending state", () => {
+    const events: SessionEvent[] = [];
+    const treeRef: ToolFileRef = {
+      origin: "git_status_delta",
+      localPath: "/tree/changed.md",
+      repoUrl: "https://github.com/acme/context.git",
+      repoRelativePath: "changed.md",
+      pathKind: "file",
+    };
+    const captureBaseline = vi.fn();
+    const gitWriteTracker: ContextTreeGitWriteTracker = {
+      captureBaseline,
+      refsForSuccessfulToolCall: vi.fn(() => [treeRef]),
+    };
+    const processor = createToolCallProcessor(
+      (event) => events.push(event),
+      {
+        path: "/tree",
+        repoUrl: "https://github.com/acme/context.git",
+        branch: "main",
+      },
+      { cwd: "/workspace", gitWriteTracker },
+    );
+
+    processor.onMessage({ type: "unknown" });
+    processor.onMessage({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "tool_use", id: "tool-read", name: "Read", input: { file_path: "/tree/NODE.md" } },
+          { type: "text", text: " Assistant output " },
+          { type: "thinking", thinking: "hidden" },
+          { type: "text", text: "   " },
+        ],
+      },
+    });
+    processor.onMessage({
+      type: "user",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool-read",
+            content: [{ type: "text", text: "result body" }],
+          },
+        ],
+      },
+    });
+    processor.onMessage({
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_use", id: "tool-error", name: "Write", input: { file_path: "/tree/BAD.md" } }],
+      },
+    });
+    processor.onMessage({
+      type: "user",
+      message: { content: [{ type: "tool_result", tool_use_id: "tool-error", content: "failed", is_error: true }] },
+    });
+    processor.onMessage({
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_use", id: "tool-flush", name: "Read", input: { file_path: "/tree/LATE.md" } }],
+      },
+    });
+    processor.flush();
+    processor.onMessage({
+      type: "user",
+      message: { content: [{ type: "tool_result", tool_use_id: "tool-flush", content: "ignored" }] },
+    });
+
+    expect(captureBaseline).toHaveBeenCalledTimes(4);
+    expect(events.map((event) => event.kind)).toEqual([
+      "tool_call",
+      "assistant_text",
+      "thinking",
+      "tool_call",
+      "tool_call",
+      "tool_call",
+      "tool_call",
+    ]);
+    expect(events[0]).toMatchObject({
+      kind: "tool_call",
+      payload: { toolUseId: "tool-read", name: "Read", status: "pending" },
+    });
+    expect(events[1]).toEqual({ kind: "assistant_text", payload: { text: "Assistant output" } });
+    expect(events[2]).toEqual({ kind: "thinking", payload: {} });
+    expect(events[3]).toMatchObject({
+      kind: "tool_call",
+      payload: {
+        toolUseId: "tool-read",
+        status: "ok",
+        resultPreview: "result body",
+        toolFileRefs: [
+          {
+            origin: "tool_arg",
+            localPath: "/tree/NODE.md",
+            repoUrl: "https://github.com/acme/context.git",
+            repoBranch: "main",
+            repoRelativePath: "NODE.md",
+            pathKind: "file",
+          },
+          treeRef,
+        ],
+      },
+    });
+    expect(events[5]).toMatchObject({
+      kind: "tool_call",
+      payload: { toolUseId: "tool-error", status: "error", resultPreview: "failed" },
+    });
+    expect(events[6]).toMatchObject({
+      kind: "tool_call",
+      payload: { toolUseId: "tool-flush", status: "pending" },
+    });
+  });
+});

--- a/packages/client/src/__tests__/managed-state.test.ts
+++ b/packages/client/src/__tests__/managed-state.test.ts
@@ -47,6 +47,31 @@ describe("managed-state", () => {
     expect(readManagedState(workspace)).toBeNull();
   });
 
+  it("returns null when the record is not an object", () => {
+    writeFileSync(join(workspace, MANAGED_STATE_REL), "null", "utf-8");
+    expect(readManagedState(workspace)).toBeNull();
+  });
+
+  it("normalizes invalid optional metadata while preserving valid skills", () => {
+    writeFileSync(
+      join(workspace, MANAGED_STATE_REL),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: 42,
+        updatedAt: false,
+        skills: ["first-tree-write"],
+      }),
+      "utf-8",
+    );
+
+    expect(readManagedState(workspace)).toEqual({
+      schemaVersion: 1,
+      cliVersion: null,
+      updatedAt: "1970-01-01T00:00:00.000Z",
+      skills: ["first-tree-write"],
+    });
+  });
+
   it("filters non-string entries out of the skills array (defensive read)", () => {
     writeFileSync(
       join(workspace, MANAGED_STATE_REL),
@@ -139,5 +164,21 @@ describe("managed-state", () => {
     expect(raw.endsWith("\n")).toBe(true);
     // Pretty-printed: indented entries should be present.
     expect(raw).toContain('  "schemaVersion"');
+  });
+
+  it("cleans up the temp file when the atomic rename fails", () => {
+    mkdirSync(join(workspace, MANAGED_STATE_REL), { recursive: true });
+
+    expect(() =>
+      writeManagedState(workspace, {
+        schemaVersion: 1,
+        cliVersion: null,
+        updatedAt: "2026-06-08T16:00:00.000Z",
+        skills: [],
+      }),
+    ).toThrow();
+
+    const agentDir = join(workspace, ".first-tree-workspace");
+    expect(readdirSync(agentDir).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
   });
 });

--- a/packages/client/src/__tests__/provider-retry-policy.test.ts
+++ b/packages/client/src/__tests__/provider-retry-policy.test.ts
@@ -184,6 +184,60 @@ describe("classifyProviderFailure", () => {
       );
     }
   });
+
+  it("reads retry-after hints from numbers, strings, and date strings", () => {
+    const numeric = classifyProviderFailure(
+      { message: "rate limit", retryAfter: 2 },
+      {
+        provider: "codex",
+        scope: "session_start",
+        source: "sdk",
+      },
+    );
+    expect(numeric).toMatchObject({ category: "provider_capacity", retryAfterMs: 2000 });
+
+    const text = classifyProviderFailure(
+      { message: "rate limit", retryAfter: "3" },
+      {
+        provider: "codex",
+        scope: "session_start",
+        source: "sdk",
+      },
+    );
+    expect(text).toMatchObject({ category: "provider_capacity", retryAfterMs: 3000 });
+
+    const now = Date.now();
+    const date = classifyProviderFailure(
+      { message: "rate limit", retryAfter: new Date(now + 60_000).toUTCString() },
+      { provider: "codex", scope: "session_start", source: "sdk" },
+    );
+    expect(date.retryAfterMs ?? 0).toBeGreaterThan(0);
+  });
+
+  it("classifies string, null, and unshaped object failures without throwing", () => {
+    expect(classifyProviderFailure("upstream 502", { provider: "codex", scope: "provider_turn" })).toMatchObject({
+      category: "transient_transport",
+      reasonCode: "provider_transient_transport",
+    });
+    expect(classifyProviderFailure(null, { provider: "codex", scope: "provider_turn" })).toMatchObject({
+      category: "unknown",
+    });
+    expect(classifyProviderFailure({ code: "EPIPE" }, { provider: "codex", scope: "provider_turn" })).toMatchObject({
+      category: "transient_transport",
+    });
+  });
+
+  it("maps ambiguous capacity and context-room messages to deterministic reasons", () => {
+    expect(
+      classifyProviderFailure({ message: "capacity is overloaded" }, { provider: "codex", scope: "provider_turn" }),
+    ).toMatchObject({ category: "provider_capacity", reasonCode: "provider_overloaded" });
+    expect(
+      classifyProviderFailure("ran out of room in the context window", {
+        provider: "claude-code",
+        scope: "provider_turn",
+      }),
+    ).toMatchObject({ category: "deterministic_input", reasonCode: "provider_deterministic_input" });
+  });
 });
 
 describe("decideProviderRetry", () => {
@@ -268,6 +322,38 @@ describe("decideProviderRetry", () => {
       }),
     ).toMatchObject({ action: "stop", terminalKind: "unsafe_replay" });
   });
+
+  it("retries short provider-entered capacity waits and overloaded responses without Retry-After", () => {
+    expect(
+      decide({
+        category: "provider_capacity",
+        reasonCode: "provider_rate_limited",
+        replaySafety: "provider_entered",
+        retryAfterMs: 25_000,
+      }),
+    ).toMatchObject({ action: "retry", delayMs: 25_000, userSeverity: "warning" });
+
+    expect(
+      decide({
+        category: "provider_capacity",
+        reasonCode: "provider_overloaded",
+        replaySafety: "provider_entered",
+      }),
+    ).toMatchObject({ action: "retry", delayMs: 500, userSeverity: "warning" });
+  });
+
+  it("normalizes non-positive and fractional attempts before choosing backoff", () => {
+    expect(decide({ category: "transient_transport", attempt: 0 })).toMatchObject({
+      action: "retry",
+      attempt: 1,
+      delayMs: 500,
+    });
+    expect(decide({ category: "unknown", attempt: 2.9 })).toMatchObject({
+      action: "retry",
+      attempt: 2,
+      delayMs: 15000,
+    });
+  });
 });
 
 describe("buildProviderRetryEvent", () => {
@@ -300,6 +386,26 @@ describe("buildProviderRetryEvent", () => {
       maxAttempts: 2,
       delayMs: 500,
       userSeverity: "info",
+    });
+  });
+
+  it("builds terminal payloads without a retry decision", () => {
+    const c = classification("credential", "provider_credential_required");
+    expect(
+      buildProviderRetryEvent({
+        event: "provider_failure_terminal",
+        provider: "claude-code",
+        scope: "session_start",
+        classification: c,
+        messagePreview: null,
+      }),
+    ).toEqual({
+      event: "provider_failure_terminal",
+      provider: "claude-code",
+      scope: "session_start",
+      category: "credential",
+      reasonCode: "provider_credential_required",
+      userSeverity: "error",
     });
   });
 });

--- a/packages/client/src/__tests__/runtime-notice.test.ts
+++ b/packages/client/src/__tests__/runtime-notice.test.ts
@@ -1,0 +1,156 @@
+import { type ProviderRetryEventPayload, RUNTIME_NOTICE_METADATA_KEY } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import {
+  formatProviderFailureRuntimeNotice,
+  isEgressForbiddenText,
+  postProviderFailureRuntimeNotice,
+  shouldPostProviderFailureRuntimeNotice,
+} from "../runtime/runtime-notice.js";
+import { FirstTreeHubSDK } from "../sdk.js";
+
+function payload(overrides: Partial<ProviderRetryEventPayload> = {}): ProviderRetryEventPayload {
+  return {
+    event: "provider_failure_terminal",
+    provider: "codex",
+    scope: "provider_turn",
+    category: "credential",
+    reasonCode: "provider_credential_required",
+    userSeverity: "error",
+    ...overrides,
+  };
+}
+
+describe("runtime notice formatting", () => {
+  it("posts runtime notices only for terminal provider failures", () => {
+    expect(shouldPostProviderFailureRuntimeNotice(payload({ event: "provider_failure_terminal" }))).toBe(true);
+    expect(shouldPostProviderFailureRuntimeNotice(payload({ event: "provider_retry_exhausted" }))).toBe(true);
+    expect(shouldPostProviderFailureRuntimeNotice(payload({ event: "provider_retry_scheduled" }))).toBe(false);
+    expect(shouldPostProviderFailureRuntimeNotice(payload({ event: "provider_retry_succeeded" }))).toBe(false);
+  });
+
+  it("formats generic provider failure categories and action scopes", () => {
+    const cases: Array<{
+      overrides: Partial<ProviderRetryEventPayload>;
+      expected: string;
+    }> = [
+      {
+        overrides: { provider: "codex", scope: "session_start", category: "credential" },
+        expected: "Codex could not start this chat session: credentials need attention.",
+      },
+      {
+        overrides: { provider: "claude-code-tui", scope: "session_resume", category: "capability" },
+        expected: "Claude Code could not resume this chat session: the runtime is unavailable",
+      },
+      {
+        overrides: { provider: "codex", category: "configuration" },
+        expected: "runtime configuration needs attention",
+      },
+      {
+        overrides: { provider: "codex", category: "deterministic_input" },
+        expected: "this input cannot be processed as-is",
+      },
+      {
+        overrides: { provider: "codex", category: "provider_capacity" },
+        expected: "provider capacity or quota blocked the request",
+      },
+      {
+        overrides: { provider: "codex", category: "transient_transport" },
+        expected: "after retrying a transient provider or network failure",
+      },
+      {
+        overrides: { provider: "codex", category: "unknown" },
+        expected: "unknown terminal failure",
+      },
+    ];
+
+    for (const item of cases) {
+      expect(formatProviderFailureRuntimeNotice(payload(item.overrides))).toContain(item.expected);
+    }
+  });
+
+  it("formats Claude provider-turn credential and capacity notices", () => {
+    expect(
+      formatProviderFailureRuntimeNotice(
+        payload({
+          provider: "claude-code",
+          category: "credential",
+          messagePreview: "API Error: 403 Request not allowed",
+        }),
+      ),
+    ).toContain("usually NOT a login problem");
+    expect(formatProviderFailureRuntimeNotice(payload({ provider: "claude-code", category: "credential" }))).toContain(
+      "Run `claude auth login`",
+    );
+    expect(
+      formatProviderFailureRuntimeNotice(
+        payload({ provider: "claude-code", category: "provider_capacity", reasonCode: "provider_billing_limit" }),
+      ),
+    ).toContain("insufficient account balance");
+    expect(
+      formatProviderFailureRuntimeNotice(
+        payload({ provider: "claude-code", category: "provider_capacity", reasonCode: "provider_rate_limited" }),
+      ),
+    ).toContain("rate-limited this account");
+    expect(
+      formatProviderFailureRuntimeNotice(
+        payload({ provider: "claude-code", category: "provider_capacity", reasonCode: "provider_overloaded" }),
+      ),
+    ).toContain("capacity or usage limit");
+  });
+
+  it("formats remaining Claude provider-turn categories", () => {
+    const cases: Array<[ProviderRetryEventPayload["category"], string]> = [
+      ["transient_transport", "Anthropic connection failed"],
+      ["configuration", "runtime configuration is invalid"],
+      ["deterministic_input", "Anthropic rejected this request as invalid"],
+      ["capability", "runtime is not launchable"],
+      ["unknown", "Claude SDK reported a provider failure"],
+    ];
+
+    for (const [category, expected] of cases) {
+      expect(formatProviderFailureRuntimeNotice(payload({ provider: "claude-code", category }))).toContain(expected);
+    }
+  });
+
+  it("redacts provider message previews and omits empty previews", () => {
+    expect(
+      formatProviderFailureRuntimeNotice(
+        payload({ messagePreview: "fetch failed with token ghp_secret_should_be_redacted" }),
+      ),
+    ).toContain("[REDACTED:ghp]");
+    expect(formatProviderFailureRuntimeNotice(payload({ messagePreview: "   " }))).not.toContain(
+      "Original provider message",
+    );
+  });
+
+  it("detects Anthropic egress 403 text", () => {
+    expect(isEgressForbiddenText("API Error: 403 Request not allowed")).toBe(true);
+    expect(isEgressForbiddenText("API Error: 403 insufficient balance")).toBe(false);
+    expect(isEgressForbiddenText("Request not allowed")).toBe(false);
+  });
+
+  it("sends the formatted notice as final API text with runtime metadata", async () => {
+    const sdk = new FirstTreeHubSDK({ serverUrl: "https://first-tree.test", getAccessToken: () => "token" });
+    const sendMessage = vi.spyOn(sdk, "sendMessage").mockResolvedValue({
+      id: "msg-1",
+      chatId: "chat-1",
+      senderId: "agent-1",
+      format: "text",
+      content: "notice",
+      metadata: {},
+      inReplyTo: null,
+      source: "api",
+      createdAt: "2026-07-09T00:00:00.000Z",
+    });
+
+    await postProviderFailureRuntimeNotice(sdk, "chat-1", payload({ messagePreview: "refresh token revoked" }));
+
+    expect(sendMessage).toHaveBeenCalledWith("chat-1", {
+      source: "api",
+      format: "text",
+      content: expect.stringContaining("refresh token revoked"),
+      metadata: { [RUNTIME_NOTICE_METADATA_KEY]: true },
+      purpose: "agent-final-text",
+    });
+  });
+});

--- a/packages/client/src/__tests__/runtime-small-coverage.test.ts
+++ b/packages/client/src/__tests__/runtime-small-coverage.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from "vitest";
+import { getCliBinding, resetCliBindingForTest, setCliBinding } from "../runtime/cli-binding.js";
+import {
+  deliveryTokenFromSessionContext,
+  noopDeliveryToken,
+  type SessionContext,
+  type SessionMessage,
+} from "../runtime/handler.js";
+
+describe("CLI binding state", () => {
+  it("throws loudly when runtime code reads the binding before startup installs it", () => {
+    resetCliBindingForTest();
+
+    expect(() => getCliBinding()).toThrow(/CLI binding not initialised/);
+  });
+
+  it("stores a defensive copy of the startup binding and allows tests to reset it", () => {
+    const binding = { binName: "first-tree-dev", packageName: null };
+    setCliBinding(binding);
+    binding.binName = "mutated";
+
+    expect(getCliBinding()).toEqual({ binName: "first-tree-dev", packageName: null });
+
+    resetCliBindingForTest();
+    expect(() => getCliBinding()).toThrow(/CLI binding not initialised/);
+  });
+});
+
+describe("Claude browser login invocation resolution", () => {
+  it("prefers a resolved on-disk claude executable", async () => {
+    vi.resetModules();
+    const resolveClaudeCodeExecutable = vi.fn(() => ({ path: "/usr/local/bin/claude", source: "path" }));
+    const resolveBundledClaudeBinary = vi.fn();
+    vi.doMock("../handlers/claude-executable.js", () => ({ resolveClaudeCodeExecutable }));
+    vi.doMock("../runtime/capabilities/claude-code.js", () => ({ resolveBundledClaudeBinary }));
+
+    const { resolveClaudeLoginInvocation } = await import("../runtime/claude-login.js");
+
+    expect(resolveClaudeLoginInvocation({ PATH: "/usr/local/bin" })).toEqual({
+      ok: true,
+      command: "/usr/local/bin/claude",
+      baseArgs: [],
+    });
+    expect(resolveClaudeCodeExecutable).toHaveBeenCalledWith({ env: { PATH: "/usr/local/bin" } });
+    expect(resolveBundledClaudeBinary).not.toHaveBeenCalled();
+  });
+
+  it("uses the bundled legacy cli.js through node when no system claude resolves", async () => {
+    vi.resetModules();
+    vi.doMock("../handlers/claude-executable.js", () => ({
+      resolveClaudeCodeExecutable: vi.fn(() => ({ path: undefined, source: "default" })),
+    }));
+    vi.doMock("../runtime/capabilities/claude-code.js", () => ({
+      resolveBundledClaudeBinary: vi.fn(() => ({ kind: "cli-js", path: "/sdk/cli.js" })),
+    }));
+
+    const { resolveClaudeLoginInvocation } = await import("../runtime/claude-login.js");
+
+    expect(resolveClaudeLoginInvocation()).toEqual({
+      ok: true,
+      command: process.execPath,
+      baseArgs: ["/sdk/cli.js"],
+    });
+  });
+
+  it("uses the bundled native binary directly when that is the SDK layout", async () => {
+    vi.resetModules();
+    vi.doMock("../handlers/claude-executable.js", () => ({
+      resolveClaudeCodeExecutable: vi.fn(() => ({ path: undefined, source: "default" })),
+    }));
+    vi.doMock("../runtime/capabilities/claude-code.js", () => ({
+      resolveBundledClaudeBinary: vi.fn(() => ({ kind: "native", path: "/sdk/claude" })),
+    }));
+
+    const { resolveClaudeLoginInvocation } = await import("../runtime/claude-login.js");
+
+    expect(resolveClaudeLoginInvocation()).toEqual({
+      ok: true,
+      command: "/sdk/claude",
+      baseArgs: [],
+    });
+  });
+
+  it("returns a readable failure when neither system nor bundled claude can be located", async () => {
+    vi.resetModules();
+    vi.doMock("../handlers/claude-executable.js", () => ({
+      resolveClaudeCodeExecutable: vi.fn(() => ({ path: undefined, source: "default" })),
+    }));
+    vi.doMock("../runtime/capabilities/claude-code.js", () => ({
+      resolveBundledClaudeBinary: vi.fn(() => {
+        throw new Error("native package missing");
+      }),
+    }));
+
+    const { resolveClaudeLoginInvocation } = await import("../runtime/claude-login.js");
+
+    expect(resolveClaudeLoginInvocation()).toEqual({
+      ok: false,
+      error: "no `claude` on PATH and the SDK-bundled Claude binary could not be located: native package missing",
+    });
+  });
+
+  it("builds the browser OAuth command with auth login and the default timeout", async () => {
+    vi.resetModules();
+    const runBrowserLogin = vi.fn(async () => ({ ok: true as const, authUrl: "https://claude.test/login" }));
+    vi.doMock("../runtime/runtime-login.js", () => ({
+      BROWSER_LOGIN_TIMEOUT_MS: 1234,
+      runBrowserLogin,
+    }));
+
+    const { runClaudeBrowserLogin } = await import("../runtime/claude-login.js");
+    const onAuthUrl = vi.fn();
+    const onRawOutput = vi.fn();
+    const spawnFn = vi.fn() as never;
+    const signal = new AbortController().signal;
+
+    await expect(
+      runClaudeBrowserLogin({
+        command: "/usr/bin/claude",
+        baseArgs: ["--profile", "work"],
+        env: { HOME: "/tmp/home" },
+        onAuthUrl,
+        onRawOutput,
+        signal,
+        spawnFn,
+      }),
+    ).resolves.toEqual({ ok: true, authUrl: "https://claude.test/login" });
+
+    expect(runBrowserLogin).toHaveBeenCalledWith({
+      command: "/usr/bin/claude",
+      args: ["--profile", "work", "auth", "login"],
+      label: "claude auth login",
+      env: { HOME: "/tmp/home" },
+      onAuthUrl,
+      onRawOutput,
+      signal,
+      timeoutMs: 1234,
+      spawnFn,
+    });
+  });
+
+  it("honors an explicit browser login timeout override", async () => {
+    vi.resetModules();
+    const runBrowserLogin = vi.fn(async () => ({ ok: false as const, error: "timed out" }));
+    vi.doMock("../runtime/runtime-login.js", () => ({
+      BROWSER_LOGIN_TIMEOUT_MS: 1234,
+      runBrowserLogin,
+    }));
+
+    const { runClaudeBrowserLogin } = await import("../runtime/claude-login.js");
+
+    await expect(
+      runClaudeBrowserLogin({
+        command: "/usr/bin/claude",
+        baseArgs: [],
+        timeoutMs: 50,
+      }),
+    ).resolves.toEqual({ ok: false, error: "timed out" });
+
+    expect(runBrowserLogin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: ["auth", "login"],
+        timeoutMs: 50,
+      }),
+    );
+  });
+});
+
+describe("delivery token helpers", () => {
+  const message: SessionMessage = {
+    id: "019f44e0-0000-7000-8000-000000000001",
+    chatId: "chat-1",
+    senderId: "agent-human",
+    format: "text",
+    content: "hello",
+    metadata: null,
+  };
+
+  it("noopDeliveryToken exposes inert async-safe methods", async () => {
+    const token = noopDeliveryToken();
+
+    expect(() => token.processingStarted(message)).not.toThrow();
+    expect(() => token.retry([message], "later")).not.toThrow();
+    await expect(token.complete(message, { status: "success" })).resolves.toBeUndefined();
+    await expect(
+      token.terminalRejected(message, "terminal", { kind: "chat_message", messageId: "msg-1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("adapts a SessionContext to the DeliveryToken contract", async () => {
+    const markMessagesConsumed = vi.fn();
+    const finishTurn = vi.fn(async () => {});
+    const retryTurn = vi.fn();
+    const ctx = {
+      markMessagesConsumed,
+      finishTurn,
+      retryTurn,
+    } as unknown as SessionContext;
+
+    const token = deliveryTokenFromSessionContext(ctx);
+
+    token.processingStarted(message);
+    await token.complete([message], { status: "error", errorKind: "transient" });
+    token.retry(message, "network");
+    await token.terminalRejected(message, "terminal", { kind: "server_terminal_record", recordId: "rec-1" });
+
+    expect(markMessagesConsumed).toHaveBeenCalledWith(message);
+    expect(finishTurn).toHaveBeenCalledWith([message], { status: "error", errorKind: "transient" });
+    expect(retryTurn).toHaveBeenCalledWith(message, "network");
+    expect(retryTurn).toHaveBeenCalledWith(message, "terminal_rejected_without_delivery_token:terminal");
+  });
+});

--- a/packages/client/src/__tests__/runtime.test.ts
+++ b/packages/client/src/__tests__/runtime.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import type { ClientConfig } from "@first-tree/shared/config";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeConfig } from "../runtime/config.js";
 import type { UpdateManagerOptions } from "../runtime/update-manager.js";
@@ -90,6 +91,16 @@ function makeRuntimeConfigWithAgentCount(count: number): RuntimeConfig {
   return {
     server: "http://first-tree.test",
     agents,
+  };
+}
+
+function makeUpdateConfig(overrides: Partial<ClientConfig["update"]> = {}): ClientConfig["update"] {
+  return {
+    policy: "auto",
+    restart_quiet_seconds: 30,
+    restart_check_interval_seconds: 10,
+    prompt_timeout_seconds: 60,
+    ...overrides,
   };
 }
 
@@ -245,6 +256,43 @@ describe("AgentRuntime", () => {
     });
 
     expect(state.connections[0]?.getMaxListeners()).toBe(12);
+  });
+
+  it("attaches update management with aggregate quiet-gate state", async () => {
+    const state = installRuntimeMocks({
+      snapshots: {
+        alpha: { activeCount: 2, lastActivityMs: 400 },
+        beta: { activeCount: 3, lastActivityMs: 900 },
+      },
+    });
+    const signals = captureProcessSignals();
+    const { AgentRuntime } = await import("../runtime/runtime.js");
+    const runtime = new AgentRuntime({
+      config: makeRuntimeConfig(),
+      currentVersion: "1.2.3",
+      getAccessToken: async () => "token",
+      update: {
+        updateConfig: makeUpdateConfig({ policy: "prompt" }),
+        prompt: vi.fn(async () => true),
+        executeUpdate: vi.fn(async () => ({ installed: true })),
+        refreshServerTarget: vi.fn(async () => ({ ok: true as const, targetVersion: "1.2.4" })),
+      },
+    });
+
+    const started = runtime.start();
+    await vi.waitFor(() => expect(signals.getSigint()).not.toBeNull());
+
+    expect(state.updateAttach).toHaveBeenCalledWith(
+      state.connections[0],
+      expect.objectContaining({ currentVersion: "1.2.3", updateConfig: makeUpdateConfig({ policy: "prompt" }) }),
+    );
+    expect(state.updateOptions?.getQuietGateSnapshot()).toEqual({ activeCount: 5, lastActivityMs: 900 });
+    state.updateOptions?.log("warn", "update log entry");
+    expect(state.logger.warn).toHaveBeenCalledWith("update log entry");
+
+    await signals.getSigint()?.();
+    await expect(started).resolves.toBeUndefined();
+    expect(state.updateDispose).toHaveBeenCalledTimes(1);
   });
 
   it("forces exit when shutdown exceeds the timeout", async () => {

--- a/packages/client/src/__tests__/sdk-comprehensive.test.ts
+++ b/packages/client/src/__tests__/sdk-comprehensive.test.ts
@@ -1,0 +1,523 @@
+import {
+  AGENT_RUNTIME_SESSION_HEADER,
+  AGENT_SELECTOR_HEADER,
+  ATTACHMENT_FILENAME_HEADER,
+  ATTACHMENT_MIME_HEADER,
+} from "@first-tree/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyClientLoggerConfig } from "../observability/logger.js";
+import { FirstTreeHubSDK, SdkError } from "../sdk.js";
+
+const SERVER_URL = "https://first-tree.example";
+type TestHeaders = Record<string, string>;
+
+const githubEntity = {
+  entityType: "pull_request",
+  entityKey: "agent-team-foundation/first-tree#42",
+  boundVia: "agent_declared",
+  htmlUrl: "https://github.com/agent-team-foundation/first-tree/pull/42",
+  title: "Add SDK tests",
+  state: "open",
+  number: 42,
+};
+
+function jsonResponse(data: unknown, status = 200, headers: TestHeaders = {}): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+  });
+}
+
+function textResponse(body: string, status = 200, headers: TestHeaders = {}): Response {
+  return new Response(body, {
+    status,
+    headers: {
+      "content-type": "text/plain",
+      ...headers,
+    },
+  });
+}
+
+function binaryResponse(bytes: Uint8Array, headers: TestHeaders = {}): Response {
+  return new Response(bytes, { status: 200, headers });
+}
+
+function mockFetch(...responses: Response[]): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn();
+  for (const response of responses) {
+    fetchMock.mockResolvedValueOnce(response);
+  }
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function makeSdk(overrides: Partial<ConstructorParameters<typeof FirstTreeHubSDK>[0]> = {}): FirstTreeHubSDK {
+  return new FirstTreeHubSDK({
+    serverUrl: `${SERVER_URL}///`,
+    agentId: "agent-1",
+    runtimeSessionToken: "runtime-session-1",
+    userAgent: "first-tree-test",
+    getAccessToken: () => "access-token",
+    ...overrides,
+  });
+}
+
+function requestInit(fetchMock: ReturnType<typeof vi.fn>, index: number): RequestInit {
+  const init = fetchMock.mock.calls[index]?.[1] as RequestInit | undefined;
+  if (!init) throw new Error(`missing fetch init at call ${index}`);
+  return init;
+}
+
+async function flush<T>(promise: Promise<T>, maxFlushes = 50): Promise<T> {
+  let settled = false;
+  let result: T | undefined;
+  let error: unknown;
+  promise.then(
+    (value) => {
+      result = value;
+      settled = true;
+    },
+    (err) => {
+      error = err;
+      settled = true;
+    },
+  );
+
+  for (let i = 0; i < maxFlushes && !settled; i++) {
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1000);
+  }
+  if (!settled) throw new Error("flush did not settle within maxFlushes");
+  if (error !== undefined) throw error;
+  return result as T;
+}
+
+describe("FirstTreeHubSDK comprehensive wrappers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    applyClientLoggerConfig({ level: "silent", format: "json", destination: process.stderr, explicit: false });
+  });
+
+  it("normalizes config and attaches scoped auth headers", async () => {
+    const fetchMock = mockFetch(jsonResponse({ accessToken: "outbox-token", expiresIn: 60 }));
+    const sdk = makeSdk();
+
+    expect(sdk.serverUrl).toBe(SERVER_URL);
+    expect(sdk.agentId).toBe("agent-1");
+    expect(sdk.runtimeSessionToken).toBe("runtime-session-1");
+
+    await expect(sdk.createAgentOutboxToken("chat/with space")).resolves.toEqual({
+      accessToken: "outbox-token",
+      expiresIn: 60,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${SERVER_URL}/api/v1/agent/chats/chat%2Fwith%20space/outbox-token`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer access-token",
+          [AGENT_SELECTOR_HEADER]: "agent-1",
+          [AGENT_RUNTIME_SESSION_HEADER]: "runtime-session-1",
+          "User-Agent": "first-tree-test",
+        }),
+      }),
+    );
+    expect(requestInit(fetchMock, 0).headers).not.toMatchObject({ "Content-Type": "application/json" });
+  });
+
+  it("builds chat and GitHub entity wrapper paths, bodies, and queries", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse({ chatIds: ["chat-1", "chat-2"] }),
+      jsonResponse({ status: "created", entity: githubEntity }, 201),
+      jsonResponse({ removed: 1 }),
+      jsonResponse({ items: [githubEntity] }),
+      jsonResponse({ id: "chat-1", topic: "New topic", description: null }),
+    );
+    const sdk = makeSdk();
+
+    await expect(sdk.listActiveRuntimeChatIds()).resolves.toEqual({ chatIds: ["chat-1", "chat-2"] });
+    await expect(sdk.followGithubEntity("chat-1", { entity: "owner/repo#42", rebind: true })).resolves.toEqual({
+      ok: true,
+      result: { status: "created", entity: githubEntity },
+    });
+    await expect(sdk.unfollowGithubEntity("chat-1", "owner/repo#42 & label")).resolves.toEqual({ removed: 1 });
+    await expect(sdk.listChatGithubEntities("chat-1")).resolves.toEqual({ items: [githubEntity] });
+    await expect(sdk.updateChat("chat-1", { topic: "New topic", description: null })).resolves.toMatchObject({
+      id: "chat-1",
+      topic: "New topic",
+    });
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      `${SERVER_URL}/api/v1/agent/chats/active-runtime-ids`,
+      `${SERVER_URL}/api/v1/agent/chats/chat-1/github-entities`,
+      `${SERVER_URL}/api/v1/agent/chats/chat-1/github-entities?entity=owner%2Frepo%2342%20%26%20label`,
+      `${SERVER_URL}/api/v1/agent/chats/chat-1/github-entities`,
+      `${SERVER_URL}/api/v1/agent/chats/chat-1`,
+    ]);
+    expect(requestInit(fetchMock, 1)).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ entity: "owner/repo#42", rebind: true }),
+    });
+    expect(requestInit(fetchMock, 2)).toMatchObject({ method: "DELETE" });
+    expect(requestInit(fetchMock, 4)).toMatchObject({
+      method: "PATCH",
+      body: JSON.stringify({ topic: "New topic", description: null }),
+    });
+  });
+
+  it("builds document wrapper paths, queries, and JSON bodies", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse({ id: "doc-1", slug: "runbook", version: 1, createdDocument: true, createdVersion: true }),
+      jsonResponse({ items: [{ id: "doc-1", slug: "runbook" }], nextCursor: "next-doc" }),
+      jsonResponse({ id: "doc-1", slug: "runbook", version: { number: 3, content: "# Runbook" } }),
+      jsonResponse({ id: "doc-1", status: "approved" }),
+      jsonResponse({ items: [{ id: "comment-1", body: "Question" }], nextCursor: null }),
+      jsonResponse({ id: "comment-1", body: "Looks good", status: "open" }),
+      jsonResponse({ id: "comment-2", parentId: "comment-1", body: "Reply", status: "open" }),
+      jsonResponse({ id: "comment-1", status: "resolved" }),
+    );
+    const sdk = makeSdk();
+
+    await expect(
+      sdk.publishDoc({
+        slug: "runbook",
+        title: "Runbook",
+        project: null,
+        content: "# Runbook",
+        note: "Initial version",
+        status: "draft",
+        ifChanged: true,
+      }),
+    ).resolves.toMatchObject({ id: "doc-1", createdDocument: true });
+    await expect(
+      sdk.listDocs({
+        slug: "runbook",
+        project: "Core Docs",
+        status: "in_review",
+        limit: 25,
+        cursor: "after value",
+      }),
+    ).resolves.toMatchObject({ nextCursor: "next-doc" });
+    await expect(sdk.getDoc("doc / 1", { version: 3 })).resolves.toMatchObject({ id: "doc-1" });
+    await expect(sdk.setDocStatus("doc / 1", "approved")).resolves.toMatchObject({ status: "approved" });
+    await expect(sdk.listDocComments("doc / 1", { status: "open", versionNumber: 2 })).resolves.toMatchObject({
+      nextCursor: null,
+    });
+    await expect(
+      sdk.createDocComment("doc / 1", {
+        body: "Looks good",
+        versionNumber: 2,
+        anchor: { exact: "Runbook", prefix: "# ", suffix: "\n" },
+      }),
+    ).resolves.toMatchObject({ id: "comment-1" });
+    await expect(sdk.replyDocComment("comment / 1", "Reply")).resolves.toMatchObject({ parentId: "comment-1" });
+    await expect(sdk.setDocCommentStatus("comment / 1", "resolved")).resolves.toMatchObject({ status: "resolved" });
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      `${SERVER_URL}/api/v1/agent/documents`,
+      `${SERVER_URL}/api/v1/agent/documents?slug=runbook&project=Core+Docs&status=in_review&limit=25&cursor=after+value`,
+      `${SERVER_URL}/api/v1/agent/documents/doc%20%2F%201?version=3`,
+      `${SERVER_URL}/api/v1/agent/documents/doc%20%2F%201`,
+      `${SERVER_URL}/api/v1/agent/documents/doc%20%2F%201/comments?status=open&versionNumber=2`,
+      `${SERVER_URL}/api/v1/agent/documents/doc%20%2F%201/comments`,
+      `${SERVER_URL}/api/v1/agent/document-comments/comment%20%2F%201/replies`,
+      `${SERVER_URL}/api/v1/agent/document-comments/comment%20%2F%201`,
+    ]);
+    expect(requestInit(fetchMock, 0)).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({
+        slug: "runbook",
+        title: "Runbook",
+        project: null,
+        content: "# Runbook",
+        note: "Initial version",
+        status: "draft",
+        ifChanged: true,
+      }),
+    });
+    expect(requestInit(fetchMock, 3)).toMatchObject({
+      method: "PATCH",
+      body: JSON.stringify({ status: "approved" }),
+    });
+    expect(requestInit(fetchMock, 5)).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({
+        body: "Looks good",
+        versionNumber: 2,
+        anchor: { exact: "Runbook", prefix: "# ", suffix: "\n" },
+      }),
+    });
+    expect(requestInit(fetchMock, 6)).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ body: "Reply" }),
+    });
+    expect(requestInit(fetchMock, 7)).toMatchObject({
+      method: "PATCH",
+      body: JSON.stringify({ status: "resolved" }),
+    });
+  });
+
+  it("does not retry non-idempotent document writes on uncertain failures", async () => {
+    const sdk = makeSdk();
+
+    let fetchMock = mockFetch(textResponse("publish failed", 500), jsonResponse({ unreached: true }));
+    await expect(sdk.publishDoc({ slug: "runbook", content: "# Runbook", ifChanged: false })).rejects.toMatchObject({
+      statusCode: 500,
+      message: "publish failed",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+    fetchMock = mockFetch(textResponse("comment failed", 500), jsonResponse({ unreached: true }));
+    await expect(sdk.createDocComment("doc-1", { body: "Question" })).rejects.toMatchObject({
+      statusCode: 500,
+      message: "comment failed",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+    fetchMock = mockFetch(textResponse("reply failed", 500), jsonResponse({ unreached: true }));
+    await expect(sdk.replyDocComment("comment-1", "Reply")).rejects.toMatchObject({
+      statusCode: 500,
+      message: "reply failed",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("parses follow conflicts and malformed conflict bodies", async () => {
+    let fetchMock = mockFetch(
+      jsonResponse(
+        {
+          error: "ENTITY_FOLLOWED_ELSEWHERE",
+          message: "Already followed",
+          conflict: { chatId: "chat-existing", topic: null },
+        },
+        409,
+      ),
+    );
+    await expect(makeSdk().followGithubEntity("chat-1", { entity: "owner/repo#42" })).resolves.toEqual({
+      ok: false,
+      conflict: {
+        error: "ENTITY_FOLLOWED_ELSEWHERE",
+        message: "Already followed",
+        conflict: { chatId: "chat-existing", topic: null },
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+    fetchMock = mockFetch(textResponse("<html>conflict</html>", 409));
+    await expect(makeSdk().followGithubEntity("chat-1", { entity: "owner/repo#42" })).rejects.toMatchObject({
+      statusCode: 409,
+      message: "Entity already followed in another chat (non-JSON conflict body)",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+    fetchMock = mockFetch(jsonResponse({ error: "ENTITY_FOLLOWED_ELSEWHERE" }, 409));
+    await expect(makeSdk().followGithubEntity("chat-1", { entity: "owner/repo#42" })).rejects.toMatchObject({
+      statusCode: 409,
+      message: "Entity already followed in another chat (malformed conflict body)",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+    fetchMock = mockFetch(jsonResponse({ error: "missing installation" }, 422));
+    await expect(makeSdk().followGithubEntity("chat-1", { entity: "owner/repo#42" })).rejects.toMatchObject({
+      statusCode: 422,
+      message: "missing installation",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uploads and downloads attachments with metadata headers and filename fallbacks", async () => {
+    const uploadBody = {
+      id: "123e4567-e89b-12d3-a456-426614174000",
+      mimeType: "image/png",
+      filename: "screen shot.png",
+      sizeBytes: 3,
+      uploadedBy: "agent-1",
+      createdAt: "2026-07-09T00:00:00.000Z",
+    };
+    const bytes = new Uint8Array([1, 2, 3]);
+    const fetchMock = mockFetch(
+      jsonResponse(uploadBody),
+      binaryResponse(bytes, {
+        "content-type": "image/png",
+        "content-disposition": 'attachment; filename="screen%20shot.png"',
+      }),
+      binaryResponse(new Uint8Array([4])),
+      binaryResponse(new Uint8Array([5]), {
+        "content-disposition": 'attachment; filename="bad%ZZname.txt"',
+      }),
+    );
+    const sdk = makeSdk();
+
+    await expect(
+      sdk.uploadAttachment({
+        orgId: "org / 1",
+        bytes,
+        mimeType: "image/png",
+        filename: "screen shot.png",
+      }),
+    ).resolves.toEqual(uploadBody);
+    const downloaded = await sdk.fetchAttachment({ id: "att / 1" });
+    expect(downloaded).toMatchObject({
+      mimeType: "image/png",
+      filename: "screen shot.png",
+      size: 3,
+    });
+    expect(Buffer.compare(downloaded.bytes, Buffer.from([1, 2, 3]))).toBe(0);
+    await expect(sdk.fetchAttachment({ id: "att-2" })).resolves.toMatchObject({
+      mimeType: "application/octet-stream",
+      filename: "blob",
+      size: 1,
+    });
+    await expect(sdk.fetchAttachment({ id: "att-3" })).resolves.toMatchObject({
+      filename: "bad%ZZname.txt",
+      size: 1,
+    });
+
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      `${SERVER_URL}/api/v1/orgs/org%20%2F%201/attachments`,
+      `${SERVER_URL}/api/v1/attachments/att%20%2F%201`,
+      `${SERVER_URL}/api/v1/attachments/att-2`,
+      `${SERVER_URL}/api/v1/attachments/att-3`,
+    ]);
+    expect(requestInit(fetchMock, 0)).toMatchObject({
+      method: "POST",
+      body: bytes,
+      headers: expect.objectContaining({
+        "Content-Type": "application/octet-stream",
+        [ATTACHMENT_MIME_HEADER]: "image/png",
+        [ATTACHMENT_FILENAME_HEADER]: "screen shot.png",
+      }),
+    });
+  });
+
+  it("rejects invalid upload metadata and maps attachment download errors", async () => {
+    let fetchMock = mockFetch(jsonResponse({ id: "not-a-uuid" }));
+
+    await expect(
+      makeSdk().uploadAttachment({
+        orgId: "org-1",
+        bytes: new Uint8Array([1]),
+        mimeType: "text/plain",
+        filename: "note.txt",
+      }),
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
+    fetchMock = mockFetch(jsonResponse({ error: "attachment missing" }, 404));
+    await expect(makeSdk().fetchAttachment({ id: "att-missing" })).rejects.toMatchObject({
+      statusCode: 404,
+      message: "attachment missing",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("parses SDK errors, Retry-After dates, invalid Retry-After values, and invalid success JSON", async () => {
+    vi.useFakeTimers({ now: new Date("2026-07-09T00:00:00.000Z") });
+
+    mockFetch(
+      jsonResponse({ error: "slow down" }, 429, { "retry-after": "Thu, 09 Jul 2026 00:00:10 GMT" }),
+      textResponse("not json", 200, { "content-type": "application/json" }),
+      jsonResponse({ error: "bad retry" }, 429, { "retry-after": "not a date" }),
+    );
+    const sdk = makeSdk();
+
+    await expect(sdk.listChats()).rejects.toMatchObject({
+      statusCode: 429,
+      message: "slow down",
+      retryAfter: "Thu, 09 Jul 2026 00:00:10 GMT",
+      retryAfterMs: 10_000,
+    });
+    await expect(sdk.listChats()).rejects.toBeInstanceOf(SyntaxError);
+
+    try {
+      await sdk.listChats();
+      throw new Error("expected listChats to reject");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SdkError);
+      if (!(err instanceof SdkError)) throw err;
+      expect(err.retryAfter).toBe("not a date");
+      expect(err.retryAfterMs).toBeUndefined();
+    }
+  });
+
+  it("retries retryable HTTP and nested network failures but skips deterministic network errors", async () => {
+    vi.useFakeTimers();
+    applyClientLoggerConfig({ level: "silent", format: "json", destination: process.stderr, explicit: false });
+
+    let fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(textResponse("busy-1", 503))
+      .mockResolvedValueOnce(textResponse("busy-2", 503))
+      .mockResolvedValueOnce(textResponse("busy-3", 503));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(flush(makeSdk().listChats())).rejects.toMatchObject({
+      statusCode: 503,
+      message: "busy-3",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    vi.unstubAllGlobals();
+    const cause = Object.assign(new Error("temporary DNS failure"), { code: "EAI_AGAIN" });
+    const nested = new Error("outer network wrapper", { cause });
+    fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(nested)
+      .mockResolvedValueOnce(jsonResponse({ items: [], nextCursor: null }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(flush(makeSdk().listChats())).resolves.toEqual({ items: [], nextCursor: null });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    vi.unstubAllGlobals();
+    const deterministic = Object.assign(new Error("host not found"), { code: "ENOTFOUND" });
+    fetchMock = vi.fn().mockRejectedValueOnce(deterministic);
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(makeSdk().listChats()).rejects.toBe(deterministic);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses startup timeout overrides and default request timeouts", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation(() => new AbortController().signal);
+    mockFetch(
+      jsonResponse({ agentId: "agent-1", version: 1, payload: {} }),
+      jsonResponse({ items: [], nextCursor: null }),
+    );
+    const sdk = makeSdk();
+
+    await expect(sdk.fetchAgentConfig()).resolves.toMatchObject({ agentId: "agent-1" });
+    await expect(sdk.listChats()).resolves.toEqual({ items: [], nextCursor: null });
+
+    expect(timeoutSpy).toHaveBeenNthCalledWith(1, 5_000);
+    expect(timeoutSpy).toHaveBeenNthCalledWith(2, 15_000);
+  });
+
+  it("checks anonymous health without requiring auth or user-agent headers", async () => {
+    const fetchMock = mockFetch(new Response(null, { status: 204 }));
+    const sdk = makeSdk({
+      userAgent: undefined,
+      getAccessToken: () => {
+        throw new Error("health should not request auth");
+      },
+    });
+
+    await expect(sdk.isHubReachable(25)).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${SERVER_URL}/api/v1/health`,
+      expect.objectContaining({
+        headers: {},
+      }),
+    );
+  });
+});

--- a/packages/client/src/__tests__/session-manager-more-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-more-coverage.test.ts
@@ -1,0 +1,512 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type AgentRuntimeConfig,
+  encodeProviderRetryEventMessage,
+  type InboxEntryWithMessage,
+  type SessionEvent,
+  type SessionState,
+} from "@first-tree/shared";
+import type pino from "pino";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentConfigCache } from "../runtime/agent-config-cache.js";
+import type { ContextTreeBinding } from "../runtime/bootstrap.js";
+import type {
+  AgentHandler,
+  DeliveryToken,
+  HandlerConfig,
+  HandlerFactory,
+  SessionContext,
+  SessionMessage,
+} from "../runtime/handler.js";
+import { InboxDeliveryCoordinator } from "../runtime/inbox-delivery-coordinator.js";
+import type { SubprocessProbe } from "../runtime/process-tree-probe.js";
+import { SessionManager, type SessionManagerShutdownOptions } from "../runtime/session-manager.js";
+import type { FirstTreeHubSDK } from "../sdk.js";
+import { recordingLogger, silentLogger } from "./_logger-helpers.js";
+import { mockEntry } from "./test-helpers.js";
+
+function mockSdk(overrides: Record<string, unknown> = {}): FirstTreeHubSDK {
+  return {
+    register: vi.fn(),
+    sendMessage: vi.fn().mockResolvedValue({ id: "msg-reply" }),
+    sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+    getChatDetail: vi.fn().mockResolvedValue({ organizationId: "org-1" }),
+    ...overrides,
+  } as unknown as FirstTreeHubSDK;
+}
+
+function mockRuntimeConfig(): AgentRuntimeConfig {
+  return {
+    agentId: "agent-1",
+    version: 1,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    updatedBy: "tester",
+    payload: {
+      kind: "claude-code",
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+      reasoningEffort: "",
+    },
+  };
+}
+
+function mockAckEntry(): (entryId: number) => Promise<void> {
+  return vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+}
+
+function createMockHandler(overrides: Partial<AgentHandler> = {}): AgentHandler {
+  return {
+    start: vi.fn().mockResolvedValue("session-id-mock"),
+    resume: vi.fn().mockResolvedValue("session-id-mock"),
+    inject: vi.fn().mockReturnValue({ kind: "owned", mode: "queued" }),
+    suspend: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function createSessionManager(opts: {
+  sdk?: FirstTreeHubSDK;
+  handler?: AgentHandler;
+  handlerConfig?: HandlerConfig;
+  handlerFactory?: HandlerFactory;
+  resolveContextTreeBinding?: () => Promise<ContextTreeBinding | null>;
+  ackEntry?: (entryId: number) => Promise<void>;
+  recoverChat?: (chatId: string) => Promise<void>;
+  agentConfigCache?: AgentConfigCache;
+  log?: pino.Logger;
+  registryPath?: string;
+  onStateChange?: (chatId: string, state: SessionState) => void;
+  onSessionEvent?: (chatId: string, event: SessionEvent) => void;
+  subprocessProbe?: SubprocessProbe;
+}) {
+  const handler = opts.handler ?? createMockHandler();
+  return new SessionManager({
+    session: {
+      idle_timeout: 300,
+      max_sessions: 10,
+      working_grace_seconds: 3600,
+      reconcile_interval_seconds: 300,
+    },
+    concurrency: 5,
+    subprocessProbe: opts.subprocessProbe,
+    handlerFactory: opts.handlerFactory ?? (() => handler),
+    handlerConfig: opts.handlerConfig ?? { workspaceRoot: "/tmp/test" },
+    resolveContextTreeBinding: opts.resolveContextTreeBinding ?? (async () => null),
+    agentIdentity: {
+      agentId: "agent-1",
+      inboxId: "inbox-agent-1",
+      displayName: "Agent",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: opts.sdk ?? mockSdk(),
+    log: opts.log ?? silentLogger(),
+    registryPath: opts.registryPath,
+    ackEntry: opts.ackEntry ?? mockAckEntry(),
+    recoverChat: opts.recoverChat,
+    agentConfigCache: opts.agentConfigCache,
+    onStateChange: opts.onStateChange,
+    onSessionEvent: opts.onSessionEvent,
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toSessionMessage(entry: InboxEntryWithMessage): SessionMessage {
+  return {
+    inboxEntryId: entry.id,
+    id: entry.message.id,
+    chatId: entry.chatId ?? entry.message.chatId,
+    senderId: entry.message.senderId,
+    format: entry.message.format,
+    content:
+      typeof entry.message.content === "string"
+        ? entry.message.content
+        : isRecord(entry.message.content)
+          ? entry.message.content
+          : {},
+    metadata: entry.message.metadata,
+    createdAt: entry.message.createdAt,
+    precedingMessages: entry.message.precedingMessages ?? [],
+  };
+}
+
+function malformedProviderRetryEvent(): SessionEvent {
+  return {
+    kind: "error",
+    payload: {
+      source: "runtime",
+      message: "provider.retry: {not valid json",
+    },
+  };
+}
+
+describe("InboxDeliveryCoordinator additional delivery coverage", () => {
+  it("retains terminal ledger entries after ACK failure and re-ACKs terminal redelivery", async () => {
+    const { logger, records } = recordingLogger();
+    const ackEntry = vi
+      .fn<(entryId: number) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("ack socket closed"))
+      .mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry,
+      recoverChat,
+      onWorkChanged: vi.fn(),
+      log: logger,
+    });
+    const entry = mockEntry({ id: 100, chatId: "chat-ack-fail", messageId: "msg-ack-fail" });
+    const message = toSessionMessage(entry);
+
+    expect(coordinator.receive(entry)).toEqual({
+      kind: "deliver",
+      work: { chatId: "chat-ack-fail", entryId: 100, messageId: "msg-ack-fail" },
+    });
+    await coordinator.finishTurn("chat-ack-fail", message, { status: "success", terminal: true });
+
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-ack-fail"));
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(coordinator.snapshot("chat-ack-fail").entries).toEqual([
+      { entryId: 100, messageId: "msg-ack-fail", phase: "terminal" },
+    ]);
+    expect(records.some((record) => typeof record.msg === "string" && record.msg.includes("ACK-through failed"))).toBe(
+      true,
+    );
+
+    expect(coordinator.receive(entry)).toEqual({ kind: "duplicate-in-flight" });
+    await vi.waitFor(() => expect(ackEntry).toHaveBeenCalledTimes(2));
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 100);
+    expect(coordinator.snapshot("chat-ack-fail").entries).toEqual([]);
+  });
+
+  it("keeps a recovery redelivery burst in recovery mode until unsettled work drains", async () => {
+    const ackEntry = mockAckEntry();
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry,
+      recoverChat,
+      onWorkChanged: vi.fn(),
+      log: silentLogger(),
+    });
+    const first = mockEntry({ id: 201, chatId: "chat-redelivery-burst", messageId: "msg-redelivery-1" });
+    const second = mockEntry({ id: 202, chatId: "chat-redelivery-burst", messageId: "msg-redelivery-2" });
+
+    expect(coordinator.receive(first).kind).toBe("deliver");
+    coordinator.retryTurn("chat-redelivery-burst", toSessionMessage(first), "provider_retry");
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-redelivery-burst"));
+
+    expect(coordinator.takeRecoveryActivationReady("chat-redelivery-burst")).toBe(true);
+    expect(coordinator.receive(first).kind).toBe("deliver");
+    expect(coordinator.takeRecoveryActivationReady("chat-redelivery-burst")).toBe(true);
+    expect(coordinator.receive(second).kind).toBe("deliver");
+
+    await coordinator.finishTurn("chat-redelivery-burst", [toSessionMessage(first), toSessionMessage(second)], {
+      status: "success",
+      terminal: true,
+    });
+
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledWith(202);
+    expect(coordinator.takeRecoveryActivationReady("chat-redelivery-burst")).toBe(false);
+  });
+
+  it("logs and ignores terminal rejection payloads without an inbox entry id", async () => {
+    const { logger, records } = recordingLogger();
+    const ackEntry = mockAckEntry();
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry,
+      onWorkChanged: vi.fn(),
+      log: logger,
+    });
+    const entry = mockEntry({ id: 301, chatId: "chat-malformed-terminal", messageId: "msg-malformed-terminal" });
+    const message = toSessionMessage(entry);
+    const malformedMessage: SessionMessage = { ...message, inboxEntryId: undefined };
+
+    expect(coordinator.receive(entry).kind).toBe("deliver");
+    await coordinator.terminalRejected("chat-malformed-terminal", malformedMessage, "deterministic_failure", {
+      kind: "chat_message",
+      messageId: "error-message-id",
+    });
+
+    expect(ackEntry).not.toHaveBeenCalled();
+    expect(coordinator.snapshot("chat-malformed-terminal").entries).toEqual([
+      { entryId: 301, messageId: "msg-malformed-terminal", phase: "open" },
+    ]);
+    expect(
+      records.some(
+        (record) =>
+          typeof record.msg === "string" &&
+          record.msg.includes("terminal rejection ignored because no inboxEntryId was provided"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("SessionManager additional delivery token and payload coverage", () => {
+  it("logs and ignores duplicate terminal outcomes from one delivery token", async () => {
+    const { logger, records } = recordingLogger();
+    const ackEntry = mockAckEntry();
+    let capturedToken: DeliveryToken | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      start: vi.fn(async (message, _ctx, token) => {
+        capturedMessage = message;
+        capturedToken = token;
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "queued" } as const };
+      }),
+    });
+    const sm = createSessionManager({ handler, ackEntry, log: logger });
+
+    await sm.dispatch(mockEntry({ id: 401, chatId: "chat-token-duplicate", messageId: "msg-token-duplicate" }));
+    if (!capturedToken || !capturedMessage) throw new Error("delivery token was not captured");
+
+    await capturedToken.complete(capturedMessage, { status: "success", terminal: true });
+    await capturedToken.terminalRejected(capturedMessage, "late_terminal_rejection", {
+      kind: "chat_message",
+      messageId: "late-error-message",
+    });
+
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledWith(401);
+    expect(
+      records.some(
+        (record) =>
+          typeof record.msg === "string" &&
+          record.msg.includes("delivery token terminal outcome ignored after prior outcome") &&
+          record.action === "terminalRejected",
+      ),
+    ).toBe(true);
+
+    await sm.shutdown();
+  });
+
+  it("retries terminalRejected instead of ACKing when the durable runtime notice cannot be posted", async () => {
+    const ackEntry = mockAckEntry();
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockRejectedValue(new Error("notice write failed"));
+    const sdk = mockSdk({ sendMessage });
+    let capturedCtx: SessionContext | undefined;
+    let capturedToken: DeliveryToken | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const emitted: SessionEvent[] = [];
+    const handler = createMockHandler({
+      start: vi.fn(async (message, ctx, token) => {
+        capturedMessage = message;
+        capturedCtx = ctx;
+        capturedToken = token;
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "queued" } as const };
+      }),
+    });
+    const sm = createSessionManager({
+      handler,
+      ackEntry,
+      recoverChat,
+      sdk,
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
+      onSessionEvent: (_chatId, event) => emitted.push(event),
+    });
+
+    await sm.dispatch(mockEntry({ id: 402, chatId: "chat-terminal-notice-fail", messageId: "msg-terminal-notice" }));
+    if (!capturedCtx || !capturedToken || !capturedMessage) throw new Error("delivery token was not captured");
+
+    capturedCtx.emitEvent({
+      kind: "error",
+      payload: {
+        source: "runtime",
+        message: encodeProviderRetryEventMessage({
+          event: "provider_failure_terminal",
+          provider: "codex",
+          scope: "provider_turn",
+          category: "credential",
+          reasonCode: "provider_credential_required",
+          replaySafety: "provider_entered",
+          userSeverity: "error",
+          messagePreview: "refresh token revoked",
+        }),
+      },
+    });
+    await capturedToken.terminalRejected(capturedMessage, "deterministic_pre_provider_failure", {
+      kind: "chat_message",
+      messageId: "runtime-notice-error",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(ackEntry).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-terminal-notice-fail"));
+    expect(
+      emitted.some(
+        (event) =>
+          event.kind === "error" &&
+          event.payload.source === "runtime" &&
+          event.payload.message.includes("runtime failure notice delivery failed"),
+      ),
+    ).toBe(true);
+
+    await sm.shutdown();
+  });
+
+  it("ignores malformed provider retry event payloads when completing a consumed error", async () => {
+    const ackEntry = mockAckEntry();
+    const sendMessage = vi.fn().mockResolvedValue({ id: "runtime-notice" });
+    const sdk = mockSdk({ sendMessage });
+    let capturedCtx: SessionContext | undefined;
+    let capturedToken: DeliveryToken | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      start: vi.fn(async (message, ctx, token) => {
+        capturedMessage = message;
+        capturedCtx = ctx;
+        capturedToken = token;
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "queued" } as const };
+      }),
+    });
+    const sm = createSessionManager({ handler, ackEntry, sdk });
+
+    await sm.dispatch(mockEntry({ id: 403, chatId: "chat-malformed-provider-event", messageId: "msg-malformed" }));
+    if (!capturedCtx || !capturedToken || !capturedMessage) throw new Error("delivery token was not captured");
+
+    capturedCtx.emitEvent(malformedProviderRetryEvent());
+    await capturedToken.complete(capturedMessage, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_clean_error",
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledWith(403);
+
+    await sm.shutdown();
+  });
+
+  it("routes malformed file payloads without eager attachment fetches", async () => {
+    const fetchAttachment = vi.fn().mockResolvedValue({ bytes: Buffer.from("image bytes") });
+    const sdk = mockSdk({ fetchAttachment });
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      start: vi.fn(async (message) => {
+        capturedMessage = message;
+        return "session-id-mock";
+      }),
+    });
+    const sm = createSessionManager({ handler, sdk });
+    const base = mockEntry({ id: 404, chatId: "chat-malformed-file", messageId: "msg-malformed-file" });
+    const malformedFileEntry: InboxEntryWithMessage = {
+      ...base,
+      message: {
+        ...base.message,
+        format: "file",
+        content: { attachments: [{ imageId: "image-without-mime-type" }] },
+      },
+    };
+
+    await sm.dispatch(malformedFileEntry);
+
+    expect(fetchAttachment).not.toHaveBeenCalled();
+    expect(handler.start).toHaveBeenCalledTimes(1);
+    expect(capturedMessage?.format).toBe("file");
+    expect(capturedMessage?.content).toEqual({ attachments: [{ imageId: "image-without-mime-type" }] });
+
+    await sm.shutdown();
+  });
+
+  it("logs config refresh failures but still routes the inbox payload", async () => {
+    const { logger, records } = recordingLogger();
+    const agentConfigCache: AgentConfigCache = {
+      get: vi.fn(),
+      refreshIfNewer: vi.fn().mockRejectedValue(new Error("config service unavailable")),
+      refresh: vi.fn().mockResolvedValue(mockRuntimeConfig()),
+      updateSdk: vi.fn(),
+      updateUrls: vi.fn(),
+      allReferencedUrls: vi.fn(() => new Set<string>()),
+      forget: vi.fn(),
+    };
+    const handler = createMockHandler();
+    const sm = createSessionManager({ handler, agentConfigCache, log: logger });
+
+    await sm.dispatch(mockEntry({ id: 405, chatId: "chat-config-log", messageId: "msg-config-log" }));
+
+    expect(handler.start).toHaveBeenCalledTimes(1);
+    expect(
+      records.some(
+        (record) =>
+          typeof record.msg === "string" &&
+          record.msg.includes("config version mismatch") &&
+          record.chatId === "chat-config-log",
+      ),
+    ).toBe(true);
+
+    await sm.shutdown();
+  });
+});
+
+describe("SessionManager additional shutdown and finalization coverage", () => {
+  it("clears pending transient retry timers during shutdown", async () => {
+    vi.useFakeTimers();
+    try {
+      const handlerFactory = vi.fn<HandlerFactory>(() =>
+        createMockHandler({
+          start: vi.fn(async () => {
+            throw Object.assign(new Error("upstream returned 503"), { status: 503 });
+          }),
+        }),
+      );
+      const sm = createSessionManager({
+        handlerFactory,
+        handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "claude-code" },
+      });
+
+      await sm.dispatch(mockEntry({ id: 501, chatId: "chat-retry-shutdown", messageId: "msg-retry-shutdown" }));
+      expect(handlerFactory).toHaveBeenCalledTimes(1);
+
+      await sm.shutdown("test-shutdown");
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(handlerFactory).toHaveBeenCalledTimes(1);
+      expect(sm.activeCount).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("can skip suspended-state reports and flush an empty registry on destructive shutdown", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "session-manager-more-coverage-"));
+    const registryPath = join(dir, "sessions.json");
+    const onStateChange = vi.fn<(chatId: string, state: SessionState) => void>();
+    const handler = createMockHandler({
+      start: vi.fn(async () => "session-to-clear"),
+      shutdown: vi.fn().mockRejectedValue(new Error("provider already closed")),
+    });
+    const sm = createSessionManager({ handler, registryPath, onStateChange });
+    const opts: SessionManagerShutdownOptions = { clearPersistedRegistry: true, reportSuspendedSessions: false };
+
+    try {
+      await sm.dispatch(mockEntry({ id: 502, chatId: "chat-clear-registry", messageId: "msg-clear-registry" }));
+
+      await expect(sm.shutdown("runtime-switch", opts)).resolves.toBeUndefined();
+
+      const raw = JSON.parse(readFileSync(registryPath, "utf-8")) as {
+        entries: Record<string, unknown>;
+      };
+      expect(raw.entries).toEqual({});
+      expect(onStateChange).toHaveBeenCalledWith("chat-clear-registry", "active");
+      expect(onStateChange).not.toHaveBeenCalledWith("chat-clear-registry", "suspended");
+      expect(handler.shutdown).toHaveBeenCalledWith("runtime-switch");
+      expect(sm.totalCount).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/client/src/__tests__/source-repos.test.ts
+++ b/packages/client/src/__tests__/source-repos.test.ts
@@ -1,0 +1,97 @@
+import { join } from "node:path";
+import { DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD, SOURCE_REPOS_DIRNAME } from "@first-tree/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import { wellKnownBinDirs } from "../runtime/install-locations.js";
+import { currentSourceRepoNamesFromPayload, declaredSourceRepos } from "../runtime/source-repos.js";
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+afterEach(() => {
+  setPlatform(originalPlatform);
+});
+
+describe("wellKnownBinDirs", () => {
+  it("includes macOS-only package-manager locations on darwin", () => {
+    setPlatform("darwin");
+
+    const dirs = wellKnownBinDirs("/Users/gandy");
+
+    expect(dirs).toContain(join("/Users/gandy", "Library", "pnpm"));
+    expect(dirs).toContain("/opt/homebrew/bin");
+    expect(dirs).toContain(join("/Users/gandy", ".local", "bin"));
+    expect(dirs).toContain("/usr/local/bin");
+  });
+
+  it("omits macOS-only locations on Linux while keeping cross-platform shims", () => {
+    setPlatform("linux");
+
+    const dirs = wellKnownBinDirs("/home/gandy");
+
+    expect(dirs).toContain(join("/home/gandy", ".volta", "bin"));
+    expect(dirs).toContain(join("/home/gandy", ".local", "share", "pnpm"));
+    expect(dirs).not.toContain(join("/home/gandy", "Library", "pnpm"));
+    expect(dirs).not.toContain("/opt/homebrew/bin");
+  });
+});
+
+describe("source repo derivation", () => {
+  it("defers current source names when the payload was not resolved", () => {
+    expect(currentSourceRepoNamesFromPayload(DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD, false)).toBeNull();
+  });
+
+  it("returns an empty set for a resolved payload without git repos", () => {
+    expect([...(currentSourceRepoNamesFromPayload(undefined, true) ?? [])]).toEqual([]);
+  });
+
+  it("derives current source repo names from explicit and URL-derived local paths", () => {
+    const names = currentSourceRepoNamesFromPayload(
+      {
+        ...DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+        gitRepos: [
+          { url: "https://github.com/acme/service-api.git" },
+          { url: "git@github.com:acme/service-api.git", localPath: "service-api-ssh" },
+        ],
+      },
+      true,
+    );
+
+    expect([...(names ?? [])]).toEqual(["service-api", "service-api-ssh"]);
+  });
+
+  it("maps declared repos to source-repos paths and keeps optional refs sparse", () => {
+    const workspace = join("/tmp", "agent-home");
+
+    const repos = declaredSourceRepos(workspace, {
+      ...DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+      gitRepos: [
+        { url: "https://github.com/acme/service-api.git" },
+        { url: "git@github.com:acme/docs.git", localPath: "docs-site", ref: "release" },
+      ],
+    });
+
+    expect(repos).toEqual([
+      {
+        absolutePath: join(workspace, SOURCE_REPOS_DIRNAME, "service-api"),
+        url: "https://github.com/acme/service-api.git",
+      },
+      {
+        absolutePath: join(workspace, SOURCE_REPOS_DIRNAME, "docs-site"),
+        url: "git@github.com:acme/docs.git",
+        ref: "release",
+      },
+    ]);
+  });
+
+  it("rejects unsafe declared repo local paths", () => {
+    expect(() =>
+      declaredSourceRepos("/tmp/agent-home", {
+        ...DEFAULT_AGENT_RUNTIME_CONFIG_PAYLOAD,
+        gitRepos: [{ url: "https://github.com/acme/repo.git", localPath: "../escape" }],
+      }),
+    ).toThrow('Unsafe git repo localPath "../escape"');
+  });
+});

--- a/packages/client/src/__tests__/tui-tmux-commands.test.ts
+++ b/packages/client/src/__tests__/tui-tmux-commands.test.ts
@@ -1,0 +1,230 @@
+import { EventEmitter } from "node:events";
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type SpawnRecord = {
+  command: string;
+  args: string[];
+  options: unknown;
+  child: FakeChild;
+};
+
+type SpawnBehavior = (record: SpawnRecord) => void;
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn();
+}
+
+function installSpawnMock(behavior: SpawnBehavior): {
+  records: SpawnRecord[];
+  spawn: ReturnType<typeof vi.fn>;
+} {
+  const records: SpawnRecord[] = [];
+  const spawn = vi.fn((command: string, args: string[], options: unknown) => {
+    const child = new FakeChild();
+    const record = { args, child, command, options };
+    records.push(record);
+    behavior(record);
+    return child;
+  });
+  vi.doMock("node:child_process", () => ({ spawn }));
+  return { records, spawn };
+}
+
+function closeSoon(
+  record: SpawnRecord,
+  options: { code?: number | null; stdout?: string; stderr?: string } = {},
+): void {
+  queueMicrotask(() => {
+    if (options.stdout) record.child.stdout.emit("data", Buffer.from(options.stdout));
+    if (options.stderr) record.child.stderr.emit("data", Buffer.from(options.stderr));
+    record.child.emit("close", options.code ?? 0);
+  });
+}
+
+describe("tmux command helpers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.doUnmock("node:child_process");
+    vi.resetModules();
+  });
+
+  it("starts a detached session with defaults, env, cwd, and command", async () => {
+    const { records } = installSpawnMock((record) => closeSoon(record));
+    const { newSession } = await import("../handlers/claude-code-tui/tmux-session.js");
+
+    await newSession({
+      name: "ftth-test",
+      cwd: "/repo",
+      command: "claude --dangerously-skip-permissions",
+      env: { FIRST_TREE_AGENT_ID: "agent-1", HOME: "/tmp/home" },
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      command: "tmux",
+      options: { stdio: ["ignore", "pipe", "pipe"] },
+    });
+    expect(records[0]?.args).toEqual([
+      "new-session",
+      "-d",
+      "-s",
+      "ftth-test",
+      "-x",
+      "220",
+      "-y",
+      "60",
+      "-c",
+      "/repo",
+      "-e",
+      "FIRST_TREE_AGENT_ID=agent-1",
+      "-e",
+      "HOME=/tmp/home",
+      "claude --dangerously-skip-permissions",
+    ]);
+  });
+
+  it("respects explicit session dimensions", async () => {
+    const { records } = installSpawnMock((record) => closeSoon(record));
+    const { newSession } = await import("../handlers/claude-code-tui/tmux-session.js");
+
+    await newSession({ name: "ftth-size", cwd: "/repo", command: "claude", width: 120, height: 40 });
+
+    expect(records[0]?.args.slice(0, 10)).toEqual([
+      "new-session",
+      "-d",
+      "-s",
+      "ftth-size",
+      "-x",
+      "120",
+      "-y",
+      "40",
+      "-c",
+      "/repo",
+    ]);
+  });
+
+  it("pastes text through a temporary buffer, sends Enter, and deletes the buffer", async () => {
+    const { records } = installSpawnMock((record) => {
+      if (record.args[0] === "load-buffer") {
+        const file = record.args.at(-1);
+        expect(typeof file).toBe("string");
+        expect(readFileSync(file as string, "utf8")).toBe("hello\n`$world");
+      }
+      closeSoon(record);
+    });
+    const { pasteText } = await import("../handlers/claude-code-tui/tmux-session.js");
+
+    await pasteText("ftth-paste", "hello\n`$world");
+
+    expect(records.map((record) => record.args.slice(0, 4))).toEqual([
+      ["load-buffer", "-b", "ftth-paste-msg", expect.stringContaining("msg.txt")],
+      ["paste-buffer", "-b", "ftth-paste-msg", "-t"],
+      ["send-keys", "-t", "ftth-paste", "Enter"],
+      ["delete-buffer", "-b", "ftth-paste-msg"],
+    ]);
+    expect(records[1]?.args).toEqual(["paste-buffer", "-b", "ftth-paste-msg", "-t", "ftth-paste", "-p", "-d"]);
+  });
+
+  it("still deletes the tmux buffer when paste fails", async () => {
+    const { records } = installSpawnMock((record) => {
+      if (record.args[0] === "paste-buffer") {
+        closeSoon(record, { code: 1, stderr: "paste failed" });
+        return;
+      }
+      closeSoon(record);
+    });
+    const { pasteText } = await import("../handlers/claude-code-tui/tmux-session.js");
+
+    await expect(pasteText("ftth-fail", "secret")).rejects.toThrow(
+      "tmux paste-buffer -b ftth-fail-msg -t ftth-fail -p -d failed",
+    );
+
+    expect(records.map((record) => record.args[0])).toEqual(["load-buffer", "paste-buffer", "delete-buffer"]);
+  });
+
+  it("wraps tmux stderr, stdout, exit code, and spawn errors for command helpers", async () => {
+    installSpawnMock((record) => {
+      if (record.args[0] === "send-keys" && record.args.at(-1) === "Escape") {
+        closeSoon(record, { code: 2, stderr: "bad key" });
+        return;
+      }
+      queueMicrotask(() => record.child.emit("error", new Error("spawn ENOENT")));
+    });
+    const { capturePane, sendKey } = await import("../handlers/claude-code-tui/tmux-session.js");
+
+    await expect(sendKey("ftth-error", "Escape")).rejects.toThrow(
+      "tmux send-keys -t ftth-error Escape failed (code=2): bad key",
+    );
+    await expect(capturePane("ftth-error")).rejects.toThrow(
+      "tmux capture-pane -t ftth-error -p failed (code=n/a): spawn ENOENT",
+    );
+  });
+
+  it("captures normal and full-scrollback panes", async () => {
+    const { records } = installSpawnMock((record) => closeSoon(record, { stdout: "pane text" }));
+    const { capturePane } = await import("../handlers/claude-code-tui/tmux-session.js");
+
+    await expect(capturePane("ftth-pane")).resolves.toBe("pane text");
+    await expect(capturePane("ftth-pane", true)).resolves.toBe("pane text");
+
+    expect(records[0]?.args).toEqual(["capture-pane", "-t", "ftth-pane", "-p"]);
+    expect(records[1]?.args).toEqual(["capture-pane", "-t", "ftth-pane", "-p", "-S", "-"]);
+  });
+
+  it("reports session existence, kills best-effort, and filters owned sessions", async () => {
+    const { records } = installSpawnMock((record) => {
+      if (record.args[0] === "has-session") {
+        closeSoon(record, { code: record.args.at(-1) === "alive" ? 0 : 1 });
+        return;
+      }
+      if (record.args[0] === "kill-session") {
+        closeSoon(record, { code: 1, stderr: "no such session" });
+        return;
+      }
+      closeSoon(record, { stdout: "ftth-abcd-one\n other \nftth-abcd-two\n\n" });
+    });
+    const { killSession, listOwnedSessions, listSessions, sessionExists } = await import(
+      "../handlers/claude-code-tui/tmux-session.js"
+    );
+
+    await expect(sessionExists("alive")).resolves.toBe(true);
+    await expect(sessionExists("missing")).resolves.toBe(false);
+    await expect(killSession("missing")).resolves.toBeUndefined();
+    await expect(listSessions()).resolves.toEqual(["ftth-abcd-one", "other", "ftth-abcd-two"]);
+    await expect(listOwnedSessions("ftth-abcd-")).resolves.toEqual(["ftth-abcd-one", "ftth-abcd-two"]);
+
+    expect(records.map((record) => record.args[0])).toEqual([
+      "has-session",
+      "has-session",
+      "kill-session",
+      "list-sessions",
+      "list-sessions",
+    ]);
+  });
+
+  it("returns an empty session list when list-sessions fails", async () => {
+    installSpawnMock((record) => closeSoon(record, { code: 1, stderr: "no server running" }));
+    const { listSessions } = await import("../handlers/claude-code-tui/tmux-session.js");
+
+    await expect(listSessions()).resolves.toEqual([]);
+  });
+
+  it("times out a tmux command and kills the child", async () => {
+    vi.useFakeTimers();
+    const { records } = installSpawnMock(() => {
+      // Intentionally never emits close/error; the helper must time out.
+    });
+    const { sendKey } = await import("../handlers/claude-code-tui/tmux-session.js");
+
+    const assertion = expect(sendKey("ftth-timeout", "Enter")).rejects.toThrow(
+      "tmux send-keys -t ftth-timeout Enter failed (code=n/a): [timeout]",
+    );
+    await vi.advanceTimersByTimeAsync(5000);
+
+    await assertion;
+    expect(records[0]?.child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+});

--- a/packages/client/src/observability/__tests__/sentry-init.test.ts
+++ b/packages/client/src/observability/__tests__/sentry-init.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type SentryMock = {
+  init: ReturnType<typeof vi.fn>;
+  setTag: ReturnType<typeof vi.fn>;
+  isEnabled: ReturnType<typeof vi.fn<() => boolean>>;
+  withScope: ReturnType<typeof vi.fn>;
+  captureException: ReturnType<typeof vi.fn>;
+  flush: ReturnType<typeof vi.fn>;
+};
+
+type MockScope = { setContext: ReturnType<typeof vi.fn> };
+
+const ORIGINAL_ENV = { ...process.env };
+
+function installSentryMocks(options: { enabled?: boolean; flushResult?: boolean } = {}): {
+  logger: { info: ReturnType<typeof vi.fn> };
+  scope: MockScope;
+  sentry: SentryMock;
+} {
+  const logger = { info: vi.fn() };
+  const scope: MockScope = { setContext: vi.fn() };
+  const sentry: SentryMock = {
+    init: vi.fn(),
+    setTag: vi.fn(),
+    isEnabled: vi.fn(() => options.enabled ?? false),
+    withScope: vi.fn((callback: (scopeArg: MockScope) => string | undefined) => callback(scope)),
+    captureException: vi.fn(() => "event-id"),
+    flush: vi.fn(async () => options.flushResult ?? true),
+  };
+
+  vi.doMock("@sentry/node", () => sentry);
+  vi.doMock("../logger.js", () => ({ createLogger: () => logger }));
+  vi.doMock("@first-tree/shared/config", () => ({
+    defaultDataDir: () => "/var/first-tree",
+    defaultHome: () => "/home/first-tree",
+  }));
+  return { logger, scope, sentry };
+}
+
+describe("initClientSentry", () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.doUnmock("@sentry/node");
+    vi.doUnmock("../logger.js");
+    vi.doUnmock("@first-tree/shared/config");
+    vi.resetModules();
+  });
+
+  it("logs a configuration skip when Sentry is explicitly enabled without a DSN", async () => {
+    process.env = { ...ORIGINAL_ENV, FIRST_TREE_CLIENT_SENTRY_ENABLED: "1" };
+    delete process.env.FIRST_TREE_CLIENT_SENTRY_DSN;
+    delete process.env.SENTRY_DSN;
+    const { logger, sentry } = installSentryMocks();
+    const { initClientSentry } = await import("../sentry.js");
+
+    initClientSentry();
+
+    expect(sentry.init).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      { enabled: true, hasDsn: false },
+      "client sentry skipped by configuration",
+    );
+  });
+
+  it("initializes Sentry with sanitized event hooks and release tags", async () => {
+    process.env = {
+      ...ORIGINAL_ENV,
+      FIRST_TREE_CLIENT_SENTRY_DSN: "https://public@example.ingest.sentry.io/1",
+      FIRST_TREE_CLIENT_SENTRY_ENVIRONMENT: "production",
+      FIRST_TREE_CLIENT_SENTRY_TRACES_SAMPLE_RATE: "0.25",
+    };
+    const { logger, sentry } = installSentryMocks();
+    const { initClientSentry } = await import("../sentry.js");
+
+    initClientSentry({ gitSha: "abc123", version: "1.2.3" });
+
+    expect(sentry.init).toHaveBeenCalledTimes(1);
+    const config = sentry.init.mock.calls[0]?.[0];
+    expect(config).toMatchObject({
+      dsn: "https://public@example.ingest.sentry.io/1",
+      environment: "production",
+      release: "first-tree-client@abc123",
+      tracesSampleRate: 0.25,
+      sendDefaultPii: false,
+      maxBreadcrumbs: 0,
+    });
+    expect(config.beforeSend({ transaction: "/home/first-tree/work?token=secret" })).toMatchObject({
+      transaction: "[LOCAL_PATH]/work?token=[REDACTED]",
+      tags: {
+        "first_tree.surface": "client",
+        "first_tree.git_sha": "abc123",
+      },
+    });
+    expect(config.beforeSendTransaction({ request: { url: "not a url?secret=1" } }).request.url).toBe("not a url");
+    expect(sentry.setTag).toHaveBeenCalledWith("first_tree.surface", "client");
+    expect(sentry.setTag).toHaveBeenCalledWith("first_tree.git_sha", "abc123");
+    expect(sentry.setTag).toHaveBeenCalledWith("first_tree.cli_version", "1.2.3");
+    expect(logger.info).toHaveBeenCalledWith(
+      { environment: "production", release: "first-tree-client@abc123" },
+      "client sentry initialized",
+    );
+  });
+});
+
+describe("captureClientException / flushClientSentry", () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.doUnmock("@sentry/node");
+    vi.doUnmock("../logger.js");
+    vi.doUnmock("@first-tree/shared/config");
+    vi.resetModules();
+  });
+
+  it("does not capture when Sentry is disabled and treats disabled flush as successful", async () => {
+    const { sentry } = installSentryMocks({ enabled: false });
+    const { captureClientException, flushClientSentry } = await import("../sentry.js");
+
+    expect(captureClientException(new Error("boom"))).toBeUndefined();
+    await expect(flushClientSentry()).resolves.toBe(true);
+    expect(sentry.withScope).not.toHaveBeenCalled();
+    expect(sentry.flush).not.toHaveBeenCalled();
+  });
+
+  it("captures with sanitized context and forwards flush timeouts when enabled", async () => {
+    const { scope, sentry } = installSentryMocks({ enabled: true, flushResult: false });
+    const { captureClientException, flushClientSentry } = await import("../sentry.js");
+
+    expect(
+      captureClientException(new Error("boom"), {
+        accessToken: "secret",
+        path: "/var/first-tree/workspaces/acme",
+        nested: { prompt: "private prompt", status: "safe" },
+      }),
+    ).toBe("event-id");
+    await expect(flushClientSentry(50)).resolves.toBe(false);
+
+    const callbackScope = sentry.withScope.mock.calls[0]?.[0];
+    expect(typeof callbackScope).toBe("function");
+    expect(scope.setContext).toHaveBeenCalledWith("first_tree", {
+      accessToken: "[REDACTED]",
+      path: "[LOCAL_PATH]/workspaces/acme",
+      nested: { prompt: "[REDACTED]", status: "safe" },
+    });
+    expect(sentry.captureException).toHaveBeenCalledWith(expect.any(Error));
+    expect(sentry.flush).toHaveBeenCalledWith(50);
+  });
+
+  it("captures without context when none is provided", async () => {
+    const { sentry } = installSentryMocks({ enabled: true });
+    const { captureClientException } = await import("../sentry.js");
+
+    expect(captureClientException("string failure")).toBe("event-id");
+
+    expect(sentry.captureException).toHaveBeenCalledWith("string failure");
+  });
+});

--- a/packages/web/src/api/__tests__/api-edge-coverage.test.ts
+++ b/packages/web/src/api/__tests__/api-edge-coverage.test.ts
@@ -1,0 +1,232 @@
+// @vitest-environment happy-dom
+
+import { ATTACHMENT_FILENAME_HEADER, ATTACHMENT_MIME_HEADER } from "@first-tree/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+const rawMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../client.js")>();
+  return {
+    ...actual,
+    api: apiMock,
+    apiFetchRaw: rawMock,
+    withOrg: (path: string) => `/orgs/current${path}`,
+  };
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  apiMock.get.mockReset();
+  apiMock.post.mockReset();
+  rawMock.mockReset();
+  apiMock.get.mockResolvedValue({});
+  apiMock.post.mockResolvedValue({});
+});
+
+describe("attachment API helpers", () => {
+  it("uploads image bytes with encoded filename and parses the response", async () => {
+    rawMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: "11111111-1111-4111-8111-111111111111",
+          mimeType: "image/png",
+          filename: "avatar 你好.png",
+          sizeBytes: 3,
+          uploadedBy: "agent-human",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        }),
+        {
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    const { uploadImageAttachment } = await import("../attachments.js");
+
+    await expect(uploadImageAttachment(new File(["abc"], "avatar 你好.png", { type: "image/png" }))).resolves.toEqual({
+      id: "11111111-1111-4111-8111-111111111111",
+      mimeType: "image/png",
+      filename: "avatar 你好.png",
+      sizeBytes: 3,
+      uploadedBy: "agent-human",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const [path, init] = rawMock.mock.calls[0] ?? [];
+    expect(path).toBe("/orgs/current/attachments");
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: {
+        "Content-Type": "application/octet-stream",
+        [ATTACHMENT_MIME_HEADER]: "image/png",
+        [ATTACHMENT_FILENAME_HEADER]: "avatar%20%E4%BD%A0%E5%A5%BD.png",
+      },
+    });
+    await expect(new Response(init.body).text()).resolves.toBe("abc");
+  });
+
+  it("downloads attachment bytes as base64, text, and a browser save", async () => {
+    rawMock
+      .mockResolvedValueOnce(new Response(new Blob(["hello"], { type: "text/plain" })))
+      .mockResolvedValueOnce(new Response("plain text", { headers: { "Content-Type": "text/markdown" } }))
+      .mockResolvedValueOnce(new Response("download", { headers: { "Content-Type": "text/plain" } }));
+    const createObjectURL = vi.fn(() => "blob:first-tree");
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
+    Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: revokeObjectURL });
+    const clicked: string[] = [];
+    const originalClick = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = function click() {
+      clicked.push(`${this.href}|${this.download}`);
+    };
+    const { downloadAttachment, fetchAttachmentBase64, fetchAttachmentText } = await import("../attachments.js");
+
+    try {
+      await expect(fetchAttachmentBase64("img/id")).resolves.toEqual({
+        base64: "aGVsbG8=",
+        mimeType: "text/plain",
+      });
+      await expect(fetchAttachmentText("doc/id")).resolves.toEqual({
+        text: "plain text",
+        mimeType: "text/markdown",
+        sizeBytes: 10,
+      });
+      await expect(downloadAttachment("file/id", "report.md")).resolves.toBeUndefined();
+    } finally {
+      HTMLAnchorElement.prototype.click = originalClick;
+    }
+
+    expect(rawMock).toHaveBeenNthCalledWith(1, "/attachments/img%2Fid");
+    expect(rawMock).toHaveBeenNthCalledWith(2, "/attachments/doc%2Fid");
+    expect(rawMock).toHaveBeenNthCalledWith(3, "/attachments/file%2Fid");
+    expect(clicked).toEqual(["blob:first-tree|report.md"]);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:first-tree");
+  });
+
+  it("computes SHA-256 through Web Crypto and reports missing subtle crypto", async () => {
+    const { sha256Hex } = await import("../attachments.js");
+
+    await expect(sha256Hex("abc")).resolves.toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+
+    const originalCrypto = globalThis.crypto;
+    Object.defineProperty(globalThis, "crypto", { configurable: true, value: {} });
+    try {
+      await expect(sha256Hex("abc")).rejects.toThrow("Web Crypto subtle digest is unavailable");
+    } finally {
+      Object.defineProperty(globalThis, "crypto", { configurable: true, value: originalCrypto });
+    }
+  });
+});
+
+describe("GitHub API wrappers", () => {
+  it("handles GitHub App 404 as empty state and rethrows other failures", async () => {
+    const { ApiError } = await import("../client.js");
+    const { getGithubAppInstallation } = await import("../github-app.js");
+
+    apiMock.get.mockRejectedValueOnce(new ApiError(404, "missing")).mockRejectedValueOnce(new ApiError(500, "bad"));
+
+    await expect(getGithubAppInstallation("org/id")).resolves.toBeNull();
+    await expect(getGithubAppInstallation("org/id")).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("formats GitHub App and GitHub repo endpoints", async () => {
+    apiMock.get
+      .mockResolvedValueOnce({ exists: true })
+      .mockResolvedValueOnce({ installUrl: "https://github.com/apps/first-tree/installations/new" })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ repos: [{ fullName: "bestony/web" }] })
+      .mockResolvedValueOnce({ repos: [{ fullName: "bestony/server" }] });
+    const githubApp = await import("../github-app.js");
+    const github = await import("../github.js");
+
+    await expect(githubApp.getGithubAppInstallationExists("org/id")).resolves.toBe(true);
+    await expect(githubApp.getGithubAppInstallUrl("org/id", "/onboarding?step=code")).resolves.toContain(
+      "github.com/apps",
+    );
+    await expect(githubApp.getGithubAppConnectPanel("org/id")).resolves.toEqual({ rows: [] });
+    await githubApp.connectGithubAppInstallation("org/id", 42);
+    await githubApp.disconnectGithubAppInstallation("org/id");
+    await expect(github.listGithubRepos()).resolves.toEqual([{ fullName: "bestony/web" }]);
+    await expect(github.listOrgGithubRepos("org/id")).resolves.toEqual([{ fullName: "bestony/server" }]);
+
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/org/id/github-app-installation/exists");
+    expect(apiMock.get).toHaveBeenCalledWith(
+      "/orgs/org/id/github-app-installation/install-url?next=%2Fonboarding%3Fstep%3Dcode",
+    );
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/org/id/github-app-installation/connect-panel");
+    expect(apiMock.post).toHaveBeenCalledWith("/orgs/org/id/github-app-installation/connect", { installationId: 42 });
+    expect(apiMock.post).toHaveBeenCalledWith("/orgs/org/id/github-app-installation/disconnect", {});
+    expect(apiMock.get).toHaveBeenCalledWith("/me/github/repos");
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/org/id/github-app-installation/repositories");
+  });
+});
+
+describe("onboarding and campaign API wrappers", () => {
+  it("swallows best-effort onboarding telemetry failures and posts required kickoff calls", async () => {
+    apiMock.post
+      .mockRejectedValueOnce(new Error("telemetry down"))
+      .mockRejectedValueOnce(new Error("completion down"))
+      .mockResolvedValueOnce({ chatId: "chat-1" })
+      .mockResolvedValueOnce({ chatId: "chat-2" });
+    apiMock.get.mockResolvedValueOnce({ needsTreeSetup: true, hasTreeBinding: false, hasTreeSetupKickoff: true });
+    const onboarding = await import("../onboarding-events.js");
+
+    await expect(onboarding.reportOnboardingEvent("team_renamed", { step: "connect-code" })).resolves.toBeUndefined();
+    await expect(onboarding.markOnboardingCompleted("org/id")).resolves.toBeUndefined();
+    await expect(
+      onboarding.postOnboardingStartChat({ agentUuid: "agent-1", bootstrap: "start", complete: true }),
+    ).resolves.toEqual({ chatId: "chat-1" });
+    await expect(
+      onboarding.postTreeSetupStartChat({ organizationId: "org/id", agentUuid: "agent-1", bootstrap: "tree" }),
+    ).resolves.toEqual({ chatId: "chat-2" });
+    await expect(onboarding.getTreeSetupStatus("org/id")).resolves.toEqual({
+      needsTreeSetup: true,
+      hasTreeBinding: false,
+      hasTreeSetupStartChat: true,
+    });
+
+    expect(apiMock.post).toHaveBeenNthCalledWith(1, "/me/onboarding/events", {
+      event: "team_renamed",
+      attrs: { step: "connect-code" },
+    });
+    expect(apiMock.post).toHaveBeenNthCalledWith(2, "/me/onboarding-completed", { organizationId: "org/id" });
+    expect(apiMock.post).toHaveBeenNthCalledWith(3, "/me/onboarding/kickoff", {
+      agentUuid: "agent-1",
+      bootstrap: "start",
+      complete: true,
+    });
+    expect(apiMock.post).toHaveBeenNthCalledWith(4, "/me/onboarding/tree-setup/kickoff", {
+      organizationId: "org/id",
+      agentUuid: "agent-1",
+      bootstrap: "tree",
+    });
+    expect(apiMock.get).toHaveBeenCalledWith("/me/onboarding/tree-setup-status?organizationId=org%2Fid");
+  });
+
+  it("validates landing campaign start responses", async () => {
+    apiMock.post.mockResolvedValueOnce({
+      chatId: "chat-1",
+      agentUuid: "agent-1",
+      campaign: "github-repo-review",
+      repoCanonicalKey: "github.com/bestony/web",
+    });
+    const { startLandingCampaign } = await import("../landing-campaigns.js");
+
+    await expect(
+      startLandingCampaign({
+        campaign: "github-repo-review",
+        repoUrl: "https://github.com/bestony/web",
+      }),
+    ).resolves.toMatchObject({ chatId: "chat-1", agentUuid: "agent-1" });
+
+    expect(apiMock.post).toHaveBeenCalledWith("/me/landing-campaigns/start", {
+      campaign: "github-repo-review",
+      repoUrl: "https://github.com/bestony/web",
+    });
+  });
+});

--- a/packages/web/src/api/__tests__/browser-stores.test.ts
+++ b/packages/web/src/api/__tests__/browser-stores.test.ts
@@ -2,6 +2,42 @@ import "fake-indexeddb/auto";
 import { IDBFactory } from "fake-indexeddb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+type Callback = () => void;
+
+type RequestStub<T> = {
+  result: T | undefined;
+  onsuccess: Callback | null;
+  onerror: Callback | null;
+};
+
+type TransactionStub = {
+  error: Error | null;
+  oncomplete: Callback | null;
+  onerror: Callback | null;
+  onabort: Callback | null;
+  objectStore: () => StoreStub;
+};
+
+type StoreStub = {
+  put: (entry: unknown) => void;
+  get: (key: unknown) => RequestStub<unknown>;
+  delete: (key: unknown) => void;
+};
+
+type OpenRequestStub = {
+  result: DatabaseStub;
+  onupgradeneeded: Callback | null;
+  onsuccess: Callback | null;
+  onerror: Callback | null;
+  onblocked: Callback | null;
+};
+
+type DatabaseStub = {
+  transaction: (storeName: string, mode: IDBTransactionMode) => TransactionStub;
+  objectStoreNames: { contains: (name: string) => boolean };
+  createObjectStore: (name: string, options?: IDBObjectStoreParameters) => StoreStub;
+};
+
 async function loadImageStore() {
   vi.resetModules();
   globalThis.indexedDB = new IDBFactory();
@@ -12,6 +48,66 @@ async function loadReadStateStore() {
   vi.resetModules();
   globalThis.indexedDB = new IDBFactory();
   return import("../read-state-store.js");
+}
+
+function installControllableIndexedDb(): {
+  request: OpenRequestStub;
+  getRequests: RequestStub<unknown>[];
+  transactions: TransactionStub[];
+} {
+  const getRequests: RequestStub<unknown>[] = [];
+  const transactions: TransactionStub[] = [];
+  const store: StoreStub = {
+    put: () => undefined,
+    get: () => {
+      const request: RequestStub<unknown> = { result: undefined, onsuccess: null, onerror: null };
+      getRequests.push(request);
+      return request;
+    },
+    delete: () => undefined,
+  };
+  const db: DatabaseStub = {
+    transaction: () => {
+      const tx: TransactionStub = {
+        error: null,
+        oncomplete: null,
+        onerror: null,
+        onabort: null,
+        objectStore: () => store,
+      };
+      transactions.push(tx);
+      return tx;
+    },
+    objectStoreNames: { contains: () => true },
+    createObjectStore: () => store,
+  };
+  const request: OpenRequestStub = {
+    result: db,
+    onupgradeneeded: null,
+    onsuccess: null,
+    onerror: null,
+    onblocked: null,
+  };
+  Object.defineProperty(globalThis, "indexedDB", {
+    configurable: true,
+    value: { open: () => request },
+  });
+  return { request, getRequests, transactions };
+}
+
+async function settleOpen(request: OpenRequestStub): Promise<void> {
+  request.onsuccess?.();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function waitForTransaction(transactions: TransactionStub[], count: number): Promise<TransactionStub> {
+  for (let i = 0; i < 5 && transactions.length < count; i += 1) {
+    await Promise.resolve();
+  }
+  const tx = transactions[count - 1];
+  if (!tx) throw new Error(`Missing transaction ${count}`);
+  return tx;
 }
 
 describe("image-store", () => {
@@ -36,6 +132,53 @@ describe("image-store", () => {
       "Image storage unavailable",
     );
     await expect(getImage("img-1")).resolves.toBeNull();
+  });
+
+  it("rejects writes when the database open is blocked", async () => {
+    vi.resetModules();
+    const { request } = installControllableIndexedDb();
+    const { putImage } = await import("../image-store.js");
+
+    const write = putImage({ imageId: "img-1", base64: "abc123", mimeType: "image/png" });
+    request.onblocked?.();
+
+    await expect(write).rejects.toThrow("Image storage unavailable");
+  });
+
+  it("rejects writes on transaction error and abort", async () => {
+    vi.resetModules();
+    const firstDb = installControllableIndexedDb();
+    const { putImage } = await import("../image-store.js");
+
+    const erroredWrite = putImage({ imageId: "img-1", base64: "abc123", mimeType: "image/png" });
+    await settleOpen(firstDb.request);
+    const erroredTx = await waitForTransaction(firstDb.transactions, 1);
+    erroredTx.error = new Error("quota exceeded");
+    erroredTx.onerror?.();
+    await expect(erroredWrite).rejects.toThrow("quota exceeded");
+
+    vi.resetModules();
+    const secondDb = installControllableIndexedDb();
+    const { putImage: putImageAgain } = await import("../image-store.js");
+    const abortedWrite = putImageAgain({ imageId: "img-2", base64: "def456", mimeType: "image/jpeg" });
+    await settleOpen(secondDb.request);
+    const abortedTx = await waitForTransaction(secondDb.transactions, 1);
+    abortedTx.onabort?.();
+    await expect(abortedWrite).rejects.toThrow("Image storage write aborted");
+  });
+
+  it("returns null when image reads fail", async () => {
+    vi.resetModules();
+    const db = installControllableIndexedDb();
+    const { getImage } = await import("../image-store.js");
+
+    const read = getImage("img-1");
+    await settleOpen(db.request);
+    const req = db.getRequests[0];
+    if (!req) throw new Error("Missing get request");
+    req.onerror?.();
+
+    await expect(read).resolves.toBeNull();
   });
 });
 
@@ -74,5 +217,47 @@ describe("read-state-store", () => {
     await expect(setReadState("chat-1", "msg-1", "msg-2")).resolves.toBeUndefined();
     await expect(clearReadState("chat-1")).resolves.toBeUndefined();
     await expect(getReadState("chat-1")).resolves.toBeNull();
+  });
+
+  it("silently no-ops when the database open is blocked", async () => {
+    vi.resetModules();
+    const { request } = installControllableIndexedDb();
+    const { setReadState } = await import("../read-state-store.js");
+
+    const write = setReadState("chat-1", "msg-1", "msg-2");
+    request.onblocked?.();
+
+    await expect(write).resolves.toBeUndefined();
+  });
+
+  it("returns null when read-state reads fail", async () => {
+    vi.resetModules();
+    const db = installControllableIndexedDb();
+    const { getReadState } = await import("../read-state-store.js");
+
+    const read = getReadState("chat-1");
+    await settleOpen(db.request);
+    const req = db.getRequests[0];
+    if (!req) throw new Error("Missing read-state get request");
+    req.onerror?.();
+
+    await expect(read).resolves.toBeNull();
+  });
+
+  it("resolves read-state writes on transaction error and abort", async () => {
+    vi.resetModules();
+    const db = installControllableIndexedDb();
+    const { clearReadState, setReadState } = await import("../read-state-store.js");
+
+    const write = setReadState("chat-1", "msg-1", "msg-2");
+    await settleOpen(db.request);
+    const writeTx = await waitForTransaction(db.transactions, 1);
+    writeTx.onerror?.();
+    await expect(write).resolves.toBeUndefined();
+
+    const clear = clearReadState("chat-1");
+    const clearTx = await waitForTransaction(db.transactions, 2);
+    clearTx.onabort?.();
+    await expect(clear).resolves.toBeUndefined();
   });
 });

--- a/packages/web/src/api/__tests__/docs-api.test.ts
+++ b/packages/web/src/api/__tests__/docs-api.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  patch: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock("../client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../client.js")>();
+  return {
+    ...actual,
+    api: apiMock,
+    withOrg: (path: string) => `/orgs/current${path}`,
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiMock.get.mockResolvedValue({});
+  apiMock.patch.mockResolvedValue({});
+  apiMock.post.mockResolvedValue({});
+});
+
+describe("document API wrappers", () => {
+  it("lists documents with an org-scoped query string and omits undefined filters", async () => {
+    const { listDocs } = await import("../docs.js");
+
+    await listDocs();
+    await listDocs({ slug: "handbook", project: "web", status: "draft", limit: 25, cursor: undefined });
+
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/documents");
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/documents?slug=handbook&project=web&status=draft&limit=25");
+  });
+
+  it("resolves a slug to the first summary or null", async () => {
+    const summary = { id: "doc-1", slug: "handbook" };
+    apiMock.get.mockResolvedValueOnce({ items: [summary] }).mockResolvedValueOnce({ items: [] });
+    const { findDocBySlug } = await import("../docs.js");
+
+    await expect(findDocBySlug("hand/book")).resolves.toBe(summary);
+    await expect(findDocBySlug("missing")).resolves.toBeNull();
+
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/documents?slug=hand%2Fbook&limit=1");
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/documents?slug=missing&limit=1");
+  });
+
+  it("formats document resource requests with encoded ids", async () => {
+    const { createDocComment, getDoc, listDocComments, replyDocComment, setDocCommentStatus, setDocStatus } =
+      await import("../docs.js");
+
+    await getDoc("doc/id", 7);
+    await getDoc("doc/id");
+    await setDocStatus("doc/id", "approved");
+    await listDocComments("doc/id", { status: "open", versionNumber: 3 });
+    await listDocComments("doc/id");
+    await createDocComment("doc/id", { body: "Looks good", anchor: { exact: "good" } });
+    await replyDocComment("comment/id", "Done");
+    await setDocCommentStatus("comment/id", "resolved");
+
+    expect(apiMock.get).toHaveBeenCalledWith("/documents/doc%2Fid?version=7");
+    expect(apiMock.get).toHaveBeenCalledWith("/documents/doc%2Fid");
+    expect(apiMock.patch).toHaveBeenCalledWith("/documents/doc%2Fid", { status: "approved" });
+    expect(apiMock.get).toHaveBeenCalledWith("/documents/doc%2Fid/comments?status=open&versionNumber=3");
+    expect(apiMock.get).toHaveBeenCalledWith("/documents/doc%2Fid/comments");
+    expect(apiMock.post).toHaveBeenCalledWith("/documents/doc%2Fid/comments", {
+      body: "Looks good",
+      anchor: { exact: "good" },
+    });
+    expect(apiMock.post).toHaveBeenCalledWith("/document-comments/comment%2Fid/replies", { body: "Done" });
+    expect(apiMock.patch).toHaveBeenCalledWith("/document-comments/comment%2Fid", { status: "resolved" });
+  });
+});

--- a/packages/web/src/components/__tests__/hover-card-dom.test.tsx
+++ b/packages/web/src/components/__tests__/hover-card-dom.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HoverCard, type HoverCardPlacement } from "../ui/hover-card.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function pointerEvent(type: string, pointerType = "mouse"): Event {
+  if (typeof PointerEvent === "function") {
+    return new PointerEvent(type, { bubbles: true, cancelable: true, pointerType });
+  }
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "pointerType", { configurable: true, value: pointerType });
+  return event;
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function keyDown(element: Element | null, key: string): Promise<void> {
+  if (!element) throw new Error("Expected element for keyDown");
+  await act(async () => {
+    element.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+function renderHoverCard(placement: HoverCardPlacement = "bottom"): {
+  container: HTMLElement;
+  root: Root;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const ui: ReactElement = (
+    <MemoryRouter initialEntries={["/one"]}>
+      <HoverCard
+        ariaLabel="Agent details"
+        placement={placement}
+        content={({ close }) => (
+          <div>
+            <button type="button" onClick={close}>
+              Close card
+            </button>
+            <a href="/agent">Agent link</a>
+          </div>
+        )}
+      >
+        Agent trigger
+      </HoverCard>
+    </MemoryRouter>
+  );
+  act(() => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+function dialog(): HTMLElement | null {
+  return document.body.querySelector<HTMLElement>('[role="dialog"]');
+}
+
+function buttonByText(text: string): HTMLButtonElement | null {
+  return (
+    Array.from(document.body.querySelectorAll("button")).find((button) => button.textContent?.includes(text)) ?? null
+  );
+}
+
+describe("HoverCard", () => {
+  let roots: Root[] = [];
+  let originalOffsetWidth: PropertyDescriptor | undefined;
+  let originalOffsetHeight: PropertyDescriptor | undefined;
+  let originalRect: typeof HTMLElement.prototype.getBoundingClientRect;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+    roots = [];
+    originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetWidth");
+    originalOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetHeight");
+    originalRect = HTMLElement.prototype.getBoundingClientRect;
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get() {
+        return this.getAttribute("role") === "dialog" ? 160 : 80;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      get() {
+        return this.getAttribute("role") === "dialog" ? 120 : 24;
+      },
+    });
+    HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+      if (this.tagName === "BUTTON") {
+        return {
+          bottom: 76,
+          height: 24,
+          left: 72,
+          right: 152,
+          top: 52,
+          width: 80,
+          x: 72,
+          y: 52,
+          toJSON: () => ({}),
+        };
+      }
+      return originalRect.call(this);
+    };
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 320 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 240 });
+  });
+
+  afterEach(() => {
+    for (const root of roots) {
+      act(() => root.unmount());
+    }
+    document.body.innerHTML = "";
+    if (originalOffsetWidth) Object.defineProperty(HTMLElement.prototype, "offsetWidth", originalOffsetWidth);
+    if (originalOffsetHeight) Object.defineProperty(HTMLElement.prototype, "offsetHeight", originalOffsetHeight);
+    HTMLElement.prototype.getBoundingClientRect = originalRect;
+    vi.useRealTimers();
+  });
+
+  function mount(placement?: HoverCardPlacement): HTMLElement {
+    const rendered = renderHoverCard(placement);
+    roots.push(rendered.root);
+    return rendered.container;
+  }
+
+  it("opens pinned on click and closes from content or outside pointer", async () => {
+    const container = mount("right");
+    const trigger = container.querySelector("button");
+
+    await click(trigger);
+    expect(dialog()?.style.visibility).toBe("visible");
+    expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+
+    await click(buttonByText("Close card"));
+    expect(dialog()).toBeNull();
+
+    await click(trigger);
+    expect(dialog()).not.toBeNull();
+    await act(async () => {
+      document.dispatchEvent(pointerEvent("pointerdown"));
+    });
+    await flush();
+    expect(dialog()).toBeNull();
+  });
+
+  it("opens after hover intent and respects close grace while crossing into the card", async () => {
+    const container = mount("left");
+    const trigger = container.querySelector("button");
+
+    await act(async () => {
+      trigger?.dispatchEvent(pointerEvent("pointerover"));
+      vi.advanceTimersByTime(399);
+    });
+    expect(dialog()).toBeNull();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    await flush();
+    expect(dialog()).not.toBeNull();
+
+    await act(async () => {
+      trigger?.dispatchEvent(pointerEvent("pointerout"));
+      vi.advanceTimersByTime(100);
+      dialog()?.dispatchEvent(pointerEvent("pointerover"));
+      vi.advanceTimersByTime(100);
+    });
+    await flush();
+    expect(dialog()).not.toBeNull();
+
+    await act(async () => {
+      dialog()?.dispatchEvent(pointerEvent("pointerout"));
+      vi.advanceTimersByTime(150);
+    });
+    await flush();
+    expect(dialog()).toBeNull();
+  });
+
+  it("opens from keyboard, restores focus on Escape, and closes on window scroll", async () => {
+    const container = mount("bottom");
+    const trigger = container.querySelector("button");
+    trigger?.focus();
+
+    await keyDown(trigger, "Enter");
+    expect(dialog()).not.toBeNull();
+    expect(document.activeElement?.textContent).toBe("Close card");
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+    });
+    await flush();
+    expect(dialog()).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+
+    await click(trigger);
+    expect(dialog()).not.toBeNull();
+    await act(async () => {
+      window.dispatchEvent(new Event("scroll", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+    expect(dialog()).toBeNull();
+  });
+});

--- a/packages/web/src/components/__tests__/support-menu-dom.test.tsx
+++ b/packages/web/src/components/__tests__/support-menu-dom.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SupportMenu } from "../support-menu.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+
+async function render(element: ReactElement): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(element);
+  });
+  return container;
+}
+
+async function dispatch(target: EventTarget, event: Event): Promise<void> {
+  await act(async () => {
+    target.dispatchEvent(event);
+  });
+}
+
+function trigger(rootNode: ParentNode): HTMLButtonElement {
+  const button = rootNode.querySelector<HTMLButtonElement>('button[aria-label="Help and community"]');
+  if (!button) throw new Error("Missing support menu trigger");
+  return button;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  root = null;
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  document.body.innerHTML = "";
+});
+
+describe("SupportMenu", () => {
+  it("opens the community menu, toggles hover color, and closes on Escape", async () => {
+    const dom = await render(<SupportMenu />);
+    const button = trigger(dom);
+
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+
+    await dispatch(button, new MouseEvent("mouseover", { bubbles: true }));
+    expect(button.style.color).toBe("var(--fg)");
+    await dispatch(button, new MouseEvent("mouseout", { bubbles: true }));
+    expect(button.style.color).toBe("var(--fg-3)");
+
+    await dispatch(button, new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(document.body.textContent).toContain("Need help?");
+    expect(document.body.textContent).toContain("WeChat group");
+    expect(document.body.textContent).toContain("Discord");
+
+    await dispatch(window, new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
+
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+  });
+
+  it("keeps inside clicks open and closes on outside mousedown", async () => {
+    const dom = await render(<SupportMenu />);
+    const button = trigger(dom);
+    await dispatch(button, new MouseEvent("click", { bubbles: true, cancelable: true }));
+    const menu = document.querySelector('[role="menu"]');
+    if (!menu) throw new Error("Missing support menu panel");
+
+    await dispatch(menu, new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    expect(document.querySelector('[role="menu"]')).not.toBeNull();
+
+    await dispatch(document.body, new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+  });
+});

--- a/packages/web/src/components/__tests__/team-switcher-dom.test.tsx
+++ b/packages/web/src/components/__tests__/team-switcher-dom.test.tsx
@@ -104,6 +104,20 @@ async function submit(form: HTMLFormElement | null): Promise<void> {
   await flush();
 }
 
+async function keyDown(element: Element | Window, key: string): Promise<void> {
+  await act(async () => {
+    element.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key }));
+  });
+  await flush();
+}
+
+async function mouseDown(element: Element | Window): Promise<void> {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
 async function waitForText(container: ParentNode, text: string, timeoutMs = 3000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -265,6 +279,37 @@ describe("TeamSwitcher", () => {
     await act(async () => root.unmount());
   });
 
+  it("cancels rename edits with Escape, cancel click, and same-name submit without saving", async () => {
+    const { container, root } = await renderHarness(vi.fn(async () => {}));
+
+    await click(anchorOf(container));
+    await click(buttonByLabel(container, "Edit team name"));
+    let input = container.querySelector<HTMLInputElement>('input[aria-label="Team name"]');
+    if (!input) throw new Error("Team name input missing");
+    await setInputValue(input, "Draft Team");
+    await keyDown(input, "Escape");
+
+    expect(container.querySelector<HTMLInputElement>('input[aria-label="Team name"]')).toBeNull();
+    expect(orgMocks.updateOrganization).not.toHaveBeenCalled();
+
+    await click(buttonByLabel(container, "Edit team name"));
+    input = container.querySelector<HTMLInputElement>('input[aria-label="Team name"]');
+    if (!input) throw new Error("Team name input missing");
+    await setInputValue(input, "Another Draft");
+    await click(buttonByLabel(container, "Cancel team name edit"));
+
+    expect(container.querySelector<HTMLInputElement>('input[aria-label="Team name"]')).toBeNull();
+    expect(orgMocks.updateOrganization).not.toHaveBeenCalled();
+
+    await click(buttonByLabel(container, "Edit team name"));
+    await submit(container.querySelector("form"));
+
+    expect(container.querySelector<HTMLInputElement>('input[aria-label="Team name"]')).toBeNull();
+    expect(orgMocks.updateOrganization).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
   it("keeps the rename form open and shows the server error when rename fails", async () => {
     orgMocks.updateOrganization.mockRejectedValueOnce(new Error("rename failed"));
     const { container, root } = await renderHarness(vi.fn(async () => {}));
@@ -350,6 +395,49 @@ describe("TeamSwitcher", () => {
     await act(async () => root.unmount());
   });
 
+  it("clears stale switch errors when the menu is dismissed by Escape or outside click", async () => {
+    const select = vi.fn(async () => {
+      throw new Error("switch failed");
+    });
+    const { container, root } = await renderHarness(select);
+
+    await click(anchorOf(container));
+    await click(buttonByText(container, "Globex"));
+    await waitForText(container, "Couldn't switch");
+
+    await keyDown(window, "Escape");
+    expect(container.textContent).not.toContain("Couldn't switch");
+    expect(anchorOf(container).getAttribute("aria-expanded")).toBe("false");
+
+    await click(anchorOf(container));
+    await click(buttonByText(container, "Globex"));
+    await waitForText(container, "Couldn't switch");
+
+    await mouseDown(document.body);
+    expect(container.textContent).not.toContain("Couldn't switch");
+    expect(anchorOf(container).getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => root.unmount());
+  });
+
+  it("opens team management actions and invite affordances from the menu", async () => {
+    const { container, root } = await renderHarness(vi.fn(async () => {}));
+
+    await click(anchorOf(container));
+    await click(buttonByText(container, "Create new team"));
+    expect(anchorOf(container).getAttribute("aria-expanded")).toBe("false");
+
+    await click(anchorOf(container));
+    await click(buttonByText(container, "Join with invite link"));
+    expect(anchorOf(container).getAttribute("aria-expanded")).toBe("false");
+
+    await click(anchorOf(container));
+    await click(buttonByText(container, "Invite teammates"));
+    expect(anchorOf(container).getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => root.unmount());
+  });
+
   it("keeps the anchor but hides the switch list for a single-team user", async () => {
     clientMocks.get.mockResolvedValue([ORGS[0]]);
     const { container, root } = await renderHarness(vi.fn(async () => {}));
@@ -403,6 +491,23 @@ describe("TeamSwitcher", () => {
     expect(refreshMe).toHaveBeenCalledTimes(1);
     expect(select).not.toHaveBeenCalled();
     expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/onboarding");
+
+    await act(async () => root.unmount());
+  });
+
+  it("surfaces leave-team failures and lets the user dismiss the confirmation dialog", async () => {
+    memberMocks.leaveMembership.mockRejectedValueOnce(new Error("cannot leave last admin"));
+    const { container, root } = await renderHarness(vi.fn(async () => {}));
+
+    await click(anchorOf(container));
+    await click(buttonByText(container, "Leave this team"));
+    await click(buttonByText(document.body, "Leave team"));
+
+    await waitForText(document.body, "cannot leave last admin");
+    expect(document.body.querySelector('[role="dialog"]')).not.toBeNull();
+
+    await click(buttonByText(document.body, "Cancel"));
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
@@ -27,6 +27,20 @@ const OPTS = [
 const CANDIDATES = [{ agentId: "agent-alice", name: "alice", displayName: "Alice", managedByMe: false }];
 
 const roots: Root[] = [];
+function installImmediateAnimationFrame(): () => void {
+  const original = globalThis.requestAnimationFrame;
+  globalThis.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+    callback(0);
+    return 1;
+  };
+  return () => {
+    if (original) {
+      globalThis.requestAnimationFrame = original;
+    } else {
+      delete (globalThis as { requestAnimationFrame?: typeof requestAnimationFrame }).requestAnimationFrame;
+    }
+  };
+}
 async function renderDom(element: ReactElement): Promise<HTMLElement> {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -41,7 +55,9 @@ async function renderDom(element: ReactElement): Promise<HTMLElement> {
   return container;
 }
 afterEach(() => {
-  for (const r of roots.splice(0)) r.unmount();
+  act(() => {
+    for (const r of roots.splice(0)) r.unmount();
+  });
   document.body.innerHTML = "";
 });
 
@@ -53,6 +69,13 @@ async function click(el: Element | null): Promise<void> {
 }
 async function keyDown(el: EventTarget, key: string, init: KeyboardEventInit = {}): Promise<KeyboardEvent> {
   const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...init });
+  await act(async () => {
+    el.dispatchEvent(event);
+  });
+  return event;
+}
+async function mouseDown(el: EventTarget): Promise<MouseEvent> {
+  const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
   await act(async () => {
     el.dispatchEvent(event);
   });
@@ -71,10 +94,40 @@ async function changeFiles(el: HTMLInputElement, files: File[]): Promise<void> {
     el.dispatchEvent(new Event("change", { bubbles: true }));
   });
 }
+async function pasteFiles(el: Element | null, files: File[]): Promise<Event> {
+  if (!el) throw new Error("paste target missing");
+  const event = new Event("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clipboardData", { configurable: true, value: { files } });
+  await act(async () => {
+    el.dispatchEvent(event);
+  });
+  return event;
+}
+async function dragOver(el: Element | null): Promise<Event> {
+  if (!el) throw new Error("drag target missing");
+  const event = new Event("dragover", { bubbles: true, cancelable: true });
+  await act(async () => {
+    el.dispatchEvent(event);
+  });
+  return event;
+}
+async function dropFiles(el: Element | null, files: File[]): Promise<Event> {
+  if (!el) throw new Error("drop target missing");
+  const event = new Event("drop", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { configurable: true, value: { files } });
+  await act(async () => {
+    el.dispatchEvent(event);
+  });
+  return event;
+}
 function freeTextBox(c: ParentNode): HTMLTextAreaElement | null {
   return c.querySelector<HTMLTextAreaElement>(
     'textarea[placeholder^="Type your answer"], textarea[placeholder^="Other"]',
   );
+}
+function answerSurface(c: ParentNode): HTMLElement | null {
+  const textarea = freeTextBox(c);
+  return textarea?.parentElement?.parentElement ?? null;
 }
 function thumbnails(c: ParentNode): HTMLImageElement[] {
   return [...c.querySelectorAll<HTMLImageElement>("img")];
@@ -91,6 +144,48 @@ function btn(c: ParentNode, text: string): HTMLButtonElement | null {
 }
 
 describe("AskTakeover", () => {
+  it("lifts above the visual viewport keyboard inset and unregisters viewport listeners", async () => {
+    const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+    const visualViewport = {
+      height: 500,
+      offsetTop: 25,
+      addEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        const set = listeners.get(type) ?? new Set<EventListenerOrEventListenerObject>();
+        set.add(listener);
+        listeners.set(type, set);
+      }),
+      removeEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        listeners.get(type)?.delete(listener);
+      }),
+    };
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 720 });
+    Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport });
+
+    const c = await renderDom(
+      <AskTakeover body="# Concerns?" payload={{ multiSelect: false }} onReply={() => {}} onSkip={() => {}} />,
+    );
+    const scrim = c.firstElementChild;
+    if (!(scrim instanceof HTMLElement)) throw new Error("scrim missing");
+    expect(Number.parseFloat(scrim.style.bottom)).toBe(195);
+
+    visualViewport.height = 690;
+    visualViewport.offsetTop = 20;
+    await act(async () => {
+      for (const listener of listeners.get("resize") ?? []) {
+        if (typeof listener === "function") listener(new Event("resize"));
+        else listener.handleEvent(new Event("resize"));
+      }
+    });
+    expect(Number.parseFloat(scrim.style.bottom)).toBe(10);
+
+    await act(async () => {
+      for (const r of roots.splice(0)) r.unmount();
+    });
+    expect(visualViewport.removeEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
+    expect(visualViewport.removeEventListener).toHaveBeenCalledWith("scroll", expect.any(Function));
+    Object.defineProperty(window, "visualViewport", { configurable: true, value: undefined });
+  });
+
   it("single-select: Reply gated on a pick, preview shows only when selected, sends the label", async () => {
     const onReply = vi.fn();
     const c = await renderDom(
@@ -356,6 +451,38 @@ describe("AskTakeover", () => {
     expect(listbox?.textContent).toContain("Alice");
   });
 
+  it("commits a mention from the popover and through the explicit mention button", async () => {
+    const restoreRaf = installImmediateAnimationFrame();
+    try {
+      const c = await renderDom(
+        <AskTakeover
+          body="# Who?"
+          payload={{ multiSelect: false }}
+          mentionCandidates={CANDIDATES}
+          onReply={() => {}}
+          onSkip={() => {}}
+        />,
+      );
+      const ta = freeTextBox(c);
+      if (!ta) throw new Error("free-text input missing");
+      await setValue(ta, "@al");
+      const alice = c.querySelector<HTMLElement>('[role="option"]');
+      if (!alice) throw new Error("mention option missing");
+      const picked = await mouseDown(alice);
+      expect(picked.defaultPrevented).toBe(true);
+      expect(ta.value).toBe("@alice ");
+
+      await act(async () => {
+        ta.setSelectionRange(ta.value.length, ta.value.length);
+        ta.dispatchEvent(new Event("select", { bubbles: true }));
+      });
+      await click(c.querySelector('[aria-label="Mention an agent"]'));
+      expect(ta.value).toBe("@alice @");
+    } finally {
+      restoreRaf();
+    }
+  });
+
   it("stages a pasted/attached image and lets an image-only answer resolve", async () => {
     const onReply = vi.fn();
     const c = await renderDom(
@@ -375,6 +502,51 @@ describe("AskTakeover", () => {
 
     await click(btn(c, "Reply"));
     expect(onReply).toHaveBeenCalledWith({ content: "", mentions: [], images: [file] });
+  });
+
+  it("opens the file picker, stages pasted and dropped images, and removes thumbnails", async () => {
+    const c = await renderDom(
+      <AskTakeover body="# Evidence?" payload={{ multiSelect: false }} onReply={() => {}} onSkip={() => {}} />,
+    );
+    const fileInput = c.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) throw new Error("file input missing");
+    const openPicker = vi.spyOn(fileInput, "click");
+    await click(c.querySelector('[aria-label="Attach image"]'));
+    expect(openPicker).toHaveBeenCalledTimes(1);
+
+    const pasted = new File(["paste"], "paste.png", { type: "image/png" });
+    const ta = freeTextBox(c);
+    const paste = await pasteFiles(ta, [pasted]);
+    expect(paste.defaultPrevented).toBe(true);
+    expect(thumbnails(c).map((img) => img.alt)).toEqual(["paste.png"]);
+
+    const removed = c.querySelector<HTMLButtonElement>('[aria-label="Remove image"]');
+    await click(removed);
+    expect(thumbnails(c)).toEqual([]);
+
+    const dropped = new File(["drop"], "drop.png", { type: "image/png" });
+    const drag = await dragOver(answerSurface(c));
+    expect(drag.defaultPrevented).toBe(true);
+    const drop = await dropFiles(answerSurface(c), [dropped]);
+    expect(drop.defaultPrevented).toBe(true);
+    expect(thumbnails(c).map((img) => img.alt)).toEqual(["drop.png"]);
+  });
+
+  it("keeps the trial answer input plain by ignoring mention, paste, and drop affordances", async () => {
+    const c = await renderDom(
+      <AskTakeover body="# Evidence?" isTrial payload={{ multiSelect: false }} onReply={() => {}} onSkip={() => {}} />,
+    );
+    expect(c.querySelector('[aria-label="Mention an agent"]')).toBeNull();
+    expect(c.querySelector('[aria-label="Attach image"]')).toBeNull();
+
+    const file = new File(["x"], "trial.png", { type: "image/png" });
+    const paste = await pasteFiles(freeTextBox(c), [file]);
+    const drag = await dragOver(answerSurface(c));
+    const drop = await dropFiles(answerSurface(c), [file]);
+    expect(paste.defaultPrevented).toBe(false);
+    expect(drag.defaultPrevented).toBe(false);
+    expect(drop.defaultPrevented).toBe(false);
+    expect(thumbnails(c)).toEqual([]);
   });
 
   it("rejects an oversized image with an error and stages nothing", async () => {

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -1,0 +1,348 @@
+// @vitest-environment happy-dom
+
+import {
+  type AgentChatStatus,
+  type AgentChatStatusInput,
+  buildAgentChatStatus,
+  type ChatParticipantDetail,
+  type LiveActivity,
+} from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+
+const agentStatusApiMocks = vi.hoisted(() => ({
+  fetchChatAgentStatuses: vi.fn(),
+}));
+
+const sessionApiMocks = vi.hoisted(() => ({
+  suspendSession: vi.fn(),
+  resumeSession: vi.fn(),
+}));
+
+const timelineMocks = vi.hoisted(() => ({
+  scrollToAgentTimeline: vi.fn(),
+}));
+
+vi.mock("../../../api/agent-status.js", () => ({
+  chatAgentStatusQueryKey: (chatId: string) => ["chat-agent-status", chatId] as const,
+  fetchChatAgentStatuses: agentStatusApiMocks.fetchChatAgentStatuses,
+}));
+
+vi.mock("../../../api/sessions.js", () => ({
+  suspendSession: sessionApiMocks.suspendSession,
+  resumeSession: sessionApiMocks.resumeSession,
+}));
+
+vi.mock("../../../lib/scroll-to-agent-timeline.js", () => timelineMocks);
+
+import { AgentStatusPanel } from "../agent-status-panel.js";
+import { ComposeStatusBar } from "../compose-status-bar.js";
+import { LiveTurnAgentsContext } from "../live-turn-context.js";
+
+const BASE_STATUS: Omit<AgentChatStatusInput, "agentId"> = {
+  reachable: true,
+  errored: false,
+  working: false,
+  engagement: "none",
+};
+
+function status(agentId: string, overrides: Partial<AgentChatStatusInput> = {}): AgentChatStatus {
+  return buildAgentChatStatus({
+    ...BASE_STATUS,
+    agentId,
+    ...overrides,
+  });
+}
+
+function activity(agentId: string, overrides: Partial<LiveActivity> = {}): LiveActivity {
+  return {
+    agentId,
+    kind: "tool_call",
+    label: "Bash",
+    detail: "packages/web/src/pages/docs/doc-page.tsx",
+    startedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function agent(agentId: string, displayName: string): ChatParticipantDetail {
+  return {
+    agentId,
+    role: "speaker",
+    mode: "participant",
+    joinedAt: "2026-07-04T12:00:00.000Z",
+    displayName,
+    name: displayName.toLowerCase().replace(/\s+/g, "-"),
+    type: "agent",
+    avatarColorToken: null,
+    avatarImageUrl: null,
+  };
+}
+
+function withProviders(ui: ReactElement, liveTurnAgentIds: ReadonlySet<string> = new Set()): ReactElement {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <LiveTurnAgentsContext.Provider value={liveTurnAgentIds}>{ui}</LiveTurnAgentsContext.Provider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+async function waitForSettled(h: DomHarness, assertion: () => void): Promise<void> {
+  let lastErr: unknown;
+  for (let i = 0; i < 50; i++) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      lastErr = err;
+    }
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
+    await h.flush();
+  }
+  throw lastErr;
+}
+
+async function click(h: DomHarness, element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await h.flush();
+}
+
+async function keyDown(h: DomHarness, target: EventTarget, key: string): Promise<void> {
+  await act(async () => {
+    target.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  });
+  await h.flush();
+}
+
+class ResizeObserverMock {
+  observe(): void {}
+  disconnect(): void {}
+}
+
+describe("ComposeStatusBar extra DOM coverage", () => {
+  let h: DomHarness;
+
+  beforeEach(() => {
+    h = createDomHarness();
+    vi.clearAllMocks();
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  });
+
+  afterEach(() => {
+    h.cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("stays hidden when every status is quiet", async () => {
+    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([status("agent-ready", { engagement: "active" })]);
+
+    h.render(withProviders(<ComposeStatusBar chatId="chat-1" agents={[agent("agent-ready", "Ready Agent")]} />));
+
+    await waitForSettled(h, () => expect(agentStatusApiMocks.fetchChatAgentStatuses).toHaveBeenCalledWith("chat-1"));
+    expect(h.container.textContent).toBe("");
+  });
+
+  it("renders a working lead, expands full narration, and closes it on Escape", async () => {
+    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
+      status("agent-nova", {
+        working: true,
+        engagement: "active",
+        activity: activity("agent-nova", {
+          turnText: "Write **extra** DOM tests",
+          turnTextFull: "Write **extra** DOM tests\n\nCover the status rail.",
+        }),
+      }),
+    ]);
+
+    h.render(withProviders(<ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} />));
+
+    await waitForSettled(h, () => {
+      expect(h.container.textContent).toContain("Nova");
+      expect(h.container.textContent).toContain("Write extra DOM tests");
+      expect(h.container.textContent).toContain("Bash");
+      expect(h.container.textContent).toContain("doc-page.tsx");
+    });
+
+    await click(h, h.container.querySelector('button[aria-label="Expand full narration"]'));
+    await waitForSettled(h, () => {
+      expect(h.container.querySelector('section[aria-label*="full narration"]')).not.toBeNull();
+      expect(h.container.textContent).toContain("Cover the status rail.");
+    });
+
+    await keyDown(h, document, "Escape");
+    await waitForSettled(h, () =>
+      expect(h.container.querySelector('section[aria-label*="full narration"]')).toBeNull(),
+    );
+  });
+
+  it("shows status reasons and suppresses the narration expander for reason rows", async () => {
+    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
+      status("agent-waiting", {
+        statusReason: {
+          kind: "waiting",
+          severity: "warning",
+          provider: "codex",
+          scope: "session_resume",
+          category: "provider_capacity",
+          reasonCode: "provider_rate_limited",
+          label: "Waiting for provider capacity",
+          detail: "capacity queue",
+        },
+      }),
+    ]);
+
+    h.render(withProviders(<ComposeStatusBar chatId="chat-1" agents={[agent("agent-waiting", "Beacon")]} />));
+
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("Waiting for provider capacity"));
+    expect(h.container.querySelector('[title="capacity queue"]')).not.toBeNull();
+    expect(h.container.querySelector('button[aria-label="Expand full narration"]')).toBeNull();
+  });
+
+  it("expands the secondary rows without duplicating the lead row", async () => {
+    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
+      status("agent-atlas", { errored: true }),
+      status("agent-nova", {
+        working: true,
+        engagement: "active",
+        activity: activity("agent-nova", { turnText: "Run the focused suite" }),
+      }),
+    ]);
+
+    h.render(
+      withProviders(
+        <ComposeStatusBar chatId="chat-1" agents={[agent("agent-atlas", "Atlas"), agent("agent-nova", "Nova")]} />,
+      ),
+    );
+
+    await waitForSettled(h, () => {
+      expect(h.container.textContent).toContain("Atlas");
+      expect(h.container.textContent).not.toContain("Nova");
+    });
+
+    await click(h, h.container.querySelector('button[aria-label="Expand activity"]'));
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("Nova"));
+
+    const atlasCount = h.container.textContent?.match(/Atlas/g)?.length ?? 0;
+    expect(atlasCount).toBe(1);
+  });
+});
+
+describe("AgentStatusPanel extra DOM coverage", () => {
+  let h: DomHarness;
+
+  beforeEach(() => {
+    h = createDomHarness();
+    vi.clearAllMocks();
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    sessionApiMocks.suspendSession.mockResolvedValue({
+      agentId: "agent-nova",
+      chatId: "chat-1",
+      state: "suspended",
+      transitioned: true,
+    });
+    sessionApiMocks.resumeSession.mockResolvedValue({
+      agentId: "agent-paused",
+      chatId: "chat-1",
+      state: "active",
+      transitioned: true,
+    });
+  });
+
+  afterEach(() => {
+    h.cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("upgrades a ready row with a live turn and offers Pause", async () => {
+    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([status("agent-nova", { engagement: "active" })]);
+
+    h.render(
+      withProviders(
+        <AgentStatusPanel chatId="chat-1" agents={[agent("agent-nova", "Nova")]} canManage={() => true} compact />,
+        new Set(["agent-nova"]),
+      ),
+    );
+
+    await waitForSettled(h, () => {
+      expect(h.container.textContent).toContain("Nova");
+      expect(h.container.textContent).toContain("Working");
+    });
+
+    await click(h, h.container.querySelector('button[aria-label="Pause agent"]'));
+    await waitForSettled(h, () => expect(sessionApiMocks.suspendSession).toHaveBeenCalledWith("agent-nova", "chat-1"));
+  });
+
+  it("renders missing statuses as empty, and resumes suspended rows", async () => {
+    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([status("agent-paused", { engagement: "suspended" })]);
+
+    h.render(
+      withProviders(
+        <AgentStatusPanel
+          chatId="chat-1"
+          agents={[agent("agent-paused", "Paused Agent"), agent("agent-missing", "Missing Agent")]}
+          canManage={() => true}
+        />,
+      ),
+    );
+
+    await waitForSettled(h, () => {
+      expect(h.container.textContent).toContain("Paused Agent");
+      expect(h.container.textContent).toContain("Missing Agent");
+      expect(h.container.textContent).toContain("\u2026");
+      expect(h.container.querySelector('button[aria-label="Resume agent"]')).not.toBeNull();
+    });
+
+    expect(h.container.querySelector('button[aria-label="Pause agent"]')).toBeNull();
+    await click(h, h.container.querySelector('button[aria-label="Resume agent"]'));
+    await waitForSettled(h, () => expect(sessionApiMocks.resumeSession).toHaveBeenCalledWith("agent-paused", "chat-1"));
+  });
+
+  it("sorts priority rows by attention before the original agent order", async () => {
+    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
+      status("agent-idle", { engagement: "active" }),
+      status("agent-worker", {
+        working: true,
+        engagement: "active",
+        activity: activity("agent-worker", { label: "Read", detail: "packages/web/src/app.tsx" }),
+      }),
+      status("agent-failed", { errored: true }),
+    ]);
+
+    h.render(
+      withProviders(
+        <AgentStatusPanel
+          chatId="chat-1"
+          agents={[
+            agent("agent-idle", "Idle Agent"),
+            agent("agent-worker", "Worker Agent"),
+            agent("agent-failed", "Failed Agent"),
+          ]}
+          canManage={() => false}
+          order="priority"
+        />,
+      ),
+    );
+
+    await waitForSettled(h, () => {
+      const text = h.container.textContent ?? "";
+      expect(text.indexOf("Failed Agent")).toBeLessThan(text.indexOf("Worker Agent"));
+      expect(text.indexOf("Worker Agent")).toBeLessThan(text.indexOf("Idle Agent"));
+    });
+    const text = h.container.textContent ?? "";
+    expect(text.indexOf("Failed Agent")).toBeLessThan(text.indexOf("Worker Agent"));
+    expect(text.indexOf("Worker Agent")).toBeLessThan(text.indexOf("Idle Agent"));
+  });
+});

--- a/packages/web/src/components/chat/__tests__/source-icon.test.tsx
+++ b/packages/web/src/components/chat/__tests__/source-icon.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import { SourceIcon } from "../source-icon.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+async function render(ui: ReactElement): Promise<{ container: HTMLDivElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => root.render(ui));
+  return { container, root };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("SourceIcon", () => {
+  it("uses source-level labels and the defensive missing-source fallback", async () => {
+    const { container, root } = await render(
+      <div>
+        <SourceIcon source="manual" />
+        <SourceIcon source="agent" emphasize size={20} />
+        <SourceIcon source={undefined} />
+      </div>,
+    );
+
+    expect(container.querySelector('[aria-label="Human-created chat"]')).not.toBeNull();
+    const agent = container.querySelector<SVGElement>('[aria-label="Agent-created task"]');
+    expect(agent).not.toBeNull();
+    expect(agent?.getAttribute("width")).toBe("20");
+    expect(agent?.style.color).toBe("var(--fg)");
+    expect(container.querySelector('[aria-label="Conversation"]')).not.toBeNull();
+    await act(async () => root.unmount());
+  });
+
+  it("uses GitHub entity labels and falls back for null or unknown entity types", async () => {
+    const { container, root } = await render(
+      <div>
+        <SourceIcon source="github" entityType="pull_request" />
+        <SourceIcon source="github" entityType="issue" />
+        <SourceIcon source="github" entityType="discussion" />
+        <SourceIcon source="github" entityType="commit" />
+        <SourceIcon source="github" entityType={null} />
+        <SourceIcon source="github" entityType={"constructor" as never} />
+      </div>,
+    );
+
+    for (const label of ["Pull request", "Issue", "Discussion", "Commit"]) {
+      expect(container.querySelector(`[aria-label="${label}"]`)).not.toBeNull();
+    }
+    expect(container.querySelectorAll('[aria-label="GitHub"]')).toHaveLength(2);
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/lib/__tests__/small-lib-coverage.test.ts
+++ b/packages/web/src/lib/__tests__/small-lib-coverage.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from "vitest";
+import { humanizeAgentType, humanizeVisibility } from "../agent-labels.js";
+import { AVATAR_HUE_COUNT, avatarHueColor, fgOnVividColor } from "../avatar-hues.js";
+import { TONE_STYLES, type Tone, toneOf } from "../tones.js";
+
+const cssRgb = (...channels: number[]): string => ["rgb", `(${channels.join(", ")})`].join("");
+
+describe("agent label helpers", () => {
+  it("humanizes agent type and visibility literals", () => {
+    expect(humanizeAgentType("human")).toBe("Human");
+    expect(humanizeAgentType("agent")).toBe("Agent");
+    expect(humanizeVisibility("private")).toBe("Private");
+    expect(humanizeVisibility("organization")).toBe("Organization");
+  });
+});
+
+describe("avatar hue colors", () => {
+  it("resolves avatar CSS tokens through the DOM style engine", () => {
+    document.documentElement.style.setProperty("--avatar-hue-3", cssRgb(1, 2, 3));
+    document.documentElement.style.setProperty("--fg-on-vivid", cssRgb(250, 251, 252));
+
+    expect(AVATAR_HUE_COUNT).toBe(8);
+    expect(avatarHueColor(3)).toBe(cssRgb(1, 2, 3));
+    expect(fgOnVividColor()).toBe(cssRgb(250, 251, 252));
+  });
+});
+
+describe("tone styles", () => {
+  it("returns the style for every known tone and falls back to neutral for unknown runtime input", () => {
+    const tones = [
+      "neutral",
+      "accent",
+      "warn",
+      "error",
+      "outline",
+      "idle",
+      "working",
+      "blocked",
+      "offline",
+    ] satisfies Tone[];
+
+    for (const tone of tones) {
+      expect(toneOf(tone)).toBe(TONE_STYLES[tone]);
+    }
+
+    expect(toneOf("missing" as Tone)).toBe(TONE_STYLES.neutral);
+  });
+});

--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -26,6 +26,8 @@ const resourceApiMocks = vi.hoisted(() => ({
 
 const onboardingEventMocks = vi.hoisted(() => ({
   getTreeSetupStatus: vi.fn(),
+  postOnboardingStartChat: vi.fn(),
+  postTreeSetupStartChat: vi.fn(),
   reportOnboardingEvent: vi.fn(),
 }));
 
@@ -143,6 +145,15 @@ async function waitForText(container: ParentNode, text: string, timeoutMs = 3000
   throw new Error(`Missing text: ${text}\n${container.textContent ?? ""}`);
 }
 
+async function waitForCondition(check: () => boolean, message: string, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) return;
+    await flush();
+  }
+  throw new Error(message);
+}
+
 function snapshot(overrides: Partial<ContextTreeSnapshot> = {}): ContextTreeSnapshot {
   return {
     ...MOCK_CONTEXT_SNAPSHOT,
@@ -193,6 +204,8 @@ beforeEach(() => {
   resourceApiMocks.listTeamResourcesForOrg.mockReset();
   resourceApiMocks.createTeamResourceForOrg.mockReset();
   onboardingEventMocks.getTreeSetupStatus.mockReset();
+  onboardingEventMocks.postOnboardingStartChat.mockReset();
+  onboardingEventMocks.postTreeSetupStartChat.mockReset();
   onboardingEventMocks.reportOnboardingEvent.mockReset();
   orgSettingsMocks.getContextTreeSetting.mockReset();
   agentApiMocks.listManagedAgents.mockResolvedValue([]);
@@ -212,6 +225,8 @@ beforeEach(() => {
     hasTreeBinding: true,
     hasTreeSetupStartChat: true,
   });
+  onboardingEventMocks.postOnboardingStartChat.mockResolvedValue({ chatId: "chat-onboarding-1" });
+  onboardingEventMocks.postTreeSetupStartChat.mockResolvedValue({ chatId: "chat-tree-1" });
   githubAppMocks.getGithubAppInstallation.mockReset();
   githubAppMocks.getGithubAppInstallationExists.mockReset();
   githubAppMocks.getGithubAppInstallUrl.mockReset();
@@ -538,6 +553,36 @@ describe("ContextPage DOM behavior", () => {
     status: "active",
     avatarImageUrl: null,
   };
+  const secondTreeAgent = {
+    ...treeAgent,
+    uuid: "agent-2",
+    name: "backup-agent",
+    displayName: "",
+    inboxId: "inbox-agent-2",
+    clientId: "client-agent-2",
+  };
+  const grantedRepo = {
+    fullName: "acme/acme-web",
+    cloneUrl: "https://github.com/acme/acme-web.git",
+    htmlUrl: "https://github.com/acme/acme-web",
+    private: true,
+    defaultBranch: "main",
+    pushedAt: null,
+  };
+  const grantedApiRepo = {
+    fullName: "acme/api",
+    cloneUrl: "https://github.com/acme/api.git",
+    htmlUrl: "https://github.com/acme/api",
+    private: false,
+    defaultBranch: "main",
+    pushedAt: null,
+  };
+  const recommendedRepoResource = {
+    id: "repo-1",
+    type: "repo",
+    defaultEnabled: "recommended",
+    payload: { url: "https://github.com/acme/acme-web.git" },
+  };
   const unavailableSnapshot = () =>
     snapshot({
       repo: null,
@@ -614,6 +659,64 @@ describe("ContextPage DOM behavior", () => {
     await click(container.querySelector('input[type="checkbox"]'));
     await waitForText(container, "Build your Context Tree");
     expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/");
+    await click(buttonByText(container, "Clear all"));
+    await waitForCondition(
+      () => buttonByText(container, "Build your Context Tree") === null,
+      "Expected clearing selected repos to hide the build CTA",
+    );
+
+    await act(async () => root.unmount());
+  });
+
+  it("starts the tree setup chat for selected repos and the chosen builder agent", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent, secondTreeAgent]);
+    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValueOnce([]).mockResolvedValueOnce([recommendedRepoResource]);
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue({
+      installationId: 7,
+      accountLogin: "acme",
+      accountType: "Organization",
+      manageUrl: "https://github.com/organizations/acme/settings/installations/7",
+      suspended: false,
+      permissions: {},
+      events: [],
+    });
+    githubMocks.listOrgGithubRepos.mockResolvedValue([grantedRepo]);
+    onboardingEventMocks.postTreeSetupStartChat.mockResolvedValue({ chatId: "chat-tree-success" });
+    const { ContextPage } = await import("../context.js");
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailableSnapshot());
+
+    const { container, root } = await renderDom(<ContextPage />);
+    await waitForText(container, "acme-web");
+    await click(container.querySelector('input[type="checkbox"]'));
+    await waitForText(container, "Which agent builds the tree?");
+    expect(container.textContent).toContain("backup-agent");
+
+    await click(container.querySelector('button[aria-label="Agent that builds the Context Tree"]'));
+    await click(
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Tree Agent") ?? null,
+    );
+    await click(buttonByText(container, "Build your Context Tree"));
+
+    await waitForCondition(
+      () => onboardingEventMocks.postTreeSetupStartChat.mock.calls.length > 0,
+      "Expected tree setup chat kickoff",
+    );
+    expect(resourceApiMocks.createTeamResourceForOrg).toHaveBeenCalledWith("org-1", {
+      type: "repo",
+      name: "acme/acme-web",
+      defaultEnabled: "recommended",
+      payload: { url: "https://github.com/acme/acme-web.git" },
+    });
+    expect(onboardingEventMocks.postTreeSetupStartChat).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "org-1",
+        agentUuid: "agent-1",
+        topic: "Set up shared context",
+        complete: true,
+      }),
+    );
+    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/?c=chat-tree-success");
 
     await act(async () => root.unmount());
   });
@@ -657,6 +760,165 @@ describe("ContextPage DOM behavior", () => {
     expect(githubMocks.listOrgGithubRepos.mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(resourceApiMocks.createTeamResourceForOrg).not.toHaveBeenCalled();
     expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/");
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps still-granted repos selected when only part of the GitHub App grant is revoked", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
+    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue({
+      installationId: 7,
+      accountLogin: "acme",
+      accountType: "Organization",
+      manageUrl: "https://github.com/organizations/acme/settings/installations/7",
+      suspended: false,
+      permissions: {},
+      events: [],
+    });
+    githubMocks.listOrgGithubRepos
+      .mockResolvedValueOnce([grantedRepo, grantedApiRepo])
+      .mockResolvedValueOnce([grantedRepo])
+      .mockResolvedValue([grantedRepo]);
+    const { ContextPage } = await import("../context.js");
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailableSnapshot());
+
+    const { container, root } = await renderDom(<ContextPage />);
+    await waitForText(container, "acme-web");
+    await waitForText(container, "api");
+    const repoInputs = [...container.querySelectorAll('input[type="checkbox"]')];
+    await click(repoInputs[0] ?? null);
+    await click(repoInputs[1] ?? null);
+    await waitForText(container, "2 selected");
+    await click(buttonByText(container, "Build your Context Tree"));
+
+    await waitForText(container, "Some selected source repos are no longer available to First Tree");
+    expect(container.textContent).toContain("1 selected");
+    expect(resourceApiMocks.createTeamResourceForOrg).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("surfaces GitHub grant check failures before writing repo resources", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
+    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue({
+      installationId: 7,
+      accountLogin: "acme",
+      accountType: "Organization",
+      manageUrl: "https://github.com/organizations/acme/settings/installations/7",
+      suspended: false,
+      permissions: {},
+      events: [],
+    });
+    githubMocks.listOrgGithubRepos.mockResolvedValueOnce([grantedRepo]).mockRejectedValueOnce(new Error("GitHub down"));
+    const { ContextPage } = await import("../context.js");
+    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailableSnapshot());
+
+    const { container, root } = await renderDom(<ContextPage />);
+    await waitForText(container, "acme-web");
+    await click(container.querySelector('input[type="checkbox"]'));
+    await waitForText(container, "Build your Context Tree");
+    await click(buttonByText(container, "Build your Context Tree"));
+
+    await waitForText(container, "Couldn't check your repositories with GitHub just now");
+    expect(resourceApiMocks.createTeamResourceForOrg).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("retries repo loading after a connected GitHub App query fails", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
+    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue({
+      installationId: 7,
+      accountLogin: "acme",
+      accountType: "Organization",
+      manageUrl: "https://github.com/organizations/acme/settings/installations/7",
+      suspended: false,
+      permissions: {},
+      events: [],
+    });
+    githubMocks.listOrgGithubRepos.mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce([grantedRepo]);
+    const { ContextTreeBuildEntry } = await import("../context-tree-build-entry.js");
+
+    const { container, root } = await renderDom(<ContextTreeBuildEntry />);
+    await waitForText(container, "Couldn't load your team's repos");
+    await click(buttonByText(container, "Try again"));
+    await waitForText(container, "acme-web");
+
+    await act(async () => root.unmount());
+  });
+
+  it("surfaces install failures and lets the user start a stuck install over", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
+    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
+    githubAppMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new Error("network failed"));
+    const fakeTab = { location: { href: "" }, close: vi.fn() };
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(fakeTab as unknown as Window);
+    const { ContextTreeBuildEntry } = await import("../context-tree-build-entry.js");
+
+    const { container, root } = await renderDom(<ContextTreeBuildEntry />);
+    await waitForText(container, "Install First Tree on GitHub");
+    await click(buttonByText(container, "Install First Tree on GitHub"));
+    await waitForText(container, "Something went wrong. Try again in a moment.");
+    expect(fakeTab.close).toHaveBeenCalled();
+    await act(async () => root.unmount());
+    openSpy.mockRestore();
+
+    window.sessionStorage.setItem("context-build:install-attempt", "1");
+    const stuck = await renderDom(<ContextTreeBuildEntry />);
+    await waitForText(stuck.container, "Waiting for GitHub");
+    await click(buttonByText(stuck.container, "Didn't work? Start over"));
+    await waitForCondition(
+      () => !stuck.container.textContent?.includes("Waiting for GitHub"),
+      "Expected install waiting state to clear",
+    );
+    expect(window.sessionStorage.getItem("context-build:install-attempt")).toBeNull();
+    await act(async () => stuck.root.unmount());
+  });
+
+  it("shows the owner recovery copy for non-inline-fixable install failures", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
+    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
+    const { ApiError } = await import("../../api/client.js");
+    const { ContextTreeBuildEntry } = await import("../context-tree-build-entry.js");
+
+    for (const status of [503, 403]) {
+      githubAppMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new ApiError(status, "blocked"));
+      const fakeTab = { location: { href: "" }, close: vi.fn() };
+      const openSpy = vi.spyOn(window, "open").mockReturnValue(fakeTab as unknown as Window);
+      const { container, root } = await renderDom(<ContextTreeBuildEntry />);
+      await waitForText(container, "Install First Tree on GitHub");
+      await click(buttonByText(container, "Install First Tree on GitHub"));
+      await waitForText(container, "Building your team's Context Tree needs First Tree connected to GitHub");
+      expect(fakeTab.close).toHaveBeenCalled();
+      openSpy.mockRestore();
+      await act(async () => root.unmount());
+    }
+  });
+
+  it("resets the build button and shows an error when tree setup chat kickoff fails", async () => {
+    authMock.value = { organizationId: "org-1", role: "admin" };
+    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
+    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
+    onboardingEventMocks.postTreeSetupStartChat.mockRejectedValueOnce(new Error("tree setup unavailable"));
+    const { ContextTreeBuildEntry } = await import("../context-tree-build-entry.js");
+
+    const { container, root } = await renderDom(
+      <ContextTreeBuildEntry treeBindingPlan="useBoundTree" detectedTreeUrl="https://github.com/acme/context-tree" />,
+    );
+    await waitForText(container, "Build your Context Tree");
+    await click(buttonByText(container, "Build your Context Tree"));
+    await waitForText(container, "tree setup unavailable");
+    expect(buttonByText(container, "Build your Context Tree")?.hasAttribute("disabled")).toBe(false);
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/__tests__/docs-extra-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/docs-extra-dom.test.tsx
@@ -157,6 +157,63 @@ function optionByText(text: string): HTMLButtonElement | null {
   );
 }
 
+function submitCommentButton(root: ParentNode): HTMLButtonElement | null {
+  const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>("button"));
+  for (let index = buttons.length - 1; index >= 0; index--) {
+    const button = buttons[index];
+    if (button?.textContent?.trim() === "Comment") return button;
+  }
+  return null;
+}
+
+function mockDocSelection(
+  root: ParentNode,
+  selectedText: string,
+): {
+  paragraph: HTMLParagraphElement;
+  removeAllRanges: ReturnType<typeof vi.fn>;
+  restore: () => void;
+} {
+  const paragraph = Array.from(root.querySelectorAll<HTMLParagraphElement>("p")).find((item) =>
+    item.textContent?.includes("latest quote"),
+  );
+  if (!paragraph?.firstChild) throw new Error("Expected rendered document paragraph");
+
+  const cloneTexts = ["# Docs Review Plan\n\nThe ", " needs review."];
+  const range = {
+    startContainer: paragraph.firstChild,
+    endContainer: paragraph.firstChild,
+    startOffset: 4,
+    endOffset: 16,
+    cloneRange: () => ({
+      setStart: vi.fn(),
+      setEnd: vi.fn(),
+      toString: () => cloneTexts.shift() ?? "",
+    }),
+    getBoundingClientRect: () => ({
+      bottom: 16,
+      height: 16,
+      left: 12,
+      right: 96,
+      top: 0,
+      width: 84,
+      x: 12,
+      y: 0,
+      toJSON: () => ({}),
+    }),
+  };
+  const removeAllRanges = vi.fn();
+  const selection = {
+    isCollapsed: false,
+    rangeCount: 1,
+    getRangeAt: () => range,
+    removeAllRanges,
+    toString: () => selectedText,
+  };
+  const spy = vi.spyOn(window, "getSelection").mockReturnValue(selection as unknown as Selection);
+  return { paragraph, removeAllRanges, restore: () => spy.mockRestore() };
+}
+
 describe("DocsListPage extra DOM coverage", () => {
   let h: DomHarness;
 
@@ -282,6 +339,90 @@ describe("DocPage extra DOM coverage", () => {
       expect(h.container.textContent).toContain("Note: original draft");
       expect(h.container.textContent).toContain("The original quote needs review.");
     });
+  });
+
+  it("creates an anchored comment from selected document text", async () => {
+    docsApiMocks.createDocComment.mockResolvedValue(comment({ body: "Please clarify this." }));
+    renderDocPage();
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("The latest quote needs review."));
+    const selection = mockDocSelection(h.container, "latest quote");
+
+    await act(async () => {
+      selection.paragraph.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+    });
+    await h.flush();
+    await click(h, submitCommentButton(h.container));
+    const textarea = h.container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea).not.toBeNull();
+    if (!textarea) return;
+
+    await setTextareaValue(h, textarea, "  Please clarify this.  ");
+    await click(h, submitCommentButton(h.container));
+
+    await waitForSettled(h, () => expect(docsApiMocks.createDocComment).toHaveBeenCalledTimes(1));
+    expect(docsApiMocks.createDocComment).toHaveBeenCalledWith(
+      "doc-1",
+      expect.objectContaining({
+        body: "Please clarify this.",
+        versionNumber: 2,
+        anchor: expect.objectContaining({ exact: "latest quote" }),
+      }),
+    );
+    await waitForSettled(h, () => expect(h.container.querySelector("textarea")).toBeNull());
+    expect(selection.removeAllRanges).toHaveBeenCalled();
+    selection.restore();
+  });
+
+  it("falls back to document-level comments when the selection cannot be anchored", async () => {
+    docsApiMocks.createDocComment.mockResolvedValue(comment({ body: "Fallback note." }));
+    renderDocPage();
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("The latest quote needs review."));
+    const selection = mockDocSelection(h.container, "rendered only");
+
+    await act(async () => {
+      selection.paragraph.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+    });
+    await h.flush();
+    await click(h, submitCommentButton(h.container));
+    await waitForSettled(h, () => {
+      expect(h.container.textContent).toContain("This selection spans formatting");
+    });
+    const textarea = h.container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea).not.toBeNull();
+    if (!textarea) return;
+
+    await setTextareaValue(h, textarea, "Fallback note.");
+    await click(h, submitCommentButton(h.container));
+
+    await waitForSettled(h, () => expect(docsApiMocks.createDocComment).toHaveBeenCalledTimes(1));
+    expect(docsApiMocks.createDocComment).toHaveBeenCalledWith("doc-1", {
+      body: "> rendered only\n\nFallback note.",
+      versionNumber: 2,
+    });
+    expect(selection.removeAllRanges).toHaveBeenCalled();
+    selection.restore();
+  });
+
+  it("cancels an open selection composer without posting a comment", async () => {
+    renderDocPage();
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("The latest quote needs review."));
+    const selection = mockDocSelection(h.container, "latest quote");
+
+    await act(async () => {
+      selection.paragraph.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+    });
+    await h.flush();
+    await click(h, submitCommentButton(h.container));
+    const textarea = h.container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea).not.toBeNull();
+    if (!textarea) return;
+    await setTextareaValue(h, textarea, "Never posted");
+
+    await click(h, buttonByText(h.container, "Cancel"));
+
+    expect(h.container.querySelector("textarea")).toBeNull();
+    expect(docsApiMocks.createDocComment).not.toHaveBeenCalled();
+    selection.restore();
   });
 });
 

--- a/packages/web/src/pages/__tests__/docs-extra-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/docs-extra-dom.test.tsx
@@ -1,0 +1,361 @@
+// @vitest-environment happy-dom
+
+import type { DocComment, DocSummary, DocWithVersion } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, createRef, type ReactElement } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../test-utils/dom-harness.js";
+
+const docsApiMocks = vi.hoisted(() => ({
+  listDocs: vi.fn(),
+  findDocBySlug: vi.fn(),
+  getDoc: vi.fn(),
+  setDocStatus: vi.fn(),
+  listDocComments: vi.fn(),
+  createDocComment: vi.fn(),
+  replyDocComment: vi.fn(),
+  setDocCommentStatus: vi.fn(),
+}));
+
+const authMock = vi.hoisted(() => ({
+  value: {
+    organizationId: "org-1" as string | null,
+    docsEnabled: true,
+    role: "member" as "admin" | "member" | null,
+  },
+}));
+
+vi.mock("../../api/docs.js", () => docsApiMocks);
+vi.mock("../../auth/auth-context.js", () => ({
+  useAuth: () => authMock.value,
+}));
+
+import { DocCommentSidebar } from "../docs/doc-comment-sidebar.js";
+import { DocPage } from "../docs/doc-page.js";
+import { DocsListPage } from "../docs/docs-list-page.js";
+
+const AUTHOR = { kind: "agent" as const, id: "agent-1", name: "liuchao-fable" };
+const HUMAN = { kind: "human" as const, id: "human-1", name: "liuchao-001" };
+
+function summary(overrides: Partial<DocSummary> = {}): DocSummary {
+  return {
+    id: "doc-1",
+    slug: "docs-review-plan",
+    title: "Docs Review Plan",
+    project: "first-tree",
+    status: "in_review",
+    latestVersion: 2,
+    openCommentCount: 1,
+    createdBy: AUTHOR,
+    createdAt: "2026-07-04T10:00:00.000Z",
+    updatedAt: "2026-07-04T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function docWithVersion(versionNumber = 2, overrides: Partial<DocWithVersion> = {}): DocWithVersion {
+  return {
+    ...summary(),
+    version: {
+      number: versionNumber,
+      content:
+        versionNumber === 1
+          ? "# Docs Review Plan\n\nThe original quote needs review."
+          : "# Docs Review Plan\n\nThe latest quote needs review.",
+      note: versionNumber === 1 ? "original draft" : "latest pass",
+      author: AUTHOR,
+      createdAt: "2026-07-04T12:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+function comment(overrides: Partial<DocComment> = {}): DocComment {
+  return {
+    id: "c-1",
+    documentId: "doc-1",
+    versionNumber: 2,
+    parentId: null,
+    author: HUMAN,
+    body: "Please tighten this section.",
+    anchor: { exact: "quote needs review" },
+    status: "open",
+    createdAt: "2026-07-04T12:30:00.000Z",
+    updatedAt: "2026-07-04T12:30:00.000Z",
+    ...overrides,
+  };
+}
+
+function withProviders(ui: ReactElement, initialPath = "/context/docs"): ReactElement {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+async function waitForSettled(h: DomHarness, assertion: () => void): Promise<void> {
+  let lastErr: unknown;
+  for (let i = 0; i < 50; i++) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      lastErr = err;
+    }
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
+    await h.flush();
+  }
+  throw lastErr;
+}
+
+async function click(h: DomHarness, element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await h.flush();
+}
+
+async function setInputValue(h: DomHarness, element: HTMLInputElement, value: string): Promise<void> {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+    setter?.call(element, value);
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await h.flush();
+}
+
+async function setTextareaValue(h: DomHarness, element: HTMLTextAreaElement, value: string): Promise<void> {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value")?.set;
+    setter?.call(element, value);
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await h.flush();
+}
+
+function buttonByText(root: ParentNode, text: string): HTMLButtonElement | null {
+  return (
+    Array.from(root.querySelectorAll<HTMLButtonElement>("button")).find((button) =>
+      button.textContent?.includes(text),
+    ) ?? null
+  );
+}
+
+function optionByText(text: string): HTMLButtonElement | null {
+  return (
+    Array.from(document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')).find((button) =>
+      button.textContent?.includes(text),
+    ) ?? null
+  );
+}
+
+describe("DocsListPage extra DOM coverage", () => {
+  let h: DomHarness;
+
+  beforeEach(() => {
+    h = createDomHarness();
+    vi.clearAllMocks();
+    authMock.value = { organizationId: "org-1", docsEnabled: true, role: "member" };
+  });
+
+  afterEach(() => h.cleanup());
+
+  it("redirects to Context without fetching when docs are disabled", async () => {
+    authMock.value = { organizationId: "org-1", docsEnabled: false, role: "member" };
+
+    h.render(
+      withProviders(
+        <Routes>
+          <Route path="/context/docs" element={<DocsListPage />} />
+          <Route path="/context" element={<div>Context target</div>} />
+        </Routes>,
+      ),
+    );
+
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("Context target"));
+    expect(docsApiMocks.listDocs).not.toHaveBeenCalled();
+  });
+
+  it("sends the selected status filter to the docs API", async () => {
+    docsApiMocks.listDocs.mockResolvedValue({
+      items: [summary({ id: "doc-approved", slug: "approved-plan", title: "Approved Plan", status: "approved" })],
+      nextCursor: null,
+    });
+
+    h.render(withProviders(<DocsListPage />));
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("Approved Plan"));
+
+    await click(h, h.container.querySelector('button[aria-label="Status filter"]'));
+    await waitForSettled(h, () => expect(optionByText("Approved")).not.toBeNull());
+    await click(h, optionByText("Approved"));
+
+    await waitForSettled(h, () =>
+      expect(docsApiMocks.listDocs).toHaveBeenCalledWith({ status: "approved", limit: 200 }),
+    );
+  });
+
+  it("shows the client-side no-match state after filtering loaded documents", async () => {
+    docsApiMocks.listDocs.mockResolvedValue({
+      items: [summary({ title: "Visible Plan", slug: "visible-plan" })],
+      nextCursor: null,
+    });
+
+    h.render(withProviders(<DocsListPage />));
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("Visible Plan"));
+
+    const input = h.container.querySelector<HTMLInputElement>('input[aria-label="Filter documents"]');
+    expect(input).not.toBeNull();
+    if (!input) return;
+    await setInputValue(h, input, "missing");
+
+    await waitForSettled(h, () => {
+      expect(h.container.textContent).toContain("No documents match the filter.");
+      expect(h.container.textContent).not.toContain("Visible Plan");
+    });
+  });
+
+  it("surfaces list API errors", async () => {
+    docsApiMocks.listDocs.mockRejectedValue(new Error("docs service unavailable"));
+
+    h.render(withProviders(<DocsListPage />));
+
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("docs service unavailable"));
+  });
+});
+
+describe("DocPage extra DOM coverage", () => {
+  let h: DomHarness;
+
+  beforeEach(() => {
+    h = createDomHarness();
+    vi.clearAllMocks();
+    authMock.value = { organizationId: "org-1", docsEnabled: true, role: "member" };
+    docsApiMocks.findDocBySlug.mockResolvedValue(summary());
+    docsApiMocks.getDoc.mockImplementation((_docId: string, version?: number) =>
+      Promise.resolve(docWithVersion(version ?? 2)),
+    );
+    docsApiMocks.listDocComments.mockResolvedValue({ items: [] });
+  });
+
+  afterEach(() => h.cleanup());
+
+  function renderDocPage(): void {
+    h.render(
+      withProviders(
+        <Routes>
+          <Route path="/context/docs/:slug" element={<DocPage />} />
+          <Route path="/context" element={<div>Context target</div>} />
+        </Routes>,
+        "/context/docs/docs-review-plan",
+      ),
+    );
+  }
+
+  it("redirects to Context without fetching when docs are disabled", async () => {
+    authMock.value = { organizationId: "org-1", docsEnabled: false, role: "member" };
+
+    renderDocPage();
+
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("Context target"));
+    expect(docsApiMocks.findDocBySlug).not.toHaveBeenCalled();
+  });
+
+  it("loads an older version and shows the old-version note", async () => {
+    renderDocPage();
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("The latest quote needs review."));
+
+    await click(h, h.container.querySelector('button[aria-label="Version"]'));
+    await waitForSettled(h, () => expect(optionByText("v1")).not.toBeNull());
+    await click(h, optionByText("v1"));
+
+    await waitForSettled(h, () => {
+      expect(docsApiMocks.getDoc).toHaveBeenCalledWith("doc-1", 1);
+      expect(h.container.textContent).toContain("Viewing v1");
+      expect(h.container.textContent).toContain("Note: original draft");
+      expect(h.container.textContent).toContain("The original quote needs review.");
+    });
+  });
+});
+
+describe("DocCommentSidebar extra DOM coverage", () => {
+  let h: DomHarness;
+  let scrollIntoView: ReturnType<typeof vi.fn>;
+  let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
+
+  beforeEach(() => {
+    h = createDomHarness();
+    vi.clearAllMocks();
+    originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    scrollIntoView = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+  });
+
+  afterEach(() => {
+    HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    h.cleanup();
+  });
+
+  function renderSidebar(comments: DocComment[], contentText = "The quote needs review in this paragraph.") {
+    const content = document.createElement("div");
+    content.innerHTML = `<p>${contentText}</p>`;
+    document.body.appendChild(content);
+    const ref = createRef<HTMLDivElement>();
+    ref.current = content;
+    const onChanged = vi.fn();
+
+    h.render(
+      withProviders(
+        <DocCommentSidebar comments={comments} currentVersion={2} contentRef={ref} onChanged={onChanged} />,
+      ),
+    );
+
+    return { onChanged };
+  }
+
+  it("keeps resolved threads hidden until toggled, locates their quote, and reopens them", async () => {
+    docsApiMocks.setDocCommentStatus.mockResolvedValue(comment({ status: "open" }));
+    renderSidebar([comment({ status: "resolved" })]);
+
+    expect(h.container.textContent).toContain("No open comments");
+    expect(h.container.textContent).not.toContain("Please tighten this section.");
+
+    await click(h, buttonByText(h.container, "Show 1 resolved"));
+    expect(h.container.textContent).toContain("Please tighten this section.");
+
+    await click(h, h.container.querySelector('button[title="Locate in document"]'));
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+
+    await click(h, h.container.querySelector('button[aria-label="Reopen thread"]'));
+    await waitForSettled(h, () => expect(docsApiMocks.setDocCommentStatus).toHaveBeenCalledWith("c-1", "open"));
+  });
+
+  it("trims replies, disables blank submits, and notifies after a successful reply", async () => {
+    const { onChanged } = renderSidebar([comment()]);
+    docsApiMocks.replyDocComment.mockResolvedValue(comment({ id: "reply-1", parentId: "c-1", body: "Looks good" }));
+
+    await click(h, buttonByText(h.container, "Reply"));
+    const textarea = h.container.querySelector<HTMLTextAreaElement>("textarea");
+    expect(textarea).not.toBeNull();
+    if (!textarea) return;
+
+    let submit = buttonByText(h.container, "Reply");
+    expect(submit?.disabled).toBe(true);
+
+    await setTextareaValue(h, textarea, "  Looks good  ");
+    submit = buttonByText(h.container, "Reply");
+    expect(submit?.disabled).toBe(false);
+    await click(h, submit);
+
+    await waitForSettled(h, () => expect(docsApiMocks.replyDocComment).toHaveBeenCalledWith("c-1", "Looks good"));
+    await waitForSettled(h, () => expect(onChanged).toHaveBeenCalled());
+    expect(h.container.querySelector("textarea")).toBeNull();
+  });
+});

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -1,0 +1,455 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthContext } from "../../auth/auth-context.js";
+import { ToastProvider } from "../../components/ui/toast.js";
+import { AgentDetailPreviewPage } from "../agent-detail-preview.js";
+import { ChatOfflineNoticePreviewPage } from "../chat-offline-notice-preview.js";
+import { ChatSummaryPreviewPage } from "../chat-summary-preview.js";
+import { CommandPalettePreviewPage } from "../command-palette-preview.js";
+import { ContextTreePreviewPage } from "../context-tree-preview.js";
+import { ConversationListPreviewPage } from "../conversation-list-preview.js";
+import { MockTeamStepsA, MockTeamStepsB, MockWelcomeCeremonial } from "../onboarding-team-steps-mocks.js";
+import { RequestDockPreviewPage } from "../request-dock-preview.js";
+import { ResourcesPreviewPage } from "../resources-preview.js";
+import { SettingsGithubPreviewPage } from "../settings-github-preview.js";
+import { SupportMenuPreviewPage } from "../support-menu-preview.js";
+import { TeamSwitcherPreviewPage } from "../team-switcher-preview.js";
+import { UserMenuPreviewPage } from "../user-menu-preview.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+type Rendered = {
+  container: HTMLElement;
+  queryClient: QueryClient;
+  root: Root;
+};
+
+type AuthValue = React.ComponentProps<typeof AuthContext.Provider>["value"];
+
+const DEFAULT_AUTH = {
+  isAuthenticated: true,
+  meLoaded: true,
+  user: { id: "preview-human", displayName: "Gandy", username: "gandy2025", avatarUrl: null },
+  memberships: [],
+  currentMembership: null,
+  organizationId: "org-preview",
+  memberId: "member-preview",
+  role: "admin",
+  agentId: "preview-human",
+  teamDisplayName: "Preview Team",
+  orgHasOtherMembers: true,
+  currentOrgHasUsableAgent: true,
+  currentOrgHasPersonalAgent: true,
+  docsEnabled: true,
+  onboardingStep: "completed",
+  onboardingDismissedAt: null,
+  onboardingCompletedAt: "2026-01-01T00:00:00.000Z",
+  switchingOrg: null,
+  setSwitchingOrg: () => undefined,
+  dismissOnboarding: async () => undefined,
+  restoreOnboarding: async () => undefined,
+  markOnboardingCompleted: async () => undefined,
+  login: async () => undefined,
+  adoptTokens: async () => undefined,
+  selectOrganization: async () => undefined,
+  refreshMe: async () => undefined,
+  logout: () => undefined,
+} as AuthValue;
+
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: JSON_HEADERS });
+}
+
+function installBrowserMocks(): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+  Object.defineProperty(window, "ResizeObserver", {
+    configurable: true,
+    value: class ResizeObserver {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    },
+  });
+  Object.defineProperty(globalThis, "ResizeObserver", {
+    configurable: true,
+    value: window.ResizeObserver,
+  });
+  Object.defineProperty(window, "PointerEvent", { configurable: true, value: MouseEvent });
+  Object.defineProperty(globalThis, "PointerEvent", { configurable: true, value: MouseEvent });
+  HTMLElement.prototype.scrollIntoView = () => undefined;
+  HTMLElement.prototype.hasPointerCapture = () => false;
+  HTMLElement.prototype.releasePointerCapture = () => undefined;
+  HTMLElement.prototype.setPointerCapture = () => undefined;
+  Object.defineProperty(window, "requestAnimationFrame", {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => window.setTimeout(() => callback(Date.now()), 0),
+  });
+  Object.defineProperty(window, "cancelAnimationFrame", {
+    configurable: true,
+    value: (id: number) => window.clearTimeout(id),
+  });
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: window.requestAnimationFrame,
+  });
+  Object.defineProperty(globalThis, "cancelAnimationFrame", { configurable: true, value: window.cancelAnimationFrame });
+}
+
+function installFetchMock(): void {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.includes("/me/organizations")) {
+      return jsonResponse([{ id: "real-org", name: "real", displayName: "Real Team", role: "member" }]);
+    }
+    if (url.includes("/settings/context_tree_features")) {
+      return jsonResponse({ contextReviewer: { enabled: false, agentUuid: null } });
+    }
+    if (url.includes("/settings/context_tree")) return jsonResponse({ repo: null, branch: null });
+    if (url.includes("/me/chats")) return jsonResponse({ rows: [], nextCursor: null });
+    if (url.includes("/agents")) return jsonResponse({ items: [], nextCursor: null });
+    if (url.includes("/team-resources") || url.includes("/resources")) return jsonResponse([]);
+    return jsonResponse({});
+  }) as unknown as typeof fetch;
+}
+
+function createClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: { retry: false, gcTime: Number.POSITIVE_INFINITY },
+    },
+  });
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function renderPreview(element: ReactElement, path = "/"): Promise<Rendered> {
+  window.history.replaceState(null, "", path);
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = createClient();
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <AuthContext.Provider value={DEFAULT_AUTH}>
+            <MemoryRouter initialEntries={[path]}>{element}</MemoryRouter>
+          </AuthContext.Provider>
+        </ToastProvider>
+      </QueryClientProvider>,
+    );
+  });
+  await flush();
+  return { container, queryClient, root };
+}
+
+async function cleanupRendered(rendered: Rendered): Promise<void> {
+  await act(async () => rendered.root.unmount());
+  rendered.queryClient.clear();
+}
+
+function text(container: ParentNode = document.body): string {
+  return container.textContent ?? "";
+}
+
+function buttonByText(container: ParentNode, label: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")].find((candidate) => candidate.textContent?.includes(label));
+  if (!button) throw new Error(`Missing button: ${label}`);
+  return button;
+}
+
+function buttonByLabel(container: ParentNode, label: RegExp): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")].find((candidate) => {
+    const ariaLabel = candidate.getAttribute("aria-label") ?? "";
+    return label.test(ariaLabel);
+  });
+  if (!button) throw new Error(`Missing labelled button: ${label}`);
+  return button;
+}
+
+async function click(element: Element): Promise<void> {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function setInputValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): Promise<void> {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), "value")?.set;
+    setter?.call(element, value);
+    element.dispatchEvent(new InputEvent("input", { bubbles: true, data: value, inputType: "insertText" }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await flush();
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  document.body.innerHTML = "";
+  document.documentElement.className = "";
+  localStorage.clear();
+  sessionStorage.clear();
+  installBrowserMocks();
+  installFetchMock();
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  document.documentElement.className = "";
+  vi.restoreAllMocks();
+});
+
+describe("extra preview pages", () => {
+  it("renders the seeded agent-detail preview sections", async () => {
+    const rendered = await renderPreview(<AgentDetailPreviewPage />);
+
+    expect(text(rendered.container)).toContain("Agent switcher");
+    expect(text(rendered.container)).toContain("Environment tab");
+    expect(text(rendered.container)).toContain("Tools & skills tab");
+    expect(text(rendered.container)).toContain("Instructions tab");
+    expect(text(rendered.container)).toContain("Usage tab");
+    expect(text(rendered.container)).toContain("Vega");
+    expect(text(rendered.container)).toContain("first-tree");
+    expect(text(rendered.container)).toContain("release-notes");
+    expect(text(rendered.container)).toContain("Team style guide");
+    expect(text(rendered.container)).toContain("claude-haiku-4-5");
+
+    await cleanupRendered(rendered);
+  });
+
+  it("renders and filters the conversation-list preview", async () => {
+    const rendered = await renderPreview(<ConversationListPreviewPage />, "/preview/conversation-list?theme=dark");
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(text(rendered.container)).toContain("Deploy pipeline");
+    expect(text(rendered.container)).toContain("Row-state legend");
+    expect(text(rendered.container)).toContain("Refactor the auth flow");
+
+    await click(buttonByText(rendered.container, "Watching"));
+    expect(text(rendered.container)).toContain("PR repo 688: adapter retries");
+    expect(text(rendered.container)).toContain("research squad");
+
+    await click(buttonByText(rendered.container, "Unread"));
+    expect(text(rendered.container)).toContain("Q2 hero copy");
+    expect(text(rendered.container)).toContain("release-train");
+
+    await click(buttonByText(rendered.container, "toggle"));
+    expect(localStorage.getItem("theme")).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    await cleanupRendered(rendered);
+  });
+
+  it("renders every settings-github preview state and toggles collapsed details", async () => {
+    const rendered = await renderPreview(<SettingsGithubPreviewPage />);
+
+    expect(text(rendered.container)).toContain("Settings");
+    expect(text(rendered.container)).toContain("GitHub");
+    expect(text(rendered.container)).toContain("Connected");
+    expect(text(rendered.container)).toContain("default");
+    expect(text(rendered.container)).toContain("details expanded");
+    expect(text(rendered.container)).toContain("Suspended upstream");
+    expect(text(rendered.container)).toContain("Not installed");
+    expect(text(rendered.container)).toContain("waiting");
+    expect(text(rendered.container)).toContain("Loading");
+    expect(text(rendered.container)).toContain("Waiting for GitHub");
+
+    const detailsButtons = [...rendered.container.querySelectorAll("button")].filter((button) =>
+      button.textContent?.includes("Connection details"),
+    );
+    expect(detailsButtons.length).toBe(3);
+    expect(detailsButtons[0]?.getAttribute("aria-expanded")).toBe("false");
+    await click(detailsButtons[0] ?? detailsButtons[1] ?? buttonByText(rendered.container, "Connection details"));
+    expect(detailsButtons[0]?.getAttribute("aria-expanded")).toBe("true");
+    expect(text(rendered.container)).toContain("Installation #131952074");
+
+    await cleanupRendered(rendered);
+  });
+
+  it("renders the context-tree preview gallery", async () => {
+    const rendered = await renderPreview(<ContextTreePreviewPage />);
+
+    expect(text(rendered.container)).toContain("Context tree");
+    expect(text(rendered.container)).toContain("preview");
+    expect(text(rendered.container)).toContain("admin, team HAS a tree");
+    expect(text(rendered.container)).toContain("member (read-only)");
+    expect(text(rendered.container)).toContain("Context Reviewer");
+    expect(text(rendered.container)).toContain("repo connected");
+    expect(text(rendered.container)).toContain("no repo");
+    expect(text(rendered.container)).toContain("acme/acme-api");
+
+    await cleanupRendered(rendered);
+  });
+
+  it("renders and reopens the command-palette preview with demo chats and teammates", async () => {
+    const rendered = await renderPreview(<CommandPalettePreviewPage />);
+
+    expect(text(document.body)).toContain("Command palette preview");
+    expect(text(document.body)).toContain("Recent");
+    expect(text(document.body)).toContain("Teammates");
+    expect(text(document.body)).toContain("Jump to palette polish");
+    expect(text(document.body)).toContain("Archived onboarding audit");
+    expect(text(document.body)).toContain("Gandy");
+    expect(text(document.body)).toContain("@gandy-coder");
+
+    const input = document.body.querySelector<HTMLInputElement>('input[placeholder^="Jump to chat or teammate"]');
+    if (!input) throw new Error("Command palette input missing");
+    await setInputValue(input, "CapRover");
+    expect(text(document.body)).toContain("CapRover feedback route");
+
+    await cleanupRendered(rendered);
+  });
+
+  it("renders resources, chat-summary, offline-notice, and support/user menu previews", async () => {
+    const resources = await renderPreview(<ResourcesPreviewPage />);
+    expect(text(resources.container)).toContain("Code review checklist");
+    expect(text(resources.container)).toContain("frontend design system");
+    expect(text(resources.container)).toContain("github");
+    await click(buttonByText(resources.container, "theme"));
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    await cleanupRendered(resources);
+
+    document.documentElement.className = "";
+    const summary = await renderPreview(<ChatSummaryPreviewPage />);
+    expect(text(summary.container)).toContain("Chat summary");
+    expect(text(summary.container)).toContain("states");
+    expect(text(summary.container)).toContain("Unread new summary version");
+    expect(text(summary.container)).toContain("No description");
+    expect(text(summary.container)).toContain("Dark theme");
+    await cleanupRendered(summary);
+
+    const offline = await renderPreview(<ChatOfflineNoticePreviewPage />, "/preview/chat-offline-notice?theme=light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(text(offline.container)).toContain("phase 1");
+    expect(text(offline.container)).toContain("phase 2");
+    expect(text(offline.container)).toContain("gandy-assistant");
+    await cleanupRendered(offline);
+
+    const support = await renderPreview(<SupportMenuPreviewPage />);
+    await click(buttonByLabel(support.container, /Help and community/));
+    expect(text(support.container)).toContain("Need help?");
+    expect(text(support.container)).toContain("WeChat group");
+    expect(text(support.container)).toContain("Discord");
+    await click(buttonByText(support.container, "theme"));
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    await cleanupRendered(support);
+
+    document.documentElement.className = "";
+    const userMenu = await renderPreview(<UserMenuPreviewPage />);
+    await click(buttonByLabel(userMenu.container, /User menu, Gandy/));
+    expect(text(userMenu.container)).toContain("Gandy");
+    expect(text(userMenu.container)).toContain("@gandy2025");
+    expect(text(userMenu.container)).toContain("Sign out");
+    await click(buttonByText(userMenu.container, "theme"));
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    await cleanupRendered(userMenu);
+  });
+
+  it("renders request-dock modes and exercises reply and skip status branches", async () => {
+    const rendered = await renderPreview(<RequestDockPreviewPage />);
+
+    expect(text(rendered.container)).toContain("AskTakeover preview");
+    expect(text(rendered.container)).toContain("options");
+    expect(text(rendered.container)).toContain("single");
+    expect(text(rendered.container)).toContain("multi");
+    expect(text(rendered.container)).toContain("free text");
+    expect(text(rendered.container)).toContain("cramped height");
+
+    await click(buttonByText(rendered.container, "Ship to 20%"));
+    const enabledReply = [...rendered.container.querySelectorAll("button")].find(
+      (button) => button.textContent === "Reply" && !button.disabled,
+    );
+    if (!enabledReply) throw new Error("Enabled Reply button missing");
+    await click(enabledReply);
+    expect(text(rendered.container)).toContain("Reply");
+    expect(text(rendered.container)).toContain("Ship to 20%");
+
+    const firstSkip = [...rendered.container.querySelectorAll("button")].find(
+      (button) => button.textContent === "Skip",
+    );
+    if (!firstSkip) throw new Error("Skip button missing");
+    await click(firstSkip);
+    expect(text(rendered.container)).toContain("Skipped");
+    expect(text(rendered.container)).toContain("resolves the request with a skipped answer");
+
+    await cleanupRendered(rendered);
+  });
+
+  it("renders team-switcher preview toggles and path-scoped mock organizations", async () => {
+    const rendered = await renderPreview(<TeamSwitcherPreviewPage />, "/preview/team-switcher");
+
+    expect(text(rendered.container)).toContain("First Tree");
+    expect(text(rendered.container)).toContain("Single team");
+    expect(text(rendered.container)).toContain("Force switch failure");
+    expect(text(rendered.container)).toContain("Compact anchor");
+
+    await click(buttonByLabel(rendered.container, /Switch team/));
+    expect(text(rendered.container)).toContain("Switch team");
+    expect(text(rendered.container)).toContain("Globex");
+    expect(text(rendered.container)).toContain("Invite teammates");
+
+    await click(buttonByText(rendered.container, "Single team"));
+    await click(buttonByLabel(rendered.container, /Switch team/));
+    expect(text(rendered.container)).not.toContain("Globex");
+    expect(text(rendered.container)).toContain("Create new team");
+
+    await click(buttonByText(rendered.container, "Compact anchor"));
+    await click(buttonByText(rendered.container, "Theme"));
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    await cleanupRendered(rendered);
+  });
+
+  it("renders onboarding team-step mock variants and updates their editable names", async () => {
+    const list = await renderPreview(<MockTeamStepsA />);
+    expect(text(list.container)).toContain("What's next");
+    expect(text(list.container)).toContain("Install First Tree");
+    expect(text(list.container)).toContain("Create your first agent");
+    const listInput = list.container.querySelector<HTMLInputElement>("#mock-team");
+    if (!listInput) throw new Error("MockTeamStepsA input missing");
+    await setInputValue(listInput, "Renamed Team");
+    expect(listInput.value).toBe("Renamed Team");
+    await cleanupRendered(list);
+
+    const oneLine = await renderPreview(<MockTeamStepsB />);
+    expect(text(oneLine.container)).toContain("Next:");
+    expect(text(oneLine.container)).toContain("Connect to GitHub");
+    await cleanupRendered(oneLine);
+
+    const ceremonial = await renderPreview(<MockWelcomeCeremonial />);
+    expect(text(ceremonial.container)).toContain("rename it freely");
+    const ceremonialInput = ceremonial.container.querySelector<HTMLInputElement>("#mock-cer-team");
+    if (!ceremonialInput) throw new Error("MockWelcomeCeremonial input missing");
+    await setInputValue(ceremonialInput, "Ceremonial Team");
+    expect(ceremonialInput.value).toBe("Ceremonial Team");
+    await cleanupRendered(ceremonial);
+  });
+});

--- a/packages/web/src/pages/__tests__/styleguide-preview-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/styleguide-preview-dom.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ToastProvider } from "../../components/ui/toast.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function renderDom(element: ReactElement): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(<ToastProvider>{element}</ToastProvider>);
+  });
+  await flush();
+  return { container, root };
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected clickable element");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function keydown(element: Element | null, key: string): Promise<void> {
+  if (!element) throw new Error(`Expected key target for ${key}`);
+  await act(async () => {
+    element.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+function buttonByText(root: ParentNode, text: string): HTMLButtonElement | null {
+  return [...root.querySelectorAll("button")].find((button) => button.textContent?.trim() === text) ?? null;
+}
+
+function buttonContaining(root: ParentNode, text: string): HTMLButtonElement | null {
+  return [...root.querySelectorAll("button")].find((button) => button.textContent?.includes(text)) ?? null;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.documentElement.className = "";
+  localStorage.clear();
+  window.history.replaceState(null, "", "/preview/styleguide");
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  document.documentElement.className = "";
+});
+
+describe("StyleguidePreviewPage", () => {
+  it("renders interactive styleguide controls and preview feedback", async () => {
+    const { StyleguidePreviewPage } = await import("../styleguide-preview.js");
+    const { container, root } = await renderDom(<StyleguidePreviewPage />);
+
+    expect(container.textContent).toContain("First Tree · Design System");
+
+    await click(buttonByText(container, "Activity 3"));
+    expect(container.textContent).toContain("Activity");
+    await click(buttonByText(container, "Settings"));
+    expect(document.body.querySelector('[aria-label="unsaved changes"]')).not.toBeNull();
+    await click(buttonByText(container, "Overview"));
+    expect(container.textContent).toContain("Overview");
+
+    await click(buttonByText(container, "Open popover"));
+    expect(document.body.textContent).toContain("Anchored popover panel");
+    await click(buttonByText(document.body, "Close"));
+    expect(document.body.textContent).not.toContain("Anchored popover panel");
+
+    await click(buttonByText(container, "Show toast"));
+    expect(document.body.textContent).toContain("Changes saved");
+    await click(buttonByText(document.body, "Undo"));
+    expect(document.body.textContent).not.toContain("Changes saved");
+
+    await click(buttonByText(container, "Dark mode"));
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("theme")).toBe("dark");
+    await click(buttonByText(container, "Light mode"));
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(localStorage.getItem("theme")).toBe("light");
+
+    const model = container.querySelector<HTMLButtonElement>('button[aria-label="Model"]');
+    await click(model);
+    await keydown(document.body.querySelector('[role="listbox"][aria-label="Model"]'), "End");
+    await click(buttonContaining(document.body, "claude-haiku-4-5"));
+    expect(model?.textContent).toContain("claude-haiku-4-5");
+
+    const delegate = container.querySelector<HTMLButtonElement>('button[aria-label="Delegate"]');
+    await click(delegate);
+    await click(buttonContaining(document.body, "Cleo (@cleo)"));
+    expect(delegate?.textContent).toContain("Cleo (@cleo)");
+
+    await click(delegate);
+    await keydown(document.body.querySelector('input[role="combobox"]'), "Escape");
+
+    await act(async () => root.unmount());
+  });
+
+  it("honors a theme query override on mount", async () => {
+    window.history.replaceState(null, "", "/preview/styleguide?theme=dark");
+    const { StyleguidePreviewPage } = await import("../styleguide-preview.js");
+    const { root } = await renderDom(<StyleguidePreviewPage />);
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/pages/__tests__/team-switcher-preview.test.ts
+++ b/packages/web/src/pages/__tests__/team-switcher-preview.test.ts
@@ -1,14 +1,21 @@
 // @vitest-environment happy-dom
 
-import type { OrgBrief } from "@first-tree/shared";
+import type { Organization, OrgBrief } from "@first-tree/shared";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
 const REAL_ORGS: OrgBrief[] = [{ id: "real-org", name: "real", displayName: "Real Team", role: "member" }];
+
+type PreviewWindow = Window & {
+  __ftTeamSwitcherPreviewOriginalGet?: unknown;
+  __ftTeamSwitcherPreviewOriginalPatch?: unknown;
+};
 
 beforeEach(() => {
   vi.resetModules();
   localStorage.clear();
   window.history.replaceState(null, "", "/preview/team-switcher");
+  delete (window as PreviewWindow).__ftTeamSwitcherPreviewOriginalGet;
+  delete (window as PreviewWindow).__ftTeamSwitcherPreviewOriginalPatch;
   globalThis.fetch = vi.fn(async () => {
     return new Response(JSON.stringify(REAL_ORGS), {
       status: 200,
@@ -34,4 +41,25 @@ it("scopes the mocked organizations endpoint to the team-switcher preview path",
 
   await expect(api.get<OrgBrief[]>("/me/organizations")).resolves.toEqual(REAL_ORGS);
   expect(globalThis.fetch).toHaveBeenCalledWith("/api/v1/me/organizations", expect.objectContaining({ method: "GET" }));
+});
+
+it("scopes the mocked organization rename endpoint to the team-switcher preview path", async () => {
+  const { api } = await import("../../api/client.js");
+  await import("../team-switcher-preview.js");
+
+  const renamed = await api.patch<Organization>("/orgs/org-2", { displayName: "  Globex Renamed  " });
+  expect(renamed).toMatchObject({
+    id: "org-2",
+    name: "globex",
+    displayName: "Globex Renamed",
+  });
+  expect(globalThis.fetch).not.toHaveBeenCalled();
+
+  const previewOrgs = await api.get<OrgBrief[]>("/me/organizations");
+  expect(previewOrgs.find((org) => org.id === "org-2")?.displayName).toBe("Globex Renamed");
+
+  window.history.replaceState(null, "", "/");
+
+  await expect(api.patch<unknown>("/orgs/org-2", { displayName: "Outside Preview" })).resolves.toEqual(REAL_ORGS);
+  expect(globalThis.fetch).toHaveBeenCalledWith("/api/v1/orgs/org-2", expect.objectContaining({ method: "PATCH" }));
 });

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1910,6 +1910,130 @@ describe("web DOM interaction coverage", () => {
     await unmountRoot(root);
   });
 
+  it("drives create-agent name, runtime, visibility, and submit actions", async () => {
+    authMock.value = { ...authMock.value, currentOrgHasPersonalAgent: false };
+    const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
+    const setAgentDisplayName = vi.fn();
+    const setVisibility = vi.fn();
+    const setSelectedRuntime = vi.fn();
+    const createAgent = vi.fn(async () => undefined);
+    const { flow, container, root } = await renderOnboardingDom(<StepCreateAgent />, {
+      activeStep: "create-agent",
+      agentDisplayName: "  Release Helper  ",
+      setAgentDisplayName,
+      visibility: "organization",
+      setVisibility,
+      createAgent,
+      computer: {
+        connectedClient: CLIENTS[0] ?? null,
+        capabilitiesLoaded: true,
+        okRuntimes: ["claude-code", "codex"],
+        selectedRuntime: "claude-code",
+        setSelectedRuntime,
+        cliCommand: "first-tree-dev login token",
+        tokenError: null,
+        retry: vi.fn(),
+      },
+    });
+    await waitForText("Choose your local coding agent", container);
+
+    const nameInput = container.querySelector<HTMLInputElement>("#onboarding-agent-name");
+    expect(nameInput).not.toBeNull();
+    if (!nameInput) return;
+    await setValue(nameInput, "New helper name");
+    expect(setAgentDisplayName).toHaveBeenCalledWith("New helper name");
+
+    const runtimeInputs = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[name="onboarding-coding-agent"]'),
+    );
+    await click(runtimeInputs[1] ?? null);
+    expect(setSelectedRuntime).toHaveBeenCalledWith("codex");
+
+    const visibilityInputs = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[name="onboarding-visibility"]'),
+    );
+    await click(visibilityInputs[1] ?? null);
+    expect(setVisibility).toHaveBeenCalledWith("private");
+
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Create agent")) ?? null,
+    );
+    expect(createAgent).toHaveBeenCalledWith({
+      displayName: "Release Helper",
+      clientId: CLIENTS[0]?.id,
+      runtimeProvider: "claude-code",
+      visibility: "organization",
+      organizationId: flow.organizationId,
+    });
+    await unmountRoot(root);
+  });
+
+  it("handles create-agent timeout actions", async () => {
+    const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
+    const retryAgent = vi.fn(async () => undefined);
+    const finishLater = vi.fn(async () => undefined);
+    const { container, root } = await renderOnboardingDom(<StepCreateAgent />, {
+      activeStep: "create-agent",
+      agentPhase: "timeout",
+      retryAgent,
+      finishLater,
+    });
+    await waitForText("taking longer than usual", container);
+
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Keep waiting")) ?? null,
+    );
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("I'll finish later")) ??
+        null,
+    );
+
+    expect(retryAgent).toHaveBeenCalledTimes(1);
+    expect(finishLater).toHaveBeenCalledTimes(1);
+    await unmountRoot(root);
+  });
+
+  it("keeps the selected coding agent visible while disconnected and routes reconnect", async () => {
+    authMock.value = { ...authMock.value, currentOrgHasPersonalAgent: false };
+    const { StepCreateAgent } = await import("../onboarding/steps/step-create-agent.js");
+    const goTo = vi.fn();
+    const setSelectedRuntime = vi.fn();
+    const { flow, container, root } = await renderOnboardingDom(<StepCreateAgent />, {
+      activeStep: "create-agent",
+      goTo,
+      computer: {
+        connectedClient: null,
+        capabilitiesLoaded: true,
+        okRuntimes: [],
+        selectedRuntime: "codex",
+        setSelectedRuntime,
+        cliCommand: "first-tree-dev login token",
+        tokenError: null,
+        retry: vi.fn(),
+      },
+    });
+    await waitForText("Not ready", container);
+    await waitForText("Codex", container);
+    const create = [...container.querySelectorAll<HTMLButtonElement>("button")].find((button) =>
+      button.textContent?.includes("Create agent"),
+    );
+    expect(create?.disabled).toBe(true);
+
+    const codingAgentInput = container.querySelector<HTMLInputElement>('input[name="onboarding-coding-agent"]');
+    expect(codingAgentInput?.disabled).toBe(true);
+    await act(async () => {
+      codingAgentInput?.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await flush();
+    expect(setSelectedRuntime).not.toHaveBeenCalled();
+
+    await click(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("reconnect it")) ?? null,
+    );
+    expect(goTo).toHaveBeenCalledWith(flow.sequence.indexOf("connect-computer"));
+    await unmountRoot(root);
+  });
+
   it("drives StepStartChat admin and invitee start flows", async () => {
     const { StepStartChat } = await import("../onboarding/steps/step-start-chat.js");
     const findButton = (container: ParentNode, text: string): HTMLButtonElement | null =>

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
@@ -1,0 +1,698 @@
+// @vitest-environment happy-dom
+
+import type {
+  Agent,
+  AgentResourceBindingInput,
+  AgentResourcesOutput,
+  AgentRuntimeConfig,
+  UsageAgentSummary,
+  UsageTurnsResponse,
+} from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentDetailContext } from "../layout-context.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const contextMock = vi.hoisted(() => ({
+  value: null as AgentDetailContext | null,
+}));
+
+const agentResourceMocks = vi.hoisted(() => ({
+  getAgentResources: vi.fn(),
+  updateAgentResources: vi.fn(),
+}));
+
+const usageMocks = vi.hoisted(() => ({
+  getAgentUsageSummary: vi.fn(),
+  getAgentUsageTurns: vi.fn(),
+}));
+
+const agentApiMocks = vi.hoisted(() => ({
+  deleteAgentAvatar: vi.fn(),
+  listAgents: vi.fn(),
+  listManagedAgents: vi.fn(),
+  uploadAgentAvatar: vi.fn(),
+}));
+
+const authMock = vi.hoisted(() => ({
+  value: {
+    memberId: "member-self",
+    role: "member",
+    agentId: "human-self",
+    organizationId: "org-1",
+  },
+}));
+
+vi.mock("../layout-context.js", () => ({
+  useAgentDetailContext: () => {
+    if (!contextMock.value) throw new Error("Missing agent detail context");
+    return contextMock.value;
+  },
+}));
+
+vi.mock("../../../api/agent-resources.js", () => agentResourceMocks);
+
+vi.mock("../../../api/usage.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../api/usage.js")>()),
+  getAgentUsageSummary: usageMocks.getAgentUsageSummary,
+  getAgentUsageTurns: usageMocks.getAgentUsageTurns,
+}));
+
+vi.mock("../../../api/agents.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../api/agents.js")>()),
+  deleteAgentAvatar: agentApiMocks.deleteAgentAvatar,
+  listAgents: agentApiMocks.listAgents,
+  listManagedAgents: agentApiMocks.listManagedAgents,
+  uploadAgentAvatar: agentApiMocks.uploadAgentAvatar,
+}));
+
+vi.mock("../../../auth/auth-context.js", () => ({
+  useAuth: () => authMock.value,
+}));
+
+const NOW = "2026-06-01T12:00:00.000Z";
+const roots: Root[] = [];
+
+function agent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    uuid: overrides.uuid ?? "agent-1",
+    name: overrides.name ?? "nova",
+    displayName: overrides.displayName ?? "Nova",
+    type: overrides.type ?? "agent",
+    managerId: overrides.managerId ?? "member-self",
+    visibility: overrides.visibility ?? "organization",
+    avatarColorToken: overrides.avatarColorToken ?? null,
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+    status: overrides.status ?? "active",
+    organizationId: overrides.organizationId ?? "org-1",
+    delegateMention: overrides.delegateMention ?? null,
+    inboxId: overrides.inboxId ?? "inbox-1",
+    metadata: overrides.metadata ?? {},
+    source: overrides.source ?? "portal",
+    clientId: overrides.clientId === undefined ? "client-1" : overrides.clientId,
+    runtimeProvider: overrides.runtimeProvider ?? "claude-code",
+    runtimeState: overrides.runtimeState ?? "idle",
+    createdAt: overrides.createdAt ?? NOW,
+    updatedAt: overrides.updatedAt ?? NOW,
+  };
+}
+
+function config(overrides: Partial<AgentRuntimeConfig> = {}): AgentRuntimeConfig {
+  return {
+    agentId: overrides.agentId ?? "agent-1",
+    version: overrides.version ?? 4,
+    payload: overrides.payload ?? {
+      kind: "claude-code",
+      prompt: { append: "Fallback prompt body." },
+      model: "sonnet",
+      reasoningEffort: "medium",
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+    },
+    updatedAt: overrides.updatedAt ?? NOW,
+    updatedBy: overrides.updatedBy ?? "member-self",
+  };
+}
+
+function createContext(overrides: Partial<AgentDetailContext> = {}): AgentDetailContext {
+  const baseAgent = overrides.agent ?? agent();
+  return {
+    uuid: baseAgent.uuid,
+    agent: baseAgent,
+    isHuman: baseAgent.type === "human",
+    canManageAgent: true,
+    canEditConfig: baseAgent.type !== "human",
+    navigateAway: vi.fn(),
+    config: config(),
+    configLoading: false,
+    configError: null,
+    configSave: {
+      save: vi.fn(),
+      pending: false,
+      saveError: null,
+      conflict: false,
+      errorField: null,
+      justSaved: false,
+      savedField: null,
+    },
+    clientStatus: undefined,
+    clientStatusLoading: false,
+    clientStatusError: null,
+    isUnclaimed: false,
+    isOffline: false,
+    boundClientLabel: "gandy-macbook",
+    setupRuntimeProvider: "claude-code",
+    runtimeSwitchClaim: null,
+    onOpenBindDialog: vi.fn(),
+    bindClientPending: false,
+    onOpenRuntimeSwitchDialog: vi.fn(),
+    runtimeSwitchPending: false,
+    runtimeSwitchRecoveryPending: false,
+    runtimeSwitchRecoveryError: null,
+    onRecoverRuntimeSwitch: vi.fn(),
+    saveIdentity: vi.fn(),
+    refreshAgent: vi.fn(),
+    suspendPending: false,
+    reactivatePending: false,
+    deletePending: false,
+    dangerError: null,
+    onSuspend: vi.fn(),
+    onReactivate: vi.fn(),
+    onDelete: vi.fn(),
+    ...overrides,
+  };
+}
+
+type EffectivePromptRow = AgentResourcesOutput["effective"]["prompts"][number];
+
+function promptRow(overrides: Partial<EffectivePromptRow> = {}): EffectivePromptRow {
+  const base: EffectivePromptRow = {
+    id: "resource:team-prompt",
+    bindingId: null,
+    resourceId: "team-prompt",
+    replacesResourceId: null,
+    type: "prompt",
+    name: "Team prompt",
+    scope: "team",
+    source: "team_recommended",
+    mode: "enabled",
+    defaultEnabled: "recommended",
+    payload: null,
+    repo: null,
+    promptBody: "Use the team playbook.",
+    unavailableReason: null,
+    order: 0,
+  };
+  return { ...base, ...overrides };
+}
+
+function agentResources(overrides: Partial<AgentResourcesOutput> = {}): AgentResourcesOutput {
+  return {
+    version: overrides.version ?? 9,
+    effective: overrides.effective ?? {
+      version: overrides.version ?? 9,
+      repos: [],
+      prompts: [],
+      skills: [],
+      mcp: [],
+      unavailable: [],
+    },
+    bindings: overrides.bindings ?? [],
+    availableTeamResources: overrides.availableTeamResources ?? [],
+  };
+}
+
+function availablePrompt(): AgentResourcesOutput["availableTeamResources"][number] {
+  return {
+    id: "prompt-available",
+    organizationId: "org-1",
+    type: "prompt",
+    scope: "team",
+    ownerAgentId: null,
+    name: "Optional safety prompt",
+    repoCanonicalKey: null,
+    defaultEnabled: "available",
+    status: "active",
+    payload: { body: "Check safety constraints." },
+    createdBy: "member-self",
+    updatedBy: "member-self",
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function availableSkill(): AgentResourcesOutput["availableTeamResources"][number] {
+  return {
+    id: "skill-available",
+    organizationId: "org-1",
+    type: "skill",
+    scope: "team",
+    ownerAgentId: null,
+    name: "Optional skill",
+    repoCanonicalKey: null,
+    defaultEnabled: "available",
+    status: "active",
+    payload: { name: "Optional skill", description: "Optional helper.", body: "Do work.", metadata: {} },
+    createdBy: "member-self",
+    updatedBy: "member-self",
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function summary(): UsageAgentSummary {
+  return {
+    agentId: "agent-1",
+    from: "2026-05-01T00:00:00.000Z",
+    to: NOW,
+    totals: {
+      inputTokens: 100,
+      cachedInputTokens: 20,
+      outputTokens: 10,
+      turns: 1,
+      chats: 1,
+      lastUsageAt: NOW,
+    },
+    daily: [],
+  };
+}
+
+function turns(limit = 10, nextCursor: string | null = "next"): UsageTurnsResponse {
+  return {
+    agentId: "agent-1",
+    from: "2026-05-01T00:00:00.000Z",
+    to: NOW,
+    rows: [
+      {
+        seq: limit,
+        chatId: `chat-${limit}`,
+        chatTitle: `Turn batch ${limit}`,
+        createdAt: NOW,
+        inputTokens: 100,
+        cachedInputTokens: 50,
+        outputTokens: 25,
+        provider: "codex",
+        model: "gpt-5",
+      },
+    ],
+    nextCursor,
+  };
+}
+
+function installBrowserStubs(): void {
+  Object.defineProperty(window, "requestAnimationFrame", {
+    configurable: true,
+    value: (cb: FrameRequestCallback) => window.setTimeout(() => cb(performance.now()), 0),
+  });
+  Object.defineProperty(window, "cancelAnimationFrame", {
+    configurable: true,
+    value: (id: number) => window.clearTimeout(id),
+  });
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function renderWithProviders(element: ReactElement, route = "/agents/agent-1/prompt"): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={createQueryClient()}>
+        <MemoryRouter initialEntries={[route]}>{element}</MemoryRouter>
+      </QueryClientProvider>,
+    );
+  });
+  await flush();
+  return container;
+}
+
+async function renderPlain(element: ReactElement): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => {
+    root.render(element);
+  });
+  await flush();
+  return container;
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected clickable element");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function setInputValue(element: HTMLInputElement, value: string): Promise<void> {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    setter?.call(element, value);
+    element.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
+  });
+  await flush();
+}
+
+async function waitForCondition(check: () => boolean, message: string, timeoutMs = 1200): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (check()) return;
+    await flush();
+  }
+  throw new Error(message);
+}
+
+async function waitForText(scope: ParentNode, text: string, timeoutMs = 1200): Promise<void> {
+  await waitForCondition(() => scope.textContent?.includes(text) === true, `Expected text "${text}"`, timeoutMs);
+}
+
+function buttonByText(scope: ParentNode, text: string): HTMLButtonElement | null {
+  return [...scope.querySelectorAll("button")].find((button) => button.textContent?.includes(text)) ?? null;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  installBrowserStubs();
+  contextMock.value = createContext();
+  authMock.value = {
+    memberId: "member-self",
+    role: "member",
+    agentId: "human-self",
+    organizationId: "org-1",
+  };
+  vi.clearAllMocks();
+  agentResourceMocks.getAgentResources.mockResolvedValue(agentResources());
+  agentResourceMocks.updateAgentResources.mockImplementation(
+    async (_uuid: string, input: { bindings: AgentResourceBindingInput[] }) =>
+      agentResources({ version: 10, bindings: input.bindings }),
+  );
+  usageMocks.getAgentUsageSummary.mockResolvedValue(summary());
+  usageMocks.getAgentUsageTurns.mockImplementation(async (_agentId: string, args: { limit: number }) =>
+    turns(args.limit, args.limit >= 30 ? null : "next"),
+  );
+  agentApiMocks.deleteAgentAvatar.mockResolvedValue(undefined);
+  agentApiMocks.uploadAgentAvatar.mockResolvedValue({ avatarImageUrl: "/avatars/agent-1.webp" });
+  agentApiMocks.listAgents.mockResolvedValue({ items: [], nextCursor: null });
+  agentApiMocks.listManagedAgents.mockResolvedValue([]);
+});
+
+afterEach(async () => {
+  while (roots.length > 0) {
+    const root = roots.pop();
+    if (root) await act(async () => root.unmount());
+  }
+  document.body.innerHTML = "";
+});
+
+describe("PromptTab extra DOM states", () => {
+  it("keeps the fallback prompt visible when resources fail to load", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    agentResourceMocks.getAgentResources.mockRejectedValue(new Error("resources offline"));
+    contextMock.value = createContext({
+      config: config({
+        payload: {
+          kind: "claude-code",
+          prompt: { append: "Fallback instructions from config." },
+          model: "sonnet",
+          reasoningEffort: "medium",
+          mcpServers: [],
+          env: [],
+          gitRepos: [],
+          resourceSkills: [],
+        },
+      }),
+    });
+
+    const container = await renderWithProviders(<PromptTab />);
+    await waitForText(container, "resources offline");
+
+    expect(container.textContent).toContain("Fallback instructions from config.");
+    expect(container.querySelector('button[aria-label="Add instructions"]')).toBeNull();
+  });
+
+  it("enables optional team prompts and routes the settings escape through navigateAway", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    const navigateAway = vi.fn();
+    contextMock.value = createContext({
+      navigateAway,
+      config: config({
+        payload: {
+          kind: "claude-code",
+          prompt: { append: "" },
+          model: "sonnet",
+          reasoningEffort: "medium",
+          mcpServers: [],
+          env: [],
+          gitRepos: [],
+          resourceSkills: [],
+        },
+      }),
+    });
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        effective: { version: 9, repos: [], prompts: [], skills: [], mcp: [], unavailable: [] },
+        availableTeamResources: [availablePrompt()],
+      }),
+    );
+
+    const container = await renderWithProviders(<PromptTab />);
+    await waitForText(container, "No instructions yet.");
+
+    await click(container.querySelector('button[aria-label="Add instructions"]'));
+    await click(buttonByText(document.body, "Manage in Settings"));
+    expect(navigateAway).toHaveBeenCalledWith("/settings/resources");
+
+    await click(container.querySelector('button[aria-label="Add instructions"]'));
+    await waitForText(document.body, "Optional safety prompt");
+    await click(buttonByText(document.body, "Optional safety prompt"));
+    await waitForCondition(
+      () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
+      "Expected optional prompt enable mutation",
+    );
+    expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
+      expectedVersion: 9,
+      bindings: [{ type: "prompt", mode: "include", resourceId: "prompt-available", order: 1 }],
+    });
+  });
+
+  it("re-enables disabled prompts and removes orphan inline bindings", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        effective: {
+          version: 9,
+          repos: [],
+          prompts: [
+            promptRow({
+              id: "binding:disable-1:disabled",
+              bindingId: "disable-1",
+              resourceId: "team-prompt",
+              mode: "disabled",
+              promptBody: "Use the team playbook.",
+              order: 1,
+            }),
+          ],
+          skills: [],
+          mcp: [],
+          unavailable: [],
+        },
+        bindings: [
+          { id: "disable-1", type: "prompt", mode: "disable", resourceId: "team-prompt", order: 1 },
+          {
+            id: "orphan-inline",
+            type: "prompt",
+            mode: "include",
+            resourceId: null,
+            replacesResourceId: null,
+            inlinePromptBody: "",
+            order: 2,
+          },
+        ],
+      }),
+    );
+
+    const container = await renderWithProviders(<PromptTab />);
+    await waitForText(container, "Team prompt");
+
+    const disabledSwitch = container.querySelector('button[role="switch"][aria-label="Enable Team prompt"]');
+    expect(disabledSwitch?.getAttribute("aria-checked")).toBe("false");
+    await click(disabledSwitch);
+    expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
+      expectedVersion: 9,
+      bindings: [
+        {
+          id: "orphan-inline",
+          type: "prompt",
+          mode: "include",
+          resourceId: null,
+          replacesResourceId: null,
+          inlinePromptBody: "",
+          order: 2,
+        },
+      ],
+    });
+
+    agentResourceMocks.updateAgentResources.mockClear();
+    await click(container.querySelector('button[aria-label="More actions for custom instructions"]'));
+    await click(buttonByText(container, "Remove"));
+    expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
+      expectedVersion: 10,
+      bindings: [],
+    });
+  });
+});
+
+describe("ProfileEditDialog extra DOM states", () => {
+  it("does not wipe unsaved fields on same-agent refresh, but resets when the agent changes", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push(root);
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+
+    const renderDialog = async (nextAgent: Agent) => {
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={createQueryClient()}>
+            <ProfileEditDialog agent={nextAgent} open onOpenChange={onOpenChange} onSave={onSave} />
+          </QueryClientProvider>,
+        );
+      });
+      await flush();
+    };
+
+    await renderDialog(agent({ uuid: "agent-1", displayName: "Nova" }));
+    const displayInput = document.body.querySelector<HTMLInputElement>("#profile-display");
+    if (!displayInput) throw new Error("Expected display input");
+    await setInputValue(displayInput, "Unsaved local rename");
+
+    await renderDialog(agent({ uuid: "agent-1", displayName: "Server refreshed name", avatarImageUrl: "/new.png" }));
+    expect(document.body.querySelector<HTMLInputElement>("#profile-display")?.value).toBe("Unsaved local rename");
+
+    await renderDialog(agent({ uuid: "agent-2", displayName: "Vega" }));
+    expect(document.body.querySelector<HTMLInputElement>("#profile-display")?.value).toBe("Vega");
+  });
+});
+
+describe("Resources and runtime extra sections", () => {
+  it("surfaces resource load and save errors from the Tools & skills tab", async () => {
+    const { ResourcesTab } = await import("../resources-tab.js");
+    agentResourceMocks.getAgentResources.mockRejectedValueOnce(new Error("resource query failed"));
+
+    const loadError = await renderWithProviders(<ResourcesTab />, "/agents/agent-1/capabilities");
+    await waitForText(loadError, "resource query failed");
+
+    const loadErrorRoot = roots.pop();
+    if (loadErrorRoot) await act(async () => loadErrorRoot.unmount());
+    document.body.innerHTML = "";
+
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        effective: { version: 9, repos: [], prompts: [], skills: [], mcp: [], unavailable: [] },
+        availableTeamResources: [availableSkill()],
+      }),
+    );
+    agentResourceMocks.updateAgentResources.mockRejectedValue(new Error("resource save failed"));
+
+    const saveError = await renderWithProviders(<ResourcesTab />, "/agents/agent-1/capabilities");
+    await waitForText(saveError, "Skills");
+    await click(saveError.querySelector('button[aria-label="Add Skill"]'));
+    await click(buttonByText(document.body, "Optional skill"));
+    await waitForText(saveError, "resource save failed");
+  });
+
+  it("renders runtime binding, switch, and recovery edge states", async () => {
+    const { RuntimeSection, RuntimeSwitchRecoveryNotice } = await import("../runtime-section.js");
+    const onBind = vi.fn();
+    const onSwitch = vi.fn();
+    const onRecover = vi.fn();
+
+    const binding = await renderPlain(
+      <RuntimeSection
+        runtimeProvider="codex"
+        computerLabel={null}
+        canBindComputer
+        bindComputerPending
+        onBindComputer={onBind}
+      />,
+    );
+    expect(binding.textContent).toContain("No computer bound");
+    const bindingButton = buttonByText(binding, "Binding");
+    expect(bindingButton?.disabled).toBe(true);
+
+    const error = await renderPlain(
+      <RuntimeSection
+        runtimeProvider="claude-code-tui"
+        computerLabel={null}
+        computerStatusError="lookup failed"
+        canBindComputer
+        onBindComputer={onBind}
+        canSwitchRuntime
+        runtimeSwitchPending
+        onSwitchRuntime={onSwitch}
+      />,
+    );
+    expect(error.textContent).toContain("Could not verify computer binding: lookup failed");
+    expect(buttonByText(error, "Bind computer")).toBeNull();
+    expect(buttonByText(error, "Switching")?.disabled).toBe(true);
+
+    const recovery = await renderPlain(
+      <RuntimeSwitchRecoveryNotice
+        claim={{ claimId: null, phase: null }}
+        pending
+        error="recovery failed"
+        onRecover={onRecover}
+      />,
+    );
+    expect(recovery.textContent).toContain("Claim unknown is in phase unknown");
+    expect(recovery.textContent).toContain("recovery failed");
+    expect(buttonByText(recovery, "Recovering")?.disabled).toBe(true);
+  });
+});
+
+describe("UsageTab extra DOM states", () => {
+  it("grows the recent-turn query limit from Show more", async () => {
+    const { UsageTab } = await import("../usage-tab.js");
+    const container = await renderWithProviders(<UsageTab refetchInterval={false} />, "/agents/agent-1/usage");
+    await waitForText(container, "Turn batch 10");
+
+    await click(buttonByText(container, "Show more"));
+    await waitForCondition(
+      () =>
+        usageMocks.getAgentUsageTurns.mock.calls.some(
+          (call) => call[0] === "agent-1" && call[1]?.window === "30d" && call[1]?.limit === 30,
+        ),
+      "Expected usage turns to refetch with the larger limit",
+    );
+    await waitForText(container, "Turn batch 30");
+  });
+});
+
+describe("agent detail pure helpers", () => {
+  it("covers access, tab resolution, and bindability edge cases", async () => {
+    const { canManageAgentDetail } = await import("../access.js");
+    const { buildTabs, canEditConfigFor, resolveTabPath } = await import("../tabs.js");
+    const { isBindableClient } = await import("../action-state.js");
+
+    expect(canManageAgentDetail(undefined, "member-self", "admin")).toBe(false);
+    expect(canManageAgentDetail({ managerId: "member-self" }, null, "member")).toBe(false);
+    expect(canManageAgentDetail({ managerId: "member-other" }, null, "admin")).toBe(true);
+
+    expect(canEditConfigFor(agent(), "member-self", "member")).toBe(true);
+    expect(canEditConfigFor(agent({ type: "human", clientId: null }), "member-self", "admin")).toBe(false);
+    expect(resolveTabPath(agent({ type: "human", clientId: null }), "member-self", "admin", "usage")).toBe("profile");
+    expect(resolveTabPath(agent(), "member-other", "member", "usage")).toBe("usage");
+    expect(resolveTabPath(agent(), "member-other", "member", "runtime")).toBe("profile");
+    expect(buildTabs(false, false).map((tab) => tab.path)).toEqual(["profile", "capabilities", "usage"]);
+
+    expect(isBindableClient({ status: "connected" })).toBe(true);
+    expect(isBindableClient({ status: "retired" })).toBe(false);
+  });
+});

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-extra-dom.test.tsx
@@ -358,6 +358,22 @@ async function setInputValue(element: HTMLInputElement, value: string): Promise<
   await flush();
 }
 
+async function setTextareaValue(element: HTMLTextAreaElement, value: string): Promise<void> {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+    setter?.call(element, value);
+    element.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
+  });
+  await flush();
+}
+
+async function pressKey(element: Element, key: string): Promise<void> {
+  await act(async () => {
+    element.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
 async function waitForCondition(check: () => boolean, message: string, timeoutMs = 1200): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -544,6 +560,223 @@ describe("PromptTab extra DOM states", () => {
       expectedVersion: 10,
       bindings: [],
     });
+  });
+
+  it("edits orphan inline prompt bindings and cancels the editor with Escape", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        effective: { version: 9, repos: [], prompts: [], skills: [], mcp: [], unavailable: [] },
+        bindings: [
+          {
+            id: "orphan-inline",
+            type: "prompt",
+            mode: "include",
+            resourceId: null,
+            replacesResourceId: null,
+            inlinePromptBody: "Recovered from an invisible binding.",
+            order: 3,
+          },
+        ],
+      }),
+    );
+
+    const container = await renderWithProviders(<PromptTab />);
+    await waitForText(container, "No instructions yet.");
+
+    await click(container.querySelector('button[aria-label="More actions for custom instructions"]'));
+    await click(buttonByText(container, "Edit custom instructions"));
+    await waitForText(container, "Save instructions");
+    const firstTextarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
+    expect(firstTextarea?.value).toBe("Recovered from an invisible binding.");
+    if (!firstTextarea) throw new Error("Expected orphan prompt textarea");
+    await pressKey(firstTextarea, "Escape");
+    await waitForCondition(
+      () => !container.textContent?.includes("Save instructions"),
+      "Expected Escape to close the orphan editor",
+    );
+    expect(agentResourceMocks.updateAgentResources).not.toHaveBeenCalled();
+
+    await click(container.querySelector('button[aria-label="More actions for custom instructions"]'));
+    await click(buttonByText(container, "Edit custom instructions"));
+    await waitForText(container, "Save instructions");
+    const secondTextarea = container.querySelector<HTMLTextAreaElement>("#custom-prompt-body");
+    if (!secondTextarea) throw new Error("Expected orphan prompt textarea");
+    await setTextareaValue(secondTextarea, "Recovered and saved.");
+    await click(buttonByText(container, "Save instructions"));
+    await waitForCondition(
+      () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
+      "Expected orphan prompt update",
+    );
+    expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
+      expectedVersion: 9,
+      bindings: [
+        {
+          id: "orphan-inline",
+          type: "prompt",
+          mode: "include",
+          resourceId: null,
+          replacesResourceId: null,
+          inlinePromptBody: "Recovered and saved.",
+          order: 3,
+        },
+      ],
+    });
+  });
+
+  it("expands prompt rows and removes a replaced row without a live replacement", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    agentResourceMocks.getAgentResources.mockResolvedValue(
+      agentResources({
+        effective: {
+          version: 9,
+          repos: [],
+          prompts: [
+            promptRow({
+              id: "resource:active-prompt",
+              resourceId: "active-prompt",
+              name: "Active prompt",
+              promptBody: "Active body is hidden until expanded.",
+              order: 1,
+            }),
+            promptRow({
+              id: "binding:replace-1:replaced",
+              bindingId: "replace-1",
+              resourceId: "team-prompt",
+              replacesResourceId: null,
+              name: "Overridden prompt",
+              mode: "replaced",
+              promptBody: "Original body is hidden until expanded.",
+              order: 2,
+            }),
+          ],
+          skills: [],
+          mcp: [],
+          unavailable: [],
+        },
+        bindings: [
+          {
+            id: "replace-1",
+            type: "prompt",
+            mode: "replace",
+            resourceId: null,
+            replacesResourceId: "team-prompt",
+            inlinePromptBody: "",
+            order: 2,
+          },
+          {
+            id: "kept-inline",
+            type: "prompt",
+            mode: "include",
+            resourceId: null,
+            replacesResourceId: null,
+            inlinePromptBody: "Keep me.",
+            order: 3,
+          },
+        ],
+      }),
+    );
+
+    const container = await renderWithProviders(<PromptTab />);
+    await waitForText(container, "Active prompt");
+    expect(container.textContent).not.toContain("Active body is hidden until expanded.");
+
+    await click(container.querySelector('button[aria-label="Expand Active prompt"]'));
+    expect(container.textContent).toContain("Active body is hidden until expanded.");
+    await click(container.querySelector('button[aria-label="Collapse Active prompt"]'));
+    expect(container.textContent).not.toContain("Active body is hidden until expanded.");
+
+    await click(container.querySelector('button[aria-label="Expand Overridden prompt"]'));
+    expect(container.textContent).toContain("Original body is hidden until expanded.");
+    await click(container.querySelector('button[aria-label="More actions for Overridden prompt"]'));
+    await click(buttonByText(container, "Remove"));
+    await waitForCondition(
+      () => agentResourceMocks.updateAgentResources.mock.calls.length > 0,
+      "Expected replaced prompt removal",
+    );
+    expect(agentResourceMocks.updateAgentResources).toHaveBeenCalledWith("agent-1", {
+      expectedVersion: 9,
+      bindings: [
+        {
+          id: "kept-inline",
+          type: "prompt",
+          mode: "include",
+          resourceId: null,
+          replacesResourceId: null,
+          inlinePromptBody: "Keep me.",
+          order: 3,
+        },
+      ],
+    });
+  });
+
+  it("toggles the clamped effective instructions block", async () => {
+    const { PromptTab } = await import("../prompt-tab.js");
+    const scrollDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollHeight");
+    const clientDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientHeight");
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", { configurable: true, get: () => 600 });
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", { configurable: true, get: () => 80 });
+    try {
+      contextMock.value = createContext({
+        config: config({
+          payload: {
+            kind: "claude-code",
+            prompt: {
+              append: "Team section.\n\nCustom section.",
+              sections: [
+                { scope: "team", name: "Team guide", body: "Team section." },
+                { scope: "agent", name: "", body: "Custom section." },
+              ],
+            },
+            model: "sonnet",
+            reasoningEffort: "medium",
+            mcpServers: [],
+            env: [],
+            gitRepos: [],
+            resourceSkills: [],
+          },
+        }),
+      });
+      agentResourceMocks.getAgentResources.mockResolvedValue(
+        agentResources({
+          effective: {
+            version: 9,
+            repos: [],
+            prompts: [
+              promptRow({ id: "team-guide", name: "Team guide", promptBody: "Team section.", order: 1 }),
+              promptRow({
+                id: "binding:inline-1:enabled",
+                bindingId: "inline-1",
+                source: "inline_prompt",
+                scope: "agent",
+                resourceId: null,
+                name: "Custom instructions",
+                promptBody: "Custom section.",
+                order: 2,
+              }),
+            ],
+            skills: [],
+            mcp: [],
+            unavailable: [],
+          },
+        }),
+      );
+
+      const container = await renderWithProviders(<PromptTab />);
+      await waitForText(container, "All instructions");
+      await waitForText(container, "Show all");
+      const toggle = buttonByText(container, "Show all");
+      expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+      await click(toggle);
+      expect(buttonByText(container, "Collapse")?.getAttribute("aria-expanded")).toBe("true");
+      await click(buttonByText(container, "Collapse"));
+      expect(buttonByText(container, "Show all")?.getAttribute("aria-expanded")).toBe("false");
+    } finally {
+      if (scrollDescriptor) Object.defineProperty(HTMLElement.prototype, "scrollHeight", scrollDescriptor);
+      else Reflect.deleteProperty(HTMLElement.prototype, "scrollHeight");
+      if (clientDescriptor) Object.defineProperty(HTMLElement.prototype, "clientHeight", clientDescriptor);
+      else Reflect.deleteProperty(HTMLElement.prototype, "clientHeight");
+    }
   });
 });
 

--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -78,6 +78,15 @@ async function flush(): Promise<void> {
   });
 }
 
+async function waitForText(scope: ParentNode, text: string, timeoutMs = 1200): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (scope.textContent?.includes(text)) return;
+    await flush();
+  }
+  throw new Error(`Missing text: ${text}`);
+}
+
 async function renderDom(element: ReactElement): Promise<{ container: HTMLElement; root: Root }> {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -162,6 +171,7 @@ function installBrowserStubs(): void {
     configurable: true,
     value: vi.fn(() => ({
       drawImage: vi.fn(),
+      fillRect: vi.fn(),
     })),
   });
   Object.defineProperty(HTMLCanvasElement.prototype, "toBlob", {
@@ -529,6 +539,138 @@ describe("ProfileEditDialog (merged identity + appearance)", () => {
     // The custom-image upload path stays available to humans.
     expect(buttonByText(document.body, "Upload image")).not.toBeNull();
     await act(async () => human.root.unmount());
+  });
+
+  it("generates and applies a baked pixel avatar candidate", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const { root } = await renderDom(
+      <ProfileEditDialog
+        agent={agent({ type: "agent" })}
+        open
+        onOpenChange={vi.fn()}
+        onSave={vi.fn()}
+        onRefresh={onRefresh}
+      />,
+    );
+
+    await click(buttonByText(document.body, "Generate"));
+    expect(document.body.textContent).toContain("Shuffle");
+    expect(document.body.querySelectorAll('button[title="Use this pixel avatar"]')).toHaveLength(5);
+
+    await click(document.body.querySelector('button[aria-label="Use pixel avatar 1"]'));
+    expect(agentApiMocks.uploadAgentAvatar).toHaveBeenCalledWith("agent-1", expect.any(Blob));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    await waitForText(document.body, "Generate");
+
+    await act(async () => root.unmount());
+  });
+
+  it("surfaces pixel avatar encoding errors without uploading", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    const toBlob = vi
+      .spyOn(HTMLCanvasElement.prototype, "toBlob")
+      .mockImplementation((callback: BlobCallback) => callback(null));
+    const { root } = await renderDom(
+      <ProfileEditDialog agent={agent({ type: "agent" })} open onOpenChange={vi.fn()} onSave={vi.fn()} />,
+    );
+
+    await click(buttonByText(document.body, "Generate"));
+    await click(document.body.querySelector('button[aria-label="Use pixel avatar 1"]'));
+    await waitForText(document.body, "Failed to encode the pixel avatar to WEBP.");
+    expect(agentApiMocks.uploadAgentAvatar).not.toHaveBeenCalled();
+
+    toBlob.mockRestore();
+    await act(async () => root.unmount());
+  });
+
+  it("surfaces image decode and remove failures", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    class BrokenImage {
+      naturalWidth = 480;
+      naturalHeight = 320;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      set src(_value: string) {
+        setTimeout(() => this.onerror?.(), 0);
+      }
+    }
+    Object.defineProperty(globalThis, "Image", { configurable: true, value: BrokenImage });
+
+    const decodeFailure = await renderDom(
+      <ProfileEditDialog agent={agent()} open onOpenChange={vi.fn()} onSave={vi.fn()} />,
+    );
+    const fileInput = document.body.querySelector<HTMLInputElement>('input[type="file"]');
+    if (!fileInput) throw new Error("Expected file input");
+    await setFileInput(fileInput, new File(["avatar"], "broken.png", { type: "image/png" }));
+    await waitForText(document.body, "Unable to decode the selected image.");
+    expect(agentApiMocks.uploadAgentAvatar).not.toHaveBeenCalled();
+    await act(async () => decodeFailure.root.unmount());
+
+    installBrowserStubs();
+    agentApiMocks.deleteAgentAvatar.mockRejectedValueOnce(new Error("Delete failed"));
+    const deleteFailure = await renderDom(
+      <ProfileEditDialog
+        agent={agent({ avatarImageUrl: "/avatars/agent-1.png" })}
+        open
+        onOpenChange={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+    await click(buttonByText(document.body, "Remove image"));
+    await waitForText(document.body, "Delete failed");
+    expect(agentApiMocks.deleteAgentAvatar).toHaveBeenCalledWith("agent-1");
+    await act(async () => deleteFailure.root.unmount());
+  });
+
+  it("submits display name through the form and saves the auto color swatch", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { root } = await renderDom(
+      <ProfileEditDialog agent={agent({ avatarColorToken: "hue-2" })} open onOpenChange={vi.fn()} onSave={onSave} />,
+    );
+    const displayInput = document.body.querySelector<HTMLInputElement>("#profile-display");
+    const form = document.body.querySelector("form");
+    if (!displayInput || !form) throw new Error("Expected profile form");
+
+    await setInputValue(displayInput, "Nova Form");
+    await act(async () => {
+      form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+    expect(onSave).toHaveBeenCalledWith({ displayName: "Nova Form" });
+
+    await click(document.body.querySelector('button[title="Auto"]'));
+    expect(onSave).toHaveBeenCalledWith({ avatarColorToken: null });
+
+    await act(async () => root.unmount());
+  });
+
+  it("renders a resolved read-only delegate chip for other human members", async () => {
+    const { ProfileEditDialog } = await import("../profile-edit-dialog.js");
+    authMock.value = { memberId: "member-other", role: "member", agentId: "human-other" };
+    const { root } = await renderDom(
+      <ProfileEditDialog
+        agent={agent({
+          uuid: "human-1",
+          name: "bestony",
+          displayName: "Bestony",
+          type: "human",
+          delegateMention: "delegate-1",
+        })}
+        open
+        onOpenChange={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    await waitForText(document.body, "Helper");
+    expect(document.body.textContent).toContain("@helper");
+    expect(document.body.querySelector("#profile-delegate")).toBeNull();
+    expect(document.body.textContent).toContain("Only the member themselves can set their own delegate.");
+
+    await act(async () => root.unmount());
   });
 
   it("edits human visibility + delegate, and disables visibility for non-owners", async () => {

--- a/packages/web/src/pages/agent-detail/__tests__/repositories-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/repositories-tab-dom.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Outlet, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthContext } from "../../../auth/auth-context.js";
+import type { AgentDetailContext } from "../layout-context.js";
+import { RepositoriesTab } from "../repositories-tab.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const resourceMocks = vi.hoisted(() => ({
+  useAgentResources: vi.fn(),
+}));
+const orgSettingMocks = vi.hoisted(() => ({
+  getContextTreeSetting: vi.fn(),
+}));
+
+vi.mock("../capability-section.js", () => ({
+  useAgentResources: resourceMocks.useAgentResources,
+  ResourceTypeSection: ({
+    canEdit,
+    pending,
+    saved,
+    onNavigateAway,
+  }: {
+    canEdit: boolean;
+    pending: boolean;
+    saved: boolean;
+    onNavigateAway: (to: string) => void;
+  }) => (
+    <div data-testid="resource-section">
+      resources {canEdit ? "editable" : "read-only"} {pending ? "pending" : "idle"} {saved ? "saved" : "unsaved"}
+      <button type="button" onClick={() => onNavigateAway("/settings/resources")}>
+        Leave repositories
+      </button>
+    </div>
+  ),
+}));
+vi.mock("../../../api/org-settings.js", () => orgSettingMocks);
+
+const roots: Root[] = [];
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function baseContext(overrides: Partial<AgentDetailContext> = {}): AgentDetailContext {
+  return {
+    uuid: "agent-1",
+    agent: {
+      id: "agent-1",
+      name: "build-agent",
+      status: "active",
+      type: "agent",
+    } as unknown as AgentDetailContext["agent"],
+    isHuman: false,
+    canManageAgent: true,
+    canEditConfig: true,
+    navigateAway: vi.fn(),
+    config: undefined,
+    configLoading: false,
+    configError: null,
+    configSave: {} as AgentDetailContext["configSave"],
+    clientStatus: undefined,
+    clientStatusLoading: false,
+    clientStatusError: null,
+    isUnclaimed: false,
+    isOffline: false,
+    boundClientLabel: null,
+    setupRuntimeProvider: "codex",
+    runtimeSwitchClaim: null,
+    onOpenBindDialog: vi.fn(),
+    bindClientPending: false,
+    onOpenRuntimeSwitchDialog: vi.fn(),
+    runtimeSwitchPending: false,
+    runtimeSwitchRecoveryPending: false,
+    runtimeSwitchRecoveryError: null,
+    onRecoverRuntimeSwitch: vi.fn(),
+    saveIdentity: vi.fn(),
+    refreshAgent: vi.fn(),
+    suspendPending: false,
+    reactivatePending: false,
+    deletePending: false,
+    dangerError: null,
+    onSuspend: vi.fn(),
+    onReactivate: vi.fn(),
+    onDelete: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function renderTab({
+  context = baseContext(),
+  organizationId = "org-1",
+  initialEntry = "/agents/agent-1/repositories",
+}: {
+  context?: AgentDetailContext;
+  organizationId?: string | null;
+  initialEntry?: string;
+} = {}): Promise<{ container: HTMLElement; context: AgentDetailContext }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const authValue = {
+    organizationId,
+  } as unknown as Parameters<typeof AuthContext.Provider>[0]["value"];
+  const ui: ReactElement = (
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <AuthContext.Provider value={authValue}>
+          <Routes>
+            <Route path="/agents/:uuid" element={<Outlet context={context} />}>
+              <Route path="repositories" element={<RepositoriesTab />} />
+              <Route path="profile" element={<div>Profile tab</div>} />
+            </Route>
+          </Routes>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+  await act(async () => {
+    root.render(ui);
+  });
+  await flush();
+  return { container, context };
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  resourceMocks.useAgentResources.mockReturnValue({
+    data: { bindings: [] },
+    error: null,
+    isLoading: false,
+    justSaved: false,
+    mutateBindings: vi.fn(),
+    pending: false,
+    saveError: null,
+  });
+  orgSettingMocks.getContextTreeSetting.mockResolvedValue({
+    repo: "https://github.com/acme/context-tree.git",
+    branch: "main",
+  });
+});
+
+afterEach(() => {
+  act(() => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+});
+
+describe("RepositoriesTab", () => {
+  it("redirects non-editors back to the profile tab without loading resources", async () => {
+    const context = baseContext({ canEditConfig: false });
+
+    const { container } = await renderTab({ context });
+
+    expect(container.textContent).toContain("Profile tab");
+    expect(resourceMocks.useAgentResources).toHaveBeenCalledWith("agent-1", { enabled: false });
+  });
+
+  it("renders the repository section and configured context tree row", async () => {
+    const navigateAway = vi.fn();
+    const { container } = await renderTab({ context: baseContext({ navigateAway }) });
+
+    expect(container.querySelector('[data-testid="resource-section"]')?.textContent).toContain("resources editable");
+    await waitForText(container, "context-tree");
+    expect(container.textContent).toContain("acme/context-tree");
+
+    await click(container.querySelector("button"));
+    expect(navigateAway).toHaveBeenCalledWith("/settings/resources");
+  });
+
+  it("renders loading, fetch errors, save errors, and context-tree empty/error states", async () => {
+    resourceMocks.useAgentResources.mockReturnValueOnce({
+      data: null,
+      error: null,
+      isLoading: true,
+      justSaved: false,
+      mutateBindings: vi.fn(),
+      pending: false,
+      saveError: null,
+    });
+    const loading = await renderTab();
+    expect(loading.container.textContent).toContain("Loading repositories");
+
+    resourceMocks.useAgentResources.mockReturnValueOnce({
+      data: null,
+      error: new Error("repo load failed"),
+      isLoading: false,
+      justSaved: false,
+      mutateBindings: vi.fn(),
+      pending: false,
+      saveError: new Error("repo save failed"),
+    });
+    orgSettingMocks.getContextTreeSetting.mockResolvedValueOnce({ repo: null, branch: null });
+    const failed = await renderTab();
+    expect(failed.container.textContent).toContain("repo load failed");
+    expect(failed.container.textContent).toContain("repo save failed");
+    await waitForText(failed.container, "Not configured");
+
+    orgSettingMocks.getContextTreeSetting.mockRejectedValueOnce(new Error("context failed"));
+    const contextFailed = await renderTab({ organizationId: "org-2" });
+    await waitForText(contextFailed.container, "Couldn't load context tree.");
+
+    const noOrg = await renderTab({ organizationId: null });
+    expect(noOrg.container.textContent).toContain("Loading");
+  });
+});
+
+async function waitForText(container: ParentNode, text: string): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    if (container.textContent?.includes(text)) return;
+    await flush();
+  }
+  throw new Error(`Expected text: ${text}`);
+}

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -341,6 +341,7 @@ function seedDefaultMocks(): void {
 beforeEach(() => {
   installBrowserStubs();
   document.body.innerHTML = "";
+  window.history.replaceState({}, "", "/");
   vi.clearAllMocks();
   authMock.value = {
     role: "admin",
@@ -355,6 +356,34 @@ afterEach(() => {
 });
 
 describe("ClientsPage computer cards", () => {
+  it("renders demo mode through the page and wires scenario navigation", async () => {
+    window.history.replaceState({}, "", "/settings/computers?demo=admin-grouped");
+    const { ClientsPage } = await import("../../clients.js");
+    const { container, root } = await renderDom(<ClientsPage />);
+
+    await waitForText(document.body, "DEMO");
+    await waitForText(container, "GandydeMacBook-Pro.local");
+    await waitForText(container, "gandy-developer");
+
+    const select = document.body.querySelector<HTMLSelectElement>('aside select[aria-label="Scenario"]');
+    if (!select) throw new Error("Expected demo scenario selector");
+    await act(async () => {
+      select.value = "empty";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await flush();
+    expect(window.location.search).toContain("demo=empty");
+    await waitForText(container, "No computers connected yet.");
+
+    await click(
+      [...document.body.querySelectorAll("aside button")].find((button) => button.textContent === "Exit") ?? null,
+    );
+    await waitForCondition(() => !document.body.textContent?.includes("DEMO"), "Expected demo navigator to close");
+    expect(window.location.search).not.toContain("demo=");
+
+    await act(async () => root.unmount());
+  });
+
   it("renders admin cards, team table, action dialogs, runtime commands, and connect dialog", async () => {
     const { ClientsPage } = await import("../../clients.js");
     const { container, root } = await renderDom(<ClientsPage />);
@@ -423,6 +452,39 @@ describe("ClientsPage computer cards", () => {
     await click(exactButton(container, "Connect"));
     await waitForText(document.body, "Connect computer");
     await click(exactButton(document.body, "Cancel"));
+
+    await act(async () => root.unmount());
+  });
+
+  it("opens reconnect and cancels destructive computer dialogs", async () => {
+    const { ClientsPage } = await import("../../clients.js");
+    const { container, root } = await renderDom(<ClientsPage />);
+
+    await waitForText(container, "offline-box");
+    await click(exactButton(container, "Reconnect"));
+    await waitForText(document.body, "Connect computer");
+    await click(exactButton(document.body, "Cancel"));
+
+    await click(container.querySelector('button[aria-label="Computer actions"]'));
+    await click(exactButton(container, "Disconnect"));
+    await waitForText(document.body, "Disconnect Computer");
+    await waitForText(document.body, "No bound agents");
+    await click(exactButton(document.body, "Cancel"));
+    await waitForCondition(
+      () => !document.body.textContent?.includes("Disconnect Computer"),
+      "Expected disconnect dialog to close",
+    );
+    expect(activityMocks.disconnectClient).not.toHaveBeenCalled();
+
+    await click(container.querySelector('button[aria-label="Computer actions"]'));
+    await click(exactButton(container, "Retire"));
+    await waitForText(document.body, "Retire Computer");
+    await click(exactButton(document.body, "Cancel"));
+    await waitForCondition(
+      () => !document.body.textContent?.includes("Retire Computer"),
+      "Expected retire dialog to close",
+    );
+    expect(activityMocks.retireClient).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/clients/__tests__/runtime-auth-controls-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/runtime-auth-controls-dom.test.tsx
@@ -57,9 +57,10 @@ async function render(element: ReactElement): Promise<HTMLElement> {
   const container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  queryClient = createClient();
+  const client = createClient();
+  queryClient = client;
   await act(async () => {
-    root?.render(<QueryClientProvider client={queryClient}>{element}</QueryClientProvider>);
+    root?.render(<QueryClientProvider client={client}>{element}</QueryClientProvider>);
   });
   return container;
 }
@@ -198,7 +199,7 @@ describe("RuntimeAuthControls", () => {
       vi.advanceTimersByTime(3000);
     });
 
-    expect(invalidate.mock.calls.filter(([arg]) => arg.queryKey?.[0] === "clients")).toHaveLength(2);
+    expect(invalidate.mock.calls.filter(([arg]) => arg?.queryKey?.[0] === "clients")).toHaveLength(2);
     expect(onStarted).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/web/src/pages/clients/__tests__/runtime-auth-controls-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/runtime-auth-controls-dom.test.tsx
@@ -1,0 +1,260 @@
+// @vitest-environment happy-dom
+
+import type { CapabilityEntry, RuntimeAuthLastError } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RuntimeAuthControls } from "../cards/shared/runtime-auth-controls.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const activityMocks = vi.hoisted(() => ({
+  startRuntimeAuth: vi.fn(),
+}));
+
+vi.mock("../../../api/activity.js", () => ({
+  startRuntimeAuth: activityMocks.startRuntimeAuth,
+}));
+
+const NOW = "2026-06-22T12:00:00.000Z";
+
+let root: Root | null = null;
+let queryClient: QueryClient | null = null;
+
+function capability(overrides: Partial<CapabilityEntry> = {}): CapabilityEntry {
+  return {
+    state: "ok",
+    available: true,
+    detectedAt: NOW,
+    ...overrides,
+  };
+}
+
+function lastError(overrides: Partial<RuntimeAuthLastError> = {}): RuntimeAuthLastError {
+  return {
+    reason: "timeout",
+    at: "2026-06-22T11:55:00.000Z",
+    ...overrides,
+  };
+}
+
+function createClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function currentClient(): QueryClient {
+  if (!queryClient) throw new Error("QueryClient was not created");
+  return queryClient;
+}
+
+async function render(element: ReactElement): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  queryClient = createClient();
+  await act(async () => {
+    root?.render(<QueryClientProvider client={queryClient}>{element}</QueryClientProvider>);
+  });
+  return container;
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function flushRealTimerNotifications(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+  });
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+function buttonByText(rootNode: ParentNode, text: string): HTMLButtonElement {
+  const button = [...rootNode.querySelectorAll<HTMLButtonElement>("button")].find((item) =>
+    item.textContent?.includes(text),
+  );
+  if (!button) throw new Error(`Missing button ${text}`);
+  return button;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+  activityMocks.startRuntimeAuth.mockResolvedValue({ ref: "auth-ref", started: true });
+  root = null;
+  queryClient = null;
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  document.body.innerHTML = "";
+  queryClient?.clear();
+  vi.useRealTimers();
+});
+
+describe("RuntimeAuthControls", () => {
+  it("renders nothing when a provider has no in-product auth affordance", async () => {
+    const dom = await render(<RuntimeAuthControls clientId="client-1" provider="codex" entry={capability()} />);
+
+    expect(dom.textContent).toBe("");
+  });
+
+  it("shows the pending browser-auth fallback link only for http URLs", async () => {
+    const dom = await render(
+      <RuntimeAuthControls
+        clientId="client-1"
+        provider="codex"
+        entry={capability({
+          pendingAuth: {
+            method: "browser",
+            expiresAt: "2999-06-22T12:05:00.000Z",
+            authUrl: "https://auth.example/start",
+          },
+        })}
+      />,
+    );
+
+    expect(dom.textContent).toContain("Waiting for you to authorize");
+    expect(dom.querySelector("a")?.getAttribute("href")).toBe("https://auth.example/start");
+  });
+
+  it("hides malformed pending-auth links", async () => {
+    const dom = await render(
+      <RuntimeAuthControls
+        clientId="client-1"
+        provider="codex"
+        entry={capability({
+          pendingAuth: {
+            method: "browser",
+            expiresAt: "2999-06-22T12:05:00.000Z",
+            authUrl: "not a url",
+          },
+        })}
+      />,
+    );
+
+    expect(dom.textContent).toContain("Waiting for you to authorize");
+    expect(dom.querySelector("a")).toBeNull();
+  });
+
+  it("hides non-http pending-auth links", async () => {
+    const dom = await render(
+      <RuntimeAuthControls
+        clientId="client-1"
+        provider="codex"
+        entry={capability({
+          pendingAuth: {
+            method: "browser",
+            expiresAt: "2999-06-22T12:05:00.000Z",
+            authUrl: "ftp://auth.example/start",
+          },
+        })}
+      />,
+    );
+
+    expect(dom.querySelector("a")).toBeNull();
+  });
+
+  it("starts in-product auth, latches the pending UI, and polls capabilities", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW));
+    const onStarted = vi.fn();
+    const dom = await render(
+      <RuntimeAuthControls
+        clientId="client-1"
+        provider="claude-code"
+        entry={capability()}
+        forceConnectable={true}
+        onStarted={onStarted}
+      />,
+    );
+    const invalidate = vi.spyOn(currentClient(), "invalidateQueries");
+
+    await click(buttonByText(dom, "Connect Claude Code"));
+
+    expect(activityMocks.startRuntimeAuth).toHaveBeenCalledWith("client-1", { provider: "claude-code" });
+    expect(dom.textContent).toContain("Waiting for you to authorize");
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["clients"] });
+    expect(onStarted).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(invalidate.mock.calls.filter(([arg]) => arg.queryKey?.[0] === "clients")).toHaveLength(2);
+    expect(onStarted).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the connect affordance and shows an inline error when start fails", async () => {
+    activityMocks.startRuntimeAuth.mockRejectedValue(new Error("offline"));
+    const onStarted = vi.fn();
+    const dom = await render(
+      <RuntimeAuthControls
+        clientId="client-1"
+        provider="codex"
+        entry={capability()}
+        forceConnectable={true}
+        onStarted={onStarted}
+      />,
+    );
+
+    await click(buttonByText(dom, "Connect Codex"));
+    await flushRealTimerNotifications();
+
+    expect(activityMocks.startRuntimeAuth).toHaveBeenCalledWith("client-1", { provider: "codex" });
+    expect(onStarted).toHaveBeenCalledTimes(1);
+    expect(dom.textContent).toContain("Could not start sign-in");
+    expect(dom.textContent).toContain("Connect Codex");
+  });
+
+  it.each([
+    [lastError({ reason: "timeout" }), "Last sign-in timed out before it finished in the browser. Try again."],
+    [lastError({ reason: "aborted" }), "Last sign-in was canceled. Try again."],
+    [lastError({ reason: "exit-nonzero" }), "Last sign-in didn't complete. Try again."],
+  ])("shows terminal auth failure copy %#", async (error, expected) => {
+    const dom = await render(
+      <RuntimeAuthControls
+        clientId="client-1"
+        provider="claude-code"
+        entry={capability({ lastAuthError: error })}
+        forceConnectable={true}
+      />,
+    );
+
+    expect(dom.textContent).toContain(expected);
+    expect(dom.textContent).toContain("Try Claude Code again");
+  });
+
+  it("includes truncated provider details for launch failures", async () => {
+    const detail = "provider detail ".repeat(12);
+    const dom = await render(
+      <RuntimeAuthControls
+        clientId="client-1"
+        provider="claude-code"
+        entry={capability({ lastAuthError: lastError({ reason: "spawn-error", message: detail }) })}
+        forceConnectable={true}
+      />,
+    );
+
+    expect(dom.textContent).toContain("Couldn't launch the sign-in on this computer.");
+    expect(dom.textContent).toContain(detail.slice(0, 139));
+    expect(dom.textContent).not.toContain(detail);
+  });
+});

--- a/packages/web/src/pages/onboarding/steps/__tests__/step-connect-computer-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/steps/__tests__/step-connect-computer-dom.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment happy-dom
+
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ComputerConnection } from "../../../../features/agent-setup/use-computer-connection.js";
+import type { OnboardingFlowValue } from "../../onboarding-flow.js";
+import { OnboardingFlowContext } from "../../onboarding-flow.js";
+import { StepConnectComputer } from "../step-connect-computer.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const roots: Root[] = [];
+
+function computer(overrides: Partial<ComputerConnection> = {}): ComputerConnection {
+  return {
+    connectedClient: null,
+    capabilitiesLoaded: false,
+    okRuntimes: [],
+    selectedRuntime: null,
+    setSelectedRuntime: vi.fn(),
+    cliCommand: "first-tree connect --token abc123",
+    tokenError: null,
+    retry: vi.fn(),
+    ...overrides,
+  };
+}
+
+function flow(overrides: Partial<OnboardingFlowValue> = {}): OnboardingFlowValue {
+  return {
+    path: "admin",
+    sequence: ["connect-computer", "create-agent", "start-chat"],
+    activeIndex: 0,
+    activeStep: "connect-computer",
+    goNext: vi.fn(),
+    goTo: vi.fn(),
+    organizationId: "org-1",
+    memberId: "member-1",
+    role: "admin",
+    username: "gandy",
+    teamDisplayName: "Acme",
+    orgHasOtherMembers: false,
+    computer: computer(),
+    agentDisplayName: "Build Agent",
+    setAgentDisplayName: vi.fn(),
+    visibility: "private",
+    setVisibility: vi.fn(),
+    agentPhase: "idle",
+    agentError: null,
+    createAgent: vi.fn(),
+    retryAgent: vi.fn(),
+    createdAgentUuid: null,
+    hasAgent: false,
+    selectedRepoUrls: [],
+    setSelectedRepoUrls: vi.fn(),
+    hasRepoDraft: false,
+    treeBindingPlan: "agentSeed",
+    setTreeBindingPlan: vi.fn(),
+    treeUrl: "",
+    setTreeUrl: vi.fn(),
+    treeAutoDetectDone: false,
+    markTreeAutoDetectDone: vi.fn(),
+    completeAndEnterChat: vi.fn(),
+    finishLater: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function renderStep(value: OnboardingFlowValue, initialStuck = false): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  const ui: ReactElement = (
+    <OnboardingFlowContext.Provider value={value}>
+      <StepConnectComputer initialStuck={initialStuck} />
+    </OnboardingFlowContext.Provider>
+  );
+  await act(async () => {
+    root.render(ui);
+  });
+  return container;
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
+function buttonByText(scope: ParentNode, text: string): HTMLButtonElement | null {
+  return [...scope.querySelectorAll("button")].find((button) => button.textContent?.includes(text)) ?? null;
+}
+
+afterEach(() => {
+  act(() => {
+    for (const root of roots.splice(0)) root.unmount();
+  });
+  document.body.innerHTML = "";
+  vi.useRealTimers();
+});
+
+describe("StepConnectComputer", () => {
+  it("renders both connect command paths, stuck recovery, and a disabled continue while waiting", async () => {
+    const value = flow();
+
+    const container = await renderStep(value, true);
+
+    expect(container.textContent).toContain("first-tree connect --token abc123");
+    expect(container.textContent).toContain("Node.js");
+    expect(buttonByText(container, "Continue")?.disabled).toBe(true);
+  });
+
+  it("switches the primary action to retry when token minting fails", async () => {
+    const retry = vi.fn();
+    const value = flow({ computer: computer({ tokenError: "token failed", retry }) });
+
+    const container = await renderStep(value);
+    await click(buttonByText(container, "Try again"));
+
+    expect(container.textContent).toContain("couldn't prepare your setup command");
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders connected, detecting, no-runtime, and ready runtime states", async () => {
+    const connectedClient = {
+      id: "client-1",
+      userId: "user-1",
+      hostname: "workstation",
+      status: "connected",
+      authState: "ok",
+      binName: "first-tree",
+      sdkVersion: "0.1.0",
+      os: "linux",
+      agentCount: 0,
+      connectedAt: "2026-01-01T00:00:00.000Z",
+      lastSeenAt: "2026-01-01T00:00:00.000Z",
+      capabilities: {},
+    } satisfies NonNullable<ComputerConnection["connectedClient"]>;
+
+    const detecting = await renderStep(flow({ computer: computer({ connectedClient }) }));
+    expect(detecting.textContent).toContain("workstation");
+    expect(detecting.textContent).toContain("Looking for coding agents");
+    expect(buttonByText(detecting, "Continue")?.disabled).toBe(true);
+
+    const noRuntime = await renderStep(
+      flow({ computer: computer({ connectedClient, capabilitiesLoaded: true, okRuntimes: [] }) }),
+    );
+    expect(noRuntime.textContent).toContain("No coding agent found yet");
+
+    const goNext = vi.fn();
+    const ready = await renderStep(
+      flow({
+        goNext,
+        computer: computer({ connectedClient, capabilitiesLoaded: true, okRuntimes: ["codex", "claude-code"] }),
+      }),
+    );
+    expect(ready.textContent).toContain("Codex");
+    expect(ready.textContent).toContain("Claude Code");
+    expect(buttonByText(ready, "Continue")?.disabled).toBe(false);
+    await click(buttonByText(ready, "Continue"));
+    expect(goNext).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/pages/settings/__tests__/resource-preview-dialog.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/resource-preview-dialog.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+
+import type { ResourceRow } from "@first-tree/shared";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ResourcePreviewDialog } from "../resource-preview-dialog.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function resource(overrides: Partial<ResourceRow> = {}): ResourceRow {
+  return {
+    id: "resource-1",
+    organizationId: "org-1",
+    type: "prompt",
+    scope: "team",
+    ownerAgentId: null,
+    name: "Review prompt",
+    repoCanonicalKey: null,
+    defaultEnabled: "recommended",
+    status: "active",
+    payload: {},
+    createdBy: "user-1",
+    updatedBy: "user-1",
+    createdAt: "2026-07-04T10:00:00.000Z",
+    updatedAt: "2026-07-04T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+async function render(ui: ReactElement): Promise<{ container: HTMLDivElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => root.render(ui));
+  return { container, root };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("ResourcePreviewDialog", () => {
+  it("renders repo and mcp metadata without a body region", async () => {
+    const onClose = vi.fn();
+    const repo = await render(
+      <ResourcePreviewDialog
+        resource={resource({
+          type: "repo",
+          name: "Runtime repo",
+          defaultEnabled: "available",
+          payload: { url: "https://github.com/acme/runtime", defaultBranch: "main" },
+        })}
+        onClose={onClose}
+      />,
+    );
+
+    expect(document.body.textContent).toContain("Runtime repo");
+    expect(document.body.textContent).toContain("Opt-in");
+    expect(document.body.textContent).toContain("Repository URL");
+    expect(document.body.textContent).toContain("https://github.com/acme/runtime");
+    expect(document.body.textContent).toContain("main");
+    expect(document.body.textContent).not.toContain("Body");
+    await act(async () => repo.root.unmount());
+
+    const mcp = await render(
+      <ResourcePreviewDialog
+        resource={resource({
+          type: "mcp",
+          name: "filesystem",
+          defaultEnabled: null,
+          payload: {
+            name: "fs-server",
+            transport: "stdio",
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-filesystem"],
+            url: "http://localhost/mcp",
+          },
+        })}
+        onClose={onClose}
+      />,
+    );
+
+    expect(document.body.textContent).toContain("filesystem");
+    expect(document.body.textContent).toContain("fs-server");
+    expect(document.body.textContent).toContain("stdio");
+    expect(document.body.textContent).toContain("npx");
+    expect(document.body.textContent).toContain("@modelcontextprotocol/server-filesystem");
+    expect(document.body.textContent).toContain("http://localhost/mcp");
+    await act(async () => mcp.root.unmount());
+  });
+
+  it("renders skill and prompt bodies, metadata, empty bodies, and close callbacks", async () => {
+    const onClose = vi.fn();
+    const skill = await render(
+      <ResourcePreviewDialog
+        resource={resource({
+          type: "skill",
+          name: "Planning skill",
+          payload: {
+            name: "planning",
+            namespace: "ops",
+            description: "Reusable planning procedure",
+            metadata: { owner: "team", retries: 2 },
+            body: "# Plan\n\nUse this procedure.",
+          },
+        })}
+        onClose={onClose}
+      />,
+    );
+
+    expect(document.body.textContent).toContain("Planning skill");
+    expect(document.body.textContent).toContain("Content");
+    expect(document.body.textContent).toContain("planning");
+    expect(document.body.textContent).toContain("ops");
+    expect(document.body.textContent).toContain("Reusable planning procedure");
+    expect(document.body.textContent).toContain("owner: team");
+    expect(document.body.textContent).toContain("retries: 2");
+    expect(document.body.textContent).toContain("Use this procedure.");
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await act(async () => undefined);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    await act(async () => skill.root.unmount());
+
+    const prompt = await render(
+      <ResourcePreviewDialog
+        resource={resource({
+          type: "prompt",
+          name: "Empty prompt",
+          defaultEnabled: null,
+          payload: { description: "", body: "   " },
+        })}
+        onClose={onClose}
+      />,
+    );
+
+    expect(document.body.textContent).toContain("Empty prompt");
+    expect(document.body.textContent).toContain("Body");
+    expect(document.body.textContent).toContain("Empty.");
+    await act(async () => prompt.root.unmount());
+  });
+});

--- a/packages/web/src/pages/workspace/__tests__/workspace-sidebars-extra-dom.test.tsx
+++ b/packages/web/src/pages/workspace/__tests__/workspace-sidebars-extra-dom.test.tsx
@@ -1,0 +1,558 @@
+// @vitest-environment happy-dom
+
+import type { ChatGithubEntity, ChatParticipantDetail } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActivityOverview, RuntimeAgent } from "../../../api/activity.js";
+import type { SessionListItem } from "../../../api/sessions.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const activityMocks = vi.hoisted(() => ({
+  getActivityOverview: vi.fn(),
+}));
+
+const chatMocks = vi.hoisted(() => ({
+  createAgentChat: vi.fn(),
+  listChatGithubEntities: vi.fn(),
+}));
+
+const sessionMocks = vi.hoisted(() => ({
+  listAgentSessions: vi.fn(),
+}));
+
+const authMock = vi.hoisted(() => ({
+  role: "admin" as "admin" | "member",
+}));
+
+const pulseMock = vi.hoisted(() => ({
+  value: {
+    stale: false,
+    aggregated: [
+      { workingCount: 2, errorMask: false },
+      { workingCount: 1, errorMask: true },
+      { workingCount: 0, errorMask: false },
+    ],
+  },
+}));
+
+vi.mock("../../../api/activity.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../api/activity.js")>()),
+  getActivityOverview: activityMocks.getActivityOverview,
+}));
+
+vi.mock("../../../api/chats.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../api/chats.js")>()),
+  createAgentChat: chatMocks.createAgentChat,
+  listChatGithubEntities: chatMocks.listChatGithubEntities,
+}));
+
+vi.mock("../../../api/sessions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../api/sessions.js")>()),
+  agentSessionsQueryKey: (agentId: string) => ["agent-sessions", agentId] as const,
+  listAgentSessions: sessionMocks.listAgentSessions,
+}));
+
+vi.mock("../../../auth/auth-context.js", () => ({
+  useAuth: () => ({ role: authMock.role }),
+}));
+
+vi.mock("../../../components/add-participant-dropdown.js", () => ({
+  AddParticipantDropdown: ({ variant }: { variant: "icon" | "inline" }) => (
+    <button aria-label="Add participant" type="button">
+      Add participant ({variant})
+    </button>
+  ),
+}));
+
+vi.mock("../../../components/avatar.js", () => ({
+  Avatar: ({ name }: { name: string }) => (
+    <span aria-label={`Avatar ${name}`} role="img">
+      {name.slice(0, 1)}
+    </span>
+  ),
+}));
+
+vi.mock("../../../components/chat/agent-status-panel.js", () => ({
+  AgentStatusPanel: ({
+    agents,
+    canManage,
+  }: {
+    agents: ChatParticipantDetail[];
+    canManage: (agentId: string) => boolean;
+  }) => (
+    <div data-testid="agent-status-panel">
+      {agents.map((agent) => (
+        <div key={agent.agentId}>
+          {agent.displayName} · {canManage(agent.agentId) ? "manageable" : "readonly"}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../../../hooks/pulse-context.js", () => ({
+  usePulse: () => pulseMock.value,
+}));
+
+vi.mock("../../../lib/use-agent-name-map.js", () => ({
+  useAgentNameMap: () => (id: string) =>
+    ({
+      "agent-working": "Working Agent",
+      "agent-blocked": "Blocked Agent",
+      "agent-idle": "Idle Agent",
+      "human-1": "Human One",
+    })[id] ?? id,
+}));
+
+vi.mock("../../../lib/use-client-map.js", () => ({
+  useClientMap: () => ({
+    resolve: (clientId: string) =>
+      ({
+        "client-working": { hostname: "workstation.local" },
+        "client-blocked": { hostname: "blocked-host.local" },
+      })[clientId] ?? null,
+  }),
+}));
+
+const NOW = "2026-05-28T12:00:00.000Z";
+
+function createClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+}
+
+async function renderDom(element: ReactElement): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(<QueryClientProvider client={createClient()}>{element}</QueryClientProvider>);
+  });
+  await flush();
+  return { container, root };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function keyDown(element: Element | null, key: string): Promise<void> {
+  if (!element) throw new Error("Expected element for keydown");
+  await act(async () => {
+    element.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function setValue(element: HTMLInputElement, value: string): Promise<void> {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+    setter?.call(element, value);
+    element.dispatchEvent(new InputEvent("input", { bubbles: true, data: value, inputType: "insertText" }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await flush();
+}
+
+async function waitForText(container: ParentNode, text: string, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (container.textContent?.includes(text)) return;
+    await flush();
+  }
+  throw new Error(`Expected text "${text}"`);
+}
+
+function buttonByText(container: ParentNode, text: string): HTMLButtonElement | null {
+  return [...container.querySelectorAll("button")].find((button) => button.textContent?.trim() === text) ?? null;
+}
+
+function cssPx(value: number): string {
+  return `${value}${"px"}`;
+}
+
+function participant(id: string, type: "human" | "agent", displayName = id): ChatParticipantDetail {
+  return {
+    agentId: id,
+    role: "member",
+    mode: "full",
+    joinedAt: NOW,
+    name: id,
+    displayName,
+    type,
+    avatarColorToken: null,
+    avatarImageUrl: null,
+  };
+}
+
+function runtimeAgent(overrides: Partial<RuntimeAgent> & { agentId: string }): RuntimeAgent {
+  return {
+    agentId: overrides.agentId,
+    clientId: overrides.clientId ?? "client-working",
+    runtimeType: overrides.runtimeType ?? "claude-code",
+    runtimeState: overrides.runtimeState ?? "idle",
+    activeSessions: overrides.activeSessions ?? 0,
+    totalSessions: overrides.totalSessions ?? 0,
+    runtimeUpdatedAt: overrides.runtimeUpdatedAt ?? NOW,
+    type: overrides.type ?? "agent",
+    managedByMe: overrides.managedByMe ?? true,
+  };
+}
+
+function activityOverview(agents: RuntimeAgent[]): ActivityOverview {
+  return {
+    total: agents.length,
+    running: agents.filter((agent) => agent.runtimeState === "working").length,
+    byState: {
+      idle: agents.filter((agent) => agent.runtimeState === "idle").length,
+      working: agents.filter((agent) => agent.runtimeState === "working").length,
+      blocked: agents.filter((agent) => agent.runtimeState === "blocked").length,
+      error: agents.filter((agent) => agent.runtimeState === "error").length,
+    },
+    clients: 2,
+    agents,
+  };
+}
+
+function session(overrides: Partial<SessionListItem> & { chatId: string }): SessionListItem {
+  return {
+    agentId: overrides.agentId ?? "agent-working",
+    chatId: overrides.chatId,
+    state: overrides.state ?? "active",
+    runtimeState: overrides.runtimeState ?? "working",
+    startedAt: overrides.startedAt ?? NOW,
+    lastActivityAt: overrides.lastActivityAt ?? NOW,
+    messageCount: overrides.messageCount ?? 1,
+    summary: overrides.summary ?? null,
+    topic: overrides.topic ?? null,
+  };
+}
+
+function githubEntity(
+  overrides: Partial<ChatGithubEntity> & { entityType: ChatGithubEntity["entityType"] },
+): ChatGithubEntity {
+  return {
+    entityType: overrides.entityType,
+    entityKey: overrides.entityKey ?? "acme/web#1",
+    boundVia: overrides.boundVia ?? "direct",
+    htmlUrl: overrides.htmlUrl ?? "https://github.com/acme/web/pull/1",
+    title: overrides.title ?? null,
+    state: overrides.state ?? null,
+    number: overrides.number ?? null,
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  window.localStorage.clear();
+  vi.clearAllMocks();
+  authMock.role = "admin";
+  pulseMock.value = {
+    stale: false,
+    aggregated: [
+      { workingCount: 2, errorMask: false },
+      { workingCount: 1, errorMask: true },
+      { workingCount: 0, errorMask: false },
+    ],
+  };
+  activityMocks.getActivityOverview.mockResolvedValue(
+    activityOverview([
+      runtimeAgent({
+        agentId: "agent-working",
+        runtimeState: "working",
+        activeSessions: 1,
+        totalSessions: 2,
+        clientId: "client-working",
+      }),
+      runtimeAgent({
+        agentId: "agent-blocked",
+        runtimeState: "blocked",
+        activeSessions: 0,
+        totalSessions: 1,
+        clientId: "client-blocked",
+      }),
+      runtimeAgent({ agentId: "agent-idle", runtimeState: "idle", clientId: null, totalSessions: 0 }),
+      runtimeAgent({ agentId: "human-1", runtimeState: "idle", clientId: null, type: "human" }),
+    ]),
+  );
+  chatMocks.createAgentChat.mockResolvedValue({ id: "chat-new" });
+  chatMocks.listChatGithubEntities.mockResolvedValue({ items: [] });
+  sessionMocks.listAgentSessions.mockResolvedValue([
+    session({ chatId: "chat-build", topic: "Build deploy", state: "active" }),
+    session({ chatId: "chat-notes", topic: null, summary: "Notes summary", state: "suspended" }),
+    session({ chatId: "chat-evicted", topic: "Hidden old session", state: "evicted" }),
+  ]);
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("ParticipantsSection extra DOM behavior", () => {
+  it("shows loading, empty, capped roster, and read-only add gates", async () => {
+    const { ParticipantsSection } = await import("../right-sidebar/participants-section.js");
+    const loading = await renderDom(
+      <ParticipantsSection
+        chatId="chat-1"
+        participants={[]}
+        participantsLoading
+        managedByMe={new Map()}
+        onAdded={() => undefined}
+        readOnly={false}
+      />,
+    );
+    expect(loading.container.textContent).toContain("Loading…");
+    await act(async () => loading.root.unmount());
+
+    const empty = await renderDom(
+      <ParticipantsSection
+        chatId="chat-1"
+        participants={[]}
+        participantsLoading={false}
+        managedByMe={new Map()}
+        onAdded={() => undefined}
+        readOnly={false}
+      />,
+    );
+    expect(empty.container.textContent).toContain("No participants yet.");
+    expect(empty.container.querySelector('button[aria-label="Add participant"]')).not.toBeNull();
+    await act(async () => empty.root.unmount());
+
+    authMock.role = "member";
+    const people = [
+      participant("agent-1", "agent", "Agent One"),
+      participant("agent-2", "agent", "Agent Two"),
+      participant("agent-3", "agent", "Agent Three"),
+      participant("agent-4", "agent", "Agent Four"),
+      participant("human-1", "human", "Human One"),
+      participant("human-2", "human", "Human Two"),
+    ];
+    const roster = await renderDom(
+      <ParticipantsSection
+        chatId="chat-1"
+        participants={people}
+        participantsLoading={false}
+        managedByMe={new Map([["agent-2", true]])}
+        onAdded={() => undefined}
+        readOnly
+      />,
+    );
+    expect(roster.container.textContent).toContain("Participants · 6");
+    expect(roster.container.textContent).toContain("Agent Two · manageable");
+    expect(roster.container.textContent).toContain("Agent One · readonly");
+    expect(roster.container.textContent).toContain("Human One");
+    expect(roster.container.textContent).not.toContain("Human Two");
+    expect(roster.container.querySelector('button[aria-label="Add participant"]')).toBeNull();
+
+    await click(buttonByText(roster.container, "Show all · 6"));
+    expect(roster.container.textContent).toContain("Human Two");
+    await click(buttonByText(roster.container, "Show less"));
+    expect(roster.container.textContent).not.toContain("Human Two");
+    await act(async () => roster.root.unmount());
+  });
+});
+
+describe("ChatRightSidebar extra DOM behavior", () => {
+  it("resizes with keyboard, persists commits, resets, and disables resize for fixed width", async () => {
+    const { ChatRightSidebar } = await import("../right-sidebar/index.js");
+    localStorage.setItem("first-tree:chat-right-sidebar:width:v1", "320");
+    const participants = [participant("agent-1", "agent", "Agent One")];
+    const resizable = await renderDom(
+      <ChatRightSidebar
+        chatId="chat-1"
+        participants={participants}
+        participantsLoading={false}
+        managedByMe={new Map([["agent-1", true]])}
+        onAdded={() => undefined}
+        readOnly={false}
+      />,
+    );
+    const aside = resizable.container.querySelector<HTMLElement>('aside[aria-label="Chat details"]');
+    expect(aside?.style.width).toBe(cssPx(320));
+
+    const handle = resizable.container.querySelector('button[aria-label="Resize chat details"]');
+    await keyDown(handle, "ArrowLeft");
+    expect(aside?.style.width).toBe(cssPx(336));
+    expect(localStorage.getItem("first-tree:chat-right-sidebar:width:v1")).toBe("336");
+    await keyDown(handle, "ArrowRight");
+    expect(aside?.style.width).toBe(cssPx(320));
+    await act(async () => {
+      handle?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true }));
+    });
+    await flush();
+    expect(aside?.style.width).toBe(cssPx(360));
+    expect(localStorage.getItem("first-tree:chat-right-sidebar:width:v1")).toBe("360");
+    await act(async () => resizable.root.unmount());
+
+    const fixed = await renderDom(
+      <ChatRightSidebar
+        chatId="chat-1"
+        participants={participants}
+        participantsLoading={false}
+        managedByMe={new Map()}
+        onAdded={() => undefined}
+        readOnly
+        width={312}
+      />,
+    );
+    const fixedAside = fixed.container.querySelector<HTMLElement>('aside[aria-label="Chat details"]');
+    expect(fixedAside?.style.width).toBe(cssPx(312));
+    expect(fixed.container.querySelector('button[aria-label="Resize chat details"]')).toBeNull();
+    expect(fixed.container.querySelector('button[aria-label="Add participant"]')).toBeNull();
+    await act(async () => fixed.root.unmount());
+  });
+});
+
+describe("GitHubSection extra DOM behavior", () => {
+  it("renders nothing for empty bindings and sorts populated rows by type", async () => {
+    const { GitHubSection } = await import("../right-sidebar/github-section.js");
+    const empty = await renderDom(<GitHubSection chatId="chat-empty" />);
+    await flush();
+    expect(empty.container.textContent).toBe("");
+    await act(async () => empty.root.unmount());
+
+    chatMocks.listChatGithubEntities.mockResolvedValueOnce({
+      items: [
+        githubEntity({
+          entityType: "commit",
+          entityKey: "acme/web@abc123",
+          htmlUrl: "https://github.com/acme/web/commit/abc123",
+        }),
+        githubEntity({
+          entityType: "issue",
+          entityKey: "acme/web#8",
+          htmlUrl: "https://github.com/acme/web/issues/8",
+          title: "Crash on launch",
+          state: "closed",
+        }),
+        githubEntity({
+          entityType: "pull_request",
+          entityKey: "acme/web#9",
+          htmlUrl: "https://github.com/acme/web/pull/9",
+          title: "Ship release",
+          state: "merged",
+        }),
+        githubEntity({
+          entityType: "discussion",
+          entityKey: "acme/web#10",
+          htmlUrl: "https://github.com/acme/web/discussions/10",
+          title: "Roadmap",
+          state: "open",
+        }),
+      ],
+    });
+    const populated = await renderDom(<GitHubSection chatId="chat-populated" />);
+    await waitForText(populated.container, "GitHub · 4");
+
+    const hrefs = [...populated.container.querySelectorAll<HTMLAnchorElement>("a")].map((a) => a.href);
+    expect(hrefs).toEqual([
+      "https://github.com/acme/web/pull/9",
+      "https://github.com/acme/web/issues/8",
+      "https://github.com/acme/web/discussions/10",
+      "https://github.com/acme/web/commit/abc123",
+    ]);
+    expect(populated.container.textContent).toContain("Ship release");
+    expect(populated.container.textContent).toContain("web#9");
+    expect(populated.container.textContent).not.toContain("acme/web#9Merged");
+    expect(populated.container.textContent).toContain("Closed");
+    expect(populated.container.textContent).toContain("Open");
+    expect(populated.container.textContent).toContain("acme/web@abc123");
+    await act(async () => populated.root.unmount());
+  });
+});
+
+describe("AgentRoster extra DOM behavior", () => {
+  it("filters by search and attention pill, opens sessions, and starts a new chat", async () => {
+    const { AgentRoster } = await import("../roster/index.js");
+    const onSelectAgent = vi.fn();
+    const onSelectChat = vi.fn();
+    const { container, root } = await renderDom(
+      <AgentRoster
+        selectedAgentId="agent-working"
+        selectedChatId="chat-build"
+        onSelectAgent={onSelectAgent}
+        onSelectChat={onSelectChat}
+      />,
+    );
+
+    await waitForText(container, "4 members");
+    await waitForText(container, "Build deploy");
+    expect(container.textContent).toContain("1 / 2");
+    expect(container.textContent).not.toContain("Hidden old session");
+
+    await click(buttonByText(container, "Notes summary"));
+    expect(onSelectChat).toHaveBeenCalledWith("agent-working", "chat-notes");
+
+    await click(buttonByText(container, "New chat"));
+    await flush();
+    expect(chatMocks.createAgentChat).toHaveBeenCalledWith("agent-working");
+    expect(onSelectChat).toHaveBeenCalledWith("agent-working", "chat-new");
+
+    const input = container.querySelector<HTMLInputElement>('input[placeholder="Filter…"]');
+    if (!input) throw new Error("Roster filter input missing");
+    await setValue(input, "blocked-host");
+    expect(container.textContent).toContain("Blocked Agent");
+    expect(container.textContent).not.toContain("Working Agent");
+
+    const attnButton =
+      [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+        (button) => button.textContent?.replace(/\s+/g, "").startsWith("attn") ?? false,
+      ) ?? null;
+    await click(attnButton);
+    expect(container.textContent).toContain("Blocked Agent");
+    expect(container.textContent).not.toContain("Human One");
+
+    await act(async () => root.unmount());
+  });
+
+  it("renders the no-agents and no-matches empty states", async () => {
+    const { AgentRoster } = await import("../roster/index.js");
+    activityMocks.getActivityOverview.mockResolvedValueOnce(activityOverview([]));
+    const empty = await renderDom(
+      <AgentRoster
+        selectedAgentId={null}
+        selectedChatId={null}
+        onSelectAgent={() => undefined}
+        onSelectChat={() => undefined}
+      />,
+    );
+    await waitForText(empty.container, "No agents");
+    expect(empty.container.textContent).toContain("Your first agent will appear here.");
+    await act(async () => empty.root.unmount());
+
+    const noMatches = await renderDom(
+      <AgentRoster
+        selectedAgentId={null}
+        selectedChatId={null}
+        onSelectAgent={() => undefined}
+        onSelectChat={() => undefined}
+      />,
+    );
+    await waitForText(noMatches.container, "4 members");
+    const input = noMatches.container.querySelector<HTMLInputElement>('input[placeholder="Filter…"]');
+    if (!input) throw new Error("Roster filter input missing");
+    await setValue(input, "does-not-match");
+    expect(noMatches.container.textContent).toContain("No matches");
+    await act(async () => noMatches.root.unmount());
+  });
+});

--- a/packages/web/src/pages/workspace/center/__tests__/workspace-center-extra-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/workspace-center-extra-dom.test.tsx
@@ -1,0 +1,742 @@
+// @vitest-environment happy-dom
+
+import {
+  AGENT_FINAL_TEXT_METADATA_KEY,
+  type Agent,
+  type ChatDetail,
+  type ChatParticipantDetail,
+} from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HubClient } from "../../../../api/activity.js";
+import type { MessageWithDelivery, PaginatedMessages } from "../../../../api/chats.js";
+import type { SessionEventRow } from "../../../../api/sessions.js";
+import { agentSessionsQueryKey } from "../../../../api/sessions.js";
+import { ToastProvider } from "../../../../components/ui/toast.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const activityMocks = vi.hoisted(() => ({
+  getClient: vi.fn(),
+  listClients: vi.fn(),
+  startRuntimeAuth: vi.fn(),
+}));
+
+const agentStatusMocks = vi.hoisted(() => ({
+  fetchChatAgentStatuses: vi.fn(),
+}));
+
+const agentMocks = vi.hoisted(() => ({
+  getAgentSkills: vi.fn(),
+}));
+
+const attachmentMocks = vi.hoisted(() => ({
+  fetchAttachmentBase64: vi.fn(),
+  uploadImageAttachment: vi.fn(),
+}));
+
+const chatMocks = vi.hoisted(() => ({
+  getChat: vi.fn(),
+  getChatTokenUsage: vi.fn(),
+  listChatGithubEntities: vi.fn(),
+  listChatMessages: vi.fn(),
+  listChatOpenRequests: vi.fn(),
+  patchChatEngagement: vi.fn(),
+  readFileAsBase64: vi.fn(),
+  renameChat: vi.fn(),
+  sendChatMessage: vi.fn(),
+  sendFileMessageBatch: vi.fn(),
+}));
+
+const imageStoreMocks = vi.hoisted(() => ({
+  getImage: vi.fn(),
+  putImage: vi.fn(),
+}));
+
+const readStateMocks = vi.hoisted(() => ({
+  getReadState: vi.fn(),
+  setReadState: vi.fn(),
+}));
+
+const sessionMocks = vi.hoisted(() => ({
+  listSessionEvents: vi.fn(),
+  listSessionOutputs: vi.fn(),
+}));
+
+const authMock = vi.hoisted(() => ({
+  value: {
+    agentId: "human-agent-self",
+    memberId: "member-self",
+    role: "admin",
+    user: { id: "user-self" },
+  },
+}));
+
+const serverChannelMock = vi.hoisted(() => ({
+  value: "dev" as "dev" | "staging" | "prod",
+}));
+
+vi.mock("../../../../api/activity.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../../api/activity.js")>()),
+  getClient: activityMocks.getClient,
+  listClients: activityMocks.listClients,
+  startRuntimeAuth: activityMocks.startRuntimeAuth,
+}));
+
+vi.mock("../../../../api/agent-status.js", () => ({
+  chatAgentStatusQueryKey: (chatId: string) => ["chat-agent-status", chatId] as const,
+  fetchChatAgentStatuses: agentStatusMocks.fetchChatAgentStatuses,
+}));
+
+vi.mock("../../../../api/agents.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../../api/agents.js")>()),
+  getAgentSkills: agentMocks.getAgentSkills,
+}));
+
+vi.mock("../../../../api/attachments.js", () => attachmentMocks);
+
+vi.mock("../../../../api/chats.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../../api/chats.js")>()),
+  ...chatMocks,
+}));
+
+vi.mock("../../../../api/image-store.js", () => imageStoreMocks);
+
+vi.mock("../../../../api/read-state-store.js", () => readStateMocks);
+
+vi.mock("../../../../api/sessions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../../api/sessions.js")>()),
+  listSessionEvents: sessionMocks.listSessionEvents,
+  listSessionOutputs: sessionMocks.listSessionOutputs,
+}));
+
+vi.mock("../../../../auth/auth-context.js", () => ({
+  useAuth: () => authMock.value,
+}));
+
+vi.mock("../../../../components/add-participant-dropdown.js", () => ({
+  AddParticipantDropdown: ({ variant }: { variant: "icon" | "inline" }) => (
+    <button aria-label="Add participant" type="button">
+      Add participant ({variant})
+    </button>
+  ),
+}));
+
+vi.mock("../../../../hooks/use-server-channel.js", () => ({
+  useServerChannel: () => serverChannelMock.value,
+}));
+
+vi.mock("../../../../lib/use-agent-name-map.js", () => ({
+  useAgentIdentityMap: () => resolveAgentIdentityForTest,
+  useAgentNameMap: () => resolveAgentNameForTest,
+  useAgentSlugToIdMap: () => resolveAgentSlugForTest,
+}));
+
+vi.mock("../../../../lib/use-org-agents.js", () => ({
+  useOrgAgents: () => ({ data: { items: ORG_AGENTS, nextCursor: null } }),
+  useOrgAgentsSearch: () => ({ data: { items: ORG_AGENTS, nextCursor: null }, isFetching: false }),
+}));
+
+vi.mock("../../../../lib/visibility-interval.js", () => ({
+  runVisibilityAwareInterval: (tick: () => void | Promise<void>) => {
+    void tick();
+    return () => undefined;
+  },
+}));
+
+const NOW = "2026-05-28T12:00:00.000Z";
+const DOC_ATTACHMENT_ID = "00000000-0000-4000-8000-000000000101";
+const IMAGE_ID = "00000000-0000-4000-8000-000000000202";
+
+const AGENT_NAMES: Record<string, string> = {
+  "agent-1": "Nova",
+  "agent-2": "Design Critique",
+  "human-agent-self": "Gandy",
+};
+
+const AGENT_SLUGS: Record<string, string> = {
+  "agent-1": "nova",
+  "agent-2": "design",
+  "human-agent-self": "gandy",
+};
+
+function resolveAgentIdentityForTest(id: string | null | undefined) {
+  if (!id) return null;
+  return {
+    name: AGENT_SLUGS[id] ?? id,
+    displayName: AGENT_NAMES[id] ?? id,
+    avatarImageUrl: null,
+    avatarColorToken: id === "agent-1" ? "hue-2" : null,
+  };
+}
+
+function resolveAgentNameForTest(id: string | null | undefined): string {
+  return id ? (AGENT_NAMES[id] ?? id) : "unknown";
+}
+
+function resolveAgentSlugForTest(slug: string | null | undefined): string | null {
+  if (!slug) return null;
+  return Object.entries(AGENT_SLUGS).find(([, value]) => value === slug)?.[0] ?? null;
+}
+
+function agent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    uuid: overrides.uuid ?? "agent-1",
+    name: overrides.name ?? "nova",
+    displayName: overrides.displayName ?? "Nova",
+    type: overrides.type ?? "agent",
+    managerId: overrides.managerId ?? "member-self",
+    visibility: overrides.visibility ?? "organization",
+    avatarColorToken: overrides.avatarColorToken ?? null,
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+    status: overrides.status ?? "active",
+    organizationId: overrides.organizationId ?? "org-1",
+    delegateMention: overrides.delegateMention ?? null,
+    inboxId: overrides.inboxId ?? "inbox-1",
+    metadata: overrides.metadata ?? {},
+    source: overrides.source ?? "portal",
+    clientId: overrides.clientId ?? "client-1",
+    runtimeProvider: overrides.runtimeProvider ?? "claude-code",
+    runtimeState: overrides.runtimeState ?? "idle",
+    createdAt: overrides.createdAt ?? NOW,
+    updatedAt: overrides.updatedAt ?? NOW,
+  };
+}
+
+const ORG_AGENTS = [
+  agent({ uuid: "human-agent-self", name: "gandy", displayName: "Gandy", type: "human", clientId: null }),
+  agent(),
+  agent({ uuid: "agent-2", name: "design", displayName: "Design Critique", managerId: "member-alice" }),
+];
+
+function participant(overrides: Partial<ChatParticipantDetail> & { agentId: string }): ChatParticipantDetail {
+  return {
+    agentId: overrides.agentId,
+    role: overrides.role ?? "member",
+    mode: overrides.mode ?? "full",
+    joinedAt: overrides.joinedAt ?? NOW,
+    name: overrides.name ?? AGENT_SLUGS[overrides.agentId] ?? overrides.agentId,
+    displayName: overrides.displayName ?? AGENT_NAMES[overrides.agentId] ?? overrides.agentId,
+    type: overrides.type ?? "agent",
+    avatarColorToken: overrides.avatarColorToken ?? null,
+    avatarImageUrl: overrides.avatarImageUrl ?? null,
+  };
+}
+
+const PARTICIPANTS: ChatParticipantDetail[] = [
+  participant({ agentId: "human-agent-self", type: "human", name: "gandy", displayName: "Gandy" }),
+  participant({ agentId: "agent-1", name: "nova", displayName: "Nova" }),
+  participant({ agentId: "agent-2", name: "design", displayName: "Design Critique" }),
+];
+
+function chatDetail(overrides: Partial<ChatDetail> = {}): ChatDetail {
+  return {
+    id: overrides.id ?? "chat-1",
+    organizationId: overrides.organizationId ?? "org-1",
+    type: overrides.type ?? "group",
+    topic: overrides.topic ?? "Launch planning",
+    description: overrides.description ?? null,
+    descriptionUpdatedAt: overrides.descriptionUpdatedAt ?? null,
+    lastReadAt: overrides.lastReadAt ?? null,
+    lifecyclePolicy: overrides.lifecyclePolicy ?? null,
+    metadata: overrides.metadata ?? { source: "github", entityUrl: "https://github.com/acme/web/pull/42" },
+    createdAt: overrides.createdAt ?? NOW,
+    updatedAt: overrides.updatedAt ?? NOW,
+    participants: overrides.participants ?? PARTICIPANTS,
+    title: overrides.title ?? "Launch planning",
+    firstMessagePreview: overrides.firstMessagePreview ?? "Please review the launch checklist.",
+    engagementStatus: overrides.engagementStatus ?? "active",
+    viewerMembershipKind: overrides.viewerMembershipKind ?? "participant",
+  };
+}
+
+function message(overrides: Partial<MessageWithDelivery> & { id: string; senderId: string }): MessageWithDelivery {
+  return {
+    id: overrides.id,
+    chatId: overrides.chatId ?? "chat-1",
+    senderId: overrides.senderId,
+    format: overrides.format ?? "text",
+    content: overrides.content ?? "Message body",
+    metadata: overrides.metadata ?? {},
+    inReplyTo: overrides.inReplyTo ?? null,
+    source: overrides.source ?? "web",
+    createdAt: overrides.createdAt ?? NOW,
+    deliveryStatus: overrides.deliveryStatus,
+  };
+}
+
+function messages(items: MessageWithDelivery[]): PaginatedMessages {
+  return { items, nextCursor: null };
+}
+
+const BASE_MESSAGES = messages([
+  message({
+    id: "msg-1",
+    senderId: "human-agent-self",
+    content: "Please review @nova.",
+    metadata: { mentions: ["agent-1"] },
+  }),
+  message({
+    id: "msg-2",
+    senderId: "agent-1",
+    content: "I am reviewing now.",
+    source: "api",
+    createdAt: "2026-05-28T12:01:00.000Z",
+  }),
+]);
+
+const SESSION_EVENTS: { items: SessionEventRow[]; nextCursor: number | null } = {
+  items: [],
+  nextCursor: null,
+};
+
+function installBrowserStubs(): void {
+  const storage = createStorage();
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: { randomUUID: () => "00000000-0000-4000-8000-000000000000" },
+  });
+  Object.defineProperty(window.URL, "createObjectURL", { configurable: true, value: () => "blob:test-image" });
+  Object.defineProperty(window.URL, "revokeObjectURL", { configurable: true, value: vi.fn() });
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) => ({
+      matches: query.includes("48rem") || query.includes("80rem"),
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", { configurable: true, value: vi.fn() });
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", { configurable: true, value: vi.fn() });
+  class TestResizeObserver {
+    observe = vi.fn();
+    disconnect = vi.fn();
+    unobserve = vi.fn();
+  }
+  class TestIntersectionObserver {
+    observe = vi.fn();
+    disconnect = vi.fn();
+    unobserve = vi.fn();
+  }
+  Object.defineProperty(globalThis, "ResizeObserver", { configurable: true, value: TestResizeObserver });
+  Object.defineProperty(globalThis, "IntersectionObserver", { configurable: true, value: TestIntersectionObserver });
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: (cb: FrameRequestCallback) => window.setTimeout(() => cb(Date.now()), 0),
+  });
+}
+
+function createStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => [...data.keys()][index] ?? null,
+    removeItem: (key: string) => data.delete(key),
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+function createClient(): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+  queryClient.setQueryData(["agents", "org-list"], { items: ORG_AGENTS, nextCursor: null });
+  queryClient.setQueryData(["chat-agent-status", "chat-1"], []);
+  queryClient.setQueryData(agentSessionsQueryKey("agent-1"), []);
+  return queryClient;
+}
+
+function seedChat(
+  queryClient: QueryClient,
+  detail: ChatDetail = chatDetail(),
+  page: PaginatedMessages = BASE_MESSAGES,
+): void {
+  queryClient.setQueryData(["chat-detail", detail.id], detail);
+  queryClient.setQueryData(["chat-messages-cache", detail.id], []);
+  queryClient.setQueryData(["chat-messages", detail.id], page);
+  queryClient.setQueryData(["chat-open-requests", detail.id], { items: [] });
+  queryClient.setQueryData(["session-events", "agent-1", detail.id], SESSION_EVENTS);
+  queryClient.setQueryData(["chat-read-state", detail.id], null);
+  queryClient.setQueryData(["chat-token-usage", detail.id], {
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  });
+  queryClient.setQueryData(["chat-right-sidebar", "github-entities", detail.id], {
+    items: [
+      {
+        entityType: "pull_request",
+        entityKey: "acme/web#42",
+        htmlUrl: "https://github.com/acme/web/pull/42",
+        title: "Release checklist",
+        state: "open",
+        boundVia: "direct",
+        number: 42,
+      },
+    ],
+  });
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
+async function renderDom(
+  element: ReactElement,
+  seed?: (queryClient: QueryClient) => void,
+  route = "/",
+): Promise<{ container: HTMLElement; queryClient: QueryClient; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = createClient();
+  seedChat(queryClient);
+  seed?.(queryClient);
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[route]}>
+        <QueryClientProvider client={queryClient}>
+          <LocationProbe />
+          <ToastProvider>{element}</ToastProvider>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+  });
+  await flush();
+  return { container, queryClient, root };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function waitForText(container: ParentNode, text: string, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (container.textContent?.includes(text)) return;
+    await flush();
+  }
+  throw new Error(`Expected text "${text}"`);
+}
+
+async function waitForCondition(predicate: () => boolean, message: string, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await flush();
+  }
+  throw new Error(message);
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+async function setValue(element: HTMLInputElement | HTMLTextAreaElement, value: string): Promise<void> {
+  await act(async () => {
+    const proto = element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
+    setter?.call(element, value);
+    element.dispatchEvent(new InputEvent("input", { bubbles: true, data: value, inputType: "insertText" }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  await flush();
+}
+
+function buttonByText(container: ParentNode, text: string): HTMLButtonElement | null {
+  return [...container.querySelectorAll("button")].find((button) => button.textContent?.trim() === text) ?? null;
+}
+
+function buttonByTitle(container: ParentNode, title: string): HTMLButtonElement | null {
+  return container.querySelector<HTMLButtonElement>(`button[title="${title}"]`);
+}
+
+function locationParams(container: ParentNode): URLSearchParams {
+  const locationText = container.querySelector('[data-testid="location"]')?.textContent ?? "/";
+  const query = locationText.includes("?") ? (locationText.split("?")[1] ?? "") : "";
+  return new URLSearchParams(query);
+}
+
+beforeEach(() => {
+  installBrowserStubs();
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+  serverChannelMock.value = "dev";
+  authMock.value = {
+    agentId: "human-agent-self",
+    memberId: "member-self",
+    role: "admin",
+    user: { id: "user-self" },
+  };
+  const client = {
+    id: "client-1",
+    userId: "user-self",
+    status: "connected",
+    authState: "ok",
+    binName: "first-tree-dev",
+    sdkVersion: "0.5.0",
+    hostname: "gandy-macbook",
+    os: "darwin",
+    agentCount: 1,
+    connectedAt: NOW,
+    lastSeenAt: NOW,
+    capabilities: {},
+  } satisfies HubClient;
+  activityMocks.getClient.mockResolvedValue(client);
+  activityMocks.listClients.mockResolvedValue([client]);
+  activityMocks.startRuntimeAuth.mockResolvedValue({ ref: "auth-ref", started: true });
+  agentStatusMocks.fetchChatAgentStatuses.mockResolvedValue([]);
+  agentMocks.getAgentSkills.mockResolvedValue({ skills: [] });
+  attachmentMocks.fetchAttachmentBase64.mockResolvedValue({ base64: "image-base64", mimeType: "image/png" });
+  attachmentMocks.uploadImageAttachment.mockResolvedValue({ id: IMAGE_ID, mimeType: "image/png", size: 3 });
+  chatMocks.getChat.mockResolvedValue(chatDetail());
+  chatMocks.getChatTokenUsage.mockResolvedValue({
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  });
+  chatMocks.listChatGithubEntities.mockResolvedValue({ items: [] });
+  chatMocks.listChatMessages.mockResolvedValue(BASE_MESSAGES);
+  chatMocks.listChatOpenRequests.mockResolvedValue({ items: [] });
+  chatMocks.patchChatEngagement.mockResolvedValue({ chatId: "chat-1", engagementStatus: "active" });
+  chatMocks.readFileAsBase64.mockResolvedValue("image-base64");
+  chatMocks.renameChat.mockResolvedValue({ id: "chat-1", topic: "Renamed launch" });
+  chatMocks.sendChatMessage.mockResolvedValue(
+    message({ id: "msg-sent", senderId: "human-agent-self", content: "sent" }),
+  );
+  chatMocks.sendFileMessageBatch.mockResolvedValue(
+    message({ id: "msg-file", senderId: "human-agent-self", format: "file", content: { attachments: [] } }),
+  );
+  imageStoreMocks.getImage.mockResolvedValue(null);
+  imageStoreMocks.putImage.mockResolvedValue(undefined);
+  readStateMocks.getReadState.mockResolvedValue(null);
+  readStateMocks.setReadState.mockResolvedValue(undefined);
+  sessionMocks.listSessionEvents.mockResolvedValue(SESSION_EVENTS);
+  sessionMocks.listSessionOutputs.mockResolvedValue({ items: [], nextCursor: null });
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("chat-view exported helpers", () => {
+  it("parses failed document mentions and returns stable drawer query keys", async () => {
+    const { docAttachmentRefQueryKey, docMessageAttachmentRefsQueryKey, failedDocMentionsFromMetadata } = await import(
+      "../chat-view.js"
+    );
+
+    expect(docAttachmentRefQueryKey(DOC_ATTACHMENT_ID)).toEqual(["chat-doc-attachment-ref", DOC_ATTACHMENT_ID]);
+    expect(docMessageAttachmentRefsQueryKey("msg-doc")).toEqual(["chat-doc-message-attachment-refs", "msg-doc"]);
+    expect(failedDocMentionsFromMetadata(undefined)).toBeUndefined();
+    expect(failedDocMentionsFromMetadata({ documentContext: { kind: "none" } })).toBeUndefined();
+
+    const failed = failedDocMentionsFromMetadata({
+      documentContext: {
+        kind: "snapshot",
+        failedMentions: [
+          { raw: "docs/private.md", reason: "hidden-segment" },
+          { raw: "docs/missing.md", reason: "missing" },
+        ],
+      },
+    });
+
+    expect(failed?.get("docs/private.md")).toBe("hidden-segment");
+    expect(failed?.get("docs/missing.md")).toBe("missing");
+  });
+});
+
+describe("ChatView extra DOM branches", () => {
+  it("supports cancel and blank-save rename branches", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />);
+
+    await waitForText(container, "Launch planning");
+    await click(buttonByTitle(container, "Click to rename"));
+    const firstInput = container.querySelector<HTMLInputElement>("input");
+    if (!firstInput) throw new Error("Rename input missing");
+    await act(async () => {
+      firstInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+    });
+    await flush();
+    expect(chatMocks.renameChat).not.toHaveBeenCalled();
+    expect(buttonByTitle(container, "Click to rename")).not.toBeNull();
+
+    await click(buttonByTitle(container, "Click to rename"));
+    const secondInput = container.querySelector<HTMLInputElement>("input");
+    if (!secondInput) throw new Error("Rename input missing after reopening");
+    await setValue(secondInput, "   ");
+    await click(buttonByTitle(container, "Save"));
+    await waitForCondition(() => chatMocks.renameChat.mock.calls.length === 1, "Expected blank rename commit");
+    expect(chatMocks.renameChat).toHaveBeenCalledWith("chat-1", null);
+
+    await act(async () => root.unmount());
+  });
+
+  it("replaces an attachment preview with the chat details sidebar from the header toggle", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    localStorage.setItem("first-tree:chat-right-sidebar:open:v1", "1");
+    const route = `/?docChat=chat-1&docMsg=msg-doc&docAttachment=${DOC_ATTACHMENT_ID}&docAgent=agent-1&docPath=docs%2Fplan.md`;
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, undefined, route);
+
+    await waitForText(container, "Launch planning");
+    await flush();
+    expect(container.textContent).not.toContain("Participants ·");
+
+    await click(container.querySelector('button[aria-label="Show chat details"]'));
+    await waitForText(container, "Participants · 3");
+    expect(locationParams(container).get("docChat")).toBeNull();
+    expect(locationParams(container).get("docAttachment")).toBeNull();
+    expect(locationParams(container).get("docAgent")).toBeNull();
+    expect(locationParams(container).get("docPath")).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("seeds doc-preview query data when an attachment link is opened", async () => {
+    const { ChatView, docAttachmentRefQueryKey, docMessageAttachmentRefsQueryKey } = await import("../chat-view.js");
+    const docMessage = message({
+      id: "msg-doc",
+      senderId: "agent-1",
+      source: "api",
+      content: `Open [the captured doc](attachment:${DOC_ATTACHMENT_ID}) now.`,
+      metadata: {
+        attachments: [
+          {
+            attachmentId: DOC_ATTACHMENT_ID,
+            kind: "document",
+            mimeType: "text/markdown",
+            filename: "plan.md",
+            size: 21,
+            sha256: "a".repeat(64),
+            source: { path: "docs/plan.md" },
+          },
+        ],
+      },
+    });
+    const { container, queryClient, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, (client) =>
+      seedChat(client, chatDetail(), messages([docMessage])),
+    );
+
+    await waitForText(container, "the captured doc");
+    const link = container.querySelector<HTMLAnchorElement>(`a[href="attachment:${DOC_ATTACHMENT_ID}"]`);
+    await click(link);
+
+    expect(locationParams(container).get("docChat")).toBe("chat-1");
+    expect(locationParams(container).get("docMsg")).toBe("msg-doc");
+    expect(locationParams(container).get("docAttachment")).toBe(DOC_ATTACHMENT_ID);
+    expect(queryClient.getQueryData(docAttachmentRefQueryKey(DOC_ATTACHMENT_ID))).toMatchObject({
+      attachmentId: DOC_ATTACHMENT_ID,
+      filename: "plan.md",
+    });
+    expect(queryClient.getQueryData(docMessageAttachmentRefsQueryKey("msg-doc"))).toEqual([
+      expect.objectContaining({ attachmentId: DOC_ATTACHMENT_ID }),
+    ]);
+
+    await act(async () => root.unmount());
+  });
+
+  it("renders image fallbacks, read receipts, and the dev final-text visibility toggle", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    attachmentMocks.fetchAttachmentBase64.mockRejectedValueOnce(new Error("deleted"));
+    const page = messages([
+      message({
+        id: "msg-self-sent",
+        senderId: "human-agent-self",
+        content: "Sent receipt branch",
+        deliveryStatus: "sent",
+      }),
+      message({
+        id: "msg-self-delivered",
+        senderId: "human-agent-self",
+        content: "Delivered receipt branch",
+        createdAt: "2026-05-28T12:01:00.000Z",
+        deliveryStatus: "delivered",
+      }),
+      message({
+        id: "msg-image-miss",
+        senderId: "agent-1",
+        format: "file",
+        content: { imageId: IMAGE_ID, mimeType: "image/png", filename: "missing.png", size: 3 },
+        source: "api",
+        createdAt: "2026-05-28T12:02:00.000Z",
+      }),
+      message({
+        id: "msg-final",
+        senderId: "agent-1",
+        content: "Hidden final mirror row",
+        metadata: { [AGENT_FINAL_TEXT_METADATA_KEY]: true },
+        source: "api",
+        createdAt: "2026-05-28T12:03:00.000Z",
+      }),
+    ]);
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, (client) =>
+      seedChat(client, chatDetail(), page),
+    );
+
+    await waitForText(container, "Sent receipt branch");
+    expect(container.textContent).toContain("✓ sent");
+    expect(container.textContent).toContain("✓✓");
+    await waitForText(container, '[Image "missing.png" failed to load]');
+    await waitForText(container, "Hidden final mirror row");
+
+    await click(container.querySelector('button[aria-label="Hide agent final messages"]'));
+    await waitForCondition(
+      () => !container.textContent?.includes("Hidden final mirror row"),
+      "Expected final-text row to be hidden",
+    );
+    expect(localStorage.getItem("first-tree:chat:hide-agent-final-text:v1")).toBe("1");
+    expect(container.querySelector('button[aria-label="Show agent final messages"]')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("renders a disabled joining panel for read-only watchers", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const onJoin = vi.fn();
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" readOnly joinAction={{ joining: true, error: null, onJoin }} />,
+    );
+
+    await waitForText(container, "You're watching this chat");
+    const joinButton = buttonByText(container, "Joining…");
+    expect(joinButton?.disabled).toBe(true);
+    expect(container.querySelector("textarea")).toBeNull();
+    expect(container.querySelector('button[aria-label="Add participant"]')).toBeNull();
+
+    await click(joinButton);
+    expect(onJoin).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/pages/workspace/conversations/__tests__/row-engagement-menu-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/row-engagement-menu-dom.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RowEngagementMenu } from "../row-engagement-menu.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const meChatMocks = vi.hoisted(() => ({
+  markMeChatUnread: vi.fn(),
+}));
+
+const chatMocks = vi.hoisted(() => ({
+  patchChatEngagement: vi.fn(),
+}));
+
+vi.mock("../../../../api/me-chats.js", () => meChatMocks);
+vi.mock("../../../../api/chats.js", () => ({
+  patchChatEngagement: chatMocks.patchChatEngagement,
+}));
+
+let root: Root | null = null;
+let queryClient: QueryClient | null = null;
+
+function createClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+async function render(element: ReactElement): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  queryClient = createClient();
+  await act(async () => {
+    root?.render(<QueryClientProvider client={queryClient}>{element}</QueryClientProvider>);
+  });
+  return container;
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Expected element to click");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+function manageButton(rootNode: ParentNode): HTMLButtonElement | null {
+  return rootNode.querySelector<HTMLButtonElement>('button[aria-label="Manage chat"]');
+}
+
+function menuItem(label: string): HTMLButtonElement {
+  const button = [...document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')].find(
+    (item) => item.textContent === label,
+  );
+  if (!button) throw new Error(`Missing menu item ${label}`);
+  return button;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+  meChatMocks.markMeChatUnread.mockResolvedValue(undefined);
+  chatMocks.patchChatEngagement.mockResolvedValue(undefined);
+  root = null;
+  queryClient = null;
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  document.body.innerHTML = "";
+  queryClient?.clear();
+});
+
+describe("RowEngagementMenu", () => {
+  it("marks active chats unread and invalidates chat caches", async () => {
+    const dom = await render(<RowEngagementMenu chatId="chat-active" status="active" hasUnread={false} />);
+    const invalidate = vi.spyOn(queryClient as QueryClient, "invalidateQueries");
+
+    await click(manageButton(dom));
+    await click(menuItem("Mark as unread"));
+
+    expect(meChatMocks.markMeChatUnread).toHaveBeenCalledWith("chat-active");
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["me", "chats"] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["chat-detail", "chat-active"] });
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+  });
+
+  it("disables mark-unread when the active row already has unread work", async () => {
+    const dom = await render(<RowEngagementMenu chatId="chat-unread" status="active" hasUnread={true} />);
+
+    await click(manageButton(dom));
+    const markUnread = menuItem("Mark as unread");
+
+    expect(markUnread.disabled).toBe(true);
+    await click(markUnread);
+    expect(meChatMocks.markMeChatUnread).not.toHaveBeenCalled();
+  });
+
+  it("archives and deletes active chats through engagement mutations", async () => {
+    const dom = await render(<RowEngagementMenu chatId="chat-active" status="active" hasUnread={false} />);
+
+    await click(manageButton(dom));
+    await click(menuItem("Archive"));
+    await click(manageButton(dom));
+    await click(menuItem("Delete"));
+
+    expect(chatMocks.patchChatEngagement.mock.calls).toEqual([
+      ["chat-active", "archived"],
+      ["chat-active", "deleted"],
+    ]);
+  });
+
+  it("offers archived-row recovery without the active-only mark-unread action", async () => {
+    const dom = await render(<RowEngagementMenu chatId="chat-archived" status="archived" hasUnread={false} />);
+
+    await click(manageButton(dom));
+    expect(document.body.textContent).toContain("Unarchive");
+    expect(document.body.textContent).toContain("Delete");
+    expect(document.body.textContent).not.toContain("Mark as unread");
+    expect(document.body.textContent).not.toContain("Archive");
+
+    await click(menuItem("Unarchive"));
+
+    expect(chatMocks.patchChatEngagement).toHaveBeenCalledWith("chat-archived", "active");
+  });
+
+  it("renders no menu for deleted rows", async () => {
+    const dom = await render(<RowEngagementMenu chatId="chat-deleted" status="deleted" hasUnread={false} />);
+
+    expect(manageButton(dom)).toBeNull();
+  });
+});

--- a/packages/web/src/pages/workspace/conversations/__tests__/row-engagement-menu-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/row-engagement-menu-dom.test.tsx
@@ -37,9 +37,10 @@ async function render(element: ReactElement): Promise<HTMLElement> {
   const container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
-  queryClient = createClient();
+  const client = createClient();
+  queryClient = client;
   await act(async () => {
-    root?.render(<QueryClientProvider client={queryClient}>{element}</QueryClientProvider>);
+    root?.render(<QueryClientProvider client={client}>{element}</QueryClientProvider>);
   });
   return container;
 }

--- a/packages/web/src/pages/workspace/right-sidebar/__tests__/resize-handle-dom.test.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/__tests__/resize-handle-dom.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SidebarResizeHandle } from "../resize-handle.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+async function render(element: ReactElement): Promise<HTMLElement> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(element);
+  });
+  return container;
+}
+
+async function dispatchMouse(target: EventTarget, type: string, init: MouseEventInit = {}): Promise<void> {
+  await act(async () => {
+    target.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, ...init }));
+  });
+}
+
+async function dispatchKey(target: EventTarget, key: string): Promise<void> {
+  await act(async () => {
+    target.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key }));
+  });
+}
+
+function handle(rootNode: ParentNode): HTMLButtonElement {
+  const button = rootNode.querySelector<HTMLButtonElement>('button[aria-label="Resize chat details"]');
+  if (!button) throw new Error("Missing resize handle");
+  return button;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.body.style.userSelect = "";
+  document.body.style.cursor = "";
+  root = null;
+  container = null;
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  document.body.innerHTML = "";
+  document.body.style.userSelect = "";
+  document.body.style.cursor = "";
+});
+
+describe("SidebarResizeHandle", () => {
+  it("streams clamped drag widths and commits the settled width on mouseup", async () => {
+    const onWidthChange = vi.fn();
+    const onCommit = vi.fn();
+    document.body.style.userSelect = "text";
+    document.body.style.cursor = "default";
+
+    const dom = await render(
+      <SidebarResizeHandle
+        width={320}
+        min={240}
+        max={480}
+        onWidthChange={onWidthChange}
+        onCommit={onCommit}
+        onReset={() => undefined}
+      />,
+    );
+
+    await dispatchMouse(handle(dom), "mousedown", { button: 0, clientX: 100 });
+    expect(document.body.style.userSelect).toBe("none");
+    expect(document.body.style.cursor).toBe("col-resize");
+
+    await dispatchMouse(window, "mousemove", { clientX: 10 });
+    await dispatchMouse(window, "mousemove", { clientX: -100 });
+    await dispatchMouse(window, "mouseup");
+
+    expect(onWidthChange).toHaveBeenNthCalledWith(1, 410);
+    expect(onWidthChange).toHaveBeenNthCalledWith(2, 480);
+    expect(onCommit).toHaveBeenCalledWith(480);
+    expect(document.body.style.userSelect).toBe("text");
+    expect(document.body.style.cursor).toBe("default");
+  });
+
+  it("ignores non-primary mouse buttons", async () => {
+    const onWidthChange = vi.fn();
+    const onCommit = vi.fn();
+    const dom = await render(
+      <SidebarResizeHandle
+        width={320}
+        min={240}
+        max={480}
+        onWidthChange={onWidthChange}
+        onCommit={onCommit}
+        onReset={() => undefined}
+      />,
+    );
+
+    await dispatchMouse(handle(dom), "mousedown", { button: 1, clientX: 100 });
+    await dispatchMouse(window, "mousemove", { clientX: 0 });
+    await dispatchMouse(window, "mouseup");
+
+    expect(onWidthChange).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(document.body.style.cursor).toBe("");
+  });
+
+  it("nudges width from the keyboard and ignores unrelated keys", async () => {
+    const onCommit = vi.fn();
+    const onWidthChange = vi.fn((next: number) => {
+      void next;
+    });
+
+    function StatefulHandle() {
+      const [width, setWidth] = useState(320);
+      return (
+        <SidebarResizeHandle
+          width={width}
+          min={300}
+          max={336}
+          onWidthChange={(next) => {
+            onWidthChange(next);
+            setWidth(next);
+          }}
+          onCommit={onCommit}
+          onReset={() => undefined}
+        />
+      );
+    }
+
+    const dom = await render(<StatefulHandle />);
+    const resizeHandle = handle(dom);
+
+    await dispatchKey(resizeHandle, "ArrowLeft");
+    await dispatchKey(resizeHandle, "ArrowLeft");
+    await dispatchKey(resizeHandle, "ArrowRight");
+    await dispatchKey(resizeHandle, "Enter");
+
+    expect(onWidthChange.mock.calls).toEqual([[336], [336], [320]]);
+    expect(onCommit.mock.calls).toEqual([[336], [336], [320]]);
+  });
+
+  it("delegates double-click reset to the parent", async () => {
+    const onReset = vi.fn();
+    const dom = await render(
+      <SidebarResizeHandle
+        width={320}
+        min={240}
+        max={480}
+        onWidthChange={() => undefined}
+        onCommit={() => undefined}
+        onReset={onReset}
+      />,
+    );
+
+    await dispatchMouse(handle(dom), "dblclick");
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add client runtime, Codex/Claude handler, SDK, session, capability, retry, source repo, tmux, and observability coverage
- add web DOM coverage for workspace, agent detail, client cards, resource previews, docs, settings-style previews, onboarding, menus, sidebars, and styleguide interactions
- cover additional browser store, docs API, chat component, and small utility edge paths

## Testing
- pnpm --filter @first-tree/web test -- packages/web/src/pages/__tests__/styleguide-preview-dom.test.tsx
- pnpm check && pnpm typecheck

Notes: the targeted web test command currently runs the package test suite because of the package script argument handling. It passed: 156 files / 1283 tests. `pnpm check` reported existing Biome warnings in assistant-text, workspace-migrations, and index.css, but exited 0.