### PR TITLE
fix(cli): fall back to latest upgrade without server URL

### DIFF
--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -1072,6 +1072,20 @@ describe("logout and upgrade commands", () => {
       "first-tree-dev upgrade --latest",
     );
 
+    printLineMock.mockClear();
+    coreMocks.fetchServerCommandVersion.mockResolvedValueOnce({
+      ok: false,
+      reasonCode: "server_url_not_configured",
+      reason:
+        "Server URL not configured.\n" +
+        "  Provide via: --server <url>, FIRST_TREE_SERVER_URL env var, or\n" +
+        "  first-tree-dev config set server.url <url>",
+    });
+    await expect(runTopLevel(registerUpgradeCommand, ["upgrade"])).rejects.toMatchObject({ code: 1 });
+    const missingServerUrlOutput = printLineMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(missingServerUrlOutput).toContain("Could not fetch server update target: Server URL not configured");
+    expect(missingServerUrlOutput).not.toContain("upgrade --latest");
+
     coreMocks.fetchLatestVersion.mockReturnValueOnce({ ok: false, reason: "npm down" });
     await expect(runTopLevel(registerUpgradeCommand, ["upgrade", "--latest"])).rejects.toMatchObject({ code: 1 });
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(

--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -1068,11 +1068,10 @@ describe("logout and upgrade commands", () => {
     coreMocks.detectInstallMode.mockReturnValue("global");
     coreMocks.fetchServerCommandVersion.mockResolvedValueOnce({ ok: false, reason: "server down" });
     await expect(runTopLevel(registerUpgradeCommand, ["upgrade"])).rejects.toMatchObject({ code: 1 });
-    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain(
-      "first-tree-dev upgrade --latest",
-    );
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).not.toContain("upgrade --latest");
 
     printLineMock.mockClear();
+    coreMocks.installGlobalLatest.mockClear();
     coreMocks.fetchServerCommandVersion.mockResolvedValueOnce({
       ok: false,
       reasonCode: "server_url_not_configured",
@@ -1081,10 +1080,11 @@ describe("logout and upgrade commands", () => {
         "  Provide via: --server <url>, FIRST_TREE_SERVER_URL env var, or\n" +
         "  first-tree-dev config set server.url <url>",
     });
-    await expect(runTopLevel(registerUpgradeCommand, ["upgrade"])).rejects.toMatchObject({ code: 1 });
+    await runTopLevel(registerUpgradeCommand, ["upgrade", "--no-restart"]);
     const missingServerUrlOutput = printLineMock.mock.calls.map((call) => String(call[0])).join("");
-    expect(missingServerUrlOutput).toContain("Could not fetch server update target: Server URL not configured");
+    expect(missingServerUrlOutput).toContain("Checking channel latest release data");
     expect(missingServerUrlOutput).not.toContain("upgrade --latest");
+    expect(coreMocks.installGlobalLatest).toHaveBeenCalled();
 
     coreMocks.fetchLatestVersion.mockReturnValueOnce({ ok: false, reason: "npm down" });
     await expect(runTopLevel(registerUpgradeCommand, ["upgrade", "--latest"])).rejects.toMatchObject({ code: 1 });

--- a/apps/cli/src/__tests__/core-attention-update-extra.test.ts
+++ b/apps/cli/src/__tests__/core-attention-update-extra.test.ts
@@ -5,10 +5,19 @@ import { join } from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const bootstrapMocks = vi.hoisted(() => ({
-  ensureFreshAccessToken: vi.fn(),
-  resolveServerUrl: vi.fn(),
-}));
+const bootstrapMocks = vi.hoisted(() => {
+  class ServerUrlNotConfiguredError extends Error {
+    constructor() {
+      super("Server URL not configured.");
+      this.name = "ServerUrlNotConfiguredError";
+    }
+  }
+  return {
+    ensureFreshAccessToken: vi.fn(),
+    resolveServerUrl: vi.fn(),
+    ServerUrlNotConfiguredError,
+  };
+});
 
 const printLineMock = vi.hoisted(() => vi.fn());
 const cliFetchMock = vi.hoisted(() => vi.fn());
@@ -537,5 +546,14 @@ describe("core update helpers", () => {
 
     cliFetchMock.mockResolvedValueOnce(jsonResponse({}, false, 503));
     await expect(fetchServerCommandVersion()).resolves.toEqual({ ok: false, reason: "server returned HTTP 503" });
+
+    bootstrapMocks.resolveServerUrl.mockImplementationOnce(() => {
+      throw new bootstrapMocks.ServerUrlNotConfiguredError();
+    });
+    await expect(fetchServerCommandVersion()).resolves.toEqual({
+      ok: false,
+      reason: "Server URL not configured.",
+      reasonCode: "server_url_not_configured",
+    });
   });
 });

--- a/apps/cli/src/__tests__/update-global-extra.test.ts
+++ b/apps/cli/src/__tests__/update-global-extra.test.ts
@@ -24,9 +24,18 @@ vi.mock("@first-tree/client", () => ({
   getChildProcessRegistry: () => ({ spawn: registrySpawnMock }),
 }));
 
-vi.mock("../core/bootstrap.js", () => ({
-  resolveServerUrl: resolveServerUrlMock,
-}));
+vi.mock("../core/bootstrap.js", () => {
+  class ServerUrlNotConfiguredError extends Error {
+    constructor() {
+      super("Server URL not configured.");
+      this.name = "ServerUrlNotConfiguredError";
+    }
+  }
+  return {
+    resolveServerUrl: resolveServerUrlMock,
+    ServerUrlNotConfiguredError,
+  };
+});
 
 vi.mock("../core/cli-fetch.js", () => ({
   cliFetch: cliFetchMock,

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -36,7 +36,7 @@ import { print } from "../core/output.js";
 export function registerUpgradeCommand(program: Command): void {
   program
     .command("upgrade")
-    .description("Upgrade this First Tree CLI to the server-recommended version and restart the daemon")
+    .description("Upgrade this First Tree CLI from the server target or channel latest fallback")
     .option("--check", "Only check whether a newer version is available; do not install")
     .addOption(new Option("--latest", "Deprecated compatibility: query the channel latest directly").hideHelp())
     .option("--no-restart", "Install the new version but skip restarting the background service")

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import * as semver from "semver";
 import { channelConfig } from "../core/channel.js";
+import type { VersionLookupResult } from "../core/index.js";
 import {
   COMMAND_VERSION,
   detectInstallMode,
@@ -78,7 +79,7 @@ export function registerUpgradeCommand(program: Command): void {
             : "latest version"
           : "server update target";
         print.line(`  Could not fetch ${targetLabel}: ${target.reason}\n`);
-        if (!useLatest) {
+        if (!useLatest && shouldSuggestLatestBypass(target)) {
           print.line(`  Run \`${binName} upgrade --latest\` to install latest instead.\n`);
         }
         print.line("\n");
@@ -166,4 +167,8 @@ export function registerUpgradeCommand(program: Command): void {
       }
       print.line(`  Service restarted on ${installed}.\n\n`);
     });
+}
+
+function shouldSuggestLatestBypass(target: Extract<VersionLookupResult, { ok: false }>): boolean {
+  return target.reasonCode !== "server_url_not_configured";
 }

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -1,7 +1,6 @@
-import type { Command } from "commander";
+import { type Command, Option } from "commander";
 import * as semver from "semver";
 import { channelConfig } from "../core/channel.js";
-import type { VersionLookupResult } from "../core/index.js";
 import {
   COMMAND_VERSION,
   detectInstallMode,
@@ -31,14 +30,15 @@ import { print } from "../core/output.js";
  * when a connected client falls behind the server-bundled version. This
  * command is the manual equivalent by default: same server-selected target
  * version plus the same install + restart sequence, but triggered on the
- * operator's terms. `--latest` is the explicit npm bypass.
+ * operator's terms. When no server URL is configured yet, it falls back to the
+ * channel's latest release data so update remains useful before login/config.
  */
 export function registerUpgradeCommand(program: Command): void {
   program
     .command("upgrade")
     .description("Upgrade this First Tree CLI to the server-recommended version and restart the daemon")
     .option("--check", "Only check whether a newer version is available; do not install")
-    .option("--latest", "Bypass the server target and install npm latest")
+    .addOption(new Option("--latest", "Deprecated compatibility: query the channel latest directly").hideHelp())
     .option("--no-restart", "Install the new version but skip restarting the background service")
     .action(async (options: { check?: boolean; latest?: boolean; restart?: boolean }) => {
       const binName = channelConfig.binName;
@@ -58,20 +58,30 @@ export function registerUpgradeCommand(program: Command): void {
         return;
       }
 
-      const useLatest = options.latest === true;
+      const requestedLatest = options.latest === true;
+      let useLatest = requestedLatest;
       const isPortable = mode === "portable";
       print.line(
-        useLatest
+        requestedLatest
           ? isPortable
             ? "\n  Checking portable update target...\n"
             : "\n  Checking npm registry...\n"
-          : "\n  Checking server update target...\n",
+          : "\n  Checking update target...\n",
       );
-      const target = useLatest
+      let target = requestedLatest
         ? isPortable
           ? await fetchPortableLatestVersion()
           : fetchLatestVersion()
         : await fetchServerCommandVersion();
+
+      if (!requestedLatest && !target.ok && target.reasonCode === "server_url_not_configured") {
+        useLatest = true;
+        print.line(
+          isPortable ? "  Checking portable update target...\n" : "  Checking channel latest release data...\n",
+        );
+        target = isPortable ? await fetchPortableLatestVersion() : fetchLatestVersion();
+      }
+
       if (!target.ok) {
         const targetLabel = useLatest
           ? isPortable
@@ -79,9 +89,6 @@ export function registerUpgradeCommand(program: Command): void {
             : "latest version"
           : "server update target";
         print.line(`  Could not fetch ${targetLabel}: ${target.reason}\n`);
-        if (!useLatest && shouldSuggestLatestBypass(target)) {
-          print.line(`  Run \`${binName} upgrade --latest\` to install latest instead.\n`);
-        }
         print.line("\n");
         process.exit(1);
       }
@@ -96,7 +103,7 @@ export function registerUpgradeCommand(program: Command): void {
 
       if (options.check) {
         print.line(`  Upgrade available: ${current} → ${target.version}\n`);
-        print.line(`  Run \`${binName} upgrade${useLatest ? " --latest" : ""}\` to install.\n\n`);
+        print.line(`  Run \`${binName} upgrade${requestedLatest ? " --latest" : ""}\` to install.\n\n`);
         return;
       }
 
@@ -167,8 +174,4 @@ export function registerUpgradeCommand(program: Command): void {
       }
       print.line(`  Service restarted on ${installed}.\n\n`);
     });
-}
-
-function shouldSuggestLatestBypass(target: Extract<VersionLookupResult, { ok: false }>): boolean {
-  return target.reasonCode !== "server_url_not_configured";
 }

--- a/apps/cli/src/core/bootstrap.ts
+++ b/apps/cli/src/core/bootstrap.ts
@@ -11,6 +11,17 @@ function credentialsPath(): string {
   return join(defaultConfigDir(), "credentials.json");
 }
 
+export class ServerUrlNotConfiguredError extends Error {
+  constructor() {
+    super(
+      "Server URL not configured.\n" +
+        "  Provide via: --server <url>, FIRST_TREE_SERVER_URL env var, or\n" +
+        `  ${channelConfig.binName} config set server.url <url>`,
+    );
+    this.name = "ServerUrlNotConfiguredError";
+  }
+}
+
 type StoredCredentials = {
   accessToken: string;
   refreshToken: string;
@@ -34,11 +45,7 @@ export function resolveServerUrl(flagValue?: string): string {
     if (typeof url === "string" && url.length > 0) return url;
   }
 
-  throw new Error(
-    "Server URL not configured.\n" +
-      "  Provide via: --server <url>, FIRST_TREE_SERVER_URL env var, or\n" +
-      `  ${channelConfig.binName} config set server.url <url>`,
-  );
+  throw new ServerUrlNotConfiguredError();
 }
 
 /**

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -19,7 +19,7 @@ import {
 } from "@first-tree/shared";
 import { inferChannelFromVersion } from "@first-tree/shared/channel";
 import * as semver from "semver";
-import { resolveServerUrl } from "./bootstrap.js";
+import { resolveServerUrl, ServerUrlNotConfiguredError } from "./bootstrap.js";
 import { channelConfig } from "./channel.js";
 import { cliFetch } from "./cli-fetch.js";
 import { print } from "./output.js";
@@ -30,7 +30,10 @@ const NPM_INSTALL_TIMEOUT_MS = 5 * 60 * 1000;
 const NPM_METADATA_TIMEOUT_MS = 10 * 1000;
 
 export type InstallMode = "global" | "npx" | "source" | "portable";
-export type VersionLookupResult = { ok: true; version: string } | { ok: false; reason: string };
+export type VersionLookupFailureCode = "server_url_not_configured";
+export type VersionLookupResult =
+  | { ok: true; version: string }
+  | { ok: false; reason: string; reasonCode?: VersionLookupFailureCode };
 
 type PortableMetadataIdentity = {
   channel: string;
@@ -751,7 +754,11 @@ export async function fetchServerCommandVersion(timeoutMs = 10_000): Promise<Ver
   try {
     serverUrl = resolveServerUrl();
   } catch (err) {
-    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+      ...(err instanceof ServerUrlNotConfiguredError ? { reasonCode: "server_url_not_configured" as const } : {}),
+    };
   }
 
   let res: Response;

--- a/apps/cli/src/core/update.ts
+++ b/apps/cli/src/core/update.ts
@@ -618,10 +618,10 @@ export async function fetchPortableLatestVersion(): Promise<VersionLookupResult>
  * that (so the UpdateManager can attempt the restart itself while this
  * function remains side-effect-scoped).
  *
- * Why both shapes exist: the auto-update path and the default manual
- * `upgrade` command receive an exact target version from the server and MUST
- * install that exact version. The explicit `upgrade --latest` escape hatch keeps the dist-tag form for
- * operators who want the freshest package directly from npm.
+ * Why both shapes exist: managed update paths usually receive an exact target
+ * version from the server and MUST install that exact version. The dist-tag
+ * form remains for default `upgrade` fallback before server URL configuration
+ * and for hidden compatibility with older operator scripts.
  */
 export async function installGlobalSpec(
   spec: string,
@@ -736,9 +736,10 @@ export async function installGlobalSpec(
 }
 
 /**
- * Back-compat shim: install `<pkg>@latest`. Used by
- * `upgrade --latest`; managed update paths prefer
- * `installGlobalSpec` with the server-advertised target version.
+ * Back-compat shim: install `<pkg>@latest`. Used by default `upgrade` fallback
+ * before server URL configuration and by the hidden `upgrade --latest`
+ * compatibility path; managed update paths prefer `installGlobalSpec` with the
+ * server-advertised target version.
  */
 export async function installGlobalLatest(options?: InstallGlobalSpecOptions): Promise<ExecuteUpdateResult> {
   return installGlobalSpec("latest", options);

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -165,11 +165,14 @@ tarball, including the bundled Node.js runtime. npm installs run `npm install
 -g` against the channel package and keep using the system Node.js runtime. Use
 `--latest` only when you intentionally want to bypass the server target and
 install the channel's latest release data directly.
+If the configured server URL is missing, configure it with
+`first-tree config set server.url <url>` or `FIRST_TREE_SERVER_URL`; `--latest`
+does not repair that server-target configuration.
 
 | Flag | Effect |
 |---|---|
 | `--check` | Only check for an available version; print "update available" or "already on latest". Do not install. |
-| `--latest` | Bypass the server target and query npm for the package's latest published version. |
+| `--latest` | Bypass the server target and query the channel's latest release data directly: npm for global installs, portable metadata for portable installs. |
 | `--no-restart` | Install the new version and refresh the supervisor definition, but leave the running service alone. Used for staged rollouts. |
 
 Refusing to run from a source checkout (anywhere under a `.git`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -154,25 +154,22 @@ red and you want a guided drill-down.
 ## upgrade
 
 ```
-first-tree upgrade [--check] [--latest] [--no-restart]
+first-tree upgrade [--check] [--no-restart]
 ```
 
 Self-update for the CLI: query the configured server for its recommended
-Command version, install that exact version through the current install mode,
-refresh the supervisor definition on top of the new bits, then restart the
-client service. Portable installs download the channel manifest and verified
-tarball, including the bundled Node.js runtime. npm installs run `npm install
--g` against the channel package and keep using the system Node.js runtime. Use
-`--latest` only when you intentionally want to bypass the server target and
-install the channel's latest release data directly.
-If the configured server URL is missing, configure it with
-`first-tree config set server.url <url>` or `FIRST_TREE_SERVER_URL`; `--latest`
-does not repair that server-target configuration.
+Command version when a server URL is configured, install that exact version
+through the current install mode, refresh the supervisor definition on top of
+the new bits, then restart the client service. If no server URL is configured
+yet, `upgrade` falls back to the current channel's latest release data directly
+so the update path still works before login/config. Portable installs download
+the channel manifest and verified tarball, including the bundled Node.js
+runtime. npm installs run `npm install -g` against the channel package and keep
+using the system Node.js runtime.
 
 | Flag | Effect |
 |---|---|
 | `--check` | Only check for an available version; print "update available" or "already on latest". Do not install. |
-| `--latest` | Bypass the server target and query the channel's latest release data directly: npm for global installs, portable metadata for portable installs. |
 | `--no-restart` | Install the new version and refresh the supervisor definition, but leave the running service alone. Used for staged rollouts. |
 
 Refusing to run from a source checkout (anywhere under a `.git`


### PR DESCRIPTION
## Summary

- make default `first-tree upgrade` query the configured server target when a server URL exists, but fall back to the current channel's latest release data when the server URL is missing
- hide the deprecated `--latest` help surface while keeping the flag accepted for older scripts that already call it
- keep other server-target failures as hard failures, and update CLI docs/tests/comments for the new user-facing contract
- clarify `first-tree upgrade --help` so the command description no longer promises only the server-recommended version

## Related

- Tracking issue: https://github.com/agent-team-foundation/first-tree/issues/1566
- Paired Context Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/704

## Verification

- `pnpm --filter first-tree-dev exec vitest run src/__tests__/agent-lifecycle-commands-extra.test.ts src/__tests__/update-global-extra.test.ts src/__tests__/resolve-server-url.test.ts`
- `pnpm exec biome check apps/cli/src/commands/upgrade.ts apps/cli/src/core/update.ts apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts docs/cli-reference.md`
- `pnpm --filter first-tree-dev typecheck`

Note: an earlier broad CLI test invocation ran more than the targeted file and surfaced unrelated existing platform/path failures in `tree-init-command-extra.test.ts`, `core-attention-update-extra.test.ts`, and `client-switch-platform-extra.test.ts`; the affected targeted tests above pass.
