### PR TITLE
fix(web): strip markdown from mobile card previews + honest install-guide copy

### DIFF
--- a/packages/web/src/pages/mobile/__tests__/data.test.ts
+++ b/packages/web/src/pages/mobile/__tests__/data.test.ts
@@ -4,6 +4,7 @@ import {
   countAttentionRows,
   countUnreadRows,
   isNowFeedRow,
+  mobileChatPreview,
   mobileChatSignal,
   mobileFeedReasonLabel,
   sortMobileChats,
@@ -145,5 +146,30 @@ describe("isNowFeedRow (needs-attention admission)", () => {
     // unreadMentionCount also counts the implicit 1:1 DM auto-mention; only an
     // explicit @me qualifies.
     expect(isNowFeedRow(chatRow({ unreadMentionCount: 3, chatHasExplicitMentionToMe: false }))).toBe(false);
+  });
+});
+
+describe("mobileChatPreview", () => {
+  it("peels inline markdown so the card preview shows plain text", () => {
+    const preview = mobileChatPreview(
+      chatRow({ description: "**Task:** Build the tree from scratch (`first-tree-seed`)." }),
+    );
+    expect(preview).toBe("Task: Build the tree from scratch (first-tree-seed).");
+    expect(preview).not.toContain("**");
+    expect(preview).not.toContain("`");
+  });
+
+  it("prefers description, falls back to lastMessagePreview, then a placeholder", () => {
+    expect(mobileChatPreview(chatRow({ description: "  hello  ", lastMessagePreview: "later" }))).toBe("hello");
+    expect(mobileChatPreview(chatRow({ description: null, lastMessagePreview: "`only` this" }))).toBe("only this");
+    expect(mobileChatPreview(chatRow({ description: null, lastMessagePreview: "" }))).toBe("No messages yet.");
+  });
+
+  it("shows the placeholder when a markup-only preview strips to empty", () => {
+    // lastMessagePreview is stored verbatim server-side, so an image-only
+    // message arrives as `![](url)`, which strips to "" — must not render blank.
+    expect(mobileChatPreview(chatRow({ description: null, lastMessagePreview: "![](https://x/y.png)" }))).toBe(
+      "No messages yet.",
+    );
   });
 });

--- a/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
@@ -185,4 +185,26 @@ describe("mobile density tiers", () => {
     expect(listCard.querySelector("[data-mobile-card-title]")?.className).toContain("text-mobile-subtitle");
     expect(harness.container.querySelector('[data-mobile-card="feed"]')).toBeNull();
   });
+
+  it("renders card previews with inline markdown peeled, not as literal markers", async () => {
+    meChatMocks.listMeChats.mockReset();
+    meChatMocks.listMeChats.mockResolvedValue({
+      rows: [
+        chatRow({
+          chatId: "md",
+          title: "Markdown preview",
+          openRequestCount: 1,
+          description: "**Task:** run the seed (`first-tree-seed`)",
+        }),
+      ],
+      nextCursor: null,
+    });
+    renderWithClient(harness, <MobileNowPage />, "/m/now");
+    await harness.waitFor(() => expect(harness.container.textContent).toContain("Markdown preview"));
+
+    const preview = harness.container.querySelector("[data-mobile-card-preview]");
+    expect(preview?.textContent).toBe("Task: run the seed (first-tree-seed)");
+    expect(preview?.textContent).not.toContain("**");
+    expect(preview?.textContent).not.toContain("`");
+  });
 });

