### PR TITLE
feat(web): full-width mobile pickers for Chat slash + new-chat

### DIFF
--- a/packages/web/src/components/__tests__/mention-autocomplete.test.ts
+++ b/packages/web/src/components/__tests__/mention-autocomplete.test.ts
@@ -3,6 +3,7 @@ import {
   buildMentionInsert,
   buildPickerSections,
   type CandidateDivider,
+  composerPickerVisible,
   detectMentionTrigger,
   groupAndSortCandidates,
   type MentionCandidate,
@@ -359,5 +360,21 @@ describe("buildPickerSections", () => {
     const { items, selectable } = buildPickerSections([], []);
     expect(items).toEqual([]);
     expect(selectable).toEqual([]);
+  });
+});
+
+describe("composerPickerVisible", () => {
+  it("welds when a mention or slash panel is open on a non-trial composer", () => {
+    expect(composerPickerVisible({ isTrial: false, mentionOpen: true, slashOpen: false })).toBe(true);
+    expect(composerPickerVisible({ isTrial: false, mentionOpen: false, slashOpen: true })).toBe(true);
+  });
+
+  it("does not weld when no picker is open", () => {
+    expect(composerPickerVisible({ isTrial: false, mentionOpen: false, slashOpen: false })).toBe(false);
+  });
+
+  it("never welds on the trial composer, even with a live trigger — trial renders no panel", () => {
+    expect(composerPickerVisible({ isTrial: true, mentionOpen: false, slashOpen: true })).toBe(false);
+    expect(composerPickerVisible({ isTrial: true, mentionOpen: true, slashOpen: true })).toBe(false);
   });
 });

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -413,6 +413,22 @@ export function buildMentionInsert(
 }
 
 /**
+ * Whether a composer host should enter its phone "welded" state — i.e. flatten
+ * its top corners because a picker panel is actually docked flush above it.
+ *
+ * True only when a panel is *visible*. Trial composers keep the mention/slash
+ * hooks live (so `@`/`/` still drive keyboard handling) but intentionally render
+ * no panel, so a trial trigger must NOT weld the host — that would square the
+ * input's top corners with nothing docked above them. A shared predicate so a
+ * welding host's open-state can't drift from its panel render guard (the chat
+ * composer today; other hosts when they adopt the dock).
+ */
+export function composerPickerVisible(opts: { isTrial: boolean; mentionOpen: boolean; slashOpen: boolean }): boolean {
+  if (opts.isTrial) return false;
+  return opts.mentionOpen || opts.slashOpen;
+}
+
+/**
  * Handle mapped keyboard events from the host textarea so the caller can
  * wire them into its own `onKeyDown`. Returns true when the event was
  * consumed (i.e. caller should `preventDefault`).

--- a/packages/web/src/components/slash-command-autocomplete.tsx
+++ b/packages/web/src/components/slash-command-autocomplete.tsx
@@ -1,6 +1,5 @@
 import type { SkillDescriptor } from "@first-tree/shared";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { cn } from "../lib/utils.js";
 
 /**
  * `/`-triggered slash-command popover, mirrored on the `@mention`
@@ -341,22 +340,7 @@ export function SlashCommandPopover({
   let lastKind: SlashCommandItem["kind"] | null = null;
 
   return (
-    <div
-      ref={popoverRef}
-      role="listbox"
-      aria-label="Slash command suggestions"
-      className={cn(
-        "absolute z-20 max-h-72 overflow-auto rounded-[var(--radius-panel)] border shadow-[var(--shadow-md)]",
-      )}
-      style={{
-        bottom: "calc(100% + var(--sp-1))",
-        left: 0,
-        minWidth: 280,
-        maxWidth: 420,
-        background: "var(--bg-raised)",
-        borderColor: "var(--border)",
-      }}
-    >
+    <div ref={popoverRef} role="listbox" aria-label="Slash command suggestions" className="slash-popover">
       {results.map((item, i) => {
         const headerEl =
           item.kind !== lastKind ? (
@@ -396,7 +380,7 @@ export function SlashCommandPopover({
                 e.preventDefault();
                 onPick(item);
               }}
-              className="flex w-full flex-col items-start gap-0.5 px-3 py-1.5 text-left"
+              className="slash-option flex w-full flex-col items-start gap-0.5 px-3 py-1.5 text-left"
               style={{
                 background: active ? "var(--bg-hover)" : "transparent",
                 color: "var(--fg)",

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -416,8 +416,8 @@
   --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.06);
   --shadow-md: 0 4px 12px oklch(0 0 0 / 0.08);
   /* Upward cast of --shadow-md, for panels docked flush above a surface (e.g.
-     the mobile mention popover) that must lift off the content above without
-     casting a shadow down onto the surface welded below them. */
+     the mobile mention popover) that must lift off the content above them
+     without casting a shadow down onto the surface welded below. */
   --shadow-md-up: 0 -4px 12px oklch(0 0 0 / 0.08);
 
   /* State pairs for callouts / inline notices (light mode).
@@ -919,32 +919,22 @@
   }
 }
 
-/* @mention / recipient-picker popover (MentionAutocompletePopover), anchored
-   to the composer's relative wrapper.
-
-   Desktop: a compact panel floating just above the textarea.
-
-   Phone (<48rem): the desktop float is a poor fit — capped at 360px and
-   left-aligned, it is narrower than the message column, so the message behind
-   it pokes out on the right (looks broken), and the gap above the input makes
-   it read as a detached overlay rather than part of the composer. On phones we
-   stretch the panel to the full composer width and dock it flush to the input's
-   top edge, so it reads as one surface growing upward out of the input. */
-
-/* The editable composer input card (chat-view). Radius lives here (not inline)
-   so the phone-only weld rule below can flatten its top corners while the
-   mention panel is docked above it. */
+/* The chat composer card. Radius lives here (not inline) so the phone-only weld
+   rule below can flatten its top corners while a picker panel is docked flush
+   above it. */
 .composer-card {
   border-radius: var(--radius-panel);
 }
 
