### PR TITLE
docs: add support question issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/support_question.md
+++ b/.github/ISSUE_TEMPLATE/support_question.md
@@ -1,0 +1,40 @@
+---
+name: Support question
+about: Ask for help with using First Tree or its documentation.
+title: "[Question] "
+labels: question
+assignees: ""
+---
+
+Before posting, review [SUPPORT.md](../../SUPPORT.md). Do not disclose suspected vulnerabilities here; follow [SECURITY.md](../../SECURITY.md) instead.
+
+## Affected Surface
+
+- CLI
+- web
+- server
+- docs
+- GitHub integration
+- other
+
+## Version and Installation
+
+- version or commit:
+- install method or source checkout:
+- operating system or browser, if relevant:
+
+## Command, Screen, or Workflow
+
+Provide the exact command, screen, or workflow involved.
+
+## Expected Behavior
+
+What did you expect to happen?
+
+## What I Tried
+
+What have you already tried, and what happened?
+
+## Additional Context
+
+Add non-sensitive logs, screenshots, or related links.

--- a/.github/ISSUE_TEMPLATE/support_question.md
+++ b/.github/ISSUE_TEMPLATE/support_question.md
@@ -6,7 +6,7 @@ labels: question
 assignees: ""
 ---
 
-Before posting, review [SUPPORT.md](../../SUPPORT.md). Do not disclose suspected vulnerabilities here; follow [SECURITY.md](../../SECURITY.md) instead.
+Before posting, review [SUPPORT.md](https://github.com/agent-team-foundation/first-tree/blob/main/SUPPORT.md). Do not disclose suspected vulnerabilities here; follow [SECURITY.md](https://github.com/agent-team-foundation/first-tree/blob/main/SECURITY.md) instead.
 
 ## Affected Surface
 


### PR DESCRIPTION
## Summary

- add a support/question issue template using the repository's existing Markdown frontmatter format
- collect the affected surface, version and install context, exact workflow, expected behavior, and prior troubleshooting
- route users to `SUPPORT.md` and security-sensitive reports to `SECURITY.md`

Closes #888

## Validation

- `git diff --check` (exit 0)
- frontmatter structure check with Node.js (exit 0)
- automated acceptance review: 14/14 required content checks, both relative links resolved, and exactly one changed file (exit 0)
- scope check after every validation step: only `.github/ISSUE_TEMPLATE/support_question.md` changed

## Limitations

- `pnpm exec biome check` was not run because the fresh clone had no `node_modules`; no pnpm command was run to avoid dependency or workspace metadata mutation.
- This repository-metadata-only change was not subjected to application build, typecheck, or test commands.

## Disclosure

This contribution was prepared and validated by Codex AI automation under user direction. No human review is claimed.
