### PR TITLE
fix: dedup production-scan fix launcher across both entry paths

### DIFF
--- a/docs/development/onboarding-kickoff-contract.md
+++ b/docs/development/onboarding-kickoff-contract.md
@@ -23,6 +23,15 @@ chats and the adjacent campaign quickstart handoff.
 - The first-chat endpoint does not accept the retired `kind` discriminator.
 - `POST /api/v1/me/onboarding/tree-setup/kickoff` is the only tree setup
   kickoff entry. It uses the org-level `tree-setup` idempotency key.
+- A `/me/onboarding/kickoff` request carrying `scanFixRepoSlug` (`owner/repo`)
+  is a production-scan fix conversion arriving via onboarding. It keys the
+  kickoff chat `<humanAgent>:scan-fix:<repoSlug>` instead of the default
+  `<humanAgent>:<agent>:onboarding` key. This is the SAME key the
+  already-onboarded direct path composes (`POST /api/v1/orgs/:orgId/chats` task
+  mode, also from `scanFixRepoSlug`): both write `chats.onboarding_kickoff_key`,
+  so its unique constraint makes re-entering the fix link — through either path
+  — reuse the one fix launcher instead of creating a duplicate. It still stamps
+  onboarding completion like any onboarding kickoff.
 
 ## Retired Contract Boundary
 

