### PR TITLE
fix(cli): prefer Windows cmd shim for supervisor

### DIFF
--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -166,6 +166,20 @@ describe("service install helpers", () => {
     expect(() => resolveCliInvocation()).toThrow("Cannot resolve CLI entry point");
   });
 
+  it("uses the Windows cmd shim when where returns npm's extensionless shell shim first", () => {
+    setPlatform("win32");
+    const npmBinDir = join(home, "npm");
+    const extensionlessShim = join(npmBinDir, channelConfig.binName);
+    const cmdShim = `${extensionlessShim}.cmd`;
+    mkdirSync(npmBinDir, { recursive: true });
+    writeFileSync(extensionlessShim, "#!/bin/sh\nexec node cli.mjs \"$@\"\n");
+    writeFileSync(cmdShim, "@ECHO off\r\nnode cli.mjs %*\r\n");
+
+    execFileSyncMock.mockReturnValueOnce(`${extensionlessShim}\r\n${cmdShim}\r\n`);
+
+    expect(resolveCliInvocation()).toEqual({ kind: "bin", program: cmdShim });
+  });
+
   it("renders service templates with escaped values and quoted shell arguments", () => {
     const plist = renderPlist("/tmp/First & Tree");
     expect(plist).toContain("<string>/tmp/First &amp; Tree</string>");

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -172,7 +172,7 @@ describe("service install helpers", () => {
     const extensionlessShim = join(npmBinDir, channelConfig.binName);
     const cmdShim = `${extensionlessShim}.cmd`;
     mkdirSync(npmBinDir, { recursive: true });
-    writeFileSync(extensionlessShim, "#!/bin/sh\nexec node cli.mjs \"$@\"\n");
+    writeFileSync(extensionlessShim, '#!/bin/sh\nexec node cli.mjs "$@"\n');
     writeFileSync(cmdShim, "@ECHO off\r\nnode cli.mjs %*\r\n");
 
     execFileSyncMock.mockReturnValueOnce(`${extensionlessShim}\r\n${cmdShim}\r\n`);

--- a/apps/cli/src/core/supervisor/shared.ts
+++ b/apps/cli/src/core/supervisor/shared.ts
@@ -184,6 +184,14 @@ function whichBin(name: string): string | null {
   }
 }
 
+function normalizeWindowsCliBin(bin: string): string {
+  if (process.platform !== "win32") return bin;
+  if (/\.(?:cmd|bat|exe)$/iu.test(bin)) return bin;
+
+  const cmdShim = `${bin}.cmd`;
+  return existsSync(cmdShim) ? cmdShim : bin;
+}
+
 /**
  * Resolve how the service should launch the CLI.
  *
@@ -207,11 +215,12 @@ function whichBin(name: string): string | null {
 export function resolveCliInvocation(): ResolvedBinary {
   const bin = whichBin(channelConfig.binName);
   if (bin && isAbsolute(bin)) {
+    const serviceBin = normalizeWindowsCliBin(bin);
     try {
       // Resolve symlinks so launchd records a stable path.
-      return { kind: "bin", program: realpathSync(bin) };
+      return { kind: "bin", program: realpathSync(serviceBin) };
     } catch {
-      return { kind: "bin", program: bin };
+      return { kind: "bin", program: serviceBin };
     }
   }
 


### PR DESCRIPTION
## Summary
- Normalize Windows CLI service launches to prefer the `.cmd` npm shim when `where.exe` returns an extensionless shell shim first.
- Keep non-Windows behavior unchanged and preserve existing absolute binary resolution.
- Add a regression test for the Task Scheduler supervisor resolution path.

## Verification
- `corepack pnpm --filter first-tree-dev exec vitest run src/__tests__/service-install-core.test.ts -t "uses the Windows cmd shim"`
- `corepack pnpm --filter first-tree-dev exec vitest run src/__tests__/windows-supervisor.test.ts`
- `corepack pnpm --filter first-tree-dev typecheck`

## Manual Windows validation
- Built `first-tree-dev` from this branch.
- Installed the dev Task Scheduler service with an npm-like shim layout where `where.exe first-tree-dev` returns the extensionless shim before `.cmd`.
- Confirmed the generated wrapper invokes `first-tree-dev.cmd daemon supervise`.
- Confirmed `first-tree-dev daemon start` reports the task-scheduler service running and writes a runtime marker under `.first-tree-dev\state\client-runtimes`.
