### PR TITLE
Fix Windows Task Scheduler XML encoding

### DIFF
--- a/apps/cli/src/__tests__/render-unit-channel.test.ts
+++ b/apps/cli/src/__tests__/render-unit-channel.test.ts
@@ -163,6 +163,10 @@ describe("renderWindowsTaskXml — channel identity baked into Task Scheduler te
   const wrapperPath = join(defaultHome(), "service", `${channelConfig.launchdLabel}-supervisor.cmd`);
   const taskXml = renderWindowsTaskXml(wrapperPath, "ACME\\developer");
 
+  it("declares the UTF-16 encoding used for the imported task XML file", () => {
+    expect(taskXml).toMatch(/^<\?xml version="1\.0" encoding="UTF-16"\?>/u);
+  });
+
   it("uses an interactive least-privilege logon trigger", () => {
     expect(taskXml).toContain("<LogonTrigger>");
     expect(taskXml).toContain("<LogonType>InteractiveToken</LogonType>");

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -34,6 +34,12 @@ const execFileSyncMock = vi.hoisted(() => vi.fn());
 const userInfoMock = vi.hoisted(() => vi.fn(() => ({ uid: 501, username: "gandy" })));
 const homedirMock = vi.hoisted(() => vi.fn(() => "/Users/gandy"));
 
+function readWindowsTaskXmlFixture(path: string): { raw: Buffer; xml: string } {
+  const raw = readFileSync(path);
+  const body = raw.toString("utf16le");
+  return { raw, xml: body.startsWith("\uFEFF") ? body.slice(1) : body };
+}
+
 vi.mock("node:child_process", () => ({
   spawnSync: spawnSyncMock,
   execFileSync: execFileSyncMock,
@@ -165,6 +171,7 @@ describe("service install helpers", () => {
     expect(windowsWrapper).toContain("supervisor.log");
     expect(windowsWrapper).toContain(" 2>&1");
     const taskXml = renderWindowsTaskXml("C:\\First Tree\\supervisor.cmd", "ACME\\gandy & team");
+    expect(taskXml).toMatch(/^<\?xml version="1\.0" encoding="UTF-16"\?>/u);
     expect(taskXml).toContain("<LogonTrigger>");
     expect(taskXml).toContain("<LogonType>InteractiveToken</LogonType>");
     expect(taskXml).toContain("ACME\\gandy &amp; team");
@@ -665,7 +672,7 @@ describe("service install helpers", () => {
 
     const info = installClientService();
     const wrapper = readFileSync(windowsSupervisorWrapperPath(), "utf-8");
-    const xml = readFileSync(windowsTaskXmlPath(), "utf-8");
+    const { raw: xmlRaw, xml } = readWindowsTaskXmlFixture(windowsTaskXmlPath());
 
     expect(info).toMatchObject({
       platform: "task-scheduler",
@@ -675,6 +682,8 @@ describe("service install helpers", () => {
     });
     expect(wrapper).toContain(`set "FIRST_TREE_HOME=${process.env.FIRST_TREE_HOME}"`);
     expect(wrapper).toContain('"daemon" "supervise"');
+    expect([...xmlRaw.subarray(0, 2)]).toEqual([0xff, 0xfe]);
+    expect(xml).toMatch(/^<\?xml version="1\.0" encoding="UTF-16"\?>/u);
     expect(xml).toContain("<LogonTrigger>");
     expect(xml).toContain("<LogonType>InteractiveToken</LogonType>");
     expect(xml).toContain("<RunLevel>LeastPrivilege</RunLevel>");
@@ -683,6 +692,32 @@ describe("service install helpers", () => {
       ["schtasks.exe", ["/Create", "/TN", windowsTaskName(), "/XML", windowsTaskXmlPath(), "/F"]],
       ["schtasks.exe", ["/Run", "/TN", windowsTaskName()]],
     ]);
+  });
+
+  it("does not report Windows Task Scheduler XML drift after UTF-16LE writes", () => {
+    setPlatform("win32");
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: "", stderr: "" });
+
+    installClientService();
+
+    spawnSyncMock.mockClear();
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: "Ready", stderr: "" });
+    expect(isServiceUnitDriftDetected()).toBe(false);
+  });
+
+  it("does not surface mojibake from localized Windows native command stderr", () => {
+    setPlatform("win32");
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "\uFFFD\uFFFD\uFFFD\uFFFD: XML" });
+
+    expect(() => installClientService()).toThrow(
+      "schtasks /Create failed: exit 1; Windows returned localized stderr that could not be decoded as UTF-8",
+    );
   });
 
   it("reports Windows Task Scheduler status from the task state plus service runtime marker", () => {

--- a/apps/cli/src/core/supervisor/task-scheduler.ts
+++ b/apps/cli/src/core/supervisor/task-scheduler.ts
@@ -65,6 +65,7 @@ type TrustedMarkersForStopResult = { ok: true; markers: LiveServiceRuntimeMarker
 
 const POWERSHELL_ARGS = ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command"] as const;
 const PID_REUSE_CREATION_TOLERANCE_MS = 5_000;
+const UTF_16LE_BOM = "\uFEFF";
 
 function windowsInfo(state: ServiceState, pid?: number, detail?: string): ServiceInfo {
   return {
@@ -86,6 +87,16 @@ function escapePowerShellSingleQuoted(value: string): string {
   return value.replace(/'/g, "''");
 }
 
+function windowsNativeFailureDetail(res: { stderr: string; code: number | null }): string {
+  const stderr = res.stderr.trim();
+  const fallback = `exit ${res.code ?? "unknown"}`;
+  if (!stderr) return fallback;
+  if (stderr.includes("\uFFFD")) {
+    return `${fallback}; Windows returned localized stderr that could not be decoded as UTF-8`;
+  }
+  return stderr;
+}
+
 function currentWindowsUserId(): string {
   const domain = process.env.USERDOMAIN?.trim();
   const username = process.env.USERNAME?.trim() || userInfo().username;
@@ -94,7 +105,7 @@ function currentWindowsUserId(): string {
 
 export function renderWindowsTaskXml(wrapperPath: string, userId = currentWindowsUserId()): string {
   const taskName = `${channelConfig.displayName} Client`;
-  return `<?xml version="1.0" encoding="UTF-8"?>
+  return `<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
     <Author>${escapeXml(userId)}</Author>
@@ -141,6 +152,23 @@ export function renderWindowsTaskXml(wrapperPath: string, userId = currentWindow
 `;
 }
 
+function encodeWindowsTaskXml(xml: string): Buffer {
+  return Buffer.from(`${UTF_16LE_BOM}${xml}`, "utf16le");
+}
+
+function readWindowsTaskXml(path: string): string {
+  const xml = readFileSync(path, "utf16le");
+  return xml.startsWith(UTF_16LE_BOM) ? xml.slice(1) : xml;
+}
+
+function readWindowsTaskXmlOrFlagDrift(path: string, expected: string): boolean {
+  try {
+    return readWindowsTaskXml(path) !== expected;
+  } catch {
+    return true;
+  }
+}
+
 function writeWindowsSupervisorFiles(): { wrapperPath: string; xmlPath: string } {
   const invocation = resolveCliInvocation();
   ensureLogDir();
@@ -148,7 +176,7 @@ function writeWindowsSupervisorFiles(): { wrapperPath: string; xmlPath: string }
   const wrapperPath = windowsSupervisorWrapperPath();
   const xmlPath = windowsTaskXmlPath();
   writeFileSync(wrapperPath, renderWindowsSupervisorCmd(invocation), { mode: 0o755 });
-  writeFileSync(xmlPath, renderWindowsTaskXml(wrapperPath), { mode: 0o600 });
+  writeFileSync(xmlPath, encodeWindowsTaskXml(renderWindowsTaskXml(wrapperPath)), { mode: 0o600 });
   return { wrapperPath, xmlPath };
 }
 
@@ -362,13 +390,13 @@ function statusFromTaskAndMarkers(): ServiceInfo {
 function createOrUpdateTask(xmlPath: string): void {
   const res = runCapture("schtasks.exe", ["/Create", "/TN", windowsTaskName(), "/XML", xmlPath, "/F"], 10_000);
   if (!res.ok) {
-    throw new Error(`schtasks /Create failed: ${res.stderr || `exit ${res.code ?? "unknown"}`}`);
+    throw new Error(`schtasks /Create failed: ${windowsNativeFailureDetail(res)}`);
   }
 }
 
 function runTask(): ServiceOpResult {
   const res = runCapture("schtasks.exe", ["/Run", "/TN", windowsTaskName()], 10_000);
-  if (!res.ok) return { ok: false, reason: res.stderr || `exit ${res.code ?? "unknown"}` };
+  if (!res.ok) return { ok: false, reason: windowsNativeFailureDetail(res) };
   return { ok: true };
 }
 
@@ -378,7 +406,7 @@ function endTask(): ServiceOpResult {
     if (/not currently running|is not running|cannot find|does not exist|not found/i.test(res.stderr)) {
       return { ok: true, detail: "not running" };
     }
-    return { ok: false, reason: res.stderr || `exit ${res.code ?? "unknown"}` };
+    return { ok: false, reason: windowsNativeFailureDetail(res) };
   }
   return { ok: true };
 }
@@ -409,7 +437,7 @@ function killRuntimeMarker(marker: LiveServiceRuntimeMarker): KillRuntimeMarkerR
   const forced = runCapture("taskkill.exe", ["/PID", String(marker.pid), "/T", "/F"], 10_000);
   if (waitForPidExit(marker.pid, forced.ok ? 5_000 : 0)) return { ok: true, killAttempted: true };
   if (!forced.ok) {
-    return { ok: false, reason: forced.stderr || `taskkill /F exit ${forced.code ?? "unknown"}`, killAttempted: true };
+    return { ok: false, reason: windowsNativeFailureDetail(forced), killAttempted: true };
   }
   return { ok: false, reason: `pid ${marker.pid} did not exit after taskkill /F`, killAttempted: true };
 }
@@ -450,7 +478,7 @@ function windowsTaskSchedulerDriftDetected(): boolean {
   const invocation = resolveCliInvocation();
   const wrapperPath = windowsSupervisorWrapperPath();
   const wrapperDrift = readFileOrFlagDrift(wrapperPath, renderWindowsSupervisorCmd(invocation));
-  const xmlDrift = readFileOrFlagDrift(windowsTaskXmlPath(), renderWindowsTaskXml(wrapperPath));
+  const xmlDrift = readWindowsTaskXmlOrFlagDrift(windowsTaskXmlPath(), renderWindowsTaskXml(wrapperPath));
   const taskMissing = taskState().state === "missing";
   return taskMissing || wrapperDrift || xmlDrift;
 }
@@ -532,7 +560,7 @@ function uninstallWindowsTaskScheduler(): ServiceInfo {
   }
   const res = runCapture("schtasks.exe", ["/Delete", "/TN", windowsTaskName(), "/F"], 10_000);
   if (!res.ok && !/cannot find|does not exist|not found/i.test(res.stderr)) {
-    throw new Error(`schtasks /Delete failed: ${res.stderr || `exit ${res.code ?? "unknown"}`}`);
+    throw new Error(`schtasks /Delete failed: ${windowsNativeFailureDetail(res)}`);
   }
   rmSync(windowsSupervisorWrapperPath(), { force: true });
   rmSync(windowsTaskXmlPath(), { force: true });


### PR DESCRIPTION
## Summary

- Write Windows Task Scheduler XML as UTF-16LE with a BOM and declare `encoding="UTF-16"` so `schtasks /Create /XML` can import the generated task reliably on Windows.
- Read the task XML back as UTF-16LE for drift detection, stripping the BOM before comparing with the rendered definition.
- Avoid surfacing mojibake from localized Windows native command stderr when `schtasks.exe` / `taskkill.exe` output cannot be decoded as UTF-8.

## Context

Follow-up to the Windows Task Scheduler supervisor backend. A Windows PowerShell run of `first-tree-staging login <code>` authenticated and registered the computer, then failed during Task Scheduler import with an XML parse error at the XML declaration encoding field.

## Validation

- `pnpm --filter first-tree-dev test --maxWorkers=2 --minWorkers=1 src/__tests__/service-install-core.test.ts src/__tests__/render-unit-channel.test.ts`
- `pnpm --filter first-tree-dev typecheck`
- `git diff --check`
- `pnpm check` (exits 0; reports existing warnings/info outside this PR's files)
- Clean-env full `first-tree-dev` test before the final main sync/stderr fallback: 89 files / 972 tests passed
