### PR TITLE
feat(web): extract shared AgentOption/AgentToken picker atoms (phase 1)

### DIFF
--- a/packages/web/src/components/add-participant-dropdown.tsx
+++ b/packages/web/src/components/add-participant-dropdown.tsx
@@ -5,12 +5,11 @@ import { addMeChatParticipants } from "../api/me-chats.js";
 import { useAuth } from "../auth/auth-context.js";
 import { useDebouncedValue } from "../lib/use-debounced-value.js";
 import { useOrgAgentsSearch } from "../lib/use-org-agents.js";
-import { Avatar as RealAvatar } from "./avatar.js";
 import {
+  AgentOption,
   ambiguousDisplayNames,
   buildPickerSections,
   type MentionCandidate,
-  MentionLabel,
 } from "./mention-autocomplete.js";
 
 /**
@@ -64,20 +63,16 @@ export function AddParticipantDropdown({
         name: a.name,
         displayName: a.displayName,
         managedByMe: Boolean(myMemberId && a.managerId === myMemberId),
+        // Candidate carries its own avatar (image + hue token) so the
+        // shared AgentOption renders straight from the row — no side-map,
+        // and no re-routing through the identity cache (itself capped at
+        // the first 100 agents, so it would miss search hits past that).
+        avatarImageUrl: a.avatarImageUrl ?? null,
+        avatarColorToken: a.avatarColorToken ?? null,
       });
     }
     return out;
   }, [agentsPage?.items, myAgentId, myMemberId]);
-
-  // Server response carries the resolved avatar URL — keep a uuid → URL
-  // index so each row can render straight from it without re-routing the
-  // lookup through the identity-map cache (which is itself capped at the
-  // first 100 agents and would miss search hits beyond that window).
-  const avatarById = useMemo(() => {
-    const map = new Map<string, string | null>();
-    for (const a of agentsPage?.items ?? []) map.set(a.uuid, a.avatarImageUrl ?? null);
-    return map;
-  }, [agentsPage?.items]);
 
   // Click-outside closes the dropdown.
   useEffect(() => {
@@ -352,8 +347,6 @@ export function AddParticipantDropdown({
                     );
                   }
                   const isInChat = participantSet.has(it.agentId);
-                  const fallback = it.displayName ?? it.name ?? it.agentId.slice(0, 8);
-                  const avatarSrc = avatarById.get(it.agentId) ?? null;
                   if (isInChat) {
                     return (
                       <div
@@ -362,18 +355,17 @@ export function AddParticipantDropdown({
                         title={it.name ? `@${it.name} — already in this chat` : "Already in this chat"}
                         className="flex w-full items-center text-left"
                         style={{
-                          gap: "var(--sp-2_5)",
                           padding: "var(--sp-1_75) var(--sp-2)",
                           background: "transparent",
                           color: "var(--fg-3)",
                           cursor: "default",
                         }}
                       >
-                        <RealAvatar src={avatarSrc} name={fallback} seed={it.agentId} size={28} />
-                        <span className="flex min-w-0 flex-1 items-baseline gap-2">
-                          <MentionLabel candidate={it} ambiguous={ambiguous} />
-                        </span>
-                        <Check className="h-3.5 w-3.5 shrink-0" aria-label="Already in chat" />
+                        <AgentOption
+                          candidate={it}
+                          ambiguous={ambiguous}
+                          trailing={<Check className="h-3.5 w-3.5" aria-label="Already in chat" />}
+                        />
                       </div>
                     );
                   }
@@ -391,15 +383,13 @@ export function AddParticipantDropdown({
                       disabled={addMut.isPending}
                       className="flex w-full items-center text-left transition-colors"
                       style={{
-                        gap: "var(--sp-2_5)",
                         padding: "var(--sp-1_75) var(--sp-2)",
                         border: 0,
                         background: active ? "var(--bg-hover)" : "transparent",
                         cursor: addMut.isPending ? "default" : "pointer",
                       }}
                     >
-                      <RealAvatar src={avatarSrc} name={fallback} seed={it.agentId} size={28} />
-                      <MentionLabel candidate={it} ambiguous={ambiguous} />
+                      <AgentOption candidate={it} ambiguous={ambiguous} />
                     </button>
                   );
                 });

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -1,5 +1,8 @@
+import { X } from "lucide-react";
+import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "../lib/utils.js";
+import { Avatar } from "./avatar.js";
 
 /**
  * Minimal `@mention` autocomplete surfaced as a popover anchored above a
@@ -36,6 +39,15 @@ export type MentionCandidate = {
    *  `useAuth`); callers that can't determine it should pass `false`
    *  rather than omitting — there's no "unknown" state. */
   managedByMe: boolean;
