### PR TITLE
test: improve coverage for CLI and client edges

### DIFF
--- a/apps/cli/src/__tests__/daemon-supervise-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-supervise-command.test.ts
@@ -1,0 +1,80 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const outputMocks = vi.hoisted(() => ({
+  print: {
+    line: vi.fn(),
+  },
+}));
+
+const supervisorMocks = vi.hoisted(() => ({
+  runWindowsSupervisorLoop: vi.fn(),
+}));
+
+vi.mock("../core/output.js", () => outputMocks);
+vi.mock("../core/supervisor/windows-supervisor.js", () => supervisorMocks);
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+async function runSuperviseCommand(): Promise<void> {
+  const { registerDaemonSuperviseCommand } = await import("../commands/daemon/supervise.js");
+  const daemon = new Command();
+  registerDaemonSuperviseCommand(daemon);
+  await daemon.parseAsync(["supervise"], { from: "user" });
+}
+
+describe("daemon supervise command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined): never => {
+      throw Object.assign(new Error(`process.exit ${code}`), { exitCode: code });
+    });
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("rejects non-Windows platforms before starting the supervisor loop", async () => {
+    setPlatform("linux");
+
+    await expect(runSuperviseCommand()).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(supervisorMocks.runWindowsSupervisorLoop).not.toHaveBeenCalled();
+    expect(outputMocks.print.line).toHaveBeenCalledWith(expect.stringContaining("only supported on win32"));
+  });
+
+  it("attempts to exit with the Windows supervisor loop result code", async () => {
+    setPlatform("win32");
+    supervisorMocks.runWindowsSupervisorLoop.mockResolvedValueOnce(75);
+
+    await expect(runSuperviseCommand()).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(supervisorMocks.runWindowsSupervisorLoop).toHaveBeenCalledTimes(1);
+    expect(process.exit).toHaveBeenNthCalledWith(1, 75);
+  });
+
+  it("prints Error failures from the Windows supervisor loop", async () => {
+    setPlatform("win32");
+    supervisorMocks.runWindowsSupervisorLoop.mockRejectedValueOnce(new Error("child spawn failed"));
+
+    await expect(runSuperviseCommand()).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(outputMocks.print.line).toHaveBeenCalledWith(expect.stringContaining("child spawn failed"));
+  });
+
+  it("stringifies non-Error supervisor loop failures", async () => {
+    setPlatform("win32");
+    supervisorMocks.runWindowsSupervisorLoop.mockRejectedValueOnce("string failure");
+
+    await expect(runSuperviseCommand()).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(outputMocks.print.line).toHaveBeenCalledWith(expect.stringContaining("string failure"));
+  });
+});

