### PR TITLE
feat: support GPT-5.6 Codex models

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.187",
     "@inquirer/prompts": "^8.3.0",
-    "@openai/codex-sdk": "^0.140.0",
+    "@openai/codex-sdk": "^0.144.1",
     "commander": "^13.1.0",
     "ejs": "^6.0.1",
     "gray-matter": "^4.0.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.187",
-    "@openai/codex-sdk": "^0.140.0",
+    "@openai/codex-sdk": "^0.144.1",
     "@sentry/node": "^10.62.0",
     "ejs": "^6.0.1",
     "pino": "^9.5.0",

--- a/packages/web/src/pages/agent-detail/__tests__/model-section-options.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/model-section-options.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { CODEX_MODEL_IDS, CODEX_MODEL_OPTIONS } from "../model-section.js";
+
+describe("Codex model options", () => {
+  it("exposes every enum-style model id exactly once", () => {
+    expect(CODEX_MODEL_OPTIONS.map((option) => option.value)).toEqual(Object.values(CODEX_MODEL_IDS));
+  });
+
+  it("includes the complete GPT-5.6 model family", () => {
+    expect(CODEX_MODEL_IDS).toMatchObject({
+      GPT_5_6: "gpt-5.6",
+      GPT_5_6_SOL: "gpt-5.6-sol",
+      GPT_5_6_TERRA: "gpt-5.6-terra",
+      GPT_5_6_LUNA: "gpt-5.6-luna",
+    });
+  });
+});

--- a/packages/web/src/pages/agent-detail/__tests__/model-section-options.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/model-section-options.test.ts
@@ -6,12 +6,11 @@ describe("Codex model options", () => {
     expect(CODEX_MODEL_OPTIONS.map((option) => option.value)).toEqual(Object.values(CODEX_MODEL_IDS));
   });
 
