### PR TITLE
test: improve coverage for CLI and client edges

### DIFF
--- a/apps/cli/src/__tests__/daemon-supervise-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-supervise-command.test.ts
@@ -1,0 +1,80 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const outputMocks = vi.hoisted(() => ({
+  print: {
+    line: vi.fn(),
+  },
+}));
+
+const supervisorMocks = vi.hoisted(() => ({
+  runWindowsSupervisorLoop: vi.fn(),
+}));
+
+vi.mock("../core/output.js", () => outputMocks);
+vi.mock("../core/supervisor/windows-supervisor.js", () => supervisorMocks);
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+async function runSuperviseCommand(): Promise<void> {
+  const { registerDaemonSuperviseCommand } = await import("../commands/daemon/supervise.js");
+  const daemon = new Command();
+  registerDaemonSuperviseCommand(daemon);
+  await daemon.parseAsync(["supervise"], { from: "user" });
+}
+
+describe("daemon supervise command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "exit").mockImplementation((code?: string | number | null | undefined): never => {
+      throw Object.assign(new Error(`process.exit ${code}`), { exitCode: code });
+    });
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("rejects non-Windows platforms before starting the supervisor loop", async () => {
+    setPlatform("linux");
+
+    await expect(runSuperviseCommand()).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(supervisorMocks.runWindowsSupervisorLoop).not.toHaveBeenCalled();
+    expect(outputMocks.print.line).toHaveBeenCalledWith(expect.stringContaining("only supported on win32"));
+  });
+
+  it("attempts to exit with the Windows supervisor loop result code", async () => {
+    setPlatform("win32");
+    supervisorMocks.runWindowsSupervisorLoop.mockResolvedValueOnce(75);
+
+    await expect(runSuperviseCommand()).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(supervisorMocks.runWindowsSupervisorLoop).toHaveBeenCalledTimes(1);
+    expect(process.exit).toHaveBeenNthCalledWith(1, 75);
+  });
+
+  it("prints Error failures from the Windows supervisor loop", async () => {
+    setPlatform("win32");
+    supervisorMocks.runWindowsSupervisorLoop.mockRejectedValueOnce(new Error("child spawn failed"));
+
+    await expect(runSuperviseCommand()).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(outputMocks.print.line).toHaveBeenCalledWith(expect.stringContaining("child spawn failed"));
+  });
+
+  it("stringifies non-Error supervisor loop failures", async () => {
+    setPlatform("win32");
+    supervisorMocks.runWindowsSupervisorLoop.mockRejectedValueOnce("string failure");
+
+    await expect(runSuperviseCommand()).rejects.toMatchObject({ exitCode: 1 });
+
+    expect(outputMocks.print.line).toHaveBeenCalledWith(expect.stringContaining("string failure"));
+  });
+});

--- a/apps/cli/src/__tests__/task-scheduler-edge-paths.test.ts
+++ b/apps/cli/src/__tests__/task-scheduler-edge-paths.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const sharedMocks = vi.hoisted(() => ({
+  ensureLogDir: vi.fn(),
+  readFileOrFlagDrift: vi.fn(),
+  resolveCliInvocation: vi.fn(() => ({ kind: "bin", program: "first-tree-dev" })),
+  runCapture: vi.fn(),
+  runCaptureOut: vi.fn(),
+  sleepSync: vi.fn(),
+}));
+
+const configMocks = vi.hoisted(() => ({
+  defaultHome: vi.fn(() => "C:\\FirstTree"),
+}));
+
+type ShellResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+type ShellOutResult =
+  | { readonly ok: true; readonly stdout: string }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+
+vi.mock("node:fs", () => fsMocks);
+vi.mock("@first-tree/shared/config", () => configMocks);
+vi.mock("../core/supervisor/shared.js", () => sharedMocks);
+
+function ok(): ShellResult {
+  return { ok: true };
+}
+
+function fail(stderr: string, code = 1): ShellResult {
+  return { ok: false, stderr, code };
+}
+
+function out(stdout: string): ShellOutResult {
+  return { ok: true, stdout };
+}
+
+function outFail(stderr: string, code = 1): ShellOutResult {
+  return { ok: false, stderr, code };
+}
+
+function marker(pid: number, createdAt = "2026-01-01T00:00:05.000Z"): string {
+  return JSON.stringify({
+    version: 1,
+    pid,
+    clientId: "client-1",
+    home: "C:\\FirstTree",
+    mode: "service",
+    createdAt,
+  });
+}
+
+function processJson(pid: number, commandLine: string, creationTimeUtc = "2026-01-01T00:00:01.000Z"): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: "100",
+    Name: "node.exe",
+    CommandLine: commandLine,
+    ExecutablePath: "C:\\Program Files\\nodejs\\node.exe",
+    CreationTimeUtc: creationTimeUtc,
+  });
+}
+
+function supervisorJson(pid: number): string {
+  return JSON.stringify({
+    ProcessId: String(pid),
+    ParentProcessId: 100,
+    Name: "wscript.exe",
+    CommandLine: '"C:\\FirstTree\\service\\first-tree-dev-supervisor.vbs"',
+    ExecutablePath: "C:\\Windows\\System32\\wscript.exe",
+    CreationTimeUtc: "2026-01-01T00:00:01.000Z",
+  });
+}
+
+async function backend(): Promise<typeof import("../core/supervisor/task-scheduler.js").taskSchedulerBackend> {
+  const { taskSchedulerBackend } = await import("../core/supervisor/task-scheduler.js");
+  return taskSchedulerBackend;
+}
+
+function queuePowershell(taskResults: readonly ShellOutResult[], processResults: readonly ShellOutResult[] = []): void {
+  const tasks = [...taskResults];
+  const processes = [...processResults];
+  sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+    const script = String(args.at(-1) ?? "");
+    if (script.includes("Get-ScheduledTask")) return tasks.shift() ?? out("Ready");
+    if (script.includes("ProcessId = 4242"))
+      return processes.shift() ?? out(processJson(4242, "first-tree-dev daemon start --no-interactive"));
+    if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return out("");
+    throw new Error(`unexpected powershell script: ${script}`);
+  });
+}
+
+function setRuntimeMarkers(...bodies: string[]): void {
+  fsMocks.existsSync.mockReturnValue(true);
+  fsMocks.readdirSync.mockReturnValue(bodies.map((_, index) => `runtime-${index}.json`));
+  fsMocks.readFileSync.mockImplementation((path) => {
+    const match = String(path).match(/runtime-(\d+)\.json$/u);
+    return bodies[Number(match?.[1] ?? 0)] ?? "";
+  });
+}
+
+describe("task scheduler edge paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.readdirSync.mockReturnValue([]);
+    fsMocks.readFileSync.mockReturnValue("");
+    sharedMocks.runCapture.mockReturnValue(ok());
+    queuePowershell([out("Ready")]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("falls back from PowerShell task query errors to schtasks missing and unknown states", async () => {
+    sharedMocks.runCapture
+      .mockReturnValueOnce(fail("cannot find the file", 1))
+      .mockReturnValueOnce(fail("access denied", 5));
+    queuePowershell([outFail("powershell failed", 5), outFail("powershell failed", 5)]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({ state: "not-installed" });
+    expect(taskScheduler.status()).toMatchObject({ state: "unknown", detail: "powershell failed\naccess denied" });
+  });
+
+  it("reports unreadable runtime marker directories and files", async () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readdirSync.mockImplementation(() => {
+      throw new Error("permission denied");
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "Unable to inspect runtime markers: permission denied",
+    });
+
+    fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+    fsMocks.readFileSync.mockImplementation(() => {
+      throw new Error("bad json");
+    });
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: expect.stringContaining("Unable to read runtime marker"),
+    });
+  });
+
+  it("removes dead runtime markers while computing inactive status", async () => {
+    setRuntimeMarkers(marker(4242));
+    vi.mocked(process.kill).mockImplementation(() => {
+      throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({ state: "inactive", detail: "task state Ready" });
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(expect.stringContaining("runtime-0.json"), { force: true });
+  });
+
+  it("reports inconsistent task and runtime marker status combinations", async () => {
+    setRuntimeMarkers(marker(4242), marker(4343));
+    queuePowershell([outFail("", 3), out("Running"), out("Ready")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "task missing but service runtime marker is live",
+    });
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "task running with 2 live service markers",
+    });
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "task not running but service runtime marker is live",
+    });
+  });
+
+  it("refuses start while a residual supervisor process is live", async () => {
+    sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+      const script = String(args.at(-1) ?? "");
+      if (script.includes("Get-ScheduledTask")) return out("Ready");
+      if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return out(supervisorJson(777));
+      throw new Error(`unexpected powershell script: ${script}`);
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.start()).toEqual({
+      ok: false,
+      reason: "supervisor process is live without a running task; run daemon stop and wait before starting again",
+    });
+  });
+
+  it("refuses stop when marker trust checks detect pid reuse or malformed process data", async () => {
+    setRuntimeMarkers(marker(4242, "not-a-date"));
+    queuePowershell([out("Running")], [out(processJson(4242, "first-tree-dev daemon start --no-interactive"))]);
+    const taskScheduler = await backend();
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason:
+        "refusing to taskkill untrusted service runtime marker pid 4242: runtime marker has invalid createdAt not-a-date",
+    });
+
+    setRuntimeMarkers(marker(4242));
+    queuePowershell([out("Running")], [out(processJson(4242, "notepad.exe"))]);
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: expect.stringContaining("pid command does not match First Tree daemon start"),
+    });
+
+    queuePowershell([out("Running")], [out("{")]);
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: "refusing to taskkill untrusted service runtime marker pid 4242: process query returned malformed JSON",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/task-scheduler-final-branches.test.ts
+++ b/apps/cli/src/__tests__/task-scheduler-final-branches.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const sharedMocks = vi.hoisted(() => ({
+  ensureLogDir: vi.fn(),
+  readFileOrFlagDrift: vi.fn(),
+  resolveCliInvocation: vi.fn(() => ({ kind: "bin", program: "first-tree-dev" })),
+  runCapture: vi.fn(),
+  runCaptureOut: vi.fn(),
+  sleepSync: vi.fn(),
+}));
+
+const configMocks = vi.hoisted(() => ({
+  defaultHome: vi.fn(() => "C:\\FirstTree"),
+}));
+
+type ShellResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+type ShellOutResult =
+  | { readonly ok: true; readonly stdout: string }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+
+vi.mock("node:fs", () => fsMocks);
+vi.mock("@first-tree/shared/config", () => configMocks);
+vi.mock("../core/supervisor/shared.js", () => sharedMocks);
+
+function ok(): ShellResult {
+  return { ok: true };
+}
+
+function fail(stderr: string, code = 1): ShellResult {
+  return { ok: false, stderr, code };
+}
+
+function out(stdout: string): ShellOutResult {
+  return { ok: true, stdout };
+}
+
+function outFail(stderr: string, code = 1): ShellOutResult {
+  return { ok: false, stderr, code };
+}
+
+function taskMissing(): ShellOutResult {
+  return { ok: false, stderr: "", code: 3 };
+}
+
+function markerJson(pid: number): string {
+  return JSON.stringify({
+    version: 1,
+    pid,
+    clientId: "client-1",
+    home: "C:\\FirstTree",
+    mode: "service",
+    createdAt: "2026-01-01T00:00:05.000Z",
+  });
+}
+
+function processJson(pid: number, commandLine = "first-tree-dev daemon start --no-interactive"): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: 100,
+    Name: "node.exe",
+    CommandLine: commandLine,
+    ExecutablePath: "C:\\Program Files\\nodejs\\node.exe",
+    CreationTimeUtc: "2026-01-01T00:00:01.000Z",
+  });
+}
+
+function supervisorJson(pid: number): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: 100,
+    Name: "wscript.exe",
+    CommandLine: '"C:\\FirstTree\\service\\first-tree-dev-supervisor.vbs"',
+    ExecutablePath: "C:\\Windows\\System32\\wscript.exe",
+    CreationTimeUtc: "2026-01-01T00:00:01.000Z",
+  });
+}
+
+async function backend(): Promise<typeof import("../core/supervisor/task-scheduler.js").taskSchedulerBackend> {
+  const { taskSchedulerBackend } = await import("../core/supervisor/task-scheduler.js");
+  return taskSchedulerBackend;
+}
+
+function setMarkerFile(body: string): void {
+  fsMocks.existsSync.mockReturnValue(true);
+  fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+  fsMocks.readFileSync.mockReturnValue(body);
+}
+
+function queuePowershell(
+  taskResults: readonly ShellOutResult[],
+  processResults: readonly ShellOutResult[] = [],
+  supervisorResults: readonly ShellOutResult[] = [out("")],
+): void {
+  const tasks = [...taskResults];
+  const processes = [...processResults];
+  const supervisors = [...supervisorResults];
+  sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+    const script = String(args.at(-1) ?? "");
+    if (script.includes("Get-ScheduledTask")) return tasks.shift() ?? out("Ready");
+    if (script.includes("ProcessId = 4242")) return processes.shift() ?? out(processJson(4242));
+    if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return supervisors.shift() ?? out("");
+    throw new Error(`unexpected powershell script: ${script}`);
+  });
+}
+
+describe("task scheduler final branch coverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.readdirSync.mockReturnValue([]);
+    fsMocks.readFileSync.mockReturnValue("");
+    sharedMocks.runCapture.mockReturnValue(ok());
+    queuePowershell([out("Ready")]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns marker read failures from stop", async () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+    fsMocks.readFileSync.mockImplementation(() => {
+      throw new Error("cannot read marker");
+    });
+    queuePowershell([out("Running")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: expect.stringContaining("Unable to read runtime marker"),
+    });
+  });
+
+  it("reports missing task with residual supervisor process and malformed supervisor JSON", async () => {
+    queuePowershell([taskMissing(), taskMissing()], [], [out(supervisorJson(777)), out("{")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "task missing but supervisor process is still live",
+    });
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "supervisor process query returned malformed JSON",
+    });
+  });
+
+  it("reports supervisor query failures during start and cleanup verification", async () => {
+    queuePowershell(
+      [out("Ready"), taskMissing()],
+      [],
+      [outFail("query denied", 5), out(supervisorJson(777)), outFail("gone", 9)],
+    );
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.start()).toEqual({ ok: false, reason: "query denied" });
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: "unable to verify supervisor process cleanup: gone",
+    });
+  });
+
+  it("reports end task failures while preserving not-running as a successful end", async () => {
+    queuePowershell([out("Running"), out("Ready"), out("Running")]);
+    sharedMocks.runCapture
+      .mockReturnValueOnce(fail("not currently running", 1))
+      .mockReturnValueOnce(fail("access denied", 5));
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: true,
+      detail: "task ended without a runtime marker; check Task Manager for any residual first-tree process",
+    });
+    expect(taskScheduler.stop()).toEqual({ ok: false, reason: "access denied" });
+  });
+
+  it("reports untrusted marker pids discovered during the kill phase", async () => {
+    setMarkerFile(markerJson(4242));
+    queuePowershell([out("Running")], [out(processJson(4242)), out(processJson(4242, "notepad.exe"))]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: expect.stringContaining("refusing to taskkill untrusted service runtime marker pid 4242"),
+    });
+  });
+
+  it("reports when a forced taskkill succeeds but the pid stays alive", async () => {
+    setMarkerFile(markerJson(4242));
+    const times = [0, 6000, 12_000, 18_000];
+    vi.spyOn(Date, "now").mockImplementation(() => times.shift() ?? 18_000);
+    queuePowershell([out("Running")], [out(processJson(4242)), out(processJson(4242))]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: "pid 4242 did not exit after taskkill /F",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/task-scheduler-final-branches.test.ts
+++ b/apps/cli/src/__tests__/task-scheduler-final-branches.test.ts
@@ -37,7 +37,7 @@ function ok(): ShellResult {
   return { ok: true };
 }
 
-function fail(stderr: string, code = 1): ShellResult {
+function fail(stderr: string, code: number | null = 1): ShellResult {
   return { ok: false, stderr, code };
 }
 
@@ -45,7 +45,7 @@ function out(stdout: string): ShellOutResult {
   return { ok: true, stdout };
 }
 
-function outFail(stderr: string, code = 1): ShellOutResult {
+function outFail(stderr: string, code: number | null = 1): ShellOutResult {
   return { ok: false, stderr, code };
 }
 
@@ -53,7 +53,7 @@ function taskMissing(): ShellOutResult {
   return { ok: false, stderr: "", code: 3 };
 }
 
-function markerJson(pid: number): string {
+function markerJson(pid: number, overrides: Record<string, unknown> = {}): string {
   return JSON.stringify({
     version: 1,
     pid,
@@ -61,10 +61,15 @@ function markerJson(pid: number): string {
     home: "C:\\FirstTree",
     mode: "service",
     createdAt: "2026-01-01T00:00:05.000Z",
+    ...overrides,
   });
 }
 
-function processJson(pid: number, commandLine = "first-tree-dev daemon start --no-interactive"): string {
+function processJson(
+  pid: number,
+  commandLine = "first-tree-dev daemon start --no-interactive",
+  overrides: Record<string, unknown> = {},
+): string {
   return JSON.stringify({
     ProcessId: pid,
     ParentProcessId: 100,
@@ -72,10 +77,11 @@ function processJson(pid: number, commandLine = "first-tree-dev daemon start --n
     CommandLine: commandLine,
     ExecutablePath: "C:\\Program Files\\nodejs\\node.exe",
     CreationTimeUtc: "2026-01-01T00:00:01.000Z",
+    ...overrides,
   });
 }
 
-function supervisorJson(pid: number): string {
+function supervisorJson(pid: number, overrides: Record<string, unknown> = {}): string {
   return JSON.stringify({
     ProcessId: pid,
     ParentProcessId: 100,
@@ -83,7 +89,12 @@ function supervisorJson(pid: number): string {
     CommandLine: '"C:\\FirstTree\\service\\first-tree-dev-supervisor.vbs"',
     ExecutablePath: "C:\\Windows\\System32\\wscript.exe",
     CreationTimeUtc: "2026-01-01T00:00:01.000Z",
+    ...overrides,
   });
+}
+
+function throwUnknown(value: unknown): never {
+  throw value;
 }
 
 async function backend(): Promise<typeof import("../core/supervisor/task-scheduler.js").taskSchedulerBackend> {
@@ -126,6 +137,7 @@ describe("task scheduler final branch coverage", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
     vi.resetModules();
   });
@@ -210,5 +222,275 @@ describe("task scheduler final branch coverage", () => {
       ok: false,
       reason: "pid 4242 did not exit after taskkill /F",
     });
+  });
+
+  it("renders the task XML from explicit Windows identity and system-root environment", async () => {
+    vi.stubEnv("USERDOMAIN", "ACME");
+    vi.stubEnv("USERNAME", "alice");
+    vi.stubEnv("SystemRoot", "C:\\Windows\\");
+    const { renderWindowsTaskXml } = await import("../core/supervisor/task-scheduler.js");
+
+    const xml = renderWindowsTaskXml("C:\\FirstTree\\service\\supervisor.vbs");
+
+    expect(xml).toContain("<Author>ACME\\alice</Author>");
+    expect(xml).toContain("<Command>C:\\Windows\\System32\\wscript.exe</Command>");
+  });
+
+  it("reports an unknown native exit when task installation cannot request a run", async () => {
+    sharedMocks.runCapture.mockImplementation((_program, args) => (args.includes("/Run") ? fail("", null) : ok()));
+    const taskScheduler = await backend();
+
+    expect(() => taskScheduler.install()).toThrow("schtasks /Run failed: exit unknown");
+  });
+
+  it("detects drift when the task XML is readable without a byte-order mark", async () => {
+    fsMocks.readFileSync.mockReturnValue("plain xml");
+    sharedMocks.readFileOrFlagDrift.mockReturnValue(false);
+    queuePowershell([out("Ready")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.isUnitDriftDetected()).toBe(true);
+  });
+
+  it("covers empty task states and native query fallback details", async () => {
+    const taskScheduler = await backend();
+
+    queuePowershell([out("")]);
+    expect(taskScheduler.status()).toMatchObject({ state: "inactive", detail: "task registered" });
+
+    queuePowershell([outFail("", null)]);
+    sharedMocks.runCapture.mockReturnValue(fail("", null));
+    expect(taskScheduler.status()).toMatchObject({ state: "unknown", detail: "powershell exit unknown" });
+
+    queuePowershell([outFail("", null)]);
+    sharedMocks.runCapture.mockReturnValue(ok());
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "task exists but state query failed (exit unknown)",
+    });
+  });
+
+  it("rejects malformed process identities and mismatched process ids", async () => {
+    setMarkerFile(markerJson(4242));
+    const taskScheduler = await backend();
+
+    for (const stdout of ["[]", JSON.stringify({ ProcessId: "NaN" }), JSON.stringify({ ProcessId: null })]) {
+      queuePowershell([out("Running")], [out(stdout)]);
+      expect(taskScheduler.stop()).toEqual({
+        ok: false,
+        reason: "refusing to taskkill untrusted service runtime marker pid 4242: process query returned malformed JSON",
+      });
+    }
+
+    queuePowershell([out("Running")], [out(processJson(999))]);
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason:
+        "refusing to taskkill untrusted service runtime marker pid 4242: process query returned pid 999 for pid 4242",
+    });
+
+    queuePowershell([out("Running")], [outFail("", null)]);
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: "refusing to taskkill untrusted service runtime marker pid 4242: powershell exit unknown",
+    });
+  });
+
+  it("coerces optional process fields before rejecting an unavailable creation time", async () => {
+    setMarkerFile(markerJson(4242));
+    queuePowershell(
+      [out("Running")],
+      [
+        out(
+          processJson(4242, "first-tree-dev daemon start --no-interactive", {
+            ParentProcessId: "NaN",
+            Name: 123,
+            CreationTimeUtc: "",
+          }),
+        ),
+      ],
+    );
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: "refusing to taskkill untrusted service runtime marker pid 4242: process creation time is unavailable",
+    });
+  });
+
+  it("describes empty and truncated non-daemon process commands", async () => {
+    setMarkerFile(markerJson(4242));
+    const taskScheduler = await backend();
+
+    queuePowershell([out("Running")], [out(processJson(4242, "", { ExecutablePath: "" }))]);
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason:
+        "refusing to taskkill untrusted service runtime marker pid 4242: pid command does not match First Tree daemon start: empty command line",
+    });
+
+    const longCommand = "x".repeat(220);
+    queuePowershell([out("Running")], [out(processJson(4242, longCommand, { ExecutablePath: "" }))]);
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: expect.stringMatching(/pid command does not match First Tree daemon start: x+\.\.\.$/u),
+    });
+  });
+
+  it("rejects null, invalid-item, and failed supervisor process lists", async () => {
+    const taskScheduler = await backend();
+
+    queuePowershell([taskMissing()], [], [out("null")]);
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "supervisor process query returned malformed JSON",
+    });
+
+    queuePowershell([taskMissing()], [], [out("[null]")]);
+    expect(taskScheduler.status()).toMatchObject({
+      state: "unknown",
+      detail: "supervisor process query returned malformed JSON",
+    });
+
+    queuePowershell([taskMissing()], [], [outFail("", null)]);
+    expect(taskScheduler.status()).toMatchObject({ state: "unknown", detail: "powershell exit unknown" });
+
+    queuePowershell([taskMissing()], [], [outFail("initial query denied", 5)]);
+    expect(taskScheduler.stop()).toEqual({ ok: false, reason: "initial query denied" });
+  });
+
+  it("summarizes a long residual supervisor command after cleanup times out", async () => {
+    const process = supervisorJson(777, { Name: 123, CommandLine: "x".repeat(220) });
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(6001);
+    queuePowershell([taskMissing()], [], [out(process), out(process)]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: expect.stringMatching(/supervisor process still running after task end: 123 pid=777 x+\.\.\.$/u),
+    });
+  });
+
+  it("stringifies primitive marker filesystem failures", async () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readdirSync.mockImplementation(() => throwUnknown("marker directory denied"));
+    queuePowershell([out("Ready")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.start()).toEqual({
+      ok: false,
+      reason: "Unable to inspect runtime markers: marker directory denied",
+    });
+
+    fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+    fsMocks.readFileSync.mockImplementation(() => throwUnknown("marker read denied"));
+    queuePowershell([out("Running")]);
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: expect.stringContaining("marker read denied"),
+    });
+  });
+
+  it("skips non-marker files and markers for another runtime context", async () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readdirSync.mockReturnValue(["notes.txt", "version.json", "home.json", "mode.json"]);
+    fsMocks.readFileSync.mockImplementation((path) => {
+      const name = String(path);
+      if (name.endsWith("version.json")) return markerJson(4242, { version: 2 });
+      if (name.endsWith("home.json")) return markerJson(4242, { home: "C:\\Other" });
+      return markerJson(4242, { mode: "foreground" });
+    });
+    queuePowershell([out("Ready")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({ state: "inactive", detail: "task state Ready" });
+    expect(process.kill).not.toHaveBeenCalled();
+  });
+
+  it("removes invalid-pid markers before checking process liveness", async () => {
+    setMarkerFile(markerJson(0));
+    queuePowershell([out("Ready")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({ state: "inactive" });
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(expect.stringContaining("runtime.json"), { force: true });
+  });
+
+  it("treats primitive process-kill failures as an indeterminate live pid", async () => {
+    setMarkerFile(markerJson(4242));
+    vi.mocked(process.kill).mockImplementation(() => throwUnknown("permission denied"));
+    queuePowershell([out("Running")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.status()).toMatchObject({ state: "active", pid: 4242 });
+  });
+
+  it("skips a marker that dies between listing and stop prevalidation", async () => {
+    setMarkerFile(markerJson(4242));
+    let killCalls = 0;
+    vi.mocked(process.kill).mockImplementation(() => {
+      killCalls += 1;
+      if (killCalls === 2) throwUnknown(Object.assign(new Error("gone"), { code: "ESRCH" }));
+      return true;
+    });
+    queuePowershell([out("Running"), out("Ready")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: true });
+  });
+
+  it("accepts a marker that dies immediately before the kill phase", async () => {
+    setMarkerFile(markerJson(4242));
+    let killCalls = 0;
+    vi.mocked(process.kill).mockImplementation(() => {
+      killCalls += 1;
+      if (killCalls === 3) throwUnknown(Object.assign(new Error("gone"), { code: "ESRCH" }));
+      return true;
+    });
+    queuePowershell([out("Running"), out("Ready")], [out(processJson(4242))]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: true });
+  });
+
+  it("accepts a marker whose process query reports gone during the kill phase", async () => {
+    setMarkerFile(markerJson(4242));
+    queuePowershell([out("Running"), out("Ready")], [out(processJson(4242)), outFail("", 3)]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: true });
+  });
+
+  it("waits once when a gracefully killed marker exits after the first probe", async () => {
+    setMarkerFile(markerJson(4242));
+    vi.spyOn(Date, "now").mockReturnValue(0);
+    let killCalls = 0;
+    vi.mocked(process.kill).mockImplementation(() => {
+      killCalls += 1;
+      if (killCalls === 5) throwUnknown(Object.assign(new Error("gone"), { code: "ESRCH" }));
+      return true;
+    });
+    queuePowershell([out("Running"), out("Ready")], [out(processJson(4242)), out(processJson(4242))]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: true });
+    expect(sharedMocks.sleepSync).toHaveBeenCalledWith(200);
+  });
+
+  it("covers start, restart, and successful uninstall terminal states", async () => {
+    const taskScheduler = await backend();
+
+    queuePowershell([out("Running")]);
+    expect(taskScheduler.start()).toEqual({ ok: true, detail: "already running" });
+
+    queuePowershell([outFail("state unavailable", 5)]);
+    sharedMocks.runCapture.mockReturnValue(ok());
+    expect(taskScheduler.start()).toEqual({ ok: false, reason: "state unavailable" });
+
+    queuePowershell([outFail("restart state unavailable", 5)]);
+    expect(taskScheduler.restart()).toEqual({ ok: false, reason: "restart state unavailable" });
+
+    queuePowershell([taskMissing()], [], [out("")]);
+    expect(taskScheduler.uninstall()).toMatchObject({ state: "not-installed", detail: undefined });
   });
 });

