### PR TITLE
feat(web): portal the AskTakeover mobile @picker out of the scroll clip

### DIFF
--- a/packages/web/src/components/__tests__/mention-autocomplete-portal-dom.test.tsx
+++ b/packages/web/src/components/__tests__/mention-autocomplete-portal-dom.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment happy-dom
+
+import { act, useEffect, useRef, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MentionAutocompletePopover, type MentionCandidate, useMentionAutocomplete } from "../mention-autocomplete.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * Portal-mode lifecycle contracts (AskTakeover's clip-escaping `@` picker),
+ * guarded against regression:
+ *   1. a field scrolled fully out of its inner scrollport dismisses the picker,
+ *      so Enter can't commit a hidden candidate;
+ *   2. a coordinate-only field move (no scroll/resize/size change) is followed
+ *      on the next animation frame;
+ *   3. near the viewport top the panel height is clamped to the space above the
+ *      field (so its first/active row never renders off-screen), and dismisses
+ *      when there isn't room for even one row.
+ *
+ * happy-dom has no layout, so element rects, the scrollport lookup, and rAF are
+ * stubbed deterministically.
+ */
+
+type RectLike = { top: number; bottom: number; left: number; right: number; width: number; height: number };
+
+const twoCandidates: MentionCandidate[] = [
+  { agentId: "a1", name: "alice", displayName: "alice", managedByMe: false },
+  { agentId: "a2", name: "bob", displayName: "bob", managedByMe: false },
+];
+
+let harnessCandidates: MentionCandidate[];
+let picked: Array<{ text: string; cursor: number }>;
+let fieldRect: RectLike;
+let portRect: RectLike;
+let rafCb: FrameRequestCallback | null;
+
+function Harness() {
+  const taRef = useRef<HTMLTextAreaElement>(null);
+  // Re-render once after mount so `open` recomputes with the textarea ref
+  // attached (mirrors a real `@` keystroke re-render).
+  const [, force] = useState(0);
+  useEffect(() => force(1), []);
+  const mention = useMentionAutocomplete({
+    value: "@",
+    cursor: 1,
+    candidates: harnessCandidates,
+    onSelect: (u) => picked.push(u),
+  });
+  return (
+    <div data-scroll style={{ overflowY: "auto" }}>
+      <div data-field>
+        <MentionAutocompletePopover
+          trigger={mention.trigger}
+          results={mention.results}
+          highlightIndex={mention.highlightIndex}
+          anchorRef={taRef}
+          onPick={mention.pick}
+          portal
+          onDismiss={mention.dismiss}
+        />
+        <textarea data-ta ref={taRef} onKeyDown={(e) => mention.handleKey(e)} />
+      </div>
+    </div>
+  );
+}
+
+function mount(): { container: HTMLElement; root: Root } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<Harness />));
+  return { container, root };
+}
+
+const listbox = () => document.body.querySelector<HTMLElement>('[role="listbox"]');
+const px = (v: string) => Number.parseInt(v, 10);
+const flushFrame = () => {
+  const cb = rafCb;
+  rafCb = null;
+  if (cb) act(() => cb(0));
+};
+
+describe("MentionAutocompletePopover portal lifecycle", () => {
+  beforeEach(() => {
+    harnessCandidates = twoCandidates;
+    picked = [];
+    fieldRect = { top: 400, bottom: 440, left: 20, right: 340, width: 320, height: 40 };
+    portRect = { top: 100, bottom: 500, left: 0, right: 360, width: 360, height: 400 };
+    rafCb = null;
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      rafCb = cb;
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {
+      rafCb = null;
+    });
+    Object.defineProperty(window, "innerHeight", { value: 800, configurable: true });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+      if (this.hasAttribute("data-field")) return fieldRect as DOMRect;
+      if (this.hasAttribute("data-scroll")) return portRect as DOMRect;
+      return { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0 } as DOMRect;
+    });
+    const realGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, "getComputedStyle").mockImplementation((el: Element) => {
+      if (el.hasAttribute?.("data-scroll")) return { overflowY: "auto" } as CSSStyleDeclaration;
+      return realGetComputedStyle(el);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("renders the portal listbox docked above the field when it is in view", () => {
+    const { root } = mount();
+    expect(listbox()).not.toBeNull();
+    expect(px(listbox()?.style.bottom ?? "")).toBe(400); // innerHeight(800) - field.top(400)
+    act(() => root.unmount());
+  });
+
+  it("dismisses when the field is out of its scrollport, and Enter then selects nothing", () => {
+    fieldRect = { ...fieldRect, top: 40, bottom: 90 }; // fully above the scrollport top (bottom <= 100)
+    const { container, root } = mount();
+
+    expect(listbox()).toBeNull();
+
+    const ta = container.querySelector<HTMLTextAreaElement>("[data-ta]");
+    act(() => {
+      ta?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    });
+    expect(picked).toHaveLength(0);
+    act(() => root.unmount());
+  });
+
+  it("follows a coordinate-only field move on the next animation frame", () => {
+    const { root } = mount();
+    expect(px(listbox()?.style.bottom ?? "")).toBe(400);
+
+    fieldRect = { ...fieldRect, top: 300, bottom: 340 }; // moved up 100; no scroll/resize/size change
+    flushFrame();
+
+    expect(px(listbox()?.style.bottom ?? "")).toBe(500); // 800 - 300
+    act(() => root.unmount());
+  });
+
+  it("clamps the panel height to the space above the field near the viewport top", () => {
+    // Scrollport reaches the viewport top; field sits 60 below it — in the
+    // scrollport, but with only 60 of usable space above.
+    portRect = { ...portRect, top: 0 };
+    fieldRect = { ...fieldRect, top: 60, bottom: 100 };
+    const { root } = mount();
+    expect(listbox()).not.toBeNull();
+    expect(px(listbox()?.style.maxHeight ?? "")).toBe(60); // clamped, not the 16rem cap
+    act(() => root.unmount());
+  });
+
+  it("dismisses when there isn't room above the field for even the active row", () => {
+    portRect = { ...portRect, top: 0 };
+    fieldRect = { ...fieldRect, top: 30, bottom: 70 }; // 30 < one row (46)
+    const { container, root } = mount();
+    expect(listbox()).toBeNull();
+
+    const ta = container.querySelector<HTMLTextAreaElement>("[data-ta]");
+    act(() => {
+      ta?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    });
+    expect(picked).toHaveLength(0);
+    act(() => root.unmount());
+  });
+
+  it("re-scrolls the active row into view when a geometry-only clamp shrinks the panel", () => {
+    // Eight candidates, scrollport from the viewport top so the field can move
+    // near the top and shrink the clamp.
+    harnessCandidates = Array.from({ length: 8 }, (_, i) => ({
+      agentId: `a${i}`,
+      name: `n${i}`,
+      displayName: `n${i}`,
+      managedByMe: false,
+    }));
+    portRect = { ...portRect, top: 0 };
+    const scrollSpy = vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(() => {});
+    const { container, root } = mount();
+    const ta = container.querySelector<HTMLTextAreaElement>("[data-ta]");
+
+    // Highlight a later row (7th) — field is far from the top, panel is tall.
+    for (let i = 0; i < 6; i++) {
+      act(() => ta?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true })));
+    }
+    scrollSpy.mockClear();
+
+    // Coordinate-only move toward the viewport top → maxHeight clamps 256 → 60,
+    // highlight index unchanged. The active row must be re-scrolled into view.
+    fieldRect = { ...fieldRect, top: 60, bottom: 100 };
+    flushFrame();
+
+    expect(px(listbox()?.style.maxHeight ?? "")).toBe(60);
+    expect(scrollSpy).toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+});

