### PR TITLE
feat(web): compact grouped list for admin Team computers

### DIFF
--- a/packages/web/src/api/activity.ts
+++ b/packages/web/src/api/activity.ts
@@ -4,6 +4,7 @@ import type {
   ConnectTokenResponse,
   RuntimeAuthMethod,
   RuntimeProvider,
+  UpdateAttempt,
 } from "@first-tree/shared";
 import { api, withOrg } from "./client.js";
 
@@ -61,6 +62,15 @@ export type HubClient = {
    * (≥1 capability `state=ok`) from Setup incomplete (all `≠ ok`).
    */
   capabilities: ClientCapabilities;
+  /**
+   * Outcome of the client's last self-update attempt, persisted by the
+   * server into `clients.metadata.lastUpdateAttempt` and returned by
+   * `/me/clients` and `/orgs/:orgId/clients`. A `failed` / `blocked`
+   * result means the machine is stuck on an old version and needs admin
+   * attention even while it's otherwise connected — see
+   * `teamNeedsAttention` in `pages/clients/derive-status.ts`.
+   */
+  lastUpdateAttempt?: UpdateAttempt | null;
 };
 
 export function retireClient(clientId: string): Promise<void> {

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1840,6 +1840,20 @@
   border-top: var(--hairline) solid var(--border-faint);
 }
 
+/* Team computers audit list (admin) — compact grouped rows with a hairline
+   between every row/group-header and a neutral hover. The health split is
+   carried by row order + the "Needs attention" group header + each row's
+   status pill, not a full-row color wash. */
+.team-computers-list > * + * {
+  border-top: var(--hairline) solid var(--border-faint);
+}
+.team-computer-row {
+  transition: background-color 120ms ease-out;
+}
+.team-computer-row:hover {
+  background-color: var(--bg-hover);
+}
+
 /* Dense table row hover — used by DenseTableRow[data-interactive] */
 tr[data-interactive]:hover {
   background: var(--bg-hover);

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1844,14 +1844,34 @@
    between every row/group-header and a neutral hover. The health split is
    carried by row order + the "Needs attention" group header + each row's
    status pill, not a full-row color wash. */
+.team-computers-list {
+  /* Query the list's own width (not the viewport): the Settings nav eats
+     width, so a row can be narrow even on a wide screen. */
+  container-type: inline-size;
+}
 .team-computers-list > * + * {
   border-top: var(--hairline) solid var(--border-faint);
 }
 .team-computer-row {
+  display: grid;
+  /* identity | agents | status. Fixed trailing tracks keep the agent counts
+     and status pills column-aligned across rows when there's room. */
+  grid-template-columns: minmax(0, 1fr) var(--sp-20) var(--sp-45);
+  align-items: center;
+  column-gap: var(--sp-3);
+  padding: var(--sp-2_5) var(--sp-3_5);
   transition: background-color 120ms ease-out;
 }
 .team-computer-row:hover {
   background-color: var(--bg-hover);
+}
+/* Narrow list (mobile / cramped Settings): drop the fixed trailing tracks to
+   intrinsic width so the hostname/meta identity column never collapses. */
+@container (max-width: 34rem) {
+  .team-computer-row {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    column-gap: var(--sp-2_5);
+  }
 }
 
 /* Dense table row hover — used by DenseTableRow[data-interactive] */

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -1,4 +1,3 @@
-import type { CapabilityEntry, ClientCapabilities, RuntimeProvider } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ChevronDown, ChevronRight, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -16,14 +15,6 @@ import { listMembers } from "../api/members.js";
 import { useAuth } from "../auth/auth-context.js";
 import { Button } from "../components/ui/button.js";
 import {
-  DenseTable,
-  DenseTableBody,
-  DenseTableCell,
-  DenseTableHead,
-  DenseTableHeader,
-  DenseTableRow,
-} from "../components/ui/dense-table.js";
-import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -32,13 +23,11 @@ import {
   DialogTitle,
 } from "../components/ui/dialog.js";
 import { PresenceChip, runtimeStateToPresence } from "../components/ui/presence-chip.js";
-import { RowActionsMenu } from "../components/ui/row-actions-menu.js";
 import { Section } from "../components/ui/section.js";
 import { UppercaseLabel } from "../components/ui/section-header.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
-import { formatDate, formatRelative } from "../lib/utils.js";
 import { ComputerCard } from "./clients/cards/computer-card.js";
-import { PROVIDER_LABEL, PROVIDER_ORDER, providerInstallHint } from "./clients/cards/shared/providers.js";
+import { formatOfflineDuration } from "./clients/cards/view-models.js";
 import { ComputerStatusPill } from "./clients/computer-status-pill.js";
 import { DemoNavigator, useDemoScenarioParam } from "./clients/demo-navigator.js";
 import { compareByPillPriority, deriveComputerStatus } from "./clients/derive-status.js";
@@ -87,11 +76,6 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
         return DEMO_AGENT_NAMES[uuid] ?? realAgentName(uuid);
       }
     : realAgentName;
-  // Personal scope: a user typically has 1-3 computers, so expand by default
-  // and only let them collapse rows they actively want to hide. New clients
-  // arriving via the 10s poll auto-expand too — we only treat the closed set
-  // as "rows the user explicitly closed".
-  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() => new Set());
   // Admin's Team computers section starts collapsed so it doesn't push the
   // viewer's own machines below the fold. Visible count badge on the
   // header still tells admins "you have N teammates" — they click to
@@ -577,20 +561,7 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
                   {teamList.length === 0 ? (
                     <EmptyCardsNote message="No other team computers." />
                   ) : teamExpanded ? (
-                    // Team rows stay as table for now — read-only audit
-                    // view. Per-row inline affordances (Generate new
-                    // token / install guide) don't apply to teammates;
-                    // the full team-card redesign with "Copy suggestion
-                    // → Alice" buttons is deferred to a follow-up PR
-                    // (proposal §"Variant D").
-                    <TeamComputersTable
-                      teamList={teamList}
-                      collapsedIds={collapsedIds}
-                      setCollapsedIds={setCollapsedIds}
-                      agentName={agentName}
-                      getClientAgents={getClientAgents}
-                      resolveOwner={resolveOwner}
-                    />
+                    <TeamComputersList teamList={teamList} resolveOwner={resolveOwner} />
                   ) : null}
                 </Section>
               </>
@@ -652,173 +623,139 @@ function EmptyCardsNote({ message }: { message: string }) {
 }
 
 /**
- * Team computers table — preserved from pre-PR-B as the admin's
- * read-only audit view. Wraps the existing `ClientRow` component with
- * the table chrome that used to live inline in `ClientsPage`.
+ * Team computers — the admin's read-only audit list. One compact line per
+ * machine (hostname focus + `owner · OS · version` meta), grouped so
+ * unhealthy machines ("Needs attention": auth-expired / setup-incomplete /
+ * offline) bubble to the top; a fully-healthy fleet renders as a flat list
+ * with no group chrome. Replaces the pre-PR-B DenseTable audit table.
+ *
+ * These rows are intentionally not expandable: the per-machine runtime /
+ * agent detail is owner-only (the capability probe 403s on non-owners), so
+ * there is nothing to reveal for a teammate's computer. The wrapping div
+ * bleeds the rows past the Section's horizontal padding so a row's hover /
+ * needs-attention tint spans the full width while the hostname still lines
+ * up with the Section title.
  */
