### PR TITLE
fix(web): converge GitHub install+connect to Settings, unstick Context build

### DIFF
--- a/packages/web/src/pages/__tests__/context-page-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/context-page-dom.test.tsx
@@ -591,30 +591,27 @@ describe("ContextPage DOM behavior", () => {
       contextStatus: { label: "Not configured", detail: null, severity: "warning" },
     });
 
-  it("installs the GitHub App inline for a no-repo admin instead of bouncing to Resources", async () => {
+  it("links to Settings → GitHub for a no-repo admin instead of installing inline or bouncing to Resources", async () => {
     authMock.value = { organizationId: "org-1", role: "admin" };
     agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
     resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
     githubAppMocks.getGithubAppInstallation.mockResolvedValue(null); // GitHub not connected yet
-    const fakeTab = { location: { href: "" }, close: vi.fn() };
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(fakeTab as unknown as Window);
     const { ContextPage } = await import("../context.js");
     contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailableSnapshot());
 
     const { container, root } = await renderDom(<ContextPage />);
-    // No repo connected → the inline install CTA, NOT a bounce to /settings/resources.
-    await waitForText(container, "Install First Tree on GitHub");
+    // No GitHub connection → a link to the single connect place (Settings → GitHub),
+    // NOT an inline install and NOT a bounce to /settings/resources.
+    await waitForText(container, "Connect GitHub in Settings");
+    expect(container.textContent).not.toContain("Install First Tree on GitHub");
     expect(container.textContent).not.toContain("Create private GitHub repo");
     expect(contextApiMocks.initializeContextTree).not.toHaveBeenCalled();
 
-    // Clicking it mints the install URL into a popup and stays on the page.
-    await click(buttonByText(container, "Install First Tree on GitHub"));
-    await flush();
-    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/onboarding/connected");
-    expect(fakeTab.location.href).toContain("installations/new");
-    expect(container.querySelector('[data-testid="location"]')?.textContent).toBe("/");
+    // The CTA is a link carrying the `from=context` return marker so Settings can
+    // hand the user back to building once connected — no inline install machinery.
+    expect(container.querySelector('a[href="/settings/github?from=context"]')).not.toBeNull();
+    expect(githubAppMocks.getGithubAppInstallUrl).not.toHaveBeenCalled();
 
-    openSpy.mockRestore();
     await act(async () => root.unmount());
   });
 
@@ -853,58 +850,6 @@ describe("ContextPage DOM behavior", () => {
     await act(async () => root.unmount());
   });
 
-  it("surfaces install failures and lets the user start a stuck install over", async () => {
-    authMock.value = { organizationId: "org-1", role: "admin" };
-    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
-    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
-    githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
-    githubAppMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new Error("network failed"));
-    const fakeTab = { location: { href: "" }, close: vi.fn() };
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(fakeTab as unknown as Window);
-    const { ContextTreeBuildEntry } = await import("../context-tree-build-entry.js");
-
-    const { container, root } = await renderDom(<ContextTreeBuildEntry />);
-    await waitForText(container, "Install First Tree on GitHub");
-    await click(buttonByText(container, "Install First Tree on GitHub"));
-    await waitForText(container, "Something went wrong. Try again in a moment.");
-    expect(fakeTab.close).toHaveBeenCalled();
-    await act(async () => root.unmount());
-    openSpy.mockRestore();
-
-    window.sessionStorage.setItem("context-build:install-attempt", "1");
-    const stuck = await renderDom(<ContextTreeBuildEntry />);
-    await waitForText(stuck.container, "Waiting for GitHub");
-    await click(buttonByText(stuck.container, "Didn't work? Start over"));
-    await waitForCondition(
-      () => !stuck.container.textContent?.includes("Waiting for GitHub"),
-      "Expected install waiting state to clear",
-    );
-    expect(window.sessionStorage.getItem("context-build:install-attempt")).toBeNull();
-    await act(async () => stuck.root.unmount());
-  });
-
-  it("shows the owner recovery copy for non-inline-fixable install failures", async () => {
-    authMock.value = { organizationId: "org-1", role: "admin" };
-    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
-    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
-    githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
-    const { ApiError } = await import("../../api/client.js");
-    const { ContextTreeBuildEntry } = await import("../context-tree-build-entry.js");
-
-    for (const status of [503, 403]) {
-      githubAppMocks.getGithubAppInstallUrl.mockRejectedValueOnce(new ApiError(status, "blocked"));
-      const fakeTab = { location: { href: "" }, close: vi.fn() };
-      const openSpy = vi.spyOn(window, "open").mockReturnValue(fakeTab as unknown as Window);
-      const { container, root } = await renderDom(<ContextTreeBuildEntry />);
-      await waitForText(container, "Install First Tree on GitHub");
-      await click(buttonByText(container, "Install First Tree on GitHub"));
-      await waitForText(container, "Building your team's Context Tree needs First Tree connected to GitHub");
-      expect(fakeTab.close).toHaveBeenCalled();
-      openSpy.mockRestore();
-      await act(async () => root.unmount());
-    }
-  });
-
   it("resets the build button and shows an error when tree setup chat kickoff fails", async () => {
     authMock.value = { organizationId: "org-1", role: "admin" };
     agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
@@ -920,30 +865,6 @@ describe("ContextPage DOM behavior", () => {
     await waitForText(container, "tree setup unavailable");
     expect(buttonByText(container, "Build your Context Tree")?.hasAttribute("disabled")).toBe(false);
 
-    await act(async () => root.unmount());
-  });
-
-  it("returns to the allowlisted /context route when the install popup is blocked", async () => {
-    authMock.value = { organizationId: "org-1", role: "admin" };
-    agentApiMocks.listManagedAgents.mockResolvedValue([treeAgent]);
-    resourceApiMocks.listTeamResourcesForOrg.mockResolvedValue([]);
-    githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
-    // Popup blocked → window.open returns null → full-page redirect. The post-
-    // install `next` must be the allowlisted "/context" (not the raw pathname),
-    // or the server bounces the user to /settings/github after install.
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
-    const assignSpy = vi.spyOn(window.location, "assign").mockImplementation(() => undefined);
-    const { ContextPage } = await import("../context.js");
-    contextApiMocks.getContextTreeSnapshot.mockResolvedValue(unavailableSnapshot());
-
-    const { container, root } = await renderDom(<ContextPage />);
-    await waitForText(container, "Install First Tree on GitHub");
-    await click(buttonByText(container, "Install First Tree on GitHub"));
-    await flush();
-    expect(githubAppMocks.getGithubAppInstallUrl).toHaveBeenCalledWith("org-1", "/context");
-
-    openSpy.mockRestore();
-    assignSpy.mockRestore();
     await act(async () => root.unmount());
   });
 

--- a/packages/web/src/pages/context-tree-build-entry.tsx
+++ b/packages/web/src/pages/context-tree-build-entry.tsx
@@ -1,35 +1,19 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Github, RefreshCw } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router";
+import { useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router";
 import { listManagedAgents, type ManagedAgent } from "../api/agents.js";
-import { ApiError } from "../api/client.js";
 import { listOrgGithubRepos } from "../api/github.js";
-import { getGithubAppInstallation, getGithubAppInstallUrl } from "../api/github-app.js";
+import { getGithubAppInstallation } from "../api/github-app.js";
 import { listTeamResourcesForOrg } from "../api/resources.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
 import { Select } from "../components/ui/select.js";
 import { COPY } from "./onboarding/copy.js";
-import { FlowHint, RepoTokenPicker, StatusRow } from "./onboarding/flow-ui.js";
+import { FlowHint, RepoTokenPicker } from "./onboarding/flow-ui.js";
 import type { TreeBindingPlan } from "./onboarding/onboarding-flow.js";
 import { startChatErrorMessage } from "./onboarding/provision-tree.js";
 import { ensureStartChatRepos, startTreeSetupChat } from "./onboarding/tree-setup-chat.js";
-
-/**
- * Per-tab marker set when the user kicks off a GitHub App install from this
- * card, so a return render shows "waiting for GitHub" + a deliberate re-mint.
- * Distinct key from the onboarding step so the two flows never cross. Same
- * install-popup discipline as the onboarding connect-code step (see
- * steps/step-connect-code.tsx) — kept as a small local copy on purpose so the
- * critical first-run path stays untouched.
- */
-const INSTALL_ATTEMPT_KEY = "context-build:install-attempt";
-const INSTALL_OWNER_HINT = {
-  pre: "Only ",
-  emphasis: "a GitHub org owner",
-  post: " can install First Tree. If that's not you, GitHub will ask an owner to approve access first.",
-};
 
 /**
  * The team's single "build your Context Tree" action, on the Context tab.
@@ -39,10 +23,11 @@ const INSTALL_OWNER_HINT = {
  * server-side provisioning. This replaced the standalone `/build-tree` wizard
  * page — there is one build home.
  *
- * When no code is connected yet, the connect + repo pick happens INLINE here
- * (install the GitHub App, then choose from the repos it grants) instead of
- * bouncing to Settings — the team already grants those repos, so sending the
- * user off to retype a URL was busywork.
+ * When GitHub isn't connected yet, this card links to Settings → GitHub — the
+ * single place that installs the App and connects it to the team (binding is an
+ * explicit connect action that only lives there). Once connected, the user
+ * returns here to pick a repo and build; the card advances on its own via the
+ * installed poll below.
  *
  * Admin-only (the caller gates on role + setup status). It never edits the tree
  * in the tab; it just launches the chat where the agent does, so it does not
@@ -182,10 +167,9 @@ export function ContextTreeBuildEntry({
 }
 
 /**
- * Inline "connect your code" for the no-repo state: install the GitHub App (if
- * needed) in a popup, then pick from the repos the team's installation grants —
- * the same install + pick the onboarding connect-code step does, surfaced here
- * so the user never leaves the Context tab to wire up a repo.
+ * The no-repo state on the Context tab. When GitHub isn't connected yet it links
+ * to Settings → GitHub (the one place that installs + connects the App); once
+ * connected it picks from the repos the team's installation grants and builds.
  */
 function ConnectAndPickRepos({
   organizationId,
@@ -207,14 +191,10 @@ function ConnectAndPickRepos({
   const [selectedRepoUrls, setSelectedRepoUrls] = useState<string[]>([]);
   const [grantCheckError, setGrantCheckError] = useState<string | null>(null);
   const [checkingGrant, setCheckingGrant] = useState(false);
-  const [redirecting, setRedirecting] = useState(false);
-  const [installError, setInstallError] = useState<"not_configured" | "not_admin" | "generic" | null>(null);
-  const [attempted, setAttempted] = useState(
-    () => typeof window !== "undefined" && !!window.sessionStorage.getItem(INSTALL_ATTEMPT_KEY),
-  );
 
-  // Poll for the installation until it appears: the popup installs on GitHub and
-  // self-closes, and this card advances on its own once the row shows up.
+  // Poll for the team's installation: connecting happens on Settings → GitHub,
+  // so once the user connects there and returns, this card advances on its own
+  // to the repo pick the moment the bound installation shows up.
   const installQuery = useQuery({
     queryKey: ["context-build", "installation", organizationId],
     queryFn: () => getGithubAppInstallation(organizationId ?? ""),
@@ -222,10 +202,6 @@ function ConnectAndPickRepos({
     refetchInterval: (query) => (query.state.data ? false : 4000),
   });
   const installed = !!installQuery.data;
-
-  useEffect(() => {
-    if (installed && typeof window !== "undefined") window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
-  }, [installed]);
 
   // The pickable repos come from the App installation's grant (server-minted
   // token), not the caller's personal repos — so only repos the agent can
@@ -237,46 +213,6 @@ function ConnectAndPickRepos({
   });
   const loadFailed = !!reposQuery.error;
   const hasPickableRepos = !reposQuery.error && (reposQuery.data?.length ?? 0) > 0;
-
-  const handleConnect = async (): Promise<void> => {
-    if (!organizationId) return;
-    setInstallError(null);
-    setRedirecting(true);
-    // Open the popup synchronously inside the click gesture so the browser doesn't
-    // treat the post-await open as a blocked popup; fill its location once the
-    // install URL is minted. GitHub installs in that tab and lands it on
-    // /onboarding/connected to self-close, while this card keeps polling above.
-    const installTab = window.open("", "_blank");
-    // Popup path lands the new tab on the self-closing /onboarding/connected
-    // page; the popup-blocked full-redirect must return THIS tab to the card to
-    // finish the inline pick. Both targets are on the server's post-install
-    // allowlist (ALLOWED_POST_INSTALL_NEXT) — "/context" is the card's route, so
-    // an off-allowlist value isn't silently bounced to /settings/github.
-    const postInstallNext = installTab ? "/onboarding/connected" : "/context";
-    try {
-      const url = await getGithubAppInstallUrl(organizationId, postInstallNext);
-      window.sessionStorage.setItem(INSTALL_ATTEMPT_KEY, String(Date.now()));
-      setAttempted(true);
-      if (installTab) installTab.location.href = url;
-      else window.location.assign(url); // popup blocked — fall back to a full redirect
-      setRedirecting(false);
-    } catch (err) {
-      installTab?.close();
-      setRedirecting(false);
-      if (err instanceof ApiError && err.status === 503) setInstallError("not_configured");
-      else if (err instanceof ApiError && err.status === 403) setInstallError("not_admin");
-      else setInstallError("generic");
-    }
-  };
-
-  // Deliberate re-mint after a stuck install: a fresh URL overwrites the
-  // oauth-state nonce cookie, so retry is an explicit action — never an auto
-  // re-click while the first popup may still be mid-flow.
-  const handleStartOver = (): void => {
-    window.sessionStorage.removeItem(INSTALL_ATTEMPT_KEY);
-    setAttempted(false);
-    setInstallError(null);
-  };
 
   const toggleRepo = (cloneUrl: string): void => {
     setGrantCheckError(null);
@@ -316,47 +252,26 @@ function ConnectAndPickRepos({
     }
   };
 
-  // ── Not connected yet ──────────────────────────────────────────────────
+  // ── GitHub not connected yet → point at Settings ───────────────────────
+  // Install + connect both live on Settings → GitHub (binding an installation to
+  // the team is an explicit connect action that only exists there). Link out
+  // with `from=context` so Settings can offer a "back to building" return once
+  // connected; this card then advances on its own via the installed poll above.
   if (!installed) {
-    // The two install errors that can't be fixed here (App not set up on this
-    // server / caller isn't an org admin) share one message — building needs the
-    // App and only an org owner can install it, so there's no inline way forward.
-    if (installError === "not_configured" || installError === "not_admin") {
-      return <FlowHint>{COPY.connectCode.cantConnectRecovery}</FlowHint>;
-    }
     return (
       <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
         <div className="flex">
-          <Button
-            type="button"
-            variant="cta"
-            onClick={() => void handleConnect()}
-            disabled={redirecting || attempted || !organizationId}
-          >
-            <Github className="h-4 w-4" />
-            <span>{COPY.connectCode.cta}</span>
+          <Button asChild variant="cta">
+            <Link to="/settings/github?from=context">
+              <Github className="h-4 w-4" aria-hidden />
+              <span>{COPY.connectCode.connectInSettings}</span>
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
           </Button>
         </div>
         <p className="text-label" style={{ margin: 0, color: "var(--fg-4)" }}>
-          {INSTALL_OWNER_HINT.pre}
-          <span className="font-medium" style={{ color: "var(--fg-3)" }}>
-            {INSTALL_OWNER_HINT.emphasis}
-          </span>
-          {INSTALL_OWNER_HINT.post}
+          {COPY.connectCode.connectInSettingsHint}
         </p>
-        {installError === "generic" && (
-          <FlowHint tone="error" role="alert">
-            {COPY.errors.generic}
-          </FlowHint>
-        )}
-        {attempted ? (
-          <div className="flex items-center" style={{ gap: "var(--sp-2_5)", flexWrap: "wrap" }}>
-            <StatusRow state="waiting" label={COPY.connectCode.waiting} />
-            <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={handleStartOver}>
-              {COPY.connectCode.restartInstall}
-            </Button>
-          </div>
-        ) : null}
       </div>
     );
   }

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -106,6 +106,11 @@ export const COPY = {
     // 3" read as confusing progress-within-progress. `phases` is gone.)
     cta: "Install First Tree on GitHub",
     waiting: "Waiting for GitHub…",
+    // Context-tab build entry sends GitHub install + connect to Settings → GitHub
+    // (the single place that binds an installation to the team) rather than doing
+    // it inline, so the whole flow lives in one place. See context-tree-build-entry.tsx.
+    connectInSettings: "Connect GitHub in Settings",
+    connectInSettingsHint: "Install and connect there, then come back to build.",
     /** Post-install confirmation. The account a GitHub App is installed on is
         set by whoever's github.com session was active at install time — which
         is NOT necessarily the account the user signed into First Tree with. So

--- a/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The GitHub round-trip return is the only logic under test here; stub the heavy
+// children (the installation panel and the repo resource sections) so the test
+// stays focused on the `?from=context` return affordance.
+const githubAppMocks = vi.hoisted(() => ({ getGithubAppInstallation: vi.fn() }));
+const authMock = vi.hoisted(() => ({
+  value: { role: "admin" as string | null, organizationId: "org-1" as string | null },
+}));
+
+vi.mock("../../../api/github-app.js", () => githubAppMocks);
+vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
+vi.mock("../../github-app-installation-panel.js", () => ({
+  GithubAppInstallationPanel: () => <div data-testid="panel-stub">panel</div>,
+}));
+vi.mock("../resource-sections.js", () => ({
+  ResourceTypeSections: () => <div data-testid="resources-stub">resources</div>,
+}));
+
+function createClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false }, mutations: { retry: false } },
+  });
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function renderAt(path: string, element: ReactElement): Promise<{ container: HTMLElement; root: Root }> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[path]}>
+        <QueryClientProvider client={createClient()}>{element}</QueryClientProvider>
+      </MemoryRouter>,
+    );
+  });
+  await flush();
+  return { container, root };
+}
+
+async function waitForText(container: ParentNode, text: string, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (container.textContent?.includes(text)) return;
+    await flush();
+  }
+  throw new Error(`Expected text "${text}"\n${container.textContent ?? ""}`);
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+  authMock.value = { role: "admin", organizationId: "org-1" };
+  githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("SettingsGithubPage — Context round-trip return", () => {
+  it("offers a 'back to building' link once connected when arriving from Context", async () => {
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue({ installationId: 7, accountLogin: "acme" });
+    const { SettingsGithubPage } = await import("../github.js");
+
+    const { container, root } = await renderAt("/settings/github?from=context", <SettingsGithubPage />);
+    await waitForText(container, "GitHub is connected");
+    const back = container.querySelector('a[href="/context"]');
+    expect(back).not.toBeNull();
+    expect(back?.textContent).toContain("Back to building your Context Tree");
+
+    await act(async () => root.unmount());
+  });
+
+  it("shows a quiet hint (not the return button) when arriving from Context but not yet connected", async () => {
+    githubAppMocks.getGithubAppInstallation.mockResolvedValue(null);
+    const { SettingsGithubPage } = await import("../github.js");
+
+    const { container, root } = await renderAt("/settings/github?from=context", <SettingsGithubPage />);
+    await waitForText(container, "then head back to build");
+    expect(container.querySelector('a[href="/context"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("shows no Context return affordance (and skips the probe) when not arriving from Context", async () => {
+    const { SettingsGithubPage } = await import("../github.js");
+
+    const { container, root } = await renderAt("/settings/github", <SettingsGithubPage />);
+    await waitForText(container, "panel"); // page rendered
+    expect(container.querySelector('a[href="/context"]')).toBeNull();
+    expect(container.textContent).not.toContain("then head back to build");
+    // The page's own return probe is gated on `?from=context`. With the panel
+    // stubbed, nothing queries the installation here — asserting the PAGE adds no
+    // probe when not arriving from Context. (The real panel keeps its own query.)
+    expect(githubAppMocks.getGithubAppInstallation).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/pages/settings/github.tsx
+++ b/packages/web/src/pages/settings/github.tsx
@@ -1,4 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight, Check } from "lucide-react";
+import { Link, useSearchParams } from "react-router";
+import { getGithubAppInstallation } from "../../api/github-app.js";
 import { useAuth } from "../../auth/auth-context.js";
+import { Button } from "../../components/ui/button.js";
 import { PageHeader } from "../../components/ui/page-header.js";
 import { Section } from "../../components/ui/section.js";
 import { GithubAppInstallationPanel } from "../github-app-installation-panel.js";
@@ -14,9 +19,29 @@ import { ResourceTypeSections } from "./resource-sections.js";
  *   - Source Repos — the team's `repo` runtime resources, moved here from
  *     Settings → Resources so the repos agents work on sit next to the
  *     GitHub connection their code and events flow through.
+ *
+ * `?from=context`: the Context tab is the single place a team builds its
+ * Context Tree, but installing + connecting GitHub lives here (the one place
+ * that binds an installation to the team). When the Context tab sends the user
+ * here to connect, we mark the trip so this page can hand them back — a return
+ * CTA appears the moment the team is connected, so they don't have to find
+ * their own way back to building.
  */
 export function SettingsGithubPage() {
-  const { role } = useAuth();
+  const { role, organizationId } = useAuth();
+  const [searchParams] = useSearchParams();
+  const fromContext = searchParams.get("from") === "context";
+
+  // Only needed to drive the "back to building" return for the Context round
+  // trip. Shares the query key the connection panel invalidates on connect, so
+  // this flips to connected the moment the user finishes connecting below.
+  const installationQuery = useQuery({
+    queryKey: ["github-app-installation", organizationId],
+    queryFn: () => (organizationId ? getGithubAppInstallation(organizationId) : Promise.reject(new Error("no org"))),
+    enabled: fromContext && !!organizationId,
+  });
+  const connected = installationQuery.data != null;
+
   if (role === null) {
     return (
       <div className="text-body" style={{ padding: "var(--sp-5)", color: "var(--fg-3)" }}>
@@ -30,11 +55,52 @@ export function SettingsGithubPage() {
     <>
       <PageHeader title="GitHub" subtitle="GitHub App connection and the source repos agents work on" />
       <div className="flex flex-col" style={{ gap: "var(--sp-5)", padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
+        {fromContext ? <ContextReturn connected={connected} /> : null}
         <Section title="GitHub Connection">
           <GithubAppInstallationPanel readOnly={!isAdmin} />
         </Section>
         <ResourceTypeSections types={["repo"]} titleFor={() => "Source Repos"} />
       </div>
     </>
+  );
+}
+
+/**
+ * The Context round-trip return. Before the team is connected it's a quiet line
+ * explaining why the user was sent here; once connected it becomes the explicit
+ * way back to building (deliberately a button, not an auto-redirect, so the user
+ * stays in control and can adjust source repos below first if they want).
+ */
+function ContextReturn({ connected }: { connected: boolean }) {
+  if (!connected) {
+    return (
+      <p className="text-body" style={{ margin: 0, color: "var(--fg-3)" }}>
+        Connect GitHub below, then head back to build your team's Context Tree.
+      </p>
+    );
+  }
+  return (
+    <div
+      className="flex flex-col"
+      style={{
+        gap: "var(--sp-2)",
+        padding: "var(--sp-3)",
+        borderRadius: "var(--radius-panel)",
+        background: "var(--color-success-soft)",
+      }}
+    >
+      <div className="flex items-center text-body" style={{ gap: "var(--sp-2)", color: "var(--fg)" }}>
+        <Check className="h-4 w-4" style={{ color: "var(--color-success)" }} aria-hidden />
+        <span>GitHub is connected.</span>
+      </div>
+      <div className="flex">
+        <Button asChild variant="cta">
+          <Link to="/context">
+            <span>Back to building your Context Tree</span>
+            <ArrowRight className="h-4 w-4" aria-hidden />
+          </Link>
+        </Button>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

Installing the GitHub App from the **Context tab** leaves users stuck forever on "Waiting for GitHub…" (reported by a user; see screenshots). The card installs the App inline, then polls `getGithubAppInstallation` for an installation *bound to the team* — but nothing in the Context flow ever binds it.

## Root cause

Since #1392, the `installation.created` webhook records installations **UNBOUND**, and binding to a team is an **explicit Connect action that only exists on Settings → GitHub**. The Context tab's inline card (and, historically, the onboarding connect-code step) still assumed install ⇒ auto-bound and only polled for a bound installation, with no Connect step — so the poll never resolves. Verified end-to-end against a live server (unbound install → `GET github-app-installation` 404 → `POST connect` → 200).

Note: **onboarding is not affected** — the value-first redesign already removed the connect-code step (`onboarding/steps.ts`), so the only broken live inline-install surface was the Context tab.

## Fix — converge install + connect onto Settings → GitHub

The single place that binds an installation to a team is Settings → GitHub; this stops duplicating install/connect UI and routes the Context tab there.

- **Context card** (`context-tree-build-entry.tsx`): when GitHub isn't connected, render a **"Connect GitHub in Settings →"** link to `/settings/github?from=context` instead of installing inline. The installed poll is kept, so the card advances to repo-pick/build on its own once the user connects and returns. Removes the now-dead inline-install machinery (install-URL mint, popup, waiting/start-over, install-error branches).
- **Settings → GitHub** (`settings/github.tsx`): when arriving with `?from=context`, show a quiet hint before connecting and a success banner + **"Back to building your Context Tree →"** return once connected. Uses the shared `["github-app-installation", orgId]` query that the connect panel invalidates on connect, so it flips the moment connect succeeds. No server changes.

This builds on the #1392 model unchanged (binding stays an explicit, server-authorized Connect action).

## Testing

- `pnpm --filter @first-tree/web typecheck` (tsc + lint:tokens design-token gate) ✓
- `pnpm check` (biome) ✓, root `pnpm typecheck` ✓
- Full web suite green (1283 tests). Updated `context-page-dom` (link behavior; removed inline-install cases) and added `settings/__tests__/github-page-dom.test.tsx` for the return affordance (connected → return CTA; not-connected → hint; no probe when not from Context).
- **Live real-browser e2e** (local dev stack): Context → "Connect GitHub in Settings" → `/settings/github?from=context` (hint) → connect → success banner + "Back to building" → back to Context (advanced past the connect gate). Both new surfaces render correctly.
- 2 independent code reviews; addressed findings: success banner now uses the `--color-success` token family (not the agent-liveness `--state-working`), tightened copy, aria-hidden on decorative icons.

## Known minor limitation

If the install **popup is blocked** while on `/settings/github?from=context`, the full-page install redirect returns to `/settings/github` without the `?from=context` marker (the post-install `next` allowlist is path-only), so the auto "back to building" CTA is lost and the user navigates back via the nav. Rare (popup-blocked) path; left as follow-up to avoid expanding the post-install allowlist here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---
**Companion tree PR:** agent-team-foundation/first-tree-context#702 (draft — reconciles the Context Tree; merge this code PR first).
