### PR TITLE
fix(cli): preserve Windows supervisor cmd quoting

### DIFF
--- a/apps/cli/src/__tests__/windows-supervisor.test.ts
+++ b/apps/cli/src/__tests__/windows-supervisor.test.ts
@@ -72,6 +72,7 @@ describe("Windows supervisor loop", () => {
       ["/d", "/s", "/c", '""first-tree-dev" "daemon" "start" "--no-interactive""'],
       expect.objectContaining({
         detached: false,
+        windowsVerbatimArguments: true,
         env: expect.objectContaining({
           FIRST_TREE_HOME: home,
           FIRST_TREE_SERVICE_MODE: "1",
@@ -100,7 +101,7 @@ describe("Windows supervisor loop", () => {
         "/c",
         '""C:\\Users\\baixi\\AppData\\Roaming\\npm\\first-tree-staging" "daemon" "start" "--no-interactive""',
       ],
-      expect.objectContaining({ detached: false, windowsHide: true }),
+      expect.objectContaining({ detached: false, windowsHide: true, windowsVerbatimArguments: true }),
     );
   });
 
@@ -124,13 +125,13 @@ describe("Windows supervisor loop", () => {
       1,
       process.env.ComSpec || "cmd.exe",
       ["/d", "/s", "/c", '""C:\\First Tree\\old\\first-tree-dev.cmd" "daemon" "start" "--no-interactive""'],
-      expect.any(Object),
+      expect.objectContaining({ windowsVerbatimArguments: true }),
     );
     expect(spawnProcess).toHaveBeenNthCalledWith(
       2,
       process.env.ComSpec || "cmd.exe",
       ["/d", "/s", "/c", '""C:\\First Tree\\new\\first-tree-dev.cmd" "daemon" "start" "--no-interactive""'],
-      expect.any(Object),
+      expect.objectContaining({ windowsVerbatimArguments: true }),
     );
   });
 

--- a/apps/cli/src/core/supervisor/windows-supervisor.ts
+++ b/apps/cli/src/core/supervisor/windows-supervisor.ts
@@ -156,7 +156,7 @@ function isWindowsCommandShim(program: string): boolean {
 function childSpawnTarget(
   invocation: ResolvedBinary,
   platform: NodeJS.Platform,
-): { program: string; args: string[]; display: string } {
+): { program: string; args: string[]; display: string; windowsVerbatimArguments?: boolean } {
   const program = childProgram(invocation);
   const args = childArgs(invocation);
   const display = [program, ...args].join(" ");
@@ -169,6 +169,7 @@ function childSpawnTarget(
     program: process.env.ComSpec || "cmd.exe",
     args: ["/d", "/s", "/c", `"${commandLine}"`],
     display,
+    windowsVerbatimArguments: true,
   };
 }
 
@@ -267,6 +268,7 @@ export async function runWindowsSupervisorLoop(options: WindowsSupervisorLoopOpt
           FIRST_TREE_SERVICE_MODE: "1",
         },
         stdio: ["ignore", "pipe", "pipe"],
+        windowsVerbatimArguments: target.windowsVerbatimArguments,
         windowsHide: true,
       });
     } catch (err) {


### PR DESCRIPTION
## Summary
- Preserve Windows command-line quoting when the Task Scheduler supervisor spawns the daemon child through `cmd.exe`.
- Pass `windowsVerbatimArguments: true` for the `cmd.exe /c` supervisor child launch path so Node does not rewrite quotes into `\"` sequences.
- Tighten Windows supervisor tests to assert the verbatim argument mode is used.

## Root cause
`first-tree-staging` 0.5.13-staging.790.1 includes #1568, so the generated Task Scheduler wrapper now launches `first-tree-staging.cmd daemon supervise`. The remaining failure is one layer deeper: `daemon supervise` resolves the daemon child to `first-tree-staging.cmd daemon start --no-interactive`, but spawns it through `cmd.exe` without `windowsVerbatimArguments`. Node rewrites the quoted command string, and `cmd.exe` sees the whole `\"\"...\"\"` string as a command name, so the child exits before writing a runtime marker.

## Verification
- `corepack pnpm --filter first-tree-dev exec vitest run src/__tests__/windows-supervisor.test.ts`
- `corepack pnpm --filter first-tree-dev typecheck`
- `corepack pnpm --filter @first-tree/shared build`
- `corepack pnpm --filter @first-tree/client build`
- `corepack pnpm --filter first-tree-dev build`

## Manual Windows validation
- Reproduced the staging failure on 0.5.13-staging.790.1: Task Scheduler runs `wscript -> .cmd -> node ... daemon supervise`, then supervisor logs repeated child failures for `first-tree-staging.cmd daemon start --no-interactive` with the `\"\"...\"\"` command string.
- Verified with a Node `spawnSync(cmd.exe, ['/d','/s','/c', command])` smoke test that the current non-verbatim spawn fails while the verbatim spawn succeeds.
- Built `first-tree-dev` from this branch and installed the dev Task Scheduler service with an npm-like shim layout where `where.exe first-tree-dev` returns the extensionless shim before `.cmd`.
- Confirmed `first-tree-dev status` reports `Service: ? running (task-scheduler, pid 23812)` and a runtime marker is written under `.first-tree-dev\state\client-runtimes`.
