### PR TITLE
feat(server): chat list ordering + priority projection (attention/pinned)

### DIFF
--- a/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
+++ b/packages/server/src/__tests__/direct-chat-auto-mention.test.ts
@@ -49,12 +49,17 @@ describe("1:1 chat wake-up + unread badge (explicit-mention contract)", () => {
     organizationId: string,
   ): Promise<number> {
     const app = getApp();
-    const { rows } = await listMeChats(app.db, agentUuid, memberId, organizationId, {
+    const { priorityRows, rows } = await listMeChats(app.db, agentUuid, memberId, organizationId, {
       limit: 10,
       filter: "all",
       engagement: "all",
     });
-    return rows.find((r) => r.chatId === chatId)?.unreadMentionCount ?? 0;
+    // A `request` DM opens a request, routing the chat into the attention group
+    // rather than ordinary `rows` — search all groups for the unread counter.
+    return (
+      [...priorityRows.attention, ...priorityRows.pinned, ...rows].find((r) => r.chatId === chatId)
+        ?.unreadMentionCount ?? 0
+    );
   }
 
   async function notifyInboxRows(chatId: string, agentUuid: string) {

--- a/packages/server/src/__tests__/me-chat-helpers.test.ts
+++ b/packages/server/src/__tests__/me-chat-helpers.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 import { decodeCursor, encodeCursor, resolveChatTitle } from "../services/me-chat.js";
 
 describe("me-chat encodeCursor / decodeCursor", () => {
-  it("round-trips a timestamp + chat id", () => {
+  it("round-trips a timestamp + chat id as an `ok` cursor", () => {
     const ts = new Date("2026-05-06T10:24:00.000Z");
-    const cursor = encodeCursor(ts, "chat-123");
-    const decoded = decodeCursor(cursor);
-    expect(decoded?.activityAt?.toISOString()).toBe(ts.toISOString());
-    expect(decoded?.chatId).toBe("chat-123");
+    const decoded = decodeCursor(encodeCursor(ts, "chat-123"));
+    expect(decoded.status).toBe("ok");
+    if (decoded.status === "ok") {
+      expect(decoded.activityAt.toISOString()).toBe(ts.toISOString());
+      expect(decoded.chatId).toBe("chat-123");
+    }
   });
 
   it("emits a versioned payload (v2 prefix)", () => {
@@ -15,39 +17,42 @@ describe("me-chat encodeCursor / decodeCursor", () => {
     expect(Buffer.from(cursor, "base64url").toString("utf8")).toBe("v2|2026-05-06T10:24:00.000Z|chat-123");
   });
 
-  it("rejects an unversioned pre-PR cursor rather than reinterpreting it", () => {
-    // The old shape was `<lastMessageAt>|<chatId>` (2 parts) — indistinguishable
-    // from a raw activity cursor, so it MUST be rejected across the rollout, not
-    // resumed from a wrong boundary.
+  it("classifies a recognized unversioned pre-PR cursor as `legacy` (never reinterpreted as v2)", () => {
+    // The old shape was `<lastMessageAt>|<chatId>` (2 parts) — its timestamp meant
+    // last_message_at, so it must NOT be reinterpreted against activity ordering;
+    // `legacy` lets the caller restart from page 1 instead of resuming wrongly.
     const legacy = Buffer.from("2026-05-06T10:24:00.000Z|chat-123", "utf8").toString("base64url");
-    expect(decodeCursor(legacy)).toBeNull();
+    expect(decodeCursor(legacy).status).toBe("legacy");
   });
 
-  it("rejects a cursor with a different version", () => {
+  it("marks a different version `invalid`", () => {
     const wrongVersion = Buffer.from("v1|2026-05-06T10:24:00.000Z|chat-123", "utf8").toString("base64url");
-    expect(decodeCursor(wrongVersion)).toBeNull();
+    expect(decodeCursor(wrongVersion).status).toBe("invalid");
   });
 
-  it("rejects a v2 cursor with an empty timestamp or chat id", () => {
-    expect(decodeCursor(Buffer.from("v2||chat-no-ts", "utf8").toString("base64url"))).toBeNull();
-    expect(decodeCursor(Buffer.from("v2|2026-05-06T10:24:00.000Z|", "utf8").toString("base64url"))).toBeNull();
+  it("marks a v2 cursor with an empty timestamp or chat id `invalid`", () => {
+    expect(decodeCursor(Buffer.from("v2||chat-no-ts", "utf8").toString("base64url")).status).toBe("invalid");
+    expect(decodeCursor(Buffer.from("v2|2026-05-06T10:24:00.000Z|", "utf8").toString("base64url")).status).toBe(
+      "invalid",
+    );
   });
 
-  it("returns null for malformed cursor strings", () => {
-    expect(decodeCursor("not-a-cursor")).toBeNull();
-    expect(decodeCursor("")).toBeNull();
-    // base64-decodable but no separators
-    expect(decodeCursor(Buffer.from("nosep", "utf8").toString("base64url"))).toBeNull();
+  it("marks malformed cursor strings `invalid`", () => {
+    expect(decodeCursor("").status).toBe("invalid");
+    // one part, no separator
+    expect(decodeCursor(Buffer.from("nosep", "utf8").toString("base64url")).status).toBe("invalid");
+    // two parts but a bad timestamp (not a recognizable legacy cursor)
+    expect(decodeCursor(Buffer.from("not-a-date|chat", "utf8").toString("base64url")).status).toBe("invalid");
     // right version + shape but a bad timestamp
-    expect(decodeCursor(Buffer.from("v2|not-a-date|chat", "utf8").toString("base64url"))).toBeNull();
+    expect(decodeCursor(Buffer.from("v2|not-a-date|chat", "utf8").toString("base64url")).status).toBe("invalid");
   });
 
-  it("returns null when base64 decoding throws", () => {
+  it("marks a cursor `invalid` when base64 decoding throws", () => {
     const spy = vi.spyOn(Buffer, "from").mockImplementationOnce(() => {
       throw new Error("decode failed");
     });
     try {
-      expect(decodeCursor("bad-base64")).toBeNull();
+      expect(decodeCursor("bad-base64").status).toBe("invalid");
     } finally {
       spy.mockRestore();
     }

--- a/packages/server/src/__tests__/me-chat-helpers.test.ts
+++ b/packages/server/src/__tests__/me-chat-helpers.test.ts
@@ -2,19 +2,16 @@ import { describe, expect, it, vi } from "vitest";
 import { decodeCursor, encodeCursor, resolveChatTitle } from "../services/me-chat.js";
 
 describe("me-chat encodeCursor / decodeCursor", () => {
-  it("round-trips a non-null timestamp + chat id", () => {
+  it("round-trips a timestamp + chat id", () => {
     const ts = new Date("2026-05-06T10:24:00.000Z");
     const cursor = encodeCursor(ts, "chat-123");
     const decoded = decodeCursor(cursor);
-    expect(decoded?.lastMessageAt?.toISOString()).toBe(ts.toISOString());
+    expect(decoded?.activityAt?.toISOString()).toBe(ts.toISOString());
     expect(decoded?.chatId).toBe("chat-123");
   });
 
-  it("round-trips a null timestamp", () => {
-    const cursor = encodeCursor(null, "chat-no-msgs");
-    const decoded = decodeCursor(cursor);
-    expect(decoded?.lastMessageAt).toBeNull();
-    expect(decoded?.chatId).toBe("chat-no-msgs");
+  it("rejects a cursor with an empty timestamp part (activity_at is never null)", () => {
+    expect(decodeCursor(Buffer.from("|chat-no-ts", "utf8").toString("base64url"))).toBeNull();
   });
 
   it("returns null for malformed cursor strings", () => {

--- a/packages/server/src/__tests__/me-chat-helpers.test.ts
+++ b/packages/server/src/__tests__/me-chat-helpers.test.ts
@@ -17,12 +17,16 @@ describe("me-chat encodeCursor / decodeCursor", () => {
     expect(Buffer.from(cursor, "base64url").toString("utf8")).toBe("v2|2026-05-06T10:24:00.000Z|chat-123");
   });
 
-  it("classifies a recognized unversioned pre-PR cursor as `legacy` (never reinterpreted as v2)", () => {
-    // The old shape was `<lastMessageAt>|<chatId>` (2 parts) — its timestamp meant
-    // last_message_at, so it must NOT be reinterpreted against activity ordering;
-    // `legacy` lets the caller restart from page 1 instead of resuming wrongly.
-    const legacy = Buffer.from("2026-05-06T10:24:00.000Z|chat-123", "utf8").toString("base64url");
-    expect(decodeCursor(legacy).status).toBe("legacy");
+  it("classifies both recognized unversioned pre-PR cursor shapes as `legacy`", () => {
+    // The old encoder emitted `<lastMessageAt>|<chatId>` for a normal boundary AND
+    // `|<chatId>` (empty timestamp) for a `last_message_at IS NULL` tail boundary.
+    // Both are deployed shapes whose timestamp meant last_message_at, so neither
+    // may be reinterpreted against activity ordering; `legacy` lets the caller
+    // restart from page 1 instead of resuming wrongly (or 400ing).
+    const withTs = Buffer.from("2026-05-06T10:24:00.000Z|chat-123", "utf8").toString("base64url");
+    const emptyTs = Buffer.from("|chat-123", "utf8").toString("base64url");
+    expect(decodeCursor(withTs).status).toBe("legacy");
+    expect(decodeCursor(emptyTs).status).toBe("legacy");
   });
 
   it("marks a different version `invalid`", () => {

--- a/packages/server/src/__tests__/me-chat-helpers.test.ts
+++ b/packages/server/src/__tests__/me-chat-helpers.test.ts
@@ -10,19 +10,36 @@ describe("me-chat encodeCursor / decodeCursor", () => {
     expect(decoded?.chatId).toBe("chat-123");
   });
 
-  it("rejects a cursor with an empty timestamp part (activity_at is never null)", () => {
-    expect(decodeCursor(Buffer.from("|chat-no-ts", "utf8").toString("base64url"))).toBeNull();
+  it("emits a versioned payload (v2 prefix)", () => {
+    const cursor = encodeCursor(new Date("2026-05-06T10:24:00.000Z"), "chat-123");
+    expect(Buffer.from(cursor, "base64url").toString("utf8")).toBe("v2|2026-05-06T10:24:00.000Z|chat-123");
+  });
+
+  it("rejects an unversioned pre-PR cursor rather than reinterpreting it", () => {
+    // The old shape was `<lastMessageAt>|<chatId>` (2 parts) — indistinguishable
+    // from a raw activity cursor, so it MUST be rejected across the rollout, not
+    // resumed from a wrong boundary.
+    const legacy = Buffer.from("2026-05-06T10:24:00.000Z|chat-123", "utf8").toString("base64url");
+    expect(decodeCursor(legacy)).toBeNull();
+  });
+
+  it("rejects a cursor with a different version", () => {
+    const wrongVersion = Buffer.from("v1|2026-05-06T10:24:00.000Z|chat-123", "utf8").toString("base64url");
+    expect(decodeCursor(wrongVersion)).toBeNull();
+  });
+
+  it("rejects a v2 cursor with an empty timestamp or chat id", () => {
+    expect(decodeCursor(Buffer.from("v2||chat-no-ts", "utf8").toString("base64url"))).toBeNull();
+    expect(decodeCursor(Buffer.from("v2|2026-05-06T10:24:00.000Z|", "utf8").toString("base64url"))).toBeNull();
   });
 
   it("returns null for malformed cursor strings", () => {
     expect(decodeCursor("not-a-cursor")).toBeNull();
     expect(decodeCursor("")).toBeNull();
-    // base64-decodable but no separator
+    // base64-decodable but no separators
     expect(decodeCursor(Buffer.from("nosep", "utf8").toString("base64url"))).toBeNull();
-    // separator but empty chatId
-    expect(decodeCursor(Buffer.from("ts|", "utf8").toString("base64url"))).toBeNull();
-    // bad timestamp
-    expect(decodeCursor(Buffer.from("not-a-date|chat", "utf8").toString("base64url"))).toBeNull();
+    // right version + shape but a bad timestamp
+    expect(decodeCursor(Buffer.from("v2|not-a-date|chat", "utf8").toString("base64url"))).toBeNull();
   });
 
   it("returns null when base64 decoding throws", () => {

--- a/packages/server/src/__tests__/me-chat-pin-activity.test.ts
+++ b/packages/server/src/__tests__/me-chat-pin-activity.test.ts
@@ -35,12 +35,20 @@ describe("pinMeChat + chats.activity_at", () => {
   }
 
   async function rowFor(app: App, chatId: string, admin: Admin) {
-    const { rows } = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
-      limit: 50,
-      filter: "all",
-      engagement: "all",
-    });
-    return rows.find((r) => r.chatId === chatId) ?? null;
+    const { priorityRows, rows } = await listMeChats(
+      app.db,
+      admin.humanAgentUuid,
+      admin.memberId,
+      admin.organizationId,
+      {
+        limit: 50,
+        filter: "all",
+        engagement: "all",
+      },
+    );
+    // A chat can surface in any group now (attention > pinned > ordinary rows) —
+    // a pinned chat lives in `priorityRows.pinned`, so search all three.
+    return [...priorityRows.attention, ...priorityRows.pinned, ...rows].find((r) => r.chatId === chatId) ?? null;
   }
 
   async function activityAtOf(app: App, chatId: string): Promise<Date | null> {

--- a/packages/server/src/__tests__/me-chat-priority.test.ts
+++ b/packages/server/src/__tests__/me-chat-priority.test.ts
@@ -1,25 +1,14 @@
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { chats } from "../db/schema/chats.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { createAgent } from "../services/agent.js";
-import { resolveAgentChatStatuses } from "../services/agent-chat-status.js";
-import { createMeChat, listMeChats, pinMeChat } from "../services/me-chat.js";
+import { createMeChat, listMeChats, pinMeChat, selectAttentionCandidateRows } from "../services/me-chat.js";
 import { sendMessage } from "../services/message.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
-
-// Wrap (not replace) the canonical status resolver so a test can count how many
-// times the priority + ordinary enrichment passes invoke it — the observable
-// signal for whether a chat was admitted to the attention candidate set. Real
-// behavior is preserved; only calls are recorded.
-vi.mock("../services/agent-chat-status.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../services/agent-chat-status.js")>();
-  return { ...actual, resolveAgentChatStatuses: vi.fn(actual.resolveAgentChatStatuses) };
-});
-const resolveStatusesSpy = vi.mocked(resolveAgentChatStatuses);
 
 /**
  * Server-side priority projection (PR3): `listMeChats` splits its result into
@@ -416,16 +405,69 @@ describe("listMeChats — server priority projection (PR3)", () => {
         SET state = 'active', runtime_state = 'idle', runtime_state_at = NOW()
     `);
 
-    resolveStatusesSpy.mockClear();
     const res = await list(app, owner);
     expect(groupOf(res, chatId)).toBe("rows");
     expect(res.priorityRows.attention.some((r) => r.chatId === chatId)).toBe(false);
-    // Perf contract (candidate narrowing, not just final output): the stamped-idle
-    // chat is NOT admitted to the attention candidate set, so the priority
-    // enrichment pass has an empty union and never runs the canonical resolver.
-    // With no pins / open requests here, the resolver therefore runs exactly ONCE
-    // — for the ordinary page. The pre-narrowing candidate SQL admitted this chat,
-    // which would have invoked the resolver a second time (the priority pass).
-    expect(resolveStatusesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("the attention-candidate query admits a failed managed speaker but NOT a stamped-idle one", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const failedPeer = await managedAgent(app, owner, "cand-failed");
+    const idlePeer = await managedAgent(app, owner, "cand-idle");
+    const healthyPeer = await managedAgent(app, owner, "cand-healthy");
+
+    // failed: session `errored` → a candidate (the perf contract's positive path).
+    const failedChat = await chatWith(app, owner, failedPeer.uuid);
+    await markFailed(app, failedPeer.uuid, failedPeer.clientId, failedChat);
+
+    // stamped-idle: agent-global runtime error, but the per-chat session is active
+    // with a STAMPED idle runtime — the stamp overrides the global error, so it is
+    // canonically NOT failed. This is exactly the row the pre-narrowing SQL wrongly
+    // admitted (and re-enriched on every poll).
+    const idleChat = await chatWith(app, owner, idlePeer.uuid);
+    await app.db
+      .insert(agentPresence)
+      .values({
+        agentId: idlePeer.uuid,
+        clientId: idlePeer.clientId,
+        lastSeenAt: new Date(),
+        runtimeState: "error",
+        activeSessions: 1,
+        totalSessions: 1,
+      })
+      .onConflictDoUpdate({
+        target: [agentPresence.agentId],
+        set: { clientId: idlePeer.clientId, runtimeState: "error" },
+      });
+    await app.db.execute(sql`
+      INSERT INTO agent_chat_sessions (agent_id, chat_id, state, runtime_state, runtime_state_at, updated_at)
+      VALUES (${idlePeer.uuid}, ${idleChat}, 'active', 'idle', NOW(), NOW())
+      ON CONFLICT (agent_id, chat_id) DO UPDATE
+        SET state = 'active', runtime_state = 'idle', runtime_state_at = NOW()
+    `);
+
+    // healthy: reachable, no error anywhere → NOT a candidate.
+    const healthyChat = await chatWith(app, owner, healthyPeer.uuid);
+
+    // Observe the candidate boundary DIRECTLY (no mocking): this query is what
+    // decides which chats pay the expensive canonical enrichment on every poll.
+    const candidateIds = (
+      await selectAttentionCandidateRows(app.db, {
+        humanAgentId: owner.humanAgentUuid,
+        organizationId: owner.organizationId,
+        callerMemberId: owner.memberId,
+        filters: sql`TRUE`,
+        orderBy: sql`c.id`,
+      })
+    ).map((r) => r.chat_id);
+
+    // Positive control — the mechanism genuinely admits candidates, so the
+    // exclusions below can't pass vacuously on an always-empty result.
+    expect(candidateIds).toContain(failedChat);
+    // The narrowing under test: a stamped-idle (and a healthy) managed speaker
+    // are NOT admitted, so they never reach canonical enrichment.
+    expect(candidateIds).not.toContain(idleChat);
+    expect(candidateIds).not.toContain(healthyChat);
   });
 });

--- a/packages/server/src/__tests__/me-chat-priority.test.ts
+++ b/packages/server/src/__tests__/me-chat-priority.test.ts
@@ -1,22 +1,34 @@
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { chats } from "../db/schema/chats.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { createAgent } from "../services/agent.js";
+import { resolveAgentChatStatuses } from "../services/agent-chat-status.js";
 import { createMeChat, listMeChats, pinMeChat } from "../services/me-chat.js";
 import { sendMessage } from "../services/message.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
+
+// Wrap (not replace) the canonical status resolver so a test can count how many
+// times the priority + ordinary enrichment passes invoke it — the observable
+// signal for whether a chat was admitted to the attention candidate set. Real
+// behavior is preserved; only calls are recorded.
+vi.mock("../services/agent-chat-status.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/agent-chat-status.js")>();
+  return { ...actual, resolveAgentChatStatuses: vi.fn(actual.resolveAgentChatStatuses) };
+});
+const resolveStatusesSpy = vi.mocked(resolveAgentChatStatuses);
 
 /**
  * Server-side priority projection (PR3): `listMeChats` splits its result into
  * `priorityRows.attention` (a caller-managed speaker in `failed`, OR an open
  * request to the caller) → `priorityRows.pinned` (the caller's pins) → ordinary
  * `rows`, computed across the FULL matching set so a priority chat surfaces on
- * page 1 even when its `activity_at` would page it far down. Every chat appears
- * in exactly one group. Plus a page-independent `counts.unread` aggregate.
+ * page 1 even when its `activity_at` would page it far down. `attention` and
+ * `pinned` are disjoint; `rows` is additive (priority chats repeat there and the
+ * client de-duplicates), and the priority groups are first-page only.
  */
 describe("listMeChats — server priority projection (PR3)", () => {
   const getApp = useTestApp();
@@ -404,8 +416,16 @@ describe("listMeChats — server priority projection (PR3)", () => {
         SET state = 'active', runtime_state = 'idle', runtime_state_at = NOW()
     `);
 
+    resolveStatusesSpy.mockClear();
     const res = await list(app, owner);
     expect(groupOf(res, chatId)).toBe("rows");
     expect(res.priorityRows.attention.some((r) => r.chatId === chatId)).toBe(false);
+    // Perf contract (candidate narrowing, not just final output): the stamped-idle
+    // chat is NOT admitted to the attention candidate set, so the priority
+    // enrichment pass has an empty union and never runs the canonical resolver.
+    // With no pins / open requests here, the resolver therefore runs exactly ONCE
+    // — for the ordinary page. The pre-narrowing candidate SQL admitted this chat,
+    // which would have invoked the resolver a second time (the priority pass).
+    expect(resolveStatusesSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/server/src/__tests__/me-chat-priority.test.ts
+++ b/packages/server/src/__tests__/me-chat-priority.test.ts
@@ -1,0 +1,294 @@
+import { eq, sql } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it } from "vitest";
+import { agentPresence } from "../db/schema/agent-presence.js";
+import { chats } from "../db/schema/chats.js";
+import { clients } from "../db/schema/clients.js";
+import { members } from "../db/schema/members.js";
+import { createAgent } from "../services/agent.js";
+import { createMeChat, listMeChats, markMeChatRead, pinMeChat } from "../services/me-chat.js";
+import { sendMessage } from "../services/message.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+/**
+ * Server-side priority projection (PR3): `listMeChats` splits its result into
+ * `priorityRows.attention` (a caller-managed speaker in `failed`, OR an open
+ * request to the caller) → `priorityRows.pinned` (the caller's pins) → ordinary
+ * `rows`, computed across the FULL matching set so a priority chat surfaces on
+ * page 1 even when its `activity_at` would page it far down. Every chat appears
+ * in exactly one group. Plus a page-independent `counts.unread` aggregate.
+ */
+describe("listMeChats — server priority projection (PR3)", () => {
+  const getApp = useTestApp();
+
+  type Admin = Awaited<ReturnType<typeof createTestAdmin>>;
+  type ListResult = Awaited<ReturnType<typeof listMeChats>>;
+
+  async function ownerUserId(app: FastifyInstance, owner: Admin): Promise<string> {
+    const [m] = await app.db.select().from(members).where(eq(members.id, owner.memberId)).limit(1);
+    if (!m) throw new Error("owner member missing");
+    return m.userId;
+  }
+
+  /** A non-human agent the caller manages, pinned to a fresh connected client. */
+  async function managedAgent(
+    app: FastifyInstance,
+    owner: Admin,
+    name: string,
+  ): Promise<{ uuid: string; clientId: string }> {
+    const clientId = `cli-${crypto.randomUUID().slice(0, 8)}`;
+    await app.db.insert(clients).values({
+      id: clientId,
+      userId: await ownerUserId(app, owner),
+      organizationId: owner.organizationId,
+      status: "connected",
+    });
+    const agent = await createAgent(app.db, {
+      name,
+      type: "agent",
+      displayName: name,
+      managerId: owner.memberId,
+      organizationId: owner.organizationId,
+      clientId,
+    });
+    if (!agent) throw new Error("managed agent setup failed");
+    return { uuid: agent.uuid, clientId };
+  }
+
+  async function chatWith(app: FastifyInstance, owner: Admin, agentUuid: string, topic?: string): Promise<string> {
+    const { chatId } = await createMeChat(app.db, owner.humanAgentUuid, owner.organizationId, {
+      participantIds: [agentUuid],
+      topic: topic ?? null,
+    });
+    return chatId;
+  }
+
+  /** Set a chat's `activity_at` directly so ordering across pages is deterministic. */
+  async function setActivity(app: FastifyInstance, chatId: string, iso: string): Promise<void> {
+    await app.db
+      .update(chats)
+      .set({ activityAt: new Date(iso) })
+      .where(eq(chats.id, chatId));
+  }
+
+  /** Agent → human `request` message: bumps the human's open_request_count + unread mention. */
+  async function raiseRequest(app: FastifyInstance, chatId: string, fromAgent: string, toHuman: string): Promise<void> {
+    await sendMessage(app.db, chatId, fromAgent, {
+      source: "api",
+      format: "request",
+      content: "Please look",
+      metadata: { mentions: [toHuman] },
+    });
+  }
+
+  /** Make a caller-managed speaker read `failed`: reachable (client presence) + session `errored`. */
+  async function markFailed(app: FastifyInstance, agentUuid: string, clientId: string, chatId: string): Promise<void> {
+    await app.db
+      .insert(agentPresence)
+      .values({ agentId: agentUuid, clientId, lastSeenAt: new Date(), activeSessions: 0, totalSessions: 0 })
+      .onConflictDoUpdate({ target: [agentPresence.agentId], set: { clientId, lastSeenAt: new Date() } });
+    await app.db.execute(sql`
+      INSERT INTO agent_chat_sessions (agent_id, chat_id, state, runtime_state, updated_at)
+      VALUES (${agentUuid}, ${chatId}, 'errored', 'idle', NOW())
+      ON CONFLICT (agent_id, chat_id) DO UPDATE SET state = 'errored', updated_at = NOW()
+    `);
+  }
+
+  function list(
+    app: FastifyInstance,
+    owner: Admin,
+    query: Partial<Parameters<typeof listMeChats>[4]> = {},
+  ): Promise<ListResult> {
+    return listMeChats(app.db, owner.humanAgentUuid, owner.memberId, owner.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "all",
+      ...query,
+    });
+  }
+
+  function groupOf(res: ListResult, chatId: string): "attention" | "pinned" | "rows" | null {
+    if (res.priorityRows.attention.some((r) => r.chatId === chatId)) return "attention";
+    if (res.priorityRows.pinned.some((r) => r.chatId === chatId)) return "pinned";
+    if (res.rows.some((r) => r.chatId === chatId)) return "rows";
+    return null;
+  }
+
+  it("pinned chats surface in priorityRows.pinned (pinned_at DESC) and drop out of ordinary rows", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "pin-peer");
+
+    const first = await chatWith(app, owner, peer.uuid, "first");
+    const second = await chatWith(app, owner, peer.uuid, "second");
+    await pinMeChat(app.db, first, owner.humanAgentUuid, true);
+    // Later pin → sorts ahead (pinned_at DESC).
+    await pinMeChat(app.db, second, owner.humanAgentUuid, true);
+
+    const res = await list(app, owner);
+    expect(res.priorityRows.pinned.map((r) => r.chatId)).toEqual([second, first]);
+    // Not duplicated in ordinary rows.
+    expect(res.rows.some((r) => r.chatId === first || r.chatId === second)).toBe(false);
+  });
+
+  it("pinned extraction is global — a low-activity pinned chat appears on page 1 despite paging", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "global-peer");
+
+    // Four fresh ordinary chats + one OLD pinned chat that would page far down.
+    const ordinary: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      const c = await chatWith(app, owner, peer.uuid, `ordinary-${i}`);
+      await setActivity(app, c, `2026-06-0${i + 1}T00:00:00.000Z`);
+      ordinary.push(c);
+    }
+    const oldPinned = await chatWith(app, owner, peer.uuid, "old-pinned");
+    await setActivity(app, oldPinned, "2020-01-01T00:00:00.000Z");
+    await pinMeChat(app.db, oldPinned, owner.humanAgentUuid, true);
+
+    const page1 = await list(app, owner, { limit: 2 });
+    // The old pinned chat is on page 1's priority group even though its activity
+    // would put it dead last in the ordinary stream.
+    expect(page1.priorityRows.pinned.map((r) => r.chatId)).toEqual([oldPinned]);
+    expect(page1.rows.some((r) => r.chatId === oldPinned)).toBe(false);
+    // Ordinary page still returns the freshest 2 ordinary chats.
+    expect(page1.rows.map((r) => r.chatId)).toEqual([ordinary[3], ordinary[2]]);
+    expect(page1.nextCursor).not.toBeNull();
+  });
+
+  it("an open request routes the chat into priorityRows.attention, not ordinary rows", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "req-peer");
+
+    const chatId = await chatWith(app, owner, peer.uuid);
+    await raiseRequest(app, chatId, peer.uuid, owner.humanAgentUuid);
+
+    const res = await list(app, owner);
+    expect(groupOf(res, chatId)).toBe("attention");
+    const row = res.priorityRows.attention.find((r) => r.chatId === chatId);
+    expect(row?.openRequestCount).toBe(1);
+  });
+
+  it("a failed caller-managed speaker routes the chat into priorityRows.attention", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "failed-peer");
+
+    const chatId = await chatWith(app, owner, peer.uuid);
+    await markFailed(app, peer.uuid, peer.clientId, chatId);
+
+    const res = await list(app, owner);
+    expect(groupOf(res, chatId)).toBe("attention");
+    expect(res.priorityRows.attention.find((r) => r.chatId === chatId)?.failedAgentIds).toContain(peer.uuid);
+  });
+
+  it("a healthy managed speaker (no request, no failure) stays in ordinary rows", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "healthy-peer");
+
+    // Chat has a caller-managed non-human speaker — so it enters the attention
+    // CANDIDATE set — but the speaker is neither failed nor has an open request,
+    // so it must NOT be promoted to attention.
+    const chatId = await chatWith(app, owner, peer.uuid);
+
+    const res = await list(app, owner);
+    expect(groupOf(res, chatId)).toBe("rows");
+  });
+
+  it("attention orders failed before request", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const failPeer = await managedAgent(app, owner, "fail-peer");
+    const reqPeer = await managedAgent(app, owner, "req-peer");
+
+    // Request chat is fresher than the failed chat — proving failed still sorts
+    // first (tier beats activity), then activity within a tier.
+    const failedChat = await chatWith(app, owner, failPeer.uuid);
+    await markFailed(app, failPeer.uuid, failPeer.clientId, failedChat);
+    await setActivity(app, failedChat, "2026-01-01T00:00:00.000Z");
+
+    const requestChat = await chatWith(app, owner, reqPeer.uuid);
+    await raiseRequest(app, requestChat, reqPeer.uuid, owner.humanAgentUuid);
+    await setActivity(app, requestChat, "2026-12-01T00:00:00.000Z");
+
+    const res = await list(app, owner);
+    expect(res.priorityRows.attention.map((r) => r.chatId)).toEqual([failedChat, requestChat]);
+  });
+
+  it("attention outranks pinned — a pinned chat with an open request appears only in attention", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "both-peer");
+
+    const chatId = await chatWith(app, owner, peer.uuid);
+    await pinMeChat(app.db, chatId, owner.humanAgentUuid, true);
+    await raiseRequest(app, chatId, peer.uuid, owner.humanAgentUuid);
+
+    const res = await list(app, owner);
+    expect(groupOf(res, chatId)).toBe("attention");
+    expect(res.priorityRows.pinned.some((r) => r.chatId === chatId)).toBe(false);
+  });
+
+  it("every chat appears exactly once across attention / pinned / rows", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "once-peer");
+
+    const attn = await chatWith(app, owner, peer.uuid);
+    await raiseRequest(app, attn, peer.uuid, owner.humanAgentUuid);
+    const pinnedChat = await chatWith(app, owner, peer.uuid);
+    await pinMeChat(app.db, pinnedChat, owner.humanAgentUuid, true);
+    const ordinary = await chatWith(app, owner, peer.uuid);
+
+    const res = await list(app, owner);
+    const all = [...res.priorityRows.attention, ...res.priorityRows.pinned, ...res.rows].map((r) => r.chatId);
+    // No chat id appears twice.
+    expect(new Set(all).size).toBe(all.length);
+    expect(groupOf(res, attn)).toBe("attention");
+    expect(groupOf(res, pinnedChat)).toBe("pinned");
+    expect(groupOf(res, ordinary)).toBe("rows");
+  });
+
+  it("counts.unread aggregates the caller's unread chats independent of the page", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "unread-peer");
+
+    const a = await chatWith(app, owner, peer.uuid);
+    const b = await chatWith(app, owner, peer.uuid);
+    await raiseRequest(app, a, peer.uuid, owner.humanAgentUuid);
+    await raiseRequest(app, b, peer.uuid, owner.humanAgentUuid);
+
+    const before = await list(app, owner, { limit: 1 });
+    expect(before.counts.unread).toBe(2);
+
+    // Reading one clears its unread; the aggregate follows, still page-independent.
+    await markMeChatRead(app.db, a, owner.humanAgentUuid);
+    const after = await list(app, owner, { limit: 1 });
+    expect(after.counts.unread).toBe(1);
+  });
+
+  it("the active filter narrows the priority groups too (origin filter drops a mismatched pinned chat)", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "origin-peer");
+
+    const manualChat = await chatWith(app, owner, peer.uuid, "manual");
+    const githubChat = await chatWith(app, owner, peer.uuid, "github");
+    await app.db
+      .update(chats)
+      .set({ metadata: { source: "github", entityType: "github_pull_request" } })
+      .where(eq(chats.id, githubChat));
+    await pinMeChat(app.db, manualChat, owner.humanAgentUuid, true);
+    await pinMeChat(app.db, githubChat, owner.humanAgentUuid, true);
+
+    const manualOnly = await list(app, owner, { origin: ["manual"] });
+    expect(manualOnly.priorityRows.pinned.map((r) => r.chatId)).toEqual([manualChat]);
+
+    const githubOnly = await list(app, owner, { origin: ["github"] });
+    expect(githubOnly.priorityRows.pinned.map((r) => r.chatId)).toEqual([githubChat]);
+  });
+});

--- a/packages/server/src/__tests__/me-chat-priority.test.ts
+++ b/packages/server/src/__tests__/me-chat-priority.test.ts
@@ -114,7 +114,7 @@ describe("listMeChats — server priority projection (PR3)", () => {
     return null;
   }
 
-  it("pinned chats surface in priorityRows.pinned (pinned_at DESC) and drop out of ordinary rows", async () => {
+  it("pinned chats surface in priorityRows.pinned (pinned_at DESC); rows stays additive", async () => {
     const app = getApp();
     const owner = await createTestAdmin(app);
     const peer = await managedAgent(app, owner, "pin-peer");
@@ -127,8 +127,11 @@ describe("listMeChats — server priority projection (PR3)", () => {
 
     const res = await list(app, owner);
     expect(res.priorityRows.pinned.map((r) => r.chatId)).toEqual([second, first]);
-    // Not duplicated in ordinary rows.
-    expect(res.rows.some((r) => r.chatId === first || r.chatId === second)).toBe(false);
+    // ADDITIVE contract: pinned chats ALSO appear in `rows` (the complete recency
+    // stream) so a client that ignores priorityRows never loses them; the
+    // priority-aware client de-duplicates them against priorityRows on render.
+    expect(res.rows.some((r) => r.chatId === first)).toBe(true);
+    expect(res.rows.some((r) => r.chatId === second)).toBe(true);
   });
 
   it("pinned extraction is global — a low-activity pinned chat appears on page 1 despite paging", async () => {
@@ -149,15 +152,17 @@ describe("listMeChats — server priority projection (PR3)", () => {
 
     const page1 = await list(app, owner, { limit: 2 });
     // The old pinned chat is on page 1's priority group even though its activity
-    // would put it dead last in the ordinary stream.
+    // would put it dead last in the recency stream.
     expect(page1.priorityRows.pinned.map((r) => r.chatId)).toEqual([oldPinned]);
-    expect(page1.rows.some((r) => r.chatId === oldPinned)).toBe(false);
-    // Ordinary page still returns the freshest 2 ordinary chats.
+    // Ordinary page 1 returns the freshest 2 chats; `oldPinned` is absent here
+    // only because its activity pages it far down (additive rows, not exclusion) —
+    // it reappears in a later page and the client de-dupes it against the group.
     expect(page1.rows.map((r) => r.chatId)).toEqual([ordinary[3], ordinary[2]]);
+    expect(page1.rows.some((r) => r.chatId === oldPinned)).toBe(false);
     expect(page1.nextCursor).not.toBeNull();
   });
 
-  it("an open request routes the chat into priorityRows.attention, not ordinary rows", async () => {
+  it("an open request routes the chat into priorityRows.attention (render group), additively in rows", async () => {
     const app = getApp();
     const owner = await createTestAdmin(app);
     const peer = await managedAgent(app, owner, "req-peer");
@@ -166,9 +171,12 @@ describe("listMeChats — server priority projection (PR3)", () => {
     await raiseRequest(app, chatId, peer.uuid, owner.humanAgentUuid);
 
     const res = await list(app, owner);
+    // groupOf uses render precedence (attention > pinned > rows).
     expect(groupOf(res, chatId)).toBe("attention");
     const row = res.priorityRows.attention.find((r) => r.chatId === chatId);
     expect(row?.openRequestCount).toBe(1);
+    // ADDITIVE: also present in the recency stream (client de-dupes on render).
+    expect(res.rows.some((r) => r.chatId === chatId)).toBe(true);
   });
 
   it("a failed caller-managed speaker routes the chat into priorityRows.attention", async () => {
@@ -232,7 +240,7 @@ describe("listMeChats — server priority projection (PR3)", () => {
     expect(res.priorityRows.pinned.some((r) => r.chatId === chatId)).toBe(false);
   });
 
-  it("every chat appears exactly once across attention / pinned / rows", async () => {
+  it("renders each chat in exactly one group: attention and pinned are disjoint, precedence picks the group", async () => {
     const app = getApp();
     const owner = await createTestAdmin(app);
     const peer = await managedAgent(app, owner, "once-peer");
@@ -244,15 +252,18 @@ describe("listMeChats — server priority projection (PR3)", () => {
     const ordinary = await chatWith(app, owner, peer.uuid);
 
     const res = await list(app, owner);
-    const all = [...res.priorityRows.attention, ...res.priorityRows.pinned, ...res.rows].map((r) => r.chatId);
-    // No chat id appears twice.
-    expect(new Set(all).size).toBe(all.length);
+    // The two PRIORITY groups are disjoint (a chat is in at most one of them) —
+    // that is the server's "once" guarantee. `rows` is additive on top, and the
+    // client renders each chat once via the same precedence `groupOf` encodes.
+    const attnIds = new Set(res.priorityRows.attention.map((r) => r.chatId));
+    const pinnedIds = new Set(res.priorityRows.pinned.map((r) => r.chatId));
+    expect([...attnIds].some((id) => pinnedIds.has(id))).toBe(false);
     expect(groupOf(res, attn)).toBe("attention");
     expect(groupOf(res, pinnedChat)).toBe("pinned");
     expect(groupOf(res, ordinary)).toBe("rows");
   });
 
-  it("counts.unread aggregates the caller's unread chats independent of the page", async () => {
+  it("priority groups + counts.unread are computed on the first page and gated off on load-more", async () => {
     const app = getApp();
     const owner = await createTestAdmin(app);
     const peer = await managedAgent(app, owner, "unread-peer");
@@ -262,13 +273,23 @@ describe("listMeChats — server priority projection (PR3)", () => {
     await raiseRequest(app, a, peer.uuid, owner.humanAgentUuid);
     await raiseRequest(app, b, peer.uuid, owner.humanAgentUuid);
 
-    const before = await list(app, owner, { limit: 1 });
-    expect(before.counts.unread).toBe(2);
+    // First page (cursor === null): priority groups + the global unread aggregate.
+    const page1 = await list(app, owner, { limit: 1 });
+    expect(page1.counts.unread).toBe(2);
+    expect(page1.priorityRows.attention.length).toBe(2);
+    expect(page1.nextCursor).not.toBeNull();
 
-    // Reading one clears its unread; the aggregate follows, still page-independent.
+    // Load-more page (cursor set): priority + counts are gated OFF — the client
+    // reads them from page 1 only — so the whole-set work runs once per open.
+    const page2 = await list(app, owner, { cursor: page1.nextCursor ?? undefined, limit: 1 });
+    expect(page2.priorityRows.attention).toEqual([]);
+    expect(page2.priorityRows.pinned).toEqual([]);
+    expect(page2.counts.unread).toBe(0);
+
+    // Reading one clears its unread; the first-page aggregate follows.
     await markMeChatRead(app.db, a, owner.humanAgentUuid);
-    const after = await list(app, owner, { limit: 1 });
-    expect(after.counts.unread).toBe(1);
+    const afterRead = await list(app, owner, { limit: 1 });
+    expect(afterRead.counts.unread).toBe(1);
   });
 
   it("the active filter narrows the priority groups too (origin filter drops a mismatched pinned chat)", async () => {
@@ -290,5 +311,53 @@ describe("listMeChats — server priority projection (PR3)", () => {
 
     const githubOnly = await list(app, owner, { origin: ["github"] });
     expect(githubOnly.priorityRows.pinned.map((r) => r.chatId)).toEqual([githubChat]);
+  });
+
+  it("keyset pagination walks the complete activity-ordered recency stream (no gaps or dups)", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "page-peer");
+
+    // Five chats with strictly descending activity (c-4 newest … c-0 oldest).
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const c = await chatWith(app, owner, peer.uuid, `c-${i}`);
+      await setActivity(app, c, `2026-05-0${i + 1}T00:00:00.000Z`);
+      ids.push(c);
+    }
+    const expectedNewestFirst = [...ids].reverse();
+
+    // Walk pages of 2 via nextCursor, collecting the ordinary stream.
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    for (let guard = 0; guard < 10; guard++) {
+      const page = await list(app, owner, { limit: 2, cursor });
+      seen.push(...page.rows.map((r) => r.chatId));
+      if (!page.nextCursor) break;
+      cursor = page.nextCursor;
+    }
+    // Complete + ordered across every page boundary — the cursor never skips or
+    // repeats a row (the `(activity_at, id)` keyset is a total order).
+    expect(seen).toEqual(expectedNewestFirst);
+  });
+
+  it("a peer's failed speaker (not caller-managed) never pins the chat — it stays in rows", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    // A second member in the same org whose managed agent will fail.
+    const peerAdmin = await createTestAdmin(app);
+    const peerAgent = await managedAgent(app, peerAdmin, "peer-failed");
+
+    const chatId = await chatWith(app, owner, peerAgent.uuid);
+    await markFailed(app, peerAgent.uuid, peerAgent.clientId, chatId);
+
+    const res = await list(app, owner);
+    // The failed speaker belongs to a PEER (manager != caller), so the
+    // manager-scoped candidate filter + the `isMine` failed narrowing keep it out
+    // of the caller's attention — someone else's broken agent is not my problem.
+    expect(groupOf(res, chatId)).toBe("rows");
+    expect(res.priorityRows.attention.some((r) => r.chatId === chatId)).toBe(false);
+    // And the row the caller does see carries no failed marker for the peer agent.
+    expect(res.rows.find((r) => r.chatId === chatId)?.failedAgentIds).toEqual([]);
   });
 });

--- a/packages/server/src/__tests__/me-chat-priority.test.ts
+++ b/packages/server/src/__tests__/me-chat-priority.test.ts
@@ -6,7 +6,7 @@ import { chats } from "../db/schema/chats.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
 import { createAgent } from "../services/agent.js";
-import { createMeChat, listMeChats, markMeChatRead, pinMeChat } from "../services/me-chat.js";
+import { createMeChat, listMeChats, pinMeChat } from "../services/me-chat.js";
 import { sendMessage } from "../services/message.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
@@ -263,33 +263,43 @@ describe("listMeChats — server priority projection (PR3)", () => {
     expect(groupOf(res, ordinary)).toBe("rows");
   });
 
-  it("priority groups + counts.unread are computed on the first page and gated off on load-more", async () => {
+  it("priority groups are computed on the first page and gated off on load-more", async () => {
     const app = getApp();
     const owner = await createTestAdmin(app);
-    const peer = await managedAgent(app, owner, "unread-peer");
+    const peer = await managedAgent(app, owner, "gate-peer");
 
     const a = await chatWith(app, owner, peer.uuid);
     const b = await chatWith(app, owner, peer.uuid);
     await raiseRequest(app, a, peer.uuid, owner.humanAgentUuid);
     await raiseRequest(app, b, peer.uuid, owner.humanAgentUuid);
 
-    // First page (cursor === null): priority groups + the global unread aggregate.
+    // First page (no cursor): the whole-set priority groups.
     const page1 = await list(app, owner, { limit: 1 });
-    expect(page1.counts.unread).toBe(2);
     expect(page1.priorityRows.attention.length).toBe(2);
     expect(page1.nextCursor).not.toBeNull();
 
-    // Load-more page (cursor set): priority + counts are gated OFF — the client
+    // Load-more page (cursor set): priority groups are gated OFF — the client
     // reads them from page 1 only — so the whole-set work runs once per open.
     const page2 = await list(app, owner, { cursor: page1.nextCursor ?? undefined, limit: 1 });
     expect(page2.priorityRows.attention).toEqual([]);
     expect(page2.priorityRows.pinned).toEqual([]);
-    expect(page2.counts.unread).toBe(0);
+  });
 
-    // Reading one clears its unread; the first-page aggregate follows.
-    await markMeChatRead(app.db, a, owner.humanAgentUuid);
-    const afterRead = await list(app, owner, { limit: 1 });
-    expect(afterRead.counts.unread).toBe(1);
+  it("an undecodable / legacy cursor restarts from the first page instead of erroring", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "cursor-peer");
+    const pinnedChat = await chatWith(app, owner, peer.uuid);
+    await pinMeChat(app.db, pinnedChat, owner.humanAgentUuid, true);
+
+    // A pre-PR (unversioned) cursor shape: base64url of `<iso>|<chatId>`, which
+    // the v2 decoder no longer accepts. It must recover as a first-page request,
+    // not throw or strand the caller.
+    const legacyCursor = Buffer.from("2026-05-06T10:24:00.000Z|some-old-chat", "utf8").toString("base64url");
+    const res = await list(app, owner, { cursor: legacyCursor });
+    // Treated as page 1: the priority groups are populated (they would be gated
+    // off on a genuine load-more page), and the call did not error.
+    expect(res.priorityRows.pinned.some((r) => r.chatId === pinnedChat)).toBe(true);
   });
 
   it("the active filter narrows the priority groups too (origin filter drops a mismatched pinned chat)", async () => {

--- a/packages/server/src/__tests__/me-chat-priority.test.ts
+++ b/packages/server/src/__tests__/me-chat-priority.test.ts
@@ -370,4 +370,42 @@ describe("listMeChats — server priority projection (PR3)", () => {
     // And the row the caller does see carries no failed marker for the peer agent.
     expect(res.rows.find((r) => r.chatId === chatId)?.failedAgentIds).toEqual([]);
   });
+
+  it("a managed agent with a global error but a stamped per-chat idle session stays in rows", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "stamped-idle");
+    const chatId = await chatWith(app, owner, peer.uuid);
+
+    // Agent-global presence error (reachable), BUT the per-chat session is active
+    // with a STAMPED per-chat runtime of `idle`. Once a per-chat stamp exists, the
+    // per-chat runtime is authoritative and the global error is ignored — so the
+    // agent is canonically NOT failed here. The narrowed candidate filter must
+    // gate the presence fallback on the missing stamp, so this chat is neither a
+    // candidate nor attention.
+    await app.db
+      .insert(agentPresence)
+      .values({
+        agentId: peer.uuid,
+        clientId: peer.clientId,
+        lastSeenAt: new Date(),
+        runtimeState: "error",
+        activeSessions: 1,
+        totalSessions: 1,
+      })
+      .onConflictDoUpdate({
+        target: [agentPresence.agentId],
+        set: { clientId: peer.clientId, runtimeState: "error" },
+      });
+    await app.db.execute(sql`
+      INSERT INTO agent_chat_sessions (agent_id, chat_id, state, runtime_state, runtime_state_at, updated_at)
+      VALUES (${peer.uuid}, ${chatId}, 'active', 'idle', NOW(), NOW())
+      ON CONFLICT (agent_id, chat_id) DO UPDATE
+        SET state = 'active', runtime_state = 'idle', runtime_state_at = NOW()
+    `);
+
+    const res = await list(app, owner);
+    expect(groupOf(res, chatId)).toBe("rows");
+    expect(res.priorityRows.attention.some((r) => r.chatId === chatId)).toBe(false);
+  });
 });

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -884,18 +884,21 @@ describe("chat-first workspace service layer", () => {
     expect(page2.rows[0]?.chatId).toBe(c1.chatId);
   });
 
-  it("listMeChats rejects an invalid cursor", async () => {
+  it("listMeChats recovers an undecodable cursor as a first-page request", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
 
-    await expect(
-      listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
-        limit: 50,
-        filter: "all",
-        engagement: "all",
-        cursor: "not-a-valid-cursor",
-      }),
-    ).rejects.toThrow(/invalid cursor/i);
+    // No longer a 400: an undecodable (or pre-PR unversioned) cursor is treated
+    // as "start from the first page" so an already-open client recovers
+    // gracefully across the rollout instead of looping its load-more Retry.
+    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "all",
+      cursor: "not-a-valid-cursor",
+    });
+    expect(res.priorityRows).toEqual({ attention: [], pinned: [] });
+    expect(Array.isArray(res.rows)).toBe(true);
   });
 
   it("listMeChats nested-chat filter: parent_chat_id IS NOT NULL is excluded", async () => {

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -888,10 +888,11 @@ describe("chat-first workspace service layer", () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
 
-    // A recognized pre-PR legacy cursor (`<iso>|<chatId>`, 2 parts) restarts from
-    // page 1 so an already-open client recovers across the rollout instead of
-    // looping its load-more Retry.
-    const legacy = Buffer.from("2026-05-06T10:24:00.000Z|old-chat", "utf8").toString("base64url");
+    // A recognized pre-PR legacy cursor restarts from page 1 so an already-open
+    // client recovers across the rollout instead of looping its load-more Retry.
+    // Use the deployed null-tail shape `|<chatId>` (empty timestamp) the old
+    // encoder emitted for a `last_message_at IS NULL` boundary.
+    const legacy = Buffer.from("|old-chat", "utf8").toString("base64url");
     const recovered = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -884,21 +884,34 @@ describe("chat-first workspace service layer", () => {
     expect(page2.rows[0]?.chatId).toBe(c1.chatId);
   });
 
-  it("listMeChats recovers an undecodable cursor as a first-page request", async () => {
+  it("listMeChats recovers a legacy cursor as a first-page request but 400s an invalid one", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
 
-    // No longer a 400: an undecodable (or pre-PR unversioned) cursor is treated
-    // as "start from the first page" so an already-open client recovers
-    // gracefully across the rollout instead of looping its load-more Retry.
-    const res = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+    // A recognized pre-PR legacy cursor (`<iso>|<chatId>`, 2 parts) restarts from
+    // page 1 so an already-open client recovers across the rollout instead of
+    // looping its load-more Retry.
+    const legacy = Buffer.from("2026-05-06T10:24:00.000Z|old-chat", "utf8").toString("base64url");
+    const recovered = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "all",
-      cursor: "not-a-valid-cursor",
+      cursor: legacy,
     });
-    expect(res.priorityRows).toEqual({ attention: [], pinned: [] });
-    expect(Array.isArray(res.rows)).toBe(true);
+    expect(recovered.priorityRows).toEqual({ attention: [], pinned: [] });
+    expect(Array.isArray(recovered.rows)).toBe(true);
+
+    // A genuinely invalid cursor (here: an unsupported version) still surfaces as
+    // a typed 400 so a real client/API bug is not masked as a first-page request.
+    const invalid = Buffer.from("v9|2026-05-06T10:24:00.000Z|chat", "utf8").toString("base64url");
+    await expect(
+      listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
+        limit: 50,
+        filter: "all",
+        engagement: "all",
+        cursor: invalid,
+      }),
+    ).rejects.toThrow(/invalid cursor/i);
   });
 
   it("listMeChats nested-chat filter: parent_chat_id IS NOT NULL is excluded", async () => {

--- a/packages/server/src/__tests__/me-chat-service.test.ts
+++ b/packages/server/src/__tests__/me-chat-service.test.ts
@@ -181,12 +181,17 @@ describe("chat-first workspace service layer", () => {
       metadata: { mentions: [owner.humanAgentUuid] },
     });
 
+    // The `request` message opens a request to the human, so the chat surfaces
+    // in the attention group, not the ordinary `rows` — search all groups.
+    const findChat = (res: Awaited<ReturnType<typeof listMeChats>>) =>
+      [...res.priorityRows.attention, ...res.priorityRows.pinned, ...res.rows].find((r) => r.chatId === chatId);
+
     const before = await listMeChats(app.db, owner.humanAgentUuid, owner.memberId, owner.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "all",
     });
-    expect(before.rows.find((r) => r.chatId === chatId)).toMatchObject({
+    expect(findChat(before)).toMatchObject({
       unreadMentionCount: 1,
       chatHasExplicitMentionToMe: true,
     });
@@ -197,7 +202,7 @@ describe("chat-first workspace service layer", () => {
       filter: "all",
       engagement: "all",
     });
-    expect(after.rows.find((r) => r.chatId === chatId)).toMatchObject({
+    expect(findChat(after)).toMatchObject({
       unreadMentionCount: 0,
       chatHasExplicitMentionToMe: false,
     });

--- a/packages/server/src/__tests__/me-chats-http-e2e.test.ts
+++ b/packages/server/src/__tests__/me-chats-http-e2e.test.ts
@@ -1,7 +1,7 @@
 import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { createAgent } from "../services/agent.js";
-import { createMeChat } from "../services/me-chat.js";
+import { createMeChat, pinMeChat } from "../services/me-chat.js";
 import { sendMessage } from "../services/message.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
@@ -414,5 +414,51 @@ describe("cross-user isolation — the original #366 / #367 bug scenario", () =>
       .json<{ rows: Array<Record<string, unknown>> }>()
       .rows.find((r) => r.chatId === bobChat.chatId);
     expect(bobRow?.liveActivity, "Bob's row: no live activity").toBeNull();
+  });
+
+  it("wire response carries priorityRows + counts (Fastify serializes the new fields)", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const agent = await createAgent(app.db, {
+      name: `prio-${crypto.randomUUID().slice(0, 6)}`,
+      type: "agent",
+      displayName: "Prio Agent",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+    });
+
+    const pinned = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [agent.uuid],
+    });
+    await pinMeChat(app.db, pinned.chatId, admin.humanAgentUuid, true);
+
+    const request = await createMeChat(app.db, admin.humanAgentUuid, admin.organizationId, {
+      participantIds: [agent.uuid],
+    });
+    await sendMessage(app.db, request.chatId, agent.uuid, {
+      source: "api",
+      format: "request",
+      content: "please look",
+      metadata: { mentions: [admin.humanAgentUuid] },
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${encodeURIComponent(admin.organizationId)}/chats`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      priorityRows: { attention: Array<{ chatId: string }>; pinned: Array<{ chatId: string }> };
+      rows: Array<{ chatId: string }>;
+      counts: { unread: number };
+    }>();
+
+    // The route has no Fastify response schema, so the new fields must survive
+    // the default serializer end-to-end (the failure mode that would strip them).
+    expect(body.priorityRows.attention.some((r) => r.chatId === request.chatId)).toBe(true);
+    expect(body.priorityRows.pinned.some((r) => r.chatId === pinned.chatId)).toBe(true);
+    expect(typeof body.counts.unread).toBe("number");
+    expect(body.counts.unread).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/server/src/__tests__/me-chats-http-e2e.test.ts
+++ b/packages/server/src/__tests__/me-chats-http-e2e.test.ts
@@ -416,7 +416,7 @@ describe("cross-user isolation — the original #366 / #367 bug scenario", () =>
     expect(bobRow?.liveActivity, "Bob's row: no live activity").toBeNull();
   });
 
-  it("wire response carries priorityRows + counts (Fastify serializes the new fields)", async () => {
+  it("wire response carries priorityRows (Fastify serializes the new field)", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const agent = await createAgent(app.db, {
@@ -451,14 +451,11 @@ describe("cross-user isolation — the original #366 / #367 bug scenario", () =>
     const body = res.json<{
       priorityRows: { attention: Array<{ chatId: string }>; pinned: Array<{ chatId: string }> };
       rows: Array<{ chatId: string }>;
-      counts: { unread: number };
     }>();
 
-    // The route has no Fastify response schema, so the new fields must survive
-    // the default serializer end-to-end (the failure mode that would strip them).
+    // The route has no Fastify response schema, so priorityRows must survive the
+    // default serializer end-to-end (the failure mode that would strip it).
     expect(body.priorityRows.attention.some((r) => r.chatId === request.chatId)).toBe(true);
     expect(body.priorityRows.pinned.some((r) => r.chatId === pinned.chatId)).toBe(true);
-    expect(typeof body.counts.unread).toBe("number");
-    expect(body.counts.unread).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/server/src/__tests__/open-question.test.ts
+++ b/packages/server/src/__tests__/open-question.test.ts
@@ -817,12 +817,17 @@ describe("open_request_count surfaces in the listMeChats projection (needs_you r
       metadata: { mentions: [admin.humanAgentUuid], request: { question: "ship today?" } },
     });
 
+    // An open request routes the chat into the attention group (not ordinary
+    // `rows`), so search every group for it.
+    const findChat = (res: Awaited<ReturnType<typeof listMeChats>>) =>
+      [...res.priorityRows.attention, ...res.priorityRows.pinned, ...res.rows].find((r) => r.chatId === chat.id);
+
     const listAfterRaise = await listMeChats(app.db, admin.humanAgentUuid, admin.memberId, admin.organizationId, {
       limit: 50,
       filter: "all",
       engagement: "all",
     });
-    expect(listAfterRaise.rows.find((r) => r.chatId === chat.id)?.openRequestCount).toBe(1);
+    expect(findChat(listAfterRaise)?.openRequestCount).toBe(1);
 
     // Human answers explicitly (metadata.resolves) → counter clears.
     await sendMessage(
@@ -844,6 +849,6 @@ describe("open_request_count surfaces in the listMeChats projection (needs_you r
       filter: "all",
       engagement: "all",
     });
-    expect(listAfterAnswer.rows.find((r) => r.chatId === chat.id)?.openRequestCount).toBe(0);
+    expect(findChat(listAfterAnswer)?.openRequestCount).toBe(0);
   });
 });

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -581,27 +581,33 @@ async function enrichMeChatRows(
  * GET /me/chats — cursor-paginated conversation list with server-side priority
  * projection.
  *
- * The response is three groups, computed so every chat appears in AT MOST ONE
- * of them (attention > pinned > ordinary `rows`):
+ * The response carries two whole-set priority groups plus the ordinary page:
  *   1. `priorityRows.attention` — extracted across the *full* matching set (not
  *      just the loaded page): a caller-managed non-human speaker in `failed`,
  *      OR an open request to the caller. Ordered failed-first then activity DESC.
  *   2. `priorityRows.pinned` — the caller's pinned chats (private per-user
  *      state), `pinned_at` DESC, minus anything already in attention.
- *   3. `rows` — the ordinary activity-ordered page, EXCLUDING every priority
- *      chat id, keyset-paginated on `activity_at`.
+ *   3. `rows` — the ordinary activity-ordered keyset page on `activity_at`.
  * Plus `counts.unread`, a page-independent global aggregate.
  *
  * `failed` is a composite status derived by `resolveAgentChatStatuses`, not a
- * column, so attention is built via a bounded CANDIDATE set (open request OR a
+ * column, so attention is built via a CANDIDATE set (open request OR a
  * caller-managed non-human speaker present) that the enrichment pass resolves
  * canonically — never a SQL re-implementation of the status folding.
  *
- * NOTE (v1 cost): the priority groups + `counts.unread` are recomputed on every
- * page; the web reads them from the first page only. The sets are bounded
- * (pins / open requests / managed agents), but `resolveAgentChatStatuses` runs
- * on the candidate set each call — a fair follow-up is to gate the priority
- * work on `cursor === null` once the client contract is settled.
+ * ADDITIVE contract (deliberate, for safe rollout): `rows` is NOT filtered
+ * against the priority ids. A pinned / attention chat appears in `rows` too, and
+ * the client de-duplicates it against `priorityRows` when it renders the groups
+ * (each chat shown once: attention > pinned > recency). This keeps the response
+ * backward-compatible with the already-shipped web that reads only `rows` — a
+ * server deploy ahead of the priority-aware client never makes a chat vanish.
+ *
+ * FIRST-PAGE gating: the two priority groups + `counts.unread` are computed only
+ * when `cursor === null` and returned empty/zero on `load-more` pages (the
+ * client reads them from the first page). This bounds cost — `resolveAgentChatStatuses`
+ * over the candidate set runs once per list open, not per scroll page — and is
+ * exactly what the additive `rows` above makes safe (later pages need no priority
+ * ids to exclude).
  */
 export async function listMeChats(
   db: Database,
@@ -647,87 +653,97 @@ export async function listMeChats(
 
   const activityOrder = sql`c.activity_at DESC, c.id DESC`;
 
-  // --- Global attention candidates ---------------------------------------
-  // Bounded set the enrichment pass resolves into the attention group: any chat
-  // with an open request OR a caller-managed non-human speaker present. The
-  // `EXISTS` is speaker + non-human + manager-scoped so a chat only becomes a
-  // candidate for MY broken agent, never a peer's.
-  const managedSpeakerExists = sql`EXISTS (
-    SELECT 1 FROM chat_membership cm_s
-      JOIN agents a_s ON a_s.uuid = cm_s.agent_id
-     WHERE cm_s.chat_id = c.id
-       AND cm_s.access_mode = 'speaker'
-       AND a_s.type <> 'human'
-       AND a_s.manager_id = ${callerMemberId})`;
-  const attnCandidateRaw = await selectMeChatRawRows(db, {
-    humanAgentId,
-    organizationId,
-    filters,
-    extra: sql`(COALESCE(cus.open_request_count, 0) > 0 OR ${managedSpeakerExists})`,
-    orderBy: activityOrder,
-    limit: null,
-  });
-
-  // --- Global pinned ------------------------------------------------------
-  const pinnedRaw = await selectMeChatRawRows(db, {
-    humanAgentId,
-    organizationId,
-    filters,
-    extra: sql`cus.pinned_at IS NOT NULL`,
-    orderBy: sql`cus.pinned_at DESC, c.id DESC`,
-    limit: null,
-  });
-
-  // Enrich the priority union once (candidates ∪ pinned; disjoint from the
-  // ordinary page, which excludes them). `failedByChat` splits attention below.
-  const priorityRawUnion = dedupeRawByChatId([...attnCandidateRaw, ...pinnedRaw]);
-  const { rows: priorityRowsFlat, failedByChat } = await enrichMeChatRows(db, priorityRawUnion, {
-    humanAgentId,
-    managedAgentIds,
-  });
-  const priorityRowById = new Map(priorityRowsFlat.map((r) => [r.chatId, r]));
-
-  // Attention = candidates that actually qualify (failed OR open request),
-  // ordered failed-first then by activity. Each candidate slice is already
-  // activity DESC from the query and `filter` preserves order.
-  const attnQualified = attnCandidateRaw.filter((r) => failedByChat.has(r.chat_id) || r.open_request_count > 0);
-  const attention = [
-    ...attnQualified.filter((r) => failedByChat.has(r.chat_id)),
-    ...attnQualified.filter((r) => !failedByChat.has(r.chat_id)),
-  ]
-    .map((r) => priorityRowById.get(r.chat_id))
-    .filter((r): r is MeChatRow => r !== undefined);
-  const attentionIds = new Set(attention.map((r) => r.chatId));
-
-  // Pinned excludes anything already surfaced in attention (attention wins),
-  // preserving the `pinned_at` DESC order.
-  const pinned = pinnedRaw
-    .filter((r) => !attentionIds.has(r.chat_id))
-    .map((r) => priorityRowById.get(r.chat_id))
-    .filter((r): r is MeChatRow => r !== undefined);
-
-  // --- Ordinary page ------------------------------------------------------
-  // Excludes every priority chat id so a chat appears exactly once. The
-  // exclusion holds on ALL pages (priority chats can have any activity_at), so
-  // a pinned/attention chat never re-surfaces in a later ordinary page.
-  const priorityIds = new Set<string>([...attentionIds, ...pinned.map((r) => r.chatId)]);
+  // Keyset cursor predicate (sort: activity_at DESC, id DESC). `chats.activity_at`
+  // is NOT NULL, so this is a plain keyset with no null-timestamp branch.
   const cursorTsIso = cursor ? cursor.activityAt.toISOString() : null;
   const cursorPredicate = !cursor
     ? sql`TRUE`
     : sql`(c.activity_at < ${cursorTsIso}::timestamptz
            OR (c.activity_at = ${cursorTsIso}::timestamptz AND c.id < ${cursor.chatId}))`;
-  const exclusionPredicate =
-    priorityIds.size === 0
-      ? sql`TRUE`
-      : sql`c.id NOT IN (${sql.join(
-          [...priorityIds].map((id) => sql`${id}`),
-          sql.raw(", "),
-        )})`;
+
+  // --- Priority groups + unread aggregate: FIRST PAGE ONLY -----------------
+  // These are whole-set projections the client reads once (from the first page).
+  // Computing them only when `cursor === null` keeps `load-more` cheap AND is
+  // what lets `rows` stay ADDITIVE: because later pages never exclude priority
+  // ids, the ordinary stream remains the complete recency list, so the change is
+  // backward-compatible with a client that ignores `priorityRows`. See docblock.
+  let attention: MeChatRow[] = [];
+  let pinned: MeChatRow[] = [];
+  let unread = 0;
+  if (cursor === null) {
+    // Attention candidates: any chat with an open request OR a caller-managed
+    // non-human speaker present. The `EXISTS` is speaker + non-human +
+    // manager-scoped, so a chat is only a candidate for MY broken agent, never a
+    // peer's. `failed` itself is a composite status from resolveAgentChatStatuses
+    // (never re-implemented in SQL) — the enrichment pass below resolves it.
+    const managedSpeakerExists = sql`EXISTS (
+      SELECT 1 FROM chat_membership cm_s
+        JOIN agents a_s ON a_s.uuid = cm_s.agent_id
+       WHERE cm_s.chat_id = c.id
+         AND cm_s.access_mode = 'speaker'
+         AND a_s.type <> 'human'
+         AND a_s.manager_id = ${callerMemberId})`;
+    const attnCandidateRaw = await selectMeChatRawRows(db, {
+      humanAgentId,
+      organizationId,
+      filters,
+      extra: sql`(COALESCE(cus.open_request_count, 0) > 0 OR ${managedSpeakerExists})`,
+      orderBy: activityOrder,
+      limit: null,
+    });
+    const pinnedRaw = await selectMeChatRawRows(db, {
+      humanAgentId,
+      organizationId,
+      filters,
+      extra: sql`cus.pinned_at IS NOT NULL`,
+      orderBy: sql`cus.pinned_at DESC, c.id DESC`,
+      limit: null,
+    });
+
+    // Enrich the priority union once; `failedByChat` splits attention below.
+    const priorityRawUnion = dedupeRawByChatId([...attnCandidateRaw, ...pinnedRaw]);
+    const { rows: priorityRowsFlat, failedByChat } = await enrichMeChatRows(db, priorityRawUnion, {
+      humanAgentId,
+      managedAgentIds,
+    });
+    const priorityRowById = new Map(priorityRowsFlat.map((r) => [r.chatId, r]));
+
+    // Attention = candidates that qualify (failed OR open request), failed-first
+    // then activity DESC. Each candidate slice is already activity DESC from the
+    // query and `filter` preserves order.
+    const attnQualified = attnCandidateRaw.filter((r) => failedByChat.has(r.chat_id) || r.open_request_count > 0);
+    attention = [
+      ...attnQualified.filter((r) => failedByChat.has(r.chat_id)),
+      ...attnQualified.filter((r) => !failedByChat.has(r.chat_id)),
+    ]
+      .map((r) => priorityRowById.get(r.chat_id))
+      .filter((r): r is MeChatRow => r !== undefined);
+    const attentionIds = new Set(attention.map((r) => r.chatId));
+
+    // Pinned excludes anything already surfaced in attention (attention wins),
+    // preserving the `pinned_at` DESC order.
+    pinned = pinnedRaw
+      .filter((r) => !attentionIds.has(r.chat_id))
+      .map((r) => priorityRowById.get(r.chat_id))
+      .filter((r): r is MeChatRow => r !== undefined);
+
+    // Page-independent global aggregate ("you have N unread"), org-scoped and
+    // not narrowed by the transient filter (matches the existing totalUnread
+    // pill). Returned on the first page only; the client reads it from there.
+    unread = await countUnreadMeChats(db, humanAgentId, organizationId);
+  }
+
+  // --- Ordinary page (EVERY page) -----------------------------------------
+  // ADDITIVE: no priority-id exclusion. `rows` is the complete activity-ordered
+  // recency stream; a priority chat also appears here and the client
+  // de-duplicates it against `priorityRows` when it renders the groups. This
+  // keeps the response backward-compatible with the already-shipped web that
+  // reads only `rows` (a pinned / open-request / failed chat never vanishes).
   const ordinaryRaw = await selectMeChatRawRows(db, {
     humanAgentId,
     organizationId,
     filters,
-    extra: sql`${cursorPredicate} AND ${exclusionPredicate}`,
+    extra: cursorPredicate,
     orderBy: activityOrder,
     limit: limit + 1,
   });
@@ -738,10 +754,6 @@ export async function listMeChats(
   const lastActivity = last ? toChatDate(last.activity_at) : null;
   const nextCursor = hasMore && last && lastActivity ? encodeCursor(lastActivity, last.chat_id) : null;
   const { rows } = await enrichMeChatRows(db, pageRaw, { humanAgentId, managedAgentIds });
-
-  // Page-independent global aggregate ("you have N unread"), not narrowed by
-  // the transient filter — matches the existing totalUnread pill semantics.
-  const unread = await countUnreadMeChats(db, humanAgentId, organizationId);
 
   return {
     priorityRows: { attention, pinned },

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -56,24 +56,36 @@ import { ensureCanJoin, joinAsParticipant, leaveAsParticipant, resolveChatMember
 // Cursor encoding
 // ---------------------------------------------------------------------------
 //
-// Cursor is `<activityAtIso>|<chatId>`. Encoded base64url so it survives
-// query strings without escaping. Sort ordering is
-// `(activity_at DESC, chat_id DESC)`. `chats.activity_at` is NOT NULL, so —
-// unlike the pre-PR `last_message_at` cursor — there is no null-timestamp case.
+// Cursor is `v2|<activityAtIso>|<chatId>`, base64url so it survives query
+// strings. Sort ordering is `(activity_at DESC, chat_id DESC)`; `activity_at`
+// is NOT NULL, so there is no null-timestamp case.
+//
+// The `v2` version prefix is load-bearing: the PRE-PR cursor was
+// `<lastMessageAt>|<chatId>` — an INDISTINGUISHABLE shape whose timestamp meant
+// `last_message_at`, not `activity_at`. Without the version, a browser holding
+// an old `nextCursor` across the server rollout would pass validation and
+// resume from a wrong boundary (silently skipping / repeating chats whenever
+// the two timestamps differ). Versioning makes an old cursor fail to decode so
+// it is rejected (400 → the client restarts from page 1) rather than
+// misinterpreted.
+
+const CURSOR_VERSION = "v2";
 
 export function encodeCursor(activityAt: Date, chatId: string): string {
-  const payload = `${activityAt.toISOString()}|${chatId}`;
+  const payload = `${CURSOR_VERSION}|${activityAt.toISOString()}|${chatId}`;
   return Buffer.from(payload, "utf8").toString("base64url");
 }
 
 export function decodeCursor(cursor: string): { activityAt: Date; chatId: string } | null {
   try {
     const decoded = Buffer.from(cursor, "base64url").toString("utf8");
-    const sep = decoded.indexOf("|");
-    if (sep < 0) return null;
-    const tsPart = decoded.slice(0, sep);
-    const chatId = decoded.slice(sep + 1);
-    if (!chatId || tsPart.length === 0) return null;
+    // Exactly `<version>|<iso>|<chatId>` (chat ids are UUIDs — never contain
+    // `|`). An old unversioned cursor (`<iso>|<chatId>`) is 2 parts, so it — and
+    // anything else malformed — is rejected rather than reinterpreted.
+    const parts = decoded.split("|");
+    if (parts.length !== 3) return null;
+    const [version, tsPart, chatId] = parts;
+    if (version !== CURSOR_VERSION || !tsPart || !chatId) return null;
     const activityAt = new Date(tsPart);
     if (Number.isNaN(activityAt.getTime())) return null;
     return { activityAt, chatId };

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -337,7 +337,7 @@ const toChatDate = (v: Date | string | null): Date | null => {
  * global attention candidates) shares so the three row sets are byte-identical
  * in shape.
  */
-type RawMeChatRow = {
+export type RawMeChatRow = {
   chat_id: string;
   type: string;
   topic: string | null;
@@ -449,6 +449,55 @@ async function selectMeChatRawRows(
      ORDER BY ${orderBy}
      ${limitClause}
   `)) as unknown as RawMeChatRow[];
+}
+
+/**
+ * Run the attention-candidate query: chats matching the caller's view `filters`
+ * that COULD canonically be `failed` or have an open request. A chat qualifies
+ * if it has an open request OR a caller-managed non-human speaker whose stored
+ * error inputs mirror `computeErrored`'s branches exactly (minus the freshness /
+ * reachability the canonical resolver still applies) — a strict SUPERSET of
+ * failed (no false negatives) that still excludes the common HEALTHY managed
+ * speaker that would otherwise make nearly every active chat a candidate on the
+ * 30s poll:
+ *   - session `errored` (C-axis lifecycle) always contributes;
+ *   - an active session with a per-chat runtime stamp: only the per-chat
+ *     `runtime_state = 'error'` is authoritative (D-axis);
+ *   - an active session with NO per-chat stamp (old client): fall back to the
+ *     agent-global `presence.runtime_state = 'error'`.
+ * Gating the presence fallback on `runtime_state_at IS NULL` keeps one
+ * agent-global error from admitting that agent's stamped-idle chats. `failed` is
+ * never decided here; the enrichment pass confirms it canonically.
+ *
+ * Exported so a test can observe the candidate boundary directly (no mocking).
+ */
+export async function selectAttentionCandidateRows(
+  db: Database,
+  params: { humanAgentId: string; organizationId: string; callerMemberId: string; filters: SQL; orderBy: SQL },
+): Promise<RawMeChatRow[]> {
+  const { humanAgentId, organizationId, callerMemberId, filters, orderBy } = params;
+  const managedFailureCandidate = sql`EXISTS (
+    SELECT 1 FROM chat_membership cm_s
+      JOIN agents a_s ON a_s.uuid = cm_s.agent_id
+      JOIN agent_chat_sessions acs ON acs.agent_id = a_s.uuid AND acs.chat_id = c.id
+      LEFT JOIN agent_presence ap ON ap.agent_id = a_s.uuid
+     WHERE cm_s.chat_id = c.id
+       AND cm_s.access_mode = 'speaker'
+       AND a_s.type <> 'human'
+       AND a_s.manager_id = ${callerMemberId}
+       AND (
+         acs.state = 'errored'
+         OR (acs.state = 'active' AND acs.runtime_state_at IS NOT NULL AND acs.runtime_state = 'error')
+         OR (acs.state = 'active' AND acs.runtime_state_at IS NULL AND ap.runtime_state = 'error')
+       ))`;
+  return selectMeChatRawRows(db, {
+    humanAgentId,
+    organizationId,
+    filters,
+    extra: sql`(COALESCE(cus.open_request_count, 0) > 0 OR ${managedFailureCandidate})`,
+    orderBy,
+    limit: null,
+  });
 }
 
 /**
@@ -712,42 +761,14 @@ export async function listMeChats(
   let attention: MeChatRow[] = [];
   let pinned: MeChatRow[] = [];
   if (cursor === null) {
-    // Attention candidates — a bounded pre-canonical set the enrichment pass
-    // resolves. A chat qualifies if it has an open request OR a caller-managed
-    // non-human speaker whose stored error inputs mirror `computeErrored`'s
-    // branches exactly (minus the freshness / reachability the canonical resolver
-    // still applies), so this is a strict SUPERSET of failed — no false negatives
-    // — while excluding the common HEALTHY managed speaker that would otherwise
-    // make nearly every active chat a candidate on the 30s poll:
-    //   - session `errored` (C-axis lifecycle) always contributes;
-    //   - an active session with a per-chat runtime stamp: only the per-chat
-    //     `runtime_state = 'error'` is authoritative (D-axis);
-    //   - an active session with NO per-chat stamp (old client): fall back to the
-    //     agent-global `presence.runtime_state = 'error'`.
-    // Gating the presence fallback on `runtime_state_at IS NULL` is what keeps
-    // one agent-global error from admitting that agent's stamped-idle chats.
-    // `failed` is still never decided in SQL; the enrichment pass confirms it.
-    const managedFailureCandidate = sql`EXISTS (
-      SELECT 1 FROM chat_membership cm_s
-        JOIN agents a_s ON a_s.uuid = cm_s.agent_id
-        JOIN agent_chat_sessions acs ON acs.agent_id = a_s.uuid AND acs.chat_id = c.id
-        LEFT JOIN agent_presence ap ON ap.agent_id = a_s.uuid
-       WHERE cm_s.chat_id = c.id
-         AND cm_s.access_mode = 'speaker'
-         AND a_s.type <> 'human'
-         AND a_s.manager_id = ${callerMemberId}
-         AND (
-           acs.state = 'errored'
-           OR (acs.state = 'active' AND acs.runtime_state_at IS NOT NULL AND acs.runtime_state = 'error')
-           OR (acs.state = 'active' AND acs.runtime_state_at IS NULL AND ap.runtime_state = 'error')
-         ))`;
-    const attnCandidateRaw = await selectMeChatRawRows(db, {
+    // Attention candidates — the bounded pre-canonical set the enrichment pass
+    // resolves (see `selectAttentionCandidateRows` for the superset rationale).
+    const attnCandidateRaw = await selectAttentionCandidateRows(db, {
       humanAgentId,
       organizationId,
+      callerMemberId,
       filters,
-      extra: sql`(COALESCE(cus.open_request_count, 0) > 0 OR ${managedFailureCandidate})`,
       orderBy: activityOrder,
-      limit: null,
     });
     const pinnedRaw = await selectMeChatRawRows(db, {
       humanAgentId,

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -294,69 +294,91 @@ function participantsFilterSql(agentIds: ReadonlyArray<string>): SQL {
 // List
 // ---------------------------------------------------------------------------
 
+const toChatDate = (v: Date | string | null): Date | null => {
+  if (v === null) return null;
+  return v instanceof Date ? v : new Date(v);
+};
+
 /**
- * GET /me/chats — cursor-paginated conversation list.
+ * Raw row shape returned by `selectMeChatRawRows` — the single-stream
+ * projection every `listMeChats` sub-query (ordinary page, global pinned,
+ * global attention candidates) shares so the three row sets are byte-identical
+ * in shape.
+ */
+type RawMeChatRow = {
+  chat_id: string;
+  type: string;
+  topic: string | null;
+  description: string | null;
+  parent_chat_id: string | null;
+  last_message_at: Date | string | null;
+  last_message_preview: string | null;
+  activity_at: Date | string | null;
+  access_mode: "speaker" | "watcher";
+  membership_role: string;
+  unread_mention_count: number;
+  open_request_count: number;
+  engagement_status: ChatEngagementStatus;
+  pinned_at: Date | string | null;
+  source: ChatSource;
+  entity_type: string | null;
+  chat_has_explicit_mention_to_me: boolean;
+};
+
+/** First-wins de-dup by `chat_id` (a chat can be both pinned and an attention candidate). */
+function dedupeRawByChatId(rows: RawMeChatRow[]): RawMeChatRow[] {
+  const seen = new Set<string>();
+  const out: RawMeChatRow[] = [];
+  for (const r of rows) {
+    if (seen.has(r.chat_id)) continue;
+    seen.add(r.chat_id);
+    out.push(r);
+  }
+  return out;
+}
+
+/**
+ * The single-stream projection behind every `listMeChats` sub-query. Keeping
+ * ONE SELECT guarantees the ordinary / pinned / attention row sets are
+ * shape-identical — same columns, same source / entity / explicit-mention
+ * derivation — so a chat looks the same wherever it surfaces.
  *
  * SQL strategy:
- *   - Single-stream query: `chats JOIN chat_membership LEFT JOIN
- *     chat_user_state`. The membership row carries access_mode
- *     (speaker → "participant" / watcher → "watching"); the user
- *     state row supplies the unread counter (COALESCE → 0 when
- *     row is missing).
- *   - Filter `parent_chat_id IS NULL` defensively. First Tree has no sub-chat
- *     product layer (see first-tree-context PR #281); the column is
- *     decision-inert scaffolding, so any historical non-null row stays
- *     hidden from the conversation list.
- *   - Filter `c.organization_id = ?` to defend against historical
- *     cross-org pollution rows that may still reference the caller
- *     (see fix/cross-org-direct-chat-pollution).
- *   - Sort `(last_message_at DESC NULLS LAST, chat_id DESC)`.
- *   - Cursor narrows the result to rows STRICTLY before the cursor.
- *   - Followed by a participants-list lookup for the page only.
+ *   - `chats JOIN chat_membership LEFT JOIN chat_user_state`. Membership
+ *     carries access_mode (speaker → participant / watcher → watching); user
+ *     state supplies the unread + pin + engagement columns (COALESCE defaults
+ *     when the lazy row is missing).
+ *   - `parent_chat_id IS NULL` — First Tree has no sub-chat product layer
+ *     (first-tree-context PR #281); any historical non-null row stays hidden.
+ *   - `c.organization_id = ?` — defend against historical cross-org membership
+ *     pollution (fix/cross-org-direct-chat-pollution) that would otherwise leak
+ *     into the list and 404 on click via `requireChatAccess`.
+ *   - `chat_has_explicit_mention_to_me` scans the caller's unread window for a
+ *     message whose `metadata.mentions` contains the caller's uuid,
+ *     distinguishing an explicit `@me` from the v1 1-on-1 implicit DM
+ *     auto-mention (services/message.ts `dmAutoProjection`).
+ *
+ * `filters` carries the view-scoped predicates (unread / watching / engagement
+ * / origin / participants), computed once and reused verbatim so every group
+ * honours the active filter identically. `extra` is the per-sub-query predicate
+ * (pinned / attention-candidate / cursor + priority-exclusion). `limit === null`
+ * runs unbounded — the priority groups are naturally bounded by the user's pins
+ * / open requests / managed agents.
  */
-export async function listMeChats(
+async function selectMeChatRawRows(
   db: Database,
-  humanAgentId: string,
-  callerMemberId: string,
-  organizationId: string,
-  query: ListMeChatsQuery,
-): Promise<ListMeChatsResponse> {
-  const limit = query.limit;
-  const cursor = query.cursor ? decodeCursor(query.cursor) : null;
-  if (query.cursor && !cursor) {
-    throw new BadRequestError("Invalid cursor");
-  }
-
-  const filterUnreadOnly = query.filter === "unread";
-  const filterWatchingOnly = query.watching === true;
-  const engagementPredicate = ENGAGEMENT_VIEW_PREDICATE[query.engagement];
-  const originPredicate = query.origin ? originsFilterSql(query.origin) : sql`TRUE`;
-  const participantsPredicate = query.with ? participantsFilterSql(query.with) : sql`TRUE`;
-
-  // Cursor predicate (sort: activity_at DESC, chat_id DESC). `chats.activity_at`
-  // is NOT NULL, so this is a plain keyset with no null-timestamp branches.
-  // postgres-js can't serialize a JS Date through a raw sql template without
-  // column metadata; pre-stringify to ISO so the param goes through as text and
-  // the `::timestamptz` cast handles the rest.
-  const cursorTsIso = cursor ? cursor.activityAt.toISOString() : null;
-  const cursorPredicate = !cursor
-    ? sql`TRUE`
-    : sql`(c.activity_at < ${cursorTsIso}::timestamptz
-           OR (c.activity_at = ${cursorTsIso}::timestamptz AND c.id < ${cursor.chatId}))`;
-
-  // postgres-js returns timestamptz as ISO strings when bound through
-  // a raw sql template; coerce below so the response uses ISO
-  // strings consistently.
-  //
-  // The `chat_has_explicit_mention_to_me` correlated subquery scans the
-  // caller's unread window (`m.created_at > last_read_at`) for any message
-  // whose `metadata.mentions` JSONB array contains the caller's
-  // human-agent uuid. Distinguishes explicit `@<me>` from the v1 1-on-1
-  // implicit DM auto-mention (services/message.ts:282 `dmAutoProjection`),
-  // which bumps `unread_mention_count` for the red dot but never writes
-  // the recipient into `metadata.mentions`. Uses the existing
-  // `idx_messages_chat_time` for the chat+window scan.
-  const rawRows = (await db.execute(sql`
+  params: {
+    humanAgentId: string;
+    organizationId: string;
+    filters: SQL;
+    extra: SQL;
+    orderBy: SQL;
+    limit: number | null;
+  },
+): Promise<RawMeChatRow[]> {
+  const { humanAgentId, organizationId, filters, extra, orderBy, limit } = params;
+  const limitClause = limit === null ? sql`` : sql`LIMIT ${limit}`;
+  return (await db.execute(sql`
     SELECT
       c.id                  AS chat_id,
       c.type                AS type,
@@ -389,58 +411,36 @@ export async function listMeChats(
       LEFT JOIN chat_user_state cus
         ON cus.chat_id = c.id AND cus.agent_id = ${humanAgentId}
      WHERE c.parent_chat_id IS NULL
-       /* Scope to the caller's org. Without this, cross-org dirty
-          chats whose chat_membership still references the caller's
-          human agent (historical pollution — see
-          fix/cross-org-direct-chat-pollution) would leak into the
-          list and 404 on click via requireChatAccess. */
        AND c.organization_id = ${organizationId}
-       AND (${!filterUnreadOnly}::bool OR COALESCE(cus.unread_mention_count, 0) > 0)
-       AND (${!filterWatchingOnly}::bool OR cm.access_mode = 'watcher')
-       AND ${engagementPredicate}
-       AND ${originPredicate}
-       AND ${participantsPredicate}
-       AND ${cursorPredicate}
-     ORDER BY c.activity_at DESC, c.id DESC
-     LIMIT ${limit + 1}
-  `)) as unknown as Array<{
-    chat_id: string;
-    type: string;
-    topic: string | null;
-    description: string | null;
-    parent_chat_id: string | null;
-    last_message_at: Date | string | null;
-    last_message_preview: string | null;
-    activity_at: Date | string | null;
-    access_mode: "speaker" | "watcher";
-    membership_role: string;
-    unread_mention_count: number;
-    open_request_count: number;
-    engagement_status: ChatEngagementStatus;
-    pinned_at: Date | string | null;
-    source: ChatSource;
-    entity_type: string | null;
-    chat_has_explicit_mention_to_me: boolean;
-  }>;
+       AND ${filters}
+       AND ${extra}
+     ORDER BY ${orderBy}
+     ${limitClause}
+  `)) as unknown as RawMeChatRow[];
+}
 
-  const toDate = (v: Date | string | null): Date | null => {
-    if (v === null) return null;
-    return v instanceof Date ? v : new Date(v);
-  };
+/**
+ * Hydrate raw rows into `MeChatRow`s: participant chips, the live-dot / failed
+ * / busy status projections (shared with `GET /chats/:id/agent-status`), and
+ * the first-message title fallback. Returns `failedByChat` so the caller can
+ * build the "Needs attention" group without re-deriving composite status in
+ * SQL. `managedAgentIds` is the caller-scoped "mine" set (computed once and
+ * shared across the priority + ordinary passes) that narrows `failed` to the
+ * caller's own agents. `withTurnText: false` — the chat-list never renders turn
+ * narration.
+ */
+async function enrichMeChatRows(
+  db: Database,
+  rawRows: RawMeChatRow[],
+  params: { humanAgentId: string; managedAgentIds: ReadonlySet<string> },
+): Promise<{ rows: MeChatRow[]; failedByChat: Map<string, string[]> }> {
+  const { humanAgentId, managedAgentIds } = params;
+  if (rawRows.length === 0) return { rows: [], failedByChat: new Map() };
 
-  const hasMore = rawRows.length > limit;
-  const pageRaw = hasMore ? rawRows.slice(0, limit) : rawRows;
-  const last = pageRaw[pageRaw.length - 1];
-  const lastActivity = last ? toDate(last.activity_at) : null;
-  const nextCursor = hasMore && last && lastActivity ? encodeCursor(lastActivity, last.chat_id) : null;
+  const chatIds = rawRows.map((r) => r.chat_id);
 
-  if (pageRaw.length === 0) return { rows: [], nextCursor: null };
-
-  const chatIds = pageRaw.map((r) => r.chat_id);
-
-  // Lookup participants (speakers only — watchers do not appear in the
-  // conversation row's participant chip list). Drives the participant chips
-  // AND the per-chat non-human speaker set the status projections filter on.
+  // Speakers only — watchers do not appear in the row's participant chips. Also
+  // drives the per-chat non-human speaker set the status projections filter on.
   const participantRows = await db
     .select({
       chatId: chatMembership.chatId,
@@ -458,8 +458,6 @@ export async function listMeChats(
     .where(and(inArray(chatMembership.chatId, chatIds), eq(chatMembership.accessMode, "speaker")));
 
   const participantsByChat = new Map<string, MeChatRow["participants"]>();
-  // Per-chat non-human speaker set — the filter for the failed / live-dot
-  // projections below (pending is intentionally NOT speaker-filtered).
   const nonHumanSpeakersByChat = new Map<string, Set<string>>();
   for (const p of participantRows) {
     const list = participantsByChat.get(p.chatId) ?? [];
@@ -486,38 +484,9 @@ export async function listMeChats(
     }
   }
 
-  // One producer for every per-(agent,chat) status signal this list needs
-  // (live-dot / failed), shared with `GET /chats/:id/agent-status`.
-  // `withTurnText: false` — the chat-list never renders the turn narration
-  // (only the compose status bar does). Each signal is projected below.
+  // One producer for every per-(agent,chat) status signal (live-dot / failed /
+  // busy), shared with `GET /chats/:id/agent-status`.
   const statusByChat = await resolveAgentChatStatuses(db, chatIds, { withTurnText: false });
-
-  // Manager-scope: non-human agent UUIDs the caller manages
-  // (`agents.manager_id = caller.member_id`). Drives the "mine" narrowing on
-  // the `failedAgentIds` projection below — so a watcher (or peer speaker) is
-  // no longer pinned into "Needs attention" by someone else's broken agent.
-  //
-  // The `ne(type, 'human')` guard excludes the caller's own human agent (which
-  // is self-managed, `manager_id = caller.member_id` per `createTestAdmin` /
-  // `createMember`). Today the downstream projection is safe regardless —
-  // `resolveAgentChatStatuses` already filters non-human, so a human agent in
-  // this set never reaches the loop. The guard is defensive: if a future
-  // change ever surfaces human statuses (e.g. an "adapter offline" signal),
-  // we don't want the caller's own human agent's main accidentally flowing
-  // into `failedAgentIds`. Belt-and-braces flagged in PR #579 review.
-  //
-  // One indexed read via `idx_agents_manager`. Filtering by `manager_id` alone
-  // (no `organization_id` clause) is sufficient — `members.id` is unique per
-  // (user, org) so any agent whose manager is `callerMemberId` is necessarily
-  // in the caller's org. An extra `organization_id` clause would silently drop
-  // a legitimate "mine" agent in the (rare) case where the create-time
-  // invariant `agents.organization_id == manager.organization_id` was broken
-  // by a buggy admin path. Read-side trusts the invariant; write-side guards.
-  const managedRows = await db
-    .select({ uuid: agents.uuid })
-    .from(agents)
-    .where(and(eq(agents.managerId, callerMemberId), ne(agents.type, "human")));
-  const managedAgentIds = new Set(managedRows.map((r) => r.uuid));
 
   const liveActivityByChat = new Map<string, LiveActivity>();
   const failedByChat = new Map<string, string[]>();
@@ -525,9 +494,8 @@ export async function listMeChats(
 
   for (const [chatId, statuses] of statusByChat) {
     const speakers = nonHumanSpeakersByChat.get(chatId);
-    // live-dot: freshest activity among non-human SPEAKERS. (Narrowed from the
-    // old session-holder source — drops stray dots from agents that left the
-    // chat, and never lights for a human predictive-active session.)
+    // live-dot: freshest activity among non-human SPEAKERS (drops stray dots
+    // from agents that left the chat; never lights for a human session).
     let freshest: { activity: LiveActivity; startedMs: number } | null = null;
     const failed: string[] = [];
     const busy: string[] = [];
@@ -538,14 +506,11 @@ export async function listMeChats(
         const startedMs = new Date(s.activity.startedAt).getTime();
         if (!freshest || startedMs > freshest.startedMs) freshest = { activity: s.activity, startedMs };
       }
-      // failed — speaker-filtered AND narrowed to "mine" (R1). A peer's broken
-      // agent in a chat I'm in no longer pins my row to "Needs attention".
+      // failed — speaker-filtered AND narrowed to "mine" (R1): a peer's broken
+      // agent in a shared chat no longer pins my row to "Needs attention".
       if (isSpeaker && s.main === "failed" && isMine) failed.push(s.agentId);
-      // busy = speakers with composite `working` (the D-axis truth from
-      // `agent_chat_sessions.runtime_state`). Drives the chat-list activity
-      // indicator authoritatively, so it lights even when a runtime emits
-      // no intermediate session_events (codex no-events case) — the gap
-      // `liveActivity` alone can never cover. NOT narrowed to mine — "someone
+      // busy — speakers with composite `working` (the D-axis truth from
+      // `agent_chat_sessions.runtime_state`). NOT narrowed to mine — "someone
       // is working" is informational, not an attention signal.
       if (isSpeaker && s.working) busy.push(s.agentId);
     }
@@ -554,12 +519,8 @@ export async function listMeChats(
     if (busy.length > 0) busyByChat.set(chatId, busy);
   }
 
-  // First-message lookup for auto-title fallback. Mirrors
-  // `session.ts:listAgentSessions`'s `selectDistinctOn` pattern. The
-  // logic is the same as before the schema refactor — first-message
-  // resolution is a `messages` concern, independent of the membership
-  // tables.
-  const chatIdsNeedingFirstMessage = pageRaw
+  // First-message lookup for the auto-title fallback (only chats with no topic).
+  const chatIdsNeedingFirstMessage = rawRows
     .filter((r) => r.topic === null || r.topic.length === 0)
     .map((r) => r.chat_id);
   const firstMessageRows =
@@ -577,17 +538,13 @@ export async function listMeChats(
     if (s) firstMessageSummary.set(row.chatId, s);
   }
 
-  const rows: MeChatRow[] = pageRaw.map((r) => {
+  const rows: MeChatRow[] = rawRows.map((r) => {
     const participants = participantsByChat.get(r.chat_id) ?? [];
     const title = resolveChatTitle(r.topic, firstMessageSummary.get(r.chat_id) ?? null, participants, humanAgentId);
     const isSpeaker = r.access_mode === "speaker";
-    // Narrow the raw `metadata->>'entityType'` text to the
-    // `GithubEntityType` literal union when it matches a known value,
-    // otherwise null. Github rows always have a `entityType` set by
-    // the webhook writer (see `chat-metadata.ts`'s discriminated
-    // union); the explicit narrowing rejects values we don't ship —
-    // e.g. metadata hand-edited via SQL or an in-flight rollout that
-    // introduces a new entity type before shared/web learn about it.
+    // Narrow raw `metadata->>'entityType'` to the `GithubEntityType` union when
+    // it matches a known value, else null (rejects version-skew / hand-edited
+    // values).
     const entityType: MeChatRow["entityType"] =
       r.source === "github" && r.entity_type !== null && isKnownGithubEntityType(r.entity_type) ? r.entity_type : null;
     return {
@@ -602,14 +559,14 @@ export async function listMeChats(
       description: r.description,
       participants,
       participantCount: participants.length,
-      lastMessageAt: toDate(r.last_message_at)?.toISOString() ?? null,
+      lastMessageAt: toChatDate(r.last_message_at)?.toISOString() ?? null,
       lastMessagePreview: r.last_message_preview,
-      activityAt: toDate(r.activity_at)?.toISOString() ?? null,
+      activityAt: toChatDate(r.activity_at)?.toISOString() ?? null,
       unreadMentionCount: r.unread_mention_count,
       openRequestCount: r.open_request_count,
       canReply: isSpeaker,
       engagementStatus: r.engagement_status,
-      pinnedAt: toDate(r.pinned_at)?.toISOString() ?? null,
+      pinnedAt: toChatDate(r.pinned_at)?.toISOString() ?? null,
       liveActivity: liveActivityByChat.get(r.chat_id) ?? null,
       failedAgentIds: failedByChat.get(r.chat_id) ?? [],
       busyAgentIds: busyByChat.get(r.chat_id) ?? [],
@@ -617,7 +574,181 @@ export async function listMeChats(
     };
   });
 
-  return { rows, nextCursor };
+  return { rows, failedByChat };
+}
+
+/**
+ * GET /me/chats — cursor-paginated conversation list with server-side priority
+ * projection.
+ *
+ * The response is three groups, computed so every chat appears in AT MOST ONE
+ * of them (attention > pinned > ordinary `rows`):
+ *   1. `priorityRows.attention` — extracted across the *full* matching set (not
+ *      just the loaded page): a caller-managed non-human speaker in `failed`,
+ *      OR an open request to the caller. Ordered failed-first then activity DESC.
+ *   2. `priorityRows.pinned` — the caller's pinned chats (private per-user
+ *      state), `pinned_at` DESC, minus anything already in attention.
+ *   3. `rows` — the ordinary activity-ordered page, EXCLUDING every priority
+ *      chat id, keyset-paginated on `activity_at`.
+ * Plus `counts.unread`, a page-independent global aggregate.
+ *
+ * `failed` is a composite status derived by `resolveAgentChatStatuses`, not a
+ * column, so attention is built via a bounded CANDIDATE set (open request OR a
+ * caller-managed non-human speaker present) that the enrichment pass resolves
+ * canonically — never a SQL re-implementation of the status folding.
+ *
+ * NOTE (v1 cost): the priority groups + `counts.unread` are recomputed on every
+ * page; the web reads them from the first page only. The sets are bounded
+ * (pins / open requests / managed agents), but `resolveAgentChatStatuses` runs
+ * on the candidate set each call — a fair follow-up is to gate the priority
+ * work on `cursor === null` once the client contract is settled.
+ */
+export async function listMeChats(
+  db: Database,
+  humanAgentId: string,
+  callerMemberId: string,
+  organizationId: string,
+  query: ListMeChatsQuery,
+): Promise<ListMeChatsResponse> {
+  const limit = query.limit;
+  const cursor = query.cursor ? decodeCursor(query.cursor) : null;
+  if (query.cursor && !cursor) {
+    throw new BadRequestError("Invalid cursor");
+  }
+
+  const filterUnreadOnly = query.filter === "unread";
+  const filterWatchingOnly = query.watching === true;
+  const engagementPredicate = ENGAGEMENT_VIEW_PREDICATE[query.engagement];
+  const originPredicate = query.origin ? originsFilterSql(query.origin) : sql`TRUE`;
+  const participantsPredicate = query.with ? participantsFilterSql(query.with) : sql`TRUE`;
+
+  // View-scoped filters shared by every group (ordinary + priority) so the
+  // active filter narrows all of them identically.
+  const filters = sql`(${!filterUnreadOnly}::bool OR COALESCE(cus.unread_mention_count, 0) > 0)
+       AND (${!filterWatchingOnly}::bool OR cm.access_mode = 'watcher')
+       AND ${engagementPredicate}
+       AND ${originPredicate}
+       AND ${participantsPredicate}`;
+
+  // Caller-scoped "mine" set — the non-human agents the caller manages
+  // (`agents.manager_id = caller.member_id`, one indexed read via
+  // `idx_agents_manager`). Shared across the priority + ordinary enrichment
+  // passes and drives the "mine" narrowing on `failed`. The `ne(type, 'human')`
+  // guard excludes the caller's own self-managed human agent — defensive today
+  // (`resolveAgentChatStatuses` already filters non-human) but belt-and-braces
+  // if a future change ever surfaces human statuses. Filtering by `manager_id`
+  // alone is sufficient: `members.id` is unique per (user, org), so any agent
+  // whose manager is `callerMemberId` is necessarily in the caller's org.
+  const managedRows = await db
+    .select({ uuid: agents.uuid })
+    .from(agents)
+    .where(and(eq(agents.managerId, callerMemberId), ne(agents.type, "human")));
+  const managedAgentIds = new Set(managedRows.map((r) => r.uuid));
+
+  const activityOrder = sql`c.activity_at DESC, c.id DESC`;
+
+  // --- Global attention candidates ---------------------------------------
+  // Bounded set the enrichment pass resolves into the attention group: any chat
+  // with an open request OR a caller-managed non-human speaker present. The
+  // `EXISTS` is speaker + non-human + manager-scoped so a chat only becomes a
+  // candidate for MY broken agent, never a peer's.
+  const managedSpeakerExists = sql`EXISTS (
+    SELECT 1 FROM chat_membership cm_s
+      JOIN agents a_s ON a_s.uuid = cm_s.agent_id
+     WHERE cm_s.chat_id = c.id
+       AND cm_s.access_mode = 'speaker'
+       AND a_s.type <> 'human'
+       AND a_s.manager_id = ${callerMemberId})`;
+  const attnCandidateRaw = await selectMeChatRawRows(db, {
+    humanAgentId,
+    organizationId,
+    filters,
+    extra: sql`(COALESCE(cus.open_request_count, 0) > 0 OR ${managedSpeakerExists})`,
+    orderBy: activityOrder,
+    limit: null,
+  });
+
+  // --- Global pinned ------------------------------------------------------
+  const pinnedRaw = await selectMeChatRawRows(db, {
+    humanAgentId,
+    organizationId,
+    filters,
+    extra: sql`cus.pinned_at IS NOT NULL`,
+    orderBy: sql`cus.pinned_at DESC, c.id DESC`,
+    limit: null,
+  });
+
+  // Enrich the priority union once (candidates ∪ pinned; disjoint from the
+  // ordinary page, which excludes them). `failedByChat` splits attention below.
+  const priorityRawUnion = dedupeRawByChatId([...attnCandidateRaw, ...pinnedRaw]);
+  const { rows: priorityRowsFlat, failedByChat } = await enrichMeChatRows(db, priorityRawUnion, {
+    humanAgentId,
+    managedAgentIds,
+  });
+  const priorityRowById = new Map(priorityRowsFlat.map((r) => [r.chatId, r]));
+
+  // Attention = candidates that actually qualify (failed OR open request),
+  // ordered failed-first then by activity. Each candidate slice is already
+  // activity DESC from the query and `filter` preserves order.
+  const attnQualified = attnCandidateRaw.filter((r) => failedByChat.has(r.chat_id) || r.open_request_count > 0);
+  const attention = [
+    ...attnQualified.filter((r) => failedByChat.has(r.chat_id)),
+    ...attnQualified.filter((r) => !failedByChat.has(r.chat_id)),
+  ]
+    .map((r) => priorityRowById.get(r.chat_id))
+    .filter((r): r is MeChatRow => r !== undefined);
+  const attentionIds = new Set(attention.map((r) => r.chatId));
+
+  // Pinned excludes anything already surfaced in attention (attention wins),
+  // preserving the `pinned_at` DESC order.
+  const pinned = pinnedRaw
+    .filter((r) => !attentionIds.has(r.chat_id))
+    .map((r) => priorityRowById.get(r.chat_id))
+    .filter((r): r is MeChatRow => r !== undefined);
+
+  // --- Ordinary page ------------------------------------------------------
+  // Excludes every priority chat id so a chat appears exactly once. The
+  // exclusion holds on ALL pages (priority chats can have any activity_at), so
+  // a pinned/attention chat never re-surfaces in a later ordinary page.
+  const priorityIds = new Set<string>([...attentionIds, ...pinned.map((r) => r.chatId)]);
+  const cursorTsIso = cursor ? cursor.activityAt.toISOString() : null;
+  const cursorPredicate = !cursor
+    ? sql`TRUE`
+    : sql`(c.activity_at < ${cursorTsIso}::timestamptz
+           OR (c.activity_at = ${cursorTsIso}::timestamptz AND c.id < ${cursor.chatId}))`;
+  const exclusionPredicate =
+    priorityIds.size === 0
+      ? sql`TRUE`
+      : sql`c.id NOT IN (${sql.join(
+          [...priorityIds].map((id) => sql`${id}`),
+          sql.raw(", "),
+        )})`;
+  const ordinaryRaw = await selectMeChatRawRows(db, {
+    humanAgentId,
+    organizationId,
+    filters,
+    extra: sql`${cursorPredicate} AND ${exclusionPredicate}`,
+    orderBy: activityOrder,
+    limit: limit + 1,
+  });
+
+  const hasMore = ordinaryRaw.length > limit;
+  const pageRaw = hasMore ? ordinaryRaw.slice(0, limit) : ordinaryRaw;
+  const last = pageRaw[pageRaw.length - 1];
+  const lastActivity = last ? toChatDate(last.activity_at) : null;
+  const nextCursor = hasMore && last && lastActivity ? encodeCursor(lastActivity, last.chat_id) : null;
+  const { rows } = await enrichMeChatRows(db, pageRaw, { humanAgentId, managedAgentIds });
+
+  // Page-independent global aggregate ("you have N unread"), not narrowed by
+  // the transient filter — matches the existing totalUnread pill semantics.
+  const unread = await countUnreadMeChats(db, humanAgentId, organizationId);
+
+  return {
+    priorityRows: { attention, pinned },
+    rows,
+    nextCursor,
+    counts: { unread },
+  };
 }
 
 /**

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -56,26 +56,27 @@ import { ensureCanJoin, joinAsParticipant, leaveAsParticipant, resolveChatMember
 // Cursor encoding
 // ---------------------------------------------------------------------------
 //
-// Cursor is `<lastMessageAtIso>|<chatId>`. Encoded base64url so it survives
+// Cursor is `<activityAtIso>|<chatId>`. Encoded base64url so it survives
 // query strings without escaping. Sort ordering is
-// `(last_message_at DESC NULLS LAST, chat_id DESC)`.
+// `(activity_at DESC, chat_id DESC)`. `chats.activity_at` is NOT NULL, so —
+// unlike the pre-PR `last_message_at` cursor — there is no null-timestamp case.
 
-export function encodeCursor(lastMessageAt: Date | null, chatId: string): string {
-  const payload = `${lastMessageAt ? lastMessageAt.toISOString() : ""}|${chatId}`;
+export function encodeCursor(activityAt: Date, chatId: string): string {
+  const payload = `${activityAt.toISOString()}|${chatId}`;
   return Buffer.from(payload, "utf8").toString("base64url");
 }
 
-export function decodeCursor(cursor: string): { lastMessageAt: Date | null; chatId: string } | null {
+export function decodeCursor(cursor: string): { activityAt: Date; chatId: string } | null {
   try {
     const decoded = Buffer.from(cursor, "base64url").toString("utf8");
     const sep = decoded.indexOf("|");
     if (sep < 0) return null;
     const tsPart = decoded.slice(0, sep);
     const chatId = decoded.slice(sep + 1);
-    if (!chatId) return null;
-    const lastMessageAt = tsPart.length > 0 ? new Date(tsPart) : null;
-    if (lastMessageAt && Number.isNaN(lastMessageAt.getTime())) return null;
-    return { lastMessageAt, chatId };
+    if (!chatId || tsPart.length === 0) return null;
+    const activityAt = new Date(tsPart);
+    if (Number.isNaN(activityAt.getTime())) return null;
+    return { activityAt, chatId };
   } catch {
     return null;
   }
@@ -332,21 +333,16 @@ export async function listMeChats(
   const originPredicate = query.origin ? originsFilterSql(query.origin) : sql`TRUE`;
   const participantsPredicate = query.with ? participantsFilterSql(query.with) : sql`TRUE`;
 
-  // Cursor predicate (sort: last_message_at DESC NULLS LAST, chat_id DESC).
-  // See the original commentary in git history for the case-by-case
-  // analysis — preserved verbatim from the pre-refactor implementation
-  // because the entity-layer (chats) sort key has not changed.
-  // postgres-js can't serialize a JS Date through a raw sql template
-  // without column metadata; pre-stringify to ISO so the param goes
-  // through as text and the `::timestamptz` cast handles the rest.
-  const cursorTsIso = cursor?.lastMessageAt ? cursor.lastMessageAt.toISOString() : null;
+  // Cursor predicate (sort: activity_at DESC, chat_id DESC). `chats.activity_at`
+  // is NOT NULL, so this is a plain keyset with no null-timestamp branches.
+  // postgres-js can't serialize a JS Date through a raw sql template without
+  // column metadata; pre-stringify to ISO so the param goes through as text and
+  // the `::timestamptz` cast handles the rest.
+  const cursorTsIso = cursor ? cursor.activityAt.toISOString() : null;
   const cursorPredicate = !cursor
     ? sql`TRUE`
-    : cursor.lastMessageAt === null
-      ? sql`(c.last_message_at IS NULL AND c.id < ${cursor.chatId})`
-      : sql`(c.last_message_at IS NULL
-             OR c.last_message_at < ${cursorTsIso}::timestamptz
-             OR (c.last_message_at = ${cursorTsIso}::timestamptz AND c.id < ${cursor.chatId}))`;
+    : sql`(c.activity_at < ${cursorTsIso}::timestamptz
+           OR (c.activity_at = ${cursorTsIso}::timestamptz AND c.id < ${cursor.chatId}))`;
 
   // postgres-js returns timestamptz as ISO strings when bound through
   // a raw sql template; coerce below so the response uses ISO
@@ -405,7 +401,7 @@ export async function listMeChats(
        AND ${originPredicate}
        AND ${participantsPredicate}
        AND ${cursorPredicate}
-     ORDER BY c.last_message_at DESC NULLS LAST, c.id DESC
+     ORDER BY c.activity_at DESC, c.id DESC
      LIMIT ${limit + 1}
   `)) as unknown as Array<{
     chat_id: string;
@@ -435,7 +431,8 @@ export async function listMeChats(
   const hasMore = rawRows.length > limit;
   const pageRaw = hasMore ? rawRows.slice(0, limit) : rawRows;
   const last = pageRaw[pageRaw.length - 1];
-  const nextCursor = hasMore && last ? encodeCursor(toDate(last.last_message_at), last.chat_id) : null;
+  const lastActivity = last ? toDate(last.activity_at) : null;
+  const nextCursor = hasMore && last && lastActivity ? encodeCursor(lastActivity, last.chat_id) : null;
 
   if (pageRaw.length === 0) return { rows: [], nextCursor: null };
 

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -59,39 +59,50 @@ import { ensureCanJoin, joinAsParticipant, leaveAsParticipant, resolveChatMember
 // Cursor is `v2|<activityAtIso>|<chatId>`, base64url so it survives query
 // strings. Sort ordering is `(activity_at DESC, chat_id DESC)`; `activity_at`
 // is NOT NULL, so there is no null-timestamp case.
-//
-// The `v2` version prefix is load-bearing: the PRE-PR cursor was
-// `<lastMessageAt>|<chatId>` — an INDISTINGUISHABLE shape whose timestamp meant
-// `last_message_at`, not `activity_at`. Without the version, a browser holding
-// an old `nextCursor` across the server rollout would pass validation and
-// resume from a wrong boundary (silently skipping / repeating chats whenever
-// the two timestamps differ). Versioning makes an old cursor fail to decode so
-// it is rejected (400 → the client restarts from page 1) rather than
-// misinterpreted.
 
 const CURSOR_VERSION = "v2";
+
+/**
+ * A decoded cursor is one of three cases so the caller can treat them
+ * differently across a rollout:
+ *   - `ok`     — a valid `v2|<iso>|<chatId>` cursor; resume from it.
+ *   - `legacy` — the recognized PRE-PR shape `<iso>|<chatId>` (2 parts, valid
+ *     ISO first). Its timestamp meant `last_message_at`, not `activity_at`, so
+ *     it can't be reinterpreted against the new ordering; a client that held one
+ *     across the rollout is restarted from page 1 rather than stranded.
+ *   - `invalid` — anything else (truncated / wrong-version / garbage). Kept as a
+ *     typed failure (→ 400) so a genuine client/API bug still surfaces instead of
+ *     being silently served page 1.
+ */
+type DecodedCursor = { status: "ok"; activityAt: Date; chatId: string } | { status: "legacy" } | { status: "invalid" };
 
 export function encodeCursor(activityAt: Date, chatId: string): string {
   const payload = `${CURSOR_VERSION}|${activityAt.toISOString()}|${chatId}`;
   return Buffer.from(payload, "utf8").toString("base64url");
 }
 
-export function decodeCursor(cursor: string): { activityAt: Date; chatId: string } | null {
+export function decodeCursor(cursor: string): DecodedCursor {
+  let decoded: string;
   try {
-    const decoded = Buffer.from(cursor, "base64url").toString("utf8");
-    // Exactly `<version>|<iso>|<chatId>` (chat ids are UUIDs — never contain
-    // `|`). An old unversioned cursor (`<iso>|<chatId>`) is 2 parts, so it — and
-    // anything else malformed — is rejected rather than reinterpreted.
-    const parts = decoded.split("|");
-    if (parts.length !== 3) return null;
-    const [version, tsPart, chatId] = parts;
-    if (version !== CURSOR_VERSION || !tsPart || !chatId) return null;
-    const activityAt = new Date(tsPart);
-    if (Number.isNaN(activityAt.getTime())) return null;
-    return { activityAt, chatId };
+    decoded = Buffer.from(cursor, "base64url").toString("utf8");
   } catch {
-    return null;
+    return { status: "invalid" };
   }
+  // Chat ids are UUIDs (never contain `|`), so a well-formed payload splits
+  // cleanly: current `v2|<iso>|<chatId>` is 3 parts, legacy `<iso>|<chatId>` is 2.
+  const parts = decoded.split("|");
+  if (parts.length === 3) {
+    const [version, tsPart, chatId] = parts;
+    if (version === CURSOR_VERSION && tsPart && chatId && !Number.isNaN(new Date(tsPart).getTime())) {
+      return { status: "ok", activityAt: new Date(tsPart), chatId };
+    }
+    return { status: "invalid" };
+  }
+  if (parts.length === 2) {
+    const [tsPart, chatId] = parts;
+    if (tsPart && chatId && !Number.isNaN(new Date(tsPart).getTime())) return { status: "legacy" };
+  }
+  return { status: "invalid" };
 }
 
 // ---------------------------------------------------------------------------
@@ -621,9 +632,9 @@ async function enrichMeChatRows(
  * what the additive `rows` above makes safe (later pages need no priority ids to
  * exclude).
  *
- * An undecodable / pre-PR (unversioned) cursor is treated as a first-page request
- * rather than a 400, so a client that held an old cursor across the rollout
- * recovers gracefully instead of looping its load-more Retry.
+ * A recognized pre-PR (legacy) cursor is treated as a first-page request rather
+ * than a 400, so a client that held one across the rollout recovers gracefully
+ * instead of looping its load-more Retry; a genuinely invalid cursor still 400s.
  */
 export async function listMeChats(
   db: Database,
@@ -633,13 +644,16 @@ export async function listMeChats(
   query: ListMeChatsQuery,
 ): Promise<ListMeChatsResponse> {
   const limit = query.limit;
-  // A cursor that fails to decode — including a pre-PR (unversioned) cursor held
-  // across the server rollout — is treated as "start from the first page" rather
-  // than a 400. That recovers an already-open client gracefully: it gets page 1
-  // (whose rows it de-duplicates against what it already showed) plus a fresh v2
-  // nextCursor to resume from. A hard 400 would instead leave the client's
-  // load-more Retry looping on the same rejected cursor until a page-0 refresh.
-  const cursor = query.cursor ? decodeCursor(query.cursor) : null;
+  // Resolve the cursor into a keyset anchor. A recognized `legacy` cursor (a
+  // pre-PR shape a client held across the rollout) restarts from page 1 — the
+  // client de-duplicates the repeated rows and picks up a fresh v2 cursor — while
+  // an `invalid` cursor stays a typed 400 so a genuine client/API bug surfaces
+  // instead of being silently masked as a first-page request.
+  const decoded = query.cursor ? decodeCursor(query.cursor) : null;
+  if (decoded?.status === "invalid") {
+    throw new BadRequestError("Invalid cursor");
+  }
+  const cursor = decoded?.status === "ok" ? decoded : null;
 
   const filterUnreadOnly = query.filter === "unread";
   const filterWatchingOnly = query.watching === true;
@@ -691,14 +705,19 @@ export async function listMeChats(
   if (cursor === null) {
     // Attention candidates — a bounded pre-canonical set the enrichment pass
     // resolves. A chat qualifies if it has an open request OR a caller-managed
-    // non-human speaker ACTUALLY in an error state: session `errored`, or an
-    // active session whose per-chat / agent-global runtime is `error`. Those are
-    // exactly the inputs `computeErrored` folds into composite `failed` (minus
-    // the freshness / reachability the canonical resolver still applies), so this
-    // is a strict SUPERSET of failed — no false negatives — while excluding the
-    // common HEALTHY managed speaker that would otherwise make nearly every
-    // active chat a candidate on the 30s poll. `failed` is still never decided in
-    // SQL; the enrichment pass below confirms it canonically.
+    // non-human speaker whose stored error inputs mirror `computeErrored`'s
+    // branches exactly (minus the freshness / reachability the canonical resolver
+    // still applies), so this is a strict SUPERSET of failed — no false negatives
+    // — while excluding the common HEALTHY managed speaker that would otherwise
+    // make nearly every active chat a candidate on the 30s poll:
+    //   - session `errored` (C-axis lifecycle) always contributes;
+    //   - an active session with a per-chat runtime stamp: only the per-chat
+    //     `runtime_state = 'error'` is authoritative (D-axis);
+    //   - an active session with NO per-chat stamp (old client): fall back to the
+    //     agent-global `presence.runtime_state = 'error'`.
+    // Gating the presence fallback on `runtime_state_at IS NULL` is what keeps
+    // one agent-global error from admitting that agent's stamped-idle chats.
+    // `failed` is still never decided in SQL; the enrichment pass confirms it.
     const managedFailureCandidate = sql`EXISTS (
       SELECT 1 FROM chat_membership cm_s
         JOIN agents a_s ON a_s.uuid = cm_s.agent_id
@@ -708,8 +727,11 @@ export async function listMeChats(
          AND cm_s.access_mode = 'speaker'
          AND a_s.type <> 'human'
          AND a_s.manager_id = ${callerMemberId}
-         AND (acs.state = 'errored'
-              OR (acs.state = 'active' AND (acs.runtime_state = 'error' OR ap.runtime_state = 'error'))))`;
+         AND (
+           acs.state = 'errored'
+           OR (acs.state = 'active' AND acs.runtime_state_at IS NOT NULL AND acs.runtime_state = 'error')
+           OR (acs.state = 'active' AND acs.runtime_state_at IS NULL AND ap.runtime_state = 'error')
+         ))`;
     const attnCandidateRaw = await selectMeChatRawRows(db, {
       humanAgentId,
       organizationId,

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -600,12 +600,12 @@ async function enrichMeChatRows(
  *   2. `priorityRows.pinned` — the caller's pinned chats (private per-user
  *      state), `pinned_at` DESC, minus anything already in attention.
  *   3. `rows` — the ordinary activity-ordered keyset page on `activity_at`.
- * Plus `counts.unread`, a page-independent global aggregate.
  *
  * `failed` is a composite status derived by `resolveAgentChatStatuses`, not a
  * column, so attention is built via a CANDIDATE set (open request OR a
- * caller-managed non-human speaker present) that the enrichment pass resolves
- * canonically — never a SQL re-implementation of the status folding.
+ * caller-managed non-human speaker whose session/runtime is actually in error —
+ * a strict superset of `computeErrored`'s inputs) that the enrichment pass
+ * resolves canonically — never a SQL re-implementation of the status folding.
  *
  * ADDITIVE contract (deliberate, for safe rollout): `rows` is NOT filtered
  * against the priority ids. A pinned / attention chat appears in `rows` too, and
@@ -614,12 +614,16 @@ async function enrichMeChatRows(
  * backward-compatible with the already-shipped web that reads only `rows` — a
  * server deploy ahead of the priority-aware client never makes a chat vanish.
  *
- * FIRST-PAGE gating: the two priority groups + `counts.unread` are computed only
- * when `cursor === null` and returned empty/zero on `load-more` pages (the
- * client reads them from the first page). This bounds cost — `resolveAgentChatStatuses`
- * over the candidate set runs once per list open, not per scroll page — and is
- * exactly what the additive `rows` above makes safe (later pages need no priority
- * ids to exclude).
+ * FIRST-PAGE gating: the two priority groups are computed only when there is no
+ * `cursor` and returned empty on `load-more` pages (the client reads them from
+ * the first page). This bounds cost — `resolveAgentChatStatuses` over the
+ * candidate set runs once per list open, not per scroll page — and is exactly
+ * what the additive `rows` above makes safe (later pages need no priority ids to
+ * exclude).
+ *
+ * An undecodable / pre-PR (unversioned) cursor is treated as a first-page request
+ * rather than a 400, so a client that held an old cursor across the rollout
+ * recovers gracefully instead of looping its load-more Retry.
  */
 export async function listMeChats(
   db: Database,
@@ -629,10 +633,13 @@ export async function listMeChats(
   query: ListMeChatsQuery,
 ): Promise<ListMeChatsResponse> {
   const limit = query.limit;
+  // A cursor that fails to decode — including a pre-PR (unversioned) cursor held
+  // across the server rollout — is treated as "start from the first page" rather
+  // than a 400. That recovers an already-open client gracefully: it gets page 1
+  // (whose rows it de-duplicates against what it already showed) plus a fresh v2
+  // nextCursor to resume from. A hard 400 would instead leave the client's
+  // load-more Retry looping on the same rejected cursor until a page-0 refresh.
   const cursor = query.cursor ? decodeCursor(query.cursor) : null;
-  if (query.cursor && !cursor) {
-    throw new BadRequestError("Invalid cursor");
-  }
 
   const filterUnreadOnly = query.filter === "unread";
   const filterWatchingOnly = query.watching === true;
@@ -673,33 +680,41 @@ export async function listMeChats(
     : sql`(c.activity_at < ${cursorTsIso}::timestamptz
            OR (c.activity_at = ${cursorTsIso}::timestamptz AND c.id < ${cursor.chatId}))`;
 
-  // --- Priority groups + unread aggregate: FIRST PAGE ONLY -----------------
-  // These are whole-set projections the client reads once (from the first page).
-  // Computing them only when `cursor === null` keeps `load-more` cheap AND is
-  // what lets `rows` stay ADDITIVE: because later pages never exclude priority
-  // ids, the ordinary stream remains the complete recency list, so the change is
-  // backward-compatible with a client that ignores `priorityRows`. See docblock.
+  // --- Priority groups: FIRST PAGE ONLY -----------------------------------
+  // Whole-set projections the client reads once (from the first page). Gating
+  // them on `cursor === null` keeps `load-more` cheap AND is what lets `rows`
+  // stay ADDITIVE: later pages never exclude priority ids, so the ordinary
+  // stream is the complete recency list — backward-compatible with a client that
+  // ignores `priorityRows`. See docblock.
   let attention: MeChatRow[] = [];
   let pinned: MeChatRow[] = [];
-  let unread = 0;
   if (cursor === null) {
-    // Attention candidates: any chat with an open request OR a caller-managed
-    // non-human speaker present. The `EXISTS` is speaker + non-human +
-    // manager-scoped, so a chat is only a candidate for MY broken agent, never a
-    // peer's. `failed` itself is a composite status from resolveAgentChatStatuses
-    // (never re-implemented in SQL) — the enrichment pass below resolves it.
-    const managedSpeakerExists = sql`EXISTS (
+    // Attention candidates — a bounded pre-canonical set the enrichment pass
+    // resolves. A chat qualifies if it has an open request OR a caller-managed
+    // non-human speaker ACTUALLY in an error state: session `errored`, or an
+    // active session whose per-chat / agent-global runtime is `error`. Those are
+    // exactly the inputs `computeErrored` folds into composite `failed` (minus
+    // the freshness / reachability the canonical resolver still applies), so this
+    // is a strict SUPERSET of failed — no false negatives — while excluding the
+    // common HEALTHY managed speaker that would otherwise make nearly every
+    // active chat a candidate on the 30s poll. `failed` is still never decided in
+    // SQL; the enrichment pass below confirms it canonically.
+    const managedFailureCandidate = sql`EXISTS (
       SELECT 1 FROM chat_membership cm_s
         JOIN agents a_s ON a_s.uuid = cm_s.agent_id
+        JOIN agent_chat_sessions acs ON acs.agent_id = a_s.uuid AND acs.chat_id = c.id
+        LEFT JOIN agent_presence ap ON ap.agent_id = a_s.uuid
        WHERE cm_s.chat_id = c.id
          AND cm_s.access_mode = 'speaker'
          AND a_s.type <> 'human'
-         AND a_s.manager_id = ${callerMemberId})`;
+         AND a_s.manager_id = ${callerMemberId}
+         AND (acs.state = 'errored'
+              OR (acs.state = 'active' AND (acs.runtime_state = 'error' OR ap.runtime_state = 'error'))))`;
     const attnCandidateRaw = await selectMeChatRawRows(db, {
       humanAgentId,
       organizationId,
       filters,
-      extra: sql`(COALESCE(cus.open_request_count, 0) > 0 OR ${managedSpeakerExists})`,
+      extra: sql`(COALESCE(cus.open_request_count, 0) > 0 OR ${managedFailureCandidate})`,
       orderBy: activityOrder,
       limit: null,
     });
@@ -738,11 +753,6 @@ export async function listMeChats(
       .filter((r) => !attentionIds.has(r.chat_id))
       .map((r) => priorityRowById.get(r.chat_id))
       .filter((r): r is MeChatRow => r !== undefined);
-
-    // Page-independent global aggregate ("you have N unread"), org-scoped and
-    // not narrowed by the transient filter (matches the existing totalUnread
-    // pill). Returned on the first page only; the client reads it from there.
-    unread = await countUnreadMeChats(db, humanAgentId, organizationId);
   }
 
   // --- Ordinary page (EVERY page) -----------------------------------------
@@ -771,7 +781,6 @@ export async function listMeChats(
     priorityRows: { attention, pinned },
     rows,
     nextCursor,
-    counts: { unread },
   };
 }
 

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -66,9 +66,11 @@ const CURSOR_VERSION = "v2";
  * A decoded cursor is one of three cases so the caller can treat them
  * differently across a rollout:
  *   - `ok`     — a valid `v2|<iso>|<chatId>` cursor; resume from it.
- *   - `legacy` — the recognized PRE-PR shape `<iso>|<chatId>` (2 parts, valid
- *     ISO first). Its timestamp meant `last_message_at`, not `activity_at`, so
- *     it can't be reinterpreted against the new ordering; a client that held one
+ *   - `legacy` — a recognized PRE-PR shape (2 parts, non-empty chat id): either
+ *     `<iso>|<chatId>` (a normal boundary) or `|<chatId>` (an empty timestamp,
+ *     which the old encoder emitted for a `last_message_at IS NULL` tail
+ *     boundary). Its timestamp meant `last_message_at`, not `activity_at`, so it
+ *     can't be reinterpreted against the new ordering; a client that held one
  *     across the rollout is restarted from page 1 rather than stranded.
  *   - `invalid` — anything else (truncated / wrong-version / garbage). Kept as a
  *     typed failure (→ 400) so a genuine client/API bug still surfaces instead of
@@ -100,7 +102,14 @@ export function decodeCursor(cursor: string): DecodedCursor {
   }
   if (parts.length === 2) {
     const [tsPart, chatId] = parts;
-    if (tsPart && chatId && !Number.isNaN(new Date(tsPart).getTime())) return { status: "legacy" };
+    // The deployed pre-PR encoder emitted `<iso>|<chatId>` for a normal boundary
+    // AND `|<chatId>` (EMPTY timestamp) for a `last_message_at IS NULL` tail
+    // boundary. Recognize both exact old shapes — empty or parseable timestamp,
+    // with a non-empty chat id — as legacy so every real deployed cursor takes
+    // the page-1 recovery path instead of 400ing.
+    if (tsPart !== undefined && chatId && (tsPart === "" || !Number.isNaN(new Date(tsPart).getTime()))) {
+      return { status: "legacy" };
+    }
   }
   return { status: "invalid" };
 }

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -369,15 +369,25 @@ export const meChatRowSchema = z.object({
 export type MeChatRow = z.infer<typeof meChatRowSchema>;
 
 /**
- * Priority groups extracted server-side across the *full* matching set (not
- * just the loaded page), rendered above the ordinary list. Every chat appears
- * in at most one place — attention > pinned > ordinary `rows` — so the client
- * never has to de-duplicate a chat across groups.
- *   - `attention`: chats needing the viewer now — a caller-managed speaker in
- *     `failed`, or an open request to the viewer — ordered failed-first, then
- *     by `activityAt` DESC.
+ * Priority groups extracted server-side across the *full matching set* (the same
+ * engagement / origin / participant / unread / watch filters as the ordinary
+ * list, just without the loaded-page boundary), rendered above the ordinary
+ * list. Populated on the FIRST page only (`nextCursor === null` request); empty
+ * on load-more pages, which the client reads from page 0.
+ *   - `attention`: chats needing the viewer now — a *caller-managed* non-human
+ *     speaker in `failed`, or an open request addressed to the viewer — ordered
+ *     failed-first, then by `activityAt` DESC. (A peer's failed agent / another
+ *     human's request stays in the ordinary stream.)
  *   - `pinned`: the viewer's pinned chats (private per-user state), ordered by
  *     `pinnedAt` DESC, excluding any already surfaced in `attention`.
+ *
+ * `attention` and `pinned` are server-DISJOINT (a chat is in at most one of the
+ * two). The ordinary `rows`, however, are ADDITIVE: a priority chat is NOT
+ * removed from `rows` (that keeps the response backward-compatible with a client
+ * that ignores these groups). A client that renders the groups must therefore
+ * de-duplicate `rows` against the priority chat ids so each chat shows once
+ * (attention > pinned > recency).
+ *
  * `.default({...})` for version skew: a web bundle ahead of a server that
  * predates these groups reads them as empty rather than `undefined`.
  */

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -372,8 +372,8 @@ export type MeChatRow = z.infer<typeof meChatRowSchema>;
  * Priority groups extracted server-side across the *full matching set* (the same
  * engagement / origin / participant / unread / watch filters as the ordinary
  * list, just without the loaded-page boundary), rendered above the ordinary
- * list. Populated on the FIRST page only (`nextCursor === null` request); empty
- * on load-more pages, which the client reads from page 0.
+ * list. Populated on the FIRST page only (a request with no `cursor`); empty on
+ * load-more pages, which the client reads from page 0.
  *   - `attention`: chats needing the viewer now — a *caller-managed* non-human
  *     speaker in `failed`, or an open request addressed to the viewer — ordered
  *     failed-first, then by `activityAt` DESC. (A peer's failed agent / another
@@ -403,18 +403,10 @@ export const listMeChatsResponseSchema = z.object({
   priorityRows: meChatPriorityRowsSchema,
   rows: z.array(meChatRowSchema),
   nextCursor: z.string().nullable(),
-  /**
-   * Page-independent aggregate counters over the viewer's chats.
-   *   - `unread`: total chats with an unread mention for the viewer
-   *     (org-scoped, non-deleted) — the global "you have N unread" signal, not
-   *     narrowed by the transient filter. `.default` for the same version-skew
-   *     reason as `priorityRows`.
-   */
-  counts: z
-    .object({
-      unread: z.number().int(),
-    })
-    .default({ unread: 0 }),
+  // NOTE: a global unread `counts` aggregate is intentionally NOT part of this
+  // response yet — its scope (global vs the active engagement view) is a product
+  // decision that belongs with the unread badge that consumes it, landing in the
+  // desktop-rail PR. Adding it here first would publish an unsettled contract.
 });
 export type ListMeChatsResponse = z.infer<typeof listMeChatsResponseSchema>;
 

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -368,9 +368,43 @@ export const meChatRowSchema = z.object({
 });
 export type MeChatRow = z.infer<typeof meChatRowSchema>;
 
+/**
+ * Priority groups extracted server-side across the *full* matching set (not
+ * just the loaded page), rendered above the ordinary list. Every chat appears
+ * in at most one place — attention > pinned > ordinary `rows` — so the client
+ * never has to de-duplicate a chat across groups.
+ *   - `attention`: chats needing the viewer now — a caller-managed speaker in
+ *     `failed`, or an open request to the viewer — ordered failed-first, then
+ *     by `activityAt` DESC.
+ *   - `pinned`: the viewer's pinned chats (private per-user state), ordered by
+ *     `pinnedAt` DESC, excluding any already surfaced in `attention`.
+ * `.default({...})` for version skew: a web bundle ahead of a server that
+ * predates these groups reads them as empty rather than `undefined`.
+ */
+export const meChatPriorityRowsSchema = z
+  .object({
+    attention: z.array(meChatRowSchema),
+    pinned: z.array(meChatRowSchema),
+  })
+  .default({ attention: [], pinned: [] });
+export type MeChatPriorityRows = z.infer<typeof meChatPriorityRowsSchema>;
+
 export const listMeChatsResponseSchema = z.object({
+  priorityRows: meChatPriorityRowsSchema,
   rows: z.array(meChatRowSchema),
   nextCursor: z.string().nullable(),
+  /**
+   * Page-independent aggregate counters over the viewer's chats.
+   *   - `unread`: total chats with an unread mention for the viewer
+   *     (org-scoped, non-deleted) — the global "you have N unread" signal, not
+   *     narrowed by the transient filter. `.default` for the same version-skew
+   *     reason as `priorityRows`.
+   */
+  counts: z
+    .object({
+      unread: z.number().int(),
+    })
+    .default({ unread: 0 }),
 });
 export type ListMeChatsResponse = z.infer<typeof listMeChatsResponseSchema>;
 

--- a/packages/web/src/api/__tests__/api-wrappers.test.ts
+++ b/packages/web/src/api/__tests__/api-wrappers.test.ts
@@ -212,7 +212,12 @@ describe("api wrapper paths", () => {
     await chats.createAgentChat("agent/id");
     await chats.listChatMessages("chat/id", { limit: 20, cursor: "older" });
 
-    await meChats.listMeChats({
+    // listMeChats now parses the response, so it needs a valid payload. Seed the
+    // shape an OLDER server (pre-priorityRows) would return and assert the schema
+    // fills the version-skew default — that both keeps this request-shape test
+    // reaching its assertion and proves the fallback the parse exists to provide.
+    apiMock.get.mockResolvedValueOnce({ rows: [], nextCursor: null });
+    const listed = await meChats.listMeChats({
       limit: 10,
       cursor: "next",
       filter: "unread",
@@ -221,6 +226,7 @@ describe("api wrapper paths", () => {
       with: ["agent-1", "agent-2"],
       watching: true,
     });
+    expect(listed.priorityRows).toEqual({ attention: [], pinned: [] });
     await meChats.listMeChatSourceCounts({ engagement: "archived" });
     await meChats.createMeChat({ participantIds: ["agent-1"] });
     await meChats.createMeTaskChat({

--- a/packages/web/src/api/me-chats.ts
+++ b/packages/web/src/api/me-chats.ts
@@ -10,6 +10,7 @@ import type {
   MeChatSourceCounts,
   MeChatUnreadResponse,
 } from "@first-tree/shared";
+import { listMeChatsResponseSchema } from "@first-tree/shared";
 import { api, withOrg } from "./client.js";
 
 /**
@@ -25,7 +26,10 @@ export type ListMeChatsParams = Partial<
   Pick<ListMeChatsQuery, "cursor" | "limit" | "filter" | "engagement" | "origin" | "with" | "watching">
 >;
 
-export function listMeChats(params?: ListMeChatsParams, opts?: { signal?: AbortSignal }): Promise<ListMeChatsResponse> {
+export async function listMeChats(
+  params?: ListMeChatsParams,
+  opts?: { signal?: AbortSignal },
+): Promise<ListMeChatsResponse> {
   const qs = new URLSearchParams();
   if (params?.limit !== undefined) qs.set("limit", String(params.limit));
   if (params?.cursor) qs.set("cursor", params.cursor);
@@ -41,7 +45,13 @@ export function listMeChats(params?: ListMeChatsParams, opts?: { signal?: AbortS
   const query = qs.toString();
   // `opts.signal` lets React Query cancel the in-flight request when the
   // filter/cursor changes, so a superseded page never lands.
-  return api.get<ListMeChatsResponse>(withOrg(`/chats${query ? `?${query}` : ""}`), opts);
+  //
+  // Parse (not just cast): the schema's version-skew `.default`s only run when
+  // something actually parses the payload. A web bundle ahead of a server that
+  // predates `priorityRows` therefore reads it as the empty default rather than
+  // `undefined`. Zod ignores unknown keys, so a newer server stays compatible.
+  const res = await api.get<unknown>(withOrg(`/chats${query ? `?${query}` : ""}`), opts);
+  return listMeChatsResponseSchema.parse(res);
 }
 
 export function listMeChatSourceCounts(params?: { engagement?: ChatEngagementView }): Promise<MeChatSourceCounts> {

--- a/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
@@ -299,12 +299,17 @@ describe("ChatByIdView and CenterPanel", () => {
     // patch is exercised against each cache shape it must handle.
     const paletteKey = ["me", "chats", "palette"];
     const infinite = (rows: MeChatRow[]): InfiniteData<ListMeChatsResponse> => ({
-      pages: [{ rows, nextCursor: null }],
+      pages: [{ rows, nextCursor: null, priorityRows: { attention: [], pinned: [] }, counts: { unread: 0 } }],
       pageParams: [undefined],
     });
     queryClient.setQueryData<InfiniteData<ListMeChatsResponse>>(allKey, infinite([currentUnread, otherUnread]));
     queryClient.setQueryData<InfiniteData<ListMeChatsResponse>>(unreadKey, infinite([currentUnread, otherUnread]));
-    queryClient.setQueryData<ListMeChatsResponse>(paletteKey, { rows: [currentUnread, otherUnread], nextCursor: null });
+    queryClient.setQueryData<ListMeChatsResponse>(paletteKey, {
+      rows: [currentUnread, otherUnread],
+      nextCursor: null,
+      priorityRows: { attention: [], pinned: [] },
+      counts: { unread: 0 },
+    });
 
     const { container, root } = await renderDom(
       <ChatByIdView chatId="chat-1" narrow onShowConversations={onShowConversations} />,

--- a/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-by-id-center-dom.test.tsx
@@ -299,7 +299,7 @@ describe("ChatByIdView and CenterPanel", () => {
     // patch is exercised against each cache shape it must handle.
     const paletteKey = ["me", "chats", "palette"];
     const infinite = (rows: MeChatRow[]): InfiniteData<ListMeChatsResponse> => ({
-      pages: [{ rows, nextCursor: null, priorityRows: { attention: [], pinned: [] }, counts: { unread: 0 } }],
+      pages: [{ rows, nextCursor: null, priorityRows: { attention: [], pinned: [] } }],
       pageParams: [undefined],
     });
     queryClient.setQueryData<InfiniteData<ListMeChatsResponse>>(allKey, infinite([currentUnread, otherUnread]));
@@ -308,7 +308,6 @@ describe("ChatByIdView and CenterPanel", () => {
       rows: [currentUnread, otherUnread],
       nextCursor: null,
       priorityRows: { attention: [], pinned: [] },
-      counts: { unread: 0 },
     });
 
     const { container, root } = await renderDom(

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -138,7 +138,7 @@ function page(
   pageParams: Array<string | undefined>;
 } {
   return {
-    pages: [{ rows, nextCursor, priorityRows: { attention: [], pinned: [] }, counts: { unread: 0 } }],
+    pages: [{ rows, nextCursor, priorityRows: { attention: [], pinned: [] } }],
     pageParams: [undefined],
   };
 }

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -137,7 +137,10 @@ function page(
   pages: ListMeChatsResponse[];
   pageParams: Array<string | undefined>;
 } {
-  return { pages: [{ rows, nextCursor }], pageParams: [undefined] };
+  return {
+    pages: [{ rows, nextCursor, priorityRows: { attention: [], pinned: [] }, counts: { unread: 0 } }],
+    pageParams: [undefined],
+  };
 }
 
 function createClient(rows = BASE_ROWS, nextCursor: string | null = "cursor-1"): QueryClient {


### PR DESCRIPTION
## What

PR 3 of the Workspace chat-list refactor: **server-side ordering + priority projection**. Builds on PR 1 (`useInfiniteQuery` foundation) and PR 2 (`pinned_at` / `activity_at` / pin mutation), both merged.

`listMeChats` (backing `GET /orgs/:orgId/chats?scope=mine`) now returns two whole-set priority groups plus the ordinary page:

```jsonc
{
  "priorityRows": {
    "attention": [ /* MeChatRow[] — failed-first, then activity DESC */ ],
    "pinned":    [ /* MeChatRow[] — pinned_at DESC, minus attention */ ]
  },
  "rows": [ /* the complete activity-ordered recency page */ ],
  "nextCursor": "…"
}
```

- **attention** — a *caller-managed* non-human speaker in `failed`, OR an open request addressed to the caller. Ordered failed-first, then `activity_at` DESC. Viewer-scoped: a peer's failed agent / another human's request stays in the ordinary stream.
- **pinned** — the caller's pins (`pinned_at` DESC), minus anything already in attention (attention and pinned are disjoint).
- **rows** — the ordinary `activity_at`-ordered keyset page.

## Two design decisions (called out for review)

**1. `rows` is ADDITIVE, not exclusive.** A pinned / attention chat also appears in `rows`; the client renders it once by de-duplicating the recency stream against `priorityRows`. This is deliberate: the already-shipped web (PR 1) reads **only** `rows` and does not consume `priorityRows` until PR 4. An *exclusive* `rows` would make pinned / open-request / failed chats **vanish** from the live list during the window between this server deploy and PR 4. Additive keeps the change backward-compatible and standalone-deployable.

**2. Priority groups are computed on the first page only** (no `cursor`), returned empty on load-more pages (the client reads them from page 1). This bounds cost — `resolveAgentChatStatuses` over the candidate set runs once per list-open, not per scroll page — and the additive `rows` above is what makes it safe (later pages need no priority ids to exclude).

## Why / implementation

- **Ordering key is `activity_at`** (PR 2): real-work recency, `NOT NULL`, so the keyset cursor drops the old `NULLS LAST` / null-timestamp branches.
- **Versioned cursor.** The payload is now `v2|<activityAtIso>|<chatId>`. The pre-PR cursor was an indistinguishable `<lastMessageAt>|<chatId>`, so `decodeCursor` classifies **valid-v2 / recognized-legacy / invalid**: a legacy cursor held across the rollout restarts from page 1 (graceful), while a malformed/unsupported cursor stays a typed 400.
- **`failed` is never re-implemented in SQL.** It is a composite status from `resolveAgentChatStatuses`. Attention is built from a **bounded candidate set** — an open request, OR a caller-managed non-human speaker whose *stored error inputs* mirror `computeErrored`'s branches (session `errored`; per-chat runtime `error` when stamped; agent-global presence `error` only when unstamped). That is a strict superset of failed (no false negatives; the canonical resolver still confirms freshness / reachability) while excluding the common healthy managed speaker — so a 30s poll no longer enriches the caller's whole active list.
- **One projection, three sets.** The single-stream `SELECT` is factored into `selectMeChatRawRows` + `enrichMeChatRows` so attention / pinned / ordinary rows are byte-identical in shape and share one enrichment path.
- **Web boundary parses.** `listMeChats` (web) now `parse`s the response with `listMeChatsResponseSchema` (was a bare cast), so the schema's version-skew `.default` actually fills a missing `priorityRows` against an older server.

## `counts.unread` deferred

An earlier revision added a global unread `counts` aggregate. Its scope (global vs the active engagement view) is a product decision that belongs with the unread badge that consumes it (the desktop-rail PR), and shipping it here first would publish an unsettled shared contract — so `counts` is **not** part of this response. The `countUnreadMeChats` helper stays for its existing caller.

## Testing

- `me-chat-priority.test.ts` — 15 tests on real Postgres (testcontainers): genuine `failed → attention` (reachable + `errored`); pinned `pinned_at` DESC; global cross-page extraction; open-request → attention; healthy managed speaker stays ordinary; **peer's failed speaker stays in rows** (viewer-scoping); **global-error + stamped per-chat idle stays in rows** (candidate gating); a **direct attention-candidate-query boundary test** — via the extracted `selectAttentionCandidateRows` — asserting a failed speaker IS admitted (positive control) while stamped-idle / healthy are NOT; failed-before-request ordering; attention outranks pinned; disjoint priority groups; keyset pagination completeness; first-page gating; **legacy-cursor recovery**; origin-filter narrowing.
- `me-chat-helpers.test.ts` — cursor codec incl. the three-way legacy / invalid classification.
- `me-chats-http-e2e.test.ts` — Fastify serializes `priorityRows` end-to-end.
- `me-chat-service.test.ts` — legacy cursor → page 1, invalid cursor → 400.
- Web `api-wrappers.test.ts` — proves the version-skew default via a parsed older-server payload.
- `typecheck` (server + web) + `biome` clean; full server suite green (one unrelated pre-existing failure is a local git-locale artifact in `context-tree-snapshot`, passes on CI).

## Independent review

Two pre-push independent reviews + three GitHub-reviewer rounds (baixiaohang + yuezengwu). SQL, multi-org isolation, keyset determinism verified sound; deploy-compat (additive), per-page cost (first-page gating + candidate narrowing), cursor safety (versioning + 3-way recovery), version-skew (web parse), and `counts` scope (deferred) all addressed.

## Paired tree PR

Reconciles the ranking contract in `system/cloud/chat/workspace-conversations.md` (owners @baixiaohang @yuezengwu): real-work recency basis + the viewer's private **Pinned** tier below viewer-scoped attention, extracted across the whole *matching* set, "each chat rendered once." Draft, marked ready after this PR + the desktop-rail client merge: **agent-team-foundation/first-tree-context#724**.
