### PR TITLE
fix(ci): prevent vitest OOM on GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,12 @@ jobs:
           --health-retries 10
     env:
       CI_DATABASE_URL: postgres://test:test@localhost:5432/test
+      # GitHub-hosted runners are ~7GB. Node's default heap is ~4GB/process;
+      # stacking turbo package suites + multi-fork vitest OOM'd CLI workers
+      # (Mark-Compact ~4057MB, then tinypool `Channel closed`). Cap forks
+      # package-wide; the steps below also limit turbo concurrency and run
+      # the CLI suite alone so it never shares the runner with server/web.
+      VITEST_MAX_FORKS: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -159,7 +165,12 @@ jobs:
       # all 233 tests passed. Building before vitest starts keeps the
       # heavy work outside the worker IPC window.
       - run: pnpm build
-      - run: pnpm test
+      # Keep a single `vitest run` per package (no multi-batch shell chains).
+      # Memory isolation is: turbo concurrency + VITEST_MAX_FORKS + CLI last.
+      - name: Test packages (excluding CLI)
+        run: pnpm exec turbo run test --filter='!first-tree-dev' --concurrency=2
+      - name: Test CLI
+        run: pnpm --filter first-tree-dev test
 
   portable-smoke:
     name: Portable CLI Smoke

--- a/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
+++ b/apps/cli/src/__tests__/client-runtime-context-tree.test.ts
@@ -190,6 +190,11 @@ describe("ClientRuntime context-tree wiring", () => {
     rmSync(home, { recursive: true, force: true });
     if (originalHome === undefined) delete process.env.FIRST_TREE_HOME;
     else process.env.FIRST_TREE_HOME = originalHome;
+    // Release per-case runtime fixtures so this 1.3k-line suite does not keep
+    // slot/connection graphs alive until the next beforeEach in the same fork.
+    slotInstances.length = 0;
+    connectionListeners.clear();
+    connectionCtorOptions.length = 0;
     vi.clearAllMocks();
   });
 

--- a/apps/cli/src/__tests__/login-command.test.ts
+++ b/apps/cli/src/__tests__/login-command.test.ts
@@ -304,6 +304,9 @@ afterEach(() => {
   if (originalClientId === undefined) delete process.env.FIRST_TREE_CLIENT_ID;
   else process.env.FIRST_TREE_CLIENT_ID = originalClientId;
   process.exitCode = undefined;
+  // Drop mock call history so the large command-graph suite cannot retain
+  // multi-MB argument snapshots across the 29 login cases in one worker.
+  vi.clearAllMocks();
 });
 
 // `runLogin` dynamic-imports `commands/login.js` on every test run, which

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from "vitest/config";
 import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
 import { unitCoverageConfig } from "../../scripts/vitest-coverage.js";
+import { isCiEnvironment, resolveVitestMaxForks } from "../../scripts/vitest-max-forks.js";
 
