### PR TITLE
fix(web): make the mobile shell scroll and size to the dynamic viewport

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -703,6 +703,29 @@
     font-variant-numeric: tabular-nums;
   }
 
+  /* Dynamic viewport height with a universal fallback: `100vh` ships as the
+     base for browsers without `dvh`, then `100dvh` overrides where supported
+     (iOS 15.4+, Chrome 108+) so a full-height shell tracks the mobile URL-bar /
+     home-indicator resize instead of overflowing the visible viewport. Split
+     into a base rule + `@supports` override rather than two `height`
+     declarations in one rule, which inline styles cannot express and the
+     linter flags as a duplicate property. */
+  .h-dvh-screen {
+    height: 100vh;
+  }
+  @supports (height: 100dvh) {
+    .h-dvh-screen {
+      height: 100dvh;
+    }
+  }
+
+  /* Reserve the top safe-area inset (notch / status bar) so a full-height
+     shell without its own top chrome does not render content under the
+     status bar on notched devices. */
+  .pt-safe-top {
+    padding-top: env(safe-area-inset-top);
+  }
+
   /* Surface utilities — consolidate Panel / PageHeader / Tab containers.
      Prefer these over hand-rolled background/border/radius combinations. */
   .surface-base {

--- a/packages/web/src/pages/mobile/__tests__/shell-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/shell-dom.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
-import { MobileSignalChip } from "../components.js";
+import { MobilePage, MobileSignalChip } from "../components.js";
 import { MobileShell } from "../shell.js";
 
 const authMock = vi.hoisted(() => {
@@ -115,6 +115,21 @@ describe("MobileShell", () => {
     expect(harness.container.textContent).not.toContain("Current team");
   });
 
+  it("sizes the live shell to the dynamic viewport and reserves the top safe area", async () => {
+    renderShell(harness, "/m/now");
+    await harness.flush();
+
+    // Dynamic-viewport height comes from the .h-dvh-screen utility (100vh
+    // fallback + 100dvh override), not a raw inline 100vh that overflows the
+    // visible viewport on mobile browsers while the address bar is shown. The
+    // top safe-area inset is reserved via .pt-safe-top so content does not
+    // render under the status bar on notched devices.
+    const shell = harness.container.querySelector(".h-dvh-screen");
+    expect(shell).not.toBeNull();
+    expect((shell as HTMLElement).style.height).toBe("");
+    expect(shell?.className).toContain("pt-safe-top");
+  });
+
   it("uses the high-contrast token for needs-you signal text", () => {
     harness.render(
       <MobileSignalChip signal={{ tone: "needs-you", label: "Needs answer", rank: 0, attention: true }} />,
@@ -122,5 +137,19 @@ describe("MobileShell", () => {
 
     const chip = harness.container.querySelector("span");
     expect(chip?.getAttribute("style")).toContain("var(--fg-needs-you-strong)");
+  });
+});
+
+describe("MobilePage", () => {
+  it("is a bounded scroll container so page content can scroll", () => {
+    const harness = createDomHarness();
+    harness.render(<MobilePage>work feed</MobilePage>);
+
+    const scroller = harness.container.querySelector(".overflow-y-auto");
+    expect(scroller).not.toBeNull();
+    // h-full bounds the scroller to the parent height so overflow-y-auto
+    // engages; min-h-full would grow with content and never scroll.
+    expect(scroller?.className).toContain("h-full");
+    expect(scroller?.className).not.toContain("min-h-full");
   });
 });

--- a/packages/web/src/pages/mobile/components.tsx
+++ b/packages/web/src/pages/mobile/components.tsx
@@ -78,7 +78,7 @@ export function MobilePage({
 }) {
   return (
     <div
-      className={cn("min-h-full overflow-y-auto", className)}
+      className={cn("h-full overflow-y-auto", className)}
       style={{
         padding: padded ? "var(--sp-4) var(--sp-4) var(--sp-6)" : undefined,
       }}

--- a/packages/web/src/pages/mobile/shell.tsx
+++ b/packages/web/src/pages/mobile/shell.tsx
@@ -46,14 +46,7 @@ export function MobileShell() {
   const rows = tabCountsQuery.data?.rows ?? [];
 
   return (
-    <div
-      className="flex flex-col overflow-hidden"
-      style={{
-        height: "100vh",
-        minHeight: "100dvh",
-        background: "var(--bg)",
-      }}
-    >
+    <div className="h-dvh-screen pt-safe-top flex flex-col overflow-hidden" style={{ background: "var(--bg)" }}>
       <TeamSwitchOverlay />
       <main className="flex-1 min-h-0 overflow-hidden">
         <Outlet />


### PR DESCRIPTION
## What

Follow-up to the merged mobile phase 1 (#1594). Fixes two mobile shell layout defects:

**1. Vertical scroll was broken (Now / Chat / Team / Me).** `MobilePage` used `min-h-full overflow-y-auto`. `min-height:100%` has no upper bound, so the scroll container grew with its content instead of being capped at the viewport height, and `overflow-y-auto` never engaged — content overflowed the `overflow-hidden` `<main>` and was clipped. Fixed by bounding it with `h-full`.

**2. Shell used the layout viewport, not the dynamic one (yzw-codex post-merge finding #1).** The shell root used inline `height:100vh` with an ineffective `minHeight:100dvh`, which resolves to the larger 100vh on mobile browsers while the address bar is visible and pushes the bottom tabs below the fold. Moved to a new `.h-dvh-screen` utility (`100vh` base + `@supports (height:100dvh)` override) and reserve the top safe-area inset via `.pt-safe-top` so content clears the status bar on notched devices.

## Verification

- **Browse (real browser, 390px):** with `h-full`, the scroll container has clientHeight 740 < scrollHeight 799 and scrollTop moves → scrolls. Control test forcing `min-h-full` reproduces the bug (clientHeight grows to content, `scrollable:false`) — causation confirmed.
- Added regression tests: the real `MobileShell` uses `.h-dvh-screen` + `.pt-safe-top` (not raw inline `100vh`), and `MobilePage` is a bounded `h-full` scroll container (guards against reverting to `min-h-full`).
- Gates green: full web suite (168 files / 1320 tests), typecheck + design-token guardrails, `pnpm check`, web build.

Scope: `packages/web/**` only. No server/schema/API/auth changes.

## Note

This is finding **#1** of yzw-codex's 4 post-merge review items on #1594. The others — #2 (mobile attention caches outside the `['me','chats']` realtime invalidation family), #3 (captured document links are a no-op on `/m/chat`), #4 (title rename still gated on `narrow` for generic narrow Workspace) — are separate follow-ups.

Related: #1594.
