### PR TITLE
[codex] Sort chat participants by activity

### DIFF
--- a/packages/web/src/components/chat/__tests__/compose-status-bar.test.ts
+++ b/packages/web/src/components/chat/__tests__/compose-status-bar.test.ts
@@ -34,13 +34,23 @@ describe("selectAttention — the bar surfaces only actionable/active states, mo
     expect(idx).toEqual([...idx].sort((x, y) => x - y));
   });
 
-  it("uses the shared participant order when supplied", () => {
+  it("keeps failed attention ahead of the shared participant order", () => {
     const working = mk("working", { working: true });
     const failed = mk("failed", { errored: true });
 
     expect(selectAttention([failed, working], ["working", "failed"]).map((s) => s.agentId)).toEqual([
-      "working",
       "failed",
+      "working",
+    ]);
+  });
+
+  it("uses the shared participant order within the same attention tier", () => {
+    const workingA = mk("working-a", { working: true });
+    const workingB = mk("working-b", { working: true });
+
+    expect(selectAttention([workingA, workingB], ["working-b", "working-a"]).map((s) => s.agentId)).toEqual([
+      "working-b",
+      "working-a",
     ]);
   });
 

--- a/packages/web/src/components/chat/__tests__/compose-status-bar.test.ts
+++ b/packages/web/src/components/chat/__tests__/compose-status-bar.test.ts
@@ -1,6 +1,6 @@
 import { type AgentChatStatusInput, buildAgentChatStatus, MAIN_STATUS_PRIORITY } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
-import { pickLead, selectAttention, statusReasonView } from "../compose-status-bar.js";
+import { selectAttention, statusReasonView } from "../compose-status-bar.js";
 
 const mk = (agentId: string, over: Partial<AgentChatStatusInput>) =>
   buildAgentChatStatus({
@@ -32,6 +32,16 @@ describe("selectAttention — the bar surfaces only actionable/active states, mo
     const out = selectAttention([mk("w", { working: true }), mk("f", { errored: true })]);
     const idx = out.map((s) => MAIN_STATUS_PRIORITY.indexOf(s.main));
     expect(idx).toEqual([...idx].sort((x, y) => x - y));
+  });
+
+  it("uses the shared participant order when supplied", () => {
+    const working = mk("working", { working: true });
+    const failed = mk("failed", { errored: true });
+
+    expect(selectAttention([failed, working], ["working", "failed"]).map((s) => s.agentId)).toEqual([
+      "working",
+      "failed",
+    ]);
   });
 
   it("surfaces provider retry reasons without requiring the status to be working", () => {
@@ -116,42 +126,5 @@ describe("selectAttention — the bar surfaces only actionable/active states, mo
 
     expect(selectAttention([workingWithTerminalReason]).map((s) => s.agentId)).toEqual(["working-terminal"]);
     expect(statusReasonView(workingWithTerminalReason)).toBeNull();
-  });
-});
-
-const workingAt = (id: string, startedAt: string) =>
-  mk(id, { working: true, activity: { agentId: id, kind: "tool_call", label: "Bash", startedAt } });
-
-describe("pickLead — rail lead with anti-flicker", () => {
-  const NOW = 1_000_000;
-  const HOLD = 4000;
-  const atlas = workingAt("atlas", "2026-05-22T00:00:00.000Z");
-  const beacon = workingAt("beacon", "2026-05-22T00:00:05.000Z"); // more recent than atlas
-
-  it("an alert (failure) preempts immediately, regardless of the held working lead", () => {
-    const failed = mk("cypher", { errored: true });
-    expect(pickLead({ agentId: "atlas", since: NOW }, NOW + 100, [failed], [atlas], HOLD)?.agentId).toBe("cypher");
-  });
-
-  it("with no current lead, picks the most-recently-active working agent", () => {
-    expect(pickLead(null, NOW, [], [atlas, beacon], HOLD)?.agentId).toBe("beacon");
-  });
-
-  it("holds the current working lead until the hold elapses", () => {
-    expect(pickLead({ agentId: "atlas", since: NOW }, NOW + 1000, [], [atlas, beacon], HOLD)?.agentId).toBe("atlas");
-  });
-
-  it("switches to the most-recent working agent once the hold elapses", () => {
-    expect(pickLead({ agentId: "atlas", since: NOW }, NOW + HOLD + 1, [], [atlas, beacon], HOLD)?.agentId).toBe(
-      "beacon",
-    );
-  });
-
-  it("if the held lead is no longer working, picks the most-recent immediately", () => {
-    expect(pickLead({ agentId: "gone", since: NOW }, NOW + 100, [], [atlas, beacon], HOLD)?.agentId).toBe("beacon");
-  });
-
-  it("returns null when nothing is active", () => {
-    expect(pickLead(null, NOW, [], [], HOLD)).toBeNull();
   });
 });

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -52,8 +52,9 @@ function visibleStatusReason(status: AgentChatStatus): AgentChatStatus["statusRe
 
 /**
  * The agents worth raising the bar for — failed / working — sorted
- * by the caller's participant order when provided. ready / paused / offline
- * are filtered out unless they carry a visible provider status reason.
+ * by recovery severity first, then the caller's participant order when
+ * provided. ready / paused / offline are filtered out unless they carry a
+ * visible provider status reason.
  * Exported for tests.
  */
 export function selectAttention(
@@ -67,12 +68,14 @@ export function selectAttention(
   return statuses
     .filter((s) => ATTENTION.has(s.main) || visibleStatusReason(s) !== undefined)
     .sort((a, b) => {
+      const rank = attentionRank(a) - attentionRank(b);
+      if (rank !== 0) return rank;
       const aOrder = order.get(a.agentId);
       const bOrder = order.get(b.agentId);
       if (aOrder !== undefined && bOrder !== undefined && aOrder !== bOrder) return aOrder - bOrder;
       if (aOrder !== undefined) return -1;
       if (bOrder !== undefined) return 1;
-      return attentionRank(a) - attentionRank(b) || compareMainStatus(a.main, b.main);
+      return compareMainStatus(a.main, b.main);
     });
 }
 

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -25,9 +25,8 @@ import { formatElapsed } from "./working-chip.js";
  * Scope: only **working** and **failed** raise the bar.
  *
  * Single line = lead + N:
- *   - lead = the highest-priority active agent (failed > working; within
- *     working, the most-recently-active, held ~4s so working agents don't swap
- *     faces too fast — but a failure preempts immediately).
+ *   - lead = the first active agent in the chat's shared participant order
+ *     (currently-working agents first, then recent chat activity).
  *   - lead shows `[coloured dot] <name> · <goal> · <tool> · 12s`: working puts
  *     the agent's running narration (`turnText`, the *goal* — what it's trying
  *     to do) first, then the live action (the *means* — `Bash · npm test`,
@@ -44,33 +43,37 @@ import { formatElapsed } from "./working-chip.js";
  */
 const ATTENTION: ReadonlySet<string> = new Set(["failed", "working"]);
 const TICK_INTERVAL_MS = 1000;
-const LEAD_HOLD_MS = 4000;
 const EXPANDED_MAX_HEIGHT = 180;
-
-/** A failure preempts the working-lead anti-flicker hold (see {@link pickLead}).
- *  "alert" is just "failed". */
-function isAlert(s: AgentChatStatus): boolean {
-  return s.main === "failed" || isFatalStatusReason(s);
-}
 
 function visibleStatusReason(status: AgentChatStatus): AgentChatStatus["statusReason"] {
   if (status.main === "working" && status.statusReason?.kind === "terminal") return undefined;
   return status.statusReason;
 }
 
-function activityStartedMs(s: AgentChatStatus): number {
-  return s.activity ? new Date(s.activity.startedAt).getTime() : 0;
-}
-
 /**
  * The agents worth raising the bar for — failed / working — sorted
- * highest-attention first. ready / paused / offline are filtered out.
+ * by the caller's participant order when provided. ready / paused / offline
+ * are filtered out unless they carry a visible provider status reason.
  * Exported for tests.
  */
-export function selectAttention(statuses: AgentChatStatus[]): AgentChatStatus[] {
+export function selectAttention(
+  statuses: AgentChatStatus[],
+  orderedAgentIds: ReadonlyArray<string> = [],
+): AgentChatStatus[] {
+  const order = new Map<string, number>();
+  orderedAgentIds.forEach((agentId, idx) => {
+    order.set(agentId, idx);
+  });
   return statuses
     .filter((s) => ATTENTION.has(s.main) || visibleStatusReason(s) !== undefined)
-    .sort((a, b) => attentionRank(a) - attentionRank(b) || compareMainStatus(a.main, b.main));
+    .sort((a, b) => {
+      const aOrder = order.get(a.agentId);
+      const bOrder = order.get(b.agentId);
+      if (aOrder !== undefined && bOrder !== undefined && aOrder !== bOrder) return aOrder - bOrder;
+      if (aOrder !== undefined) return -1;
+      if (bOrder !== undefined) return 1;
+      return attentionRank(a) - attentionRank(b) || compareMainStatus(a.main, b.main);
+    });
 }
 
 function attentionRank(status: AgentChatStatus): number {
@@ -86,32 +89,6 @@ function attentionRank(status: AgentChatStatus): number {
 function isFatalStatusReason(status: AgentChatStatus): boolean {
   const reason = visibleStatusReason(status);
   return reason?.kind === "terminal" && reason.severity === "error";
-}
-
-/**
- * Pick the rail's lead with anti-flicker, given the previously-held lead.
- * Pure & exported for tests.
- *
- * Rules: an alert (failed) preempts immediately. Among working agents the
- * most-recently-active is the candidate, but if the current lead is still
- * working it's held until `holdMs` has elapsed (so working agents don't swap
- * faces every tick). Returns the new held lead (`{ agentId, since }`), or null
- * when nothing is active.
- */
-export function pickLead(
-  current: { agentId: string; since: number } | null,
-  now: number,
-  alerts: AgentChatStatus[],
-  working: AgentChatStatus[],
-  holdMs: number,
-): { agentId: string; since: number } | null {
-  const alert = alerts[0];
-  if (alert) return { agentId: alert.agentId, since: now };
-  const mostRecent = [...working].sort((a, b) => activityStartedMs(b) - activityStartedMs(a))[0];
-  if (!mostRecent) return null; // nothing working
-  const heldStillWorking = current !== null && working.some((w) => w.agentId === current.agentId);
-  if (heldStillWorking && now - current.since < holdMs) return current; // hold the current face
-  return { agentId: mostRecent.agentId, since: now };
 }
 
 /** Live wall-clock elapsed since `startedAt`, re-rendering each second. */
@@ -148,7 +125,6 @@ export function ComposeStatusBar({
   // Stable so TurnTextCard's document-listener effect doesn't re-subscribe on
   // every parent re-render (query refetch / elapsed tick).
   const closeCard = useCallback(() => setCardOpenFor(null), []);
-  const [lead, setLead] = useState<{ agentId: string; since: number } | null>(null);
   const { data: rawStatuses } = useQuery({
     queryKey: chatAgentStatusQueryKey(chatId),
     queryFn: () => fetchChatAgentStatuses(chatId),
@@ -169,26 +145,9 @@ export function ComposeStatusBar({
   // (runtime_state + freshness stamp) and pushed via admin-WS delta, so the
   // local stale-clear ticker that used to live here is gone — the server
   // self-heals after RUNTIME_STALE_MS and pushes the delta down.
-  // Re-pick the lead whenever the status set changes, and once more after
-  // the hold could expire so a steadily most-recent agent can take over
-  // even with no new data. pickLead is pure; the timer just lets the hold
-  // lapse.
-  useEffect(() => {
-    const attention = selectAttention(statuses ?? []);
-    const alerts = attention.filter(isAlert);
-    const working = attention.filter((s) => s.main === "working");
-    const repick = () => setLead((prev) => pickLead(prev, Date.now(), alerts, working, LEAD_HOLD_MS));
-    repick();
-    const t = setTimeout(repick, LEAD_HOLD_MS);
-    return () => clearTimeout(t);
-  }, [statuses]);
-
-  const attention = selectAttention(statuses ?? []);
-  // Resolve the held lead to a live row; fall back to the top of `attention`
-  // before the effect has settled (or if the held agent just dropped out).
-  // Computed before the early returns so the stale-card effect below runs
-  // unconditionally (Rules of Hooks).
-  const leadRow = (lead && attention.find((s) => s.agentId === lead.agentId)) ?? attention[0];
+  const orderedAgentIds = useMemo(() => agents.map((agent) => agent.agentId), [agents]);
+  const attention = useMemo(() => selectAttention(statuses ?? [], orderedAgentIds), [statuses, orderedAgentIds]);
+  const leadRow = attention[0];
   // The lead's full narration — present only when the server attached
   // `turnTextFull` (strictly more than the one-line goal). Only working leads
   // carry live activity.

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1,5 +1,6 @@
 import {
   type Agent,
+  type AgentChatStatus,
   type AttachmentRef,
   attachmentRefsFromMetadata,
   type CapabilityEntry,
@@ -121,7 +122,7 @@ import { UnreadDivider } from "../../../components/unread-divider.js";
 import { useChatScroll } from "../../../hooks/use-chat-scroll.js";
 import { useReadTracker } from "../../../hooks/use-read-tracker.js";
 import { useServerChannel } from "../../../hooks/use-server-channel.js";
-import { viewOf } from "../../../lib/agent-status-view.js";
+import { reconcileLiveTurn, viewOf } from "../../../lib/agent-status-view.js";
 import { attachmentIdFromHref, parseFailedDocHref, wrapFailedDocMentions } from "../../../lib/doc-preview-links.js";
 import { parkFailedDraftIfSwitched } from "../../../lib/draft-store.js";
 import { isNavigableWebHref } from "../../../lib/safe-href.js";
@@ -141,6 +142,7 @@ import { filterEventsForTimeline } from "../../../utils/session-timeline.js";
 import { PROVIDER_LABEL } from "../../clients/cards/shared/providers.js";
 import { RuntimeAuthControls } from "../../clients/cards/shared/runtime-auth-controls.js";
 import { loginTargetProvider } from "../../clients/cards/shared/runtime-auth-view.js";
+import { orderParticipantsByActivity } from "../participant-order.js";
 import { ChatRightSidebar } from "../right-sidebar/index.js";
 import { ChatSummary } from "./chat-summary.js";
 
@@ -1711,6 +1713,14 @@ export function ChatView({
     staleTime: 10_000,
   });
 
+  const hasNonHumanParticipants = chatDetail?.participants.some((p) => p.type !== "human") ?? false;
+  const { data: participantStatuses } = useQuery({
+    queryKey: chatAgentStatusQueryKey(chatId),
+    queryFn: () => fetchChatAgentStatuses(chatId),
+    enabled: !!chatId && hasNonHumanParticipants,
+    refetchInterval: 30_000,
+  });
+
   // The right rail no longer auto-opens per chat: the running summary moved to
   // the pinned ChatSummary (above the stream), so the rail — now just
   // participants + GitHub bindings — simply follows the user's stored
@@ -2451,6 +2461,17 @@ export function ChatView({
           .filter((id): id is string => id != null),
       ),
     [items],
+  );
+
+  const orderedParticipants = useMemo(
+    () =>
+      orderParticipantsByActivity(
+        chatDetail?.participants ?? [],
+        mergedMessages,
+        participantStatuses ?? [],
+        liveTurnAgentIds,
+      ),
+    [chatDetail?.participants, mergedMessages, participantStatuses, liveTurnAgentIds],
   );
 
   // Blocking truncation: while a question blocks me (the FIFO-oldest live
@@ -3772,9 +3793,10 @@ export function ChatView({
               opens the same dropdown the sidebar's "+ Add participant"
               uses (shared backend mutation, single one-way-door notice). */}
                   <ParticipantsStats
-                    participants={chatDetail?.participants ?? []}
-                    chatId={chatId}
+                    participants={orderedParticipants}
                     agentIdentity={chatScopedAgentIdentity}
+                    statuses={participantStatuses ?? []}
+                    liveTurnAgentIds={liveTurnAgentIds}
                     onOpen={() => setSidebarByUser(true)}
                   />
                   {/* Vertical divider splits "look" (avatar strip = identity +
@@ -4013,10 +4035,7 @@ export function ChatView({
                         {formatTokenCount(chatProcessedTokens)} processed tokens in this chat
                       </div>
                     ) : null}
-                    <ComposeStatusBar
-                      chatId={chatId}
-                      agents={(chatDetail?.participants ?? []).filter((p) => p.type !== "human")}
-                    />
+                    <ComposeStatusBar chatId={chatId} agents={orderedParticipants.filter((p) => p.type !== "human")} />
                     {/* A blocking question is answered in the full-coverage
                         AskTakeover overlay (rendered over the workspace), not in
                         the composer. */}
@@ -4497,7 +4516,7 @@ export function ChatView({
               <div className="absolute top-0 bottom-0 right-0 z-30 flex" style={{ boxShadow: "var(--shadow-md)" }}>
                 <ChatRightSidebar
                   chatId={chatId}
-                  participants={chatDetail?.participants ?? []}
+                  participants={orderedParticipants}
                   participantsLoading={chatDetailLoading}
                   managedByMe={managedByMeMap}
                   onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
@@ -4509,7 +4528,7 @@ export function ChatView({
           ) : (
             <ChatRightSidebar
               chatId={chatId}
-              participants={chatDetail?.participants ?? []}
+              participants={orderedParticipants}
               participantsLoading={chatDetailLoading}
               managedByMe={managedByMeMap}
               onAdded={() => queryClient.invalidateQueries({ queryKey: ["chat-detail", chatId] })}
@@ -4538,23 +4557,26 @@ const MAX_VISIBLE_AVATARS = 4;
 
 function ParticipantsStats({
   participants,
-  chatId,
   agentIdentity,
+  statuses,
+  liveTurnAgentIds,
   onOpen,
 }: {
   participants: ChatParticipantDetail[];
-  chatId: string;
   agentIdentity: (uuid: string | null | undefined) => {
     name: string | null;
     displayName: string;
     avatarImageUrl: string | null;
     avatarColorToken: string | null;
   } | null;
+  statuses: ReadonlyArray<AgentChatStatus>;
+  liveTurnAgentIds: ReadonlySet<string>;
   onOpen: () => void;
 }) {
   if (participants.length === 0) return null;
   const visible = participants.slice(0, MAX_VISIBLE_AVATARS);
   const overflow = participants.length - visible.length;
+  const statusByAgent = new Map(statuses.map((status) => [status.agentId, status]));
 
   return (
     <div className="inline-flex items-center" style={{ paddingLeft: 0 }}>
@@ -4562,8 +4584,9 @@ function ParticipantsStats({
         <ParticipantAvatar
           key={p.agentId}
           participant={p}
-          chatId={chatId}
           agentIdentity={agentIdentity}
+          status={statusByAgent.get(p.agentId) ?? null}
+          hasLiveTurn={liveTurnAgentIds.has(p.agentId)}
           stackIndex={idx}
           onOpen={onOpen}
         />
@@ -4594,19 +4617,21 @@ function ParticipantsStats({
 
 function ParticipantAvatar({
   participant,
-  chatId,
   agentIdentity,
+  status,
+  hasLiveTurn,
   stackIndex,
   onOpen,
 }: {
   participant: ChatParticipantDetail;
-  chatId: string;
   agentIdentity: (uuid: string | null | undefined) => {
     name: string | null;
     displayName: string;
     avatarImageUrl: string | null;
     avatarColorToken: string | null;
   } | null;
+  status: AgentChatStatus | null;
+  hasLiveTurn: boolean;
   stackIndex: number;
   onOpen: () => void;
 }) {
@@ -4615,18 +4640,10 @@ function ParticipantAvatar({
   const label = ident?.displayName ?? ident?.name ?? participant.agentId.slice(0, 8);
 
   // Composite per-agent status for the dot, from the chat-level /agent-status
-  // query — the same key the sidebar's AgentStatusPanel uses, so React Query
-  // dedupes it to one request and the admin WS keeps it live (no per-avatar
-  // poll). Humans have no runtime status. Rendered through the shared
-  // viewOf / StatusGlyph vocabulary so the header strip and the sidebar agree.
-  const { data: statuses } = useQuery({
-    queryKey: chatAgentStatusQueryKey(chatId),
-    queryFn: () => fetchChatAgentStatuses(chatId),
-    enabled: !isHuman,
-    refetchInterval: 30_000,
-  });
-  const status = isHuman ? undefined : statuses?.find((s) => s.agentId === participant.agentId);
-  const view = status ? viewOf(status.main) : null;
+  // query owned by ChatView. Reconcile with the live timeline turn so the
+  // header and sidebar can't disagree while a turn is visibly running.
+  const displayStatus = !isHuman && status ? reconcileLiveTurn(status, hasLiveTurn) : null;
+  const view = displayStatus ? viewOf(displayStatus.main) : null;
   const stateText = view ? view.label : isHuman ? "human" : "…";
 
   return (

--- a/packages/web/src/pages/workspace/participant-order.ts
+++ b/packages/web/src/pages/workspace/participant-order.ts
@@ -16,10 +16,29 @@ function isActiveAgent(
   return liveTurnAgentIds.has(participant.agentId) || status?.working === true || status?.main === "working";
 }
 
+function isRecoveryAgent(participant: ChatParticipantDetail, status: AgentChatStatus | null): boolean {
+  if (participant.type === "human" || !status) return false;
+  return (
+    status.main === "failed" ||
+    (status.main !== "working" && status.statusReason?.kind === "terminal" && status.statusReason.severity === "error")
+  );
+}
+
+function participantTier(
+  participant: ChatParticipantDetail,
+  status: AgentChatStatus | null,
+  liveTurnAgentIds: ReadonlySet<string>,
+): number {
+  if (isRecoveryAgent(participant, status)) return 0;
+  if (isActiveAgent(participant, status, liveTurnAgentIds)) return 1;
+  return 2;
+}
+
 /**
  * Rank the chat-local roster by what matters in the conversation:
- * currently-working agents first, then the most recent speakers, then the
- * server's stable membership order for ties/no-activity rows.
+ * failed/fatal recovery agents first, then currently-working agents, then the
+ * most recent speakers, then the server's stable membership order for
+ * ties/no-activity rows.
  */
 export function orderParticipantsByActivity(
   participants: ChatParticipantDetail[],
@@ -43,9 +62,11 @@ export function orderParticipantsByActivity(
   const statusByAgent = new Map(statuses.map((status) => [status.agentId, status]));
 
   return [...participants].sort((a, b) => {
-    const aActive = isActiveAgent(a, statusByAgent.get(a.agentId) ?? null, liveTurnAgentIds);
-    const bActive = isActiveAgent(b, statusByAgent.get(b.agentId) ?? null, liveTurnAgentIds);
-    if (aActive !== bActive) return aActive ? -1 : 1;
+    const aStatus = statusByAgent.get(a.agentId) ?? null;
+    const bStatus = statusByAgent.get(b.agentId) ?? null;
+    const aTier = participantTier(a, aStatus, liveTurnAgentIds);
+    const bTier = participantTier(b, bStatus, liveTurnAgentIds);
+    if (aTier !== bTier) return aTier - bTier;
 
     const aActivity = latestActivity.get(a.agentId);
     const bActivity = latestActivity.get(b.agentId);

--- a/packages/web/src/pages/workspace/participant-order.ts
+++ b/packages/web/src/pages/workspace/participant-order.ts
@@ -1,0 +1,75 @@
+import type { AgentChatStatus, ChatParticipantDetail } from "@first-tree/shared";
+
+export const VISIBLE_LIMIT = 5;
+
+export type ParticipantActivityMessage = {
+  senderId: string;
+  createdAt: string;
+};
+
+function isActiveAgent(
+  participant: ChatParticipantDetail,
+  status: AgentChatStatus | null,
+  liveTurnAgentIds: ReadonlySet<string>,
+): boolean {
+  if (participant.type === "human") return false;
+  return liveTurnAgentIds.has(participant.agentId) || status?.working === true || status?.main === "working";
+}
+
+/**
+ * Rank the chat-local roster by what matters in the conversation:
+ * currently-working agents first, then the most recent speakers, then the
+ * server's stable membership order for ties/no-activity rows.
+ */
+export function orderParticipantsByActivity(
+  participants: ChatParticipantDetail[],
+  messages: ReadonlyArray<ParticipantActivityMessage>,
+  statuses: ReadonlyArray<AgentChatStatus> = [],
+  liveTurnAgentIds: ReadonlySet<string> = new Set(),
+): ChatParticipantDetail[] {
+  const originalIndex = new Map<string, number>();
+  participants.forEach((p, idx) => {
+    originalIndex.set(p.agentId, idx);
+  });
+
+  const latestActivity = new Map<string, string>();
+  for (const message of messages) {
+    const previous = latestActivity.get(message.senderId);
+    if (!previous || previous.localeCompare(message.createdAt) < 0) {
+      latestActivity.set(message.senderId, message.createdAt);
+    }
+  }
+
+  const statusByAgent = new Map(statuses.map((status) => [status.agentId, status]));
+
+  return [...participants].sort((a, b) => {
+    const aActive = isActiveAgent(a, statusByAgent.get(a.agentId) ?? null, liveTurnAgentIds);
+    const bActive = isActiveAgent(b, statusByAgent.get(b.agentId) ?? null, liveTurnAgentIds);
+    if (aActive !== bActive) return aActive ? -1 : 1;
+
+    const aActivity = latestActivity.get(a.agentId);
+    const bActivity = latestActivity.get(b.agentId);
+    if (aActivity && bActivity && aActivity !== bActivity) return bActivity.localeCompare(aActivity);
+    if (aActivity !== bActivity) return aActivity ? -1 : 1;
+
+    return (originalIndex.get(a.agentId) ?? 0) - (originalIndex.get(b.agentId) ?? 0);
+  });
+}
+
+export function partitionRoster(
+  participants: ChatParticipantDetail[],
+  showAll: boolean,
+  limit: number = VISIBLE_LIMIT,
+): {
+  total: number;
+  visibleParticipants: ChatParticipantDetail[];
+  hiddenCount: number;
+} {
+  const total = participants.length;
+  const visibleParticipants = showAll ? participants : participants.slice(0, limit);
+  return {
+    total,
+    visibleParticipants,
+    hiddenCount: total - visibleParticipants.length,
+  };
+}

--- a/packages/web/src/pages/workspace/right-sidebar/__tests__/participants-roster.test.ts
+++ b/packages/web/src/pages/workspace/right-sidebar/__tests__/participants-roster.test.ts
@@ -68,6 +68,47 @@ const statusBase: Omit<AgentChatStatusInput, "agentId"> = {
 };
 
 describe("orderParticipantsByActivity", () => {
+  it("keeps failed agents ahead of working and recent speakers", () => {
+    const roster = [participant("working", "agent"), participant("human-1", "human"), participant("failed", "agent")];
+
+    const ordered = orderParticipantsByActivity(
+      roster,
+      [{ senderId: "human-1", createdAt: "2026-07-09T04:00:00.000Z" }],
+      [
+        buildAgentChatStatus({ ...statusBase, agentId: "working", working: true }),
+        buildAgentChatStatus({ ...statusBase, agentId: "failed", errored: true }),
+      ],
+    );
+
+    expect(ordered.map((p) => p.agentId)).toEqual(["failed", "working", "human-1"]);
+  });
+
+  it("keeps fatal terminal recovery reasons ahead of recent speakers", () => {
+    const roster = [participant("human-1", "human"), participant("fatal", "agent")];
+
+    const ordered = orderParticipantsByActivity(
+      roster,
+      [{ senderId: "human-1", createdAt: "2026-07-09T04:00:00.000Z" }],
+      [
+        buildAgentChatStatus({
+          ...statusBase,
+          agentId: "fatal",
+          statusReason: {
+            kind: "terminal",
+            severity: "error",
+            provider: "codex",
+            scope: "provider_turn",
+            category: "unknown",
+            reasonCode: "unknown_exhausted",
+            label: "Provider retry exhausted",
+          },
+        }),
+      ],
+    );
+
+    expect(ordered.map((p) => p.agentId)).toEqual(["fatal", "human-1"]);
+  });
+
   it("puts currently working agents before more recent speakers", () => {
     const roster = [participant("human-1", "human"), participant("agent-1", "agent"), participant("agent-2", "agent")];
 

--- a/packages/web/src/pages/workspace/right-sidebar/__tests__/participants-roster.test.ts
+++ b/packages/web/src/pages/workspace/right-sidebar/__tests__/participants-roster.test.ts
@@ -1,6 +1,6 @@
-import type { ChatParticipantDetail } from "@first-tree/shared";
+import { type AgentChatStatusInput, buildAgentChatStatus, type ChatParticipantDetail } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
-import { partitionRoster, VISIBLE_LIMIT } from "../participants-section.js";
+import { orderParticipantsByActivity, partitionRoster, VISIBLE_LIMIT } from "../../participant-order.js";
 
 function participant(id: string, type: "human" | "agent"): ChatParticipantDetail {
   return {
@@ -17,43 +17,39 @@ function participant(id: string, type: "human" | "agent"): ChatParticipantDetail
 }
 
 describe("partitionRoster", () => {
-  it("orders agents before humans, preserving server order within each group", () => {
+  it("preserves the supplied order", () => {
     const roster = [
       participant("human-1", "human"),
       participant("agent-1", "agent"),
       participant("human-2", "human"),
       participant("agent-2", "agent"),
     ];
-    const { visibleAgents, visibleHumans } = partitionRoster(roster, true);
-    expect(visibleAgents.map((p) => p.agentId)).toEqual(["agent-1", "agent-2"]);
-    expect(visibleHumans.map((p) => p.agentId)).toEqual(["human-1", "human-2"]);
+    const { visibleParticipants } = partitionRoster(roster, true);
+    expect(visibleParticipants.map((p) => p.agentId)).toEqual(["human-1", "agent-1", "human-2", "agent-2"]);
   });
 
   it("caps the visible roster at the limit and reports the hidden remainder", () => {
     const roster = Array.from({ length: 8 }, (_, i) => participant(`agent-${i}`, "agent"));
-    const { total, visibleAgents, visibleHumans, hiddenCount } = partitionRoster(roster, false);
+    const { total, visibleParticipants, hiddenCount } = partitionRoster(roster, false);
     expect(total).toBe(8);
-    expect(visibleAgents).toHaveLength(VISIBLE_LIMIT);
-    expect(visibleHumans).toHaveLength(0);
+    expect(visibleParticipants).toHaveLength(VISIBLE_LIMIT);
     expect(hiddenCount).toBe(3);
   });
 
-  it("fills the visible slice with agents first, then humans, when over the cap", () => {
+  it("uses the supplied order when taking the visible slice", () => {
     const roster = [
-      ...Array.from({ length: 3 }, (_, i) => participant(`agent-${i}`, "agent")),
-      ...Array.from({ length: 4 }, (_, i) => participant(`human-${i}`, "human")),
+      ...Array.from({ length: 3 }, (_, i) => participant(`human-${i}`, "human")),
+      ...Array.from({ length: 4 }, (_, i) => participant(`agent-${i}`, "agent")),
     ];
-    const { visibleAgents, visibleHumans, hiddenCount } = partitionRoster(roster, false);
-    // 3 agents + first 2 humans = 5 visible; 2 humans hidden.
-    expect(visibleAgents.map((p) => p.agentId)).toEqual(["agent-0", "agent-1", "agent-2"]);
-    expect(visibleHumans.map((p) => p.agentId)).toEqual(["human-0", "human-1"]);
+    const { visibleParticipants, hiddenCount } = partitionRoster(roster, false);
+    expect(visibleParticipants.map((p) => p.agentId)).toEqual(["human-0", "human-1", "human-2", "agent-0", "agent-1"]);
     expect(hiddenCount).toBe(2);
   });
 
   it("reveals everyone when showAll is set", () => {
     const roster = Array.from({ length: 8 }, (_, i) => participant(`agent-${i}`, "agent"));
-    const { visibleAgents, hiddenCount } = partitionRoster(roster, true);
-    expect(visibleAgents).toHaveLength(8);
+    const { visibleParticipants, hiddenCount } = partitionRoster(roster, true);
+    expect(visibleParticipants).toHaveLength(8);
     expect(hiddenCount).toBe(0);
   });
 
@@ -61,5 +57,63 @@ describe("partitionRoster", () => {
     const roster = Array.from({ length: 5 }, (_, i) => participant(`agent-${i}`, "agent"));
     const { hiddenCount } = partitionRoster(roster, false);
     expect(hiddenCount).toBe(0);
+  });
+});
+
+const statusBase: Omit<AgentChatStatusInput, "agentId"> = {
+  reachable: true,
+  errored: false,
+  working: false,
+  engagement: "active",
+};
+
+describe("orderParticipantsByActivity", () => {
+  it("puts currently working agents before more recent speakers", () => {
+    const roster = [participant("human-1", "human"), participant("agent-1", "agent"), participant("agent-2", "agent")];
+
+    const ordered = orderParticipantsByActivity(
+      roster,
+      [
+        { senderId: "human-1", createdAt: "2026-07-09T03:00:00.000Z" },
+        { senderId: "agent-2", createdAt: "2026-07-09T02:00:00.000Z" },
+      ],
+      [
+        buildAgentChatStatus({ ...statusBase, agentId: "agent-1", working: true }),
+        buildAgentChatStatus({ ...statusBase, agentId: "agent-2" }),
+      ],
+    );
+
+    expect(ordered.map((p) => p.agentId)).toEqual(["agent-1", "human-1", "agent-2"]);
+  });
+
+  it("uses latest message time when no participant is currently working", () => {
+    const roster = [participant("agent-1", "agent"), participant("human-1", "human"), participant("agent-2", "agent")];
+
+    const ordered = orderParticipantsByActivity(roster, [
+      { senderId: "agent-1", createdAt: "2026-07-09T01:00:00.000Z" },
+      { senderId: "human-1", createdAt: "2026-07-09T03:00:00.000Z" },
+      { senderId: "agent-1", createdAt: "2026-07-09T04:00:00.000Z" },
+    ]);
+
+    expect(ordered.map((p) => p.agentId)).toEqual(["agent-1", "human-1", "agent-2"]);
+  });
+
+  it("keeps membership order for participants with no activity", () => {
+    const roster = [participant("human-1", "human"), participant("agent-1", "agent"), participant("agent-2", "agent")];
+
+    expect(orderParticipantsByActivity(roster, []).map((p) => p.agentId)).toEqual(["human-1", "agent-1", "agent-2"]);
+  });
+
+  it("treats live timeline turns as active even before the status query catches up", () => {
+    const roster = [participant("human-1", "human"), participant("agent-1", "agent")];
+
+    const ordered = orderParticipantsByActivity(
+      roster,
+      [{ senderId: "human-1", createdAt: "2026-07-09T04:00:00.000Z" }],
+      [],
+      new Set(["agent-1"]),
+    );
+
+    expect(ordered.map((p) => p.agentId)).toEqual(["agent-1", "human-1"]);
   });
 });

--- a/packages/web/src/pages/workspace/right-sidebar/participants-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/participants-section.tsx
@@ -5,50 +5,16 @@ import { useAuth } from "../../../auth/auth-context.js";
 import { AddParticipantDropdown } from "../../../components/add-participant-dropdown.js";
 import { Avatar as RealAvatar } from "../../../components/avatar.js";
 import { AgentStatusPanel } from "../../../components/chat/agent-status-panel.js";
-
-/** Roster rows shown before the "Show all" fold. The rail is a calm
- *  inspection surface, not a member-management screen — a long roster
- *  shouldn't push Description / GitHub off-screen, so we cap the visible
- *  rows and tuck the rest behind a toggle. */
-export const VISIBLE_LIMIT = 5;
-
-/**
- * Order the roster agents-first (their live status is the glanceable pulse),
- * then humans, preserving server order within each group; cap to `limit`
- * unless `showAll`. Pure so the ordering / fold math is unit-testable without
- * rendering the query-backed AgentStatusPanel.
- */
-export function partitionRoster(
-  participants: ChatParticipantDetail[],
-  showAll: boolean,
-  limit: number = VISIBLE_LIMIT,
-): {
-  total: number;
-  visibleAgents: ChatParticipantDetail[];
-  visibleHumans: ChatParticipantDetail[];
-  hiddenCount: number;
-} {
-  const agents = participants.filter((p) => p.type !== "human");
-  const humans = participants.filter((p) => p.type === "human");
-  const ordered = [...agents, ...humans];
-  const total = ordered.length;
-  const visible = showAll ? ordered : ordered.slice(0, limit);
-  return {
-    total,
-    visibleAgents: visible.filter((p) => p.type !== "human"),
-    visibleHumans: visible.filter((p) => p.type === "human"),
-    hiddenCount: total - visible.length,
-  };
-}
+import { partitionRoster, VISIBLE_LIMIT } from "../participant-order.js";
 
 /**
  * Participants section — full chat membership (humans + agents), the top
- * section of the rail. Agents render first (their live status is the
- * glanceable pulse of the work) through <AgentStatusPanel> (one
+ * section of the rail. Non-human agents render through <AgentStatusPanel> (one
  * /chats/:id/agent-status call drives every agent's composite status +
- * per-row Pause when the caller can manage). Humans follow as a simplified
+ * per-row Pause when the caller can manage). Humans render as a simplified
  * roster (no session state, no actions in v1 — Remove / Change role are
- * deferred alongside the missing backend routes for member-side removal).
+ * deferred alongside the missing backend routes for member-side removal). The
+ * caller supplies the display order so header and rail stay aligned.
  *
  * The roster is capped at VISIBLE_LIMIT; the remainder collapses behind a
  * "Show all" toggle so a crowded chat can't dominate the rail.
@@ -79,7 +45,7 @@ export function ParticipantsSection({
   const [showAll, setShowAll] = useState(false);
 
   const isAdmin = role === "admin";
-  const { total, visibleAgents, visibleHumans, hiddenCount } = useMemo(
+  const { total, visibleParticipants, hiddenCount } = useMemo(
     () => partitionRoster(participants, showAll),
     [participants, showAll],
   );
@@ -101,17 +67,19 @@ export function ParticipantsSection({
           </div>
         ) : (
           <>
-            {visibleAgents.length > 0 ? (
-              <AgentStatusPanel
-                chatId={chatId}
-                agents={visibleAgents}
-                canManage={(id) => isAdmin || (managedByMe.get(id) ?? false)}
-                compact
-              />
-            ) : null}
-            {visibleHumans.map((p) => (
-              <HumanRow key={p.agentId} participant={p} />
-            ))}
+            {visibleParticipants.map((p) =>
+              p.type === "human" ? (
+                <HumanRow key={p.agentId} participant={p} />
+              ) : (
+                <AgentStatusPanel
+                  key={p.agentId}
+                  chatId={chatId}
+                  agents={[p]}
+                  canManage={(id) => isAdmin || (managedByMe.get(id) ?? false)}
+                  compact
+                />
+              ),
+            )}
             {hiddenCount > 0 ? (
               <RosterToggle onClick={() => setShowAll(true)}>Show all · {total}</RosterToggle>
             ) : showAll && total > VISIBLE_LIMIT ? (


### PR DESCRIPTION
## Summary
- add a shared chat participant ordering helper for active agents and recent speakers
- preserve failed/fatal recovery priority ahead of activity ordering
- apply the same order to the chat header avatars, right-sidebar Participants roster, and composer status bar
- update focused web tests around roster partitioning and composer status ordering

## Why
Participants were ordered differently across chat surfaces. The right rail forced agents before humans, the header used raw membership order, and the composer status bar had its own active-agent priority logic. This made the currently active agent and recently active participants inconsistent across the page.

The first implementation also let working/recent participants hide failed/fatal recovery agents. This PR keeps recovery states in the highest tier, then uses the shared participant order only within the same severity tier.

## Review history
Supersedes closed PR #1539: https://github.com/agent-team-foundation/first-tree/pull/1539

The branch was renamed from `jeremy/chat-participant-sort` to `feat/chat-participant-sort` to satisfy the branch-name check; GitHub closed the original PR because the old head branch was deleted. The replacement PR contains the same commits, including the review fix commit `1939d886`.

Prior review outcome on #1539:
- yuezengwu: LGTM
- baixiaohang: LGTM after the recovery-priority fix

## Validation
- `pnpm exec biome check packages/web/src/pages/workspace/participant-order.ts packages/web/src/pages/workspace/right-sidebar/participants-section.tsx packages/web/src/pages/workspace/right-sidebar/__tests__/participants-roster.test.ts packages/web/src/pages/workspace/center/chat-view.tsx packages/web/src/components/chat/compose-status-bar.tsx packages/web/src/components/chat/__tests__/compose-status-bar.test.ts`
- `pnpm --filter @first-tree/web exec vitest run src/pages/workspace/right-sidebar/__tests__/participants-roster.test.ts src/components/chat/__tests__/compose-status-bar.test.ts`
- `pnpm --filter @first-tree/web typecheck`
