### PR TITLE
refactor(web): distribute Team computers audit into width-filling columns

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1934,7 +1934,10 @@
 .team-computers-table thead th {
   border-bottom: var(--hairline) solid var(--border-faint);
 }
-.team-computers-table tbody tr:first-child {
+/* Only the very first row-group's first row skips the separator (its top edge
+   is the header's bottom border); later `<tbody>` groups keep the top border so
+   there's a hairline above each "Ready" / "Needs attention" divider. */
+.team-computers-table tbody:first-of-type tr:first-child {
   border-top: 0;
 }
 .team-computer-row {
@@ -1943,8 +1946,9 @@
 .team-computer-row:hover {
   background-color: var(--bg-hover);
 }
-.team-group-row td {
+.team-group-row th {
   padding: 0;
+  font-weight: inherit;
 }
 /* `__meta` is the owner · OS · version line under the hostname, used only on a
    narrow container (below) where those columns collapse. */
@@ -1972,9 +1976,11 @@
     align-items: center;
     padding: var(--sp-2_5) var(--sp-3_5);
   }
+  /* Clear the base cell padding entirely on the reflowed grid rows — the row
+     itself carries the padding, so keeping it on the cells too would double the
+     vertical rhythm and bloat each stacked row. */
   .team-computers-table tr.team-computer-row > * {
-    padding-left: 0;
-    padding-right: 0;
+    padding: 0;
   }
   .team-computers-table tr.team-group-row {
     display: block;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1867,33 +1867,75 @@
   border-top: var(--hairline) solid var(--border-faint);
 }
 
-/* Team computers audit list (admin) — a grouped data table that fills the
-   Settings content width via distributed columns
-   (Hostname | Owner | OS | First Tree | Agents | Status), with a hairline
-   between every row / group-header and a neutral hover. The health split is
-   carried by row order + the "Needs attention" group header + each row's
-   status pill, not a full-row color wash.
+/* Team computers audit table (admin) — a semantic <table> whose distributed
+   columns (Hostname | Owner | OS | First Tree | Agents | Status) fill the
+   Settings content width, with a hairline between rows and a neutral hover.
+   The health split is carried by row order + the "Needs attention" group row
+   + each row's status pill, not a full-row color wash.
 
-   Width strategy: Hostname is the only elastic column (minmax(0,1fr)) so long
-   names absorb the slack and short names leave no mid-row void; Owner is
-   capped + truncates; OS / First Tree / Agents are fixed (content-bounded);
-   Status is fixed to its worst case ("Offline · N days" / "Setup incomplete").
-   Agents + Status right-align. */
+   Width strategy (table-layout: fixed): Hostname is the only column left
+   auto-width, so it absorbs the slack — long names truncate, short ones leave
+   no mid-row void. Owner is capped + truncates; OS / First Tree / Agents are
+   fixed (content-bounded); Status is fixed to its worst case ("Offline · N
+   days" / "Setup incomplete"). Agents + Status right-align. */
 .team-computers-list {
   /* Query the list's own width (not the viewport): the Settings nav eats
-     width, so the list can be narrow even on a wide screen. */
+     width, so the table can be narrow even on a wide screen. */
   container-type: inline-size;
 }
-.team-computers-list > * + * {
+.team-computers-table {
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+}
+.team-computers-table th,
+.team-computers-table td {
+  padding: var(--sp-2_5) var(--sp-3_5);
+  text-align: left;
+  vertical-align: middle;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Column widths — set on the header cells; the unspecified Hostname column
+   takes the remaining space under table-layout: fixed. */
+.team-computers-table th:nth-child(2) {
+  width: 11rem;
+}
+.team-computers-table th:nth-child(3) {
+  width: 5rem;
+}
+.team-computers-table th:nth-child(4) {
+  width: 6rem;
+}
+.team-computers-table th:nth-child(5) {
+  width: 5.5rem;
+}
+.team-computers-table th:nth-child(6) {
+  /* Wide enough for the worst-case status incl. padding:
+     "Offline · N days" / "Setup incomplete". */
+  width: 10rem;
+}
+.team-computers-table thead th {
+  color: var(--fg-3);
+}
+.team-cell--num {
+  text-align: right;
+}
+.team-cell--status .inline-flex {
+  justify-content: flex-end;
+}
+/* Hairline between rows; the first body row's separator is the header's
+   bottom edge, so skip it (and it keeps the narrow layout — thead hidden —
+   flush at the top). */
+.team-computers-table tbody tr {
   border-top: var(--hairline) solid var(--border-faint);
 }
-.team-computers-header,
-.team-computer-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 11rem) 5rem 6rem 5.5rem 8.5rem;
-  align-items: center;
-  column-gap: var(--sp-3_5);
-  padding: var(--sp-2_5) var(--sp-3_5);
+.team-computers-table thead th {
+  border-bottom: var(--hairline) solid var(--border-faint);
+}
+.team-computers-table tbody tr:first-child {
+  border-top: 0;
 }
 .team-computer-row {
   transition: background-color 120ms ease-out;
@@ -1901,35 +1943,41 @@
 .team-computer-row:hover {
   background-color: var(--bg-hover);
 }
+.team-group-row td {
+  padding: 0;
+}
 /* `__meta` is the owner · OS · version line under the hostname, used only on a
    narrow container (below) where those columns collapse. */
 .team-computer-row__meta {
   display: none;
 }
-/* Narrow container (mobile / cramped Settings): drop the owner / OS / version
-   columns and reflow them under the hostname as the meta line; keep Hostname
-   (elastic) | Agents | Status with intrinsic trailing tracks so the identity
-   column never collapses.
-
-   Breakpoint math: the five non-hostname columns + gaps + padding sum to
-   ~42rem, and grid fills those finite tracks (incl. the `minmax(0,11rem)`
-   owner) to their caps *before* the `1fr` hostname gets any width. So the
-   columns only earn their keep once the container clears that sum plus a
-   comfortable hostname floor — switch to the stacked layout below ~52rem
-   rather than let the primary identity column collapse to a sliver. */
+/* Narrow container (mobile / cramped Settings): reflow the table — hide the
+   column header, drop the owner / OS / version cells, and let owner/OS/version
+   fall back under the hostname as the meta line. Data rows become a 3-track
+   grid (Hostname elastic | Agents | Status) so the identity column never
+   collapses. Breakpoint ~52rem clears the fixed-column budget (~42rem) plus a
+   comfortable hostname floor before the columns are allowed to render. */
 @container (max-width: 52rem) {
-  .team-computers-header {
+  .team-computers-table,
+  .team-computers-table tbody {
+    display: block;
+  }
+  .team-computers-table thead {
     display: none;
   }
-  /* The hidden header still occupies a DOM slot, so the `> * + *` separator
-     would paint a stray hairline above the first *visible* element. Cancel it
-     so the narrow list's top edge stays flush like the wide one. */
-  .team-computers-header + * {
-    border-top: 0;
-  }
-  .team-computer-row {
+  .team-computers-table tr.team-computer-row {
+    display: grid;
     grid-template-columns: minmax(0, 1fr) auto auto;
     column-gap: var(--sp-2_5);
+    align-items: center;
+    padding: var(--sp-2_5) var(--sp-3_5);
+  }
+  .team-computers-table tr.team-computer-row > * {
+    padding-left: 0;
+    padding-right: 0;
+  }
+  .team-computers-table tr.team-group-row {
+    display: block;
   }
   .team-computer-row__col-owner,
   .team-computer-row__col-os,

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1867,37 +1867,77 @@
   border-top: var(--hairline) solid var(--border-faint);
 }
 
-/* Team computers audit list (admin) — compact grouped rows with a hairline
-   between every row/group-header and a neutral hover. The health split is
+/* Team computers audit list (admin) — a grouped data table that fills the
+   Settings content width via distributed columns
+   (Hostname | Owner | OS | First Tree | Agents | Status), with a hairline
+   between every row / group-header and a neutral hover. The health split is
    carried by row order + the "Needs attention" group header + each row's
-   status pill, not a full-row color wash. */
+   status pill, not a full-row color wash.
+
+   Width strategy: Hostname is the only elastic column (minmax(0,1fr)) so long
+   names absorb the slack and short names leave no mid-row void; Owner is
+   capped + truncates; OS / First Tree / Agents are fixed (content-bounded);
+   Status is fixed to its worst case ("Offline · N days" / "Setup incomplete").
+   Agents + Status right-align. */
 .team-computers-list {
   /* Query the list's own width (not the viewport): the Settings nav eats
-     width, so a row can be narrow even on a wide screen. */
+     width, so the list can be narrow even on a wide screen. */
   container-type: inline-size;
 }
 .team-computers-list > * + * {
   border-top: var(--hairline) solid var(--border-faint);
 }
+.team-computers-header,
 .team-computer-row {
   display: grid;
-  /* identity | agents | status. Fixed trailing tracks keep the agent counts
-     and status pills column-aligned across rows when there's room. */
-  grid-template-columns: minmax(0, 1fr) var(--sp-20) var(--sp-45);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 11rem) 5rem 6rem 5.5rem 8.5rem;
   align-items: center;
-  column-gap: var(--sp-3);
+  column-gap: var(--sp-3_5);
   padding: var(--sp-2_5) var(--sp-3_5);
+}
+.team-computer-row {
   transition: background-color 120ms ease-out;
 }
 .team-computer-row:hover {
   background-color: var(--bg-hover);
 }
-/* Narrow list (mobile / cramped Settings): drop the fixed trailing tracks to
-   intrinsic width so the hostname/meta identity column never collapses. */
-@container (max-width: 34rem) {
+/* `__meta` is the owner · OS · version line under the hostname, used only on a
+   narrow container (below) where those columns collapse. */
+.team-computer-row__meta {
+  display: none;
+}
+/* Narrow container (mobile / cramped Settings): drop the owner / OS / version
+   columns and reflow them under the hostname as the meta line; keep Hostname
+   (elastic) | Agents | Status with intrinsic trailing tracks so the identity
+   column never collapses.
+
+   Breakpoint math: the five non-hostname columns + gaps + padding sum to
+   ~42rem, and grid fills those finite tracks (incl. the `minmax(0,11rem)`
+   owner) to their caps *before* the `1fr` hostname gets any width. So the
+   columns only earn their keep once the container clears that sum plus a
+   comfortable hostname floor — switch to the stacked layout below ~52rem
+   rather than let the primary identity column collapse to a sliver. */
+@container (max-width: 52rem) {
+  .team-computers-header {
+    display: none;
+  }
+  /* The hidden header still occupies a DOM slot, so the `> * + *` separator
+     would paint a stray hairline above the first *visible* element. Cancel it
+     so the narrow list's top edge stays flush like the wide one. */
+  .team-computers-header + * {
+    border-top: 0;
+  }
   .team-computer-row {
     grid-template-columns: minmax(0, 1fr) auto auto;
     column-gap: var(--sp-2_5);
+  }
+  .team-computer-row__col-owner,
+  .team-computer-row__col-os,
+  .team-computer-row__col-ver {
+    display: none;
+  }
+  .team-computer-row__meta {
+    display: block;
   }
 }
 

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -656,6 +656,7 @@ function TeamComputersList({
       className="team-computers-list"
       style={{ marginLeft: "calc(-1 * var(--sp-3_5))", marginRight: "calc(-1 * var(--sp-3_5))" }}
     >
+      <TeamColumnHeader />
       {grouped && <TeamGroupHeader label="Needs attention" count={attention.length} attention />}
       {attention.map((client) => (
         <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
@@ -664,6 +665,26 @@ function TeamComputersList({
       {ready.map((client) => (
         <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
       ))}
+    </div>
+  );
+}
+
+/**
+ * Column headers for the audit table — flat sentence-case labels (matching the
+ * DenseTable convention). Distributes owner / OS / version into their own
+ * columns so the row fills the Settings content width instead of leaving a
+ * mid-row void. Hidden on a narrow container, where rows reflow to a stacked
+ * hostname + meta line (see the `@container` rule in index.css).
+ */
+function TeamColumnHeader() {
+  return (
+    <div className="team-computers-header text-label" style={{ color: "var(--fg-3)" }}>
+      <span>Hostname</span>
+      <span>Owner</span>
+      <span>OS</span>
+      <span>First Tree</span>
+      <span style={{ textAlign: "right" }}>Agents</span>
+      <span style={{ textAlign: "right" }}>Status</span>
     </div>
   );
 }
@@ -716,6 +737,8 @@ function updateProblemView(client: HubClient): { label: string; color: string; t
   return null;
 }
 
+const ELLIPSIS: React.CSSProperties = { overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" };
+
 function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel: { text: string; title?: string } }) {
   const status = deriveComputerStatus(client);
   const version = client.sdkVersion;
@@ -726,31 +749,43 @@ function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel
   // status only for offline machines, where "how long" is the actionable bit.
   const offlineFor = status.pill === "offline" ? formatOfflineDuration(client.lastSeenAt) : null;
   const agentCount = client.agentCount;
+  // Owner · OS · version, shown *only* on a narrow container where the owner /
+  // OS / version columns collapse — reflows them back under the hostname (the
+  // shipped mobile-friendly layout) so the identity column never gets starved.
+  // `title` carries the full (un-truncated, full-build-version) meta so a
+  // narrow viewer can still recover it on hover, matching the desktop columns.
+  const metaSegments = [ownerLabel.text, client.os, version ? shortVersion(version) : null].filter(Boolean);
+  const metaTitle = [ownerLabel.text, client.os, version].filter(Boolean).join(" · ");
   return (
     <div className="team-computer-row">
       <div style={{ minWidth: 0 }}>
-        <div
-          className="mono text-subtitle"
-          style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
-          title={client.hostname ?? undefined}
-        >
+        <div className="mono text-subtitle" style={ELLIPSIS} title={client.hostname ?? undefined}>
           {client.hostname ?? "—"}
         </div>
         <div
-          className="text-caption"
-          style={{ color: "var(--fg-3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+          className="team-computer-row__meta text-caption"
+          style={{ color: "var(--fg-3)", ...ELLIPSIS }}
+          title={metaTitle}
         >
-          <span title={ownerLabel.title}>{ownerLabel.text}</span>
-          {client.os ? ` · ${client.os}` : ""}
-          {version ? (
-            <>
-              {" · "}
-              <span className="mono" title={version}>
-                {shortVersion(version)}
-              </span>
-            </>
-          ) : null}
+          {metaSegments.join(" · ")}
         </div>
+      </div>
+      <div
+        className="team-computer-row__col-owner text-body"
+        style={{ color: "var(--fg-2)", ...ELLIPSIS }}
+        title={ownerLabel.title}
+      >
+        {ownerLabel.text}
+      </div>
+      <div className="team-computer-row__col-os text-body" style={{ color: "var(--fg-3)", ...ELLIPSIS }}>
+        {client.os ?? "—"}
+      </div>
+      <div
+        className="team-computer-row__col-ver mono text-caption"
+        style={{ color: "var(--fg-3)", ...ELLIPSIS }}
+        title={version ?? undefined}
+      >
+        {version ? shortVersion(version) : "—"}
       </div>
       <span
         className="text-caption tnum"

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -671,32 +671,50 @@ function TeamComputersList({
             <th className="text-label team-cell--num">Status</th>
           </tr>
         </thead>
-        <tbody>
-          {grouped && <TeamGroupRow label="Needs attention" count={attention.length} attention />}
-          {attention.map((client) => (
-            <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
-          ))}
-          {grouped && ready.length > 0 && <TeamGroupRow label="Ready" count={ready.length} />}
-          {ready.map((client) => (
-            <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
-          ))}
-        </tbody>
+        {grouped ? (
+          <>
+            {/* Each health split is its own <tbody> row-group headed by a
+                `<th scope="rowgroup">`, so assistive tech ties the "Needs
+                attention" / "Ready" label to the rows under it. */}
+            <tbody>
+              <TeamGroupRow label="Needs attention" count={attention.length} attention />
+              {attention.map((client) => (
+                <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
+              ))}
+            </tbody>
+            {ready.length > 0 && (
+              <tbody>
+                <TeamGroupRow label="Ready" count={ready.length} />
+                {ready.map((client) => (
+                  <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
+                ))}
+              </tbody>
+            )}
+          </>
+        ) : (
+          <tbody>
+            {ready.map((client) => (
+              <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
+            ))}
+          </tbody>
+        )}
       </table>
     </div>
   );
 }
 
 /**
- * Group divider for the health split — a full-width `<td colSpan>` row. The
- * "Needs attention" header carries a warm `--fg-needs-you-strong` tint (the one
- * meaningful color on this audit list); "Ready" stays neutral. The row status
- * pills carry each machine's specific state hue — the group is set apart by
- * order + this header, not by a full-row color wash.
+ * Row-group header for a health split — a `<th scope="rowgroup" colSpan>` so
+ * the "Needs attention" / "Ready" label is announced as the heading for the
+ * rows in its `<tbody>`, not read as an ordinary data cell. "Needs attention"
+ * carries a warm `--fg-needs-you-strong` tint (the one meaningful color on this
+ * audit table); "Ready" stays neutral. The row status pills carry each
+ * machine's specific state hue — the group is set apart by order + this header.
  */
 function TeamGroupRow({ label, count, attention = false }: { label: string; count: number; attention?: boolean }) {
   return (
     <tr className="team-group-row">
-      <td colSpan={6}>
+      <th scope="rowgroup" colSpan={6}>
         <UppercaseLabel
           style={{
             display: "block",
@@ -706,7 +724,7 @@ function TeamGroupRow({ label, count, attention = false }: { label: string; coun
         >
           {label} · {count}
         </UppercaseLabel>
-      </td>
+      </th>
     </tr>
   );
 }
@@ -760,7 +778,16 @@ function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel
   // and this meta title fall back to it so hover always recovers the full value
   // even when the visible text is a short-id or the cell truncates).
   const ownerFull = ownerLabel.title ?? ownerLabel.text;
-  const metaSegments = [ownerLabel.text, client.os, version ? shortVersion(version) : null].filter(Boolean);
+  // Compact meta (owner · OS · version under the hostname) — each field carries
+  // a visually-hidden label so a screen reader on the reflowed narrow layout
+  // (where the labeled Owner / OS / First Tree columns collapse out of the
+  // tree) still hears "Owner: … OS: … First Tree: …" instead of three bare
+  // values. `title` recovers the full (un-truncated, full-build) meta on hover.
+  const metaParts: { label: string; value: string }[] = [
+    { label: "Owner", value: ownerLabel.text },
+    ...(client.os ? [{ label: "OS", value: client.os }] : []),
+    ...(version ? [{ label: "First Tree", value: shortVersion(version) }] : []),
+  ];
   const metaTitle = [ownerFull, client.os, version].filter(Boolean).join(" · ");
   return (
     <tr className="team-computer-row">
@@ -773,7 +800,13 @@ function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel
           style={{ color: "var(--fg-3)", ...ELLIPSIS }}
           title={metaTitle}
         >
-          {metaSegments.join(" · ")}
+          {metaParts.map((part, i) => (
+            <span key={part.label}>
+              {i > 0 ? " · " : null}
+              <span className="sr-only">{part.label}: </span>
+              {part.value}
+            </span>
+          ))}
         </div>
       </th>
       <td className="team-computer-row__col-owner text-body" style={{ color: "var(--fg-2)" }} title={ownerFull}>

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -656,57 +656,58 @@ function TeamComputersList({
       className="team-computers-list"
       style={{ marginLeft: "calc(-1 * var(--sp-3_5))", marginRight: "calc(-1 * var(--sp-3_5))" }}
     >
-      <TeamColumnHeader />
-      {grouped && <TeamGroupHeader label="Needs attention" count={attention.length} attention />}
-      {attention.map((client) => (
-        <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
-      ))}
-      {grouped && ready.length > 0 && <TeamGroupHeader label="Ready" count={ready.length} />}
-      {ready.map((client) => (
-        <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
-      ))}
+      {/* A real <table> so the six audit columns carry native header / row /
+          cell semantics; the `.team-computers-list` container-query reflows it
+          to a stacked hostname + meta line on narrow (see index.css). Flat
+          sentence-case header labels match the DenseTable convention. */}
+      <table className="team-computers-table" aria-label="Team computers">
+        <thead>
+          <tr>
+            <th className="text-label">Hostname</th>
+            <th className="text-label">Owner</th>
+            <th className="text-label">OS</th>
+            <th className="text-label">First Tree</th>
+            <th className="text-label team-cell--num">Agents</th>
+            <th className="text-label team-cell--num">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {grouped && <TeamGroupRow label="Needs attention" count={attention.length} attention />}
+          {attention.map((client) => (
+            <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
+          ))}
+          {grouped && ready.length > 0 && <TeamGroupRow label="Ready" count={ready.length} />}
+          {ready.map((client) => (
+            <TeamComputerRow key={client.id} client={client} ownerLabel={resolveOwner(client)} />
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
 
 /**
- * Column headers for the audit table — flat sentence-case labels (matching the
- * DenseTable convention). Distributes owner / OS / version into their own
- * columns so the row fills the Settings content width instead of leaving a
- * mid-row void. Hidden on a narrow container, where rows reflow to a stacked
- * hostname + meta line (see the `@container` rule in index.css).
+ * Group divider for the health split — a full-width `<td colSpan>` row. The
+ * "Needs attention" header carries a warm `--fg-needs-you-strong` tint (the one
+ * meaningful color on this audit list); "Ready" stays neutral. The row status
+ * pills carry each machine's specific state hue — the group is set apart by
+ * order + this header, not by a full-row color wash.
  */
-function TeamColumnHeader() {
+function TeamGroupRow({ label, count, attention = false }: { label: string; count: number; attention?: boolean }) {
   return (
-    <div className="team-computers-header text-label" style={{ color: "var(--fg-3)" }}>
-      <span>Hostname</span>
-      <span>Owner</span>
-      <span>OS</span>
-      <span>First Tree</span>
-      <span style={{ textAlign: "right" }}>Agents</span>
-      <span style={{ textAlign: "right" }}>Status</span>
-    </div>
-  );
-}
-
-/**
- * Group divider for the health split. The "Needs attention" header carries a
- * warm `--fg-needs-you-strong` tint (the one meaningful color on this audit
- * list); "Ready" stays neutral. The row status pills carry each machine's
- * specific state hue — the group is set apart by order + this header, not by a
- * full-row color wash.
- */
-function TeamGroupHeader({ label, count, attention = false }: { label: string; count: number; attention?: boolean }) {
-  return (
-    <UppercaseLabel
-      style={{
-        display: "block",
-        padding: "var(--sp-3) var(--sp-3_5) var(--sp-1_5)",
-        ...(attention ? { color: "var(--fg-needs-you-strong)" } : {}),
-      }}
-    >
-      {label} · {count}
-    </UppercaseLabel>
+    <tr className="team-group-row">
+      <td colSpan={6}>
+        <UppercaseLabel
+          style={{
+            display: "block",
+            padding: "var(--sp-3) var(--sp-3_5) var(--sp-1_5)",
+            ...(attention ? { color: "var(--fg-needs-you-strong)" } : {}),
+          }}
+        >
+          {label} · {count}
+        </UppercaseLabel>
+      </td>
+    </tr>
   );
 }
 
@@ -754,11 +755,16 @@ function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel
   // shipped mobile-friendly layout) so the identity column never gets starved.
   // `title` carries the full (un-truncated, full-build-version) meta so a
   // narrow viewer can still recover it on hover, matching the desktop columns.
+  // `ownerLabel.title` is the full identifier — the un-truncated resolved
+  // display name, or the full UUID when the owner can't be resolved (owner cell
+  // and this meta title fall back to it so hover always recovers the full value
+  // even when the visible text is a short-id or the cell truncates).
+  const ownerFull = ownerLabel.title ?? ownerLabel.text;
   const metaSegments = [ownerLabel.text, client.os, version ? shortVersion(version) : null].filter(Boolean);
-  const metaTitle = [ownerLabel.text, client.os, version].filter(Boolean).join(" · ");
+  const metaTitle = [ownerFull, client.os, version].filter(Boolean).join(" · ");
   return (
-    <div className="team-computer-row">
-      <div style={{ minWidth: 0 }}>
+    <tr className="team-computer-row">
+      <th scope="row" className="team-cell--id">
         <div className="mono text-subtitle" style={ELLIPSIS} title={client.hostname ?? undefined}>
           {client.hostname ?? "—"}
         </div>
@@ -769,36 +775,32 @@ function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel
         >
           {metaSegments.join(" · ")}
         </div>
-      </div>
-      <div
-        className="team-computer-row__col-owner text-body"
-        style={{ color: "var(--fg-2)", ...ELLIPSIS }}
-        title={ownerLabel.title}
-      >
+      </th>
+      <td className="team-computer-row__col-owner text-body" style={{ color: "var(--fg-2)" }} title={ownerFull}>
         {ownerLabel.text}
-      </div>
-      <div className="team-computer-row__col-os text-body" style={{ color: "var(--fg-3)", ...ELLIPSIS }}>
+      </td>
+      <td className="team-computer-row__col-os text-body" style={{ color: "var(--fg-3)" }}>
         {client.os ?? "—"}
-      </div>
-      <div
+      </td>
+      <td
         className="team-computer-row__col-ver mono text-caption"
-        style={{ color: "var(--fg-3)", ...ELLIPSIS }}
+        style={{ color: "var(--fg-3)" }}
         title={version ?? undefined}
       >
         {version ? shortVersion(version) : "—"}
-      </div>
-      <span
-        className="text-caption tnum"
-        style={{ color: agentCount > 0 ? "var(--fg-2)" : "var(--fg-4)", textAlign: "right", whiteSpace: "nowrap" }}
+      </td>
+      <td
+        className="team-cell--num text-caption tnum"
+        style={{ color: agentCount > 0 ? "var(--fg-2)" : "var(--fg-4)" }}
       >
         {agentCount} {agentCount === 1 ? "agent" : "agents"}
-      </span>
-      <span className="inline-flex items-center justify-end gap-1.5" style={{ whiteSpace: "nowrap" }}>
+      </td>
+      <td className="team-cell--num team-cell--status">
         {updateProblem ? (
           <span
             role="status"
             aria-label={`Computer status: ${updateProblem.label}`}
-            className="mono inline-flex items-center gap-1.5 text-caption"
+            className="mono inline-flex items-center justify-end gap-1.5 text-caption"
             style={{ color: updateProblem.color }}
             title={updateProblem.title}
           >
@@ -806,17 +808,17 @@ function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel
             {updateProblem.label}
           </span>
         ) : (
-          <>
+          <span className="inline-flex items-center justify-end gap-1.5">
             <ComputerStatusPill pill={status.pill} />
             {offlineFor ? (
               <span className="text-caption" style={{ color: "var(--fg-3)" }}>
                 · {offlineFor}
               </span>
             ) : null}
-          </>
+          </span>
         )}
-      </span>
-    </div>
+      </td>
+    </tr>
   );
 }
 

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -185,6 +185,20 @@ const TEAM_UPDATE_FAILED = client({
     at: NOW,
   },
 });
+// Long *resolved* owner name — the truncating owner cell must expose it in full
+// via its title.
+const LONG_OWNER_NAME = "Diana Alexandra Wintersmith-Longname";
+const TEAM_LONG_OWNER = client({ id: "client-team-long", userId: "user-diana", hostname: "diana-box", os: "darwin" });
+// Unresolved owner (userId absent from the members map) — the cell shows the
+// short-id but the full UUID must survive in the title (desktop) and the
+// compact meta title (narrow).
+const UNRESOLVED_OWNER_ID = "user-ghost-1234567890abcdef";
+const TEAM_UNRESOLVED_OWNER = client({
+  id: "client-team-ghost",
+  userId: UNRESOLVED_OWNER_ID,
+  hostname: "ghost-box",
+  os: "linux",
+});
 
 const AGENTS: RuntimeAgent[] = [
   {
@@ -343,6 +357,8 @@ function seedDefaultMocks(): void {
     OFFLINE,
     TEAM,
     TEAM_UPDATE_FAILED,
+    TEAM_LONG_OWNER,
+    TEAM_UNRESOLVED_OWNER,
   ]);
   activityMocks.listClients.mockResolvedValue([READY, AUTH_EXPIRED, SETUP_INCOMPLETE, OFFLINE]);
   activityMocks.getActivityOverview.mockResolvedValue({
@@ -365,6 +381,7 @@ function seedDefaultMocks(): void {
   memberMocks.listMembers.mockResolvedValue([
     { userId: "user-self", displayName: "Gandy" },
     { userId: "user-alice", displayName: "Alice" },
+    { userId: "user-diana", displayName: LONG_OWNER_NAME },
   ]);
 }
 
@@ -457,6 +474,27 @@ describe("ClientsPage computer cards", () => {
     // surface under "Needs attention" as "Update failed", not hidden as Ready.
     await waitForText(container, "Needs attention");
     await waitForText(container, "Update failed");
+    // Health splits are <tbody> row-groups headed by a scope="rowgroup" cell.
+    const rowGroupHeaders = [...(teamTable?.querySelectorAll('th[scope="rowgroup"]') ?? [])];
+    expect(rowGroupHeaders.some((el) => el.textContent?.includes("Needs attention"))).toBe(true);
+    // The compact meta line labels each collapsed field for assistive tech.
+    const metaLabels = [...(teamTable?.querySelectorAll(".team-computer-row__meta .sr-only") ?? [])].map(
+      (el) => el.textContent,
+    );
+    expect(metaLabels).toEqual(expect.arrayContaining(["Owner: ", "OS: ", "First Tree: "]));
+    // Owner recovery: a long *resolved* name survives in full via the cell
+    // title, and an *unresolved* owner keeps its full UUID in both the cell and
+    // the compact meta title even though only the short-id is visible.
+    const findRow = (hostname: string) =>
+      [...(teamTable?.querySelectorAll("tr.team-computer-row") ?? [])].find((tr) =>
+        tr.querySelector('th[scope="row"]')?.textContent?.includes(hostname),
+      );
+    expect(findRow("diana-box")?.querySelector(".team-computer-row__col-owner")?.getAttribute("title")).toBe(
+      LONG_OWNER_NAME,
+    );
+    const ghostRow = findRow("ghost-box");
+    expect(ghostRow?.querySelector(".team-computer-row__col-owner")?.getAttribute("title")).toBe(UNRESOLVED_OWNER_ID);
+    expect(ghostRow?.querySelector(".team-computer-row__meta")?.getAttribute("title")).toContain(UNRESOLVED_OWNER_ID);
     await click(exactButton(container, "Hide"));
 
     await click(container.querySelector('button[aria-label="Computer actions"]'));

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -441,11 +441,17 @@ describe("ClientsPage computer cards", () => {
 
     await click(exactButton(container, "Show"));
     await waitForText(container, "Team computers");
-    // Distributed audit columns: the header labels owner / OS / version so the
-    // row fills the width instead of leaving a mid-row void.
+    // Distributed audit columns render as a semantic <table>: a 6-column header
+    // (Hostname … Status), each data row a <tr> whose hostname is a
+    // <th scope="row">, owner/os/version <td> cells. Assert the accessible
+    // structure, not just header strings.
     await waitForText(container, "Hostname");
     await waitForText(container, "First Tree");
-    await waitForText(container, "alice-linux");
+    const teamTable = container.querySelector<HTMLTableElement>('table[aria-label="Team computers"]');
+    expect(teamTable).not.toBeNull();
+    expect(teamTable?.querySelectorAll("thead th").length).toBe(6);
+    const rowHeaders = [...(teamTable?.querySelectorAll('th[scope="row"]') ?? [])];
+    expect(rowHeaders.some((el) => el.textContent?.includes("alice-linux"))).toBe(true);
     await waitForText(container, "Alice");
     // A connected + Ready-runtime team machine whose self-update failed must
     // surface under "Needs attention" as "Update failed", not hidden as Ready.

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -441,6 +441,10 @@ describe("ClientsPage computer cards", () => {
 
     await click(exactButton(container, "Show"));
     await waitForText(container, "Team computers");
+    // Distributed audit columns: the header labels owner / OS / version so the
+    // row fills the width instead of leaving a mid-row void.
+    await waitForText(container, "Hostname");
+    await waitForText(container, "First Tree");
     await waitForText(container, "alice-linux");
     await waitForText(container, "Alice");
     // A connected + Ready-runtime team machine whose self-update failed must

--- a/packages/web/src/pages/clients/dev-fixtures.ts
+++ b/packages/web/src/pages/clients/dev-fixtures.ts
@@ -447,10 +447,11 @@ function buildDemoData(): { scenarios: DemoScenario[]; agentNames: Record<string
       whatToCheck: [
         "'Your computers · 2' section as Section heading with hairline below",
         "'Team computers · 5' second Section, collapsed by default — click Show",
-        "Compact list: hostname (mono, the focus) over an 'owner · OS · version' meta line",
+        "Distributed columns fill the width (no mid-row void): Hostname | Owner | OS | First Tree | Agents | Status, with a flat sentence-case column header",
         "'Needs attention · 3' on top: Auth expired, Offline, then 'Update failed' (a Ready runtime whose self-update failed), then a neutral 'Ready · 2'",
-        "Version drops the build suffix (0.5.2-staging.31.4 → 0.5.2); full string on hover",
-        "Long hostname truncates with an ellipsis; Offline row reads 'Offline · 3 days'; 'Update failed' shows its reason on hover",
+        "Version column drops the build suffix (0.5.2-staging.31.4 → 0.5.2); full string on hover",
+        "Hostname is the only elastic column — long names truncate, short ones leave no void; Offline row reads 'Offline · 3 days'; 'Update failed' shows its reason on hover",
+        "Narrow the browser: owner/OS/version reflow under the hostname as a meta line and the column header hides (the identity column never collapses)",
         "Owner labels: 'gandy · you' on own cards, no '· you' on team rows",
       ],
       clients: [


### PR DESCRIPTION
## What

The admin **Team computers** audit list (shipped in #1755 as a compact hostname + meta-line row) left a **wide mid-row void** on the full Settings content width — hostname pinned far-left, agents/status far-right. This distributes the metadata into real columns that **fill the width**, as a semantic table:

`Hostname | Owner | OS | First Tree | Agents | Status`, a native `<table>` with flat sentence-case `<th>` column headers (DenseTable convention).

## Width strategy (`table-layout: fixed`)

- **Hostname** — the only column left auto-width, so it absorbs the slack: long names truncate, short names leave no void.
- **Owner** — fixed 11rem + truncates.
- **OS / First Tree / Agents** — fixed, content-bounded. Agents right-aligned `tnum`.
- **Status** — fixed 10rem (fits "Offline · N days" / "Setup incomplete"), right-aligned.
- Keeps the **global** Settings width (`SettingsLayout` `maxWidth: 1160`) — no per-page cap, consistent with the other settings sub-pages.

## Accessibility

- Native `<table>` → `<thead>`/`<th>` column headers, each data row a `<tr>` with a `<th scope="row">` hostname + `<td>` cells.
- Health splits are **row-groups**: each is its own `<tbody>` headed by a `<th scope="rowgroup" colSpan={6}>`, so "Needs attention" / "Ready" is announced as the heading for its rows.
- The **compact** meta line (below) carries visually-hidden `Owner` / `OS` / `First Tree` labels, so a screen reader on the reflowed layout hears labeled fields, not three bare values.
- Owner recovery: the owner cell + compact meta `title` fall back to the full identifier (`ownerLabel.title ?? ownerLabel.text`) — full resolved display name, or full UUID for an unresolved member — even when the visible text is a short-id or truncated.

## Responsive

A container query (`container-type: inline-size` on the wrapping list, `@container (max-width: 52rem)`) reflows the table: `table`/`tbody` → `block`, `thead` hidden, data rows → grid (`minmax(0,1fr) auto auto` — Hostname elastic | Agents | Status), with owner/OS/version falling back under the hostname as the labeled meta line. The 52rem breakpoint clears the fixed-column budget (~42rem) plus a comfortable hostname floor, so the identity column **never collapses** (verified across a viewport sweep). Compact rows clear the base cell padding so the row's own padding isn't doubled.

## Unchanged from #1755

Health grouping, Update-failed/blocked status, short version (full string on hover), Offline duration folded into status.

## Verification

- `pnpm --filter @first-tree/web typecheck` (tsc + `lint:tokens`) — clean.
- `pnpm biome check` — clean (one unrelated pre-existing CSS `!important` warning).
- `pnpm --filter @first-tree/web test` — **1435 passed** (DOM regression covers the table structure, row-groups, compact field labels, and owner-value recovery for resolved + unresolved owners).
- Real browser: desktop columns + narrow reflow, light + dark, plus a viewport sweep confirming no identity-column collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
