### PR TITLE
fix(onboarding): simplify portable bootstrap commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,15 +127,18 @@ At the "connect a computer" step, setup gives you the channel-aware commands
 to install the CLI and link the machine. Hosted production uses:
 
 ```bash
-installer_tmp=$(mktemp "${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && sh "$installer_tmp" &&
-~/.local/bin/first-tree login <connect-code>)
+curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh
+~/.local/bin/first-tree login <connect-code>
 ```
 
 Use the exact commands shown in the web console, especially for staging or a
 self-hosted deployment. The macOS/Linux installer bundles Node.js, so new
-users do not need to install Node separately. The command only logs in after
-the installer succeeds, and the explicit `~/.local/bin` path works immediately,
-even before the shell reloads its `PATH`.
+users do not need to install Node separately. The two lines are intentionally
+independent and do not provide shell-level transaction protection: when pasted
+together, an install-line failure does not automatically prevent the login line
+from running, and POSIX `sh` does not guarantee that `curl | sh` preserves a
+`curl` failure status. The explicit `~/.local/bin` path works immediately, even
+before the shell reloads its `PATH`.
 
 ## CLI
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -83,14 +83,15 @@ First Tree 围绕 Context Tree 连接五个部分：
 命令。托管生产环境使用：
 
 ```bash
-installer_tmp=$(mktemp "${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && sh "$installer_tmp" &&
-~/.local/bin/first-tree login <connect-code>)
+curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh
+~/.local/bin/first-tree login <connect-code>
 ```
 
 请以 Web 控制台显示的命令为准，尤其是在使用 staging 或自托管部署时。
-macOS/Linux 安装脚本已内置 Node.js，无需另行安装。命令仅在安装成功后
-执行登录；登录命令显式使用 `~/.local/bin`，因此即使当前 shell 尚未刷新
-`PATH` 也能立即执行。
+macOS/Linux 安装脚本已内置 Node.js，无需另行安装。为保持易读，这两行命令
+相互独立，不提供 shell 级事务保护：整段粘贴时，安装行失败不会自动阻止登录
+行运行，POSIX `sh` 也不保证 `curl | sh` 保留 `curl` 的失败状态。登录命令
+显式使用 `~/.local/bin`，因此即使当前 shell 尚未刷新 `PATH` 也能立即执行。
 
 ## CLI
 

--- a/apps/doc-website/docs/cli/index.md
+++ b/apps/doc-website/docs/cli/index.md
@@ -6,23 +6,25 @@ the computer in with a connect code from the First Tree web console.
 ## Production
 
 ```bash
-installer_tmp=$(mktemp "${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && sh "$installer_tmp" &&
-~/.local/bin/first-tree login <connect-code>)
+curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh
+~/.local/bin/first-tree login <connect-code>
 ```
 
 ## Staging
 
 ```bash
-installer_tmp=$(mktemp "${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; curl -fsSL https://download.first-tree.ai/releases/staging/install.sh -o "$installer_tmp" && sh "$installer_tmp" &&
-~/.local/bin/first-tree-staging login <connect-code>)
+curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh
+~/.local/bin/first-tree-staging login <connect-code>
 ```
 
 The macOS/Linux installers bundle Node.js. The explicit `~/.local/bin` paths
-work immediately, even before the current shell reloads `PATH`. Each command
-downloads the installer to a temporary file and only logs in after installation
-succeeds. For a self-hosted deployment, use the exact two-line command shown
-by its web console so the installer and login command receive the correct
-server and download-base overrides.
+work immediately, even before the current shell reloads `PATH`. The two lines
+are intentionally independent and do not provide shell-level transaction
+protection: when pasted together, an install-line failure does not automatically
+prevent the login line from running, and POSIX `sh` does not guarantee that
+`curl | sh` preserves a `curl` failure status. For a self-hosted deployment,
+use the exact two-line command shown by its web console so the installer and
+login command receive the correct server and download-base overrides.
 
 Development builds use `scripts/dev-install.sh` from a source checkout and
 sign in with `first-tree-dev login <connect-code>`.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -17,23 +17,25 @@ human-friendly index over them.
 Production:
 
 ```bash
-installer_tmp=$(mktemp "${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && sh "$installer_tmp" &&
-~/.local/bin/first-tree login <connect-code>)
+curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh
+~/.local/bin/first-tree login <connect-code>
 ```
 
 Staging:
 
 ```bash
-installer_tmp=$(mktemp "${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; curl -fsSL https://download.first-tree.ai/releases/staging/install.sh -o "$installer_tmp" && sh "$installer_tmp" &&
-~/.local/bin/first-tree-staging login <connect-code>)
+curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh
+~/.local/bin/first-tree-staging login <connect-code>
 ```
 
 The public shell installers support macOS and Linux and bundle Node.js. They
 install channel-specific binaries under `~/.local/bin`: `first-tree` / `ft`
 for production and `first-tree-staging` / `fts` for staging. The full path in
 the login command works immediately, before the current shell reloads `PATH`.
-The success chain preserves download and installer failures, removes the
-temporary installer, and does not run login unless installation completes.
+The two lines are intentionally independent and do not provide shell-level
+transaction protection: when pasted together, an install-line failure does not
+automatically prevent the login line from running, and POSIX `sh` does not
+guarantee that `curl | sh` preserves a `curl` failure status.
 
 For self-hosted deployments, use the two-line command returned by the web
 console. It includes the server and portable download-base overrides when

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -30,19 +30,22 @@ Hosted production and staging use these commands respectively:
 
 ```bash
 # Production
-installer_tmp=$(mktemp "${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && sh "$installer_tmp" &&
-~/.local/bin/first-tree login <connect-code>)
+curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh
+~/.local/bin/first-tree login <connect-code>
 
 # Staging
-installer_tmp=$(mktemp "${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; curl -fsSL https://download.first-tree.ai/releases/staging/install.sh -o "$installer_tmp" && sh "$installer_tmp" &&
-~/.local/bin/first-tree-staging login <connect-code>)
+curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh
+~/.local/bin/first-tree-staging login <connect-code>
 ```
 
 Use the exact command from the web console for self-hosted deployments. It
 includes the server and download-base overrides when they differ from the
