### PR TITLE
feat(cli): enforce strict Context Tree validation

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -64,6 +64,7 @@
     "ejs": "^6.0.1",
     "gray-matter": "^4.0.3",
     "jose": "^6.0.0",
+    "mdast-util-from-markdown": "^2.0.3",
     "semver": "^7.6.3",
     "ws": "^8.20.0",
     "yaml": "^2.8.3",

--- a/apps/cli/src/__tests__/tree-init.test.ts
+++ b/apps/cli/src/__tests__/tree-init.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -73,7 +73,8 @@ describe("buildScaffoldFiles", () => {
   it("produces a minimal tree that passes `tree verify`", () => {
     const dir = makeTempDir();
     writeScaffold(dir, buildScaffoldFiles({ title: "Acme", ownerLogin: "octocat", withWorkflow: false }));
-    expect(verifyTreeRoot(dir).ok).toBe(true);
+    expect(readFileSync(join(dir, "NODE.md"), "utf-8")).not.toContain("validationPolicyVersion");
+    expect(verifyTreeRoot(dir)).toMatchObject({ findings: [], ok: true });
   });
 
   it("reports root NODE frontmatter problems", () => {
@@ -108,6 +109,7 @@ describe("buildScaffoldFiles", () => {
   it("uses the current repo root when tree verify omits --tree-path", () => {
     const dir = makeTempDir();
     writeScaffold(dir, buildScaffoldFiles({ title: "Acme", ownerLogin: "octocat", withWorkflow: false }));
+    mkdirSync(join(dir, ".git"));
     process.chdir(dir);
     const command = new Command("verify");
     const log = vi.spyOn(console, "log").mockImplementation(() => {});

--- a/apps/cli/src/__tests__/tree-tree-command.test.ts
+++ b/apps/cli/src/__tests__/tree-tree-command.test.ts
@@ -280,7 +280,7 @@ describe("tree tree renderer", () => {
     expect(output).not.toContain(".turbo");
   });
 
-  it("treats blank optional metadata as absent", () => {
+  it("does not render nodes with invalid optional metadata", () => {
     const root = makeTreeFixture();
     const blank = join(root, "blank-description");
     mkdirSync(blank, { recursive: true });
@@ -289,8 +289,7 @@ describe("tree tree renderer", () => {
       `${frontmatter("title: Blank Description\nowners: [alice]\ndescription: '   '\n")}# Blank\n`,
     );
 
-    expect(renderContextTree(root)).toContain("blank-description/ [Blank Description]\n");
-    expect(renderContextTree(root)).not.toContain("Blank Description] ->");
+    expect(renderContextTree(root)).not.toContain("blank-description/");
   });
 
   it("rejects roots and targets that are not valid Context Tree directories", () => {

--- a/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
+++ b/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveLocalTreeTarget } from "../commands/tree/context-links.js";
 import { registerTreeCommands } from "../commands/tree/index.js";
 import { renderContextTree } from "../commands/tree/tree.js";
 import { VERIFY_USAGE, verifyCommand, verifyTreeRoot } from "../commands/tree/verify.js";
@@ -90,6 +91,56 @@ describe("tree verify strict content policy", () => {
     );
   });
 
+  it("rejects escaping archive and repo-infra Markdown symlinks before class skips", (ctx) => {
+    const root = makeValidTree();
+    const outside = makeTempDir();
+    write(join(outside, "outside.md"), node("Outside"));
+    write(join(root, "raw-context", "placeholder.md"), "archive\n");
+    write(join(root, "system", "NODE.md"), node("System"));
+    try {
+      symlinkSync(join(outside, "outside.md"), join(root, "raw-context", "escaped.md"));
+      symlinkSync(join(outside, "outside.md"), join(root, "AGENTS.md"));
+      symlinkSync(join(outside, "outside.md"), join(root, "system", "WHITEPAPER.md"));
+      symlinkSync(join(outside, "outside.md"), join(root, "WHITEPAPER.md"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    const findings = verifyTreeRoot(root).findings;
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "TREE_MARKDOWN_FILE_PATH_ESCAPE", path: "raw-context/escaped.md" }),
+        expect.objectContaining({ code: "TREE_MARKDOWN_FILE_PATH_ESCAPE", path: "AGENTS.md" }),
+        expect.objectContaining({ code: "TREE_MARKDOWN_FILE_PATH_ESCAPE", path: "system/WHITEPAPER.md" }),
+      ]),
+    );
+    expect(findings.some((finding) => finding.path === "WHITEPAPER.md")).toBe(false);
+  });
+
+  it("rejects Markdown symlink aliases across content-class boundaries", (ctx) => {
+    const root = makeValidTree();
+    write(join(root, "raw-context", "proposal.md"), "archive\n");
+    write(join(root, "system", "links.md"), node("Links", "[archive](../alias.md)\n", "soft_links: [/alias.md]\n"));
+    try {
+      symlinkSync("raw-context/proposal.md", join(root, "alias.md"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    expect(verifyTreeRoot(root).findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "TREE_MARKDOWN_FILE_CONTENT_CLASS_MISMATCH",
+          path: "alias.md",
+          target: "raw-context/proposal.md",
+        }),
+        expect.objectContaining({ code: "TREE_SOFT_LINK_ARCHIVE_DEPENDENCY", target: "/alias.md" }),
+        expect.objectContaining({ code: "TREE_MARKDOWN_LINK_ARCHIVE_DEPENDENCY", target: "../alias.md" }),
+      ]),
+    );
+  });
+
   it("rejects in-tree and escaping directory symlinks explicitly", (ctx) => {
     const root = makeValidTree();
     const outside = makeTempDir();
@@ -114,6 +165,29 @@ describe("tree verify strict content policy", () => {
         }),
       ]),
     );
+  });
+
+  it("reports member directory symlinks once without following them", (ctx) => {
+    const root = makeValidTree();
+    const outside = makeTempDir();
+    write(join(outside, "NODE.md"), "# invalid external member\n");
+    try {
+      symlinkSync("..", join(root, "members", "alice", "loop"), "dir");
+      symlinkSync(outside, join(root, "members", "alice", "outside"), "dir");
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    const findings = verifyTreeRoot(root).findings;
+
+    expect(findings.filter((finding) => finding.path === "members/alice/loop")).toEqual([
+      expect.objectContaining({ code: "TREE_DIRECTORY_SYMLINK_UNSUPPORTED" }),
+    ]);
+    expect(findings.filter((finding) => finding.path === "members/alice/outside")).toEqual([
+      expect.objectContaining({ code: "TREE_DIRECTORY_SYMLINK_PATH_ESCAPE" }),
+    ]);
+    expect(findings.some((finding) => finding.path.includes("loop/loop"))).toBe(false);
+    expect(findings.some((finding) => finding.path.includes("outside/NODE.md"))).toBe(false);
   });
 
   it.each([
@@ -206,6 +280,28 @@ describe("tree verify strict content policy", () => {
       ]),
     );
     expect(findings.some((finding) => finding.target === "missing.md")).toBe(false);
+  });
+
+  it("treats Windows drive and UNC absolute paths as escaping tree-local targets", () => {
+    const root = makeValidTree();
+    write(join(root, "system", "links.md"), node("Links", "[drive](C:/outside.md)\n"));
+
+    expect(verifyTreeRoot(root).findings).toContainEqual(
+      expect.objectContaining({ code: "TREE_MARKDOWN_LINK_PATH_ESCAPE", target: "C:/outside.md" }),
+    );
+    for (const target of ["C:/outside.md", "C:\\outside.md", "\\\\server\\share\\outside.md"]) {
+      expect(
+        resolveLocalTreeTarget({ sourcePath: "system/links.md", target, treeRoot: root, softLink: false }),
+      ).toMatchObject({ escaped: true, exists: false });
+    }
+    expect(
+      resolveLocalTreeTarget({
+        sourcePath: "system/links.md",
+        target: "https://example.com",
+        treeRoot: root,
+        softLink: false,
+      }),
+    ).toBeNull();
   });
 
   it("allows prose, external links, anchors, and member-to-archive links", () => {

--- a/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
+++ b/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
@@ -1,0 +1,327 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerTreeCommands } from "../commands/tree/index.js";
+import { renderContextTree } from "../commands/tree/tree.js";
+import { VERIFY_USAGE, verifyCommand, verifyTreeRoot } from "../commands/tree/verify.js";
+import type { CommandContext } from "../commands/types.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ft-tree-content-classes-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function write(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function node(title: string, body = "", extra = ""): string {
+  return `---\ntitle: ${title}\nowners: [alice]\n${extra}---\n# ${title}\n${body}\n`;
+}
+
+function memberNode(overrides = ""): string {
+  return `---\ntitle: Alice\nowners: [alice]\ntype: human\nrole: Engineer\ndomains: [system]\n${overrides}---\n# Alice\n`;
+}
+
+function makeValidTree(): string {
+  const root = makeTempDir();
+  write(join(root, "NODE.md"), node("Root"));
+  write(join(root, "members", "NODE.md"), node("Members"));
+  write(join(root, "members", "alice", "NODE.md"), memberNode());
+  return root;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.exitCode = undefined;
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("tree verify strict content policy", () => {
+  it("accepts structured block-array owners for the root and normal leaves", () => {
+    const root = makeValidTree();
+    write(join(root, "NODE.md"), "---\ntitle: Root\nowners:\n  - alice\n  - bob\n---\n# Root\n");
+    write(join(root, "system", "NODE.md"), node("System"));
+    write(join(root, "system", "leaf.md"), "---\ntitle: Leaf\nowners:\n  - alice\n---\n# Leaf\n");
+
+    const summary = verifyTreeRoot(root);
+
+    expect(summary).toMatchObject({ findings: [], ok: true });
+    expect(renderContextTree(root)).toContain("system/leaf.md [Leaf]");
+  });
+
+  it("validates in-tree root and leaf Markdown symlinks", (ctx) => {
+    const root = makeValidTree();
+    rmSync(join(root, "NODE.md"));
+    write(join(root, "root-source.md"), node("Root"));
+    write(join(root, "system", "leaf-source.md"), node("Leaf"));
+    try {
+      symlinkSync("root-source.md", join(root, "NODE.md"));
+      symlinkSync("leaf-source.md", join(root, "system", "leaf.md"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    expect(verifyTreeRoot(root)).toMatchObject({ findings: [], ok: true });
+  });
+
+  it("rejects normal Markdown symlinks that escape the tree root", (ctx) => {
+    const root = makeValidTree();
+    const outside = makeTempDir();
+    write(join(outside, "outside.md"), node("Outside"));
+    try {
+      symlinkSync(join(outside, "outside.md"), join(root, "escaped.md"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    expect(verifyTreeRoot(root).findings).toContainEqual(
+      expect.objectContaining({ code: "TREE_MARKDOWN_FILE_PATH_ESCAPE", path: "escaped.md" }),
+    );
+  });
+
+  it("rejects in-tree and escaping directory symlinks explicitly", (ctx) => {
+    const root = makeValidTree();
+    const outside = makeTempDir();
+    write(join(root, "system", "NODE.md"), node("System"));
+    write(join(outside, "NODE.md"), node("Outside"));
+    try {
+      symlinkSync("system", join(root, "system-alias"), "dir");
+      symlinkSync(outside, join(root, "outside-alias"), "dir");
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    expect(verifyTreeRoot(root).findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "TREE_DIRECTORY_SYMLINK_UNSUPPORTED",
+          path: "system-alias",
+        }),
+        expect.objectContaining({
+          code: "TREE_DIRECTORY_SYMLINK_PATH_ESCAPE",
+          path: "outside-alias",
+        }),
+      ]),
+    );
+  });
+
+  it.each([
+    ["---\nowners: [alice]\n---\n# Missing\n", "TREE_TITLE_MISSING"],
+    ["---\ntitle: []\nowners: [alice]\n---\n# Invalid\n", "TREE_TITLE_INVALID"],
+    ["---\ntitle: Missing owners\n---\n# Missing\n", "TREE_OWNERS_MISSING"],
+    ["---\ntitle: Empty owners\nowners: []\n---\n# Empty\n", "TREE_OWNERS_INVALID"],
+    ["---\ntitle: Bad description\nowners: [alice]\ndescription: []\n---\n# Bad\n", "TREE_DESCRIPTION_INVALID"],
+    ["---\ntitle: Bad links\nowners: [alice]\nsoft_links: []\n---\n# Bad\n", "TREE_SOFT_LINKS_INVALID"],
+  ])("rejects invalid structured normal metadata", (content, code) => {
+    const root = makeValidTree();
+    write(join(root, "invalid.md"), content);
+
+    expect(verifyTreeRoot(root)).toMatchObject({ ok: false });
+    expect(verifyTreeRoot(root).findings).toContainEqual(expect.objectContaining({ code, path: "invalid.md" }));
+  });
+
+  it("allows an omitted description but rejects malformed normal YAML", () => {
+    const root = makeValidTree();
+    write(join(root, "valid.md"), node("No description"));
+    write(join(root, "invalid.md"), "---\ntitle: Invalid\nowners: [*]\n---\n# Invalid\n");
+
+    const summary = verifyTreeRoot(root);
+
+    expect(summary.findings).toContainEqual(
+      expect.objectContaining({ code: "TREE_FRONTMATTER_PARSE", path: "invalid.md" }),
+    );
+    expect(summary.findings.some((finding) => finding.path === "valid.md")).toBe(false);
+  });
+
+  it("skips archive/supporting and repo-infra Markdown", () => {
+    const root = makeValidTree();
+    write(join(root, "raw-context", "proposal.md"), "no frontmatter\n[broken](missing.md)\n");
+    write(join(root, ".github", "notes.md"), "not frontmatter\n");
+    write(join(root, "AGENTS.md"), "runtime guidance\n");
+
+    const summary = verifyTreeRoot(root);
+
+    expect(summary.ok).toBe(true);
+    expect(summary.scannedByContentClass).toMatchObject({
+      normal: 1,
+      "archive-supporting": 1,
+      member: 2,
+      "repo-infra": 1,
+    });
+  });
+
+  it("rejects broken, escaping, and archive-dependent soft_links", () => {
+    const root = makeValidTree();
+    write(join(root, "raw-context", "proposal.md"), "archive\n");
+    write(
+      join(root, "system", "links.md"),
+      node("Links", "", "soft_links:\n  - /missing.md\n  - ../../outside.md\n  - /raw-context/proposal.md\n"),
+    );
+
+    expect(verifyTreeRoot(root).findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "TREE_SOFT_LINK_BROKEN", target: "/missing.md" }),
+        expect.objectContaining({ code: "TREE_SOFT_LINK_PATH_ESCAPE", target: "../../outside.md" }),
+        expect.objectContaining({
+          code: "TREE_SOFT_LINK_ARCHIVE_DEPENDENCY",
+          target: "/raw-context/proposal.md",
+        }),
+      ]),
+    );
+  });
+
+  it("checks tree-local Markdown authority but ignores ordinary missing targets", () => {
+    const root = makeValidTree();
+    write(join(root, "raw-context", "proposal.md"), "archive\n");
+    write(join(root, "raw-context", "reference.md"), "archive\n");
+    write(
+      join(root, "system", "links.md"),
+      node(
+        "Links",
+        "[archive](../raw-context/proposal.md)\n[archive-ref][proposal]\n\n[proposal]: ../raw-context/reference.md\n\n[escape](../../outside.md)\n[missing](missing.md)\n",
+      ),
+    );
+
+    const findings = verifyTreeRoot(root).findings;
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "TREE_MARKDOWN_LINK_ARCHIVE_DEPENDENCY" }),
+        expect.objectContaining({
+          code: "TREE_MARKDOWN_LINK_ARCHIVE_DEPENDENCY",
+          target: "../raw-context/reference.md",
+        }),
+        expect.objectContaining({ code: "TREE_MARKDOWN_LINK_PATH_ESCAPE" }),
+      ]),
+    );
+    expect(findings.some((finding) => finding.target === "missing.md")).toBe(false);
+  });
+
+  it("allows prose, external links, anchors, and member-to-archive links", () => {
+    const root = makeValidTree();
+    write(join(root, "raw-context", "proposal.md"), "archive\n");
+    write(
+      join(root, "system", "policy.md"),
+      node(
+        "Policy",
+        "raw-context/ is supporting material; use `raw-context/` only when needed. [site](https://example.com) [mail](mailto:a@example.com) [here](#policy) [future](missing.md)",
+      ),
+    );
+    write(join(root, "members", "alice", "notes.md"), node("Notes", "", "soft_links: [/raw-context/proposal.md]\n"));
+
+    expect(verifyTreeRoot(root)).toMatchObject({ findings: [], ok: true });
+  });
+
+  it("keeps malformed optional frontmatter in personal member Markdown relaxed", () => {
+    const root = makeValidTree();
+    write(join(root, "members", "alice", "notes.md"), "---\nowners: [*]\n---\n# Personal notes\n");
+
+    expect(verifyTreeRoot(root)).toMatchObject({ findings: [], ok: true });
+  });
+
+  it("preserves the member identity contract", () => {
+    const root = makeValidTree();
+    write(join(root, "members", "NODE.md"), "---\ntitle: Members\nowners: []\n---\n# Members\n");
+    write(
+      join(root, "members", "alice", "NODE.md"),
+      "---\ntitle: Alice\nowners: [alice]\ntype: human\ndomains: [system]\n---\n# Alice\n",
+    );
+
+    const summary = verifyTreeRoot(root);
+
+    expect(summary.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "TREE_OWNERS_INVALID", path: "members/NODE.md" }),
+        expect.objectContaining({ code: "TREE_MEMBER_ROLE_INVALID", path: "members/alice/NODE.md" }),
+      ]),
+    );
+  });
+
+  it("keeps JSON fields additive with stable findings", () => {
+    const root = makeValidTree();
+    write(join(root, "invalid.md"), "---\ntitle: Invalid\nowners: []\n---\n# Invalid\n");
+    const command = new Command("verify");
+    command.setOptionValue("treePath", root);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    verifyCommand.action({
+      command,
+      options: { debug: false, json: true, quiet: false },
+    } satisfies CommandContext);
+
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0])) as Record<string, unknown>;
+    expect(payload).toHaveProperty("checks.nodes.ok", false);
+    expect(payload).toHaveProperty("checks.nodes.errors.0");
+    expect(payload).toHaveProperty("checks.progress.uncheckedItems");
+    expect(payload).toHaveProperty("findings.0.code", "TREE_OWNERS_INVALID");
+    expect(payload).not.toHaveProperty("findings.0.severity");
+    expect(payload).toHaveProperty("scannedByContentClass.normal");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("preserves legacy check error strings while adding structured findings", () => {
+    const root = makeValidTree();
+    write(join(root, "invalid.md"), "---\nfoo: bar\n---\n# Invalid\n");
+    write(
+      join(root, "members", "alice", "NODE.md"),
+      "---\ntitle: Alice\nowners: [alice]\ntype: human\ndomains: [system]\n---\n# Alice\n",
+    );
+
+    const summary = verifyTreeRoot(root);
+
+    expect(summary.checks.nodes.errors).toEqual(
+      expect.arrayContaining([
+        "invalid.md: missing 'title' field in frontmatter",
+        "invalid.md: missing 'owners' field in frontmatter",
+      ]),
+    );
+    expect(summary.checks.members.errors).toContain("members/alice/NODE.md: missing or empty 'role' field");
+    expect(summary.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "TREE_TITLE_MISSING", path: "invalid.md" }),
+        expect.objectContaining({ code: "TREE_MEMBER_ROLE_INVALID", path: "members/alice/NODE.md" }),
+      ]),
+    );
+  });
+
+  it("prints stable finding codes in the human failure output", () => {
+    const root = makeValidTree();
+    write(join(root, "invalid.md"), "---\ntitle: Invalid\nowners: []\n---\n# Invalid\n");
+    const command = new Command("verify");
+    command.setOptionValue("treePath", root);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    verifyCommand.action({
+      command,
+      options: { debug: false, json: false, quiet: false },
+    } satisfies CommandContext);
+
+    const output = log.mock.calls.map((call) => String(call[0] ?? "")).join("\n");
+    expect(output).toContain("[TREE_OWNERS_INVALID]");
+    expect(output).toContain("Some checks failed.");
+  });
+
+  it("keeps verify as the only validation command and exposes no strict mode", () => {
+    const program = new Command();
+    registerTreeCommands(program);
+    const tree = program.commands.find((command) => command.name() === "tree");
+    const verify = tree?.commands.find((command) => command.name() === "verify");
+
+    expect(tree?.commands.map((command) => command.name())).toEqual(["verify", "tree", "init"]);
+    expect(tree?.commands.some((command) => command.name() === "validate")).toBe(false);
+    expect(verify?.options.some((option) => option.long === "--strict")).toBe(false);
+    expect(VERIFY_USAGE).not.toContain("strict");
+    expect(VERIFY_USAGE).not.toContain("validationPolicyVersion");
+  });
+});

