### PR TITLE
refactor(web): chat list query foundation — useInfiniteQuery + error states

### DIFF
--- a/packages/web/src/api/__tests__/api-wrappers.test.ts
+++ b/packages/web/src/api/__tests__/api-wrappers.test.ts
@@ -288,6 +288,7 @@ describe("api wrapper paths", () => {
     });
     expect(apiMock.get).toHaveBeenCalledWith(
       "/orgs/current/chats?limit=10&cursor=next&filter=unread&engagement=active&origin=manual%2Cgithub%2Cagent&with=agent-1%2Cagent-2&watching=1",
+      undefined,
     );
     expect(apiMock.post).toHaveBeenCalledWith("/orgs/current/chats", {
       mode: "task",

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -168,8 +168,11 @@ async function tryRefresh(refreshToken: string): Promise<StoredTokens | null> {
   return refreshPromise;
 }
 
-async function request<T>(path: string, options?: { method?: string; body?: unknown }): Promise<T> {
-  const { method = "GET", body } = options ?? {};
+async function request<T>(
+  path: string,
+  options?: { method?: string; body?: unknown; signal?: AbortSignal },
+): Promise<T> {
+  const { method = "GET", body, signal } = options ?? {};
 
   // No path rewriting here — callers prefix org-scoped paths with `withOrg` /
   // `withOrgAt` before passing in; everything else (`/me/...`, `/auth/...`,
@@ -184,6 +187,7 @@ async function request<T>(path: string, options?: { method?: string; body?: unkn
       method,
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal,
     });
   };
 
@@ -274,7 +278,7 @@ export async function apiFetchRaw(
 }
 
 export const api = {
-  get: <T>(path: string) => request<T>(path),
+  get: <T>(path: string, options?: { signal?: AbortSignal }) => request<T>(path, options),
   post: <T>(path: string, body?: unknown) => request<T>(path, { method: "POST", body }),
   patch: <T>(path: string, body?: unknown) => request<T>(path, { method: "PATCH", body }),
   put: <T>(path: string, body?: unknown) => request<T>(path, { method: "PUT", body }),

--- a/packages/web/src/api/me-chats.ts
+++ b/packages/web/src/api/me-chats.ts
@@ -25,7 +25,7 @@ export type ListMeChatsParams = Partial<
   Pick<ListMeChatsQuery, "cursor" | "limit" | "filter" | "engagement" | "origin" | "with" | "watching">
 >;
 
-export function listMeChats(params?: ListMeChatsParams): Promise<ListMeChatsResponse> {
+export function listMeChats(params?: ListMeChatsParams, opts?: { signal?: AbortSignal }): Promise<ListMeChatsResponse> {
   const qs = new URLSearchParams();
   if (params?.limit !== undefined) qs.set("limit", String(params.limit));
   if (params?.cursor) qs.set("cursor", params.cursor);
@@ -39,7 +39,9 @@ export function listMeChats(params?: ListMeChatsParams): Promise<ListMeChatsResp
   if (params?.with && params.with.length > 0) qs.set("with", params.with.join(","));
   if (params?.watching) qs.set("watching", "1");
   const query = qs.toString();
-  return api.get<ListMeChatsResponse>(withOrg(`/chats${query ? `?${query}` : ""}`));
+  // `opts.signal` lets React Query cancel the in-flight request when the
+  // filter/cursor changes, so a superseded page never lands.
+  return api.get<ListMeChatsResponse>(withOrg(`/chats${query ? `?${query}` : ""}`), opts);
 }
 
 export function listMeChatSourceCounts(params?: { engagement?: ChatEngagementView }): Promise<MeChatSourceCounts> {

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -598,8 +598,14 @@ function createClient(): QueryClient {
       topic: "Launch planning",
     },
   ]);
-  queryClient.setQueryData(["me", "chats", "all", "active", false, null, null], {
-    rows: [
+  // The rail reads via `useInfiniteQuery`, so seed the `InfiniteData` shape.
+  const meInfinite = (rows: ReturnType<typeof chatRow>[]) => ({
+    pages: [{ rows, nextCursor: null }],
+    pageParams: [undefined],
+  });
+  queryClient.setQueryData(
+    ["me", "chats", "all", "active", false, null, null],
+    meInfinite([
       chatRow(),
       chatRow({
         chatId: "chat-2",
@@ -613,18 +619,15 @@ function createClient(): QueryClient {
         lastMessageAt: "2026-05-27T09:00:00.000Z",
         lastMessagePreview: "Looks good.",
       }),
-    ],
-    nextCursor: null,
-  });
+    ]),
+  );
   // The triad is single-select: rendering with both `unread` + `watching`
   // canonicalizes to Unread, so the component requests watchingParam=false
   // (the 5th key slot) even though the smoke render passes both.
-  queryClient.setQueryData(["me", "chats", "unread", "active", false, "manual", "agent-1"], {
-    rows: [chatRow()],
-    nextCursor: null,
-  });
-  queryClient.setQueryData(["me", "chats", "all", "archived", false, null, null], {
-    rows: [
+  queryClient.setQueryData(["me", "chats", "unread", "active", false, "manual", "agent-1"], meInfinite([chatRow()]));
+  queryClient.setQueryData(
+    ["me", "chats", "all", "archived", false, null, null],
+    meInfinite([
       chatRow({
         chatId: "chat-2",
         title: "Archived design review",
@@ -635,9 +638,8 @@ function createClient(): QueryClient {
         chatHasExplicitMentionToMe: false,
         engagementStatus: "archived",
       }),
-    ],
-    nextCursor: null,
-  });
+    ]),
+  );
   queryClient.setQueryData(["chat-detail", "chat-1"], chatDetail());
   queryClient.setQueryData(["chat-messages-cache", "chat-1"], CHAT_MESSAGES.items.slice(0, 1));
   queryClient.setQueryData(["chat-messages", "chat-1"], CHAT_MESSAGES);

--- a/packages/web/src/pages/conversation-list-preview.tsx
+++ b/packages/web/src/pages/conversation-list-preview.tsx
@@ -218,7 +218,9 @@ function seededClient(): QueryClient {
       },
     },
   });
-  const page = (rows: MeChatRow[]) => ({ rows, nextCursor: null });
+  // `ConversationList` reads via `useInfiniteQuery`, so seeded cache entries
+  // must be the `InfiniteData` shape (`{ pages, pageParams }`).
+  const page = (rows: MeChatRow[]) => ({ pages: [{ rows, nextCursor: null }], pageParams: [undefined] });
   // Triad views — keys mirror `ConversationList`'s queryKey shape exactly:
   // ["me","chats", filter, engagement, watching, origin, with].
   client.setQueryData(["me", "chats", "all", "active", false, null, null], page(ACTIVE_ALL));

--- a/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import type { ChatDetail, ChatParticipantDetail, ListMeChatsResponse, MeChatRow } from "@first-tree/shared";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type InfiniteData, QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -288,8 +288,17 @@ describe("ChatByIdView and CenterPanel", () => {
       unreadMentionCount: 1,
       chatHasExplicitMentionToMe: true,
     });
-    queryClient.setQueryData<ListMeChatsResponse>(allKey, { rows: [currentUnread, otherUnread], nextCursor: null });
-    queryClient.setQueryData<ListMeChatsResponse>(unreadKey, { rows: [currentUnread, otherUnread], nextCursor: null });
+    // The desktop rail stores InfiniteData (`useInfiniteQuery`); the command
+    // palette stores a bare ListMeChatsResponse. Seed both so the mark-read
+    // patch is exercised against each cache shape it must handle.
+    const paletteKey = ["me", "chats", "palette"];
+    const infinite = (rows: MeChatRow[]): InfiniteData<ListMeChatsResponse> => ({
+      pages: [{ rows, nextCursor: null }],
+      pageParams: [undefined],
+    });
+    queryClient.setQueryData<InfiniteData<ListMeChatsResponse>>(allKey, infinite([currentUnread, otherUnread]));
+    queryClient.setQueryData<InfiniteData<ListMeChatsResponse>>(unreadKey, infinite([currentUnread, otherUnread]));
+    queryClient.setQueryData<ListMeChatsResponse>(paletteKey, { rows: [currentUnread, otherUnread], nextCursor: null });
 
     const { container, root } = await renderDom(
       <ChatByIdView chatId="chat-1" narrow onShowConversations={onShowConversations} />,
@@ -300,17 +309,22 @@ describe("ChatByIdView and CenterPanel", () => {
     expect(chatMocks.getChat).toHaveBeenCalledWith("chat-1");
     expect(meChatMocks.markMeChatRead).toHaveBeenCalledTimes(1);
     expect(invalidateSpy).not.toHaveBeenCalled();
-    const patchedAll = queryClient.getQueryData<ListMeChatsResponse>(allKey);
-    expect(patchedAll?.rows.find((row) => row.chatId === "chat-1")).toMatchObject({
+    const allRows = queryClient.getQueryData<InfiniteData<ListMeChatsResponse>>(allKey)?.pages.flatMap((p) => p.rows);
+    expect(allRows?.find((row) => row.chatId === "chat-1")).toMatchObject({
       unreadMentionCount: 0,
       chatHasExplicitMentionToMe: false,
     });
-    expect(patchedAll?.rows.find((row) => row.chatId === "chat-2")).toMatchObject({
+    expect(allRows?.find((row) => row.chatId === "chat-2")).toMatchObject({
       unreadMentionCount: 1,
       chatHasExplicitMentionToMe: true,
     });
-    const patchedUnread = queryClient.getQueryData<ListMeChatsResponse>(unreadKey);
-    expect(patchedUnread?.rows.map((row) => row.chatId)).toEqual(["chat-2"]);
+    const unreadRows = queryClient
+      .getQueryData<InfiniteData<ListMeChatsResponse>>(unreadKey)
+      ?.pages.flatMap((p) => p.rows);
+    expect(unreadRows?.map((row) => row.chatId)).toEqual(["chat-2"]);
+    // The bare-response (palette / mobile) shape is patched in place too.
+    const patchedPalette = queryClient.getQueryData<ListMeChatsResponse>(paletteKey);
+    expect(patchedPalette?.rows.find((row) => row.chatId === "chat-1")).toMatchObject({ unreadMentionCount: 0 });
     expect(chatViewMocks.props.at(-1)).toMatchObject({
       agentId: "agent-1",
       chatId: "chat-1",

--- a/packages/web/src/pages/workspace/center/chat-by-id.tsx
+++ b/packages/web/src/pages/workspace/center/chat-by-id.tsx
@@ -1,5 +1,5 @@
-import type { ListMeChatsResponse } from "@first-tree/shared";
-import { type QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ListMeChatsResponse, MeChatRow } from "@first-tree/shared";
+import { type InfiniteData, type QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
 import { getChat } from "../../../api/chats.js";
@@ -43,20 +43,34 @@ function patchReadChatInCachedLists(queryClient: QueryClient, chatId: string, un
   const cachedQueries = queryClient.getQueryCache().findAll({ queryKey: ["me", "chats"] });
   for (const query of cachedQueries) {
     const unreadFilter = query.queryKey[2] === "unread";
-    queryClient.setQueryData<ListMeChatsResponse>(query.queryKey, (prev) => {
-      if (!prev) return prev;
+    // Decrement the opened chat's unread within a single page's rows; in the
+    // unread-only view drop it once it reaches zero.
+    const patchRows = (rows: MeChatRow[]): { rows: MeChatRow[]; changed: boolean } => {
       let changed = false;
-      const rows = prev.rows.flatMap((row) => {
+      const next = rows.flatMap((row) => {
         if (row.chatId !== chatId) return [row];
         changed = true;
-        const patched = {
-          ...row,
-          unreadMentionCount,
-          chatHasExplicitMentionToMe: false,
-        };
+        const patched = { ...row, unreadMentionCount, chatHasExplicitMentionToMe: false };
         return unreadFilter && unreadMentionCount <= 0 ? [] : [patched];
       });
-      return changed ? { ...prev, rows } : prev;
+      return { rows: next, changed };
+    };
+    // The desktop rail stores `InfiniteData` (`useInfiniteQuery`); the command
+    // palette and mobile lists store a bare `ListMeChatsResponse`. The prefix
+    // `findAll(["me","chats"])` matches both, so patch whichever this holds.
+    queryClient.setQueryData<InfiniteData<ListMeChatsResponse> | ListMeChatsResponse>(query.queryKey, (prev) => {
+      if (!prev) return prev;
+      if ("pages" in prev) {
+        let changed = false;
+        const pages = prev.pages.map((page) => {
+          const res = patchRows(page.rows);
+          if (res.changed) changed = true;
+          return res.changed ? { ...page, rows: res.rows } : page;
+        });
+        return changed ? { ...prev, pages } : prev;
+      }
+      const res = patchRows(prev.rows);
+      return res.changed ? { ...prev, rows: res.rows } : prev;
     });
   }
 }

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -533,4 +533,39 @@ describe("ConversationList", () => {
     expect(container.textContent).toContain("No conversations yet.");
     expect(container.textContent).not.toContain("Couldn't load conversations");
   });
+
+  it("refreshes clock-derived row times after a successful refetch with an unchanged payload", async () => {
+    // Fake only the clock so `flush()`'s real setTimeout still resolves.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-05-28T12:00:00.000Z"));
+    try {
+      const client = new QueryClient({
+        defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false }, mutations: { retry: false } },
+      });
+      // Each fetch returns a fresh object with structurally-identical rows, so
+      // React Query keeps `data` identity across refetches (structural sharing).
+      meChatMocks.listMeChats.mockReset();
+      meChatMocks.listMeChats.mockImplementation(async () => ({
+        rows: [row({ chatId: "chat-time", title: "Timed chat", lastMessageAt: "2026-05-28T11:58:00.000Z" })],
+        nextCursor: null,
+      }));
+
+      const container = await renderDom(<StatefulList rows={[]} nextCursor={null} />, client);
+      expect(rowButton(container, "Timed chat").textContent).toContain("2m");
+
+      // Advance an hour, then a successful (structurally identical) refetch. The
+      // relative time must refresh even though `data` keeps its identity — the
+      // component tracks `dataUpdatedAt` as the successful-refetch clock.
+      vi.setSystemTime(new Date("2026-05-28T13:00:00.000Z"));
+      await act(async () => {
+        await client.refetchQueries({ queryKey: ["me", "chats"] });
+      });
+      await flush();
+
+      expect(rowButton(container, "Timed chat").textContent).toContain("1h");
+      expect(rowButton(container, "Timed chat").textContent).not.toContain("2m");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import type { ChatSource, MeChatRow } from "@first-tree/shared";
+import type { ChatSource, ListMeChatsResponse, MeChatRow } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, type ReactElement, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -122,6 +122,18 @@ const BASE_ROWS: MeChatRow[] = [
   }),
 ];
 
+// The rail now uses `useInfiniteQuery`, so seeded cache entries must be the
+// `InfiniteData` shape (`{ pages, pageParams }`) rather than a bare response.
+function page(
+  rows: MeChatRow[],
+  nextCursor: string | null = null,
+): {
+  pages: ListMeChatsResponse[];
+  pageParams: Array<string | undefined>;
+} {
+  return { pages: [{ rows, nextCursor }], pageParams: [undefined] };
+}
+
 function createClient(rows = BASE_ROWS, nextCursor: string | null = "cursor-1"): QueryClient {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -129,15 +141,12 @@ function createClient(rows = BASE_ROWS, nextCursor: string | null = "cursor-1"):
       mutations: { retry: false },
     },
   });
-  queryClient.setQueryData(["me", "chats", "all", "active", false, null, null], { rows, nextCursor });
-  queryClient.setQueryData(["me", "chats", "unread", "active", false, "manual,github", "agent-1"], {
-    rows: [],
-    nextCursor: null,
-  });
-  queryClient.setQueryData(["me", "chats", "all", "archived", false, null, null], {
-    rows: [row({ chatId: "chat-archived", title: "Archived review", engagementStatus: "archived" })],
-    nextCursor: null,
-  });
+  queryClient.setQueryData(["me", "chats", "all", "active", false, null, null], page(rows, nextCursor));
+  queryClient.setQueryData(["me", "chats", "unread", "active", false, "manual,github", "agent-1"], page([], null));
+  queryClient.setQueryData(
+    ["me", "chats", "all", "archived", false, null, null],
+    page([row({ chatId: "chat-archived", title: "Archived review", engagementStatus: "archived" })], null),
+  );
   return queryClient;
 }
 
@@ -290,14 +299,17 @@ describe("ConversationList", () => {
     expect(onNewChat).toHaveBeenCalledTimes(1);
 
     await click(buttonByText(container, "Load more"));
-    expect(meChatMocks.listMeChats).toHaveBeenCalledWith({
-      filter: "all",
-      engagement: "active",
-      watching: undefined,
-      origin: undefined,
-      with: undefined,
-      cursor: "cursor-1",
-    });
+    expect(meChatMocks.listMeChats).toHaveBeenCalledWith(
+      {
+        filter: "all",
+        engagement: "active",
+        watching: undefined,
+        origin: undefined,
+        with: undefined,
+        cursor: "cursor-1",
+      },
+      { signal: expect.anything() },
+    );
     expect(container.textContent).toContain("Loaded more");
 
     await click(container.querySelector('button[aria-label="Manage chat"]'));
@@ -323,13 +335,17 @@ describe("ConversationList", () => {
 
     await click(buttonByText(container, "Unread"));
     await flush();
-    expect(meChatMocks.listMeChats).toHaveBeenCalledWith({
-      filter: "unread",
-      engagement: "active",
-      watching: undefined,
-      origin: ["manual", "github"],
-      with: undefined,
-    });
+    expect(meChatMocks.listMeChats).toHaveBeenCalledWith(
+      {
+        filter: "unread",
+        engagement: "active",
+        watching: undefined,
+        origin: ["manual", "github"],
+        with: undefined,
+        cursor: undefined,
+      },
+      { signal: expect.anything() },
+    );
 
     await click(
       [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Reset all") ?? null,
@@ -349,13 +365,17 @@ describe("ConversationList", () => {
       [...document.body.querySelectorAll("label")].find((label) => label.textContent?.includes("Active")) ?? null,
     );
     await flush();
-    expect(meChatMocks.listMeChats).toHaveBeenCalledWith({
-      filter: "all",
-      engagement: "archived",
-      watching: undefined,
-      origin: undefined,
-      with: undefined,
-    });
+    expect(meChatMocks.listMeChats).toHaveBeenCalledWith(
+      {
+        filter: "all",
+        engagement: "archived",
+        watching: undefined,
+        origin: undefined,
+        with: undefined,
+        cursor: undefined,
+      },
+      { signal: expect.anything() },
+    );
     expect(container.textContent).toContain("Older");
   });
 
@@ -379,7 +399,10 @@ describe("ConversationList", () => {
     meChatMocks.listMeChats.mockRejectedValueOnce(new Error("cursor expired"));
     const error = await renderDom(<StatefulList />);
     await click(buttonByText(error, "Load more"));
-    expect(error.textContent).toContain("cursor expired");
+    // A failed "Load more" surfaces a retry affordance instead of the empty
+    // state or a leaked raw error string.
+    expect(error.textContent).toContain("Couldn't load more");
+    expect(error.textContent).not.toContain("No conversations yet.");
     await act(async () => root?.unmount());
     root = null;
 
@@ -398,13 +421,17 @@ describe("ConversationList", () => {
 
     await click(buttonByText(container, "Unread"));
 
-    expect(meChatMocks.listMeChats).toHaveBeenCalledWith({
-      filter: "unread",
-      engagement: "active",
-      watching: undefined,
-      origin: undefined,
-      with: undefined,
-    });
+    expect(meChatMocks.listMeChats).toHaveBeenCalledWith(
+      {
+        filter: "unread",
+        engagement: "active",
+        watching: undefined,
+        origin: undefined,
+        with: undefined,
+        cursor: undefined,
+      },
+      { signal: expect.anything() },
+    );
     expect(buttonByText(container, "Unread").getAttribute("aria-pressed")).toBe("true");
     expect(buttonByText(container, "All").getAttribute("aria-pressed")).toBe("false");
     expect(container.textContent).toContain("No unread conversations.");
@@ -432,5 +459,78 @@ describe("ConversationList", () => {
     for (const title of ["Has summary", "No summary", "Empty chat"]) {
       expect(rowButton(container, title).querySelector('[data-testid="row-description-skeleton"]')).toBeNull();
     }
+  });
+
+  it("shows an error with retry when the first page fails, not an empty state", async () => {
+    const errorClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false }, mutations: { retry: false } },
+    });
+    meChatMocks.listMeChats.mockReset();
+    meChatMocks.listMeChats.mockRejectedValue(new Error("network down"));
+
+    const container = await renderDom(<StatefulList rows={[]} nextCursor={null} />, errorClient);
+
+    // A failed first page must NOT masquerade as the "nothing here yet" state.
+    expect(container.textContent).not.toContain("No conversations yet.");
+    expect(container.textContent).toContain("Couldn't load conversations");
+    expect(buttonByText(container, "Retry")).toBeTruthy();
+  });
+
+  it("recovers when the first-page error is retried", async () => {
+    const retryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false }, mutations: { retry: false } },
+    });
+    meChatMocks.listMeChats.mockReset();
+    meChatMocks.listMeChats
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValue({ rows: [row({ chatId: "chat-ok", title: "Recovered chat" })], nextCursor: null });
+
+    const container = await renderDom(<StatefulList rows={[]} nextCursor={null} />, retryClient);
+    expect(container.textContent).toContain("Couldn't load conversations");
+
+    await click(buttonByText(container, "Retry"));
+    expect(container.textContent).toContain("Recovered chat");
+    expect(container.textContent).not.toContain("Couldn't load conversations");
+  });
+
+  it("de-duplicates a chat that appears on more than one page", async () => {
+    const dupClient = createClient([row({ chatId: "chat-dup", title: "Duplicated chat" })], "cursor-1");
+    meChatMocks.listMeChats.mockReset();
+    // A background refetch can pull a page-2 chat into page 1, so the same
+    // chatId briefly lives on two pages. The rail must render it once.
+    meChatMocks.listMeChats.mockResolvedValue({
+      rows: [row({ chatId: "chat-dup", title: "Duplicated chat" }), row({ chatId: "chat-two", title: "Second chat" })],
+      nextCursor: null,
+    });
+
+    const container = await renderDom(<StatefulList />, dupClient);
+    await click(buttonByText(container, "Load more"));
+
+    const dupRows = [...container.querySelectorAll("button")].filter((b) => b.textContent?.includes("Duplicated chat"));
+    expect(dupRows.length).toBe(1);
+    expect(container.textContent).toContain("Second chat");
+  });
+
+  it("keeps the empty state when a background refetch fails, not an error", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false }, mutations: { retry: false } },
+    });
+    meChatMocks.listMeChats.mockReset();
+    // First load succeeds with no chats; the next (background) refetch fails.
+    meChatMocks.listMeChats
+      .mockResolvedValueOnce({ rows: [], nextCursor: null })
+      .mockRejectedValue(new Error("refetch blip"));
+
+    const container = await renderDom(<StatefulList rows={[]} nextCursor={null} />, client);
+    expect(container.textContent).toContain("No conversations yet.");
+
+    // React Query retains the (empty) data on a refetch failure, so this must
+    // NOT flip a legitimately-empty list into the first-load error state.
+    await act(async () => {
+      await client.refetchQueries({ queryKey: ["me", "chats"] }).catch(() => undefined);
+    });
+    await flush();
+    expect(container.textContent).toContain("No conversations yet.");
+    expect(container.textContent).not.toContain("Couldn't load conversations");
   });
 });

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -120,6 +120,7 @@ export function ConversationList({
 
   const {
     data,
+    dataUpdatedAt,
     isLoading,
     isLoadingError,
     refetch,
@@ -190,29 +191,34 @@ export function ConversationList({
     return rows;
   }, [data]);
 
-  // Buckets are recomputed whenever the rows or group mode change.
-  // Day-rollover (a chat that was "Today" at 23:59 should drift into
-  // "Yesterday" after midnight) is handled implicitly by the 30s
-  // `useInfiniteQuery` refetch — the refetched response changes
-  // `data`'s identity, which invalidates `allRows` and this memo. A
-  // user who leaves the rail open past midnight without a refetch
-  // (e.g. an inactive tab the browser throttles) won't see the bucket
-  // shift until the next refetch lands; that's an acceptable degree
-  // of staleness for a presentational concern.
+  // Bucket by recency against a fresh `now`. Row meta (`formatRowTime`:
+  // now / 5m / 3h) and the Today / Yesterday buckets are clock-derived, so
+  // they must re-evaluate on the 30s refetch cadence. TanStack Query
+  // structurally shares a structurally-identical successful response, so on a
+  // quiet list `data` (and thus `allRows`) keeps its identity across a refetch
+  // and neither this memo nor a render would otherwise fire. `dataUpdatedAt`
+  // advances on every successful refetch and is a tracked result field, so
+  // depending on it both forces a re-render (refreshing the inline
+  // `formatRowTime` calls) and re-runs this memo with a new `now`. A tab
+  // throttled past a refetch stays stale until the next one lands — acceptable
+  // for a presentational concern.
+  //
   // Hoist attention chats (failed + open request) into a pinned section at
   // the top WITHOUT touching cursor pagination or reordering the main list:
   // partition them out, group the rest as usual, then prepend a synthetic
   // "Needs attention" bucket (failed > request). A plain unread mention /
   // red dot deliberately does NOT pin, so the list stays stable. A chat
   // appears in exactly one place (pinned OR its normal group), never both.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `dataUpdatedAt` is the successful-refetch time tick — it re-runs this memo with a fresh `now` (and re-renders the clock-derived row times) even when the payload is structurally identical.
   const buckets = useMemo(() => {
+    const now = new Date();
     const { attention, rest } = splitAttentionRows(allRows);
-    if (attention.length === 0) return groupRows(allRows, group);
+    if (attention.length === 0) return groupRows(allRows, group, now);
     return [
       { key: "needs-attention", label: "Needs attention", rows: attention, defaultCollapsed: false },
-      ...groupRows(rest, group),
+      ...groupRows(rest, group, now),
     ];
-  }, [allRows, group]);
+  }, [allRows, group, dataUpdatedAt]);
 
   const totalUnread = useMemo(() => allRows.reduce((acc, r) => acc + (r.unreadMentionCount > 0 ? 1 : 0), 0), [allRows]);
   const isDraftActive = selectedChatId === DRAFT_CHAT_ID;

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -1,7 +1,7 @@
-import { type ChatEngagementView, type ChatSource, type MeChatRow, RUNTIME_STALE_MS } from "@first-tree/shared";
-import { useQuery } from "@tanstack/react-query";
+import type { ChatEngagementView, ChatSource, MeChatRow } from "@first-tree/shared";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { ChevronDown, ChevronRight, Eye, ListTree, Plus, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { listMeChats } from "../../../api/me-chats.js";
 import { useAuth } from "../../../auth/auth-context.js";
 import { ActivityDots } from "../../../components/chat/activity-dots.js";
@@ -99,19 +99,6 @@ export function ConversationList({
   onGroupChange: (next: GroupMode) => void;
 }) {
   const { agentId: selfAgentId } = useAuth();
-  // Pages loaded via `Load more` carry a `fetchedAt` timestamp so the busy
-  // dot can be aged out on those rows. The parent useQuery refetches every
-  // 30s and re-discovers stale `runtime_state_at` for the first page, but
-  // extraPages bypass react-query entirely — without this stamp, a row from
-  // an older page whose agent crashed mid-turn would keep flashing busy
-  // forever. The render path drops busyAgentIds on rows from pages older
-  // than RUNTIME_STALE_MS (60s) plus one refetchInterval (30s) — total
-  // worst-case stuck-busy window ~90s on these rows, vs ≤60s for the first
-  // page that refetches directly. No UX disruption from the user's
-  // loaded position.
-  const [extraPages, setExtraPages] = useState<Array<{ fetchedAt: number; rows: MeChatRow[] }>>([]);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [moreError, setMoreError] = useState<string | null>(null);
   // Per-bucket collapse override. Absence in the map means "use the
   // bucket's defaultCollapsed". Session-scoped — not worth a URL slot
   // because it's purely a presentation preference and any reload that
@@ -131,11 +118,23 @@ export function ConversationList({
   const originParam = origin.length > 0 ? [...origin] : undefined;
   const withParam = participants.length > 0 ? [...participants] : undefined;
 
-  const { data, isLoading, dataUpdatedAt } = useQuery({
+  const {
+    data,
+    isLoading,
+    isLoadingError,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetchNextPageError,
+  } = useInfiniteQuery({
     // `origin` / `with` are arrays — react-query needs a stable key
     // signature, so we serialise them into the query key the same way
     // the wire does. Empty array collapses to `null` so an unchanged
-    // "no filter" state doesn't churn the key.
+    // "no filter" state doesn't churn the key. A filter change swaps the
+    // whole query (with its own page list) atomically — react-query
+    // isolates cache entries by key, so a superseded response can never
+    // bleed into the new filter's list.
     queryKey: [
       "me",
       "chats",
@@ -145,76 +144,57 @@ export function ConversationList({
       originParam ? originParam.join(",") : null,
       withParam ? withParam.join(",") : null,
     ] as const,
-    queryFn: () =>
-      listMeChats({
-        filter,
-        engagement,
-        watching: watchingParam,
-        origin: originParam,
-        with: withParam,
-      }),
+    queryFn: ({ pageParam, signal }) =>
+      listMeChats(
+        {
+          filter,
+          engagement,
+          watching: watchingParam,
+          origin: originParam,
+          with: withParam,
+          cursor: pageParam,
+        },
+        { signal },
+      ),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     // Bounded refetch is the safety floor for the per-chat composite
     // signals projected onto each row: `busyAgentIds` lights the chat-list
     // dot for the working / codex-no-events case, and the only way the
-    // dot self-heals after a client crash is for a fresh `listMeChats`
-    // to discover `runtime_state_at` aged past `RUNTIME_STALE_MS` (60s)
-    // — the server emits no notification when staleness is reached
-    // passively. Without this interval the dot would stay lit forever
-    // until some unrelated invalidation. 30s matches the
-    // `chat-agent-status` query, so the first-page stuck-busy window is
-    // bounded by RUNTIME_STALE_MS (60s) + one refetch (30s) ≈ 90s upper.
+    // dot self-heals after a client crash is for a fresh `listMeChats` to
+    // discover `runtime_state_at` aged past `RUNTIME_STALE_MS` (60s) — the
+    // server emits no notification when staleness is reached passively. An
+    // infinite query refetches every loaded page on each interval, so every
+    // row (not just the first page) self-heals within `RUNTIME_STALE_MS` +
+    // one refetch (~90s). 30s matches the `chat-agent-status` query.
     refetchInterval: 30_000,
   });
 
-  // Mirror in an effect so a URL-only change (browser back/forward, deep
-  // link, parent-driven toggle) can't bleed previous-view rows into the
-  // new list. Identity-only deps; the body doesn't read them.
-  //
-  // `origin` and `participants` are arrays — their object identity changes
-  // on every render even when the contents are unchanged, which would
-  // re-fire the effect every paint. We collapse each into a stable string
-  // key (their canonical URL serialisation) so the effect only fires on
-  // actual content changes.
-  const originKey = origin.join(",");
-  const participantsKey = participants.join(",");
-  // biome-ignore lint/correctness/useExhaustiveDependencies: these are triggers, not reads
-  useEffect(() => {
-    setExtraPages((prev) => (prev.length > 0 ? [] : prev));
-    setMoreError(null);
-  }, [filter, engagement, watching, originKey, participantsKey]);
-
-  const baseRows = data?.rows ?? [];
-  // Render-time staleness sieve for extraPages: any row whose page was
-  // fetched > RUNTIME_STALE_MS (60s) ago has its `busyAgentIds` blanked.
-  // The check tracks the server's fail-closed window but the recompute
-  // cadence is bounded by react-query's refetchInterval (30s), so the
-  // real upper bound is `RUNTIME_STALE_MS + refetchInterval` ≈ 90s on
-  // extraPage rows specifically (vs ≤60s on the first page, which
-  // refetches directly). `dataUpdatedAt` (set on every successful
-  // refetch, even when content is structurally identical) is the time
-  // anchor — `baseRows` identity can stay stable across refetches when
-  // structural sharing kicks in, so depending on it alone would leave
-  // a memo that never re-evaluates `Date.now()` and an old extraPage
-  // row could keep flashing busy forever. Rationale: see the comment on
-  // the `extraPages` declaration.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: dataUpdatedAt is the time-tick that drives stale recomputation; not a value read
+  // Flatten every loaded page into one list, de-duplicating by chatId. A
+  // background refetch can pull a chat from a later page onto page 1 when it
+  // gets fresh activity, briefly leaving the same chatId on two pages until
+  // the tail refetches; keeping the first occurrence yields a duplicate-free
+  // list and a stable React key. No per-page staleness sieve is needed — the
+  // infinite query refetches every loaded page on `refetchInterval`, so each
+  // row's `busyAgentIds` is refreshed on the same cadence.
   const allRows = useMemo(() => {
-    const now = Date.now();
-    const expanded: MeChatRow[] = [];
-    for (const page of extraPages) {
-      const stale = now - page.fetchedAt > RUNTIME_STALE_MS;
-      for (const row of page.rows) {
-        expanded.push(stale && row.busyAgentIds.length > 0 ? { ...row, busyAgentIds: [] } : row);
+    const seen = new Set<string>();
+    const rows: MeChatRow[] = [];
+    for (const page of data?.pages ?? []) {
+      for (const chatRow of page.rows) {
+        if (seen.has(chatRow.chatId)) continue;
+        seen.add(chatRow.chatId);
+        rows.push(chatRow);
       }
     }
-    return [...baseRows, ...expanded];
-  }, [baseRows, extraPages, dataUpdatedAt]);
+    return rows;
+  }, [data]);
 
   // Buckets are recomputed whenever the rows or group mode change.
   // Day-rollover (a chat that was "Today" at 23:59 should drift into
-  // "Yesterday" after midnight) is handled implicitly by the 15 s
-  // `useQuery` refetch on the parent query — the refetched response
-  // changes `data.rows`' identity, which invalidates this memo. A
+  // "Yesterday" after midnight) is handled implicitly by the 30s
+  // `useInfiniteQuery` refetch — the refetched response changes
+  // `data`'s identity, which invalidates `allRows` and this memo. A
   // user who leaves the rail open past midnight without a refetch
   // (e.g. an inactive tab the browser throttles) won't see the bucket
   // shift until the next refetch lands; that's an acceptable degree
@@ -233,39 +213,6 @@ export function ConversationList({
       ...groupRows(rest, group),
     ];
   }, [allRows, group]);
-
-  // Track the cursor for follow-up page loads. Mirrored from the latest
-  // base-query response: any background refetch resets `nextCursor` so the
-  // "Load more" button reflects the freshest tail.
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const baseCursor = data?.nextCursor ?? null;
-  useEffect(() => {
-    setNextCursor(baseCursor);
-  }, [baseCursor]);
-
-  const handleLoadMore = async (): Promise<void> => {
-    if (loadingMore) return;
-    const cursor = nextCursor;
-    if (!cursor) return;
-    setLoadingMore(true);
-    setMoreError(null);
-    try {
-      const next = await listMeChats({
-        filter,
-        engagement,
-        watching: watchingParam,
-        origin: originParam,
-        with: withParam,
-        cursor,
-      });
-      setExtraPages((prev) => [...prev, { fetchedAt: Date.now(), rows: next.rows }]);
-      setNextCursor(next.nextCursor);
-    } catch (err) {
-      setMoreError(err instanceof Error ? err.message : "Failed to load more");
-    } finally {
-      setLoadingMore(false);
-    }
-  };
 
   const totalUnread = useMemo(() => allRows.reduce((acc, r) => acc + (r.unreadMentionCount > 0 ? 1 : 0), 0), [allRows]);
   const isDraftActive = selectedChatId === DRAFT_CHAT_ID;
@@ -460,7 +407,32 @@ export function ConversationList({
             Loading…
           </div>
         )}
-        {!isLoading && allRows.length === 0 && (
+        {/* A failed FIRST load (error with no data) surfaces an error + retry,
+            never falling through to the "No conversations yet" empty state.
+            `isLoadingError` (not `isError`) is deliberate: a failed background
+            refetch keeps the prior data, so gating on `isError` would flip a
+            legitimately-empty list into an error on a transient 30s-refetch blip. */}
+        {isLoadingError && allRows.length === 0 && (
+          <div className="text-center text-body" style={{ padding: "var(--sp-6) var(--sp-3)", color: "var(--fg-3)" }}>
+            <p style={{ margin: 0 }}>{"Couldn't load conversations."}</p>
+            <button
+              type="button"
+              onClick={() => refetch()}
+              className="text-label cursor-pointer hover:bg-[var(--bg-hover)] transition-colors"
+              style={{
+                marginTop: "var(--sp-2)",
+                padding: "var(--sp-0_5) var(--sp-2)",
+                border: "var(--hairline) solid var(--border)",
+                borderRadius: "var(--radius-input)",
+                background: "var(--bg-sunken)",
+                color: "var(--fg-2)",
+              }}
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {!isLoading && !isLoadingError && allRows.length === 0 && (
           <div className="text-center text-body" style={{ padding: "var(--sp-6) var(--sp-3)", color: "var(--fg-3)" }}>
             <p style={{ margin: 0 }}>{emptyCopy.title}</p>
             <p className="text-label" style={{ margin: "var(--sp-1) 0 0", color: "var(--fg-4)" }}>
@@ -584,12 +556,12 @@ export function ConversationList({
             </div>
           );
         })}
-        {nextCursor && allRows.length > 0 && (
+        {hasNextPage && allRows.length > 0 && (
           <div style={{ padding: "var(--sp-2) var(--sp-3)" }}>
             <button
               type="button"
-              onClick={handleLoadMore}
-              disabled={loadingMore}
+              onClick={() => fetchNextPage()}
+              disabled={isFetchingNextPage}
               className="w-full text-body mono"
               style={{
                 padding: "var(--sp-1_25) var(--sp-2)",
@@ -597,15 +569,23 @@ export function ConversationList({
                 borderRadius: "var(--radius-input)",
                 background: "var(--bg-sunken)",
                 color: "var(--fg-2)",
-                cursor: loadingMore ? "default" : "pointer",
-                opacity: loadingMore ? 0.6 : 1,
+                cursor: isFetchingNextPage ? "default" : "pointer",
+                opacity: isFetchingNextPage ? 0.6 : 1,
               }}
             >
-              {loadingMore ? "Loading…" : "Load more"}
+              {isFetchingNextPage ? "Loading…" : "Load more"}
             </button>
-            {moreError && (
+            {isFetchNextPageError && (
               <p className="mono text-caption" style={{ color: "var(--state-error)", marginTop: 4 }}>
-                {moreError}
+                {"Couldn't load more. "}
+                <button
+                  type="button"
+                  onClick={() => fetchNextPage()}
+                  className="cursor-pointer"
+                  style={{ border: 0, background: "transparent", padding: 0, color: "var(--primary)" }}
+                >
+                  Retry
+                </button>
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary

PR 1 of 5 in the Workspace Chat List refactor — the **query foundation**. It replaces the
hand-rolled `useQuery + extraPages + manual cursor` pagination in the left-rail chat list
with `useInfiniteQuery`, and adds first-class error/retry states. Web-only; **no server or
API-contract change**. All existing behavior is preserved except the new error states.

This de-risks the later PRs (Pin, `activity_at` ordering, filter redesign) by removing the
pagination race that any further work would otherwise inherit.

## Why

The old rail managed pages by hand (`extraPages` appended outside React Query), which caused
two real bugs and made the component hard to extend:

- **P0 — stale pages pollute a new filter / duplicate rows.** A "Load more" response that
  resolved after the user changed filters was appended to the new list; a background refetch
  could also surface a chat on two pages at once (duplicate React keys).
- **P1 — a failed first page masqueraded as empty.** The query never read `isError`, so a
  network/API failure fell through to "No conversations yet." instead of an error.

## Changes

- `conversations/index.tsx`: `useQuery` + `extraPages`/`loadingMore`/`moreError`/`nextCursor`
  state + two effects + `handleLoadMore` → a single `useInfiniteQuery`
  (`getNextPageParam` = `nextCursor ?? undefined`). Rows are flattened across pages and
  **de-duplicated by `chatId`** (first occurrence wins).
- Error states: a first-page error now renders "Couldn't load conversations." + **Retry**
  (`refetch`); a failed "Load more" renders an inline **Retry** (`fetchNextPage`). The empty
  state is now gated on `!isError`, so a failed load can never read as "no chats".
- Load more is driven by `hasNextPage` / `fetchNextPage` / `isFetchingNextPage` /
  `isFetchNextPageError`.
- `api/client.ts` + `api/me-chats.ts`: thread an optional `AbortSignal` so React Query can
  cancel the in-flight request when the filter/cursor changes.
- Removed the per-page `fetchedAt` busy-staleness sieve: an infinite query refetches **every
  loaded page** on the 30s `refetchInterval`, so each row's `busyAgentIds` self-heals on the
  same cadence (≤ `RUNTIME_STALE_MS` + one refetch), with no page bypassing it.
- The `["me","chats", …]` query key is unchanged, so the WebSocket prefix-invalidation and
  the throttled invalidator keep working untouched.

## Behavior preserved

Grouping, "Needs attention" (failed > request, page-local for now), the All/Unread/Watching
triad, Status/Source filters, chips, the unread count, row states, and the selected-row
treatment are all unchanged. Confirmed via the existing DOM tests + a real-browser pass.

## Testing

- **TDD**: added failing DOM tests first (first-page error + retry recovery, cross-page
  dedup), then implemented.
- `pnpm --filter @first-tree/web test` — **1331 passed**.
- `pnpm check` (Biome) + `pnpm --filter @first-tree/web typecheck` (tsc + design-token lint) — clean.
- **browse·QA** on `/preview/conversation-list` (renders the real component through
  `useInfiniteQuery`): rows/groups/attention/selection render correctly, no console errors.

## Scope notes

Deferred to later PRs (unchanged here, by design): canonical `FilterSpec` refactor, the
"Outside current filters" hint, Status single-select, server aggregate unread count, and the
cross-page attention/pinned projection. Part of the Chat List refactor whose durable filter
semantics are captured in first-tree-context#721.