+  /** Manager-selected avatar color token (the agent row's
+   *  `avatarColorToken`); drives the identicon hue when no image is set.
+   *  Optional — callers that don't have it omit it and {@link Avatar}
+   *  falls back to a deterministic hash of the seed. */
+  avatarColorToken?: string | null;
+  /** Resolved avatar image URL (the agent row's `avatarImageUrl`),
+   *  rendered as a circle when present. Optional for the same reason as
+   *  `avatarColorToken`. */
+  avatarImageUrl?: string | null;
 };
 
 /**
@@ -98,6 +110,102 @@ export function MentionLabel({ candidate, ambiguous }: { candidate: MentionCandi
         </span>
       )}
     </>
+  );
+}
+
+/**
+ * Candidate row atom: circle avatar + {@link MentionLabel}, with an
+ * optional trailing slot (e.g. a ✓ for already-in-chat rows). This is the
+ * single candidate-row renderer shared by every agent picker — the
+ * composer / ask `@` popover, the add-participant dropdown, and the
+ * new-chat `[+]` recipient picker — so the avatar and the
+ * display-name/`@handle` format stay pixel-identical across surfaces
+ * (before this atom the popover had no avatar at all and each dropdown
+ * hand-rolled its own `<Avatar> + label`).
+ *
+ * Presentational only: the caller still owns the surrounding
+ * `<button>`/wrapper, click handlers, hover/active background, and the
+ * `title` attribute. Wraps `MentionLabel` rather than re-implementing it
+ * so there stays exactly one label renderer.
+ */
+export function AgentOption({
+  candidate,
+  ambiguous,
+  avatarSize = 28,
+  trailing,
+}: {
+  candidate: MentionCandidate;
+  ambiguous: Set<string>;
+  avatarSize?: number;
+  trailing?: ReactNode;
+}) {
+  const fallback = candidate.displayName ?? candidate.name ?? candidate.agentId.slice(0, 8);
+  return (
+    <span className="flex min-w-0 flex-1 items-center" style={{ gap: "var(--sp-2_5)" }}>
+      <Avatar
+        src={candidate.avatarImageUrl ?? null}
+        name={fallback}
+        seed={candidate.agentId}
+        colorToken={candidate.avatarColorToken ?? null}
+        size={avatarSize}
+      />
+      <span className="flex min-w-0 flex-1 items-baseline gap-2">
+        <MentionLabel candidate={candidate} ambiguous={ambiguous} />
+      </span>
+      {trailing != null && <span className="flex shrink-0 items-center">{trailing}</span>}
+    </span>
+  );
+}
+
+/**
+ * Selected-agent chip atom: compact avatar + label + optional remove
+ * button. The single "a chosen agent" visual — used by the new-chat
+ * recipient chips today, and any future single/multi-select field — so a
+ * picked agent looks the same everywhere (the new-chat chip was a bare
+ * `<span>` label with no avatar before this). Hover reveals the remove
+ * `X`; omit `onRemove` for a read-only token.
+ */
+export function AgentToken({ candidate, onRemove }: { candidate: MentionCandidate; onRemove?: () => void }) {
+  const label = candidate.displayName ?? candidate.name ?? candidate.agentId.slice(0, 8);
+  return (
+    <span
+      className="group inline-flex items-center text-label"
+      style={{
+        gap: "var(--sp-1)",
+        padding: "var(--sp-0_5) var(--sp-1_5)",
+        borderRadius: "var(--radius-chip)",
+        background: "var(--bg-sunken)",
+        color: "var(--fg)",
+      }}
+    >
+      <Avatar
+        src={candidate.avatarImageUrl ?? null}
+        name={label}
+        seed={candidate.agentId}
+        colorToken={candidate.avatarColorToken ?? null}
+        size={16}
+      />
+      <span>{label}</span>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          title="Remove participant"
+          className="opacity-0 transition-opacity group-hover:opacity-100"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            border: "none",
+            background: "none",
+            padding: 0,
+            cursor: "pointer",
+            color: "var(--fg-3)",
+          }}
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    </span>
   );
 }
 
@@ -490,7 +598,7 @@ export function MentionAutocompletePopover({
                 e.preventDefault();
                 onPick(c);
               }}
