### PR TITLE
fix(web): mobile presentation polish (team card, Now filter, back arrow)

### DIFF
--- a/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { MemoryRouter, Route, Routes, useNavigationType } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+import { MobileChatPage } from "../chat.js";
+
+const authMock = vi.hoisted(() => ({ value: { agentId: "human-agent-self" } }));
+const meChatMocks = vi.hoisted(() => ({ listMeChats: vi.fn() }));
+
+vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
+vi.mock("../../../api/me-chats.js", () => meChatMocks);
+// Stub the heavy chat-detail so we can drive the back affordance directly.
+vi.mock("../../workspace/center/index.js", () => ({
+  CenterPanel: ({ onShowConversations }: { onShowConversations: (() => void) | null }) => (
+    <button type="button" aria-label="back" onClick={() => onShowConversations?.()}>
+      back
+    </button>
+  ),
+}));
+
+let lastNavType = "";
+function NavProbe() {
+  lastNavType = useNavigationType();
+  return null;
+}
+
+describe("MobileChatPage back navigation", () => {
+  let harness: DomHarness;
+
+  beforeEach(() => {
+    harness = createDomHarness();
+    meChatMocks.listMeChats.mockReset();
+    meChatMocks.listMeChats.mockResolvedValue({ rows: [] });
+    lastNavType = "";
+  });
+
+  it("replaces the detail entry on back so browser Back does not reopen it", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    // Start on the chat detail (c=chat-1) with the list already behind it.
+    harness.render(
+      <MemoryRouter initialEntries={["/m/chat", "/m/chat?c=chat-1"]}>
+        <QueryClientProvider client={queryClient}>
+          <NavProbe />
+          <Routes>
+            <Route path="/m/chat" element={<MobileChatPage />} />
+          </Routes>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    const back = harness.container.querySelector<HTMLButtonElement>('button[aria-label="back"]');
+    expect(back).not.toBeNull();
+    expect(lastNavType).toBe("POP"); // initial
+
+    await act(async () => {
+      back?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await harness.flush();
+
+    // clearChat must REPLACE the detail with the list (not PUSH), so the
+    // browser Back button / swipe cannot reopen the chat detail just exited.
+    expect(lastNavType).toBe("REPLACE");
+  });
+});

--- a/packages/web/src/pages/mobile/__tests__/data.test.ts
+++ b/packages/web/src/pages/mobile/__tests__/data.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   countAttentionRows,
   countUnreadRows,
+  isNowFeedRow,
   mobileChatSignal,
   mobileFeedReasonLabel,
   sortMobileChats,
@@ -109,5 +110,38 @@ describe("mobile chat projection", () => {
         }),
       ),
     ).toBe("Question waiting");
