### PR TITLE
feat: touch-optimize new-chat participant chips + NewChatDraft mobile tests

### DIFF
--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -164,7 +164,17 @@ export function AgentOption({
  * `<span>` label with no avatar before this). Hover reveals the remove
  * `X`; omit `onRemove` for a read-only token.
  */
-export function AgentToken({ candidate, onRemove }: { candidate: MentionCandidate; onRemove?: () => void }) {
+export function AgentToken({
+  candidate,
+  onRemove,
+  mobile = false,
+}: {
+  candidate: MentionCandidate;
+  onRemove?: () => void;
+  /** Touch surface: the remove × is always visible (no hover on touch) and its
+   *  tap target is enlarged. Desktop keeps the hover-revealed compact ×. */
+  mobile?: boolean;
+}) {
   const label = candidate.displayName ?? candidate.name ?? candidate.agentId.slice(0, 8);
   return (
     <span
@@ -190,18 +200,24 @@ export function AgentToken({ candidate, onRemove }: { candidate: MentionCandidat
           type="button"
           onClick={onRemove}
           title="Remove participant"
-          className="opacity-0 transition-opacity group-hover:opacity-100"
+          aria-label={`Remove ${label}`}
+          // Touch has no hover, so the × must stay visible on mobile; desktop
+          // keeps it hover-revealed to keep the chip row calm.
+          className={mobile ? "transition-opacity" : "opacity-0 transition-opacity group-hover:opacity-100"}
           style={{
             display: "inline-flex",
             alignItems: "center",
+            justifyContent: "center",
             border: "none",
             background: "none",
             padding: 0,
             cursor: "pointer",
             color: "var(--fg-3)",
+            // Mobile: a roomier tap target (kept modest so it doesn't bloat the chip).
+            ...(mobile ? { width: 26, height: 26 } : {}),
           }}
         >
-          <X className="h-3 w-3" />
+          <X className={mobile ? "h-4 w-4" : "h-3 w-3"} />
         </button>
       )}
     </span>

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -207,14 +207,15 @@ export function AgentToken({
           style={{
             display: "inline-flex",
             alignItems: "center",
-            justifyContent: "center",
             border: "none",
             background: "none",
             padding: 0,
             cursor: "pointer",
             color: "var(--fg-3)",
-            // Mobile: a roomier tap target (kept modest so it doesn't bloat the chip).
-            ...(mobile ? { width: 26, height: 26 } : {}),
+            // Mobile: a full 44 touch target that clears the minimum the composer
+            // controls use; the × glyph stays small, just centered in the box.
+            // Desktop keeps the compact, hover-revealed × unchanged.
+            ...(mobile ? { width: 44, height: 44, justifyContent: "center" } : {}),
           }}
         >
           <X className={mobile ? "h-4 w-4" : "h-3 w-3"} />

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -63,6 +63,7 @@ const imageStoreMocks = vi.hoisted(() => ({
 
 const meChatMocks = vi.hoisted(() => ({
   addMeChatParticipants: vi.fn(),
+  createMeTaskChat: vi.fn(),
 }));
 
 const readStateMocks = vi.hoisted(() => ({
@@ -2022,6 +2023,73 @@ describe("ChatView", () => {
     });
     await waitForCondition(() => chatMocks.sendChatMessage.mock.calls.length > 0, "Expected Enter send on desktop");
     expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-empty", "hello there", ["agent-1"]);
+
+    await act(async () => root.unmount());
+  });
+
+  it("mobile new-chat draft: 44-unit send, Enter does not create, chip × visible + [+] enlarged", async () => {
+    const { CenterPanel } = await import("../index.js");
+    const { DRAFT_CHAT_ID } = await import("../../conversations/index.js");
+    const { container, root } = await renderDom(
+      <CenterPanel
+        selectedChatId={DRAFT_CHAT_ID}
+        onSelectChat={() => {}}
+        onClearChat={() => {}}
+        narrow
+        onShowConversations={() => {}}
+        initialParticipantIds={["agent-1"]}
+        presentation="mobile"
+      />,
+      undefined,
+      "/",
+    );
+    await flush();
+    const send = container.querySelector<HTMLButtonElement>('button[aria-label="Send"]');
+    const addBtn = container.querySelector<HTMLButtonElement>('button[aria-label="Add participant"]');
+    const chipRemove = container.querySelector<HTMLButtonElement>('button[aria-label^="Remove "]');
+    if (!send || !addBtn || !chipRemove) throw new Error("Mobile new-chat controls missing");
+    // Composer send clears the touch minimum (mobile prop reached the composer).
+    expect(Number.parseInt(send.style.width, 10)).toBe(44);
+    // The [+] add-participant button is enlarged for touch.
+    expect(Number.parseInt(addBtn.style.minWidth, 10)).toBe(40);
+    // The seeded chip's remove × is always visible on mobile (no hover on touch).
+    expect(chipRemove.className).not.toContain("opacity-0");
+
+    // Enter inserts a newline; it does not create the chat (button-only submit).
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) throw new Error("draft textarea missing");
+    await setValue(textarea, "do the thing @nova");
+    await act(async () => {
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    });
+    await flush();
+    expect(meChatMocks.createMeTaskChat).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("desktop new-chat draft: compact send and hover-revealed chip ×", async () => {
+    const { CenterPanel } = await import("../index.js");
+    const { DRAFT_CHAT_ID } = await import("../../conversations/index.js");
+    const { container, root } = await renderDom(
+      <CenterPanel
+        selectedChatId={DRAFT_CHAT_ID}
+        onSelectChat={() => {}}
+        onClearChat={() => {}}
+        narrow={false}
+        onShowConversations={null}
+        initialParticipantIds={["agent-1"]}
+      />,
+      undefined,
+      "/",
+    );
+    await flush();
+    const send = container.querySelector<HTMLButtonElement>('button[aria-label="Send"]');
+    const chipRemove = container.querySelector<HTMLButtonElement>('button[aria-label^="Remove "]');
+    if (!send || !chipRemove) throw new Error("Desktop new-chat controls missing");
+    expect(Number.parseInt(send.style.width, 10)).toBe(28);
+    // Desktop keeps the compact hover-revealed × .
+    expect(chipRemove.className).toContain("opacity-0");
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -2050,10 +2050,14 @@ describe("ChatView", () => {
     if (!send || !addBtn || !chipRemove) throw new Error("Mobile new-chat controls missing");
     // Composer send clears the touch minimum (mobile prop reached the composer).
     expect(Number.parseInt(send.style.width, 10)).toBe(44);
-    // The [+] add-participant button is enlarged for touch.
-    expect(Number.parseInt(addBtn.style.minWidth, 10)).toBe(40);
-    // The seeded chip's remove × is always visible on mobile (no hover on touch).
+    // The [+] add-participant button is a full 44x44 touch target.
+    expect(Number.parseInt(addBtn.style.minWidth, 10)).toBe(44);
+    expect(Number.parseInt(addBtn.style.minHeight, 10)).toBe(44);
+    // The seeded chip's remove × is always visible on mobile (no hover on touch)
+    // and is a full 44x44 hit area.
     expect(chipRemove.className).not.toContain("opacity-0");
+    expect(Number.parseInt(chipRemove.style.width, 10)).toBe(44);
+    expect(Number.parseInt(chipRemove.style.height, 10)).toBe(44);
 
     // Enter inserts a newline; it does not create the chat (button-only submit).
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -1061,9 +1061,9 @@ function ParticipantChips({
             background: "transparent",
             color: "var(--fg-3)",
             cursor: "pointer",
-            // Mobile: enlarge to a real tap target (matches the chip height so
-            // the row stays tidy). Desktop keeps the compact affordance.
-            ...(mobile ? { minWidth: 40, minHeight: 32 } : {}),
+            // Mobile: a full 44 touch target matching the composer controls;
+            // desktop keeps the compact affordance.
+            ...(mobile ? { minWidth: 44, minHeight: 44 } : {}),
           }}
         >
           <Plus className={mobile ? "h-4 w-4" : "h-3 w-3"} />

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -659,6 +659,7 @@ export function NewChatDraft({
               pickerContainerRef={pickerContainerRef}
               onAdd={addChip}
               onRemove={removeChip}
+              mobile={mobile}
             />
             {/* Attachment preview row — between the chip row and the textarea. */}
             {pendingAttachments.length > 0 && (
@@ -927,6 +928,7 @@ function ParticipantChips({
   pickerContainerRef,
   onAdd,
   onRemove,
+  mobile,
 }: {
   chips: string[];
   candidates: MentionCandidate[];
@@ -943,6 +945,9 @@ function ParticipantChips({
   pickerContainerRef: React.RefObject<HTMLDivElement | null>;
   onAdd: (agentId: string) => void;
   onRemove: (agentId: string) => void;
+  /** Touch surface: enlarge the [+] add-participant button and keep each chip's
+   *  remove × visible + tappable (desktop keeps the compact hover affordances). */
+  mobile: boolean;
 }) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [highlight, setHighlight] = useState(0);
@@ -1034,7 +1039,7 @@ function ParticipantChips({
           displayName: null,
           managedByMe: false,
         };
-        return <AgentToken key={id} candidate={cand} onRemove={() => onRemove(id)} />;
+        return <AgentToken key={id} candidate={cand} onRemove={() => onRemove(id)} mobile={mobile} />;
       })}
 
       <div ref={pickerContainerRef} style={{ position: "relative" }}>
@@ -1045,7 +1050,10 @@ function ParticipantChips({
           aria-label="Add participant"
           aria-haspopup="listbox"
           aria-expanded={pickerOpen}
-          className="inline-flex items-center transition-colors hover:bg-[var(--bg-sunken)]"
+          className={cn(
+            "inline-flex items-center transition-colors hover:bg-[var(--bg-sunken)]",
+            mobile && "justify-center",
+          )}
           style={{
             padding: "var(--sp-0_5) var(--sp-1)",
             borderRadius: "var(--radius-chip)",
@@ -1053,9 +1061,12 @@ function ParticipantChips({
             background: "transparent",
             color: "var(--fg-3)",
             cursor: "pointer",
+            // Mobile: enlarge to a real tap target (matches the chip height so
+            // the row stays tidy). Desktop keeps the compact affordance.
+            ...(mobile ? { minWidth: 40, minHeight: 32 } : {}),
           }}
         >
-          <Plus className="h-3 w-3" />
+          <Plus className={mobile ? "h-4 w-4" : "h-3 w-3"} />
         </button>
         {pickerOpen && (
           <div


### PR DESCRIPTION
## What

Closes the two non-blocking follow-ups from #1744's reviews, finishing the mobile **New task** surface.

**1. Participant-chip controls are touch-usable (`AgentToken` + the `[+]` picker):**
- The chip **remove ×** was `opacity-0 group-hover:opacity-100` — invisible on touch (no hover). On mobile it's now always visible with a roomier tap target; desktop keeps the compact hover-revealed ×.
- The **`[+]` add-participant** button is enlarged to a real tap target on mobile. Its desktop className stays byte-equivalent (the `justify-center` is gated on `mobile`).
- Uses the existing `mobile` prop, threaded `NewChatDraft → ParticipantChips → AgentToken`. `AgentToken` is only used by NewChatDraft, so no other surface changes.

**2. NewChatDraft regression tests** (the coverage gap both reviewers flagged):
- New render tests (via `CenterPanel` draft, reusing the chat-view harness mocks) assert the **mobile** contract — 44px send, Enter-does-not-create, chip × visible, `[+]` enlarged — and the unchanged **desktop** branch (compact send, hover-revealed ×).

Desktop is unchanged; every visual/behavior change is `mobile`-gated (default false).

## Verification

- ✅ `tsc` + `lint:tokens` + biome clean
- ✅ 304 tests green across `components/chat`, `mention-autocomplete`, `center`, `conversations` (incl. the 2 new NewChatDraft cases)

With this, all three mobile composers **and** the new-task recipient controls are touch-complete and consistent. Same QA caveat as #1742/#1744: no live authed on-device render from my environment; low risk by construction (constant `mobile` prop, same elements restyled).