-hosted channel defaults. The success chain only logs in after installation
-completes and removes the temporary installer on exit. The explicit
-`~/.local/bin` path works before the current shell reloads its `PATH`.
+hosted channel defaults. The two lines are intentionally independent and do
+not provide shell-level transaction protection: when pasted together, an
+install-line failure does not automatically prevent the login line from
+running, and POSIX `sh` does not guarantee that `curl | sh` preserves a `curl`
+failure status. The explicit `~/.local/bin` path works before the current shell
+reloads its `PATH`.
 
 Local development continues to use the source checkout:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,8 +32,8 @@ Your agent runs on a real machine, so the next step links one to your team.
 Copy the command the page shows and run it in a terminal on that machine:
 
 ```bash
-installer_tmp=$(mktemp "${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && sh "$installer_tmp" &&
-~/.local/bin/first-tree login <connect-code>)
+curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh
+~/.local/bin/first-tree login <connect-code>
 ```
 
 This is the exact command for hosted production. Use the command from the
@@ -41,9 +41,11 @@ page for staging or a self-hosted deployment: it selects the correct installer,
 binary, and server URL. The explicit `~/.local/bin` path works before a shell
 reload adds that directory to `PATH`.
 
-The first line downloads and installs the CLI through a temporary file. The
-second line signs the computer in only after the download and installation
-succeed. The temporary installer is removed when the command exits.
+The first line streams the installer to `sh`; the second line signs the
+computer in. They are intentionally independent and do not provide shell-level
+transaction protection: when pasted together, an install-line failure does not
+automatically prevent the login line from running, and POSIX `sh` does not
+guarantee that `curl | sh` preserves a `curl` failure status.
 `first-tree login`:
 
 - Exchanges the short connect code against the CLI channel's default server

--- a/packages/qa/cases/cross-surface/portable-shell-onboarding.md
+++ b/packages/qa/cases/cross-surface/portable-shell-onboarding.md
@@ -1,6 +1,6 @@
 ---
 id: portable-shell-onboarding
-description: Validate that hosted prod and staging onboarding install the public portable artifact, invoke the channel-correct binary only after installer success, and recover an existing stale installation safely.
+description: Validate that hosted prod and staging onboarding copy the server-authored bootstrap verbatim and complete the public portable install, channel-correct login, and daemon startup path.
 areas: [cross-surface]
 surfaces: [server, web, cli]
 ---
@@ -9,27 +9,30 @@ surfaces: [server, web, cli]
 
 ## Goal
 
-Confirm the fresh-computer and recovery paths across server, web, the public download service, and CLI: a prod or staging
-server mints the canonical guarded shell bootstrap, the web copies it without reconstructing it, the public installer
-selects the matching channel artifact, and only a successfully installed binary may run `login`. A failed fetch or
-installer run must never fall through to an older executable already present at the channel's `~/.local/bin` path.
+Confirm the fresh-computer path across server, web, the public download service, and CLI: a prod or staging server mints
+the canonical two-line shell bootstrap, the web displays and copies it without reconstructing it, the public installer
+selects the matching channel artifact, and the installed full-path binary completes `login` and starts its daemon.
 
 Run both hosted channels. The expected commands, with the minted connect code substituted for `<connect-code>`, are:
 
 ```sh
-# Staging
-installer_tmp=$(mktemp "${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; curl -fsSL https://download.first-tree.ai/releases/staging/install.sh -o "$installer_tmp" && sh "$installer_tmp" &&
-~/.local/bin/first-tree-staging login <connect-code>)
-
 # Production
-installer_tmp=$(mktemp "${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && sh "$installer_tmp" &&
-~/.local/bin/first-tree login <connect-code>)
+curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh
+~/.local/bin/first-tree login <connect-code>
+
+# Staging
+curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh
+~/.local/bin/first-tree-staging login <connect-code>
 ```
 
-Deterministic product tests own string construction and escaping. This case owns the live boundaries those tests cannot
-prove: the web/API handoff, the public installer chain, the installed channel identity, a real first login, and recovery
-from a stale executable. The separate `curl -o` step must preserve a fetch failure without relying on non-POSIX
-`pipefail`; the shared `&&` chain must gate login on download, verification, and installation success.
+The two lines are intentionally independent and provide no shell-level transaction protection. If both are submitted
+together, a failure on the install line does not automatically stop the login line, and POSIX `sh` does not guarantee
+that `curl | sh` preserves a `curl` failure status. This is an accepted usability tradeoff, not a fault-injection claim
+owned by this case.
+
+Deterministic product tests own exact string construction and escaping. This case owns the live boundaries those tests
+cannot prove: the server-to-web handoff, byte-for-byte clipboard content, public installer chain, installed channel
+identity, real first login, daemon startup, and server-side client registration.
 
 ## Preconditions
 
@@ -37,20 +40,14 @@ from a stale executable. The separate `curl -o` step must preserve a fetch failu
   operator host or reuse its First Tree homes, credentials, daemon, or shell profile.
 - Build the shipped server/web artifact from the target ref. Run separate prod and staging server stacks, or reset all
   database and client state before switching channel configuration.
-- Give each channel a fresh-install runner with a clean writable `HOME` and a separate recovery runner whose writable
-  `HOME` contains a known older, still login-compatible channel installation at `~/.local/bin/first-tree` or
-  `~/.local/bin/first-tree-staging`. Both runners should have `sh`, `curl`, CA certificates, and the installer's normal
-  archive/checksum tools, but no system Node.js requirement; the portable artifact must supply its own runtime.
+- Give each channel a clean writable `HOME`. The runner must have `sh`, `curl`, CA certificates, and the installer's
+  normal archive/checksum tools, but no system Node.js requirement; the portable artifact must supply its own runtime.
 - On Linux, give the runner's test user a real systemd user manager and D-Bus user session. Verify that
   `systemctl --user status` can reach the manager before testing. A plain container without a working user bus cannot
   validate this case: `login` must install and start the background daemon, so a missing manager or bus is `BLOCKED`.
   Do not add `--no-start`, mock the supervisor, or accept a credentials-only login as a substitute.
 - Public network access to `https://download.first-tree.ai` is required. Record the resolved public metadata/version for
   each mutable `install.sh` entry point so the report distinguishes the tested public release from the source target ref.
