### PR TITLE
feat: support max and ultra Codex reasoning

### DIFF
--- a/apps/cli/src/__tests__/agent-config-cli.test.ts
+++ b/apps/cli/src/__tests__/agent-config-cli.test.ts
@@ -63,6 +63,18 @@ describe("agent config CLI registration (Step 8)", () => {
     expect(setEnv?.options.some((o) => o.long === "--sensitive")).toBe(true);
   });
 
+  it("documents Codex max and ultra reasoning effort", () => {
+    const root = new Command();
+    const agent = root.command("agent");
+    registerAgentConfigCommands(agent);
+    const reasoningEffort = agent.commands
+      .find((c) => c.name() === "config")
+      ?.commands.find((c) => c.name() === "set-reasoning-effort");
+
+    expect(reasoningEffort?.description()).toContain("xhigh | max | ultra");
+    expect(reasoningEffort?.description()).toContain("model-dependent");
+  });
+
   it("add-mcp accepts --transport / --command / --url / --args", () => {
     const root = new Command();
     const agent = root.command("agent");

--- a/apps/cli/src/commands/agent/config/set-reasoning-effort.ts
+++ b/apps/cli/src/commands/agent/config/set-reasoning-effort.ts
@@ -7,7 +7,7 @@ export function registerAgentConfigSetReasoningEffortCommand(config: Command): v
   config
     .command("set-reasoning-effort <agent> <level>")
     .description(
-      'Set reasoning effort. claude-code: "" (inherit local) | low | medium | high | max. codex: low | medium | high | xhigh.',
+      'Set reasoning effort. claude-code: "" (inherit local) | low | medium | high | max. codex: low | medium | high | xhigh | max | ultra (model-dependent).',
     )
     .action(async (agentName: string, level: string) => {
       const serverUrl = resolveServerUrl(process.env.FIRST_TREE_SERVER_URL);

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -262,6 +262,7 @@ through the Admin API.
 first-tree agent config
 ├── show <agent>
 ├── set-model <agent> <model>                       # alias: opus | sonnet | haiku, or full id (e.g. claude-opus-4-7)
+├── set-reasoning-effort <agent> <level>
 ├── prompt show <agent> [--raw]                     # per-agent prompt fragment; --raw is verbatim (round-trippable)
 ├── prompt set <agent> [-f <file>] [--force]        # replace the fragment ONLY; reads stdin if no file.
 │                                                   #   Rejects copies of the assembled AGENTS.md (generated marker /
@@ -274,6 +275,12 @@ first-tree agent config
 ├── add-repo <agent> <url> [--ref <branch>] [--path <local>]
 └── dry-run <agent> -f <patch.json>                 # validate + diff, no persist
 ```
+
+Reasoning effort values are provider-specific. Claude Code and Claude Code
+TUI accept `""` (inherit the operator's local setting), `low`, `medium`,
+`high`, or `max`. Codex accepts `low`, `medium`, `high`, `xhigh`, `max`, or
+`ultra`; availability of the higher levels is model-dependent and rejected
+combinations are reported by the provider.
 
 ### agent bind
 

--- a/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
@@ -636,6 +636,58 @@ describe("codex app-server handler extra branches", () => {
     await handler.shutdown();
   });
 
+  it.each([
+    "max",
+    "ultra",
+  ] as const)("passes Codex %s effort through app-server turn/start", async (reasoningEffort) => {
+    const fake = new FakeAppServerClient();
+    const payload = {
+      kind: "codex",
+      prompt: { append: "" },
+      model: "gpt-5.6-sol",
+      reasoningEffort,
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+    } satisfies AgentRuntimeConfigPayload;
+    const cachedConfig = runtimeConfig(payload);
+    const agentConfigCache = {
+      refresh: vi.fn(async () => cachedConfig),
+      get: vi.fn(() => cachedConfig),
+    } as unknown as AgentConfigCache;
+    const handler = createCodexAppServerHandler({
+      workspaceRoot,
+      agentConfigCache,
+      codexRuntimeBinaryResolver: async () => ({
+        ok: true,
+        binary: "/tmp/fake-codex",
+        runtimeSource: "path",
+        runtimePath: "/tmp/fake-codex",
+        version: "0.0.0-test",
+      }),
+      codexAppServerClientFactory: async (options: {
+        onNotification?: NotificationHandler;
+        onClose?: CloseHandler;
+      }) => {
+        fake.onNotification = options.onNotification ?? null;
+        fake.onClose = options.onClose ?? null;
+        return fake;
+      },
+    });
+
+    const startPromise = handler.start(makeMessage("m-effort", "run"), makeContext());
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"), "effort turn/start");
+    const turnStart = fake.requests.find((request) => request.method === "turn/start");
+    expect(asRecord(turnStart?.params)?.effort).toBe(reasoningEffort);
+    fake.emit("turn/completed", {
+      threadId: "thread-app-server",
+      turn: { id: "turn-1", status: "completed", error: null, items: [{ type: "agentMessage", text: "done" }] },
+    });
+    await startPromise;
+    await handler.shutdown();
+  });
+
   it("returns a queued route and retries when initial inbound formatting fails", async () => {
     const fake = new FakeAppServerClient();
     const token = makeDeliveryToken();

--- a/packages/client/src/__tests__/codex-thread-options.test.ts
+++ b/packages/client/src/__tests__/codex-thread-options.test.ts
@@ -55,12 +55,11 @@ describe("buildCodexThreadOptions", () => {
   });
 
   it("passes the operator-configured reasoning effort through to the SDK", () => {
-    expect(buildCodexThreadOptions(basePayload({ reasoningEffort: "medium" }), "/tmp/wsk").modelReasoningEffort).toBe(
-      "medium",
-    );
-    expect(buildCodexThreadOptions(basePayload({ reasoningEffort: "xhigh" }), "/tmp/wsk").modelReasoningEffort).toBe(
-      "xhigh",
-    );
+    for (const reasoningEffort of ["medium", "xhigh", "max", "ultra"] as const) {
+      expect(buildCodexThreadOptions(basePayload({ reasoningEffort }), "/tmp/wsk").modelReasoningEffort).toBe(
+        reasoningEffort,
+      );
+    }
   });
 
   it("derives additionalDirectories from gitRepos (with deriveRepoLocalPath fallback)", () => {

--- a/packages/client/src/handlers/codex/sdk.ts
+++ b/packages/client/src/handlers/codex/sdk.ts
@@ -259,16 +259,19 @@ export function buildCodexThreadOptions(payload: AgentRuntimeConfigPayload, work
   // their primary local-execution surface. Landing campaign trials are forced
   // through the app-server handler, which supplies a custom managed permissions
   // profile instead of this SDK-only legacy sandbox field.
+  const reasoningEffort = payload.kind === "codex" ? payload.reasoningEffort : "high";
   const opts: ThreadOptions = {
     workingDirectory: workspaceCwd,
     skipGitRepoCheck: true,
     sandboxMode: "danger-full-access",
     approvalPolicy: "never",
     // Operator-configured reasoning effort. Defaults to "high" (the value this
-    // previously hard-coded). The codex variant's enum (low|medium|high|xhigh)
-    // is a subset of the SDK's ModelReasoningEffort and deliberately omits
-    // "minimal", which is incompatible with the default tool set (footgun F3).
-    modelReasoningEffort: payload.kind === "codex" ? payload.reasoningEffort : "high",
+    // previously hard-coded). Codex CLI/app-server 0.144.1 accepts the newer
+    // provider-native "max" and "ultra" values, but the SDK's TypeScript union
+    // still stops at "xhigh" even though its runtime serializer forwards the
+    // literal as `model_reasoning_effort`. Keep this assertion isolated at the
+    // third-party boundary until the upstream declaration catches up.
+    modelReasoningEffort: reasoningEffort as ThreadOptions["modelReasoningEffort"],
     webSearchEnabled: false,
     additionalDirectories,
   };

--- a/packages/qa/cases/runtime/codex-reasoning-effort.md
+++ b/packages/qa/cases/runtime/codex-reasoning-effort.md
@@ -1,0 +1,54 @@
+---
+id: codex-reasoning-effort
+description: Verify Codex agents preserve provider-native max and ultra effort without local downgrade.
+areas: [runtime]
+surfaces: [web, cli, server, client]
+---
+
+# Codex Reasoning Effort
+
+## Goal
+
+Confirm that a Codex agent can save and run with the provider-native `max` and `ultra` reasoning-effort values, while
+leaving model compatibility and rejection behavior to the provider.
+
+Use this case when agent runtime configuration or Codex effort forwarding changes. Pair it with the runtime-provider
+readiness case because credible positive-path evidence requires a real authenticated Codex turn.
+
+## Preconditions
+
+- Run in the isolated QA run cell selected by the plan.
+- Use a Codex CLI/app-server version that advertises `max` and `ultra` support.
+- Select models/accounts that the live provider reports as compatible with each value. If a compatible model is not
+  available in the run cell, mark that value `BLOCKED`, not product `FAIL`.
+- Do not change the production agent or the operator's persistent Codex configuration.
+
+## Checklist
+
+- Save `max` through one First Tree configuration surface and `ultra` through the other (Web and CLI), then read the
+  effective agent config back to confirm each literal was preserved.
+- Start a fresh provider session after each change; do not treat an already-running session as evidence because effort
+  changes apply at session bootstrap.
+- Complete a minimal real turn at each supported effort and capture enough runtime/provider evidence to distinguish the
+  selected value from a local downgrade to `xhigh` or `high`.
+- If the run cell has a known unsupported model/value combination, verify that the provider rejection is surfaced
+  explicitly through the existing failure path and that First Tree does not silently retry with a lower effort.
+- Recover by choosing a compatible model or lower effort and starting a fresh session.
+
+## Expected Result
+
+`PASS` means `max` and `ultra` both round-trip unchanged through First Tree configuration and reach successful real Codex
+turns on compatible models, with no evidence of local aliasing or downgrade. If a reliable negative branch is available,
+the incompatible combination must fail visibly and recover after an explicit config change.
+
+`FAIL` means First Tree rejects a provider-supported value, rewrites it to another effort, applies it only on one runtime
+path, silently downgrades an incompatible value, or leaves the user without the existing provider-failure recovery path.
+
+`BLOCKED` means provider binary, authentication, account entitlement, or compatible model availability prevents a real
+turn. `INCONCLUSIVE` means the value round-trips but the run cannot prove which effort reached the provider.
+
+## Evidence
+
+Keep the provider version/model catalog evidence, config write/readback, the fresh-session boundary, one minimal turn per
+supported value, and the relevant runtime/provider trace or observable response. Redact credentials and private session
+content.

--- a/packages/server/src/__tests__/admin-agent-config.test.ts
+++ b/packages/server/src/__tests__/admin-agent-config.test.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
 import { agentConfigs } from "../db/schema/agent-configs.js";
+import { agents } from "../db/schema/agents.js";
 import { isEncryptedValue } from "../services/crypto.js";
 import { createTestAdmin, seedAgentFactory, useTestApp } from "./helpers.js";
 
@@ -194,6 +195,29 @@ describe("Admin agent-config API (Step 2)", () => {
       payload: { reasoningEffort: "xhigh" },
     });
     expect(bad.statusCode).toBe(400);
+  });
+
+  it("persists model-dependent max and ultra values for codex agents", async () => {
+    const app = getApp();
+    const req = await authedRequest(app);
+    const agent = await (await seedAgentFactory(app))({
+      name: `cfg-codex-effort-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+    });
+    await app.db.update(agents).set({ runtimeProvider: "codex" }).where(eq(agents.uuid, agent.uuid));
+
+    for (const [expectedVersion, reasoningEffort] of [
+      [1, "max"],
+      [2, "ultra"],
+    ] as const) {
+      const response = await req("PATCH", `/api/v1/agents/${agent.uuid}/config`, {
+        expectedVersion,
+        payload: { reasoningEffort },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json().payload).toMatchObject({ kind: "codex", reasoningEffort });
+      await app.configService.flush(agent.uuid);
+    }
   });
 
   it("PATCH with stale expectedVersion returns 409", async () => {

--- a/packages/shared/src/__tests__/agent-runtime-config.test.ts
+++ b/packages/shared/src/__tests__/agent-runtime-config.test.ts
@@ -161,14 +161,14 @@ describe("agent runtime config — reasoning effort", () => {
     );
   });
 
-  it("codex accepts low/medium/high/xhigh", () => {
-    for (const v of ["low", "medium", "high", "xhigh"]) {
+  it("codex accepts low/medium/high/xhigh/max/ultra", () => {
+    for (const v of ["low", "medium", "high", "xhigh", "max", "ultra"]) {
       expect(agentRuntimeConfigPayloadSchema.parse({ kind: "codex", reasoningEffort: v }).reasoningEffort).toBe(v);
     }
   });
 
-  it("codex rejects minimal (breaks tools), claude-only max, and the '' sentinel", () => {
-    for (const v of ["minimal", "max", ""]) {
+  it("codex rejects minimal/none (incompatible with the default tools), the '' sentinel, and unknown values", () => {
+    for (const v of ["minimal", "none", "", "extreme"]) {
       expect(agentRuntimeConfigPayloadSchema.safeParse({ kind: "codex", reasoningEffort: v }).success).toBe(false);
     }
   });

--- a/packages/shared/src/schemas/agent-runtime-config.ts
+++ b/packages/shared/src/schemas/agent-runtime-config.ts
@@ -262,10 +262,13 @@ const claudeCodeTuiRuntimeConfigPayloadShape = agentRuntimeConfigPayloadShape.ex
 const codexRuntimeConfigPayloadShape = agentRuntimeConfigPayloadShape.extend({
   kind: z.literal("codex"),
   // Maps to codex-sdk ThreadOptions.modelReasoningEffort. Default "high"
-  // preserves the value the handler previously hardcoded. "minimal" is
+  // preserves the value the handler previously hardcoded. Newer Codex models
+  // additionally advertise provider-native "max" and "ultra" values. Support
+  // is model-dependent, so the runtime passes them through and lets the
+  // provider return an explicit compatibility error. "minimal" remains
   // intentionally excluded — it is incompatible with the default tool set and
   // breaks tool calls (see the codex handler's footgun notes).
-  reasoningEffort: z.enum(["low", "medium", "high", "xhigh"]).default("high"),
+  reasoningEffort: z.enum(["low", "medium", "high", "xhigh", "max", "ultra"]).default("high"),
 });
 
 const taggedPayloadUnion = z.discriminatedUnion("kind", [

--- a/packages/shared/src/schemas/agent-runtime-config.ts
+++ b/packages/shared/src/schemas/agent-runtime-config.ts
@@ -451,7 +451,7 @@ const agentRuntimeConfigPatchShape = z
     // patch shape is flat and provider-agnostic, while the allowed values
     // differ per provider. Validity is enforced when the merged payload is
     // re-parsed against the tagged union in `commitWrite` — an out-of-range
-    // value (e.g. "max" for codex, "xhigh" for claude) is rejected there.
+    // value (e.g. "" for codex, "xhigh" for claude) is rejected there.
     reasoningEffort: z.string(),
   })
   .partial();

--- a/packages/web/src/pages/agent-detail/__tests__/reasoning-effort-section-options.test.ts
+++ b/packages/web/src/pages/agent-detail/__tests__/reasoning-effort-section-options.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { CODEX_EFFORT_OPTIONS } from "../reasoning-effort-section.js";
+
+describe("Codex reasoning effort options", () => {
+  it("orders the provider-native levels through max and ultra", () => {
+    expect(CODEX_EFFORT_OPTIONS.map((option) => option.value)).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultra",
+    ]);
+  });
+
+  it("marks max and ultra as model-dependent", () => {
+    expect(CODEX_EFFORT_OPTIONS.filter((option) => ["max", "ultra"].includes(option.value))).toEqual([
+      { value: "max", label: "max", hint: "model-dependent" },
+      { value: "ultra", label: "ultra", hint: "deepest; model-dependent" },
+    ]);
+  });
+});

--- a/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
+++ b/packages/web/src/pages/agent-detail/reasoning-effort-section.tsx
@@ -8,8 +8,9 @@ import { ConfigRow } from "./flat-section.js";
  * help copy are provider-specific (no abstraction over the providers):
  *   - claude-code maps to the SDK `effort` (low/medium/high/max), plus an
  *     "" inherit option that defers to the operator's local effortLevel.
- *   - codex maps to `modelReasoningEffort` (low/medium/high/xhigh); "minimal"
- *     is excluded because it breaks the default tool set.
+ *   - codex maps to its provider-native effort (low/medium/high/xhigh/max/ultra).
+ *     The higher values are model-dependent; "minimal" is excluded because it
+ *     breaks the default tool set.
  */
 
 const CLAUDE_EFFORT_OPTIONS: SelectOption[] = [
@@ -20,11 +21,13 @@ const CLAUDE_EFFORT_OPTIONS: SelectOption[] = [
   { value: "max", label: "max", hint: "Opus only" },
 ];
 
-const CODEX_EFFORT_OPTIONS: SelectOption[] = [
+export const CODEX_EFFORT_OPTIONS: SelectOption[] = [
   { value: "low", label: "low", hint: "fastest" },
   { value: "medium", label: "medium" },
   { value: "high", label: "high", hint: "default" },
-  { value: "xhigh", label: "xhigh", hint: "most" },
+  { value: "xhigh", label: "xhigh" },
+  { value: "max", label: "max", hint: "model-dependent" },
+  { value: "ultra", label: "ultra", hint: "deepest; model-dependent" },
 ];
 
 const EFFORT_OPTIONS_BY_PROVIDER: Record<RuntimeProvider, SelectOption[]> = {
@@ -38,7 +41,7 @@ const EFFORT_OPTIONS_BY_PROVIDER: Record<RuntimeProvider, SelectOption[]> = {
 const EFFORT_HELP_BY_PROVIDER: Record<RuntimeProvider, string> = {
   "claude-code": "Applies to new sessions. Unset inherits the local ~/.claude effortLevel; setting it overrides.",
   "claude-code-tui": "Applies to new sessions. Unset inherits the local ~/.claude effortLevel; setting it overrides.",
-  codex: "Applies to new sessions. Higher means more reasoning per turn.",
+  codex: "Applies to new sessions. Higher means more reasoning per turn; max and ultra require a compatible model.",
 };
 
 export type ReasoningEffortSectionProps = {


### PR DESCRIPTION
## Summary

- add provider-native `max` and `ultra` reasoning effort values to the Codex agent config variant
- expose the new model-dependent levels in Agent Runtime, `agent config set-reasoning-effort`, and the canonical CLI reference
- preserve the literals through app-server turns and the SDK fallback without local downgrade or compatibility matrices
- add deterministic shared, server, client, Web, CLI coverage plus a reusable formal-QA case

## Compatibility

- default remains `high`
- no database migration or persisted-config rewrite
- model/account compatibility stays provider-owned; unsupported combinations use the existing explicit provider-failure path
- the SDK boundary has a documented narrow assertion because `@openai/codex-sdk@0.144.1` runtime forwards the values while its TypeScript union still stops at `xhigh`

Official provider guidance:

- https://developers.openai.com/api/docs/guides/latest-model#what-is-new
- https://learn.chatgpt.com/docs/agent-configuration/subagents#reasoning-effort-model_reasoning_effort

## Verification

- `pnpm check` (passes; three pre-existing warnings/info remain outside this diff)
- `pnpm typecheck` (10/10 tasks)
- targeted package suites:
  - shared: 563 tests
  - client: 1,475 tests
  - Web: 1,310 tests
  - CLI reasoning config: 6 tests
  - server agent config: 14 tests
- `pnpm test` was attempted; all feature-related packages passed, but the CLI suite is blocked in this Codex-hosted workspace by 7 existing local-client-switch process-scan failures. The same 7 failures reproduce on a clean `origin/main` worktree because the scanner treats `CODEX_THREAD_ID` / Codex PATH entries as untrusted provider processes.

## QA

Formal QA is warranted because this crosses configuration surfaces and provider runtime paths. A reusable `codex-reasoning-effort` case is included; formal Docker QA was not auto-run because it is human-requested.

## Context Tree

Companion draft: https://github.com/agent-team-foundation/first-tree-context/pull/714

It records only the durable compatibility boundary, not the provider value list or implementation details. Merge this implementation first, then reconcile the Context Tree PR against the final merged behavior before marking it ready.
