### PR TITLE
fix(web): clamp iOS standalone root scrolling

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -672,6 +672,15 @@
     text-rendering: optimizeLegibility;
     font-synthesis: none;
   }
+  /* iOS standalone Web Apps can leave a root scroll range equal to the
+     Home Indicator safe area after the keyboard closes. Mobile pages own
+     their scrolling, so lock every document-level box while the guard is
+     mounted and let the bounded page scroller handle touch movement. */
+  html.ios-standalone-root-scroll-guard,
+  html.ios-standalone-root-scroll-guard body,
+  html.ios-standalone-root-scroll-guard #root {
+    overflow: hidden;
+  }
   ::selection {
     background: var(--brand-bg);
     color: var(--fg);

--- a/packages/web/src/pages/mobile/__tests__/root-scroll-guard.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/root-scroll-guard.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+import { isIosStandalone, useIosStandaloneRootScrollGuard } from "../use-ios-standalone-root-scroll-guard.js";
+
+function GuardProbe({ resetKey = "route-1" }: { resetKey?: string }) {
+  useIosStandaloneRootScrollGuard(resetKey);
+  return <div>guard</div>;
+}
+
+describe("iOS standalone root scroll guard", () => {
+  let harness: DomHarness;
+  let scrollX = 0;
+  let scrollY = 0;
+  let nextAnimationFrame = 1;
+  let animationFrames: Map<number, FrameRequestCallback>;
+  let visualViewportListeners: Map<string, Set<EventListenerOrEventListenerObject>>;
+  let visualViewport: {
+    addEventListener: ReturnType<typeof vi.fn>;
+    removeEventListener: ReturnType<typeof vi.fn>;
+  };
+
+  const flushAnimationFrames = () => {
+    const pending = [...animationFrames.values()];
+    animationFrames.clear();
+    act(() => {
+      for (const callback of pending) callback(performance.now());
+    });
+  };
+
+  beforeEach(() => {
+    harness = createDomHarness();
+    animationFrames = new Map();
+    visualViewportListeners = new Map();
+    scrollX = 0;
+    scrollY = 0;
+    nextAnimationFrame = 1;
+
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (iPhone; CPU iPhone OS 26_5 like Mac OS X)",
+    });
+    Object.defineProperty(window.navigator, "platform", { configurable: true, value: "iPhone" });
+    Object.defineProperty(window.navigator, "standalone", { configurable: true, value: true });
+    Object.defineProperty(window, "scrollX", { configurable: true, get: () => scrollX });
+    Object.defineProperty(window, "scrollY", { configurable: true, get: () => scrollY });
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: vi.fn((callback: FrameRequestCallback) => {
+        const id = nextAnimationFrame++;
+        animationFrames.set(id, callback);
+        return id;
+      }),
+    });
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      value: vi.fn((id: number) => animationFrames.delete(id)),
+    });
+    Object.defineProperty(window, "scrollTo", {
+      configurable: true,
+      value: vi.fn(() => {
+        scrollX = 0;
+        scrollY = 0;
+      }),
+    });
+
+    visualViewport = {
+      addEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        const listeners = visualViewportListeners.get(type) ?? new Set<EventListenerOrEventListenerObject>();
+        listeners.add(listener);
+        visualViewportListeners.set(type, listeners);
+      }),
+      removeEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+        visualViewportListeners.get(type)?.delete(listener);
+      }),
+    };
+    Object.defineProperty(window, "visualViewport", { configurable: true, value: visualViewport });
+  });
+
+  afterEach(() => {
+    harness.cleanup();
+    document.documentElement.classList.remove("ios-standalone-root-scroll-guard");
+    vi.restoreAllMocks();
+  });
+
+  it("detects the iOS home-screen display mode", () => {
+    expect(isIosStandalone()).toBe(true);
+
+    Object.defineProperty(window.navigator, "standalone", { configurable: true, value: false });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({ matches: false })),
+    });
+    expect(isIosStandalone()).toBe(false);
+  });
+
+  it("clamps root scrolling after keyboard and viewport signals, then cleans up", async () => {
+    scrollY = 38;
+    harness.render(<GuardProbe />);
+    await harness.flush();
+
+    expect(document.documentElement.classList).toContain("ios-standalone-root-scroll-guard");
+    flushAnimationFrames();
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+
+    scrollY = 24;
+    document.dispatchEvent(new FocusEvent("focusout"));
+    flushAnimationFrames();
+    expect(window.scrollTo).toHaveBeenCalledTimes(2);
+
+    scrollY = 12;
+    act(() => {
+      for (const listener of visualViewportListeners.get("resize") ?? []) {
+        if (typeof listener === "function") listener(new Event("resize"));
+        else listener.handleEvent(new Event("resize"));
+      }
+    });
+    flushAnimationFrames();
+    expect(window.scrollTo).toHaveBeenCalledTimes(3);
+
+    scrollY = 6;
+    harness.render(<GuardProbe resetKey="route-2" />);
+    await harness.flush();
+    flushAnimationFrames();
+    expect(window.scrollTo).toHaveBeenCalledTimes(4);
+
+    harness.cleanup();
+    expect(document.documentElement.classList).not.toContain("ios-standalone-root-scroll-guard");
+    expect(visualViewport.removeEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
+    expect(visualViewport.removeEventListener).toHaveBeenCalledWith("scroll", expect.any(Function));
+
+    harness = createDomHarness();
+  });
+
+  it("does not mount the guard outside iOS standalone mode", async () => {
+    Object.defineProperty(window.navigator, "standalone", { configurable: true, value: false });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({ matches: false })),
+    });
+
+    scrollY = 20;
+    harness.render(<GuardProbe />);
+    await harness.flush();
+    flushAnimationFrames();
+
+    expect(document.documentElement.classList).not.toContain("ios-standalone-root-scroll-guard");
+    expect(window.scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/pages/mobile/__tests__/shell-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/shell-dom.test.tsx
@@ -151,5 +151,6 @@ describe("MobilePage", () => {
     // engages; min-h-full would grow with content and never scroll.
     expect(scroller?.className).toContain("h-full");
     expect(scroller?.className).not.toContain("min-h-full");
+    expect(scroller?.className).toContain("overscroll-y-contain");
   });
 });

