### PR TITLE
feat(web): enable mobile surface on the production release channel

### DIFF
--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -304,6 +304,25 @@ describe("App routes", () => {
     expect(document.head.querySelector('link[rel="manifest"]')).toBeNull();
   });
 
+  it("recovers a settled unusable channel to the desktop root", async () => {
+    serverChannelStateMock.channel = null;
+    serverChannelStateMock.settled = true;
+    setViewportWidth(390);
+
+    expect(await renderAppAt("/")).toContain("workspace page");
+    expect(document.head.querySelector('link[rel="manifest"]')).toBeNull();
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    setViewportWidth(390);
+    expect(await renderAppAt("/m/now")).toContain("workspace page");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    setViewportWidth(390);
+    expect(await renderAppAt("/m/chat")).toContain("workspace page");
+  });
+
   it("opens mobile routes, phone root, and PWA metadata on staging", async () => {
     serverChannelStateMock.channel = "staging";
     setViewportWidth(390);

--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -273,22 +273,25 @@ describe("App routes", () => {
     expect(await renderAppAt("/preview/command-palette")).toContain("command palette preview");
   });
 
-  it("keeps the mobile experience disabled on prod", async () => {
+  it("opens the mobile experience on prod", async () => {
     setViewportWidth(390);
-    expect(await renderAppAt("/")).toContain("workspace page");
-    expect(document.head.querySelector('link[rel="manifest"]')).toBeNull();
+    expect(await renderAppAt("/")).toContain("mobile now");
+    expect(document.head.querySelector('link[rel="manifest"]')?.getAttribute("href")).toBe("/manifest.webmanifest");
     await act(async () => root?.unmount());
     document.body.innerHTML = "";
 
-    expect(await renderAppAt("/m")).toContain("workspace page");
+    setViewportWidth(390);
+    expect(await renderAppAt("/m")).toContain("mobile now");
     await act(async () => root?.unmount());
     document.body.innerHTML = "";
 
-    expect(await renderAppAt("/m/now")).toContain("workspace page");
+    setViewportWidth(390);
+    expect(await renderAppAt("/m/now")).toContain("mobile now");
     await act(async () => root?.unmount());
     document.body.innerHTML = "";
 
-    expect(await renderAppAt("/m/chat")).toContain("workspace page");
+    setViewportWidth(390);
+    expect(await renderAppAt("/m/chat")).toContain("mobile chat");
   });
 
   it("waits for the server channel before choosing the mobile or desktop shell", async () => {

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -496,7 +496,10 @@ function useMobileExperienceState(): MobileExperienceState {
   if (!channelSettled) {
     return { enabled: false, settled: false };
   }
-  return { enabled: channel === "dev" || channel === "staging", settled: true };
+  return {
+    enabled: channel === "dev" || channel === "staging" || channel === "prod",
+    settled: true,
+  };
 }
 
 function MobileExperienceGate() {


### PR DESCRIPTION
## What

Enable the mobile web surface on the **production** release channel. It was gated to `dev` and `staging` only.

`useMobileExperienceState()` in `packages/web/src/app.tsx` now returns `enabled` for `dev`, `staging`, **or** `prod`. This one gate drives all three consumers: `/m/*` route admission, the phone-width auto-redirect from `/` to `/m/now`, and PWA head-tag injection (manifest / apple-touch). So prod users on a phone now get the mobile experience.

Fail-closed behavior is two distinct states, not one: while the channel fetch is **unresolved** (`settled: false`) the client renders neither shell — a neutral no-flash state; once **settled** with no usable channel (`channel: null`) a direct `/m/*` visit recovers to the **desktop root** and the manifest is omitted. Correctly-configured prod servers report `channel: "prod"` via `FIRST_TREE_CHANNEL`, so the unusable-channel path is a degraded-server fallback only.

## Scope unchanged

Mobile **capability scope is untouched** — still closed-by-default (`Now / Chat / Team / Me` + handoff primitives). Widening channel *availability* does not widen the mobile capability set.

## Verification

- `packages/web/src/__tests__/app-routes.test.tsx`: the `prod` route test is flipped from "disabled on prod" to **"opens the mobile experience on prod"** — it mounts the real `<App/>` router through the real gate (only the channel-state boundary is mocked) and asserts `/`, `/m`, `/m/now`, `/m/chat` render mobile plus the manifest link is present. Two distinct fail-closed cases are covered separately: the **unresolved-channel** test (`settled: false`) asserts the **neutral no-flash state** — neither shell renders, no manifest — while the new **settled-unusable** test (`channel: null, settled: true`) asserts **desktop-root recovery** for `/m/*` with the manifest omitted.
- `pnpm --filter @first-tree/web test` → **1417 passed**. `biome check`, `tsc --noEmit`, `lint:tokens` clean.
- Two independent reviews confirmed the channel gate is the only mobile restriction point, PWA assets (`manifest.webmanifest`, icons) are static and ship to every channel (no server-side gating, no service worker), so nothing half-ships on prod.

## Paired Context Tree PR

Records the production-enablement decision on the Mobile Surface node (its constraint previously required this as an explicit recorded decision): agent-team-foundation/first-tree-context#732

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Production-readiness acceptance (surface owner: @Gandy2025)

The paired Mobile Surface node gates production enablement on the owner's recorded staging acceptance. Recorded here as the delivery artifact:

- **Mobile IA / auth entry / Now attention quality** — owner reviewed the mobile experience on staging and reports **no blocking issues**; authorized the full production rollout.
- **Manual staging exercise + outcome** — authenticated end-to-end pass on staging (`/m/*`, owner session, iPhone viewport) across Now / Chat list / chat thread / Team / Me / install guide / `/`→`/m/now` redirect / `/?desktop=1` desktop guard / light+dark: **0 console errors**, full flow operational. 6 minor findings; the 2 highest-value (install-guide over-promise, card previews leaking raw markdown) fixed & merged in #1759; the rest pre-existing / cosmetic and non-blocking.
- **Release-channel behavior + route recovery** — staging serves the mobile surface end-to-end across the server→client channel boundary; disabled/unusable-channel recovery to the desktop root is covered by the automated route test in this PR.