-function TeamComputersTable({
+function TeamComputersList({
   teamList,
-  collapsedIds,
-  setCollapsedIds,
-  agentName,
-  getClientAgents,
   resolveOwner,
 }: {
   teamList: HubClient[];
-  collapsedIds: Set<string>;
-  setCollapsedIds: (updater: (prev: Set<string>) => Set<string>) => void;
-  agentName: (uuid: string | null | undefined) => string;
-  getClientAgents: (clientId: string) => RuntimeAgent[];
   resolveOwner: (client: HubClient) => { text: string; title?: string };
 }) {
-  // Wrapping div pulls the table left by the first cell's left padding
-  // so the chevron column lines up with the parent Section's title left
-  // edge. Without this the hostname column sits inside the section,
-  // breaking the page's vertical alignment rhythm. Audit-only table,
-  // no horizontal scroll concerns — safe to bleed past padding.
+  const sorted = useMemo(() => [...teamList].sort(compareByPillPriority), [teamList]);
+  const attention = sorted.filter((client) => deriveComputerStatus(client).pill !== "ready");
+  const ready = sorted.filter((client) => deriveComputerStatus(client).pill === "ready");
+  // Group headers earn their chrome only once something needs attention — a
+  // healthy fleet is a plain flat list, no "Ready" header stating the obvious.
+  const grouped = attention.length > 0;
   return (
-    <div style={{ marginLeft: "calc(-1 * var(--sp-3_5))", marginRight: "calc(-1 * var(--sp-3_5))" }}>
-      <DenseTable>
-        <DenseTableHeader>
-          <DenseTableRow>
-            <DenseTableHead style={{ width: "var(--sp-4)" }} />
-            <DenseTableHead>Hostname</DenseTableHead>
-            <DenseTableHead>Owner</DenseTableHead>
-            <DenseTableHead>OS</DenseTableHead>
-            <DenseTableHead>First Tree</DenseTableHead>
-            <DenseTableHead>Agents</DenseTableHead>
-            <DenseTableHead>Last seen</DenseTableHead>
-            <DenseTableHead>Status</DenseTableHead>
-          </DenseTableRow>
-        </DenseTableHeader>
-        <DenseTableBody>
-          {teamList.map((client) => {
-            const isExpanded = !collapsedIds.has(client.id);
-            const boundAgents = getClientAgents(client.id);
-            return (
-              <ClientRow
-                key={client.id}
-                client={client}
-                boundAgents={boundAgents}
-                isExpanded={isExpanded}
-                agentName={agentName}
-                onToggle={() =>
-                  setCollapsedIds((prev) => {
-                    const next = new Set(prev);
-                    if (next.has(client.id)) next.delete(client.id);
-                    else next.add(client.id);
-                    return next;
-                  })
-                }
-                onDisconnect={() => {}}
-                onRetire={() => {}}
-                onReconnect={() => {}}
-                showOwner
-                ownerLabel={resolveOwner(client)}
-                restricted
-              />
-            );
-          })}
-        </DenseTableBody>
-      </DenseTable>
+    <div
+      className="team-computers-list"
+      style={{ marginLeft: "calc(-1 * var(--sp-3_5))", marginRight: "calc(-1 * var(--sp-3_5))" }}
+    >
+      {grouped && <TeamGroupHeader label="Needs attention" count={attention.length} attention />}
+      {attention.map((client) => (
+        <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
+      ))}
+      {grouped && ready.length > 0 && <TeamGroupHeader label="Ready" count={ready.length} />}
+      {ready.map((client) => (
+        <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
+      ))}
     </div>
   );
 }
 
 /**
- * Runtime-provider capability matrix shown inside the expanded row of the
- * Computers table. The snapshot is pre-loaded with the list response now
- * (single-source via `/me/clients` / `/orgs/:orgId/clients`), so the
- * matrix renders synchronously — no extra round-trip when a row opens.
- *
- * Constants for label / order / hints live in `cards/shared/providers.ts`
- * — the card-based IA uses the same vocabulary, so duplicating strings
- * here would invite drift.
+ * Group divider for the health split. The "Needs attention" header carries a
+ * warm `--fg-needs-you-strong` tint (the one meaningful color on this audit
+ * list); "Ready" stays neutral. The row status pills carry each machine's
+ * specific state hue — the group is set apart by order + this header, not by a
+ * full-row color wash.
  */
-function CapabilityMatrix({ capabilities, os }: { capabilities: ClientCapabilities; os: string | null }) {
-  const empty = Object.keys(capabilities).length === 0;
+function TeamGroupHeader({ label, count, attention = false }: { label: string; count: number; attention?: boolean }) {
   return (
-    <>
-      <UppercaseLabel style={{ display: "block", marginBottom: "var(--sp-1_5)" }}>Runtimes</UppercaseLabel>
-      {empty ? (
-        <div className="text-body" style={{ color: "var(--fg-3)" }}>
-          Capabilities not yet reported. Reconnect this computer to refresh.
-        </div>
-      ) : (
-        <div className="flex flex-col gap-1">
-          {PROVIDER_ORDER.map((provider) => (
-            <ProviderRow key={provider} provider={provider} entry={capabilities[provider] ?? null} os={os} />
-          ))}
-        </div>
-      )}
-    </>
+    <UppercaseLabel
+      style={{
+        display: "block",
+        padding: "var(--sp-3) var(--sp-3_5) var(--sp-1_5)",
+        ...(attention ? { color: "var(--fg-needs-you-strong)" } : {}),
+      }}
+    >
+      {label} · {count}
+    </UppercaseLabel>
   );
 }
 
-function ProviderRow({
-  provider,
-  entry,
-  os,
-}: {
-  provider: RuntimeProvider;
-  entry: CapabilityEntry | null;
-  os: string | null;
-}) {
-  const label = PROVIDER_LABEL[provider];
-  if (!entry) {
-    return (
-      <div className="flex items-center gap-2.5 text-body" style={{ opacity: 0.7 }}>
-        <span className="font-medium" style={{ minWidth: "var(--sp-35)" }}>
-          {label}
-        </span>
-        <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-          not reported · {providerInstallHint(provider, os)}
-        </span>
-      </div>
-    );
-  }
-  switch (entry.state) {
-    case "ok":
-      return (
-        <div className="flex items-center gap-2.5 text-body">
-          <span className="font-medium" style={{ minWidth: "var(--sp-35)" }}>
-            {label}
-          </span>
-          <span className="text-caption" style={{ color: "var(--success)" }}>
-            ✓ installed{entry.sdkVersion ? ` v${entry.sdkVersion}` : ""}
-          </span>
-        </div>
-      );
-    case "missing":
-      return (
-        <div className="flex items-center gap-2.5 text-body" style={{ opacity: 0.7 }}>
-          <span className="font-medium" style={{ minWidth: "var(--sp-35)" }}>
-            {label}
-          </span>
-          <span className="text-caption" style={{ color: "var(--fg-4)" }}>
-            ✗ {providerInstallHint(provider, os, entry.error)}
-          </span>
-        </div>
-      );
-    case "error":
-      return (
-        <div className="flex items-center gap-2.5 text-body">
-          <span className="font-medium" style={{ minWidth: "var(--sp-35)" }}>
-            {label}
-          </span>
-          <span className="text-caption" style={{ color: "var(--state-error)" }}>
-            error · {entry.error ?? "probe failed"}
-          </span>
-        </div>
-      );
-  }
+/**
+ * Trim the build/channel suffix ("0.5.14-staging.841.1" → "0.5.14"). The
+ * major.minor.patch is the version signal an admin scans for; the build
+ * number is noise on an audit line. The full string stays in the `title`.
+ */
+function shortVersion(version: string): string {
+  const dash = version.indexOf("-");
+  return dash === -1 ? version : version.slice(0, dash);
 }
 
-// Column count in member mode — `chevron | Hostname | OS | First Tree |
-// Agents | Last seen | Status | Actions`. admin mode inserts an Owner column
-// between Hostname and OS, bumping the count by 1.
-const MEMBER_COLSPAN = 8;
-const ADMIN_COLSPAN = MEMBER_COLSPAN + 1;
+function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel: { text: string; title?: string } }) {
+  const status = deriveComputerStatus(client);
+  const version = client.sdkVersion;
+  // "Last seen" is redundant with a live "Ready" pill — fold it into the
+  // status only for offline machines, where "how long" is the actionable bit.
+  const offlineFor = status.pill === "offline" ? formatOfflineDuration(client.lastSeenAt) : null;
+  const agentCount = client.agentCount;
+  return (
+    <div
+      className="team-computer-row"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "minmax(0, 1fr) var(--sp-20) var(--sp-45)",
+        alignItems: "center",
+        columnGap: "var(--sp-3)",
+        padding: "var(--sp-2_5) var(--sp-3_5)",
+      }}
+    >
+      <div style={{ minWidth: 0 }}>
+        <div
+          className="mono text-subtitle"
+          style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+          title={client.hostname ?? undefined}
+        >
+          {client.hostname ?? "—"}
+        </div>
+        <div
+          className="text-caption"
+          style={{ color: "var(--fg-3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+        >
+          <span title={ownerLabel.title}>{ownerLabel.text}</span>
+          {client.os ? ` · ${client.os}` : ""}
+          {version ? (
+            <>
+              {" · "}
+              <span className="mono" title={version}>
+                {shortVersion(version)}
+              </span>
+            </>
+          ) : null}
+        </div>
+      </div>
+      <span
+        className="text-caption tnum"
+        style={{ color: agentCount > 0 ? "var(--fg-2)" : "var(--fg-4)", textAlign: "right", whiteSpace: "nowrap" }}
+      >
+        {agentCount} {agentCount === 1 ? "agent" : "agents"}
+      </span>
+      <span className="inline-flex items-center justify-end gap-1.5" style={{ whiteSpace: "nowrap" }}>
+        <ComputerStatusPill pill={status.pill} />
+        {offlineFor ? (
+          <span className="text-caption" style={{ color: "var(--fg-3)" }}>
+            · {offlineFor}
+          </span>
+        ) : null}
+      </span>
+    </div>
+  );
+}
 
 function TeamLoadErrorBanner() {
   return (
@@ -835,147 +772,5 @@ function TeamLoadErrorBanner() {
     >
       Failed to load team computers. Showing only your computers.
     </div>
-  );
-}
-
-function ClientRow({
-  client,
-  boundAgents,
-  isExpanded,
-  agentName,
-  onToggle,
-  onDisconnect,
-  onRetire,
-  onReconnect,
-  showOwner = false,
-  ownerLabel,
-  restricted = false,
-}: {
-  client: HubClient;
-  boundAgents: RuntimeAgent[];
-  isExpanded: boolean;
-  agentName: (uuid: string | null | undefined) => string;
-  onToggle: () => void;
-  onDisconnect: () => void;
-  onRetire: () => void;
-  onReconnect: () => void;
-  /** When true, render the Owner column between Hostname and OS (admin view). */
-  showOwner?: boolean;
-  /** Resolved owner display value. Required when `showOwner` is true. */
-  ownerLabel?: { text: string; title?: string };
-  /**
-   * Read-only mode for rows the viewer doesn't own (admin viewing team
-   * computers). Collapses three behaviors into one flag because they're
-   * always toggled together:
-   *   - Hides Reconnect / Disconnect / Retire (server-side owner check
-   *     would 403 anyway).
-   *   - Suppresses the expand chevron and ignores `onToggle` so clicking
-   *     the row does nothing (and the capability-matrix `GET /clients/:id`
-   *     — which also 403s on non-owners — is never fired, avoiding both
-   *     wasted retries and a misleading "not reported" fallback).
-   *   - Drops the `interactive` hover styling so the row reads as inert
-   *     metadata, not a clickable target.
-   */
-  restricted?: boolean;
-}) {
-  const colSpan = showOwner ? ADMIN_COLSPAN : MEMBER_COLSPAN;
-  const isOffline = client.status !== "connected";
-  // The expanded sub-row carries owner-only capability data — we never let
-  // it render in restricted mode (see prop doc). `effectiveExpanded` mirrors
-  // `isExpanded` for owner rows and is forced to false for team rows so a
-  // stale collapsed-set never accidentally opens one.
-  const effectiveExpanded = restricted ? false : isExpanded;
-  // Row status pill is computed by `deriveComputerStatus` — pure function
-  // over (status, authState, capabilities). Encodes the priority rules
-  // ("auth expired wins over offline") that previously lived in this
-  // component, and unlocks `setup_incomplete` which the prior visuals
-  // could not express. See `clients/derive-status.ts`.
-  const status = deriveComputerStatus(client);
-  return (
-    <>
-      <DenseTableRow interactive={!restricted} selected={effectiveExpanded} onClick={restricted ? undefined : onToggle}>
-        <DenseTableCell style={{ width: "var(--sp-4)" }}>
-          {restricted ? null : (
-            <span style={{ color: "var(--fg-4)", display: "inline-flex" }}>
-              {effectiveExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-            </span>
-          )}
-        </DenseTableCell>
-        <DenseTableCell className="font-medium">{client.hostname ?? "—"}</DenseTableCell>
-        {showOwner && (
-          <DenseTableCell style={{ color: "var(--fg-3)" }} title={ownerLabel?.title}>
-            {ownerLabel?.text ?? "—"}
-          </DenseTableCell>
-        )}
-        <DenseTableCell style={{ color: "var(--fg-3)" }}>{client.os ?? "—"}</DenseTableCell>
-        <DenseTableCell className="mono text-label" style={{ color: "var(--fg-3)" }}>
-          {client.sdkVersion ?? "—"}
-        </DenseTableCell>
-        <DenseTableCell>
-          <span className="mono tnum text-label">{client.agentCount}</span>
-        </DenseTableCell>
-        <DenseTableCell
-          className="mono text-caption"
-          style={{ color: "var(--fg-4)" }}
-          title={formatDate(client.lastSeenAt)}
-        >
-          {formatRelative(client.lastSeenAt)}
-        </DenseTableCell>
-        <DenseTableCell>
-          <ComputerStatusPill pill={status.pill} />
-        </DenseTableCell>
-        {/* Overflow menu for row actions. Reconnect / Disconnect / Retire
-            are all low-frequency operations (Retire is destructive and
-            once-off, Disconnect is rare, Reconnect only matters when offline)
-            so a kebab menu keeps the table clean. Team rows in admin view
-            get no menu — the underlying ops are owner-checked server-side
-            (DELETE /clients/:id 403s on non-owners), so surfacing them here
-            would just produce errors. */}
-        <DenseTableCell style={{ width: "var(--hairline)", whiteSpace: "nowrap" }}>
-          {restricted ? null : (
-            <div className="flex items-center justify-end">
-              <RowActionsMenu
-                ariaLabel="Computer actions"
-                actions={[
-                  ...(isOffline ? [{ key: "reconnect", label: "Reconnect", onSelect: onReconnect }] : []),
-                  { key: "disconnect", label: "Disconnect", onSelect: onDisconnect },
-                  { key: "retire", label: "Retire", destructive: true, onSelect: onRetire },
-                ]}
-              />
-            </div>
-          )}
-        </DenseTableCell>
-      </DenseTableRow>
-      {effectiveExpanded && (
-        <tr style={{ background: "var(--bg-sunken)" }}>
-          <DenseTableCell />
-          <DenseTableCell colSpan={colSpan - 1} style={{ padding: "var(--sp-2_5) var(--sp-3) var(--sp-3_5)" }}>
-            <CapabilityMatrix capabilities={client.capabilities} os={client.os} />
-            {boundAgents.length > 0 && (
-              <>
-                <UppercaseLabel style={{ display: "block", marginTop: "var(--sp-3)", marginBottom: "var(--sp-1_5)" }}>
-                  Agents · {boundAgents.length}
-                </UppercaseLabel>
-                <div className="flex flex-col gap-1">
-                  {boundAgents.map((a) => (
-                    <div key={a.agentId} className="flex items-center gap-2.5 text-body">
-                      <span className="font-medium" style={{ minWidth: "var(--sp-35)" }}>
-                        {agentName(a.agentId)}
-                      </span>
-                      <PresenceChip status={runtimeStateToPresence(a.runtimeState)} />
-                      {a.activeSessions !== null && (
-                        <span className="mono tnum text-caption" style={{ color: "var(--fg-3)" }}>
-                          {a.activeSessions} / {a.totalSessions ?? 0} sessions
-                        </span>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </>
-            )}
-          </DenseTableCell>
-        </tr>
-      )}
-    </>
   );
 }

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -297,19 +297,21 @@ export function ClientsPage({ embedded = false }: { embedded?: boolean } = {}) {
         : orgClientsQuery.isLoading || meClientsQuery.isLoading
       : meClientsQuery.isLoading;
 
-  // A discreet always-available "+ Connect" entry shows whenever the viewer
-  // already has at least one of their own computers. Hidden when they have 0
-  // (the empty-state CTA "Connect your first computer" covers that case, no
-  // need to double up).
+  // A discreet always-available "+ Add computer" entry shows whenever the
+  // viewer already has at least one of their own computers. Hidden when they
+  // have 0 (the empty-state CTA "Connect your first computer" covers that
+  // case, no need to double up). "Add computer" over a bare "Connect": once
+  // you already have machines, the button adds a *new* one — "Connect" alone
+  // reads like connecting to an existing computer.
   const viewerOwnCount = grouped ? mineList.length : (memberList?.length ?? 0);
   const showHeaderConnectButton = viewerOwnCount >= 1;
 
-  // "+ Connect" lives in the "Your computers" section header, not a page header:
-  // the Settings layout now owns the single page heading (see settings.tsx).
+  // Lives in the "Your computers" section header, not a page header: the
+  // Settings layout now owns the single page heading (see settings.tsx).
   const connectButton = showHeaderConnectButton ? (
     <Button variant="outline" size="sm" onClick={openNewConnection}>
       <Plus className="h-3.5 w-3.5" />
-      Connect
+      Add computer
     </Button>
   ) : undefined;
 

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -25,12 +25,13 @@ import {
 import { PresenceChip, runtimeStateToPresence } from "../components/ui/presence-chip.js";
 import { Section } from "../components/ui/section.js";
 import { UppercaseLabel } from "../components/ui/section-header.js";
+import { StatusGlyph } from "../components/ui/status-glyph.js";
 import { useAgentNameMap } from "../lib/use-agent-name-map.js";
 import { ComputerCard } from "./clients/cards/computer-card.js";
 import { formatOfflineDuration } from "./clients/cards/view-models.js";
 import { ComputerStatusPill } from "./clients/computer-status-pill.js";
 import { DemoNavigator, useDemoScenarioParam } from "./clients/demo-navigator.js";
-import { compareByPillPriority, deriveComputerStatus } from "./clients/derive-status.js";
+import { compareByPillPriority, deriveComputerStatus, partitionTeamComputers } from "./clients/derive-status.js";
 import { DEMO_AGENT_NAMES, DEMO_SELF_USER_ID, findDemoScenario } from "./clients/dev-fixtures.js";
 import { NewConnectionDialog } from "./clients/new-connection-dialog.js";
 
@@ -625,16 +626,17 @@ function EmptyCardsNote({ message }: { message: string }) {
 /**
  * Team computers — the admin's read-only audit list. One compact line per
  * machine (hostname focus + `owner · OS · version` meta), grouped so
- * unhealthy machines ("Needs attention": auth-expired / setup-incomplete /
- * offline) bubble to the top; a fully-healthy fleet renders as a flat list
- * with no group chrome. Replaces the pre-PR-B DenseTable audit table.
+ * machines that need attention (auth-expired / setup-incomplete / offline, or
+ * a failed/blocked self-update) bubble to the top; a fully-healthy fleet
+ * renders as a flat list with no group chrome. Replaces the pre-PR-B
+ * DenseTable audit table.
  *
  * These rows are intentionally not expandable: the per-machine runtime /
  * agent detail is owner-only (the capability probe 403s on non-owners), so
  * there is nothing to reveal for a teammate's computer. The wrapping div
- * bleeds the rows past the Section's horizontal padding so a row's hover /
- * needs-attention tint spans the full width while the hostname still lines
- * up with the Section title.
+ * bleeds the rows past the Section's horizontal padding so a row's hover
+ * spans the full width while the hostname still lines up with the Section
+ * title.
  */
 function TeamComputersList({
   teamList,
@@ -643,9 +645,7 @@ function TeamComputersList({
   teamList: HubClient[];
   resolveOwner: (client: HubClient) => { text: string; title?: string };
 }) {
-  const sorted = useMemo(() => [...teamList].sort(compareByPillPriority), [teamList]);
-  const attention = sorted.filter((client) => deriveComputerStatus(client).pill !== "ready");
-  const ready = sorted.filter((client) => deriveComputerStatus(client).pill === "ready");
+  const { attention, ready } = useMemo(() => partitionTeamComputers(teamList), [teamList]);
   // Group headers earn their chrome only once something needs attention — a
   // healthy fleet is a plain flat list, no "Ready" header stating the obvious.
   const grouped = attention.length > 0;
@@ -697,24 +697,35 @@ function shortVersion(version: string): string {
   return dash === -1 ? version : version.slice(0, dash);
 }
 
+/**
+ * Row-status view for a stuck self-update, shown *in place of* the `Ready`
+ * pill when the machine is otherwise ready but its last update failed/blocked
+ * — so a stuck machine never reads as plain `Ready`. The reason (npm error,
+ * etc.) rides in the `title`. Returns null when there is no update problem.
+ */
+function updateProblemView(client: HubClient): { label: string; color: string; title?: string } | null {
+  const attempt = client.lastUpdateAttempt;
+  if (attempt?.result === "failed") {
+    return { label: "Update failed", color: "var(--state-error)", title: attempt.reason ?? undefined };
+  }
+  if (attempt?.result === "blocked") {
+    return { label: "Update blocked", color: "var(--state-blocked)", title: attempt.reason ?? undefined };
+  }
+  return null;
+}
+
 function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel: { text: string; title?: string } }) {
   const status = deriveComputerStatus(client);
   const version = client.sdkVersion;
+  // A stuck self-update only overrides the *Ready* pill — a real pill problem
+  // (offline / auth-expired) is the more urgent thing to show.
+  const updateProblem = status.pill === "ready" ? updateProblemView(client) : null;
   // "Last seen" is redundant with a live "Ready" pill — fold it into the
   // status only for offline machines, where "how long" is the actionable bit.
   const offlineFor = status.pill === "offline" ? formatOfflineDuration(client.lastSeenAt) : null;
   const agentCount = client.agentCount;
   return (
-    <div
-      className="team-computer-row"
-      style={{
-        display: "grid",
-        gridTemplateColumns: "minmax(0, 1fr) var(--sp-20) var(--sp-45)",
-        alignItems: "center",
-        columnGap: "var(--sp-3)",
-        padding: "var(--sp-2_5) var(--sp-3_5)",
-      }}
-    >
+    <div className="team-computer-row">
       <div style={{ minWidth: 0 }}>
         <div
           className="mono text-subtitle"
@@ -746,12 +757,27 @@ function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel
         {agentCount} {agentCount === 1 ? "agent" : "agents"}
       </span>
       <span className="inline-flex items-center justify-end gap-1.5" style={{ whiteSpace: "nowrap" }}>
-        <ComputerStatusPill pill={status.pill} />
-        {offlineFor ? (
-          <span className="text-caption" style={{ color: "var(--fg-3)" }}>
-            · {offlineFor}
+        {updateProblem ? (
+          <span
+            role="status"
+            aria-label={`Computer status: ${updateProblem.label}`}
+            className="mono inline-flex items-center gap-1.5 text-caption"
+            style={{ color: updateProblem.color }}
+            title={updateProblem.title}
+          >
+            <StatusGlyph shape="dot" colorVar={updateProblem.color} size={7} />
+            {updateProblem.label}
           </span>
-        ) : null}
+        ) : (
+          <>
+            <ComputerStatusPill pill={status.pill} />
+            {offlineFor ? (
+              <span className="text-caption" style={{ color: "var(--fg-3)" }}>
+                · {offlineFor}
+              </span>
+            ) : null}
+          </>
+        )}
       </span>
     </div>
   );

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -113,6 +113,7 @@ function client(overrides: Partial<HubClient> = {}): HubClient {
     binName: overrides.binName ?? "first-tree-dev",
     sdkVersion: overrides.sdkVersion ?? "0.5.0",
     ...(overrides.serverCommandVersion !== undefined ? { serverCommandVersion: overrides.serverCommandVersion } : {}),
+    ...(overrides.lastUpdateAttempt !== undefined ? { lastUpdateAttempt: overrides.lastUpdateAttempt } : {}),
     hostname: overrides.hostname ?? "gandy-macbook",
     os: overrides.os ?? "darwin",
     agentCount: overrides.agentCount ?? 1,
@@ -166,6 +167,23 @@ const TEAM = client({
   hostname: "alice-linux",
   os: "linux",
   agentCount: 1,
+});
+// Connected + OK runtime (pill = Ready) but its self-update failed — must
+// surface under "Needs attention" as "Update failed", never hidden as Ready.
+const TEAM_UPDATE_FAILED = client({
+  id: "client-team-stuck",
+  userId: "user-alice",
+  hostname: "erin-stuck",
+  os: "linux",
+  agentCount: 2,
+  lastUpdateAttempt: {
+    result: "failed",
+    target: "0.6.0",
+    currentBefore: "0.5.0",
+    installedVersion: null,
+    reason: "npm E404",
+    at: NOW,
+  },
 });
 
 const AGENTS: RuntimeAgent[] = [
@@ -318,7 +336,14 @@ function copyButtonForCommand(container: ParentNode, command: string): HTMLButto
 }
 
 function seedDefaultMocks(): void {
-  activityMocks.listOrgClients.mockResolvedValue([READY, AUTH_EXPIRED, SETUP_INCOMPLETE, OFFLINE, TEAM]);
+  activityMocks.listOrgClients.mockResolvedValue([
+    READY,
+    AUTH_EXPIRED,
+    SETUP_INCOMPLETE,
+    OFFLINE,
+    TEAM,
+    TEAM_UPDATE_FAILED,
+  ]);
   activityMocks.listClients.mockResolvedValue([READY, AUTH_EXPIRED, SETUP_INCOMPLETE, OFFLINE]);
   activityMocks.getActivityOverview.mockResolvedValue({
     clients: 5,
@@ -418,6 +443,10 @@ describe("ClientsPage computer cards", () => {
     await waitForText(container, "Team computers");
     await waitForText(container, "alice-linux");
     await waitForText(container, "Alice");
+    // A connected + Ready-runtime team machine whose self-update failed must
+    // surface under "Needs attention" as "Update failed", not hidden as Ready.
+    await waitForText(container, "Needs attention");
+    await waitForText(container, "Update failed");
     await click(exactButton(container, "Hide"));
 
     await click(container.querySelector('button[aria-label="Computer actions"]'));

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -389,7 +389,7 @@ describe("ClientsPage computer cards", () => {
     await act(async () => root.unmount());
   });
 
-  it("renders admin cards, team table, action dialogs, runtime commands, and connect dialog", async () => {
+  it("renders admin cards, team list, action dialogs, runtime commands, and connect dialog", async () => {
     const { ClientsPage } = await import("../../clients.js");
     const { container, root } = await renderDom(<ClientsPage />);
 

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -483,7 +483,7 @@ describe("ClientsPage computer cards", () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(STAGING_BOOTSTRAP_COMMAND);
     await click(exactButton(document.body, "Cancel"));
 
-    await click(exactButton(container, "Connect"));
+    await click(exactButton(container, "Add computer"));
     await waitForText(document.body, "Connect computer");
     await click(exactButton(document.body, "Cancel"));
 

--- a/packages/web/src/pages/clients/__tests__/derive-status.test.ts
+++ b/packages/web/src/pages/clients/__tests__/derive-status.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { HubClient } from "../../../api/activity.js";
-import { compareByPillPriority, deriveComputerStatus, PILL_PRIORITY } from "../derive-status.js";
+import {
+  compareByPillPriority,
+  deriveComputerStatus,
+  hasUpdateProblem,
+  PILL_PRIORITY,
+  partitionTeamComputers,
+  teamNeedsAttention,
+} from "../derive-status.js";
 
 /**
  * Pure-function unit tests for the 4-state Settings → Computers status
@@ -149,5 +156,84 @@ describe("compareByPillPriority", () => {
     const sorted = [b, a].sort(compareByPillPriority);
     expect(sorted[0]?.id).toBe("a");
     expect(sorted[1]?.id).toBe("b");
+  });
+});
+
+function updateAttempt(result: "ok" | "failed" | "blocked") {
+  return { result, target: "1.4.0", currentBefore: "1.3.2", installedVersion: null, reason: "npm E404", at: T };
+}
+
+describe("hasUpdateProblem", () => {
+  it("is false when there is no update attempt", () => {
+    expect(hasUpdateProblem(client({}))).toBe(false);
+  });
+
+  it("is false for a successful update", () => {
+    expect(hasUpdateProblem(client({ lastUpdateAttempt: updateAttempt("ok") }))).toBe(false);
+  });
+
+  it("is true for a failed or blocked update", () => {
+    expect(hasUpdateProblem(client({ lastUpdateAttempt: updateAttempt("failed") }))).toBe(true);
+    expect(hasUpdateProblem(client({ lastUpdateAttempt: updateAttempt("blocked") }))).toBe(true);
+  });
+});
+
+describe("teamNeedsAttention", () => {
+  it("is false for a healthy Ready machine with no update problem", () => {
+    const c = client({ capabilities: { "claude-code": capability("ok") } });
+    expect(deriveComputerStatus(c).pill).toBe("ready");
+    expect(teamNeedsAttention(c)).toBe(false);
+  });
+
+  it("is true for any non-ready pill", () => {
+    expect(teamNeedsAttention(client({ status: "disconnected", authState: "ok" }))).toBe(true);
+    expect(teamNeedsAttention(client({ status: "disconnected", authState: "expired" }))).toBe(true);
+    expect(teamNeedsAttention(client({ capabilities: {} }))).toBe(true);
+  });
+
+  it("is true for a Ready machine whose self-update failed/blocked (never hidden under Ready)", () => {
+    const stuck = client({
+      capabilities: { "claude-code": capability("ok") },
+      lastUpdateAttempt: updateAttempt("failed"),
+    });
+    expect(deriveComputerStatus(stuck).pill).toBe("ready");
+    expect(teamNeedsAttention(stuck)).toBe(true);
+  });
+});
+
+describe("partitionTeamComputers", () => {
+  it("splits attention (non-ready OR update-stuck) from the ready fleet", () => {
+    const offline = client({ id: "offline", hostname: "z-off", status: "disconnected", authState: "ok" });
+    const readyClean = client({ id: "ready", hostname: "a-ready", capabilities: { "claude-code": capability("ok") } });
+    const updateStuck = client({
+      id: "stuck",
+      hostname: "m-stuck",
+      capabilities: { "claude-code": capability("ok") },
+      lastUpdateAttempt: updateAttempt("failed"),
+    });
+    const { attention, ready } = partitionTeamComputers([readyClean, updateStuck, offline]);
+    // offline (pill priority 2) sorts ahead of the update-stuck Ready machine (pill 3).
+    expect(attention.map((c) => c.id)).toEqual(["offline", "stuck"]);
+    expect(ready.map((c) => c.id)).toEqual(["ready"]);
+  });
+
+  it("orders the attention group by pill priority, with update-stuck Ready machines last", () => {
+    const authExpired = client({ id: "auth", status: "disconnected", authState: "expired" });
+    const offline = client({ id: "offline", status: "disconnected", authState: "ok" });
+    const updateStuck = client({
+      id: "stuck",
+      capabilities: { "claude-code": capability("ok") },
+      lastUpdateAttempt: updateAttempt("blocked"),
+    });
+    const { attention } = partitionTeamComputers([updateStuck, offline, authExpired]);
+    expect(attention.map((c) => c.id)).toEqual(["auth", "offline", "stuck"]);
+  });
+
+  it("returns an empty attention group for an all-healthy fleet", () => {
+    const a = client({ id: "a", hostname: "a", capabilities: { "claude-code": capability("ok") } });
+    const b = client({ id: "b", hostname: "b", capabilities: { "claude-code": capability("ok") } });
+    const { attention, ready } = partitionTeamComputers([a, b]);
+    expect(attention).toEqual([]);
+    expect(ready.map((c) => c.id)).toEqual(["a", "b"]);
   });
 });

--- a/packages/web/src/pages/clients/__tests__/derive-status.test.ts
+++ b/packages/web/src/pages/clients/__tests__/derive-status.test.ts
@@ -172,13 +172,20 @@ describe("hasUpdateProblem", () => {
     expect(hasUpdateProblem(client({ lastUpdateAttempt: updateAttempt("ok") }))).toBe(false);
   });
 
-  it("is true for a failed/blocked update while still behind the target", () => {
-    // Default sdkVersion is v1.3.2, target 1.4.0 → still behind → unresolved.
-    expect(hasUpdateProblem(client({ lastUpdateAttempt: updateAttempt("failed") }))).toBe(true);
-    expect(hasUpdateProblem(client({ lastUpdateAttempt: updateAttempt("blocked") }))).toBe(true);
+  it("is true for a failed/blocked update still behind the target, within one channel", () => {
+    // prod behind prod
+    expect(hasUpdateProblem(client({ sdkVersion: "1.3.2", lastUpdateAttempt: updateAttempt("failed", "1.4.0") }))).toBe(
+      true,
+    );
+    // same staging channel, older build
+    expect(
+      hasUpdateProblem(
+        client({ sdkVersion: "0.5.3-staging.20.1", lastUpdateAttempt: updateAttempt("blocked", "0.5.3-staging.49.1") }),
+      ),
+    ).toBe(true);
   });
 
-  it("is false once the reported version reached/passed the failed target (stale record)", () => {
+  it("is false once a valid same-channel version reached/passed the target (stale record)", () => {
     // Manual `first-tree upgrade` recovers without clearing the record: the
     // client re-registers on the target version but keeps the old failure.
     expect(
@@ -187,32 +194,36 @@ describe("hasUpdateProblem", () => {
     expect(hasUpdateProblem(client({ sdkVersion: "1.5.0", lastUpdateAttempt: updateAttempt("failed", "1.4.0") }))).toBe(
       false,
     );
-    // Channel build past the target core also counts as recovered.
+    // staging ahead by build number
     expect(
       hasUpdateProblem(
-        client({ sdkVersion: "1.4.0-staging.5.1", lastUpdateAttempt: updateAttempt("blocked", "1.4.0") }),
+        client({ sdkVersion: "0.5.3-staging.60.1", lastUpdateAttempt: updateAttempt("blocked", "0.5.3-staging.49.1") }),
       ),
     ).toBe(false);
   });
 
-  it("stays true for an older channel build of the same core (still behind by build)", () => {
-    expect(
-      hasUpdateProblem(
-        client({
-          sdkVersion: "1.4.0-staging.20.1",
-          lastUpdateAttempt: updateAttempt("failed", "1.4.0-staging.49.1"),
-        }),
-      ),
-    ).toBe(true);
-  });
-
-  it("fails safe (stays true) when the reported version is unparseable/missing", () => {
-    expect(hasUpdateProblem(client({ sdkVersion: null, lastUpdateAttempt: updateAttempt("blocked", "1.4.0") }))).toBe(
-      true,
-    );
-    expect(hasUpdateProblem(client({ sdkVersion: "dev", lastUpdateAttempt: updateAttempt("failed", "1.4.0") }))).toBe(
-      true,
-    );
+  it("fails closed (stays true) for malformed, unknown-channel, or channel-mismatched versions", () => {
+    const cases: Array<[string | null, string]> = [
+      // digit-bearing garbage must not outrank a valid target
+      ["garbage999", "1.4.0"],
+      // partial version is not a valid release
+      ["1.4", "1.4.0"],
+      // unknown prerelease channels fail closed even if numerically "ahead"
+      ["1.4.0-alpha.999.1", "1.4.0-staging.49.1"],
+      ["1.4.0-beta.1", "1.4.0-staging.1.1"],
+      ["1.4.0-rc.1", "1.4.0"],
+      // channel mismatch: a staging prerelease has NOT reached a stable prod target
+      ["1.4.0-staging.5.1", "1.4.0"],
+      ["1.4.0", "1.4.0-staging.49.1"],
+      // missing / non-numeric current
+      [null, "1.4.0"],
+      ["dev", "1.4.0"],
+      // malformed target also fails closed
+      ["1.5.0", "not-a-version"],
+    ];
+    for (const [sdkVersion, target] of cases) {
+      expect(hasUpdateProblem(client({ sdkVersion, lastUpdateAttempt: updateAttempt("blocked", target) }))).toBe(true);
+    }
   });
 });
 

--- a/packages/web/src/pages/clients/__tests__/derive-status.test.ts
+++ b/packages/web/src/pages/clients/__tests__/derive-status.test.ts
@@ -215,6 +215,9 @@ describe("hasUpdateProblem", () => {
       // channel mismatch: a staging prerelease has NOT reached a stable prod target
       ["1.4.0-staging.5.1", "1.4.0"],
       ["1.4.0", "1.4.0-staging.49.1"],
+      // leading-zero numeric identifiers are invalid SemVer → fail closed
+      ["01.4.0", "1.4.0"],
+      ["1.4.0-staging.049.1", "1.4.0-staging.49.1"],
       // missing / non-numeric current
       [null, "1.4.0"],
       ["dev", "1.4.0"],
@@ -224,6 +227,20 @@ describe("hasUpdateProblem", () => {
     for (const [sdkVersion, target] of cases) {
       expect(hasUpdateProblem(client({ sdkVersion, lastUpdateAttempt: updateAttempt("blocked", target) }))).toBe(true);
     }
+  });
+
+  it("compares numeric identifiers exactly past 2^53 (no IEEE-754 collapse)", () => {
+    // These differ by 1 but round to the same JS double; string compare keeps them apart.
+    const lower = "9007199254740992.0.0";
+    const higher = "9007199254740993.0.0";
+    // current one build behind target → still unresolved
+    expect(hasUpdateProblem(client({ sdkVersion: lower, lastUpdateAttempt: updateAttempt("blocked", higher) }))).toBe(
+      true,
+    );
+    // current at/beyond target → resolved
+    expect(hasUpdateProblem(client({ sdkVersion: higher, lastUpdateAttempt: updateAttempt("failed", lower) }))).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/web/src/pages/clients/__tests__/derive-status.test.ts
+++ b/packages/web/src/pages/clients/__tests__/derive-status.test.ts
@@ -159,8 +159,8 @@ describe("compareByPillPriority", () => {
   });
 });
 
-function updateAttempt(result: "ok" | "failed" | "blocked") {
-  return { result, target: "1.4.0", currentBefore: "1.3.2", installedVersion: null, reason: "npm E404", at: T };
+function updateAttempt(result: "ok" | "failed" | "blocked", target = "1.4.0") {
+  return { result, target, currentBefore: "1.3.2", installedVersion: null, reason: "npm E404", at: T };
 }
 
 describe("hasUpdateProblem", () => {
@@ -172,9 +172,47 @@ describe("hasUpdateProblem", () => {
     expect(hasUpdateProblem(client({ lastUpdateAttempt: updateAttempt("ok") }))).toBe(false);
   });
 
-  it("is true for a failed or blocked update", () => {
+  it("is true for a failed/blocked update while still behind the target", () => {
+    // Default sdkVersion is v1.3.2, target 1.4.0 → still behind → unresolved.
     expect(hasUpdateProblem(client({ lastUpdateAttempt: updateAttempt("failed") }))).toBe(true);
     expect(hasUpdateProblem(client({ lastUpdateAttempt: updateAttempt("blocked") }))).toBe(true);
+  });
+
+  it("is false once the reported version reached/passed the failed target (stale record)", () => {
+    // Manual `first-tree upgrade` recovers without clearing the record: the
+    // client re-registers on the target version but keeps the old failure.
+    expect(
+      hasUpdateProblem(client({ sdkVersion: "1.4.0", lastUpdateAttempt: updateAttempt("blocked", "1.4.0") })),
+    ).toBe(false);
+    expect(hasUpdateProblem(client({ sdkVersion: "1.5.0", lastUpdateAttempt: updateAttempt("failed", "1.4.0") }))).toBe(
+      false,
+    );
+    // Channel build past the target core also counts as recovered.
+    expect(
+      hasUpdateProblem(
+        client({ sdkVersion: "1.4.0-staging.5.1", lastUpdateAttempt: updateAttempt("blocked", "1.4.0") }),
+      ),
+    ).toBe(false);
+  });
+
+  it("stays true for an older channel build of the same core (still behind by build)", () => {
+    expect(
+      hasUpdateProblem(
+        client({
+          sdkVersion: "1.4.0-staging.20.1",
+          lastUpdateAttempt: updateAttempt("failed", "1.4.0-staging.49.1"),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails safe (stays true) when the reported version is unparseable/missing", () => {
+    expect(hasUpdateProblem(client({ sdkVersion: null, lastUpdateAttempt: updateAttempt("blocked", "1.4.0") }))).toBe(
+      true,
+    );
+    expect(hasUpdateProblem(client({ sdkVersion: "dev", lastUpdateAttempt: updateAttempt("failed", "1.4.0") }))).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/web/src/pages/clients/derive-status.ts
+++ b/packages/web/src/pages/clients/derive-status.ts
@@ -92,14 +92,51 @@ export function compareByPillPriority(a: HubClient, b: HubClient): number {
 }
 
 /**
+ * Ordered numeric components of a version string — every integer run, in
+ * order: "0.5.3-staging.49.1" → [0, 5, 3, 49, 1]. Lets us compare both plain
+ * semver ("0.6.0") and channel builds without a semver dependency. Returns
+ * null when there's no parseable number (so callers can fail safe).
+ */
+function versionParts(version: string | null | undefined): number[] | null {
+  if (!version) return null;
+  const runs = version.match(/\d+/g);
+  return runs ? runs.map((n) => Number.parseInt(n, 10)) : null;
+}
+
+/**
+ * Is `current` strictly behind `target`? Conservative on unparseable input:
+ * when we can't compare, we return `true` so a recorded failure is surfaced
+ * rather than silently hidden.
+ */
+function isVersionBehind(current: string | null | undefined, target: string): boolean {
+  const c = versionParts(current);
+  const t = versionParts(target);
+  if (!c || !t) return true;
+  const len = Math.max(c.length, t.length);
+  for (let i = 0; i < len; i++) {
+    const cv = c[i] ?? 0;
+    const tv = t[i] ?? 0;
+    if (cv !== tv) return cv < tv;
+  }
+  return false;
+}
+
+/**
  * A `failed` / `blocked` self-update leaves the machine stuck on an old
- * version. The server exposes it (`lastUpdateAttempt`) precisely so the
- * admin dashboard can flag it — it needs attention even while the client is
+ * version. The server exposes it (`lastUpdateAttempt`) precisely so the admin
+ * dashboard can flag it — it needs attention even while the client is
  * otherwise connected with an OK runtime (so the 4-state pill reads `Ready`).
+ *
+ * The record is the *last* attempt, not a live "still stuck" flag, and the
+ * manual recovery paths (`first-tree upgrade` / manual reinstall) don't write
+ * an `ok` attempt or clear it. So a machine that has since reached the target
+ * carries a stale failure — we treat it as a problem only while the reported
+ * `sdkVersion` is still behind the attempt's `target`.
  */
 export function hasUpdateProblem(client: HubClient): boolean {
-  const result = client.lastUpdateAttempt?.result;
-  return result === "failed" || result === "blocked";
+  const attempt = client.lastUpdateAttempt;
+  if (attempt?.result !== "failed" && attempt?.result !== "blocked") return false;
+  return isVersionBehind(client.sdkVersion, attempt.target);
 }
 
 /**

--- a/packages/web/src/pages/clients/derive-status.ts
+++ b/packages/web/src/pages/clients/derive-status.ts
@@ -95,28 +95,45 @@ export function compareByPillPriority(a: HubClient, b: HubClient): number {
  * A version parsed into a same-channel comparable form. Only the two shapes
  * First Tree's durable channel contract accepts are supported (mirrors
  * `inferChannelFromVersion` in `@first-tree/shared`'s channel module):
- *   - prod:    `X.Y.Z`             → { channel: "prod",    parts: [X, Y, Z] }
- *   - staging: `X.Y.Z-staging.N.M` → { channel: "staging", parts: [X, Y, Z, N, M] }
- * Anything else — dev, alpha/beta/rc, partial (`1.4`), or otherwise malformed
- * — is unsupported and returns null so callers fail closed.
+ *   - prod:    `X.Y.Z`             → { channel: "prod",    parts: ["X","Y","Z"] }
+ *   - staging: `X.Y.Z-staging.N.M` → { channel: "staging", parts: ["X".."M"] }
+ * Each component is a SemVer-valid numeric identifier — no leading zeros, so
+ * `01.4.0` / `…staging.049.1` are rejected the same way `semver.valid` does.
+ * Parts stay as strings and are compared digit-wise (below) so ordering is
+ * exact past `Number.MAX_SAFE_INTEGER`. Anything else — dev, alpha/beta/rc,
+ * partial (`1.4`), leading-zero, or otherwise malformed — returns null so
+ * callers fail closed.
  */
-type ParsedVersion = { channel: "prod" | "staging"; parts: number[] };
+type ParsedVersion = { channel: "prod" | "staging"; parts: string[] };
+
+// SemVer numeric identifier: 0, or a non-zero digit followed by any digits.
+const PROD_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const STAGING_VERSION_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-staging\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
 function parseSupportedVersion(version: string | null | undefined): ParsedVersion | null {
   if (!version) return null;
-  const staging = /^(\d+)\.(\d+)\.(\d+)-staging\.(\d+)\.(\d+)$/.exec(version);
-  if (staging) return { channel: "staging", parts: staging.slice(1).map((n) => Number.parseInt(n, 10)) };
-  const prod = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
-  if (prod) return { channel: "prod", parts: prod.slice(1).map((n) => Number.parseInt(n, 10)) };
+  const staging = STAGING_VERSION_RE.exec(version);
+  if (staging) return { channel: "staging", parts: staging.slice(1) };
+  const prod = PROD_VERSION_RE.exec(version);
+  if (prod) return { channel: "prod", parts: prod.slice(1) };
   return null;
 }
 
-function comparePartsAscending(a: number[], b: number[]): number {
+/**
+ * Compare two SemVer-valid numeric identifiers (digit strings, no leading
+ * zeros) without `Number` precision loss: more digits ⇒ larger, otherwise
+ * lexicographic.
+ */
+function compareNumericIdentifier(a: string, b: string): number {
+  if (a.length !== b.length) return a.length - b.length;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function comparePartsAscending(a: string[], b: string[]): number {
   const len = Math.max(a.length, b.length);
   for (let i = 0; i < len; i++) {
-    const av = a[i] ?? 0;
-    const bv = b[i] ?? 0;
-    if (av !== bv) return av - bv;
+    const cmp = compareNumericIdentifier(a[i] ?? "0", b[i] ?? "0");
+    if (cmp !== 0) return cmp;
   }
   return 0;
 }

--- a/packages/web/src/pages/clients/derive-status.ts
+++ b/packages/web/src/pages/clients/derive-status.ts
@@ -90,3 +90,39 @@ export function compareByPillPriority(a: HubClient, b: HubClient): number {
 
   return a.id.localeCompare(b.id);
 }
+
+/**
+ * A `failed` / `blocked` self-update leaves the machine stuck on an old
+ * version. The server exposes it (`lastUpdateAttempt`) precisely so the
+ * admin dashboard can flag it — it needs attention even while the client is
+ * otherwise connected with an OK runtime (so the 4-state pill reads `Ready`).
+ */
+export function hasUpdateProblem(client: HubClient): boolean {
+  const result = client.lastUpdateAttempt?.result;
+  return result === "failed" || result === "blocked";
+}
+
+/**
+ * Whether a computer belongs in the Team-list "Needs attention" group: any
+ * non-`ready` runtime pill (auth-expired / setup-incomplete / offline) OR a
+ * failed/blocked self-update on an otherwise-ready machine. This is the audit
+ * view's health predicate — broader than the pill alone so a stuck update is
+ * never hidden under `Ready`.
+ */
+export function teamNeedsAttention(client: HubClient): boolean {
+  return deriveComputerStatus(client).pill !== "ready" || hasUpdateProblem(client);
+}
+
+/**
+ * Split a team-computer list into the "Needs attention" and "Ready" groups,
+ * each pill-priority sorted (problems first; a Ready-but-update-stuck machine
+ * sorts after the true pill problems since its pill is still `ready`).
+ */
+export function partitionTeamComputers(clients: HubClient[]): { attention: HubClient[]; ready: HubClient[] } {
+  const attention: HubClient[] = [];
+  const ready: HubClient[] = [];
+  for (const client of [...clients].sort(compareByPillPriority)) {
+    (teamNeedsAttention(client) ? attention : ready).push(client);
+  }
+  return { attention, ready };
+}

--- a/packages/web/src/pages/clients/derive-status.ts
+++ b/packages/web/src/pages/clients/derive-status.ts
@@ -92,33 +92,49 @@ export function compareByPillPriority(a: HubClient, b: HubClient): number {
 }
 
 /**
- * Ordered numeric components of a version string — every integer run, in
- * order: "0.5.3-staging.49.1" → [0, 5, 3, 49, 1]. Lets us compare both plain
- * semver ("0.6.0") and channel builds without a semver dependency. Returns
- * null when there's no parseable number (so callers can fail safe).
+ * A version parsed into a same-channel comparable form. Only the two shapes
+ * First Tree's durable channel contract accepts are supported (mirrors
+ * `inferChannelFromVersion` in `@first-tree/shared`'s channel module):
+ *   - prod:    `X.Y.Z`             → { channel: "prod",    parts: [X, Y, Z] }
+ *   - staging: `X.Y.Z-staging.N.M` → { channel: "staging", parts: [X, Y, Z, N, M] }
+ * Anything else — dev, alpha/beta/rc, partial (`1.4`), or otherwise malformed
+ * — is unsupported and returns null so callers fail closed.
  */
-function versionParts(version: string | null | undefined): number[] | null {
+type ParsedVersion = { channel: "prod" | "staging"; parts: number[] };
+
+function parseSupportedVersion(version: string | null | undefined): ParsedVersion | null {
   if (!version) return null;
-  const runs = version.match(/\d+/g);
-  return runs ? runs.map((n) => Number.parseInt(n, 10)) : null;
+  const staging = /^(\d+)\.(\d+)\.(\d+)-staging\.(\d+)\.(\d+)$/.exec(version);
+  if (staging) return { channel: "staging", parts: staging.slice(1).map((n) => Number.parseInt(n, 10)) };
+  const prod = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (prod) return { channel: "prod", parts: prod.slice(1).map((n) => Number.parseInt(n, 10)) };
+  return null;
+}
+
+function comparePartsAscending(a: number[], b: number[]): number {
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av !== bv) return av - bv;
+  }
+  return 0;
 }
 
 /**
- * Is `current` strictly behind `target`? Conservative on unparseable input:
- * when we can't compare, we return `true` so a recorded failure is surfaced
- * rather than silently hidden.
+ * Has a recorded failed/blocked update since been resolved? Only a **valid,
+ * same-channel** current version at or beyond a **valid** target clears the
+ * historical failure. Malformed, unknown/mismatched-channel, or missing
+ * versions fail closed (return false) so a genuine failure is never hidden by
+ * an unparseable version — e.g. a staging build never counts as having reached
+ * a stable prod target (prerelease < stable), and `garbage999` never outranks
+ * `1.4.0`.
  */
-function isVersionBehind(current: string | null | undefined, target: string): boolean {
-  const c = versionParts(current);
-  const t = versionParts(target);
-  if (!c || !t) return true;
-  const len = Math.max(c.length, t.length);
-  for (let i = 0; i < len; i++) {
-    const cv = c[i] ?? 0;
-    const tv = t[i] ?? 0;
-    if (cv !== tv) return cv < tv;
-  }
-  return false;
+function updateResolved(current: string | null | undefined, target: string): boolean {
+  const c = parseSupportedVersion(current);
+  const t = parseSupportedVersion(target);
+  if (!c || !t || c.channel !== t.channel) return false;
+  return comparePartsAscending(c.parts, t.parts) >= 0;
 }
 
 /**
@@ -130,13 +146,13 @@ function isVersionBehind(current: string | null | undefined, target: string): bo
  * The record is the *last* attempt, not a live "still stuck" flag, and the
  * manual recovery paths (`first-tree upgrade` / manual reinstall) don't write
  * an `ok` attempt or clear it. So a machine that has since reached the target
- * carries a stale failure — we treat it as a problem only while the reported
- * `sdkVersion` is still behind the attempt's `target`.
+ * carries a stale failure — treat it as a problem unless we can prove, within
+ * one accepted channel, that the reported version reached/passed the target.
  */
 export function hasUpdateProblem(client: HubClient): boolean {
   const attempt = client.lastUpdateAttempt;
   if (attempt?.result !== "failed" && attempt?.result !== "blocked") return false;
-  return isVersionBehind(client.sdkVersion, attempt.target);
+  return !updateResolved(client.sdkVersion, attempt.target);
 }
 
 /**

--- a/packages/web/src/pages/clients/dev-fixtures.ts
+++ b/packages/web/src/pages/clients/dev-fixtures.ts
@@ -200,8 +200,49 @@ function buildDemoData(): { scenarios: DemoScenario[]; agentNames: Record<string
     id: "demo-team-machine",
     userId: "other-user",
     hostname: "alice-MBP.lan",
+    agentCount: 1,
     capabilities: {
       "claude-code": cap("ok", { sdkVersion: "0.2.141" }),
+    },
+  });
+
+  const TEAM_READY_LINUX = client({
+    id: "demo-team-ready-linux",
+    userId: "dave-user",
+    hostname: "BAI-MATEBOOK",
+    os: "linux",
+    agentCount: 5,
+    capabilities: {
+      "claude-code": cap("ok", { sdkVersion: "0.2.141" }),
+    },
+  });
+
+  // Long hostname exercises single-line ellipsis truncation on the team row.
+  const TEAM_OFFLINE = client({
+    id: "demo-team-offline",
+    userId: "bob-user",
+    hostname: "ci-runner-7f3a91b2c4d5e6f8a0b1.internal",
+    os: "linux",
+    status: "disconnected",
+    lastSeenAt: isoMinutesAgo(3 * 24 * 60),
+    sdkVersion: "0.5.1-staging.12.1",
+    agentCount: 1,
+    capabilities: {
+      "claude-code": cap("ok", { sdkVersion: "0.2.120" }),
+    },
+  });
+
+  const TEAM_AUTH_EXPIRED = client({
+    id: "demo-team-auth-expired",
+    userId: "carol-user",
+    hostname: "carol-mac-mini.local",
+    status: "disconnected",
+    authState: "expired",
+    lastSeenAt: isoMinutesAgo(6 * 60),
+    sdkVersion: "0.5.2-staging.31.4",
+    agentCount: 1,
+    capabilities: {
+      "claude-code": cap("ok", { sdkVersion: "0.2.130" }),
     },
   });
 
@@ -377,16 +418,19 @@ function buildDemoData(): { scenarios: DemoScenario[]; agentNames: Record<string
     {
       key: "admin-grouped",
       group: "Cross-cutting",
-      title: "Admin grouped: 2 own + 1 team machine",
+      title: "Admin grouped: 2 own + 4 team machines",
       summary:
-        "Admin view with 'Your computers' + 'Team computers'. Real Settings layout including the table for team rows.",
+        "Admin view with 'Your computers' cards + the redesigned compact 'Team computers' list — one line per machine, health-grouped so problem machines sort to the top.",
       whatToCheck: [
         "'Your computers · 2' section as Section heading with hairline below",
-        "'Team computers · 1' second Section",
-        "Team table uses the legacy dense-table chrome (deferred to Variant D)",
+        "'Team computers · 4' second Section, collapsed by default — click Show",
+        "Compact list: hostname (mono, the focus) over an 'owner · OS · version' meta line",
+        "'Needs attention · 2' group on top (amber header: Auth expired + Offline), then a neutral 'Ready · 2'",
+        "Version drops the build suffix (0.5.2-staging.31.4 → 0.5.2); full string on hover",
+        "Long hostname truncates with an ellipsis; Offline row reads 'Offline · 3 days'",
         "Owner labels: 'gandy · you' on own cards, no '· you' on team rows",
       ],
-      clients: [READY_BOTH, OFFLINE_RECENT, TEAM_MACHINE],
+      clients: [READY_BOTH, OFFLINE_RECENT, TEAM_AUTH_EXPIRED, TEAM_OFFLINE, TEAM_MACHINE, TEAM_READY_LINUX],
       agents: [
         agent({ agentId: "a-dev", clientId: READY_BOTH.id, runtimeState: "idle" }),
         agent({ agentId: "a-asst", clientId: READY_BOTH.id, runtimeState: "idle" }),

--- a/packages/web/src/pages/clients/dev-fixtures.ts
+++ b/packages/web/src/pages/clients/dev-fixtures.ts
@@ -56,6 +56,7 @@ function client(overrides: Partial<HubClient>): HubClient {
     connectedAt: overrides.connectedAt ?? isoMinutesAgo(30),
     lastSeenAt: overrides.lastSeenAt ?? isoMinutesAgo(0.2),
     capabilities: overrides.capabilities ?? {},
+    lastUpdateAttempt: overrides.lastUpdateAttempt,
   };
 }
 
@@ -246,6 +247,28 @@ function buildDemoData(): { scenarios: DemoScenario[]; agentNames: Record<string
     },
   });
 
+  // Connected + OK runtime (pill would read Ready) but stuck on an old version
+  // because its self-update keeps failing — surfaces under Needs attention.
+  const TEAM_UPDATE_STUCK = client({
+    id: "demo-team-update-stuck",
+    userId: "erin-user",
+    hostname: "erin-devbox",
+    os: "linux",
+    sdkVersion: "0.4.9-staging.988.1",
+    agentCount: 2,
+    capabilities: {
+      "claude-code": cap("ok", { sdkVersion: "0.2.100" }),
+    },
+    lastUpdateAttempt: {
+      result: "failed",
+      target: "0.5.3-staging.49.1",
+      currentBefore: "0.4.9-staging.988.1",
+      installedVersion: null,
+      reason: "npm ETIMEDOUT while fetching @first-tree/cli",
+      at: isoMinutesAgo(20),
+    },
+  });
+
   const agentNames: Record<string, string> = {
     "a-dev": "gandy-developer",
     "a-asst": "gandy-assistant",
@@ -418,19 +441,27 @@ function buildDemoData(): { scenarios: DemoScenario[]; agentNames: Record<string
     {
       key: "admin-grouped",
       group: "Cross-cutting",
-      title: "Admin grouped: 2 own + 4 team machines",
+      title: "Admin grouped: 2 own + 5 team machines",
       summary:
         "Admin view with 'Your computers' cards + the redesigned compact 'Team computers' list — one line per machine, health-grouped so problem machines sort to the top.",
       whatToCheck: [
         "'Your computers · 2' section as Section heading with hairline below",
-        "'Team computers · 4' second Section, collapsed by default — click Show",
+        "'Team computers · 5' second Section, collapsed by default — click Show",
         "Compact list: hostname (mono, the focus) over an 'owner · OS · version' meta line",
-        "'Needs attention · 2' group on top (amber header: Auth expired + Offline), then a neutral 'Ready · 2'",
+        "'Needs attention · 3' on top: Auth expired, Offline, then 'Update failed' (a Ready runtime whose self-update failed), then a neutral 'Ready · 2'",
         "Version drops the build suffix (0.5.2-staging.31.4 → 0.5.2); full string on hover",
-        "Long hostname truncates with an ellipsis; Offline row reads 'Offline · 3 days'",
+        "Long hostname truncates with an ellipsis; Offline row reads 'Offline · 3 days'; 'Update failed' shows its reason on hover",
         "Owner labels: 'gandy · you' on own cards, no '· you' on team rows",
       ],
-      clients: [READY_BOTH, OFFLINE_RECENT, TEAM_AUTH_EXPIRED, TEAM_OFFLINE, TEAM_MACHINE, TEAM_READY_LINUX],
+      clients: [
+        READY_BOTH,
+        OFFLINE_RECENT,
+        TEAM_AUTH_EXPIRED,
+        TEAM_OFFLINE,
+        TEAM_UPDATE_STUCK,
+        TEAM_MACHINE,
+        TEAM_READY_LINUX,
+      ],
       agents: [
         agent({ agentId: "a-dev", clientId: READY_BOTH.id, runtimeState: "idle" }),
         agent({ agentId: "a-asst", clientId: READY_BOTH.id, runtimeState: "idle" }),


### PR DESCRIPTION
## What

Redesigns the admin **Team computers** audit view on Settings → Computers from a dense 7-column table into a **compact, health-grouped list**.

- One line per machine: **hostname** (mono, the focus) over an `owner · OS · version` meta line; right-aligned agent count and status pill.
- **Health grouping**: machines whose status is *not* `ready` (auth-expired / setup-incomplete / offline) sort under a **`Needs attention`** header at the top; the ready fleet follows under `Ready`. A fully-healthy fleet renders as a **flat list with no group chrome**.
- **Less noise**: the version drops its `-staging.NN` build suffix (`0.5.14-staging.841.1` → `0.5.14`, full string on hover); "last seen" folds into the **Offline** status (`Offline · 3 days`) instead of a redundant column beside a live `Ready` pill. Long hostnames truncate with an ellipsis, so the row stops wrapping.

The section stays **collapsed by default** (unchanged) and carries no attention badge — the health signal lives inside, surfaced on expand.

## Why

The old table wrapped versions/owners/timestamps onto two lines and read like a back-office spreadsheet. The audit view's real job is spotting *unhealthy* machines, so problems now sort to the top. The row vocabulary mirrors the existing "Your computers" card meta line for cross-surface consistency.

## Removed (dead code)

The old `DenseTable` path — `ClientRow`, `TeamComputersTable`, `CapabilityMatrix`, `ProviderRow`, and the `collapsedIds` state — is deleted. Team rows were always rendered `restricted`, which already force-disabled per-row expansion and the owner-only capability probe, so that branch never rendered in production. Net ‑141 lines.

## Notes for reviewers

- The one meaningful color is the amber `Needs attention` header (`--fg-needs-you-strong`); rows carry each machine's own status-pill hue. An earlier iteration tinted the whole attention group amber — dropped after review as a token-semantics stretch (amber wash behind red/gray pills) and to stay restrained.
- `dev-fixtures.ts`: the DEV-only `admin-grouped` demo scenario gains varied-status team machines so `/settings/computers?demo=admin-grouped` previews the grouped list.

## Verification

- `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens` design-token gate) — clean.
- `pnpm biome check` on changed files — clean.
- `pnpm --filter @first-tree/web test` — **1416 passed** (incl. the clients-page DOM test).
- Real browser (Chrome, dev server) — verified the grouped list in **light and dark**, expand/collapse, ellipsis truncation, and the `Offline · 3 days` fold via the `admin-grouped` demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