-.mention-popover {
+/* Shared base for the composer picker popovers — the `@`mention list and the
+   `/`slash-command list. Desktop presentation: a compact panel floating just
+   above the input. Each keeps its own min/max width below. */
+.mention-popover,
+.slash-popover {
   position: absolute;
   z-index: 20;
   left: 0;
   bottom: calc(100% + var(--sp-1));
-  min-width: 240px;
-  max-width: 360px;
   max-height: 14rem;
   overflow: auto;
   background: var(--bg-raised);
@@ -952,47 +942,54 @@
   border-radius: var(--radius-panel);
   box-shadow: var(--shadow-md);
 }
+.mention-popover {
+  min-width: 240px;
+  max-width: 360px;
+}
+.slash-popover {
+  min-width: 280px;
+  max-width: 420px;
+  max-height: 18rem;
+}
 
 @media (max-width: 47.999rem) {
-  /* The full-width dock/weld is scoped to the Chat composer host, whose
-     `.composer-card` implements the matching flattened-top state below. The
-     other two hosts of this shared popover (AskTakeover answer box,
-     NewChatDraft recipient input) do NOT flatten their input, so welding a
-     square-bottomed panel onto their still-rounded chrome would reproduce the
-     very seam this rule removes. They keep the compact float on phones; a full
-     mobile treatment for those surfaces is a separate follow-up. */
-  .composer-card .mention-popover {
+  /* Phone: a composer picker popover spans the full input width and docks flush
+     to the input's top edge, so panel + input read as one surface instead of a
+     narrow float that lets the row behind it poke out on the right. Opt-in via
+     the `.composer-input` host marker — a future consumer of these shared
+     popovers can't silently inherit the dock without a participating input. */
+  .composer-input .mention-popover,
+  .composer-input .slash-popover {
+    left: 0;
     right: 0;
     min-width: 0;
     max-width: none;
-    /* Flush to the input's top edge — no gap — so panel + input read as one. */
     bottom: 100%;
     max-height: 16rem;
-    /* Round only the top; the bottom butts seamlessly against the input. Match
-       the composer card's --radius-panel so the welded panel + input read as a
-       single 6px-rounded surface. */
+    /* Rounded top (panel radius), squared bottom butting the input. */
     border-radius: var(--radius-panel) var(--radius-panel) 0 0;
     border-bottom-color: transparent;
-    /* Lift off the messages above with a genuinely top-only shadow. A blurred
-       box-shadow spreads in every direction, so a negative Y offset alone still
-       paints a lower lobe (offsetY + blur = 8px) down onto the welded input —
-       visible as a dark seam, worst in dark mode. Clip everything at/below the
-       panel's bottom edge so only the upward lobe survives; the panel and input
-       then read as one continuous surface. */
+    /* Genuinely top-only shadow: a blurred box-shadow spreads in every
+       direction, so a negative Y offset alone still paints a lower lobe
+       (offsetY + blur = 8px) down onto the input — a dark seam, worst in dark
+       mode. Clip at/below the panel's bottom edge so only the upward lobe
+       survives and panel + input read as one continuous surface. */
     box-shadow: var(--shadow-md-up);
     clip-path: inset(-18px 0 0 0);
   }
-  /* Comfortable thumb targets on touch: the 28px avatar + py-1.5 row is ~40px;
-     lift the whole row to the ~46px iOS tap floor. Global — a bigger tap target
-     helps every host and introduces no seam. */
-  .mention-option {
+  /* Comfortable touch targets (28px avatar + py-1.5 row is ~40px → ~46px iOS
+     floor). No seam, so applied to every host. */
+  .mention-option,
+  .slash-option {
     min-height: 2.875rem;
   }
-  /* Complete the weld: while the mention panel is docked above it, the composer
-     card drops its top rounding so the panel's flat bottom meets a flat top —
-     one continuous surface. Desktop keeps the float + gap, so its corners stay
-     rounded (this rule is phone-only). */
-  .composer-card[data-mention-open="true"] {
+  /* The chat composer has a clean top edge flush against the panel, so it drops
+     its top rounding while a picker is open → the panel's flat bottom meets a
+     flat top, one continuous surface. A host whose picker docks above a mid-card
+     text row (NewChatDraft: a chip row sits above the field) omits
+     `data-picker-open`, keeping its corners — the panel is still full-width,
+     just not corner-welded. */
+  .composer-card[data-picker-open="true"] {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
   }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -106,6 +106,7 @@ import {
 import { WorkingTurn } from "../../../components/chat/working-turn.js";
 import { HistoryGapBanner } from "../../../components/history-gap-banner.js";
 import {
+  composerPickerVisible,
   MentionAutocompletePopover,
   type MentionCandidate,
   useMentionAutocomplete,
@@ -4054,11 +4055,23 @@ export function ChatView({
                         the composer. */}
                     {/* biome-ignore lint/a11y/noStaticElementInteractions: drop target for image upload */}
                     <div
-                      className="composer-card"
-                      // Phone-only: flatten the card's top corners while the mention
-                      // panel is docked flush above it so the two read as one welded
-                      // surface (see `.composer-card[data-mention-open]` in index.css).
-                      data-mention-open={mention.trigger != null ? "true" : undefined}
+                      className="composer-card composer-input"
+                      // Phone-only: flatten the card's top corners while a picker
+                      // panel (mention or slash) is docked flush above it so the two
+                      // read as one welded surface (see
+                      // `.composer-card[data-picker-open]` in index.css). Gated via
+                      // composerPickerVisible on `!isTrial`: trial keeps the slash
+                      // hook live but renders no panel, so a trial `/` must not weld
+                      // an empty input.
+                      data-picker-open={
+                        composerPickerVisible({
+                          isTrial,
+                          mentionOpen: mention.trigger != null,
+                          slashOpen: slash.trigger != null,
+                        })
+                          ? "true"
+                          : undefined
+                      }
                       style={{
                         position: "relative",
                         border: "var(--hairline) solid var(--border)",

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -742,7 +742,11 @@ export function NewChatDraft({
                 )}
               </div>
             )}
-            <div style={{ position: "relative" }}>
+            {/* `composer-input` opts the mention popover into the phone full-width
+                dock. No `data-picker-open`: the popover docks above the message
+                textarea, which sits below the chip row (not at the card's top
+                edge), so the panel is full-width but not corner-welded. */}
+            <div className="composer-input" style={{ position: "relative" }}>
               <MentionAutocompletePopover
                 trigger={mention.trigger}
                 results={mention.results}


### PR DESCRIPTION
## What & why

Extend #1741's phone-only picker dock from the Chat `@`mention to the other **cleanly-dockable** composer pickers, so mobile is consistent:

- **`/` slash-command popover** (Chat composer) — welds like `@`.
- **NewChatDraft recipient input** (`@`) — full-width dock above the message row, **not** corner-welded (a chip row sits above the field, so there's no clean top edge).

**AskTakeover is deferred** (not in this PR): its answer surface lives in an `overflow:auto` scroller that clips an upward-docked picker — hiding the first/active candidates (a wrong-selection hazard). Escaping the clip needs the picker to be portaled out, which conflicts with the CSS-descendant weld, so it's a separate structural follow-up. Its mention picker is untouched here (keeps the pre-existing float).

## How

Generalize the #1741 weld into an **opt-in `.composer-input` host marker**:

- `@media (max-width: 47.999rem) { .composer-input .mention-popover, .composer-input .slash-popover { …full-width dock… } }` — a picker docks only when its host opts in (a future consumer can't silently inherit it).
- The Chat composer (clean top edge, `.composer-card`) sets `data-picker-open="true"` to flatten its top corners while a **mention or slash** picker is visible; NewChat sets only `.composer-input` (no flatten).
- The `/` popover moved its inline/Tailwind box styling into a `.slash-popover` class sharing the `.mention-popover` desktop base; rows get `.slash-option`.
- `composerPickerVisible({ isTrial, mentionOpen, slashOpen })` centralizes the trial guard — a live trial `/` (slash hook stays up while the panel is suppressed) must not weld an empty input. The chat composer is its only welding caller today.

**Desktop presentation is unchanged** (the new behavior lives entirely in the phone media query; `.slash-popover` reproduces the prior slash styling verbatim).

## Rebase

Rebased onto current `main` — **#1742** (touch-optimize mobile chat composer) and **#1744** (touch-optimize mobile new-chat/ask composers). My weld targets the unchanged outer composer-card / popover-wrapper anchors; the touch-optimizations are internal (tap targets, one-line textarea) and don't move the picker's dock point. `ask-takeover.tsx`, its DOM test, and `center/index.tsx` have **zero diff** here — #1742/#1744's work is preserved.

## Verification

- typecheck + lint:tokens clean, `biome` clean (only the pre-existing `index.css` `noImportantStyles` warning), **1341 web tests pass** (incl. the `composerPickerVisible` trial-boundary tests).
- Real-browser 390px in **light and dark**: Chat slash welds, NewChat docks full-width; no dark seam; desktop unchanged.

## Scope

`packages/web` styling + the Chat/NewChat composer hosts + shared picker helper. No data/schema/routing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
