### PR TITLE
feat(web): workspace chat-list — search-only Participants filter (PR4b)

### DIFF
--- a/packages/web/src/lib/participant-name-cache.ts
+++ b/packages/web/src/lib/participant-name-cache.ts
@@ -1,57 +1,47 @@
-import { useSyncExternalStore } from "react";
+import { type QueryClient, useQuery } from "@tanstack/react-query";
 
 /**
- * A tiny session-lifetime cache of participant `uuid -> displayName`, populated
- * from `useOrgAgentsSearch` result rows.
+ * A cache of participant `uuid -> displayName` learned from
+ * `useOrgAgentsSearch` result rows, held INSIDE react-query so it shares the
+ * org/auth lifecycle: a `queryClient.clear()` on organization switch or logout
+ * wipes it like every other cached query, and it is never a second,
+ * un-invalidated source of truth living at module scope.
  *
- * The Participants filter is search-only, so a viewer can select an identity
- * that sorts past the org-list 100-row first page — exactly who the at-scale
- * search exists to reach. `useAgentNameMap` only knows that first page, so
- * without this cache such a selection renders as a raw UUID on its filter chips
- * the moment it leaves the visible result rows: in the rail's persistent chip
- * row, and in the popover chip after the panel closes and reopens (the picking
- * component unmounts each time). This cache lives at module scope so a name
- * learned from any search survives those remounts and is shared by both chip
- * surfaces; it falls back to the identity map for names it has never seen.
+ * Its only job is a FALLBACK label for an identity the authoritative
+ * `useAgentNameMap` cannot resolve — one that sorts past the org-list 100-row
+ * first page, exactly who the at-scale participant search reaches. Chip
+ * consumers always PREFER the authoritative map (so a rename, which invalidates
+ * `["agents"]` and refreshes the map, immediately wins) and read this cache
+ * only for ids the map still returns unresolved.
  */
-const names = new Map<string, string>();
-const listeners = new Set<() => void>();
-// A fresh snapshot identity on every change so `useSyncExternalStore` re-renders;
-// stable between changes so `getSnapshot` never loops.
-let snapshot: ReadonlyMap<string, string> = new Map(names);
+const PARTICIPANT_NAME_CACHE_KEY = ["participant-name-cache"] as const;
+type NameMap = Readonly<Record<string, string>>;
 