--- a/packages/web/src/pages/mobile/__tests__/install-guide-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/install-guide-dom.test.tsx
@@ -29,6 +29,10 @@ describe("InstallGuideSheet", () => {
     const sheet = harness.container.querySelector('[data-mobile-install-sheet="true"]');
     expect(sheet?.textContent).toContain("Add First Tree to your home screen");
     expect(sheet?.textContent).toContain("Opens instantly");
+    // The benefits are one shared list across all install modes, so it must not
+    // promise "no signing in again" — false on iOS, where an installed PWA runs
+    // in a storage partition separate from Safari and needs one sign-in.
+    expect(sheet?.textContent).not.toContain("signing in again");
     // Native mode is one-tap, not a step list.
     expect(sheet?.textContent).not.toContain("Share button");
 

--- a/packages/web/src/pages/mobile/data.ts
+++ b/packages/web/src/pages/mobile/data.ts
@@ -1,4 +1,5 @@
 import type { MeChatRow } from "@first-tree/shared";
+import { stripInlineMarkdown } from "../../lib/strip-inline-markdown.js";
 import { rowAttentionReason } from "../workspace/conversations/group-rows.js";
 
 export type MobileChatSignalTone = "needs-you" | "error" | "unread" | "working" | "idle";
@@ -54,7 +55,13 @@ export function mobileChatSignal(row: MeChatRow): MobileChatSignal {
 }
 
 export function mobileChatPreview(row: MeChatRow): string {
-  return row.description?.trim() || row.lastMessagePreview?.trim() || "No messages yet.";
+  const raw = row.description?.trim() || row.lastMessagePreview?.trim();
+  // Card previews are a one-line glance, not a rendered surface: peel inline
+  // markdown so `**Task:**` / `` `code` `` don't leak their literal markers.
+  // Fall back on the *stripped* value — a preview that is only markup (e.g. an
+  // `![](url)` image) strips to empty and must show the placeholder, not blank.
+  const stripped = raw ? stripInlineMarkdown(raw) : "";
+  return stripped || "No messages yet.";
 }
 
 export function mobileFeedReasonLabel(row: MeChatRow): string {

--- a/packages/web/src/pages/mobile/install-guide-sheet.tsx
+++ b/packages/web/src/pages/mobile/install-guide-sheet.tsx
@@ -4,7 +4,7 @@ import { Button } from "../../components/ui/button.js";
 import type { InstallGuideMode } from "./use-install-guide.js";
 
 const BENEFITS = [
-  "Opens instantly — no hunting for the link or signing in again",
+  "Opens instantly — no hunting for the link",
   "Full screen — no browser address bar in the way",
 ] as const;
 


### PR DESCRIPTION
## What

Two small, independent mobile UX fixes found during a full staging E2E pass of the mobile surface (each its own commit).

### 1. Strip inline markdown from card previews
The Now feed and Chat list card previews rendered `description` / `lastMessagePreview` verbatim, leaking literal markdown markers (`**Task:**`, backticks) into the one-line glance. Now they run through the existing `stripInlineMarkdown` helper (already used by the compose status bar, resource snippets, and chat summary).

- Falls back on the **stripped** value: a preview that is only markup (e.g. an `![](url)` image, which the server stores verbatim in `lastMessagePreview`) strips to empty and must show the `"No messages yet."` placeholder, not a blank line.
- Guards both the pure `mobileChatPreview` function and the rendered card DOM path.

### 2. Drop false "no signing in again" install-guide claim
The add-to-home-screen sheet promised *"Opens instantly — no hunting for the link or signing in again"*. That benefit list is shared across all install modes, and the claim is **false on iOS**: an installed standalone PWA runs in a storage partition separate from Safari, so the session token doesn't carry over and the user signs in once. Dropped the "or signing in again" clause so the copy is honest on every platform.

## Verification

- `pnpm --filter @first-tree/web test` → **1422 passed** (added: preview stripping + strip-to-empty fallback + render-path guard + install-copy assertion). `biome`, `tsc`, `lint:tokens` clean.
- **Real browser**: ran my local build against staging data at iPhone viewport — confirmed Now/Chat previews render stripped (no `**`/backticks) and the install sheet no longer says "signing in again", 0 console errors.
- Two independent reviews; the first caught a strip-to-empty→blank-card regression in the initial version, now fixed and tested.

## Scope

Both are pre-existing issues, independent of the mobile prod-channel rollout (#1754). Not touched: the shared message renderer (heading rendering, wide-code-block overflow) — those are product-wide and belong in a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
