### PR TITLE
[jeremy] Fix inviteable mention candidates

### DIFF
--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -100,6 +100,7 @@ export function AskTakeover({
   askerName,
   sending = false,
   mentionCandidates = [],
+  mentionAutocompleteCandidates = mentionCandidates,
   error,
   onMentionQueryChange,
   onMentionTextChange,
@@ -116,11 +117,14 @@ export function AskTakeover({
   payload: AskRequest;
   askerName?: string;
   sending?: boolean;
-  /** Candidates the free-text `@` autocomplete suggests + resolves against
-   *  (self-excluded chat speakers plus host-supplied inviteable agents, same
-   *  source as the composer). Empty → no autocomplete and every `@<token>`
-   *  stays plain text. */
+  /** Candidates the answer resolves against (self-excluded chat speakers plus
+   *  retained inviteable agents, same source as the composer). Empty → every
+   *  `@<token>` stays plain text. */
   mentionCandidates?: MentionCandidate[];
+  /** Capped candidate list shown by the free-text `@` autocomplete. Defaults
+   *  to `mentionCandidates` when the host does not need a separate display
+   *  projection. */
+  mentionAutocompleteCandidates?: MentionCandidate[];
   /** A host-side send failure to surface in the card (the composer is covered,
    *  so a failed resolve must show here or it looks like nothing happened). */
   error?: string;
@@ -190,7 +194,7 @@ export function AskTakeover({
   const mention = useMentionAutocomplete({
     value: freeText,
     cursor,
-    candidates: mentionCandidates,
+    candidates: mentionAutocompleteCandidates,
     disabled: sending,
     onSelect: (update, picked) => {
       onMentionSelect?.(picked);

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -241,6 +241,14 @@ const ORG_AGENTS = [
     managerId: "member-alice",
     clientId: "client-teammate",
   }),
+  agent({
+    uuid: "human-agent-first-tree-ai",
+    name: "first-tree-ai",
+    displayName: "first-tree-ai",
+    type: "human",
+    managerId: "member-alice",
+    clientId: null,
+  }),
 ];
 
 function participant(overrides: Partial<ChatParticipantDetail> & { agentId: string }): ChatParticipantDetail {
@@ -1535,6 +1543,23 @@ describe("ChatView", () => {
       participantIds: ["agent-teammate"],
     });
     expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "Please @teammate", ["agent-teammate"]);
+
+    await act(async () => root.unmount());
+  });
+
+  it("does not show human rows as inviteable non-participant agents", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, undefined, "/");
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Composer textarea missing");
+
+    await setValue(textarea, "Please @");
+    await waitForCondition(
+      () => container.querySelector<HTMLButtonElement>('button[title="@teammate"]') !== null,
+      "Expected bare @ to show runtime agent non-participant",
+    );
+    expect(container.querySelector<HTMLButtonElement>('button[title="@first-tree-ai"]')).toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1564,6 +1564,34 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("limits inviteable non-participant mention candidates to three", async () => {
+    orgAgentsHookMocks.searchOnlyItems = Array.from({ length: 5 }, (_, index) =>
+      agent({
+        uuid: `agent-cap-${index + 1}`,
+        name: `cap-agent-${index + 1}`,
+        displayName: `Cap Agent ${index + 1}`,
+        managerId: "member-alice",
+      }),
+    );
+
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, undefined, "/");
+
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("Composer textarea missing");
+
+    await setValue(textarea, "Please @cap");
+    await waitForCondition(
+      () => container.querySelector<HTMLButtonElement>('button[title="@cap-agent-1"]') !== null,
+      "Expected matching inviteable mention candidates",
+    );
+
+    expect(container.querySelectorAll<HTMLButtonElement>('button[title^="@cap-agent-"]').length).toBe(3);
+    expect(container.querySelector<HTMLButtonElement>('button[title="@cap-agent-4"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
   it("clears the mention tip when switching to another group chat", async () => {
     const { ChatView } = await import("../chat-view.js");
     const { container, queryClient, root } = await renderDom(

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -3124,6 +3124,7 @@ export function ChatView({
 
   const toInviteableMentionCandidate = useCallback(
     (a: Agent): MentionCandidate | null => {
+      if (a.type !== "agent") return null;
       if (a.status === "suspended") return null;
       if (myAgentId && a.uuid === myAgentId) return null;
       if (chatParticipantIdSet.has(a.uuid)) return null;

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -103,6 +103,7 @@ import {
   detectMentionTrigger,
   MentionAutocompletePopover,
   type MentionCandidate,
+  rankCandidates,
   useMentionAutocomplete,
 } from "../../../components/mention-autocomplete.js";
 import { MentionHighlightOverlay } from "../../../components/mention-highlight-overlay.js";
@@ -145,6 +146,7 @@ import { ChatRightSidebar } from "../right-sidebar/index.js";
 import { ChatSummary } from "./chat-summary.js";
 
 const SIDEBAR_OPEN_STORAGE_KEY = "first-tree:chat-right-sidebar:open:v1";
+const MAX_INVITEABLE_MENTION_CANDIDATES = 3;
 const LANDING_TRIAL_CHAT_ENDED_PLACEHOLDER =
   'Your trial chat has ended. To keep using First Tree, click "Set up First Tree for your team" ' +
   "at the top of the page to create your team.";
@@ -3210,6 +3212,16 @@ export function ChatView({
     toInviteableMentionCandidate,
   ]);
 
+  const visibleInviteableMentionCandidates = useMemo(
+    () => rankCandidates(inviteableMentionCandidates, activeMentionQuery).slice(0, MAX_INVITEABLE_MENTION_CANDIDATES),
+    [activeMentionQuery, inviteableMentionCandidates],
+  );
+
+  const mentionAutocompleteCandidates = useMemo<MentionCandidate[]>(
+    () => [...inChatMentionCandidates, ...visibleInviteableMentionCandidates],
+    [inChatMentionCandidates, visibleInviteableMentionCandidates],
+  );
+
   const mentionCandidates = useMemo<MentionCandidate[]>(
     () => [...inChatMentionCandidates, ...inviteableMentionCandidates],
     [inChatMentionCandidates, inviteableMentionCandidates],
@@ -3391,7 +3403,7 @@ export function ChatView({
   const mention = useMentionAutocomplete({
     value: draft,
     cursor,
-    candidates: mentionCandidates,
+    candidates: mentionAutocompleteCandidates,
     disabled: landingCampaignChatLocked || sendMut.isPending || uploading,
     onSelect: (update, picked) => {
       autoPrimedDraftRef.current = false;
@@ -3530,6 +3542,7 @@ export function ChatView({
                 sending={askBusy}
                 error={askError ?? undefined}
                 mentionCandidates={mentionCandidates}
+                mentionAutocompleteCandidates={mentionAutocompleteCandidates}
                 isTrial={isTrial}
                 onMentionQueryChange={setAskMentionQuery}
                 onMentionTextChange={setAskMentionText}


### PR DESCRIPTION
## Summary

- Filter inviteable non-participant mention candidates to runtime agents only.
- Keep in-chat human mentions unchanged, but prevent human org rows from appearing as inviteable “agents”.
- Cap the inviteable non-participant autocomplete section at 3 visible candidates while preserving the full resolver set for selected mentions.
- Add regressions for human-row filtering and the 3-candidate inviteable cap.

## Root cause

The auto-invite PR allowed all addressable org rows through the inviteable candidate projection. A `type: "human"` row could therefore be selected and invited from the “unjoined agents” section, but runtime activation only happens for notify-worthy agent recipients. Inviting a human participant does not wake an agent runtime.

The same inviteable projection could also be too large for the `@` picker. The display projection now caps inviteable suggestions to 3, while the resolver projection remains complete so already-selected inviteable `@name` tokens still invite and route correctly at send time.

## Validation

- `pnpm --filter @first-tree/web exec vitest run src/pages/workspace/center/__tests__/chat-view-dom.test.tsx src/components/__tests__/mention-autocomplete.test.ts`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check packages/web/src/pages/workspace/center/chat-view.tsx packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx packages/web/src/components/chat/ask-takeover.tsx packages/web/src/components/mention-autocomplete.tsx packages/web/src/components/__tests__/mention-autocomplete.test.ts packages/web/src/lib/use-org-agents.ts`

Supersedes #1549 and #1555, which used branch names that failed the repository branch-name check.