--- a/apps/cli/src/__tests__/task-scheduler-edge-paths.test.ts
+++ b/apps/cli/src/__tests__/task-scheduler-edge-paths.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const sharedMocks = vi.hoisted(() => ({
+  ensureLogDir: vi.fn(),
+  readFileOrFlagDrift: vi.fn(),
+  resolveCliInvocation: vi.fn(() => ({ kind: "bin", program: "first-tree-dev" })),
+  runCapture: vi.fn(),
+  runCaptureOut: vi.fn(),
+  sleepSync: vi.fn(),
+}));
+
+const configMocks = vi.hoisted(() => ({
+  defaultHome: vi.fn(() => "C:\\FirstTree"),
+}));
+
+type ShellResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+type ShellOutResult =
+  | { readonly ok: true; readonly stdout: string }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+
+vi.mock("node:fs", () => fsMocks);
+vi.mock("@first-tree/shared/config", () => configMocks);
+vi.mock("../core/supervisor/shared.js", () => sharedMocks);
+
+function ok(): ShellResult {
+  return { ok: true };
+}
+
+function fail(stderr: string, code = 1): ShellResult {
+  return { ok: false, stderr, code };
+}
+
+function out(stdout: string): ShellOutResult {
+  return { ok: true, stdout };
+}
+
+function outFail(stderr: string, code = 1): ShellOutResult {
+  return { ok: false, stderr, code };
+}
+
+function marker(pid: number, createdAt = "2026-01-01T00:00:05.000Z"): string {
+  return JSON.stringify({
+    version: 1,
+    pid,
+    clientId: "client-1",
+    home: "C:\\FirstTree",
+    mode: "service",
+    createdAt,
+  });
+}
+
+function processJson(pid: number, commandLine: string, creationTimeUtc = "2026-01-01T00:00:01.000Z"): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: "100",
+    Name: "node.exe",
+    CommandLine: commandLine,
+    ExecutablePath: "C:\\Program Files\\nodejs\\node.exe",
+    CreationTimeUtc: creationTimeUtc,
+  });
+}
+
+function supervisorJson(pid: number): string {
+  return JSON.stringify({
+    ProcessId: String(pid),
+    ParentProcessId: 100,
+    Name: "wscript.exe",
+    CommandLine: '"C:\\FirstTree\\service\\first-tree-dev-supervisor.vbs"',
+    ExecutablePath: "C:\\Windows\\System32\\wscript.exe",
+    CreationTimeUtc: "2026-01-01T00:00:01.000Z",
+  });
+}
+
+async function backend(): Promise<typeof import("../core/supervisor/task-scheduler.js").taskSchedulerBackend> {
+  const { taskSchedulerBackend } = await import("../core/supervisor/task-scheduler.js");
+  return taskSchedulerBackend;
+}
+
+function queuePowershell(taskResults: readonly ShellOutResult[], processResults: readonly ShellOutResult[] = []): void {
+  const tasks = [...taskResults];
+  const processes = [...processResults];
+  sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+    const script = String(args.at(-1) ?? "");
+    if (script.includes("Get-ScheduledTask")) return tasks.shift() ?? out("Ready");
+    if (script.includes("ProcessId = 4242"))
+      return processes.shift() ?? out(processJson(4242, "first-tree-dev daemon start --no-interactive"));
+    if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return out("");
+    throw new Error(`unexpected powershell script: ${script}`);
+  });
+}
+
+function setRuntimeMarkers(...bodies: string[]): void {
+  fsMocks.existsSync.mockReturnValue(true);
+  fsMocks.readdirSync.mockReturnValue(bodies.map((_, index) => `runtime-${index}.json`));
+  fsMocks.readFileSync.mockImplementation((path) => {
+    const match = String(path).match(/runtime-(\d+)\.json$/u);
+    return bodies[Number(match?.[1] ?? 0)] ?? "";
+  });
+}
+
+describe("task scheduler edge paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.readdirSync.mockReturnValue([]);
+    fsMocks.readFileSync.mockReturnValue("");
+    sharedMocks.runCapture.mockReturnValue(ok());
+    queuePowershell([out("Ready")]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("falls back from PowerShell task query errors to schtasks missing and unknown states", async () => {
+    sharedMocks.runCapture
+      .mockReturnValueOnce(fail("cannot find the file", 1))
+      .mockReturnValueOnce(fail("access denied", 5));
+    queuePowershell([outFail("powershell failed", 5), outFail("powershell failed", 5)]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({ state: "not-installed" });
+    expect(taskScheduler.status()).toMatchObject({ state: "unknown", detail: "powershell failed\naccess denied" });
+  });
+
+  it("reports unreadable runtime marker directories and files", async () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readdirSync.mockImplementation(() => {
+      throw new Error("permission denied");
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "Unable to inspect runtime markers: permission denied",
+    });
+
+    fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+    fsMocks.readFileSync.mockImplementation(() => {
+      throw new Error("bad json");
+    });
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: expect.stringContaining("Unable to read runtime marker"),
+    });
+  });
+
+  it("removes dead runtime markers while computing inactive status", async () => {
+    setRuntimeMarkers(marker(4242));
+    vi.mocked(process.kill).mockImplementation(() => {
+      throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({ state: "inactive", detail: "task state Ready" });
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(expect.stringContaining("runtime-0.json"), { force: true });
+  });
+
+  it("reports inconsistent task and runtime marker status combinations", async () => {
+    setRuntimeMarkers(marker(4242), marker(4343));
+    queuePowershell([outFail("", 3), out("Running"), out("Ready")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "task missing but service runtime marker is live",
+    });
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "task running with 2 live service markers",
+    });
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "task not running but service runtime marker is live",
+    });
+  });
+
+  it("refuses start while a residual supervisor process is live", async () => {
+    sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+      const script = String(args.at(-1) ?? "");
+      if (script.includes("Get-ScheduledTask")) return out("Ready");
+      if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return out(supervisorJson(777));
+      throw new Error(`unexpected powershell script: ${script}`);
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.start()).toEqual({
+      ok: false,
+      reason: "supervisor process is live without a running task; run daemon stop and wait before starting again",
+    });
+  });
+
+  it("refuses stop when marker trust checks detect pid reuse or malformed process data", async () => {
+    setRuntimeMarkers(marker(4242, "not-a-date"));
+    queuePowershell([out("Running")], [out(processJson(4242, "first-tree-dev daemon start --no-interactive"))]);
+    const taskScheduler = await backend();
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason:
+        "refusing to taskkill untrusted service runtime marker pid 4242: runtime marker has invalid createdAt not-a-date",
+    });
+
+    setRuntimeMarkers(marker(4242));
+    queuePowershell([out("Running")], [out(processJson(4242, "notepad.exe"))]);
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: expect.stringContaining("pid command does not match First Tree daemon start"),
+    });
+
+    queuePowershell([out("Running")], [out("{")]);
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: "refusing to taskkill untrusted service runtime marker pid 4242: process query returned malformed JSON",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/task-scheduler-final-branches.test.ts
+++ b/apps/cli/src/__tests__/task-scheduler-final-branches.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const sharedMocks = vi.hoisted(() => ({
+  ensureLogDir: vi.fn(),
+  readFileOrFlagDrift: vi.fn(),
+  resolveCliInvocation: vi.fn(() => ({ kind: "bin", program: "first-tree-dev" })),
+  runCapture: vi.fn(),
+  runCaptureOut: vi.fn(),
+  sleepSync: vi.fn(),
+}));
+
+const configMocks = vi.hoisted(() => ({
+  defaultHome: vi.fn(() => "C:\\FirstTree"),
+}));
+
+type ShellResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+type ShellOutResult =
+  | { readonly ok: true; readonly stdout: string }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+
+vi.mock("node:fs", () => fsMocks);
+vi.mock("@first-tree/shared/config", () => configMocks);
+vi.mock("../core/supervisor/shared.js", () => sharedMocks);
+
+function ok(): ShellResult {
+  return { ok: true };
+}
+
+function fail(stderr: string, code = 1): ShellResult {
+  return { ok: false, stderr, code };
+}
+
+function out(stdout: string): ShellOutResult {
+  return { ok: true, stdout };
+}
+
+function outFail(stderr: string, code = 1): ShellOutResult {
+  return { ok: false, stderr, code };
+}
+
+function taskMissing(): ShellOutResult {
+  return { ok: false, stderr: "", code: 3 };
+}
+
+function markerJson(pid: number): string {
+  return JSON.stringify({
+    version: 1,
+    pid,
+    clientId: "client-1",
+    home: "C:\\FirstTree",
+    mode: "service",
+    createdAt: "2026-01-01T00:00:05.000Z",
+  });
+}
+
+function processJson(pid: number, commandLine = "first-tree-dev daemon start --no-interactive"): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: 100,
+    Name: "node.exe",
+    CommandLine: commandLine,
+    ExecutablePath: "C:\\Program Files\\nodejs\\node.exe",
+    CreationTimeUtc: "2026-01-01T00:00:01.000Z",
+  });
+}
+
+function supervisorJson(pid: number): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: 100,
+    Name: "wscript.exe",
+    CommandLine: '"C:\\FirstTree\\service\\first-tree-dev-supervisor.vbs"',
+    ExecutablePath: "C:\\Windows\\System32\\wscript.exe",
+    CreationTimeUtc: "2026-01-01T00:00:01.000Z",
+  });
+}
+
+async function backend(): Promise<typeof import("../core/supervisor/task-scheduler.js").taskSchedulerBackend> {
+  const { taskSchedulerBackend } = await import("../core/supervisor/task-scheduler.js");
+  return taskSchedulerBackend;
+}
+
+function setMarkerFile(body: string): void {
+  fsMocks.existsSync.mockReturnValue(true);
+  fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+  fsMocks.readFileSync.mockReturnValue(body);
+}
+
+function queuePowershell(
+  taskResults: readonly ShellOutResult[],
+  processResults: readonly ShellOutResult[] = [],
+  supervisorResults: readonly ShellOutResult[] = [out("")],
+): void {
+  const tasks = [...taskResults];
+  const processes = [...processResults];
+  const supervisors = [...supervisorResults];
+  sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+    const script = String(args.at(-1) ?? "");
+    if (script.includes("Get-ScheduledTask")) return tasks.shift() ?? out("Ready");
+    if (script.includes("ProcessId = 4242")) return processes.shift() ?? out(processJson(4242));
+    if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return supervisors.shift() ?? out("");
+    throw new Error(`unexpected powershell script: ${script}`);
+  });
+}
+
+describe("task scheduler final branch coverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.readdirSync.mockReturnValue([]);
+    fsMocks.readFileSync.mockReturnValue("");
+    sharedMocks.runCapture.mockReturnValue(ok());
+    queuePowershell([out("Ready")]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns marker read failures from stop", async () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+    fsMocks.readFileSync.mockImplementation(() => {
+      throw new Error("cannot read marker");
+    });
+    queuePowershell([out("Running")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: expect.stringContaining("Unable to read runtime marker"),
+    });
+  });
+
+  it("reports missing task with residual supervisor process and malformed supervisor JSON", async () => {
+    queuePowershell([taskMissing(), taskMissing()], [], [out(supervisorJson(777)), out("{")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "task missing but supervisor process is still live",
+    });
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "supervisor process query returned malformed JSON",
+    });
+  });
+
+  it("reports supervisor query failures during start and cleanup verification", async () => {
+    queuePowershell(
+      [out("Ready"), taskMissing()],
+      [],
+      [outFail("query denied", 5), out(supervisorJson(777)), outFail("gone", 9)],
+    );
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.start()).toEqual({ ok: false, reason: "query denied" });
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: "unable to verify supervisor process cleanup: gone",
+    });
+  });
+
+  it("reports end task failures while preserving not-running as a successful end", async () => {
+    queuePowershell([out("Running"), out("Ready"), out("Running")]);
+    sharedMocks.runCapture
+      .mockReturnValueOnce(fail("not currently running", 1))
+      .mockReturnValueOnce(fail("access denied", 5));
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: true,
+      detail: "task ended without a runtime marker; check Task Manager for any residual first-tree process",
+    });
+    expect(taskScheduler.stop()).toEqual({ ok: false, reason: "access denied" });
+  });
+
+  it("reports untrusted marker pids discovered during the kill phase", async () => {
+    setMarkerFile(markerJson(4242));
+    queuePowershell([out("Running")], [out(processJson(4242)), out(processJson(4242, "notepad.exe"))]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: expect.stringContaining("refusing to taskkill untrusted service runtime marker pid 4242"),
+    });
+  });
+
+  it("reports when a forced taskkill succeeds but the pid stays alive", async () => {
+    setMarkerFile(markerJson(4242));
+    const times = [0, 6000, 12_000, 18_000];
+    vi.spyOn(Date, "now").mockImplementation(() => times.shift() ?? 18_000);
+    queuePowershell([out("Running")], [out(processJson(4242)), out(processJson(4242))]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: "pid 4242 did not exit after taskkill /F",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/task-scheduler-marker-kill.test.ts
+++ b/apps/cli/src/__tests__/task-scheduler-marker-kill.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const sharedMocks = vi.hoisted(() => ({
+  ensureLogDir: vi.fn(),
+  readFileOrFlagDrift: vi.fn(),
+  resolveCliInvocation: vi.fn(() => ({ kind: "bin", program: "first-tree-dev" })),
+  runCapture: vi.fn(),
+  runCaptureOut: vi.fn(),
+  sleepSync: vi.fn(),
+}));
+
+const configMocks = vi.hoisted(() => ({
+  defaultHome: vi.fn(() => "C:\\FirstTree"),
+}));
+
+type ShellResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+type ShellOutResult =
+  | { readonly ok: true; readonly stdout: string }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+
+vi.mock("node:fs", () => fsMocks);
+vi.mock("@first-tree/shared/config", () => configMocks);
+vi.mock("../core/supervisor/shared.js", () => sharedMocks);
+
+function ok(): ShellResult {
+  return { ok: true };
+}
+
+function fail(stderr: string, code = 1): ShellResult {
+  return { ok: false, stderr, code };
+}
+
+function taskState(stdout: string): ShellOutResult {
+  return { ok: true, stdout };
+}
+
+function taskQueryFailure(stderr: string, code = 1): ShellOutResult {
+  return { ok: false, stderr, code };
+}
+
+function processGone(): ShellOutResult {
+  return { ok: false, stderr: "", code: 3 };
+}
+
+function markerJson(pid: number): string {
+  return JSON.stringify({
+    version: 1,
+    pid,
+    clientId: "client-1",
+    home: "C:\\FirstTree",
+    mode: "service",
+    createdAt: "2026-01-01T00:00:05.000Z",
+  });
+}
+
+function daemonProcessJson(pid: number): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: 100,
+    Name: "node.exe",
+    CommandLine: '"C:\\Program Files\\nodejs\\node.exe" "C:\\FirstTree\\cli\\index.mjs" daemon start --no-interactive',
+    ExecutablePath: "C:\\Program Files\\nodejs\\node.exe",
+    CreationTimeUtc: "2026-01-01T00:00:01.000Z",
+  });
+}
+
+async function backend(): Promise<typeof import("../core/supervisor/task-scheduler.js").taskSchedulerBackend> {
+  const { taskSchedulerBackend } = await import("../core/supervisor/task-scheduler.js");
+  return taskSchedulerBackend;
+}
+
+function queueTaskQueries(results: readonly ShellOutResult[], processResult: ShellOutResult): void {
+  const queue = [...results];
+  sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+    const script = String(args.at(-1) ?? "");
+    if (script.includes("Get-ScheduledTask")) return queue.shift() ?? taskState("Ready");
+    if (script.includes("ProcessId = 4242")) return processResult;
+    if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return { ok: true, stdout: "" };
+    throw new Error(`unexpected powershell script: ${script}`);
+  });
+}
+
+function setLiveMarker(): void {
+  fsMocks.existsSync.mockReturnValue(true);
+  fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+  fsMocks.readFileSync.mockReturnValue(markerJson(4242));
+}
+
+function setPidAliveUntilTaskkill(forcedOnly = false): void {
+  let killed = false;
+  vi.spyOn(process, "kill").mockImplementation(() => {
+    if (killed) throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    return true;
+  });
+  sharedMocks.runCapture.mockImplementation((_program, args) => {
+    if (args.includes("/PID") && (!forcedOnly || args.includes("/F"))) killed = true;
+    return ok();
+  });
+}
+
+describe("task scheduler runtime marker stop paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.readdirSync.mockReturnValue([]);
+    fsMocks.readFileSync.mockReturnValue("");
+    sharedMocks.runCapture.mockReturnValue(ok());
+    queueTaskQueries([taskState("Ready")], { ok: true, stdout: daemonProcessJson(4242) });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("kills a trusted service runtime marker before ending a running task", async () => {
+    setLiveMarker();
+    setPidAliveUntilTaskkill();
+    queueTaskQueries([taskState("Running"), taskState("Ready")], { ok: true, stdout: daemonProcessJson(4242) });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: true });
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith(
+      "taskkill.exe",
+      expect.arrayContaining(["/PID", "4242"]),
+      10_000,
+    );
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith("schtasks.exe", expect.arrayContaining(["/End"]), 10_000);
+  });
+
+  it("escalates to forced taskkill when the graceful kill does not stop the marker pid", async () => {
+    setLiveMarker();
+    setPidAliveUntilTaskkill(true);
+    const times = [0, 6000, 12_000, 18_000, 24_000, 24_000];
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      return times.shift() ?? 24_000;
+    });
+    queueTaskQueries([taskState("Running"), taskState("Ready")], { ok: true, stdout: daemonProcessJson(4242) });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: true });
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith(
+      "taskkill.exe",
+      expect.arrayContaining(["/PID", "4242", "/F"]),
+      10_000,
+    );
+  });
+
+  it("reports the forced taskkill failure when the marker pid remains alive", async () => {
+    setLiveMarker();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    let tick = -1;
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      tick += 1;
+      return tick * 6000;
+    });
+    sharedMocks.runCapture.mockImplementation((_program, args) => (args.includes("/PID") ? fail("denied", 5) : ok()));
+    queueTaskQueries([taskState("Running")], { ok: true, stdout: daemonProcessJson(4242) });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: false, reason: "denied" });
+  });
+
+  it("reports when the scheduled task remains running after the end request", async () => {
+    queueTaskQueries([taskState("Running"), taskState("Running")], { ok: true, stdout: daemonProcessJson(4242) });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: false, reason: "task did not stop: task running" });
+  });
+
+  it("ignores a marker pid that disappears between liveness and trust checks", async () => {
+    setLiveMarker();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    queueTaskQueries([taskState("Running"), taskState("Ready")], processGone());
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: true });
+    expect(sharedMocks.runCapture).not.toHaveBeenCalledWith(
+      "taskkill.exe",
+      expect.arrayContaining(["/PID", "4242"]),
+      10_000,
+    );
+  });
+
+  it("reports task state query errors after the end request", async () => {
+    queueTaskQueries([taskState("Running"), taskQueryFailure("still busy", 9)], {
+      ok: true,
+      stdout: daemonProcessJson(4242),
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: false, reason: "task did not stop: still busy" });
+  });
+});