--- a/packages/web/src/pages/mobile/components.tsx
+++ b/packages/web/src/pages/mobile/components.tsx
@@ -78,7 +78,7 @@ export function MobilePage({
 }) {
   return (
     <div
-      className={cn("h-full overflow-y-auto", className)}
+      className={cn("h-full overflow-y-auto overscroll-y-contain", className)}
       style={{
         padding: padded ? "var(--sp-4) var(--sp-4) var(--sp-6)" : undefined,
       }}

--- a/packages/web/src/pages/mobile/shell.tsx
+++ b/packages/web/src/pages/mobile/shell.tsx
@@ -7,6 +7,7 @@ import { useAdminWs } from "../../hooks/use-admin-ws.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
 import { MobileBottomTabs } from "./components.js";
 import { countAttentionRows, countUnreadRows } from "./data.js";
+import { useIosStandaloneRootScrollGuard } from "./use-ios-standalone-root-scroll-guard.js";
 
 export function MobileShell() {
   const {
@@ -19,6 +20,8 @@ export function MobileShell() {
   } = useAuth();
   const location = useLocation();
   const [searchParams] = useSearchParams();
+
+  useIosStandaloneRootScrollGuard(`${location.pathname}${location.search}`);
 
   useAdminWs();
 

--- a/packages/web/src/pages/mobile/use-ios-standalone-root-scroll-guard.ts
+++ b/packages/web/src/pages/mobile/use-ios-standalone-root-scroll-guard.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef } from "react";
+
+const ROOT_SCROLL_GUARD_CLASS = "ios-standalone-root-scroll-guard";
+
+function isIosDevice(): boolean {
+  if (typeof navigator === "undefined") return false;
+  if (/iPad|iPhone|iPod/.test(navigator.userAgent)) return true;
+
+  // iPadOS can identify itself as macOS while retaining touch input.
+  return navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
+}
+
+function isStandaloneDisplayMode(): boolean {
+  if (typeof window === "undefined" || typeof navigator === "undefined") return false;
+
+  const displayModeStandalone = window.matchMedia?.("(display-mode: standalone)").matches === true;
+  const legacyIosStandalone = "standalone" in navigator && navigator.standalone === true;
+  return displayModeStandalone || legacyIosStandalone;
+}
+
+export function isIosStandalone(): boolean {
+  return isIosDevice() && isStandaloneDisplayMode();
+}
+
+function rootHasScrollOffset(): boolean {
+  const root = document.documentElement;
+  const body = document.body;
+  return (
+    window.scrollX !== 0 ||
+    window.scrollY !== 0 ||
+    root.scrollLeft !== 0 ||
+    root.scrollTop !== 0 ||
+    body.scrollLeft !== 0 ||
+    body.scrollTop !== 0
+  );
+}
+
+/**
+ * iOS standalone Web Apps can retain a root scroll range equal to the bottom
+ * safe-area inset after the software keyboard closes (WebKit 292603). The
+ * mobile pages already own their scrolling, so any window/document scroll is
+ * invalid and can be clamped back to the origin without losing page position.
+ *
+ * `resetKey` lets route changes trigger a fresh clamp. visualViewport events
+ * are signals only: its dimensions are themselves unreliable in standalone
+ * mode, so this guard never derives layout height from them.
+ */
+export function useIosStandaloneRootScrollGuard(resetKey: string): void {
+  const scheduleClampRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    if (!isIosStandalone()) return;
+
+    const root = document.documentElement;
+    const visualViewport = window.visualViewport;
+    let animationFrame: number | null = null;
+
+    const clampRootScroll = () => {
+      animationFrame = null;
+      if (!rootHasScrollOffset()) return;
+
+      window.scrollTo(0, 0);
+      // Keep both legacy scrolling roots at the origin as a fallback for iOS
+      // versions that disagree about which element owns the root scroll.
+      document.documentElement.scrollLeft = 0;
+      document.documentElement.scrollTop = 0;
+      document.body.scrollLeft = 0;
+      document.body.scrollTop = 0;
+    };
+
+    const scheduleClamp = () => {
+      if (animationFrame !== null) return;
+      animationFrame = window.requestAnimationFrame(clampRootScroll);
+    };
+
+    const onVisibilityChange = () => {
+      if (!document.hidden) scheduleClamp();
+    };
+
+    scheduleClampRef.current = scheduleClamp;
+    root.classList.add(ROOT_SCROLL_GUARD_CLASS);
+    scheduleClamp();
+    window.addEventListener("scroll", scheduleClamp, { passive: true });
+    window.addEventListener("pageshow", scheduleClamp);
+    window.addEventListener("orientationchange", scheduleClamp);
+    document.addEventListener("focusout", scheduleClamp);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    visualViewport?.addEventListener("resize", scheduleClamp);
+    visualViewport?.addEventListener("scroll", scheduleClamp);
+
+    return () => {
+      scheduleClampRef.current = null;
+      root.classList.remove(ROOT_SCROLL_GUARD_CLASS);
+      window.removeEventListener("scroll", scheduleClamp);
+      window.removeEventListener("pageshow", scheduleClamp);
+      window.removeEventListener("orientationchange", scheduleClamp);
+      document.removeEventListener("focusout", scheduleClamp);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      visualViewport?.removeEventListener("resize", scheduleClamp);
+      visualViewport?.removeEventListener("scroll", scheduleClamp);
+      if (animationFrame !== null) window.cancelAnimationFrame(animationFrame);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (resetKey.length > 0) scheduleClampRef.current?.();
+  }, [resetKey]);
+}


### PR DESCRIPTION
## Summary

- add an iOS standalone-only guard that keeps the document scrolling root at the origin after keyboard, viewport, route, resume, and orientation events
- lock document-level overflow only while the mobile shell is mounted, leaving each mobile page as the bounded scroller
- contain vertical overscroll in `MobilePage` and cover the guard lifecycle and scroll clamping with regression tests

## Context

On an iPhone 14 Pro running iOS 26.5, the home-screen Web App can reveal an extra Home Indicator-sized blank strip below the bottom navigation after using the chat keyboard and then scrolling. The existing `100dvh` fix is present but does not prevent WebKit from retaining a document-level scroll range. The behavior matches [WebKit bug 292603](https://bugs.webkit.org/show_bug.cgi?id=292603).

## Validation

- `pnpm check`
- `pnpm typecheck`
- targeted mobile tests: 8 passed
- Web Vitest suite: all 1,336 unit tests passed; the command then returned non-zero because the existing `tests/visual-regression.spec.ts` Playwright file was collected by Vitest and contains no Vitest suite
- repository-wide `pnpm test` was additionally attempted; unrelated CLI client-switch tests detect the currently running First Tree Codex provider process and fail their process-drain assertions in this agent environment

## QA

Retest the original chat-keyboard flow on the reported iPhone 14 Pro / iOS 26.5 device after this branch reaches staging.