--- a/packages/server/src/__tests__/scan-fix-idempotency.test.ts
+++ b/packages/server/src/__tests__/scan-fix-idempotency.test.ts
@@ -1,0 +1,187 @@
+import crypto from "node:crypto";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { chats } from "../db/schema/chats.js";
+import { clients } from "../db/schema/clients.js";
+import { messages } from "../db/schema/messages.js";
+import { createAgent } from "../services/agent.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * The production-scan "fix blockers" conversion creates its launcher through
+ * two different endpoints — the not-yet-onboarded onboarding path
+ * (`POST /me/onboarding/kickoff`) and the already-onboarded direct path
+ * (`POST /orgs/:orgId/chats` task mode). Both now compose the SAME idempotency
+ * key `<humanAgent>:scan-fix:<repoSlug>` and write it to
+ * `chats.onboarding_kickoff_key`, so re-entering the fix link — via either path
+ * — reuses the one launcher instead of creating a duplicate `Fix production
+ * scan blockers` chat.
+ */
+
+async function createOrgAgent(
+  app: ReturnType<ReturnType<typeof useTestApp>>,
+  admin: Awaited<ReturnType<typeof createTestAdmin>>,
+) {
+  const clientId = `cli-${crypto.randomUUID().slice(0, 8)}`;
+  await app.db.insert(clients).values({
+    id: clientId,
+    userId: admin.userId,
+    organizationId: admin.organizationId,
+    status: "connected",
+  });
+  return createAgent(app.db, {
+    name: `bootstrap-${crypto.randomUUID().slice(0, 8)}`,
+    type: "agent",
+    displayName: "Bootstrap Agent",
+    managerId: admin.memberId,
+    clientId,
+  });
+}
+
+const KICKOFF_URL = "/api/v1/me/onboarding/kickoff";
+const FIX_TOPIC = "Fix production scan blockers";
+const REPO_SLUG = "acme/orders";
+
+function kickoffFixPayload(admin: Awaited<ReturnType<typeof createTestAdmin>>, agentUuid: string) {
+  return {
+    organizationId: admin.organizationId,
+    agentUuid,
+    bootstrap: "Fix the launch blockers (onboarding path).",
+    topic: FIX_TOPIC,
+    scanFixRepoSlug: REPO_SLUG,
+    complete: true,
+  };
+}
+
+function directFixPayload(agentUuid: string) {
+  return {
+    mode: "task" as const,
+    topic: FIX_TOPIC,
+    scanFixRepoSlug: REPO_SLUG,
+    initialRecipientAgentIds: [agentUuid],
+    initialRecipientNames: [],
+    contextParticipantAgentIds: [],
+    contextParticipantNames: [],
+    initialMessage: { source: "web" as const, format: "text" as const, content: "Fix the launch blockers (direct)." },
+  };
+}
+
+describe("production-scan fix conversion — cross-path idempotency", () => {
+  const getApp = useTestApp({ growthLandingPagesEnabled: true });
+
+  it("dedups the fix launcher across the onboarding path and the direct path", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const agent = await createOrgAgent(app, admin);
+
+    // PATH 1 — not-yet-onboarded: onboarding kickoff creates the fix launcher,
+    // keyed `<human>:scan-fix:<repoSlug>`.
+    const onboarding = await app.inject({
+      method: "POST",
+      url: KICKOFF_URL,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: kickoffFixPayload(admin, agent.uuid),
+    });
+    expect(onboarding.statusCode).toBe(200);
+    const chat1 = onboarding.json<{ chatId: string }>().chatId;
+
+    // Its kickoff key is the scan-fix key, not the default onboarding key.
+    const [row1] = await app.db.select().from(chats).where(eq(chats.id, chat1)).limit(1);
+    expect(row1?.onboardingKickoffKey).toBe(`${admin.humanAgentUuid}:scan-fix:${REPO_SLUG}`);
+
+    // PATH 2 — user re-enters the fix link once onboarded → direct path. Same
+    // key ⇒ reuse chat1, not a second launcher.
+    const direct = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${encodeURIComponent(admin.organizationId)}/chats`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: directFixPayload(agent.uuid),
+    });
+    expect(direct.statusCode).toBe(201);
+    const chat2 = direct.json<{ chatId: string }>().chatId;
+
+    expect(chat2).toBe(chat1);
+    const fixChats = await app.db.select().from(chats).where(eq(chats.topic, FIX_TOPIC));
+    expect(fixChats).toHaveLength(1);
+    // Reuse must be clean: the second path reopened the launcher without
+    // appending a duplicate bootstrap message.
+    const msgs = await app.db.select().from(messages).where(eq(messages.chatId, chat1));
+    expect(msgs).toHaveLength(1);
+  });
+
+  it("the direct path alone is idempotent on re-entry", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const agent = await createOrgAgent(app, admin);
+    const url = `/api/v1/orgs/${encodeURIComponent(admin.organizationId)}/chats`;
+    const headers = { authorization: `Bearer ${admin.accessToken}` };
+
+    const a = await app.inject({ method: "POST", url, headers, payload: directFixPayload(agent.uuid) });
+    const b = await app.inject({ method: "POST", url, headers, payload: directFixPayload(agent.uuid) });
+    expect(a.json<{ chatId: string }>().chatId).toBe(b.json<{ chatId: string }>().chatId);
+    const fixChats = await app.db.select().from(chats).where(eq(chats.topic, FIX_TOPIC));
+    expect(fixChats).toHaveLength(1);
+  });
+
+  it("the onboarding path alone is idempotent on re-entry", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const agent = await createOrgAgent(app, admin);
+    const first = await app.inject({
+      method: "POST",
+      url: KICKOFF_URL,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: kickoffFixPayload(admin, agent.uuid),
+    });
+    const second = await app.inject({
+      method: "POST",
+      url: KICKOFF_URL,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: kickoffFixPayload(admin, agent.uuid),
+    });
+    expect(first.json<{ chatId: string }>().chatId).toBe(second.json<{ chatId: string }>().chatId);
+    const fixChats = await app.db.select().from(chats).where(eq(chats.topic, FIX_TOPIC));
+    expect(fixChats).toHaveLength(1);
+  });
+
+  it("dedups across differently-cased slugs (GitHub repos are case-insensitive)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const agent = await createOrgAgent(app, admin);
+
+    const onboarding = await app.inject({
+      method: "POST",
+      url: KICKOFF_URL,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { ...kickoffFixPayload(admin, agent.uuid), scanFixRepoSlug: "Acme/Orders" },
+    });
+    const direct = await app.inject({
+      method: "POST",
+      url: `/api/v1/orgs/${encodeURIComponent(admin.organizationId)}/chats`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { ...directFixPayload(agent.uuid), scanFixRepoSlug: "acme/orders" },
+    });
+    expect(direct.json<{ chatId: string }>().chatId).toBe(onboarding.json<{ chatId: string }>().chatId);
+    const fixChats = await app.db.select().from(chats).where(eq(chats.topic, FIX_TOPIC));
+    expect(fixChats).toHaveLength(1);
+  });
+
+  it("a non-scan-fix onboarding kickoff keeps the default onboarding key", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const agent = await createOrgAgent(app, admin);
+    const res = await app.inject({
+      method: "POST",
+      url: KICKOFF_URL,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: {
+        organizationId: admin.organizationId,
+        agentUuid: agent.uuid,
+        bootstrap: "Get started.",
+        topic: "Get started with First Tree",
+      },
+    });
+    const [row] = await app.db.select().from(chats).where(eq(chats.id, res.json<{ chatId: string }>().chatId)).limit(1);
+    expect(row?.onboardingKickoffKey).toBe(`${admin.humanAgentUuid}:${agent.uuid}:onboarding`);
+  });
+});

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -40,7 +40,7 @@ import {
   selfCreateOrganization,
 } from "../services/membership.js";
 import { notifyRecipients } from "../services/notifier.js";
-import { hasTreeSetupKickoffMessage, kickoffOnboarding } from "../services/onboarding-kickoff.js";
+import { hasTreeSetupKickoffMessage, kickoffOnboarding, scanFixKickoffKey } from "../services/onboarding-kickoff.js";
 import { getOrgContextTreeWithMeta } from "../services/org-settings.js";
 import { resolvePublicUrl } from "../utils/public-url.js";
 import { serializeDate } from "../utils.js";
@@ -348,7 +348,12 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
       targetAgentId: body.agentUuid,
       bootstrap: body.bootstrap,
       topic: body.topic ?? "Get started with First Tree",
-      kickoffKey: `${humanAgentId}:${body.agentUuid}:onboarding`,
+      // A production-scan fix conversion keys on the repo so this launcher
+      // dedups with the already-onboarded direct path; a normal onboarding
+      // kickoff keeps the per-(human, agent) onboarding key.
+      kickoffKey: body.scanFixRepoSlug
+        ? scanFixKickoffKey(humanAgentId, body.scanFixRepoSlug)
+        : `${humanAgentId}:${body.agentUuid}:onboarding`,
       complete: body.complete ?? true,
     });
     if (result.sent) {

--- a/packages/server/src/api/orgs/chats.ts
+++ b/packages/server/src/api/orgs/chats.ts
@@ -15,6 +15,7 @@ import { createChat, listChatsForMember, resolveAgentIdsByNameInOrg } from "../.
 import { assertNoLandingCampaignTrialAgents } from "../../services/landing-campaigns/guards.js";
 import { createMeChat, listMeChatSourceCounts, listMeChats } from "../../services/me-chat.js";
 import { notifyRecipients } from "../../services/notifier.js";
+import { scanFixKickoffKey } from "../../services/onboarding-kickoff.js";
 
 /**
  * Class B — org-scoped chat collection routes. Mounted at
@@ -142,6 +143,12 @@ export async function orgChatRoutes(app: FastifyInstance): Promise<void> {
         description: body.description ?? null,
         initialMessage: { ...body.initialMessage, source: "web" },
         source: "manual",
+        // Production-scan fix conversion: key the launcher on the repo so
+        // re-entering the fix link reuses it (and dedups with the onboarding
+        // path that carries the same key) instead of creating a duplicate.
+        ...(body.scanFixRepoSlug
+          ? { onboardingKickoffKey: scanFixKickoffKey(scope.humanAgentId, body.scanFixRepoSlug) }
+          : {}),
       });
       notifyRecipients(app.notifier, result.recipients, result.message.id);
       return reply.status(201).send({

--- a/packages/server/src/services/onboarding-kickoff.ts
+++ b/packages/server/src/services/onboarding-kickoff.ts
@@ -6,6 +6,21 @@ import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
 import { createChat } from "./chat.js";
 
+/**
+ * Idempotency key for a production-scan fix launcher, shared by BOTH entry
+ * paths so re-entering the fix link cannot create a second launcher:
+ * the not-yet-onboarded path (`POST /me/onboarding/kickoff`) and the
+ * already-onboarded direct path (`POST /orgs/:orgId/chats` task mode) both
+ * compose it from the same `members.agentId` and repo slug, so the shared
+ * `chats.onboarding_kickoff_key` unique constraint dedups them.
+ */
+export function scanFixKickoffKey(humanAgentId: string, repoSlug: string): string {
+  // GitHub owner/repo are case-insensitive, and the two paths derive the slug
+  // from separate parses of the fix link — lowercasing here (the single shared
+  // composition point) keeps the key identical even if the URLs differ in case.
+  return `${humanAgentId}:scan-fix:${repoSlug.toLowerCase()}`;
+}
+
 export type KickoffOnboardingArgs = {
   /** The membership whose completion is stamped once the chat exists. */
   memberId: string;

--- a/packages/shared/src/schemas/chat.ts
+++ b/packages/shared/src/schemas/chat.ts
@@ -61,6 +61,15 @@ export const createTaskChatSchema = z
     contextParticipantAgentIds: z.array(z.string().min(1)).default([]),
     contextParticipantNames: z.array(z.string().min(1)).default([]),
     initialMessage: sendMessageSchema,
+    // Production-scan fix conversion (already-onboarded direct path). When set,
+    // this task chat is keyed `<humanAgent>:scan-fix:<repoSlug>` so re-entering
+    // the fix link reuses the same launcher instead of creating a duplicate,
+    // and it dedups with the onboarding-path kickoff that carries the same key.
+    scanFixRepoSlug: z
+      .string()
+      .max(200)
+      .regex(/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/)
+      .optional(),
   })
   .refine((v) => v.initialRecipientAgentIds.length > 0 || v.initialRecipientNames.length > 0, {
     message: "task chat creation requires at least one initial recipient",

--- a/packages/shared/src/schemas/me-extras.ts
+++ b/packages/shared/src/schemas/me-extras.ts
@@ -64,6 +64,15 @@ export const kickoffOnboardingSchema = z
     bootstrap: z.string().min(1),
     topic: z.string().trim().min(1).max(120).optional(),
     complete: z.boolean().optional(),
+    // Production-scan fix conversion: when present, the kickoff chat is keyed
+    // `<humanAgent>:scan-fix:<repoSlug>` instead of the default onboarding key,
+    // so the fix launcher created here dedups with the already-onboarded direct
+    // path (`POST /orgs/:orgId/chats`) that reuses the same key. `owner/repo`.
+    scanFixRepoSlug: z
+      .string()
+      .max(200)
+      .regex(/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/)
+      .optional(),
     // Retained only so stale quickstart clients receive a controlled
     // moved/disabled response from /me/onboarding/kickoff. Current campaign
     // quickstart uses /me/landing-campaigns/start; this field must not create an

--- a/packages/web/src/api/onboarding-events.ts
+++ b/packages/web/src/api/onboarding-events.ts
@@ -7,6 +7,12 @@ export type StartOnboardingChatArgs = {
   bootstrap: string;
   topic?: string;
   complete?: boolean;
+  /**
+   * Production-scan fix conversion: `owner/repo`. When set, the server keys the
+   * kickoff chat `<humanAgent>:scan-fix:<repoSlug>` so this fix launcher dedups
+   * with the already-onboarded direct path instead of duplicating it.
+   */
+  scanFixRepoSlug?: string;
 };
 
 export type StartOnboardingChatResult = {

--- a/packages/web/src/pages/onboarding/steps/__tests__/step-start-chat-scan-fix.test.tsx
+++ b/packages/web/src/pages/onboarding/steps/__tests__/step-start-chat-scan-fix.test.tsx
@@ -44,7 +44,7 @@ const resolveAgentMock = vi.hoisted(() => ({
 
 const treeSetupChatMock = vi.hoisted(() => ({
   ensureStartChatRepos: vi.fn(async () => undefined),
-  startOnboardingChat: vi.fn(async (_args: { topic: string; bootstrap: string }) => "chat-1"),
+  startOnboardingChat: vi.fn(async (_args: { topic: string; bootstrap: string; scanFixRepoSlug?: string }) => "chat-1"),
 }));
 
 vi.mock("../../onboarding-flow.js", async () => {
@@ -128,8 +128,12 @@ function expectCall<T>(value: T | undefined): T {
 }
 
 describe("AdminStartChat — production-scan fix handoff", () => {
-  it("sends the scan-fix bootstrap and topic, and clears the flag once the chat exists", async () => {
-    writeScanFixHandoffFlag({ repoUrl: "https://github.com/acme/backend", reportKey: "acme-backend-20260101-abcdef" });
+  it("sends the scan-fix bootstrap and topic, threads the repo slug, and clears the flag once the chat exists", async () => {
+    writeScanFixHandoffFlag({
+      repoUrl: "https://github.com/acme/backend",
+      reportKey: "acme-backend-20260101-abcdef",
+      repoSlug: "acme/backend",
+    });
 
     const container = await renderStep();
     clickStart(container);
@@ -138,6 +142,9 @@ describe("AdminStartChat — production-scan fix handoff", () => {
     expect(treeSetupChatMock.startOnboardingChat).toHaveBeenCalledTimes(1);
     const call = expectCall(treeSetupChatMock.startOnboardingChat.mock.calls[0]?.[0]);
     expect(call.topic).toBe("Fix production scan blockers");
+    // The repo slug must thread all the way to start-chat so the server keys
+    // the onboarding-path launcher for cross-path dedup (guards a dropped hop).
+    expect(call.scanFixRepoSlug).toBe("acme/backend");
     expect(call.bootstrap).toContain(
       "Machine-readable findings: https://report.first-tree.ai/acme-backend-20260101-abcdef.json",
     );

--- a/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
@@ -31,6 +31,8 @@ async function runStartChat(args: {
   topic: string;
   treeBindingPlan?: TreeBindingPlan | "none";
   joinPath?: "invite";
+  /** Production-scan fix conversion `owner/repo` — keys the launcher for dedup. */
+  scanFixRepoSlug?: string;
   complete: (chatId: string) => Promise<void>;
 }): Promise<void> {
   const agent = await resolveOnboardingAgent(args.organizationId);
@@ -42,6 +44,7 @@ async function runStartChat(args: {
     topic: args.topic,
     treeBindingPlan: args.treeBindingPlan ?? "none",
     joinPath: args.joinPath,
+    ...(args.scanFixRepoSlug ? { scanFixRepoSlug: args.scanFixRepoSlug } : {}),
   });
   await args.complete(chatId);
 }
@@ -117,6 +120,8 @@ function AdminStartChat() {
           organizationId,
           topic: scanFixHandoff ? "Fix production scan blockers" : "Get started with First Tree",
           treeBindingPlan: "none",
+          // Key the fix launcher on the repo so it dedups with the direct path.
+          ...(scanFixHandoff?.repoSlug ? { scanFixRepoSlug: scanFixHandoff.repoSlug } : {}),
           complete: async (chatId) => {
             // The chat now exists with the fix bootstrap — the handoff is consumed.
             writeScanFixHandoffFlag(null);

--- a/packages/web/src/pages/onboarding/tree-setup-chat.ts
+++ b/packages/web/src/pages/onboarding/tree-setup-chat.ts
@@ -49,6 +49,8 @@ export async function startOnboardingChat(args: {
   treeBindingPlan: TreeBindingPlan | "none";
   joinPath?: "invite";
   complete?: boolean;
+  /** Production-scan fix conversion `owner/repo` — keys the launcher for dedup. */
+  scanFixRepoSlug?: string;
 }): Promise<string> {
   // Create-or-reuse the start-chat target and send the bootstrap in one idempotent
   // server call. First-chat paths can let the server stamp completion after the
@@ -60,6 +62,7 @@ export async function startOnboardingChat(args: {
     bootstrap: args.bootstrap,
     topic: args.topic,
     complete: args.complete,
+    ...(args.scanFixRepoSlug ? { scanFixRepoSlug: args.scanFixRepoSlug } : {}),
   });
   void reportOnboardingEvent("kickoff_chat_started", {
     agentUuid: args.agent.uuid,

--- a/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
+++ b/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
@@ -278,6 +278,7 @@ describe("QuickstartPage — production-scan fix handoff (action=fix)", () => {
       JSON.stringify({
         repoUrl: "https://github.com/acme/backend",
         reportKey: "acme-backend-20260101-abcdef",
+        repoSlug: "acme/backend",
       }),
     );
   });
@@ -302,6 +303,9 @@ describe("QuickstartPage — production-scan fix handoff (action=fix)", () => {
       mode: "task",
       topic: "Fix production scan blockers",
       initialRecipientAgentIds: ["agent-dev-1"],
+      // The key new hop: the direct path carries the repo slug so the server
+      // keys this launcher for cross-path dedup.
+      scanFixRepoSlug: "acme/backend",
     });
     expect(body?.initialMessage).toMatchObject({ format: "text", source: "web" });
     expect(body?.initialMessage.content).toContain(
@@ -350,6 +354,7 @@ describe("QuickstartPage — production-scan fix handoff (action=fix)", () => {
       JSON.stringify({
         repoUrl: "https://github.com/acme/backend",
         reportKey: "acme-backend-20260101-abcdef",
+        repoSlug: "acme/backend",
       }),
     );
   });
@@ -388,6 +393,7 @@ describe("QuickstartPage — production-scan fix handoff (action=fix)", () => {
       JSON.stringify({
         repoUrl: "https://github.com/acme/backend",
         reportKey: "acme-backend-20260101-abcdef",
+        repoSlug: "acme/backend",
       }),
     );
     const retryBtn = [...container.querySelectorAll("button")].find((button) =>
@@ -414,6 +420,7 @@ describe("QuickstartPage — production-scan fix handoff (action=fix)", () => {
       JSON.stringify({
         repoUrl: "https://github.com/acme/backend",
         reportKey: "acme-backend-20260101-abcdef",
+        repoSlug: "acme/backend",
       }),
     );
     const retryBtn = [...container.querySelectorAll("button")].find((button) =>
@@ -438,7 +445,7 @@ describe("QuickstartPage — production-scan fix handoff (action=fix)", () => {
     expect(landingCampaignMock.startLandingCampaign).not.toHaveBeenCalled();
     expect(navigateMock).toHaveBeenCalledWith("/onboarding", { replace: true });
     expect(window.sessionStorage.getItem("onboarding:scanFixHandoff")).toBe(
-      JSON.stringify({ repoUrl: "https://github.com/acme/backend", reportKey: null }),
+      JSON.stringify({ repoUrl: "https://github.com/acme/backend", reportKey: null, repoSlug: "acme/backend" }),
     );
   });
 });

--- a/packages/web/src/pages/quickstart/quickstart-page.tsx
+++ b/packages/web/src/pages/quickstart/quickstart-page.tsx
@@ -155,6 +155,9 @@ export function QuickstartPage() {
       const created = await createMeTaskChat({
         mode: "task",
         topic: "Fix production scan blockers",
+        // Key the launcher on the repo so re-entering the fix link reuses this
+        // chat (and dedups with the onboarding path) instead of duplicating it.
+        scanFixRepoSlug: fixHandoff.repoSlug,
         initialRecipientAgentIds: [agent.uuid],
         initialRecipientNames: [],
         contextParticipantAgentIds: [],
@@ -179,7 +182,11 @@ export function QuickstartPage() {
 
   useEffect(() => {
     if (!fixHandoff || !settled || !growthLandingPagesEnabled || !meLoaded) return;
-    writeScanFixHandoffFlag({ repoUrl: fixHandoff.url, reportKey: fixHandoff.reportKey });
+    writeScanFixHandoffFlag({
+      repoUrl: fixHandoff.url,
+      reportKey: fixHandoff.reportKey,
+      repoSlug: fixHandoff.repoSlug,
+    });
     // Direct-chat eligibility is `shouldLeaveOnboarding` — the membership is
     // terminally done (past connect, has a personal agent, AND carries the
     // completion stamp). Its inverse gate, `shouldEnterOnboarding`, returns

--- a/packages/web/src/utils/onboarding-flags.ts
+++ b/packages/web/src/utils/onboarding-flags.ts
@@ -124,6 +124,13 @@ const SCAN_FIX_HANDOFF_KEY = "onboarding:scanFixHandoff";
 export type StoredScanFixHandoff = {
   repoUrl: string;
   reportKey: string | null;
+  /**
+   * `owner/repo` — used to key the onboarding-path fix launcher on the repo so
+   * it dedups with the already-onboarded direct path. Optional so a flag stored
+   * by a pre-deploy bundle still resolves (that user just misses cross-path
+   * dedup until they re-click the fix link).
+   */
+  repoSlug?: string;
 };
 
 export function readScanFixHandoffFlag(): StoredScanFixHandoff | null {
@@ -137,7 +144,17 @@ export function readScanFixHandoffFlag(): StoredScanFixHandoff | null {
     if (typeof o.repoUrl !== "string" || !(typeof o.reportKey === "string" || o.reportKey === null)) {
       throw new Error("invalid scan-fix handoff");
     }
-    return { repoUrl: o.repoUrl, reportKey: o.reportKey };
+    // Only carry a well-formed `owner/repo` slug. A corrupt same-origin flag
+    // with a malformed slug must degrade to "no slug" (falls back to the
+    // default onboarding key) rather than reach the server and 400 the whole
+    // kickoff — the server keys on this and rejects anything off-pattern.
+    const repoSlug =
+      typeof o.repoSlug === "string" && /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(o.repoSlug) ? o.repoSlug : undefined;
+    return {
+      repoUrl: o.repoUrl,
+      reportKey: o.reportKey,
+      ...(repoSlug ? { repoSlug } : {}),
+    };
   } catch {
     window.sessionStorage.removeItem(SCAN_FIX_HANDOFF_KEY);
     return null;


### PR DESCRIPTION
## What

Gives the production-scan **fix conversion** a shared idempotency key so re-entering the fix link reuses the one `Fix production scan blockers` launcher instead of creating duplicates. Follow-up to #1563 (which fixed the *agent-spawned* same-name duplicate); this fixes the second, **cross-path / re-entry** mechanism.

## Why

The fix launcher is created through two endpoints with no shared idempotency:
- not-yet-onboarded → `POST /me/onboarding/kickoff` (keyed `<human>:<agent>:onboarding`)
- already-onboarded direct → `POST /orgs/:orgId/chats` task mode (unkeyed)

So re-entering `/quickstart?action=fix` (re-click, reload, back) created a second launcher. The growth funnel's primary user is **new** and goes through the onboarding path, so only a **shared** key across both paths dedups their first re-click (chat via kickoff vs chat via the direct path).

## Change

- Both paths compose `<humanAgent>:scan-fix:<repoSlug>` (server helper `scanFixKickoffKey`, slug lowercased — GitHub owner/repo are case-insensitive) and write it to `chats.onboarding_kickoff_key`; its unique constraint + `onConflictDoNothing` dedups. Reuse returns the existing launcher with no duplicate message / participants / notify (verified in `chat.ts`).
- `scanFixRepoSlug` (optional, `owner/repo`) added to the kickoff + task-chat schemas; threaded web-side from quickstart through both paths (session flag + 4 call sites).
- Onboarding kickoff still stamps completion; a malformed slug in a corrupt session flag degrades to the default onboarding key rather than 400-ing the kickoff.
- Contract doc (`onboarding-kickoff-contract.md`) updated with the scan-fix key shape.

## Verification

- New `scan-fix-idempotency.test.ts` (5): cross-path dedup, both-path re-entry idempotency, case-insensitive dedup, clean reuse (single message), non-scan-fix key regression.
- `step-start-chat-scan-fix` web test asserts `scanFixRepoSlug` threads through the onboarding layer (guards a future dropped hop the server tests structurally can't catch).
- shared / server / web typecheck; biome + `lint:tokens`; adjacent regressions green (me-onboarding-kickoff, orgs-chats, chat-service-edge, landing-campaigns-start).
- 2 independent reviews (correctness + end-to-end/edge-case); all findings folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