-- Provide an isolated HTTP fault server and a run-local mirror of the selected channel's installer, metadata, checksum,
-  and portable artifact. The fault server must be reachable only inside the QA run cell and support deterministic outer
-  installer-fetch failure, downstream installer failure, and successful unmodified mirror modes. Do not change public
-  download objects or route fault traffic through the operator host.
 - Use throwaway server secrets, databases, users, and connect codes. A non-production QA auth bootstrap may be enabled
   inside the run cell, but never bridge a real hosted account or credentials into it.
 
@@ -60,79 +57,47 @@ the isolated server to exchange the code. Supply a run-local `FIRST_TREE_SERVER_
 the copied bootstrap text, while leaving the server's canonical public URL in place so issuer validation and the emitted
 hosted command remain representative. Record this routing override as QA harness configuration, not product output.
 
-For recovery fault injection, run a separate candidate server instance for each channel, or restart and reset the
-isolated channel stack, with `FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL` set to the controlled mirror origin. Mint new connect
-codes from that server for every failure and success attempt. The resulting custom-base command is product output and
-must retain the same temporary-file, cleanup, and `&&` guard structure; it should pass the custom base to the downloaded
-installer as generated by the server. Never edit the copied command to insert a harness-side success guard.
-
 ## Operate
 
 For each of `prod` and `staging`:
 
 - Start the candidate server/web stack with the matching `FIRST_TREE_CHANNEL`, create a throwaway authenticated user, and
-  enter a fresh-computer connection flow in the web UI. Exercise onboarding or **Computers -> New Connection**; when the
-  new-agent no-computer path is available, confirm it presents the same server-supplied bootstrap rather than building a
-  different command.
-- Capture the `POST /api/v1/me/connect-tokens` response and the command copied from the UI. Compare them byte-for-byte
-  after redacting the connect code in shared evidence. The UI copy must equal `bootstrapCommand`; `installerUrl`,
-  `binName`, and the standalone installed-CLI `command` must all describe the same channel.
+  exercise the onboarding connection step and **Computers -> New Connection**. When the new-agent no-computer path is
+  available, confirm that it presents the same server-supplied bootstrap instead of building a different command.
+- Capture the `POST /api/v1/me/connect-tokens` response and the command copied from every exercised UI surface. Compare
+  them byte-for-byte before redaction. The UI copy must equal `bootstrapCommand`; `installerUrl`, `binName`, and the
+  standalone installed-CLI `command` must all describe the same channel. Redact the connect code in shared evidence.
 - Fetch the public `install.sh` separately for HTTP status and `sh -n` evidence. The default latest install path reads
   `latest.json` directly and downloads the matching platform asset from that document; record its channel, version,
   binary name, asset URL, and checksum. Independently fetch the immutable manifest referenced by `manifestUrl` and that
   version's `SHA256SUMS`, then cross-check their identity and checksum data without modifying public objects. Do not
   report the manifest or `SHA256SUMS` as files consumed by the installer itself.
-- In the clean CLI runner, execute the exact copied guarded bootstrap once. The only harness addition is the externally
-  supplied run-local `FIRST_TREE_SERVER_URL` needed to route the login to the isolated server. Do not rewrite the
-  installer URL, binary path, connect code, or command lines, and do not append `--no-start`.
-- Observe the installed executable and the isolated server after login. Use current black-box CLI/API surfaces to confirm
-  the client registration belongs to the throwaway user and was created by the channel-correct binary.
-- Prepare the recovery runner from a recorded immutable older release of the same channel. Put a thin executable wrapper
-  at the normal `~/.local/bin` path that records invocation without arguments and then delegates to that older binary, so
-  an unsafe fallthrough would be both observable and capable of consuming the new code and reconnecting. Record the
-  wrapper hash, installed version, client list, and service state before fault injection; do not log the connect code.
-- Point the recovery server at the controlled mirror, mint a fresh code, force the outer `install.sh` request to fail
-  with a deterministic HTTP error before writing a usable response, and run the exact server-supplied command under
-  POSIX `sh` without `pipefail`. First record the direct `curl -fsSL` status for the same response; require the complete
-  bootstrap to return that exact status, with no stale-wrapper invocation, an unchanged wrapper hash, no
-  new/reconnected client, and no leaked `first-tree-install.*` temporary file.
-- Mint another fresh code and allow the outer `install.sh` fetch to succeed, but use the genuine channel installer with a
-  deterministic downstream failure such as a checksum mismatch or unavailable portable asset. Require a non-zero
-  installer status, require the complete bootstrap to return that same status, and make the same no-invocation,
-  unchanged-wrapper, no-client, and temporary-file cleanup observations. Do not substitute a harness script that merely
-  pretends to be the installer for this step.
-- Restore every mirrored object to the recorded valid channel release, mint a third fresh code, and execute the newly
-  supplied command from the same recovery home. Require the installer to replace or repair the stale installation before
-  login runs, then verify the repaired channel binary completes login, starts the real user service, and creates the
-  expected client. The stale-wrapper invocation marker must remain absent throughout all three attempts.
+- In the clean CLI runner, execute the exact copied two-line bootstrap once. The only harness addition is the externally
+  supplied run-local `FIRST_TREE_SERVER_URL` needed to route login to the isolated server. Do not rewrite the installer
+  URL, binary path, connect code, or command lines; do not add a shell guard or append `--no-start`.
+- Observe the installed executable, daemon, and isolated server after login. Use current black-box CLI/API surfaces to
+  confirm that the client registration belongs to the throwaway user and was created by the channel-correct binary.
 
 ## Observe
 
 - `observe browser-ui`: every exercised web entry point displays and copies the server response exactly. There is no npm
-  install step, Node.js fallback, `curl | sh` pipeline, or PATH-dependent bare login command.
-- `observe http-api`: prod returns the prod installer URL, `first-tree`, and the exact prod guarded bootstrap. Staging
-  returns the staging installer URL, `first-tree-staging`, and the exact staging guarded bootstrap. Each command downloads
-  to a temporary file and places installer execution plus full-path login in one `&&` chain. The connect code appears only
-  in the login command, never in `installerUrl` or public download requests.
+  install step, Node.js fallback, or PATH-dependent bare login command.
+- `observe http-api`: prod returns the prod installer URL, `first-tree`, and the exact prod two-line bootstrap. Staging
+  returns the staging installer URL, `first-tree-staging`, and the exact staging two-line bootstrap. The first line uses
+  `curl -fsSL ... | sh`; the second uses the channel's full binary path. The connect code appears only in the login line,
+  never in `installerUrl` or public download requests.
 - `observe public-http`: both public installers return successfully and pass `sh -n`; each default install reads its
   channel's `latest.json` asset and verifies that tarball's checksum. As a separate consistency check, the referenced
   immutable manifest and versioned `SHA256SUMS` agree with the latest metadata and downloaded asset.
-- `observe filesystem`: from a fresh home, the installer creates `~/.local/bin/first-tree` for prod or
+- `observe filesystem`: from a clean home, the installer creates `~/.local/bin/first-tree` for prod or
   `~/.local/bin/first-tree-staging` for staging. The full path in the second line works immediately without sourcing a
   shell profile, and installed metadata identifies the matching channel and portable install mode.
-- `observe recovery-failure`: under plain POSIX `sh`, each complete bootstrap returns the recorded status of its failed
-  fetch or installer, removes the downloaded temporary installer, leaves the stale wrapper byte-for-byte unchanged and
-  uninvoked, and leaves server client/connection state unchanged. A fetch failure must not be masked by `sh` reading an
-  empty pipeline because no pipeline is used.
-- `observe recovery-success`: after the mirror is restored, the same installer entry point replaces or repairs the stale
-  channel installation, and only that repaired binary receives `login`. Its metadata matches the recorded mirrored
-  release, while the stale-wrapper marker remains absent.
 - `observe cli-output`: the installed executable launches with its bundled Node.js runtime and the first `login` exits
   successfully against the isolated server without `--no-start`.
-- `observe service-state`: the login installs and starts the channel-correct systemd user service, and
-  `systemctl --user` reports it active through the runner's real user manager and bus.
+- `observe service-state`: login installs and starts the channel-correct systemd user service, and `systemctl --user`
+  reports it active through the runner's real user manager and bus.
 - `observe http-api`: the isolated server reports the newly registered client for the throwaway user after login. Prod
-  and staging homes/clients stay isolated; neither flow invokes the other channel's binary.
+  and staging homes and clients stay isolated; neither flow invokes the other channel's binary.
 
 Follow current typed response and installed-metadata schemas if field names evolve, but keep the evidence tied to the
 same cross-surface claims. Do not treat source inspection, unit-test output, or a successful installer download alone as
@@ -140,33 +105,28 @@ proof that first login worked.
 
 ## Expected Result
 
-`PASS`: both prod and staging web/API flows supplied the exact hosted guarded command, each live public installer resolved
-and installed its matching channel artifact in a clean Node-free runner, and both recovery runners preserved fetch and
-installer failures without invoking or reconnecting through their stale binary. After valid mirror service resumed, each
-installer repaired the channel installation before the full-path binary completed login with its background service
-active, and the isolated server observed a client only for the successful attempts.
+`PASS`: both prod and staging web/API flows supplied the exact hosted two-line command, every exercised web surface
+copied it byte-for-byte, each live public installer installed its matching channel artifact in a clean Node-free runner,
+the full-path binary completed login with its background service active, and the isolated server observed the expected
+channel-correct client.
 
 `FAIL`: a reproducible product defect, such as web copy diverging from `bootstrapCommand`, an npm/Node fallback appearing,
 the public URL or metadata crossing channels, the expected full-path binary being absent, a bundled-runtime launch
-failure, daemon installation/start failing despite a healthy user manager and bus, a valid fresh connect code failing to
-register against a healthy isolated server, a failed fetch/installer returning success, the stale wrapper being invoked
-or changed during failure, or any client appearing/reconnecting before a verified installation succeeds.
+failure, daemon installation/start failing despite a healthy user manager and bus, or a valid fresh connect code failing
+to register against a healthy isolated server.
 
-`BLOCKED`: Docker or public download access is unavailable, QA auth/data bootstrap cannot mint a connect code, or a
-required public channel release or suitable previous compatible release has not been published. An unavailable isolated
-fault server/mirror also blocks the recovery portion. A Linux runner without a reachable systemd user manager and D-Bus
-user session is also `BLOCKED`; do not downgrade this case to `login --no-start`.
+`BLOCKED`: Docker or public download access is unavailable, QA auth/data bootstrap cannot mint a connect code, a required
+public channel release has not been published, or the Linux runner lacks a reachable systemd user manager and D-Bus user
+session. Do not downgrade this case to `login --no-start`.
 
-`INCONCLUSIVE`: only one channel or one recovery mode completed, the mutable public installer changed during the run, the
-public artifact could not be attributed to the recorded metadata/version, or login/reconnection evidence was partial or
-unstable.
+`INCONCLUSIVE`: only one channel completed, the mutable public installer changed during the run, the public artifact
+could not be attributed to the recorded metadata/version, or clipboard, login, daemon, or registration evidence was
+partial or unstable.
 
 ## Evidence
 
 Keep redacted API responses, browser screenshots plus clipboard capture, installer, latest metadata, immutable-manifest,
 and `SHA256SUMS` HTTP responses, `sh -n` output, checksum/install logs, installed binary/version/channel evidence, CLI
-login output, systemd user-service state, and the server-side client registration. For recovery, also retain fault-server
-request logs, exact non-zero statuses, redacted command shapes, temporary-directory listings, stale-wrapper hashes and
-invocation markers, and before/after server client snapshots. Record target ref, public artifact versions, previous
-compatible versions, container image digests, and run-local routing overrides. Never retain connect codes, bearer tokens,
-cookies, or generated client credentials in shared artifacts.
+login output, systemd user-service state, and server-side client registration. Record the target ref, public artifact
+versions, container image digests, and run-local routing overrides. Never retain connect codes, bearer tokens, cookies,
+or generated client credentials in shared artifacts.

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -439,10 +439,8 @@ describe("small API route handlers", () => {
     expect(result.token).toBe(token);
     expect(result.command).toBe("first-tree login 'code'\\''$(id);x'");
     expect(result.bootstrapCommand).toBe(
-      `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && ` +
-        `(trap 'rm -f "$installer_tmp"' 0; ` +
-        'curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && ' +
-        `sh "$installer_tmp" &&\n~/.local/bin/first-tree login 'code'\\''$(id);x')`,
+      `curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh\n` +
+        `~/.local/bin/first-tree login 'code'\\''$(id);x'`,
     );
     expect(result.installerUrl).toBe("https://download.first-tree.ai/releases/prod/install.sh");
     expect(result.installerUrl).not.toContain(token);

