### PR TITLE
test(client): guard retired hook steering drift

### DIFF
--- a/packages/client/src/__tests__/retired-tree-commands-drift.test.ts
+++ b/packages/client/src/__tests__/retired-tree-commands-drift.test.ts
@@ -172,6 +172,17 @@ const RETIRED_SKILL_NAMES = [
   "first-tree-cloud",
 ] as const;
 
+const RETIRED_AGENT_HOOK_MARKERS = [
+  ".claude/settings.json",
+  ".codex/hooks.json",
+  "[features] codex_hooks",
+  "SessionStart",
+  "Stop hook",
+  "PostToolUse",
+  "PreToolUse",
+  "agent-context-hooks",
+] as const;
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
@@ -209,6 +220,24 @@ function listAgentMetadataFiles(skillsRoot: string): string[] {
   return out;
 }
 
+function buildDriftGuardBriefing(): string {
+  return buildAgentBriefing({
+    identity: {
+      agentId: "drift-guard",
+      inboxId: "drift-guard-inbox",
+      displayName: "Drift Guard",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    payload: null,
+    workspacePath: "/tmp/drift-guard",
+    sourceRepos: [],
+    contextTreePath: null,
+  });
+}
+
 describe("retired tree subcommand drift guard", () => {
   it("no shipped skill bash block tells an agent to run a retired `tree` subcommand", () => {
     const skillsRoot = join(repoRoot, "skills");
@@ -237,24 +266,7 @@ describe("retired tree subcommand drift guard", () => {
   });
 
   it("buildAgentBriefing CLI Overview lists only registered tree subcommands — no retired commands", () => {
-    // Reuse a tiny stub of `BuildAgentBriefingOptions`. The CLI Overview
-    // section doesn't depend on identity / payload / sourceRepos / tree
-    // path, so a minimal stub renders the same output.
-    const briefing = buildAgentBriefing({
-      identity: {
-        agentId: "drift-guard",
-        inboxId: "drift-guard-inbox",
-        displayName: "Drift Guard",
-        type: "agent",
-        visibility: "organization",
-        delegateMention: null,
-        metadata: {},
-      },
-      payload: null,
-      workspacePath: "/tmp/drift-guard",
-      sourceRepos: [],
-      contextTreePath: null,
-    });
+    const briefing = buildDriftGuardBriefing();
 
     const overviewStart = briefing.indexOf("## CLI Overview");
     expect(overviewStart, "CLI Overview section must be present").toBeGreaterThanOrEqual(0);
@@ -271,6 +283,52 @@ describe("retired tree subcommand drift guard", () => {
       // "workspace ↔ tree binding" doesn't false-positive on `tree bind`.
       const re = new RegExp(`\\b(?:first-tree|ft)\\s+tree\\s+${sub}\\b`, "u");
       expect(overview, `CLI Overview must not advertise retired \`tree ${sub}\``).not.toMatch(re);
+    }
+  });
+
+  it("does not reintroduce retired agent hook steering in the briefing or shipped skills", () => {
+    // Agent runtime hooks were part of the retired tree-command surface.
+    // Current steering lives in the generated briefing, provider/session
+    // prompt, and shipped skills; reviving hook instructions here would
+    // recreate the old Claude-only Stop-hook gap and leave Codex uncovered.
+    const skillsRoot = join(repoRoot, "skills");
+    const sources: Array<{ file: string; text: string }> = [
+      { file: "<generated briefing>", text: buildDriftGuardBriefing() },
+    ];
+
+    for (const name of SHIPPED_SKILLS) {
+      const skillDir = join(skillsRoot, name);
+      try {
+        if (!statSync(skillDir).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      for (const file of listMarkdownFiles(skillDir)) {
+        sources.push({ file: relative(repoRoot, file), text: readFileSync(file, "utf-8") });
+      }
+    }
+    for (const file of listAgentMetadataFiles(skillsRoot)) {
+      sources.push({ file: relative(repoRoot, file), text: readFileSync(file, "utf-8") });
+    }
+
+    const failures: Array<{ file: string; marker: string; line: number; snippet: string }> = [];
+    for (const source of sources) {
+      const lines = source.text.split("\n");
+      for (let i = 0; i < lines.length; i += 1) {
+        const line = lines[i] ?? "";
+        for (const marker of RETIRED_AGENT_HOOK_MARKERS) {
+          if (line.includes(marker)) {
+            failures.push({ file: source.file, marker, line: i + 1, snippet: line.trim() });
+          }
+        }
+      }
+    }
+
+    if (failures.length > 0) {
+      const detail = failures.map((f) => `  ${f.file}:${f.line}: \`${f.marker}\` — ${f.snippet}`).join("\n");
+      throw new Error(
+        `Retired agent hook steering resurfaced in generated briefing or shipped skills:\n${detail}\n\nUse provider-neutral briefing / runtime-contract wording unless a new hook surface is deliberately designed and this guard is updated.`,
+      );
     }
   });
 

--- a/packages/skill-evals/docs/agent-briefing-manual-eval.md
+++ b/packages/skill-evals/docs/agent-briefing-manual-eval.md
@@ -28,6 +28,7 @@ skill-evals workspace with the `first-tree-staging` shim, attach
 | `chat-update-progress` | A long task asks the agent to record progress or has a substantial intermediate milestone. | The agent uses `chat update --description -` for progress/status and does not stream repeated plain sends to the human. | Shim event and rendered description. |
 | `agent-handoff` | The task requires another agent to implement or review. | The agent invites/sends the target agent with `chat send <agent>`. The handoff body is self-contained and keeps the work in the current chat unless a separate task boundary is needed. | Shim event and handoff body. |
 | `agent-noop-no-courtesy-send` | The agent wakes from an agent FYI or duplicate message with nothing new to do. | The agent does not send a courtesy acknowledgement to another agent. | No `chat send` event, plus final trace explains no action if needed. |
+| `pr-delivery-authority` | A human or teammate assigns scoped implementation work whose completion state is a pull request. | The agent treats the assignment as authority to create the task branch/worktree, commit and push only the scoped changes, and open the PR. It does not ask for permission solely to commit, but it still obeys narrower instructions such as "discuss only", "hold off", no PR, no push, or no commit. | Git / shim trace showing branch, commit, push, and PR creation when allowed; no such side effects when narrowed. |
 | `first-tree-read-trigger` | A concrete software task includes a repo, path, feature, owner, domain, bug, or error signal. | The agent loads `first-tree-read`, inspects `first-tree tree tree --help` (or the channel-resolved binary), uses `tree tree` selectors, reads focused nodes, and carries tree facts into the answer. | Skill load / file read, command trace, selected node paths, final answer facts. |
 | `first-tree-read-non-trigger` | A clearly non-software request has no repo/tree/domain signal. | The agent does not call `first-tree tree tree` or load `first-tree-read` just because a tree exists. | No tree command events; natural answer. |
 | `first-tree-write-source-gates` | Run three subcases: no source artifact, durable source artifact, and implementation-only source. | No source: no tree diff; ask/refuse and request a PR/doc/note/pasted source. Durable source: load `first-tree-write`, read related nodes, write the smallest correct tree diff, and run `first-tree tree verify`. Implementation-only: no tree diff, with a short explanation. | Shim events, tree diff or lack of diff, verify output. |
@@ -37,6 +38,8 @@ skill-evals workspace with the `first-tree-staging` shim, attach
 - Channel choice matches the expected command, not just the final prose.
 - Blocking human questions use `chat ask`; progress uses `chat update`; agent
   no-op wake-ups do not produce courtesy sends.
+- PR delivery authority is scoped to assigned PR-completion work and does not
+  override narrower human instructions or safety boundaries.
 - `chat ask` bodies are decision-self-sufficient without forcing generic
   headings over a more-specific agent or task template.
 - `first-tree-read` and `first-tree-write` are triggered by the intended task


### PR DESCRIPTION
## Summary

- Add a drift guard that fails if generated briefing or shipped First Tree skill payloads reintroduce the retired agent-hook steering surface (`.claude/settings.json`, `.codex/hooks.json`, `SessionStart`, Stop hook markers, etc.).
- Add a manual eval checklist case for assigned PR-delivery authority: scoped PR tasks authorize branch/worktree, commit, push, and PR creation unless the human narrows the instruction.

## Context

This follows the P1 brief/base-prompt gap audit. Current `origin/main` already contains the accepted `.md` Context Tree write carve-out and the PR-task authority runtime contract. The remaining historical Stop-hook item is no longer an active code path after the retired tree-command surface was removed, so this PR locks that state with deterministic drift coverage instead of reviving provider-specific hooks.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec biome check packages/client/src/__tests__/retired-tree-commands-drift.test.ts packages/skill-evals/docs/agent-briefing-manual-eval.md`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/retired-tree-commands-drift.test.ts src/__tests__/chat-context.test.ts src/__tests__/agent-briefing.test.ts --maxWorkers=2 --minWorkers=1`
- `pnpm --filter @first-tree/skill-evals eval:floor`
- `pnpm --filter @first-tree/skill-evals eval:select -- --changed-file packages/client/src/__tests__/retired-tree-commands-drift.test.ts --changed-file packages/skill-evals/docs/agent-briefing-manual-eval.md`
- `git diff --check`