-  it("includes the complete GPT-5.6 model family", () => {
-    expect(CODEX_MODEL_IDS).toMatchObject({
-      GPT_5_6: "gpt-5.6",
-      GPT_5_6_SOL: "gpt-5.6-sol",
-      GPT_5_6_TERRA: "gpt-5.6-terra",
-      GPT_5_6_LUNA: "gpt-5.6-luna",
-    });
+  it("includes only the concrete GPT-5.6 Codex models", () => {
+    expect(Object.values(CODEX_MODEL_IDS).filter((model) => model.startsWith("gpt-5.6"))).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+    ]);
   });
 });

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -28,7 +28,6 @@ export const CLAUDE_MODEL_OPTIONS: ModelOption[] = [
  * remain usable before this picker is refreshed.
  */
 export const CODEX_MODEL_IDS = {
-  GPT_5_6: "gpt-5.6",
   GPT_5_6_SOL: "gpt-5.6-sol",
   GPT_5_6_TERRA: "gpt-5.6-terra",
   GPT_5_6_LUNA: "gpt-5.6-luna",
@@ -42,7 +41,6 @@ export const CODEX_MODEL_IDS = {
 export type CodexModelId = (typeof CODEX_MODEL_IDS)[keyof typeof CODEX_MODEL_IDS];
 
 export const CODEX_MODEL_OPTIONS: Array<ModelOption & { value: CodexModelId }> = [
-  { value: CODEX_MODEL_IDS.GPT_5_6, label: CODEX_MODEL_IDS.GPT_5_6, hint: "latest" },
   { value: CODEX_MODEL_IDS.GPT_5_6_SOL, label: CODEX_MODEL_IDS.GPT_5_6_SOL, hint: "flagship" },
   { value: CODEX_MODEL_IDS.GPT_5_6_TERRA, label: CODEX_MODEL_IDS.GPT_5_6_TERRA, hint: "balanced" },
   { value: CODEX_MODEL_IDS.GPT_5_6_LUNA, label: CODEX_MODEL_IDS.GPT_5_6_LUNA, hint: "fastest" },

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -21,18 +21,40 @@ export const CLAUDE_MODEL_OPTIONS: ModelOption[] = [
 ];
 
 /**
- * Codex CLI model slugs baked into `@openai/codex@0.125.0` — extracted from
- * the bundled binary's config schema. ChatGPT-account auth restricts which
- * are usable at runtime (gpt-5.5 works; older slugs reject); API-key auth
- * accepts the wider set. The picker lists all and lets the runtime surface
- * actual permission errors instead of pre-validating per auth mode.
+ * Curated Codex model ids exposed by the picker. Keep this as an enum-style
+ * `as const` object (rather than a TypeScript enum) so option values stay
+ * literal-typed and easy to reuse in Zod-compatible code. Runtime config still
+ * accepts arbitrary strings: account access differs and newer model ids must
+ * remain usable before this picker is refreshed.
  */
-export const CODEX_MODEL_OPTIONS: ModelOption[] = [
-  { value: "gpt-5.5", label: "gpt-5.5", hint: "latest" },
-  { value: "gpt-5.4", label: "gpt-5.4" },
-  { value: "gpt-5.4-mini", label: "gpt-5.4-mini", hint: "fastest" },
-  { value: "gpt-5.3-codex", label: "gpt-5.3-codex", hint: "coding-specialized" },
-  { value: "gpt-5.2", label: "gpt-5.2" },
+export const CODEX_MODEL_IDS = {
+  GPT_5_6: "gpt-5.6",
+  GPT_5_6_SOL: "gpt-5.6-sol",
+  GPT_5_6_TERRA: "gpt-5.6-terra",
+  GPT_5_6_LUNA: "gpt-5.6-luna",
+  GPT_5_5: "gpt-5.5",
+  GPT_5_4: "gpt-5.4",
+  GPT_5_4_MINI: "gpt-5.4-mini",
+  GPT_5_3_CODEX: "gpt-5.3-codex",
+  GPT_5_2: "gpt-5.2",
+} as const;
+
+export type CodexModelId = (typeof CODEX_MODEL_IDS)[keyof typeof CODEX_MODEL_IDS];
+
+export const CODEX_MODEL_OPTIONS: Array<ModelOption & { value: CodexModelId }> = [
+  { value: CODEX_MODEL_IDS.GPT_5_6, label: CODEX_MODEL_IDS.GPT_5_6, hint: "latest" },
+  { value: CODEX_MODEL_IDS.GPT_5_6_SOL, label: CODEX_MODEL_IDS.GPT_5_6_SOL, hint: "flagship" },
+  { value: CODEX_MODEL_IDS.GPT_5_6_TERRA, label: CODEX_MODEL_IDS.GPT_5_6_TERRA, hint: "balanced" },
+  { value: CODEX_MODEL_IDS.GPT_5_6_LUNA, label: CODEX_MODEL_IDS.GPT_5_6_LUNA, hint: "fastest" },
+  { value: CODEX_MODEL_IDS.GPT_5_5, label: CODEX_MODEL_IDS.GPT_5_5 },
+  { value: CODEX_MODEL_IDS.GPT_5_4, label: CODEX_MODEL_IDS.GPT_5_4 },
+  { value: CODEX_MODEL_IDS.GPT_5_4_MINI, label: CODEX_MODEL_IDS.GPT_5_4_MINI },
+  {
+    value: CODEX_MODEL_IDS.GPT_5_3_CODEX,
+    label: CODEX_MODEL_IDS.GPT_5_3_CODEX,
+    hint: "coding-specialized",
+  },
+  { value: CODEX_MODEL_IDS.GPT_5_2, label: CODEX_MODEL_IDS.GPT_5_2 },
 ];
 
 const MODEL_OPTIONS_BY_PROVIDER: Record<RuntimeProvider, ModelOption[]> = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^8.3.0
         version: 8.3.2(@types/node@22.19.15)
       '@openai/codex-sdk':
-        specifier: ^0.140.0
-        version: 0.140.0
+        specifier: ^0.144.1
+        version: 0.144.1
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -100,8 +100,8 @@ importers:
         specifier: ^0.3.187
         version: 0.3.187(@anthropic-ai/sdk@0.105.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@openai/codex-sdk':
-        specifier: ^0.140.0
-        version: 0.140.0
+        specifier: ^0.144.1
+        version: 0.144.1
       '@sentry/node':
         specifier: ^10.62.0
         version: 10.62.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.215.0(@opentelemetry/api@1.9.1))
@@ -1340,47 +1340,47 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@openai/codex-sdk@0.140.0':
-    resolution: {integrity: sha512-sHErDmCss08GMFo3FYVDFtVYiDpf1f3VRdhB4PBILBauZVYuFVYr3INvf6xc6t+oD2MbjuU+gtrw0it9aGesdA==}
+  '@openai/codex-sdk@0.144.1':
+    resolution: {integrity: sha512-NVb1R5+QJBecLrLrtljHkS7djXu/fGWVaA0FUhop6KgPTdeDzvgMo9uhgAuLi+4mwgf29IhMyNGU/kHG3aV4NA==}
     engines: {node: '>=18'}
 
-  '@openai/codex@0.140.0':
-    resolution: {integrity: sha512-FMnN12kJzVPljMTYRydLCNgd0cXXmVasNSfq2PtS42RMEIxoQ3dHtMvmno35hu2tfwrKNAAPCm4s+2PaFTEBGg==}
+  '@openai/codex@0.144.1':
+    resolution: {integrity: sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.140.0-darwin-arm64':
-    resolution: {integrity: sha512-KDyQHsxdc8FHZKziSBXs82ABgben/8lLPdhi2Nu+wj6qs2RAp4k/IvE8foafVnp3OeGqhtEFbhlZp0H4Dg/Slg==}
+  '@openai/codex@0.144.1-darwin-arm64':
+    resolution: {integrity: sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.140.0-darwin-x64':
-    resolution: {integrity: sha512-xA77AcKbP8BKxKqaJz8bqXtU1dUtanEKpWCMJ68LuYU054EC31BD7NftFe5/vpLUQR95fhRr7V9a91SLtCuLAg==}
+  '@openai/codex@0.144.1-darwin-x64':
+    resolution: {integrity: sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.140.0-linux-arm64':
-    resolution: {integrity: sha512-rGOgWEONilm+pQoQgcGpPRzvnou1CawyBOe8gvtuS32PQ00Pn+9nZF4O7iKBVlNh6Jeun8kpdJSjFdULm2wr4A==}
+  '@openai/codex@0.144.1-linux-arm64':
+    resolution: {integrity: sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.140.0-linux-x64':
-    resolution: {integrity: sha512-7+N/cHB74nsDkOoL+VQVFVFRlfGj6GFSIAQHgs9DQIsvG+UdzWgUeeDE3l926taJqmzcP9NH8bysptKlZ2Ff6g==}
+  '@openai/codex@0.144.1-linux-x64':
+    resolution: {integrity: sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.140.0-win32-arm64':
-    resolution: {integrity: sha512-vs5Ed5OF+4671SZoO0MN5WoHl/K9aOSNzLgzbyyDyM7Jwm/PZYvF6OmIPRWf5AGatYqEOWt8Ovp5+df5PFPM7A==}
+  '@openai/codex@0.144.1-win32-arm64':
+    resolution: {integrity: sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.140.0-win32-x64':
-    resolution: {integrity: sha512-dP+nzd8UQ3Gdby+F5x0Sxd0hu6V9s6/cZYFsGtmmA6eCpU+IIu5tCOnUfgSu5HDw4BvXg046yd8Ihy5bOhwO4A==}
+  '@openai/codex@0.144.1-win32-x64':
+    resolution: {integrity: sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -6015,35 +6015,35 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@openai/codex-sdk@0.140.0':
+  '@openai/codex-sdk@0.144.1':
     dependencies:
-      '@openai/codex': 0.140.0
+      '@openai/codex': 0.144.1
 
-  '@openai/codex@0.140.0':
+  '@openai/codex@0.144.1':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.140.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.140.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.140.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.140.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.140.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.140.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.144.1-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.144.1-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.144.1-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.144.1-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.144.1-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.144.1-win32-x64'
 
-  '@openai/codex@0.140.0-darwin-arm64':
+  '@openai/codex@0.144.1-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.140.0-darwin-x64':
+  '@openai/codex@0.144.1-darwin-x64':
     optional: true
 
-  '@openai/codex@0.140.0-linux-arm64':
+  '@openai/codex@0.144.1-linux-arm64':
     optional: true
 
-  '@openai/codex@0.140.0-linux-x64':
+  '@openai/codex@0.144.1-linux-x64':
     optional: true
 
-  '@openai/codex@0.140.0-win32-arm64':
+  '@openai/codex@0.144.1-win32-arm64':
     optional: true
 
-  '@openai/codex@0.140.0-win32-x64':
+  '@openai/codex@0.144.1-win32-x64':
     optional: true
 
   '@opentelemetry/api-logs@0.214.0':


### PR DESCRIPTION
## Summary

- upgrade `@openai/codex-sdk` and the bundled Codex CLI from 0.140.0 to 0.144.1
- add enum-style model IDs for `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`
- expose the three concrete GPT-5.6 models in the agent model picker
- add regression coverage that keeps the model ID enum and picker options synchronized and excludes unsupported GPT-5.6 aliases

## Why

The Codex runtime already passes configured model IDs through as strings, but the web picker was a stale hard-coded list originating from an older Codex release. GPT-5.6 users therefore could not select the newly released concrete model variants from the UI.

The backend remains open to arbitrary model strings so future releases are not blocked by this curated picker list. The unsupported `gpt-5.6` alias is intentionally not exposed.

## Impact

Codex agents can select the explicit Sol, Terra, or Luna model ID. Existing defaults and stored model values are unchanged.

## Validation

- `pnpm check` (passes; only pre-existing warnings/info in untouched files)
- `pnpm typecheck` (10/10 tasks)
- `pnpm --filter @first-tree/client test` (1458 passed, 3 skipped)
- `pnpm --filter @first-tree/web exec vitest run src/pages/agent-detail/__tests__/model-section-options.test.ts` (2 passed)
- Codex targeted regression suite (104 passed)
- full web suite (162 files, 1308 tests passed)
- live ChatGPT-auth QA: `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` completed successfully

## Known unrelated baseline failures

The full monorepo `pnpm test` run reaches four existing CLI environment-sensitive failures that reproduce with one worker and do not touch this diff:

- macOS temporary-directory canonicalization (`/tmp` vs `/private/tmp`) in two tests
- a portable-platform mock expecting `freebsd-x64` while the arm64 host leaks into the result
- client-switch drain detection observing live local provider processes