--- a/packages/web/src/components/__tests__/mention-autocomplete.test.ts
+++ b/packages/web/src/components/__tests__/mention-autocomplete.test.ts
@@ -5,8 +5,10 @@ import {
   type CandidateDivider,
   composerPickerVisible,
   detectMentionTrigger,
+  fieldOutOfScrollport,
   groupAndSortCandidates,
   type MentionCandidate,
+  portalPanelPlacement,
   rankCandidates,
 } from "../mention-autocomplete.js";
 
@@ -376,5 +378,55 @@ describe("composerPickerVisible", () => {
   it("never welds on the trial composer, even with a live trigger — trial renders no panel", () => {
     expect(composerPickerVisible({ isTrial: true, mentionOpen: false, slashOpen: true })).toBe(false);
     expect(composerPickerVisible({ isTrial: true, mentionOpen: true, slashOpen: true })).toBe(false);
+  });
+});
+
+describe("fieldOutOfScrollport", () => {
+  const port = { top: 100, bottom: 500 };
+
+  it("is in view while the field overlaps the scrollport", () => {
+    expect(fieldOutOfScrollport({ top: 400, bottom: 440 }, port)).toBe(false);
+    // partially above the top still counts as in view (some rows visible)
+    expect(fieldOutOfScrollport({ top: 80, bottom: 130 }, port)).toBe(false);
+    // partially below the bottom still counts as in view
+    expect(fieldOutOfScrollport({ top: 470, bottom: 520 }, port)).toBe(false);
+  });
+
+  it("is out of view when fully above the scrollport top (dismiss)", () => {
+    expect(fieldOutOfScrollport({ top: 40, bottom: 90 }, port)).toBe(true);
+    // touching edge (bottom === port.top) counts as out
+    expect(fieldOutOfScrollport({ top: 60, bottom: 100 }, port)).toBe(true);
+  });
+
+  it("is out of view when fully below the scrollport bottom (dismiss)", () => {
+    expect(fieldOutOfScrollport({ top: 540, bottom: 580 }, port)).toBe(true);
+    // touching edge (top === port.bottom) counts as out
+    expect(fieldOutOfScrollport({ top: 500, bottom: 560 }, port)).toBe(true);
+  });
+});
+
+describe("portalPanelPlacement", () => {
+  const port = { top: 0, bottom: 800 };
+
+  it("clamps max height to the space above the field, capped at 16rem (256)", () => {
+    expect(portalPanelPlacement({ field: { top: 60, bottom: 100 }, port, viewportTop: 0 })).toEqual({ maxHeight: 60 });
+    // plenty of room above → capped at the 16rem panel max
+    expect(portalPanelPlacement({ field: { top: 400, bottom: 440 }, port, viewportTop: 0 })).toEqual({
+      maxHeight: 256,
+    });
+  });
+
+  it("subtracts the visual-viewport top offset from the available space", () => {
+    expect(portalPanelPlacement({ field: { top: 120, bottom: 160 }, port, viewportTop: 40 })).toEqual({
+      maxHeight: 80,
+    });
+  });
+
+  it("dismisses (null) when the field is out of its scrollport", () => {
+    expect(portalPanelPlacement({ field: { top: 850, bottom: 890 }, port, viewportTop: 0 })).toBeNull();
+  });
+
+  it("dismisses (null) when there isn't room above the field for even one row", () => {
+    expect(portalPanelPlacement({ field: { top: 30, bottom: 70 }, port, viewportTop: 0 })).toBeNull();
   });
 });

