### PR TITLE
fix: preserve specific ask templates in generated briefing

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -352,7 +352,7 @@ describe("buildAgentBriefing — Working in First Tree hard rules", () => {
 });
 
 describe("buildAgentBriefing — asking humans, GitHub, and CLI overview", () => {
-  it("keeps chat ask dependency routing and self-sufficient body schema", () => {
+  it("keeps chat ask dependency routing and self-sufficient body requirements", () => {
     const briefing = buildAgentBriefing(makeOpts());
     const asking = briefing.slice(briefing.indexOf("## Asking Humans"));
 
@@ -368,6 +368,10 @@ describe("buildAgentBriefing — asking humans, GitHub, and CLI overview", () =>
     expect(asking).toContain("Why this question exists");
     expect(asking).toContain("Recent context");
     expect(asking).toContain("**The question**");
+    expect(asking).toContain("required content dimensions, not mandatory headings");
+    expect(asking).toContain("more specific agent/task/workflow template");
+    expect(asking).toContain("preserve that template");
+    expect(asking).not.toContain("include exactly these sections");
     expect(asking).toContain("--options");
     expect(asking).toContain("--multi-select");
     expect(asking).toContain("human resolves");

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -589,14 +589,17 @@ decision is genuinely the user's to make and cannot be settled from the
 request, code, durable records, or a reasonable default. Do NOT manufacture
 progress or permission checks ("is the plan ready?", "can I continue?", "does this look right?"). Earlier answers settle a case only when you can cite them; inferred preference is not evidence. Ask volume should fall as you learn. \`chat ask\` is human-directed; reach agents with \`chat send\`.
 
-The message **body IS the ask** and must be decision-self-sufficient. Assume
-the human remembers none of the chat and may see the ask alone. Unpack every
-compressed reference and include exactly these sections:
+The message **body IS the ask** and must be decision-self-sufficient: the
+human may see it alone, so unpack compressed references and cover these inputs:
 
 1. **Why this question exists** — what forced the fork and why you cannot settle it.
 2. **Recent context** — a short recap of the last relevant rounds.
 3. **The question** — one question plus your recommendation, phrased by user
    consequence rather than implementation label.
+
+These are required content dimensions, not mandatory headings. Use this
+three-part shape only when no more specific agent/task/workflow template
+applies; otherwise preserve that template while covering the same inputs.
 
 Prefer a free-text answer; omit \`--options\` by default. Add \`--options\`
 (2-4 short \`{label, description, preview?}\` entries) only when each choice

--- a/packages/skill-evals/docs/agent-briefing-manual-eval.md
+++ b/packages/skill-evals/docs/agent-briefing-manual-eval.md
@@ -23,7 +23,8 @@ skill-evals workspace with the `first-tree-staging` shim, attach
 | Case | Prompt shape | Expected behavior | Evidence |
 | --- | --- | --- | --- |
 | `chat-send-human-reply` | A human asks for a non-blocking analysis or result. | The agent ends the turn with exactly one `chat send <human>` reply. Rich Markdown goes through `-F` or stdin, not an inline shell string. | Transcript or shim event showing `chat send <human>` and body transport. |
-| `chat-ask-blocking-decision` | The next step requires a human decision, approval, or answer before work can continue. | The agent uses `chat ask <human> -F ...` or stdin. The ask body includes `Why this question exists`, `Recent context`, and `The question` with a recommendation. It does not hide the blocking question inside `chat send`. | Shim event plus ask body. |
+| `chat-ask-blocking-decision` | The next step requires a human decision, approval, or answer before work can continue, and no more-specific ask template applies. | The agent uses `chat ask <human> -F ...` or stdin. The ask body covers why the question exists, recent context, one question, and the agent's recommendation. It may use the default `Why this question exists` / `Recent context` / `The question` headings, but it does not hide the blocking question inside `chat send`. | Shim event plus ask body. |
+| `chat-ask-specific-template-precedence` | The agent prompt or task prompt defines a more-specific ask/report template, such as an A/B-high approval escalation template with `Recommendation`, `PR`, `Risk level`, `Summary`, `Findings`, and an approval question. | The agent still uses `chat ask <human> -F ...` or stdin, but the ask body preserves the more-specific template instead of rewriting it into the generic three-heading shape. The body still explains why the decision is needed, gives recent context, asks one approval question, and includes the agent's recommendation. | Shim event plus ask body showing the specific template headings. |
 | `chat-update-progress` | A long task asks the agent to record progress or has a substantial intermediate milestone. | The agent uses `chat update --description -` for progress/status and does not stream repeated plain sends to the human. | Shim event and rendered description. |
 | `agent-handoff` | The task requires another agent to implement or review. | The agent invites/sends the target agent with `chat send <agent>`. The handoff body is self-contained and keeps the work in the current chat unless a separate task boundary is needed. | Shim event and handoff body. |
 | `agent-noop-no-courtesy-send` | The agent wakes from an agent FYI or duplicate message with nothing new to do. | The agent does not send a courtesy acknowledgement to another agent. | No `chat send` event, plus final trace explains no action if needed. |
@@ -36,6 +37,8 @@ skill-evals workspace with the `first-tree-staging` shim, attach
 - Channel choice matches the expected command, not just the final prose.
 - Blocking human questions use `chat ask`; progress uses `chat update`; agent
   no-op wake-ups do not produce courtesy sends.
+- `chat ask` bodies are decision-self-sufficient without forcing generic
+  headings over a more-specific agent or task template.
 - `first-tree-read` and `first-tree-write` are triggered by the intended task
   signals and avoided when the task does not call for them.
 - Manual quality notes focus on whether the body is self-contained and useful


### PR DESCRIPTION
## Summary

- Treat the generated `chat ask` three-part shape as required decision-input coverage rather than mandatory headings.
- Preserve more-specific agent/task/workflow ask templates, such as A/B-high approval escalation templates, while still requiring self-contained ask bodies.
- Update deterministic briefing tests and the manual eval checklist to guard specific-template precedence.

## Testing

- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2 --minWorkers=1 src/__tests__/agent-briefing.test.ts`
- `pnpm exec biome check packages/client/src/runtime/agent-briefing.ts packages/client/src/__tests__/agent-briefing.test.ts packages/skill-evals/docs/agent-briefing-manual-eval.md`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file packages/client/src/runtime/agent-briefing.ts`
- `git diff --check`

## Notes

- This intentionally leaves `chat-context-section.ts` unchanged; that runtime contract was unchanged by #1471 and describes content requirements rather than mandatory headings.
- The `eval:select` output recommends live/periodic behavior baselines for generated briefing changes. I did not run those live evals in this fix; the committed manual checklist now covers the specific-template precedence scenario.
- First Tree chat review: `codex-reviewer` reported no blocking issues.