--- a/apps/cli/src/__tests__/task-scheduler-marker-kill.test.ts
+++ b/apps/cli/src/__tests__/task-scheduler-marker-kill.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const sharedMocks = vi.hoisted(() => ({
+  ensureLogDir: vi.fn(),
+  readFileOrFlagDrift: vi.fn(),
+  resolveCliInvocation: vi.fn(() => ({ kind: "bin", program: "first-tree-dev" })),
+  runCapture: vi.fn(),
+  runCaptureOut: vi.fn(),
+  sleepSync: vi.fn(),
+}));
+
+const configMocks = vi.hoisted(() => ({
+  defaultHome: vi.fn(() => "C:\\FirstTree"),
+}));
+
+type ShellResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+type ShellOutResult =
+  | { readonly ok: true; readonly stdout: string }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+
+vi.mock("node:fs", () => fsMocks);
+vi.mock("@first-tree/shared/config", () => configMocks);
+vi.mock("../core/supervisor/shared.js", () => sharedMocks);
+
+function ok(): ShellResult {
+  return { ok: true };
+}
+
+function fail(stderr: string, code = 1): ShellResult {
+  return { ok: false, stderr, code };
+}
+
+function taskState(stdout: string): ShellOutResult {
+  return { ok: true, stdout };
+}
+
+function taskQueryFailure(stderr: string, code = 1): ShellOutResult {
+  return { ok: false, stderr, code };
+}
+
+function processGone(): ShellOutResult {
+  return { ok: false, stderr: "", code: 3 };
+}
+
+function markerJson(pid: number): string {
+  return JSON.stringify({
+    version: 1,
+    pid,
+    clientId: "client-1",
+    home: "C:\\FirstTree",
+    mode: "service",
+    createdAt: "2026-01-01T00:00:05.000Z",
+  });
+}
+
+function daemonProcessJson(pid: number): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: 100,
+    Name: "node.exe",
+    CommandLine: '"C:\\Program Files\\nodejs\\node.exe" "C:\\FirstTree\\cli\\index.mjs" daemon start --no-interactive',
+    ExecutablePath: "C:\\Program Files\\nodejs\\node.exe",
+    CreationTimeUtc: "2026-01-01T00:00:01.000Z",
+  });
+}
+
+async function backend(): Promise<typeof import("../core/supervisor/task-scheduler.js").taskSchedulerBackend> {
+  const { taskSchedulerBackend } = await import("../core/supervisor/task-scheduler.js");
+  return taskSchedulerBackend;
+}
+
+function queueTaskQueries(results: readonly ShellOutResult[], processResult: ShellOutResult): void {
+  const queue = [...results];
+  sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+    const script = String(args.at(-1) ?? "");
+    if (script.includes("Get-ScheduledTask")) return queue.shift() ?? taskState("Ready");
+    if (script.includes("ProcessId = 4242")) return processResult;
+    if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return { ok: true, stdout: "" };
+    throw new Error(`unexpected powershell script: ${script}`);
+  });
+}
+
+function setLiveMarker(): void {
+  fsMocks.existsSync.mockReturnValue(true);
+  fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+  fsMocks.readFileSync.mockReturnValue(markerJson(4242));
+}
+
+function setPidAliveUntilTaskkill(forcedOnly = false): void {
+  let killed = false;
+  vi.spyOn(process, "kill").mockImplementation(() => {
+    if (killed) throw Object.assign(new Error("gone"), { code: "ESRCH" });
+    return true;
+  });
+  sharedMocks.runCapture.mockImplementation((_program, args) => {
+    if (args.includes("/PID") && (!forcedOnly || args.includes("/F"))) killed = true;
+    return ok();
+  });
+}
+
+describe("task scheduler runtime marker stop paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.readdirSync.mockReturnValue([]);
+    fsMocks.readFileSync.mockReturnValue("");
+    sharedMocks.runCapture.mockReturnValue(ok());
+    queueTaskQueries([taskState("Ready")], { ok: true, stdout: daemonProcessJson(4242) });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("kills a trusted service runtime marker before ending a running task", async () => {
+    setLiveMarker();
+    setPidAliveUntilTaskkill();
+    queueTaskQueries([taskState("Running"), taskState("Ready")], { ok: true, stdout: daemonProcessJson(4242) });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: true });
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith(
+      "taskkill.exe",
+      expect.arrayContaining(["/PID", "4242"]),
+      10_000,
+    );
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith("schtasks.exe", expect.arrayContaining(["/End"]), 10_000);
+  });
+
+  it("escalates to forced taskkill when the graceful kill does not stop the marker pid", async () => {
+    setLiveMarker();
+    setPidAliveUntilTaskkill(true);
+    const times = [0, 6000, 12_000, 18_000, 24_000, 24_000];
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      return times.shift() ?? 24_000;
+    });
+    queueTaskQueries([taskState("Running"), taskState("Ready")], { ok: true, stdout: daemonProcessJson(4242) });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: true });
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith(
+      "taskkill.exe",
+      expect.arrayContaining(["/PID", "4242", "/F"]),
+      10_000,
+    );
+  });
+
+  it("reports the forced taskkill failure when the marker pid remains alive", async () => {
+    setLiveMarker();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    let tick = -1;
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      tick += 1;
+      return tick * 6000;
+    });
+    sharedMocks.runCapture.mockImplementation((_program, args) => (args.includes("/PID") ? fail("denied", 5) : ok()));
+    queueTaskQueries([taskState("Running")], { ok: true, stdout: daemonProcessJson(4242) });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: false, reason: "denied" });
+  });
+
+  it("reports when the scheduled task remains running after the end request", async () => {
+    queueTaskQueries([taskState("Running"), taskState("Running")], { ok: true, stdout: daemonProcessJson(4242) });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: false, reason: "task did not stop: task running" });
+  });
+
+  it("ignores a marker pid that disappears between liveness and trust checks", async () => {
+    setLiveMarker();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    queueTaskQueries([taskState("Running"), taskState("Ready")], processGone());
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: true });
+    expect(sharedMocks.runCapture).not.toHaveBeenCalledWith(
+      "taskkill.exe",
+      expect.arrayContaining(["/PID", "4242"]),
+      10_000,
+    );
+  });
+
+  it("reports task state query errors after the end request", async () => {
+    queueTaskQueries([taskState("Running"), taskQueryFailure("still busy", 9)], {
+      ok: true,
+      stdout: daemonProcessJson(4242),
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({ ok: false, reason: "task did not stop: still busy" });
+  });
+});

