### PR TITLE
fix(web): open captured document links on mobile chat

### DIFF
--- a/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
+++ b/packages/web/src/components/__tests__/doc-preview-drawer.test.tsx
@@ -192,6 +192,25 @@ describe("DocPreviewDrawer", () => {
     expect(latestSearch).not.toContain("docAttachment=");
   });
 
+  it("reserves top and bottom safe-area insets in the mobile full-screen branch", async () => {
+    setupDom(true);
+    latestSearch = "";
+    const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");
+    const route = `/?docChat=chat-1&docMsg=msg-1&docAttachment=${ATT_ID}`;
+    const dom = await renderAt(route, <DocPreviewDrawer />, (client) => {
+      client.setQueryData(docAttachmentRefQueryKey(ATT_ID), docRef);
+    });
+
+    const drawer = dom.querySelector("[data-doc-preview-drawer]");
+    expect(drawer).not.toBeNull();
+    // Mobile branch is a viewport-fixed overlay, so it must reserve its own
+    // safe-area insets — the shell's pt-safe-top does not constrain a fixed
+    // child, so without this the header / close button can sit under the notch.
+    expect(drawer?.className).toContain("fixed inset-0");
+    expect(drawer?.className).toContain("pt-safe-top");
+    expect(drawer?.className).toContain("pb-safe-bottom");
+  });
+
   it("shows an integrity warning when the fetched bytes do not match ref.sha256", async () => {
     attachmentsMocks.sha256Hex.mockResolvedValue("b".repeat(64));
     const { DocPreviewDrawer } = await import("../doc-preview-drawer.js");

--- a/packages/web/src/components/doc-preview-drawer.tsx
+++ b/packages/web/src/components/doc-preview-drawer.tsx
@@ -400,6 +400,11 @@ export function DocPreviewDrawer() {
   if (!hasDocRef) return null;
 
   return (
+    // The mobile branch is a viewport-fixed overlay, so it reserves its own top
+    // and bottom safe-area insets (pt-safe-top / pb-safe-bottom): the shell's
+    // pt-safe-top does not constrain a fixed child, so without these the header /
+    // close button can render under the notch and the scroll surface under the
+    // home indicator.
     <aside
       aria-label="Document preview"
       aria-modal={isMobile}
@@ -408,7 +413,7 @@ export function DocPreviewDrawer() {
         "z-40 flex flex-col bg-card text-foreground",
         "animate-in slide-in-from-right duration-200",
         isMobile
-          ? "fixed inset-0 w-full border-l border-border"
+          ? "fixed inset-0 w-full border-l border-border pt-safe-top pb-safe-bottom"
           : "relative h-auto shrink-0 overflow-hidden border-l border-border-faint max-w-[calc(100vw-var(--sp-8))]",
       )}
       onKeyDown={trapMobileFocus}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -726,6 +726,12 @@
     padding-top: env(safe-area-inset-top);
   }
 
+  /* Reserve the bottom safe-area inset (home indicator) for a viewport-fixed
+     overlay whose own scroll surface reaches the bottom edge. */
+  .pb-safe-bottom {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
   /* Surface utilities — consolidate Panel / PageHeader / Tab containers.
      Prefer these over hand-rolled background/border/radius combinations. */
   .surface-base {

--- a/packages/web/src/pages/mobile/__tests__/doc-preview.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/doc-preview.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+import { MobileChatPage } from "../chat.js";
+
+const authMock = vi.hoisted(() => ({ value: { agentId: "human-agent-self" } }));
+const meChatMocks = vi.hoisted(() => ({ listMeChats: vi.fn() }));
+
+vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
+vi.mock("../../../api/me-chats.js", () => meChatMocks);
+// The drawer's own mobile presentation + attachment fetch is covered by
+// components/__tests__/doc-preview-drawer.test.tsx. Here we only assert that
+// the mobile chat page mounts it, so a captured `attachment:` link on /m/chat
+// has a surface to open instead of silently changing the URL.
+vi.mock("../../../components/doc-preview-drawer.js", () => ({
+  DocPreviewDrawer: () => <div data-testid="mobile-doc-drawer" />,
+}));
+
+describe("MobileChatPage document-evidence surface", () => {
+  let harness: DomHarness;
+
+  beforeEach(() => {
+    harness = createDomHarness();
+    meChatMocks.listMeChats.mockReset();
+    meChatMocks.listMeChats.mockResolvedValue({ rows: [] });
+  });
+
+  it("mounts the document preview drawer so captured doc links are not a no-op", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    harness.render(
+      <MemoryRouter initialEntries={["/m/chat"]}>
+        <QueryClientProvider client={queryClient}>
+          <Routes>
+            <Route path="/m/chat" element={<MobileChatPage />} />
+          </Routes>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    await harness.waitFor(() =>
+      expect(harness.container.querySelector('[data-testid="mobile-doc-drawer"]')).not.toBeNull(),
+    );
+  });
+});

--- a/packages/web/src/pages/mobile/chat.tsx
+++ b/packages/web/src/pages/mobile/chat.tsx
@@ -7,6 +7,7 @@ import { listMeChats } from "../../api/me-chats.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { ActivityDots } from "../../components/chat/activity-dots.js";
 import { ChatRowAvatar } from "../../components/chat/chat-row-avatar.js";
+import { DocPreviewDrawer } from "../../components/doc-preview-drawer.js";
 import { Button } from "../../components/ui/button.js";
 import { formatRowTime } from "../../lib/utils.js";
 import { CenterPanel } from "../workspace/center/index.js";
@@ -41,23 +42,30 @@ export function MobileChatPage() {
     setSearchParams(next);
   }, [searchParams, setSearchParams]);
 
-  if (selectedChatId !== null) {
-    return (
-      <div className="flex h-full min-h-0 overflow-hidden">
-        <CenterPanel
-          selectedChatId={selectedChatId}
-          onSelectChat={selectChat}
-          onClearChat={clearChat}
-          narrow
-          onShowConversations={clearChat}
-          initialParticipantIds={parseParticipantList(searchParams)}
-          presentation="mobile"
-        />
-      </div>
-    );
-  }
-
-  return <MobileChatList onSelectChat={selectChat} />;
+  return (
+    <>
+      {selectedChatId !== null ? (
+        <div className="flex h-full min-h-0 overflow-hidden">
+          <CenterPanel
+            selectedChatId={selectedChatId}
+            onSelectChat={selectChat}
+            onClearChat={clearChat}
+            narrow
+            onShowConversations={clearChat}
+            initialParticipantIds={parseParticipantList(searchParams)}
+            presentation="mobile"
+          />
+        </div>
+      ) : (
+        <MobileChatList onSelectChat={selectChat} />
+      )}
+      {/* Mobile document-evidence surface: a captured `attachment:` link in the
+          chat timeline sets docChat/docMsg/docAttachment params; the drawer
+          (fixed inset-0 on mobile) consumes them so the doc opens instead of
+          the click being a no-op. Renders null when no doc ref is set. */}
+      <DocPreviewDrawer />
+    </>
+  );
 }
 
 function MobileChatList({ onSelectChat }: { onSelectChat: (chatId: string) => void }) {


### PR DESCRIPTION
## What

Follow-up to mobile phase 1 (#1594), resolving yzw-codex post-merge finding **#3**.

A captured `attachment:` link in the shared chat timeline sets `docChat/docMsg/docAttachment` search params, and the desktop Workspace mounts `DocPreviewDrawer` to consume them. `MobileChatPage` mounted only `CenterPanel`, so on `/m/chat` a captured document link looked actionable but only changed the URL and showed nothing.

Fix: mount `DocPreviewDrawer` on `MobileChatPage`. The drawer is already mobile-aware — it renders full-screen (`fixed inset-0`) under `useIsMobileDocPreview()` and returns `null` when no doc ref is set — so the same document evidence is now reachable on mobile instead of the click being a no-op. This matches the mobile surface's "selected-work evidence stays reachable" contract (from `product/surfaces/mobile-surface.md`).

## Verification

- New `mobile/__tests__/doc-preview.test.tsx`: asserts `MobileChatPage` mounts the document preview surface (the exact regression). The drawer's own mobile presentation + attachment fetch is already covered by `components/__tests__/doc-preview-drawer.test.tsx` (9 tests).
- Gates green: full web suite (169 files / 1321 tests), typecheck + design-token guardrails, `pnpm check`, web build.

Scope: `packages/web/**` only. Related: #1594, #1596, #1597, #1598.