-const requestedMaxForks = Number.parseInt(process.env.VITEST_MAX_FORKS ?? "", 10);
-const maxForks = Number.isFinite(requestedMaxForks) && requestedMaxForks > 0 ? requestedMaxForks : 2;
+// Keep a single `vitest run` in package.json. Splitting into multi-process
+// shell chains (login → portable → … → bulk) restarts collect/transform each
+// time, lengthens CI, and still OOM'd the bulk batch on GH runners. Memory
+// pressure is controlled here + in `.github/workflows/ci.yml` instead.
+const maxForks = resolveVitestMaxForks(2);
+const isCi = isCiEnvironment();
 
 export default defineConfig({
   test: {
@@ -16,11 +21,23 @@ export default defineConfig({
     // so transient CPU starvation can't trip them; a genuine hang still fails,
     // just at 15s.
     testTimeout: 15_000,
+    // Known heavy files (large mock graphs / dynamic import of command trees):
+    // - src/__tests__/client-runtime-context-tree.test.ts
+    // - src/__tests__/service-install-core.test.ts
+    // - src/__tests__/login-command.test.ts
+    // - src/__tests__/update-portable-install.test.ts
+    // Under CI we serialize file execution so those graphs cannot sit in two
+    // fork heaps at once next to server/web suites.
+    fileParallelism: !isCi && maxForks > 1,
     pool: "forks",
     poolOptions: {
       forks: {
         maxForks,
         minForks: 1,
+        // Explicit isolate so each file gets a clean module graph; without it
+        // the ~100 CLI files can accumulate transform/module state toward the
+        // ~4GB Node heap ceiling (observed as JSON.stringify OOM in tinypool).
+        isolate: true,
       },
     },
     coverage: unitCoverageConfig({

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vitest/config";
 import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
 import { unitCoverageConfig } from "../../scripts/vitest-coverage.js";
+import { resolveVitestMaxForks } from "../../scripts/vitest-max-forks.js";
+
+const maxForks = resolveVitestMaxForks(2);
 
 export default defineConfig({
   resolve: {
@@ -12,5 +15,14 @@ export default defineConfig({
     // tests that indirectly invoke `bootstrap.ts` don't have to stub it
     // themselves. See vitest.setup.ts for details.
     setupFiles: ["./vitest.setup.ts"],
+    // Cap forks so client tests do not overcommit memory when turbo runs
+    // server/web/cli suites on the same GH runner (~7GB).
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        maxForks,
+        minForks: 1,
+      },
+    },
   },
 });

--- a/packages/server/src/__tests__/test-config.ts
+++ b/packages/server/src/__tests__/test-config.ts
@@ -1,17 +1,17 @@
 // File-level parallelism cap for vitest. Lives in src/ so global-setup.ts can
 // import it under tsc's rootDir constraint; vitest.config.ts also imports it.
 //
-// Default is a hard 2 — not a cpu-count formula — because:
-//  * 4+ forks tripped OOM locally on a 16 GB box (`isolate: false` keeps
-//    fastify+otel+pino module state alive in each fork).
-//  * GitHub-hosted `ubuntu-latest` runners are 2-core; a `cpus - 1` formula
-//    would silently degrade to 1 fork there and erase the speedup. Hardcoded
-//    2 keeps file parallelism on in CI without overcommitting (workers are
-//    PG-IO-bound, so 2-on-2-cores doesn't thrash CPU).
+// Defaults:
+//  * Local: hard 2 — not a cpu-count formula — because 4+ forks tripped OOM
+//    on a 16 GB box (`isolate: false` keeps fastify+otel+pino module state
+//    alive in each fork). Workers are PG-IO-bound, so 2 forks is enough.
+//  * CI / GITHUB_ACTIONS: 1 — GH `ubuntu-latest` is ~7GB and turbo runs
+//    several packages at once; stacked forks OOM'd sibling CLI workers.
 //
 // Override via `VITEST_MAX_FORKS` for beefier CI runners or to bisect.
 const envCap = Number.parseInt(process.env.VITEST_MAX_FORKS ?? "", 10);
-export const MAX_FORKS = Number.isFinite(envCap) && envCap > 0 ? envCap : 2;
+const isCi = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
+export const MAX_FORKS = Number.isFinite(envCap) && envCap > 0 ? envCap : isCi ? 1 : 2;
 
 export const WORKER_DB_PREFIX = "vitest_w";
 export const TEMPLATE_DB = "vitest_template";

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -2,6 +2,9 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 import { monorepoSourceAliases } from "../../scripts/vitest-aliases.js";
 import { unitCoverageConfig } from "../../scripts/vitest-coverage.js";
+import { resolveVitestMaxForks } from "../../scripts/vitest-max-forks.js";
+
+const maxForks = resolveVitestMaxForks(2);
 
 // Many web tests import `.tsx` modules, and the DOM smoke tests render React
 // directly, so the React plugin is needed at transform time to strip JSX.
@@ -18,6 +21,15 @@ export default defineConfig({
     coverage: unitCoverageConfig(),
     testTimeout: 20_000,
     hookTimeout: 20_000,
+    // Cap forks so jsdom/react suites do not stack on the same ~7GB GH runner
+    // as server/cli tests under turbo.
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        maxForks,
+        minForks: 1,
+      },
+    },
   },
   resolve: {
     alias: monorepoSourceAliases,

--- a/scripts/vitest-max-forks.ts
+++ b/scripts/vitest-max-forks.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared Vitest fork cap for monorepo packages.
+ *
+ * Why this exists:
+ * - GitHub-hosted `ubuntu-latest` runners have ~7GB RAM.
+ * - Node's default heap ceiling is ~4GB per process.
+ * - `turbo run test` fans out several packages at once; each package's
+ *   vitest workers then stack on top of that. CLI workers have already
+ *   OOM'd at Mark-Compact ~4057MB under the previous defaults.
+ *
+ * Defaults:
+ * - Local: 2 forks (enough file parallelism without starving a laptop).
+ * - CI / GITHUB_ACTIONS: 1 fork unless `VITEST_MAX_FORKS` overrides.
+ *
+ * Override via `VITEST_MAX_FORKS` for beefier CI runners or local bisects.
+ */
+export function resolveVitestMaxForks(defaultLocal = 2): number {
+  const envCap = Number.parseInt(process.env.VITEST_MAX_FORKS ?? "", 10);
+  if (Number.isFinite(envCap) && envCap > 0) {
+    return envCap;
+  }
+
+  const isCi = process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
+  return isCi ? 1 : defaultLocal;
+}
+
+export function isCiEnvironment(): boolean {
+  return process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true";
+}

--- a/turbo.json
+++ b/turbo.json
@@ -24,8 +24,10 @@
       "inputs": ["$TURBO_DEFAULT$"]
     },
     "test": {
-      "inputs": ["$TURBO_DEFAULT$"]
+      "inputs": ["$TURBO_DEFAULT$"],
+      "passThroughEnv": ["VITEST_MAX_FORKS", "CI", "GITHUB_ACTIONS", "CI_DATABASE_URL"]
     },
+
     "coverage": {
       "dependsOn": ["^build"],
       "cache": false,


### PR DESCRIPTION
## Summary

- Cap Vitest forks under CI (`VITEST_MAX_FORKS=1`, shared helper + package configs for CLI/client/server/web) so multi-fork workers no longer stack toward the ~4GB Node heap ceiling on ~7GB GH runners.
- Limit turbo package fan-out (`--concurrency=2`) and **run `first-tree-dev` tests alone after other packages**, so the CLI suite never shares the runner with server/web graphs (root cause of `first-tree-dev#test` OOM / tinypool `Channel closed`).
- Keep a single `vitest run` per package (no multi-batch shell chains); CLI config forces `isolate: true` and serial file execution under CI, with tighter mock/fixture cleanup in the heaviest login/runtime suites.

## Context

Observed on CI Test jobs (e.g. [run 29064487984](https://github.com/agent-team-foundation/first-tree/actions/runs/29064487984/job/86273066158)):

```text
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
Mark-Compact ~4057 MB
Error: Channel closed (ERR_IPC_CHANNEL_CLOSED)
Failed: first-tree-dev#test
```

This is infrastructure memory pressure, not a product assertion failure.

## Verification

- `pnpm check` (pre-existing repo warnings only)
- `CI=true VITEST_MAX_FORKS=1 pnpm --filter first-tree-dev exec vitest run` on a sample of CLI unit files
- `pnpm exec turbo run test --filter='!first-tree-dev' --dry-run` confirms CLI is excluded from the first step

## Test plan

- [ ] CI **Test** job is green on this PR
- [ ] Confirm job logs show `Test packages (excluding CLI)` then `Test CLI` as separate steps
- [ ] Confirm no `Reached heap limit` / `Channel closed` in CLI vitest output
- [ ] Spot-check local `pnpm test` still works without `CI=true` (default maxForks=2)