--- a/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
@@ -702,4 +702,80 @@ describe("AskTakeover", () => {
     await keyDown(window, "Enter");
     expect(onReply).toHaveBeenCalledWith({ content: "looks risky", mentions: [], images: [] });
   });
+
+  it("narrow: portals the @picker, then dismisses it (no hidden Enter selection) when the field leaves its scrollport", async () => {
+    // Controlled rAF (the portal loop reschedules itself, so an immediate rAF
+    // would recurse); drive one frame manually after moving the field.
+    let rafCb: FrameRequestCallback | null = null;
+    const origRaf = globalThis.requestAnimationFrame;
+    const origCancel = globalThis.cancelAnimationFrame;
+    const origMatchMedia = window.matchMedia;
+    globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      rafCb = cb;
+      return 1;
+    };
+    globalThis.cancelAnimationFrame = () => {
+      rafCb = null;
+    };
+    // Force the phone-width viewport so AskTakeover opts into portal mode
+    // (useWorkspaceViewport → "narrow" when no wider query matches).
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+    // Mutable field rect (starts inside the scrollport); the answer scroller is
+    // the element with inline `overflow-y: auto`.
+    const field = { top: 300, bottom: 340, left: 20, right: 340, width: 320, height: 40 };
+    const PORT = { top: 100, bottom: 500, left: 0, right: 360, width: 360, height: 400 } as DOMRect;
+    const realGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+      if (this.classList.contains("ask-answer-field")) return field as DOMRect;
+      if (this.style?.overflowY === "auto") return PORT;
+      return { top: 0, bottom: 0, left: 0, right: 0, width: 0, height: 0 } as DOMRect;
+    });
+    vi.spyOn(window, "getComputedStyle").mockImplementation((el: Element) => {
+      if ((el as HTMLElement).style?.overflowY === "auto") return { overflowY: "auto" } as CSSStyleDeclaration;
+      return realGetComputedStyle(el);
+    });
+
+    try {
+      const c = await renderDom(
+        <AskTakeover
+          body="# Pick"
+          payload={{ multiSelect: false }}
+          mentionCandidates={CANDIDATES}
+          onReply={() => {}}
+          onSkip={() => {}}
+        />,
+      );
+      const ta = freeTextBox(c);
+      if (!ta) throw new Error("free-text input missing");
+      await setValue(ta, "@");
+
+      // AskTakeover wired `portal`: a body-portaled picker appears (not in-flow).
+      const panel = document.body.querySelector<HTMLElement>('[role="listbox"]');
+      expect(panel).not.toBeNull();
+      expect(panel?.classList.contains("mention-popover--portal")).toBe(true);
+
+      // Field scrolls fully above its scrollport top → picker dismissed.
+      field.top = 10;
+      field.bottom = 50;
+      await act(async () => rafCb?.(0));
+      expect(document.body.querySelector('[role="listbox"]')).toBeNull();
+
+      // AskTakeover wired `onDismiss`: Enter now commits nothing (no hidden row).
+      await keyDown(ta, "Enter");
+      expect(ta.value).toBe("@");
+    } finally {
+      globalThis.requestAnimationFrame = origRaf;
+      globalThis.cancelAnimationFrame = origCancel;
+      window.matchMedia = origMatchMedia;
+    }
+  });
 });

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -35,7 +35,12 @@ import { AtSign, Paperclip, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { usePendingAttachments } from "../../lib/use-pending-attachments.js";
-import { MentionAutocompletePopover, type MentionCandidate, useMentionAutocomplete } from "../mention-autocomplete.js";
+import {
+  composerPickerVisible,
+  MentionAutocompletePopover,
+  type MentionCandidate,
+  useMentionAutocomplete,
+} from "../mention-autocomplete.js";
 import { MentionHighlightOverlay } from "../mention-highlight-overlay.js";
 import { FileChip } from "../ui/file-chip.js";
 import { Markdown } from "../ui/markdown.js";
@@ -274,10 +279,11 @@ export function AskTakeover({
   // behind it can draw the actual glyphs (PR 1256). An opaque textarea
   // background sits *above* that overlay and hides the typed text — the
   // white-on-white regression this restores. Mirrors chat-view's composer.
+  // Radius lives in `.ask-answer-field` (index.css), not inline, so the phone
+  // weld rule can flatten the top corners while the portal picker is docked.
   const fieldChrome = {
     position: "relative" as const,
     border: "var(--hairline) solid var(--border-strong)",
-    borderRadius: "var(--radius-input)",
     background: "var(--bg)",
   };
 
@@ -312,7 +318,17 @@ export function AskTakeover({
    *  as the sole box on a free-text ask): mention autocomplete + highlight +
    *  image paste, with the text drawn by the mirror overlay. */
   const renderAnswerInput = (placeholder: string, minHeight: number) => (
-    <div style={fieldChrome}>
+    <div
+      className="ask-answer-field"
+      // Phone-only weld: flatten the field's top corners while the portal picker
+      // is docked flush above it (`.ask-answer-field[data-picker-open]` in
+      // index.css). composerPickerVisible keeps a trial `@` (no panel rendered)
+      // from welding an empty field.
+      data-picker-open={
+        composerPickerVisible({ isTrial, mentionOpen: mention.trigger != null, slashOpen: false }) ? "true" : undefined
+      }
+      style={fieldChrome}
+    >
       {/* No mention autocomplete on the trial answer input (single agent). */}
       {isTrial ? null : (
         <MentionAutocompletePopover
@@ -321,6 +337,13 @@ export function AskTakeover({
           highlightIndex={mention.highlightIndex}
           anchorRef={taRef}
           onPick={mention.pick}
+          // Phone: portal the picker out of the answer card's scroll clip so its
+          // first/active candidates stay visible. Wider viewports keep the
+          // in-flow float (the card is tall enough there not to clip).
+          portal={viewport === "narrow"}
+          // Dismiss (not just hide) when the field scrolls out of the card so the
+          // now-invisible picker can't be Enter-selected.
+          onDismiss={mention.dismiss}
         />
       )}
       <MentionHighlightOverlay

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -1,6 +1,7 @@
 import { X } from "lucide-react";
 import type { ReactNode } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Avatar } from "./avatar.js";
 
 /**
@@ -549,6 +550,60 @@ export function useMentionAutocomplete({
 }
 
 /**
+ * True when `field` is fully outside `port` on the vertical axis — the field has
+ * scrolled past its clipping scrollport, so a panel glued above it would float
+ * over unrelated content (or off-screen). The portal picker uses this to
+ * dismiss (not just hide) so an invisible panel is never keyboard-selectable.
+ */
+export function fieldOutOfScrollport(
+  field: { top: number; bottom: number },
+  port: { top: number; bottom: number },
+): boolean {
+  return field.bottom <= port.top || field.top >= port.bottom;
+}
+
+/** One `.mention-option` row (`min-height: 2.875rem` = 46). */
+const PORTAL_MIN_PANEL = 46;
+/** Portal panel height cap (`.mention-popover--portal max-height: 16rem`). */
+const PORTAL_MAX_PANEL = 256;
+
+/**
+ * Placement for the upward-docked portal panel, or `null` to dismiss. The panel
+ * welds its bottom to the field top and grows upward, so it must be clamped to
+ * the space above the field within the visible viewport — otherwise its top
+ * (first/active, Enter-selected) rows render above the viewport top, off-screen
+ * yet selectable. Dismiss when the field is out of its scrollport, or when there
+ * isn't room above it for even the active row (a hidden active row is worse than
+ * no picker). Pure so the geometry is unit-testable without layout.
+ */
+export function portalPanelPlacement(opts: {
+  field: { top: number; bottom: number };
+  port: { top: number; bottom: number };
+  viewportTop: number;
+}): { maxHeight: number } | null {
+  const { field, port, viewportTop } = opts;
+  if (fieldOutOfScrollport(field, port)) return null;
+  const available = field.top - viewportTop;
+  if (available < PORTAL_MIN_PANEL) return null;
+  return { maxHeight: Math.min(available, PORTAL_MAX_PANEL) };
+}
+
+/**
+ * Nearest scrolling ancestor of `el` — the element whose `overflow` clips an
+ * in-flow descendant. Used by the portal picker to bound visibility to the
+ * actual clipping scrollport rather than the layout viewport.
+ */
+function nearestScrollableAncestor(el: HTMLElement): HTMLElement | null {
+  let node = el.parentElement;
+  while (node) {
+    const oy = getComputedStyle(node).overflowY;
+    if (oy === "auto" || oy === "scroll") return node;
+    node = node.parentElement;
+  }
+  return null;
+}
+
+/**
  * Popover body. Expects `anchorRef` to point at a textarea so the popover
  * can sit directly above it (the textarea is at the bottom of the chat
  * view; dropping above avoids covering the input while typing).
@@ -559,59 +614,180 @@ export function MentionAutocompletePopover({
   highlightIndex,
   onPick,
   anchorRef,
+  portal = false,
+  onDismiss,
 }: {
   trigger: ActiveTrigger | null;
   results: MentionCandidate[];
   highlightIndex: number;
   onPick: (candidate: MentionCandidate) => void;
   anchorRef: { current: HTMLTextAreaElement | null };
+  /** Render into a `document.body` portal with fixed positioning so the panel
+   *  escapes an ancestor's overflow clip. AskTakeover's answer field lives in a
+   *  scrolling card that clips an in-flow panel docked above it (hiding the
+   *  first / active candidates — a wrong-selection hazard). Only hosts inside a
+   *  clipping scroller pass this; the panel is positioned flush above the field
+   *  and re-measures every frame while open. See `.mention-popover--portal` in
+   *  index.css. Same idiom as `ui/popover.tsx` / `ui/hover-card.tsx`. */
+  portal?: boolean;
+  /** Portal only: called when the field scrolls fully out of its clipping
+   *  scrollport. The host dismisses the trigger so a panel the user can no
+   *  longer see is never keyboard-selectable (visibility atomic with the
+   *  active-row selection). Wire to the mention hook's `dismiss`. */
+  onDismiss?: () => void;
 }) {
   const popoverRef = useRef<HTMLDivElement | null>(null);
+  const [fixedRect, setFixedRect] = useState<{
+    left: number;
+    width: number;
+    bottom: number;
+    maxHeight: number;
+  } | null>(null);
+  // Keep the latest onDismiss without re-running the positioning effect (the
+  // host passes a fresh closure each render).
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
 
-  // Scroll the active row into view when the highlight changes.
-  useEffect(() => {
+  const open = trigger != null && results.length > 0 && anchorRef.current != null;
+
+  // Scroll the active row into view when the highlight changes — and also when
+  // the portal clamp shrinks the panel (`fixedRect.maxHeight`), which can push a
+  // previously-visible highlighted row below the smaller viewport while the
+  // highlight index is unchanged, hiding an Enter-selectable active row.
+  // `useLayoutEffect` so it re-establishes visibility before paint (no flash of
+  // the hidden active row); the `maxHeight` dep runs it only on a committed
+  // clamp change, not on every rAF frame.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fixedRect.maxHeight IS the trigger — re-run on a committed clamp shrink to re-scroll the active row, even though the body reads the row via the DOM, not the value.
+  useLayoutEffect(() => {
     const el = popoverRef.current?.querySelector<HTMLElement>(`[data-mention-index="${highlightIndex}"]`);
     el?.scrollIntoView({ block: "nearest" });
-  }, [highlightIndex]);
+  }, [highlightIndex, fixedRect?.maxHeight]);
+
+  // Portal positioning: keep the fixed panel flush above the anchor's field. A
+  // requestAnimationFrame loop re-measures every frame while open, so the panel
+  // stays glued through ANY anchor movement — inner-scroller scroll, keyboard,
+  // resize, and in-card reflow that moves the field without a scroll/resize
+  // event or a field size change (which scroll listeners + ResizeObserver miss).
+  // The field is the anchor textarea's parent (popover + textarea are siblings
+  // inside it) — measuring the field welds the panel to its outer edge. setState
+  // bails when the rect is unchanged, so idle frames don't re-render.
+  useLayoutEffect(() => {
+    if (!portal || !open) {
+      setFixedRect(null);
+      return;
+    }
+    const anchor = anchorRef.current;
+    if (!anchor) return;
+    const field = anchor.parentElement ?? anchor;
+    // Boundary = the clipping scrollport (the ancestor whose overflow does the
+    // clipping), not the window: the field can scroll out of the card's scroller
+    // while still inside the layout viewport.
+    const scrollport = nearestScrollableAncestor(field);
+    let raf = 0;
+    let dismissed = false;
+    const measure = () => {
+      const r = field.getBoundingClientRect();
+      const portRect = scrollport ? scrollport.getBoundingClientRect() : { top: 0, bottom: window.innerHeight };
+      // Top of the visible viewport (shifts under pinch-zoom; 0 normally).
+      const viewportTop = window.visualViewport ? window.visualViewport.offsetTop : 0;
+      // null → dismiss: the field left its scrollport, or there isn't room above
+      // it (within the viewport) for even the active row. Otherwise the panel is
+      // height-clamped so its top (first/active) rows never render above the
+      // viewport — off-screen but still Enter-selectable.
+      const placement = portalPanelPlacement({ field: r, port: portRect, viewportTop });
+      if (!placement) {
+        setFixedRect(null);
+        if (!dismissed) {
+          dismissed = true;
+          onDismissRef.current?.();
+        }
+        return;
+      }
+      setFixedRect((prev) => {
+        const next = {
+          left: r.left,
+          width: r.width,
+          bottom: window.innerHeight - r.top,
+          maxHeight: placement.maxHeight,
+        };
+        return prev &&
+          prev.left === next.left &&
+          prev.width === next.width &&
+          prev.bottom === next.bottom &&
+          prev.maxHeight === next.maxHeight
+          ? prev
+          : next;
+      });
+    };
+    const tick = () => {
+      measure();
+      raf = requestAnimationFrame(tick);
+    };
+    measure(); // sync first measure so the panel never paints at (0,0)
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [portal, open, anchorRef]);
 
   if (!trigger || results.length === 0) return null;
   const anchor = anchorRef.current;
   if (!anchor) return null;
 
+  const ambiguous = ambiguousDisplayNames(results);
+  const rows = results.map((c, i) => {
+    const active = i === highlightIndex;
+    return (
+      <button
+        key={c.agentId}
+        type="button"
+        role="option"
+        aria-selected={active}
+        data-mention-index={i}
+        title={c.name ? `@${c.name}` : undefined}
+        onMouseDown={(e) => {
+          // preventDefault keeps the textarea focused so `selectionStart`
+          // can still be used to compute the insertion point.
+          e.preventDefault();
+          onPick(c);
+        }}
+        className="mention-option flex w-full items-center px-3 py-1.5 text-left text-body"
+        style={{
+          background: active ? "var(--bg-hover)" : "transparent",
+          color: "var(--fg)",
+          border: "none",
+          cursor: "pointer",
+          whiteSpace: "nowrap",
+        }}
+      >
+        <AgentOption candidate={c} ambiguous={ambiguous} />
+      </button>
+    );
+  });
+
+  if (portal) {
+    // Skip the first paint until measured (avoids a flash at 0,0).
+    if (!fixedRect) return null;
+    return createPortal(
+      <div
+        ref={popoverRef}
+        role="listbox"
+        aria-label="Mention suggestions"
+        className="mention-popover mention-popover--portal"
+        style={{
+          left: fixedRect.left,
+          width: fixedRect.width,
+          bottom: fixedRect.bottom,
+          maxHeight: fixedRect.maxHeight,
+        }}
+      >
+        {rows}
+      </div>,
+      document.body,
+    );
+  }
+
   return (
     <div ref={popoverRef} role="listbox" aria-label="Mention suggestions" className="mention-popover">
-      {(() => {
-        const ambiguous = ambiguousDisplayNames(results);
-        return results.map((c, i) => {
-          const active = i === highlightIndex;
-          return (
-            <button
-              key={c.agentId}
-              type="button"
-              role="option"
-              aria-selected={active}
-              data-mention-index={i}
-              title={c.name ? `@${c.name}` : undefined}
-              onMouseDown={(e) => {
-                // preventDefault keeps the textarea focused so `selectionStart`
-                // can still be used to compute the insertion point.
-                e.preventDefault();
-                onPick(c);
-              }}
-              className="mention-option flex w-full items-center px-3 py-1.5 text-left text-body"
-              style={{
-                background: active ? "var(--bg-hover)" : "transparent",
-                color: "var(--fg)",
-                border: "none",
-                cursor: "pointer",
-                whiteSpace: "nowrap",
-              }}
-            >
-              <AgentOption candidate={c} ambiguous={ambiguous} />
-            </button>
-          );
-        });
-      })()}
+      {rows}
     </div>
   );
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -952,6 +952,35 @@
   max-height: 18rem;
 }
 
+/* The ask answer box. Radius lives here (not inline) so the phone weld rule can
+   flatten its top corners while the portal picker is docked above it. */
+.ask-answer-field {
+  border-radius: var(--radius-input);
+}
+
+/* Portal variant (AskTakeover): the panel renders in a `document.body` portal
+   with fixed positioning (left/width/bottom set inline from the field rect) so
+   it escapes the answer card's overflow clip — an in-flow panel docked above
+   the field would be cut off, hiding the first/active candidates. Full field
+   width, welded flush above the field with a top-only shadow: the same look as
+   the in-flow docks, without the clip. Used only on phones (the host gates the
+   portal on viewport width). Same portal idiom as ui/popover.tsx /
+   ui/hover-card.tsx (fixed, body-portaled, z above the modal scrim). */
+.mention-popover--portal {
+  position: fixed;
+  /* Between the ask scrim (z-index 30) and the Radix modal layer (dialog /
+     command palette, z-index 50): the picker sits above the ask card but never
+     over a modal opened on top (e.g. Cmd+K with an active `@`). */
+  z-index: 40;
+  min-width: 0;
+  max-width: none;
+  max-height: 16rem;
+  border-radius: var(--radius-panel) var(--radius-panel) 0 0;
+  border-bottom-color: transparent;
+  box-shadow: var(--shadow-md-up);
+  clip-path: inset(-18px 0 0 0);
+}
+
 @media (max-width: 47.999rem) {
   /* Phone: a composer picker popover spans the full input width and docks flush
      to the input's top edge, so panel + input read as one surface instead of a
@@ -983,13 +1012,15 @@
   .slash-option {
     min-height: 2.875rem;
   }
-  /* The chat composer has a clean top edge flush against the panel, so it drops
-     its top rounding while a picker is open → the panel's flat bottom meets a
-     flat top, one continuous surface. A host whose picker docks above a mid-card
-     text row (NewChatDraft: a chip row sits above the field) omits
-     `data-picker-open`, keeping its corners — the panel is still full-width,
-     just not corner-welded. */
-  .composer-card[data-picker-open="true"] {
+  /* Welding hosts have a clean top edge flush against the panel, so they drop
+     their top rounding while a picker is open → the panel's flat bottom meets a
+     flat top, one continuous surface. Chat composer = in-flow dock; ask answer
+     box = portal dock (`.mention-popover--portal`). A host whose picker docks
+     above a mid-card text row (NewChatDraft: a chip row sits above the field)
+     omits `data-picker-open`, keeping its corners — full-width, not corner-
+     welded. */
+  .composer-card[data-picker-open="true"],
+  .ask-answer-field[data-picker-open="true"] {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
   }


### PR DESCRIPTION
## What & why

Follow-up to #1743 (which deferred AskTakeover). AskTakeover's answer field lives inside an `overflow-y:auto` card, so an in-flow `@`mention panel docked above the field is **clipped** — hiding the first/active candidates while Enter still selects a hidden row (a wrong-selection hazard, reproduced at 390×844).

## How

Opt-in **`portal`** mode on `MentionAutocompletePopover`: it renders into a `document.body` portal with `position: fixed`, positioned from the field's `getBoundingClientRect()`, so it **escapes the clip**. Full field width, welded flush above the field with the same top-only clipped shadow as the in-flow docks. Same idiom as `ui/popover.tsx` / `ui/hover-card.tsx`.

Positioning lifecycle (hardened over review):
- **`requestAnimationFrame` loop** while open re-measures every frame, so it follows *any* anchor movement — inner-scroller scroll, keyboard, resize, and coordinate-only reflow (attachment tray growing above the field) that scroll listeners + `ResizeObserver` miss. setState bails on an unchanged rect; the loop stops on close/dismiss.
- **Visibility bounded by the real clipping scrollport** (`nearestScrollableAncestor`), not the window. When the field scrolls fully out of its scrollport the picker **dismisses** (`onDismiss` → the mention hook's `dismiss`), not just hides — so a hidden panel is never Enter/Tab-selectable.
- **Height clamped to the visible space above the field** (incl. `visualViewport.offsetTop`) so the panel's first/active row never renders above the viewport top; **dismisses** when there isn't room for even one row.
- **`z-index: 40`** — above the ask scrim (30), below the Radix modal layer (dialog / command palette, 50), so Cmd+K over an active `@` sits above the picker.

`AskTakeover` passes `portal` only on phone widths (`viewport === "narrow"`); wider viewports keep the in-flow float. The field welds via `.ask-answer-field` + `data-picker-open` (`composerPickerVisible` → no empty weld on a trial `@`). **Chat/NewChat pickers untouched** (`portal` defaults false). **Desktop unchanged.**

## Verification

- typecheck + lint:tokens clean, `biome` clean (only the pre-existing `index.css` `noImportantStyles` warning), **1353 web tests pass**.
- New deterministic coverage: pure `fieldOutOfScrollport` / `portalPanelPlacement` geometry tests, plus **portal DOM lifecycle tests** (`mention-autocomplete-portal-dom.test.tsx`): out-of-scrollport → no listbox + Enter selects nothing; coordinate-only move → position follows next frame; near-viewport-top → height clamped; too-tight → dismissed.
- Rendered the shipped CSS + positioning at 390px in **light and dark**: full candidate list visible (clip escaped), welded, no dark seam.

## Scope

`packages/web` — shared picker component + AskTakeover host + picker styles + tests. No data/schema/routing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
