### PR TITLE
fix: reject backticks in backtick-fence info strings in doc-link scan

### DIFF
--- a/packages/shared/src/lib/__tests__/doc-link-scan.test.ts
+++ b/packages/shared/src/lib/__tests__/doc-link-scan.test.ts
@@ -117,6 +117,31 @@ describe("scanBareDocPathTokens", () => {
     expect(tokens(text)).toEqual(["docs/after.md"]);
   });
 
+  it("does not treat a backtick fence line with backticks after the marker as an opener", () => {
+    // CommonMark: a backtick-fence info string may not contain backticks, so
+    // this line renders as a paragraph with inline code, not a code block.
+    const text = ["```pnpm test``` runs the suite", "docs/after.md"].join("\n");
+    expect(tokens(text)).toEqual(["docs/after.md"]);
+  });
+
+  it("keeps real fences skipped after a backtick-containing pseudo-fence line", () => {
+    const text = [
+      "```docs/inline.md``` as inline code",
+      "```",
+      "docs/fenced.md",
+      "```",
+      "docs/after.md",
+    ].join("\n");
+    const matches = scanBareDocPathTokens(text);
+    expect(matches.map((m) => m.raw)).toEqual(["docs/inline.md", "docs/after.md"]);
+    expect(matches[0]?.enclosingCodeSpan).toBeDefined();
+  });
+
+  it("allows backticks in a tilde fence info string", () => {
+    const text = ["~~~ `note`", "docs/fenced.md", "~~~", "docs/after.md"].join("\n");
+    expect(tokens(text)).toEqual(["docs/after.md"]);
+  });
+
   it("ignores indented (4-space / tab) code blocks", () => {
     expect(tokens("    docs/indented.md")).toEqual([]);
     expect(tokens("\tdocs/tabbed.md")).toEqual([]);

--- a/packages/shared/src/lib/__tests__/doc-link-scan.test.ts
+++ b/packages/shared/src/lib/__tests__/doc-link-scan.test.ts
@@ -125,13 +125,7 @@ describe("scanBareDocPathTokens", () => {
   });
 
   it("keeps real fences skipped after a backtick-containing pseudo-fence line", () => {
-    const text = [
-      "```docs/inline.md``` as inline code",
-      "```",
-      "docs/fenced.md",
-      "```",
-      "docs/after.md",
-    ].join("\n");
+    const text = ["```docs/inline.md``` as inline code", "```", "docs/fenced.md", "```", "docs/after.md"].join("\n");
     const matches = scanBareDocPathTokens(text);
     expect(matches.map((m) => m.raw)).toEqual(["docs/inline.md", "docs/after.md"]);
     expect(matches[0]?.enclosingCodeSpan).toBeDefined();

--- a/packages/shared/src/lib/doc-link-scan.ts
+++ b/packages/shared/src/lib/doc-link-scan.ts
@@ -156,6 +156,10 @@ function parseOpeningFence(line: string): FenceState | null {
   if (!marker) return null;
   const markerChar = marker[0];
   if (markerChar !== "`" && markerChar !== "~") return null;
+  // CommonMark: the info string of a backtick fence may not contain backticks
+  // (such a line is a paragraph with inline code, e.g. "```pnpm test``` to
+  // run"). Tilde-fence info strings have no such restriction.
+  if (markerChar === "`" && line.slice(match[0].length).includes("`")) return null;
   return { marker: markerChar, length: marker.length };
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1592, closing the last known fence-state divergence in the shared doc-preview scanner.

A line starting with a backtick fence marker that has more backticks after the marker (e.g. a Slack-style inline line like ```` ```pnpm test``` runs the suite ````) was treated as opening a fenced block. Per CommonMark, the info string of a backtick fence may not contain backticks, so such a line is actually a paragraph with inline code — which is exactly how react-markdown renders it.

## Root Cause

`parseOpeningFence` accepted any line matching the fence-marker pattern without checking the rest of the line. The misjudged phantom fence then swallowed following prose (missed links/snapshots), and worse, inverted fence parsing for subsequent real code blocks: the web linkify pass rewrites the markdown source, so it could inject literal `[path](path)` syntax into content the renderer displays as a code block — the same state-inversion class as #1572, triggered by a rarer input.

## Changes

- `parseOpeningFence`: a backtick fence line whose remainder contains a backtick is not an opening fence. Tilde fences are unaffected (CommonMark allows backticks in tilde-fence info strings).
- Regression tests: pseudo-fence line followed by prose, pseudo-fence line followed by a real fence (inversion case, with `enclosingCodeSpan` assertion for the inline-code path), and a tilde fence with backticks in its info string.

## Validation

- `pnpm --filter @first-tree/shared exec vitest run src/lib/__tests__/doc-link-scan.test.ts` (27 tests)
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/doc-snapshots.test.ts src/__tests__/doc-snapshots.fs-mocks.test.ts` (30 tests)
- `pnpm --filter @first-tree/web exec vitest run src/lib/__tests__/doc-preview-links.test.ts` (14 tests)
- `pnpm exec biome check` on the touched files
- `pnpm --filter @first-tree/shared typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
