### PR TITLE
feat(web): lift dense type scale by 1px

### DIFF
--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -200,10 +200,10 @@ Three marketing tiers for the public landing page only.
 | Tier | Size | Weight | Typical use |
 |------|------|--------|-------------|
 | `text-eyebrow` | 10px | 600 | all-caps kickers (0.1em tracking) |
-| `text-caption` | 10px | 500 | dense metadata |
-| `text-label` | 11px | 500 | form labels, chips |
-| `text-body` | 12px | 400 | body copy, buttons |
-| `text-subtitle` | 13px | 600 | row titles (**default body size**) |
+| `text-caption` | 11px | 500 | dense metadata |
+| `text-label` | 12px | 500 | form labels, chips |
+| `text-body` | 13px | 400 | body copy, buttons |
+| `text-subtitle` | 14px | 600 | row titles (**default body size**) |
 | `text-title` | 16px | 600 | section / page titles |
 | — marketing — | | | |
 | `text-lead` | 18px | 400 | landing lead copy |
@@ -350,7 +350,7 @@ through to system fonts.
   FOUT stability) → system stack (incl. PingFang SC / Microsoft YaHei for CJK).
 - **Mono:** JetBrains Mono (400–600) → ui-monospace stack.
 
-Body defaults: 13px / 1.45, `cv11 ss01 ss03` features, `tabular-nums`,
+Body defaults: 14px / 1.45, `cv11 ss01 ss03` features, `tabular-nums`,
 antialiased, `font-synthesis: none`.
 
 ---

--- a/packages/web/docs/cross-platform-visual-qa.md
+++ b/packages/web/docs/cross-platform-visual-qa.md
@@ -32,10 +32,10 @@ Windows at non-integer DPI scale is the highest-risk environment — all P0 regr
 | Check | Pass criteria |
 |---|---|
 | `text-eyebrow` uppercase labels | 10px, 600, `0.1em` tracking everywhere — no collapse to 9px or mixed weights |
-| `text-caption` inline timestamps | 10px, 500, `0.06em` tracking — clearly lighter than eyebrow |
-| `text-label` form labels + badges | 11px, 500, `0.02em` tracking — readable on Windows at 125% |
-| `text-body` default body | 12px, 400, line-height 1.5 — most common; sanity-check across dense tables |
-| `text-subtitle` section/card titles | 13px, 600, `-0.1px` tracking — clearly distinct from body but not title |
+| `text-caption` inline timestamps | 11px, 500, `0.06em` tracking — clearly lighter than eyebrow |
+| `text-label` form labels + badges | 12px, 500, `0.02em` tracking — readable on Windows at 125% |
+| `text-body` default body | 13px, 400, line-height 1.5 — most common; sanity-check across dense tables |
+| `text-subtitle` section/card titles | 14px, 600, `-0.1px` tracking — clearly distinct from body but not title |
 | `text-title` page titles | 16px, 600, `-0.2px` tracking — only appears in `<PageHeader>` and dialog titles |
 | No Tailwind `text-xs/sm/base/lg/2xl` classes visible in computed styles | Run guardrail script: `pnpm --filter @first-tree/web lint:tokens` |
 
@@ -94,7 +94,7 @@ These only surface on Windows at 125% / 150% DPI. Do not ship without this pass.
 | Check | Pass criteria |
 |---|---|
 | 1px borders render as antialiased-but-visible line (inevitable at 1.25x, acceptable trade-off) | Not invisible; not 2px thick |
-| 11px `text-label` still legible | No blurry edges on uppercase letters |
+| 12px `text-label` still legible | No blurry edges on uppercase letters |
 | 10px `text-eyebrow` readable with `font-weight: 600` + 0.1em tracking | Uppercase `REGISTERED`, `WORKSPACE`, etc. still crisp |
 | `text-subtitle` letter-spacing `-0.1px` — not clamped to 0 | Title widths visually match Figma mocks |
 | Scrollbar width matches Mac overlay scrollbar (via `scrollbar-width: thin`) | Column widths do not jump by ~15px when scrollbar appears |

--- a/packages/web/docs/cross-platform-visual-qa.md
+++ b/packages/web/docs/cross-platform-visual-qa.md
@@ -34,8 +34,8 @@ Windows at non-integer DPI scale is the highest-risk environment — all P0 regr
 | `text-eyebrow` uppercase labels | 10px, 600, `0.1em` tracking everywhere — no collapse to 9px or mixed weights |
 | `text-caption` inline timestamps | 11px, 500, `0.06em` tracking — clearly lighter than eyebrow |
 | `text-label` form labels + badges | 12px, 500, `0.02em` tracking — readable on Windows at 125% |
-| `text-body` default body | 13px, 400, line-height 1.5 — most common; sanity-check across dense tables |
-| `text-subtitle` section/card titles | 14px, 600, `-0.1px` tracking — clearly distinct from body but not title |
+| `text-body` body copy | 13px, 400, line-height 1.5 — secondary body / button text; sanity-check across dense tables |
+| `text-subtitle` titles + default body | 14px, 600, `-0.1px` tracking — the `body` default; clearly distinct from body copy but not title |
 | `text-title` page titles | 16px, 600, `-0.2px` tracking — only appears in `<PageHeader>` and dialog titles |
 | No Tailwind `text-xs/sm/base/lg/2xl` classes visible in computed styles | Run guardrail script: `pnpm --filter @first-tree/web lint:tokens` |
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -86,21 +86,21 @@
   --text-eyebrow--letter-spacing: 0.1em;
   --text-eyebrow--font-weight: 600;
 
