### PR TITLE
Complete mobile phase 1 shell routes

### DIFF
--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -42,6 +42,21 @@ vi.mock("../pages/onboarding/onboarding-page.js", () => ({ OnboardingPage: () =>
 vi.mock("../pages/workspace/index.js", () => ({ WorkspacePage: () => <div>workspace page</div> }));
 vi.mock("../pages/context.js", () => ({ ContextPage: () => <div>context page</div> }));
 vi.mock("../pages/team/index.js", () => ({ TeamPage: () => <div>team page</div> }));
+vi.mock("../pages/mobile/shell.js", async () => {
+  const { Outlet } = await import("react-router");
+  return {
+    MobileShell: () => (
+      <div data-testid="mobile-shell">
+        mobile shell
+        <Outlet />
+      </div>
+    ),
+  };
+});
+vi.mock("../pages/mobile/today.js", () => ({ MobileTodayPage: () => <div>mobile today</div> }));
+vi.mock("../pages/mobile/chat.js", () => ({ MobileChatPage: () => <div>mobile chat</div> }));
+vi.mock("../pages/mobile/team.js", () => ({ MobileTeamPage: () => <div>mobile team</div> }));
+vi.mock("../pages/mobile/me.js", () => ({ MobileMePage: () => <div>mobile me</div> }));
 vi.mock("../pages/settings.js", async () => {
   const { Outlet } = await import("react-router");
   return {
@@ -141,6 +156,22 @@ describe("App routes", () => {
     document.body.innerHTML = "";
 
     expect(await renderAppAt("/admin#agents")).toContain("team page");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/m")).toContain("mobile today");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/m/chat")).toContain("mobile chat");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/m/team")).toContain("mobile team");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    expect(await renderAppAt("/m/me")).toContain("mobile me");
     await act(async () => root?.unmount());
     document.body.innerHTML = "";
 

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -19,6 +19,11 @@ import { DocPage } from "./pages/docs/doc-page.js";
 import { DocsListPage } from "./pages/docs/docs-list-page.js";
 import { InviteAcceptPage } from "./pages/invite-accept.js";
 import { LoginPage } from "./pages/login.js";
+import { MobileChatPage } from "./pages/mobile/chat.js";
+import { MobileMePage } from "./pages/mobile/me.js";
+import { MobileShell } from "./pages/mobile/shell.js";
+import { MobileTeamPage } from "./pages/mobile/team.js";
+import { MobileTodayPage } from "./pages/mobile/today.js";
 import { OAuthCompletePage } from "./pages/oauth-complete.js";
 import { GithubConnectedPage } from "./pages/onboarding/github-connected.js";
 import { OnboardingPage } from "./pages/onboarding/onboarding-page.js";
@@ -342,6 +347,19 @@ export function App() {
                     chrome. The workspace root redirects incomplete users
                     here; this route redirects back once setup is complete. */}
                 <Route path="/onboarding" element={<OnboardingPage />} />
+                <Route
+                  element={
+                    <PulseProvider>
+                      <MobileShell />
+                    </PulseProvider>
+                  }
+                >
+                  <Route path="m" element={<Navigate to="/m/today" replace />} />
+                  <Route path="m/today" element={<MobileTodayPage />} />
+                  <Route path="m/chat" element={<MobileChatPage />} />
+                  <Route path="m/team" element={<MobileTeamPage />} />
+                  <Route path="m/me" element={<MobileMePage />} />
+                </Route>
                 <Route
                   element={
                     <PulseProvider>

--- a/packages/web/src/pages/mobile/__tests__/data.test.ts
+++ b/packages/web/src/pages/mobile/__tests__/data.test.ts
@@ -1,0 +1,74 @@
+import type { MeChatRow } from "@first-tree/shared";
+import { describe, expect, it } from "vitest";
+import { countAttentionRows, countUnreadRows, mobileChatSignal, sortMobileChats } from "../data.js";
+
+const NOW = "2026-07-09T10:00:00.000Z";
+
+function chatRow(overrides: Partial<MeChatRow> = {}): MeChatRow {
+  return {
+    chatId: overrides.chatId ?? "chat-1",
+    type: overrides.type ?? "group",
+    membershipKind: overrides.membershipKind ?? "participant",
+    createdByMe: overrides.createdByMe ?? false,
+    source: overrides.source ?? "manual",
+    entityType: overrides.entityType ?? null,
+    title: overrides.title ?? "Launch planning",
+    topic: overrides.topic ?? "Launch planning",
+    description: overrides.description ?? null,
+    participants:
+      overrides.participants ??
+      [
+        {
+          agentId: "human-agent-self",
+          displayName: "Gandy",
+          type: "human",
+          avatarColorToken: null,
+          avatarImageUrl: null,
+        },
+      ],
+    participantCount: overrides.participantCount ?? 1,
+    lastMessageAt: overrides.lastMessageAt ?? NOW,
+    lastMessagePreview: overrides.lastMessagePreview ?? "Please review the launch checklist.",
+    unreadMentionCount: overrides.unreadMentionCount ?? 0,
+    openRequestCount: overrides.openRequestCount ?? 0,
+    canReply: overrides.canReply ?? true,
+    engagementStatus: overrides.engagementStatus ?? "active",
+    liveActivity: overrides.liveActivity ?? null,
+    failedAgentIds: overrides.failedAgentIds ?? [],
+    busyAgentIds: overrides.busyAgentIds ?? [],
+    chatHasExplicitMentionToMe: overrides.chatHasExplicitMentionToMe ?? false,
+  };
+}
+
+describe("mobile chat projection", () => {
+  it("ranks answer-needed chats before failed, unread, working, and recent chats", () => {
+    const recent = chatRow({ chatId: "recent", lastMessageAt: "2026-07-09T10:05:00.000Z" });
+    const working = chatRow({ chatId: "working", busyAgentIds: ["agent-1"] });
+    const unread = chatRow({ chatId: "unread", unreadMentionCount: 2 });
+    const failed = chatRow({ chatId: "failed", failedAgentIds: ["agent-2"] });
+    const question = chatRow({ chatId: "question", openRequestCount: 1 });
+
+    expect(sortMobileChats([recent, working, unread, failed, question]).map((row) => row.chatId)).toEqual([
+      "question",
+      "failed",
+      "unread",
+      "working",
+      "recent",
+    ]);
+  });
+
+  it("counts attention and unread rows separately for mobile tab badges", () => {
+    const explicitMention = chatRow({ chatId: "explicit", chatHasExplicitMentionToMe: true });
+    const rows = [
+      chatRow({ chatId: "question", openRequestCount: 1 }),
+      chatRow({ chatId: "failed", failedAgentIds: ["agent-1"] }),
+      explicitMention,
+      chatRow({ chatId: "unread", unreadMentionCount: 1 }),
+      chatRow({ chatId: "working", busyAgentIds: ["agent-2"] }),
+    ];
+
+    expect(countAttentionRows(rows)).toBe(4);
+    expect(countUnreadRows(rows)).toBe(1);
+    expect(mobileChatSignal(explicitMention).label).toBe("Unread");
+  });
+});

--- a/packages/web/src/pages/mobile/__tests__/me-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/me-dom.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+
+import type { MeMembership } from "@first-tree/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+
+const authMock = vi.hoisted(() => {
+  const memberships: MeMembership[] = [];
+  const currentMembership: MeMembership | null = null;
+  return {
+    logout: vi.fn(),
+    value: {
+      isAuthenticated: true,
+      meLoaded: true,
+      user: { id: "user-self", username: "gandy", displayName: "Gandy", avatarUrl: null },
+      memberships,
+      currentMembership,
+      organizationId: "org-1",
+      memberId: "member-self",
+      role: "admin",
+      agentId: "human-agent-self",
+      teamDisplayName: "Acme Research",
+      orgHasOtherMembers: true,
+      currentOrgHasUsableAgent: true,
+      currentOrgHasPersonalAgent: true,
+      docsEnabled: false,
+      onboardingStep: "completed" as const,
+      onboardingDismissedAt: null,
+      onboardingCompletedAt: "2026-07-01T00:00:00.000Z",
+      dismissOnboarding: vi.fn(async () => undefined),
+      restoreOnboarding: vi.fn(async () => undefined),
+      markOnboardingCompleted: vi.fn(async () => undefined),
+      login: vi.fn(async () => undefined),
+      adoptTokens: vi.fn(async () => undefined),
+      selectOrganization: vi.fn(async () => undefined),
+      switchingOrg: null,
+      setSwitchingOrg: vi.fn(),
+      refreshMe: vi.fn(async () => undefined),
+      logout: vi.fn(),
+    },
+  };
+});
+
+vi.mock("../../../auth/auth-context.js", () => ({
+  useAuth: () => authMock.value,
+}));
+
+vi.mock("../../../components/team-switcher.js", () => ({
+  TeamSwitcher: () => <button type="button">Switch team</button>,
+}));
+
+vi.mock("../../../components/ui/theme-toggle.js", () => ({
+  ThemeToggle: () => <button type="button">Switch theme</button>,
+}));
+
+function renderMePage(harness: DomHarness) {
+  return import("../me.js").then(({ MobileMePage }) => {
+    harness.render(
+      <MemoryRouter>
+        <MobileMePage />
+      </MemoryRouter>,
+    );
+  });
+}
+
+describe("MobileMePage", () => {
+  let harness: DomHarness;
+
+  beforeEach(() => {
+    harness = createDomHarness();
+    authMock.value.logout = vi.fn();
+  });
+
+  it("renders account, team, preference, support, and sign-out controls without admin panels", async () => {
+    await renderMePage(harness);
+
+    expect(harness.container.textContent).toContain("Gandy");
+    expect(harness.container.textContent).toContain("@gandy");
+    expect(harness.container.textContent).toContain("Acme Research");
+    expect(harness.container.textContent).toContain("Switch team");
+    expect(harness.container.textContent).toContain("Switch theme");
+    expect(harness.container.textContent).toContain("Desktop settings");
+    expect(harness.container.textContent).toContain("Support");
+    expect(harness.container.textContent).toContain("Sign out");
+    expect(harness.container.textContent).not.toContain("Agent runtime");
+    expect(harness.container.textContent).not.toContain("Context tree setup");
+    expect(harness.container.textContent).not.toContain("GitHub integration");
+
+    const signOut =
+      [...harness.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Sign out")) ??
+      null;
+    signOut?.click();
+    expect(authMock.value.logout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/pages/mobile/__tests__/shell-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/shell-dom.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+
+import type { MeMembership } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+import { MobileShell } from "../shell.js";
+
+const authMock = vi.hoisted(() => {
+  const memberships: MeMembership[] = [];
+  const currentMembership: MeMembership | null = null;
+  return {
+    value: {
+      isAuthenticated: true,
+      meLoaded: true,
+      user: { id: "user-self", username: "gandy", displayName: "Gandy", avatarUrl: null },
+      memberships,
+      currentMembership,
+      organizationId: "org-1",
+      memberId: "member-self",
+      role: "admin",
+      agentId: "human-agent-self",
+      teamDisplayName: "Acme Research",
+      orgHasOtherMembers: true,
+      currentOrgHasUsableAgent: true,
+      currentOrgHasPersonalAgent: true,
+      docsEnabled: false,
+      onboardingStep: "completed" as const,
+      onboardingDismissedAt: null,
+      onboardingCompletedAt: "2026-07-01T00:00:00.000Z",
+      dismissOnboarding: vi.fn(async () => undefined),
+      restoreOnboarding: vi.fn(async () => undefined),
+      markOnboardingCompleted: vi.fn(async () => undefined),
+      login: vi.fn(async () => undefined),
+      adoptTokens: vi.fn(async () => undefined),
+      selectOrganization: vi.fn(async () => undefined),
+      switchingOrg: null,
+      setSwitchingOrg: vi.fn(),
+      refreshMe: vi.fn(async () => undefined),
+      logout: vi.fn(),
+    },
+  };
+});
+
+const meChatMocks = vi.hoisted(() => ({
+  listMeChats: vi.fn(),
+}));
+
+vi.mock("../../../auth/auth-context.js", () => ({
+  useAuth: () => authMock.value,
+}));
+
+vi.mock("../../../api/me-chats.js", () => meChatMocks);
+
+vi.mock("../../../hooks/use-admin-ws.js", () => ({
+  useAdminWs: () => undefined,
+}));
+
+vi.mock("../../../components/team-switcher.js", () => ({
+  TeamSwitcher: () => <button type="button">Current team</button>,
+}));
+
+vi.mock("../../../components/team-switch-overlay.js", () => ({
+  TeamSwitchOverlay: () => null,
+}));
+
+function renderShell(harness: DomHarness, path: string) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  harness.render(
+    <MemoryRouter initialEntries={[path]}>
+      <QueryClientProvider client={queryClient}>
+        <Routes>
+          <Route element={<MobileShell />}>
+            <Route path="/m/today" element={<div>today content</div>} />
+            <Route path="/m/chat" element={<div>chat content</div>} />
+          </Route>
+        </Routes>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("MobileShell", () => {
+  let harness: DomHarness;
+
+  beforeEach(() => {
+    harness = createDomHarness();
+    meChatMocks.listMeChats.mockReset();
+    meChatMocks.listMeChats.mockReturnValue(new Promise(() => undefined));
+  });
+
+  it("keeps bottom tabs on primary tabs and hides them for chat detail", async () => {
+    renderShell(harness, "/m/today");
+    await harness.flush();
+    expect(harness.container.querySelector('nav[aria-label="Mobile"]')).not.toBeNull();
+
+    harness.cleanup();
+    harness = createDomHarness();
+
+    renderShell(harness, "/m/chat?c=chat-1");
+    await harness.flush();
+    expect(harness.container.textContent).toContain("chat content");
+    expect(harness.container.querySelector('nav[aria-label="Mobile"]')).toBeNull();
+    expect(harness.container.textContent).not.toContain("Current team");
+  });
+});

--- a/packages/web/src/pages/mobile/data.ts
+++ b/packages/web/src/pages/mobile/data.ts
@@ -29,7 +29,8 @@ export function mobileChatSignal(row: MeChatRow): MobileChatSignal {
   if (row.chatHasExplicitMentionToMe || row.unreadMentionCount > 0) {
     return {
       tone: "unread",
-      label: row.unreadMentionCount === 1 ? "Unread" : `${row.unreadMentionCount} unread`,
+      label:
+        row.unreadMentionCount === 0 || row.unreadMentionCount === 1 ? "Unread" : `${row.unreadMentionCount} unread`,
       rank: 2,
       attention: true,
     };

--- a/packages/web/src/pages/mobile/me.tsx
+++ b/packages/web/src/pages/mobile/me.tsx
@@ -1,0 +1,212 @@
+import { ExternalLink, HelpCircle, LogOut, MonitorCog, Palette } from "lucide-react";
+import type { ReactNode } from "react";
+import { Link } from "react-router";
+import { useAuth } from "../../auth/auth-context.js";
+import { Avatar } from "../../components/avatar.js";
+import { TeamSwitcher } from "../../components/team-switcher.js";
+import { Button } from "../../components/ui/button.js";
+import { ThemeToggle } from "../../components/ui/theme-toggle.js";
+import { MobilePage, MobileSection } from "./components.js";
+
+export function MobileMePage() {
+  const { user, teamDisplayName, role, logout } = useAuth();
+  const displayName = user?.displayName ?? "Signed-in user";
+  const username = user?.username ?? "";
+  const avatarSrc = user?.avatarUrl ?? null;
+
+  return (
+    <MobilePage className="flex flex-col" padded>
+      <div className="flex items-center" style={{ gap: "var(--sp-3)", marginBottom: "var(--sp-5)" }}>
+        <Avatar src={avatarSrc} name={displayName} seed={user?.id ?? displayName} size={48} />
+        <div className="min-w-0" style={{ flex: 1 }}>
+          <p className="text-title truncate" style={{ color: "var(--fg)", margin: 0 }}>
+            {displayName}
+          </p>
+          {username ? (
+            <p className="mono text-caption truncate" style={{ color: "var(--fg-3)", margin: "var(--sp-0_5) 0 0" }}>
+              @{username}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex flex-col" style={{ gap: "var(--sp-5)" }}>
+        <MobileSection title="Team">
+          <MobilePanel>
+            <div className="flex items-center" style={{ gap: "var(--sp-3)" }}>
+              <div className="min-w-0" style={{ flex: 1 }}>
+                <p className="text-subtitle truncate" style={{ color: "var(--fg)", margin: 0 }}>
+                  {teamDisplayName ?? "Current team"}
+                </p>
+                <p className="text-body" style={{ color: "var(--fg-3)", margin: "var(--sp-0_5) 0 0" }}>
+                  {role === "admin" ? "Admin" : "Member"}
+                </p>
+              </div>
+              <TeamSwitcher variant="compact" redirectHomeOnSwitch={false} />
+            </div>
+          </MobilePanel>
+        </MobileSection>
+
+        <MobileSection title="Preferences">
+          <MobilePanel>
+            <MobileSettingRow
+              icon={<Palette aria-hidden className="h-4 w-4" />}
+              title="Theme"
+              detail="Use the same preference across mobile and desktop."
+              action={<ThemeToggle />}
+            />
+          </MobilePanel>
+        </MobileSection>
+
+        <MobileSection title="More">
+          <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+            <MobileLinkRow
+              to="/settings/computers"
+              icon={<MonitorCog aria-hidden className="h-4 w-4" />}
+              title="Desktop settings"
+              detail="Computers, resources, GitHub, and setup stay on desktop."
+            />
+            <MobileExternalRow
+              href="https://first-tree.ai/support"
+              icon={<HelpCircle aria-hidden className="h-4 w-4" />}
+              title="Support"
+              detail="Open help and product support."
+            />
+          </div>
+        </MobileSection>
+
+        <Button type="button" variant="outline" className="min-h-11 justify-start" onClick={logout}>
+          <LogOut className="h-4 w-4" />
+          Sign out
+        </Button>
+      </div>
+    </MobilePage>
+  );
+}
+
+function MobilePanel({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        padding: "var(--sp-3)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-dialog)",
+        background: "var(--bg-raised)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function MobileSettingRow({
+  icon,
+  title,
+  detail,
+  action,
+}: {
+  icon: ReactNode;
+  title: string;
+  detail: string;
+  action: ReactNode;
+}) {
+  return (
+    <div className="flex items-center" style={{ gap: "var(--sp-3)", minHeight: "var(--sp-11)" }}>
+      <span className="shrink-0" style={{ color: "var(--fg-3)" }}>
+        {icon}
+      </span>
+      <div className="min-w-0" style={{ flex: 1 }}>
+        <p className="text-subtitle" style={{ color: "var(--fg)", margin: 0 }}>
+          {title}
+        </p>
+        <p className="text-body" style={{ color: "var(--fg-3)", margin: "var(--sp-0_5) 0 0" }}>
+          {detail}
+        </p>
+      </div>
+      <div className="shrink-0">{action}</div>
+    </div>
+  );
+}
+
+function MobileLinkRow({
+  to,
+  icon,
+  title,
+  detail,
+}: {
+  to: string;
+  icon: ReactNode;
+  title: string;
+  detail: string;
+}) {
+  return (
+    <Link
+      to={to}
+      className="flex items-center transition-colors hover:bg-[var(--bg-hover)]"
+      style={{
+        minHeight: "var(--sp-16)",
+        gap: "var(--sp-3)",
+        padding: "var(--sp-3)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-dialog)",
+        background: "var(--bg-raised)",
+        color: "var(--fg)",
+        textDecoration: "none",
+      }}
+    >
+      <span className="shrink-0" style={{ color: "var(--fg-3)" }}>
+        {icon}
+      </span>
+      <div className="min-w-0" style={{ flex: 1 }}>
+        <p className="text-subtitle" style={{ margin: 0 }}>
+          {title}
+        </p>
+        <p className="text-body" style={{ color: "var(--fg-3)", margin: "var(--sp-0_5) 0 0" }}>
+          {detail}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+function MobileExternalRow({
+  href,
+  icon,
+  title,
+  detail,
+}: {
+  href: string;
+  icon: ReactNode;
+  title: string;
+  detail: string;
+}) {
+  return (
+    <a
+      href={href}
+      className="flex items-center transition-colors hover:bg-[var(--bg-hover)]"
+      style={{
+        minHeight: "var(--sp-16)",
+        gap: "var(--sp-3)",
+        padding: "var(--sp-3)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-dialog)",
+        background: "var(--bg-raised)",
+        color: "var(--fg)",
+        textDecoration: "none",
+      }}
+    >
+      <span className="shrink-0" style={{ color: "var(--fg-3)" }}>
+        {icon}
+      </span>
+      <div className="min-w-0" style={{ flex: 1 }}>
+        <p className="text-subtitle" style={{ margin: 0 }}>
+          {title}
+        </p>
+        <p className="text-body" style={{ color: "var(--fg-3)", margin: "var(--sp-0_5) 0 0" }}>
+          {detail}
+        </p>
+      </div>
+      <ExternalLink aria-hidden className="h-3.5 w-3.5 shrink-0" style={{ color: "var(--fg-4)" }} />
+    </a>
+  );
+}

--- a/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-summary.test.ts
@@ -167,6 +167,24 @@ describe("ChatSummary", () => {
     overlayEl.remove();
   });
 
+  it("can keep an unread summary collapsed on narrow mobile entry", async () => {
+    localStorage.clear();
+    const scrollEl = document.createElement("div");
+    const { container, overlayEl, root } = await renderSummary(scrollEl, {
+      descriptionUpdatedAt: unreadVersionAt,
+      lastReadAt: readRecentlyAt,
+      autoExpandUnread: false,
+    });
+
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Expand summary"]')).not.toBeNull();
+    expect(overlayEl.querySelector("strong")).toBeNull();
+    expect(container.textContent).toContain("Updated");
+
+    await act(async () => root.unmount());
+    container.remove();
+    overlayEl.remove();
+  });
+
   it("does not auto-expand the same unread summary version after the user manually collapses it", async () => {
     localStorage.clear();
     const scrollEl = document.createElement("div");

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -161,6 +161,7 @@ export function ChatSummary({
   descriptionUpdatedAt,
   lastReadAt,
   freshnessReady,
+  autoExpandUnread = true,
   scrollContainerRef,
   overlayContainerRef,
 }: {
@@ -172,6 +173,10 @@ export function ChatSummary({
    *  list-nav initialData stub, which lacks the freshness fields). The
    *  auto-expand decision waits for this so it reads true unread/last-read. */
   freshnessReady: boolean;
+  /** Narrow mobile chat routes keep the summary as an in-flow bar on entry so
+   * the floating card does not cover the first messages. Desktop preserves the
+   * unread auto-open behavior by default. */
+  autoExpandUnread?: boolean;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
   /** The message timeline's `relative` wrapper. The expanded summary is
    *  portaled here and floated `absolute; top:0` over the message area. */
@@ -237,14 +242,14 @@ export function ChatSummary({
     manualExpandTopRef.current = null;
     setScrollCollapsed(false);
     const dismissedVersion = loadDismissedVersion(chatId);
-    if (unread && descriptionUpdatedAt && dismissedVersion !== descriptionUpdatedAt) {
+    if (autoExpandUnread && unread && descriptionUpdatedAt && dismissedVersion !== descriptionUpdatedAt) {
       setOpen(true);
       setHighlighted(true);
     } else {
       setOpen(loadManualPref(chatId) ?? false);
       setHighlighted(false);
     }
-  }, [entryKey, chatId, descriptionUpdatedAt, hasDescription, freshnessReady, unread]);
+  }, [autoExpandUnread, entryKey, chatId, descriptionUpdatedAt, hasDescription, freshnessReady, unread]);
 
   const onToggle = useCallback(() => {
     setOpen((prev) => {

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -3744,6 +3744,7 @@ export function ChatView({
             descriptionUpdatedAt={chatDetail?.descriptionUpdatedAt ?? null}
             lastReadAt={chatDetail?.lastReadAt ?? null}
             freshnessReady={!chatDetailFetching && chatDetail?.id === chatId}
+            autoExpandUnread={!narrow}
             scrollContainerRef={scrollContainerRef}
             overlayContainerRef={overlayContainerRef}
           />


### PR DESCRIPTION
## Summary
- Adds the authenticated `/m/*` mobile route group for Today, Chat, Team, and Me.
- Adds `MobileMePage` with account, team, theme, desktop-settings handoff, support, and sign-out controls.
- Tightens mobile chat projection labeling and keeps narrow chat Summary collapsed on entry so it does not cover the first messages.
- Adds focused mobile projection, shell, Me page, route, and Summary regression tests.

## Scope Notes
- No server files, schema, migrations, or API contracts changed.
- Mobile phase 1 stays a daily work surface; it does not add agent configuration, context-tree management, or dense desktop admin flows.

## Verification
- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/web test`
- `pnpm --filter @first-tree/web build`
- Browser E2E / visual QA: 30 screenshots across 320/375/390/430/768 widths, with 390px dark-mode coverage. Local evidence: `output/playwright/mobile-phase1/qa-summary.json` and `output/playwright/mobile-phase1/audit-notes.md` in the agent worktree.

## Manual Product/UI Review
- Checked Today, Chat list, Chat detail, Team, and Me from a mobile daily-work perspective.
- Found and fixed a narrow chat detail issue where auto-expanded Summary covered the first message.
- Remaining polish candidate: 320px chat-detail header title truncation is acceptable for phase 1 but could be refined later with a dedicated mobile title/details sheet.