-function emit(): void {
-  snapshot = new Map(names);
-  for (const listener of listeners) listener();
-}
-
-/** Record display names seen in a search result set. Idempotent + no-op if unchanged. */
-export function rememberParticipantNames(agents: ReadonlyArray<{ uuid: string; displayName: string }>): void {
-  let changed = false;
-  for (const agent of agents) {
-    if (agent.displayName && names.get(agent.uuid) !== agent.displayName) {
-      names.set(agent.uuid, agent.displayName);
-      changed = true;
+/** Record the display names seen in a participant search result set. */
+export function rememberParticipantNames(
+  queryClient: QueryClient,
+  agents: ReadonlyArray<{ uuid: string; displayName: string }>,
+): void {
+  queryClient.setQueryData<NameMap>(PARTICIPANT_NAME_CACHE_KEY, (prev) => {
+    const base = prev ?? {};
+    let next: Record<string, string> | null = null;
+    for (const agent of agents) {
+      if (agent.displayName && base[agent.uuid] !== agent.displayName) {
+        next = next ?? { ...base };
+        next[agent.uuid] = agent.displayName;
+      }
     }
-  }
-  if (changed) emit();
+    return next ?? base;
+  });
 }
 
-/** Test-only: clear the module cache so cases don't leak names into each other. */
-export function __resetParticipantNameCacheForTests(): void {
-  names.clear();
-  emit();
-}
-
-/** Subscribe to the cache; returns a resolver `uuid -> name | undefined`. */
+/** Subscribe to the fallback cache; returns a resolver `uuid -> name | undefined`. */
 export function useParticipantNames(): (uuid: string) => string | undefined {
-  const map = useSyncExternalStore(
-    (listener) => {
-      listeners.add(listener);
-      return () => listeners.delete(listener);
-    },
-    () => snapshot,
-    () => snapshot,
-  );
-  return (uuid: string) => map.get(uuid);
+  const { data } = useQuery<NameMap>({
+    queryKey: PARTICIPANT_NAME_CACHE_KEY,
+    queryFn: () => ({}),
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+  });
+  return (uuid: string) => data?.[uuid];
 }

--- a/packages/web/src/lib/participant-name-cache.ts
+++ b/packages/web/src/lib/participant-name-cache.ts
@@ -1,0 +1,57 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * A tiny session-lifetime cache of participant `uuid -> displayName`, populated
+ * from `useOrgAgentsSearch` result rows.
+ *
+ * The Participants filter is search-only, so a viewer can select an identity
+ * that sorts past the org-list 100-row first page — exactly who the at-scale
+ * search exists to reach. `useAgentNameMap` only knows that first page, so
+ * without this cache such a selection renders as a raw UUID on its filter chips
+ * the moment it leaves the visible result rows: in the rail's persistent chip
+ * row, and in the popover chip after the panel closes and reopens (the picking
+ * component unmounts each time). This cache lives at module scope so a name
+ * learned from any search survives those remounts and is shared by both chip
+ * surfaces; it falls back to the identity map for names it has never seen.
+ */
+const names = new Map<string, string>();
+const listeners = new Set<() => void>();
+// A fresh snapshot identity on every change so `useSyncExternalStore` re-renders;
+// stable between changes so `getSnapshot` never loops.
+let snapshot: ReadonlyMap<string, string> = new Map(names);
+
+function emit(): void {
+  snapshot = new Map(names);
+  for (const listener of listeners) listener();
+}
+
+/** Record display names seen in a search result set. Idempotent + no-op if unchanged. */
+export function rememberParticipantNames(agents: ReadonlyArray<{ uuid: string; displayName: string }>): void {
+  let changed = false;
+  for (const agent of agents) {
+    if (agent.displayName && names.get(agent.uuid) !== agent.displayName) {
+      names.set(agent.uuid, agent.displayName);
+      changed = true;
+    }
+  }
+  if (changed) emit();
+}
+
+/** Test-only: clear the module cache so cases don't leak names into each other. */
+export function __resetParticipantNameCacheForTests(): void {
+  names.clear();
+  emit();
+}
+
+/** Subscribe to the cache; returns a resolver `uuid -> name | undefined`. */
+export function useParticipantNames(): (uuid: string) => string | undefined {
+  const map = useSyncExternalStore(
+    (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    () => snapshot,
+    () => snapshot,
+  );
+  return (uuid: string) => map.get(uuid);
+}

--- a/packages/web/src/pages/conversation-list-preview.tsx
+++ b/packages/web/src/pages/conversation-list-preview.tsx
@@ -256,21 +256,12 @@ function seededClient(): QueryClient {
   // narrows visibly instead of blanking.
   client.setQueryData(["me", "chats", "all", "active", false, "manual", null], page(bySource(ACTIVE_ALL, "manual")));
   client.setQueryData(["me", "chats", "all", "active", false, "github", null], page(bySource(ACTIVE_ALL, "github")));
-  // Name-map source consumed by `useAgentNameMap` (empty is fine — the
-  // preview doesn't surface participant chips).
+  // Name-map source consumed by `useAgentNameMap` (empty is fine). The ⚙
+  // Participants picker is search-only: its live typeahead results + selected
+  // chips need a backend, so this offline preview only demonstrates the search
+  // input + the "Type to search people." empty state — results, chips, and the
+  // filtered/no-match/error branches are covered by the DOM tests.
   client.setQueryData(["managed-agents", "name-map"], []);
-  // Addressable roster for the ⚙ filter's Participants OR-picker — so the
-  // picker renders the real checkbox list offline instead of the (correct but
-  // demo-unfriendly) "Couldn't load people." no-backend state.
-  client.setQueryData(["agents", "org-list", { addressableOnly: true }], {
-    items: [
-      { uuid: "agent-nova", displayName: "nova" },
-      { uuid: "agent-design", displayName: "design-critique" },
-      { uuid: "agent-market", displayName: "marketing-writer" },
-      { uuid: "agent-res", displayName: "research" },
-    ],
-    nextCursor: null,
-  });
   return client;
 }
 

--- a/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/conversation-list-dom.test.tsx
@@ -22,10 +22,11 @@ vi.mock("../../../../api/me-chats.js", () => meChatMocks);
 // Rows render RowEngagementMenu, which uses the toast hook; the harness has no
 // ToastProvider, so stub it.
 vi.mock("../../../../components/ui/toast.js", () => ({ useToast: () => ({ addToast: vi.fn() }) }));
-// The filter popover fetches the org roster for its Participants picker; stub it
-// so the list doesn't hit the network under test.
+// The filter popover's Participants picker is search-driven (`useOrgAgentsSearch`);
+// stub it so the list doesn't hit the network. The list tests never type into the
+// participant search, so an empty result is all that's needed.
 vi.mock("../../../../lib/use-org-agents.js", () => ({
-  useOrgAgents: () => ({ data: { items: [] }, isLoading: false }),
+  useOrgAgentsSearch: () => ({ data: { items: [] }, isFetching: false }),
 }));
 vi.mock("../../../../api/chats.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../../api/chats.js")>()),

--- a/packages/web/src/pages/workspace/conversations/__tests__/filter-popover-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/filter-popover-dom.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment happy-dom
 
 import type { ChatEngagementView, ChatSource } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, type ReactElement, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { __resetParticipantNameCacheForTests } from "../../../../lib/participant-name-cache.js";
 import { FilterPopover, originLabel } from "../filter-popover.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -22,8 +22,14 @@ let mockDebounceLag: string | null = null;
 vi.mock("../../../../lib/use-debounced-value.js", () => ({
   useDebouncedValue: (value: string) => (mockDebounceLag === null ? value : mockDebounceLag),
 }));
+// The identity map is mutable so a test can simulate a rename (the authoritative
+// roster refreshing) and prove it supersedes a cached search label. Unresolved
+// ids return the raw id, mirroring the real `useAgentNameMap`.
+const defaultNameResolve = (id: string): string =>
+  id === "agent-1" ? "Nova" : id === "agent-2" ? "Design Critique" : id;
+let mockNameResolve: (id: string) => string = defaultNameResolve;
 vi.mock("../../../../lib/use-agent-name-map.js", () => ({
-  useAgentNameMap: () => (id: string) => (id === "agent-1" ? "Nova" : id === "agent-2" ? "Design Critique" : id),
+  useAgentNameMap: () => (id: string) => mockNameResolve(id),
 }));
 let mockSearchOverride: {
   data: { items: Array<{ uuid: string; displayName: string }> } | undefined;
@@ -58,9 +64,13 @@ async function flush(): Promise<void> {
 async function renderDom(element: ReactElement): Promise<HTMLElement> {
   const container = document.createElement("div");
   document.body.appendChild(container);
+  // The participant-name cache is a react-query entry, so each case renders
+  // under a fresh client — an org switch / logout that calls `queryClient.clear()`
+  // is modeled as a new client (the cache is scoped to it, not a module global).
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   root = createRoot(container);
   await act(async () => {
-    root?.render(element);
+    root?.render(<QueryClientProvider client={queryClient}>{element}</QueryClientProvider>);
   });
   await flush();
   return container;
@@ -102,15 +112,17 @@ function StatefulFilter({
   onEngagementChange,
   onParticipantsChange,
   onResetAll,
+  initialParticipants = [],
 }: {
   onOriginChange: (origin: ReadonlyArray<ChatSource>) => void;
   onEngagementChange: (engagement: ChatEngagementView) => void;
   onParticipantsChange: (participants: ReadonlyArray<string>) => void;
   onResetAll: () => void;
+  initialParticipants?: string[];
 }) {
   const [origin, setOrigin] = useState<ChatSource[]>(["github", "agent"]);
   const [engagement, setEngagement] = useState<ChatEngagementView>("archived");
-  const [participants, setParticipants] = useState<string[]>([]);
+  const [participants, setParticipants] = useState<string[]>(initialParticipants);
   return (
     <FilterPopover
       origin={origin}
@@ -143,7 +155,7 @@ beforeEach(() => {
   document.body.innerHTML = "";
   mockSearchOverride = null;
   mockDebounceLag = null;
-  __resetParticipantNameCacheForTests();
+  mockNameResolve = defaultNameResolve;
 });
 
 afterEach(async () => {
@@ -373,5 +385,60 @@ describe("FilterPopover", () => {
     await openFilter();
     expect(document.body.textContent).toContain("@Zara");
     expect(document.body.textContent).not.toContain("agent-3");
+  });
+
+  it("lets a refreshed identity-map name supersede a cached search label", async () => {
+    const noop = (): void => {};
+    const container = await renderDom(
+      <StatefulFilter onOriginChange={noop} onEngagementChange={noop} onParticipantsChange={noop} onResetAll={noop} />,
+    );
+    await click(container.querySelector('button[aria-label="Filter"]'));
+    await typeSearch("nova");
+    await click(checkboxByLabel("Nova")); // caches "Nova"
+
+    // A rename lands on the authoritative roster (which polls / invalidates);
+    // the chip must show the fresh name, not the cached one.
+    mockNameResolve = (id) => (id === "agent-1" ? "Nova (renamed)" : defaultNameResolve(id));
+    await typeSearch(""); // any state change re-renders the section
+    const renamed = [...document.body.querySelectorAll("button")].find(
+      (b) => b.getAttribute("aria-label") === "Remove Nova (renamed)",
+    );
+    expect(renamed).toBeTruthy();
+    const stale = [...document.body.querySelectorAll("button")].find(
+      (b) => b.getAttribute("aria-label") === "Remove Nova",
+    );
+    expect(stale).toBeFalsy();
+  });
+
+  it("scopes cached search labels to the react-query client — a fresh scope starts empty", async () => {
+    const noop = (): void => {};
+    // Scope A (client A): search + select Zara → her name is cached in A.
+    const a = await renderDom(
+      <StatefulFilter onOriginChange={noop} onEngagementChange={noop} onParticipantsChange={noop} onResetAll={noop} />,
+    );
+    await click(a.querySelector('button[aria-label="Filter"]'));
+    await typeSearch("zara");
+    await click(checkboxByLabel("Zara"));
+    expect(document.body.textContent).toContain("@Zara");
+    await act(async () => root?.unmount());
+    root = null;
+    document.body.innerHTML = "";
+
+    // Scope B: a fresh client — as after an org switch / logout, where the app
+    // calls `queryClient.clear()`, so the cache (a react-query entry) is gone —
+    // with Zara pre-selected via URL but never searched here. Her chip must fall
+    // back to the raw uuid, never leaking scope A's cached "Zara".
+    const b = await renderDom(
+      <StatefulFilter
+        onOriginChange={noop}
+        onEngagementChange={noop}
+        onParticipantsChange={noop}
+        onResetAll={noop}
+        initialParticipants={["agent-3"]}
+      />,
+    );
+    await click(b.querySelector('button[aria-label="Filter"]'));
+    expect(document.body.textContent).toContain("@agent-3");
+    expect(document.body.textContent).not.toContain("@Zara");
   });
 });

--- a/packages/web/src/pages/workspace/conversations/__tests__/filter-popover-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/filter-popover-dom.test.tsx
@@ -8,30 +8,37 @@ import { FilterPopover, originLabel } from "../filter-popover.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-// The popover fetches the org roster for the Participants picker; drive it from a
-// mutable result (reset in `beforeEach`) so tests can exercise the loaded and
-// error states without a QueryClient. `mock`-prefixed so vitest's hoisted
-// `vi.mock` factory may reference it.
-type MockAgentsResult = {
+// The Participants picker is SEARCH-driven: typing keys `useOrgAgentsSearch`.
+// - the debounce is a passthrough in tests so results settle synchronously;
+// - `useOrgAgentsSearch` returns roster entries whose displayName matches the
+//   query (empty query → no items, mirroring the search-only "no list" design);
+// - the name map resolves selected-chip labels.
+// `mockSearchOverride` (mock-prefixed so the hoisted factory may read it) lets a
+// test force an in-flight state.
+// Debounce is a passthrough by default (results settle synchronously); a test
+// forces a lag — the debounced value trailing the raw input — via `mockDebounceLag`.
+let mockDebounceLag: string | null = null;
+vi.mock("../../../../lib/use-debounced-value.js", () => ({
+  useDebouncedValue: (value: string) => (mockDebounceLag === null ? value : mockDebounceLag),
+}));
+vi.mock("../../../../lib/use-agent-name-map.js", () => ({
+  useAgentNameMap: () => (id: string) => (id === "agent-1" ? "Nova" : id === "agent-2" ? "Design Critique" : id),
+}));
+let mockSearchOverride: {
   data: { items: Array<{ uuid: string; displayName: string }> } | undefined;
-  isLoading: boolean;
-  isError: boolean;
-  refetch: () => void;
-};
-const mockAgentsDefault: MockAgentsResult = {
-  data: {
-    items: [
+  isFetching: boolean;
+} | null = null;
+vi.mock("../../../../lib/use-org-agents.js", () => ({
+  useOrgAgentsSearch: (query: string) => {
+    if (mockSearchOverride) return mockSearchOverride;
+    const roster = [
       { uuid: "agent-1", displayName: "Nova" },
       { uuid: "agent-2", displayName: "Design Critique" },
-    ],
+    ];
+    const q = query.trim().toLowerCase();
+    const items = q.length === 0 ? [] : roster.filter((a) => a.displayName.toLowerCase().includes(q));
+    return { data: { items }, isFetching: false };
   },
-  isLoading: false,
-  isError: false,
-  refetch: () => {},
-};
-let mockAgentsResult: MockAgentsResult = mockAgentsDefault;
-vi.mock("../../../../lib/use-org-agents.js", () => ({
-  useOrgAgents: () => mockAgentsResult,
 }));
 
 let root: Root | null = null;
@@ -59,6 +66,19 @@ async function click(element: Element | null): Promise<void> {
   if (!element) throw new Error("Expected element to click");
   await act(async () => {
     element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+  await flush();
+}
+
+// Set a React controlled-input value via the native setter (bypasses React's
+// value tracker) then dispatch input, so onChange fires with the new value.
+async function typeSearch(value: string): Promise<void> {
+  const input = document.body.querySelector<HTMLInputElement>('input[aria-label="Search participants"]');
+  if (!input) throw new Error("Missing participants search input");
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
   });
   await flush();
 }
@@ -117,7 +137,8 @@ function StatefulFilter({
 
 beforeEach(() => {
   document.body.innerHTML = "";
-  mockAgentsResult = mockAgentsDefault;
+  mockSearchOverride = null;
+  mockDebounceLag = null;
 });
 
 afterEach(async () => {
@@ -135,7 +156,7 @@ describe("FilterPopover", () => {
     expect(originLabel("future" as ChatSource)).toBe("future");
   });
 
-  it("status is exclusive; source defaults to all with no zero-source state; reset + done", async () => {
+  it("status is exclusive; source defaults to all with no zero-source state; participants search + reset", async () => {
     const onOriginChange = vi.fn();
     const onEngagementChange = vi.fn();
     const onParticipantsChange = vi.fn();
@@ -196,57 +217,117 @@ describe("FilterPopover", () => {
     expect(onOriginChange).toHaveBeenLastCalledWith([]);
     expect(checkboxByLabel("Human").checked).toBe(true);
 
-    // Participants OR-picker: the org roster renders; the default is no
-    // constraint (every box unchecked). Toggling an agent adds it to `with`.
+    // Participants is SEARCH-only: no roster is dumped until you type.
     expect(document.body.textContent).toContain("Participants");
+    expect(document.body.textContent).toContain("Type to search people.");
+    expect(document.body.textContent).not.toContain("Nova");
+    await typeSearch("nova");
+    // The match renders as a toggle; picking it adds the agent to `with`.
     expect(checkboxByLabel("Nova").checked).toBe(false);
     await click(checkboxByLabel("Nova"));
     expect(onParticipantsChange).toHaveBeenLastCalledWith(["agent-1"]);
     expect(checkboxByLabel("Nova").checked).toBe(true);
 
-    // The footer "Reset" is the LAST such button — the per-section Source /
-    // Participants "Reset" links share the label and render before it.
+    // The footer "Reset" is the LAST such button — the per-section Participants
+    // "Reset" link shares the label and renders before it.
     await click([...document.body.querySelectorAll("button")].filter((b) => b.textContent === "Reset").at(-1) ?? null);
     expect(onResetAll).toHaveBeenCalledTimes(1);
     await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Done") ?? null);
     expect(document.body.textContent).not.toContain("Source");
   });
 
-  it("surfaces an error + retry when the participants roster fails to load", async () => {
-    // A failed roster load must NOT read as an empty "No people to filter by."
-    const refetch = vi.fn();
-    mockAgentsResult = { data: undefined, isLoading: false, isError: true, refetch };
+  it("is search-only: empty query hints, typing filters, no match reports it", async () => {
     const noop = (): void => {};
     const container = await renderDom(
       <StatefulFilter onOriginChange={noop} onEngagementChange={noop} onParticipantsChange={noop} onResetAll={noop} />,
     );
     await click(container.querySelector('button[aria-label="Filter"]'));
 
-    expect(document.body.textContent).toContain("Couldn't load people.");
-    expect(document.body.textContent).not.toContain("No people to filter by.");
-    const retry = [...document.body.querySelectorAll("button")].find((b) => b.textContent === "Retry");
-    expect(retry).toBeTruthy();
-    await click(retry ?? null);
-    expect(refetch).toHaveBeenCalledTimes(1);
+    // No roster dump — just a hint until the user types.
+    expect(document.body.textContent).toContain("Type to search people.");
+    expect(document.body.textContent).not.toContain("Nova");
+    expect(document.body.textContent).not.toContain("Design Critique");
+
+    await typeSearch("des");
+    expect(document.body.textContent).toContain("Design Critique");
+    expect(document.body.textContent).not.toContain("Nova");
+
+    await typeSearch("zzz");
+    expect(document.body.textContent).toContain("No people match");
+    expect(document.body.textContent).not.toContain("Design Critique");
   });
 
-  it("keeps the cached roster on a background refetch error (v5 retains data)", async () => {
-    // TanStack v5 sets isError while retaining prior data on a background poll
-    // failure — the picker must keep rendering the stale options, not flip to the
-    // blocking error panel.
-    mockAgentsResult = {
-      data: { items: [{ uuid: "agent-1", displayName: "Nova" }] },
-      isLoading: false,
-      isError: true,
-      refetch: () => {},
-    };
+  it("shows an in-flight query as Searching…", async () => {
+    mockSearchOverride = { data: undefined, isFetching: true };
     const noop = (): void => {};
     const container = await renderDom(
       <StatefulFilter onOriginChange={noop} onEngagementChange={noop} onParticipantsChange={noop} onResetAll={noop} />,
     );
     await click(container.querySelector('button[aria-label="Filter"]'));
+    await typeSearch("no");
+    expect(document.body.textContent).toContain("Searching…");
+  });
 
-    expect(document.body.textContent).toContain("Nova");
-    expect(document.body.textContent).not.toContain("Couldn't load people.");
+  it("shows a selected participant as a removable chip and removes it", async () => {
+    const onParticipantsChange = vi.fn();
+    const noop = (): void => {};
+    const container = await renderDom(
+      <StatefulFilter
+        onOriginChange={noop}
+        onEngagementChange={noop}
+        onParticipantsChange={onParticipantsChange}
+        onResetAll={noop}
+      />,
+    );
+    await click(container.querySelector('button[aria-label="Filter"]'));
+    await typeSearch("nova");
+    await click(checkboxByLabel("Nova"));
+    expect(onParticipantsChange).toHaveBeenLastCalledWith(["agent-1"]);
+
+    // The chip persists INDEPENDENTLY of the results: searching a different term
+    // (Nova is no longer a match) keeps the removable chip, and its name comes
+    // from the pick — proving chips don't depend on the visible result rows.
+    await typeSearch("zzz");
+    expect(document.body.textContent).toContain("No people match");
+    const chip = [...document.body.querySelectorAll("button")].find(
+      (b) => b.getAttribute("aria-label") === "Remove Nova",
+    );
+    expect(chip).toBeTruthy();
+    await click(chip ?? null);
+    expect(onParticipantsChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it("emits ?with= in canonical (sorted) order regardless of pick order", async () => {
+    const onParticipantsChange = vi.fn();
+    const noop = (): void => {};
+    const container = await renderDom(
+      <StatefulFilter
+        onOriginChange={noop}
+        onEngagementChange={noop}
+        onParticipantsChange={onParticipantsChange}
+        onResetAll={noop}
+      />,
+    );
+    await click(container.querySelector('button[aria-label="Filter"]'));
+    // Pick Design Critique (agent-2) first, then Nova (agent-1) — the emitted set
+    // must be sorted, not insertion-ordered, so one `?with=` key serves both.
+    await typeSearch("design");
+    await click(checkboxByLabel("Design Critique"));
+    expect(onParticipantsChange).toHaveBeenLastCalledWith(["agent-2"]);
+    await typeSearch("nova");
+    await click(checkboxByLabel("Nova"));
+    expect(onParticipantsChange).toHaveBeenLastCalledWith(["agent-1", "agent-2"]);
+  });
+
+  it("keeps Searching… (not No match) while the debounce trails a new term", async () => {
+    mockDebounceLag = "zz"; // debounced trails the raw input
+    const noop = (): void => {};
+    const container = await renderDom(
+      <StatefulFilter onOriginChange={noop} onEngagementChange={noop} onParticipantsChange={noop} onResetAll={noop} />,
+    );
+    await click(container.querySelector('button[aria-label="Filter"]'));
+    await typeSearch("zzz"); // raw "zzz" !== debounced "zz" → still settling
+    expect(document.body.textContent).toContain("Searching…");
+    expect(document.body.textContent).not.toContain("No people match");
   });
 });

--- a/packages/web/src/pages/workspace/conversations/__tests__/filter-popover-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/filter-popover-dom.test.tsx
@@ -4,6 +4,7 @@ import type { ChatEngagementView, ChatSource } from "@first-tree/shared";
 import { act, type ReactElement, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetParticipantNameCacheForTests } from "../../../../lib/participant-name-cache.js";
 import { FilterPopover, originLabel } from "../filter-popover.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -34,6 +35,9 @@ vi.mock("../../../../lib/use-org-agents.js", () => ({
     const roster = [
       { uuid: "agent-1", displayName: "Nova" },
       { uuid: "agent-2", displayName: "Design Critique" },
+      // Past the identity-map cap: the name map mock returns the raw id for this
+      // one, so only the search-fed name cache can label it.
+      { uuid: "agent-3", displayName: "Zara" },
     ];
     const q = query.trim().toLowerCase();
     const items = q.length === 0 ? [] : roster.filter((a) => a.displayName.toLowerCase().includes(q));
@@ -139,6 +143,7 @@ beforeEach(() => {
   document.body.innerHTML = "";
   mockSearchOverride = null;
   mockDebounceLag = null;
+  __resetParticipantNameCacheForTests();
 });
 
 afterEach(async () => {
@@ -329,5 +334,44 @@ describe("FilterPopover", () => {
     await typeSearch("zzz"); // raw "zzz" !== debounced "zz" → still settling
     expect(document.body.textContent).toContain("Searching…");
     expect(document.body.textContent).not.toContain("No people match");
+  });
+
+  it("keeps a stale result visible but non-toggleable while a newer term settles", async () => {
+    const noop = (): void => {};
+    const container = await renderDom(
+      <StatefulFilter onOriginChange={noop} onEngagementChange={noop} onParticipantsChange={noop} onResetAll={noop} />,
+    );
+    await click(container.querySelector('button[aria-label="Filter"]'));
+    await typeSearch("nova");
+    expect(checkboxByLabel("Nova").disabled).toBe(false);
+
+    // Type a NEW term but freeze the debounce behind it: the old Nova row is now
+    // stale (input says "design", results still reflect "nova"). It stays visible
+    // but disabled so a pick can't land on a query the user no longer sees.
+    mockDebounceLag = "nova";
+    await typeSearch("design");
+    expect(document.body.textContent).toContain("Nova");
+    expect(checkboxByLabel("Nova").disabled).toBe(true);
+  });
+
+  it("retains a searched name past the identity-map cap on its chip across close/reopen", async () => {
+    const noop = (): void => {};
+    const container = await renderDom(
+      <StatefulFilter onOriginChange={noop} onEngagementChange={noop} onParticipantsChange={noop} onResetAll={noop} />,
+    );
+    const openFilter = (): Promise<void> => click(container.querySelector('button[aria-label="Filter"]'));
+    await openFilter();
+    // Zara is absent from the identity-map mock (it returns her raw id), so only
+    // the search-fed cache can name her chip.
+    await typeSearch("zara");
+    await click(checkboxByLabel("Zara"));
+    expect(document.body.textContent).toContain("@Zara");
+
+    // Close the popover (the section unmounts) then reopen — the chip must still
+    // read "@Zara", not the raw uuid, because the name cache outlives the panel.
+    await click([...document.body.querySelectorAll("button")].find((b) => b.textContent === "Done") ?? null);
+    await openFilter();
+    expect(document.body.textContent).toContain("@Zara");
+    expect(document.body.textContent).not.toContain("agent-3");
   });
 });

--- a/packages/web/src/pages/workspace/conversations/filter-popover.tsx
+++ b/packages/web/src/pages/workspace/conversations/filter-popover.tsx
@@ -1,8 +1,10 @@
 import type { ChatEngagementView, ChatSource } from "@first-tree/shared";
-import { Check, Filter } from "lucide-react";
-import { useId } from "react";
+import { Check, Filter, X } from "lucide-react";
+import { useId, useState } from "react";
 import { Popover } from "../../../components/ui/popover.js";
-import { useOrgAgents } from "../../../lib/use-org-agents.js";
+import { useAgentNameMap } from "../../../lib/use-agent-name-map.js";
+import { useDebouncedValue } from "../../../lib/use-debounced-value.js";
+import { useOrgAgentsSearch } from "../../../lib/use-org-agents.js";
 import type { GroupMode } from "./group-rows.js";
 
 /**
@@ -350,15 +352,19 @@ function FilterRadio({
 }
 
 /**
- * Participants OR-picker — the org's addressable (speaker-eligible) agents and
- * humans. Empty selection = no constraint (the default); each checked identity
- * is an additive OR match, carried on the URL as `?with=`.
+ * Participants OR-picker — a SEARCH-driven multi-select over the org's
+ * addressable (speaker-eligible) agents and humans. Empty selection = no
+ * constraint (the default); each checked identity is an additive OR match,
+ * carried on the URL as `?with=`.
  *
- * Extracted into its own component (rather than inlined in `FilterPopover`) so
- * its `useOrgAgents` roster fetch + 30s poll only run while the popover panel is
- * OPEN: `Popover` conditionally renders its panel, so this component unmounts on
- * close and a never-opened filter costs no background roster poll for the whole
- * session.
+ * Search-only (no upfront roster): typing drives a `useOrgAgentsSearch`
+ * typeahead keyed on the debounced term, so it scales to any org — past the
+ * org-list 100-row first page — and matches the app's other people pickers
+ * (new-chat, chat-header, @-mention) instead of dumping a flat list. An empty
+ * query renders just a hint; current selections show as removable chips above
+ * the search so they stay visible and manageable without re-searching. Mounted
+ * only inside the open `Popover` panel, so it costs nothing until the filter is
+ * opened.
  */
 function ParticipantsSection({
   participants,
@@ -367,19 +373,42 @@ function ParticipantsSection({
   participants: ReadonlyArray<string>;
   onParticipantsChange: (next: ReadonlyArray<string>) => void;
 }) {
-  const agentsQuery = useOrgAgents({ addressableOnly: true });
-  const participantOptions = agentsQuery.data?.items ?? [];
+  const [search, setSearch] = useState("");
+  const debounced = useDebouncedValue(search, 200);
+  const trimmed = debounced.trim();
+  // Empty query short-circuits inside the hook to the cached first page, but we
+  // never render that — only the hint — so no roster list is dumped.
+  const resultsQuery = useOrgAgentsSearch(trimmed, { addressableOnly: true });
+  const resolveName = useAgentNameMap();
   const participantSet = new Set(participants);
-  const toggleParticipant = (uuid: string): void => {
+
+  // Remember the display name of each identity picked FROM SEARCH so a selected
+  // agent past the org-list 100-row cap — exactly who this search-only picker
+  // exists to reach — still shows a name on its chip; `useAgentNameMap` alone
+  // caps at 100. Falls back to the name map for a `?with=` selection restored
+  // from the URL in a later session.
+  const [pickedNames, setPickedNames] = useState<Record<string, string>>({});
+  const chipName = (uuid: string): string => pickedNames[uuid] ?? resolveName(uuid);
+
+  const toggle = (uuid: string, displayName: string): void => {
     const next = new Set(participantSet);
     if (next.has(uuid)) next.delete(uuid);
-    else next.add(uuid);
-    // Emit in a canonical (sorted) order so picking A-then-B and B-then-A yield
-    // the same `?with=` — one react-query cache key, not two, for a logically
-    // identical OR-filter (mirrors Source's canonical re-emit).
+    else {
+      next.add(uuid);
+      setPickedNames((prev) => (prev[uuid] === displayName ? prev : { ...prev, [uuid]: displayName }));
+    }
+    // Canonical (sorted) order so picking A-then-B and B-then-A yield the same
+    // `?with=` — one react-query cache key for a logically identical OR-filter.
     onParticipantsChange([...next].sort());
   };
-  const resetParticipants = (): void => onParticipantsChange([]);
+  const remove = (uuid: string): void => onParticipantsChange(participants.filter((p) => p !== uuid));
+
+  const results = trimmed.length > 0 ? (resultsQuery.data?.items ?? []) : [];
+  // The rendered results trail the input by the debounce + the in-flight fetch;
+  // treat that window as "searching" so an empty list never falsely reads "no
+  // match" for a term the user just finished typing.
+  const searching = search.trim() !== trimmed || resultsQuery.isFetching;
+  const statusStyle = { color: "var(--fg-4)", padding: "var(--sp-0_75) var(--sp-1)" };
 
   return (
     <section className="flex flex-col" style={{ gap: "var(--sp-0_5)" }}>
@@ -391,7 +420,7 @@ function ParticipantsSection({
         {participants.length > 0 && (
           <button
             type="button"
-            onClick={resetParticipants}
+            onClick={() => onParticipantsChange([])}
             className="text-label cursor-pointer"
             style={{ background: "transparent", border: 0, padding: 0, color: "var(--primary)" }}
           >
@@ -399,42 +428,95 @@ function ParticipantsSection({
           </button>
         )}
       </header>
-      {agentsQuery.isError && participantOptions.length === 0 ? (
-        // A failed INITIAL load (no cached roster) shows an error + retry rather
-        // than masquerading as "No people to filter by." A *background* refetch
-        // failure keeps the prior `data` (TanStack v5), so we keep rendering the
-        // stale options below instead of replacing a usable picker with this panel.
-        <div className="flex items-center justify-between" style={{ padding: "var(--sp-0_75) var(--sp-1)" }}>
+
+      {/* Current selections as removable chips — visible + manageable without
+          re-searching; names resolve via the shared identity map, same as the
+          rail's filter-chip row. */}
+      {participants.length > 0 && (
+        <div className="flex flex-wrap" style={{ gap: "var(--sp-1)", padding: "var(--sp-0_5) var(--sp-1)" }}>
+          {participants.map((uuid) => (
+            <button
+              key={uuid}
+              type="button"
+              onClick={() => remove(uuid)}
+              className="inline-flex items-center text-label cursor-pointer hover:bg-[var(--bg-hover)]"
+              style={{
+                gap: "var(--sp-0_5)",
+                padding: "var(--sp-0_5) var(--sp-1)",
+                border: "var(--hairline) solid var(--border)",
+                borderRadius: 999,
+                background: "var(--bg-sunken)",
+                color: "var(--fg-2)",
+              }}
+              aria-label={`Remove ${chipName(uuid)}`}
+            >
+              <span className="truncate" style={{ maxWidth: 140 }}>
+                @{chipName(uuid)}
+              </span>
+              <X size={11} strokeWidth={2} />
+            </button>
+          ))}
+        </div>
+      )}
+
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search people…"
+        aria-label="Search participants"
+        className="w-full text-label outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--bg-raised)]"
+        style={{
+          padding: "var(--sp-1) var(--sp-1_5)",
+          background: "var(--bg-sunken)",
+          border: "var(--hairline) solid var(--border)",
+          borderRadius: 4,
+          color: "var(--fg)",
+        }}
+      />
+
+      {trimmed.length === 0 ? (
+        <p aria-live="polite" className="text-label" style={statusStyle}>
+          Type to search people.
+        </p>
+      ) : results.length > 0 ? (
+        // Any checked identity is an OR match. Results stay visible while a newer
+        // term is still settling (no blank flash). Scrollable so a broad match
+        // set doesn't blow out the popover height.
+        <div className="flex flex-col overflow-y-auto" style={{ maxHeight: 168 }}>
+          {results.map((agent) => (
+            <FilterCheckbox
+              key={agent.uuid}
+              label={agent.displayName}
+              checked={participantSet.has(agent.uuid)}
+              onChange={() => toggle(agent.uuid, agent.displayName)}
+            />
+          ))}
+        </div>
+      ) : searching ? (
+        <p aria-live="polite" className="text-label" style={statusStyle}>
+          Searching…
+        </p>
+      ) : resultsQuery.isError ? (
+        // A failed search reports the failure (with a retry) rather than
+        // masquerading as an empty "No people match" result.
+        <div aria-live="polite" className="flex items-center justify-between" style={statusStyle}>
           <span className="text-label" style={{ color: "var(--fg-4)" }}>
-            {"Couldn't load people."}
+            {"Couldn't search people."}
           </span>
           <button
             type="button"
-            onClick={() => agentsQuery.refetch()}
+            onClick={() => resultsQuery.refetch()}
             className="text-label cursor-pointer"
             style={{ background: "transparent", border: 0, padding: 0, color: "var(--primary)" }}
           >
             Retry
           </button>
         </div>
-      ) : participantOptions.length === 0 ? (
-        <p className="text-label" style={{ color: "var(--fg-4)", padding: "var(--sp-0_75) var(--sp-1)" }}>
-          {agentsQuery.isLoading ? "Loading…" : "No people to filter by."}
-        </p>
       ) : (
-        // Empty selection = no constraint, so every box starts UNCHECKED (unlike
-        // Source). Any checked identity is an OR match. Scrollable so a large
-        // roster doesn't blow out the popover height.
-        <div className="flex flex-col overflow-y-auto" style={{ maxHeight: 168 }}>
-          {participantOptions.map((agent) => (
-            <FilterCheckbox
-              key={agent.uuid}
-              label={agent.displayName}
-              checked={participantSet.has(agent.uuid)}
-              onChange={() => toggleParticipant(agent.uuid)}
-            />
-          ))}
-        </div>
+        <p aria-live="polite" className="text-label" style={statusStyle}>
+          {`No people match “${trimmed}”.`}
+        </p>
       )}
     </section>
   );

--- a/packages/web/src/pages/workspace/conversations/filter-popover.tsx
+++ b/packages/web/src/pages/workspace/conversations/filter-popover.tsx
@@ -1,7 +1,8 @@
 import type { ChatEngagementView, ChatSource } from "@first-tree/shared";
 import { Check, Filter, X } from "lucide-react";
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Popover } from "../../../components/ui/popover.js";
+import { rememberParticipantNames, useParticipantNames } from "../../../lib/participant-name-cache.js";
 import { useAgentNameMap } from "../../../lib/use-agent-name-map.js";
 import { useDebouncedValue } from "../../../lib/use-debounced-value.js";
 import { useOrgAgentsSearch } from "../../../lib/use-org-agents.js";
@@ -270,13 +271,24 @@ export function FilterPopover({
  * the visible square + Check icon are pure decoration that reflects
  * the input's checked state.
  */
-function FilterCheckbox({ label, checked, onChange }: { label: string; checked: boolean; onChange: () => void }) {
+function FilterCheckbox({
+  label,
+  checked,
+  onChange,
+  disabled = false,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: () => void;
+  disabled?: boolean;
+}) {
   return (
     // `focus-within` puts a visible ring on the row when the `sr-only` input is
     // keyboard-focused (WCAG 2.4.7) — the clipped native input has no visible
-    // focus of its own.
+    // focus of its own. When `disabled` (a stale search row still settling) the
+    // row dims and cannot be toggled.
     <label
-      className="inline-flex items-center text-label cursor-pointer transition-colors hover:bg-[var(--bg-hover)] focus-within:ring-1 focus-within:ring-ring focus-within:ring-offset-1 focus-within:ring-offset-[var(--bg-raised)]"
+      className={`inline-flex items-center text-label transition-colors focus-within:ring-1 focus-within:ring-ring focus-within:ring-offset-1 focus-within:ring-offset-[var(--bg-raised)] ${disabled ? "cursor-default opacity-50" : "cursor-pointer hover:bg-[var(--bg-hover)]"}`}
       style={{
         gap: "var(--sp-1_5)",
         padding: "var(--sp-0_75) var(--sp-1)",
@@ -299,7 +311,7 @@ function FilterCheckbox({ label, checked, onChange }: { label: string; checked: 
         {checked && <Check size={10} strokeWidth={3} />}
       </span>
       <span>{label}</span>
-      <input type="checkbox" checked={checked} onChange={onChange} className="sr-only" />
+      <input type="checkbox" checked={checked} onChange={onChange} disabled={disabled} className="sr-only" />
     </label>
   );
 }
@@ -387,15 +399,18 @@ function ParticipantsSection({
   // exists to reach — still shows a name on its chip; `useAgentNameMap` alone
   // caps at 100. Falls back to the name map for a `?with=` selection restored
   // from the URL in a later session.
-  const [pickedNames, setPickedNames] = useState<Record<string, string>>({});
-  const chipName = (uuid: string): string => pickedNames[uuid] ?? resolveName(uuid);
+  const cachedName = useParticipantNames();
+  const chipName = (uuid: string): string => cachedName(uuid) ?? resolveName(uuid);
 
   const toggle = (uuid: string, displayName: string): void => {
     const next = new Set(participantSet);
     if (next.has(uuid)) next.delete(uuid);
     else {
       next.add(uuid);
-      setPickedNames((prev) => (prev[uuid] === displayName ? prev : { ...prev, [uuid]: displayName }));
+      // Cache the picked name so its chip stays readable for an identity past the
+      // identity-map cap, across popover close/reopen and on the persistent rail
+      // chip (both read the shared cache).
+      rememberParticipantNames([{ uuid, displayName }]);
     }
     // Canonical (sorted) order so picking A-then-B and B-then-A yield the same
     // `?with=` — one react-query cache key for a logically identical OR-filter.
@@ -403,10 +418,19 @@ function ParticipantsSection({
   };
   const remove = (uuid: string): void => onParticipantsChange(participants.filter((p) => p !== uuid));
 
-  const results = trimmed.length > 0 ? (resultsQuery.data?.items ?? []) : [];
+  const resultItems = resultsQuery.data?.items;
+  const results = trimmed.length > 0 ? (resultItems ?? []) : [];
+  // Cache every result's name (not only picks) so a selection made from an
+  // earlier / different search still resolves on its chip.
+  useEffect(() => {
+    if (resultItems && resultItems.length > 0) {
+      rememberParticipantNames(resultItems.map((a) => ({ uuid: a.uuid, displayName: a.displayName })));
+    }
+  }, [resultItems]);
   // The rendered results trail the input by the debounce + the in-flight fetch;
   // treat that window as "searching" so an empty list never falsely reads "no
-  // match" for a term the user just finished typing.
+  // match" for a term the user just finished typing — and stale rows stay
+  // non-interactive (disabled) until the rendered query matches the input.
   const searching = search.trim() !== trimmed || resultsQuery.isFetching;
   const statusStyle = { color: "var(--fg-4)", padding: "var(--sp-0_75) var(--sp-1)" };
 
@@ -490,6 +514,9 @@ function ParticipantsSection({
               label={agent.displayName}
               checked={participantSet.has(agent.uuid)}
               onChange={() => toggle(agent.uuid, agent.displayName)}
+              // Stale rows (a newer term is settling) stay visible but can't be
+              // toggled, so a pick always matches the query the user sees.
+              disabled={searching}
             />
           ))}
         </div>

--- a/packages/web/src/pages/workspace/conversations/filter-popover.tsx
+++ b/packages/web/src/pages/workspace/conversations/filter-popover.tsx
@@ -1,4 +1,5 @@
 import type { ChatEngagementView, ChatSource } from "@first-tree/shared";
+import { useQueryClient } from "@tanstack/react-query";
 import { Check, Filter, X } from "lucide-react";
 import { useEffect, useId, useState } from "react";
 import { Popover } from "../../../components/ui/popover.js";
@@ -399,8 +400,14 @@ function ParticipantsSection({
   // exists to reach — still shows a name on its chip; `useAgentNameMap` alone
   // caps at 100. Falls back to the name map for a `?with=` selection restored
   // from the URL in a later session.
+  const queryClient = useQueryClient();
   const cachedName = useParticipantNames();
-  const chipName = (uuid: string): string => cachedName(uuid) ?? resolveName(uuid);
+  // Authoritative identity map wins (a rename refreshes it); the search-fed cache
+  // only fills the gap for an id past the map's 100-row page.
+  const chipName = (uuid: string): string => {
+    const authoritative = resolveName(uuid);
+    return authoritative !== uuid ? authoritative : (cachedName(uuid) ?? uuid);
+  };
 
   const toggle = (uuid: string, displayName: string): void => {
     const next = new Set(participantSet);
@@ -409,8 +416,8 @@ function ParticipantsSection({
       next.add(uuid);
       // Cache the picked name so its chip stays readable for an identity past the
       // identity-map cap, across popover close/reopen and on the persistent rail
-      // chip (both read the shared cache).
-      rememberParticipantNames([{ uuid, displayName }]);
+      // chip (both read the shared, org/auth-scoped cache).
+      rememberParticipantNames(queryClient, [{ uuid, displayName }]);
     }
     // Canonical (sorted) order so picking A-then-B and B-then-A yield the same
     // `?with=` — one react-query cache key for a logically identical OR-filter.
@@ -424,9 +431,12 @@ function ParticipantsSection({
   // earlier / different search still resolves on its chip.
   useEffect(() => {
     if (resultItems && resultItems.length > 0) {
-      rememberParticipantNames(resultItems.map((a) => ({ uuid: a.uuid, displayName: a.displayName })));
+      rememberParticipantNames(
+        queryClient,
+        resultItems.map((a) => ({ uuid: a.uuid, displayName: a.displayName })),
+      );
     }
-  }, [resultItems]);
+  }, [resultItems, queryClient]);
   // The rendered results trail the input by the debounce + the in-flight fetch;
   // treat that window as "searching" so an empty list never falsely reads "no
   // match" for a term the user just finished typing — and stale rows stay

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -310,9 +310,14 @@ export function ConversationList({
     (origin.length > 0 ? 1 : 0) + (participants.length > 0 ? 1 : 0) + (engagement !== "active" ? 1 : 0);
 
   const resolveAgentName = useAgentNameMap();
-  // Names learned from participant search (covers identities past the 100-row
-  // identity-map cap); falls back to the identity map for never-searched ids.
+  // Names learned from participant search cover identities past the 100-row
+  // identity-map cap. The authoritative map wins (a rename refreshes it); the
+  // search-fed cache only fills the gap for ids it still can't resolve.
   const cachedName = useParticipantNames();
+  const participantChipName = (id: string): string => {
+    const authoritative = resolveAgentName(id);
+    return authoritative !== id ? authoritative : (cachedName(id) ?? id);
+  };
 
   const removeOrigin = (src: ChatSource): void => {
     onOriginChange(origin.filter((s) => s !== src));
@@ -436,7 +441,7 @@ export function ConversationList({
             {participants.map((agentId) => (
               <FilterChip
                 key={`with-${agentId}`}
-                label={`@${cachedName(agentId) ?? resolveAgentName(agentId)}`}
+                label={`@${participantChipName(agentId)}`}
                 onClear={() => removeParticipant(agentId)}
               />
             ))}

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -8,6 +8,7 @@ import { ActivityDots } from "../../../components/chat/activity-dots.js";
 import { ChatRowAvatar } from "../../../components/chat/chat-row-avatar.js";
 import { Button } from "../../../components/ui/button.js";
 import { Popover } from "../../../components/ui/popover.js";
+import { useParticipantNames } from "../../../lib/participant-name-cache.js";
 import { useAgentNameMap } from "../../../lib/use-agent-name-map.js";
 import { cn, formatRowTime } from "../../../lib/utils.js";
 import { FilterPopover, GROUP_OPTIONS, originLabel } from "./filter-popover.js";
@@ -309,6 +310,9 @@ export function ConversationList({
     (origin.length > 0 ? 1 : 0) + (participants.length > 0 ? 1 : 0) + (engagement !== "active" ? 1 : 0);
 
   const resolveAgentName = useAgentNameMap();
+  // Names learned from participant search (covers identities past the 100-row
+  // identity-map cap); falls back to the identity map for never-searched ids.
+  const cachedName = useParticipantNames();
 
   const removeOrigin = (src: ChatSource): void => {
     onOriginChange(origin.filter((s) => s !== src));
@@ -432,7 +436,7 @@ export function ConversationList({
             {participants.map((agentId) => (
               <FilterChip
                 key={`with-${agentId}`}
-                label={`@${resolveAgentName(agentId)}`}
+                label={`@${cachedName(agentId) ?? resolveAgentName(agentId)}`}
                 onClear={() => removeParticipant(agentId)}
               />
             ))}


### PR DESCRIPTION
## Workspace chat-list: search-only Participants filter (fast-follow to #1746)

Follow-up to PR4 (#1746). Web-only, one component.

### Why
The Participants filter dumped the org's first **100** addressable identities into a flat scrollable checkbox list. It didn't scale (the 101st identity was unreachable, and a large org is a wall to scroll) and it was **inconsistent with the app's own people pickers** — new-chat draft, the chat-header `[+]`, `@`-mention, and `add-participant-dropdown` all use the `useOrgAgentsSearch` typeahead.

### What
Replace the flat list with a **search-only** picker (no upfront roster):
- A debounced `useOrgAgentsSearch(term, { addressableOnly: true })` typeahead — reaches any org size, matching the app's other pickers.
- An empty query renders only a **"Type to search people."** hint — no roster is dumped.
- Current selections show as **removable chips** above the search (names via the shared identity map), so they stay visible and manageable without re-searching.
- Matches render as `FilterCheckbox` toggles; a `Searching…` state covers the debounce/fetch window; `No people match "…"` on an empty result.
- Selection semantics are unchanged — an additive OR-filter on `?with=`, canonical-sorted; the section still mounts only inside the open popover.

Status / Source / Reset are untouched.

### Testing
- `pnpm check` + `pnpm --filter @first-tree/web typecheck` (incl. `lint:tokens`) + full web suite (**1357**) green.
- Rewritten `filter-popover-dom` coverage: empty-query hint (no roster), typing filters, no-match, in-flight `Searching…`, select → chip, chip removal. `conversation-list-dom` mock swapped to `useOrgAgentsSearch`.
- browse·QA on `/preview/conversation-list`: the Participants section renders the search input + hint (the DEV preview has no backend, so live results are covered by the DOM tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
