### PR TITLE
fix: log codex app-server usage-limit turn failures to the slot log

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-extra-coverage.test.ts
@@ -925,7 +925,8 @@ describe("codex app-server handler extra branches", () => {
     const successFake = new FakeAppServerClient();
     const successToken = makeDeliveryToken();
     const successHandler = makeHandler(successFake);
-    const successCtx = makeContext();
+    const successLog = vi.fn<(message: string) => void>();
+    const successCtx = makeContext({ log: successLog });
     const successSendMessage = vi.fn<SessionContext["sdk"]["sendMessage"]>().mockResolvedValue(sentMessageResponse());
     successCtx.sdk.sendMessage = successSendMessage;
 
@@ -957,6 +958,13 @@ describe("codex app-server handler extra branches", () => {
       completion: "consumed",
       reason: "usage_limit_notice_posted",
     });
+    // The usage-limit turn must leave a slot-log line (issue #1732): external
+    // log watchers (account-failover automation) tail client.log and can only
+    // react if the failure is logged with the stable provider_usage_limit tag.
+    const successLogLines = successLog.mock.calls.map(([line]) => line);
+    expect(successLogLines.some((line) => line.includes("provider_usage_limit"))).toBe(true);
+    expect(successLogLines.some((line) => line.includes("usage limit reached"))).toBe(true);
+    expect(successLogLines.some((line) => line.includes("usage exhausted"))).toBe(true);
     await successHandler.shutdown();
 
     const failureFake = new FakeAppServerClient();

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -1250,6 +1250,16 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
           message: "codex usage limit reached: turn completed without a usable model response",
         },
       });
+      // Slot-log line for external log watchers (e.g. account-failover
+      // automation tailing client.log) — the sdk runtime's usage-limit branch
+      // already logs; keep the `provider_usage_limit` tag stable.
+      sessionCtx.log(
+        `codex app-server usage limit reached (provider_usage_limit) chatId=${sessionCtx.chatId}: ${
+          usageLimitFailure && turn.failure
+            ? `turn failed with usage-limit error: ${turn.failure.message}`
+            : "empty turn, model not invoked (zero token delta)"
+        }; posting a chat notice instead of silently acking the message`,
+      );
       // Post the usage-limit notice as a deliberate, chat-visible runtime
       // message — an EXPLICIT send, not the retired final-text forward
       // (`forwardResult` no longer delivers). It rides the `agent-final-text`


### PR DESCRIPTION
## Summary

When a codex **app-server** turn fails on a provider usage limit, the handler emits the error event and posts the "⚠️ My runtime has reached its usage limit…" chat notice — but writes **no slot-log line**. Every sibling branch in `settleTurn` logs, and the codex **sdk** runtime's variant of the same branch logs (`codex usage limit reached chatId=…`). External log watchers tailing `client.log` (e.g. account-failover automation that cools an exhausted provider account and switches to a backup) therefore never see the event.

This PR adds the missing `sessionCtx.log` call to the app-server usage-limit branch, covering both variants:

- provider-reported usage-limit failure (`usageLimitFailure`) — includes the provider error message
- empty turn with zero token delta (`usageLimitEmptyTurn`)

The line carries a stable machine-parseable tag, e.g.:

```
codex app-server usage limit reached (provider_usage_limit) chatId=…: turn failed with usage-limit error: …; posting a chat notice instead of silently acking the message
```

Watchers can match `provider_usage_limit` (or `usage limit reached`, which also matches the sdk runtime's existing line).

Addresses the missing-slot-log half of #1732. The second half of that issue (auth-epoch restarts deferred indefinitely behind wedged in-flight turns) is a separate design-level change and is not touched here.

## Testing

- Extended the existing app-server usage-limit test (`codex-app-server-extra-coverage.test.ts`) to assert the slot-log line and its `provider_usage_limit` tag are emitted.
- `pnpm vitest run` on the four codex app-server / usage-limit test files: 89 passed, 3 skipped.
- `pnpm typecheck` (client package) and `biome check` on the changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