-              className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-body"
+              className="flex w-full items-center px-3 py-1.5 text-left text-body"
               style={{
                 background: active ? "var(--bg-hover)" : "transparent",
                 color: "var(--fg)",
@@ -499,7 +607,7 @@ export function MentionAutocompletePopover({
                 whiteSpace: "nowrap",
               }}
             >
-              <MentionLabel candidate={c} ambiguous={ambiguous} />
+              <AgentOption candidate={c} ambiguous={ambiguous} />
             </button>
           );
         });

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -3089,6 +3089,8 @@ export function ChatView({
         name: ident.name,
         displayName: ident.displayName,
         managedByMe: managedByMeMap.get(p.agentId) ?? false,
+        avatarImageUrl: ident.avatarImageUrl ?? null,
+        avatarColorToken: ident.avatarColorToken ?? null,
       });
     }
     return out;

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -9,12 +9,13 @@ import { putImage } from "../../../api/image-store.js";
 import { createMeTaskChat } from "../../../api/me-chats.js";
 import { useAuth } from "../../../auth/auth-context.js";
 import {
+  AgentOption,
+  AgentToken,
   ambiguousDisplayNames,
   buildPickerSections,
   detectMentionTrigger,
   MentionAutocompletePopover,
   type MentionCandidate,
-  MentionLabel,
   useMentionAutocomplete,
 } from "../../../components/mention-autocomplete.js";
 import { clearDraft, type DraftSnapshot, loadDraft, newChatDraftScope, saveDraft } from "../../../lib/draft-store.js";
@@ -187,6 +188,8 @@ export function NewChatDraft({
             name: a.name,
             displayName: a.displayName,
             managedByMe: Boolean(myMemberId && a.managerId === myMemberId),
+            avatarImageUrl: a.avatarImageUrl ?? null,
+            avatarColorToken: a.avatarColorToken ?? null,
           };
           const existing = next.get(a.uuid);
           // Skip writes when nothing the cache exposes has changed — bouncing
@@ -196,7 +199,9 @@ export function NewChatDraft({
             existing &&
             existing.name === entry.name &&
             existing.displayName === entry.displayName &&
-            existing.managedByMe === entry.managedByMe
+            existing.managedByMe === entry.managedByMe &&
+            existing.avatarImageUrl === entry.avatarImageUrl &&
+            existing.avatarColorToken === entry.avatarColorToken
           ) {
             continue;
           }
@@ -277,6 +282,8 @@ export function NewChatDraft({
         name: a.name,
         displayName: a.displayName,
         managedByMe: Boolean(myMemberId && a.managerId === myMemberId),
+        avatarImageUrl: a.avatarImageUrl ?? null,
+        avatarColorToken: a.avatarColorToken ?? null,
       });
     }
     return out;
@@ -301,6 +308,8 @@ export function NewChatDraft({
         name: ident?.name ?? a.name,
         displayName: ident?.displayName ?? a.displayName,
         managedByMe: Boolean(myMemberId && a.managerId === myMemberId),
+        avatarImageUrl: ident?.avatarImageUrl ?? a.avatarImageUrl ?? null,
+        avatarColorToken: ident?.avatarColorToken ?? a.avatarColorToken ?? null,
       });
     }
     return Array.from(byId.values());
@@ -939,41 +948,17 @@ function ParticipantChips({
       }}
     >
       {chips.map((id) => {
-        const cand = candidates.find((c) => c.agentId === id);
-        const label = cand?.displayName ?? cand?.name ?? id;
-        return (
-          <span
-            key={id}
-            className="group inline-flex items-center text-label"
-            style={{
-              gap: 2,
-              padding: "var(--sp-0_5) var(--sp-1_5)",
-              borderRadius: "var(--radius-chip)",
-              background: "var(--bg-sunken)",
-              color: "var(--fg)",
-            }}
-          >
-            <span>{label}</span>
-            <button
-              type="button"
-              onClick={() => onRemove(id)}
-              title="Remove participant"
-              className="opacity-0 group-hover:opacity-100 transition-opacity"
-              style={{
-                background: "none",
-                border: "none",
-                padding: 0,
-                marginLeft: 2,
-                cursor: "pointer",
-                color: "var(--fg-3)",
-                display: "inline-flex",
-                alignItems: "center",
-              }}
-            >
-              <X className="h-3 w-3" />
-            </button>
-          </span>
-        );
+        // Fall back to a bare candidate when the id isn't in the known
+        // set yet (search cache not warmed). Carry the id through as
+        // `name` so the token still shows the full identifier — matching
+        // the prior chip's `?? id` fallback — with a seed-hashed identicon.
+        const cand = candidates.find((c) => c.agentId === id) ?? {
+          agentId: id,
+          name: id,
+          displayName: null,
+          managedByMe: false,
+        };
+        return <AgentToken key={id} candidate={cand} onRemove={() => onRemove(id)} />;
       })}
 
       <div ref={pickerContainerRef} style={{ position: "relative" }}>
