### PR TITLE
release: bump apps/cli to v0.5.13

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

- bump the source CLI package version from `0.5.12` to `0.5.13`
- keep the source package identity as `first-tree-dev`; CI rewrites package identity, binaries, and channel only in its ephemeral production-publish workspace
- leave the lockfile and all other package metadata unchanged

## Draft GitHub Release

**Title:** `v0.5.13 — Windows daemon support, file attachments, chat-first Context setup`

## Highlights

- Run First Tree agents on Windows through a per-user Task Scheduler daemon supervisor, with service restart/recovery hardening and reliable npm/Codex executable resolution.
- Attach documents and other files from existing chats, new-chat drafts, and request answers; agent runtimes can download non-image attachments for Claude and Codex handoff.
- Start or recover Context Tree setup in a private chat, resolving sources from declared workspace repositories, a local Git repository, or a GitHub URL.
- Use GPT-5.6 Sol, Terra, and Luna Codex models with `max` and `ultra` reasoning, and discover the Codex CLI bundled with the ChatGPT desktop app.
- Hosted macOS/Linux onboarding now uses the channel-aware portable installer with simpler copyable install and login commands.

## Notable fixes

- Surface terminal provider failures as durable, actionable chat notices, including clearer Claude proxy and connectivity guidance.
- Resolve runtime-session tokens fresh from per-agent files and tolerate token-rotation races during soft enforcement.
- Make `first-tree upgrade` fall back to the current channel's latest release when no server URL is configured.
- Let self-directed GitHub assignments and mentions create a tracking chat when none exists.
- Reject malformed double-escaped agent messages while preserving intentional stdin and message-file bodies.
- Correct CommonMark fence handling in document-link previews to avoid missed or spurious links.
- Reduce generated agent briefing size while preserving the hard collaboration, worktree, Context Tree, and skill rules.

## Compatibility notes

- Windows daemon support is per-user and starts after sign-in through Task Scheduler; it is not a Windows Service or pre-login daemon.
- The new mobile `/m/*` shell remains channel-gated and disabled in production.
- Existing npm-installed clients keep upgrade compatibility; hosted fresh installs on macOS/Linux use the portable installer.

## Verification

- target preflight: no remote `v0.5.13` tag, GitHub Release, `first-tree@0.5.13` npm version, or remote `chore/release-v0.5.13` branch existed before this PR
- `pnpm install --frozen-lockfile`
- `pnpm check` (passes; reports existing warnings/info in untouched files)
- `pnpm typecheck` (10/10 tasks)
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/package-metadata.test.ts` (3/3 tests)
- package invariant check: `first-tree-dev@0.5.13`
- `git diff --check`
- PR CI: all required jobs passed, including full Test, lint/typecheck, Portable CLI Smoke, Migrations, and CodeQL

Full `pnpm test` was not run locally because this PR changes only the release version coordinate; the PR CI full Test job passed.

## Post-merge release gate

Do not tag from this branch. After merge, capture the merge commit on `main`, wait for the main-branch CI/npm-staging/Docker runs, repeat the target-coordinate preflight, and obtain human confirmation of the version, tag, target SHA, title, and notes before creating `v0.5.13` as a GitHub Release. The tag-triggered npm workflow will use trusted publishing for npm and portable assets; the tag-triggered Docker workflow will publish the production image.