--- a/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
+++ b/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -135,6 +136,49 @@ describe("tree verify strict content policy", () => {
     expect(summary.checks.rootNodeFrontmatter.errors).toEqual(["Root NODE.md symlink target cannot be resolved."]);
   });
 
+  it("rejects Markdown symlinks to non-regular targets", (ctx) => {
+    if (process.platform === "win32") {
+      ctx.skip("FIFO fixtures are not portable to Windows.");
+    }
+
+    const root = makeValidTree();
+    const fifoPath = join(root, "special-target");
+    try {
+      execFileSync("mkfifo", [fifoPath]);
+      symlinkSync("special-target", join(root, "special.md"));
+    } catch {
+      ctx.skip("FIFO or symlink creation is not supported in this environment.");
+    }
+
+    expect(verifyTreeRoot(root).findings).toContainEqual(
+      expect.objectContaining({ code: "TREE_MARKDOWN_FILE_SYMLINK_UNSUPPORTED", path: "special.md" }),
+    );
+  });
+
+  it("keeps the legacy root check failed when NODE.md targets a directory", (ctx) => {
+    const root = makeValidTree();
+    rmSync(join(root, "NODE.md"));
+    write(join(root, "system", "NODE.md"), node("System"));
+    try {
+      symlinkSync("system", join(root, "NODE.md"), "dir");
+    } catch {
+      ctx.skip("Directory symlink creation is not supported in this environment.");
+    }
+
+    const summary = verifyTreeRoot(root);
+
+    expect(summary.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "TREE_DIRECTORY_SYMLINK_UNSUPPORTED", path: "NODE.md" }),
+        expect.objectContaining({ code: "TREE_FRONTMATTER_MISSING", path: "NODE.md" }),
+      ]),
+    );
+    expect(summary.checks.rootNodeFrontmatter).toEqual({
+      errors: ["Root NODE.md is missing frontmatter."],
+      ok: false,
+    });
+  });
+
   it("rejects escaping archive and repo-infra Markdown symlinks before class skips", (ctx) => {
     const root = makeValidTree();
     const outside = makeTempDir();
@@ -211,6 +255,32 @@ describe("tree verify strict content policy", () => {
         expect.objectContaining({
           code: "TREE_DIRECTORY_SYMLINK_UNSUPPORTED",
           path: "WHITEPAPER.md",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects repo-infra Markdown symlinks to directories before class skips", (ctx) => {
+    const root = makeValidTree();
+    const outside = makeTempDir();
+    write(join(root, "system", "NODE.md"), node("System"));
+    write(join(outside, "NODE.md"), node("Outside"));
+    try {
+      symlinkSync("system", join(root, "AGENTS.md"), "dir");
+      symlinkSync(outside, join(root, "CLAUDE.md"), "dir");
+    } catch {
+      ctx.skip("Directory symlink creation is not supported in this environment.");
+    }
+
+    expect(verifyTreeRoot(root).findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "TREE_DIRECTORY_SYMLINK_UNSUPPORTED",
+          path: "AGENTS.md",
+        }),
+        expect.objectContaining({
+          code: "TREE_DIRECTORY_SYMLINK_PATH_ESCAPE",
+          path: "CLAUDE.md",
         }),
       ]),
     );

--- a/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
+++ b/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
@@ -91,6 +91,50 @@ describe("tree verify strict content policy", () => {
     );
   });
 
+  it("rejects dangling Markdown symlinks before content-class skips", (ctx) => {
+    const root = makeValidTree();
+    write(join(root, "raw-context", "placeholder.md"), "archive\n");
+    try {
+      symlinkSync("missing.md", join(root, "dangling.md"));
+      symlinkSync("missing.md", join(root, "raw-context", "dangling.md"));
+      symlinkSync("missing.md", join(root, "AGENTS.md"));
+      symlinkSync("missing.md", join(root, "WHITEPAPER.md"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    const findings = verifyTreeRoot(root).findings;
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "TREE_MARKDOWN_FILE_SYMLINK_BROKEN", path: "dangling.md" }),
+        expect.objectContaining({
+          code: "TREE_MARKDOWN_FILE_SYMLINK_BROKEN",
+          path: "raw-context/dangling.md",
+        }),
+        expect.objectContaining({ code: "TREE_MARKDOWN_FILE_SYMLINK_BROKEN", path: "AGENTS.md" }),
+      ]),
+    );
+    expect(findings.some((finding) => finding.path === "WHITEPAPER.md")).toBe(false);
+  });
+
+  it("reports a dangling root NODE.md symlink precisely", (ctx) => {
+    const root = makeValidTree();
+    rmSync(join(root, "NODE.md"));
+    try {
+      symlinkSync("missing.md", join(root, "NODE.md"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    const summary = verifyTreeRoot(root);
+
+    expect(summary.findings).toContainEqual(
+      expect.objectContaining({ code: "TREE_MARKDOWN_FILE_SYMLINK_BROKEN", path: "NODE.md" }),
+    );
+    expect(summary.checks.rootNodeFrontmatter.errors).toEqual(["Root NODE.md symlink target cannot be resolved."]);
+  });
+
   it("rejects escaping archive and repo-infra Markdown symlinks before class skips", (ctx) => {
     const root = makeValidTree();
     const outside = makeTempDir();
@@ -148,6 +192,7 @@ describe("tree verify strict content policy", () => {
     write(join(outside, "NODE.md"), node("Outside"));
     try {
       symlinkSync("system", join(root, "system-alias"), "dir");
+      symlinkSync("system", join(root, "WHITEPAPER.md"), "dir");
       symlinkSync(outside, join(root, "outside-alias"), "dir");
     } catch {
       ctx.skip("Symlink creation is not supported in this environment.");
@@ -162,6 +207,10 @@ describe("tree verify strict content policy", () => {
         expect.objectContaining({
           code: "TREE_DIRECTORY_SYMLINK_PATH_ESCAPE",
           path: "outside-alias",
+        }),
+        expect.objectContaining({
+          code: "TREE_DIRECTORY_SYMLINK_UNSUPPORTED",
+          path: "WHITEPAPER.md",
         }),
       ]),
     );
@@ -284,12 +333,16 @@ describe("tree verify strict content policy", () => {
 
   it("treats Windows drive and UNC absolute paths as escaping tree-local targets", () => {
     const root = makeValidTree();
-    write(join(root, "system", "links.md"), node("Links", "[drive](C:/outside.md)\n"));
+    write(join(root, "system", "links.md"), node("Links", "[drive](C:/outside.md)\n[root-relative](\\outside.md)\n"));
 
-    expect(verifyTreeRoot(root).findings).toContainEqual(
-      expect.objectContaining({ code: "TREE_MARKDOWN_LINK_PATH_ESCAPE", target: "C:/outside.md" }),
+    expect(verifyTreeRoot(root).findings).toEqual(
+      expect.arrayContaining(
+        ["C:/outside.md", "\\outside.md"].map((target) =>
+          expect.objectContaining({ code: "TREE_MARKDOWN_LINK_PATH_ESCAPE", target }),
+        ),
+      ),
     );
-    for (const target of ["C:/outside.md", "C:\\outside.md", "\\\\server\\share\\outside.md"]) {
+    for (const target of ["C:/outside.md", "C:\\outside.md", "\\outside.md", "\\\\server\\share\\outside.md"]) {
       expect(
         resolveLocalTreeTarget({ sourcePath: "system/links.md", target, treeRoot: root, softLink: false }),
       ).toMatchObject({ escaped: true, exists: false });

--- a/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
+++ b/apps/cli/src/__tests__/tree-verify-content-classes.test.ts
@@ -286,6 +286,39 @@ describe("tree verify strict content policy", () => {
     );
   });
 
+  it("reports invalid managed paths before source and tree identity preflight", (ctx) => {
+    const outside = makeTempDir();
+    write(
+      join(outside, "source.md"),
+      "<!-- BEGIN FIRST-TREE-SOURCE-INTEGRATION -->\nFIRST-TREE-BINDING-MODE: standalone-source\nFIRST-TREE-TREE-REPO-SLUG: acme/context\n<!-- END FIRST-TREE-SOURCE-INTEGRATION -->\n",
+    );
+
+    const escapingRoot = makeValidTree();
+    try {
+      symlinkSync(join(outside, "source.md"), join(escapingRoot, "AGENTS.md"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+    expect(verifyTreeRoot(escapingRoot).findings).toContainEqual(
+      expect.objectContaining({ code: "TREE_MARKDOWN_FILE_PATH_ESCAPE", path: "AGENTS.md" }),
+    );
+
+    const mixedRoot = makeValidTree();
+    write(join(mixedRoot, "system", "NODE.md"), node("System"));
+    write(
+      join(mixedRoot, "CLAUDE.md"),
+      "<!-- BEGIN FIRST-TREE-SOURCE-INTEGRATION -->\nFIRST-TREE-BINDING-MODE: standalone-source\nFIRST-TREE-TREE-REPO-SLUG: acme/context\n<!-- END FIRST-TREE-SOURCE-INTEGRATION -->\n",
+    );
+    try {
+      symlinkSync("system", join(mixedRoot, "AGENTS.md"), "dir");
+    } catch {
+      ctx.skip("Directory symlink creation is not supported in this environment.");
+    }
+    expect(verifyTreeRoot(mixedRoot).findings).toContainEqual(
+      expect.objectContaining({ code: "TREE_DIRECTORY_SYMLINK_UNSUPPORTED", path: "AGENTS.md" }),
+    );
+  });
+
   it("reports member directory symlinks once without following them", (ctx) => {
     const root = makeValidTree();
     const outside = makeTempDir();

--- a/apps/cli/src/commands/tree/binding-contract.ts
+++ b/apps/cli/src/commands/tree/binding-contract.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
 import { readSourceState, type SourceBindingMode, type TreeMode } from "./binding-state.js";
@@ -157,6 +157,14 @@ export function readManagedSourceBinding(root: string): ManagedSourceBinding | u
     const path = join(root, file);
 
     if (!existsSync(path)) {
+      continue;
+    }
+
+    try {
+      if (!statSync(path).isFile()) {
+        continue;
+      }
+    } catch {
       continue;
     }
 

--- a/apps/cli/src/commands/tree/binding-contract.ts
+++ b/apps/cli/src/commands/tree/binding-contract.ts
@@ -1,7 +1,7 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
 import { readSourceState, type SourceBindingMode, type TreeMode } from "./binding-state.js";
+import { inspectRepoInfraMarkdownFile } from "./content-class.js";
 import { parseGitHubRemoteUrl } from "./shared.js";
 
 export type SourceIntegrationFile = "AGENTS.md" | "CLAUDE.md";
@@ -155,20 +155,12 @@ export function parseManagedSourceBindingText(text: string): ParsedSourceBinding
 export function readManagedSourceBinding(root: string): ManagedSourceBinding | undefined {
   for (const file of SOURCE_INTEGRATION_FILES) {
     const path = join(root, file);
-
-    if (!existsSync(path)) {
+    const inspected = inspectRepoInfraMarkdownFile(root, file);
+    if (inspected.kind !== "valid") {
       continue;
     }
 
-    try {
-      if (!statSync(path).isFile()) {
-        continue;
-      }
-    } catch {
-      continue;
-    }
-
-    const parsed = parseManagedSourceBindingText(readFileSync(path, "utf-8"));
+    const parsed = parseManagedSourceBindingText(inspected.source);
 
     if (parsed !== undefined) {
       return {

--- a/apps/cli/src/commands/tree/content-class.ts
+++ b/apps/cli/src/commands/tree/content-class.ts
@@ -8,6 +8,8 @@ export type ContextContentClassCounts = Record<ContextContentClass, number>;
 
 export type ContextMarkdownFile = {
   absolutePath: string;
+  canonicalContentClass: ContextContentClass;
+  canonicalRelativePath: string;
   contentClass: ContextContentClass;
   escaped: boolean;
   relativePath: string;
@@ -26,7 +28,7 @@ export type ContextMarkdownCollection = {
 
 const GENERATED_DIRECTORY_NAMES = new Set(["node_modules", "__pycache__", "dist", "build", ".next", ".turbo"]);
 const REPO_INFRA_MARKDOWN_FILES = new Set(["AGENTS.md", "CLAUDE.md"]);
-const MANAGED_SYMLINK_FILES = new Set(["WHITEPAPER.md"]);
+const MANAGED_SYMLINK_PATHS = new Set(["WHITEPAPER.md"]);
 
 export function toTreeRelativePosixPath(treeRoot: string, targetPath: string): string {
   return relative(treeRoot, targetPath).replace(/\\/gu, "/");
@@ -80,6 +82,7 @@ function pathIsInside(root: string, target: string): boolean {
 export function collectContextMarkdownContent(treeRoot: string): ContextMarkdownCollection {
   const directorySymlinks: ContextDirectorySymlink[] = [];
   const files: ContextMarkdownFile[] = [];
+  const realTreeRoot = realpathSync(treeRoot);
 
   function walk(directoryPath: string): void {
     for (const entry of readDirectoryEntries(directoryPath)) {
@@ -116,7 +119,7 @@ export function collectContextMarkdownContent(treeRoot: string): ContextMarkdown
         continue;
       }
 
-      if (symbolicLink && MANAGED_SYMLINK_FILES.has(entry.name)) {
+      if (symbolicLink && MANAGED_SYMLINK_PATHS.has(relativePath)) {
         continue;
       }
 
@@ -129,15 +132,29 @@ export function collectContextMarkdownContent(treeRoot: string): ContextMarkdown
       }
 
       let escaped = false;
+      let canonicalContentClass = contentClass;
+      let canonicalRelativePath = relativePath;
       if (symbolicLink) {
         try {
-          escaped = !pathIsInside(realpathSync(treeRoot), realpathSync(absolutePath));
+          const realTarget = realpathSync(absolutePath);
+          escaped = !pathIsInside(realTreeRoot, realTarget);
+          canonicalRelativePath = toTreeRelativePosixPath(realTreeRoot, realTarget);
+          if (!escaped) {
+            canonicalContentClass = classifyContextContent(canonicalRelativePath);
+          }
         } catch {
           continue;
         }
       }
 
-      files.push({ absolutePath, contentClass, escaped, relativePath });
+      files.push({
+        absolutePath,
+        canonicalContentClass,
+        canonicalRelativePath,
+        contentClass,
+        escaped,
+        relativePath,
+      });
     }
   }
 

--- a/apps/cli/src/commands/tree/content-class.ts
+++ b/apps/cli/src/commands/tree/content-class.ts
@@ -1,5 +1,5 @@
 import type { Dirent } from "node:fs";
-import { readdirSync, realpathSync, statSync } from "node:fs";
+import { lstatSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, join, relative } from "node:path";
 
 export type ContextContentClass = "normal" | "archive-supporting" | "member" | "repo-infra";
@@ -27,6 +27,8 @@ export type ContextMarkdownCollection = {
   directorySymlinks: ContextDirectorySymlink[];
   files: ContextMarkdownFile[];
 };
+
+export type RepoInfraMarkdownInspection = { kind: "absent" } | { kind: "invalid" } | { kind: "valid"; source: string };
 
 const GENERATED_DIRECTORY_NAMES = new Set(["node_modules", "__pycache__", "dist", "build", ".next", ".turbo"]);
 const REPO_INFRA_MARKDOWN_FILES = new Set(["AGENTS.md", "CLAUDE.md"]);
@@ -79,6 +81,44 @@ function readDirectoryEntries(path: string): Dirent[] {
 function pathIsInside(root: string, target: string): boolean {
   const relativePath = relative(root, target);
   return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+export function inspectRepoInfraMarkdownFile(treeRoot: string, relativePath: string): RepoInfraMarkdownInspection {
+  const absolutePath = join(treeRoot, relativePath);
+  let entry: ReturnType<typeof lstatSync>;
+
+  try {
+    entry = lstatSync(absolutePath);
+  } catch {
+    return { kind: "absent" };
+  }
+
+  if (entry.isSymbolicLink()) {
+    try {
+      if (!statSync(absolutePath).isFile()) {
+        return { kind: "invalid" };
+      }
+      const realTreeRoot = realpathSync(treeRoot);
+      const realTarget = realpathSync(absolutePath);
+      if (!pathIsInside(realTreeRoot, realTarget)) {
+        return { kind: "invalid" };
+      }
+      const canonicalRelativePath = toTreeRelativePosixPath(realTreeRoot, realTarget);
+      if (classifyContextContent(canonicalRelativePath) !== "repo-infra") {
+        return { kind: "invalid" };
+      }
+    } catch {
+      return { kind: "invalid" };
+    }
+  } else if (!entry.isFile()) {
+    return { kind: "invalid" };
+  }
+
+  try {
+    return { kind: "valid", source: readFileSync(absolutePath, "utf-8") };
+  } catch {
+    return { kind: "invalid" };
+  }
 }
 
 export function collectContextMarkdownContent(treeRoot: string): ContextMarkdownCollection {

--- a/apps/cli/src/commands/tree/content-class.ts
+++ b/apps/cli/src/commands/tree/content-class.ts
@@ -13,6 +13,7 @@ export type ContextMarkdownFile = {
   contentClass: ContextContentClass;
   escaped: boolean;
   relativePath: string;
+  unresolved: boolean;
 };
 
 export type ContextDirectorySymlink = {
@@ -111,6 +112,20 @@ export function collectContextMarkdownContent(treeRoot: string): ContextMarkdown
             continue;
           }
         } catch {
+          if (MANAGED_SYMLINK_PATHS.has(relativePath)) {
+            continue;
+          }
+          if (entry.name.endsWith(".md")) {
+            files.push({
+              absolutePath,
+              canonicalContentClass: contentClass,
+              canonicalRelativePath: relativePath,
+              contentClass,
+              escaped: false,
+              relativePath,
+              unresolved: true,
+            });
+          }
           continue;
         }
       }
@@ -154,6 +169,7 @@ export function collectContextMarkdownContent(treeRoot: string): ContextMarkdown
         contentClass,
         escaped,
         relativePath,
+        unresolved: false,
       });
     }
   }

--- a/apps/cli/src/commands/tree/content-class.ts
+++ b/apps/cli/src/commands/tree/content-class.ts
@@ -1,0 +1,146 @@
+import type { Dirent } from "node:fs";
+import { readdirSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, join, relative } from "node:path";
+
+export type ContextContentClass = "normal" | "archive-supporting" | "member" | "repo-infra";
+
+export type ContextContentClassCounts = Record<ContextContentClass, number>;
+
+export type ContextMarkdownFile = {
+  absolutePath: string;
+  contentClass: ContextContentClass;
+  escaped: boolean;
+  relativePath: string;
+};
+
+export type ContextDirectorySymlink = {
+  contentClass: ContextContentClass;
+  escaped: boolean;
+  relativePath: string;
+};
+
+export type ContextMarkdownCollection = {
+  directorySymlinks: ContextDirectorySymlink[];
+  files: ContextMarkdownFile[];
+};
+
+const GENERATED_DIRECTORY_NAMES = new Set(["node_modules", "__pycache__", "dist", "build", ".next", ".turbo"]);
+const REPO_INFRA_MARKDOWN_FILES = new Set(["AGENTS.md", "CLAUDE.md"]);
+const MANAGED_SYMLINK_FILES = new Set(["WHITEPAPER.md"]);
+
+export function toTreeRelativePosixPath(treeRoot: string, targetPath: string): string {
+  return relative(treeRoot, targetPath).replace(/\\/gu, "/");
+}
+
+export function classifyContextContent(relativePath: string): ContextContentClass {
+  const normalized = relativePath.replace(/\\/gu, "/").replace(/^\.\//u, "");
+  const parts = normalized.split("/").filter((part) => part.length > 0);
+
+  if (
+    parts.length === 0 ||
+    parts.some((part) => part.startsWith(".") || GENERATED_DIRECTORY_NAMES.has(part)) ||
+    REPO_INFRA_MARKDOWN_FILES.has(parts.at(-1) ?? "")
+  ) {
+    return "repo-infra";
+  }
+
+  if (parts[0] === "raw-context") {
+    return "archive-supporting";
+  }
+
+  if (parts[0] === "members") {
+    return "member";
+  }
+
+  return "normal";
+}
+
+export function emptyContentClassCounts(): ContextContentClassCounts {
+  return {
+    normal: 0,
+    "archive-supporting": 0,
+    member: 0,
+    "repo-infra": 0,
+  };
+}
+
+function readDirectoryEntries(path: string): Dirent[] {
+  try {
+    return readdirSync(path, { withFileTypes: true }).sort((left, right) => left.name.localeCompare(right.name));
+  } catch {
+    return [];
+  }
+}
+
+function pathIsInside(root: string, target: string): boolean {
+  const relativePath = relative(root, target);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+export function collectContextMarkdownContent(treeRoot: string): ContextMarkdownCollection {
+  const directorySymlinks: ContextDirectorySymlink[] = [];
+  const files: ContextMarkdownFile[] = [];
+
+  function walk(directoryPath: string): void {
+    for (const entry of readDirectoryEntries(directoryPath)) {
+      const absolutePath = join(directoryPath, entry.name);
+      const relativePath = toTreeRelativePosixPath(treeRoot, absolutePath);
+      const contentClass = classifyContextContent(relativePath);
+
+      if (entry.isDirectory()) {
+        if (contentClass !== "repo-infra") {
+          walk(absolutePath);
+        }
+        continue;
+      }
+
+      const symbolicLink = entry.isSymbolicLink();
+      if (symbolicLink) {
+        try {
+          if (statSync(absolutePath).isDirectory()) {
+            if (contentClass !== "repo-infra") {
+              directorySymlinks.push({
+                contentClass,
+                escaped: !pathIsInside(realpathSync(treeRoot), realpathSync(absolutePath)),
+                relativePath,
+              });
+            }
+            continue;
+          }
+        } catch {
+          continue;
+        }
+      }
+
+      if ((!entry.isFile() && !symbolicLink) || !entry.name.endsWith(".md")) {
+        continue;
+      }
+
+      if (symbolicLink && MANAGED_SYMLINK_FILES.has(entry.name)) {
+        continue;
+      }
+
+      try {
+        if (!statSync(absolutePath).isFile()) {
+          continue;
+        }
+      } catch {
+        continue;
+      }
+
+      let escaped = false;
+      if (symbolicLink) {
+        try {
+          escaped = !pathIsInside(realpathSync(treeRoot), realpathSync(absolutePath));
+        } catch {
+          continue;
+        }
+      }
+
+      files.push({ absolutePath, contentClass, escaped, relativePath });
+    }
+  }
+
+  walk(treeRoot);
+  return { directorySymlinks, files };
+}

--- a/apps/cli/src/commands/tree/content-class.ts
+++ b/apps/cli/src/commands/tree/content-class.ts
@@ -13,6 +13,7 @@ export type ContextMarkdownFile = {
   contentClass: ContextContentClass;
   escaped: boolean;
   relativePath: string;
+  unsupported: boolean;
   unresolved: boolean;
 };
 
@@ -101,14 +102,53 @@ export function collectContextMarkdownContent(treeRoot: string): ContextMarkdown
       const symbolicLink = entry.isSymbolicLink();
       if (symbolicLink) {
         try {
-          if (statSync(absolutePath).isDirectory()) {
-            if (contentClass !== "repo-infra") {
+          const targetStat = statSync(absolutePath);
+          if (targetStat.isDirectory()) {
+            if (contentClass !== "repo-infra" || entry.name.endsWith(".md")) {
               directorySymlinks.push({
                 contentClass,
-                escaped: !pathIsInside(realpathSync(treeRoot), realpathSync(absolutePath)),
+                escaped: !pathIsInside(realTreeRoot, realpathSync(absolutePath)),
                 relativePath,
               });
             }
+            continue;
+          }
+
+          if (!targetStat.isFile() && entry.name.endsWith(".md")) {
+            let escaped = false;
+            let canonicalContentClass = contentClass;
+            let canonicalRelativePath = relativePath;
+            try {
+              const realTarget = realpathSync(absolutePath);
+              escaped = !pathIsInside(realTreeRoot, realTarget);
+              canonicalRelativePath = toTreeRelativePosixPath(realTreeRoot, realTarget);
+              if (!escaped) {
+                canonicalContentClass = classifyContextContent(canonicalRelativePath);
+              }
+            } catch {
+              files.push({
+                absolutePath,
+                canonicalContentClass,
+                canonicalRelativePath,
+                contentClass,
+                escaped: false,
+                relativePath,
+                unsupported: false,
+                unresolved: true,
+              });
+              continue;
+            }
+
+            files.push({
+              absolutePath,
+              canonicalContentClass,
+              canonicalRelativePath,
+              contentClass,
+              escaped,
+              relativePath,
+              unsupported: true,
+              unresolved: false,
+            });
             continue;
           }
         } catch {
@@ -123,6 +163,7 @@ export function collectContextMarkdownContent(treeRoot: string): ContextMarkdown
               contentClass,
               escaped: false,
               relativePath,
+              unsupported: false,
               unresolved: true,
             });
           }
@@ -169,6 +210,7 @@ export function collectContextMarkdownContent(treeRoot: string): ContextMarkdown
         contentClass,
         escaped,
         relativePath,
+        unsupported: false,
         unresolved: false,
       });
     }

--- a/apps/cli/src/commands/tree/context-document.ts
+++ b/apps/cli/src/commands/tree/context-document.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from "node:fs";
+
+import matter from "gray-matter";
+
+import { isRecord } from "./shared.js";
+
+export type ContextDocument = {
+  body: string;
+  data: Record<string, unknown> | null;
+  error?: string;
+  frontmatter: "invalid" | "missing" | "valid";
+};
+
+export type NodeMetadata = {
+  description?: string;
+  owners: string[];
+  title: string;
+};
+
+export type ContextField<T> =
+  | { present: false; valid: false }
+  | { present: true; valid: false }
+  | { present: true; valid: true; value: T };
+
+const FRONTMATTER_SOURCE_RE = /^---\s*\r?\n([\s\S]*?)\r?\n---(?:\s*\r?\n|\s*$)/u;
+
+function splitFrontmatterSource(source: string): { body: string; hasFrontmatter: boolean } {
+  const match = source.match(FRONTMATTER_SOURCE_RE);
+  if (match === null) {
+    return { body: source, hasFrontmatter: false };
+  }
+
+  return {
+    body: source.slice(match[0].length),
+    hasFrontmatter: true,
+  };
+}
+
+export function readContextDocument(path: string): ContextDocument {
+  let source: string;
+
+  try {
+    source = readFileSync(path, "utf-8");
+  } catch (error) {
+    return {
+      body: "",
+      data: null,
+      error: error instanceof Error ? error.message : String(error),
+      frontmatter: "invalid",
+    };
+  }
+
+  const sourceParts = splitFrontmatterSource(source);
+  if (!matter.test(source) || !sourceParts.hasFrontmatter) {
+    return { body: source, data: null, frontmatter: "missing" };
+  }
+
+  try {
+    const parsed = matter(source);
+    const data: unknown = parsed.data;
+
+    if (!isRecord(data)) {
+      return {
+        body: parsed.content,
+        data: null,
+        error: "frontmatter must be a YAML mapping",
+        frontmatter: "invalid",
+      };
+    }
+
+    return { body: parsed.content, data, frontmatter: "valid" };
+  } catch (error) {
+    return {
+      body: sourceParts.body,
+      data: null,
+      error: error instanceof Error ? error.message : String(error),
+      frontmatter: "invalid",
+    };
+  }
+}
+
+export function readNonEmptyStringField(data: Record<string, unknown>, key: string): ContextField<string> {
+  if (!(key in data)) {
+    return { present: false, valid: false };
+  }
+
+  const value = data[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return { present: true, valid: false };
+  }
+
+  return { present: true, valid: true, value: value.trim() };
+}
+
+export function readNonEmptyStringArrayField(data: Record<string, unknown>, key: string): ContextField<string[]> {
+  if (!(key in data)) {
+    return { present: false, valid: false };
+  }
+
+  const value = data[key];
+  if (!Array.isArray(value) || value.length === 0) {
+    return { present: true, valid: false };
+  }
+
+  const items: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string" || item.trim().length === 0) {
+      return { present: true, valid: false };
+    }
+    items.push(item.trim());
+  }
+
+  return { present: true, valid: true, value: items };
+}
+
+export function readNodeMetadata(path: string): NodeMetadata | null {
+  const document = readContextDocument(path);
+  if (document.frontmatter !== "valid" || document.data === null) {
+    return null;
+  }
+
+  const title = readNonEmptyStringField(document.data, "title");
+  const owners = readNonEmptyStringArrayField(document.data, "owners");
+  const description = readNonEmptyStringField(document.data, "description");
+
+  if (!title.valid || !owners.valid || (description.present && !description.valid)) {
+    return null;
+  }
+
+  return {
+    title: title.value,
+    owners: owners.value,
+    ...(description.valid ? { description: description.value } : {}),
+  };
+}

--- a/apps/cli/src/commands/tree/context-links.ts
+++ b/apps/cli/src/commands/tree/context-links.ts
@@ -1,0 +1,126 @@
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { isAbsolute, posix, relative, resolve } from "node:path";
+
+import { fromMarkdown } from "mdast-util-from-markdown";
+
+import { type ContextContentClass, classifyContextContent } from "./content-class.js";
+import { isRecord } from "./shared.js";
+
+export type LocalTreeTarget = {
+  contentClass: ContextContentClass;
+  escaped: boolean;
+  exists: boolean;
+  relativePath: string;
+};
+
+function stripQueryAndFragment(target: string): string {
+  const queryIndex = target.indexOf("?");
+  const fragmentIndex = target.indexOf("#");
+  const indexes = [queryIndex, fragmentIndex].filter((index) => index >= 0);
+  const end = indexes.length === 0 ? target.length : Math.min(...indexes);
+  return target.slice(0, end);
+}
+
+function decodeTarget(target: string): string {
+  try {
+    return decodeURIComponent(target);
+  } catch {
+    return target;
+  }
+}
+
+export function isTreeLocalTarget(target: string): boolean {
+  const trimmed = target.trim();
+  return (
+    trimmed.length > 0 && !trimmed.startsWith("#") && !trimmed.startsWith("//") && !/^[a-z][a-z\d+.-]*:/iu.test(trimmed)
+  );
+}
+
+function pathIsInside(root: string, target: string): boolean {
+  const relativePath = relative(root, target);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+function targetExists(path: string, softLink: boolean): boolean {
+  try {
+    const stat = statSync(path);
+    if (stat.isFile()) {
+      return !softLink || path.endsWith(".md");
+    }
+    return stat.isDirectory() && (!softLink || existsSync(resolve(path, "NODE.md")));
+  } catch {
+    return false;
+  }
+}
+
+export function resolveLocalTreeTarget(options: {
+  sourcePath: string;
+  target: string;
+  treeRoot: string;
+  softLink: boolean;
+}): LocalTreeTarget | null {
+  if (!isTreeLocalTarget(options.target)) {
+    return null;
+  }
+
+  const withoutSuffix = decodeTarget(stripQueryAndFragment(options.target.trim())).replace(/\\/gu, "/");
+  if (withoutSuffix.length === 0) {
+    return null;
+  }
+
+  const sourceDirectory = posix.dirname(options.sourcePath);
+  const relativePath = posix.normalize(
+    options.softLink || withoutSuffix.startsWith("/")
+      ? withoutSuffix.replace(/^\/+/, "")
+      : posix.join(sourceDirectory, withoutSuffix),
+  );
+  const absoluteRoot = resolve(options.treeRoot);
+  const absoluteTarget = resolve(absoluteRoot, relativePath);
+  const lexicalEscape = !pathIsInside(absoluteRoot, absoluteTarget);
+  const contentClass = classifyContextContent(relativePath);
+
+  if (lexicalEscape) {
+    return { contentClass, escaped: true, exists: false, relativePath };
+  }
+
+  const exists = targetExists(absoluteTarget, options.softLink);
+  if (!exists) {
+    return { contentClass, escaped: false, exists: false, relativePath };
+  }
+
+  try {
+    const realRoot = realpathSync(absoluteRoot);
+    const realTarget = realpathSync(absoluteTarget);
+    if (!pathIsInside(realRoot, realTarget)) {
+      return { contentClass, escaped: true, exists: true, relativePath };
+    }
+  } catch {
+    return { contentClass, escaped: false, exists: false, relativePath };
+  }
+
+  return { contentClass, escaped: false, exists: true, relativePath };
+}
+
+export function readMarkdownLinkTargets(markdown: string): string[] {
+  const root = fromMarkdown(markdown);
+  const targets: string[] = [];
+
+  function visit(node: unknown): void {
+    if (!isRecord(node)) {
+      return;
+    }
+
+    if ((node.type === "link" || node.type === "image" || node.type === "definition") && typeof node.url === "string") {
+      targets.push(node.url);
+    }
+
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) {
+        visit(child);
+      }
+    }
+  }
+
+  visit(root);
+  return targets;
+}

--- a/apps/cli/src/commands/tree/context-links.ts
+++ b/apps/cli/src/commands/tree/context-links.ts
@@ -30,7 +30,7 @@ function decodeTarget(target: string): string {
 }
 
 function isWindowsAbsoluteTarget(target: string): boolean {
-  return /^[a-z]:[\\/]/iu.test(target) || /^\\\\[^\\]+\\[^\\]+/u.test(target);
+  return /^[a-z]:[\\/]/iu.test(target) || /^\\/u.test(target);
 }
 
 export function isTreeLocalTarget(target: string): boolean {

--- a/apps/cli/src/commands/tree/context-links.ts
+++ b/apps/cli/src/commands/tree/context-links.ts
@@ -29,8 +29,15 @@ function decodeTarget(target: string): string {
   }
 }
 
+function isWindowsAbsoluteTarget(target: string): boolean {
+  return /^[a-z]:[\\/]/iu.test(target) || /^\\\\[^\\]+\\[^\\]+/u.test(target);
+}
+
 export function isTreeLocalTarget(target: string): boolean {
   const trimmed = target.trim();
+  if (isWindowsAbsoluteTarget(decodeTarget(stripQueryAndFragment(trimmed)))) {
+    return true;
+  }
   return (
     trimmed.length > 0 && !trimmed.startsWith("#") && !trimmed.startsWith("//") && !/^[a-z][a-z\d+.-]*:/iu.test(trimmed)
   );
@@ -63,9 +70,19 @@ export function resolveLocalTreeTarget(options: {
     return null;
   }
 
-  const withoutSuffix = decodeTarget(stripQueryAndFragment(options.target.trim())).replace(/\\/gu, "/");
+  const decodedTarget = decodeTarget(stripQueryAndFragment(options.target.trim()));
+  const withoutSuffix = decodedTarget.replace(/\\/gu, "/");
   if (withoutSuffix.length === 0) {
     return null;
+  }
+
+  if (isWindowsAbsoluteTarget(decodedTarget)) {
+    return {
+      contentClass: classifyContextContent(withoutSuffix),
+      escaped: true,
+      exists: false,
+      relativePath: withoutSuffix,
+    };
   }
 
   const sourceDirectory = posix.dirname(options.sourcePath);
@@ -77,7 +94,7 @@ export function resolveLocalTreeTarget(options: {
   const absoluteRoot = resolve(options.treeRoot);
   const absoluteTarget = resolve(absoluteRoot, relativePath);
   const lexicalEscape = !pathIsInside(absoluteRoot, absoluteTarget);
-  const contentClass = classifyContextContent(relativePath);
+  let contentClass = classifyContextContent(relativePath);
 
   if (lexicalEscape) {
     return { contentClass, escaped: true, exists: false, relativePath };
@@ -94,6 +111,7 @@ export function resolveLocalTreeTarget(options: {
     if (!pathIsInside(realRoot, realTarget)) {
       return { contentClass, escaped: true, exists: true, relativePath };
     }
+    contentClass = classifyContextContent(relative(realRoot, realTarget).replace(/\\/gu, "/"));
   } catch {
     return { contentClass, escaped: false, exists: false, relativePath };
   }

--- a/apps/cli/src/commands/tree/tree-identity.ts
+++ b/apps/cli/src/commands/tree/tree-identity.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
 import { readTreeState, type TreeMode } from "./binding-state.js";
+import { inspectRepoInfraMarkdownFile } from "./content-class.js";
 import { ensureTrailingNewline } from "./shared.js";
 
 const TREE_IDENTITY_BEGIN = "<!-- BEGIN FIRST-TREE-TREE-IDENTITY -->";
@@ -149,12 +150,12 @@ function writeIdentityFile(path: string, identity: TreeIdentityContract): SyncAc
 export function readManagedTreeIdentity(root: string): ManagedTreeIdentity | undefined {
   for (const file of TREE_IDENTITY_FILES) {
     const path = join(root, file);
-
-    if (!existsSync(path)) {
+    const inspected = inspectRepoInfraMarkdownFile(root, file);
+    if (inspected.kind !== "valid") {
       continue;
     }
 
-    const parsed = parseManagedTreeIdentity(readFileSync(path, "utf-8"));
+    const parsed = parseManagedTreeIdentity(inspected.source);
 
     if (parsed !== undefined) {
       return {

--- a/apps/cli/src/commands/tree/tree.ts
+++ b/apps/cli/src/commands/tree/tree.ts
@@ -1,19 +1,14 @@
 import type { Dirent } from "node:fs";
-import { readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { readdirSync, realpathSync, statSync } from "node:fs";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
 
 import type { Command } from "commander";
-import matter from "gray-matter";
-
 import { isJsonMode, print } from "../../core/output.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
-import { asString, findGitRoot, isRecord, runCommand } from "./shared.js";
-
-export type NodeMetadata = {
-  title: string;
-  description?: string;
-  owners: string[];
-};
+import { classifyContextContent } from "./content-class.js";
+import type { NodeMetadata } from "./context-document.js";
+import { readNodeMetadata } from "./context-document.js";
+import { asString, findGitRoot, runCommand } from "./shared.js";
 
 export type ContextTreeNode = {
   kind: "directory" | "file";
@@ -74,8 +69,7 @@ type ResolvedTreeTarget = {
 };
 
 const NODE_FILE = "NODE.md";
-const LEAF_FILE_EXCLUDES = new Set([NODE_FILE, "AGENTS.md", "CLAUDE.md"]);
-const SKIPPED_DIRECTORY_NAMES = new Set(["node_modules", "__pycache__", "dist", "build", ".next", ".turbo"]);
+const LEAF_FILE_EXCLUDES = new Set([NODE_FILE]);
 const TREE_TREE_INVALID_LEVEL = "TREE_TREE_INVALID_LEVEL";
 const TREE_TREE_INVALID_PATH = "TREE_TREE_INVALID_PATH";
 const TREE_TREE_FAILED = "TREE_TREE_FAILED";
@@ -91,71 +85,12 @@ class TreeTreeCommandError extends Error {
   }
 }
 
-function isHidden(name: string): boolean {
-  return name.startsWith(".");
-}
-
 function toPosixRelativePath(root: string, target: string): string {
   return relative(root, target).replace(/\\/gu, "/");
 }
 
 function fileHasMarkdownExtension(name: string): boolean {
   return name.endsWith(".md");
-}
-
-function asNonEmptyString(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function asNonEmptyStringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value) || value.length === 0) {
-    return undefined;
-  }
-
-  const items: string[] = [];
-
-  for (const item of value) {
-    const normalized = asNonEmptyString(item);
-
-    if (normalized === undefined) {
-      return undefined;
-    }
-
-    items.push(normalized);
-  }
-
-  return items;
-}
-
-function readFrontmatterMetadata(path: string): NodeMetadata | null {
-  try {
-    const parsed = matter(readFileSync(path, "utf-8"));
-    const data: unknown = parsed.data;
-
-    if (!isRecord(data)) {
-      return null;
-    }
-
-    const title = asNonEmptyString(data.title);
-    const owners = asNonEmptyStringArray(data.owners);
-
-    if (title === undefined || owners === undefined) {
-      return null;
-    }
-
-    return {
-      title,
-      description: asNonEmptyString(data.description),
-      owners,
-    };
-  } catch {
-    return null;
-  }
 }
 
 function formatDisplayValue(value: string): string {
@@ -189,12 +124,16 @@ function compareEntryNames(left: string, right: string): number {
   return 0;
 }
 
-function shouldSkipDirectory(name: string): boolean {
-  return isHidden(name) || SKIPPED_DIRECTORY_NAMES.has(name);
+function shouldSkipDirectory(relativePath: string): boolean {
+  return classifyContextContent(relativePath) === "repo-infra";
 }
 
-function shouldSkipFile(name: string): boolean {
-  return isHidden(name) || !fileHasMarkdownExtension(name) || LEAF_FILE_EXCLUDES.has(name);
+function shouldSkipFile(name: string, relativePath: string): boolean {
+  return (
+    classifyContextContent(relativePath) === "repo-infra" ||
+    !fileHasMarkdownExtension(name) ||
+    LEAF_FILE_EXCLUDES.has(name)
+  );
 }
 
 function isFile(path: string): boolean {
@@ -253,7 +192,7 @@ function buildDirectoryNode(
 ): ContextTreeNode | null {
   const nodePath = join(path, NODE_FILE);
   const hasNode = isFile(nodePath);
-  const metadata = readFrontmatterMetadata(nodePath);
+  const metadata = readNodeMetadata(nodePath);
   const relativePath = toPosixRelativePath(root, path);
   const children: ContextTreeNode[] = [];
 
@@ -263,8 +202,9 @@ function buildDirectoryNode(
 
   if (targetSegments.length > 0) {
     const [nextSegment, ...remainingSegments] = targetSegments;
+    const nextRelativePath = relativePath.length === 0 ? nextSegment : `${relativePath}/${nextSegment}`;
 
-    if (!shouldSkipDirectory(nextSegment)) {
+    if (!shouldSkipDirectory(nextRelativePath)) {
       const child = buildDirectoryNode(root, join(path, nextSegment), depth + 1, nextSegment, remainingSegments);
 
       if (child !== null) {
@@ -275,9 +215,10 @@ function buildDirectoryNode(
     for (const entry of readDirectoryEntries(path)) {
       const entryName = entry.name;
       const childPath = join(path, entryName);
+      const childRelativePath = toPosixRelativePath(root, childPath);
 
       if (entry.isDirectory()) {
-        if (shouldSkipDirectory(entryName)) {
+        if (shouldSkipDirectory(childRelativePath)) {
           continue;
         }
 
@@ -290,11 +231,11 @@ function buildDirectoryNode(
         continue;
       }
 
-      if (!entry.isFile() || shouldSkipFile(entryName)) {
+      if (!entry.isFile() || shouldSkipFile(entryName, childRelativePath)) {
         continue;
       }
 
-      const childMetadata = readFrontmatterMetadata(childPath);
+      const childMetadata = readNodeMetadata(childPath);
 
       if (childMetadata === null) {
         continue;

--- a/apps/cli/src/commands/tree/validate-members.ts
+++ b/apps/cli/src/commands/tree/validate-members.ts
@@ -1,133 +1,133 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join, relative } from "node:path";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 
-const FRONTMATTER_RE = /^---\s*\n(.*?)\n---/su;
+import { toTreeRelativePosixPath } from "./content-class.js";
+import { readContextDocument, readNonEmptyStringArrayField, readNonEmptyStringField } from "./context-document.js";
+import {
+  formatValidationFinding,
+  type TreeValidationFinding,
+  VALIDATION_CODES,
+  type ValidationCode,
+} from "./validation-finding.js";
+
 const VALID_TYPES = new Set(["human", "agent"]);
 const VALID_STATUSES = new Set(["invited"]);
 
-function rel(path: string, root: string): string {
-  return relative(root, path).replace(/\\/gu, "/");
+export type MemberValidationResult = {
+  findings: TreeValidationFinding[];
+};
+
+function addFinding(findings: TreeValidationFinding[], code: ValidationCode, path: string, message: string): void {
+  findings.push({ code, message, path });
 }
 
-function parseFrontmatter(path: string): string | null {
-  try {
-    const text = readFileSync(path, "utf-8");
-    const match = text.match(FRONTMATTER_RE);
-    return match ? match[1] : null;
-  } catch {
-    return null;
+function validateMember(nodePath: string, treeRoot: string): TreeValidationFinding[] {
+  const findings: TreeValidationFinding[] = [];
+  const location = toTreeRelativePosixPath(treeRoot, nodePath);
+  const document = readContextDocument(nodePath);
+
+  if (document.frontmatter === "missing") {
+    addFinding(findings, VALIDATION_CODES.memberFrontmatterMissing, location, "no frontmatter found");
+    return findings;
   }
-}
-
-function extractScalar(fm: string, key: string): string | null {
-  const regex = new RegExp(`^${key}:\\s*"?([^"\\n]+?)"?\\s*$`, "mu");
-  const match = fm.match(regex);
-  return match ? match[1].trim() : null;
-}
-
-function extractList(fm: string, key: string): string[] | null {
-  const inlineRegex = new RegExp(`^${key}:\\s*\\[([^\\]]*)\\]`, "mu");
-  const inlineMatch = fm.match(inlineRegex);
-
-  if (inlineMatch) {
-    const raw = inlineMatch[1].trim();
-    if (!raw) {
-      return [];
-    }
-    return raw
-      .split(",")
-      .map((value) => value.trim().replace(/^['"]|['"]$/gu, ""))
-      .filter(Boolean);
-  }
-
-  const blockRegex = new RegExp(`^${key}:\\s*\\n((?:\\s+-\\s+.+\\n?)+)`, "mu");
-  const blockMatch = fm.match(blockRegex);
-
-  if (!blockMatch) {
-    return null;
-  }
-
-  return blockMatch[1]
-    .trim()
-    .split("\n")
-    .filter((line) => line.trim())
-    .map((line) =>
-      line
-        .trim()
-        .replace(/^-\s*/u, "")
-        .trim()
-        .replace(/^['"]|['"]$/gu, ""),
+  if (document.frontmatter === "invalid" || document.data === null) {
+    addFinding(
+      findings,
+      VALIDATION_CODES.memberFrontmatterParse,
+      location,
+      `frontmatter could not be parsed${document.error === undefined ? "" : `: ${document.error}`}`,
     );
+    return findings;
+  }
+
+  const title = readNonEmptyStringField(document.data, "title");
+  if (!title.valid) {
+    addFinding(findings, VALIDATION_CODES.memberTitleInvalid, location, "missing or invalid 'title' field");
+  }
+
+  const owners = readNonEmptyStringArrayField(document.data, "owners");
+  if (!owners.present) {
+    addFinding(findings, VALIDATION_CODES.memberOwnersMissing, location, "missing 'owners' field");
+  } else if (!owners.valid) {
+    addFinding(findings, VALIDATION_CODES.memberOwnersInvalid, location, "'owners' must be a non-empty string array");
+  }
+
+  const memberType = readNonEmptyStringField(document.data, "type");
+  if (!memberType.present) {
+    addFinding(findings, VALIDATION_CODES.memberTypeMissing, location, "missing 'type' field");
+  } else if (!memberType.valid) {
+    addFinding(findings, VALIDATION_CODES.memberTypeShape, location, "'type' must be a non-empty string");
+  } else if (!VALID_TYPES.has(memberType.value)) {
+    addFinding(
+      findings,
+      VALIDATION_CODES.memberTypeInvalid,
+      location,
+      `invalid type '${memberType.value}' — must be one of: ${[...VALID_TYPES].sort().join(", ")}`,
+    );
+  }
+
+  const status = readNonEmptyStringField(document.data, "status");
+  if (status.present && !status.valid) {
+    addFinding(
+      findings,
+      VALIDATION_CODES.memberStatusShape,
+      location,
+      "'status' must be a non-empty string when present",
+    );
+  } else if (status.valid && !VALID_STATUSES.has(status.value)) {
+    addFinding(
+      findings,
+      VALIDATION_CODES.memberStatusInvalid,
+      location,
+      `invalid status '${status.value}' — must be one of: ${[...VALID_STATUSES].sort().join(", ")}`,
+    );
+  }
+
+  const role = readNonEmptyStringField(document.data, "role");
+  if (!role.present) {
+    addFinding(findings, VALIDATION_CODES.memberRoleInvalid, location, "missing 'role' field");
+  } else if (!role.valid) {
+    addFinding(findings, VALIDATION_CODES.memberRoleShape, location, "'role' must be a non-empty string");
+  }
+
+  const domains = readNonEmptyStringArrayField(document.data, "domains");
+  if (!domains.present) {
+    addFinding(findings, VALIDATION_CODES.memberDomainsInvalid, location, "missing 'domains' field");
+  } else if (!domains.valid) {
+    const value = document.data.domains;
+    addFinding(
+      findings,
+      Array.isArray(value) && value.length === 0
+        ? VALIDATION_CODES.memberDomainsInvalid
+        : VALIDATION_CODES.memberDomainsShape,
+      location,
+      Array.isArray(value) && value.length === 0
+        ? "'domains' must contain at least one entry"
+        : "'domains' must be a non-empty string array",
+    );
+  }
+
+  return findings;
 }
 
-function validateMember(nodePath: string, treeRoot: string): string[] {
-  const errors: string[] = [];
-  const location = rel(nodePath, treeRoot);
-  const fm = parseFrontmatter(nodePath);
-
-  if (fm === null) {
-    return [`${location}: no frontmatter found`];
-  }
-
-  const title = extractScalar(fm, "title");
-  if (!title) {
-    errors.push(`${location}: missing or empty 'title' field`);
-  }
-
-  const owners = extractList(fm, "owners");
-  if (owners === null) {
-    errors.push(`${location}: missing 'owners' field`);
-  }
-
-  const memberType = extractScalar(fm, "type");
-  if (!memberType) {
-    errors.push(`${location}: missing 'type' field`);
-  } else if (!VALID_TYPES.has(memberType)) {
-    errors.push(`${location}: invalid type '${memberType}' — must be one of: ${[...VALID_TYPES].sort().join(", ")}`);
-  }
-
-  const status = extractScalar(fm, "status");
-  if (status !== null && !VALID_STATUSES.has(status)) {
-    errors.push(`${location}: invalid status '${status}' — must be one of: ${[...VALID_STATUSES].sort().join(", ")}`);
-  }
-
-  const role = extractScalar(fm, "role");
-  if (!role) {
-    errors.push(`${location}: missing or empty 'role' field`);
-  }
-
-  const domains = extractList(fm, "domains");
-  if (domains === null) {
-    errors.push(`${location}: missing 'domains' field`);
-  } else if (domains.length === 0) {
-    errors.push(`${location}: 'domains' must contain at least one entry`);
-  }
-
-  return errors;
-}
-
-export function runValidateMembers(treeRoot: string): {
-  exitCode: number;
-  errors: string[];
-} {
+export function collectMemberValidationFindings(treeRoot: string): MemberValidationResult {
   const membersDir = join(treeRoot, "members");
+  const findings: TreeValidationFinding[] = [];
 
   if (!existsSync(membersDir) || !statSync(membersDir).isDirectory()) {
-    return {
-      exitCode: 1,
-      errors: [`Members directory not found: ${membersDir}`],
-    };
+    addFinding(
+      findings,
+      VALIDATION_CODES.membersDirectoryMissing,
+      "members/",
+      `Members directory not found: ${membersDir}`,
+    );
+    return { findings };
   }
 
-  const allErrors: string[] = [];
   let memberCount = 0;
 
-  // Top-level directories under `members/` must each be a member node
-  // (have NODE.md). Nested directories deeper than that are allowed to
-  // exist as non-node containers — personal research notes, attachments,
-  // assistants without a node yet, etc. Nested dirs that DO carry a
-  // NODE.md are still validated as nested members (preserves the
-  // `<member>/<member>-assistant/NODE.md` pattern).
+  // Top-level directories under members are member nodes. Nested directories
+  // may be personal containers; nested NODE.md files still use this contract.
   function walk(dir: string, requireNode: boolean): void {
     for (const child of readdirSync(dir).sort()) {
       const childPath = join(dir, child);
@@ -143,14 +143,15 @@ export function runValidateMembers(treeRoot: string): {
       const nodePath = join(childPath, "NODE.md");
       if (!existsSync(nodePath)) {
         if (requireNode) {
-          allErrors.push(`${rel(childPath, treeRoot)}/: directory exists but missing NODE.md`);
+          const path = `${toTreeRelativePosixPath(treeRoot, childPath)}/`;
+          addFinding(findings, VALIDATION_CODES.memberNodeMissing, path, "directory exists but is missing NODE.md");
           walk(childPath, false);
         }
         continue;
       }
 
       memberCount += 1;
-      allErrors.push(...validateMember(nodePath, treeRoot));
+      findings.push(...validateMember(nodePath, treeRoot));
       walk(childPath, false);
     }
   }
@@ -158,11 +159,41 @@ export function runValidateMembers(treeRoot: string): {
   walk(membersDir, true);
 
   if (memberCount === 0) {
-    allErrors.push("members/: no member nodes were found");
+    addFinding(findings, VALIDATION_CODES.memberNodesEmpty, "members/", "no member nodes were found");
   }
 
-  return {
-    exitCode: allErrors.length === 0 ? 0 : 1,
-    errors: allErrors,
-  };
+  return { findings };
+}
+
+export function formatLegacyMemberError(finding: TreeValidationFinding): string {
+  switch (finding.code) {
+    case VALIDATION_CODES.memberFrontmatterMissing:
+      return `${finding.path}: no frontmatter found`;
+    case VALIDATION_CODES.memberTitleInvalid:
+      return `${finding.path}: missing or empty 'title' field`;
+    case VALIDATION_CODES.memberOwnersMissing:
+      return `${finding.path}: missing 'owners' field`;
+    case VALIDATION_CODES.memberTypeMissing:
+      return `${finding.path}: missing 'type' field`;
+    case VALIDATION_CODES.memberTypeInvalid:
+    case VALIDATION_CODES.memberStatusInvalid:
+      return `${finding.path}: ${finding.message}`;
+    case VALIDATION_CODES.memberRoleInvalid:
+      return `${finding.path}: missing or empty 'role' field`;
+    case VALIDATION_CODES.memberDomainsInvalid:
+      return `${finding.path}: ${finding.message}`;
+    case VALIDATION_CODES.membersDirectoryMissing:
+      return finding.message;
+    case VALIDATION_CODES.memberNodeMissing:
+      return `${finding.path}: directory exists but missing NODE.md`;
+    case VALIDATION_CODES.memberNodesEmpty:
+      return "members/: no member nodes were found";
+    default:
+      return formatValidationFinding(finding);
+  }
+}
+
+export function runValidateMembers(treeRoot: string): { errors: string[]; exitCode: number } {
+  const errors = collectMemberValidationFindings(treeRoot).findings.map(formatLegacyMemberError);
+  return { errors, exitCode: errors.length === 0 ? 0 : 1 };
 }

--- a/apps/cli/src/commands/tree/validate-members.ts
+++ b/apps/cli/src/commands/tree/validate-members.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { toTreeRelativePosixPath } from "./content-class.js";
@@ -114,7 +114,31 @@ export function collectMemberValidationFindings(treeRoot: string): MemberValidat
   const membersDir = join(treeRoot, "members");
   const findings: TreeValidationFinding[] = [];
 
-  if (!existsSync(membersDir) || !statSync(membersDir).isDirectory()) {
+  if (!existsSync(membersDir)) {
+    addFinding(
+      findings,
+      VALIDATION_CODES.membersDirectoryMissing,
+      "members/",
+      `Members directory not found: ${membersDir}`,
+    );
+    return { findings };
+  }
+
+  try {
+    const membersStat = lstatSync(membersDir);
+    if (membersStat.isSymbolicLink()) {
+      return { findings };
+    }
+    if (!membersStat.isDirectory()) {
+      addFinding(
+        findings,
+        VALIDATION_CODES.membersDirectoryMissing,
+        "members/",
+        `Members directory not found: ${membersDir}`,
+      );
+      return { findings };
+    }
+  } catch {
     addFinding(
       findings,
       VALIDATION_CODES.membersDirectoryMissing,
@@ -129,16 +153,14 @@ export function collectMemberValidationFindings(treeRoot: string): MemberValidat
   // Top-level directories under members are member nodes. Nested directories
   // may be personal containers; nested NODE.md files still use this contract.
   function walk(dir: string, requireNode: boolean): void {
-    for (const child of readdirSync(dir).sort()) {
-      const childPath = join(dir, child);
-
-      try {
-        if (!statSync(childPath).isDirectory()) {
-          continue;
-        }
-      } catch {
+    const entries = readdirSync(dir, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name),
+    );
+    for (const entry of entries) {
+      if (entry.isSymbolicLink() || !entry.isDirectory()) {
         continue;
       }
+      const childPath = join(dir, entry.name);
 
       const nodePath = join(childPath, "NODE.md");
       if (!existsSync(nodePath)) {

--- a/apps/cli/src/commands/tree/validate-nodes.ts
+++ b/apps/cli/src/commands/tree/validate-nodes.ts
@@ -213,6 +213,16 @@ export function collectNodeValidationFindings(treeRoot: string): NodeValidationR
       continue;
     }
 
+    if (file.unsupported) {
+      addFinding(
+        findings,
+        VALIDATION_CODES.markdownFileSymlinkUnsupported,
+        file.relativePath,
+        "Markdown file symlink must resolve to a regular file",
+      );
+      continue;
+    }
+
     if (file.canonicalContentClass !== file.contentClass) {
       addFinding(
         findings,

--- a/apps/cli/src/commands/tree/validate-nodes.ts
+++ b/apps/cli/src/commands/tree/validate-nodes.ts
@@ -1,177 +1,265 @@
-import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join, relative } from "node:path";
+import {
+  type ContextContentClassCounts,
+  collectContextMarkdownContent,
+  emptyContentClassCounts,
+} from "./content-class.js";
+import {
+  type ContextDocument,
+  readContextDocument,
+  readNonEmptyStringArrayField,
+  readNonEmptyStringField,
+} from "./context-document.js";
+import { readMarkdownLinkTargets, resolveLocalTreeTarget } from "./context-links.js";
+import {
+  formatValidationFinding,
+  type TreeValidationFinding,
+  VALIDATION_CODES,
+  type ValidationCode,
+} from "./validation-finding.js";
 
-const FRONTMATTER_RE = /^---\s*\n(.*?)\n---/su;
-const OWNERS_RE = /^owners:\s*\[([^\]]*)\]/mu;
-const SOFT_LINKS_INLINE_RE = /^soft_links:\s*\[([^\]]*)\]/mu;
-const SOFT_LINKS_BLOCK_RE = /^soft_links:\s*\n((?:\s+-\s+.+\n?)+)/mu;
-const TITLE_RE = /^title:\s*['"]?(.+?)['"]?\s*$/mu;
-// Personal path = a member's own subtree under `members/<me>/`.
-// `members/NODE.md` itself is the members domain root and stays non-personal.
-const PERSONAL_PATH_RE = /^members\/[^/]+\//u;
+const MEMBERS_INDEX_PATH = "members/NODE.md";
 
-const SKIP_DIRS = new Set(["node_modules", "__pycache__"]);
-const SKIP_FILES = new Set(["AGENTS.md", "CLAUDE.md"]);
-// Managed framework files that bootstrap writes as symlinks into `.agents/skills/`.
-// They carry skill-payload frontmatter (`name:`/`version:`), not tree-node frontmatter
-// (`title:`/`owners:`), so the node validator must not treat them as tree content.
-const MANAGED_SYMLINK_FILES = new Set(["WHITEPAPER.md"]);
+export type NodeValidationResult = {
+  findings: TreeValidationFinding[];
+  scannedByContentClass: ContextContentClassCounts;
+};
 
-function rel(path: string, root: string): string {
-  return relative(root, path).replace(/\\/gu, "/");
+function addFinding(
+  findings: TreeValidationFinding[],
+  code: ValidationCode,
+  path: string,
+  message: string,
+  target?: string,
+): void {
+  findings.push({ code, message, path, ...(target === undefined ? {} : { target }) });
 }
 
-function shouldSkipPath(path: string, treeRoot: string): boolean {
-  const relPath = rel(path, treeRoot);
-  const parts = relPath.split("/");
-
-  if (parts.some((part) => part.startsWith(".") || SKIP_DIRS.has(part))) {
-    return true;
+function validateRequiredNodeMetadata(
+  document: ContextDocument,
+  path: string,
+  findings: TreeValidationFinding[],
+): void {
+  if (document.frontmatter === "missing") {
+    addFinding(findings, VALIDATION_CODES.frontmatterMissing, path, "missing frontmatter");
+    return;
   }
 
-  return false;
-}
-
-function collectMarkdownFiles(treeRoot: string): string[] {
-  const files: string[] = [];
-
-  function walk(dir: string): void {
-    let entries: string[] = [];
-    try {
-      entries = readdirSync(dir).sort();
-    } catch {
-      return;
-    }
-
-    for (const entry of entries) {
-      const fullPath = join(dir, entry);
-
-      if (shouldSkipPath(fullPath, treeRoot)) {
-        continue;
-      }
-
-      try {
-        const stat = statSync(fullPath);
-        if (stat.isDirectory()) {
-          walk(fullPath);
-          continue;
-        }
-        if (!stat.isFile() || !entry.endsWith(".md") || SKIP_FILES.has(entry)) {
-          continue;
-        }
-        if (MANAGED_SYMLINK_FILES.has(entry) && lstatSync(fullPath).isSymbolicLink()) {
-          continue;
-        }
-        files.push(fullPath);
-      } catch {
-        // Ignore unreadable entries.
-      }
-    }
+  if (document.frontmatter === "invalid" || document.data === null) {
+    addFinding(
+      findings,
+      VALIDATION_CODES.frontmatterParse,
+      path,
+      `frontmatter could not be parsed${document.error === undefined ? "" : `: ${document.error}`}`,
+    );
+    return;
   }
 
-  walk(treeRoot);
-  return files;
-}
+  const title = readNonEmptyStringField(document.data, "title");
+  if (!title.present) {
+    addFinding(findings, VALIDATION_CODES.titleMissing, path, "missing 'title' field in frontmatter");
+  } else if (!title.valid) {
+    addFinding(findings, VALIDATION_CODES.titleInvalid, path, "'title' must be a non-empty string");
+  }
 
-function parseFrontmatter(path: string): string | null {
-  try {
-    const text = readFileSync(path, "utf-8");
-    const match = text.match(FRONTMATTER_RE);
-    return match ? match[1] : null;
-  } catch {
-    return null;
+  const owners = readNonEmptyStringArrayField(document.data, "owners");
+  if (!owners.present) {
+    addFinding(findings, VALIDATION_CODES.ownersMissing, path, "missing 'owners' field in frontmatter");
+  } else if (!owners.valid) {
+    addFinding(findings, VALIDATION_CODES.ownersInvalid, path, "'owners' must be a non-empty string array");
+  }
+
+  const description = readNonEmptyStringField(document.data, "description");
+  if (description.present && !description.valid) {
+    addFinding(
+      findings,
+      VALIDATION_CODES.descriptionInvalid,
+      path,
+      "'description' must be a non-empty string when present",
+    );
   }
 }
 
-function parseSoftLinks(frontmatter: string): string[] {
-  const inlineMatch = frontmatter.match(SOFT_LINKS_INLINE_RE);
-  if (inlineMatch) {
-    return inlineMatch[1]
-      .split(",")
-      .map((value) => value.trim().replace(/^['"]|['"]$/gu, ""))
-      .filter(Boolean);
-  }
-
-  const blockMatch = frontmatter.match(SOFT_LINKS_BLOCK_RE);
-  if (!blockMatch) {
+function readSoftLinks(document: ContextDocument, path: string, findings: TreeValidationFinding[]): string[] {
+  if (document.data === null) {
     return [];
   }
 
-  return blockMatch[1]
-    .trim()
-    .split("\n")
-    .map((line) =>
-      line
-        .trim()
-        .replace(/^-\s*/u, "")
-        .trim()
-        .replace(/^['"]|['"]$/gu, ""),
-    )
-    .filter(Boolean);
+  const softLinks = readNonEmptyStringArrayField(document.data, "soft_links");
+  if (!softLinks.present) {
+    return [];
+  }
+  if (!softLinks.valid) {
+    addFinding(
+      findings,
+      VALIDATION_CODES.softLinksInvalid,
+      path,
+      "'soft_links' must be a non-empty string array when present",
+    );
+    return [];
+  }
+  return softLinks.value;
 }
 
-function resolveSoftLink(treeRoot: string, link: string): boolean {
-  const cleaned = link.replace(/^\/+/u, "");
-  const target = join(treeRoot, cleaned);
+function validateSoftLinks(options: {
+  allowArchive: boolean;
+  document: ContextDocument;
+  findings: TreeValidationFinding[];
+  path: string;
+  treeRoot: string;
+}): void {
+  for (const target of readSoftLinks(options.document, options.path, options.findings)) {
+    const resolved = resolveLocalTreeTarget({
+      sourcePath: options.path,
+      target,
+      treeRoot: options.treeRoot,
+      softLink: true,
+    });
 
-  try {
-    if (statSync(target).isFile() && target.endsWith(".md")) {
-      return true;
+    if (resolved === null || !resolved.exists) {
+      addFinding(options.findings, VALIDATION_CODES.softLinkBroken, options.path, "broken soft_links target", target);
     }
-  } catch {
-    // Fall through.
-  }
-
-  try {
-    return statSync(target).isDirectory() && existsSync(join(target, "NODE.md"));
-  } catch {
-    return false;
+    if (resolved === null) {
+      continue;
+    }
+    if (!options.allowArchive && resolved.contentClass === "archive-supporting") {
+      addFinding(
+        options.findings,
+        VALIDATION_CODES.softLinkArchiveDependency,
+        options.path,
+        "normal content must not link to archive/supporting content",
+        target,
+      );
+    }
+    if (resolved.escaped) {
+      addFinding(
+        options.findings,
+        VALIDATION_CODES.softLinkPathEscape,
+        options.path,
+        "soft_links target resolves outside the Context Tree root",
+        target,
+      );
+    }
   }
 }
 
-export function runValidateNodes(treeRoot: string): {
-  exitCode: number;
-  errors: string[];
-} {
-  const errors: string[] = [];
-  const markdownFiles = collectMarkdownFiles(treeRoot);
+function validateMarkdownLinks(
+  document: ContextDocument,
+  path: string,
+  treeRoot: string,
+  findings: TreeValidationFinding[],
+): void {
+  for (const target of readMarkdownLinkTargets(document.body)) {
+    const resolved = resolveLocalTreeTarget({ sourcePath: path, target, treeRoot, softLink: false });
+    if (resolved === null) {
+      continue;
+    }
+    if (resolved.contentClass === "archive-supporting") {
+      addFinding(
+        findings,
+        VALIDATION_CODES.markdownArchiveDependency,
+        path,
+        "normal content must not link to archive/supporting content",
+        target,
+      );
+    }
+    if (resolved.escaped) {
+      addFinding(
+        findings,
+        VALIDATION_CODES.markdownPathEscape,
+        path,
+        "Markdown link resolves outside the Context Tree root",
+        target,
+      );
+    }
+  }
+}
 
-  for (const path of markdownFiles) {
-    const relPath = rel(path, treeRoot);
-    const personal = PERSONAL_PATH_RE.test(relPath);
-    const frontmatter = parseFrontmatter(path);
+export function collectNodeValidationFindings(treeRoot: string): NodeValidationResult {
+  const findings: TreeValidationFinding[] = [];
+  const scannedByContentClass = emptyContentClassCounts();
+  const content = collectContextMarkdownContent(treeRoot);
 
-    if (frontmatter === null) {
-      // Personal files (`members/<me>/**`) may be plain markdown — the owner is
-      // inferred from the path. Non-personal files still must declare frontmatter.
-      if (!personal) {
-        errors.push(`${relPath}: missing frontmatter`);
-      }
+  for (const directory of content.directorySymlinks) {
+    addFinding(
+      findings,
+      directory.escaped ? VALIDATION_CODES.directorySymlinkPathEscape : VALIDATION_CODES.directorySymlinkUnsupported,
+      directory.relativePath,
+      directory.escaped
+        ? "directory symlink resolves outside the Context Tree root"
+        : "Context Tree domain directories must not be symlinks",
+    );
+  }
+
+  for (const file of content.files) {
+    scannedByContentClass[file.contentClass] += 1;
+
+    if (file.contentClass === "repo-infra" || file.contentClass === "archive-supporting") {
       continue;
     }
 
-    // Title and owners are required only outside personal paths. Inside
-    // `members/<me>/**` the owner is the path-derived member; an explicit
-    // `owners` field is optional and not cross-checked here.
-    if (!personal) {
-      if (!TITLE_RE.test(frontmatter)) {
-        errors.push(`${relPath}: missing 'title' field in frontmatter`);
-      }
-
-      if (!OWNERS_RE.test(frontmatter)) {
-        errors.push(`${relPath}: missing 'owners' field in frontmatter`);
-      }
+    if (file.escaped) {
+      addFinding(
+        findings,
+        VALIDATION_CODES.markdownFilePathEscape,
+        file.relativePath,
+        "Markdown file resolves outside the Context Tree root",
+      );
+      continue;
     }
 
-    for (const softLink of parseSoftLinks(frontmatter)) {
-      if (!resolveSoftLink(treeRoot, softLink)) {
-        errors.push(`${relPath}: broken soft_links target '${softLink}'`);
+    const document = readContextDocument(file.absolutePath);
+    const personalMemberContent = file.contentClass === "member" && file.relativePath !== MEMBERS_INDEX_PATH;
+
+    if (personalMemberContent) {
+      if (document.frontmatter === "missing") {
+        continue;
       }
+      if (document.frontmatter === "invalid") {
+        continue;
+      }
+      validateSoftLinks({
+        allowArchive: true,
+        document,
+        findings,
+        path: file.relativePath,
+        treeRoot,
+      });
+      continue;
+    }
+
+    validateRequiredNodeMetadata(document, file.relativePath, findings);
+    validateSoftLinks({
+      allowArchive: file.contentClass === "member",
+      document,
+      findings,
+      path: file.relativePath,
+      treeRoot,
+    });
+
+    if (file.contentClass === "normal") {
+      validateMarkdownLinks(document, file.relativePath, treeRoot, findings);
     }
   }
 
-  return {
-    exitCode: errors.length === 0 ? 0 : 1,
-    errors,
-  };
+  return { findings, scannedByContentClass };
+}
+
+export function formatLegacyNodeError(finding: TreeValidationFinding): string {
+  switch (finding.code) {
+    case VALIDATION_CODES.frontmatterMissing:
+      return `${finding.path}: missing frontmatter`;
+    case VALIDATION_CODES.titleMissing:
+      return `${finding.path}: missing 'title' field in frontmatter`;
+    case VALIDATION_CODES.ownersMissing:
+      return `${finding.path}: missing 'owners' field in frontmatter`;
+    case VALIDATION_CODES.softLinkBroken:
+      return `${finding.path}: broken soft_links target '${finding.target ?? ""}'`;
+    default:
+      return formatValidationFinding(finding);
+  }
+}
+
+export function runValidateNodes(treeRoot: string): { errors: string[]; exitCode: number } {
+  const errors = collectNodeValidationFindings(treeRoot).findings.map(formatLegacyNodeError);
+  return { errors, exitCode: errors.length === 0 ? 0 : 1 };
 }

--- a/apps/cli/src/commands/tree/validate-nodes.ts
+++ b/apps/cli/src/commands/tree/validate-nodes.ts
@@ -193,10 +193,6 @@ export function collectNodeValidationFindings(treeRoot: string): NodeValidationR
   for (const file of content.files) {
     scannedByContentClass[file.contentClass] += 1;
 
-    if (file.contentClass === "repo-infra" || file.contentClass === "archive-supporting") {
-      continue;
-    }
-
     if (file.escaped) {
       addFinding(
         findings,
@@ -204,6 +200,21 @@ export function collectNodeValidationFindings(treeRoot: string): NodeValidationR
         file.relativePath,
         "Markdown file resolves outside the Context Tree root",
       );
+      continue;
+    }
+
+    if (file.canonicalContentClass !== file.contentClass) {
+      addFinding(
+        findings,
+        VALIDATION_CODES.markdownFileContentClassMismatch,
+        file.relativePath,
+        `Markdown file symlink crosses content-class boundary from ${file.contentClass} to ${file.canonicalContentClass}`,
+        file.canonicalRelativePath,
+      );
+      continue;
+    }
+
+    if (file.contentClass === "repo-infra" || file.contentClass === "archive-supporting") {
       continue;
     }
 

--- a/apps/cli/src/commands/tree/validate-nodes.ts
+++ b/apps/cli/src/commands/tree/validate-nodes.ts
@@ -193,6 +193,16 @@ export function collectNodeValidationFindings(treeRoot: string): NodeValidationR
   for (const file of content.files) {
     scannedByContentClass[file.contentClass] += 1;
 
+    if (file.unresolved) {
+      addFinding(
+        findings,
+        VALIDATION_CODES.markdownFileSymlinkBroken,
+        file.relativePath,
+        "Markdown file symlink target cannot be resolved",
+      );
+      continue;
+    }
+
     if (file.escaped) {
       addFinding(
         findings,

--- a/apps/cli/src/commands/tree/validation-finding.ts
+++ b/apps/cli/src/commands/tree/validation-finding.ts
@@ -12,6 +12,7 @@ export const VALIDATION_CODES = {
   softLinkArchiveDependency: "TREE_SOFT_LINK_ARCHIVE_DEPENDENCY",
   markdownPathEscape: "TREE_MARKDOWN_LINK_PATH_ESCAPE",
   markdownArchiveDependency: "TREE_MARKDOWN_LINK_ARCHIVE_DEPENDENCY",
+  markdownFileSymlinkBroken: "TREE_MARKDOWN_FILE_SYMLINK_BROKEN",
   markdownFilePathEscape: "TREE_MARKDOWN_FILE_PATH_ESCAPE",
   markdownFileContentClassMismatch: "TREE_MARKDOWN_FILE_CONTENT_CLASS_MISMATCH",
   directorySymlinkUnsupported: "TREE_DIRECTORY_SYMLINK_UNSUPPORTED",

--- a/apps/cli/src/commands/tree/validation-finding.ts
+++ b/apps/cli/src/commands/tree/validation-finding.ts
@@ -13,6 +13,7 @@ export const VALIDATION_CODES = {
   markdownPathEscape: "TREE_MARKDOWN_LINK_PATH_ESCAPE",
   markdownArchiveDependency: "TREE_MARKDOWN_LINK_ARCHIVE_DEPENDENCY",
   markdownFileSymlinkBroken: "TREE_MARKDOWN_FILE_SYMLINK_BROKEN",
+  markdownFileSymlinkUnsupported: "TREE_MARKDOWN_FILE_SYMLINK_UNSUPPORTED",
   markdownFilePathEscape: "TREE_MARKDOWN_FILE_PATH_ESCAPE",
   markdownFileContentClassMismatch: "TREE_MARKDOWN_FILE_CONTENT_CLASS_MISMATCH",
   directorySymlinkUnsupported: "TREE_DIRECTORY_SYMLINK_UNSUPPORTED",

--- a/apps/cli/src/commands/tree/validation-finding.ts
+++ b/apps/cli/src/commands/tree/validation-finding.ts
@@ -1,0 +1,49 @@
+export const VALIDATION_CODES = {
+  frontmatterMissing: "TREE_FRONTMATTER_MISSING",
+  frontmatterParse: "TREE_FRONTMATTER_PARSE",
+  titleMissing: "TREE_TITLE_MISSING",
+  titleInvalid: "TREE_TITLE_INVALID",
+  ownersMissing: "TREE_OWNERS_MISSING",
+  ownersInvalid: "TREE_OWNERS_INVALID",
+  descriptionInvalid: "TREE_DESCRIPTION_INVALID",
+  softLinksInvalid: "TREE_SOFT_LINKS_INVALID",
+  softLinkBroken: "TREE_SOFT_LINK_BROKEN",
+  softLinkPathEscape: "TREE_SOFT_LINK_PATH_ESCAPE",
+  softLinkArchiveDependency: "TREE_SOFT_LINK_ARCHIVE_DEPENDENCY",
+  markdownPathEscape: "TREE_MARKDOWN_LINK_PATH_ESCAPE",
+  markdownArchiveDependency: "TREE_MARKDOWN_LINK_ARCHIVE_DEPENDENCY",
+  markdownFilePathEscape: "TREE_MARKDOWN_FILE_PATH_ESCAPE",
+  directorySymlinkUnsupported: "TREE_DIRECTORY_SYMLINK_UNSUPPORTED",
+  directorySymlinkPathEscape: "TREE_DIRECTORY_SYMLINK_PATH_ESCAPE",
+  memberFrontmatterMissing: "TREE_MEMBER_FRONTMATTER_MISSING",
+  memberFrontmatterParse: "TREE_MEMBER_FRONTMATTER_PARSE",
+  memberTitleInvalid: "TREE_MEMBER_TITLE_INVALID",
+  memberOwnersMissing: "TREE_MEMBER_OWNERS_MISSING",
+  memberOwnersInvalid: "TREE_MEMBER_OWNERS_INVALID",
+  memberTypeMissing: "TREE_MEMBER_TYPE_MISSING",
+  memberTypeInvalid: "TREE_MEMBER_TYPE_INVALID",
+  memberTypeShape: "TREE_MEMBER_TYPE_SHAPE",
+  memberStatusInvalid: "TREE_MEMBER_STATUS_INVALID",
+  memberStatusShape: "TREE_MEMBER_STATUS_SHAPE",
+  memberRoleInvalid: "TREE_MEMBER_ROLE_INVALID",
+  memberRoleShape: "TREE_MEMBER_ROLE_SHAPE",
+  memberDomainsInvalid: "TREE_MEMBER_DOMAINS_INVALID",
+  memberDomainsShape: "TREE_MEMBER_DOMAINS_SHAPE",
+  membersDirectoryMissing: "TREE_MEMBERS_DIRECTORY_MISSING",
+  memberNodeMissing: "TREE_MEMBER_NODE_MISSING",
+  memberNodesEmpty: "TREE_MEMBER_NODES_EMPTY",
+} as const;
+
+export type ValidationCode = (typeof VALIDATION_CODES)[keyof typeof VALIDATION_CODES];
+
+export type TreeValidationFinding = {
+  code: ValidationCode;
+  message: string;
+  path: string;
+  target?: string;
+};
+
+export function formatValidationFinding(finding: TreeValidationFinding): string {
+  const target = finding.target === undefined ? "" : ` (target: ${finding.target})`;
+  return `[${finding.code}] ${finding.path}: ${finding.message}${target}`;
+}

--- a/apps/cli/src/commands/tree/validation-finding.ts
+++ b/apps/cli/src/commands/tree/validation-finding.ts
@@ -13,6 +13,7 @@ export const VALIDATION_CODES = {
   markdownPathEscape: "TREE_MARKDOWN_LINK_PATH_ESCAPE",
   markdownArchiveDependency: "TREE_MARKDOWN_LINK_ARCHIVE_DEPENDENCY",
   markdownFilePathEscape: "TREE_MARKDOWN_FILE_PATH_ESCAPE",
+  markdownFileContentClassMismatch: "TREE_MARKDOWN_FILE_CONTENT_CLASS_MISMATCH",
   directorySymlinkUnsupported: "TREE_DIRECTORY_SYMLINK_UNSUPPORTED",
   directorySymlinkPathEscape: "TREE_DIRECTORY_SYMLINK_PATH_ESCAPE",
   memberFrontmatterMissing: "TREE_MEMBER_FRONTMATTER_MISSING",

--- a/apps/cli/src/commands/tree/verify.ts
+++ b/apps/cli/src/commands/tree/verify.ts
@@ -1,4 +1,4 @@
-import { readFileSync, statSync } from "node:fs";
+import { lstatSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import type { Command } from "commander";
@@ -96,12 +96,14 @@ const ROOT_METADATA_CODES = new Set<ValidationCode>([
   VALIDATION_CODES.titleInvalid,
   VALIDATION_CODES.ownersMissing,
   VALIDATION_CODES.ownersInvalid,
+  VALIDATION_CODES.markdownFileSymlinkBroken,
   VALIDATION_CODES.markdownFilePathEscape,
 ]);
 
 function rootNodeExists(path: string): boolean {
   try {
-    return statSync(path).isFile();
+    const entry = lstatSync(path);
+    return entry.isFile() || entry.isSymbolicLink();
   } catch {
     return false;
   }
@@ -120,6 +122,8 @@ function formatRootNodeError(finding: TreeValidationFinding): string {
       return "Root NODE.md is missing owners.";
     case VALIDATION_CODES.markdownFilePathEscape:
       return "Root NODE.md resolves outside the Context Tree root.";
+    case VALIDATION_CODES.markdownFileSymlinkBroken:
+      return "Root NODE.md symlink target cannot be resolved.";
     default:
       return formatValidationFinding(finding);
   }

--- a/apps/cli/src/commands/tree/verify.ts
+++ b/apps/cli/src/commands/tree/verify.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import type { Command } from "commander";
@@ -7,14 +7,18 @@ import { channelConfig } from "../../core/channel.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
 import { readSourceBindingContract } from "./binding-contract.js";
 import { TREE_PROGRESS_FILE } from "./binding-state.js";
+import type { ContextContentClassCounts } from "./content-class.js";
 import { resolveRepoRoot } from "./shared.js";
 import { readTreeIdentityContract } from "./tree-identity.js";
-import { runValidateMembers } from "./validate-members.js";
-import { runValidateNodes } from "./validate-nodes.js";
+import { collectMemberValidationFindings, formatLegacyMemberError } from "./validate-members.js";
+import { collectNodeValidationFindings, formatLegacyNodeError } from "./validate-nodes.js";
+import {
+  formatValidationFinding,
+  type TreeValidationFinding,
+  VALIDATION_CODES,
+  type ValidationCode,
+} from "./validation-finding.js";
 
-const FRONTMATTER_RE = /^---\s*\n(.*?)\n---/su;
-const OWNERS_RE = /^owners:\s*\[([^\]]*)\]/mu;
-const TITLE_RE = /^title:\s*['"]?(.+?)['"]?\s*$/mu;
 const UNCHECKED_RE = /^- \[ \] (.+)$/gmu;
 
 export const VERIFY_USAGE = `usage: ${channelConfig.binName} tree verify [--tree-path PATH]
@@ -39,7 +43,9 @@ export type VerifySummary = {
     rootNodeFrontmatter: VerifyCheck;
     treeState: VerifyCheck;
   };
+  findings: TreeValidationFinding[];
   ok: boolean;
+  scannedByContentClass: ContextContentClassCounts;
   targetRoot: string;
 };
 
@@ -55,16 +61,6 @@ function readTargetRoot(command: Command): string {
   }
 
   return resolveRepoRoot(process.cwd());
-}
-
-function parseFrontmatter(path: string): string | null {
-  try {
-    const text = readFileSync(path, "utf-8");
-    const match = text.match(FRONTMATTER_RE);
-    return match ? match[1] : null;
-  } catch {
-    return null;
-  }
 }
 
 function readUncheckedProgressItems(root: string): string[] {
@@ -83,28 +79,78 @@ function formatSourceRepoError(targetRoot: string): string {
   return `This repo only has source/workspace integration installed. Verify the tree repo instead, for example \`${channelConfig.binName} tree verify --tree-path ${examplePath}\`.`;
 }
 
+function deduplicateFindings(findings: TreeValidationFinding[]): TreeValidationFinding[] {
+  return findings.filter(
+    (finding, index, all) =>
+      all.findIndex(
+        (candidate) =>
+          candidate.code === finding.code && candidate.path === finding.path && candidate.target === finding.target,
+      ) === index,
+  );
+}
+
+const ROOT_METADATA_CODES = new Set<ValidationCode>([
+  VALIDATION_CODES.frontmatterMissing,
+  VALIDATION_CODES.frontmatterParse,
+  VALIDATION_CODES.titleMissing,
+  VALIDATION_CODES.titleInvalid,
+  VALIDATION_CODES.ownersMissing,
+  VALIDATION_CODES.ownersInvalid,
+  VALIDATION_CODES.markdownFilePathEscape,
+]);
+
+function rootNodeExists(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function formatRootNodeError(finding: TreeValidationFinding): string {
+  switch (finding.code) {
+    case VALIDATION_CODES.frontmatterMissing:
+    case VALIDATION_CODES.frontmatterParse:
+      return "Root NODE.md is missing frontmatter.";
+    case VALIDATION_CODES.titleMissing:
+    case VALIDATION_CODES.titleInvalid:
+      return "Root NODE.md is missing a title.";
+    case VALIDATION_CODES.ownersMissing:
+    case VALIDATION_CODES.ownersInvalid:
+      return "Root NODE.md is missing owners.";
+    case VALIDATION_CODES.markdownFilePathEscape:
+      return "Root NODE.md resolves outside the Context Tree root.";
+    default:
+      return formatValidationFinding(finding);
+  }
+}
+
 export function verifyTreeRoot(targetRoot: string): VerifySummary {
   if (readSourceBindingContract(targetRoot) !== undefined && readTreeIdentityContract(targetRoot) === undefined) {
     throw new Error(formatSourceRepoError(targetRoot));
   }
 
-  const rootFrontmatter = parseFrontmatter(join(targetRoot, "NODE.md"));
-  const rootNodeErrors: string[] = [];
-
-  if (rootFrontmatter === null) {
-    rootNodeErrors.push("Root NODE.md is missing frontmatter.");
-  } else {
-    if (!TITLE_RE.test(rootFrontmatter)) {
-      rootNodeErrors.push("Root NODE.md is missing a title.");
-    }
-    if (!OWNERS_RE.test(rootFrontmatter)) {
-      rootNodeErrors.push("Root NODE.md is missing owners.");
-    }
-  }
-
   const progressItems = readUncheckedProgressItems(targetRoot);
-  const nodeResult = runValidateNodes(targetRoot);
-  const memberResult = runValidateMembers(targetRoot);
+  const nodeResult = collectNodeValidationFindings(targetRoot);
+  const memberResult = collectMemberValidationFindings(targetRoot);
+  const missingRootFinding: TreeValidationFinding[] = rootNodeExists(join(targetRoot, "NODE.md"))
+    ? []
+    : [
+        {
+          code: VALIDATION_CODES.frontmatterMissing,
+          message: "root NODE.md is missing",
+          path: "NODE.md",
+        },
+      ];
+  const nodeFindings = [...missingRootFinding, ...nodeResult.findings];
+  const rootFindings = nodeFindings.filter(
+    (finding) => finding.path === "NODE.md" && ROOT_METADATA_CODES.has(finding.code),
+  );
+  const findings = deduplicateFindings([...nodeFindings, ...memberResult.findings]);
+  const nodeErrors = nodeFindings.map(formatLegacyNodeError);
+  const memberErrors = memberResult.findings.map(formatLegacyMemberError);
+  const rootNodeErrors = rootFindings.map(formatRootNodeError);
+
   // W1 moved workspace/tree identity out of the tree repo and into the
   // workspace-root manifest. A fresh CI checkout of a tree repo is therefore
   // valid without the pre-W1 `.first-tree/VERSION` / `tree.json` files.
@@ -116,12 +162,12 @@ export function verifyTreeRoot(targetRoot: string): VerifySummary {
         ok: true,
       },
       members: {
-        ok: memberResult.exitCode === 0,
-        ...(memberResult.exitCode === 0 ? {} : { errors: memberResult.errors }),
+        ok: memberErrors.length === 0,
+        ...(memberErrors.length === 0 ? {} : { errors: memberErrors }),
       },
       nodes: {
-        ok: nodeResult.exitCode === 0,
-        ...(nodeResult.exitCode === 0 ? {} : { errors: nodeResult.errors }),
+        ok: nodeErrors.length === 0,
+        ...(nodeErrors.length === 0 ? {} : { errors: nodeErrors }),
       },
       progress: {
         ok: progressItems.length === 0,
@@ -138,7 +184,9 @@ export function verifyTreeRoot(targetRoot: string): VerifySummary {
         ok: true,
       },
     },
+    findings,
     ok: false,
+    scannedByContentClass: nodeResult.scannedByContentClass,
     targetRoot,
   };
 
@@ -164,6 +212,13 @@ function printVerifySummary(summary: VerifySummary): void {
     console.log(`  [${icon}] ${label}`);
     for (const error of check.errors ?? []) {
       console.log(`    - ${error}`);
+    }
+  }
+
+  if (summary.findings.length > 0) {
+    console.log("\n  Findings");
+    for (const finding of summary.findings) {
+      console.log(`    - ${formatValidationFinding(finding)}`);
     }
   }
 

--- a/apps/cli/src/commands/tree/verify.ts
+++ b/apps/cli/src/commands/tree/verify.ts
@@ -5,9 +5,10 @@ import type { Command } from "commander";
 
 import { channelConfig } from "../../core/channel.js";
 import type { CommandContext, SubcommandModule } from "../types.js";
-import { readSourceBindingContract } from "./binding-contract.js";
+import { readSourceBindingContract, SOURCE_INTEGRATION_FILES } from "./binding-contract.js";
 import { TREE_PROGRESS_FILE } from "./binding-state.js";
 import type { ContextContentClassCounts } from "./content-class.js";
+import { inspectRepoInfraMarkdownFile } from "./content-class.js";
 import { resolveRepoRoot } from "./shared.js";
 import { readTreeIdentityContract } from "./tree-identity.js";
 import { collectMemberValidationFindings, formatLegacyMemberError } from "./validate-members.js";
@@ -143,7 +144,14 @@ function formatRootNodeError(finding: TreeValidationFinding): string {
 }
 
 export function verifyTreeRoot(targetRoot: string): VerifySummary {
-  if (readSourceBindingContract(targetRoot) !== undefined && readTreeIdentityContract(targetRoot) === undefined) {
+  const invalidManagedPath = SOURCE_INTEGRATION_FILES.some(
+    (file) => inspectRepoInfraMarkdownFile(targetRoot, file).kind === "invalid",
+  );
+  if (
+    !invalidManagedPath &&
+    readSourceBindingContract(targetRoot) !== undefined &&
+    readTreeIdentityContract(targetRoot) === undefined
+  ) {
     throw new Error(formatSourceRepoError(targetRoot));
   }
 

--- a/apps/cli/src/commands/tree/verify.ts
+++ b/apps/cli/src/commands/tree/verify.ts
@@ -1,4 +1,4 @@
-import { lstatSync, readFileSync } from "node:fs";
+import { lstatSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import type { Command } from "commander";
@@ -97,13 +97,24 @@ const ROOT_METADATA_CODES = new Set<ValidationCode>([
   VALIDATION_CODES.ownersMissing,
   VALIDATION_CODES.ownersInvalid,
   VALIDATION_CODES.markdownFileSymlinkBroken,
+  VALIDATION_CODES.markdownFileSymlinkUnsupported,
   VALIDATION_CODES.markdownFilePathEscape,
 ]);
 
 function rootNodeExists(path: string): boolean {
   try {
     const entry = lstatSync(path);
-    return entry.isFile() || entry.isSymbolicLink();
+    if (entry.isFile()) {
+      return true;
+    }
+    if (!entry.isSymbolicLink()) {
+      return false;
+    }
+    try {
+      return !statSync(path).isDirectory();
+    } catch {
+      return true;
+    }
   } catch {
     return false;
   }
@@ -124,6 +135,8 @@ function formatRootNodeError(finding: TreeValidationFinding): string {
       return "Root NODE.md resolves outside the Context Tree root.";
     case VALIDATION_CODES.markdownFileSymlinkBroken:
       return "Root NODE.md symlink target cannot be resolved.";
+    case VALIDATION_CODES.markdownFileSymlinkUnsupported:
+      return "Root NODE.md symlink target is not a regular file.";
     default:
       return formatValidationFinding(finding);
   }

--- a/apps/cli/tests/validate-members.test.ts
+++ b/apps/cli/tests/validate-members.test.ts
@@ -170,6 +170,18 @@ describe("runValidateMembers — nested directories under a member node", () => 
     expect(result.exitCode).toBe(1);
     expect(result.errors.some((message) => message.includes("missing 'domains' field"))).toBe(true);
   });
+
+  it("does not follow directory symlink loops in personal member subtrees", (ctx) => {
+    const root = makeTempDir("validate-members-");
+    write(root, "members/alice/NODE.md", VALID_MEMBER_FRONTMATTER("alice"));
+    try {
+      symlinkSync("..", join(root, "members", "alice", "loop"), "dir");
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    expect(runValidateMembers(root)).toEqual({ exitCode: 0, errors: [] });
+  });
 });
 
 describe("runValidateMembers — missing members directory", () => {

--- a/apps/cli/tests/validate-nodes.test.ts
+++ b/apps/cli/tests/validate-nodes.test.ts
@@ -100,7 +100,7 @@ describe("runValidateNodes — non-personal files", () => {
     }
   });
 
-  it("ignores entries that disappear before stat", (ctx) => {
+  it("rejects dangling Markdown symlinks", (ctx) => {
     const root = makeTempDir("validate-nodes-");
     write(root, "NODE.md", ROOT_FRONTMATTER);
     try {
@@ -111,7 +111,10 @@ describe("runValidateNodes — non-personal files", () => {
 
     const result = runValidateNodes(root);
 
-    expect(result).toEqual({ exitCode: 0, errors: [] });
+    expect(result).toEqual({
+      exitCode: 1,
+      errors: ["[TREE_MARKDOWN_FILE_SYMLINK_BROKEN] broken.md: Markdown file symlink target cannot be resolved"],
+    });
   });
 });
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -720,8 +720,9 @@ an otherwise tree-local Markdown target may be absent; external links, anchors,
 and plain prose that explains the archive class remain allowed. JSON output
 preserves the existing summary and adds stable findings plus per-class scan
 counts. Context Tree domain directories must not be symlinks; Markdown file
-symlinks are validated and must resolve inside the tree, except for the managed
-`WHITEPAPER.md` pointer. This is a breaking tightening for trees that relied on legacy metadata
+symlinks are validated, must resolve inside the tree, and must not cross content
+classes, except for the managed root-level `WHITEPAPER.md` pointer. This is a
+breaking tightening for trees that relied on legacy metadata
 or normal-to-archive links: mechanical syntax can be corrected directly, while
 ownership assignments and promotion of durable archive content require human
 or source-backed decisions. Run `first-tree tree verify --help` for options.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -720,11 +720,11 @@ an otherwise tree-local Markdown target may be absent; external links, anchors,
 and plain prose that explains the archive class remain allowed. JSON output
 preserves the existing summary and adds stable findings plus per-class scan
 counts. Context Tree domain directories must not be symlinks; Markdown file
-symlinks are validated, dangling targets fail, resolved targets must stay inside
-the tree and must not cross content classes, except for the managed root-level
-`WHITEPAPER.md` pointer. That historical runtime-managed pointer remains exempt
-for compatibility only; writers must not add it to new trees. This is a
-breaking tightening for trees that relied on legacy metadata
+symlinks are validated, must resolve to regular Markdown files, and must stay
+inside the tree without crossing content classes, except for the managed
+root-level `WHITEPAPER.md` pointer. That historical runtime-managed pointer
+remains exempt for compatibility only; writers must not add it to new trees.
+This is a breaking tightening for trees that relied on legacy metadata
 or normal-to-archive links: mechanical syntax can be corrected directly, while
 ownership assignments and promotion of durable archive content require human
 or source-backed decisions. Run `first-tree tree verify --help` for options.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -720,8 +720,10 @@ an otherwise tree-local Markdown target may be absent; external links, anchors,
 and plain prose that explains the archive class remain allowed. JSON output
 preserves the existing summary and adds stable findings plus per-class scan
 counts. Context Tree domain directories must not be symlinks; Markdown file
-symlinks are validated, must resolve inside the tree, and must not cross content
-classes, except for the managed root-level `WHITEPAPER.md` pointer. This is a
+symlinks are validated, dangling targets fail, resolved targets must stay inside
+the tree and must not cross content classes, except for the managed root-level
+`WHITEPAPER.md` pointer. That historical runtime-managed pointer remains exempt
+for compatibility only; writers must not add it to new trees. This is a
 breaking tightening for trees that relied on legacy metadata
 or normal-to-archive links: mechanical syntax can be corrected directly, while
 ownership assignments and promotion of durable archive content require human

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -708,7 +708,23 @@ to replace an existing team binding unless `--rebind` is passed. Key options:
 `--owner`, `--name`, `--title`, `--public`, `--dir`, `--with-workflow`, `--no-bind`,
 `--rebind`, `--org`. Run `first-tree tree init --help` for the full list.
 
-Run `first-tree tree verify --help` for options.
+`first-tree tree verify` applies the current strict structural policy. Normal
+content requires parseable YAML frontmatter with non-empty `title` and `owners`;
+`description` and `soft_links`, when present, must have valid shapes. The
+separate member-node contract remains in force, while archive/supporting and
+repo-infrastructure Markdown are not treated as normal nodes.
+
+Broken `soft_links`, tree-local path escapes, and normal links into
+`raw-context/` fail verification. Markdown links are parsed structurally, but
+an otherwise tree-local Markdown target may be absent; external links, anchors,
+and plain prose that explains the archive class remain allowed. JSON output
+preserves the existing summary and adds stable findings plus per-class scan
+counts. Context Tree domain directories must not be symlinks; Markdown file
+symlinks are validated and must resolve inside the tree, except for the managed
+`WHITEPAPER.md` pointer. This is a breaking tightening for trees that relied on legacy metadata
+or normal-to-archive links: mechanical syntax can be corrected directly, while
+ownership assignments and promotion of durable archive content require human
+or source-backed decisions. Run `first-tree tree verify --help` for options.
 
 `first-tree tree tree [path]` resolves `path` relative to the current
 working directory, then renders from the current git repository root down

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -217,7 +217,7 @@ describe("buildAgentBriefing — Context Tree policy and skill routing", () => {
     expect(tree).toContain("`lastReviewed` records an actual\nowner review");
     expect(tree).toContain("update it only through that review/audit workflow");
     expect(tree).toContain("never during\na source-backed write");
-    expect(tree).toContain("Use `owners: [*]` only when a human explicitly opens");
+    expect(tree).toContain('Use `owners: ["*"]` only when a human explicitly opens');
     expect(tree).toContain("ownership to everyone");
     expect(tree).toContain("Metadata supports scanning, routing, and responsibility");
     expect(tree).toContain("### Write / Verify / PR Discipline");

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -720,7 +720,7 @@ owners: [alice, bob]
 Useful optional frontmatter: \`description\`, \`soft_links\`,
 \`lastReviewed\`, and \`decisionLocksCode\`. \`lastReviewed\` records an actual
 owner review; update it only through that review/audit workflow, never during
-a source-backed write. Use \`owners: [*]\` only when a human explicitly opens
+a source-backed write. Use \`owners: ["*"]\` only when a human explicitly opens
 ownership to everyone. Metadata supports scanning, routing, and responsibility.
 
 Prefer body sections in this order, omitting any that do not apply:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       jose:
         specifier: ^6.0.0
         version: 6.2.2
+      mdast-util-from-markdown:
+        specifier: ^2.0.3
+        version: 2.0.3
       semver:
         specifier: ^7.6.3
         version: 7.7.4


### PR DESCRIPTION
## Summary

- replace the legacy frontmatter regexes with one structured YAML parser and a shared normal/archive-supporting/member/repo-infra classifier
- make `tree verify` enforce deterministic metadata, `soft_links`, authority-boundary, path-escape, and symlink rules while preserving the existing check/error JSON fields and adding stable structured findings
- classify existing link and symlink targets by canonical real path; reject dangling, non-regular, escaping, directory-target, and cross-content-class Markdown symlinks before content-class skips
- parse Markdown links through mdast, keep ordinary missing Markdown targets allowed, and skip archive/supporting content as non-canonical evidence
- align the generated Context Tree policy with valid wildcard ownership YAML (`owners: ["*"]`)

## Breaking validation change

`tree verify` now always applies the current strict structural policy. There is no version marker, warning compatibility mode, or `--strict` alias. Existing trees with malformed metadata, normal-to-archive links, broken `soft_links`, unsupported directory symlinks, dangling/non-regular/escaping Markdown symlinks, or cross-content-class aliases must be repaired before their next tree PR can pass.

Mechanical syntax and path findings can be fixed directly. Ownership assignment and promotion of durable material out of archive/supporting content still require the relevant human or source-backed decision.

## Compatibility

- existing `checks.*`, `errors[]`, `ok`, and exit behavior remain intact
- `findings` and `scannedByContentClass` are additive JSON fields
- personal member Markdown keeps its relaxed optional-frontmatter behavior
- existing member identity, tree init, and tree browser contracts remain covered
- source/tree identity readers consume only contained, canonical repo-infra regular files; invalid managed paths yield strict findings before source-repo preflight
- the sole managed file-symlink exception is the historical runtime-managed root-level `WHITEPAPER.md` pointer; writers must not add it to new trees

## Validation

- final path/symlink targeted tests: 4 files, 58 tests passed
- generated briefing tests: 25 tests passed
- sanitized full CLI suite: 18/18 batches passed (tree batch: 117 tests)
- `pnpm --filter first-tree-dev build`
- `pnpm typecheck`
- `pnpm check` (only existing repository warnings/info)
- `pnpm validate:skill`
- built CLI against the companion official tree: PASS, 0 findings
- installed previous CLI against the companion official tree: PASS
- `git diff --check`

## Companion Context Tree

Draft companion Context Tree PR: https://github.com/agent-team-foundation/first-tree-context/pull/728

Merge this code PR first, then reconcile and ready the tree PR.
