### PR TITLE
test(shared): improve coverage toward 99 percent

### DIFF
--- a/packages/client/src/__tests__/agent-slot.test.ts
+++ b/packages/client/src/__tests__/agent-slot.test.ts
@@ -26,6 +26,7 @@ type FakeSessionState = {
     typeof vi.fn<(chatId: string, type: "session:suspend" | "session:terminate") => Promise<void>>
   >;
   applyStaleChatIds: ReturnType<typeof vi.fn<(chatIds: string[]) => void>>;
+  noteBindRecoveryComplete: ReturnType<typeof vi.fn<() => void>>;
   updateTransport: ReturnType<typeof vi.fn<(sdk: unknown, agentConfigCache?: unknown) => void>>;
   shutdown: ReturnType<typeof vi.fn<(reason?: string, opts?: unknown) => Promise<void>>>;
 };
@@ -51,6 +52,7 @@ class FakeClientConnection extends EventEmitter {
   reportSessionState = vi.fn();
   reportRuntimeState = vi.fn();
   reportSessionEvent = vi.fn();
+  reportSessionEventConfirmed = vi.fn(async () => {});
   reportSessionRuntime = vi.fn();
   sendSessionReconcile = vi.fn();
 
@@ -158,7 +160,9 @@ function makeFrame(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function installMocks(options: { syncResult?: MockState["syncResult"]; syncDelayMs?: number } = {}): MockState {
+function installMocks(
+  options: { syncResult?: MockState["syncResult"]; syncDelayMs?: number; dispatchRejectEntryId?: number } = {},
+): MockState {
   vi.resetModules();
   const state: MockState = {
     logger: makeLogger(),
@@ -203,9 +207,18 @@ function installMocks(options: { syncResult?: MockState["syncResult"]; syncDelay
           runtimeStates: [{ chatId: "chat-1", runtimeState: "working" }],
           aggregateRuntimeState: "working",
           heldChatIds: ["chat-1", "chat-2"],
-          dispatch: vi.fn(async () => {}),
+          dispatch: vi.fn(async (entry: unknown) => {
+            if (
+              typeof entry === "object" &&
+              entry !== null &&
+              Reflect.get(entry, "id") === options.dispatchRejectEntryId
+            ) {
+              throw new Error("buffered dispatch failed");
+            }
+          }),
           handleCommand: vi.fn(async () => {}),
           applyStaleChatIds: vi.fn(),
+          noteBindRecoveryComplete: vi.fn(),
           updateTransport: vi.fn(),
           shutdown: vi.fn(async () => {}),
         };
@@ -247,6 +260,10 @@ function installMocks(options: { syncResult?: MockState["syncResult"]; syncDelay
         this.state.applyStaleChatIds(chatIds);
       }
 
+      noteBindRecoveryComplete(): void {
+        this.state.noteBindRecoveryComplete();
+      }
+
       updateTransport(sdk: unknown, agentConfigCache?: unknown): void {
         this.state.updateTransport(sdk, agentConfigCache);
       }
@@ -275,14 +292,20 @@ async function makeSlot(options?: {
   runtimeType?: string;
   syncResult?: MockState["syncResult"];
   syncDelayMs?: number;
+  dispatchRejectEntryId?: number;
   omitReconcileInterval?: boolean;
+  deferSuspendOnSubprocess?: boolean;
 }): Promise<{
   slot: import("../runtime/agent-slot.js").AgentSlot;
   connection: FakeClientConnection;
   sdk: FirstTreeHubSDK;
   state: MockState;
 }> {
-  const state = installMocks({ syncResult: options?.syncResult, syncDelayMs: options?.syncDelayMs });
+  const state = installMocks({
+    syncResult: options?.syncResult,
+    syncDelayMs: options?.syncDelayMs,
+    dispatchRejectEntryId: options?.dispatchRejectEntryId,
+  });
   const sdk = makeSdk({
     agent: options?.agent,
     configError: options?.configError,
@@ -313,6 +336,9 @@ async function makeSlot(options?: {
       idle_timeout: 300,
       max_sessions: 3,
       working_grace_seconds: 60,
+      ...(options?.deferSuspendOnSubprocess === undefined
+        ? {}
+        : { defer_suspend_on_subprocess: options.deferSuspendOnSubprocess }),
       // AgentSlot has a defensive default for older configs; the runtime schema normally supplies a number.
       reconcile_interval_seconds: (options?.omitReconcileInterval ? undefined : 1) as unknown as number,
     },
@@ -417,6 +443,37 @@ describe("AgentSlot", () => {
     expect(state.sessions).toHaveLength(1);
   });
 
+  it("aborts a transient config backoff immediately when stop is requested", async () => {
+    const { slot, sdk, state } = await makeSlot({
+      configErrorsThenSucceed: { error: new SdkError(503, "boom"), times: 1 },
+    });
+
+    const startOutcome = slot.start().then(
+      () => ({ ok: true }) as const,
+      (err: unknown) => ({ ok: false, err }) as const,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(vi.mocked(sdk.fetchAgentConfig)).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() =>
+      expect(state.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ attempt: 1, reasonCode: "claude_server_error" }),
+        "agent config fetch failed — retrying with backoff",
+      ),
+    );
+
+    const stopOutcome = slot.stop().then(
+      () => ({ ok: true }) as const,
+      (err: unknown) => ({ ok: false, err }) as const,
+    );
+    const settled = await startOutcome;
+    await stopOutcome;
+
+    expect(settled.ok).toBe(false);
+    if (!settled.ok) expect((settled.err as Error).message).toContain("agent config fetch aborted");
+    expect(state.sessions).toHaveLength(0);
+  });
+
   it("aborts the bind after exhausting retries on a sustained transient failure", async () => {
     vi.useFakeTimers();
     const { slot, connection, sdk } = await makeSlot({ configError: new SdkError(503, "down") });
@@ -515,12 +572,14 @@ describe("AgentSlot", () => {
     const onStateChange = Reflect.get(sessionConfig, "onStateChange");
     const onRuntimeStateChange = Reflect.get(sessionConfig, "onRuntimeStateChange");
     const onSessionEvent = Reflect.get(sessionConfig, "onSessionEvent");
+    const confirmSessionEvent = Reflect.get(sessionConfig, "confirmSessionEvent");
     const onSessionRuntimeChange = Reflect.get(sessionConfig, "onSessionRuntimeChange");
     if (
       typeof ackEntry !== "function" ||
       typeof onStateChange !== "function" ||
       typeof onRuntimeStateChange !== "function" ||
       typeof onSessionEvent !== "function" ||
+      typeof confirmSessionEvent !== "function" ||
       typeof onSessionRuntimeChange !== "function"
     ) {
       throw new Error("session callbacks missing");
@@ -529,12 +588,17 @@ describe("AgentSlot", () => {
     onStateChange("chat-callback", "suspended");
     onRuntimeStateChange("blocked");
     onSessionEvent("chat-callback", { type: "error", message: "oops" });
+    await confirmSessionEvent("chat-callback", { type: "error", message: "oops" });
     onSessionRuntimeChange("chat-callback", "error");
 
     expect(connection.sendInboxAck).toHaveBeenCalledWith(123, "agent-1");
     expect(connection.reportSessionState).toHaveBeenCalledWith("agent-1", "chat-callback", "suspended");
     expect(connection.reportRuntimeState).toHaveBeenCalledWith("agent-1", "blocked");
     expect(connection.reportSessionEvent).toHaveBeenCalledWith("agent-1", "chat-callback", {
+      type: "error",
+      message: "oops",
+    });
+    expect(connection.reportSessionEventConfirmed).toHaveBeenCalledWith("agent-1", "chat-callback", {
       type: "error",
       message: "oops",
     });
@@ -563,6 +627,49 @@ describe("AgentSlot", () => {
 
     connection.emit("inbox:deliver", "inbox-1", makeFrame({ entryId: 99 }));
     expect(session.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("buffers bind-time inbox pushes until the SessionManager exists", async () => {
+    const { slot, connection, sdk, state } = await makeSlot({
+      dispatchRejectEntryId: 78,
+      omitReconcileInterval: true,
+    });
+    connection.bindAgent.mockImplementationOnce(async () => {
+      connection.emit("inbox:deliver", "inbox_agent-1", makeFrame({ entryId: 77, inboxId: "inbox_agent-1" }));
+      connection.emit("inbox:deliver", "inbox_agent-1", makeFrame({ entryId: 78, inboxId: "inbox_agent-1" }));
+      return { sdk };
+    });
+
+    await slot.start();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const session = state.sessions[0];
+    if (!session) throw new Error("session missing");
+    expect(session.dispatch).toHaveBeenCalledWith(expect.objectContaining({ id: 77, inboxId: "inbox_agent-1" }));
+    expect(session.dispatch).toHaveBeenCalledWith(expect.objectContaining({ id: 78, inboxId: "inbox_agent-1" }));
+    expect(state.logger.info).toHaveBeenCalledWith(
+      { buffered: 2 },
+      "flushing early inbox:deliver buffer — frames received during init window",
+    );
+    expect(state.logger.warn).toHaveBeenCalledWith(
+      { err: new Error("buffered dispatch failed"), entryId: 78 },
+      "buffered inbox:deliver dispatch error",
+    );
+
+    await slot.stop();
+  });
+
+  it("omits the subprocess probe when the session config disables defer-on-subprocess", async () => {
+    const { slot, state } = await makeSlot({ deferSuspendOnSubprocess: false });
+
+    await slot.start();
+
+    const sessionConfig = state.sessionConfigs[0];
+    if (typeof sessionConfig !== "object" || sessionConfig === null) throw new Error("session config missing");
+    expect(Reflect.get(sessionConfig, "subprocessProbe")).toBeUndefined();
+
+    await slot.stop();
   });
 
   it("uses the active runtime chat set for full-state sync and optimistic-adds delivered chats", async () => {
@@ -629,6 +736,7 @@ describe("AgentSlot", () => {
     expect(vi.mocked(nextSdk.listActiveRuntimeChatIds)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(sdk.listActiveRuntimeChatIds)).not.toHaveBeenCalled();
     expect(session.updateTransport).toHaveBeenCalledWith(nextSdk, expect.anything());
+    expect(session.noteBindRecoveryComplete).toHaveBeenCalled();
 
     await slot.stop();
   });
@@ -753,6 +861,38 @@ describe("AgentSlot", () => {
     await stopPromise;
   });
 
+  it("reschedules periodic active-runtime-chat refreshes while the slot remains live", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const { slot, sdk } = await makeSlot({ omitReconcileInterval: true });
+
+    await slot.start();
+    vi.mocked(sdk.listActiveRuntimeChatIds).mockClear();
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(vi.mocked(sdk.listActiveRuntimeChatIds)).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(vi.mocked(sdk.listActiveRuntimeChatIds)).toHaveBeenCalledTimes(2);
+
+    await slot.stop();
+  });
+
+  it("keeps startup alive when active runtime chat refresh fails", async () => {
+    const err = new Error("active chat list failed");
+    const { slot, state } = await makeSlot({ activeRuntimeChatIdsError: err, omitReconcileInterval: true });
+
+    await slot.start();
+
+    expect(state.sessions).toHaveLength(1);
+    expect(state.logger.warn).toHaveBeenCalledWith(
+      { err, reason: "startup" },
+      "active runtime chat ids refresh failed; keeping previous snapshot",
+    );
+
+    await slot.stop();
+  });
+
   it("shuts down sessions even when unbind fails during stop", async () => {
     const { slot, connection, state } = await makeSlot();
 
@@ -779,6 +919,37 @@ describe("AgentSlot", () => {
     expect(state.logger.info).toHaveBeenCalledWith("stopped");
   });
 
+  it("surfaces session shutdown failures after a successful unbind", async () => {
+    const { slot, connection, state } = await makeSlot();
+    await slot.start();
+    const session = state.sessions[0];
+    if (!session) throw new Error("session missing");
+    const err = new Error("shutdown failed");
+    session.shutdown.mockRejectedValueOnce(err);
+
+    await expect(slot.stop("operator stop")).rejects.toThrow("shutdown failed");
+
+    expect(connection.unbindAgent).toHaveBeenCalledWith("agent-1");
+    expect(state.logger.warn).toHaveBeenCalledWith({ err }, "failed to shut down sessions while stopping");
+    expect(state.logger.info).toHaveBeenCalledWith("stopped");
+  });
+
+  it("logs a forced-stop failure raised by a server unbind event", async () => {
+    const { slot, connection, state } = await makeSlot();
+    await slot.start();
+    const err = new Error("forced unbind failed");
+    connection.unbindAgent.mockRejectedValueOnce(err);
+
+    connection.emit("agent:unbound", "agent-1", "agent_suspended");
+
+    await vi.waitFor(() =>
+      expect(state.logger.warn).toHaveBeenCalledWith({ err }, "failed to unbind agent while stopping"),
+    );
+    await vi.waitFor(() =>
+      expect(state.logger.error).toHaveBeenCalledWith({ err, reason: "agent_suspended" }, "forced agent stop failed"),
+    );
+  });
+
   it("starts the bind-time reconcile grace window after startup full state sync", async () => {
     vi.useFakeTimers();
     const { slot, connection, sdk } = await makeSlot({ syncDelayMs: 4_900, omitReconcileInterval: true });
@@ -803,6 +974,17 @@ describe("AgentSlot", () => {
     expect(connection.sendSessionReconcile).toHaveBeenCalledWith("agent-1", ["chat-1", "chat-2"]);
 
     await slot.stop();
+  });
+
+  it("logs cleanup unbind failures after an aborted post-bind start", async () => {
+    const { slot, connection, sdk, state } = await makeSlot({ configError: new SdkError(403, "forbidden") });
+    const err = new Error("cleanup unbind failed");
+    connection.unbindAgent.mockRejectedValueOnce(err);
+
+    await expect(slot.start()).rejects.toThrow(/rejected agent config/);
+
+    expect(vi.mocked(sdk.fetchAgentConfig)).toHaveBeenCalledTimes(1);
+    expect(state.logger.warn).toHaveBeenCalledWith({ err }, "failed to unbind after aborted agent start");
   });
 
   it("stops only the matching slot when the server force-unbounds an agent", async () => {

--- a/packages/client/src/__tests__/bootstrap-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/bootstrap-extra-coverage.test.ts
@@ -2,14 +2,13 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { FirstTreeHubSDK } from "../sdk.js";
 import {
-  ensureClaudeMdSymlink,
   installCoreSkills,
   installFirstTreeIntegration,
   migrateLegacyRuntimeLayout,
   resolveAgentContextTreeBinding,
 } from "../runtime/bootstrap.js";
+import type { FirstTreeHubSDK } from "../sdk.js";
 
 const originalPlatform = process.platform;
 

--- a/packages/client/src/__tests__/bootstrap-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/bootstrap-extra-coverage.test.ts
@@ -1,0 +1,204 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FirstTreeHubSDK } from "../sdk.js";
+import {
+  ensureClaudeMdSymlink,
+  installCoreSkills,
+  installFirstTreeIntegration,
+  migrateLegacyRuntimeLayout,
+  resolveAgentContextTreeBinding,
+} from "../runtime/bootstrap.js";
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+describe("bootstrap edge coverage", () => {
+  let tmpBase: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "ft-bootstrap-extra-"));
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    vi.doUnmock("node:fs");
+    vi.doUnmock("../runtime/first-tree-skills/installer.js");
+    vi.resetModules();
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("resolves context tree binding success, unconfigured, and fetch-failure cases", async () => {
+    const logs: string[] = [];
+    const successSdk = {
+      getAgentContextTreeConfig: vi.fn(async () => ({ repo: "git@example/context-tree.git", branch: null })),
+    } as unknown as FirstTreeHubSDK;
+
+    await expect(resolveAgentContextTreeBinding(successSdk, "/workspace", (msg) => logs.push(msg))).resolves.toEqual({
+      path: join("/workspace", "context-tree"),
+      repoUrl: "git@example/context-tree.git",
+      branch: "main",
+    });
+
+    const unconfiguredSdk = {
+      getAgentContextTreeConfig: vi.fn(async () => ({ repo: null, branch: null })),
+    } as unknown as FirstTreeHubSDK;
+    await expect(
+      resolveAgentContextTreeBinding(unconfiguredSdk, "/workspace", (msg) => logs.push(msg)),
+    ).resolves.toBeNull();
+
+    const failingSdk = {
+      getAgentContextTreeConfig: vi.fn(async () => {
+        throw new Error("server offline");
+      }),
+    } as unknown as FirstTreeHubSDK;
+    await expect(resolveAgentContextTreeBinding(failingSdk, "/workspace", (msg) => logs.push(msg))).resolves.toBeNull();
+
+    expect(logs).toContain("Context Tree binding skipped: not configured on server");
+    expect(logs).toContain("Context Tree binding skipped: failed to fetch config from server (server offline)");
+  });
+
+  it("merges legacy runtime directories recursively without overwriting newer target files", () => {
+    const workspace = join(tmpBase, "workspace");
+    mkdirSync(join(workspace, ".agent", "nested"), { recursive: true });
+    mkdirSync(join(workspace, ".agent", "new-dir"), { recursive: true });
+    mkdirSync(join(workspace, ".first-tree-workspace", "nested"), { recursive: true });
+    writeFileSync(join(workspace, ".agent", "nested", "moved.txt"), "legacy nested\n");
+    writeFileSync(join(workspace, ".agent", "new-dir", "payload.txt"), "legacy dir\n");
+    writeFileSync(join(workspace, ".agent", "loose.txt"), "legacy loose\n");
+    writeFileSync(join(workspace, ".agent", "conflict.txt"), "legacy conflict\n");
+    writeFileSync(join(workspace, ".first-tree-workspace", "conflict.txt"), "current conflict\n");
+
+    const runtimeDir = migrateLegacyRuntimeLayout(workspace);
+
+    expect(runtimeDir).toBe(join(workspace, ".first-tree-workspace"));
+    expect(readFileSync(join(runtimeDir, "nested", "moved.txt"), "utf8")).toBe("legacy nested\n");
+    expect(readFileSync(join(runtimeDir, "new-dir", "payload.txt"), "utf8")).toBe("legacy dir\n");
+    expect(readFileSync(join(runtimeDir, "loose.txt"), "utf8")).toBe("legacy loose\n");
+    expect(readFileSync(join(runtimeDir, "conflict.txt"), "utf8")).toBe("current conflict\n");
+    expect(existsSync(join(workspace, ".agent"))).toBe(false);
+  });
+
+  it("throws non-ENOENT lstat failures while checking CLAUDE.md", async () => {
+    const workspace = join(tmpBase, "lstat-error");
+    mkdirSync(workspace, { recursive: true });
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        lstatSync: () => {
+          throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+        },
+      };
+    });
+    const mod = await import("../runtime/bootstrap.js");
+
+    expect(() => mod.ensureClaudeMdSymlink(workspace, "briefing")).toThrow("permission denied");
+  });
+
+  it("cleans up and rethrows when symlink rename fails", async () => {
+    const workspace = join(tmpBase, "rename-error");
+    mkdirSync(workspace, { recursive: true });
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        renameSync: () => {
+          throw new Error("rename denied");
+        },
+      };
+    });
+    const mod = await import("../runtime/bootstrap.js");
+
+    expect(() => mod.ensureClaudeMdSymlink(workspace, "briefing")).toThrow("rename denied");
+    expect(existsSync(join(workspace, "CLAUDE.md"))).toBe(false);
+  });
+
+  it("cleans up and rethrows when the Windows fallback file rename fails", async () => {
+    const workspace = join(tmpBase, "fallback-rename-error");
+    mkdirSync(workspace, { recursive: true });
+    writeFileSync(join(workspace, "AGENTS.md"), "briefing\n");
+    setPlatform("win32");
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        symlinkSync: () => {
+          throw Object.assign(new Error("symlink denied"), { code: "EPERM" });
+        },
+        renameSync: () => {
+          throw new Error("fallback rename denied");
+        },
+      };
+    });
+    const mod = await import("../runtime/bootstrap.js");
+
+    expect(() => mod.ensureClaudeMdSymlink(workspace)).toThrow("fallback rename denied");
+    expect(existsSync(join(workspace, "CLAUDE.md"))).toBe(false);
+  });
+
+  it("logs empty tree/core skill installer results without failure", async () => {
+    vi.resetModules();
+    vi.doMock("../runtime/first-tree-skills/installer.js", () => ({
+      installFirstTreeSkills: () => ({ ok: true, installed: [], skipped: [], failed: [] }),
+      installCoreSkills: () => ({ ok: true, installed: [], skipped: [], failed: [] }),
+    }));
+    const mod = await import("../runtime/bootstrap.js");
+    const logs: string[] = [];
+
+    expect(mod.installFirstTreeIntegration({ workspacePath: tmpBase, log: (msg) => logs.push(msg) })).toBe(true);
+    expect(mod.installCoreSkills({ workspacePath: tmpBase, log: (msg) => logs.push(msg) })).toBe(true);
+
+    expect(logs).toEqual(["First-tree skills: no skills configured"]);
+  });
+
+  it("logs thrown tree/core skill installer failures and returns false", async () => {
+    vi.resetModules();
+    vi.doMock("../runtime/first-tree-skills/installer.js", () => ({
+      installFirstTreeSkills: () => {
+        throw new Error("tree installer unavailable");
+      },
+      installCoreSkills: () => {
+        throw "core installer unavailable";
+      },
+    }));
+    const mod = await import("../runtime/bootstrap.js");
+    const logs: string[] = [];
+
+    expect(mod.installFirstTreeIntegration({ workspacePath: tmpBase, log: (msg) => logs.push(msg) })).toBe(false);
+    expect(mod.installCoreSkills({ workspacePath: tmpBase, log: (msg) => logs.push(msg) })).toBe(false);
+
+    expect(logs).toEqual([
+      "First-tree skills install skipped: tree installer unavailable",
+      "Core skill install skipped: core installer unavailable",
+    ]);
+  });
+
+  it("keeps real wrapper behaviour available after dynamic installer mocks are reset", () => {
+    const logs: string[] = [];
+
+    expect(
+      installFirstTreeIntegration({
+        workspacePath: tmpBase,
+        bundledSkillsRoot: join(tmpBase, "missing-skills"),
+        log: (msg) => logs.push(msg),
+      }),
+    ).toBe(false);
+    expect(
+      installCoreSkills({
+        workspacePath: tmpBase,
+        bundledSkillsRoot: join(tmpBase, "missing-skills"),
+        log: (msg) => logs.push(msg),
+      }),
+    ).toBe(false);
+    expect(logs.join("\n")).toContain("failed first-tree-read");
+    expect(logs.join("\n")).toContain("failed first-tree-welcome");
+  });
+});

--- a/packages/client/src/__tests__/capability-probes.test.ts
+++ b/packages/client/src/__tests__/capability-probes.test.ts
@@ -21,6 +21,18 @@ import { MAX_ERROR_LENGTH, truncateError } from "../runtime/capabilities/detect.
 import { commandFailureDigest, runCommand, verifyLaunchable } from "../runtime/capabilities/launch-probe.js";
 import type { CodexExecutableVerification } from "../runtime/codex-binary.js";
 
+const originalPlatform = process.platform;
+const originalArch = process.arch;
+
+function setProcessTarget(platform: NodeJS.Platform, arch: NodeJS.Architecture): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+  Object.defineProperty(process, "arch", { configurable: true, value: arch });
+}
+
+afterEach(() => {
+  setProcessTarget(originalPlatform, originalArch);
+});
+
 /**
  * Install-only capability probes — the contract under test:
  *
@@ -458,6 +470,88 @@ describe("resolveBundledCodexBinary / resolveCodexRuntimeBinary (real node_modul
       expect(res.runtimePath).toBeNull();
     }
   });
+
+  it("reports unsupported codex targets before attempting SDK resolution", async () => {
+    setProcessTarget("linux", "ia32");
+
+    const res = await resolveBundledCodexBinary();
+
+    expect(res).toEqual({ ok: false, error: "unsupported platform for codex: linux (ia32)" });
+  });
+
+  it.each([
+    ["darwin", "arm64", "@openai/codex-darwin-arm64"],
+    ["win32", "x64", "@openai/codex-win32-x64"],
+  ] as const)("maps %s/%s to the matching optional package", async (platform, arch, expectedPackage) => {
+    setProcessTarget(platform, arch);
+    vi.resetModules();
+    vi.doMock("node:module", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:module")>();
+      return {
+        ...actual,
+        createRequire: (anchor: string | URL) => ({
+          resolve: (specifier: string) => {
+            if (specifier === "@openai/codex/package.json") {
+              return "/virtual/node_modules/@openai/codex/package.json";
+            }
+            throw new Error(`missing ${specifier} from ${String(anchor)}`);
+          },
+        }),
+      };
+    });
+    const mod = await import("../runtime/capabilities/codex.js");
+
+    const res = await mod.resolveBundledCodexBinary();
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toContain(expectedPackage);
+      expect(res.error).toContain("unable to locate codex CLI binaries");
+    }
+
+    vi.doUnmock("node:module");
+    vi.resetModules();
+  });
+
+  it("reports a missing bundled binary after the optional vendor package resolves", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ft-codex-empty-vendor-"));
+    try {
+      setProcessTarget("linux", "x64");
+      vi.resetModules();
+      vi.doMock("node:module", async (importOriginal) => {
+        const actual = await importOriginal<typeof import("node:module")>();
+        return {
+          ...actual,
+          createRequire: (anchor: string | URL) => ({
+            resolve: (specifier: string) => {
+              if (specifier === "@openai/codex/package.json") {
+                return join(root, "node_modules", "@openai", "codex", "package.json");
+              }
+              if (specifier === "@openai/codex-linux-x64/package.json") {
+                return join(root, "node_modules", "@openai", "codex-linux-x64", "package.json");
+              }
+              throw new Error(`unexpected ${specifier} from ${String(anchor)}`);
+            },
+          }),
+        };
+      });
+      const vendorRoot = join(root, "node_modules", "@openai", "codex-linux-x64", "vendor");
+      mkdirSync(join(vendorRoot, "x86_64-unknown-linux-musl"), { recursive: true });
+      const mod = await import("../runtime/capabilities/codex.js");
+
+      const res = await mod.resolveBundledCodexBinary();
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.error).toContain("codex binary not found under");
+        expect(res.error).toContain("x86_64-unknown-linux-musl");
+      }
+    } finally {
+      vi.doUnmock("node:module");
+      vi.resetModules();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 /**
@@ -505,6 +599,15 @@ describe("resolveBundledBinaryInPackageRoot (SDK resolveNativePackage parity)", 
 
   it("returns null when neither layout resolves", () => {
     expect(resolveBundledBinaryInPackageRoot(root)).toBeNull();
+  });
+
+  it("uses the Windows executable name when resolving bundled layouts", () => {
+    setProcessTarget("win32", "x64");
+    mkdirSync(join(root, "bin"), { recursive: true });
+    writeExecutable(join(root, "bin", "codex.exe"));
+    writeFileSync(join(root, "codex-package.json"), "{}");
+
+    expect(resolveBundledBinaryInPackageRoot(root)).toBe(join(root, "bin", "codex.exe"));
   });
 });
 

--- a/packages/client/src/__tests__/codex-app-server-client.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-client.test.ts
@@ -261,7 +261,7 @@ describe("CodexAppServerClient lifecycle", () => {
       [
         "#!/bin/sh",
         "while IFS= read -r line; do",
-        "  case \"$line\" in",
+        '  case "$line" in',
         "    *'\"id\":1'*) printf '%s\\n' '{\"id\":1,\"result\":{}}' ;;",
         "  esac",
         "done",

--- a/packages/client/src/__tests__/codex-app-server-client.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-client.test.ts
@@ -1,8 +1,16 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
-import { CodexAppServerClient } from "../handlers/codex/app-server/client.js";
+import {
+  CodexAppServerClient,
+  CodexAppServerRpcError,
+  isCodexAppServerTransientError,
+  smokeCodexAppServer,
+} from "../handlers/codex/app-server/client.js";
 
 /**
  * Upper-bound request timeout for the success-path tests, where the `initialize`
@@ -37,6 +45,22 @@ function makeChild(exitOnSignals: readonly NodeJS.Signals[] = []) {
     return true;
   });
   return { child, signals, stderr, stdout };
+}
+
+async function startClient(
+  childState: ReturnType<typeof makeChild>,
+  extra: Partial<Parameters<typeof CodexAppServerClient.start>[0]> = {},
+) {
+  const startPromise = CodexAppServerClient.start({
+    binary: "/tmp/fake-codex",
+    requestTimeoutMs: RESPONSE_OK_TIMEOUT_MS,
+    spawnProcess: () => childState.child,
+    ...extra,
+  });
+  setImmediate(() => {
+    childState.stdout.write(`${JSON.stringify({ id: 1, result: {} })}\n`);
+  });
+  return startPromise;
 }
 
 describe("CodexAppServerClient lifecycle", () => {
@@ -139,5 +163,129 @@ describe("CodexAppServerClient lifecycle", () => {
     expect(onClose.mock.calls[0]?.[0].message).toContain(
       "codex app-server exited with code 1. stderr: ERROR unexpected tool failure",
     );
+  });
+
+  it("exposes stderr and closed state and rejects pending requests on shutdown", async () => {
+    const childState = makeChild(["SIGTERM"]);
+    const client = await startClient(childState);
+
+    childState.stderr.write("diagnostic tail");
+    const pending = client.request("turn/start", { input: [] });
+    const rejected = expect(pending).rejects.toThrow("codex app-server client shut down");
+    await client.shutdown();
+
+    expect(client.stderr).toBe("diagnostic tail");
+    expect(client.isClosed).toBe(true);
+    await rejected;
+    expect(childState.signals).toEqual(["SIGTERM"]);
+  });
+
+  it("reports child process errors once and rejects pending requests", async () => {
+    const childState = makeChild();
+    const onClose = vi.fn();
+    const client = await startClient(childState, { onClose });
+    const pending = client.request("turn/start", { input: [] });
+
+    childState.child.emit("error", new Error("spawn failed"));
+    childState.child.emit("error", new Error("second failure"));
+
+    await expect(pending).rejects.toThrow("spawn failed");
+    expect(client.isClosed).toBe(true);
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onClose.mock.calls[0]?.[0].message).toBe("spawn failed");
+  });
+
+  it("surfaces write failures and logs stdin backpressure", async () => {
+    const childState = makeChild(["SIGTERM"]);
+    const onLog = vi.fn<(message: string) => void>();
+    const client = await startClient(childState, { onLog });
+    const write = vi.spyOn(childState.child.stdin, "write");
+
+    write.mockImplementationOnce(() => {
+      throw new Error("pipe write failed");
+    });
+    await expect(client.request("turn/start", { input: [] })).rejects.toThrow("pipe write failed");
+
+    write.mockImplementationOnce(() => false);
+    client.notify("client/backpressure");
+
+    expect(onLog).toHaveBeenCalledWith("codex app-server stdin backpressure while sending client/backpressure");
+    await client.shutdown();
+  });
+
+  it("handles requests without params and rpc errors with sparse payloads", async () => {
+    const childState = makeChild(["SIGTERM"]);
+    const client = await startClient(childState);
+
+    const noParams = client.request("thread/list");
+    childState.stdout.write(`${JSON.stringify({ id: 2, result: { ok: true } })}\n`);
+    await expect(noParams).resolves.toEqual({ ok: true });
+
+    const sparseError = client.request("bad/rpc");
+    childState.stdout.write(`${JSON.stringify({ id: 3, error: { code: "bad", message: 42 } })}\n`);
+    const err = await sparseError.catch((caught: unknown) => caught);
+    expect(err).toBeInstanceOf(CodexAppServerRpcError);
+    expect(err).toMatchObject({
+      code: null,
+      message: "codex app-server request failed: bad/rpc",
+      data: undefined,
+    });
+
+    await client.shutdown();
+  });
+
+  it("keeps shutdown best-effort when stdio close and kill throw", async () => {
+    const childState = makeChild();
+    const client = await startClient(childState);
+    const internals = client as unknown as { stdout: { close(): void } };
+    vi.spyOn(internals.stdout, "close").mockImplementationOnce(() => {
+      throw new Error("readline already closed");
+    });
+    childState.child.stdin.end = vi.fn(() => {
+      throw new Error("stdin already closed");
+    }) as unknown as typeof childState.child.stdin.end;
+    childState.child.kill.mockImplementationOnce(() => {
+      throw new Error("kill failed");
+    });
+
+    await client.shutdown(1);
+
+    expect(client.isClosed).toBe(true);
+  });
+
+  it("smokes a real app-server stdio executable", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ft-codex-app-server-smoke-"));
+    const binary = join(root, "fake-codex");
+    writeFileSync(
+      binary,
+      [
+        "#!/bin/sh",
+        "while IFS= read -r line; do",
+        "  case \"$line\" in",
+        "    *'\"id\":1'*) printf '%s\\n' '{\"id\":1,\"result\":{}}' ;;",
+        "  esac",
+        "done",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    try {
+      await expect(smokeCodexAppServer(binary, { PATH: process.env.PATH })).resolves.toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies transient transport strings", () => {
+    expect(isCodexAppServerTransientError(new CodexAppServerRpcError("turn/start", { code: -32001 }))).toBe(true);
+    expect(isCodexAppServerTransientError("server overloaded")).toBe(true);
+    expect(isCodexAppServerTransientError("retry later after overload")).toBe(true);
+    expect(isCodexAppServerTransientError("request timed out")).toBe(true);
+    expect(isCodexAppServerTransientError("timeout waiting for response")).toBe(true);
+    expect(isCodexAppServerTransientError("ECONNRESET from app-server")).toBe(true);
+    expect(isCodexAppServerTransientError("EPIPE writing request")).toBe(true);
+    expect(isCodexAppServerTransientError("transport is closed")).toBe(true);
+    expect(isCodexAppServerTransientError("fatal deterministic failure")).toBe(false);
   });
 });

--- a/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
@@ -509,6 +509,16 @@ describe("workspace-only app-server sandbox extra edges", () => {
 
 describe("codex app-server handler extra branches", () => {
   it("wraps startup failures from binary resolution, initialization, and thread/start responses", async () => {
+    const thrownResolve = makeHandler(new FakeAppServerClient(), {
+      codexRuntimeBinaryResolver: async () => {
+        throw new Error("resolver exploded");
+      },
+    });
+    await expect(thrownResolve.start(makeMessage("m0", "first"), makeContext())).rejects.toMatchObject({
+      stage: "resolve-binary",
+      message: expect.stringContaining("resolver exploded"),
+    });
+
     const resolveFailure = makeHandler(new FakeAppServerClient(), {
       codexRuntimeBinaryResolver: async () => ({ ok: false, error: "missing codex binary" }),
     });
@@ -781,6 +791,80 @@ describe("codex app-server handler extra branches", () => {
       [makeMessage("m1", "first"), makeMessage("m2", "second"), makeMessage("m3", "third")],
       { status: "success", terminal: true },
     );
+
+    await handler.shutdown();
+  });
+
+  it("replays pre-turn buffered notifications and settles terminal turn/start tool fallbacks", async () => {
+    const fake = new FakeAppServerClient();
+    fake.responders.set("turn/start", () => {
+      fake.emit("item/completed", {
+        threadId: "thread-app-server",
+        turnId: "turn-inline",
+        item: { type: "agentMessage", id: "buffered-agent", text: "buffered answer" },
+      });
+      fake.emit("unknown/event", { threadId: "thread-app-server", turnId: "turn-inline", ignored: true });
+      return {
+        turn: {
+          id: "turn-inline",
+          status: "completed",
+          error: null,
+          items: [
+            {
+              type: "commandExecution",
+              id: "cmd-failed",
+              status: "failed",
+              command: "false",
+              aggregatedOutput: { ignored: true },
+            },
+            { type: "commandExecution", id: "cmd-pending", status: "queued", command: null, cwd: 42 },
+            { type: "fileChange", id: "file-declined", status: "declined", changes: [{ path: "src/blocked.ts" }] },
+            { type: "mcpToolCall", id: "mcp-pending", status: "queued", arguments: { query: "docs" } },
+          ],
+        },
+      };
+    });
+    const emitEvent = vi.fn<(event: SessionEvent) => void>();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+
+    await handler.start(makeMessage("m1", "first"), makeContext({ emitEvent }), token);
+
+    const events = emitEvent.mock.calls.map(([event]) => event);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "assistant_text", payload: { text: "buffered answer" } }),
+        expect.objectContaining({
+          kind: "tool_call",
+          payload: expect.objectContaining({ toolUseId: "cmd-failed", name: "command", status: "error" }),
+        }),
+        expect.objectContaining({
+          kind: "tool_call",
+          payload: expect.objectContaining({ toolUseId: "cmd-pending", name: "command", status: "pending" }),
+        }),
+        expect.objectContaining({
+          kind: "tool_call",
+          payload: expect.objectContaining({ toolUseId: "file-declined", name: "file_change", status: "error" }),
+        }),
+        expect.objectContaining({
+          kind: "tool_call",
+          payload: expect.objectContaining({
+            toolUseId: "mcp-pending",
+            name: "mcp:unknown/unknown",
+            status: "pending",
+          }),
+        }),
+      ]),
+    );
+    const mcpEvent = events.find(
+      (event): event is Extract<SessionEvent, { kind: "tool_call" }> =>
+        event.kind === "tool_call" && event.payload.toolUseId === "mcp-pending",
+    );
+    expect(mcpEvent?.payload.resultPreview).toBeUndefined();
+    expect(token.complete).toHaveBeenCalledWith([makeMessage("m1", "first")], {
+      status: "success",
+      terminal: true,
+    });
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -1795,31 +1795,32 @@ describe("codex app-server handler", () => {
     await handler.shutdown();
   });
 
-  it.each(["httpConnectionFailed", "responseStreamConnectionFailed", "responseStreamDisconnected"])(
-    "keeps structured transient %s turn failures retryable",
-    async (key) => {
-      const fake = new FakeAppServerClient();
-      const token = makeDeliveryToken();
-      const handler = makeHandler(fake);
-      const ctx = makeContext();
-      const message = makeMessage("m1", "first");
+  it.each([
+    "httpConnectionFailed",
+    "responseStreamConnectionFailed",
+    "responseStreamDisconnected",
+  ])("keeps structured transient %s turn failures retryable", async (key) => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+    const message = makeMessage("m1", "first");
 
-      const startPromise = handler.start(message, ctx, token);
-      await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
 
-      failTurn(fake, "turn-1", {
-        message: `${key} while streaming`,
-        codexErrorInfo: { [key]: true },
-      });
-      await startPromise;
+    failTurn(fake, "turn-1", {
+      message: `${key} while streaming`,
+      codexErrorInfo: { [key]: true },
+    });
+    await startPromise;
 
-      expect(token.retry).toHaveBeenCalledWith([message], "codex_transient_failure");
-      expect(token.terminalRejected).not.toHaveBeenCalled();
-      expect(token.complete).not.toHaveBeenCalled();
+    expect(token.retry).toHaveBeenCalledWith([message], "codex_transient_failure");
+    expect(token.terminalRejected).not.toHaveBeenCalled();
+    expect(token.complete).not.toHaveBeenCalled();
 
-      await handler.shutdown();
-    },
-  );
+    await handler.shutdown();
+  });
 
   it("consumes accepted-turn capacity wait stops instead of terminal-rejecting them", async () => {
     const fake = new FakeAppServerClient();

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -681,6 +681,35 @@ describe("codex app-server handler", () => {
     await handler.shutdown();
   });
 
+  it("leaves landing trial delivery recoverable when confirmed success events are unsupported", async () => {
+    stubLandingTrialHostEnv("confirm-missing");
+
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const failSessionForRecovery = vi.fn<NonNullable<SessionContext["failSessionForRecovery"]>>();
+    const handler = makeHandler(fake);
+    const ctx = makeContext({
+      failSessionForRecovery,
+      agentMetadata: trialAgentMetadata,
+    });
+    const message = makeMessage("m1", "first", 102);
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    completeTurn(fake, "turn-1", "final answer");
+    await startPromise;
+
+    expect(token.complete).not.toHaveBeenCalled();
+    expect(token.retry).toHaveBeenCalledWith([message], LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED);
+    expect(failSessionForRecovery).toHaveBeenCalledWith(
+      LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED,
+      "thread-app-server",
+    );
+
+    await handler.shutdown();
+  });
+
   it("does not block ordinary Codex delivery on confirmed event rejection", async () => {
     const fake = new FakeAppServerClient();
     const token = makeDeliveryToken();
@@ -1543,6 +1572,63 @@ describe("codex app-server handler", () => {
     await handler.shutdown();
   });
 
+  it.each([
+    ["bad request", "badRequest", "bad request rejected the request", "codex_bad_request_failure"],
+    ["cyber policy", "cyberPolicy", "bad request rejected by cyber policy", "codex_cyber_policy_failure"],
+  ])("terminal-rejects deterministic %s turn failures", async (_label, codexErrorInfo, messageText, reason) => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    failTurn(fake, "turn-1", {
+      message: messageText,
+      codexErrorInfo,
+    });
+    await startPromise;
+
+    expect(token.terminalRejected).toHaveBeenCalledWith([message], reason, {
+      kind: "server_terminal_record",
+      recordId: "turn-1",
+    });
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(token.complete).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
+  it("consumes sandbox configuration turn failures instead of retrying delivery", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+    const message = makeMessage("m1", "first");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    failTurn(fake, "turn-1", {
+      message: "sandbox rejected the request",
+      codexErrorInfo: "sandboxError",
+    });
+    await startPromise;
+
+    expect(token.complete).toHaveBeenCalledWith([message], {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_configuration_error",
+    });
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(token.terminalRejected).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
   it("terminal-rejects stderr-only remote compact context-window failures", async () => {
     const fake = new FakeAppServerClient();
     const retryTurn = vi.fn<SessionContext["retryTurn"]>();
@@ -1643,6 +1729,7 @@ describe("codex app-server handler", () => {
 
   it("keeps completed empty turns without compact diagnostics as successful silence", async () => {
     const fake = new FakeAppServerClient();
+    fake.stderr = "ordinary app-server diagnostic without compact failure";
     const token = makeDeliveryToken();
     const handler = makeHandler(fake);
     const ctx = makeContext();
@@ -1707,6 +1794,32 @@ describe("codex app-server handler", () => {
 
     await handler.shutdown();
   });
+
+  it.each(["httpConnectionFailed", "responseStreamConnectionFailed", "responseStreamDisconnected"])(
+    "keeps structured transient %s turn failures retryable",
+    async (key) => {
+      const fake = new FakeAppServerClient();
+      const token = makeDeliveryToken();
+      const handler = makeHandler(fake);
+      const ctx = makeContext();
+      const message = makeMessage("m1", "first");
+
+      const startPromise = handler.start(message, ctx, token);
+      await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+      failTurn(fake, "turn-1", {
+        message: `${key} while streaming`,
+        codexErrorInfo: { [key]: true },
+      });
+      await startPromise;
+
+      expect(token.retry).toHaveBeenCalledWith([message], "codex_transient_failure");
+      expect(token.terminalRejected).not.toHaveBeenCalled();
+      expect(token.complete).not.toHaveBeenCalled();
+
+      await handler.shutdown();
+    },
+  );
 
   it("consumes accepted-turn capacity wait stops instead of terminal-rejecting them", async () => {
     const fake = new FakeAppServerClient();

--- a/packages/client/src/__tests__/doc-snapshots.test.ts
+++ b/packages/client/src/__tests__/doc-snapshots.test.ts
@@ -141,6 +141,36 @@ describe("buildMessageDocumentSnapshots — capture + attachment-link rewrite", 
     );
   });
 
+  it("rewrites a bare doc token enclosed in a code span", async () => {
+    const { refs, rewrittenText } = await buildMessageDocumentSnapshots("see `docs/intro.md`", root, opts(uploader));
+    expect(refs).toHaveLength(1);
+    expect(rewrittenText).toBe("see [`docs/intro.md`](attachment:00000000-0000-4000-8000-000000000001)");
+  });
+
+  it("caps document refs at the per-message attachment budget", async () => {
+    const names = Array.from({ length: 21 }, (_, i) => `budget-${i + 1}.md`);
+    await Promise.all(names.map((name) => writeFile(join(root, name), `# ${name}\n`, "utf8")));
+
+    const { refs, skipped, failedMentions } = await buildMessageDocumentSnapshots(
+      names.map((name) => `[${name}](${name})`).join(" "),
+      root,
+      opts(uploader),
+    );
+
+    expect(refs).toHaveLength(10);
+    expect(skipped).toBe(11);
+    expect(failedMentions).toEqual([]);
+  });
+
+  it("reports an existing .md directory as missing", async () => {
+    await mkdir(join(root, "folder.md"), { recursive: true });
+
+    const { refs, failedMentions } = await buildMessageDocumentSnapshots("see folder.md", root, opts(uploader));
+
+    expect(refs).toEqual([]);
+    expect(failedMentions).toEqual([{ raw: "folder.md", reason: "missing" }]);
+  });
+
   it("rejects a symlink whose realpath crosses into a hidden dir (relative + absolute)", async () => {
     const relOut = await buildMessageDocumentSnapshots("see [p](public.md)", root, opts(uploader));
     expect(relOut.refs).toEqual([]);
@@ -213,15 +243,20 @@ describe("buildMessageDocumentSnapshots — cross-agent workspace fence", () => 
   let workspacesRoot: string;
   let selfRoot: string;
   let crossRoot: string;
+  let otherChatRoot: string;
   const CHAT = "22222222-2222-4222-8222-222222222222";
+  const OTHER_CHAT = "33333333-3333-4333-8333-333333333333";
 
   beforeAll(async () => {
     workspacesRoot = await mkdtemp(join(tmpdir(), "doc-snap-ws-"));
     selfRoot = join(workspacesRoot, "coder", CHAT);
     crossRoot = join(workspacesRoot, "assistant", CHAT);
+    otherChatRoot = join(workspacesRoot, "assistant", OTHER_CHAT);
     await mkdir(selfRoot, { recursive: true });
     await mkdir(crossRoot, { recursive: true });
+    await mkdir(otherChatRoot, { recursive: true });
     await writeFile(join(crossRoot, "plan.md"), "# their plan\n", "utf8");
+    await writeFile(join(otherChatRoot, "plan.md"), "# other plan\n", "utf8");
   });
 
   afterAll(async () => {
@@ -251,6 +286,54 @@ describe("buildMessageDocumentSnapshots — cross-agent workspace fence", () => 
     const abs = join(crossRoot, "plan.md");
     const { refs } = await buildMessageDocumentSnapshots(`see ${abs}`, selfRoot, opts(stub.uploader));
     expect(refs).toEqual([]);
+  });
+
+  it("classifies a cross-agent doc from a different chat as out-of-fence", async () => {
+    const stub = stubUploader();
+    const abs = join(otherChatRoot, "plan.md");
+    const { refs, failedMentions } = await buildMessageDocumentSnapshots(
+      `see ${abs}`,
+      selfRoot,
+      opts(stub.uploader),
+      fence(),
+    );
+
+    expect(refs).toEqual([]);
+    expect(failedMentions).toEqual([{ raw: abs, reason: "out-of-fence" }]);
+  });
+
+  it("classifies a same-owner same-chat path outside the current agent home as missing", async () => {
+    const activeRoot = join(selfRoot, "active");
+    const sibling = join(selfRoot, "sibling.md");
+    await mkdir(activeRoot, { recursive: true });
+    await writeFile(sibling, "# sibling\n", "utf8");
+
+    const stub = stubUploader();
+    const { refs, failedMentions } = await buildMessageDocumentSnapshots(
+      `see ${sibling}`,
+      activeRoot,
+      opts(stub.uploader),
+      fence(),
+    );
+
+    expect(refs).toEqual([]);
+    expect(failedMentions).toEqual([{ raw: sibling, reason: "missing" }]);
+  });
+
+  it("classifies a cross-agent .md directory as missing", async () => {
+    const dir = join(crossRoot, "directory.md");
+    await mkdir(dir, { recursive: true });
+
+    const stub = stubUploader();
+    const { refs, failedMentions } = await buildMessageDocumentSnapshots(
+      `see ${dir}`,
+      selfRoot,
+      opts(stub.uploader),
+      fence(),
+    );
+
+    expect(refs).toEqual([]);
+    expect(failedMentions).toEqual([{ raw: dir, reason: "missing" }]);
   });
 });
 
@@ -285,6 +368,7 @@ describe("buildMessageDocumentSnapshots — wide self-fence over the agent home"
 
     outside = await mkdtemp(join(tmpdir(), "doc-snap-home-outside-"));
     await writeFile(join(outside, "external.md"), "# external\n", "utf8");
+    await symlink(outside, join(agentHome, "outside-link"), "dir");
   });
 
   afterAll(async () => {
@@ -379,6 +463,36 @@ describe("buildMessageDocumentSnapshots — wide self-fence over the agent home"
     expect(stub.uploads).toEqual([]);
     expect(rewrittenText).toBe("see .agent/secret.md");
     expect(failedMentions).toEqual([{ raw: ".agent/secret.md", reason: "hidden-segment" }]);
+  });
+
+  it("falls back to the agent home when singleRepoLocalPath is missing or outside the home", async () => {
+    const missingStub = stubUploader();
+    const missing = await buildMessageDocumentSnapshots(
+      "see docs/note.md",
+      { agentHome: agentHomeReal, singleRepoLocalPath: "missing-repo" },
+      opts(missingStub.uploader),
+    );
+    expect(missing.refs[0]?.source?.path).toBe("docs/note.md");
+
+    const outsideStub = stubUploader();
+    const outsideLink = await buildMessageDocumentSnapshots(
+      "see docs/note.md",
+      { agentHome: agentHomeReal, singleRepoLocalPath: "outside-link" },
+      opts(outsideStub.uploader),
+    );
+    expect(outsideLink.refs[0]?.source?.path).toBe("docs/note.md");
+  });
+
+  it("reports a promoted missing source-repo mention as missing", async () => {
+    const stub = stubUploader();
+    const { refs, failedMentions } = await buildMessageDocumentSnapshots(
+      "see docs/missing.md",
+      { agentHome: agentHomeReal, singleRepoLocalPath: "first-tree" },
+      opts(stub.uploader),
+    );
+
+    expect(refs).toEqual([]);
+    expect(failedMentions).toEqual([{ raw: "docs/missing.md", reason: "missing" }]);
   });
 });
 

--- a/packages/client/src/__tests__/first-tree-skills-installer-extra.test.ts
+++ b/packages/client/src/__tests__/first-tree-skills-installer-extra.test.ts
@@ -1,0 +1,208 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  installFirstTreeSkills,
+  installOneSkill,
+  resolveBundledSkillsRoot,
+  TREE_SKILL_NAMES,
+} from "../runtime/first-tree-skills/installer.js";
+import { writeManagedState } from "../runtime/managed-state.js";
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+function skillLayout(root: string, name = "first-tree-write") {
+  return {
+    name,
+    sourceDir: join(root, name),
+    agentsRelPath: join(".agents", "skills", name),
+    claudeRelPath: join(".claude", "skills", name),
+    claudeSymlinkTarget: join("..", "..", ".agents", "skills", name),
+  };
+}
+
+function writeSkill(root: string, name = "first-tree-write", version?: string): void {
+  const dir = join(root, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "SKILL.md"), `---\nname: ${name}\n---\nfixture for ${name}\n`);
+  if (version !== undefined) writeFileSync(join(dir, "VERSION"), version);
+}
+
+function writeTreeSkillsRoot(parent: string): string {
+  const root = join(parent, "bundled-skills");
+  for (const name of TREE_SKILL_NAMES) writeSkill(root, name, "1.0.0");
+  return root;
+}
+
+function plantManagedSkill(workspace: string, name: string, claudeShape: "directory" | "symlink" = "symlink"): void {
+  const agentsDir = join(workspace, ".agents", "skills", name);
+  mkdirSync(agentsDir, { recursive: true });
+  writeFileSync(join(agentsDir, "SKILL.md"), `stale ${name}\n`);
+  const claudePath = join(workspace, ".claude", "skills", name);
+  mkdirSync(join(workspace, ".claude", "skills"), { recursive: true });
+  if (claudeShape === "directory") {
+    mkdirSync(claudePath, { recursive: true });
+    writeFileSync(join(claudePath, "SKILL.md"), `stale claude ${name}\n`);
+  } else {
+    symlinkSync(join("..", "..", ".agents", "skills", name), claudePath);
+  }
+}
+
+describe("first-tree skill installer edge coverage", () => {
+  let tmpBase: string;
+  let workspace: string;
+
+  beforeEach(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "ft-skill-installer-"));
+    workspace = join(tmpBase, "workspace");
+    mkdirSync(workspace, { recursive: true });
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    vi.doUnmock("node:fs");
+    vi.resetModules();
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("reports a packaging error when bundled skills cannot be found", () => {
+    expect(() => resolveBundledSkillsRoot(join(tmpBase, "empty"))).toThrow(
+      "Could not locate bundled `skills/` payloads",
+    );
+  });
+
+  it("uses the package bundled root when installing tree skills without a test override", () => {
+    const result = installFirstTreeSkills({ workspacePath: workspace });
+
+    expect(result.ok).toBe(true);
+    for (const name of TREE_SKILL_NAMES) {
+      expect(existsSync(join(workspace, ".agents", "skills", name, "SKILL.md"))).toBe(true);
+      expect(lstatSync(join(workspace, ".claude", "skills", name)).isSymbolicLink()).toBe(true);
+    }
+  });
+
+  it("repairs a stale Claude directory companion without recopying matching agent payloads", () => {
+    const bundledRoot = join(tmpBase, "bundled");
+    writeSkill(bundledRoot, "first-tree-write", "1.0.0");
+    const layout = skillLayout(bundledRoot);
+    expect(installOneSkill(workspace, layout)).toBe("installed");
+    writeFileSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"), "keep\n");
+    rmSync(join(workspace, ".claude", "skills", "first-tree-write"), { recursive: true, force: true });
+    mkdirSync(join(workspace, ".claude", "skills", "first-tree-write"), { recursive: true });
+
+    expect(installOneSkill(workspace, layout)).toBe("skipped");
+
+    expect(readlinkSync(join(workspace, ".claude", "skills", "first-tree-write"))).toBe(
+      join("..", "..", ".agents", "skills", "first-tree-write"),
+    );
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"))).toBe(true);
+  });
+
+  it("reinstalls when installed VERSION cannot be read", () => {
+    const bundledRoot = join(tmpBase, "bundled-version-read");
+    writeSkill(bundledRoot, "first-tree-write", "1.0.0");
+    const layout = skillLayout(bundledRoot);
+    expect(installOneSkill(workspace, layout)).toBe("installed");
+    rmSync(join(workspace, ".agents", "skills", "first-tree-write", "VERSION"), { force: true });
+    mkdirSync(join(workspace, ".agents", "skills", "first-tree-write", "VERSION"));
+    writeFileSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"), "remove\n");
+
+    expect(installOneSkill(workspace, layout)).toBe("installed");
+
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"))).toBe(false);
+    expect(readFileSync(join(workspace, ".agents", "skills", "first-tree-write", "VERSION"), "utf8")).toBe("1.0.0");
+  });
+
+  it("reinstalls when installed SKILL.md cannot be read despite a matching VERSION", () => {
+    const bundledRoot = join(tmpBase, "bundled-skill-read");
+    writeSkill(bundledRoot, "first-tree-write", "1.0.0");
+    const layout = skillLayout(bundledRoot);
+    expect(installOneSkill(workspace, layout)).toBe("installed");
+    rmSync(join(workspace, ".agents", "skills", "first-tree-write", "SKILL.md"), { force: true });
+    mkdirSync(join(workspace, ".agents", "skills", "first-tree-write", "SKILL.md"));
+    writeFileSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"), "remove\n");
+
+    expect(installOneSkill(workspace, layout)).toBe("installed");
+
+    expect(existsSync(join(workspace, ".agents", "skills", "first-tree-write", ".sentinel"))).toBe(false);
+    expect(readFileSync(join(workspace, ".agents", "skills", "first-tree-write", "SKILL.md"), "utf8")).toContain(
+      "fixture for first-tree-write",
+    );
+  });
+
+  it("removes retired managed skills whose Claude companion is a directory", () => {
+    const bundledSkillsRoot = writeTreeSkillsRoot(tmpBase);
+    plantManagedSkill(workspace, "legacy-directory", "directory");
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      skills: [...TREE_SKILL_NAMES, "legacy-directory"],
+    });
+
+    const result = installFirstTreeSkills({ workspacePath: workspace, bundledSkillsRoot });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(workspace, ".agents", "skills", "legacy-directory"))).toBe(false);
+    expect(existsSync(join(workspace, ".claude", "skills", "legacy-directory"))).toBe(false);
+  });
+
+  it("throws non-Windows symlink failures after cleaning the temp symlink path", async () => {
+    const bundledRoot = join(tmpBase, "bundled-non-windows-symlink-error");
+    writeSkill(bundledRoot, "first-tree-write", "1.0.0");
+    setPlatform("linux");
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        symlinkSync: () => {
+          throw Object.assign(new Error("symlink denied"), { code: "EIO" });
+        },
+      };
+    });
+    const mod = await import("../runtime/first-tree-skills/installer.js");
+
+    expect(() => mod.installOneSkill(workspace, skillLayout(bundledRoot))).toThrow("symlink denied");
+  });
+
+  it("keeps a current Windows directory fallback after the agent payload is refreshed", async () => {
+    const bundledRoot = join(tmpBase, "bundled-windows-directory-current");
+    writeSkill(bundledRoot, "first-tree-write", "1.0.0");
+    setPlatform("win32");
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        symlinkSync: () => {
+          throw Object.assign(new Error("symlink denied"), { code: "EPERM" });
+        },
+      };
+    });
+    const mod = await import("../runtime/first-tree-skills/installer.js");
+
+    expect(mod.installOneSkill(workspace, skillLayout(bundledRoot))).toBe("installed");
+    writeFileSync(join(bundledRoot, "first-tree-write", "VERSION"), "2.0.0");
+    writeFileSync(join(workspace, ".claude", "skills", "first-tree-write", "VERSION"), "2.0.0");
+    writeFileSync(join(workspace, ".claude", "skills", "first-tree-write", ".sentinel"), "keep\n");
+    expect(mod.installOneSkill(workspace, skillLayout(bundledRoot))).toBe("installed");
+
+    expect(existsSync(join(workspace, ".claude", "skills", "first-tree-write", ".sentinel"))).toBe(true);
+  });
+});

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -4,13 +4,16 @@ import { join } from "node:path";
 import type {
   AgentRuntimeConfig,
   InboxEntryWithMessage,
+  ProviderRetryEventPayload,
   RuntimeState,
   SessionEvent,
   SessionState,
 } from "@first-tree/shared";
+import { encodeProviderRetryEventMessage } from "@first-tree/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
-import type { DeliveryDecision, DeliveryWork } from "../runtime/inbox-delivery-coordinator.js";
+import type { DeliveryDecision, DeliveryRouteOwnership, DeliveryWork } from "../runtime/inbox-delivery-coordinator.js";
+import type { SubprocessProbe } from "../runtime/process-tree-probe.js";
 import { SessionManager } from "../runtime/session-manager.js";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { recordingLogger, silentLogger } from "./_logger-helpers.js";
@@ -27,7 +30,12 @@ type SessionRecord = {
   retryNextAt: number | null;
   retryTimer: ReturnType<typeof setTimeout> | null;
   lastRetryReason: string | null;
+  lastRetryCategory: string | null;
+  lastRetryScope: "session_start" | "session_resume" | null;
+  lastRetryRawError: string | null;
   startMessage: SessionMessage | null;
+  retryQueuedMessages: SessionMessage[];
+  pendingRuntimeFailureNotice: ProviderRetryEventPayload | null;
   retryFromEvicted: { claudeSessionId: string; lastActivity: number } | null;
 };
 
@@ -35,9 +43,11 @@ type SessionManagerInternals = {
   sessions: Map<string, SessionRecord>;
   evictedMappings: Map<string, { claudeSessionId: string; lastActivity: number }>;
   pendingQueue: Array<{ message: SessionMessage | null; chatId: string; deliveryKind: string }>;
+  sessionRuntimeStates: Map<string, RuntimeState>;
+  currentTrigger: Map<string, { messageId: string; senderId: string }>;
   inboxDelivery: {
     receive(entry: InboxEntryWithMessage): DeliveryDecision;
-    markOwned(work: DeliveryWork): boolean;
+    markOwned(work: DeliveryWork): DeliveryRouteOwnership;
     markProcessingStarted(chatId: string, messages: SessionMessage | readonly SessionMessage[]): void;
     prepareOperatorSuspend(chatId: string): Promise<void>;
     hasRecoveryDebt(chatId: string): boolean;
@@ -47,10 +57,19 @@ type SessionManagerInternals = {
   routeMessage(chatId: string, message: SessionMessage): Promise<void>;
   resumeSession(entry: SessionRecord, message: SessionMessage | null | undefined): Promise<void>;
   runRetry(chatId: string): Promise<void>;
+  abortUnownedRoute(entry: SessionRecord, reason: string): void;
+  ensureContextTreeBinding(): Promise<void>;
+  markRouteOwned(
+    chatId: string,
+    message: SessionMessage,
+    receipt: { kind: "owned"; mode: "queued" },
+  ): DeliveryRouteOwnership;
   triggerImmediateRetry(chatId: string): void;
   drainPendingQueue(): void;
   evictIfNeeded(): void;
   notifySessionState(chatId: string, state: SessionState): void;
+  projectSessionRuntime(chatId: string, opts?: { drainPendingOnIdle?: boolean }): void;
+  recomputeRuntimeState(): void;
   buildSessionContext(chatId: string): SessionContext;
   confirmSessionEventOrThrow(chatId: string, event: SessionEvent): Promise<void>;
   resolveSelfFence(
@@ -150,6 +169,8 @@ function makeManager(
     maxSessions?: number;
     sdk?: FirstTreeHubSDK;
     agentConfigCache?: ReturnType<typeof makeCache>;
+    log?: ReturnType<typeof silentLogger>;
+    subprocessProbe?: SubprocessProbe;
     onStateChange?: (chatId: string, state: SessionState) => void;
     onRuntimeStateChange?: (state: TestRuntimeState) => void;
     onSessionRuntimeChange?: (chatId: string, state: TestRuntimeState) => void;
@@ -171,6 +192,7 @@ function makeManager(
   return new SessionManager({
     session: { ...sessionConfig, max_sessions: opts.maxSessions ?? sessionConfig.max_sessions },
     concurrency: opts.concurrency ?? 5,
+    subprocessProbe: opts.subprocessProbe,
     handlerFactory,
     handlerConfig: { workspaceRoot: opts.workspaceRoot ?? "/tmp/test-edge/agent-a" },
     agentIdentity: {
@@ -183,7 +205,7 @@ function makeManager(
       metadata: {},
     },
     sdk: opts.sdk ?? mockSdk(),
-    log: silentLogger(),
+    log: opts.log ?? silentLogger(),
     registryPath: opts.registryPath,
     agentConfigCache: opts.agentConfigCache,
     runtimeSessionTokenFile: opts.runtimeSessionTokenFile,
@@ -238,7 +260,12 @@ function makeSessionRecord(chatId: string, overrides: Partial<SessionRecord> = {
     retryNextAt: null,
     retryTimer: null,
     lastRetryReason: null,
+    lastRetryCategory: null,
+    lastRetryScope: null,
+    lastRetryRawError: null,
     startMessage: makeMessage(chatId),
+    retryQueuedMessages: [],
+    pendingRuntimeFailureNotice: null,
     retryFromEvicted: null,
     ...overrides,
   };
@@ -246,6 +273,7 @@ function makeSessionRecord(chatId: string, overrides: Partial<SessionRecord> = {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
@@ -1349,5 +1377,416 @@ describe("SessionManager edge coverage", () => {
       true,
     );
     await sm.shutdown();
+  });
+
+  it("reaffirms active runtime states on the jittered timer and recomputes blocked/error aggregates", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const sessionRuntimeChanges: Array<{ chatId: string; state: RuntimeState }> = [];
+    const aggregateChanges: RuntimeState[] = [];
+    const sm = makeManager({
+      onSessionRuntimeChange: (chatId, state) => sessionRuntimeChanges.push({ chatId, state }),
+      onRuntimeStateChange: (state) => aggregateChanges.push(state),
+    });
+    const i = internals(sm);
+    i.sessions.set("chat-working", makeSessionRecord("chat-working", { status: "active" }));
+    i.sessions.set("chat-error", makeSessionRecord("chat-error", { status: "errored" }));
+    i.sessions.set("chat-idle", makeSessionRecord("chat-idle", { status: "active" }));
+    i.sessionRuntimeStates.set("chat-working", "working");
+    i.sessionRuntimeStates.set("chat-error", "error");
+    i.sessionRuntimeStates.set("chat-idle", "idle");
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(sessionRuntimeChanges).toEqual([
+      { chatId: "chat-working", state: "working" },
+      { chatId: "chat-error", state: "error" },
+    ]);
+
+    i.sessionRuntimeStates.clear();
+    i.sessionRuntimeStates.set("chat-working", "working");
+    i.sessionRuntimeStates.set("chat-blocked", "blocked");
+    i.recomputeRuntimeState();
+    i.sessionRuntimeStates.set("chat-error", "error");
+    i.recomputeRuntimeState();
+
+    expect(aggregateChanges).toContain("blocked");
+    expect(aggregateChanges).toContain("error");
+    await sm.shutdown();
+  });
+
+  it("eagerly fetches valid image batches and logs failed attachment downloads", async () => {
+    const home = mkdtempSync(join(tmpdir(), "ft-session-images-"));
+    vi.stubEnv("FIRST_TREE_HOME", home);
+    const fetchAttachment = vi
+      .fn<(params: { id: string }) => Promise<{ bytes: Buffer }>>()
+      .mockResolvedValueOnce({ bytes: Buffer.from("png bytes") })
+      .mockRejectedValueOnce(new Error("blob missing"));
+    const sdk = { ...mockSdk(), fetchAttachment } as unknown as FirstTreeHubSDK;
+    const started = handler();
+    const sm = makeManager({ handlers: [started], sdk });
+    const base = mockEntry({ id: 501, chatId: "chat-images", messageId: "msg-images" });
+    const entry = {
+      ...base,
+      message: {
+        ...base.message,
+        format: "file",
+        content: {
+          caption: "two images",
+          attachments: [
+            {
+              imageId: "11111111-1111-4111-8111-111111111111",
+              mimeType: "image/png",
+              filename: "first.png",
+            },
+            {
+              imageId: "22222222-2222-4222-8222-222222222222",
+              mimeType: "image/jpeg",
+              filename: "second.jpg",
+            },
+          ],
+        },
+      },
+    } as InboxEntryWithMessage;
+
+    await sm.dispatch(entry);
+
+    expect(fetchAttachment).toHaveBeenCalledTimes(2);
+    expect(fetchAttachment).toHaveBeenNthCalledWith(1, { id: "11111111-1111-4111-8111-111111111111" });
+    expect(
+      readFileSync(
+        join(home, "data", "chats", "chat-images", "images", "11111111-1111-4111-8111-111111111111.png"),
+        "utf8",
+      ),
+    ).toBe("png bytes");
+    expect(started.start).toHaveBeenCalledTimes(1);
+
+    const singleBase = mockEntry({ id: 502, chatId: "chat-images", messageId: "msg-image-existing" });
+    await sm.dispatch({
+      ...singleBase,
+      message: {
+        ...singleBase.message,
+        format: "file",
+        content: {
+          imageId: "11111111-1111-4111-8111-111111111111",
+          mimeType: "image/png",
+          filename: "first.png",
+        },
+      },
+    } as InboxEntryWithMessage);
+
+    expect(fetchAttachment).toHaveBeenCalledTimes(2);
+    expect(started.inject).toHaveBeenCalledTimes(1);
+    await sm.shutdown();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("retries consumed error completions when runtime notice delivery and failure-event emit both fail", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockRejectedValue(new Error("notice store offline"));
+    const sdk = { ...mockSdk(), sendMessage } as unknown as FirstTreeHubSDK;
+    let capturedToken: Parameters<AgentHandler["start"]>[2] | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const started = handler({
+      async start(message, _ctx, token) {
+        capturedMessage = message;
+        capturedToken = token;
+        return "runtime-notice-session";
+      },
+    });
+    const sm = makeManager({
+      handlers: [started],
+      ackEntry,
+      recoverChat,
+      sdk,
+      onSessionEvent: () => {
+        throw new Error("event stream closed");
+      },
+    });
+
+    await sm.dispatch(mockEntry({ id: 502, chatId: "chat-notice-emit-fail", messageId: "msg-notice-emit-fail" }));
+    const entry = internals(sm).sessions.get("chat-notice-emit-fail");
+    if (!entry || !capturedMessage || !capturedToken) throw new Error("delivery was not captured");
+    entry.pendingRuntimeFailureNotice = {
+      event: "provider_failure_terminal",
+      provider: "claude-code",
+      scope: "provider_turn",
+      category: "credential",
+      reasonCode: "provider_credential_required",
+      replaySafety: "provider_entered",
+      userSeverity: "error",
+      messagePreview: "auth expired",
+    };
+
+    await capturedToken.complete(capturedMessage, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_failed",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(ackEntry).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-notice-emit-fail"));
+    await sm.shutdown();
+  });
+
+  it("retries and rethrows admission failures after local custody is still open", async () => {
+    const sm = makeManager();
+    internals(sm).ensureContextTreeBinding = vi.fn().mockRejectedValue(new Error("tree resolver failed"));
+
+    await expect(
+      sm.dispatch(mockEntry({ id: 504, chatId: "chat-admission-fail", messageId: "msg-admission-fail" })),
+    ).rejects.toThrow("tree resolver failed");
+
+    expect(internals(sm).inboxDelivery.hasRecoveryDebt("chat-admission-fail")).toBe(true);
+    await sm.shutdown();
+  });
+
+  it("logs resilience emit failures when slot queuing cannot notify listeners", async () => {
+    const sm = makeManager({
+      concurrency: 1,
+      onSessionEvent: () => {
+        throw new Error("event sink unavailable");
+      },
+    });
+    internals(sm)._activeCount = 1;
+
+    await internals(sm).routeMessage("chat-queue-emit-fail", makeMessage("chat-queue-emit-fail"));
+
+    expect(internals(sm).pendingQueue.some((item) => item.chatId === "chat-queue-emit-fail")).toBe(true);
+    await sm.shutdown();
+  });
+
+  it("logs second-stage suspend cleanup failures when the suspend warning path itself throws", async () => {
+    const log = silentLogger();
+    const warn = vi
+      .spyOn(log, "warn")
+      .mockImplementationOnce(() => {
+        throw new Error("warn transport failed");
+      })
+      .mockImplementation(() => undefined);
+    const sm = makeManager({
+      handlers: [handler({ suspend: vi.fn().mockRejectedValue(new Error("suspend failed")) })],
+      log,
+    });
+
+    await sm.dispatch(mockEntry({ id: 505, chatId: "chat-suspend-log-fail", messageId: "msg-suspend-log-fail" }));
+    await sm.handleCommand("chat-suspend-log-fail", "session:suspend");
+    const suspending = internals(sm).sessions.get("chat-suspend-log-fail")?.suspending;
+    if (suspending) await suspending;
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    await sm.shutdown();
+  });
+
+  it("cleans up unowned routes and logs asynchronous unowned shutdown failures", async () => {
+    const badShutdown = vi.fn().mockRejectedValue(new Error("shutdown failed"));
+    const sm = makeManager();
+    const i = internals(sm);
+    const record = makeSessionRecord("chat-unowned", {
+      status: "active",
+      handler: handler({ shutdown: badShutdown }),
+    });
+    i.sessions.set("chat-unowned", record);
+    i._activeCount = 1;
+
+    i.abortUnownedRoute(record, "test_unowned_route");
+
+    expect(i.sessions.has("chat-unowned")).toBe(false);
+    expect(sm.activeCount).toBe(0);
+    await vi.waitFor(() => expect(badShutdown).toHaveBeenCalledWith("test_unowned_route"));
+    await sm.shutdown();
+  });
+
+  it("aborts lost ownership receipts from start, resume, and retry routing branches", async () => {
+    const makeOwnedReceipt = (sessionId: string) => ({ sessionId, route: { kind: "owned", mode: "queued" } as const });
+
+    const startHandler = handler({ start: vi.fn().mockResolvedValue(makeOwnedReceipt("start-lost")) });
+    const startManager = makeManager({ handlers: [startHandler] });
+    internals(startManager).markRouteOwned = vi.fn(() => "lost");
+    await internals(startManager).routeMessage("chat-start-lost", makeMessage("chat-start-lost"));
+    expect(internals(startManager).sessions.has("chat-start-lost")).toBe(false);
+    await startManager.shutdown();
+
+    const evictedHandler = handler({ resume: vi.fn().mockResolvedValue(makeOwnedReceipt("evicted-lost")) });
+    const evictedManager = makeManager({ handlers: [evictedHandler] });
+    internals(evictedManager).evictedMappings.set("chat-evicted-lost", {
+      claudeSessionId: "old-evicted",
+      lastActivity: 1,
+    });
+    internals(evictedManager).markRouteOwned = vi.fn(() => "lost");
+    await internals(evictedManager).routeMessage("chat-evicted-lost", makeMessage("chat-evicted-lost"));
+    expect(internals(evictedManager).sessions.has("chat-evicted-lost")).toBe(false);
+    await evictedManager.shutdown();
+
+    const suspendedRecord = makeSessionRecord("chat-resume-lost", {
+      status: "suspended",
+      handler: handler({ resume: vi.fn().mockResolvedValue(makeOwnedReceipt("resume-lost")) }),
+    });
+    const resumeManager = makeManager();
+    internals(resumeManager).sessions.set("chat-resume-lost", suspendedRecord);
+    internals(resumeManager).markRouteOwned = vi.fn(() => "lost");
+    await internals(resumeManager).resumeSession(suspendedRecord, makeMessage("chat-resume-lost"));
+    expect(internals(resumeManager).sessions.has("chat-resume-lost")).toBe(false);
+    await resumeManager.shutdown();
+
+    const retryResumeHandler = handler({ resume: vi.fn().mockResolvedValue(makeOwnedReceipt("retry-resume-lost")) });
+    const retryResumeManager = makeManager({ handlers: [retryResumeHandler] });
+    internals(retryResumeManager).sessions.set(
+      "chat-retry-resume-lost",
+      makeSessionRecord("chat-retry-resume-lost", {
+        retryAttempt: 1,
+        status: "suspended",
+        claudeSessionId: "previous-retry",
+      }),
+    );
+    internals(retryResumeManager).markRouteOwned = vi.fn(() => "lost");
+    await internals(retryResumeManager).runRetry("chat-retry-resume-lost");
+    expect(internals(retryResumeManager).sessions.has("chat-retry-resume-lost")).toBe(false);
+    await retryResumeManager.shutdown();
+
+    const retryStartHandler = handler({ start: vi.fn().mockResolvedValue(makeOwnedReceipt("retry-start-lost")) });
+    const retryStartManager = makeManager({ handlers: [retryStartHandler] });
+    internals(retryStartManager).sessions.set(
+      "chat-retry-start-lost",
+      makeSessionRecord("chat-retry-start-lost", {
+        retryAttempt: 1,
+        status: "suspended",
+        claudeSessionId: "",
+      }),
+    );
+    internals(retryStartManager).markRouteOwned = vi.fn(() => "lost");
+    await internals(retryStartManager).runRetry("chat-retry-start-lost");
+    expect(internals(retryStartManager).sessions.has("chat-retry-start-lost")).toBe(false);
+    await retryStartManager.shutdown();
+  });
+
+  it("drains active and control pending queue branches, including asynchronous requeue failures", async () => {
+    const activeManager = makeManager();
+    const activeInternals = internals(activeManager);
+    activeInternals.sessions.set("chat-active-drain", makeSessionRecord("chat-active-drain", { status: "active" }));
+    activeInternals.pendingQueue.push({
+      chatId: "chat-active-drain",
+      message: null,
+      deliveryKind: "control",
+    });
+    activeInternals.pendingQueue.push({
+      chatId: "chat-active-drain",
+      message: makeMessage("chat-active-drain"),
+      deliveryKind: "fresh",
+    });
+    activeInternals.routeMessage = vi.fn().mockRejectedValue(new Error("active drain failed"));
+
+    activeInternals.drainPendingQueue();
+    await vi.waitFor(() => expect(activeInternals.routeMessage).toHaveBeenCalledTimes(1));
+    expect(activeInternals.pendingQueue.some((item) => item.chatId === "chat-active-drain")).toBe(true);
+    await activeManager.shutdown();
+
+    const activeInboxManager = makeManager();
+    const activeInboxInternals = internals(activeInboxManager);
+    activeInboxInternals.sessions.set(
+      "chat-active-inbox-drain",
+      makeSessionRecord("chat-active-inbox-drain", { status: "active" }),
+    );
+    const activeInboxEntry = mockEntry({
+      id: 999,
+      chatId: "chat-active-inbox-drain",
+      messageId: "msg-chat-active-inbox-drain",
+    });
+    activeInboxInternals.inboxDelivery.receive(activeInboxEntry);
+    activeInboxInternals.pendingQueue.push({
+      chatId: "chat-active-inbox-drain",
+      message: { ...makeMessage("chat-active-inbox-drain"), inboxEntryId: 999 },
+      deliveryKind: "fresh",
+    });
+    activeInboxInternals.routeMessage = vi.fn().mockRejectedValue(new Error("active inbox drain failed"));
+
+    activeInboxInternals.drainPendingQueue();
+    await vi.waitFor(() => expect(activeInboxInternals.routeMessage).toHaveBeenCalledTimes(1));
+    expect(activeInboxInternals.pendingQueue.some((item) => item.chatId === "chat-active-inbox-drain")).toBe(false);
+    await activeInboxManager.shutdown();
+
+    const controlManager = makeManager();
+    const controlInternals = internals(controlManager);
+    const suspended = makeSessionRecord("chat-control-drain", { status: "suspended" });
+    controlInternals.sessions.set("chat-control-drain", suspended);
+    controlInternals.pendingQueue.push({
+      chatId: "chat-control-drain",
+      message: null,
+      deliveryKind: "control",
+    });
+    controlInternals.resumeSession = vi.fn().mockRejectedValue(new Error("control resume failed"));
+
+    controlInternals.drainPendingQueue();
+    await vi.waitFor(() =>
+      expect(controlInternals.resumeSession).toHaveBeenCalledWith(suspended, undefined, "control"),
+    );
+    expect(controlInternals.pendingQueue.some((item) => item.chatId === "chat-control-drain")).toBe(true);
+    await controlManager.shutdown();
+  });
+
+  it("logs retry queued inject failures after a transient retry succeeds", async () => {
+    const retryHandler = handler({
+      resume: vi.fn().mockResolvedValue("retry-resumed"),
+      inject: vi.fn(() => {
+        throw new Error("queued inject failed");
+      }),
+    });
+    const sm = makeManager({ handlers: [retryHandler] });
+    const retrying = makeSessionRecord("chat-retry-inject-fail", {
+      retryAttempt: 1,
+      status: "suspended",
+      claudeSessionId: "previous-session",
+    });
+    retrying.retryQueuedMessages.push(makeMessage("chat-retry-inject-fail"));
+    internals(sm).sessions.set("chat-retry-inject-fail", retrying);
+
+    await internals(sm).runRetry("chat-retry-inject-fail");
+
+    expect(retryHandler.inject).toHaveBeenCalledTimes(1);
+    await sm.shutdown();
+  });
+
+  it("evicts idle active sessions with live subprocesses only after no better candidate exists", async () => {
+    const subprocessProbe: SubprocessProbe = {
+      hasLiveSubprocess: vi.fn((chatId: string) => chatId === "chat-live-subprocess"),
+      stop: vi.fn(),
+    };
+    const sm = makeManager({ maxSessions: 1, subprocessProbe });
+    const i = internals(sm);
+    i.sessions.set(
+      "chat-live-subprocess",
+      makeSessionRecord("chat-live-subprocess", {
+        status: "active",
+        lastActivity: 1,
+      }),
+    );
+
+    i.evictIfNeeded();
+
+    expect(i.evictedMappings.has("chat-live-subprocess")).toBe(true);
+    await sm.shutdown();
+
+    const noCandidate = makeManager({ maxSessions: 1 });
+    const noCandidateInternals = internals(noCandidate);
+    noCandidateInternals.sessions.set(
+      "chat-working-only",
+      makeSessionRecord("chat-working-only", {
+        status: "active",
+        lastActivity: 1,
+      }),
+    );
+    const entry = mockEntry({ id: 503, chatId: "chat-working-only", messageId: "msg-working-only" });
+    const decision = noCandidateInternals.inboxDelivery.receive(entry);
+    if (decision.kind !== "deliver") throw new Error("expected working delivery");
+    noCandidateInternals.inboxDelivery.markOwned(decision.work);
+    noCandidateInternals.inboxDelivery.markProcessingStarted("chat-working-only", messageFromEntry(entry));
+
+    noCandidateInternals.evictIfNeeded();
+
+    expect(noCandidateInternals.sessions.has("chat-working-only")).toBe(true);
+    await noCandidate.shutdown();
   });
 });

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -9,7 +9,6 @@ import type {
   SessionEvent,
   SessionState,
 } from "@first-tree/shared";
-import { encodeProviderRetryEventMessage } from "@first-tree/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import type { DeliveryDecision, DeliveryRouteOwnership, DeliveryWork } from "../runtime/inbox-delivery-coordinator.js";
@@ -1602,10 +1601,11 @@ describe("SessionManager edge coverage", () => {
 
   it("aborts lost ownership receipts from start, resume, and retry routing branches", async () => {
     const makeOwnedReceipt = (sessionId: string) => ({ sessionId, route: { kind: "owned", mode: "queued" } as const });
+    const loseOwnership: SessionManagerInternals["markRouteOwned"] = () => "lost";
 
     const startHandler = handler({ start: vi.fn().mockResolvedValue(makeOwnedReceipt("start-lost")) });
     const startManager = makeManager({ handlers: [startHandler] });
-    internals(startManager).markRouteOwned = vi.fn(() => "lost");
+    internals(startManager).markRouteOwned = loseOwnership;
     await internals(startManager).routeMessage("chat-start-lost", makeMessage("chat-start-lost"));
     expect(internals(startManager).sessions.has("chat-start-lost")).toBe(false);
     await startManager.shutdown();
@@ -1616,7 +1616,7 @@ describe("SessionManager edge coverage", () => {
       claudeSessionId: "old-evicted",
       lastActivity: 1,
     });
-    internals(evictedManager).markRouteOwned = vi.fn(() => "lost");
+    internals(evictedManager).markRouteOwned = loseOwnership;
     await internals(evictedManager).routeMessage("chat-evicted-lost", makeMessage("chat-evicted-lost"));
     expect(internals(evictedManager).sessions.has("chat-evicted-lost")).toBe(false);
     await evictedManager.shutdown();
@@ -1627,7 +1627,7 @@ describe("SessionManager edge coverage", () => {
     });
     const resumeManager = makeManager();
     internals(resumeManager).sessions.set("chat-resume-lost", suspendedRecord);
-    internals(resumeManager).markRouteOwned = vi.fn(() => "lost");
+    internals(resumeManager).markRouteOwned = loseOwnership;
     await internals(resumeManager).resumeSession(suspendedRecord, makeMessage("chat-resume-lost"));
     expect(internals(resumeManager).sessions.has("chat-resume-lost")).toBe(false);
     await resumeManager.shutdown();
@@ -1642,7 +1642,7 @@ describe("SessionManager edge coverage", () => {
         claudeSessionId: "previous-retry",
       }),
     );
-    internals(retryResumeManager).markRouteOwned = vi.fn(() => "lost");
+    internals(retryResumeManager).markRouteOwned = loseOwnership;
     await internals(retryResumeManager).runRetry("chat-retry-resume-lost");
     expect(internals(retryResumeManager).sessions.has("chat-retry-resume-lost")).toBe(false);
     await retryResumeManager.shutdown();
@@ -1657,7 +1657,7 @@ describe("SessionManager edge coverage", () => {
         claudeSessionId: "",
       }),
     );
-    internals(retryStartManager).markRouteOwned = vi.fn(() => "lost");
+    internals(retryStartManager).markRouteOwned = loseOwnership;
     await internals(retryStartManager).runRetry("chat-retry-start-lost");
     expect(internals(retryStartManager).sessions.has("chat-retry-start-lost")).toBe(false);
     await retryStartManager.shutdown();

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -51,6 +51,13 @@ type SessionManagerInternals = {
   drainPendingQueue(): void;
   evictIfNeeded(): void;
   notifySessionState(chatId: string, state: SessionState): void;
+  buildSessionContext(chatId: string): SessionContext;
+  confirmSessionEventOrThrow(chatId: string, event: SessionEvent): Promise<void>;
+  resolveSelfFence(
+    log: (msg: string) => void,
+    chatId: string,
+  ): Promise<{ agentHome: string; singleRepoLocalPath?: string }>;
+  resolveChatOrgId(log: (msg: string) => void, chatId: string): Promise<string | null>;
   reaffirmRuntimeStates(): void;
   persistRegistry(): void;
 };
@@ -147,6 +154,7 @@ function makeManager(
     onRuntimeStateChange?: (state: TestRuntimeState) => void;
     onSessionRuntimeChange?: (chatId: string, state: TestRuntimeState) => void;
     onSessionEvent?: (chatId: string, event: SessionEvent) => void;
+    confirmSessionEvent?: (chatId: string, event: SessionEvent) => Promise<void>;
     workspaceRoot?: string;
     runtimeSessionTokenFile?: string;
   } = {},
@@ -185,6 +193,7 @@ function makeManager(
     onRuntimeStateChange: opts.onRuntimeStateChange,
     onSessionRuntimeChange: opts.onSessionRuntimeChange,
     onSessionEvent: opts.onSessionEvent,
+    confirmSessionEvent: opts.confirmSessionEvent,
   });
 }
 
@@ -1209,6 +1218,92 @@ describe("SessionManager edge coverage", () => {
     expect(runtimeChanges).not.toContain("working");
 
     internals(sm).reaffirmRuntimeStates();
+    await sm.shutdown();
+  });
+
+  it("covers session context transport updates and confirmed event channels", async () => {
+    const events: SessionEvent[] = [];
+    const sm = makeManager({
+      onSessionEvent: (_chatId, event) => events.push(event),
+    });
+    const nextSdk = mockSdk();
+    const nextCache = makeCache();
+
+    sm.updateTransport(nextSdk, nextCache);
+    sm.noteBindRecoveryComplete();
+
+    const ctx = internals(sm).buildSessionContext("chat-context");
+    expect(ctx.sdk).toBe(nextSdk);
+    await expect(ctx.formatFromHeader(makeMessage("chat-context"))).resolves.toContain("alice");
+
+    const event: SessionEvent = { kind: "error", payload: { source: "runtime", message: "boom" } };
+    if (!ctx.emitEventConfirmed) throw new Error("confirmed event callback missing");
+    await expect(ctx.emitEventConfirmed(event)).rejects.toThrow("confirmed session event channel unavailable");
+    expect(events).toEqual([event]);
+    await sm.shutdown();
+
+    const confirmSessionEvent = vi.fn<(chatId: string, event: SessionEvent) => Promise<void>>().mockResolvedValue();
+    const confirmed = makeManager({ confirmSessionEvent });
+    const confirmedCtx = internals(confirmed).buildSessionContext("chat-confirmed");
+    if (!confirmedCtx.emitEventConfirmed) throw new Error("confirmed event callback missing");
+    await confirmedCtx.emitEventConfirmed(event);
+    expect(confirmSessionEvent).toHaveBeenCalledWith("chat-confirmed", event);
+    await confirmed.shutdown();
+  });
+
+  it("resolves document self fences from runtime config and falls back on refresh failure", async () => {
+    const workspaceRoot = "/tmp/test-edge/fence-agent";
+    const config = runtimeConfig({
+      payload: {
+        ...runtimeConfig().payload,
+        gitRepos: [{ url: "https://github.com/acme/repo.git", localPath: "repo" }],
+      },
+    });
+    const sm = makeManager({ workspaceRoot, agentConfigCache: makeCache({ config }) });
+    const logs: string[] = [];
+
+    await expect(internals(sm).resolveSelfFence((msg) => logs.push(msg), "chat-fence")).resolves.toEqual({
+      agentHome: workspaceRoot,
+      singleRepoLocalPath: "source-repos/repo",
+    });
+    expect(logs).toEqual([]);
+    await sm.shutdown();
+
+    const failing = makeManager({
+      workspaceRoot,
+      agentConfigCache: makeCache({
+        refreshIfNewer: async () => {
+          throw new Error("config unavailable");
+        },
+      }),
+    });
+    await expect(internals(failing).resolveSelfFence((msg) => logs.push(msg), "chat-fence-fallback")).resolves.toEqual({
+      agentHome: workspaceRoot,
+    });
+    expect(logs.some((msg) => msg.includes("config unavailable"))).toBe(true);
+    await failing.shutdown();
+  });
+
+  it("resolves chat org ids with caching and degrades lookup failures to null", async () => {
+    const getChatDetail = vi.fn(async (chatId: string) => {
+      if (chatId === "chat-org") return { organizationId: "org-1" };
+      if (chatId === "chat-empty-org") return { organizationId: "" };
+      throw new Error("lookup failed");
+    });
+    const sdk = { ...mockSdk(), getChatDetail } as unknown as FirstTreeHubSDK;
+    const sm = makeManager({ sdk });
+    const logs: string[] = [];
+    const log = (msg: string): void => {
+      logs.push(msg);
+    };
+
+    await expect(internals(sm).resolveChatOrgId(log, "chat-org")).resolves.toBe("org-1");
+    await expect(internals(sm).resolveChatOrgId(log, "chat-org")).resolves.toBe("org-1");
+    expect(getChatDetail).toHaveBeenCalledTimes(1);
+
+    await expect(internals(sm).resolveChatOrgId(log, "chat-empty-org")).resolves.toBeNull();
+    await expect(internals(sm).resolveChatOrgId(log, "chat-fail")).resolves.toBeNull();
+    expect(logs.some((msg) => msg.includes("lookup failed"))).toBe(true);
     await sm.shutdown();
   });
 

--- a/packages/client/src/__tests__/session-manager-more-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-more-coverage.test.ts
@@ -153,6 +153,163 @@ function malformedProviderRetryEvent(): SessionEvent {
 }
 
 describe("InboxDeliveryCoordinator additional delivery coverage", () => {
+  it("returns recovering while recovery debt is outstanding and ignores completions without entry ids", async () => {
+    const { logger, records } = recordingLogger();
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry: mockAckEntry(),
+      onWorkChanged: vi.fn(),
+      log: logger,
+    });
+    const entry = mockEntry({ id: 10, chatId: "chat-recovery-required", messageId: "msg-recovery-required" });
+    const next = mockEntry({ id: 11, chatId: "chat-recovery-required", messageId: "msg-recovery-next" });
+    const message = toSessionMessage(entry);
+
+    expect(coordinator.receive(entry).kind).toBe("deliver");
+    coordinator.retryTurn("chat-recovery-required", message, "provider_retry");
+
+    await vi.waitFor(() => expect(coordinator.snapshot("chat-recovery-required").recoveryDebt).toBe("required"));
+    expect(coordinator.receive(next)).toEqual({ kind: "recovering" });
+
+    await coordinator.finishTurn(
+      "chat-recovery-required",
+      { ...message, inboxEntryId: undefined },
+      {
+        status: "success",
+        terminal: true,
+      },
+    );
+    expect(
+      records.some(
+        (record) =>
+          typeof record.msg === "string" &&
+          record.msg.includes("turn completion ignored because no inboxEntryId was provided"),
+      ),
+    ).toBe(true);
+  });
+
+  it("deduplicates in-flight message redelivery and reports settled versus lost ownership", async () => {
+    const ackEntry = mockAckEntry();
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry,
+      onWorkChanged: vi.fn(),
+      log: silentLogger(),
+    });
+    const first = mockEntry({ id: 20, chatId: "chat-dedup", messageId: "msg-same" });
+    const duplicateMessage = mockEntry({ id: 21, chatId: "chat-dedup", messageId: "msg-same" });
+    const message = toSessionMessage(first);
+
+    const decision = coordinator.receive(first);
+    expect(decision.kind).toBe("deliver");
+    expect(coordinator.receive(duplicateMessage)).toEqual({ kind: "duplicate-in-flight" });
+    expect(coordinator.markOwned({ chatId: "chat-dedup", entryId: 999, messageId: "missing" })).toBe("lost");
+
+    await coordinator.finishTurn("chat-dedup", message, { status: "success", terminal: true });
+
+    expect(ackEntry).toHaveBeenCalledWith(20);
+    expect(coordinator.markOwned({ chatId: "chat-dedup", entryId: 20, messageId: "msg-same" })).toBe("settled");
+  });
+
+  it("blocks ACK-through when a completion skips a non-terminal prefix", async () => {
+    const { logger, records } = recordingLogger();
+    const ackEntry = mockAckEntry();
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry,
+      onWorkChanged: vi.fn(),
+      log: logger,
+    });
+    const first = mockEntry({ id: 30, chatId: "chat-prefix-gap", messageId: "msg-prefix-first" });
+    const second = mockEntry({ id: 31, chatId: "chat-prefix-gap", messageId: "msg-prefix-second" });
+
+    expect(coordinator.receive(first).kind).toBe("deliver");
+    expect(coordinator.receive(second).kind).toBe("deliver");
+    await coordinator.finishTurn("chat-prefix-gap", toSessionMessage(second), { status: "success", terminal: true });
+
+    expect(ackEntry).not.toHaveBeenCalled();
+    expect(coordinator.snapshot("chat-prefix-gap")).toMatchObject({
+      entries: [
+        { entryId: 30, messageId: "msg-prefix-first", phase: "open" },
+        { entryId: 31, messageId: "msg-prefix-second", phase: "terminal" },
+      ],
+      recoveryDebt: "required",
+    });
+    expect(
+      records.some(
+        (record) =>
+          typeof record.msg === "string" &&
+          record.msg.includes("ACK-through blocked because delivery prefix has non-terminal entries"),
+      ),
+    ).toBe(true);
+  });
+
+  it("logs untracked ACK-through attempts without mutating the active ledger", async () => {
+    const { logger, records } = recordingLogger();
+    const ackEntry = mockAckEntry();
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry,
+      onWorkChanged: vi.fn(),
+      log: logger,
+    });
+    const entry = mockEntry({ id: 40, chatId: "chat-untracked-ack", messageId: "msg-present" });
+    const untrackedMessage: SessionMessage = {
+      ...toSessionMessage(entry),
+      id: "msg-missing",
+      inboxEntryId: 999,
+    };
+
+    expect(coordinator.receive(entry).kind).toBe("deliver");
+    await coordinator.finishTurn("chat-untracked-ack", untrackedMessage, { status: "success", terminal: true });
+
+    expect(ackEntry).not.toHaveBeenCalled();
+    expect(coordinator.snapshot("chat-untracked-ack").entries).toEqual([
+      { entryId: 40, messageId: "msg-present", phase: "open" },
+    ]);
+    expect(
+      records.some(
+        (record) =>
+          typeof record.msg === "string" && record.msg.includes("attempt completion ignored for untracked inbox entry"),
+      ),
+    ).toBe(true);
+  });
+
+  it("acks terminal prefixes before suspending or terminating non-terminal tails", async () => {
+    const ackEntry = vi
+      .fn<(entryId: number) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("hold terminal entry"))
+      .mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const coordinator = new InboxDeliveryCoordinator({
+      ackEntry,
+      recoverChat,
+      onWorkChanged: vi.fn(),
+      log: silentLogger(),
+    });
+    const first = mockEntry({ id: 50, chatId: "chat-terminal-prefix", messageId: "msg-terminal" });
+    const second = mockEntry({ id: 51, chatId: "chat-terminal-prefix", messageId: "msg-tail" });
+
+    expect(coordinator.receive(first).kind).toBe("deliver");
+    await coordinator.finishTurn("chat-terminal-prefix", toSessionMessage(first), {
+      status: "success",
+      terminal: true,
+    });
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith("chat-terminal-prefix"));
+    expect(coordinator.snapshot("chat-terminal-prefix").entries).toEqual([
+      { entryId: 50, messageId: "msg-terminal", phase: "terminal" },
+    ]);
+
+    expect(coordinator.receive(second).kind).toBe("deliver");
+    await coordinator.prepareSuspend("chat-terminal-prefix", "operator_suspend");
+
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 50);
+    expect(recoverChat).toHaveBeenCalledTimes(2);
+    expect(coordinator.snapshot("chat-terminal-prefix")).toMatchObject({ entries: [], recoveryDebt: "none" });
+
+    expect(coordinator.takeRecoveryActivationReady("chat-terminal-prefix")).toBe(true);
+    expect(coordinator.receive(second).kind).toBe("deliver");
+    await coordinator.drainForTerminate("chat-terminal-prefix");
+    expect(recoverChat).toHaveBeenCalledTimes(3);
+    expect(coordinator.snapshot("chat-terminal-prefix").recoveryDebt).toBe("none");
+  });
+
   it("retains terminal ledger entries after ACK failure and re-ACKs terminal redelivery", async () => {
     const { logger, records } = recordingLogger();
     const ackEntry = vi

--- a/packages/shared/src/__tests__/agent-name-schema.test.ts
+++ b/packages/shared/src/__tests__/agent-name-schema.test.ts
@@ -4,9 +4,12 @@ import {
   AGENT_NAME_REGEX,
   agentSchema,
   createAgentSchema,
+  findReservedAgentMetadataKey,
   isReservedAgentName,
+  listAgentsQuerySchema,
   RESERVED_AGENT_NAMES,
   updateAgentSchema,
+  userAgentMetadataSchema,
 } from "../schemas/agent.js";
 
 /**
@@ -58,6 +61,49 @@ describe("isReservedAgentName", () => {
   it("does not flag ordinary names", () => {
     expect(isReservedAgentName("alice")).toBe(false);
     expect(isReservedAgentName("coder-agent")).toBe(false);
+  });
+});
+
+describe("agent metadata guards", () => {
+  it("finds the first reserved metadata key and ignores ordinary metadata", () => {
+    expect(findReservedAgentMetadataKey(undefined)).toBeNull();
+    expect(findReservedAgentMetadataKey({ theme: "dark" })).toBeNull();
+    expect(findReservedAgentMetadataKey({ runtimeSwitch: { target: "codex" }, runtimeSession: {} })).toBe(
+      "runtimeSwitch",
+    );
+    expect(findReservedAgentMetadataKey({ theme: "dark", runtimeSession: { active: true } })).toBe("runtimeSession");
+  });
+
+  it("rejects user metadata that tries to write reserved runtime keys", () => {
+    const result = userAgentMetadataSchema.safeParse({
+      runtimeSession: {
+        routeId: "session-1",
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(["runtimeSession"]);
+    }
+  });
+});
+
+describe("listAgentsQuerySchema", () => {
+  it.each([
+    [undefined, false],
+    ["", false],
+    [true, true],
+    ["true", true],
+    ["1", true],
+    [false, false],
+    ["false", false],
+    ["0", false],
+  ] as const)("normalizes addressableOnly=%s", (value, expected) => {
+    expect(listAgentsQuerySchema.parse({ addressableOnly: value }).addressableOnly).toBe(expected);
+  });
+
+  it("rejects unsupported addressableOnly values", () => {
+    expect(listAgentsQuerySchema.safeParse({ addressableOnly: "yes" }).success).toBe(false);
   });
 });
 

--- a/packages/shared/src/__tests__/agent-name-schema.test.ts
+++ b/packages/shared/src/__tests__/agent-name-schema.test.ts
@@ -75,6 +75,8 @@ describe("agent metadata guards", () => {
   });
 
   it("rejects user metadata that tries to write reserved runtime keys", () => {
+    expect(userAgentMetadataSchema.safeParse({ theme: "dark" }).success).toBe(true);
+
     const result = userAgentMetadataSchema.safeParse({
       runtimeSession: {
         routeId: "session-1",

--- a/packages/shared/src/__tests__/agent-runtime-config.test.ts
+++ b/packages/shared/src/__tests__/agent-runtime-config.test.ts
@@ -283,6 +283,8 @@ describe("agent runtime config — git repo localPath safety", () => {
     expect(normalizeRepoLocalPath(" repos/repo")).toBe(" repos/repo");
     expect(normalizeRepoLocalPath("repos//repo")).toBe("repos//repo");
     expect(normalizeRepoLocalPath("repos\\repo")).toBe("repos\\repo");
+    expect(normalizeRepoLocalPath("repos/\u0000repo")).toBe("repos/\u0000repo");
+    expect(normalizeRepoLocalPath("repos\\legacy/repo")).toBe("repos\\legacy/repo");
   });
 
   it("preserves derived repo local path behavior for repo URLs", () => {
@@ -323,6 +325,30 @@ describe("agent runtime config — git repo localPath safety", () => {
     expect(deriveRepoShortLabel("https://github.com/acme/repo.git?ref=dev")).toBe("acme/repo");
     expect(deriveRepoShortLabel("repo")).toBe("repo");
     expect(deriveRepoShortLabel("   ")).toBe("");
+  });
+
+  it("handles missing short-label split results defensively", () => {
+    const originalSplit = String.prototype.split;
+    const splitSpy = vi.spyOn(String.prototype, "split").mockImplementation(function (
+      this: string,
+      separator: string | RegExp | { [Symbol.split](string: string, limit?: number): string[] },
+      limit?: number,
+    ) {
+      if (this.toString() === "force-empty-short-query" && String(separator) === "/[?#]/") {
+        return [];
+      }
+      if (this.toString() === "force-empty-short-segments" && String(separator) === "/[/:]/") {
+        return [];
+      }
+      return Reflect.apply(originalSplit, this, [separator, limit]);
+    });
+
+    try {
+      expect(deriveRepoShortLabel("force-empty-short-query")).toBe("");
+      expect(deriveRepoShortLabel("force-empty-short-segments")).toBe("");
+    } finally {
+      splitSpy.mockRestore();
+    }
   });
 
   it("formats a repo coordinate, hiding default branch and default path", () => {

--- a/packages/shared/src/__tests__/attachment-ref.test.ts
+++ b/packages/shared/src/__tests__/attachment-ref.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { attachmentRefsFromMetadata, isAttachmentRef } from "../schemas/attachment-ref.js";
+
+const baseAttachment = {
+  attachmentId: "123e4567-e89b-12d3-a456-426614174000",
+  kind: "document",
+  mimeType: "text/markdown",
+  filename: "NODE.md",
+  size: 42,
+  sha256: "a".repeat(64),
+  source: {
+    path: "NODE.md",
+    sourcePath: "tree/NODE.md",
+  },
+} as const;
+
+describe("attachment refs", () => {
+  it("accepts a valid attachment ref with optional integrity and source metadata", () => {
+    expect(isAttachmentRef(baseAttachment)).toBe(true);
+    expect(
+      isAttachmentRef({
+        ...baseAttachment,
+        kind: "image",
+        sha256: undefined,
+        source: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects malformed attachment ref shapes", () => {
+    for (const value of [
+      null,
+      "not-an-object",
+      { ...baseAttachment, attachmentId: "not-a-uuid" },
+      { ...baseAttachment, kind: "video" },
+      { ...baseAttachment, mimeType: "" },
+      { ...baseAttachment, filename: "" },
+      { ...baseAttachment, size: 1.5 },
+      { ...baseAttachment, size: -1 },
+      { ...baseAttachment, sha256: "A".repeat(64) },
+      { ...baseAttachment, source: null },
+      { ...baseAttachment, source: { path: 42 } },
+      { ...baseAttachment, source: { path: "NODE.md", sourcePath: 42 } },
+    ]) {
+      expect(isAttachmentRef(value)).toBe(false);
+    }
+  });
+
+  it("extracts only valid attachment refs from metadata", () => {
+    expect(attachmentRefsFromMetadata(undefined)).toEqual([]);
+    expect(attachmentRefsFromMetadata({ attachments: "not-an-array" })).toEqual([]);
+    expect(
+      attachmentRefsFromMetadata({
+        attachments: [
+          { ...baseAttachment, filename: "valid.md" },
+          { ...baseAttachment, attachmentId: "bad" },
+          { ...baseAttachment, kind: "file", filename: "archive.zip", size: 0 },
+        ],
+      }),
+    ).toEqual([
+      { ...baseAttachment, filename: "valid.md" },
+      { ...baseAttachment, kind: "file", filename: "archive.zip", size: 0 },
+    ]);
+  });
+});

--- a/packages/shared/src/__tests__/canonical-git-repo-url.test.ts
+++ b/packages/shared/src/__tests__/canonical-git-repo-url.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { canonicalGitRepoUrl } from "../canonical-git-repo-url.js";
 
 describe("canonicalGitRepoUrl", () => {
@@ -29,5 +29,30 @@ describe("canonicalGitRepoUrl", () => {
     expect(canonicalGitRepoUrl("   ")).toBeNull();
     expect(canonicalGitRepoUrl("not a url")).toBeNull();
     expect(canonicalGitRepoUrl("https://github.com/")).toBeNull();
+    expect(canonicalGitRepoUrl("github.com:.git")).toBeNull();
+    expect(canonicalGitRepoUrl("git@github.com:////.git")).toBeNull();
+  });
+
+  it("defensively rejects scp-like matches with missing capture values", () => {
+    const originalExec = RegExp.prototype.exec;
+    const execSpy = vi.spyOn(RegExp.prototype, "exec").mockImplementation(function (
+      this: RegExp,
+      value: string,
+    ): RegExpExecArray | null {
+      if (value === "force-empty-scp-host") {
+        const match: RegExpExecArray = Object.assign(["force-empty-scp-host", "", "owner/repo"], {
+          index: 0,
+          input: value,
+        });
+        return match;
+      }
+      return Reflect.apply(originalExec, this, [value]);
+    });
+
+    try {
+      expect(canonicalGitRepoUrl("force-empty-scp-host")).toBeNull();
+    } finally {
+      execSpy.mockRestore();
+    }
   });
 });

--- a/packages/shared/src/__tests__/canonical-git-repo-url.test.ts
+++ b/packages/shared/src/__tests__/canonical-git-repo-url.test.ts
@@ -40,10 +40,8 @@ describe("canonicalGitRepoUrl", () => {
       value: string,
     ): RegExpExecArray | null {
       if (value === "force-empty-scp-host") {
-        const match: RegExpExecArray = Object.assign(["force-empty-scp-host", "", "owner/repo"], {
-          index: 0,
-          input: value,
-        });
+        const match = /^([^:]*):(.*)$/.exec(":owner/repo");
+        if (!match) throw new Error("test fixture failed to build scp-like match");
         return match;
       }
       return Reflect.apply(originalExec, this, [value]);

--- a/packages/shared/src/__tests__/chat-github-entities-schema.test.ts
+++ b/packages/shared/src/__tests__/chat-github-entities-schema.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  chatGithubEntitySchema,
+  githubEntityBoundViaSchema,
+  isDeclaredBoundVia,
+} from "../schemas/chat-github-entities.js";
+
+describe("chat github entity schemas", () => {
+  it("normalizes legacy agent_created bindings to agent_declared", () => {
+    expect(githubEntityBoundViaSchema.parse("direct")).toBe("direct");
+    expect(githubEntityBoundViaSchema.parse("agent_created")).toBe("agent_declared");
+    expect(
+      chatGithubEntitySchema.parse({
+        entityType: "pull_request",
+        entityKey: "acme/api#42",
+        boundVia: "agent_created",
+        htmlUrl: "https://github.com/acme/api/pull/42",
+        title: null,
+        state: "open",
+        number: 42,
+      }).boundVia,
+    ).toBe("agent_declared");
+  });
+
+  it("identifies explicitly declared follow bindings", () => {
+    expect(isDeclaredBoundVia("agent_declared")).toBe(true);
+    expect(isDeclaredBoundVia("human_declared")).toBe(true);
+    expect(isDeclaredBoundVia("direct")).toBe(false);
+    expect(isDeclaredBoundVia("agent_created")).toBe(false);
+  });
+});

--- a/packages/shared/src/__tests__/chat-schema.test.ts
+++ b/packages/shared/src/__tests__/chat-schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { addParticipantSchema, createTaskChatSchema, updateChatSchema } from "../schemas/chat.js";
+
+const initialMessage = {
+  content: "Start the task.",
+  source: "web",
+};
+
+describe("chat write schemas", () => {
+  it("requires at least one initial recipient when creating task chats", () => {
+    expect(
+      createTaskChatSchema.safeParse({
+        mode: "task",
+        initialMessage,
+      }).success,
+    ).toBe(false);
+
+    expect(
+      createTaskChatSchema.parse({
+        mode: "task",
+        initialRecipientNames: ["alice"],
+        initialMessage,
+      }),
+    ).toMatchObject({
+      mode: "task",
+      initialRecipientNames: ["alice"],
+      initialRecipientAgentIds: [],
+    });
+
+    expect(
+      createTaskChatSchema.parse({
+        mode: "task",
+        initialRecipientAgentIds: ["agent-1"],
+        initialMessage,
+      }),
+    ).toMatchObject({
+      initialRecipientAgentIds: ["agent-1"],
+      initialRecipientNames: [],
+    });
+  });
+
+  it("requires update chat requests to change at least one field", () => {
+    expect(updateChatSchema.safeParse({}).success).toBe(false);
+    expect(updateChatSchema.parse({ topic: "  Release prep  " })).toEqual({
+      topic: "Release prep",
+    });
+    expect(updateChatSchema.parse({ description: null })).toEqual({
+      description: null,
+    });
+  });
+
+  it("requires exactly one participant target", () => {
+    expect(addParticipantSchema.safeParse({}).success).toBe(false);
+    expect(addParticipantSchema.safeParse({ agentId: "agent-1", agentName: "alice" }).success).toBe(false);
+    expect(addParticipantSchema.parse({ agentId: "agent-1" })).toEqual({ agentId: "agent-1" });
+    expect(addParticipantSchema.parse({ agentName: "alice" })).toEqual({ agentName: "alice" });
+  });
+});

--- a/packages/shared/src/__tests__/doc-anchor.test.ts
+++ b/packages/shared/src/__tests__/doc-anchor.test.ts
@@ -42,6 +42,39 @@ describe("buildDocAnchor", () => {
     expect(anchor?.suffix?.startsWith(" on purpose")).toBe(true);
   });
 
+  it("uses the first repeated occurrence when no rendered context is available", () => {
+    const anchor = buildDocAnchor({
+      source: SOURCE,
+      selectedText: "The cache is per-tenant",
+    });
+
+    expect(anchor).not.toBeNull();
+    expect(anchor?.suffix?.startsWith(". The cache")).toBe(true);
+  });
+
+  it("uses rendered prefix-only context to disambiguate repeated text", () => {
+    const source = "alpha beta gamma. prefix alpha beta omega.";
+    const anchor = buildDocAnchor({
+      source,
+      selectedText: "alpha beta",
+      renderedPrefix: "prefix ",
+    });
+
+    expect(anchor).not.toBeNull();
+    expect(anchor?.prefix?.endsWith("prefix ")).toBe(true);
+  });
+
+  it("omits unavailable prefix and suffix at document boundaries", () => {
+    expect(buildDocAnchor({ source: "alpha beta", selectedText: "alpha" })).toEqual({
+      exact: "alpha",
+      suffix: " beta",
+    });
+    expect(buildDocAnchor({ source: "alpha beta", selectedText: "beta" })).toEqual({
+      exact: "beta",
+      prefix: "alpha ",
+    });
+  });
+
   it("returns null when the selection is absent from the source", () => {
     expect(buildDocAnchor({ source: SOURCE, selectedText: "not in the document" })).toBeNull();
     expect(buildDocAnchor({ source: SOURCE, selectedText: "   " })).toBeNull();
@@ -88,11 +121,23 @@ describe("locateDocAnchor", () => {
     expect(range.start).toBe(source.indexOf("alpha beta delta"));
   });
 
+  it("uses prefix-only context to pick among repeated occurrences", () => {
+    const source = "alpha beta gamma. prefix alpha beta delta.";
+    const range = locateDocAnchor(source, { exact: "alpha beta", prefix: "prefix " });
+    expect(range).not.toBeNull();
+    if (!range) return;
+    expect(range.start).toBe(source.indexOf("alpha beta delta"));
+  });
+
   it("returns null when the quoted text was deleted", () => {
     const anchor = buildDocAnchor({ source: SOURCE, selectedText: "soft delete" });
     if (!anchor) throw new Error("anchor expected");
     const v2 = SOURCE.replace("soft delete", "hard delete");
     expect(locateDocAnchor(v2, anchor)).toBeNull();
+  });
+
+  it("returns null for whitespace-only anchor exact text", () => {
+    expect(locateDocAnchor(SOURCE, { exact: "   " })).toBeNull();
   });
 
   it("tolerates whitespace-only reflows of the quote", () => {

--- a/packages/shared/src/__tests__/image-payload-batch.test.ts
+++ b/packages/shared/src/__tests__/image-payload-batch.test.ts
@@ -84,6 +84,8 @@ describe("image-payload — batch schemas", () => {
       expect(isImageBatchRefContent({ caption: "hi", attachments: [SAMPLE_REF] })).toBe(true);
       expect(isImageBatchRefContent({ attachments: [SAMPLE_REF, SAMPLE_REF] })).toBe(true);
       expect(isImageBatchRefContent(SAMPLE_REF)).toBe(false);
+      expect(isImageBatchRefContent(null)).toBe(false);
+      expect(isImageBatchRefContent("hello")).toBe(false);
       expect(isImageBatchRefContent({ attachments: [] })).toBe(false);
       expect(isImageBatchRefContent({ attachments: [SAMPLE_REF, { imageId: "x" }] })).toBe(false);
     });

--- a/packages/shared/src/__tests__/landing-campaign-schema.test.ts
+++ b/packages/shared/src/__tests__/landing-campaign-schema.test.ts
@@ -76,7 +76,11 @@ describe("landing campaign metadata schemas", () => {
     };
 
     expect(parseLandingCampaignTrialChatMetadata(null)).toBeNull();
-    expect(parseLandingCampaignTrialChatMetadata({ landingCampaignTrial: { ...unlocked.landingCampaignTrial, state: "bad" } })).toBeNull();
+    expect(
+      parseLandingCampaignTrialChatMetadata({
+        landingCampaignTrial: { ...unlocked.landingCampaignTrial, state: "bad" },
+      }),
+    ).toBeNull();
     expect(isLandingCampaignTrialChatLocked(unlocked)).toBe(false);
     expect(
       isLandingCampaignTrialChatLocked({

--- a/packages/shared/src/__tests__/landing-campaign-schema.test.ts
+++ b/packages/shared/src/__tests__/landing-campaign-schema.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLandingCampaignTrialAgentMetadata,
+  isLandingCampaignTrialChatLocked,
+  parseLandingCampaignTrialAgentMetadata,
+  parseLandingCampaignTrialChatMetadata,
+} from "../schemas/landing-campaign.js";
+
+const repo = {
+  url: "https://github.com/acme/api.git",
+  canonicalKey: "github.com/acme/api",
+  owner: "acme",
+  name: "api",
+};
+
+describe("landing campaign metadata schemas", () => {
+  it("parses valid trial agent metadata and rejects absent or invalid values", () => {
+    const metadata = {
+      landingCampaignTrial: true,
+      campaign: "seed-api",
+      skillSetId: "starter",
+      skillSetVersion: "v1",
+      repo,
+    };
+
+    expect(parseLandingCampaignTrialAgentMetadata(metadata)).toEqual(metadata);
+    expect(isLandingCampaignTrialAgentMetadata(metadata)).toBe(true);
+    expect(parseLandingCampaignTrialAgentMetadata(undefined)).toBeNull();
+    expect(isLandingCampaignTrialAgentMetadata({ ...metadata, campaign: "Invalid Slug" })).toBe(false);
+  });
+
+  it("parses valid trial chat metadata with defaults", () => {
+    expect(
+      parseLandingCampaignTrialChatMetadata({
+        landingCampaignTrial: {
+          campaign: "seed-api",
+          agentId: "agent-1",
+          skillSetId: "starter",
+          skillSetVersion: "v1",
+          repo,
+          state: "awaiting_user",
+          inputLocked: true,
+          awaitingUserKind: "request",
+        },
+      }),
+    ).toEqual({
+      campaign: "seed-api",
+      agentId: "agent-1",
+      skillSetId: "starter",
+      skillSetVersion: "v1",
+      repo,
+      state: "awaiting_user",
+      inputLocked: true,
+      awaitingUserKind: "request",
+      maxAgentTurns: 1,
+      completedAgentTurns: 0,
+      completedAgentTurnIds: [],
+      maxEstimatedTokens: null,
+      estimatedTokensUsed: 0,
+      lastObservedEstimatedTokens: 0,
+      lastObservedTokenUsageEventId: null,
+    });
+  });
+
+  it("detects locked trial chats and rejects invalid chat metadata", () => {
+    const unlocked = {
+      landingCampaignTrial: {
+        campaign: "seed-api",
+        agentId: "agent-1",
+        skillSetId: "starter",
+        skillSetVersion: "v1",
+        repo,
+        state: "running",
+        inputLocked: false,
+      },
+    };
+
+    expect(parseLandingCampaignTrialChatMetadata(null)).toBeNull();
+    expect(parseLandingCampaignTrialChatMetadata({ landingCampaignTrial: { ...unlocked.landingCampaignTrial, state: "bad" } })).toBeNull();
+    expect(isLandingCampaignTrialChatLocked(unlocked)).toBe(false);
+    expect(
+      isLandingCampaignTrialChatLocked({
+        landingCampaignTrial: {
+          ...unlocked.landingCampaignTrial,
+          inputLocked: true,
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/shared/src/__tests__/org-settings-schema.test.ts
+++ b/packages/shared/src/__tests__/org-settings-schema.test.ts
@@ -73,6 +73,18 @@ describe("org settings schemas", () => {
     expect(orgContextTreeFeaturesStorageSchema.parse({})).toEqual({
       contextReviewer: { enabled: false, agentUuid: null },
     });
+    expect(
+      orgContextTreeFeaturesStorageSchema.parse({
+        contextReviewer: { enabled: true, agentUuid: "agent-1" },
+      }),
+    ).toEqual({
+      contextReviewer: { enabled: true, agentUuid: "agent-1" },
+    });
+    expect(() =>
+      orgContextTreeFeaturesStorageSchema.parse({
+        contextReviewer: { enabled: true, agentUuid: null },
+      }),
+    ).toThrow("agentUuid is required");
     expect(orgContextTreeFeaturesOutputSchema.parse({})).toEqual({
       contextReviewer: { enabled: false, agentUuid: null, reviewerAgent: null },
     });

--- a/packages/shared/src/__tests__/provider-retry.test.ts
+++ b/packages/shared/src/__tests__/provider-retry.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  encodeProviderRetryEventMessage,
+  parseProviderRetryEventMessage,
+  statusReasonFromProviderRetryEvent,
+  type ProviderRetryEventPayload,
+} from "../schemas/provider-retry.js";
+
+function retryPayload(overrides: Partial<ProviderRetryEventPayload> = {}): ProviderRetryEventPayload {
+  return {
+    event: "provider_retry_scheduled",
+    provider: "claude-code",
+    scope: "provider_turn",
+    category: "transient_transport",
+    reasonCode: "network_reset",
+    retryMode: "foreground",
+    userSeverity: "warning",
+    attempt: 1,
+    maxAttempts: 3,
+    messagePreview: "The provider connection reset.",
+    ...overrides,
+  };
+}
+
+describe("provider retry event messages", () => {
+  it("round-trips valid retry event payloads", () => {
+    const payload = retryPayload({ delayMs: 1000, nextRetryAt: "2026-07-09T00:00:00.000Z" });
+
+    expect(parseProviderRetryEventMessage(encodeProviderRetryEventMessage(payload))).toEqual(payload);
+  });
+
+  it("returns null for non-retry, empty, malformed, and schema-invalid messages", () => {
+    expect(parseProviderRetryEventMessage("plain provider failure")).toBeNull();
+    expect(parseProviderRetryEventMessage("provider.retry:")).toBeNull();
+    expect(parseProviderRetryEventMessage("provider.retry: {bad json")).toBeNull();
+    expect(parseProviderRetryEventMessage("provider.retry: {}")).toBeNull();
+  });
+
+  it("builds retrying, waiting, and terminal status reasons", () => {
+    expect(statusReasonFromProviderRetryEvent(retryPayload())).toMatchObject({
+      kind: "retrying",
+      label: "Retrying provider",
+      detail: "The provider connection reset.",
+    });
+    expect(
+      statusReasonFromProviderRetryEvent(
+        retryPayload({
+          retryMode: "background",
+          category: "provider_capacity",
+          reasonCode: "capacity_wait_required",
+          nextRetryAt: "2026-07-09T00:05:00.000Z",
+        }),
+      ),
+    ).toMatchObject({
+      kind: "waiting",
+      label: "Waiting for provider capacity",
+    });
+    expect(
+      statusReasonFromProviderRetryEvent(
+        retryPayload({
+          retryMode: "background",
+          category: "unknown",
+          reasonCode: "will_retry_later",
+        }),
+      ),
+    ).toMatchObject({
+      kind: "waiting",
+      label: "Waiting to retry provider",
+    });
+  });
+
+  it("returns null for success and labels terminal failures", () => {
+    expect(statusReasonFromProviderRetryEvent(retryPayload({ event: "provider_retry_succeeded" }))).toBeNull();
+    expect(
+      statusReasonFromProviderRetryEvent(
+        retryPayload({
+          event: "provider_retry_exhausted",
+          category: "credential",
+          reasonCode: "auth_failed",
+          userSeverity: "error",
+        }),
+      ),
+    ).toMatchObject({
+      kind: "terminal",
+      label: "Provider retry exhausted",
+    });
+    expect(
+      statusReasonFromProviderRetryEvent(
+        retryPayload({
+          event: "provider_failure_terminal",
+          category: "provider_capacity",
+          reasonCode: "capacity_wait_required",
+          userSeverity: "error",
+        }),
+      ),
+    ).toMatchObject({
+      kind: "terminal",
+      label: "Provider capacity limit",
+    });
+    expect(
+      statusReasonFromProviderRetryEvent(
+        retryPayload({
+          event: "provider_failure_terminal",
+          category: "configuration",
+          reasonCode: "bad_config",
+          userSeverity: "error",
+        }),
+      ),
+    ).toMatchObject({
+      kind: "terminal",
+      label: "Provider failure",
+    });
+  });
+});

--- a/packages/shared/src/__tests__/provider-retry.test.ts
+++ b/packages/shared/src/__tests__/provider-retry.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   encodeProviderRetryEventMessage,
+  type ProviderRetryEventPayload,
   parseProviderRetryEventMessage,
   statusReasonFromProviderRetryEvent,
-  type ProviderRetryEventPayload,
 } from "../schemas/provider-retry.js";
 
 function retryPayload(overrides: Partial<ProviderRetryEventPayload> = {}): ProviderRetryEventPayload {

--- a/packages/shared/src/__tests__/resource-schema.test.ts
+++ b/packages/shared/src/__tests__/resource-schema.test.ts
@@ -13,6 +13,8 @@ describe("resource schemas", () => {
     expect(canonicalizeResourceRepoUrl("https://github.com/Agent-Team-Foundation/First-Tree.git")).toBe(expected);
     expect(canonicalizeResourceRepoUrl("ssh://git@github.com/agent-team-foundation/first-tree.git")).toBe(expected);
     expect(canonicalizeResourceRepoUrl("git@github.com:agent-team-foundation/first-tree.git")).toBe(expected);
+    expect(canonicalizeResourceRepoUrl("github.com:Agent-Team-Foundation/First-Tree.git")).toBe(expected);
+    expect(canonicalizeResourceRepoUrl("ssh://git@github.com:22/agent-team-foundation/first-tree.git")).toBe(expected);
   });
 
   it("canonicalizes repo URLs with repeated slashes without regex backtracking", () => {
@@ -24,6 +26,30 @@ describe("resource schemas", () => {
     expect(canonicalizeResourceRepoUrl(`git@github.com:agent-team-foundation/first-tree.git${repeatedSlashes}`)).toBe(
       expected,
     );
+  });
+
+  it("canonicalizes non-GitHub repo URLs and preserves non-default ports", () => {
+    expect(canonicalizeResourceRepoUrl("ssh://git@git.example.com:2222/Team/Repo.git")).toBe(
+      "git.example.com:2222/Team/Repo",
+    );
+    expect(canonicalizeResourceRepoUrl("https://gitlab.example.com/Group/Repo.git")).toBe(
+      "gitlab.example.com/Group/Repo",
+    );
+  });
+
+  it("rejects malformed scp-like repo URLs instead of canonicalizing unsafe shapes", () => {
+    for (const value of [
+      "repo",
+      "git@github.com:owner/repo:bad",
+      "git@github.com:owner repo",
+      "git@github.com:/owner/repo",
+      "git@github.com:1",
+    ]) {
+      expect(() => canonicalizeResourceRepoUrl(value)).toThrow();
+    }
+
+    expect(canonicalizeResourceRepoUrl("github.com:")).toBe("/");
+    expect(canonicalizeResourceRepoUrl("git@github.com:22/repo")).toBe("github.com/22/repo");
   });
 
   it("accepts inline prompt replace with no replacement resource id", () => {
@@ -43,6 +69,33 @@ describe("resource schemas", () => {
     });
   });
 
+  it("normalizes legacy nested repo local paths before validating repo bindings", () => {
+    const parsed = agentResourceBindingInputSchema.parse({
+      type: "repo",
+      mode: "include",
+      agentExtraRepo: {
+        url: "https://github.com/acme/api.git",
+      },
+      repoRef: "main",
+      repoLocalPath: "services/api",
+    });
+
+    expect(parsed.repoLocalPath).toBe("services-api");
+  });
+
+  it("rejects unsafe repo local paths on repo bindings", () => {
+    const result = agentResourceBindingInputSchema.safeParse({
+      type: "repo",
+      mode: "include",
+      agentExtraRepo: {
+        url: "https://github.com/acme/api.git",
+      },
+      repoLocalPath: "../api",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("rejects ambiguous prompt replace payloads", () => {
     expect(
       agentResourceBindingInputSchema.safeParse({
@@ -53,6 +106,107 @@ describe("resource schemas", () => {
         inlinePromptBody: "ambiguous",
       }).success,
     ).toBe(false);
+  });
+
+  it("rejects binding payloads that do not match their resource type", () => {
+    const invalidBindings = [
+      {
+        type: "repo",
+        mode: "include",
+        inlinePromptBody: "repo cannot carry prompt text",
+      },
+      {
+        type: "prompt",
+        mode: "include",
+        agentExtraRepo: {
+          url: "https://github.com/acme/api.git",
+        },
+      },
+      {
+        type: "prompt",
+        mode: "include",
+        inlinePromptBody: "valid prompt body",
+        repoRef: "main",
+      },
+      {
+        type: "skill",
+        mode: "include",
+        resourceId: "skill-1",
+        repoLocalPath: "api",
+      },
+    ];
+
+    for (const binding of invalidBindings) {
+      expect(agentResourceBindingInputSchema.safeParse(binding).success).toBe(false);
+    }
+  });
+
+  it("validates disable, replace, and include binding cardinality", () => {
+    expect(
+      agentResourceBindingInputSchema.parse({
+        type: "repo",
+        mode: "disable",
+        resourceId: "team-repo-1",
+      }),
+    ).toMatchObject({
+      type: "repo",
+      mode: "disable",
+      resourceId: "team-repo-1",
+    });
+
+    const invalidBindings = [
+      {
+        type: "repo",
+        mode: "disable",
+      },
+      {
+        type: "repo",
+        mode: "disable",
+        resourceId: "team-repo-1",
+        replacesResourceId: "other-repo",
+      },
+      {
+        type: "repo",
+        mode: "replace",
+        resourceId: "replacement-repo",
+      },
+      {
+        type: "repo",
+        mode: "replace",
+        replacesResourceId: "team-repo-1",
+      },
+      {
+        type: "repo",
+        mode: "replace",
+        replacesResourceId: "team-repo-1",
+        resourceId: "replacement-repo",
+        agentExtraRepo: {
+          url: "https://github.com/acme/api.git",
+        },
+      },
+      {
+        type: "repo",
+        mode: "include",
+      },
+      {
+        type: "repo",
+        mode: "include",
+        resourceId: "team-repo-1",
+        agentExtraRepo: {
+          url: "https://github.com/acme/api.git",
+        },
+      },
+      {
+        type: "repo",
+        mode: "include",
+        resourceId: "team-repo-1",
+        replacesResourceId: "team-repo-2",
+      },
+    ];
+
+    for (const binding of invalidBindings) {
+      expect(agentResourceBindingInputSchema.safeParse(binding).success).toBe(false);
+    }
   });
 
   it("rejects secret-bearing HTTP MCP resources", () => {

--- a/packages/shared/src/__tests__/runtime-provider-schemas.test.ts
+++ b/packages/shared/src/__tests__/runtime-provider-schemas.test.ts
@@ -4,6 +4,7 @@ import {
   capabilityEntrySchema,
   clientCapabilitiesSchema,
   DEFAULT_RUNTIME_PROVIDER,
+  isRuntimeProviderEnabled,
   RUNTIME_PROVIDERS,
   runtimeProviderSchema,
   updateClientCapabilitiesSchema,
@@ -38,6 +39,13 @@ describe("runtimeProviderSchema", () => {
 
   it("DEFAULT_RUNTIME_PROVIDER is claude-code (existing rows pre-0026 have no kind)", () => {
     expect(DEFAULT_RUNTIME_PROVIDER).toBe("claude-code");
+  });
+
+  it("marks temporarily disabled providers as unavailable for selection", () => {
+    expect(isRuntimeProviderEnabled("claude-code")).toBe(true);
+    expect(isRuntimeProviderEnabled("codex")).toBe(true);
+    expect(isRuntimeProviderEnabled("claude-code-tui")).toBe(false);
+    expect(isRuntimeProviderEnabled("future-provider")).toBe(true);
   });
 });
 

--- a/packages/shared/src/__tests__/shell-command-io.test.ts
+++ b/packages/shared/src/__tests__/shell-command-io.test.ts
@@ -7,6 +7,10 @@ describe("classifyShellCommandIo", () => {
       supported: false,
       reason: "empty",
     });
+    expect(classifyShellCommandIo("''")).toEqual({
+      supported: false,
+      reason: "empty",
+    });
     expect(classifyShellCommandIo('cat "unterminated')).toEqual({
       supported: false,
       reason: "complex_shell",
@@ -22,6 +26,19 @@ describe("classifyShellCommandIo", () => {
     expect(classifyShellCommandIo("$READER /tree/NODE.md")).toEqual({
       supported: false,
       reason: "dynamic_path",
+    });
+  });
+
+  it("rejects unsupported tools after resolving the command basename", () => {
+    expect(classifyShellCommandIo("git status")).toEqual({
+      supported: false,
+      reason: "unsupported_tool",
+      commandName: "git",
+    });
+    expect(classifyShellCommandIo("/")).toEqual({
+      supported: false,
+      reason: "unsupported_tool",
+      commandName: "/",
     });
   });
 

--- a/packages/shared/src/__tests__/shell-command-io.test.ts
+++ b/packages/shared/src/__tests__/shell-command-io.test.ts
@@ -2,6 +2,29 @@ import { describe, expect, it } from "vitest";
 import { classifyShellCommandIo, stripShellCommandDisplayWrapper } from "../shell-command-io.js";
 
 describe("classifyShellCommandIo", () => {
+  it("rejects empty, malformed, and dynamic command tokens", () => {
+    expect(classifyShellCommandIo("   ")).toEqual({
+      supported: false,
+      reason: "empty",
+    });
+    expect(classifyShellCommandIo('cat "unterminated')).toEqual({
+      supported: false,
+      reason: "complex_shell",
+    });
+    expect(classifyShellCommandIo('cat "unterminated\\')).toEqual({
+      supported: false,
+      reason: "complex_shell",
+    });
+    expect(classifyShellCommandIo("cat trailing\\")).toEqual({
+      supported: false,
+      reason: "complex_shell",
+    });
+    expect(classifyShellCommandIo("$READER /tree/NODE.md")).toEqual({
+      supported: false,
+      reason: "dynamic_path",
+    });
+  });
+
   it("classifies sed file operands after options and script", () => {
     expect(classifyShellCommandIo("sed -n '1,240p' /tree/NODE.md")).toEqual({
       supported: true,
@@ -23,8 +46,44 @@ describe("classifyShellCommandIo", () => {
     });
   });
 
+  it("classifies file-read operands after double dash and count options", () => {
+    expect(classifyShellCommandIo("head -n 5 -- /tree/-leading-dash.md")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "head",
+      pathArgs: [{ raw: "/tree/-leading-dash.md", pathKindHint: "file" }],
+    });
+    expect(classifyShellCommandIo("tail --lines=10 /tree/log.txt")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "tail",
+      pathArgs: [{ raw: "/tree/log.txt", pathKindHint: "file" }],
+    });
+    expect(classifyShellCommandIo("/usr/bin/wc -l /tree/NODE.md")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "wc",
+      pathArgs: [{ raw: "/tree/NODE.md", pathKindHint: "file" }],
+    });
+  });
+
   it("classifies ripgrep files mode directory operands", () => {
     expect(classifyShellCommandIo("rg --files /tree")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "rg",
+      pathArgs: [{ raw: "/tree", pathKindHint: "directory" }],
+    });
+  });
+
+  it("classifies ripgrep regexp, glob, and double-dash operands", () => {
+    expect(classifyShellCommandIo("rg -e Context -g '*.md' -- /tree")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "rg",
+      pathArgs: [{ raw: "/tree", pathKindHint: "unknown" }],
+    });
+    expect(classifyShellCommandIo("rg --files -g '*.md' /tree")).toEqual({
       supported: true,
       action: "read",
       commandName: "rg",
@@ -50,6 +109,27 @@ describe("classifyShellCommandIo", () => {
     });
   });
 
+  it("classifies grep combined booleans, equals options, and explicit regex patterns", () => {
+    expect(classifyShellCommandIo("grep -Rni --include=*.md Context /tree")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "grep",
+      pathArgs: [{ raw: "/tree", pathKindHint: "unknown" }],
+    });
+    expect(classifyShellCommandIo("grep -e Context -- /tree")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "grep",
+      pathArgs: [{ raw: "/tree", pathKindHint: "unknown" }],
+    });
+    expect(classifyShellCommandIo("grep -m 3 Context /tree")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "grep",
+      pathArgs: [{ raw: "/tree", pathKindHint: "unknown" }],
+    });
+  });
+
   it("rejects unsupported grep options instead of guessing path positions", () => {
     expect(classifyShellCommandIo("grep --custom-option value Context /tree")).toEqual({
       supported: false,
@@ -66,6 +146,20 @@ describe("classifyShellCommandIo", () => {
     expect(classifyShellCommandIo("cat /tree/NODE.md > /tmp/out")).toEqual({
       supported: false,
       reason: "complex_shell",
+    });
+  });
+
+  it("allows dynamic-looking grep patterns but rejects dynamic path operands", () => {
+    expect(classifyShellCommandIo("grep '$TOKEN' /tree/NODE.md")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "grep",
+      pathArgs: [{ raw: "/tree/NODE.md", pathKindHint: "unknown" }],
+    });
+    expect(classifyShellCommandIo("cat `pwd`/NODE.md")).toEqual({
+      supported: false,
+      reason: "dynamic_path",
+      commandName: "cat",
     });
   });
 
@@ -95,6 +189,27 @@ describe("classifyShellCommandIo", () => {
     });
   });
 
+  it("classifies sed scripts supplied by options and after double dash", () => {
+    expect(classifyShellCommandIo("sed -e 's/a/b/' -- /tree/NODE.md")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "sed",
+      pathArgs: [{ raw: "/tree/NODE.md", pathKindHint: "file" }],
+    });
+    expect(classifyShellCommandIo("sed --expression=s/a/b/ /tree/NODE.md")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "sed",
+      pathArgs: [{ raw: "/tree/NODE.md", pathKindHint: "file" }],
+    });
+    expect(classifyShellCommandIo("sed -- 's/a/b/' /tree/NODE.md")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "sed",
+      pathArgs: [{ raw: "/tree/NODE.md", pathKindHint: "file" }],
+    });
+  });
+
   it("rejects find expressions with mutating action primaries", () => {
     expect(classifyShellCommandIo("find /tree -delete")).toEqual({
       supported: false,
@@ -105,6 +220,27 @@ describe("classifyShellCommandIo", () => {
       supported: false,
       reason: "write_or_mutation",
       commandName: "find",
+    });
+  });
+
+  it("classifies non-mutating find and ls operands after expression boundaries", () => {
+    expect(classifyShellCommandIo("find /tree ! -name secret.md")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "find",
+      pathArgs: [{ raw: "/tree", pathKindHint: "directory" }],
+    });
+    expect(classifyShellCommandIo("find -- /tree")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "find",
+      pathArgs: [{ raw: "/tree", pathKindHint: "directory" }],
+    });
+    expect(classifyShellCommandIo("ls -la -- /tree")).toEqual({
+      supported: true,
+      action: "read",
+      commandName: "ls",
+      pathArgs: [{ raw: "/tree", pathKindHint: "unknown" }],
     });
   });
 
@@ -251,6 +387,11 @@ describe("classifyShellCommandIo", () => {
 });
 
 describe("stripShellCommandDisplayWrapper", () => {
+  it("leaves malformed shell syntax and dynamic commands unchanged for display", () => {
+    expect(stripShellCommandDisplayWrapper('cat "unterminated')).toBe('cat "unterminated');
+    expect(stripShellCommandDisplayWrapper("$SHELL -lc 'cat /tree/NODE.md'")).toBe("$SHELL -lc 'cat /tree/NODE.md'");
+  });
+
   it("strips one codex login-shell wrapper for display", () => {
     expect(stripShellCommandDisplayWrapper("/bin/zsh -lc \"sed -n '1,7p' /Users/op/tree/NODE.md\"")).toBe(
       "sed -n '1,7p' /Users/op/tree/NODE.md",

--- a/packages/shared/src/config/__tests__/server-config.test.ts
+++ b/packages/shared/src/config/__tests__/server-config.test.ts
@@ -58,6 +58,7 @@ describe("server config", () => {
     expect(fieldSchema.parse("  org_123  ")).toBe("org_123");
     expect(fieldSchema.parse("")).toBeUndefined();
     expect(fieldSchema.parse("   ")).toBeUndefined();
+    expect(fieldSchema.parse(undefined)).toBeUndefined();
   });
 
   it("keeps growth landing pages disabled by default and enables them via env", async () => {

--- a/packages/shared/src/lib/__tests__/identicon.test.ts
+++ b/packages/shared/src/lib/__tests__/identicon.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { identiconCells, identiconSvg } from "../identicon.js";
 
 /**
@@ -49,6 +49,16 @@ describe("identiconCells — deterministic symmetric grid", () => {
   it("handles the empty seed without throwing", () => {
     expect(() => identiconCells("")).not.toThrow();
     expect(identiconCells("")).toHaveLength(5);
+  });
+
+  it("skips sparse generated rows defensively", () => {
+    const fromSpy = vi.spyOn(Array, "from").mockReturnValueOnce([undefined, [false, false]]);
+
+    try {
+      expect(identiconSvg("sparse-grid", { gridSize: 2 })).toContain("<svg");
+    } finally {
+      fromSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Add focused shared package coverage for shell command IO, resource schema validation, attachment refs, landing campaign metadata, agent metadata, provider retry labels, chat write schema refinements, runtime provider enablement, GitHub entity binding schema, doc anchor disambiguation, and repo config edge branches.
- Raise shared package statement/line/function coverage above 99%, with branch coverage still in progress toward the 99% goal.

## Tests
- pnpm --filter @first-tree/shared coverage