--- a/apps/cli/src/__tests__/task-scheduler-operations.test.ts
+++ b/apps/cli/src/__tests__/task-scheduler-operations.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const sharedMocks = vi.hoisted(() => ({
+  ensureLogDir: vi.fn(),
+  readFileOrFlagDrift: vi.fn(),
+  resolveCliInvocation: vi.fn(() => ({ kind: "bin", program: "first-tree-dev" })),
+  runCapture: vi.fn(),
+  runCaptureOut: vi.fn(),
+  sleepSync: vi.fn(),
+}));
+
+const configMocks = vi.hoisted(() => ({
+  defaultHome: vi.fn(() => "C:\\FirstTree"),
+}));
+
+type ShellResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+type ShellOutResult =
+  | { readonly ok: true; readonly stdout: string }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+
+vi.mock("node:fs", () => fsMocks);
+vi.mock("@first-tree/shared/config", () => configMocks);
+vi.mock("../core/supervisor/shared.js", () => sharedMocks);
+
+function ok(): ShellResult {
+  return { ok: true };
+}
+
+function fail(stderr: string, code = 1): ShellResult {
+  return { ok: false, stderr, code };
+}
+
+function taskState(stdout: string): ShellOutResult {
+  return { ok: true, stdout };
+}
+
+function taskMissing(): ShellOutResult {
+  return { ok: false, stderr: "task not found", code: 3 };
+}
+
+function supervisorProcesses(stdout = ""): ShellOutResult {
+  return { ok: true, stdout };
+}
+
+function runtimeMarker(pid: number): string {
+  return JSON.stringify({
+    version: 1,
+    pid,
+    clientId: "client-1",
+    home: "C:\\FirstTree",
+    mode: "service",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  });
+}
+
+function supervisorProcess(pid: number): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: 100,
+    Name: "wscript.exe",
+    CommandLine: '"C:\\FirstTree\\service\\first-tree-dev-supervisor.vbs"',
+    ExecutablePath: "C:\\Windows\\System32\\wscript.exe",
+    CreationTimeUtc: "2026-01-01T00:00:00.000Z",
+  });
+}
+
+async function backend(): Promise<typeof import("../core/supervisor/task-scheduler.js").taskSchedulerBackend> {
+  const { taskSchedulerBackend } = await import("../core/supervisor/task-scheduler.js");
+  return taskSchedulerBackend;
+}
+
+function queueTaskQueries(results: readonly ShellOutResult[]): void {
+  const queue = [...results];
+  sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+    const script = String(args.at(-1) ?? "");
+    if (script.includes("Get-ScheduledTask")) return queue.shift() ?? taskState("Ready");
+    if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return supervisorProcesses();
+    throw new Error(`unexpected powershell script: ${script}`);
+  });
+}
+
+describe("task scheduler service operations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.readdirSync.mockReturnValue([]);
+    fsMocks.readFileSync.mockReturnValue("");
+    sharedMocks.runCapture.mockReturnValue(ok());
+    queueTaskQueries([taskState("Ready")]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("installs supervisor files, registers the task, and requests a run", async () => {
+    const taskScheduler = await backend();
+
+    const info = taskScheduler.install();
+
+    expect(info).toMatchObject({
+      platform: "task-scheduler",
+      state: "active",
+      detail: "task run requested",
+    });
+    expect(sharedMocks.ensureLogDir).toHaveBeenCalledTimes(1);
+    expect(fsMocks.writeFileSync).toHaveBeenCalledTimes(3);
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith(
+      "schtasks.exe",
+      expect.arrayContaining(["/Create", "/F"]),
+      10_000,
+    );
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith("schtasks.exe", expect.arrayContaining(["/Run"]), 10_000);
+  });
+
+  it("rejects start when the task is missing", async () => {
+    queueTaskQueries([taskMissing()]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.start()).toEqual({ ok: false, reason: "service not installed" });
+  });
+
+  it("starts a registered task after proving no runtime or supervisor process is live", async () => {
+    queueTaskQueries([taskState("Ready")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.start()).toEqual({ ok: true });
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith("schtasks.exe", expect.arrayContaining(["/Run"]), 10_000);
+  });
+
+  it("stops a running task without a marker and returns the residual-process warning", async () => {
+    queueTaskQueries([taskState("Running"), taskState("Ready")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: true,
+      detail: "task ended without a runtime marker; check Task Manager for any residual first-tree process",
+    });
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith("schtasks.exe", expect.arrayContaining(["/End"]), 10_000);
+  });
+
+  it("refuses stop when a live runtime marker cannot be trusted", async () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+    fsMocks.readFileSync.mockReturnValue(runtimeMarker(4242));
+    sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+      const script = String(args.at(-1) ?? "");
+      if (script.includes("Get-ScheduledTask")) return taskState("Running");
+      if (script.includes("ProcessId = 4242")) return { ok: false, stderr: "access denied", code: 5 };
+      throw new Error(`unexpected powershell script: ${script}`);
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: "refusing to taskkill untrusted service runtime marker pid 4242: access denied",
+    });
+  });
+
+  it("uninstalls task artifacts and preserves a stop warning as status detail", async () => {
+    queueTaskQueries([{ ok: false, stderr: "state query failed", code: 5 }]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.uninstall()).toMatchObject({
+      state: "not-installed",
+      detail: "state query failed",
+    });
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith(
+      "schtasks.exe",
+      expect.arrayContaining(["/Delete", "/F"]),
+      10_000,
+    );
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(expect.stringContaining("supervisor.cmd"), { force: true });
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(expect.stringContaining("supervisor.vbs"), { force: true });
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(expect.stringContaining("task.xml"), { force: true });
+  });
+
+  it("throws when deleting the task fails with a native Windows error", async () => {
+    queueTaskQueries([taskMissing()]);
+    sharedMocks.runCapture.mockImplementation((_program, args) =>
+      args.includes("/Delete") ? fail("localized failure", 87) : ok(),
+    );
+    const taskScheduler = await backend();
+
+    expect(() => taskScheduler.uninstall()).toThrow("schtasks /Delete failed: localized failure");
+  });
+
+  it("reports residual supervisor cleanup timeouts after a missing task stop", async () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(6000);
+    queueTaskQueries([taskMissing()]);
+    sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+      const script = String(args.at(-1) ?? "");
+      if (script.includes("Get-ScheduledTask")) return taskMissing();
+      if (script.includes("Get-CimInstance Win32_Process | Where-Object")) {
+        return supervisorProcesses(supervisorProcess(777));
+      }
+      throw new Error(`unexpected powershell script: ${script}`);
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: expect.stringContaining("supervisor process still running after task end"),
+    });
+  });
+});

