### PR TITLE
fix(web): keep click-to-rename on the narrow Workspace title

### DIFF
--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -808,7 +808,10 @@ describe("ChatView", () => {
     expect(container.querySelector('button[aria-label$="Open participants."]')).toBeNull();
     expect(container.querySelector('button[aria-label="Show chat details"]')).toBeNull();
     expect(container.querySelector('button[aria-label="Hide agent final messages"]')).toBeNull();
-    expect(buttonByTitle(container, "Click to rename")).toBeNull();
+    // Generic narrow Workspace keeps click-to-rename: it is gated on mobile
+    // presentation, not viewport width, so resizing to the narrow breakpoint
+    // does not drop the pre-existing rename affordance.
+    expect(buttonByTitle(container, "Click to rename")).not.toBeNull();
 
     await click(container.querySelector('button[aria-label="Show conversations"]'));
     expect(onShowConversations).toHaveBeenCalledTimes(1);
@@ -838,6 +841,8 @@ describe("ChatView", () => {
     await waitForText(container, "Launch planning");
     expect(container.querySelector('[data-mobile-participants-sheet="true"]')).toBeNull();
     expect(container.querySelector('aside[aria-label="Chat details"]')).toBeNull();
+    // Mobile presentation keeps the header context-only: no click-to-rename.
+    expect(buttonByTitle(container, "Click to rename")).toBeNull();
 
     await click(container.querySelector('button[aria-label="Show chat options"]'));
     await waitForText(container, "Participants · 4");

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -3635,10 +3635,12 @@ export function ChatView({
                       watching
                     </span>
                   </span>
-                ) : isTrial || narrow ? (
-                  // Trial and narrow mobile surfaces keep the header as
+                ) : isTrial || useMobileDetailsSheet ? (
+                  // Trial and mobile surfaces keep the header as
                   // navigation/context only. Rename remains a desktop detail
                   // action instead of a hidden tap target in the chat title.
+                  // Gated on mobile presentation, not viewport width, so the
+                  // ordinary narrow Workspace keeps its click-to-rename title.
                   <span className="truncate text-subtitle font-semibold" style={{ color: "var(--fg)" }}>
                     {chatDetail?.title ?? titleFallback ?? "…"}
                   </span>


### PR DESCRIPTION
## What

Follow-up to mobile phase 1 (#1594), resolving yzw-codex post-merge finding **#4**.

The chat title's click-to-rename affordance was hidden whenever `narrow` was set. But `narrow` is also supplied by the ordinary `/` Workspace below the narrow breakpoint, so resizing desktop Workspace narrow dropped a pre-existing rename action — even though mobile phase 1 was meant to leave desktop routes intact.

Gate the header-as-context-only branch on **mobile presentation** (`presentation === "mobile"`) instead of viewport width, matching the same decoupling used for the details rail and summary in #1593. Only `/m/chat` hides rename now; the narrow Workspace keeps it, and trial surfaces still hide it via `isTrial`.

## Verification

- Updated `chat-view-dom.test.tsx` both directions: the generic narrow Workspace path asserts click-to-rename is **present**; the `presentation="mobile"` path asserts it is **absent**. Trial test unchanged (still hidden via `isTrial`).
- Gates green: full web suite (168 files / 1318 tests), typecheck + design-token guardrails, `pnpm check`.

Scope: `packages/web/**` only. Related: #1594, #1596.
