### PR TITLE
fix: harden doc preview fence scanning

### DIFF
--- a/packages/shared/src/lib/__tests__/doc-link-scan.test.ts
+++ b/packages/shared/src/lib/__tests__/doc-link-scan.test.ts
@@ -97,6 +97,26 @@ describe("scanBareDocPathTokens", () => {
     expect(tokens(text)).toEqual(["docs/after.md"]);
   });
 
+  it("supports tilde-opened fences and does not close them on backtick markers", () => {
+    const text = ["~~~", "docs/fenced.md", "```", "docs/still-fenced.md", "~~~", "docs/after.md"].join("\n");
+    expect(tokens(text)).toEqual(["docs/after.md"]);
+  });
+
+  it("recognizes opening fences indented up to three spaces", () => {
+    const text = ["   ```", "docs/fenced.md", "   ```", "docs/after.md"].join("\n");
+    expect(tokens(text)).toEqual(["docs/after.md"]);
+  });
+
+  it("treats a four-space fence marker as indented code, not a fence opener", () => {
+    const text = ["    ```", "docs/after.md"].join("\n");
+    expect(tokens(text)).toEqual(["docs/after.md"]);
+  });
+
+  it("skips fenced blocks whose opening fence carries an info string", () => {
+    const text = ["```ts", 'const doc = "docs/fenced.md";', "```", "docs/after.md"].join("\n");
+    expect(tokens(text)).toEqual(["docs/after.md"]);
+  });
+
   it("ignores indented (4-space / tab) code blocks", () => {
     expect(tokens("    docs/indented.md")).toEqual([]);
     expect(tokens("\tdocs/tabbed.md")).toEqual([]);

--- a/packages/shared/src/lib/__tests__/doc-link-scan.test.ts
+++ b/packages/shared/src/lib/__tests__/doc-link-scan.test.ts
@@ -54,6 +54,49 @@ describe("scanBareDocPathTokens", () => {
     expect(tokens(text)).toEqual(["docs/after.md"]);
   });
 
+  it("does not close a longer backtick fence on a shorter nested marker", () => {
+    const text = [
+      "To open a code block, type:",
+      "",
+      "````",
+      "```",
+      "````",
+      "",
+      "Project layout:",
+      "",
+      "```",
+      "repo/",
+      "├── NODE.md",
+      "├── docs/setup.md",
+      "└── sub/",
+      "    └── NODE.md",
+      "```",
+      "",
+      "See `README.md` for details.",
+    ].join("\n");
+
+    expect(tokens(text)).toEqual(["README.md"]);
+  });
+
+  it("treats an unclosed fence as code through the end of the input", () => {
+    const text = ["Before README.md", "```", "docs/fenced.md", "After docs/after.md"].join("\n");
+    expect(tokens(text)).toEqual(["README.md"]);
+  });
+
+  it("requires closing fences to use the opening marker character and minimum length", () => {
+    const text = [
+      "````",
+      "docs/fenced.md",
+      "~~~",
+      "docs/still-fenced.md",
+      "```",
+      "docs/also-fenced.md",
+      "````",
+      "docs/after.md",
+    ].join("\n");
+    expect(tokens(text)).toEqual(["docs/after.md"]);
+  });
+
   it("ignores indented (4-space / tab) code blocks", () => {
     expect(tokens("    docs/indented.md")).toEqual([]);
     expect(tokens("\tdocs/tabbed.md")).toEqual([]);

--- a/packages/shared/src/lib/doc-link-scan.ts
+++ b/packages/shared/src/lib/doc-link-scan.ts
@@ -54,9 +54,14 @@ const BARE_PATH_RE =
 const INLINE_MARKDOWN_LINK_RE = /\[(?:[^\]\\\n]|\\.)*\]\([^)\n]*\)/g;
 const REFERENCE_LINK_DEFINITION_RE = /^\s*\[[^\]\n]+\]:\s*\S+/;
 const HTML_TAG_RE = /<\/?[A-Za-z][^>\n]*>/g;
-const FENCE_OPEN_RE = /^\s*(```|~~~)/;
+const FENCE_MARKER_RE = /^(?: {0,3})(?<marker>`{3,}|~{3,})/;
 const INDENT_CODE_RE = /^(?: {4}|\t)/;
 const DOMAIN_LIKE_PREFIX_RE = /^[a-z][a-z0-9.-]*\.[a-z]{2,}\//i;
+
+type FenceState = {
+  marker: "`" | "~";
+  length: number;
+};
 
 export type BarePathMatch = {
   /** The raw token as it appears in the text, including any `:line[:col]`. */
@@ -88,7 +93,7 @@ export function scanBareDocPathTokens(text: string): BarePathMatch[] {
   const out: BarePathMatch[] = [];
   // Split on newlines while preserving them in indices via a running offset.
   const lines = text.split(/(\r?\n)/);
-  let inFence = false;
+  let fence: FenceState | null = null;
   let absoluteOffset = 0;
 
   for (const line of lines) {
@@ -96,12 +101,16 @@ export function scanBareDocPathTokens(text: string): BarePathMatch[] {
       absoluteOffset += line.length;
       continue;
     }
-    if (FENCE_OPEN_RE.test(line)) {
-      inFence = !inFence;
+    if (fence) {
+      if (isClosingFence(line, fence)) {
+        fence = null;
+      }
       absoluteOffset += line.length;
       continue;
     }
-    if (inFence) {
+    const openingFence = parseOpeningFence(line);
+    if (openingFence) {
+      fence = openingFence;
       absoluteOffset += line.length;
       continue;
     }
@@ -139,6 +148,22 @@ export function scanBareDocPathTokens(text: string): BarePathMatch[] {
     absoluteOffset += line.length;
   }
   return out;
+}
+
+function parseOpeningFence(line: string): FenceState | null {
+  const match = FENCE_MARKER_RE.exec(line);
+  const marker = match?.groups?.marker;
+  if (!marker) return null;
+  const markerChar = marker[0];
+  if (markerChar !== "`" && markerChar !== "~") return null;
+  return { marker: markerChar, length: marker.length };
+}
+
+function isClosingFence(line: string, fence: FenceState): boolean {
+  const match = FENCE_MARKER_RE.exec(line);
+  const marker = match?.groups?.marker;
+  if (!marker || marker[0] !== fence.marker || marker.length < fence.length) return false;
+  return /^[ \t]*$/.test(line.slice(match[0].length));
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #1572.

This hardens the shared doc-preview bare markdown path scanner so fenced code block state follows CommonMark-style closing rules instead of toggling on every fence-looking line.

## Root Cause

`scanBareDocPathTokens` previously tracked fenced blocks with a boolean toggle. A shorter ``` marker inside a longer ```` fence, or an unclosed fence, could invert the scanner state for the rest of the message. That caused illustrative `.md` paths inside code blocks to be captured as failed document mentions while real prose mentions after the block were skipped.

## Changes

- Track the active fence marker character and length.
- Close a fence only when a line uses the same marker character, at least the opening length, and only trailing whitespace.
- Treat unclosed fences as code through the end of the message.
- Add scanner regression coverage for nested/long fences, unclosed fences, and wrong marker/short closing lines.

## Validation

- `pnpm --filter @first-tree/shared exec vitest run src/lib/__tests__/doc-link-scan.test.ts`
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/doc-snapshots.test.ts src/__tests__/doc-snapshots.fs-mocks.test.ts`
- `pnpm --filter @first-tree/web exec vitest run src/lib/__tests__/doc-preview-links.test.ts`
- `pnpm check`
- `pnpm typecheck`

Note: `pnpm check` completed successfully but reported existing lint warnings outside this change.