--- a/packages/server/src/__tests__/connect-token-bootstrap.test.ts
+++ b/packages/server/src/__tests__/connect-token-bootstrap.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -14,55 +14,27 @@ import { createTestAdmin, createTestApp, useTestApp } from "./helpers.js";
 
 const TEST_JWT_SECRET = "test-jwt-secret-key-for-vitest";
 const execFileAsync = promisify(execFile);
-const PORTABLE_BOOTSTRAP_PREFIX =
-  `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && ` + `(trap 'rm -f "$installer_tmp"' 0; `;
-
-type BootstrapExecutionMode = "fetch-failure" | "installer-failure" | "success";
-
-type BootstrapExecutionResult = {
-  exitCode: number;
-  events: string[];
-  remainingTempFiles: string[];
-};
-
 async function writeExecutable(path: string, contents: string): Promise<void> {
   await writeFile(path, contents);
   await chmod(path, 0o755);
 }
 
-async function executePortableBootstrap(
-  bootstrapCommand: string,
-  mode: BootstrapExecutionMode,
-): Promise<BootstrapExecutionResult> {
+async function executePortableBootstrap(bootstrapCommand: string): Promise<string[]> {
   const root = await mkdtemp(join(tmpdir(), "first-tree-connect-bootstrap-"));
   try {
     const homeDirectory = join(root, "home");
     const localBinDirectory = join(homeDirectory, ".local", "bin");
     const fakeBinDirectory = join(root, "fake-bin");
-    const tempDirectory = join(root, "tmp");
     const eventLog = join(root, "events.log");
     const fakeInstaller = join(root, "installer.sh");
     await Promise.all([
       mkdir(localBinDirectory, { recursive: true }),
       mkdir(fakeBinDirectory, { recursive: true }),
-      mkdir(tempDirectory, { recursive: true }),
       writeFile(eventLog, ""),
     ]);
-
-    await writeExecutable(
-      join(localBinDirectory, "first-tree"),
-      `#!/bin/sh
-printf '%s\n' "stale-login:$*" >> "$EVENT_LOG"
-`,
-    );
     await writeExecutable(
       fakeInstaller,
-      mode === "installer-failure"
-        ? `#!/bin/sh
-printf '%s\n' 'installer-start' >> "$EVENT_LOG"
-exit 9
-`
-        : `#!/bin/sh
+      `#!/bin/sh
 printf '%s\n' 'installer-start' >> "$EVENT_LOG"
 cat > "$HOME/.local/bin/first-tree" <<'SHIM'
 #!/bin/sh
@@ -75,49 +47,22 @@ printf '%s\n' 'installer-success' >> "$EVENT_LOG"
     await writeExecutable(
       join(fakeBinDirectory, "curl"),
       `#!/bin/sh
-if [ "$FAKE_CURL_MODE" = 'fetch-failure' ]; then
-  exit 22
-fi
-
-output=
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = '-o' ]; then
-    shift
-    output=$1
-  fi
-  shift
-done
-[ -n "$output" ] || exit 64
-cp "$FAKE_INSTALLER" "$output"
+cat "$FAKE_INSTALLER"
 `,
     );
 
-    let exitCode = 0;
-    try {
-      await execFileAsync("/bin/sh", ["-c", bootstrapCommand], {
-        env: {
-          ...process.env,
-          EVENT_LOG: eventLog,
-          FAKE_CURL_MODE: mode,
-          FAKE_INSTALLER: fakeInstaller,
-          HOME: homeDirectory,
-          PATH: `${fakeBinDirectory}:${process.env.PATH ?? "/usr/bin:/bin"}`,
-          TMPDIR: tempDirectory,
-        },
-        timeout: 10_000,
-      });
-    } catch (error) {
-      const code = error instanceof Error ? Reflect.get(error, "code") : undefined;
-      if (typeof code !== "number") throw error;
-      exitCode = code;
-    }
+    await execFileAsync("/bin/sh", ["-c", bootstrapCommand], {
+      env: {
+        ...process.env,
+        EVENT_LOG: eventLog,
+        FAKE_INSTALLER: fakeInstaller,
+        HOME: homeDirectory,
+        PATH: `${fakeBinDirectory}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+      },
+      timeout: 10_000,
+    });
 
-    const events = (await readFile(eventLog, "utf8")).trim().split("\n").filter(Boolean);
-    return {
-      exitCode,
-      events,
-      remainingTempFiles: await readdir(tempDirectory),
-    };
+    return (await readFile(eventLog, "utf8")).trim().split("\n").filter(Boolean);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -172,55 +117,14 @@ describe("POST /me/connect-tokens bootstrap command", () => {
       expectShortConnectCode(body.token);
       expect(body.command).toBe(`first-tree login ${body.token}`);
       expect(body.bootstrapCommand).toBe(
-        PORTABLE_BOOTSTRAP_PREFIX +
-          'curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && ' +
-          `sh "$installer_tmp" &&\n~/.local/bin/first-tree login ${body.token})`,
+        `curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh\n` +
+          `~/.local/bin/first-tree login ${body.token}`,
       );
       expect(body).not.toHaveProperty("npmSpec");
       expect(body).not.toHaveProperty("installMethod");
     });
 
-    it("preserves a fetch failure and does not invoke an existing CLI", async () => {
-      const app = getApp();
-      const admin = await createTestAdmin(app);
-      const res = await app.inject({
-        method: "POST",
-        url: "/api/v1/me/connect-tokens",
-        headers: {
-          authorization: `Bearer ${admin.accessToken}`,
-          host: "cloud.first-tree.ai",
-          "x-forwarded-proto": "https",
-        },
-      });
-      expect(res.statusCode).toBe(200);
-      const body = res.json<{ bootstrapCommand: string }>();
-
-      const result = await executePortableBootstrap(body.bootstrapCommand, "fetch-failure");
-
-      expect(result).toEqual({ exitCode: 22, events: [], remainingTempFiles: [] });
-    });
-
-    it("preserves an installer failure and does not invoke an existing CLI", async () => {
-      const app = getApp();
-      const admin = await createTestAdmin(app);
-      const res = await app.inject({
-        method: "POST",
-        url: "/api/v1/me/connect-tokens",
-        headers: {
-          authorization: `Bearer ${admin.accessToken}`,
-          host: "cloud.first-tree.ai",
-          "x-forwarded-proto": "https",
-        },
-      });
-      expect(res.statusCode).toBe(200);
-      const body = res.json<{ bootstrapCommand: string }>();
-
-      const result = await executePortableBootstrap(body.bootstrapCommand, "installer-failure");
-
-      expect(result).toEqual({ exitCode: 9, events: ["installer-start"], remainingTempFiles: [] });
-    });
-
-    it("invokes the newly installed CLI only after the installer succeeds", async () => {
+    it("executes the installer pipeline and invokes the installed CLI", async () => {
       const app = getApp();
       const admin = await createTestAdmin(app);
       const res = await app.inject({
@@ -235,13 +139,9 @@ describe("POST /me/connect-tokens bootstrap command", () => {
       expect(res.statusCode).toBe(200);
       const body = res.json<{ bootstrapCommand: string; token: string }>();
 
-      const result = await executePortableBootstrap(body.bootstrapCommand, "success");
+      const events = await executePortableBootstrap(body.bootstrapCommand);
 
-      expect(result).toEqual({
-        exitCode: 0,
-        events: ["installer-start", "installer-success", `installed-login:login ${body.token}`],
-        remainingTempFiles: [],
-      });
+      expect(events).toEqual(["installer-start", "installer-success", `installed-login:login ${body.token}`]);
     });
 
     it("adds an explicit server URL for non-default deployment hosts", async () => {
@@ -261,10 +161,8 @@ describe("POST /me/connect-tokens bootstrap command", () => {
       expectShortConnectCode(body.token);
       expect(body.command).toBe(`FIRST_TREE_SERVER_URL='https://selfhost.example.test' first-tree login ${body.token}`);
       expect(body.bootstrapCommand).toBe(
-        PORTABLE_BOOTSTRAP_PREFIX +
-          'curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && ' +
-          `sh "$installer_tmp" &&\n` +
-          `FIRST_TREE_SERVER_URL='https://selfhost.example.test' ~/.local/bin/first-tree login ${body.token})`,
+        `curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh\n` +
+          `FIRST_TREE_SERVER_URL='https://selfhost.example.test' ~/.local/bin/first-tree login ${body.token}`,
       );
     });
 
@@ -284,10 +182,8 @@ describe("POST /me/connect-tokens bootstrap command", () => {
         expectShortConnectCode(body.token);
         expect(body.command).toBe(`FIRST_TREE_SERVER_URL='first-tree.internal' first-tree login ${body.token}`);
         expect(body.bootstrapCommand).toBe(
-          PORTABLE_BOOTSTRAP_PREFIX +
-            'curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && ' +
-            `sh "$installer_tmp" &&\n` +
-            `FIRST_TREE_SERVER_URL='first-tree.internal' ~/.local/bin/first-tree login ${body.token})`,
+          `curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh\n` +
+            `FIRST_TREE_SERVER_URL='first-tree.internal' ~/.local/bin/first-tree login ${body.token}`,
         );
       } finally {
         app.config.server.publicUrl = originalPublicUrl;
@@ -310,10 +206,8 @@ describe("POST /me/connect-tokens bootstrap command", () => {
         expectShortConnectCode(body.token);
         expect(body.command).toBe(`FIRST_TREE_SERVER_URL='self'\\''host;$(id)' first-tree login ${body.token}`);
         expect(body.bootstrapCommand).toBe(
-          PORTABLE_BOOTSTRAP_PREFIX +
-            'curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && ' +
-            `sh "$installer_tmp" &&\n` +
-            `FIRST_TREE_SERVER_URL='self'\\''host;$(id)' ~/.local/bin/first-tree login ${body.token})`,
+          `curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh\n` +
+            `FIRST_TREE_SERVER_URL='self'\\''host;$(id)' ~/.local/bin/first-tree login ${body.token}`,
         );
       } finally {
         app.config.server.publicUrl = originalPublicUrl;
@@ -349,9 +243,8 @@ describe("POST /me/connect-tokens bootstrap command", () => {
       expect(body.installerUrl).toBe("https://download.first-tree.ai/releases/staging/install.sh");
       expect(body.command).toBe(`first-tree-staging login ${body.token}`);
       expect(body.bootstrapCommand).toBe(
-        PORTABLE_BOOTSTRAP_PREFIX +
-          'curl -fsSL https://download.first-tree.ai/releases/staging/install.sh -o "$installer_tmp" && ' +
-          `sh "$installer_tmp" &&\n~/.local/bin/first-tree-staging login ${body.token})`,
+        `curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh\n` +
+          `~/.local/bin/first-tree-staging login ${body.token}`,
       );
     });
   });
@@ -387,10 +280,9 @@ describe("POST /me/connect-tokens bootstrap command", () => {
       expectShortConnectCode(body.token);
       expect(body.installerUrl).toBe("https://downloads.example.test/releases/prod/install.sh");
       expect(body.bootstrapCommand).toBe(
-        PORTABLE_BOOTSTRAP_PREFIX +
-          `curl -fsSL 'https://downloads.example.test/releases/prod/install.sh' -o "$installer_tmp" && ` +
+        `curl -fsSL 'https://downloads.example.test/releases/prod/install.sh' | ` +
           `FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL='https://downloads.example.test/releases' ` +
-          `sh "$installer_tmp" &&\n~/.local/bin/first-tree login ${body.token})`,
+          `sh\n~/.local/bin/first-tree login ${body.token}`,
       );
       expect(body.installerUrl).not.toContain(body.token);
     });
@@ -415,11 +307,9 @@ describe("POST /me/connect-tokens bootstrap command", () => {
         expectShortConnectCode(body.token);
         expect(body.installerUrl).toBe("https://downloads.example.test/releases/$(id)/prod/install.sh");
         expect(body.bootstrapCommand).toBe(
-          PORTABLE_BOOTSTRAP_PREFIX +
-            `curl -fsSL 'https://downloads.example.test/releases/$(id)/prod/install.sh' ` +
-            `-o "$installer_tmp" && ` +
+          `curl -fsSL 'https://downloads.example.test/releases/$(id)/prod/install.sh' | ` +
             `FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL='https://downloads.example.test/releases/$(id)' ` +
-            `sh "$installer_tmp" &&\n~/.local/bin/first-tree login ${body.token})`,
+            `sh\n~/.local/bin/first-tree login ${body.token}`,
         );
       } finally {
         app.config.connectBootstrap.portableDownloadBaseUrl = originalPortableDownloadBaseUrl;

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -108,11 +108,7 @@ function buildPortableBootstrapCommand(options: {
     defaultServerUrl: options.defaultServerUrl,
   });
 
-  return [
-    `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && (trap 'rm -f "$installer_tmp"' 0; ` +
-      `curl -fsSL ${installerUrl} -o "$installer_tmp" && ${installerEnv}sh "$installer_tmp" &&`,
-    `${loginCommand})`,
-  ].join("\n");
+  return [`curl -fsSL ${installerUrl} | ${installerEnv}sh`, loginCommand].join("\n");
 }
 
 /**

--- a/packages/shared/src/schemas/auth.ts
+++ b/packages/shared/src/schemas/auth.ts
@@ -34,9 +34,9 @@ export const connectTokenResponseSchema = z.object({
   command: z.string(),
   /**
    * Authoritative bootstrap command shown by web onboarding and connection
-   * dialogs. Prod/staging return a guarded public installer command that runs
-   * the explicit `~/.local/bin/<binName> login <code>` line only after the
-   * download and installation succeed. Dev returns only the source-built CLI
+   * dialogs. Prod/staging return independent public installer and explicit
+   * `~/.local/bin/<binName> login <code>` lines without shell-level
+   * transactional failure protection. Dev returns only the source-built CLI
    * login command.
    */
   bootstrapCommand: z.string(),

--- a/packages/web/src/components/__tests__/new-agent-dialog-extra.test.tsx
+++ b/packages/web/src/components/__tests__/new-agent-dialog-extra.test.tsx
@@ -58,10 +58,8 @@ vi.mock("../../lib/visibility-interval.js", () => ({
 
 const NOW = "2026-05-28T12:00:00.000Z";
 const PROD_BOOTSTRAP_COMMAND =
-  `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && ` +
-  "(trap 'rm -f \"$installer_tmp\"' 0; " +
-  'curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && ' +
-  'sh "$installer_tmp" &&\n~/.local/bin/first-tree login old-token)';
+  "curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh\n" +
+  "~/.local/bin/first-tree login old-token";
 
 let root: Root | null = null;
 

--- a/packages/web/src/features/agent-setup/__tests__/setup-hooks.test.tsx
+++ b/packages/web/src/features/agent-setup/__tests__/setup-hooks.test.tsx
@@ -47,9 +47,7 @@ vi.mock("../../../lib/visibility-interval.js", () => visibilityMocks);
 let root: Root | null = null;
 const PROD_INSTALLER_URL = "https://download.first-tree.ai/releases/prod/install.sh";
 const bootstrapCommand = (token: string): string =>
-  `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && ` +
-  `(trap 'rm -f "$installer_tmp"' 0; curl -fsSL ${PROD_INSTALLER_URL} -o "$installer_tmp" && ` +
-  `sh "$installer_tmp" &&\n~/.local/bin/first-tree login ${token})`;
+  `curl -fsSL ${PROD_INSTALLER_URL} | sh\n~/.local/bin/first-tree login ${token}`;
 
 function expectHookValue<T>(value: T): NonNullable<T> {
   if (value === null || value === undefined) throw new Error("hook value was not captured");

--- a/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/onboarding-preview.test.tsx
@@ -8,11 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const PROD_BOOTSTRAP_COMMAND =
-  `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && ` +
-  "(trap 'rm -f \"$installer_tmp\"' 0; " +
-  'curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && ' +
-  'sh "$installer_tmp" &&\n' +
-  "~/.local/bin/first-tree login ft_3aK9d2hQ7s_pVx1n8Wc4Lr6)";
+  "curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh\n" +
+  "~/.local/bin/first-tree login ft_3aK9d2hQ7s_pVx1n8Wc4Lr6";
 
 const authMock = vi.hoisted(() => ({ memberships: [] as unknown[] }));
 

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -751,9 +751,8 @@ function createFlowValue(overrides: FlowOverrides = {}): OnboardingFlowValue {
       selectedRuntime: "claude-code",
       setSelectedRuntime: () => undefined,
       cliCommand:
-        `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && ` +
-        "(trap 'rm -f \"$installer_tmp\"' 0; curl -fsSL https://download.first-tree.ai/releases/prod/install.sh " +
-        '-o "$installer_tmp" && sh "$installer_tmp" &&\n~/.local/bin/first-tree login connect-token)',
+        "curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh\n" +
+        "~/.local/bin/first-tree login connect-token",
       tokenError: null,
       retry: () => undefined,
     },
@@ -1251,10 +1250,8 @@ describe("page SSR smoke coverage", () => {
       <>
         <CommandBox
           command={
-            `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && ` +
-            "(trap 'rm -f \"$installer_tmp\"' 0; " +
-            'curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && ' +
-            'sh "$installer_tmp" &&\n~/.local/bin/first-tree login token)'
+            "curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh\n" +
+            "~/.local/bin/first-tree login token"
           }
         />
         <FlowNote tone="info">Heads up</FlowNote>

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -205,10 +205,7 @@ vi.mock("../../lib/visibility-interval.js", () => ({
 
 const NOW = "2026-05-28T12:00:00.000Z";
 const PROD_INSTALLER_URL = "https://download.first-tree.ai/releases/prod/install.sh";
-const PROD_BOOTSTRAP_COMMAND =
-  `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && ` +
-  `(trap 'rm -f "$installer_tmp"' 0; curl -fsSL ${PROD_INSTALLER_URL} -o "$installer_tmp" && ` +
-  'sh "$installer_tmp" &&\n~/.local/bin/first-tree login connect-token)';
+const PROD_BOOTSTRAP_COMMAND = `curl -fsSL ${PROD_INSTALLER_URL} | sh\n~/.local/bin/first-tree login connect-token`;
 
 const AGENT_NAMES: Record<string, string> = {
   "agent-1": "Nova",

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -54,9 +54,7 @@ vi.mock("../../../lib/visibility-interval.js", () => ({
 const NOW = "2026-05-28T12:00:00.000Z";
 const STAGING_INSTALLER_URL = "https://download.first-tree.ai/releases/staging/install.sh";
 const stagingBootstrapCommand = (token: string): string =>
-  `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && ` +
-  `(trap 'rm -f "$installer_tmp"' 0; curl -fsSL ${STAGING_INSTALLER_URL} -o "$installer_tmp" && ` +
-  `sh "$installer_tmp" &&\n~/.local/bin/first-tree-staging login ${token})`;
+  `curl -fsSL ${STAGING_INSTALLER_URL} | sh\n~/.local/bin/first-tree-staging login ${token}`;
 const STAGING_BOOTSTRAP_COMMAND = stagingBootstrapCommand("connect-token");
 const STAGING_FRESH_BOOTSTRAP_COMMAND = stagingBootstrapCommand("fresh-token");
 

--- a/packages/web/src/pages/onboarding-preview.tsx
+++ b/packages/web/src/pages/onboarding-preview.tsx
@@ -51,11 +51,8 @@ const DEFAULT_AGENT_NAME = "gandy assistant";
 // URL + bin name — `first-tree` on prod; see api/me.ts) so the gallery reads
 // true for design review instead of showing placeholders a real user never sees.
 const SAMPLE_CLI =
-  `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && ` +
-  "(trap 'rm -f \"$installer_tmp\"' 0; " +
-  'curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && ' +
-  'sh "$installer_tmp" &&\n' +
-  "~/.local/bin/first-tree login ft_3aK9d2hQ7s_pVx1n8Wc4Lr6)";
+  "curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh\n" +
+  "~/.local/bin/first-tree login ft_3aK9d2hQ7s_pVx1n8Wc4Lr6";
 const GITHUB_ACCESS_GROUP = "GitHub access states";
 
 const NOW_ISO = new Date().toISOString();

--- a/packages/web/src/pages/onboarding/flow-ui.tsx
+++ b/packages/web/src/pages/onboarding/flow-ui.tsx
@@ -185,12 +185,13 @@ export function StatusRow({ state, label }: { state: "waiting" | "ok"; label: Re
 /**
  * The terminal command(s) the user pastes to connect a computer. Renders
  * whatever lines the server's bootstrap command contains — hosted channels
- * currently return a guarded download/install chain whose explicit
- * `~/.local/bin/<binName> login <code>` step runs only after installation
- * succeeds, while dev returns only its source-installed login command. Each
- * line nowraps and ellipsizes on overflow so a long opaque token shows as
- * much as fits without word-breaking; Copy puts the full multi-line command
- * on the clipboard regardless of what's visible.
+ * currently return a readable installer pipeline followed by an independent
+ * `~/.local/bin/<binName> login <code>` command, while dev returns only its
+ * source-installed login command. The hosted lines intentionally have no
+ * shell-level transaction or failure guard between them. Each line nowraps
+ * and ellipsizes on overflow so a long opaque token shows as much as fits
+ * without word-breaking; Copy puts the full multi-line command on the
+ * clipboard regardless of what's visible.
  *
  * The previous implementation pattern-matched lines by command prefix, which
  * was fragile: adding a new command or environment assignment could silently

--- a/packages/web/src/pages/onboarding/steps/__tests__/step-connect-computer-dom.test.tsx
+++ b/packages/web/src/pages/onboarding/steps/__tests__/step-connect-computer-dom.test.tsx
@@ -13,10 +13,7 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const roots: Root[] = [];
 const BOOTSTRAP_COMMAND =
-  `installer_tmp=$(mktemp "\${TMPDIR:-/tmp}/first-tree-install.XXXXXX") && ` +
-  "(trap 'rm -f \"$installer_tmp\"' 0; " +
-  'curl -fsSL https://download.first-tree.ai/releases/prod/install.sh -o "$installer_tmp" && ' +
-  'sh "$installer_tmp" &&\n~/.local/bin/first-tree login abc123)';
+  "curl -fsSL https://download.first-tree.ai/releases/prod/install.sh | sh\n" + "~/.local/bin/first-tree login abc123";
 
 function computer(overrides: Partial<ComputerConnection> = {}): ComputerConnection {
   return {


### PR DESCRIPTION
## Summary

- replace hosted portable bootstrap generation with two readable install/login commands
- keep channel, custom mirror, self-hosted server, and shell-quoting behavior intact
- update Web fixtures, user documentation, and the cross-surface QA case to the new contract

## Accepted tradeoff

The two lines intentionally provide no shell-level transactional protection. When pasted together, a failure on the install line does not automatically prevent the login line from running. The `curl | sh` pipeline also follows POSIX pipeline status semantics and may not preserve a `curl` failure status. This is an explicit usability tradeoff in this change.

## Verification

- `pnpm check`
- `pnpm typecheck`
- Server bootstrap/API focused tests: 45 passed
- Shared response-schema test: 1 passed
- Web onboarding, Computers, New Agent, preview, interaction, and SSR tests: 71 passed
- CLI package metadata tests: 3 passed
- documentation site production build
- prod and staging public `install.sh`: HTTP 200 and `sh -n` passed; no installer was executed
- `git diff --check`

Full `pnpm test` was also run. It stopped on two unrelated `@first-tree/skill-evals` failures:

- `src/core/__tests__/judge.test.ts` - `uses the selected tested-agent provider for standalone quality prerequisite gates`
- `src/suites/first-tree-seed/__tests__/periodic.test.ts` - `builds the real-source fixture from a run-scoped origin instead of the developer checkout`

Both fail while provisioning an empty Context Tree because `git commit -m chore: provision empty context tree` reports `nothing to commit`; this change does not touch `packages/skill-evals`.

## QA

This is a cross-surface Server -> Web -> public installer -> CLI -> daemon contract change. `portable-shell-onboarding` has been updated, and formal isolated QA is warranted but was not run automatically.

## Context Tree

The durable hosted bootstrap contract is updated in [first-tree-context#718](https://github.com/agent-team-foundation/first-tree-context/pull/718). The previously planned PR #712 had already merged, so the current-state rewrite is intentionally delivered as a fresh PR with fresh review requests.
