### PR TITLE
fix(server): let self-directed GitHub involves mint a tracking chat

### DIFF
--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -330,6 +330,197 @@ describe("deliverNormalizedEvent", () => {
     expect(afterOk.length).toBeGreaterThan(0);
   });
 
+  it("self-echo carve-out: a fresh self-assigned issue mints a tracking chat (#1536)", async () => {
+    // Regression for #1536. When the actor self-assigns / self-@s a brand-new
+    // entity, the sole audience target is the actor's own (human, delegate)
+    // pair with `kind: "new"`. The old blanket self-echo prune dropped it, so
+    // no chat was ever created and the entity stayed invisible to First Tree.
+    // A fresh directed involve must survive the prune and mint the chat.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `human-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegate,
+      type: "human",
+    });
+    const entityKey = "owner/repo#1536";
+    const target = {
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      kind: "new",
+      chatId: null,
+      involveReason: "assigned",
+      involveLogin: humanName.toLowerCase(),
+    } satisfies AudienceTarget;
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "issue",
+      entityKey,
+      rawEventType: "issues",
+      rawAction: "opened",
+      kind: "opened",
+      actorLogin: humanName,
+      involves: [{ githubLogin: humanName.toLowerCase(), reason: "assigned" }],
+    });
+
+    // Actor resolves to the same human that self-assigned — the exact echo
+    // condition — yet the fresh directed involve survives and mints a chat.
+    const stats = await deliverNormalizedEvent(app, event, [target], { actorHumanId: human });
+    expect(stats).toEqual({ delivered: 1, newChats: 1, failed: 0 });
+
+    const mapping = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(
+        and(
+          eq(githubEntityChatMappings.organizationId, admin.organizationId),
+          eq(githubEntityChatMappings.entityType, "issue"),
+          eq(githubEntityChatMappings.entityKey, entityKey),
+        ),
+      );
+    expect(mapping).toHaveLength(1);
+    const chatId = mapping[0]?.chatId;
+    expect(chatId).toBeTruthy();
+    if (chatId) {
+      await expect(app.db.select().from(messages).where(eq(messages.chatId, chatId))).resolves.toHaveLength(1);
+      // The payoff of #1536 is that the tracking delegate is WOKEN, not just
+      // that a chat row exists.
+      expect(await notifyCount(app, chatId, delegate)).toBe(1);
+    }
+  });
+
+  it("self-echo carve-out end-to-end: resolveAudience → deliver mints a chat for a self-assigned issue (#1536)", async () => {
+    // Closes the loop the hand-built-target tests leave open: drive the REAL
+    // `resolveAudience` on a fresh `issues.opened` whose actor == assignee, so
+    // the self target is produced by the resolver (not hand-shaped), then let
+    // delivery mint the chat. This is the exact interaction #1536 broke —
+    // `resolveActorHumanId` resolving the actor to the same human the involve
+    // names, which the old blanket prune then dropped.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `human-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegate,
+      type: "human",
+    });
+    const entityKey = "owner/repo#1537";
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "issue",
+      entityKey,
+      rawEventType: "issues",
+      rawAction: "opened",
+      kind: "opened",
+      actorLogin: humanName,
+      involves: [{ githubLogin: humanName.toLowerCase(), reason: "assigned" }],
+    });
+
+    const resolution = await resolveAudience(app.db, event);
+    // The actor resolves to the self human, and the sole target is the fresh
+    // self-directed involve.
+    expect(resolution.actorHumanId).toBe(human);
+    expect(resolution.targets).toHaveLength(1);
+    expect(resolution.targets[0]).toMatchObject({ humanAgentId: human, kind: "new", involveReason: "assigned" });
+
+    const stats = await deliverNormalizedEvent(app, event, resolution.targets, {
+      actorHumanId: resolution.actorHumanId,
+    });
+    expect(stats).toEqual({ delivered: 1, newChats: 1, failed: 0 });
+
+    const mapping = await app.db
+      .select()
+      .from(githubEntityChatMappings)
+      .where(
+        and(
+          eq(githubEntityChatMappings.organizationId, admin.organizationId),
+          eq(githubEntityChatMappings.entityType, "issue"),
+          eq(githubEntityChatMappings.entityKey, entityKey),
+        ),
+      );
+    expect(mapping).toHaveLength(1);
+    const chatId = mapping[0]?.chatId;
+    expect(chatId).toBeTruthy();
+    if (chatId) {
+      expect(await notifyCount(app, chatId, delegate)).toBe(1);
+    }
+  });
+
+  it("self-echo boundary: a self-assign on an already-bound entity stays pruned (#1536)", async () => {
+    // The other side of the #1536 carve-out. When the entity ALREADY has a
+    // bound chat (`kind: "existing"`), a self-directed involve is a true echo
+    // of the actor's own action into a chat they already sit in — nothing new
+    // to create — so it must stay pruned even though it carries an
+    // `involveReason`. Locks the carve-out to `kind: "new"` only.
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const humanName = `human-${randomUUID().slice(0, 6)}`;
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: humanName,
+      delegateMention: delegate,
+      type: "human",
+    });
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
+    await app.db.insert(chatMembership).values([
+      { chatId, agentId: human, role: "owner", accessMode: "speaker", mode: "full", source: "manual" },
+      { chatId, agentId: delegate, role: "member", accessMode: "speaker", mode: "full", source: "manual" },
+    ]);
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "issue",
+      entityKey: "owner/repo#207",
+      chatId,
+      boundVia: "direct",
+    });
+    const target = {
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      kind: "existing",
+      chatId,
+      involveReason: "assigned",
+      involveLogin: humanName.toLowerCase(),
+    } satisfies AudienceTarget;
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "issue",
+      entityKey: "owner/repo#207",
+      rawEventType: "issues",
+      rawAction: "assigned",
+      actorLogin: humanName,
+      involves: [{ githubLogin: humanName.toLowerCase(), reason: "assigned" }],
+    });
+
+    const stats = await deliverNormalizedEvent(app, event, [target], { actorHumanId: human });
+    expect(stats).toEqual({ delivered: 0, newChats: 0, failed: 0 });
+    await expect(app.db.select().from(messages).where(eq(messages.chatId, chatId))).resolves.toHaveLength(0);
+    await expect(app.db.select().from(inboxEntries).where(eq(inboxEntries.chatId, chatId))).resolves.toHaveLength(0);
+  });
+
   it("humanA requesting humanB review prunes humanA's follow delivery and wakes humanB's delegate", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -83,15 +83,19 @@ export async function deliverNormalizedEvent(
     // chat they already sit in. The carve-out is a `kind: "new"` directed
     // involve — any non-null `involveReason` (`assigned` / `mentioned`;
     // `review_requested` can't name the actor themselves on GitHub, so it's
-    // inert here). `kind: "new"` means the entity has NO bound chat yet, so
-    // pruning wouldn't just drop an echo card — it would prevent the tracking
+    // inert here). `kind: "new"` is target-human-scoped: it means THIS involved
+    // human has no existing entity line (`resolveAudience` found no
+    // `subscribedByHuman` row for them) — NOT that the entity has no chat
+    // anywhere; other humans may already track it. Pruning such a target
+    // wouldn't just drop an echo card — it would prevent this human's tracking
     // chat from ever being created (the actor self-assigns / self-@s an entity
-    // — at creation or later — and it stays invisible to First Tree). A
+    // — at creation or later — and it stays invisible to their delegate). A
     // brand-new directed involve is an intentional "track this" signal, not a
-    // passive echo, so it must survive and mint the chat. Everything else that
-    // maps to the actor (subscribed echoes, and directed involves on an entity
-    // whose chat already exists → `kind: "existing"`) stays pruned: the chat is
-    // already there and the card would be a true self-echo. See #1536.
+    // passive echo, so it must survive and mint (or reuse this human's) chat.
+    // Everything else that maps to the actor (subscribed echoes, and directed
+    // involves where this human already has an entity line → `kind: "existing"`)
+    // stays pruned: that human's chat already exists and the card would be a
+    // true self-echo. See #1536.
     //
     // The `involveReason !== null` clause is defensive, not load-bearing:
     // `resolveAudience` only ever mints `kind: "new"` alongside a non-null

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -79,7 +79,27 @@ export async function deliverNormalizedEvent(
   // Phase 1 — resolve each target to a chat and merge into per-chat deliveries.
   const byChat = new Map<string, ChatDelivery>();
   for (const target of audience) {
-    if (actorHumanId && target.humanAgentId === actorHumanId) {
+    // Self-echo prune: suppress an actor's own action from echoing back to a
+    // chat they already sit in. The carve-out is a `kind: "new"` directed
+    // involve — any non-null `involveReason` (`assigned` / `mentioned`;
+    // `review_requested` can't name the actor themselves on GitHub, so it's
+    // inert here). `kind: "new"` means the entity has NO bound chat yet, so
+    // pruning wouldn't just drop an echo card — it would prevent the tracking
+    // chat from ever being created (the actor self-assigns / self-@s an entity
+    // — at creation or later — and it stays invisible to First Tree). A
+    // brand-new directed involve is an intentional "track this" signal, not a
+    // passive echo, so it must survive and mint the chat. Everything else that
+    // maps to the actor (subscribed echoes, and directed involves on an entity
+    // whose chat already exists → `kind: "existing"`) stays pruned: the chat is
+    // already there and the card would be a true self-echo. See #1536.
+    //
+    // The `involveReason !== null` clause is defensive, not load-bearing:
+    // `resolveAudience` only ever mints `kind: "new"` alongside a non-null
+    // reason, but `deliverNormalizedEvent` is exported and takes an arbitrary
+    // target list, so a future producer that mints `kind: "new"` with no reason
+    // fail-closes to pruning rather than inventing a chat.
+    const isFreshDirectedSelfInvolve = target.kind === "new" && target.involveReason !== null;
+    if (actorHumanId && target.humanAgentId === actorHumanId && !isFreshDirectedSelfInvolve) {
       continue;
     }
     let resolved: ResolvedChat | null;


### PR DESCRIPTION
## Problem

Creating a GitHub issue and assigning it to yourself did **not** create a First Tree tracking chat, even though the assignee's delegate agent is configured correctly (issue #1536's follow-up finding).

Root cause: the assignee and the actor resolve to the **same** First Tree human. The self-echo prune in `deliverNormalizedEvent` drops any audience target whose `humanAgentId === actorHumanId` — designed to stop a delegate's own GitHub actions from echoing back as cards. But it also killed the *only* audience target for a self-assignment, so the tracking chat was never minted and the entity stayed invisible to First Tree.

## Fix

Narrow the prune with one carve-out: a **`kind: "new"` directed involve** (non-null `involveReason`, i.e. `assigned` / `mentioned`) survives.

Why this is the exact right set:
- `kind: "new"` is **target-human scoped**: it means *this involved human* has no existing entity line (`resolveAudience` found no `subscribedByHuman` row for them) — **not** that the entity has no chat anywhere; other humans may already track it. Pruning such a target doesn't drop an echo card — it prevents *this human's* tracking chat from ever existing.
- Everything else that maps to the actor stays pruned: subscribed self-echoes, **and** self-directed involves where this human already has an entity line (`kind: "existing"`). Those are true echoes into a chat the human already sits in.
- The carve-out is keyed on **target-line freshness, not the `opened` event** — a later `assigned` / `mentioned` on a still-untracked target line mints the same way.

Guiding invariant: *the prune may suppress echo cards of your own action, but must never suppress creation of a tracking chat that would not otherwise exist.* Recorded in the paired, decision-locked Context Tree node — see **first-tree-context#700** (S11).

Someone-else assigning you, or you assigning a teammate whose delegate is configured, already worked (actor ≠ target). Only the self-actor==assignee case was broken.

### Known, intentional behavior widening
Because a delegate agent acts on GitHub *as the human's login*, a delegate that opens an entity and names the human (self-assign / @-mention) will now also mint a tracking chat. This is bounded to one chat per entity by the mapping primary key, and is the intended tradeoff. Flagged for awareness.

## Tests

- Fresh self-assigned issue mints a chat and wakes the delegate — both via a hand-built target and end-to-end through the real `resolveAudience`.
- A self-assign where the human already has an entity line **stays pruned** (locks the carve-out to `kind: "new"`).
- All existing echo-prune tests unchanged and green.

`pnpm check` + `@first-tree/server typecheck` clean; `github-delivery` / `github-audience` / webhook-route suites green (100+ github tests). Paired with decision-locked Context Tree PR **first-tree-context#700**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
