### PR TITLE
feat(web): chat image sizing fix + click-to-zoom lightbox

### DIFF
--- a/packages/web/src/components/ui/image-lightbox.tsx
+++ b/packages/web/src/components/ui/image-lightbox.tsx
@@ -1,0 +1,176 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { ChevronLeft, ChevronRight, Download, X } from "lucide-react";
+import { useCallback } from "react";
+import { downloadAttachment } from "../../api/attachments.js";
+import { useImageSrc } from "../../lib/use-image-src.js";
+
+/**
+ * One image in a lightbox set. Either an `imageId` (resolved from the org
+ * attachment store / IndexedDB cache — full resolution, usually already warm
+ * from the thumbnail) or a ready `dataSrc` (inline base64 sends, which carry
+ * no attachment row).
+ */
+export type LightboxImage = {
+  imageId?: string;
+  dataSrc?: string;
+  filename: string;
+};
+
+// Control offsets keep clear of notch / home-indicator safe areas on mobile
+// (the chat surface — and this lightbox — is shared with the mobile app).
+const TOP = "calc(var(--sp-4) + env(safe-area-inset-top))";
+const RIGHT = "calc(var(--sp-4) + env(safe-area-inset-right))";
+const BOTTOM = "calc(var(--sp-4) + env(safe-area-inset-bottom))";
+const ARROW_LEFT = "calc(var(--sp-2) + env(safe-area-inset-left))";
+const ARROW_RIGHT = "calc(var(--sp-2) + env(safe-area-inset-right))";
+
+type ImageLightboxProps = {
+  images: LightboxImage[];
+  /** Index of the open image; `null` closes the lightbox. */
+  index: number | null;
+  onIndexChange: (index: number | null) => void;
+};
+
+/**
+ * Full-screen image viewer for chat images. Built on the Radix Dialog
+ * primitive (Escape / focus-trap / scroll-lock for free) but full-bleed:
+ * the image fits the viewport, with close + download always available and
+ * prev/next paging when the set has more than one image. Mobile inherits it
+ * unchanged (the chat surface is shared).
+ */
+export function ImageLightbox({ images, index, onIndexChange }: ImageLightboxProps) {
+  const open = index !== null && index >= 0 && index < images.length;
+  const current = open ? images[index] : undefined;
+  const multi = images.length > 1;
+
+  const close = useCallback(() => onIndexChange(null), [onIndexChange]);
+  const step = useCallback(
+    (delta: number) => {
+      if (index === null) return;
+      onIndexChange((index + delta + images.length) % images.length);
+    },
+    [index, images.length, onIndexChange],
+  );
+
+  const onDownload = useCallback(() => {
+    if (!current) return;
+    if (current.imageId) {
+      void downloadAttachment(current.imageId, current.filename);
+      return;
+    }
+    if (current.dataSrc) {
+      // Anchor must be in the document for a programmatic download click to
+      // fire in some browsers (matches downloadAttachment's approach).
+      const a = document.createElement("a");
+      a.href = current.dataSrc;
+      a.download = current.filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    }
+  }, [current]);
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={(next) => !next && close()}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[60] bg-overlay-scrim data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          onKeyDown={(e) => {
+            if (!multi) return;
+            if (e.key === "ArrowLeft") step(-1);
+            if (e.key === "ArrowRight") step(1);
+          }}
+          className="fixed inset-0 z-[60] flex items-center justify-center focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+          // Click on the empty backdrop (not the image or a control) closes.
+          onClick={(e) => {
+            if (e.target === e.currentTarget) close();
+          }}
+        >
+          <DialogPrimitive.Title className="sr-only">{current?.filename ?? "Image"}</DialogPrimitive.Title>
+
+          {current ? <LightboxImageView key={index} image={current} /> : null}
+
+          {/* Top-right: download + close */}
+          {current ? (
+            <div className="absolute flex items-center gap-2" style={{ top: TOP, right: RIGHT }}>
+              <button
+                type="button"
+                onClick={onDownload}
+                aria-label="Download original"
+                className="lightbox-control flex h-9 w-9 items-center justify-center rounded-[var(--radius-input)]"
+              >
+                <Download className="h-5 w-5" />
+              </button>
+              <button
+                type="button"
+                onClick={close}
+                aria-label="Close"
+                className="lightbox-control flex h-9 w-9 items-center justify-center rounded-[var(--radius-input)]"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+          ) : null}
+
+          {current && multi ? (
+            <>
+              <button
+                type="button"
+                onClick={() => step(-1)}
+                aria-label="Previous image"
+                className="lightbox-control absolute top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full"
+                style={{ left: ARROW_LEFT }}
+              >
+                <ChevronLeft className="h-6 w-6" />
+              </button>
+              <button
+                type="button"
+                onClick={() => step(1)}
+                aria-label="Next image"
+                className="lightbox-control absolute top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full"
+                style={{ right: ARROW_RIGHT }}
+              >
+                <ChevronRight className="h-6 w-6" />
+              </button>
+              <div
+                aria-live="polite"
+                className="lightbox-chip mono text-caption absolute left-1/2 -translate-x-1/2 rounded-full px-3 py-1"
+                style={{ bottom: BOTTOM }}
+              >
+                {(index ?? 0) + 1} / {images.length}
+              </div>
+            </>
+          ) : null}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+/**
+ * The current image inside the lightbox. Resolves its own `src` (inline
+ * `dataSrc`, else fetched-and-cached by `imageId`) so it can be re-keyed per
+ * index without threading resolution state up. Fits the viewport; never
+ * upscaled past its natural size.
+ */
+function LightboxImageView({ image }: { image: LightboxImage }) {
+  const refState = useImageSrc(image.dataSrc ? undefined : image.imageId);
+  const src = image.dataSrc ?? (refState.kind === "hit" ? refState.src : undefined);
+
+  if (!src) {
+    return (
+      <span className="text-body" style={{ color: "var(--fg-on-vivid)" }}>
+        {refState.kind === "miss" ? `Couldn't load "${image.filename}"` : "…"}
+      </span>
+    );
+  }
+  return (
+    <img
+      src={src}
+      alt={image.filename}
+      className="rounded-[var(--radius-dialog)]"
+      style={{ maxWidth: "92vw", maxHeight: "85vh", objectFit: "contain" }}
+    />
+  );
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -439,6 +439,11 @@
   /* Dialog / lightbox scrim (both modes — uniformly dark). */
   --overlay-scrim: oklch(0 0 0 / 0.55);
 
+  /* Lightbox control chips — translucent-dark backing with a near-white icon,
+     legible over any image (bright or dark) and identical in both themes. */
+  --overlay-control: oklch(0 0 0 / 0.4);
+  --overlay-control-hover: oklch(0 0 0 / 0.58);
+
   /* ── Context page palette ─────────────────────────────────────────────────
      The /context tab now consumes the neutral semantic ramp like every other
      tab. Every entry resolves through --fg* / --bg* / --border* / --brand /
@@ -767,6 +772,28 @@
     border: 1px solid var(--border);
     border-radius: var(--radius-dialog);
     box-shadow: var(--shadow-md);
+  }
+
+  /* Image-lightbox chips: near-white content over a translucent dark backing,
+     legible over any image. `.lightbox-chip` is the static readout (counter);
+     `.lightbox-control` adds the interactive states for the buttons. */
+  .lightbox-chip {
+    color: var(--fg-on-vivid);
+    background: var(--overlay-control);
+  }
+  .lightbox-control {
+    color: var(--fg-on-vivid);
+    background: var(--overlay-control);
+    border: none;
+    cursor: pointer;
+    transition: background 120ms ease-out;
+  }
+  .lightbox-control:hover {
+    background: var(--overlay-control-hover);
+  }
+  .lightbox-control:focus-visible {
+    outline: 2px solid var(--fg-on-vivid);
+    outline-offset: 2px;
   }
 }
 

--- a/packages/web/src/lib/use-image-src.ts
+++ b/packages/web/src/lib/use-image-src.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { fetchAttachmentBase64 } from "../api/attachments.js";
+import { getImage, putImage } from "../api/image-store.js";
+
+/**
+ * Resolve a chat image reference to a renderable `data:` URL.
+ *
+ * The per-browser IndexedDB cache is consulted first (the sender's own sends,
+ * and any already-rendered thumbnail, warm it); on a miss the bytes are fetched
+ * from the org attachment store and the cache is warmed for next time. The
+ * returned bytes are full-resolution — the same URL a thumbnail and the
+ * lightbox both use, so opening the lightbox on an already-visible image
+ * resolves from the warm cache (a fast IndexedDB read, no network refetch).
+ *
+ * Shared by the inline thumbnail ({@link ImageFromRef}) and the lightbox so the
+ * two never drift on caching / fetch behaviour.
+ */
+export type ImageSrcState = { kind: "loading" } | { kind: "hit"; src: string } | { kind: "miss" };
+
+export function useImageSrc(imageId: string | undefined): ImageSrcState {
+  const [state, setState] = useState<ImageSrcState>({ kind: "loading" });
+
+  useEffect(() => {
+    if (!imageId) {
+      setState({ kind: "miss" });
+      return;
+    }
+    let cancelled = false;
+    setState({ kind: "loading" });
+    (async () => {
+      const hit = await getImage(imageId);
+      if (cancelled) return;
+      if (hit) {
+        setState({ kind: "hit", src: `data:${hit.mimeType};base64,${hit.base64}` });
+        return;
+      }
+      try {
+        const fetched = await fetchAttachmentBase64(imageId);
+        if (cancelled) return;
+        // Warm the cache for subsequent renders; best-effort.
+        putImage({ imageId, base64: fetched.base64, mimeType: fetched.mimeType }).catch(() => {});
+        setState({ kind: "hit", src: `data:${fetched.mimeType};base64,${fetched.base64}` });
+      } catch {
+        if (!cancelled) setState({ kind: "miss" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [imageId]);
+
+  return state;
+}

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -39,6 +39,7 @@ const agentMocks = vi.hoisted(() => ({
 }));
 
 const attachmentMocks = vi.hoisted(() => ({
+  downloadAttachment: vi.fn(),
   fetchAttachmentBase64: vi.fn(),
   uploadAttachment: vi.fn(),
   uploadImageAttachment: vi.fn(),
@@ -2059,6 +2060,34 @@ describe("ChatView", () => {
     expect(container.textContent).toContain("worktrees/build-tree");
     // A genuine external link in the same message still renders as an anchor.
     expect(anchorHrefs).toContain("https://example.com/guide");
+
+    await act(async () => root.unmount());
+  });
+
+  it("opens the image lightbox on thumbnail click and closes on Escape", async () => {
+    // BASE_MESSAGES' msg-3 is a one-image message ("preview.png").
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />);
+    const thumb = () => container.querySelector<HTMLButtonElement>('button[aria-label="Open image preview.png"]');
+    await waitForCondition(() => thumb() !== null, "image thumbnail did not render");
+
+    await click(thumb());
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.querySelector('img[alt="preview.png"]')).not.toBeNull();
+    expect(dialog?.querySelector('button[aria-label="Download original"]')).not.toBeNull();
+    expect(dialog?.querySelector('button[aria-label="Close"]')).not.toBeNull();
+    // Single image: no prev/next paging affordances.
+    expect(dialog?.querySelector('button[aria-label="Next image"]')).toBeNull();
+
+    // Radix listens for Escape on document; this closes the lightbox.
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    await waitForCondition(
+      () => document.querySelector('[role="dialog"]') === null,
+      "lightbox did not close on Escape",
+    );
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -2092,6 +2092,23 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("bounds the image thumbnail by the message column (no fixed-px overflow on narrow/mobile)", async () => {
+    // The inline maxWidth must stay container-relative (`min(..., 100%)`), not a
+    // bare fixed cap that would override `img { max-width: 100% }` and overflow
+    // the narrow mobile message column. Layout isn't measurable in jsdom, so
+    // assert the container-aware declaration is present.
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />);
+    const thumbImg = () => container.querySelector<HTMLImageElement>('button[aria-label="Open image preview.png"] img');
+    await waitForCondition(() => thumbImg() !== null, "image thumbnail did not render");
+
+    const style = thumbImg()?.getAttribute("style") ?? "";
+    expect(style).toContain("100%");
+    expect(style).toContain("min(");
+
+    await act(async () => root.unmount());
+  });
+
   // The chat summary (`chat.description`) now renders in the pinned ChatSummary
   // between the chat header and the message stream — NOT in the right rail.
   describe("pinned summary", () => {

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -36,6 +36,7 @@ import {
   X as XIcon,
 } from "lucide-react";
 import {
+  type CSSProperties,
   memo,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
@@ -52,12 +53,7 @@ import { useSearchParams } from "react-router";
 import { getClient } from "../../../api/activity.js";
 import { chatAgentStatusQueryKey, fetchChatAgentStatuses } from "../../../api/agent-status.js";
 import { getAgentSkills } from "../../../api/agents.js";
-import {
-  downloadAttachment,
-  fetchAttachmentBase64,
-  uploadAttachment,
-  uploadMimeFor,
-} from "../../../api/attachments.js";
+import { downloadAttachment, uploadAttachment, uploadMimeFor } from "../../../api/attachments.js";
 import {
   type FileMessageContent,
   getChat,
@@ -74,7 +70,7 @@ import {
   sendChatMessage,
   sendFileMessageBatch,
 } from "../../../api/chats.js";
-import { getImage, putImage } from "../../../api/image-store.js";
+import { putImage } from "../../../api/image-store.js";
 import { cacheMessages, getCachedMessages } from "../../../api/message-store.js";
 import { getReadState, type ReadState, setReadState } from "../../../api/read-state-store.js";
 import {
@@ -122,6 +118,7 @@ import {
 } from "../../../components/slash-command-autocomplete.js";
 import { Button } from "../../../components/ui/button.js";
 import { FileChip } from "../../../components/ui/file-chip.js";
+import { ImageLightbox, type LightboxImage } from "../../../components/ui/image-lightbox.js";
 import { Markdown, type MarkdownProps } from "../../../components/ui/markdown.js";
 import { StatusGlyph } from "../../../components/ui/status-glyph.js";
 import { UnreadDivider } from "../../../components/unread-divider.js";
@@ -137,6 +134,7 @@ import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-nam
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { useChatDraftText } from "../../../lib/use-chat-draft-text.js";
 import { useClientMap } from "../../../lib/use-client-map.js";
+import { useImageSrc } from "../../../lib/use-image-src.js";
 import { useOrgAgents } from "../../../lib/use-org-agents.js";
 import { usePendingAttachments } from "../../../lib/use-pending-attachments.js";
 import { cn } from "../../../lib/utils.js";
@@ -757,13 +755,9 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
           rehypePlugins={messageRehypePlugins}
         />
       ) : msg.format === "file" && isInlineImageContent(msg.content) ? (
-        <img
-          src={`data:${msg.content.mimeType};base64,${msg.content.data}`}
-          alt={msg.content.filename ?? "image"}
-          style={{ maxWidth: 320, borderRadius: "var(--radius-panel)", marginTop: 4 }}
-        />
+        <InlineImage content={msg.content} />
       ) : msg.format === "file" && isImageRefContent(msg.content) ? (
-        <ImageFromRef content={msg.content} />
+        <StandaloneImageRef content={msg.content} />
       ) : msg.format === "text" || msg.format === "markdown" || msg.format === "request" ? (
         // A `request` ("ask") renders as a normal message — just its markdown
         // body. The answering surface is the AskTakeover overlay; the timeline
@@ -1049,48 +1043,68 @@ function isInlineImageContent(content: unknown): content is FileMessageContent {
 }
 
 /**
- * Render an image referenced by `{imageId}`. The per-browser IndexedDB cache
- * is consulted first (sender's own sends warm it on send); on a miss the bytes
- * are fetched from the org attachment store and the cache is warmed for next
- * time. Only a failed fetch (deleted attachment / network) falls through to
- * the placeholder.
+ * Chat-image thumbnail styling.
+ *
+ * - `standalone` (a single-image message): shown at its natural aspect within
+ *   a width AND height cap, so a tall image no longer runs the full column.
+ * - `gallery` (a multi-image batch): aligned to one common row height so mixed
+ *   aspect ratios read as one tidy row — the fix for the old `flex` default
+ *   `align-items: stretch`, which stretched every sibling to the tallest one.
+ *
+ * Neither variant upscales past the source; both open the lightbox on click.
  */
-function ImageFromRef({ content }: { content: ImageRefContent }) {
-  const [state, setState] = useState<{ kind: "loading" } | { kind: "hit"; src: string } | { kind: "miss" }>({
-    kind: "loading",
-  });
+const STANDALONE_IMG_STYLE = {
+  maxWidth: 400,
+  maxHeight: 360,
+  borderRadius: "var(--radius-panel)",
+  cursor: "zoom-in",
+  display: "block",
+} satisfies CSSProperties;
+const GALLERY_IMG_STYLE = {
+  height: 172,
+  width: "auto",
+  maxWidth: 460,
+  objectFit: "cover",
+  borderRadius: "var(--radius-panel)",
+  cursor: "zoom-in",
+  display: "block",
+} satisfies CSSProperties;
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const hit = await getImage(content.imageId);
-      if (cancelled) return;
-      if (hit) {
-        setState({ kind: "hit", src: `data:${hit.mimeType};base64,${hit.base64}` });
-        return;
-      }
-      try {
-        const fetched = await fetchAttachmentBase64(content.imageId);
-        if (cancelled) return;
-        // Warm the cache for subsequent renders; best-effort.
-        putImage({ imageId: content.imageId, base64: fetched.base64, mimeType: fetched.mimeType }).catch(() => {});
-        setState({ kind: "hit", src: `data:${fetched.mimeType};base64,${fetched.base64}` });
-      } catch {
-        if (!cancelled) setState({ kind: "miss" });
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [content.imageId]);
+/**
+ * Clickable thumbnail for an image referenced by `{imageId}`. Bytes resolve
+ * via {@link useImageSrc} (IndexedDB cache first, then the org attachment
+ * store, warming the cache) — the sender's own sends and any already-rendered
+ * thumbnail keep it warm, so the click-through to the lightbox is instant. A
+ * failed fetch (deleted attachment / network) falls through to a placeholder.
+ * The owning wrapper (standalone or batch) holds the lightbox and is notified
+ * via `onOpen`.
+ */
+function ImageFromRef({
+  content,
+  variant,
+  onOpen,
+}: {
+  content: ImageRefContent;
+  variant: "standalone" | "gallery";
+  onOpen: () => void;
+}) {
+  const state = useImageSrc(content.imageId);
 
   if (state.kind === "hit") {
     return (
-      <img
-        src={state.src}
-        alt={content.filename}
-        style={{ maxWidth: 320, borderRadius: "var(--radius-panel)", marginTop: 4 }}
-      />
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={`Open image ${content.filename}`}
+        className="block border-none bg-transparent p-0"
+        style={{ marginTop: variant === "standalone" ? 4 : 0 }}
+      >
+        <img
+          src={state.src}
+          alt={content.filename}
+          style={variant === "standalone" ? STANDALONE_IMG_STYLE : GALLERY_IMG_STYLE}
+        />
+      </button>
     );
   }
   if (state.kind === "miss") {
@@ -1108,10 +1122,49 @@ function ImageFromRef({ content }: { content: ImageRefContent }) {
 }
 
 /**
+ * A single-image `{imageId}` message: the thumbnail plus its own lightbox.
+ */
+function StandaloneImageRef({ content }: { content: ImageRefContent }) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const images: LightboxImage[] = [{ imageId: content.imageId, filename: content.filename }];
+  return (
+    <>
+      <ImageFromRef content={content} variant="standalone" onOpen={() => setOpenIndex(0)} />
+      <ImageLightbox images={images} index={openIndex} onIndexChange={setOpenIndex} />
+    </>
+  );
+}
+
+/**
+ * A single inline base64 image message (no attachment row): the thumbnail plus
+ * its own lightbox. Download in the lightbox saves the `data:` URL directly.
+ */
+function InlineImage({ content }: { content: FileMessageContent }) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const filename = content.filename ?? "image";
+  const dataSrc = `data:${content.mimeType};base64,${content.data}`;
+  const images: LightboxImage[] = [{ dataSrc, filename }];
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpenIndex(0)}
+        aria-label={`Open image ${filename}`}
+        className="block border-none bg-transparent p-0"
+        style={{ marginTop: 4 }}
+      >
+        <img src={dataSrc} alt={filename} style={STANDALONE_IMG_STYLE} />
+      </button>
+      <ImageLightbox images={images} index={openIndex} onIndexChange={setOpenIndex} />
+    </>
+  );
+}
+
+/**
  * Render a batched image message: optional caption rendered as markdown
  * (matching the regular text path so mention chips and links look the
- * same), followed by each attachment via {@link ImageFromRef}. One bubble
- * per send, regardless of how many images the user attached.
+ * same), then the images as a tidy equal-height gallery. One bubble per send,
+ * one shared lightbox that pages through the batch.
  */
 function ImageBatchFromRef({
   content,
@@ -1123,6 +1176,14 @@ function ImageBatchFromRef({
   rehypePlugins: MarkdownProps["rehypePlugins"];
 }) {
   const caption = content.caption?.trim() ?? "";
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const images: LightboxImage[] = content.attachments.map((att) => ({
+    imageId: att.imageId,
+    filename: att.filename,
+  }));
+  // A batch of one (the composer sends even a single image this way) reads as a
+  // single image, not a lone gallery tile: show it at the larger standalone size.
+  const only = content.attachments.length === 1 ? content.attachments[0] : undefined;
   return (
     <div className="flex flex-col" style={{ gap: 4 }}>
       {caption.length > 0 ? (
@@ -1130,11 +1191,16 @@ function ImageBatchFromRef({
           {caption}
         </Markdown>
       ) : null}
-      <div className="flex flex-wrap" style={{ gap: 6, marginTop: caption.length > 0 ? 2 : 0 }}>
-        {content.attachments.map((att) => (
-          <ImageFromRef key={att.imageId} content={att} />
-        ))}
-      </div>
+      {only ? (
+        <ImageFromRef content={only} variant="standalone" onOpen={() => setOpenIndex(0)} />
+      ) : (
+        <div className="flex flex-wrap items-start" style={{ gap: 6, marginTop: caption.length > 0 ? 2 : 0 }}>
+          {content.attachments.map((att, i) => (
+            <ImageFromRef key={att.imageId} content={att} variant="gallery" onOpen={() => setOpenIndex(i)} />
+          ))}
+        </div>
+      )}
+      <ImageLightbox images={images} index={openIndex} onIndexChange={setOpenIndex} />
     </div>
   );
 }

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1051,10 +1051,15 @@ function isInlineImageContent(content: unknown): content is FileMessageContent {
  *   aspect ratios read as one tidy row — the fix for the old `flex` default
  *   `align-items: stretch`, which stretched every sibling to the tallest one.
  *
- * Neither variant upscales past the source; both open the lightbox on click.
+ * The width caps are `min(<desktop cap>, 100%)` so they never exceed the
+ * (narrow, on mobile) message column — an inline `maxWidth` would otherwise
+ * override the responsive `img { max-width: 100% }` preflight and overflow the
+ * shared mobile chat surface. Neither variant upscales past the source; both
+ * open the lightbox on click. The wrapping button carries `minWidth: 0` so a
+ * gallery flex item can shrink below its intrinsic width on a narrow column.
  */
 const STANDALONE_IMG_STYLE = {
-  maxWidth: 400,
+  maxWidth: "min(25rem, 100%)",
   maxHeight: 360,
   borderRadius: "var(--radius-panel)",
   cursor: "zoom-in",
@@ -1063,7 +1068,7 @@ const STANDALONE_IMG_STYLE = {
 const GALLERY_IMG_STYLE = {
   height: 172,
   width: "auto",
-  maxWidth: 460,
+  maxWidth: "min(28.75rem, 100%)",
   objectFit: "cover",
   borderRadius: "var(--radius-panel)",
   cursor: "zoom-in",
@@ -1097,7 +1102,9 @@ function ImageFromRef({
         onClick={onOpen}
         aria-label={`Open image ${content.filename}`}
         className="block border-none bg-transparent p-0"
-        style={{ marginTop: variant === "standalone" ? 4 : 0 }}
+        // `minWidth: 0` lets a gallery flex item shrink below the image's
+        // intrinsic width on a narrow column instead of overflowing.
+        style={{ marginTop: variant === "standalone" ? 4 : 0, maxWidth: "100%", minWidth: 0 }}
       >
         <img
           src={state.src}
@@ -1151,7 +1158,7 @@ function InlineImage({ content }: { content: FileMessageContent }) {
         onClick={() => setOpenIndex(0)}
         aria-label={`Open image ${filename}`}
         className="block border-none bg-transparent p-0"
-        style={{ marginTop: 4 }}
+        style={{ marginTop: 4, maxWidth: "100%", minWidth: 0 }}
       >
         <img src={dataSrc} alt={filename} style={STANDALONE_IMG_STYLE} />
       </button>


### PR DESCRIPTION
## Problem

Inline chat images set only `maxWidth: 320`, with no height cap and no alignment control. Two visible defects:

- **Multi-image batches stretch/distort.** The gallery is a `flex flex-wrap` row, which defaults to `align-items: stretch`, so every image is stretched vertically to the tallest one. Measured: a 150×150 image rendered as **150×800**, a 600×600 as **320×800**.
- **A tall single image runs the full column** (400×1000 → 320×800), dominating the viewport, and there was **no way to see an image at full size**.

## Change

- **Single image** — shown at natural aspect within a width *and* height cap (no upscaling past source).
- **Multi-image batch** — a tidy **equal-height gallery** (preserves aspect, no stretch, no ragged sizing); a batch of one renders at the standalone size.
- **Click-to-zoom lightbox** — click any image to open a full-screen viewer built on the Radix Dialog primitive (Escape / focus-trap / scroll-lock for free): fits the viewport, **close** (X / Esc / backdrop) + **download original**, and **prev / next paging with a counter** for batches. Mobile inherits it via the shared chat surface (safe-area insets, translucent-dark control chips legible over any image, `focus-visible` rings).

New shared pieces: `useImageSrc` (cache→fetch image resolution, extracted so the thumbnail and lightbox never drift) and the `ImageLightbox` component. No schema/API changes.

## Testing

- `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens`) — clean.
- `pnpm --filter @first-tree/web test` — **1417 passed** (adds a chat-view-dom test for the lightbox open/close interaction).
- Biome — clean.
- Real-browser QA (Chrome, light + dark, against real chat data): confirmed the 150×150 now renders 172×172 (was 150×800), equal-height gallery, single-image standalone sizing, and lightbox open / fit / download / prev-next / counter / Escape-close.
- Two independent code reviews (correctness + design/a11y); their findings (download-anchor reliability, control-chip contrast, focus rings, safe-area insets, non-interactive counter, aria-live) are folded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