--- a/apps/cli/src/__tests__/task-scheduler-operations.test.ts
+++ b/apps/cli/src/__tests__/task-scheduler-operations.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const sharedMocks = vi.hoisted(() => ({
+  ensureLogDir: vi.fn(),
+  readFileOrFlagDrift: vi.fn(),
+  resolveCliInvocation: vi.fn(() => ({ kind: "bin", program: "first-tree-dev" })),
+  runCapture: vi.fn(),
+  runCaptureOut: vi.fn(),
+  sleepSync: vi.fn(),
+}));
+
+const configMocks = vi.hoisted(() => ({
+  defaultHome: vi.fn(() => "C:\\FirstTree"),
+}));
+
+type ShellResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+type ShellOutResult =
+  | { readonly ok: true; readonly stdout: string }
+  | { readonly ok: false; readonly stderr: string; readonly code: number | null };
+
+vi.mock("node:fs", () => fsMocks);
+vi.mock("@first-tree/shared/config", () => configMocks);
+vi.mock("../core/supervisor/shared.js", () => sharedMocks);
+
+function ok(): ShellResult {
+  return { ok: true };
+}
+
+function fail(stderr: string, code = 1): ShellResult {
+  return { ok: false, stderr, code };
+}
+
+function taskState(stdout: string): ShellOutResult {
+  return { ok: true, stdout };
+}
+
+function taskMissing(): ShellOutResult {
+  return { ok: false, stderr: "task not found", code: 3 };
+}
+
+function supervisorProcesses(stdout = ""): ShellOutResult {
+  return { ok: true, stdout };
+}
+
+function runtimeMarker(pid: number): string {
+  return JSON.stringify({
+    version: 1,
+    pid,
+    clientId: "client-1",
+    home: "C:\\FirstTree",
+    mode: "service",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  });
+}
+
+function supervisorProcess(pid: number): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: 100,
+    Name: "wscript.exe",
+    CommandLine: '"C:\\FirstTree\\service\\first-tree-dev-supervisor.vbs"',
+    ExecutablePath: "C:\\Windows\\System32\\wscript.exe",
+    CreationTimeUtc: "2026-01-01T00:00:00.000Z",
+  });
+}
+
+async function backend(): Promise<typeof import("../core/supervisor/task-scheduler.js").taskSchedulerBackend> {
+  const { taskSchedulerBackend } = await import("../core/supervisor/task-scheduler.js");
+  return taskSchedulerBackend;
+}
+
+function queueTaskQueries(results: readonly ShellOutResult[]): void {
+  const queue = [...results];
+  sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+    const script = String(args.at(-1) ?? "");
+    if (script.includes("Get-ScheduledTask")) return queue.shift() ?? taskState("Ready");
+    if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return supervisorProcesses();
+    throw new Error(`unexpected powershell script: ${script}`);
+  });
+}
+
+describe("task scheduler service operations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.readdirSync.mockReturnValue([]);
+    fsMocks.readFileSync.mockReturnValue("");
+    sharedMocks.runCapture.mockReturnValue(ok());
+    queueTaskQueries([taskState("Ready")]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("installs supervisor files, registers the task, and requests a run", async () => {
+    const taskScheduler = await backend();
+
+    const info = taskScheduler.install();
+
+    expect(info).toMatchObject({
+      platform: "task-scheduler",
+      state: "active",
+      detail: "task run requested",
+    });
+    expect(sharedMocks.ensureLogDir).toHaveBeenCalledTimes(1);
+    expect(fsMocks.writeFileSync).toHaveBeenCalledTimes(3);
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith(
+      "schtasks.exe",
+      expect.arrayContaining(["/Create", "/F"]),
+      10_000,
+    );
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith("schtasks.exe", expect.arrayContaining(["/Run"]), 10_000);
+  });
+
+  it("rejects start when the task is missing", async () => {
+    queueTaskQueries([taskMissing()]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.start()).toEqual({ ok: false, reason: "service not installed" });
+  });
+
+  it("starts a registered task after proving no runtime or supervisor process is live", async () => {
+    queueTaskQueries([taskState("Ready")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.start()).toEqual({ ok: true });
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith("schtasks.exe", expect.arrayContaining(["/Run"]), 10_000);
+  });
+
+  it("stops a running task without a marker and returns the residual-process warning", async () => {
+    queueTaskQueries([taskState("Running"), taskState("Ready")]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: true,
+      detail: "task ended without a runtime marker; check Task Manager for any residual first-tree process",
+    });
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith("schtasks.exe", expect.arrayContaining(["/End"]), 10_000);
+  });
+
+  it("refuses stop when a live runtime marker cannot be trusted", async () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+    fsMocks.readFileSync.mockReturnValue(runtimeMarker(4242));
+    sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+      const script = String(args.at(-1) ?? "");
+      if (script.includes("Get-ScheduledTask")) return taskState("Running");
+      if (script.includes("ProcessId = 4242")) return { ok: false, stderr: "access denied", code: 5 };
+      throw new Error(`unexpected powershell script: ${script}`);
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: "refusing to taskkill untrusted service runtime marker pid 4242: access denied",
+    });
+  });
+
+  it("uninstalls task artifacts and preserves a stop warning as status detail", async () => {
+    queueTaskQueries([{ ok: false, stderr: "state query failed", code: 5 }]);
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.uninstall()).toMatchObject({
+      state: "not-installed",
+      detail: "state query failed",
+    });
+    expect(sharedMocks.runCapture).toHaveBeenCalledWith(
+      "schtasks.exe",
+      expect.arrayContaining(["/Delete", "/F"]),
+      10_000,
+    );
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(expect.stringContaining("supervisor.cmd"), { force: true });
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(expect.stringContaining("supervisor.vbs"), { force: true });
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(expect.stringContaining("task.xml"), { force: true });
+  });
+
+  it("throws when deleting the task fails with a native Windows error", async () => {
+    queueTaskQueries([taskMissing()]);
+    sharedMocks.runCapture.mockImplementation((_program, args) =>
+      args.includes("/Delete") ? fail("localized failure", 87) : ok(),
+    );
+    const taskScheduler = await backend();
+
+    expect(() => taskScheduler.uninstall()).toThrow("schtasks /Delete failed: localized failure");
+  });
+
+  it("reports residual supervisor cleanup timeouts after a missing task stop", async () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(6000);
+    queueTaskQueries([taskMissing()]);
+    sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+      const script = String(args.at(-1) ?? "");
+      if (script.includes("Get-ScheduledTask")) return taskMissing();
+      if (script.includes("Get-CimInstance Win32_Process | Where-Object")) {
+        return supervisorProcesses(supervisorProcess(777));
+      }
+      throw new Error(`unexpected powershell script: ${script}`);
+    });
+    const taskScheduler = await backend();
+
+    expect(taskScheduler.stop()).toEqual({
+      ok: false,
+      reason: expect.stringContaining("supervisor process still running after task end"),
+    });
+  });
+});

