### PR TITLE
fix: clarify Claude provider connection failures

### DIFF
--- a/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
@@ -268,7 +268,7 @@ describe("claude-code handler — structured provider error result", () => {
       replaySafety: "user_visible",
     });
     expect(formatProviderFailureRuntimeNotice(firstProviderPayload(providerPayloads))).toContain(
-      "Anthropic connection failed after retry handling",
+      "provider API connection failed after retry handling",
     );
     expect(completed[0]?.outcome).toMatchObject({
       status: "error",

--- a/packages/client/src/__tests__/provider-retry-policy.test.ts
+++ b/packages/client/src/__tests__/provider-retry-policy.test.ts
@@ -125,7 +125,11 @@ describe("classifyProviderFailure", () => {
   });
 
   it("maps network and 5xx failures to transient_transport", () => {
-    for (const err of [new Error("fetch failed"), Object.assign(new Error("upstream 503"), { status: 503 })]) {
+    for (const err of [
+      new Error("fetch failed"),
+      new Error("API Error: Unable to connect to API (ConnectionRefused)"),
+      Object.assign(new Error("upstream 503"), { status: 503 }),
+    ]) {
       expect(classifyProviderFailure(err, { provider: "codex", scope: "provider_turn", source: "sdk" }).category).toBe(
         "transient_transport",
       );

--- a/packages/client/src/__tests__/runtime-notice.test.ts
+++ b/packages/client/src/__tests__/runtime-notice.test.ts
@@ -100,7 +100,7 @@ describe("runtime notice formatting", () => {
 
   it("formats remaining Claude provider-turn categories", () => {
     const cases: Array<[ProviderRetryEventPayload["category"], string]> = [
-      ["transient_transport", "Anthropic connection failed"],
+      ["transient_transport", "custom ANTHROPIC_BASE_URL"],
       ["configuration", "runtime configuration is invalid"],
       ["deterministic_input", "Anthropic rejected this request as invalid"],
       ["capability", "runtime is not launchable"],

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -2075,7 +2075,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     const notice = String(sendMessage.mock.calls[0]?.[1].content);
-    expect(notice).toContain("Anthropic connection failed after retry handling");
+    expect(notice).toContain("provider API connection failed after retry handling");
     expect(notice).toContain("socket connection was closed unexpectedly");
     expect(ackEntry).toHaveBeenCalledWith(25);
 
@@ -2127,7 +2127,7 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     const notice = String(sendMessage.mock.calls[0]?.[1].content);
-    expect(notice).toContain("Anthropic connection failed after retry handling");
+    expect(notice).toContain("provider API connection failed after retry handling");
     expect(notice).toContain("initial sdk transport crash");
     expect(notice).toContain("respawn build failed");
     expect(ackEntry).toHaveBeenCalledWith(26);

--- a/packages/client/src/runtime/provider-retry-policy.ts
+++ b/packages/client/src/runtime/provider-retry-policy.ts
@@ -454,7 +454,7 @@ function isCapacity(text: string, base: Classification, retryAfterMs: number | u
 function isTransportText(text: string): boolean {
   return (
     TRANSIENT_HTTP_CODE_RE.test(text) ||
-    /server error|server_error|unavailable|timed out|timeout|fetch failed|network|econnreset|econnrefused|etimedout|epipe/.test(
+    /server error|server_error|unavailable|timed out|timeout|fetch failed|network|unable to connect|connection refused|connectionrefused|econnreset|econnrefused|etimedout|epipe/.test(
       text,
     )
   );

--- a/packages/client/src/runtime/runtime-notice.ts
+++ b/packages/client/src/runtime/runtime-notice.ts
@@ -99,7 +99,11 @@ function claudeProviderTurnNoticeLead(payload: ProviderRetryEventPayload): strin
     return "Claude Code could not run this turn: Anthropic reported a capacity or usage limit. Wait or switch accounts, then retry.";
   }
   if (payload.category === "transient_transport") {
-    return "Claude Code could not run this turn: the Anthropic connection failed after retry handling. Retry later.";
+    return (
+      "Claude Code could not run this turn: the provider API connection failed after retry handling. " +
+      `If you use a proxy or custom ANTHROPIC_BASE_URL, make sure the daemon has those env vars via ${daemonEnvFile()} ` +
+      "and that the upstream endpoint is reachable, then retry."
+    );
   }
   if (payload.category === "configuration") {
     return "Claude Code could not run this turn: the Claude runtime configuration is invalid. Update the agent or provider configuration, then retry.";


### PR DESCRIPTION
## Summary

- classify Anthropic SDK `Unable to connect to API (ConnectionRefused)` messages as transient provider transport failures instead of unknown failures
- update Claude provider-turn runtime notices to point users at proxy/custom `ANTHROPIC_BASE_URL` daemon environment setup and upstream reachability
- refresh runtime notice tests that assert the durable chat notice posted before ACKing terminal provider failures

## Root Cause

The provider retry classifier recognized `ECONNREFUSED`, `fetch failed`, and generic network wording, but not the Anthropic SDK's `ConnectionRefused` text. That left the failure in the generic `unknown` path, which produced the vague "provider status" notice reported in #1547.

## Validation

- `pnpm --filter @first-tree/client exec vitest run src/__tests__/provider-retry-policy.test.ts src/__tests__/runtime-notice.test.ts src/__tests__/claude-provider-error.test.ts src/__tests__/claude-code-provider-error-result.test.ts src/__tests__/session-manager.test.ts`
- `pnpm --filter @first-tree/client test`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm typecheck`
- `pnpm check` (exit 0; existing unrelated Biome warnings remain in `assistant-text.test.ts`, `workspace-migrations.ts`, and `packages/web/src/index.css`)

Closes #1547
