### PR TITLE
feat(web): mobile add-to-home-screen install guide

### DIFF
--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -131,6 +131,12 @@ const MobilePreviewPage = import.meta.env.DEV
   ? lazy(() => import("./pages/mobile-preview.js").then((module) => ({ default: module.MobilePreviewPage })))
   : null;
 
+const InstallGuidePreviewPage = import.meta.env.DEV
+  ? lazy(() =>
+      import("./pages/install-guide-preview.js").then((module) => ({ default: module.InstallGuidePreviewPage })),
+    )
+  : null;
+
 const TeamSwitcherPreviewPage = import.meta.env.DEV
   ? lazy(() =>
       import("./pages/team-switcher-preview.js").then((module) => ({ default: module.TeamSwitcherPreviewPage })),
@@ -293,6 +299,16 @@ export function App() {
                   element={
                     <Suspense fallback={null}>
                       <MobilePreviewPage />
+                    </Suspense>
+                  }
+                />
+              ) : null}
+              {InstallGuidePreviewPage ? (
+                <Route
+                  path="/preview/install-guide"
+                  element={
+                    <Suspense fallback={null}>
+                      <InstallGuidePreviewPage />
                     </Suspense>
                   }
                 />

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1162,6 +1162,29 @@
   }
 }
 
+/* Mobile install ("add to home screen") guide — docked bottom sheet slides up,
+   scrim fades in. Mirrors the toast/mention entrance vocabulary. */
+@keyframes mobile-sheet-in {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+.mobile-sheet-in {
+  animation: mobile-sheet-in 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.mobile-scrim-in {
+  animation: subtle-fade 180ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mobile-sheet-in,
+  .mobile-scrim-in {
+    animation: none;
+  }
+}
+
 /* Left-aligned content column that fills the shared 960 canvas, matching the
    Team / Agent Detail tabs (same `--sp-2 --sp-5 --sp-7` content padding under a
    PageHeader). No min-height / centering — the page used to render as a

--- a/packages/web/src/pages/install-guide-preview.tsx
+++ b/packages/web/src/pages/install-guide-preview.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { InstallGuideSheet } from "./mobile/install-guide-sheet.js";
+import type { InstallGuideMode } from "./mobile/use-install-guide.js";
+
+// DEV-only visual harness for the install ("add to home screen") sheet. Renders
+// each platform variant over a tinted backdrop so tokens/layout can be checked
+// in light and dark without auth or a real beforeinstallprompt event.
+const MODES: ReadonlyArray<{ mode: InstallGuideMode; label: string }> = [
+  { mode: "native", label: "Android (one-tap)" },
+  { mode: "ios", label: "iOS (share steps)" },
+  { mode: "android-manual", label: "Android (menu steps)" },
+];
+
+export function InstallGuidePreviewPage() {
+  const [mode, setMode] = useState<InstallGuideMode>("ios");
+
+  return (
+    <div
+      className="min-h-dvh flex flex-col items-center"
+      style={{ background: "var(--bg)", padding: "var(--sp-6) var(--sp-4)", gap: "var(--sp-4)" }}
+    >
+      <div className="flex flex-wrap justify-center" style={{ gap: "var(--sp-2)" }}>
+        {MODES.map((option) => (
+          <button
+            key={option.mode}
+            type="button"
+            onClick={() => setMode(option.mode)}
+            className="transition-colors"
+            style={{
+              padding: "var(--sp-1_5) var(--sp-3)",
+              borderRadius: "var(--radius-input)",
+              border: "var(--hairline) solid var(--border)",
+              background: mode === option.mode ? "var(--bg-active)" : "var(--bg-raised)",
+              color: mode === option.mode ? "var(--fg)" : "var(--fg-3)",
+              cursor: "pointer",
+            }}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+      <p className="text-mobile-body" style={{ color: "var(--fg-3)", margin: 0 }}>
+        Set the browser to a phone viewport to see the sheet as it ships.
+      </p>
+      <InstallGuideSheet
+        mode={mode}
+        onInstall={() => {
+          /* preview no-op */
+        }}
+        onClose={() => {
+          /* preview no-op: keep the sheet visible */
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/pages/mobile/__tests__/install-guide-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/install-guide-dom.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+import { InstallGuideSheet } from "../install-guide-sheet.js";
+
+let harness: DomHarness;
+
+beforeEach(() => {
+  harness = createDomHarness();
+});
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+function findButton(label: string): HTMLButtonElement | null {
+  return (
+    [...harness.container.querySelectorAll("button")].find((button) => button.textContent?.includes(label)) ?? null
+  );
+}
+
+describe("InstallGuideSheet", () => {
+  it("shows the value proposition and native one-tap CTA", () => {
+    const onInstall = vi.fn();
+    const onClose = vi.fn();
+    harness.render(<InstallGuideSheet mode="native" onInstall={onInstall} onClose={onClose} />);
+
+    const sheet = harness.container.querySelector('[data-mobile-install-sheet="true"]');
+    expect(sheet?.textContent).toContain("Add First Tree to your home screen");
+    expect(sheet?.textContent).toContain("Opens instantly");
+    // Native mode is one-tap, not a step list.
+    expect(sheet?.textContent).not.toContain("Share button");
+
+    findButton("Add to Home Screen")?.click();
+    expect(onInstall).toHaveBeenCalledTimes(1);
+    findButton("Maybe later")?.click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("teaches the iOS share steps and never calls install", () => {
+    const onInstall = vi.fn();
+    const onClose = vi.fn();
+    harness.render(<InstallGuideSheet mode="ios" onInstall={onInstall} onClose={onClose} />);
+
+    const sheet = harness.container.querySelector('[data-mobile-install-sheet="true"]');
+    expect(sheet?.textContent).toContain("Share button below");
+    expect(sheet?.textContent).toContain('Add to Home Screen"');
+    expect(harness.container.querySelector("ol")).not.toBeNull();
+
+    findButton("Got it")?.click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onInstall).not.toHaveBeenCalled();
+  });
+
+  it("teaches the Android menu steps in the manual fallback", () => {
+    harness.render(<InstallGuideSheet mode="android-manual" onInstall={vi.fn()} onClose={vi.fn()} />);
+    const sheet = harness.container.querySelector('[data-mobile-install-sheet="true"]');
+    expect(sheet?.textContent).toContain("browser menu");
+    expect(sheet?.textContent).toContain("Install app");
+  });
+
+  it("dismisses on scrim click and Escape", () => {
+    const onClose = vi.fn();
+    harness.render(<InstallGuideSheet mode="ios" onInstall={vi.fn()} onClose={onClose} />);
+
+    const scrim = harness.container.querySelector<HTMLButtonElement>('button[aria-label="Dismiss"]');
+    scrim?.click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web/src/pages/mobile/__tests__/install-guide-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/install-guide-dom.test.tsx
@@ -60,6 +60,17 @@ describe("InstallGuideSheet", () => {
     expect(sheet?.textContent).toContain("Install app");
   });
 
+  it("traps focus inside the sheet on Shift+Tab from the dialog root", () => {
+    harness.render(<InstallGuideSheet mode="ios" onInstall={vi.fn()} onClose={vi.fn()} />);
+    const dialog = harness.container.querySelector<HTMLElement>('[data-mobile-install-sheet="true"]');
+    // Auto-pop lands initial focus on the dialog root; Shift+Tab must not escape
+    // backward to the scrim (which is outside the dialog).
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", shiftKey: true }));
+    const active = document.activeElement;
+    expect(dialog?.contains(active)).toBe(true);
+    expect(active?.getAttribute("aria-label")).not.toBe("Dismiss");
+  });
+
   it("dismisses on scrim click and Escape", () => {
     const onClose = vi.fn();
     harness.render(<InstallGuideSheet mode="ios" onInstall={vi.fn()} onClose={onClose} />);

--- a/packages/web/src/pages/mobile/__tests__/install-guide-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/install-guide-dom.test.tsx
@@ -60,15 +60,17 @@ describe("InstallGuideSheet", () => {
     expect(sheet?.textContent).toContain("Install app");
   });
 
-  it("traps focus inside the sheet on Shift+Tab from the dialog root", () => {
+  it("wraps Shift+Tab from the dialog root to the last in-dialog control", () => {
     harness.render(<InstallGuideSheet mode="ios" onInstall={vi.fn()} onClose={vi.fn()} />);
     const dialog = harness.container.querySelector<HTMLElement>('[data-mobile-install-sheet="true"]');
-    // Auto-pop lands initial focus on the dialog root; Shift+Tab must not escape
-    // backward to the scrim (which is outside the dialog).
+    // Auto-pop lands initial focus on the dialog root (outside the focusable
+    // set). Shift+Tab must wrap to the LAST in-dialog control ("Got it") — not
+    // fall through to the scrim, and not simply stay parked on the root.
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", shiftKey: true }));
     const active = document.activeElement;
     expect(dialog?.contains(active)).toBe(true);
-    expect(active?.getAttribute("aria-label")).not.toBe("Dismiss");
+    expect(active?.tagName).toBe("BUTTON");
+    expect(active?.textContent).toContain("Got it");
   });
 
   it("dismisses on scrim click and Escape", () => {

--- a/packages/web/src/pages/mobile/__tests__/install-guide-hook.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/install-guide-hook.test.tsx
@@ -67,7 +67,7 @@ describe("install prompt capture lifecycle", () => {
     expect(readMode()).toBe("native");
   });
 
-  it("ignores beforeinstallprompt off the supported mobile flow (no preventDefault)", async () => {
+  it("ignores beforeinstallprompt off the supported platform (no preventDefault)", async () => {
     setUserAgent(DESKTOP_UA);
     const readMode = await renderModeProbe();
 

--- a/packages/web/src/pages/mobile/__tests__/install-guide-hook.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/install-guide-hook.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+
+const ANDROID_UA = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit Chrome/125 Mobile";
+const DESKTOP_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit Chrome/125";
+
+let harness: DomHarness;
+
+function setUserAgent(ua: string): void {
+  vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(ua);
+}
+
+/** Dispatch a synthetic beforeinstallprompt; returns the preventDefault spy. */
+function fireBeforeInstallPrompt(): ReturnType<typeof vi.fn> {
+  const event = new Event("beforeinstallprompt");
+  const preventDefault = vi.fn();
+  event.preventDefault = preventDefault;
+  Object.assign(event, {
+    prompt: () => Promise.resolve(),
+    userChoice: Promise.resolve({ outcome: "accepted", platform: "web" }),
+  });
+  window.dispatchEvent(event);
+  return preventDefault;
+}
+
+// Fresh module per test: the capture is a module singleton, so we reset modules
+// and re-import to get a clean deferredPrompt/installed state each time.
+async function renderModeProbe() {
+  const mod = await import("../use-install-guide.js");
+  function ModeProbe() {
+    const { mode } = mod.useInstallPrompt();
+    return <span data-testid="mode" data-mode={mode ?? "null"} />;
+  }
+  harness.render(<ModeProbe />);
+  return () => harness.container.querySelector('[data-testid="mode"]')?.getAttribute("data-mode") ?? null;
+}
+
+beforeEach(() => {
+  harness = createDomHarness();
+  localStorage.clear();
+  sessionStorage.clear();
+  vi.resetModules();
+});
+
+afterEach(() => {
+  harness.cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("install prompt capture lifecycle", () => {
+  it("captures beforeinstallprompt on Android and offers one-tap install", async () => {
+    setUserAgent(ANDROID_UA);
+    const readMode = await renderModeProbe();
+    expect(readMode()).toBe("android-manual"); // no prompt yet
+
+    let preventDefault: ReturnType<typeof vi.fn> | undefined;
+    await harness.flush();
+    act(() => {
+      preventDefault = fireBeforeInstallPrompt();
+    });
+    await harness.flush();
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(readMode()).toBe("native");
+  });
+
+  it("ignores beforeinstallprompt off the supported mobile flow (no preventDefault)", async () => {
+    setUserAgent(DESKTOP_UA);
+    const readMode = await renderModeProbe();
+
+    let preventDefault: ReturnType<typeof vi.fn> | undefined;
+    act(() => {
+      preventDefault = fireBeforeInstallPrompt();
+    });
+    await harness.flush();
+
+    // Desktop: we leave the browser's own install UI alone and render nothing.
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(readMode()).toBe("null");
+  });
+
+  it("hides promotion reactively after a menu-driven appinstalled", async () => {
+    setUserAgent(ANDROID_UA);
+    const readMode = await renderModeProbe();
+    // Android manual path: no prompt was captured, prompt stays null.
+    expect(readMode()).toBe("android-manual");
+
+    act(() => {
+      window.dispatchEvent(new Event("appinstalled"));
+    });
+    await harness.flush();
+
+    expect(readMode()).toBe("null");
+  });
+});

--- a/packages/web/src/pages/mobile/__tests__/install-guide-state.test.ts
+++ b/packages/web/src/pages/mobile/__tests__/install-guide-state.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  canAutoShow,
+  detectPlatform,
+  hasShownThisSession,
+  type InstallGuideState,
+  isStandalone,
+  MAX_AUTO_SHOWS,
+  markInstalled,
+  markShownThisSession,
+  readInstallGuideState,
+  recordAutoShow,
+} from "../install-guide-state.js";
+
+const eligibleInput = {
+  state: { autoShowCount: 0, installed: false } satisfies InstallGuideState,
+  standalone: false,
+  platform: "ios" as const,
+  hasContent: true,
+  shownThisSession: false,
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("detectPlatform", () => {
+  it("detects Android", () => {
+    expect(detectPlatform("Mozilla/5.0 (Linux; Android 14; Pixel 8) Chrome/125")).toBe("android");
+  });
+  it("detects iOS iPhone", () => {
+    expect(detectPlatform("Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) Safari")).toBe("ios");
+  });
+  it("returns other for desktop", () => {
+    expect(detectPlatform("Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/125")).toBe("other");
+  });
+});
+
+describe("persisted state", () => {
+  it("defaults to a fresh device when unset", () => {
+    expect(readInstallGuideState()).toEqual({ autoShowCount: 0, installed: false });
+  });
+  it("counts each auto-show (the cap key, not dismissals)", () => {
+    recordAutoShow();
+    recordAutoShow();
+    expect(readInstallGuideState().autoShowCount).toBe(2);
+  });
+  it("marks installed", () => {
+    markInstalled();
+    expect(readInstallGuideState().installed).toBe(true);
+  });
+  it("survives a corrupt value", () => {
+    localStorage.setItem("first-tree:install-guide", "{not json");
+    expect(readInstallGuideState()).toEqual({ autoShowCount: 0, installed: false });
+  });
+  it("tracks per-session shown flag", () => {
+    expect(hasShownThisSession()).toBe(false);
+    markShownThisSession();
+    expect(hasShownThisSession()).toBe(true);
+  });
+});
+
+describe("isStandalone", () => {
+  it("is true under display-mode: standalone", () => {
+    vi.spyOn(window, "matchMedia").mockReturnValue({ matches: true } as MediaQueryList);
+    expect(isStandalone()).toBe(true);
+  });
+  it("is true when navigator.standalone (iOS)", () => {
+    vi.spyOn(window, "matchMedia").mockReturnValue({ matches: false } as MediaQueryList);
+    Object.defineProperty(window.navigator, "standalone", { value: true, configurable: true });
+    expect(isStandalone()).toBe(true);
+    Reflect.deleteProperty(window.navigator, "standalone");
+  });
+  it("is false in a normal browser tab", () => {
+    vi.spyOn(window, "matchMedia").mockReturnValue({ matches: false } as MediaQueryList);
+    expect(isStandalone()).toBe(false);
+  });
+});
+
+describe("canAutoShow", () => {
+  it("allows a fresh, engaged, non-installed mobile user", () => {
+    expect(canAutoShow(eligibleInput)).toBe(true);
+  });
+  it("blocks when already installed (standalone)", () => {
+    expect(canAutoShow({ ...eligibleInput, standalone: true })).toBe(false);
+  });
+  it("blocks when the installed flag is set", () => {
+    expect(canAutoShow({ ...eligibleInput, state: { autoShowCount: 0, installed: true } })).toBe(false);
+  });
+  it("blocks on desktop/other platforms", () => {
+    expect(canAutoShow({ ...eligibleInput, platform: "other" })).toBe(false);
+  });
+  it("blocks once the lifetime auto-show cap is reached", () => {
+    expect(canAutoShow({ ...eligibleInput, state: { autoShowCount: MAX_AUTO_SHOWS, installed: false } })).toBe(false);
+  });
+  it("allows the second show after a single prior show", () => {
+    expect(canAutoShow({ ...eligibleInput, state: { autoShowCount: 1, installed: false } })).toBe(true);
+  });
+  it("blocks a second show within the same session", () => {
+    expect(canAutoShow({ ...eligibleInput, shownThisSession: true })).toBe(false);
+  });
+  it("blocks over an empty feed", () => {
+    expect(canAutoShow({ ...eligibleInput, hasContent: false })).toBe(false);
+  });
+});

--- a/packages/web/src/pages/mobile/install-guide-sheet.tsx
+++ b/packages/web/src/pages/mobile/install-guide-sheet.tsx
@@ -1,0 +1,226 @@
+import { Check, MoreVertical, Share, SquarePlus, X } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { Button } from "../../components/ui/button.js";
+import type { InstallGuideMode } from "./use-install-guide.js";
+
+const BENEFITS = [
+  "Opens instantly — no hunting for the link or signing in again",
+  "Full screen — no browser address bar in the way",
+] as const;
+
+/**
+ * Bottom-sheet "add to home screen" guide. Presentational: the parent owns when
+ * it shows and what dismissal means (auto vs. manual). Mirrors the mobile team
+ * switcher sheet (docked, scrim, safe-area padding).
+ */
+export function InstallGuideSheet({
+  mode,
+  onInstall,
+  onClose,
+}: {
+  mode: InstallGuideMode;
+  /** Native one-tap install (Android). Ignored for the instructional modes. */
+  onInstall: () => void;
+  onClose: () => void;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Modal focus management: move focus into the sheet, trap Tab within it, and
+  // restore focus to the trigger on close (the sheet is hand-rolled, so unlike
+  // Radix Dialog it must do this itself). Matters most for the auto-pop, which
+  // appears unprompted.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const node = dialogRef.current;
+    node?.focus();
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab" || !node) return;
+      const focusables = node.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (!first || !last) return;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => {
+      window.removeEventListener("keydown", handler);
+      previouslyFocused?.focus?.();
+    };
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end" data-mobile-install-sheet-root>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        className="mobile-scrim-in absolute inset-0 bg-overlay-scrim"
+        onClick={onClose}
+      />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mobile-install-sheet-title"
+        data-mobile-install-sheet="true"
+        tabIndex={-1}
+        className="mobile-sheet-in relative z-10 w-full overflow-y-auto border-t shadow-[var(--shadow-md)] focus:outline-none"
+        style={{
+          maxHeight: "88dvh",
+          borderColor: "var(--border)",
+          borderRadius: "var(--radius-dialog) var(--radius-dialog) 0 0",
+          background: "var(--bg-raised)",
+          padding: "var(--sp-3) var(--sp-5) calc(var(--sp-5) + env(safe-area-inset-bottom))",
+        }}
+      >
+        <div
+          aria-hidden
+          style={{
+            width: "var(--sp-8)",
+            height: "var(--sp-1)",
+            margin: "0 auto var(--sp-4)",
+            borderRadius: "var(--radius-full)",
+            background: "var(--border-strong)",
+          }}
+        />
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="absolute inline-flex items-center justify-center rounded-[var(--radius-input)] transition-colors hover:bg-[var(--bg-hover)]"
+          style={{
+            top: "var(--sp-3)",
+            right: "var(--sp-3)",
+            height: "var(--sp-8)",
+            width: "var(--sp-8)",
+            color: "var(--fg-3)",
+          }}
+        >
+          <X aria-hidden className="h-4 w-4" />
+        </button>
+
+        <img
+          src="/icons/first-tree-pwa.svg"
+          alt=""
+          width={56}
+          height={56}
+          style={{ display: "block", borderRadius: "var(--radius-panel)", marginBottom: "var(--sp-3_5)" }}
+        />
+
+        <h2 id="mobile-install-sheet-title" className="text-mobile-title" style={{ color: "var(--fg)", margin: 0 }}>
+          Add First Tree to your home screen
+        </h2>
+        <p className="text-mobile-body" style={{ color: "var(--fg-3)", margin: "var(--sp-1_5) 0 var(--sp-4)" }}>
+          One tap straight to your agent team next time — full screen, no address bar, just like a real app.
+        </p>
+
+        <ul
+          className="flex flex-col"
+          style={{ gap: "var(--sp-2_5)", margin: `0 0 var(--sp-5)`, padding: 0, listStyle: "none" }}
+        >
+          {BENEFITS.map((benefit) => (
+            <li
+              key={benefit}
+              className="flex items-center text-mobile-body"
+              style={{ gap: "var(--sp-2_5)", color: "var(--fg-2)" }}
+            >
+              <span
+                aria-hidden
+                className="inline-flex shrink-0 items-center justify-center"
+                style={{
+                  width: "var(--sp-5)",
+                  height: "var(--sp-5)",
+                  borderRadius: "var(--radius-full)",
+                  background: "var(--brand-bg)",
+                  color: "var(--brand)",
+                }}
+              >
+                <Check className="h-3 w-3" strokeWidth={3} />
+              </span>
+              {benefit}
+            </li>
+          ))}
+        </ul>
+
+        {mode === "native" ? (
+          <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+            <Button type="button" variant="cta" size="lg" className="w-full" onClick={onInstall}>
+              Add to Home Screen
+            </Button>
+            <Button type="button" variant="ghost" className="w-full" style={{ color: "var(--fg-3)" }} onClick={onClose}>
+              Maybe later
+            </Button>
+          </div>
+        ) : (
+          <>
+            <ol
+              className="flex flex-col"
+              style={{
+                gap: "var(--sp-1)",
+                margin: `0 0 var(--sp-4)`,
+                padding: "var(--sp-3_5) var(--sp-4)",
+                listStyle: "none",
+                border: "var(--hairline) solid var(--border)",
+                borderRadius: "var(--radius-panel)",
+                background: "var(--bg)",
+              }}
+            >
+              {(mode === "ios" ? IOS_STEPS : ANDROID_STEPS).map((step, index) => (
+                <li
+                  key={step.key}
+                  className="flex items-center text-mobile-body"
+                  style={{ gap: "var(--sp-2_5)", color: "var(--fg-2)", padding: "var(--sp-1) 0" }}
+                >
+                  <span
+                    aria-hidden
+                    className="mono inline-flex shrink-0 items-center justify-center text-mobile-caption"
+                    style={{
+                      width: "var(--sp-5)",
+                      height: "var(--sp-5)",
+                      borderRadius: "var(--radius-full)",
+                      border: "var(--hairline) solid var(--border)",
+                      background: "var(--bg-raised)",
+                      color: "var(--fg-3)",
+                    }}
+                  >
+                    {index + 1}
+                  </span>
+                  <span className="inline-flex items-center" style={{ gap: "var(--sp-1_5)" }}>
+                    {step.before}
+                    <step.icon aria-hidden className="h-4 w-4 shrink-0" style={{ color: "var(--fg)" }} />
+                    {step.after}
+                  </span>
+                </li>
+              ))}
+            </ol>
+            <Button type="button" variant="ghost" className="w-full" style={{ color: "var(--fg-3)" }} onClick={onClose}>
+              Got it
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const IOS_STEPS = [
+  { key: "share", before: "Tap the", icon: Share, after: "Share button below" },
+  { key: "add", before: 'Choose "Add to Home Screen"', icon: SquarePlus, after: "" },
+] as const;
+
+const ANDROID_STEPS = [
+  { key: "menu", before: "Open the", icon: MoreVertical, after: "browser menu" },
+  { key: "add", before: 'Tap "Install app"', icon: SquarePlus, after: "" },
+] as const;

--- a/packages/web/src/pages/mobile/install-guide-sheet.tsx
+++ b/packages/web/src/pages/mobile/install-guide-sheet.tsx
@@ -40,16 +40,24 @@ export function InstallGuideSheet({
         return;
       }
       if (event.key !== "Tab" || !node) return;
-      const focusables = node.querySelectorAll<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-      );
+      const focusables = [
+        ...node.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ];
       const first = focusables[0];
       const last = focusables[focusables.length - 1];
       if (!first || !last) return;
-      if (event.shiftKey && document.activeElement === first) {
+      const active = document.activeElement as HTMLElement | null;
+      // Focus sitting on the dialog root (initial) or escaped outside the set:
+      // pull it back to the first/last control so Tab never leaves the sheet.
+      if (!active || !focusables.includes(active)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+      } else if (event.shiftKey && active === first) {
         event.preventDefault();
         last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
+      } else if (!event.shiftKey && active === last) {
         event.preventDefault();
         first.focus();
       }

--- a/packages/web/src/pages/mobile/install-guide-state.ts
+++ b/packages/web/src/pages/mobile/install-guide-state.ts
@@ -1,0 +1,124 @@
+// Add-to-home-screen ("install as app") guide — pure state, platform detection,
+// and auto-show eligibility. Kept free of React/DOM effects so the gating logic
+// is unit-testable; the hook in `use-install-guide.ts` wires this to the browser.
+
+const STORAGE_KEY = "first-tree:install-guide";
+const SESSION_KEY = "first-tree:install-guide-session";
+
+// The guide auto-shows at most twice across the app's life: once, then one more
+// on a later session. A user who *abandons* the sheet (closes the tab) rather
+// than explicitly dismissing must still count against this — so the cap is keyed
+// on shows, not dismissals. After the cap the Me page keeps a manual entry.
+export const MAX_AUTO_SHOWS = 2;
+
+// Timing for the first pop. Anchored to a value moment (the user just opened a
+// chat), then a short calm beat so it reads as a breath, not an ambush. The
+// dwell fallback catches passive readers who never tap in. Tunable on-device.
+export const VALUE_MOMENT_SETTLE_MS = 1800;
+export const DWELL_FALLBACK_MS = 25_000;
+
+export type InstallGuideState = {
+  /** How many times the guide has auto-shown on this device (the cap key). */
+  autoShowCount: number;
+  /** Set once the browser fires `appinstalled` — never auto-show again. */
+  installed: boolean;
+};
+
+export type InstallPlatform = "ios" | "android" | "other";
+
+/** The non-standard iOS-Safari flag plus the standard display-mode query. */
+type IosNavigator = Navigator & { standalone?: boolean };
+
+const DEFAULT_STATE: InstallGuideState = { autoShowCount: 0, installed: false };
+
+export function readInstallGuideState(): InstallGuideState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_STATE };
+    const parsed = JSON.parse(raw) as Partial<InstallGuideState>;
+    return {
+      autoShowCount: typeof parsed.autoShowCount === "number" ? parsed.autoShowCount : 0,
+      installed: parsed.installed === true,
+    };
+  } catch {
+    // Private-mode denial or corrupt value — behave as a fresh device.
+    return { ...DEFAULT_STATE };
+  }
+}
+
+export function writeInstallGuideState(state: InstallGuideState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // No-op: install state is a nicety, never worth throwing over.
+  }
+}
+
+export function markInstalled(): void {
+  writeInstallGuideState({ ...readInstallGuideState(), installed: true });
+}
+
+/** Persist that the guide auto-showed (bumps the lifetime cap counter). */
+export function recordAutoShow(): void {
+  const state = readInstallGuideState();
+  writeInstallGuideState({ ...state, autoShowCount: state.autoShowCount + 1 });
+}
+
+// `sessionStorage` scopes "already shown this session" to the tab and clears on
+// a fresh tab/launch — a pragmatic proxy for "a later session." It is only a
+// same-session de-dupe; the lifetime bound is the localStorage `autoShowCount`.
+export function hasShownThisSession(): boolean {
+  try {
+    return sessionStorage.getItem(SESSION_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function markShownThisSession(): void {
+  try {
+    sessionStorage.setItem(SESSION_KEY, "1");
+  } catch {
+    // No-op.
+  }
+}
+
+/** Running full-screen from the home screen (already installed)? */
+export function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  const displayModeStandalone = window.matchMedia?.("(display-mode: standalone)").matches ?? false;
+  const iosStandalone = (window.navigator as IosNavigator).standalone === true;
+  return displayModeStandalone || iosStandalone;
+}
+
+export function detectPlatform(userAgent?: string): InstallPlatform {
+  const source = userAgent ?? (typeof navigator !== "undefined" ? navigator.userAgent : "");
+  const ua = source.toLowerCase();
+  if (/android/.test(ua)) return "android";
+  // iPhone/iPod report directly; iPadOS 13+ masquerades as desktop Safari, so
+  // fall back to the touch-capable-Mac signal.
+  if (/iphone|ipad|ipod/.test(ua)) return "ios";
+  if (/macintosh/.test(ua) && typeof navigator !== "undefined" && navigator.maxTouchPoints > 1) return "ios";
+  return "other";
+}
+
+/**
+ * Whether the auto-guide may show at all right now. Deliberately excludes the
+ * moment-specific triggers (value moment / dwell / typing / visibility / other
+ * overlays) — those live in the hook. This is the durable per-device gate.
+ */
+export function canAutoShow(input: {
+  state: InstallGuideState;
+  standalone: boolean;
+  platform: InstallPlatform;
+  hasContent: boolean;
+  shownThisSession: boolean;
+}): boolean {
+  const { state, standalone, platform, hasContent, shownThisSession } = input;
+  if (standalone || state.installed) return false; // already installed
+  if (platform === "other") return false; // desktop / unknown — nothing to install to
+  if (state.autoShowCount >= MAX_AUTO_SHOWS) return false; // lifetime cap
+  if (shownThisSession) return false; // at most once per session
+  if (!hasContent) return false; // don't sell "install" over an empty feed
+  return true;
+}

--- a/packages/web/src/pages/mobile/me.tsx
+++ b/packages/web/src/pages/mobile/me.tsx
@@ -1,5 +1,5 @@
 import type { MeMembership, OrgBrief } from "@first-tree/shared";
-import { ChevronRight, ExternalLink, HelpCircle, Loader2, LogOut, Palette, X } from "lucide-react";
+import { ChevronRight, ExternalLink, HelpCircle, Loader2, LogOut, Palette, Smartphone, X } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../../auth/auth-context.js";
 import { Avatar } from "../../components/avatar.js";
@@ -7,6 +7,9 @@ import { Button } from "../../components/ui/button.js";
 import { ThemeToggle } from "../../components/ui/theme-toggle.js";
 import { DISCORD_INVITE_URL } from "../../lib/community.js";
 import { MobilePage, MobileSection, mobileCardStyle } from "./components.js";
+import { InstallGuideSheet } from "./install-guide-sheet.js";
+import { isStandalone } from "./install-guide-state.js";
+import { useInstallPrompt } from "./use-install-guide.js";
 
 export function MobileMePage() {
   const { user, teamDisplayName, role, logout } = useAuth();
@@ -50,6 +53,8 @@ export function MobileMePage() {
             />
           </MobilePanel>
         </MobileSection>
+
+        <MobileInstallEntry />
 
         <MobileSection title="Support">
           <MobileExternalRow
@@ -302,6 +307,58 @@ function MobileTeamSwitcher({
             </div>
           </div>
         </div>
+      ) : null}
+    </>
+  );
+}
+
+// Permanent "add to home screen" entry — always reachable even after the
+// auto-guide is dismissed. Manual opens never count toward the auto-show cap.
+function MobileInstallEntry() {
+  const { mode, install } = useInstallPrompt();
+  const standalone = useMemo(() => isStandalone(), []);
+  const [open, setOpen] = useState(false);
+
+  if (standalone || mode === null) return null;
+
+  return (
+    <>
+      <MobileSection title="App">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="flex w-full items-center text-left transition-colors hover:bg-[var(--bg-hover)]"
+          style={{
+            ...mobileCardStyle("panel"),
+            gap: "var(--sp-3)",
+            border: "var(--hairline) solid var(--border)",
+            color: "var(--fg)",
+            cursor: "pointer",
+          }}
+          data-mobile-card="panel"
+        >
+          <span className="shrink-0" style={{ color: "var(--fg-3)" }}>
+            <Smartphone aria-hidden className="h-4 w-4" />
+          </span>
+          <div className="min-w-0" style={{ flex: 1 }}>
+            <p className="text-mobile-subtitle" style={{ margin: 0 }}>
+              Add to Home Screen
+            </p>
+            <p className="text-mobile-body" style={{ color: "var(--fg-3)", margin: "var(--sp-0_5) 0 0" }}>
+              Install First Tree as an app for instant, full-screen access.
+            </p>
+          </div>
+          <ChevronRight aria-hidden className="h-4 w-4 shrink-0" style={{ color: "var(--fg-4)" }} />
+        </button>
+      </MobileSection>
+      {open ? (
+        <InstallGuideSheet
+          mode={mode}
+          onInstall={() => {
+            void install().finally(() => setOpen(false));
+          }}
+          onClose={() => setOpen(false)}
+        />
       ) : null}
     </>
   );

--- a/packages/web/src/pages/mobile/shell.tsx
+++ b/packages/web/src/pages/mobile/shell.tsx
@@ -7,6 +7,8 @@ import { useAdminWs } from "../../hooks/use-admin-ws.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
 import { MobileBottomTabs } from "./components.js";
 import { countAttentionRows, countUnreadRows } from "./data.js";
+import { InstallGuideSheet } from "./install-guide-sheet.js";
+import { useInstallGuideAuto } from "./use-install-guide.js";
 
 export function MobileShell() {
   const {
@@ -31,6 +33,13 @@ export function MobileShell() {
     refetchInterval: 30_000,
   });
 
+  const selectedChatId = searchParams.get("c");
+  const immersiveChat = location.pathname === "/m/chat" && selectedChatId !== null;
+  const rows = tabCountsQuery.data?.rows ?? [];
+
+  // Kept above the onboarding early-return so hook order stays unconditional.
+  const installGuide = useInstallGuideAuto({ hasContent: rows.length > 0, immersive: immersiveChat });
+
   if (
     shouldEnterOnboarding({
       meLoaded,
@@ -43,10 +52,6 @@ export function MobileShell() {
     return <Navigate to="/onboarding" replace />;
   }
 
-  const selectedChatId = searchParams.get("c");
-  const immersiveChat = location.pathname === "/m/chat" && selectedChatId !== null;
-  const rows = tabCountsQuery.data?.rows ?? [];
-
   return (
     <div className="h-dvh-screen pt-safe-top flex flex-col overflow-hidden" style={{ background: "var(--bg)" }}>
       <TeamSwitchOverlay />
@@ -56,6 +61,9 @@ export function MobileShell() {
       {immersiveChat ? null : (
         <MobileBottomTabs attentionCount={countAttentionRows(rows)} unreadCount={countUnreadRows(rows)} />
       )}
+      {installGuide.open && installGuide.mode ? (
+        <InstallGuideSheet mode={installGuide.mode} onInstall={installGuide.install} onClose={installGuide.dismiss} />
+      ) : null}
     </div>
   );
 }

--- a/packages/web/src/pages/mobile/use-install-guide.ts
+++ b/packages/web/src/pages/mobile/use-install-guide.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import {
+  canAutoShow,
+  DWELL_FALLBACK_MS,
+  detectPlatform,
+  hasShownThisSession,
+  type InstallPlatform,
+  isStandalone,
+  markInstalled,
+  markShownThisSession,
+  readInstallGuideState,
+  recordAutoShow,
+  VALUE_MOMENT_SETTLE_MS,
+} from "./install-guide-state.js";
+
+// Chrome/Android fire `beforeinstallprompt` when the manifest meets the install
+// criteria. We stash the event so our own sheet can trigger the native install
+// (one tap) instead of leaving it to Chrome's easily-missed mini-infobar.
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+};
+
+export type InstallGuideMode = "native" | "ios" | "android-manual";
+export type InstallOutcome = "accepted" | "dismissed" | "unavailable";
+
+// Module-level singleton: the event can fire before the mobile shell mounts, so
+// we start listening at import time and replay the captured event to React.
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+const subscribers = new Set<() => void>();
+
+function emit(): void {
+  for (const notify of subscribers) notify();
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("beforeinstallprompt", (event) => {
+    event.preventDefault();
+    deferredPrompt = event as BeforeInstallPromptEvent;
+    emit();
+  });
+  window.addEventListener("appinstalled", () => {
+    deferredPrompt = null;
+    markInstalled();
+    emit();
+  });
+}
+
+function subscribePrompt(callback: () => void): () => void {
+  subscribers.add(callback);
+  return () => subscribers.delete(callback);
+}
+
+function getPromptSnapshot(): BeforeInstallPromptEvent | null {
+  return deferredPrompt;
+}
+
+/** Which sheet variant to render, or null when there is nothing to install to. */
+export function resolveMode(platform: InstallPlatform, canNativeInstall: boolean): InstallGuideMode | null {
+  if (canNativeInstall) return "native";
+  if (platform === "ios") return "ios";
+  if (platform === "android") return "android-manual";
+  return null;
+}
+
+/** Platform + captured native prompt. Shared by the auto trigger and the Me-page entry. */
+export function useInstallPrompt(): {
+  platform: InstallPlatform;
+  mode: InstallGuideMode | null;
+  install: () => Promise<InstallOutcome>;
+} {
+  const prompt = useSyncExternalStore(subscribePrompt, getPromptSnapshot, () => null);
+  const platform = useMemo(() => detectPlatform(), []);
+  const mode = resolveMode(platform, prompt !== null);
+
+  const install = useCallback(async (): Promise<InstallOutcome> => {
+    if (!deferredPrompt) return "unavailable";
+    const event = deferredPrompt;
+    await event.prompt();
+    const choice = await event.userChoice;
+    deferredPrompt = null;
+    emit();
+    return choice.outcome;
+  }, []);
+
+  return { platform, mode, install };
+}
+
+function isTypingSomewhere(): boolean {
+  const el = document.activeElement as HTMLElement | null;
+  if (!el) return false;
+  return el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable;
+}
+
+/** Another modal/sheet is already open — don't stack the auto-guide on top. */
+function isOverlayOpen(): boolean {
+  return typeof document !== "undefined" && document.querySelector('[role="dialog"]') !== null;
+}
+
+/**
+ * Auto-show state machine for the first-pop guide. The first pop is anchored to
+ * a value moment (the user opened a chat) plus a short calm beat; a dwell
+ * fallback catches passive readers. Never fires over an open chat, while typing,
+ * when backgrounded, or once the per-device cap is hit. See `canAutoShow`.
+ */
+export function useInstallGuideAuto({ hasContent, immersive }: { hasContent: boolean; immersive: boolean }): {
+  open: boolean;
+  mode: InstallGuideMode | null;
+  install: () => Promise<void>;
+  dismiss: () => void;
+} {
+  const { platform, mode, install } = useInstallPrompt();
+  const [open, setOpen] = useState(false);
+  const openedChatRef = useRef(false);
+  const shownRef = useRef(false);
+
+  const eligible = useCallback((): boolean => {
+    if (mode === null) return false;
+    return canAutoShow({
+      state: readInstallGuideState(),
+      standalone: isStandalone(),
+      platform,
+      hasContent,
+      shownThisSession: hasShownThisSession(),
+    });
+  }, [mode, platform, hasContent]);
+
+  const show = useCallback((): void => {
+    if (shownRef.current) return;
+    if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
+    if (isTypingSomewhere() || isOverlayOpen()) return;
+    if (!eligible()) return;
+    shownRef.current = true;
+    recordAutoShow();
+    markShownThisSession();
+    setOpen(true);
+  }, [eligible]);
+
+  // Opening a chat is the value moment.
+  useEffect(() => {
+    if (immersive) openedChatRef.current = true;
+  }, [immersive]);
+
+  // Primary trigger: back on a resting screen after having opened a chat.
+  useEffect(() => {
+    if (open || shownRef.current) return;
+    if (immersive || !openedChatRef.current) return;
+    if (!eligible()) return;
+    const timer = window.setTimeout(show, VALUE_MOMENT_SETTLE_MS);
+    return () => window.clearTimeout(timer);
+  }, [open, immersive, eligible, show]);
+
+  // Fallback: passive readers who never open a chat. The timer resets whenever
+  // they dip into a chat — those users are served by the value-moment path.
+  useEffect(() => {
+    if (open || shownRef.current || immersive) return;
+    const timer = window.setTimeout(show, DWELL_FALLBACK_MS);
+    return () => window.clearTimeout(timer);
+  }, [open, immersive, show]);
+
+  // The show was already counted against the cap in `show()`, so dismiss/install
+  // just close — no separate dismissal bookkeeping (avoids double-counting).
+  const dismiss = useCallback((): void => {
+    setOpen(false);
+  }, []);
+
+  const onInstall = useCallback(async (): Promise<void> => {
+    await install();
+    setOpen(false);
+  }, [install]);
+
+  return { open: open && mode !== null, mode, install: onInstall, dismiss };
+}

--- a/packages/web/src/pages/mobile/use-install-guide.ts
+++ b/packages/web/src/pages/mobile/use-install-guide.ts
@@ -24,25 +24,42 @@ type BeforeInstallPromptEvent = Event & {
 export type InstallGuideMode = "native" | "ios" | "android-manual";
 export type InstallOutcome = "accepted" | "dismissed" | "unavailable";
 
-// Module-level singleton: the event can fire before the mobile shell mounts, so
-// we start listening at import time and replay the captured event to React.
+// Module-level singleton snapshot: the events can fire before the mobile shell
+// mounts, so we start listening at import time and replay state to React. The
+// snapshot object is only replaced on a real change, so useSyncExternalStore's
+// getSnapshot stays stable (no tearing / render loops). `installed` is part of
+// the snapshot so an install completed from Chrome's menu/omnibox (the Android
+// manual path, where `prompt` is already null) still re-renders consumers.
+type InstallSnapshot = { prompt: BeforeInstallPromptEvent | null; installed: boolean };
+
+const EMPTY_SNAPSHOT: InstallSnapshot = { prompt: null, installed: false };
+
 let deferredPrompt: BeforeInstallPromptEvent | null = null;
+let installedFlag = false;
+let snapshot: InstallSnapshot = EMPTY_SNAPSHOT;
 const subscribers = new Set<() => void>();
 
-function emit(): void {
+function publish(): void {
+  snapshot = { prompt: deferredPrompt, installed: installedFlag };
   for (const notify of subscribers) notify();
 }
 
 if (typeof window !== "undefined") {
+  installedFlag = readInstallGuideState().installed;
+  snapshot = { prompt: null, installed: installedFlag };
   window.addEventListener("beforeinstallprompt", (event) => {
+    // Only intercept on Android, where we render a replacement (the sheet). On
+    // desktop/other surfaces we leave the browser's own install UI untouched.
+    if (detectPlatform() !== "android") return;
     event.preventDefault();
     deferredPrompt = event as BeforeInstallPromptEvent;
-    emit();
+    publish();
   });
   window.addEventListener("appinstalled", () => {
     deferredPrompt = null;
+    installedFlag = true;
     markInstalled();
-    emit();
+    publish();
   });
 }
 
@@ -51,8 +68,8 @@ function subscribePrompt(callback: () => void): () => void {
   return () => subscribers.delete(callback);
 }
 
-function getPromptSnapshot(): BeforeInstallPromptEvent | null {
-  return deferredPrompt;
+function getSnapshot(): InstallSnapshot {
+  return snapshot;
 }
 
 /** Which sheet variant to render, or null when there is nothing to install to. */
@@ -69,9 +86,10 @@ export function useInstallPrompt(): {
   mode: InstallGuideMode | null;
   install: () => Promise<InstallOutcome>;
 } {
-  const prompt = useSyncExternalStore(subscribePrompt, getPromptSnapshot, () => null);
+  const snap = useSyncExternalStore(subscribePrompt, getSnapshot, () => EMPTY_SNAPSHOT);
   const platform = useMemo(() => detectPlatform(), []);
-  const mode = resolveMode(platform, prompt !== null);
+  // Once installed, there is nothing to promote — hides every surface reactively.
+  const mode = snap.installed ? null : resolveMode(platform, snap.prompt !== null);
 
   const install = useCallback(async (): Promise<InstallOutcome> => {
     if (!deferredPrompt) return "unavailable";
@@ -79,7 +97,7 @@ export function useInstallPrompt(): {
     await event.prompt();
     const choice = await event.userChoice;
     deferredPrompt = null;
-    emit();
+    publish();
     return choice.outcome;
   }, []);
 


### PR DESCRIPTION
## What & why

Mobile web users have no nudge to install First Tree as a home-screen app. The mobile surface (`/m/*`) is **already a valid PWA** — manifest, 192/512 + apple-touch icons, and apple-mobile-web-app meta are injected when the mobile experience is enabled. What was missing is the *guidance UX* and the native-install wiring. This adds them. **No service worker is added** — verified on staging that the current manifest already meets Chrome's Android installability criteria (Chrome removed the service-worker fetch-handler requirement for menu installation in **v108**; current criteria no longer list a service worker), and iOS A2HS never needed one. Refs: https://developer.chrome.com/blog/update-install-criteria , https://web.dev/articles/install-criteria

**Paired product-scope admission (required to merge):** agent-team-foundation/first-tree-context#730 records the product-owner decision admitting home-screen install promotion into the default-deny mobile surface (`product/surfaces/mobile-surface.md`).

## Behaviour

- **Bottom-sheet guide**, value-first copy. Mirrors the existing mobile sheet idiom (team switcher): docked, scrim, safe-area padding, `radius-dialog` top corners, slide-up with a `prefers-reduced-motion` fallback. Modal focus management (move / trap / restore).
- **Platform-adaptive:**
  - iOS Safari → teaches the two steps: tap Share → "Add to Home Screen".
  - Android with a captured `beforeinstallprompt` → one-tap "Add to Home Screen".
  - Android without it → menu-steps fallback. Capture is scoped to Android; the browser's own install UI is left untouched elsewhere.
- **First-pop timing** anchored to a value moment (open a chat → return to a resting screen, +~1.8s settle), ~25s dwell fallback for passive readers. Never pops while typing, backgrounded, over another open overlay / immersive chat, on an empty feed, or in the first moments.
- **Re-nag cap:** auto-shows **at most twice** (lifetime cap keyed on *shows*, so an abandoned sheet still counts), at most once per session. After that, a permanent **"Add to Home Screen"** entry stays on the Me page (manual opens never count). Once installed (`appinstalled` or standalone) every promotion hides reactively and never shows again. State in `localStorage`.

## Files
`pages/mobile/install-guide-state.ts` (pure state / detection / eligibility) · `use-install-guide.ts` (beforeinstallprompt capture store + trigger state machine) · `install-guide-sheet.tsx` (sheet + focus management) · wired into `shell.tsx` + `me.tsx` · keyframes in `index.css` · DEV preview `/preview/install-guide`.

## Testing
- Unit + DOM + hook-lifecycle tests (27 new): platform/standalone detection, eligibility/cap matrix, each sheet variant + dismissal, Android capture + `preventDefault`, desktop no-capture, menu-driven `appinstalled` hides promotion, reverse-tab focus trap. Full web suite green (1404).
- `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens`) and `pnpm check` green.
- **Visual E2E**: rendered the real component via the preview route in a phone viewport, both light and dark, all three variants (matches the approved design).

### Honest limitation
Headless Chromium does **not** dispatch `beforeinstallprompt`, so the Android one-tap → native install dialog can't be reproduced in automation; it needs a real Android device or Chrome DevTools → Application. Every deterministic precondition Chrome checks is satisfied (verified against the live staging manifest). iOS, the trigger/gating logic, and the capture/appinstalled lifecycle are covered by the preview + unit/hook tests.

## Design
Design doc + approved mockups tracked in the workspace (`design/mobile-a2hs/`).
