### PR TITLE
feat: touch-optimize new-chat and ask-answer composers on mobile

### DIFF
--- a/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
@@ -663,4 +663,43 @@ describe("AskTakeover", () => {
     // The opaque fill now lives on the wrapper so the field still reads as a box.
     expect(ta.parentElement?.style.background).toBe("var(--bg)");
   });
+
+  it("mobile: enlarged tap targets, Enter does not reply (Reply button is the only submit)", async () => {
+    const onReply = vi.fn();
+    const c = await renderDom(
+      <AskTakeover body="# Concerns?" payload={{ multiSelect: false }} onReply={onReply} onSkip={() => {}} mobile />,
+    );
+    const reply = btn(c, "Reply");
+    const atBtn = c.querySelector<HTMLButtonElement>('button[aria-label="Mention an agent"]');
+    const attachBtn = c.querySelector<HTMLButtonElement>('button[aria-label="Attach file"]');
+    if (!reply || !atBtn || !attachBtn) throw new Error("Mobile ask controls missing");
+    // Tap targets clear the touch minimum.
+    expect(Number.parseInt(reply.style.height, 10)).toBe(44);
+    expect(Number.parseInt(atBtn.style.width, 10)).toBe(44);
+    expect(Number.parseInt(attachBtn.style.width, 10)).toBe(44);
+
+    // Enter inserts a newline (does not resolve); the Reply button submits.
+    const ta = freeTextBox(c);
+    if (!ta) throw new Error("free-text input missing");
+    await setValue(ta, "looks risky");
+    await keyDown(window, "Enter");
+    expect(onReply).not.toHaveBeenCalled();
+    await click(reply);
+    expect(onReply).toHaveBeenCalledWith({ content: "looks risky", mentions: [], images: [] });
+  });
+
+  it("desktop: compact controls and Enter resolves the ask", async () => {
+    const onReply = vi.fn();
+    const c = await renderDom(
+      <AskTakeover body="# Concerns?" payload={{ multiSelect: false }} onReply={onReply} onSkip={() => {}} />,
+    );
+    const reply = btn(c, "Reply");
+    if (!reply) throw new Error("Reply button missing");
+    expect(Number.parseInt(reply.style.height, 10)).toBe(34);
+    const ta = freeTextBox(c);
+    if (!ta) throw new Error("free-text input missing");
+    await setValue(ta, "looks risky");
+    await keyDown(window, "Enter");
+    expect(onReply).toHaveBeenCalledWith({ content: "looks risky", mentions: [], images: [] });
+  });
 });

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -141,7 +141,10 @@ export function AskTakeover({
   const [freeText, setFreeText] = useState("");
   const [cursor, setCursor] = useState(0);
   // Tighten the horizontal padding on phone widths so the card uses the
-  // available width instead of burning it on gutters.
+  // available width instead of burning it on gutters. Note this keys off the
+  // measured *viewport width*, whereas the touch-target / Enter behavior keys
+  // off the `mobile` *route* prop — two intentionally distinct axes (a narrow
+  // desktop window wants tighter gutters but not phone-sized tap targets).
   const viewport = useWorkspaceViewport();
   const padX = viewport === "narrow" ? "var(--sp-4)" : "var(--sp-6)";
   // Keep the card (and its pinned footer) above the on-screen keyboard.

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -109,10 +109,15 @@ export function AskTakeover({
   onReply,
   onSkip,
   isTrial = false,
+  mobile = false,
 }: {
   /** Trial surface: match the minimal trial composer — no @mention / attach
    *  affordances in the answer input, just plain text. */
   isTrial?: boolean;
+  /** Touch surface (the mobile route): enlarge tap targets to the touch
+   *  minimum and make Enter insert a newline (Reply button is the only submit),
+   *  matching the mobile chat composer. */
+  mobile?: boolean;
   /** The ask itself — the request message's markdown body. */
   body: string;
   payload: AskRequest;
@@ -245,7 +250,10 @@ export function AskTakeover({
         onSkip();
         return;
       }
-      if (e.key === "Enter" && !e.shiftKey) {
+      // Mobile soft keyboards have no Shift+Enter, so Enter must insert a
+      // newline in the answer box; the Reply button is the only submit path.
+      // Desktop keeps Enter-to-reply.
+      if (e.key === "Enter" && !e.shiftKey && !mobile) {
         // An option row is a radio/checkbox button that owns Enter as its
         // toggle; let that native behavior stand rather than resolving.
         if (e.target instanceof HTMLElement && e.target.tagName === "BUTTON") return;
@@ -256,7 +264,7 @@ export function AskTakeover({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [sending, canReply, onSkip, reply]);
+  }, [sending, canReply, onSkip, reply, mobile]);
 
   // Visible chrome (border + fill + radius) lives on the WRAPPER, not the
   // textarea: the textarea is painted transparent so the mention overlay
@@ -397,8 +405,9 @@ export function AskTakeover({
                   position: "absolute",
                   top: 2,
                   right: 2,
-                  width: 16,
-                  height: 16,
+                  // Mobile: a roomier corner × (kept modest vs the small thumbnail).
+                  width: mobile ? 22 : 16,
+                  height: mobile ? 22 : 16,
                   borderRadius: "50%",
                   background: "var(--color-overlay-scrim)",
                   border: "none",
@@ -410,7 +419,7 @@ export function AskTakeover({
                   padding: 0,
                 }}
               >
-                <X className="h-2.5 w-2.5" />
+                <X className={mobile ? "h-3 w-3" : "h-2.5 w-2.5"} />
               </button>
             </div>
           ) : (
@@ -423,8 +432,9 @@ export function AskTakeover({
                   onClick={() => removeAttachment(att.id)}
                   aria-label={`Remove ${att.file.name}`}
                   style={{
-                    width: 14,
-                    height: 14,
+                    // Mobile: a roomier tap target on the file chip's remove ×.
+                    width: mobile ? 26 : 14,
+                    height: mobile ? 26 : 14,
                     borderRadius: "50%",
                     background: "var(--color-overlay-scrim)",
                     border: "none",
@@ -436,7 +446,7 @@ export function AskTakeover({
                     padding: 0,
                   }}
                 >
-                  <X className="h-2 w-2" />
+                  <X className={mobile ? "h-3.5 w-3.5" : "h-2 w-2"} />
                 </button>
               }
             />
@@ -463,9 +473,11 @@ export function AskTakeover({
             padding: 0,
             display: "inline-flex",
             alignItems: "center",
+            // Mobile: grow the tap target to the touch minimum (icon stays small).
+            ...(mobile ? { width: 44, height: 44, justifyContent: "center" } : {}),
           }}
         >
-          <AtSign className="h-3.5 w-3.5" />
+          <AtSign className={mobile ? "h-5 w-5" : "h-3.5 w-3.5"} />
         </button>
         <button
           type="button"
@@ -480,9 +492,11 @@ export function AskTakeover({
             padding: 0,
             display: "inline-flex",
             alignItems: "center",
+            // Mobile: grow the tap target to the touch minimum (icon stays small).
+            ...(mobile ? { width: 44, height: 44, justifyContent: "center" } : {}),
           }}
         >
-          <Paperclip className="h-3.5 w-3.5" />
+          <Paperclip className={mobile ? "h-5 w-5" : "h-3.5 w-3.5"} />
         </button>
         <input
           ref={fileInputRef}
@@ -637,7 +651,8 @@ export function AskTakeover({
             title="Skip (Esc)"
             className="text-label"
             style={{
-              height: 34,
+              // Mobile: 44 height clears the touch minimum.
+              height: mobile ? 44 : 34,
               padding: "0 var(--sp-4)",
               borderRadius: "var(--radius-input)",
               border: "var(--hairline) solid transparent",
@@ -652,10 +667,12 @@ export function AskTakeover({
             type="button"
             onClick={reply}
             disabled={!canReply}
-            title="Reply (Enter)"
+            title={mobile ? "Reply" : "Reply (Enter)"}
             className="text-label"
             style={{
-              height: 34,
+              // Mobile: 44 height clears the touch minimum (Reply is the only
+              // submit path there — Enter inserts a newline).
+              height: mobile ? 44 : 34,
               padding: "0 var(--sp-4)",
               borderRadius: "var(--radius-input)",
               border: "var(--hairline) solid transparent",

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -3529,6 +3529,7 @@ export function ChatView({
                 error={askError ?? undefined}
                 mentionCandidates={mentionCandidates}
                 isTrial={isTrial}
+                mobile={composerMobile}
                 onReply={(answer) => {
                   void submitAskAnswer(dockRequest, answer);
                 }}

--- a/packages/web/src/pages/workspace/center/index.tsx
+++ b/packages/web/src/pages/workspace/center/index.tsx
@@ -66,6 +66,7 @@ export function CenterPanel({
         onCreated={onSelectChat}
         onShowConversations={onShowConversations}
         initialParticipantIds={initialParticipantIds}
+        mobile={presentation === "mobile"}
       />
     );
   }

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -77,8 +77,13 @@ export function NewChatDraft({
   onCreated,
   onShowConversations = null,
   initialParticipantIds,
+  mobile = false,
 }: {
   onCreated: (chatId: string) => void;
+  /** Touch surface (the mobile route): enlarge tap targets to the touch
+   *  minimum and make Enter insert a newline (send is the button only),
+   *  matching the mobile chat composer. */
+  mobile?: boolean;
   /** Non-null only in narrow-viewport mode — renders a hamburger in the
    *  top-left corner that summons the conversation-list overlay. Without
    *  it, narrow users who land on a draft URL have no path back to their
@@ -687,8 +692,9 @@ export function NewChatDraft({
                           position: "absolute",
                           top: 1,
                           right: 1,
-                          width: 14,
-                          height: 14,
+                          // Mobile: roomier corner × (kept modest vs the thumbnail).
+                          width: mobile ? 20 : 14,
+                          height: mobile ? 20 : 14,
                           borderRadius: "50%",
                           background: "var(--color-overlay-scrim)",
                           border: "none",
@@ -700,7 +706,7 @@ export function NewChatDraft({
                           padding: 0,
                         }}
                       >
-                        <X className="h-2 w-2" />
+                        <X className={mobile ? "h-3 w-3" : "h-2 w-2"} />
                       </button>
                     </div>
                   ) : (
@@ -714,8 +720,9 @@ export function NewChatDraft({
                           title="Remove file"
                           aria-label={`Remove ${att.file.name}`}
                           style={{
-                            width: 14,
-                            height: 14,
+                            // Mobile: roomier tap target on the file chip's × .
+                            width: mobile ? 26 : 14,
+                            height: mobile ? 26 : 14,
                             borderRadius: "50%",
                             background: "var(--color-overlay-scrim)",
                             border: "none",
@@ -727,7 +734,7 @@ export function NewChatDraft({
                             padding: 0,
                           }}
                         >
-                          <X className="h-2 w-2" />
+                          <X className={mobile ? "h-3.5 w-3.5" : "h-2 w-2"} />
                         </button>
                       }
                     />
@@ -767,7 +774,9 @@ export function NewChatDraft({
                 onKeyDown={(e) => {
                   if (e.nativeEvent.isComposing) return;
                   if (mention.handleKey(e)) return;
-                  if (e.key === "Enter" && !e.shiftKey) {
+                  // Mobile soft keyboards have no Shift+Enter, so Enter inserts a
+                  // newline; sending is the button only. Desktop keeps Enter-to-send.
+                  if (!mobile && e.key === "Enter" && !e.shiftKey) {
                     e.preventDefault();
                     void handleSend();
                   }
@@ -828,16 +837,18 @@ export function NewChatDraft({
                   disabled={sending || createMut.isPending}
                   title="Attach file"
                   aria-label="Attach file"
-                  className="inline-flex items-center"
+                  className="inline-flex items-center justify-center"
                   style={{
                     background: "none",
                     border: "none",
                     cursor: sending || createMut.isPending ? "not-allowed" : "pointer",
                     color: "var(--fg-3)",
                     padding: 0,
+                    // Mobile: grow the tap target to the touch minimum.
+                    ...(mobile ? { width: 44, height: 44 } : {}),
                   }}
                 >
-                  <Paperclip className="h-3.5 w-3.5" />
+                  <Paperclip className={mobile ? "h-5 w-5" : "h-3.5 w-3.5"} />
                 </button>
                 <input
                   ref={fileInputRef}
@@ -863,22 +874,24 @@ export function NewChatDraft({
                   type="button"
                   onClick={() => void handleSend()}
                   disabled={!canSend}
-                  title={sendBlockedReason ?? "Send (Enter)"}
+                  title={sendBlockedReason ?? (mobile ? "Send" : "Send (Enter)")}
                   aria-label="Send"
                   className={cn(
                     "inline-flex items-center justify-center transition-opacity",
                     !canSend && "opacity-40 cursor-not-allowed",
                   )}
                   style={{
-                    width: 28,
-                    height: 28,
-                    borderRadius: "var(--radius-input)",
+                    // Mobile: 44 hit area (the only send path there — Enter inserts
+                    // a newline); desktop stays compact.
+                    width: mobile ? 44 : 28,
+                    height: mobile ? 44 : 28,
+                    borderRadius: mobile ? 12 : "var(--radius-input)",
                     background: "var(--fg)",
                     color: "var(--bg-raised)",
                     border: "none",
                   }}
                 >
-                  <ArrowUp className="h-3.5 w-3.5" strokeWidth={2.5} />
+                  <ArrowUp className={mobile ? "h-5 w-5" : "h-3.5 w-3.5"} strokeWidth={2.5} />
                 </button>
               </span>
             </div>

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -837,7 +837,7 @@ export function NewChatDraft({
                   disabled={sending || createMut.isPending}
                   title="Attach file"
                   aria-label="Attach file"
-                  className="inline-flex items-center justify-center"
+                  className={cn("inline-flex items-center", mobile && "justify-center")}
                   style={{
                     background: "none",
                     border: "none",


### PR DESCRIPTION
## What

Follow-up to #1742 (mobile chat composer). That PR touch-optimized only the **main** message composer. First Tree has **three** composer surfaces that appear on mobile, all sharing `MentionHighlightOverlay`; the other two were still desktop-sized. This brings them to parity.

Both changes are gated on the same mobile-route signal (a `mobile` prop derived from `presentation === "mobile"`), so **desktop is unchanged**.

## Changes

**`NewChatDraft`** — the composer when you tap **New** on mobile (`/m/chat?c=draft`):
- send 28 → **44** hit area, attach → **44**, roomier attachment-remove ×
- Enter inserts a newline (send is the button only); desktop keeps Enter-to-send
- `CenterPanel` passes `mobile={presentation === "mobile"}`
- (already `rows={1}` and already a flow toolbar, so no layout restructure)

**`AskTakeover`** — the composer when you answer a blocking `@ask` on mobile:
- `@`/attach → **44** hit areas, Skip/Reply → **44** height, roomier removes
- the global `Enter → reply` window listener is gated so Enter inserts a newline on mobile; the **Reply** button is the only submit path
- `chat-view` passes `mobile={composerMobile}`

## Verification

- ✅ `tsc` + `lint:tokens` + biome clean
- ✅ affected suites green (273 tests across `components/chat`, `center`, `conversations`)
- ✅ New `ask-takeover-dom` tests: **mobile** (44 targets, Enter-does-not-reply, Reply submits) and **desktop** (compact, Enter-replies)
- `NewChatDraft`'s mobile branch is the same `mobile ? 44 : 28` / Enter-gate pattern as the tested chat-view composer + ask-takeover; covered by typecheck + pattern parity (happy to add a render test if wanted).

Same QA caveat as #1742: the authed `/m/chat` surface can't be driven from my environment, so no live on-device render; low risk by construction (constant `mobile` prop, same elements restyled).