--- a/apps/cli/src/__tests__/task-scheduler-status.test.ts
+++ b/apps/cli/src/__tests__/task-scheduler-status.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const sharedMocks = vi.hoisted(() => ({
+  ensureLogDir: vi.fn(),
+  readFileOrFlagDrift: vi.fn(),
+  resolveCliInvocation: vi.fn(),
+  runCapture: vi.fn(),
+  runCaptureOut: vi.fn(),
+  sleepSync: vi.fn(),
+}));
+
+const configMocks = vi.hoisted(() => ({
+  defaultHome: vi.fn(() => "C:\\FirstTree"),
+}));
+
+vi.mock("node:fs", () => fsMocks);
+vi.mock("@first-tree/shared/config", () => configMocks);
+vi.mock("../core/supervisor/shared.js", () => sharedMocks);
+
+const taskQuery = {
+  code: 0,
+  ok: true,
+  stderr: "",
+  stdout: "Ready",
+};
+
+const supervisorQuery = {
+  code: 0,
+  ok: true,
+  stderr: "",
+  stdout: "",
+};
+
+function setTaskQuery(stdout: string, code = 0): void {
+  taskQuery.code = code;
+  taskQuery.ok = code === 0;
+  taskQuery.stdout = stdout;
+  taskQuery.stderr = "";
+}
+
+function setSupervisorQuery(stdout: string): void {
+  supervisorQuery.stdout = stdout;
+}
+
+function markerJson(pid: number): string {
+  return JSON.stringify({
+    version: 1,
+    pid,
+    clientId: "client-1",
+    home: "C:\\FirstTree",
+    mode: "service",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  });
+}
+
+function supervisorProcessJson(pid: number): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: 100,
+    Name: "wscript.exe",
+    CommandLine: '"C:\\FirstTree\\service\\first-tree-dev-supervisor.vbs"',
+    ExecutablePath: "C:\\Windows\\System32\\wscript.exe",
+    CreationTimeUtc: "2026-01-01T00:00:00.000Z",
+  });
+}
+
+async function status(): Promise<
+  ReturnType<typeof import("../core/supervisor/task-scheduler.js").taskSchedulerBackend.status>
+> {
+  const { taskSchedulerBackend } = await import("../core/supervisor/task-scheduler.js");
+  return taskSchedulerBackend.status();
+}
+
+describe("task scheduler status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    setTaskQuery("Ready");
+    setSupervisorQuery("");
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.readdirSync.mockReturnValue([]);
+    fsMocks.readFileSync.mockReturnValue("");
+    sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+      const script = String(args.at(-1) ?? "");
+      if (script.includes("Get-ScheduledTask")) return taskQuery;
+      if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return supervisorQuery;
+      throw new Error(`unexpected powershell script: ${script}`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("reports not-installed when the task is missing and no runtime or supervisor process is live", async () => {
+    setTaskQuery("", 3);
+
+    await expect(status()).resolves.toMatchObject({
+      platform: "task-scheduler",
+      state: "not-installed",
+    });
+  });
+
+  it("reports active with the service runtime marker pid when the task is running", async () => {
+    setTaskQuery("Running");
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+    fsMocks.readFileSync.mockReturnValue(markerJson(4242));
+
+    await expect(status()).resolves.toMatchObject({
+      state: "active",
+      pid: 4242,
+      detail: "pid 4242",
+    });
+  });
+
+  it("reports unknown when the task is running without a live service runtime marker", async () => {
+    setTaskQuery("Running");
+
+    await expect(status()).resolves.toMatchObject({
+      state: "unknown",
+      detail: "task running but no live service runtime marker",
+    });
+  });
+
+  it("reports residual supervisor processes when the task is not running", async () => {
+    setTaskQuery("Ready");
+    setSupervisorQuery(supervisorProcessJson(777));
+
+    await expect(status()).resolves.toMatchObject({
+      state: "unknown",
+      detail: "task not running but supervisor process is still live",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/unsupported-supervisor.test.ts
+++ b/apps/cli/src/__tests__/unsupported-supervisor.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { unsupportedBackend } from "../core/supervisor/unsupported.js";
+
+describe("unsupported supervisor backend", () => {
+  it("reports unsupported service metadata without throwing", () => {
+    expect(unsupportedBackend.platform).toBe("unsupported");
+    expect(unsupportedBackend.isSupported()).toBe(false);
+    expect(unsupportedBackend.isUnitDriftDetected()).toBe(false);
+
+    expect(unsupportedBackend.status()).toMatchObject({
+      platform: "unsupported",
+      state: "not-installed",
+      detail: expect.stringContaining(`platform ${process.platform} not supported`),
+    });
+    expect(unsupportedBackend.uninstall()).toMatchObject({
+      platform: "unsupported",
+      state: "not-installed",
+    });
+  });
+
+  it("rejects service control operations with platform-specific reasons", () => {
+    for (const control of [unsupportedBackend.start, unsupportedBackend.stop, unsupportedBackend.restart]) {
+      expect(control()).toEqual({
+        ok: false,
+        reason: `service control not supported on ${process.platform}`,
+      });
+    }
+  });
+
+  it("throws actionable install and refresh guidance", () => {
+    expect(() => unsupportedBackend.install()).toThrow("Background service install is not supported");
+    expect(() => unsupportedBackend.install()).toThrow("daemon start");
+    expect(() => unsupportedBackend.refreshForUpdate()).toThrow("Background service refresh is not supported");
+    expect(() => unsupportedBackend.refreshForUpdate()).toThrow("daemon start");
+  });
+});

--- a/apps/cli/src/__tests__/wsl-dbus.test.ts
+++ b/apps/cli/src/__tests__/wsl-dbus.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isWslDbusOvermount } from "../commands/daemon/_shared/wsl-dbus.js";
+
+const readFileSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: readFileSyncMock,
+  };
+});
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+describe("isWslDbusOvermount", () => {
+  beforeEach(() => {
+    readFileSyncMock.mockReset();
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it("returns false without reading /proc/version outside Linux", () => {
+    setPlatform("darwin");
+    readFileSyncMock.mockReturnValue("Linux version 5.15.90.1-microsoft-standard-WSL2");
+
+    expect(isWslDbusOvermount("Failed to connect to bus: No such file or directory")).toBe(false);
+    expect(readFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false without reading /proc/version when the reason is not a dbus connection failure", () => {
+    setPlatform("linux");
+    readFileSyncMock.mockReturnValue("Linux version 5.15.90.1-microsoft-standard-WSL2");
+
+    expect(isWslDbusOvermount("systemctl exited with code 1")).toBe(false);
+    expect(readFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("detects the WSL dbus overmount from a Linux Microsoft kernel banner", () => {
+    setPlatform("linux");
+    readFileSyncMock.mockReturnValue("Linux version 5.15.90.1-microsoft-standard-WSL2");
+
+    expect(isWslDbusOvermount("failed to connect to bus: no such file or directory")).toBe(true);
+    expect(readFileSyncMock).toHaveBeenCalledWith("/proc/version", "utf8");
+  });
+
+  it("returns false for Linux kernels that are not WSL", () => {
+    setPlatform("linux");
+    readFileSyncMock.mockReturnValue("Linux version 6.8.0-generic");
+
+    expect(isWslDbusOvermount("FAILED TO CONNECT TO BUS: No such file or directory")).toBe(false);
+  });
+
+  it("returns false when /proc/version cannot be read", () => {
+    setPlatform("linux");
+    readFileSyncMock.mockImplementation(() => {
+      throw new Error("permission denied");
+    });
+
+    expect(isWslDbusOvermount("Failed to connect to bus: No such file or directory")).toBe(false);
+  });
+});

--- a/packages/client/src/__tests__/claude-code-tool-events-search-edge.test.ts
+++ b/packages/client/src/__tests__/claude-code-tool-events-search-edge.test.ts
@@ -1,0 +1,49 @@
+import type { SessionEvent } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import { createToolCallProcessor } from "../handlers/claude-code.js";
+
+function assistantToolUse(id: string, name: string, input: unknown) {
+  return {
+    type: "assistant",
+    message: {
+      role: "assistant",
+      content: [{ type: "tool_use", id, name, input }],
+    },
+  };
+}
+
+function userToolResult(toolUseId: string, content: unknown) {
+  return {
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content }],
+    },
+  };
+}
+
+function finalToolCall(events: readonly SessionEvent[]): Extract<SessionEvent, { kind: "tool_call" }> {
+  const event = events.find((candidate) => candidate.kind === "tool_call" && candidate.payload.status === "ok");
+  if (!event || event.kind !== "tool_call") throw new Error("expected final tool_call event");
+  return event;
+}
+
+describe("createToolCallProcessor — search path edge refs", () => {
+  it("emits a directory search ref for an absolute missing path without a Context Tree binding", () => {
+    const events: SessionEvent[] = [];
+    const emit = vi.fn<(event: SessionEvent) => void>((event) => events.push(event));
+    const processor = createToolCallProcessor(emit);
+
+    processor.onMessage(assistantToolUse("grep-missing", "Grep", { path: "/tmp/first-tree-missing-search-root" }));
+    processor.onMessage(userToolResult("grep-missing", "no matches"));
+
+    const event = finalToolCall(events);
+    expect(event.payload.toolFileRefs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: "/tmp/first-tree-missing-search-root",
+        pathKind: "directory",
+      },
+    ]);
+  });
+});

--- a/packages/client/src/__tests__/codex-capability-platform-edge.test.ts
+++ b/packages/client/src/__tests__/codex-capability-platform-edge.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveBundledCodexBinary } from "../runtime/capabilities/codex.js";
+
+const originalPlatform = process.platform;
+const originalArch = process.arch;
+
+function setProcessTarget(platform: NodeJS.Platform, arch: NodeJS.Architecture): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+  Object.defineProperty(process, "arch", { configurable: true, value: arch });
+}
+
+describe("resolveBundledCodexBinary — platform edge mapping", () => {
+  afterEach(() => {
+    setProcessTarget(originalPlatform, originalArch);
+  });
+
+  it("reports unsupported platforms before resolving SDK packages", async () => {
+    setProcessTarget("freebsd", "x64");
+
+    await expect(resolveBundledCodexBinary()).resolves.toEqual({
+      ok: false,
+      error: "unsupported platform for codex: freebsd (x64)",
+    });
+  });
+
+  it.each([
+    ["linux", "arm64", "@openai/codex-linux-arm64"],
+    ["darwin", "x64", "@openai/codex-darwin-x64"],
+    ["win32", "arm64", "@openai/codex-win32-arm64"],
+  ] satisfies ReadonlyArray<
+    readonly [NodeJS.Platform, NodeJS.Architecture, string]
+  >)("uses the %s/%s optional package name in missing-binary diagnostics", async (platform, arch, expectedPackage) => {
+    setProcessTarget(platform, arch);
+
+    const result = await resolveBundledCodexBinary();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected missing bundled binary");
+    expect(result.error).toContain(expectedPackage);
+  });
+});


### PR DESCRIPTION
## Summary\n- add CLI tests for WSL dbus, daemon supervisor, unsupported supervisor, and task scheduler edge branches\n- add Client tests for Claude tool search refs and Codex platform resolution edges\n\n## Verification\n- pnpm run lint\n- pnpm run typecheck\n- pnpm run check\n- pnpm run format\n- pnpm --filter @first-tree/client exec vitest run src/__tests__/claude-code-tool-events-search-edge.test.ts\n- pnpm --filter @first-tree/client exec vitest run src/__tests__/codex-capability-platform-edge.test.ts\n- pnpm coverage\n- pnpm coverage:summary\n\n## Notes\n- Existing Biome warnings remain in assistant-text.test.ts, workspace-migrations.ts, and web index.css.\n- Full pnpm test previously hit the known @first-tree/skill-evals periodic monorepo-concurrency timeout, while the package-level test passed.