+  });
+});
+
+describe("isNowFeedRow (needs-attention admission)", () => {
+  it("admits chats with an authoritative active signal", () => {
+    expect(isNowFeedRow(chatRow({ failedAgentIds: ["agent-1"] }))).toBe(true);
+    expect(isNowFeedRow(chatRow({ openRequestCount: 1 }))).toBe(true);
+    expect(isNowFeedRow(chatRow({ chatHasExplicitMentionToMe: true }))).toBe(true);
+    expect(isNowFeedRow(chatRow({ busyAgentIds: ["agent-1"] }))).toBe(true);
+  });
+
+  it("excludes idle and watching-only chats", () => {
+    expect(isNowFeedRow(chatRow({}))).toBe(false);
+    expect(isNowFeedRow(chatRow({ membershipKind: "watching" }))).toBe(false);
+  });
+
+  it("does not admit a liveActivity-only row (description is not busy authority)", () => {
+    // A residual/cached liveActivity with no authoritative busyAgentIds must not
+    // keep a chat in the needs-attention feed.
+    expect(
+      isNowFeedRow(
+        chatRow({
+          busyAgentIds: [],
+          liveActivity: { agentId: "agent-1", kind: "tool_call", label: "Using Bash", startedAt: NOW },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not admit a plain unread 1:1 reply (implicit auto-mention only)", () => {
+    // unreadMentionCount also counts the implicit 1:1 DM auto-mention; only an
+    // explicit @me qualifies.
+    expect(isNowFeedRow(chatRow({ unreadMentionCount: 3, chatHasExplicitMentionToMe: false }))).toBe(false);
   });
 });

--- a/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
@@ -156,19 +156,21 @@ describe("mobile density tiers", () => {
     const feed = harness.container.querySelector("[data-mobile-feed]");
     if (!feed) throw new Error("Missing Now feed");
     const feedCards = [...feed.querySelectorAll<HTMLElement>('[data-mobile-card="feed"]')];
-    expect(feedCards).toHaveLength(3);
+    // Now is signal-filtered: the `idle` "Recent update" row is dropped, leaving
+    // the question (priority) and working (feed) cards.
+    expect(feedCards).toHaveLength(2);
     expect(feedCards[0]?.textContent).toContain("Release readiness");
     expect(feedCards[0]?.getAttribute("style")).toContain("min-height: var(--sp-45)");
     expect(feedCards[1]?.getAttribute("style")).toContain("min-height: var(--sp-35)");
     expect(feedCards[0]?.querySelector("[data-mobile-card-title]")?.className).toContain("text-mobile-title");
     expect(feedCards[0]?.querySelector("[data-mobile-card-preview]")?.className).toContain("text-mobile-body");
     const labels = [...feed.querySelectorAll("[data-mobile-signal-label]")].map((label) => label.textContent);
-    expect(labels).toEqual(["Question waiting", "Working now", "Recent update"]);
+    expect(labels).toEqual(["Question waiting", "Working now"]);
     expect(feedCards[0]?.querySelector("[data-mobile-signal-label]")?.className).toContain("truncate");
     expect(feedCards[0]?.querySelector("[data-mobile-primary-action]")?.textContent).toContain("Answer");
     expect(feedCards[1]?.querySelector("[data-mobile-primary-action]")).toBeNull();
-    expect(feedCards[2]?.querySelector("[data-mobile-primary-action]")).toBeNull();
     expect(feed.querySelector('[data-mobile-card="list"]')).toBeNull();
+    expect(harness.container.textContent).not.toContain("Recent update");
   });
 
   it("renders Chat rows as medium list cards, not full feed cards", async () => {

--- a/packages/web/src/pages/mobile/__tests__/realtime-cache.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/realtime-cache.test.tsx
@@ -36,7 +36,7 @@ describe("mobile projections share the realtime invalidation prefix", () => {
     // Let the first fetch settle (empty state renders) before invalidating,
     // so the invalidation queues a real refetch rather than coalescing with an
     // in-flight fetch.
-    await harness.waitFor(() => expect(harness.container.textContent).toContain("Nothing active"));
+    await harness.waitFor(() => expect(harness.container.textContent).toContain("You're all caught up"));
     expect(meChatMocks.listMeChats).toHaveBeenCalledTimes(1);
 
     // A realtime WS event (useAdminWs) or a chat send / ask-answer / new-chat

--- a/packages/web/src/pages/mobile/__tests__/team-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/team-dom.test.tsx
@@ -128,7 +128,13 @@ describe("MobileTeamPage", () => {
     await harness.waitFor(() => expect(harness.container.textContent).toContain("Gandy (you)"));
 
     expect(harness.container.querySelector('a[href="/m/chat?c=draft&with=human-agent-self"]')).toBeNull();
-    expect(harness.container.querySelector('a[href="/m/chat?c=draft&with=human-agent-teammate"]')).not.toBeNull();
+    const teammateCard = harness.container.querySelector('a[href="/m/chat?c=draft&with=human-agent-teammate"]');
+    expect(teammateCard).not.toBeNull();
     expect(harness.container.querySelector('a[href="/m/chat?c=draft&with=agent-1"]')).not.toBeNull();
+
+    // Q1: the whole card is the tap target — the title lives inside the anchor,
+    // and the separate chat-icon button is gone.
+    expect(teammateCard?.textContent).toContain("Teammate");
+    expect(harness.container.querySelector('button[aria-label^="Chat with"]')).toBeNull();
   });
 });

--- a/packages/web/src/pages/mobile/chat.tsx
+++ b/packages/web/src/pages/mobile/chat.tsx
@@ -38,7 +38,10 @@ export function MobileChatPage() {
     const next = new URLSearchParams(searchParams);
     next.delete("c");
     next.delete("with");
-    setSearchParams(next);
+    // Back semantics: replace the detail URL with the list rather than pushing,
+    // so the browser Back button / swipe does not reopen the chat detail the
+    // user just exited via the back arrow.
+    setSearchParams(next, { replace: true });
   }, [searchParams, setSearchParams]);
 
   if (selectedChatId !== null) {

--- a/packages/web/src/pages/mobile/data.ts
+++ b/packages/web/src/pages/mobile/data.ts
@@ -88,6 +88,29 @@ export function sortMobileChats(rows: readonly MeChatRow[]): MeChatRow[] {
   });
 }
 
+/**
+ * Now feed admission. A chat enters the needs-attention feed only when it
+ * carries an AUTHORITATIVE active signal, read from the source-of-truth fields
+ * rather than the display `mobileChatSignal` tone:
+ *   - a caller-managed failed agent (`failedAgentIds`);
+ *   - an open request directed at the caller (`openRequestCount`);
+ *   - an explicit `@me` mention (`chatHasExplicitMentionToMe`) — NOT the
+ *     broader `unreadMentionCount`, which also counts the implicit 1:1 DM
+ *     auto-mention, so a plain unread reply does not qualify;
+ *   - an in-flight turn (`busyAgentIds`) — NOT `liveActivity`, which is a
+ *     descriptive label the session-status contract allows to linger after the
+ *     authoritative busy projection is already false.
+ * `idle` / watching-only chats stay in the Chat tab, not Now.
+ */
+export function isNowFeedRow(row: MeChatRow): boolean {
+  return (
+    row.failedAgentIds.length > 0 ||
+    row.openRequestCount > 0 ||
+    row.chatHasExplicitMentionToMe ||
+    row.busyAgentIds.length > 0
+  );
+}
+
 export function countAttentionRows(rows: readonly MeChatRow[]): number {
   return rows.reduce((total, row) => total + (mobileChatSignal(row).attention ? 1 : 0), 0);
 }

--- a/packages/web/src/pages/mobile/now.tsx
+++ b/packages/web/src/pages/mobile/now.tsx
@@ -8,7 +8,7 @@ import { ChatRowAvatar } from "../../components/chat/chat-row-avatar.js";
 import { Button } from "../../components/ui/button.js";
 import { formatRowTime } from "../../lib/utils.js";
 import { MobilePage, MobileSignalChip, MobileSystemState, mobileCardStyle } from "./components.js";
-import { mobileChatPreview, mobileChatSignal, mobileFeedReasonLabel, sortMobileChats } from "./data.js";
+import { isNowFeedRow, mobileChatPreview, mobileChatSignal, mobileFeedReasonLabel, sortMobileChats } from "./data.js";
 
 export function MobileNowPage() {
   const { agentId } = useAuth();
@@ -21,13 +21,11 @@ export function MobileNowPage() {
     refetchInterval: 30_000,
   });
 
-  // Now is a needs-attention feed, not the full chat list: keep only chats with
-  // an active signal (failed agent, open request, unread mention, working) and
-  // drop `idle` (quiet / watching-only) chats. Ordering stays the canonical
-  // attention order; the complete list lives in the Chat tab.
-  const sortedRows = sortMobileChats(chatsQuery.data?.rows ?? []).filter(
-    (row) => mobileChatSignal(row).tone !== "idle",
-  );
+  // Now is a needs-attention feed, not the full chat list: admit only chats
+  // with an AUTHORITATIVE active signal (see isNowFeedRow — failed agent, open
+  // request, explicit @me, or an in-flight turn), then keep the canonical
+  // attention order. Quiet / watching-only chats live in the Chat tab.
+  const sortedRows = sortMobileChats(chatsQuery.data?.rows ?? []).filter(isNowFeedRow);
 
   return (
     <MobilePage className="flex flex-col" padded>

--- a/packages/web/src/pages/mobile/now.tsx
+++ b/packages/web/src/pages/mobile/now.tsx
@@ -21,7 +21,13 @@ export function MobileNowPage() {
     refetchInterval: 30_000,
   });
 
-  const sortedRows = sortMobileChats(chatsQuery.data?.rows ?? []);
+  // Now is a needs-attention feed, not the full chat list: keep only chats with
+  // an active signal (failed agent, open request, unread mention, working) and
+  // drop `idle` (quiet / watching-only) chats. Ordering stays the canonical
+  // attention order; the complete list lives in the Chat tab.
+  const sortedRows = sortMobileChats(chatsQuery.data?.rows ?? []).filter(
+    (row) => mobileChatSignal(row).tone !== "idle",
+  );
 
   return (
     <MobilePage className="flex flex-col" padded>
@@ -44,7 +50,10 @@ export function MobileNowPage() {
       ) : chatsQuery.error ? (
         <MobileSystemState title="Failed to load work" detail={formatError(chatsQuery.error)} tone="error" />
       ) : sortedRows.length === 0 ? (
-        <MobileSystemState title="Nothing active" detail="Start a chat when you are ready." />
+        <MobileSystemState
+          title="You're all caught up"
+          detail="Asks, failures, and updates show up here. Find every chat in Chat."
+        />
       ) : (
         <div className="flex flex-col" style={{ gap: "var(--sp-2)" }} data-mobile-feed>
           {sortedRows.map((row) => (

--- a/packages/web/src/pages/mobile/team.tsx
+++ b/packages/web/src/pages/mobile/team.tsx
@@ -1,13 +1,11 @@
 import type { Agent } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
-import { MessageSquareText } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
 import { Link } from "react-router";
 import { listAgents, listAllAgents } from "../../api/agents.js";
 import { listMembers } from "../../api/members.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { Avatar } from "../../components/avatar.js";
-import { Button } from "../../components/ui/button.js";
 import { Input } from "../../components/ui/input.js";
 import { PresenceChip, runtimeStateToPresence } from "../../components/ui/presence-chip.js";
 import { formatRelative } from "../../lib/utils.js";
@@ -164,15 +162,12 @@ function MobileTeamRow({
   meta: ReactNode;
   chatTarget: string | null;
 }) {
-  return (
-    <div
-      className="flex items-center"
-      style={{
-        ...mobileCardStyle("panel"),
-        gap: "var(--sp-3)",
-      }}
-      data-mobile-card="panel"
-    >
+  const cardStyle = {
+    ...mobileCardStyle("panel"),
+    gap: "var(--sp-3)",
+  };
+  const body = (
+    <>
       <div className="shrink-0">{avatar}</div>
       <div className="min-w-0" style={{ flex: 1 }}>
         <p className="text-mobile-subtitle truncate" style={{ color: "var(--fg)", margin: 0 }}>
@@ -183,14 +178,28 @@ function MobileTeamRow({
         </p>
         <div style={{ marginTop: "var(--sp-1)" }}>{meta}</div>
       </div>
-      {chatTarget ? (
-        <Button asChild size="icon" variant="outline" aria-label={`Chat with ${title}`}>
-          <Link to={`/m/chat?c=draft&with=${encodeURIComponent(chatTarget)}`}>
-            <MessageSquareText className="h-4 w-4" />
-          </Link>
-        </Button>
-      ) : null}
-    </div>
+    </>
+  );
+  // The whole card is the tap target — start/open a chat with this teammate.
+  // Self (chatTarget null) has nothing to chat with, so it stays a plain,
+  // non-interactive row.
+  if (!chatTarget) {
+    return (
+      <div className="flex items-center" style={cardStyle} data-mobile-card="panel">
+        {body}
+      </div>
+    );
+  }
+  return (
+    <Link
+      to={`/m/chat?c=draft&with=${encodeURIComponent(chatTarget)}`}
+      aria-label={`Chat with ${title}`}
+      className="flex items-center transition-colors hover:bg-[var(--bg-hover)]"
+      style={{ ...cardStyle, color: "var(--fg)", textDecoration: "none" }}
+      data-mobile-card="panel"
+    >
+      {body}
+    </Link>
   );
 }
 

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -843,6 +843,9 @@ describe("ChatView", () => {
     expect(container.querySelector('aside[aria-label="Chat details"]')).toBeNull();
     // Mobile presentation keeps the header context-only: no click-to-rename.
     expect(buttonByTitle(container, "Click to rename")).toBeNull();
+    // Q4: mobile chat detail exits with a back arrow, not the hamburger.
+    expect(container.querySelector('button[aria-label="Back to conversations"]')).not.toBeNull();
+    expect(container.querySelector('button[aria-label="Show conversations"]')).toBeNull();
 
     await click(container.querySelector('button[aria-label="Show chat options"]'));
     await waitForText(container, "Participants · 4");

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -20,6 +20,7 @@ import {
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  ArrowLeft,
   ArrowUp,
   AtSign,
   Check,
@@ -3584,8 +3585,12 @@ export function ChatView({
                 <button
                   type="button"
                   onClick={onShowConversations}
-                  aria-label="Show conversations"
-                  title="Show conversations"
+                  // Mobile chat detail is a full-screen page whose only exit is
+                  // back to the chat list, so it uses a back arrow. Desktop
+                  // narrow Workspace summons the conversation-list overlay (a
+                  // menu), so it keeps the hamburger.
+                  aria-label={useMobileDetailsSheet ? "Back to conversations" : "Show conversations"}
+                  title={useMobileDetailsSheet ? "Back to conversations" : "Show conversations"}
                   className="inline-flex shrink-0 items-center justify-center transition-colors hover:bg-[var(--bg-hover)]"
                   style={{
                     width: 28,
@@ -3597,7 +3602,11 @@ export function ChatView({
                     cursor: "pointer",
                   }}
                 >
-                  <Menu size={16} strokeWidth={2.25} />
+                  {useMobileDetailsSheet ? (
+                    <ArrowLeft size={18} strokeWidth={2.25} />
+                  ) : (
+                    <Menu size={16} strokeWidth={2.25} />
+                  )}
                 </button>
               ) : null}
               {/* Identity — title is the sole click-to-rename affordance


### PR DESCRIPTION
## What

Aligned mobile-presentation polish (Q1/Q2/Q4 from the design round with gandy). The Now **rich-card redesign (Q3)** is intentionally **not** here — it's a bigger feature (needs added projection data + in-place actions) tracked as a separate spec.

**Paired Context Tree PR:** `agent-team-foundation/first-tree-context#720` (draft) records the durable Now needs-attention admission contract that item 2 below implements. Per the paired code/tree flow it stays draft until this code PR merges, then is reconciled against the merged result and marked ready.

1. **Team card = whole-card tap** (`team.tsx`): tapping a teammate card opens/starts a chat with that agent/human, instead of a small trailing chat icon. Self (no chat target) stays a plain non-interactive row.
2. **Now = needs-attention feed** (`now.tsx`): keep only chats with an authoritative active signal (failed agent, open request, unread explicit `@me` mention, working); drop `idle` (quiet / watching-only) chats. Admission reads the source-of-truth fields via `isNowFeedRow`, not the display tone (a residual live-activity label or an implicit 1:1 unread does not qualify). Ordering stays the canonical attention order (shared with the Chat tab); the complete list lives in Chat. Empty state → "You're all caught up".
3. **Chat detail back arrow** (`chat-view.tsx`): mobile presentation exits to the chat list with a back arrow instead of the desktop-narrow hamburger, gated on `presentation === "mobile"` (viewport width still controls layout, not this affordance — same decoupling as #1597). The exit replaces history so browser Back / swipe does not reopen the detail just left.

## Verification

- Full web suite **170 files / 1326 tests**, typecheck + design-token guardrails, `pnpm check`, web build — green.
- Tests updated/added: whole-card team tap + no icon button (`team-dom`); Now density + realtime reflect the idle filter and new empty text (`density-dom`, `realtime-cache`); `isNowFeedRow` admission boundaries (`data`); back-nav REPLACE semantics (`chat-nav`); mobile chat-detail back arrow (`chat-view-dom`).
- Note: `/preview/mobile` uses mock components, so these real-component behaviors are covered by DOM tests rather than the preview gallery.

Scope: `packages/web/**` only. Related: #1594 and its follow-ups #1596/#1597/#1598/#1599 (all merged).
