### PR TITLE
fix(web): use full viewport height for iOS standalone

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -719,6 +719,18 @@
     }
   }
 
+  /* Installed WebKit apps with viewport-fit=cover report dynamic viewport
+     heights without the safe-area insets (WebKit 254868). There is no browser
+     chrome to track in standalone mode, so use the full viewport height there
+     and keep the 100dvh behavior for ordinary mobile browser tabs. */
+  @supports (-webkit-touch-callout: none) {
+    @media (display-mode: standalone) {
+      .h-dvh-screen {
+        height: 100vh;
+      }
+    }
+  }
+
   /* Reserve the top safe-area inset (notch / status bar) so a full-height
      shell without its own top chrome does not render content under the
      status bar on notched devices. */

--- a/packages/web/src/pages/mobile/__tests__/shell-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/shell-dom.test.tsx
@@ -115,14 +115,14 @@ describe("MobileShell", () => {
     expect(harness.container.textContent).not.toContain("Current team");
   });
 
-  it("sizes the live shell to the dynamic viewport and reserves the top safe area", async () => {
+  it("uses the mobile viewport utility and reserves the top safe area", async () => {
     renderShell(harness, "/m/now");
     await harness.flush();
 
-    // Dynamic-viewport height comes from the .h-dvh-screen utility (100vh
-    // fallback + 100dvh override), not a raw inline 100vh that overflows the
-    // visible viewport on mobile browsers while the address bar is shown. The
-    // top safe-area inset is reserved via .pt-safe-top so content does not
+    // Viewport height comes from the .h-dvh-screen utility: dynamic viewport
+    // sizing for browser tabs and the WebKit standalone 100vh override live in
+    // CSS, rather than an inline height that cannot distinguish display mode.
+    // The top safe-area inset is reserved via .pt-safe-top so content does not
     // render under the status bar on notched devices.
     const shell = harness.container.querySelector(".h-dvh-screen");
     expect(shell).not.toBeNull();

--- a/packages/web/src/pages/mobile/__tests__/viewport-css.test.ts
+++ b/packages/web/src/pages/mobile/__tests__/viewport-css.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const indexCss = readFileSync(new URL("../../../index.css", import.meta.url), "utf8");
+
+describe("mobile shell viewport CSS", () => {
+  it("overrides dynamic height with 100vh only for standalone WebKit", () => {
+    const dynamicViewportRule = indexCss.indexOf("@supports (height: 100dvh)");
+    const webkitRule = indexCss.indexOf("@supports (-webkit-touch-callout: none)");
+    const standaloneRule = indexCss.indexOf("@media (display-mode: standalone)", webkitRule);
+    const standaloneBlock = indexCss.slice(standaloneRule, standaloneRule + 140);
+
+    expect(dynamicViewportRule).toBeGreaterThan(-1);
+    expect(webkitRule).toBeGreaterThan(dynamicViewportRule);
+    expect(standaloneRule).toBeGreaterThan(webkitRule);
+    expect(standaloneBlock).toContain(".h-dvh-screen");
+    expect(standaloneBlock).toContain("height: 100vh");
+  });
+});


### PR DESCRIPTION
## Summary

- keep `100dvh` for ordinary mobile browser tabs where the browser chrome changes the visible height
- override the mobile shell to `100vh` only in WebKit standalone display mode
- add a source-level regression test that locks the media-query scope and cascade order

## Context

On the reported iPhone 14 Pro / iOS 26.5 home-screen Web App, the mobile shell can end above the physical bottom edge and expose a Home Indicator-sized strip after keyboard interaction.

[WebKit 254868](https://bugs.webkit.org/show_bug.cgi?id=254868) documents that installed apps using `viewport-fit=cover` report dynamic viewport heights without safe-area insets and explicitly recommends switching standalone mode back to `100vh`, which includes that space. [WebKit 292603](https://bugs.webkit.org/show_bug.cgi?id=292603) also documents that root overflow locks, overscroll containment, and scroll clamping do not suppress WebKit's extra bottom region; #1734 tried that path and was reverted by #1737 after physical-device QA made the symptom consistently reproducible.

This change therefore corrects the standalone shell height without touching document scrolling, adding global listeners, or changing ordinary browser behavior. It does not claim to eliminate every form of WebKit root overscroll; physical-device QA remains the acceptance gate for the reported layout gap.

## Validation

- mobile viewport and shell tests: 6 passed
- `pnpm check`
- `pnpm typecheck`
- Web production build passed
- built CSS verified to emit the WebKit standalone `100vh` rule after the `100dvh` rule

## QA

After staging deploy on iPhone 14 Pro / iOS 26.5:

1. fully close and reopen the home-screen First Tree app
2. open Chat and focus the composer
3. dismiss the keyboard, return to Now, and scroll to both boundaries
4. confirm the bottom navigation reaches the physical bottom safe area without an extra strip