-  --text-caption: 10px;
+  --text-caption: 11px;
   --text-caption--line-height: 1.4;
   --text-caption--letter-spacing: 0.06em;
   --text-caption--font-weight: 500;
 
-  --text-label: 11px;
+  --text-label: 12px;
   --text-label--line-height: 1.4;
   --text-label--letter-spacing: 0.02em;
   --text-label--font-weight: 500;
 
-  --text-body: 12px;
+  --text-body: 13px;
   --text-body--line-height: 1.5;
   --text-body--font-weight: 400;
 
-  --text-subtitle: 13px;
+  --text-subtitle: 14px;
   --text-subtitle--line-height: 1.35;
   --text-subtitle--letter-spacing: -0.1px;
   --text-subtitle--font-weight: 600;
@@ -2089,7 +2089,7 @@ tr[data-interactive]:hover {
    ----------------------------------------------------------------------------
    iOS Safari auto-zooms the viewport when a focused <input>/<textarea>/<select>
    resolves to a font-size below 16px. Our dense type scale puts most controls
-   at 12–13px (text-body / text-subtitle), so every tap on the composer zoomed
+   at 13–14px (text-body / text-subtitle), so every tap on the composer zoomed
    the page. On phone-width viewports, raise every form control to the 16px
    threshold so focusing one never triggers the zoom.
 

--- a/packages/web/src/pages/styleguide-preview.tsx
+++ b/packages/web/src/pages/styleguide-preview.tsx
@@ -145,10 +145,10 @@ type TypeTier = { cls: string; name: string; meta: string; sample: string; upper
 // design-token guardrail (which bans digit+px literals in src) stays clean.
 const APP_TIERS: TypeTier[] = [
   { cls: "text-eyebrow", name: "text-eyebrow", meta: "10 / 600 / +0.1em", sample: "Section eyebrow", uppercase: true },
-  { cls: "text-caption", name: "text-caption", meta: "10 / 500", sample: "Dense caption metadata" },
-  { cls: "text-label", name: "text-label", meta: "11 / 500", sample: "Form label / chip" },
-  { cls: "text-body", name: "text-body", meta: "12 / 400", sample: "Body copy and button text." },
-  { cls: "text-subtitle", name: "text-subtitle", meta: "13 / 600 · default", sample: "Row title / subtitle" },
+  { cls: "text-caption", name: "text-caption", meta: "11 / 500", sample: "Dense caption metadata" },
+  { cls: "text-label", name: "text-label", meta: "12 / 500", sample: "Form label / chip" },
+  { cls: "text-body", name: "text-body", meta: "13 / 400", sample: "Body copy and button text." },
+  { cls: "text-subtitle", name: "text-subtitle", meta: "14 / 600 · default", sample: "Row title / subtitle" },
   { cls: "text-title", name: "text-title", meta: "16 / 600", sample: "Section & page title" },
 ];
 


### PR DESCRIPTION
## What

Lift the web dashboard's dense typography scale by **1px on the four lower tiers**, keeping the two anchors (eyebrow 10px, title 16px) fixed:

| token | before | after | role |
|---|---|---|---|
| `--text-caption` | 10 | **11** | dense metadata, timestamps, chips |
| `--text-label` | 11 | **12** | form labels, badges |
| `--text-body` | 12 | **13** | secondary body, lists, buttons |
| `--text-subtitle` | 13 | **14** | row/card/dialog/page titles + **body default** + composer |

## Why

Default UI text sat at 13px (`body { font-size: var(--text-subtitle) }`) while the chat message body already renders at **14px** (`prose-sm`). The result: most list, sidebar, Team-card, and metadata text read small on desktop (10–12px), while the one comfortable surface (message body) was an outlier. This unifies the default UI text with the 14px message body and lifts the small floor, without abandoning the "control-room dense" identity.

`--text-subtitle` is the linchpin: it is both the title tier **and** the body default, so once `--text-body` moves to 13, subtitle must move to 14 to stay above it (otherwise titles collapse into body). The four tiers move together.

## Design integrity

- Clean size ladder preserved: **10 / 11 / 12 / 13 / 14 / 16**, no tier collisions; `subtitle(14) > body(13)` so the body default stays above `--text-body`.
- Removes the prior `eyebrow == caption == 10` same-size overlap.
- Line-heights are unitless ratios, so line boxes scale with the font — no fixed-height clipping.
- Mobile iOS-zoom guard still fires (13–14px < 16px); the independent `--text-mobile-*` scale is untouched.

## Scope

`packages/web/src/index.css` `@theme` (4 token values) + mobile-zoom comment. Docs kept in sync: `DESIGN.md` typography table + "Body defaults", `docs/cross-platform-visual-qa.md`, and the `/preview/styleguide` tier labels.

## Testing

- `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens` guardrail) — clean.
- `pnpm --filter @first-tree/web test` — **1336 passed**.
- Real-browser QA: injected the exact four sizes live on the running staging dashboard and captured before/after across Workspace / Context / Team / Settings. Only effect is cosmetic — glyphs ~8% wider, so single-line-truncated names (e.g. Team agent handles) truncate marginally sooner. No clipping or overflow.
- Two independent reviews (completeness + layout side-effects): both clear after the doc sync above.

Suggested reviewer glance: dense multi-column surfaces (Team roster columns, chat-list rows) for the slightly-earlier truncation.
