### PR TITLE
fix(web): keep mobile Now / Chat / badges live via shared invalidation

### DIFF
--- a/packages/web/src/pages/mobile/__tests__/realtime-cache.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/realtime-cache.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+import { MobileNowPage } from "../now.js";
+
+const authMock = vi.hoisted(() => ({ value: { agentId: "human-agent-self" } }));
+const meChatMocks = vi.hoisted(() => ({ listMeChats: vi.fn() }));
+
+vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
+vi.mock("../../../api/me-chats.js", () => meChatMocks);
+
+describe("mobile projections share the realtime invalidation prefix", () => {
+  let harness: DomHarness;
+
+  beforeEach(() => {
+    harness = createDomHarness();
+    meChatMocks.listMeChats.mockReset();
+    meChatMocks.listMeChats.mockResolvedValue({ rows: [] });
+  });
+
+  it("refetches Now when ['me','chats'] is invalidated (answer / new message / failure)", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    harness.render(
+      <MemoryRouter initialEntries={["/m/now"]}>
+        <QueryClientProvider client={queryClient}>
+          <Routes>
+            <Route path="/m/now" element={<MobileNowPage />} />
+          </Routes>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    // Let the first fetch settle (empty state renders) before invalidating,
+    // so the invalidation queues a real refetch rather than coalescing with an
+    // in-flight fetch.
+    await harness.waitFor(() => expect(harness.container.textContent).toContain("Nothing active"));
+    expect(meChatMocks.listMeChats).toHaveBeenCalledTimes(1);
+
+    // A realtime WS event (useAdminWs) or a chat send / ask-answer / new-chat
+    // mutation invalidates the shared ["me", "chats"] prefix. The mobile Now
+    // projection is nested under that prefix, so it must refetch immediately
+    // instead of waiting for the 30s poll.
+    await queryClient.invalidateQueries({ queryKey: ["me", "chats"] });
+
+    await harness.waitFor(() => expect(meChatMocks.listMeChats).toHaveBeenCalledTimes(2));
+  });
+});

--- a/packages/web/src/pages/mobile/chat.tsx
+++ b/packages/web/src/pages/mobile/chat.tsx
@@ -64,7 +64,9 @@ function MobileChatList({ onSelectChat }: { onSelectChat: (chatId: string) => vo
   const { agentId } = useAuth();
   const [view, setView] = useState<MobileChatView>("all");
   const chatsQuery = useQuery({
-    queryKey: ["mobile", "chats", view],
+    // Nested under ["me", "chats"] so the shared realtime invalidation keeps
+    // the mobile chat list live instead of poll-only.
+    queryKey: ["me", "chats", "mobile", "chats", view],
     queryFn: () =>
       listMeChats({
         limit: 80,

--- a/packages/web/src/pages/mobile/now.tsx
+++ b/packages/web/src/pages/mobile/now.tsx
@@ -13,7 +13,10 @@ import { mobileChatPreview, mobileChatSignal, mobileFeedReasonLabel, sortMobileC
 export function MobileNowPage() {
   const { agentId } = useAuth();
   const chatsQuery = useQuery({
-    queryKey: ["mobile", "now"],
+    // Nested under ["me", "chats"] so the shared realtime invalidation
+    // (useAdminWs WS events + chat send / ask-answer / new-chat mutations)
+    // refreshes Now immediately instead of waiting for the poll.
+    queryKey: ["me", "chats", "mobile", "now"],
     queryFn: () => listMeChats({ limit: 50, engagement: "active" }),
     refetchInterval: 30_000,
   });

--- a/packages/web/src/pages/mobile/shell.tsx
+++ b/packages/web/src/pages/mobile/shell.tsx
@@ -23,7 +23,9 @@ export function MobileShell() {
   useAdminWs();
 
   const tabCountsQuery = useQuery({
-    queryKey: ["mobile", "tab-counts", organizationId],
+    // Nested under ["me", "chats"] so the shared realtime invalidation keeps
+    // the bottom-tab attention / unread badges live, not just poll-driven.
+    queryKey: ["me", "chats", "mobile", "tab-counts", organizationId],
     queryFn: () => listMeChats({ limit: 50, engagement: "active" }),
     enabled: !!organizationId,
     refetchInterval: 30_000,


### PR DESCRIPTION
## What

Follow-up to mobile phase 1 (#1594), resolving yzw-codex post-merge finding **#2**.

The mobile attention projections used private `["mobile", ...]` query keys, while `useAdminWs` WS events and the reused chat send / ask-answer / new-chat mutations invalidate `["me", "chats"]`. So a newly arrived ask or failure did not update Now or the tab badge, and answering an ask or creating a chat left stale mobile rows until the 30s poll.

Fix: nest the mobile me-chats projections (Now feed, Chat list, tab-count badges) under the `["me", "chats"]` prefix so the existing realtime invalidation (which prefix-matches) refreshes them on the same frames and mutations. No changes to `useAdminWs` or the mutations — the shared invalidation just now reaches them.

- `now.tsx`: `["mobile","now"]` → `["me","chats","mobile","now"]`
- `chat.tsx`: `["mobile","chats",view]` → `["me","chats","mobile","chats",view]`
- `shell.tsx`: `["mobile","tab-counts",org]` → `["me","chats","mobile","tab-counts",org]`

(The Team roster query stays on its own key — it projects members/agents, not me-chats.)

## Verification

- New `realtime-cache.test.tsx`: renders `MobileNowPage`, lets the first fetch settle, invalidates `["me","chats"]`, and asserts the Now query refetches (the answer/new-message/failure transition).
- Gates green: full web suite (169 files / 1321 tests), typecheck + design-token guardrails, `pnpm check`, web build.

Scope: `packages/web/**` only. Related: #1594, #1596, #1597.