@@ -1067,7 +1052,7 @@ function ParticipantChips({
                           key={item.agentId}
                           role="presentation"
                           title={item.name ? `@${item.name} — already in this draft` : "Already in this draft"}
-                          className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-body"
+                          className="flex w-full items-center px-3 py-1.5 text-left text-body"
                           style={{
                             background: "transparent",
                             color: "var(--fg-3)",
@@ -1075,10 +1060,11 @@ function ParticipantChips({
                             whiteSpace: "nowrap",
                           }}
                         >
-                          <span className="flex min-w-0 flex-1 items-baseline gap-2">
-                            <MentionLabel candidate={item} ambiguous={ambiguous} />
-                          </span>
-                          <Check className="h-3.5 w-3.5 shrink-0" aria-label="Already in draft" />
+                          <AgentOption
+                            candidate={item}
+                            ambiguous={ambiguous}
+                            trailing={<Check className="h-3.5 w-3.5" aria-label="Already in draft" />}
+                          />
                         </div>
                       );
                     }
@@ -1094,7 +1080,7 @@ function ParticipantChips({
                         title={item.name ? `@${item.name}` : undefined}
                         onClick={() => onAdd(item.agentId)}
                         onMouseEnter={() => setHighlight(myIdx)}
-                        className="flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-body"
+                        className="flex w-full items-center px-3 py-1.5 text-left text-body"
                         style={{
                           background: active ? "var(--bg-hover)" : "transparent",
                           color: "var(--fg)",
@@ -1103,7 +1089,7 @@ function ParticipantChips({
                           whiteSpace: "nowrap",
                         }}
                       >
-                        <MentionLabel candidate={item} ambiguous={ambiguous} />
+                        <AgentOption candidate={item} ambiguous={ambiguous} />
                       </button>
                     );
                   });
@@ -1117,7 +1103,13 @@ function ParticipantChips({
   );
 }
 
-type KnownAgentRow = Pick<Agent, "uuid" | "type" | "status" | "name" | "displayName" | "managerId">;
+type KnownAgentRow = Pick<Agent, "uuid" | "type" | "status" | "name" | "displayName" | "managerId"> & {
+  // Optional so callers without avatar data (e.g. the default-candidate
+  // fetch) still fit; the chip then falls back to a seed-hashed identicon
+  // until a search round-trip warms the full row.
+  avatarColorToken?: string | null;
+  avatarImageUrl?: string | null;
+};
 export type StarterAgentCacheCandidate = Pick<KnownAgentRow, "uuid" | "type" | "status">;
 
 export function newChatDefaultAgentCacheKey(userId: string | null, organizationId: string | null): string | null {


### PR DESCRIPTION
## What

Phase 1 of unifying the people/agent pickers. Extracts two shared presentational atoms and swaps the hand-rolled markup at every agent-picker surface to use them, so avatars and selected-chips look identical across the app.

Before this, the "pick an agent" surfaces had drifted:
- composer / ask `@` popover: **no avatar** at all
- new-chat recipient chips: a bare `<span>` label, **no avatar**
- add-participant dropdown: an avatar, but sourced via a private `avatarById` side-map because the candidate type carried no avatar fields

## Changes

- **New atoms in `components/mention-autocomplete.tsx`** (co-located with `MentionLabel`/`MentionCandidate` to keep a single label renderer and avoid a cross-module cycle):
  - `AgentOption` — candidate row: circle avatar + `MentionLabel` + optional trailing slot (e.g. the already-in ✓).
  - `AgentToken` — selected chip: compact avatar + label + optional remove ✕.
- **`MentionCandidate` gains optional `avatarColorToken` / `avatarImageUrl`** so a candidate carries its own avatar; the `avatarById` side-map in `add-participant-dropdown` is deleted.
- Swapped call sites to the atoms: composer/ask `@` popover, `AddParticipantDropdown`, and new-chat `[+]` dropdown rows + recipient chips. Avatar fields are threaded through each candidate-construction site (`chat-view` mention candidates, add-participant, new-chat `pickerCandidates`/`candidates`/`mergeKnown`).

Behavior is unchanged: keyboard nav, the mine/others divider, already-in ✓ rows, candidate dedup/memoization, and Enter-commit alignment all go through the same helpers as before. Candidate rows standardize on a 28px avatar (matching the participant-list rows these pickers sit beside); chips use 16px.

Out of scope (later phases): merging the two "add agent to chat" pickers (P2), unifying the two delegate selectors + ⌘K row (P3), and human candidates (P4).

## Verification

- `pnpm --filter @first-tree/web typecheck` (tsc + lint:tokens gate) — green
- `pnpm --filter @first-tree/web test` — 1276 passed
- Biome — clean
- Real-browser render of both atoms (light + dark tokens, long-name + fallback-uuid cases) via a temporary DEV preview page, since removed. No console errors; layout verified.
- Two independent code reviews (correctness + design-system lenses); findings applied (dropped a dead `truncate`, removed dead `gap` on single-child wrappers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