--- a/apps/cli/src/__tests__/task-scheduler-status.test.ts
+++ b/apps/cli/src/__tests__/task-scheduler-status.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+const sharedMocks = vi.hoisted(() => ({
+  ensureLogDir: vi.fn(),
+  readFileOrFlagDrift: vi.fn(),
+  resolveCliInvocation: vi.fn(),
+  runCapture: vi.fn(),
+  runCaptureOut: vi.fn(),
+  sleepSync: vi.fn(),
+}));
+
+const configMocks = vi.hoisted(() => ({
+  defaultHome: vi.fn(() => "C:\\FirstTree"),
+}));
+
+vi.mock("node:fs", () => fsMocks);
+vi.mock("@first-tree/shared/config", () => configMocks);
+vi.mock("../core/supervisor/shared.js", () => sharedMocks);
+
+const taskQuery = {
+  code: 0,
+  ok: true,
+  stderr: "",
+  stdout: "Ready",
+};
+
+const supervisorQuery = {
+  code: 0,
+  ok: true,
+  stderr: "",
+  stdout: "",
+};
+
+function setTaskQuery(stdout: string, code = 0): void {
+  taskQuery.code = code;
+  taskQuery.ok = code === 0;
+  taskQuery.stdout = stdout;
+  taskQuery.stderr = "";
+}
+
+function setSupervisorQuery(stdout: string): void {
+  supervisorQuery.stdout = stdout;
+}
+
+function markerJson(pid: number): string {
+  return JSON.stringify({
+    version: 1,
+    pid,
+    clientId: "client-1",
+    home: "C:\\FirstTree",
+    mode: "service",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  });
+}
+
+function supervisorProcessJson(pid: number): string {
+  return JSON.stringify({
+    ProcessId: pid,
+    ParentProcessId: 100,
+    Name: "wscript.exe",
+    CommandLine: '"C:\\FirstTree\\service\\first-tree-dev-supervisor.vbs"',
+    ExecutablePath: "C:\\Windows\\System32\\wscript.exe",
+    CreationTimeUtc: "2026-01-01T00:00:00.000Z",
+  });
+}
+
+async function status(): Promise<
+  ReturnType<typeof import("../core/supervisor/task-scheduler.js").taskSchedulerBackend.status>
+> {
+  const { taskSchedulerBackend } = await import("../core/supervisor/task-scheduler.js");
+  return taskSchedulerBackend.status();
+}
+
+describe("task scheduler status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+    setTaskQuery("Ready");
+    setSupervisorQuery("");
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.readdirSync.mockReturnValue([]);
+    fsMocks.readFileSync.mockReturnValue("");
+    sharedMocks.runCaptureOut.mockImplementation((_program, args) => {
+      const script = String(args.at(-1) ?? "");
+      if (script.includes("Get-ScheduledTask")) return taskQuery;
+      if (script.includes("Get-CimInstance Win32_Process | Where-Object")) return supervisorQuery;
+      throw new Error(`unexpected powershell script: ${script}`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("reports not-installed when the task is missing and no runtime or supervisor process is live", async () => {
+    setTaskQuery("", 3);
+
+    await expect(status()).resolves.toMatchObject({
+      platform: "task-scheduler",
+      state: "not-installed",
+    });
+  });
+
+  it("reports active with the service runtime marker pid when the task is running", async () => {
+    setTaskQuery("Running");
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readdirSync.mockReturnValue(["runtime.json"]);
+    fsMocks.readFileSync.mockReturnValue(markerJson(4242));
+
+    await expect(status()).resolves.toMatchObject({
+      state: "active",
+      pid: 4242,
+      detail: "pid 4242",
+    });
+  });
+
+  it("reports unknown when the task is running without a live service runtime marker", async () => {
+    setTaskQuery("Running");
+
+    await expect(status()).resolves.toMatchObject({
+      state: "unknown",
+      detail: "task running but no live service runtime marker",
+    });
+  });
+
+  it("reports residual supervisor processes when the task is not running", async () => {
+    setTaskQuery("Ready");
+    setSupervisorQuery(supervisorProcessJson(777));
+
+    await expect(status()).resolves.toMatchObject({
+      state: "unknown",
+      detail: "task not running but supervisor process is still live",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/unsupported-supervisor.test.ts
+++ b/apps/cli/src/__tests__/unsupported-supervisor.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { unsupportedBackend } from "../core/supervisor/unsupported.js";
+
+describe("unsupported supervisor backend", () => {
+  it("reports unsupported service metadata without throwing", () => {
+    expect(unsupportedBackend.platform).toBe("unsupported");
+    expect(unsupportedBackend.isSupported()).toBe(false);
+    expect(unsupportedBackend.isUnitDriftDetected()).toBe(false);
+
+    expect(unsupportedBackend.status()).toMatchObject({
+      platform: "unsupported",
+      state: "not-installed",
+      detail: expect.stringContaining(`platform ${process.platform} not supported`),
+    });
+    expect(unsupportedBackend.uninstall()).toMatchObject({
+      platform: "unsupported",
+      state: "not-installed",
+    });
+  });
+
+  it("rejects service control operations with platform-specific reasons", () => {
+    for (const control of [unsupportedBackend.start, unsupportedBackend.stop, unsupportedBackend.restart]) {
+      expect(control()).toEqual({
+        ok: false,
+        reason: `service control not supported on ${process.platform}`,
+      });
+    }
+  });
+
+  it("throws actionable install and refresh guidance", () => {
+    expect(() => unsupportedBackend.install()).toThrow("Background service install is not supported");
+    expect(() => unsupportedBackend.install()).toThrow("daemon start");
+    expect(() => unsupportedBackend.refreshForUpdate()).toThrow("Background service refresh is not supported");
+    expect(() => unsupportedBackend.refreshForUpdate()).toThrow("daemon start");
+  });
+});

--- a/apps/cli/src/__tests__/wsl-dbus.test.ts
+++ b/apps/cli/src/__tests__/wsl-dbus.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isWslDbusOvermount } from "../commands/daemon/_shared/wsl-dbus.js";
+
+const readFileSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: readFileSyncMock,
+  };
+});
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+describe("isWslDbusOvermount", () => {
+  beforeEach(() => {
+    readFileSyncMock.mockReset();
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it("returns false without reading /proc/version outside Linux", () => {
+    setPlatform("darwin");
+    readFileSyncMock.mockReturnValue("Linux version 5.15.90.1-microsoft-standard-WSL2");
+
+    expect(isWslDbusOvermount("Failed to connect to bus: No such file or directory")).toBe(false);
+    expect(readFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false without reading /proc/version when the reason is not a dbus connection failure", () => {
+    setPlatform("linux");
+    readFileSyncMock.mockReturnValue("Linux version 5.15.90.1-microsoft-standard-WSL2");
+
+    expect(isWslDbusOvermount("systemctl exited with code 1")).toBe(false);
+    expect(readFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("detects the WSL dbus overmount from a Linux Microsoft kernel banner", () => {
+    setPlatform("linux");
+    readFileSyncMock.mockReturnValue("Linux version 5.15.90.1-microsoft-standard-WSL2");
+
+    expect(isWslDbusOvermount("failed to connect to bus: no such file or directory")).toBe(true);
+    expect(readFileSyncMock).toHaveBeenCalledWith("/proc/version", "utf8");
+  });
+
+  it("returns false for Linux kernels that are not WSL", () => {
+    setPlatform("linux");
+    readFileSyncMock.mockReturnValue("Linux version 6.8.0-generic");
+
+    expect(isWslDbusOvermount("FAILED TO CONNECT TO BUS: No such file or directory")).toBe(false);
+  });
+
+  it("returns false when /proc/version cannot be read", () => {
+    setPlatform("linux");
+    readFileSyncMock.mockImplementation(() => {
+      throw new Error("permission denied");
+    });
+
+    expect(isWslDbusOvermount("Failed to connect to bus: No such file or directory")).toBe(false);
+  });
+});

--- a/packages/client/src/__tests__/claude-code-capability-extra.test.ts
+++ b/packages/client/src/__tests__/claude-code-capability-extra.test.ts
@@ -1,0 +1,81 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { probeClaudeCodeCapability, resolveBundledClaudeBinary } from "../runtime/capabilities/claude-code.js";
+
+const originalPlatform = process.platform;
+const originalArch = process.arch;
+
+function setProcessTarget(platform: NodeJS.Platform, arch: NodeJS.Architecture): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+  Object.defineProperty(process, "arch", { configurable: true, value: arch });
+}
+
+afterEach(() => {
+  setProcessTarget(originalPlatform, originalArch);
+  vi.doUnmock("node:module");
+  vi.resetModules();
+});
+
+describe("resolveBundledClaudeBinary edge cases", () => {
+  it("reports unsupported platform targets before resolving platform packages", () => {
+    const root = mkdtempSync(join(tmpdir(), "claude-unsupported-"));
+    try {
+      const sdkDir = join(root, "sdk");
+      mkdirSync(sdkDir);
+      setProcessTarget("freebsd", "x64");
+
+      expect(() => resolveBundledClaudeBinary({ locateSdkDir: () => sdkDir })).toThrow(
+        /no bundled Claude binary for freebsd-x64/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("treats absent optional platform packages as unresolved candidates", async () => {
+    const root = mkdtempSync(join(tmpdir(), "claude-platform-missing-"));
+    try {
+      const sdkDir = join(root, "sdk");
+      mkdirSync(sdkDir);
+      vi.resetModules();
+      vi.doMock("node:module", async (importOriginal) => {
+        const actual = await importOriginal<typeof import("node:module")>();
+        return {
+          ...actual,
+          createRequire: () => ({
+            resolve: (specifier: string) => {
+              throw new Error(`missing ${specifier}`);
+            },
+          }),
+        };
+      });
+      const mod = await import("../runtime/capabilities/claude-code.js");
+
+      expect(() => mod.resolveBundledClaudeBinary({ locateSdkDir: () => sdkDir })).toThrow(
+        /no installed Claude native binary/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("probeClaudeCodeCapability edge cases", () => {
+  it("prefixes a bad override when a resolved path is missing and the bundle is absent", async () => {
+    const entry = await probeClaudeCodeCapability({
+      resolveExecutable: () => ({
+        path: "/missing/claude",
+        source: "path",
+        overrideError: "CLAUDE_CODE_EXECUTABLE points at a missing file",
+      }),
+      resolveBundled: () => ({ kind: "native", path: "/missing/bundled-claude" }),
+      exists: () => false,
+    });
+
+    expect(entry.state).toBe("missing");
+    expect(entry.error).toContain("CLAUDE_CODE_EXECUTABLE points at a missing file");
+    expect(entry.error).toContain("/missing/bundled-claude");
+  });
+});

--- a/packages/client/src/__tests__/claude-code-capability-extra.test.ts
+++ b/packages/client/src/__tests__/claude-code-capability-extra.test.ts
@@ -39,6 +39,7 @@ describe("resolveBundledClaudeBinary edge cases", () => {
     try {
       const sdkDir = join(root, "sdk");
       mkdirSync(sdkDir);
+      setProcessTarget("linux", "x64");
       vi.resetModules();
       vi.doMock("node:module", async (importOriginal) => {
         const actual = await importOriginal<typeof import("node:module")>();

--- a/packages/client/src/__tests__/claude-code-tool-events-search-edge.test.ts
+++ b/packages/client/src/__tests__/claude-code-tool-events-search-edge.test.ts
@@ -1,0 +1,49 @@
+import type { SessionEvent } from "@first-tree/shared";
+import { describe, expect, it, vi } from "vitest";
+import { createToolCallProcessor } from "../handlers/claude-code.js";
+
+function assistantToolUse(id: string, name: string, input: unknown) {
+  return {
+    type: "assistant",
+    message: {
+      role: "assistant",
+      content: [{ type: "tool_use", id, name, input }],
+    },
+  };
+}
+
+function userToolResult(toolUseId: string, content: unknown) {
+  return {
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content }],
+    },
+  };
+}
+
+function finalToolCall(events: readonly SessionEvent[]): Extract<SessionEvent, { kind: "tool_call" }> {
+  const event = events.find((candidate) => candidate.kind === "tool_call" && candidate.payload.status === "ok");
+  if (!event || event.kind !== "tool_call") throw new Error("expected final tool_call event");
+  return event;
+}
+
+describe("createToolCallProcessor — search path edge refs", () => {
+  it("emits a directory search ref for an absolute missing path without a Context Tree binding", () => {
+    const events: SessionEvent[] = [];
+    const emit = vi.fn<(event: SessionEvent) => void>((event) => events.push(event));
+    const processor = createToolCallProcessor(emit);
+
+    processor.onMessage(assistantToolUse("grep-missing", "Grep", { path: "/tmp/first-tree-missing-search-root" }));
+    processor.onMessage(userToolResult("grep-missing", "no matches"));
+
+    const event = finalToolCall(events);
+    expect(event.payload.toolFileRefs).toEqual([
+      {
+        origin: "tool_arg",
+        localPath: "/tmp/first-tree-missing-search-root",
+        pathKind: "directory",
+      },
+    ]);
+  });
+});

--- a/packages/client/src/__tests__/client-connection-more-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-more-coverage.test.ts
@@ -27,6 +27,7 @@ type ClientConnectionPrivate = {
   registered: boolean;
   pausedReason: ClientPausedReason | null;
   authRefreshTimer: ReturnType<typeof setTimeout> | null;
+  nextReconnectMinDelayMs: number;
   desiredBindings: Map<string, { agentId: string; runtimeType: string; runtimeVersion?: string }>;
   boundAgents: Map<string, BoundAgent>;
   bindRetryRecords: Map<string, BindRetryRecord>;
@@ -412,5 +413,238 @@ describe("ClientConnection — additional branch coverage", () => {
     await connectingConnection.disconnect();
 
     expect(connectingSocket.terminate).toHaveBeenCalledOnce();
+  });
+
+  it("covers legacy inbox acks, duplicate confirmed acks, and rejection confirmations", async () => {
+    vi.useFakeTimers();
+    const connection = await makeConnection();
+
+    await expect(connection.sendInboxAck(1, "agent-1")).resolves.toBeUndefined();
+
+    const legacySocket = await openRegisteredConnection(connection);
+    await bindAgent(connection, legacySocket);
+    expect(connection.agents.has("agent-1")).toBe(true);
+
+    await expect(connection.sendInboxAck(2, "agent-1")).resolves.toBeUndefined();
+    expect(parseSent(legacySocket, legacySocket.sent.length - 1)).toEqual({ type: "inbox:ack", entryId: 2 });
+
+    const confirmed = await makeConnection({ clientId: "client_confirmed_rejections" });
+    const socket = await openRegisteredConnection(confirmed, {
+      wsInboxAckConfirm: true,
+      wsSessionEventConfirm: true,
+    });
+    await bindAgent(confirmed, socket);
+
+    const ackPromise = confirmed.sendInboxAck(202, "agent-1");
+    const sameAckPromise = confirmed.sendInboxAck(202, "agent-1");
+    expect(sameAckPromise).toBe(ackPromise);
+    const ackFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({ type: "inbox:ack:rejected", entryId: "bad", ref: ackFrame.ref, reason: "prefix_gap" });
+    socket.emitMessage({ type: "inbox:ack:rejected", entryId: 202, ref: "wrong", reason: "failed_or_dead" });
+    socket.emitMessage({ type: "inbox:ack:rejected", entryId: 202, ref: ackFrame.ref, reason: "prefix_gap" });
+    await expect(ackPromise).rejects.toThrow("inbox:ack rejected (prefix_gap)");
+
+    const recoverPromise = confirmed.sendInboxRecover("agent-1", "chat-reject");
+    const recoverFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "inbox:recover:rejected",
+      ref: recoverFrame.ref,
+      agentId: 42,
+      chatId: "chat-reject",
+      reason: "recover_failed",
+    });
+    socket.emitMessage({
+      type: "inbox:recover:rejected",
+      ref: recoverFrame.ref,
+      agentId: "other-agent",
+      chatId: "chat-reject",
+      reason: "agent_not_bound",
+    });
+    socket.emitMessage({
+      type: "inbox:recover:rejected",
+      ref: recoverFrame.ref,
+      agentId: "agent-1",
+      chatId: "chat-reject",
+      reason: "recover_failed",
+    });
+    await expect(recoverPromise).rejects.toThrow("inbox:recover rejected (recover_failed)");
+
+    const eventPromise = confirmed.reportSessionEventConfirmed("agent-1", "chat-reject", sessionEvent("reject"));
+    const eventFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "session:event:rejected",
+      ref: eventFrame.ref,
+      agentId: 42,
+      chatId: "chat-reject",
+      reason: "malformed",
+    });
+    socket.emitMessage({
+      type: "session:event:rejected",
+      ref: eventFrame.ref,
+      agentId: "other-agent",
+      chatId: "chat-reject",
+      reason: "agent_not_bound",
+    });
+    socket.emitMessage({
+      type: "session:event:rejected",
+      ref: eventFrame.ref,
+      agentId: "agent-1",
+      chatId: "chat-reject",
+      reason: "persist_failed",
+    });
+    await expect(eventPromise).rejects.toThrow("session:event rejected (persist_failed)");
+
+    priv(connection).clearTimers();
+    priv(confirmed).clearTimers();
+  });
+
+  it("handles auth control frames and register rejection variants", async () => {
+    vi.useFakeTimers();
+    const retryable = await makeConnection({ clientId: "client_retryable_auth" });
+    const retryableSocket = await openRegisteredConnection(retryable);
+
+    retryableSocket.emitMessage({
+      type: "auth:retryable",
+      code: "auth_backend_unavailable",
+      retryAfterMs: 12_345,
+      message: "try later",
+    });
+
+    expect(retryableSocket.closeCalls.at(-1)).toEqual({ code: 1013, reason: "auth retryable" });
+
+    const malformedRetryable = await makeConnection({ clientId: "client_retryable_malformed" });
+    const malformedRetryableSocket = await openRegisteredConnection(malformedRetryable);
+    malformedRetryableSocket.emitMessage({ type: "auth:retryable", code: "unknown_retryable_code" });
+    expect(malformedRetryableSocket.closeCalls.at(-1)).toEqual({ code: 1013, reason: "auth retryable" });
+
+    const rejected = await makeConnection({ clientId: "client_auth_rejected" });
+    const rejectedSocket = await openRegisteredConnection(rejected);
+    const paused: ClientPausedReason[] = [];
+    const fatalNames: string[] = [];
+    rejected.on("auth:paused", (reason) => paused.push(reason));
+    rejected.on("auth:fatal", (err) => fatalNames.push(err.name));
+
+    rejectedSocket.emitMessage({ type: "auth:rejected", code: "invalid_token", message: "bad jwt" });
+    rejectedSocket.emitMessage({ type: "auth:rejected", code: "future_code", reason: "legacy bad" });
+
+    expect(rejected.isPaused()).toBe(true);
+    expect(paused).toEqual(["auth_rejected", "auth_rejected"]);
+    expect(fatalNames).toEqual(["ServerAuthRejectedError", "ServerAuthRejectedError"]);
+    expect(rejectedSocket.closeCalls.at(-1)).toEqual({ code: 4401, reason: "auth rejected" });
+
+    const userMismatch = await makeConnection({ clientId: "client_user_mismatch" });
+    const userSocket = await openRegisteredConnection(userMismatch);
+    const userErrors: string[] = [];
+    userMismatch.on("error", (err) => userErrors.push(`${err.name}:${err.message}`));
+    userSocket.emitMessage({
+      type: "client:register:rejected",
+      code: "CLIENT_USER_MISMATCH",
+      message: "belongs to somebody else",
+    });
+    expect(userErrors).toContain("ClientUserMismatchError:belongs to somebody else");
+
+    const orgMismatch = await makeConnection({ clientId: "client_org_mismatch" });
+    const orgSocket = await openRegisteredConnection(orgMismatch);
+    const orgErrors: string[] = [];
+    orgMismatch.on("error", (err) => orgErrors.push(`${err.name}:${err.message}`));
+    orgSocket.emitMessage({
+      type: "client:register:rejected",
+      code: "CLIENT_ORG_MISMATCH",
+      message: "wrong org",
+    });
+    expect(orgErrors).toContain("ClientOrgMismatchError:wrong org");
+
+    const genericRejected = await makeConnection({ clientId: "client_generic_register_rejected" });
+    const genericSocket = await openRegisteredConnection(genericRejected);
+    const genericErrors: string[] = [];
+    genericRejected.on("error", (err) => genericErrors.push(`${err.name}:${err.message}`));
+    genericSocket.emitMessage({ type: "client:register:rejected", message: "schema drift" });
+    expect(genericErrors).toContain("Error:client:register rejected: schema drift");
+
+    for (const conn of [retryable, malformedRetryable, rejected, userMismatch, orgMismatch, genericRejected]) {
+      priv(conn).clearTimers();
+    }
+  });
+
+  it("covers rebind recovery, rebind rejection, force disconnect, and control events", async () => {
+    const connection = await makeConnection();
+    const socket = await openRegisteredConnection(connection, {
+      wsInboxAckConfirm: true,
+      wsSessionEventConfirm: true,
+    });
+    await bindAgent(connection, socket, "agent-1");
+
+    const unbound: Array<{ agentId: string; reason?: string }> = [];
+    const recovered: unknown[] = [];
+    const commands: unknown[] = [];
+    const runtimeAuthStarts: unknown[] = [];
+    const reconciles: unknown[] = [];
+    connection.on("agent:unbound", (agentId, reason) => unbound.push({ agentId, reason }));
+    connection.on("resilience.bind.recovered", (payload) => recovered.push(payload));
+    connection.on("session:command", (command) => commands.push(command));
+    connection.on("runtime-auth:start", (command) => runtimeAuthStarts.push(command));
+    connection.on("session:reconcile:result", (result) => reconciles.push(result));
+
+    const pendingRecover = connection.sendInboxRecover("agent-1", "chat-force");
+    const pendingEvent = connection.reportSessionEventConfirmed("agent-1", "chat-force", sessionEvent("force"));
+    connection.sendInboxAck(303, "agent-1").catch(() => undefined);
+
+    socket.emitMessage({ type: "agent:force_disconnect", agentId: "agent-1", reason: "maintenance" });
+    await expect(pendingRecover).rejects.toThrow("agent_force_disconnect");
+    await expect(pendingEvent).rejects.toThrow("agent_force_disconnect");
+    expect(unbound).toContainEqual({ agentId: "agent-1", reason: "maintenance" });
+
+    priv(connection).desiredBindings.set("agent-1", {
+      agentId: "agent-1",
+      runtimeType: "codex",
+      runtimeVersion: "1.0",
+    });
+    priv(connection).bindRetryRecords.set("agent-1", {
+      attempts: 3,
+      nextAllowedAt: 0,
+      lastReason: "bind_wrong_client",
+    });
+    priv(connection).rebindAgents();
+
+    const reboundFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "agent:bound",
+      ref: reboundFrame.ref,
+      agentId: "agent-1",
+      displayName: null,
+      runtimeSessionToken: "",
+    });
+    await flushMicrotasks();
+    expect(recovered).toContainEqual({ agentId: "agent-1", totalAttempts: 3 });
+    expect(connection.agents.get("agent-1")?.displayName).toBe("agent-1");
+
+    priv(connection).desiredBindings.set("agent-2", { agentId: "agent-2", runtimeType: "codex" });
+    priv(connection).bindRetryRecords.set("agent-2", {
+      attempts: 1,
+      nextAllowedAt: 0,
+      lastReason: "bind_retryable",
+    });
+    priv(connection).rebindAgents();
+    const rejectedFrame = parseSent(socket, socket.sent.length - 1);
+    socket.emitMessage({
+      type: "agent:bind:rejected",
+      ref: rejectedFrame.ref,
+      reason: "wrong_client",
+    });
+    await flushMicrotasks();
+    expect(unbound).toContainEqual({ agentId: "agent-2" });
+
+    socket.emitMessage({ type: "agent:unbound", agentId: "agent-1" });
+    expect(unbound).toContainEqual({ agentId: "agent-1" });
+
+    socket.emitMessage({ type: "session:resume", agentId: "agent-1", chatId: "chat-1" });
+    socket.emitMessage({ type: "runtime-auth:start", provider: "codex", method: "browser", ref: "auth-ref" });
+    socket.emitMessage({ type: "session:reconcile:result", agentId: "agent-1", staleChatIds: ["chat-1"] });
+
+    expect(commands).toContainEqual({ type: "session:resume", agentId: "agent-1", chatId: "chat-1" });
+    expect(runtimeAuthStarts).toContainEqual({ provider: "codex", method: "browser", ref: "auth-ref" });
+    expect(reconciles).toContainEqual({ agentId: "agent-1", staleChatIds: ["chat-1"] });
+
+    priv(connection).clearTimers();
   });
 });

--- a/packages/client/src/__tests__/client-connection-more-coverage.test.ts
+++ b/packages/client/src/__tests__/client-connection-more-coverage.test.ts
@@ -223,6 +223,19 @@ describe("ClientConnection — additional branch coverage", () => {
     });
     socket.emitMessage({ type: "inbox:ack:accepted", entryId: 101, ref: "wrong-ref", disposition: "acked" });
     socket.emitMessage({
+      type: "inbox:ack:accepted",
+      entryId: "bad",
+      ref: ackFrame.ref,
+      disposition: "acked",
+    });
+    socket.emitMessage({
+      type: "inbox:recover:accepted",
+      ref: recoverFrame.ref,
+      agentId: "agent-1",
+      chatId: "chat-1",
+      resetCount: "bad",
+    });
+    socket.emitMessage({
       type: "inbox:recover:accepted",
       ref: recoverFrame.ref,
       agentId: "agent-1",
@@ -235,6 +248,29 @@ describe("ClientConnection — additional branch coverage", () => {
     expect(commands).toEqual([]);
     expect(pins).toEqual([]);
     expect(runtimeAuthStarts).toEqual([]);
+
+    const deliveredFrame = {
+      type: "inbox:deliver",
+      entryId: 102,
+      inboxId: "inbox-agent-1",
+      chatId: "chat-1",
+      message: {
+        id: "message-1",
+        chatId: "chat-1",
+        senderId: "agent-sender",
+        format: "text",
+        content: "hello",
+        metadata: {},
+        inReplyTo: null,
+        source: null,
+        createdAt: "2026-07-10T00:00:00.000Z",
+        configVersion: 1,
+        recipientMode: "full",
+        precedingMessages: [],
+      },
+    };
+    socket.emitMessage(deliveredFrame);
+    expect(delivered).toEqual([{ agentId: "inbox-agent-1", frame: deliveredFrame }]);
 
     socket.emitMessage({
       type: "session:event:accepted",
@@ -413,6 +449,56 @@ describe("ClientConnection — additional branch coverage", () => {
     await connectingConnection.disconnect();
 
     expect(connectingSocket.terminate).toHaveBeenCalledOnce();
+  });
+
+  it("rejects every pending operation during disconnect", async () => {
+    const connection = await makeConnection({ clientId: "client_disconnect_pending" });
+    const internal = priv(connection);
+    const socket = await openRegisteredConnection(connection, {
+      wsInboxAckConfirm: true,
+      wsSessionEventConfirm: true,
+    });
+    await bindAgent(connection, socket);
+
+    const pendingBind = internal.sendBind("agent-2", "codex");
+    const pendingAck = connection.sendInboxAck(404, "agent-1");
+    const pendingRecover = connection.sendInboxRecover("agent-1", "chat-disconnect");
+    const pendingEvent = connection.reportSessionEventConfirmed(
+      "agent-1",
+      "chat-disconnect",
+      sessionEvent("disconnect"),
+    );
+    const rejections = [pendingBind, pendingAck, pendingRecover, pendingEvent].map((pending) =>
+      expect(pending).rejects.toThrow("Client disconnected"),
+    );
+
+    await connection.disconnect();
+
+    await Promise.all(rejections);
+  });
+
+  it("rejects unavailable operations and falls back before reporting unsupported confirmation", async () => {
+    const connection = await makeConnection({ clientId: "client_unavailable_operations" });
+
+    connection.clearPaused();
+    expect(connection.isPaused()).toBe(false);
+    await expect(connection.sendInboxRecover("agent-1", "chat-unavailable")).rejects.toThrow("socket not bound");
+    await expect(connection.bindAgent("agent-1", "codex")).rejects.toThrow("Client not connected");
+
+    const socket = await openRegisteredConnection(connection);
+    await bindAgent(connection, socket);
+    const sentBeforeReport = socket.sent.length;
+
+    await expect(
+      connection.reportSessionEventConfirmed("agent-1", "chat-legacy", sessionEvent("legacy")),
+    ).rejects.toThrow("confirmation unsupported by server");
+    expect(parseSent(socket, sentBeforeReport)).toMatchObject({
+      type: "session:event",
+      agentId: "agent-1",
+      chatId: "chat-legacy",
+    });
+
+    priv(connection).clearTimers();
   });
 
   it("covers legacy inbox acks, duplicate confirmed acks, and rejection confirmations", async () => {

--- a/packages/client/src/__tests__/codex-capability-platform-edge.test.ts
+++ b/packages/client/src/__tests__/codex-capability-platform-edge.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveBundledCodexBinary } from "../runtime/capabilities/codex.js";
+
+const originalPlatform = process.platform;
+const originalArch = process.arch;
+
+function setProcessTarget(platform: NodeJS.Platform, arch: NodeJS.Architecture): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+  Object.defineProperty(process, "arch", { configurable: true, value: arch });
+}
+
+describe("resolveBundledCodexBinary — platform edge mapping", () => {
+  afterEach(() => {
+    setProcessTarget(originalPlatform, originalArch);
+  });
+
+  it("reports unsupported platforms before resolving SDK packages", async () => {
+    setProcessTarget("freebsd", "x64");
+
+    await expect(resolveBundledCodexBinary()).resolves.toEqual({
+      ok: false,
+      error: "unsupported platform for codex: freebsd (x64)",
+    });
+  });
+
+  it.each([
+    ["linux", "arm64", "@openai/codex-linux-arm64"],
+    ["darwin", "x64", "@openai/codex-darwin-x64"],
+    ["win32", "arm64", "@openai/codex-win32-arm64"],
+  ] satisfies ReadonlyArray<
+    readonly [NodeJS.Platform, NodeJS.Architecture, string]
+  >)("uses the %s/%s optional package name in missing-binary diagnostics", async (platform, arch, expectedPackage) => {
+    setProcessTarget(platform, arch);
+
+    const result = await resolveBundledCodexBinary();
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected missing bundled binary");
+    expect(result.error).toContain(expectedPackage);
+  });
+});

--- a/packages/client/src/__tests__/codex-capability-platform-edge.test.ts
+++ b/packages/client/src/__tests__/codex-capability-platform-edge.test.ts
@@ -1,5 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { resolveBundledCodexBinary } from "../runtime/capabilities/codex.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const originalPlatform = process.platform;
 const originalArch = process.arch;
@@ -11,11 +10,14 @@ function setProcessTarget(platform: NodeJS.Platform, arch: NodeJS.Architecture):
 
 describe("resolveBundledCodexBinary — platform edge mapping", () => {
   afterEach(() => {
+    vi.doUnmock("node:module");
+    vi.resetModules();
     setProcessTarget(originalPlatform, originalArch);
   });
 
   it("reports unsupported platforms before resolving SDK packages", async () => {
     setProcessTarget("freebsd", "x64");
+    const { resolveBundledCodexBinary } = await import("../runtime/capabilities/codex.js");
 
     await expect(resolveBundledCodexBinary()).resolves.toEqual({
       ok: false,
@@ -31,6 +33,22 @@ describe("resolveBundledCodexBinary — platform edge mapping", () => {
     readonly [NodeJS.Platform, NodeJS.Architecture, string]
   >)("uses the %s/%s optional package name in missing-binary diagnostics", async (platform, arch, expectedPackage) => {
     setProcessTarget(platform, arch);
+    vi.resetModules();
+    vi.doMock("node:module", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:module")>();
+      return {
+        ...actual,
+        createRequire: (anchor: string | URL) => ({
+          resolve: (specifier: string) => {
+            if (specifier === "@openai/codex/package.json") {
+              return "/virtual/node_modules/@openai/codex/package.json";
+            }
+            throw new Error(`missing ${specifier} from ${String(anchor)}`);
+          },
+        }),
+      };
+    });
+    const { resolveBundledCodexBinary } = await import("../runtime/capabilities/codex.js");
 
     const result = await resolveBundledCodexBinary();
 

--- a/packages/client/src/__tests__/codex-stale-rollout-helpers.test.ts
+++ b/packages/client/src/__tests__/codex-stale-rollout-helpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  CodexStaleRolloutError,
+  extractCodexStaleRolloutThreadId,
+  isCodexStaleRolloutError,
+  staleRolloutRecoveryMessage,
+} from "../handlers/codex/stale-rollout.js";
+
+const THREAD_ID = "019f2943-c0af-75b0-9d7b-d58679594749";
+
+describe("codex stale rollout helpers", () => {
+  it("detects stale rollout text from string errors", () => {
+    expect(isCodexStaleRolloutError(`thread/resume failed: no rollout found for thread id ${THREAD_ID}`)).toBe(true);
+    expect(extractCodexStaleRolloutThreadId(`thread/resume failed: no rollout found for thread id ${THREAD_ID}`)).toBe(
+      THREAD_ID,
+    );
+  });
+
+  it("includes Error code, reason, and nested cause text when extracting ids", () => {
+    const cause = Object.assign(new Error("outer failure"), {
+      cause: `thread/resume failed: no rollout found for thread id ${THREAD_ID}`,
+      code: "E_ROLLOUT",
+      reason: "missing local rollout",
+    });
+
+    expect(extractCodexStaleRolloutThreadId(cause)).toBe(THREAD_ID);
+    expect(isCodexStaleRolloutError(cause)).toBe(true);
+  });
+
+  it("falls back to the explicit thread id for non-string causes", () => {
+    const err = new CodexStaleRolloutError({ reason: "missing" }, THREAD_ID);
+
+    expect(err.threadId).toBe(THREAD_ID);
+    expect(err.message).toContain(THREAD_ID);
+    expect(isCodexStaleRolloutError(err)).toBe(true);
+  });
+
+  it("handles circular object causes without throwing", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    const err = new CodexStaleRolloutError(circular);
+
+    expect(err.threadId).toBeNull();
+    expect(err.message).toContain("[object Object]");
+  });
+
+  it("formats recovery messages with and without replacement ids", () => {
+    expect(staleRolloutRecoveryMessage(null)).toBe("codex local rollout missing; starting fresh thread");
+    expect(staleRolloutRecoveryMessage(THREAD_ID, "fresh-thread")).toBe(
+      `codex local rollout missing for stale thread ${THREAD_ID}; starting fresh thread; replacement thread fresh-thread`,
+    );
+  });
+});

--- a/packages/client/src/__tests__/handler-helper-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/handler-helper-extra-coverage.test.ts
@@ -1,6 +1,7 @@
 import type { AgentRuntimeConfigPayload, SessionEvent, ToolFileRef } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildClaudeQueryOptions,
   createToolCallProcessor,
   detectClaudeSessionLimitResult,
   detectStreamApiError,
@@ -15,6 +16,7 @@ import {
   toolFileRefsForTerminalCodexTool,
   toolFileRefsFromCodexFileChange,
 } from "../handlers/codex/index.js";
+import type { ChatContext } from "../runtime/chat-context.js";
 import type { ContextTreeGitWriteTracker } from "../runtime/context-tree-git-status.js";
 
 function claudePayload(overrides: Partial<Extract<AgentRuntimeConfigPayload, { kind: "claude-code" }>> = {}) {
@@ -111,6 +113,44 @@ describe("additional Claude helper branches", () => {
     expect(isSameModelFamily("claude-opus-4-5", "claude-sonnet-4-5")).toBe(false);
     expect(isSameModelFamily("", "claude-opus-4-5")).toBe(false);
     expect(isSameModelFamily("short", "claude-opus-4-5")).toBe(false);
+  });
+
+  it("builds Claude SDK query options from model, MCP, effort, and chat context", () => {
+    const chatContext: ChatContext = {
+      chatId: "chat-1",
+      title: "Release thread",
+      topic: "Coverage",
+      description: "Discuss coverage gaps.",
+      selfOwner: { name: "alice", displayName: "Alice" },
+      participants: [
+        { name: "alice", displayName: "Alice", type: "human" },
+        { name: "agent", displayName: "Agent", type: "agent" },
+      ],
+    };
+
+    const options = buildClaudeQueryOptions(
+      claudePayload({
+        model: "claude-opus-4-5",
+        reasoningEffort: "high",
+        mcpServers: [{ name: "stdio-server", transport: "stdio", command: "node", args: ["server.js"] }],
+      }),
+      chatContext,
+    );
+
+    expect(options).toMatchObject({
+      model: "claude-opus-4-5",
+      effort: "high",
+      mcpServers: {
+        "stdio-server": { type: "stdio", command: "node", args: ["server.js"] },
+      },
+      systemPrompt: {
+        type: "preset",
+        preset: "claude_code",
+      },
+    });
+    expect(options.systemPrompt?.append).toContain("<first-tree-runtime-contract>");
+    expect(options.systemPrompt?.append).toContain("<first-tree-current-chat-context");
+    expect(options.systemPrompt?.append).toContain('"name": "alice"');
   });
 
   it("classifies stream API and session-limit result text without false positives", () => {
@@ -245,5 +285,83 @@ describe("additional Claude helper branches", () => {
       kind: "tool_call",
       payload: { toolUseId: "tool-flush", status: "pending" },
     });
+  });
+
+  it("attributes notebook, search, and shell tool refs through the processor", () => {
+    const events: SessionEvent[] = [];
+    const processor = createToolCallProcessor(
+      (event) => events.push(event),
+      {
+        path: "/tree/",
+        repoUrl: "https://github.com/acme/context.git",
+        branch: "main",
+      },
+      { cwd: "/tree" },
+    );
+
+    for (const [id, name, input] of [
+      ["tool-notebook", "NotebookRead", { notebook_path: "/tree/notebooks/demo.ipynb" }],
+      ["tool-grep-root", "Grep", { path: "." }],
+      ["tool-bash", "Bash", { command: "cat NODE.md" }],
+      ["tool-relative-write", "Write", { file_path: "relative.md" }],
+      ["tool-no-path", "Glob", { pattern: "*.md" }],
+    ] satisfies Array<[string, string, unknown]>) {
+      processor.onMessage({
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id, name, input }] },
+      });
+      processor.onMessage({
+        type: "user",
+        message: { content: [{ type: "tool_result", tool_use_id: id, content: "" }] },
+      });
+    }
+
+    const completed = events.filter((event) => event.kind === "tool_call" && event.payload.status === "ok");
+    expect(completed).toHaveLength(5);
+    expect(completed[0]).toMatchObject({
+      payload: {
+        toolUseId: "tool-notebook",
+        toolFileRefs: [
+          {
+            localPath: "/tree/notebooks/demo.ipynb",
+            repoUrl: "https://github.com/acme/context.git",
+            repoBranch: "main",
+            repoRelativePath: "notebooks/demo.ipynb",
+            pathKind: "file",
+          },
+        ],
+      },
+    });
+    expect(completed[1]).toMatchObject({
+      payload: {
+        toolUseId: "tool-grep-root",
+        toolFileRefs: [
+          {
+            localPath: "/tree",
+            repoRelativePath: "/",
+            pathKind: "repo",
+          },
+        ],
+      },
+    });
+    expect(completed[2]).toMatchObject({
+      payload: {
+        toolUseId: "tool-bash",
+        toolFileRefs: [
+          {
+            localPath: "/tree/NODE.md",
+            repoRelativePath: "NODE.md",
+            pathKind: "file",
+          },
+        ],
+      },
+    });
+    expect(completed[3]).toMatchObject({
+      payload: {
+        toolUseId: "tool-relative-write",
+        toolFileRefs: [{ localPath: "relative.md", pathKind: "file" }],
+      },
+    });
+    expect(completed[4]?.payload).not.toHaveProperty("toolFileRefs");
   });
 });

--- a/packages/client/src/__tests__/launch-probe-spawn-edge.test.ts
+++ b/packages/client/src/__tests__/launch-probe-spawn-edge.test.ts
@@ -1,0 +1,58 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("runCommand — spawn edge failures", () => {
+  afterEach(() => {
+    vi.doUnmock("node:child_process");
+    vi.resetModules();
+  });
+
+  it("returns a spawnError when spawn throws synchronously", async () => {
+    vi.doMock("node:child_process", () => ({
+      spawn: () => {
+        throw new Error("spawn sync failed");
+      },
+    }));
+    const { runCommand } = await import("../runtime/capabilities/launch-probe.js");
+
+    const result = await runCommand("/bin/tool", ["--version"], { timeoutMs: 1000 });
+
+    expect(result).toMatchObject({
+      ok: false,
+      exitCode: null,
+      spawnError: "spawn sync failed",
+      stdout: "",
+      stderr: "",
+      timedOut: false,
+    });
+  });
+
+  it("settles once when the child emits an asynchronous error", async () => {
+    const kill = vi.fn();
+    vi.doMock("node:child_process", () => ({
+      spawn: () => {
+        const child = Object.assign(new EventEmitter(), {
+          kill,
+          stderr: new EventEmitter(),
+          stdout: new EventEmitter(),
+        });
+        queueMicrotask(() => {
+          child.emit("error", new Error("spawn async failed"));
+          child.emit("close", 0);
+        });
+        return child;
+      },
+    }));
+    const { runCommand } = await import("../runtime/capabilities/launch-probe.js");
+
+    const result = await runCommand("/bin/tool", ["--version"], { timeoutMs: 1000 });
+
+    expect(result).toMatchObject({
+      ok: false,
+      exitCode: null,
+      spawnError: "spawn async failed",
+      timedOut: false,
+    });
+    expect(kill).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/__tests__/tui-tmux-session-ready-extra.test.ts
+++ b/packages/client/src/__tests__/tui-tmux-session-ready-extra.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { waitForReady } from "../handlers/claude-code-tui/tmux-session.js";
+
+const readyPane = ['❯ Try "edit <filepath> to..."', "⏵⏵ bypass permissions on (shift+tab to cycle)"].join("\n");
+
+describe("waitForReady prompt handling", () => {
+  it("accepts the workspace trust prompt once before waiting for ready", async () => {
+    const trustPane = [
+      "Quick safety check: Is this a project you created or one you trust?",
+      " ❯ 1. Yes, I trust this folder",
+      "   2. No, exit",
+      "Enter to confirm · Esc to cancel",
+    ].join("\n");
+    const sent: string[] = [];
+    let polls = 0;
+
+    await expect(
+      waitForReady({
+        name: "ftth-trust",
+        timeoutMs: 1_000,
+        pollIntervalMs: 1,
+        capture: async () => (polls++ === 0 ? trustPane : readyPane),
+        send: async (_name, key) => {
+          sent.push(key);
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(sent).toEqual(["Enter"]);
+  });
+
+  it("selects resume-from-summary and extends the ready deadline", async () => {
+    const resumePane = [
+      "This session is 2h 41m old and 119.5k tokens.",
+      " ❯ 1. Resume from summary (recommended)",
+      "   2. Resume full session as-is",
+      "   3. Don't ask me again",
+      "Enter to confirm · Esc to cancel",
+    ].join("\n");
+    const sent: string[] = [];
+    let polls = 0;
+
+    await expect(
+      waitForReady({
+        name: "ftth-resume",
+        timeoutMs: 1_000,
+        pollIntervalMs: 1,
+        summaryReadyTimeoutMs: 2_000,
+        capture: async () => (polls++ === 0 ? resumePane : readyPane),
+        send: async (_name, key) => {
+          sent.push(key);
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(sent).toEqual(["1", "Enter"]);
+  });
+
+  it("throws a bounded timeout error when no ready surface appears", async () => {
+    await expect(
+      waitForReady({
+        name: "ftth-timeout",
+        timeoutMs: 0,
+        capture: async () => "still starting",
+      }),
+    ).rejects.toThrow(/claude TUI did not become ready within \d+ms \(session=ftth-timeout\)/);
+  });
+});

--- a/packages/client/src/__tests__/update-manager-refresh-extra.test.ts
+++ b/packages/client/src/__tests__/update-manager-refresh-extra.test.ts
@@ -1,0 +1,141 @@
+import { EventEmitter } from "node:events";
+import type { ClientConfig } from "@first-tree/shared/config";
+import { describe, expect, it, vi } from "vitest";
+import type { ServerWelcome } from "../client-connection.js";
+import {
+  type RefreshUpdateTargetResult,
+  UpdateManager,
+  type UpdateManagerConnection,
+} from "../runtime/update-manager.js";
+
+class FakeConnection extends EventEmitter implements UpdateManagerConnection {
+  emitWelcome(welcome: ServerWelcome): void {
+    this.emit("server:welcome", welcome);
+  }
+
+  on(event: "server:welcome", listener: (welcome: ServerWelcome) => void): this {
+    return super.on(event, listener);
+  }
+
+  off(event: "server:welcome", listener: (welcome: ServerWelcome) => void): this {
+    return super.off(event, listener);
+  }
+}
+
+type RefreshScenario = {
+  readonly currentVersion: string;
+  readonly advertisedVersion: string;
+  readonly refresh: () => Promise<RefreshUpdateTargetResult>;
+};
+
+function makeUpdateConfig(): ClientConfig["update"] {
+  return {
+    policy: "auto",
+    restart_quiet_seconds: 30,
+    restart_check_interval_seconds: 10,
+    prompt_timeout_seconds: 60,
+  };
+}
+
+function makeWelcome(serverCommandVersion: string): ServerWelcome {
+  return {
+    frame: {
+      type: "server:welcome",
+      serverCommandVersion,
+      serverTimeMs: 1_700_000_000_000,
+    },
+    isReconnect: false,
+  };
+}
+
+async function waitForUpdateDecision(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function runAutoRefreshScenario(input: RefreshScenario): Promise<{
+  readonly executeUpdate: ReturnType<typeof vi.fn>;
+  readonly logs: readonly string[];
+}> {
+  const conn = new FakeConnection();
+  const logs: string[] = [];
+  const executeUpdate = vi.fn(async () => ({ installed: false }));
+  const refreshServerTarget = vi.fn(input.refresh);
+
+  UpdateManager.attach(conn, {
+    currentVersion: input.currentVersion,
+    updateConfig: makeUpdateConfig(),
+    isTTY: false,
+    log: (_level, msg) => logs.push(msg),
+    getQuietGateSnapshot: () => ({ activeCount: 0, lastActivityMs: 0 }),
+    prompt: async () => false,
+    executeUpdate,
+    refreshServerTarget,
+  });
+
+  conn.emitWelcome(makeWelcome(input.advertisedVersion));
+  await waitForUpdateDecision();
+
+  return { executeUpdate, logs };
+}
+
+describe("UpdateManager auto refresh fallback decisions", () => {
+  it("continues with the advertised target when refresh reports a recoverable failure", async () => {
+    const { executeUpdate, logs } = await runAutoRefreshScenario({
+      currentVersion: "0.8.4",
+      advertisedVersion: "1.0.0",
+      refresh: async () => ({ ok: false, reason: "offline" }),
+    });
+
+    expect(logs).toContain("Could not refresh server update target (offline); continuing with 1.0.0");
+    expect(executeUpdate).toHaveBeenCalledWith({ currentVersion: "0.8.4", targetVersion: "1.0.0" });
+  });
+
+  it("continues with the advertised target when refresh returns an invalid version", async () => {
+    const { executeUpdate, logs } = await runAutoRefreshScenario({
+      currentVersion: "0.8.4",
+      advertisedVersion: "1.0.0",
+      refresh: async () => ({ ok: true, targetVersion: "not-semver" }),
+    });
+
+    expect(logs).toContain('Server target refresh returned invalid version "not-semver"; continuing with 1.0.0');
+    expect(executeUpdate).toHaveBeenCalledWith({ currentVersion: "0.8.4", targetVersion: "1.0.0" });
+  });
+
+  it("continues with the advertised target when refresh throws", async () => {
+    const { executeUpdate, logs } = await runAutoRefreshScenario({
+      currentVersion: "0.8.4",
+      advertisedVersion: "1.0.0",
+      refresh: async () => {
+        throw new Error("refresh down");
+      },
+    });
+
+    expect(logs).toContain("Server target refresh threw: refresh down; continuing with 1.0.0");
+    expect(executeUpdate).toHaveBeenCalledWith({ currentVersion: "0.8.4", targetVersion: "1.0.0" });
+  });
+
+  it("skips self-update when refresh says the target now matches the running version", async () => {
+    const { executeUpdate, logs } = await runAutoRefreshScenario({
+      currentVersion: "0.9.2",
+      advertisedVersion: "1.0.0",
+      refresh: async () => ({ ok: true, targetVersion: "0.9.2" }),
+    });
+
+    expect(logs).toContain("Server update target refreshed: 1.0.0 -> 0.9.2");
+    expect(logs).toContain("Server update target 0.9.2 now matches running version; skipping self-update");
+    expect(executeUpdate).not.toHaveBeenCalled();
+  });
+
+  it("skips self-update when refresh rolls back below the running version", async () => {
+    const { executeUpdate, logs } = await runAutoRefreshScenario({
+      currentVersion: "0.9.3",
+      advertisedVersion: "1.0.0",
+      refresh: async () => ({ ok: true, targetVersion: "0.9.2" }),
+    });
+
+    expect(logs).toContain("Server update target refreshed: 1.0.0 -> 0.9.2");
+    expect(logs).toContain("Server update target 0.9.2 is older than running 0.9.3; skipping self-update");
+    expect(executeUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/__tests__/workspace-manifest.test.ts
+++ b/packages/client/src/__tests__/workspace-manifest.test.ts
@@ -2,7 +2,7 @@ import { existsSync, lstatSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SOURCE_REPOS_DIRNAME } from "@first-tree/shared";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CONTEXT_TREE_DIRNAME, ensureWorkspaceManifest } from "../runtime/workspace-manifest.js";
 
 describe("ensureWorkspaceManifest", () => {
@@ -13,6 +13,8 @@ describe("ensureWorkspaceManifest", () => {
   });
   afterEach(() => {
     rmSync(ws, { recursive: true, force: true });
+    vi.doUnmock("@first-tree/shared");
+    vi.resetModules();
   });
 
   const manifestPath = () => join(ws, ".first-tree", "workspace.json");
@@ -90,5 +92,27 @@ describe("ensureWorkspaceManifest", () => {
     expect(() => ensureWorkspaceManifest(fileWorkspace, ["app"], (msg) => logs.push(msg))).not.toThrow();
 
     expect(logs.some((line) => line.includes("workspace manifest write failed"))).toBe(true);
+  });
+
+  it("logs and skips filesystem writes when manifest validation fails", async () => {
+    vi.resetModules();
+    vi.doMock("@first-tree/shared", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@first-tree/shared")>();
+      return {
+        ...actual,
+        workspaceManifestSchema: {
+          parse: () => {
+            throw new Error("schema rejected manifest");
+          },
+        },
+      };
+    });
+    const mod = await import("../runtime/workspace-manifest.js");
+    const logs: string[] = [];
+
+    expect(() => mod.ensureWorkspaceManifest(ws, ["app"], (msg) => logs.push(msg))).not.toThrow();
+
+    expect(existsSync(manifestPath())).toBe(false);
+    expect(logs.some((line) => line.includes("workspace manifest skipped: schema rejected manifest"))).toBe(true);
   });
 });

--- a/packages/client/src/__tests__/workspace-manifest.test.ts
+++ b/packages/client/src/__tests__/workspace-manifest.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, lstatSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SOURCE_REPOS_DIRNAME } from "@first-tree/shared";
@@ -80,5 +80,15 @@ describe("ensureWorkspaceManifest", () => {
     // The manifest may name a tree dir that does not exist yet; the runtime
     // must not create a directory or symlink (even a dangling one) at that path.
     expect(lstatSync(treeDirPath(), { throwIfNoEntry: false })).toBeUndefined();
+  });
+
+  it("logs and continues when the workspace state dir cannot be created", () => {
+    const fileWorkspace = join(ws, "not-a-directory");
+    const logs: string[] = [];
+    writeFileSync(fileWorkspace, "already a file");
+
+    expect(() => ensureWorkspaceManifest(fileWorkspace, ["app"], (msg) => logs.push(msg))).not.toThrow();
+
+    expect(logs.some((line) => line.includes("workspace manifest write failed"))).toBe(true);
   });
 });

--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -38,9 +38,15 @@ vi.mock("../components/layout.js", async () => {
 vi.mock("../pages/login.js", () => ({ LoginPage: () => <div>login page</div> }));
 vi.mock("../pages/oauth-complete.js", () => ({ OAuthCompletePage: () => <div>oauth complete</div> }));
 vi.mock("../pages/invite-accept.js", () => ({ InviteAcceptPage: () => <div>invite accept</div> }));
+vi.mock("../pages/onboarding/github-connected.js", () => ({
+  GithubConnectedPage: () => <div>github connected</div>,
+}));
 vi.mock("../pages/onboarding/onboarding-page.js", () => ({ OnboardingPage: () => <div>onboarding page</div> }));
+vi.mock("../pages/quickstart/quickstart-page.js", () => ({ QuickstartPage: () => <div>quickstart page</div> }));
 vi.mock("../pages/workspace/index.js", () => ({ WorkspacePage: () => <div>workspace page</div> }));
 vi.mock("../pages/context.js", () => ({ ContextPage: () => <div>context page</div> }));
+vi.mock("../pages/docs/docs-list-page.js", () => ({ DocsListPage: () => <div>docs list page</div> }));
+vi.mock("../pages/docs/doc-page.js", () => ({ DocPage: () => <div>doc page</div> }));
 vi.mock("../pages/team/index.js", () => ({ TeamPage: () => <div>team page</div> }));
 vi.mock("../pages/settings.js", async () => {
   const { Outlet } = await import("react-router");
@@ -54,8 +60,10 @@ vi.mock("../pages/settings.js", async () => {
   };
 });
 vi.mock("../pages/settings/computers.js", () => ({ SettingsComputersPage: () => <div>settings computers</div> }));
+vi.mock("../pages/settings/context-tree.js", () => ({ SettingsContextTreePage: () => <div>settings context</div> }));
 vi.mock("../pages/settings/github.js", () => ({ SettingsGithubPage: () => <div>settings github</div> }));
 vi.mock("../pages/settings/onboarding.js", () => ({ SettingsOnboardingPage: () => <div>settings onboarding</div> }));
+vi.mock("../pages/settings/resources.js", () => ({ SettingsResourcesPage: () => <div>settings resources</div> }));
 vi.mock("../pages/agent-detail.js", async () => {
   const { Outlet } = await import("react-router");
   return {
@@ -71,14 +79,46 @@ vi.mock("../pages/agent-detail/profile-tab.js", () => ({ ProfileTab: () => <div>
 vi.mock("../pages/agent-detail/runtime-tab.js", () => ({ RuntimeTab: () => <div>runtime tab</div> }));
 vi.mock("../pages/agent-detail/prompt-tab.js", () => ({ PromptTab: () => <div>prompt tab</div> }));
 vi.mock("../pages/agent-detail/resources-tab.js", () => ({ ResourcesTab: () => <div>resources tab</div> }));
+vi.mock("../pages/agent-detail/repositories-tab.js", () => ({ RepositoriesTab: () => <div>repositories tab</div> }));
+vi.mock("../pages/agent-detail/usage-tab.js", () => ({ UsageTab: () => <div>usage tab</div> }));
+vi.mock("../pages/context-preview.js", () => ({ ContextPreviewPage: () => <div>context preview</div> }));
+vi.mock("../pages/context-tree-preview.js", () => ({ ContextTreePreviewPage: () => <div>context tree preview</div> }));
+vi.mock("../pages/chat-row-avatar-preview.js", () => ({
+  ChatRowAvatarPreviewPage: () => <div>chat row avatar preview</div>,
+}));
+vi.mock("../pages/conversation-list-preview.js", () => ({
+  ConversationListPreviewPage: () => <div>conversation list preview</div>,
+}));
+vi.mock("../pages/compose-status-bar-preview.js", () => ({
+  ComposeStatusBarPreviewPage: () => <div>compose status bar preview</div>,
+}));
+vi.mock("../pages/chat-offline-notice-preview.js", () => ({
+  ChatOfflineNoticePreviewPage: () => <div>chat offline notice preview</div>,
+}));
+vi.mock("../pages/request-dock-preview.js", () => ({ RequestDockPreviewPage: () => <div>request dock preview</div> }));
 vi.mock("../pages/command-palette-preview.js", () => ({
   CommandPalettePreviewPage: () => <div>command palette preview</div>,
 }));
+vi.mock("../pages/user-menu-preview.js", () => ({ UserMenuPreviewPage: () => <div>user menu preview</div> }));
+vi.mock("../pages/support-menu-preview.js", () => ({ SupportMenuPreviewPage: () => <div>support menu preview</div> }));
+vi.mock("../pages/chat-summary-preview.js", () => ({ ChatSummaryPreviewPage: () => <div>chat summary preview</div> }));
+vi.mock("../pages/team-switcher-preview.js", () => ({
+  TeamSwitcherPreviewPage: () => <div>team switcher preview</div>,
+}));
+vi.mock("../pages/settings-github-preview.js", () => ({
+  SettingsGithubPreviewPage: () => <div>settings github preview</div>,
+}));
+vi.mock("../pages/onboarding-preview.js", () => ({ OnboardingPreviewPage: () => <div>onboarding preview</div> }));
+vi.mock("../pages/team-preview.js", () => ({ TeamPreviewPage: () => <div>team preview</div> }));
+vi.mock("../pages/resources-preview.js", () => ({ ResourcesPreviewPage: () => <div>resources preview</div> }));
+vi.mock("../pages/agent-detail-preview.js", () => ({ AgentDetailPreviewPage: () => <div>agent detail preview</div> }));
 vi.mock("../pages/styleguide-preview.js", () => ({ StyleguidePreviewPage: () => <div>styleguide preview</div> }));
 
 let root: Root | null = null;
 
-async function renderAppAt(path: string): Promise<string> {
+async function renderAppAt(path: string, dev = true): Promise<string> {
+  vi.resetModules();
+  vi.stubEnv("DEV", dev);
   window.history.pushState({}, "", path);
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -94,6 +134,11 @@ async function renderAppAt(path: string): Promise<string> {
   return document.body.textContent ?? "";
 }
 
+async function resetRenderedApp(): Promise<void> {
+  await act(async () => root?.unmount());
+  document.body.innerHTML = "";
+}
+
 describe("App routes", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -105,49 +150,127 @@ describe("App routes", () => {
       await act(async () => root?.unmount());
     }
     document.body.innerHTML = "";
+    vi.unstubAllEnvs();
   });
 
   it("routes public, protected, nested, preview, and redirect paths", async () => {
     expect(await renderAppAt("/login")).toContain("login page");
-    await act(async () => root?.unmount());
-    document.body.innerHTML = "";
+    await resetRenderedApp();
 
     expect(await renderAppAt("/auth/github/complete")).toContain("oauth complete");
-    await act(async () => root?.unmount());
-    document.body.innerHTML = "";
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/onboarding/connected")).toContain("github connected");
+    await resetRenderedApp();
 
     expect(await renderAppAt("/invite/token-1")).toContain("invite accept");
-    await act(async () => root?.unmount());
-    document.body.innerHTML = "";
+    await resetRenderedApp();
 
     expect(await renderAppAt("/onboarding")).toContain("onboarding page");
-    await act(async () => root?.unmount());
-    document.body.innerHTML = "";
+    await resetRenderedApp();
 
     expect(await renderAppAt("/agents/agent-1/tools")).toContain("profile tab");
-    await act(async () => root?.unmount());
-    document.body.innerHTML = "";
+    await resetRenderedApp();
 
     expect(await renderAppAt("/settings/github")).toContain("settings github");
-    await act(async () => root?.unmount());
-    document.body.innerHTML = "";
+    await resetRenderedApp();
 
     expect(await renderAppAt("/settings/setup")).toContain("settings onboarding");
-    await act(async () => root?.unmount());
-    document.body.innerHTML = "";
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/settings/context")).toContain("settings context");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/settings/resources")).toContain("settings resources");
+    await resetRenderedApp();
 
     expect(await renderAppAt("/settings/team")).toContain("settings computers");
-    await act(async () => root?.unmount());
-    document.body.innerHTML = "";
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/quickstart")).toContain("quickstart page");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/context/docs")).toContain("docs list page");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/context/docs/setup")).toContain("doc page");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/agents/agent-1/usage")).toContain("usage tab");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/agents/agent-1/runtime")).toContain("runtime tab");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/agents/agent-1/prompt")).toContain("prompt tab");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/agents/agent-1/capabilities")).toContain("resources tab");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/agents/agent-1/repositories")).toContain("repositories tab");
+    await resetRenderedApp();
 
     expect(await renderAppAt("/admin#agents")).toContain("team page");
-    await act(async () => root?.unmount());
-    document.body.innerHTML = "";
+    await resetRenderedApp();
 
     expect(await renderAppAt("/preview/styleguide")).toContain("styleguide preview");
-    await act(async () => root?.unmount());
-    document.body.innerHTML = "";
+    await resetRenderedApp();
 
     expect(await renderAppAt("/preview/command-palette")).toContain("command palette preview");
+  });
+
+  it("routes development preview pages and omits dev-only previews in production", async () => {
+    expect(await renderAppAt("/preview/context")).toContain("context preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/context-tree")).toContain("context tree preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/chat-row-avatar")).toContain("chat row avatar preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/conversation-list")).toContain("conversation list preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/compose-status-bar")).toContain("compose status bar preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/chat-offline-notice")).toContain("chat offline notice preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/request-dock")).toContain("request dock preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/user-menu")).toContain("user menu preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/support-menu")).toContain("support menu preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/chat-summary")).toContain("chat summary preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/team-switcher")).toContain("team switcher preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/settings-github")).toContain("settings github preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/onboarding")).toContain("onboarding preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/team")).toContain("team preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/resources")).toContain("resources preview");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/preview/agent-detail/profile")).toContain("agent detail preview");
+    await resetRenderedApp();
+
+    const productionPreview = await renderAppAt("/preview/styleguide", false);
+    expect(productionPreview).toContain("styleguide preview");
+    expect(productionPreview).not.toContain("context preview");
   });
 });

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -109,6 +109,11 @@ function createStorage(): Storage {
   };
 }
 
+function tokenWithPayload(payload: unknown): string {
+  const encoded = btoa(JSON.stringify(payload)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `header.${encoded}.signature`;
+}
+
 async function flush(): Promise<void> {
   await act(async () => {
     await Promise.resolve();
@@ -184,6 +189,66 @@ describe("AuthProvider", () => {
     expect(latestAuth?.currentMembership?.organizationId).toBe("org-2");
     expect(latestAuth?.role).toBe("member");
     expect(flagsMocks.clearOnboardingJoinPath).toHaveBeenCalled();
+  });
+
+  it("preseeds the selected organization from the stored token subject before /me settles", async () => {
+    localStorage.setItem("first-tree:selectedOrganizationId:user-1", "org-2");
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+
+    await renderAuth();
+
+    expect(apiMocks.setApiSelectedOrganizationId.mock.calls[0]?.[0]).toBe("org-2");
+    expect(latestAuth?.currentMembership?.organizationId).toBe("org-2");
+  });
+
+  it("ignores unreadable persisted organization storage and rolls back failed dismiss", async () => {
+    const throwingStorage = {
+      get length() {
+        return 0;
+      },
+      clear: () => undefined,
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      key: () => null,
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+    } satisfies Storage;
+    Object.defineProperty(globalThis, "localStorage", { configurable: true, value: throwingStorage });
+    Object.defineProperty(window, "localStorage", { configurable: true, value: throwingStorage });
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+    apiMocks.apiGet.mockResolvedValueOnce({
+      user: { id: "user-1", username: "gandy", displayName: "Gandy", avatarUrl: null },
+      memberships: [
+        {
+          ...MEMBERSHIPS[0],
+          onboardingSuppressedAt: "2026-05-01T00:00:00.000Z",
+          onboardingSuppressedReason: "finish_later",
+        },
+      ],
+      defaultOrganizationId: "org-1",
+      onboarding: { step: "create_agent", dismissedAt: null, completedAt: null },
+    });
+
+    await renderAuth();
+    apiMocks.apiPatch.mockRejectedValueOnce(new Error("network"));
+    await act(async () => {
+      await latestAuth?.dismissOnboarding();
+    });
+
+    expect(apiMocks.setApiSelectedOrganizationId).toHaveBeenCalledWith(null);
+    expect(latestAuth?.onboardingDismissedAt).toBe("2026-05-01T00:00:00.000Z");
+    expect(latestAuth?.currentMembership?.onboardingSuppressedReason).toBe("finish_later");
   });
 
   it("does not fall back to another membership's onboarding stamps when selected membership stamps are null", async () => {

--- a/packages/web/src/components/ui/__tests__/select-behavior.test.tsx
+++ b/packages/web/src/components/ui/__tests__/select-behavior.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+
+import { act, type ComponentProps } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Select } from "../select.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const OPTIONS = [
+  { value: "alpha", label: "Alpha" },
+  { value: "bravo", label: "Bravo", disabled: true },
+  { value: "charlie", label: "Charlie", hint: "fast" },
+] as const;
+
+describe("Select behavior", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    document.body.querySelectorAll('[role="listbox"]').forEach((listbox) => {
+      listbox.parentElement?.remove();
+    });
+  });
+
+  function renderSelect(props: Partial<ComponentProps<typeof Select>> = {}): {
+    readonly onChange: ReturnType<typeof vi.fn>;
+  } {
+    const onChange = vi.fn();
+
+    act(() => {
+      root.render(<Select aria-label="Runtime" value="alpha" onChange={onChange} options={[...OPTIONS]} {...props} />);
+    });
+
+    return { onChange };
+  }
+
+  function trigger(): HTMLButtonElement {
+    const button = document.querySelector<HTMLButtonElement>('[aria-label="Runtime"]');
+    if (!button) throw new Error("select trigger was not rendered");
+    return button;
+  }
+
+  function openSelect(): void {
+    act(() => {
+      trigger().click();
+    });
+  }
+
+  function listbox(): HTMLElement {
+    const list = document.querySelector<HTMLElement>('[role="listbox"]');
+    if (!list) throw new Error("select listbox was not rendered");
+    return list;
+  }
+
+  function option(label: string): HTMLButtonElement {
+    const item = [...document.querySelectorAll<HTMLButtonElement>('[role="option"]')].find(
+      (button) => button.textContent?.includes(label) ?? false,
+    );
+    if (!item) throw new Error(`select option was not rendered: ${label}`);
+    return item;
+  }
+
+  function keydown(target: Element, key: string): void {
+    act(() => {
+      target.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+    });
+  }
+
+  function input(element: HTMLInputElement, value: string): void {
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(element, value);
+      element.dispatchEvent(new InputEvent("input", { bubbles: true, data: value, inputType: "insertText" }));
+    });
+  }
+
+  it("filters searchable options, reports empty results, and commits the active option from the input", () => {
+    const { onChange } = renderSelect({ searchable: true });
+    openSelect();
+
+    const search = document.querySelector<HTMLInputElement>('[role="combobox"]');
+    if (!search) throw new Error("search input was not rendered");
+
+    input(search, "char");
+
+    expect(listbox().textContent).toContain("Charlie");
+    expect(listbox().textContent).not.toContain("Alpha");
+
+    keydown(search, "Enter");
+    expect(onChange).toHaveBeenCalledWith("charlie");
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+
+    openSelect();
+    const nextSearch = document.querySelector<HTMLInputElement>('[role="combobox"]');
+    if (!nextSearch) throw new Error("search input was not rendered after reopen");
+    input(nextSearch, "missing");
+
+    expect(document.body.textContent).toContain("No matches");
+    keydown(nextSearch, "Enter");
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips disabled options during keyboard and pointer navigation", () => {
+    const { onChange } = renderSelect();
+    openSelect();
+
+    keydown(listbox(), "ArrowDown");
+    keydown(listbox(), "Enter");
+    expect(onChange).toHaveBeenCalledWith("charlie");
+
+    openSelect();
+    act(() => {
+      option("Bravo").dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+      option("Bravo").click();
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('[role="listbox"]')).not.toBeNull();
+  });
+
+  it("opens from the keyboard, supports type-ahead, and closes on Escape, Tab, or outside pointer", () => {
+    const { onChange } = renderSelect({ value: "missing", placeholder: "Pick" });
+
+    expect(trigger().textContent).toContain("Pick");
+    keydown(trigger(), " ");
+    expect(listbox()).not.toBeNull();
+
+    keydown(listbox(), "c");
+    keydown(listbox(), "Enter");
+    expect(onChange).toHaveBeenCalledWith("charlie");
+
+    keydown(trigger(), "Enter");
+    keydown(listbox(), "Escape");
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+
+    keydown(trigger(), "ArrowDown");
+    keydown(listbox(), "Tab");
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+
+    keydown(trigger(), "ArrowUp");
+    act(() => {
+      document.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    });
+
+    expect(document.querySelector('[role="listbox"]')).toBeNull();
+  });
+});

--- a/packages/web/src/features/agent-setup/__tests__/setup-hooks.test.tsx
+++ b/packages/web/src/features/agent-setup/__tests__/setup-hooks.test.tsx
@@ -221,6 +221,135 @@ describe("shared setup hooks", () => {
     expect(expectHookValue(latest.current).selectedRuntime).toBe("codex");
   });
 
+  it("keeps prior runtime choice and falls back to enabled future providers after transient capability failures", async () => {
+    const latest = { current: null as ComputerConnection | null };
+    const client = {
+      id: "client-1",
+      userId: "user-self",
+      status: "connected",
+      authState: "ok",
+      binName: "first-tree-dev",
+      sdkVersion: "0.5.0",
+      hostname: "gandy-macbook",
+      os: "darwin",
+      agentCount: 0,
+      connectedAt: "2026-05-28T00:00:00.000Z",
+      lastSeenAt: "2026-05-28T12:00:00.000Z",
+      capabilities: {},
+    };
+    activityMocks.listClients.mockResolvedValue([client]);
+    activityMocks.getClientCapabilities.mockRejectedValueOnce(new Error("capabilities offline")).mockResolvedValue({
+      ...client,
+      capabilities: {
+        "claude-code-tui": {
+          state: "ok",
+          available: true,
+          detectedAt: "2026-05-28T12:00:00.000Z",
+        },
+        "future-provider": {
+          state: "ok",
+          available: true,
+          detectedAt: "2026-05-28T12:00:00.000Z",
+        },
+      },
+    });
+
+    function Probe() {
+      latest.current = useComputerConnection(true);
+      return <div>{latest.current.selectedRuntime ?? "none"}</div>;
+    }
+
+    await renderProbe(<Probe />);
+    await flush();
+    await flush();
+
+    expect(expectHookValue(latest.current).capabilitiesLoaded).toBe(false);
+
+    const tick = visibilityMocks.runVisibilityAwareInterval.mock.calls[0]?.[0];
+    if (!tick) throw new Error("visibility-aware interval was not registered");
+    await act(async () => {
+      await tick();
+    });
+    await flush();
+
+    expect(expectHookValue(latest.current).capabilitiesLoaded).toBe(true);
+    expect(expectHookValue(latest.current).okRuntimes).toEqual(["future-provider"]);
+    expect(expectHookValue(latest.current).selectedRuntime).toBe("future-provider");
+
+    await act(async () => expectHookValue(latest.current).setSelectedRuntime("future-provider"));
+    activityMocks.getClientCapabilities.mockResolvedValueOnce({
+      ...client,
+      capabilities: {
+        "future-provider": {
+          state: "ok",
+          available: true,
+          detectedAt: "2026-05-28T12:00:05.000Z",
+        },
+        codex: {
+          state: "ok",
+          available: true,
+          detectedAt: "2026-05-28T12:00:05.000Z",
+        },
+      },
+    });
+    await act(async () => {
+      await tick();
+    });
+    await flush();
+
+    expect(expectHookValue(latest.current).selectedRuntime).toBe("future-provider");
+  });
+
+  it("mints connect commands, surfaces final token failures, and retries manually", async () => {
+    const latest = { current: null as ComputerConnection | null };
+    activityMocks.listClients.mockResolvedValue([]);
+    clientMocks.api.post
+      .mockResolvedValueOnce({
+        token: "token-1",
+        expiresIn: 600,
+        command: "first-tree-dev login token-1",
+        bootstrapCommand: "first-tree-dev login token-1",
+        npmSpec: null,
+        binName: "first-tree-dev",
+      })
+      .mockRejectedValueOnce(new Error("token retry failed"))
+      .mockRejectedValueOnce("still down")
+      .mockRejectedValueOnce(new Error("token failed"))
+      .mockResolvedValueOnce({
+        token: "token-2",
+        expiresIn: 600,
+        command: "first-tree-dev login token-2",
+        bootstrapCommand: "first-tree-dev login token-2",
+        npmSpec: null,
+        binName: "first-tree-dev",
+      });
+
+    function Probe() {
+      latest.current = useComputerConnection(true);
+      return <div>{latest.current.cliCommand ?? latest.current.tokenError ?? "pending"}</div>;
+    }
+
+    await renderProbe(<Probe />);
+    await flush();
+    await flush();
+
+    expect(expectHookValue(latest.current).cliCommand).toBe("first-tree-dev login token-1");
+
+    await act(async () => expectHookValue(latest.current).retry());
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 2400));
+    });
+
+    expect(expectHookValue(latest.current).tokenError).toBe("token failed");
+
+    await act(async () => expectHookValue(latest.current).retry());
+    await flush();
+    await flush();
+
+    expect(expectHookValue(latest.current).cliCommand).toBe("first-tree-dev login token-2");
+    expect(expectHookValue(latest.current).tokenError).toBeNull();
+  }, 10_000);
+
   it("creates an agent and reports lifecycle through callbacks only", async () => {
     const latest = { current: null as ReturnType<typeof useAgentCreation> | null };
     const onOnline = vi.fn();

--- a/packages/web/src/hooks/__tests__/use-admin-ws-edge.test.tsx
+++ b/packages/web/src/hooks/__tests__/use-admin-ws-edge.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const clientMocks = vi.hoisted(() => ({
+  getStoredTokens: vi.fn(),
+  refreshAccessToken: vi.fn(),
+  getApiSelectedOrganizationId: vi.fn(),
+  ADMIN_WS_ORG_CHANGED_EVENT: "admin-ws:org-changed",
+}));
+
+vi.mock("../../api/client.js", () => clientMocks);
+
+type WsHandler = ((event: MessageEvent<string>) => void) | null;
+type CloseHandler = ((event: CloseEvent) => void) | null;
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  onmessage: WsHandler = null;
+  onopen: (() => void) | null = null;
+  onclose: CloseHandler = null;
+  closed = false;
+  readonly url: string;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  emitRaw(data: string): void {
+    this.onmessage?.(new MessageEvent("message", { data }));
+  }
+
+  emit(data: unknown): void {
+    this.emitRaw(JSON.stringify(data));
+  }
+
+  open(): void {
+    this.onopen?.();
+  }
+
+  closeWith(code: number): void {
+    this.onclose?.(new CloseEvent("close", { code }));
+  }
+}
+
+let root: Root | null = null;
+let queryClient: QueryClient;
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function renderHook(onMessage = vi.fn()): Promise<typeof onMessage> {
+  const { useAdminWs } = await import("../use-admin-ws.js");
+  function Probe() {
+    useAdminWs({ onMessage });
+    return <div>mounted</div>;
+  }
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  await act(async () => {
+    root?.render(
+      <QueryClientProvider client={queryClient}>
+        <Probe />
+      </QueryClientProvider>,
+    );
+  });
+  await flush();
+  return onMessage;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.resetModules();
+  FakeWebSocket.instances = [];
+  Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: FakeWebSocket });
+  Object.defineProperty(window, "WebSocket", { configurable: true, value: FakeWebSocket });
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { protocol: "http:", host: "first-tree.test" },
+  });
+  clientMocks.getStoredTokens.mockReturnValue({ accessToken: "access-1", refreshToken: "refresh-1" });
+  clientMocks.getApiSelectedOrganizationId.mockReturnValue("org/one");
+  clientMocks.refreshAccessToken.mockResolvedValue(null);
+  queryClient = new QueryClient();
+  root = null;
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("useAdminWs edge cases", () => {
+  it("skips opening a socket until both tokens and a selected org exist", async () => {
+    clientMocks.getStoredTokens.mockReturnValueOnce(null);
+    await renderHook();
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    await act(async () => root?.unmount());
+
+    clientMocks.getStoredTokens.mockReturnValue({ accessToken: "access-1", refreshToken: "refresh-1" });
+    clientMocks.getApiSelectedOrganizationId.mockReturnValueOnce(null);
+    await renderHook();
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+  });
+
+  it("ignores stale socket events and reconnects after a normal close", async () => {
+    const onMessage = await renderHook();
+    const first = FakeWebSocket.instances[0];
+    if (!first) throw new Error("socket missing");
+    expect(first.url).toBe("ws://first-tree.test/api/v1/orgs/org%2Fone/ws/?token=access-1");
+
+    clientMocks.getApiSelectedOrganizationId.mockReturnValue("org-two");
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("admin-ws:org-changed"));
+    });
+    const second = FakeWebSocket.instances[1];
+    if (!second) throw new Error("second socket missing");
+
+    await act(async () => {
+      first.emit({ type: "chat:updated", chatId: "stale-chat" });
+      first.open();
+      first.closeWith(1006);
+    });
+
+    expect(onMessage).not.toHaveBeenCalledWith(expect.objectContaining({ chatId: "stale-chat" }));
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    await act(async () => {
+      second.closeWith(1006);
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(FakeWebSocket.instances).toHaveLength(3);
+    expect(FakeWebSocket.instances[2]?.url).toBe("ws://first-tree.test/api/v1/orgs/org-two/ws/?token=access-1");
+  });
+
+  it("falls back to reconnect backoff when token refresh fails", async () => {
+    await renderHook();
+    const first = FakeWebSocket.instances[0];
+    if (!first) throw new Error("socket missing");
+
+    await act(async () => {
+      first.closeWith(4001);
+    });
+    await flush();
+    expect(clientMocks.refreshAccessToken).toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it("invalidates catch-up queries and broadcasts only reconnect opens", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    const onMessage = await renderHook();
+    const first = FakeWebSocket.instances[0];
+    if (!first) throw new Error("socket missing");
+
+    await act(async () => {
+      first.open();
+    });
+    expect(onMessage).not.toHaveBeenCalledWith({ type: "ws:reconnect" });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["chat-messages"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["chat-open-requests"] });
+
+    await act(async () => {
+      first.closeWith(1006);
+      vi.advanceTimersByTime(2000);
+    });
+    const second = FakeWebSocket.instances[1];
+    if (!second) throw new Error("second socket missing");
+
+    await act(async () => {
+      second.open();
+    });
+
+    expect(onMessage).toHaveBeenCalledWith({ type: "ws:reconnect" });
+  });
+
+  it("invalidates runtime, event fallback, chat update, and malformed chat message branches", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
+    const onMessage = vi.fn(() => {
+      throw new Error("subscriber failure should be isolated");
+    });
+    await renderHook(onMessage);
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) throw new Error("socket missing");
+
+    await act(async () => {
+      socket.emit({ type: "session:runtime", chatId: "chat-1", status: { invalid: true } });
+      socket.emit({ type: "session:event", chatId: "chat-1", status: { invalid: true } });
+      socket.emit({ type: "chat:updated", chatId: "chat-1" });
+      socket.emit({ type: "chat:message" });
+      socket.emitRaw("{");
+    });
+
+    expect(onMessage).toHaveBeenCalledWith(expect.objectContaining({ type: "session:runtime" }));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["chat-agent-status"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["chat-detail", "chat-1"] });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["chat-messages", "chat-1"] });
+  });
+});

--- a/packages/web/src/hooks/__tests__/use-server-channel.test.ts
+++ b/packages/web/src/hooks/__tests__/use-server-channel.test.ts
@@ -1,5 +1,48 @@
-import { describe, expect, it } from "vitest";
-import { extractChannel, extractGrowthLandingPagesEnabled } from "../use-server-channel.js";
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../api/client.js";
+import {
+  extractChannel,
+  extractGrowthLandingPagesEnabled,
+  useGrowthLandingPagesEnabled,
+  useGrowthLandingPagesState,
+  useServerChannelState,
+} from "../use-server-channel.js";
+
+vi.mock("../../api/client.js", () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+Object.assign(window, { IS_REACT_ACT_ENVIRONMENT: true });
+
+type ObservedBootstrap = {
+  channel: ReturnType<typeof useServerChannelState>;
+  growth: ReturnType<typeof useGrowthLandingPagesState>;
+  growthEnabled: boolean;
+};
+
+let root: Root | null = null;
+let queryClient: QueryClient | null = null;
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+    root = null;
+  }
+  queryClient?.clear();
+  queryClient = null;
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  Object.assign(window, { IS_REACT_ACT_ENVIRONMENT: true });
+});
 
 /**
  * Pure-function unit tests for public bootstrap-config probes. The hook wires
@@ -40,3 +83,64 @@ describe("extractGrowthLandingPagesEnabled", () => {
     expect(extractGrowthLandingPagesEnabled({ growthLandingPagesEnabled: 1 })).toBe(false);
   });
 });
+
+describe("server bootstrap hooks", () => {
+  it("reads channel and growth flags from the public bootstrap config", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({ channel: "staging", growthLandingPagesEnabled: true });
+
+    const observed = await renderBootstrapProbe();
+
+    expect(api.get).toHaveBeenCalledWith("/bootstrap/config");
+    expect(observed.channel).toEqual({ channel: "staging", settled: true });
+    expect(observed.growth).toEqual({ enabled: true, settled: true });
+    expect(observed.growthEnabled).toBe(true);
+  });
+
+  it("settles to safe defaults when the bootstrap config request fails", async () => {
+    vi.mocked(api.get).mockRejectedValueOnce(new Error("bootstrap unavailable"));
+
+    const observed = await renderBootstrapProbe();
+
+    expect(observed.channel).toEqual({ channel: null, settled: true });
+    expect(observed.growth).toEqual({ enabled: false, settled: true });
+    expect(observed.growthEnabled).toBe(false);
+  });
+});
+
+async function renderBootstrapProbe(): Promise<ObservedBootstrap> {
+  const observedRef: { current: ObservedBootstrap | null } = { current: null };
+
+  function Probe(): null {
+    observedRef.current = {
+      channel: useServerChannelState(),
+      growth: useGrowthLandingPagesState(),
+      growthEnabled: useGrowthLandingPagesEnabled(),
+    };
+    return null;
+  }
+
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  queryClient = client;
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  await act(async () => {
+    root?.render(createElement(QueryClientProvider, { client }, createElement(Probe)));
+  });
+
+  for (let i = 0; i < 10; i += 1) {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+    const observed = observedRef.current;
+    if (observed?.channel.settled && observed.growth.settled) return observed;
+  }
+  throw new Error("server bootstrap probe did not settle");
+}

--- a/packages/web/src/hooks/__tests__/use-viewport.test.tsx
+++ b/packages/web/src/hooks/__tests__/use-viewport.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useWorkspaceViewport } from "../use-viewport.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+const matches = new Map<string, boolean>();
+const listeners = new Map<string, Set<() => void>>();
+
+function renderProbe(): void {
+  function Probe() {
+    return <div>{useWorkspaceViewport()}</div>;
+  }
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(<Probe />);
+  });
+}
+
+function setMedia(query: string, next: boolean): void {
+  matches.set(query, next);
+  act(() => {
+    for (const listener of listeners.get(query) ?? []) listener();
+  });
+}
+
+beforeEach(() => {
+  matches.clear();
+  listeners.clear();
+  document.body.innerHTML = "";
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      get matches() {
+        return matches.get(query) ?? false;
+      },
+      media: query,
+      onchange: null,
+      addEventListener: (_type: string, listener: () => void) => {
+        const set = listeners.get(query) ?? new Set<() => void>();
+        set.add(listener);
+        listeners.set(query, set);
+      },
+      removeEventListener: (_type: string, listener: () => void) => {
+        listeners.get(query)?.delete(listener);
+      },
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    })),
+  });
+});
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  container = null;
+  document.body.innerHTML = "";
+});
+
+describe("useWorkspaceViewport", () => {
+  it("tracks xl, md, and narrow viewport breakpoints", () => {
+    matches.set("(min-width: 80rem)", true);
+    matches.set("(min-width: 48rem)", true);
+
+    renderProbe();
+    expect(container?.textContent).toBe("xl");
+
+    setMedia("(min-width: 80rem)", false);
+    expect(container?.textContent).toBe("md");
+
+    setMedia("(min-width: 48rem)", false);
+    expect(container?.textContent).toBe("narrow");
+
+    setMedia("(min-width: 80rem)", true);
+    expect(container?.textContent).toBe("xl");
+  });
+});

--- a/packages/web/src/observability/__tests__/sentry.test.ts
+++ b/packages/web/src/observability/__tests__/sentry.test.ts
@@ -1,6 +1,29 @@
 import type { Event } from "@sentry/react";
-import { describe, expect, it } from "vitest";
-import { resolveWebSentryConfig, sanitizeWebSentryEvent } from "../sentry.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { captureReactRootError, initWebSentry, resolveWebSentryConfig, sanitizeWebSentryEvent } from "../sentry.js";
+
+const sentryMocks = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  init: vi.fn(),
+  isEnabled: vi.fn(),
+  setTag: vi.fn(),
+  withScope: vi.fn(),
+}));
+
+vi.mock("@sentry/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@sentry/react")>()),
+  captureException: sentryMocks.captureException,
+  init: sentryMocks.init,
+  isEnabled: sentryMocks.isEnabled,
+  setTag: sentryMocks.setTag,
+  withScope: sentryMocks.withScope,
+}));
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
 
 describe("resolveWebSentryConfig", () => {
   it("defaults to enabled when a DSN is configured", () => {
@@ -22,6 +45,100 @@ describe("resolveWebSentryConfig", () => {
     } as ImportMetaEnv);
 
     expect(config.enabled).toBe(false);
+  });
+
+  it("normalizes explicit config values and rejects invalid sample rates", () => {
+    const config = resolveWebSentryConfig({
+      MODE: "development",
+      VITE_SENTRY_DSN: "  https://public@example.ingest.sentry.io/1  ",
+      VITE_SENTRY_ENABLED: "YES",
+      VITE_SENTRY_ENVIRONMENT: "  staging  ",
+      VITE_SENTRY_RELEASE: "  first-tree-web@custom  ",
+      VITE_SENTRY_TRACES_SAMPLE_RATE: "2",
+    } as ImportMetaEnv);
+
+    expect(config).toMatchObject({
+      enabled: true,
+      dsn: "https://public@example.ingest.sentry.io/1",
+      environment: "staging",
+      release: "first-tree-web@custom",
+      sampleRate: 0.1,
+    });
+  });
+
+  it("uses production only on the production host and accepts bounded sample rates", () => {
+    vi.stubGlobal("window", { location: { hostname: "cloud.first-tree.ai" } });
+
+    const config = resolveWebSentryConfig({
+      MODE: "development",
+      VITE_SENTRY_ENABLED: "1",
+      VITE_SENTRY_TRACES_SAMPLE_RATE: "0.75",
+    } as ImportMetaEnv);
+
+    expect(config.environment).toBe("production");
+    expect(config.sampleRate).toBe(0.75);
+  });
+});
+
+describe("initWebSentry", () => {
+  it("does not initialize when disabled or missing a DSN", () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "");
+    vi.stubEnv("VITE_SENTRY_ENABLED", "true");
+
+    initWebSentry();
+
+    expect(sentryMocks.init).not.toHaveBeenCalled();
+  });
+
+  it("initializes Sentry with sanitizers and release tags", () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
+    vi.stubEnv("VITE_SENTRY_ENABLED", "true");
+    vi.stubEnv("VITE_SENTRY_ENVIRONMENT", "staging");
+    vi.stubEnv("VITE_SENTRY_RELEASE", "first-tree-web@sha");
+    vi.stubEnv("VITE_SENTRY_TRACES_SAMPLE_RATE", "0.5");
+
+    initWebSentry();
+
+    const options = sentryMocks.init.mock.calls[0]?.[0];
+    expect(options).toMatchObject({
+      dsn: "https://public@example.ingest.sentry.io/1",
+      environment: "staging",
+      release: "first-tree-web@sha",
+      tracesSampleRate: 0.5,
+      sendDefaultPii: false,
+      maxBreadcrumbs: 0,
+    });
+    expect(options?.beforeSend?.({ message: "Bearer secret-token" }).message).toBe("Bearer [REDACTED]");
+    expect(options?.beforeSendTransaction?.({ transaction: "/invite/raw-token?x=1" }).transaction).toBe(
+      "/invite/[token]",
+    );
+    expect(sentryMocks.setTag).toHaveBeenCalledWith("first_tree.surface", "web");
+    expect(sentryMocks.setTag).toHaveBeenCalledWith("first_tree.git_sha", "test");
+  });
+});
+
+describe("captureReactRootError", () => {
+  it("skips disabled Sentry clients", () => {
+    sentryMocks.isEnabled.mockReturnValue(false);
+
+    captureReactRootError(new Error("boom"), { componentStack: "stack" });
+
+    expect(sentryMocks.withScope).not.toHaveBeenCalled();
+    expect(sentryMocks.captureException).not.toHaveBeenCalled();
+  });
+
+  it("captures enabled root errors with the React component stack", () => {
+    const setContext = vi.fn();
+    const error = new Error("boom");
+    sentryMocks.isEnabled.mockReturnValue(true);
+    sentryMocks.withScope.mockImplementation((callback: (scope: { setContext: typeof setContext }) => void) => {
+      callback({ setContext });
+    });
+
+    captureReactRootError(error, { componentStack: "at App" });
+
+    expect(setContext).toHaveBeenCalledWith("react", { componentStack: "at App" });
+    expect(sentryMocks.captureException).toHaveBeenCalledWith(error);
   });
 });
 
@@ -108,5 +225,45 @@ describe("sanitizeWebSentryEvent", () => {
       refreshToken: "[REDACTED]",
     });
     expect(event.exception?.values?.[0]?.value).toBe("OAuth failed at /auth/github/complete");
+  });
+
+  it("scrubs arrays, non-string headers, relative routes, and invalid URLs", () => {
+    const rawEvent: Event = {
+      request: {
+        url: "/invite/local-token?access_token=secret",
+        headers: {
+          "x-count": "3",
+          "x-api-key": "secret",
+          cookie: "session=secret",
+        },
+      },
+      transaction: "not a url /auth/github/complete?code=secret",
+      extra: {
+        redirects: ["/invite/array-token?token=secret", { password: "secret", value: "Bearer nested-token" }, 42],
+      },
+      message: "send apiKey=secret and oauth_code=abc",
+    };
+    const event = sanitizeWebSentryEvent(rawEvent, {
+      enabled: true,
+      dsn: "https://public@example.ingest.sentry.io/1",
+      environment: "production",
+      release: "first-tree-web@test-sha",
+      buildId: "test-sha",
+      sampleRate: 0.1,
+    });
+
+    expect(event.request?.url).toBe("/invite/[token]");
+    expect(event.request?.headers).toEqual({
+      "x-count": "3",
+      "x-api-key": "[REDACTED]",
+      cookie: "[REDACTED]",
+    });
+    expect(event.transaction).toBe("/not%20a%20url%20/auth/github/complete");
+    expect(event.extra?.redirects).toEqual([
+      "/invite/[token]",
+      { password: "[REDACTED]", value: "Bearer [REDACTED]" },
+      42,
+    ]);
+    expect(event.message).toBe("send apiKey=[REDACTED] and oauth_code=[REDACTED]");
   });
 });

--- a/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
@@ -19,6 +19,7 @@ async function flush(): Promise<void> {
   await act(async () => {
     await Promise.resolve();
     await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 }
 
@@ -40,6 +41,14 @@ async function clickByText(container: ParentNode, text: string): Promise<void> {
     button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
   });
   await flush();
+}
+
+async function waitForText(container: ParentNode, text: string): Promise<void> {
+  for (let i = 0; i < 10; i += 1) {
+    if (container.textContent?.includes(text)) return;
+    await flush();
+  }
+  throw new Error(`Missing text: ${text}\nRendered: ${container.textContent?.slice(0, 1200) ?? ""}`);
 }
 
 beforeEach(() => {
@@ -175,6 +184,72 @@ describe("onboarding preview review surface", () => {
     expect(window.location.search).toContain("role=invitee");
     expect(window.location.search).toContain("view=flow");
     expect(window.location.search).toContain("scenario=inv-link-signedout");
+
+    await act(async () => root.unmount());
+  });
+
+  it("renders GitHub repo loading outcomes from the active preview network profile", async () => {
+    const { OnboardingPreviewPage } = await import("../onboarding-preview.js");
+
+    window.history.replaceState(null, "", "/preview/onboarding?role=admin&view=states&scenario=admin-code-loadfailed");
+    const loadFailed = await renderDom(
+      <MemoryRouter>
+        <OnboardingPreviewPage />
+      </MemoryRouter>,
+    );
+    await waitForText(loadFailed.container, "Couldn't load your team's repos");
+    await act(async () => loadFailed.root.unmount());
+
+    window.history.replaceState(null, "", "/preview/onboarding?role=admin&view=states&scenario=admin-code-norepos");
+    const noRepos = await renderDom(
+      <MemoryRouter>
+        <OnboardingPreviewPage />
+      </MemoryRouter>,
+    );
+    await waitForText(noRepos.container, "No repos are shared with First Tree yet");
+    await waitForText(noRepos.container, "0 repositories available");
+    await act(async () => noRepos.root.unmount());
+
+    window.history.replaceState(null, "", "/preview/onboarding?role=admin&view=states&scenario=admin-code-repos-user");
+    const repos = await renderDom(
+      <MemoryRouter>
+        <OnboardingPreviewPage />
+      </MemoryRouter>,
+    );
+    await waitForText(repos.container, "Connected to");
+    await waitForText(repos.container, "gandy");
+    await waitForText(repos.container, "User");
+    await waitForText(repos.container, "3 repositories available");
+
+    await clickByText(repos.container, "dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("theme")).toBe("dark");
+
+    await clickByText(repos.container, "invitee");
+    expect(window.location.search).toContain("role=invitee");
+
+    await act(async () => repos.root.unmount());
+  });
+
+  it("surfaces preview install-url failures through the real install button", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/preview/onboarding?role=admin&view=states&scenario=admin-code-err-cantconnect",
+    );
+    vi.spyOn(window, "open").mockReturnValue(null);
+
+    const { OnboardingPreviewPage } = await import("../onboarding-preview.js");
+    const { container, root } = await renderDom(
+      <MemoryRouter>
+        <OnboardingPreviewPage />
+      </MemoryRouter>,
+    );
+
+    await clickByText(container, "Install First Tree on GitHub");
+
+    await waitForText(container, "Couldn't connect a repo here right now");
+    expect(sessionStorage.getItem("onboarding:connect-code:install-attempt")).toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
@@ -55,12 +55,14 @@ beforeEach(() => {
   document.body.innerHTML = "";
   document.documentElement.className = "";
   window.history.replaceState(null, "", "/preview/onboarding");
+  localStorage.clear();
   sessionStorage.clear();
 });
 
 afterEach(() => {
   document.body.innerHTML = "";
   document.documentElement.className = "";
+  localStorage.clear();
   vi.restoreAllMocks();
 });
 
@@ -221,14 +223,27 @@ describe("onboarding preview review surface", () => {
     await waitForText(repos.container, "User");
     await waitForText(repos.container, "3 repositories available");
 
-    await clickByText(repos.container, "dark");
+    await act(async () => repos.root.unmount());
+  });
+
+  it("wires the preview sidebar theme and role controls", async () => {
+    window.history.replaceState(null, "", "/preview/onboarding?role=admin&view=states&scenario=admin-code-repos-user");
+
+    const { OnboardingPreviewPage } = await import("../onboarding-preview.js");
+    const { container, root } = await renderDom(
+      <MemoryRouter>
+        <OnboardingPreviewPage />
+      </MemoryRouter>,
+    );
+
+    await clickByText(container, "dark");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
     expect(localStorage.getItem("theme")).toBe("dark");
 
-    await clickByText(repos.container, "invitee");
+    await clickByText(container, "invitee");
     expect(window.location.search).toContain("role=invitee");
 
-    await act(async () => repos.root.unmount());
+    await act(async () => root.unmount());
   });
 
   it("surfaces preview install-url failures through the real install button", async () => {

--- a/packages/web/src/pages/__tests__/team-preview-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/team-preview-interactions.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TeamPreviewPage } from "../team-preview.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root | null = null;
+let container: HTMLElement;
+
+function installBrowserMocks(matches: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+  Object.defineProperty(window, "innerHeight", { configurable: true, value: 900 });
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function renderPage(): Promise<void> {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(<TeamPreviewPage />);
+  });
+  await flush();
+}
+
+async function click(element: Element): Promise<void> {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+function buttonByText(label: string): HTMLButtonElement {
+  const button = [...document.querySelectorAll("button")].find((candidate) => candidate.textContent?.includes(label));
+  if (!button) throw new Error(`Missing button: ${label}`);
+  return button;
+}
+
+function buttonByLabel(label: RegExp): HTMLButtonElement {
+  const button = [...document.querySelectorAll("button")].find((candidate) =>
+    label.test(candidate.getAttribute("aria-label") ?? ""),
+  );
+  if (!button) throw new Error(`Missing labelled button: ${label}`);
+  return button;
+}
+
+function pageText(): string {
+  return document.body.textContent ?? "";
+}
+
+describe("TeamPreviewPage interactions", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    document.documentElement.className = "";
+    installBrowserMocks(true);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+      root = null;
+    }
+    document.body.innerHTML = "";
+    document.documentElement.className = "";
+    vi.restoreAllMocks();
+  });
+
+  it("drives role, filter, usage, theme, row action, and delegate controls", async () => {
+    await renderPage();
+
+    expect(pageText()).toContain("Team");
+    expect(pageText()).not.toContain("Invite link");
+
+    await click(buttonByText("Admin"));
+    expect(pageText()).toContain("Invite link");
+    expect(pageText()).toContain("Ava's Helper");
+
+    await click(buttonByText("Mine"));
+    expect(pageText()).not.toContain("Nova");
+    expect(pageText()).toContain("Scout");
+
+    await click(buttonByText("7d"));
+    expect(buttonByText("7d").getAttribute("aria-pressed")).toBe("true");
+
+    await click(buttonByLabel(/Actions for Scout/));
+    expect(pageText()).toContain("Delete");
+    await click(buttonByText("Delete"));
+    expect(pageText()).not.toContain("Delete");
+
+    await click(buttonByText("Scout"));
+    await click(buttonByText("Sandbox"));
+    expect(pageText()).toContain("Sandbox");
+
+    await click(buttonByText("theme"));
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary\n- add CLI tests for WSL dbus, daemon supervisor, unsupported supervisor, and task scheduler edge branches\n- add Client tests for Claude tool search refs and Codex platform resolution edges\n\n## Verification\n- pnpm run lint\n- pnpm run typecheck\n- pnpm run check\n- pnpm run format\n- pnpm --filter @first-tree/client exec vitest run src/__tests__/claude-code-tool-events-search-edge.test.ts\n- pnpm --filter @first-tree/client exec vitest run src/__tests__/codex-capability-platform-edge.test.ts\n- pnpm coverage\n- pnpm coverage:summary\n\n## Notes\n- Existing Biome warnings remain in assistant-text.test.ts, workspace-migrations.ts, and web index.css.\n- Full pnpm test previously hit the known @first-tree/skill-evals periodic monorepo-concurrency timeout, while the package-level test passed.\n- Supersedes #1579 because that PR used a branch name rejected by CI.