### PR TITLE
fix: file user issues/PRs into the work's repo, not First Tree's

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -412,6 +412,19 @@ describe("buildAgentBriefing — asking humans, GitHub, and CLI overview", () =>
     expect(briefing).toContain("If the current member is not an org admin");
     expect(briefing).toContain("hidden server sync path");
 
+    // Issues/PRs the agent files for the user default to the repo the work is
+    // about (the bound source repo), not reflexively First Tree's own repo.
+    // Regression guard for agents misfiling a user's issue into
+    // agent-team-foundation/first-tree; a First Tree platform defect still
+    // routes through `first-tree-file-bug`.
+    expect(briefing).toContain("target the repo the work is about with an explicit `--repo`");
+    expect(briefing).toMatch(
+      /Don't default to First Tree's own repository unless the work is genuinely about First Tree itself/,
+    );
+    expect(briefing).toContain(
+      "a First Tree platform defect specifically goes through the `first-tree-file-bug` skill",
+    );
+
     expect(briefing).toContain("Creating a PR or issue **never** follows it");
     expect(briefing).toContain("first-tree github follow <url>");
     expect(briefing).toMatch(/clearly unrelated to this chat's task/);

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -614,6 +614,45 @@ describe("buildAgentBriefing — Skills", () => {
     expect(skillMap).not.toContain("`first-tree-github-scan`");
     expect(skillMap).not.toContain("`attention`");
     expect(skillMap).not.toContain("`github-scan`");
+  });
+
+  it("locks first-tree-file-bug routing scope across every shipped surface", () => {
+    // Regression guard for the incident where a generic "file an issue" for
+    // work in the user's own/bound repo was misrouted to First Tree's public
+    // tracker (agent-team-foundation/first-tree). first-tree-file-bug is
+    // deliberately excluded from live skill-evals (UNEVALUATED_SHIPPED_SKILLS
+    // in @first-tree/skill-evals), which documents that its trigger boundary is
+    // covered by unit/drift tests here instead. Every routing surface the model
+    // sees must keep BOTH the positive "First Tree platform defect" scope AND
+    // the negative "not the user's own/bound repo" exclusion, so a future
+    // broadening of any one surface fails loudly instead of silently restoring
+    // the misroute.
+    const testFileDir = dirname(fileURLToPath(import.meta.url));
+    const skillDir = resolve(testFileDir, "..", "..", "..", "..", "skills", "first-tree-file-bug");
+
+    // Surface 1 — SKILL.md frontmatter description (primary progressive disclosure).
+    const descLine = readFileSync(join(skillDir, "SKILL.md"), "utf-8")
+      .split("\n")
+      .find((line) => line.startsWith("description:"));
+    expect(descLine, "SKILL.md must have a frontmatter description").toBeDefined();
+    expect(descLine).toMatch(/defect in First Tree itself/i);
+    expect(descLine).toMatch(/not for filing an issue into the user's own or bound source repo/i);
+
+    // Surface 2 — Codex metadata (independent routing surface for the codex provider).
+    const openaiYaml = readFileSync(join(skillDir, "agents", "openai.yaml"), "utf-8");
+    expect(openaiYaml).toMatch(/ONLY for a defect in First Tree itself/i);
+    expect(openaiYaml).toMatch(/not for filing an issue into the user's own or bound repo/i);
+    expect(openaiYaml).toMatch(/not into the user's repo/i);
+
+    // Surface 3 — both generated family-map rows (tree-bound and tree-less).
+    for (const contextTreePath of ["/tree", null]) {
+      const row = buildAgentBriefing(makeOpts({ contextTreePath }))
+        .split("\n")
+        .find((line) => line.startsWith("| `first-tree-file-bug`"));
+      expect(row, `file-bug family-map row missing for contextTreePath=${contextTreePath}`).toBeDefined();
+      expect(row).toMatch(/bug in First Tree itself/i);
+      expect(row).toMatch(/First Tree's own repo \(not the user's own\/bound repo\)/i);
+    }
   });
 
   it("nests Team Skills before First Tree Family when resource skills exist", () => {

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -481,6 +481,8 @@ function githubWorkingPostureBlock(): string {
 
 For GitHub URLs, PRs, Issues, Actions runs, repo metadata, comments, and ordinary PR / Issue creation, try the host \`gh\` CLI first. A GitHub URL is not by itself a reason to ask for First Tree GitHub App installation or repo authorization.
 
+When you create an issue or PR for the user, target the repo the work is about with an explicit \`--repo\`, and confirm that target before creating — for work in a bound source repo, that repo (see **Source Repositories**). Don't default to First Tree's own repository unless the work is genuinely about First Tree itself; a First Tree platform defect specifically goes through the \`first-tree-file-bug\` skill.
+
 If \`gh\` is missing, unauthenticated, or lacks access, report that gap and choose the narrowest recovery: local clone path, GitHub CLI install, or \`gh\` auth/access. Ask for First Tree GitHub access only for platform capabilities such as webhook following, team repo resources, Context Tree provisioning, installation-token access, or cross-session/team access. If the current member is not an org admin, do not ask them to install the GitHub App or bind repos/trees; continue with local path / host \`gh\`.
 
 Do not use local files or tree snapshots as a hidden server sync path.`;
@@ -911,7 +913,7 @@ guidance above to surface/setup/seed first.
 | \`first-tree-read\`    | read relevant Context Tree files before acting from task / path / feature signals |
 | \`first-tree-write\`   | reflect a concrete source artifact (PR, design doc, meeting note, review thread, or pasted source) into the Context Tree |
 | \`first-tree-seed\` | set up the team's Context Tree from readable sources — declared workspace repos or a local Git repo / GitHub URL supplied in chat; creates + binds the tree if none exists, fills a bound-but-empty tree, and can continue Phase 2 in the same setup chat after Phase 1 merges |
-| \`first-tree-file-bug\` | the user hit a bug in First Tree itself (CLI, runtime, chat, web, GitHub, or tree tooling) and wants it reported — gathers repro + version + chat/user IDs and opens an issue on the first-tree repo via the user's \`gh\` CLI |`;
+| \`first-tree-file-bug\` | the user hit a bug in First Tree itself (CLI, runtime, chat, web, GitHub, or tree tooling) and wants it reported — gathers repro + version + chat/user IDs and opens an issue on First Tree's own repo via the user's \`gh\` CLI |`;
   }
   return `## First Tree Family
 
@@ -927,7 +929,7 @@ harness skills (\`tdoc\`, \`review\`, \`simplify\`, \`update-config\`,
 | \`first-tree-read\`    | read relevant Context Tree files before acting from task / path / feature signals |
 | \`first-tree-write\`   | reflect a concrete source artifact (PR, design doc, meeting note, review thread, or pasted source) into the Context Tree |
 | \`first-tree-seed\`    | bootstrap the team's Context Tree from readable sources (declared repos or a local Git repo / GitHub URL supplied in chat); create + bind if none exists, fill a bound-but-empty tree, or continue Phase 2 in the same setup chat after Phase 1 merges |
-| \`first-tree-file-bug\` | you hit a bug in First Tree itself (CLI, runtime, chat, web, GitHub, or tree tooling) and want it reported — gathers repro + version + chat/user IDs and opens an issue on the first-tree repo via the user's \`gh\` CLI |`;
+| \`first-tree-file-bug\` | you hit a bug in First Tree itself (CLI, runtime, chat, web, GitHub, or tree tooling) and want it reported — gathers repro + version + chat/user IDs and opens an issue on First Tree's own repo via the user's \`gh\` CLI |`;
 }
 
 /**

--- a/packages/client/src/runtime/agent-briefing.ts
+++ b/packages/client/src/runtime/agent-briefing.ts
@@ -913,7 +913,7 @@ guidance above to surface/setup/seed first.
 | \`first-tree-read\`    | read relevant Context Tree files before acting from task / path / feature signals |
 | \`first-tree-write\`   | reflect a concrete source artifact (PR, design doc, meeting note, review thread, or pasted source) into the Context Tree |
 | \`first-tree-seed\` | set up the team's Context Tree from readable sources — declared workspace repos or a local Git repo / GitHub URL supplied in chat; creates + binds the tree if none exists, fills a bound-but-empty tree, and can continue Phase 2 in the same setup chat after Phase 1 merges |
-| \`first-tree-file-bug\` | the user hit a bug in First Tree itself (CLI, runtime, chat, web, GitHub, or tree tooling) and wants it reported — gathers repro + version + chat/user IDs and opens an issue on First Tree's own repo via the user's \`gh\` CLI |`;
+| \`first-tree-file-bug\` | the user hit a bug in First Tree itself (CLI, runtime, chat, web, GitHub, or tree tooling) and wants it reported — gathers repro + version + chat/user IDs and opens an issue on First Tree's own repo (not the user's own/bound repo) via the user's \`gh\` CLI |`;
   }
   return `## First Tree Family
 
@@ -929,7 +929,7 @@ harness skills (\`tdoc\`, \`review\`, \`simplify\`, \`update-config\`,
 | \`first-tree-read\`    | read relevant Context Tree files before acting from task / path / feature signals |
 | \`first-tree-write\`   | reflect a concrete source artifact (PR, design doc, meeting note, review thread, or pasted source) into the Context Tree |
 | \`first-tree-seed\`    | bootstrap the team's Context Tree from readable sources (declared repos or a local Git repo / GitHub URL supplied in chat); create + bind if none exists, fill a bound-but-empty tree, or continue Phase 2 in the same setup chat after Phase 1 merges |
-| \`first-tree-file-bug\` | you hit a bug in First Tree itself (CLI, runtime, chat, web, GitHub, or tree tooling) and want it reported — gathers repro + version + chat/user IDs and opens an issue on First Tree's own repo via the user's \`gh\` CLI |`;
+| \`first-tree-file-bug\` | you hit a bug in First Tree itself (CLI, runtime, chat, web, GitHub, or tree tooling) and want it reported — gathers repro + version + chat/user IDs and opens an issue on First Tree's own repo (not the user's own/bound repo) via the user's \`gh\` CLI |`;
 }
 
 /**

--- a/skills/first-tree-file-bug/SKILL.md
+++ b/skills/first-tree-file-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: first-tree-file-bug
-description: File a GitHub issue for a bug the user hit while using First Tree itself — the CLI, agent runtime, chat, web app, or Context Tree tooling. Use when the user reports that something in First Tree is broken, errored, crashed, or is not behaving as expected and wants it reported / filed / logged as a bug (e.g. "First Tree has a bug", "report this bug", "chat send keeps failing", "the CLI crashed", "开个 issue 反馈这个 bug"). The skill gathers reproduction steps, the First Tree client/CLI version, the chat ID, the reporting user's ID, OS, and error output, then opens an issue on the first-tree repo with the user's `gh` CLI. Not for bugs in the user's own project code or third-party tools — only First Tree platform defects.
+description: File a GitHub issue about a defect in First Tree itself — the CLI, agent runtime, chat, web app, GitHub integration, or Context Tree tooling — onto First Tree's own public tracker (agent-team-foundation/first-tree). Use only when the user reports that First Tree the platform is broken, errored, crashed, or misbehaving and wants it reported (e.g. "First Tree has a bug", "chat send keeps failing", "the CLI crashed", "给 First Tree 开个 issue 反馈这个 bug"). The skill gathers reproduction steps, the First Tree client/CLI version, the chat ID, the reporting user's ID, OS, and error output, then opens the issue with the user's `gh` CLI. NOT for filing an issue into the user's own or bound source repo — that is an ordinary `gh issue create` against that repo, not this skill — and not for bugs in the user's project code or third-party tools.
 ---
 
 # First Tree File Bug
@@ -42,7 +42,10 @@ secrets (see **Guardrails**).
 State briefly what you understand the bug to be and that it looks like a
 First Tree defect worth filing. If it is ambiguous whether the fault is in
 First Tree or the user's own setup, resolve that first — do not file an
-issue against First Tree for something outside it.
+issue against First Tree for something outside it. If the report is really
+about the user's own project or their bound source repo, this is not the
+skill: file it into that repo with `gh issue create --repo <their repo>`
+instead of here.
 
 ### 2. Gather the bug context
 
@@ -126,7 +129,9 @@ identifiers, not credentials.
 ### 5. Confirm before filing
 
 Filing is outward-facing and publishes to a public tracker, so show the
-user the drafted title and body and get an explicit go-ahead before
+user the drafted title and body **and state the destination explicitly —
+this files into `agent-team-foundation/first-tree` (First Tree's own public
+tracker), not the user's own repo** — then get an explicit go-ahead before
 creating the issue. Incorporate any correction they make.
 
 ### 6. File the issue

--- a/skills/first-tree-file-bug/agents/openai.yaml
+++ b/skills/first-tree-file-bug/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "First Tree File Bug"
-  short_description: "Report a First Tree bug as a GitHub issue via gh"
-  default_prompt: "Use $first-tree-file-bug to collect the bug context (repro, version, chat ID, user ID) and open a GitHub issue on the First Tree repo with the user's gh CLI."
+  short_description: "Report a defect in First Tree itself, not into the user's repo"
+  default_prompt: "Use $first-tree-file-bug ONLY for a defect in First Tree itself, not for filing an issue into the user's own or bound repo. Collect the bug context (repro, version, chat ID, user ID), confirm with the user that this files into First Tree's own public issue tracker, then open the issue with the user's gh CLI."


### PR DESCRIPTION
## Problem

A new user bound their own source repo and told their agent to "file issue X" — meaning into their bound repo. The agent instead filed the issue into First Tree's own public repo (`agent-team-foundation/first-tree`), publishing the user's content there. This is reproducible for any user, not a one-off.

## Root cause

Issue creation is entirely skill/LLM-driven (there is no non-skill code path that creates issues). Two things combine:

1. `first-tree-file-bug` is a **core, always-installed** skill whose destination is **hardcoded** to `agent-team-foundation/first-tree` (in `SKILL.md` and the codex `openai.yaml` `default_prompt`). Its trigger surface overlaps a generic "file an issue" request.
2. The generated agent briefing had **no positive default** telling the agent that an issue/PR it files for the user targets the repo the work is about (the bound source repo). So the only concrete issue destination anywhere in a generic agent's context was First Tree's own repo — and a generic "提交 issue" over-routed there.

## Changes

- **Briefing — GitHub Working Posture** (`agent-briefing.ts`): add a positive default. Issues/PRs the agent creates for the user target the repo the work is about (the bound source repo) with an explicit `--repo` and a confirmed target. First Tree's own repo is reserved for work genuinely about First Tree, and a First Tree **platform defect** goes through `first-tree-file-bug`. (Deliberately not an absolute "only file here via the skill" rule — First Tree's own contributor agents legitimately open normal PRs/issues against this repo.)
- **`first-tree-file-bug` scope** (`SKILL.md`, `openai.yaml`, both briefing skill-map rows): narrow the trigger to First Tree platform defects and add an explicit "not for the user's own/bound repo — that's an ordinary `gh issue create --repo <their repo>`" negative, kept consistent across every routing surface.
- **Confirm-before-file** (`SKILL.md` step 5): the confirmation now states the destination repo explicitly, so a misroute is catchable by the user before anything is published.
- **Regression test** (`agent-briefing.test.ts`): lock the new briefing default.

## Testing

- `pnpm --filter @first-tree/client test` — 1506 passed, 0 failed (includes `agent-briefing` and the `retired-tree-commands-drift` guard).
- `pnpm check` (biome) — clean; `pnpm typecheck` — 10/10 tasks pass.
- Two independent reviews; one flagged that an earlier draft's "the only reason to file into First Tree's repo" phrasing was wrong for First Tree's own contributor agents — reworded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
