### PR TITLE
Refresh mobile Now and Chat cards with inline triage

### DIFF
--- a/packages/web/src/components/chat/__tests__/ask-answer-transport.test.ts
+++ b/packages/web/src/components/chat/__tests__/ask-answer-transport.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const attachmentMocks = vi.hoisted(() => ({
+  uploadAttachment: vi.fn(),
+  uploadMimeFor: vi.fn(),
+}));
+const chatMocks = vi.hoisted(() => ({
+  readFileAsBase64: vi.fn(),
+  sendChatMessage: vi.fn(),
+  sendFileMessageBatch: vi.fn(),
+}));
+const imageStoreMocks = vi.hoisted(() => ({ putImage: vi.fn() }));
+
+vi.mock("../../../api/attachments.js", () => attachmentMocks);
+vi.mock("../../../api/chats.js", () => chatMocks);
+vi.mock("../../../api/image-store.js", () => imageStoreMocks);
+
+import { sendAskAnswer } from "../ask-answer-transport.js";
+
+const request = { id: "request-1", senderId: "asker-1" };
+
+describe("sendAskAnswer", () => {
+  beforeEach(() => {
+    for (const mock of Object.values(attachmentMocks)) mock.mockReset();
+    for (const mock of Object.values(chatMocks)) mock.mockReset();
+    imageStoreMocks.putImage.mockReset();
+    attachmentMocks.uploadAttachment.mockImplementation(async (file: File) => ({ id: `uploaded-${file.name}` }));
+    attachmentMocks.uploadMimeFor.mockImplementation((file: File) => file.type || "application/octet-stream");
+    chatMocks.readFileAsBase64.mockResolvedValue("base64-image");
+    chatMocks.sendChatMessage.mockResolvedValue(undefined);
+    chatMocks.sendFileMessageBatch.mockResolvedValue(undefined);
+    imageStoreMocks.putImage.mockResolvedValue(undefined);
+  });
+
+  it("routes a text answer to the asker and mentions with resolving metadata", async () => {
+    const document = new File(["plan"], "plan.md", { type: "text/markdown" });
+
+    await sendAskAnswer({
+      chatId: "chat-1",
+      request,
+      answer: {
+        content: "Ship now",
+        mentions: ["asker-1", "reviewer-1", "reviewer-1"],
+        images: [],
+        attachments: [{ file: document, kind: "document" }],
+      },
+    });
+
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledWith("chat-1", "Ship now", ["asker-1", "reviewer-1"], {
+      inReplyTo: "request-1",
+      resolves: { request: "request-1", kind: "answered" },
+      attachments: [
+        {
+          attachmentId: "uploaded-plan.md",
+          kind: "document",
+          mimeType: "text/markdown",
+          filename: "plan.md",
+          size: document.size,
+        },
+      ],
+    });
+    expect(chatMocks.sendFileMessageBatch).not.toHaveBeenCalled();
+  });
+
+  it("uses file transport for image answers and keeps cache warming best-effort", async () => {
+    const image = new File(["image"], "proof.png", { type: "image/png" });
+    imageStoreMocks.putImage.mockRejectedValueOnce(new Error("IndexedDB unavailable"));
+
+    await sendAskAnswer({
+      chatId: "chat-1",
+      request,
+      answer: { content: "Evidence attached", mentions: ["reviewer-1"], images: [image] },
+    });
+
+    expect(imageStoreMocks.putImage).toHaveBeenCalledWith({
+      imageId: "uploaded-proof.png",
+      base64: "base64-image",
+      mimeType: "image/png",
+    });
+    expect(chatMocks.sendFileMessageBatch).toHaveBeenCalledWith(
+      "chat-1",
+      {
+        caption: "Evidence attached",
+        attachments: [
+          {
+            imageId: "uploaded-proof.png",
+            mimeType: "image/png",
+            filename: "proof.png",
+            size: image.size,
+          },
+        ],
+      },
+      { mentions: ["asker-1", "reviewer-1"] },
+      { inReplyTo: "request-1", resolves: { request: "request-1", kind: "answered" } },
+    );
+    expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/ask-takeover-dom.test.tsx
@@ -677,6 +677,7 @@ describe("AskTakeover", () => {
     expect(Number.parseInt(reply.style.height, 10)).toBe(44);
     expect(Number.parseInt(atBtn.style.width, 10)).toBe(44);
     expect(Number.parseInt(attachBtn.style.width, 10)).toBe(44);
+    expect(c.querySelector<HTMLElement>("[data-ask-takeover-footer]")?.className).toContain("pb-safe-bottom");
 
     // Enter inserts a newline (does not resolve); the Reply button submits.
     const ta = freeTextBox(c);

--- a/packages/web/src/components/chat/ask-answer-transport.ts
+++ b/packages/web/src/components/chat/ask-answer-transport.ts
@@ -1,0 +1,70 @@
+import type { AttachmentRef, RequestResolution } from "@first-tree/shared";
+import { uploadAttachment, uploadMimeFor } from "../../api/attachments.js";
+import { type ImageRefContent, readFileAsBase64, sendChatMessage, sendFileMessageBatch } from "../../api/chats.js";
+import { putImage } from "../../api/image-store.js";
+import type { AskAnswer } from "./ask-takeover.js";
+
+export type AskAnswerRequestRef = {
+  id: string;
+  senderId: string;
+};
+
+/**
+ * The single request-resolution transport used by every AskTakeover host.
+ *
+ * Surface components own pending/error state and their post-send effects. This
+ * unit owns the invariants that unblock the requester: route to the asker plus
+ * explicit mentions, upload staged files, choose text vs image-batch transport,
+ * and attach the same in-reply-to + resolving metadata in either path.
+ */
+export async function sendAskAnswer({
+  chatId,
+  request,
+  answer,
+}: {
+  chatId: string;
+  request: AskAnswerRequestRef;
+  answer: AskAnswer;
+}): Promise<void> {
+  const routedMentions = [...new Set([request.senderId, ...answer.mentions])];
+  const resolves: RequestResolution = { request: request.id, kind: "answered" };
+  const documentRefs: AttachmentRef[] = [];
+
+  for (const attachment of answer.attachments ?? []) {
+    const uploaded = await uploadAttachment(attachment.file);
+    documentRefs.push({
+      attachmentId: uploaded.id,
+      kind: attachment.kind,
+      mimeType: uploadMimeFor(attachment.file),
+      filename: attachment.file.name,
+      size: attachment.file.size,
+    });
+  }
+
+  if (answer.images.length > 0) {
+    const imageRefs: ImageRefContent[] = [];
+    for (const file of answer.images) {
+      const uploaded = await uploadAttachment(file);
+      try {
+        await putImage({ imageId: uploaded.id, base64: await readFileAsBase64(file), mimeType: file.type });
+      } catch {
+        // The server attachment is authoritative; IndexedDB only makes the
+        // sender's thumbnail immediate and must never block resolution.
+      }
+      imageRefs.push({ imageId: uploaded.id, mimeType: file.type, filename: file.name, size: file.size });
+    }
+    await sendFileMessageBatch(
+      chatId,
+      { ...(answer.content ? { caption: answer.content } : {}), attachments: imageRefs },
+      { mentions: routedMentions, ...(documentRefs.length > 0 ? { attachments: documentRefs } : {}) },
+      { inReplyTo: request.id, resolves },
+    );
+    return;
+  }
+
+  await sendChatMessage(chatId, answer.content, routedMentions, {
+    inReplyTo: request.id,
+    resolves,
+    ...(documentRefs.length > 0 ? { attachments: documentRefs } : {}),
+  });
+}

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -17,7 +17,9 @@
  *     sends the composed answer; Skip sends a "skipped" answer (the caller's
  *     `onSkip` writes the resolving reply) so the asking agent unblocks rather
  *     than waiting on a never-answered question. There is no "dismiss but keep it
- *     open" path — skip is an answer, not a deferral.
+ *     open" path in the blocking chat view — skip is an answer, not a deferral.
+ *     A feed-level shortcut may supply `onDismiss` so the user can lower the
+ *     sheet and keep triaging without resolving the question.
  *
  * The free-text answer surface mirrors the chat composer: it supports `@mention`
  * autocomplete (against chat speakers plus host-supplied inviteable agents) and
@@ -113,6 +115,7 @@ export function AskTakeover({
   error,
   onReply,
   onSkip,
+  onDismiss,
   isTrial = false,
   mobile = false,
 }: {
@@ -139,6 +142,9 @@ export function AskTakeover({
   onReply: (answer: AskAnswer) => void;
   /** Resolve the question with a "skipped" answer (caller sends the reply). */
   onSkip: () => void;
+  /** Optional feed-sheet close: leaves the question open. Blocking chat views
+   *  intentionally omit this so their existing must-answer contract remains. */
+  onDismiss?: () => void;
 }) {
   const options = payload.options;
   const multi = payload.multiSelect === true;
@@ -255,7 +261,8 @@ export function AskTakeover({
       if (e.key === "Escape") {
         if (sending) return;
         e.preventDefault();
-        onSkip();
+        if (onDismiss) onDismiss();
+        else onSkip();
         return;
       }
       // Mobile soft keyboards have no Shift+Enter, so Enter must insert a
@@ -272,7 +279,7 @@ export function AskTakeover({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [sending, canReply, onSkip, reply, mobile]);
+  }, [sending, canReply, onSkip, onDismiss, reply, mobile]);
 
   // Visible chrome (border + fill + radius) lives on the WRAPPER, not the
   // textarea: the textarea is painted transparent so the mention overlay
@@ -553,9 +560,9 @@ export function AskTakeover({
         bottom: keyboardInset,
         zIndex: 30,
         display: "flex",
-        alignItems: "center",
+        alignItems: mobile ? "flex-end" : "center",
         justifyContent: "center",
-        padding: "clamp(var(--sp-2_5), 2.5%, var(--sp-7))",
+        padding: mobile ? "var(--sp-2) 0 0" : "clamp(var(--sp-2_5), 2.5%, var(--sp-7))",
         background: "color-mix(in oklch, var(--fg) 10%, transparent)",
       }}
     >
@@ -568,16 +575,40 @@ export function AskTakeover({
           // Slightly wider than the message reading column; height fits the
           // content and is capped to the area (50rem cap).
           width: "min(100%, 50rem)",
-          maxHeight: "100%",
+          maxHeight: mobile ? "min(92%, 50rem)" : "100%",
           display: "flex",
           flexDirection: "column",
           overflow: "hidden",
+          position: "relative",
           background: "var(--bg-raised)",
           border: "var(--hairline) solid var(--border)",
-          borderRadius: "var(--radius-dialog)",
+          borderRadius: mobile ? "var(--radius-dialog) var(--radius-dialog) 0 0" : "var(--radius-dialog)",
           boxShadow: "var(--shadow-md)",
         }}
       >
+        {onDismiss ? (
+          <button
+            type="button"
+            aria-label="Close question"
+            onClick={onDismiss}
+            disabled={sending}
+            className="absolute inline-flex items-center justify-center"
+            style={{
+              top: "var(--sp-2)",
+              right: "var(--sp-2)",
+              zIndex: 2,
+              width: 44,
+              height: 44,
+              border: 0,
+              borderRadius: "var(--radius-input)",
+              background: "var(--bg-raised)",
+              color: "var(--fg-3)",
+              opacity: sending ? 0.5 : 1,
+            }}
+          >
+            <X aria-hidden className="h-5 w-5" />
+          </button>
+        ) : null}
         {/* Scrolling region: the ask body PLUS the answer surface. Keeping the
             options inside the scroller (rather than in a fixed block) is what
             guarantees Reply is reachable — when the card is shorter than its

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -691,56 +691,61 @@ export function AskTakeover({
         {/* Pinned footer — Skip / Reply. Fixed (flex 0 0 auto) so it never
             scrolls out of view: Reply is reachable at any viewport height. */}
         <div
+          data-ask-takeover-footer
+          className={mobile ? "pb-safe-bottom" : undefined}
           style={{
             flex: "0 0 auto",
-            display: "flex",
-            justifyContent: "flex-end",
-            alignItems: "center",
-            gap: "var(--sp-3)",
-            padding: `var(--sp-3) ${padX}`,
             borderTop: "var(--hairline) solid var(--border-faint)",
           }}
         >
-          <button
-            type="button"
-            onClick={onSkip}
-            disabled={sending}
-            title="Skip (Esc)"
-            className="text-label"
+          <div
+            className="flex items-center justify-end"
             style={{
-              // Mobile: 44 height clears the touch minimum.
-              height: mobile ? 44 : 34,
-              padding: "0 var(--sp-4)",
-              borderRadius: "var(--radius-input)",
-              border: "var(--hairline) solid transparent",
-              background: "transparent",
-              color: "var(--fg-2)",
-              cursor: sending ? "default" : "pointer",
+              gap: "var(--sp-3)",
+              padding: `var(--sp-3) ${padX}`,
             }}
           >
-            Skip
-          </button>
-          <button
-            type="button"
-            onClick={reply}
-            disabled={!canReply}
-            title={mobile ? "Reply" : "Reply (Enter)"}
-            className="text-label"
-            style={{
-              // Mobile: 44 height clears the touch minimum (Reply is the only
-              // submit path there — Enter inserts a newline).
-              height: mobile ? 44 : 34,
-              padding: "0 var(--sp-4)",
-              borderRadius: "var(--radius-input)",
-              border: "var(--hairline) solid transparent",
-              background: "var(--primary)",
-              color: "var(--primary-on)",
-              cursor: canReply ? "pointer" : "default",
-              opacity: canReply ? 1 : 0.5,
-            }}
-          >
-            {sending ? "Replying…" : "Reply"}
-          </button>
+            <button
+              type="button"
+              onClick={onSkip}
+              disabled={sending}
+              title="Skip (Esc)"
+              className="text-label"
+              style={{
+                // Mobile: 44 height clears the touch minimum.
+                height: mobile ? 44 : 34,
+                padding: "0 var(--sp-4)",
+                borderRadius: "var(--radius-input)",
+                border: "var(--hairline) solid transparent",
+                background: "transparent",
+                color: "var(--fg-2)",
+                cursor: sending ? "default" : "pointer",
+              }}
+            >
+              Skip
+            </button>
+            <button
+              type="button"
+              onClick={reply}
+              disabled={!canReply}
+              title={mobile ? "Reply" : "Reply (Enter)"}
+              className="text-label"
+              style={{
+                // Mobile: 44 height clears the touch minimum (Reply is the only
+                // submit path there — Enter inserts a newline).
+                height: mobile ? 44 : 34,
+                padding: "0 var(--sp-4)",
+                borderRadius: "var(--radius-input)",
+                border: "var(--hairline) solid transparent",
+                background: "var(--primary)",
+                color: "var(--primary-on)",
+                cursor: canReply ? "pointer" : "default",
+                opacity: canReply ? 1 : 0.5,
+              }}
+            >
+              {sending ? "Replying…" : "Reply"}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -314,10 +314,10 @@ describe("extra preview pages", () => {
     const rendered = await renderPreview(<MobilePreviewPage />, "/preview/mobile");
 
     expect(text(rendered.container)).toContain("Now");
-    expect(text(rendered.container)).toContain("Work feed");
+    expect(rendered.container.querySelector("h1")?.textContent).toBe("Now");
     expect(text(rendered.container)).not.toContain("2 need attention");
     expect(text(rendered.container)).toContain("Release readiness");
-    expect(text(rendered.container)).toContain("Question waiting");
+    expect(text(rendered.container)).toContain("Needs your answer");
     expect(text(rendered.container)).not.toContain("Needs attention");
     expect(text(rendered.container)).not.toContain("In progress");
     expect(rendered.container.querySelector("[data-mobile-feed]")).not.toBeNull();
@@ -329,7 +329,7 @@ describe("extra preview pages", () => {
     expect(text(rendered.container)).toContain("Visual QA");
     expect(rendered.container.querySelector('[data-mobile-card="list"]')).not.toBeNull();
 
-    await click(buttonByText(rendered.container, "Release readiness"));
+    await click(buttonByLabel(rendered.container, /^Open Release readiness$/));
     expect(text(rendered.container)).toContain("Summary");
     expect(text(rendered.container)).toContain("The mobile shell is ready for review");
 

--- a/packages/web/src/pages/mobile-preview.tsx
+++ b/packages/web/src/pages/mobile-preview.tsx
@@ -1,25 +1,31 @@
 import {
   Activity,
+  Archive,
   ArrowLeft,
   ArrowRight,
   CircleUserRound,
   type LucideIcon,
+  Mail,
   MessageSquareText,
   MonitorCog,
   Palette,
+  Pin,
   Plus,
   Search,
   UsersRound,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
+import { AskTakeover } from "../components/chat/ask-takeover.js";
 import { Button } from "../components/ui/button.js";
 import { cn } from "../lib/utils.js";
+import { MobileCardActionsMenu, type MobileChatAction, MobileSwipeCard } from "./mobile/chat-card-actions.js";
 import {
   MobilePage,
   MobileSection,
   MobileSegmentedControl,
   MobileSignalChip,
+  mobileAccentColor,
   mobileCardStyle,
 } from "./mobile/components.js";
 import type { MobileChatSignal } from "./mobile/data.js";
@@ -60,7 +66,7 @@ const MOCK_CHATS: MockChat[] = [
     title: "Release readiness",
     time: "2m",
     owner: "gandy-coder",
-    signal: { tone: "needs-you", label: "Needs answer", rank: 0, attention: true },
+    signal: { tone: "needs-you", label: "Needs your answer", rank: 0, attention: true },
     preview: "Review the mobile Phase 1 PR and decide whether to keep the mock preview in the branch.",
     summary:
       "The mobile shell is ready for review. The remaining decision is whether the no-login mock preview stays as a dev-only reviewer surface.",
@@ -110,7 +116,7 @@ const MOCK_CHATS: MockChat[] = [
     title: "Context docs pass",
     time: "44m",
     owner: "docs",
-    signal: { tone: "working", label: "Working", rank: 3, attention: false },
+    signal: { tone: "working", label: "Working now", rank: 3, attention: false },
     preview: "Tighten the handoff notes so the next agent does not mistake foundation work for launch-ready mobile.",
     summary:
       "The handoff now calls out that the mobile branch is a foundation layer and intentionally avoids server schema or API changes.",
@@ -161,6 +167,7 @@ export function MobilePreviewPage() {
   const [tab, setTab] = useState<PreviewTab>("now");
   const [filter, setFilter] = useState<ChatFilter>("all");
   const [selectedChatId, setSelectedChatId] = useState<string | null>(null);
+  const [answeringChatId, setAnsweringChatId] = useState<string | null>(null);
   const selectedChat = selectedChatId ? MOCK_CHATS.find((chat) => chat.id === selectedChatId) : null;
   const attentionCount = MOCK_CHATS.filter((chat) => chat.signal.attention).length;
   const unreadCount = MOCK_CHATS.filter((chat) => chat.signal.tone === "unread").length;
@@ -174,6 +181,7 @@ export function MobilePreviewPage() {
 
   const openTab = (next: PreviewTab) => {
     setSelectedChatId(null);
+    setAnsweringChatId(null);
     setTab(next);
   };
 
@@ -199,26 +207,51 @@ export function MobilePreviewPage() {
     );
   }
 
+  const answeringChat = answeringChatId ? MOCK_CHATS.find((chat) => chat.id === answeringChatId) : null;
+
   return (
-    <PreviewFrame
-      title={title}
-      right={
-        tab === "now" ? (
-          <Button type="button" variant="cta" size="sm" onClick={() => openTab("chat")}>
-            <Plus className="h-3.5 w-3.5" />
-            New
-          </Button>
-        ) : null
-      }
-      bottom={<PreviewTabs active={tab} attentionCount={attentionCount} unreadCount={unreadCount} onChange={openTab} />}
-    >
-      {tab === "now" ? <NowPreview onOpenChat={setSelectedChatId} /> : null}
-      {tab === "chat" ? (
-        <ChatPreview filter={filter} onFilter={setFilter} rows={chatRows} onOpenChat={setSelectedChatId} />
+    <>
+      <PreviewFrame
+        title={title}
+        right={
+          tab === "now" ? (
+            <Button type="button" variant="cta" size="sm" onClick={() => openTab("chat")}>
+              <Plus className="h-3.5 w-3.5" />
+              New
+            </Button>
+          ) : null
+        }
+        bottom={
+          <PreviewTabs active={tab} attentionCount={attentionCount} unreadCount={unreadCount} onChange={openTab} />
+        }
+      >
+        {tab === "now" ? <NowPreview onOpenChat={setSelectedChatId} onOpenAnswer={setAnsweringChatId} /> : null}
+        {tab === "chat" ? (
+          <ChatPreview filter={filter} onFilter={setFilter} rows={chatRows} onOpenChat={setSelectedChatId} />
+        ) : null}
+        {tab === "team" ? <TeamPreview /> : null}
+        {tab === "me" ? <MePreview /> : null}
+      </PreviewFrame>
+      {answeringChat ? (
+        <div className="fixed inset-0" style={{ zIndex: 70 }} data-mobile-ask-sheet>
+          <AskTakeover
+            body={`## Release decision\n\n${answeringChat.preview}`}
+            payload={{
+              multiSelect: false,
+              options: [
+                { label: "Ship now", description: "Start the production rollout." },
+                { label: "Hold", description: "Keep the release on staging." },
+              ],
+            }}
+            askerName={answeringChat.owner}
+            mobile
+            onDismiss={() => setAnsweringChatId(null)}
+            onReply={() => setAnsweringChatId(null)}
+            onSkip={() => setAnsweringChatId(null)}
+          />
+        </div>
       ) : null}
-      {tab === "team" ? <TeamPreview /> : null}
-      {tab === "me" ? <MePreview /> : null}
-    </PreviewFrame>
+    </>
   );
 }
 
@@ -289,13 +322,19 @@ function PreviewMark() {
   );
 }
 
-function NowPreview({ onOpenChat }: { onOpenChat: (chatId: string) => void }) {
+function NowPreview({
+  onOpenChat,
+  onOpenAnswer,
+}: {
+  onOpenChat: (chatId: string) => void;
+  onOpenAnswer: (chatId: string) => void;
+}) {
   return (
     <MobilePage className="flex flex-col" padded>
       <div className="flex items-start" style={{ gap: "var(--sp-3)", marginBottom: "var(--sp-4)" }}>
         <div className="min-w-0" style={{ flex: 1 }}>
           <h1 className="text-mobile-title" style={{ color: "var(--fg)", margin: 0 }}>
-            Work feed
+            Now
           </h1>
         </div>
         <span
@@ -313,7 +352,13 @@ function NowPreview({ onOpenChat }: { onOpenChat: (chatId: string) => void }) {
 
       <div className="flex flex-col" style={{ gap: "var(--sp-2)" }} data-mobile-feed>
         {MOCK_CHATS.map((chat) => (
-          <MockChatRow key={chat.id} chat={chat} onOpen={onOpenChat} showPrimaryAction={chat.signal.attention} />
+          <MockChatRow
+            key={chat.id}
+            chat={chat}
+            onOpen={onOpenChat}
+            onAnswer={onOpenAnswer}
+            showPrimaryAction={chat.signal.attention}
+          />
         ))}
       </div>
     </MobilePage>
@@ -491,29 +536,57 @@ function ChatDetail({ chat }: { chat: MockChat }) {
 function MockChatRow({
   chat,
   onOpen,
+  onAnswer,
   compact = false,
   tier,
   showPrimaryAction = false,
 }: {
   chat: MockChat;
   onOpen: (chatId: string) => void;
+  onAnswer?: (chatId: string) => void;
   compact?: boolean;
   tier?: "feed" | "list";
   showPrimaryAction?: boolean;
 }) {
   const cardTier = tier ?? (compact ? "list" : "feed");
   const actionLabel = showPrimaryAction ? primaryActionLabel(chat.signal.tone) : null;
-  const reasonLabel = cardTier === "feed" ? mockFeedReasonLabel(chat) : chat.signal.label;
-  const cardStyle = mobileCardStyle(actionLabel ? "priorityFeed" : cardTier);
+  const accent = cardTier === "feed" ? mobileAccentColor(chat.signal.tone) : null;
+  const cardStyle = {
+    ...mobileCardStyle(actionLabel ? "priorityFeed" : cardTier),
+    ...(accent ? { boxShadow: `inset var(--hairline-bold) 0 0 0 ${accent}` } : {}),
+    position: "relative" as const,
+  };
+  const actions: MobileChatAction[] = [
+    { key: "pin", label: "Pin chat", shortLabel: "Pin", icon: Pin, disabled: false, onSelect: () => undefined },
+    {
+      key: "mark-unread",
+      label: "Mark as unread",
+      shortLabel: "Unread",
+      icon: Mail,
+      disabled: false,
+      onSelect: () => undefined,
+    },
+    {
+      key: "archive",
+      label: "Archive chat",
+      shortLabel: "Archive",
+      icon: Archive,
+      disabled: false,
+      onSelect: () => undefined,
+    },
+  ];
   const content = (
-    <div className="flex h-full flex-col" style={{ gap: "var(--sp-3)" }}>
+    <div className="relative flex h-full flex-col" style={{ gap: "var(--sp-3)", zIndex: 1, pointerEvents: "none" }}>
       <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
         <AvatarBubble label={chat.title} />
         <div className="min-w-0" style={{ flex: 1 }}>
-          <MobileSignalChip signal={chat.signal} label={reasonLabel} />
+          <MobileSignalChip signal={chat.signal} />
         </div>
         <span className="mono text-mobile-caption shrink-0" style={{ color: "var(--fg-4)" }}>
           {chat.time}
+        </span>
+        <span style={{ pointerEvents: "auto" }}>
+          <MobileCardActionsMenu actions={actions} title={chat.title} />
         </span>
       </div>
       <p
@@ -537,7 +610,7 @@ function MockChatRow({
             color: "var(--fg-3)",
             margin: 0,
             display: "-webkit-box",
-            WebkitLineClamp: cardTier === "feed" ? 3 : 2,
+            WebkitLineClamp: 2,
             WebkitBoxOrient: "vertical",
             overflow: "hidden",
           }}
@@ -547,8 +620,17 @@ function MockChatRow({
         </p>
       ) : null}
       {actionLabel ? (
-        <div className="flex items-center" style={{ marginTop: "auto" }}>
-          <Button type="button" variant="cta" size="sm" onClick={() => onOpen(chat.id)} data-mobile-primary-action>
+        <div className="flex items-center" style={{ marginTop: "auto", pointerEvents: "auto" }}>
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            onClick={() => {
+              if (chat.signal.tone === "needs-you" && onAnswer) onAnswer(chat.id);
+              else onOpen(chat.id);
+            }}
+            data-mobile-primary-action
+          >
             {actionLabel}
             <ArrowRight aria-hidden className="h-3.5 w-3.5" />
           </Button>
@@ -557,27 +639,19 @@ function MockChatRow({
     </div>
   );
 
-  if (actionLabel) {
-    return (
+  return (
+    <MobileSwipeCard actions={actions}>
       <article style={cardStyle} data-mobile-card={cardTier}>
+        <button
+          type="button"
+          aria-label={`Open ${chat.title}`}
+          onClick={() => onOpen(chat.id)}
+          className="absolute inset-0 cursor-pointer border-0 bg-transparent"
+          style={{ zIndex: 0 }}
+        />
         {content}
       </article>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={() => onOpen(chat.id)}
-      className="block w-full text-left transition-colors hover:bg-[var(--bg-hover)]"
-      style={{
-        ...cardStyle,
-        cursor: "pointer",
-      }}
-      data-mobile-card={cardTier}
-    >
-      {content}
-    </button>
+    </MobileSwipeCard>
   );
 }
 
@@ -591,21 +665,6 @@ function previewTabTitle(tab: PreviewTab): string {
       return "Team";
     case "me":
       return "Me";
-  }
-}
-
-function mockFeedReasonLabel(chat: MockChat): string {
-  switch (chat.signal.tone) {
-    case "needs-you":
-      return "Question waiting";
-    case "error":
-      return "Failed run";
-    case "unread":
-      return "Unread mention";
-    case "working":
-      return "Working now";
-    case "idle":
-      return chat.watching ? "Watching" : "Recent update";
   }
 }
 

--- a/packages/web/src/pages/mobile/__tests__/answer-cache.test.ts
+++ b/packages/web/src/pages/mobile/__tests__/answer-cache.test.ts
@@ -1,0 +1,66 @@
+import type { ListMeChatsResponse, MeChatRow, Message } from "@first-tree/shared";
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import { commitMobileAskResolution, locallyResolvedRequestIds, mobileResolvedRequestKey } from "../answer-cache.js";
+
+const row: MeChatRow = {
+  chatId: "chat-1",
+  type: "group",
+  membershipKind: "participant",
+  createdByMe: false,
+  source: "manual",
+  entityType: null,
+  title: "Pinned request",
+  topic: "Pinned request",
+  description: null,
+  participants: [],
+  participantCount: 2,
+  lastMessageAt: "2026-07-14T10:00:00.000Z",
+  lastMessagePreview: "Choose one",
+  unreadMentionCount: 0,
+  openRequestCount: 1,
+  canReply: true,
+  engagementStatus: "active",
+  liveActivity: null,
+  failedAgentIds: [],
+  busyAgentIds: [],
+  chatHasExplicitMentionToMe: false,
+  pinnedAt: "2026-07-14T09:00:00.000Z",
+  activityAt: "2026-07-14T10:00:00.000Z",
+};
+
+const request = {
+  id: "request-1",
+  chatId: row.chatId,
+  senderId: "agent-1",
+  format: "request",
+  content: "Choose one",
+  metadata: {},
+  inReplyTo: null,
+  source: "web",
+  createdAt: "2026-07-14T10:00:00.000Z",
+} satisfies Message;
+
+describe("mobile answer cache", () => {
+  it("tombstones the request and synchronously demotes its mobile list projection", async () => {
+    const queryClient = new QueryClient();
+    const listKey = ["me", "chats", "mobile", "now"];
+    const list: ListMeChatsResponse = {
+      priorityRows: { attention: [row], pinned: [] },
+      rows: [row],
+      nextCursor: null,
+    };
+    queryClient.setQueryData(["chat-open-requests", row.chatId], { items: [request] });
+    queryClient.setQueryData(listKey, list);
+
+    await commitMobileAskResolution(queryClient, row.chatId, request.id);
+
+    expect(queryClient.getQueryData(mobileResolvedRequestKey(row.chatId))).toEqual([request.id]);
+    expect(locallyResolvedRequestIds(queryClient, row.chatId).has(request.id)).toBe(true);
+    expect(queryClient.getQueryData<{ items: Message[] }>(["chat-open-requests", row.chatId])?.items).toEqual([]);
+    const patched = queryClient.getQueryData<ListMeChatsResponse>(listKey);
+    expect(patched?.priorityRows.attention).toEqual([]);
+    expect(patched?.priorityRows.pinned).toEqual([{ ...row, openRequestCount: 0 }]);
+    expect(patched?.rows[0]?.openRequestCount).toBe(0);
+  });
+});

--- a/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
@@ -1,0 +1,296 @@
+// @vitest-environment happy-dom
+
+import type { ChatDetail, MeChatRow, Message } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider } from "../../../components/ui/toast.js";
+import { createDomHarness, type DomHarness, setViewportSize } from "../../../test-utils/dom-harness.js";
+import { MobileChatPage } from "../chat.js";
+import { MobileNowPage } from "../now.js";
+
+const meChatMocks = vi.hoisted(() => ({
+  listMeChats: vi.fn(),
+  markMeChatUnread: vi.fn(),
+  pinMeChat: vi.fn(),
+}));
+const chatMocks = vi.hoisted(() => ({
+  getChat: vi.fn(),
+  listChatOpenRequests: vi.fn(),
+  patchChatEngagement: vi.fn(),
+  readFileAsBase64: vi.fn(),
+  sendChatMessage: vi.fn(),
+  sendFileMessageBatch: vi.fn(),
+}));
+
+vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => ({ agentId: "human-agent-self" }) }));
+vi.mock("../../../api/me-chats.js", () => meChatMocks);
+vi.mock("../../../api/chats.js", () => chatMocks);
+
+const row: MeChatRow = {
+  chatId: "question",
+  type: "group",
+  membershipKind: "participant",
+  createdByMe: false,
+  source: "manual",
+  entityType: null,
+  title: "Release readiness",
+  topic: "Release readiness",
+  description: "Choose the release path after checking the evidence.",
+  participants: [
+    {
+      agentId: "human-agent-self",
+      displayName: "Gandy",
+      type: "human",
+      avatarColorToken: null,
+      avatarImageUrl: null,
+    },
+    {
+      agentId: "agent-1",
+      displayName: "gandy-coder",
+      type: "agent",
+      avatarColorToken: null,
+      avatarImageUrl: null,
+    },
+  ],
+  participantCount: 2,
+  lastMessageAt: "2026-07-14T10:00:00.000Z",
+  lastMessagePreview: "Which rollout should we use?",
+  unreadMentionCount: 0,
+  openRequestCount: 1,
+  canReply: true,
+  engagementStatus: "active",
+  liveActivity: null,
+  failedAgentIds: [],
+  busyAgentIds: [],
+  chatHasExplicitMentionToMe: false,
+  pinnedAt: null,
+  activityAt: "2026-07-14T10:00:00.000Z",
+};
+
+const request: Message = {
+  id: "request-1",
+  chatId: row.chatId,
+  senderId: "agent-1",
+  format: "request",
+  content: "## Release decision\n\nThe staging evidence is green. Which rollout should we use?",
+  metadata: {
+    mentions: ["human-agent-self"],
+    request: {
+      multiSelect: false,
+      options: [
+        { label: "Ship now", description: "Start the production rollout." },
+        { label: "Hold", description: "Keep the release on staging." },
+      ],
+    },
+  },
+  inReplyTo: null,
+  source: "web",
+  createdAt: "2026-07-14T10:00:00.000Z",
+};
+
+const detail: ChatDetail = {
+  id: row.chatId,
+  organizationId: "org-1",
+  type: "group",
+  topic: row.topic,
+  description: row.description,
+  lifecyclePolicy: null,
+  metadata: {},
+  createdAt: "2026-07-14T09:00:00.000Z",
+  updatedAt: "2026-07-14T10:00:00.000Z",
+  title: row.title,
+  firstMessagePreview: "Release decision",
+  engagementStatus: "active",
+  viewerMembershipKind: "participant",
+  descriptionUpdatedAt: null,
+  lastReadAt: null,
+  participants: [
+    {
+      agentId: "human-agent-self",
+      role: "member",
+      mode: "full",
+      joinedAt: "2026-07-14T09:00:00.000Z",
+      name: "gandy2025",
+      displayName: "Gandy",
+      type: "human",
+      avatarColorToken: null,
+      avatarImageUrl: null,
+    },
+    {
+      agentId: "agent-1",
+      role: "member",
+      mode: "full",
+      joinedAt: "2026-07-14T09:00:00.000Z",
+      name: "gandy-coder",
+      displayName: "gandy-coder",
+      type: "agent",
+      avatarColorToken: null,
+      avatarImageUrl: null,
+    },
+  ],
+};
+
+let currentLocation = "";
+function LocationProbe() {
+  const location = useLocation();
+  currentLocation = `${location.pathname}${location.search}`;
+  return null;
+}
+
+function renderPage(harness: DomHarness, page: "now" | "chat") {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  harness.render(
+    <MemoryRouter initialEntries={[`/m/${page}`]}>
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <LocationProbe />
+          <Routes>
+            <Route path="/m/now" element={<MobileNowPage />} />
+            <Route path="/m/chat" element={<MobileChatPage />} />
+          </Routes>
+        </ToastProvider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+async function click(element: Element | null): Promise<void> {
+  if (!element) throw new Error("Missing click target");
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
+describe("mobile card actions", () => {
+  let harness: DomHarness;
+
+  beforeEach(() => {
+    harness = createDomHarness();
+    setViewportSize(390, 844);
+    currentLocation = "";
+    for (const mock of Object.values(meChatMocks)) mock.mockReset();
+    for (const mock of Object.values(chatMocks)) mock.mockReset();
+    meChatMocks.listMeChats.mockResolvedValue({
+      rows: [row],
+      priorityRows: { attention: [], pinned: [] },
+      nextCursor: null,
+    });
+    meChatMocks.pinMeChat.mockResolvedValue({ chatId: row.chatId, pinnedAt: "2026-07-14T12:00:00.000Z" });
+    meChatMocks.markMeChatUnread.mockResolvedValue({ chatId: row.chatId, unreadMentionCount: 1 });
+    chatMocks.patchChatEngagement.mockResolvedValue({ chatId: row.chatId, engagementStatus: "archived" });
+    chatMocks.listChatOpenRequests.mockResolvedValue({ items: [request] });
+    chatMocks.getChat.mockResolvedValue(detail);
+    chatMocks.sendChatMessage.mockResolvedValue({ ...request, id: "answer-1", format: "text", content: "Ship now" });
+    chatMocks.sendFileMessageBatch.mockResolvedValue({ ...request, id: "answer-file-1", format: "file" });
+  });
+
+  afterEach(() => harness.cleanup());
+
+  it("offers only the approved reversible triage actions from the card menu", async () => {
+    renderPage(harness, "chat");
+    await harness.waitFor(() => expect(harness.container.textContent).toContain(row.title));
+
+    await click(harness.container.querySelector(`button[aria-label="Manage ${row.title}"]`));
+    const menu = document.body.querySelector('[role="menu"]');
+    expect(menu?.textContent).toContain("Pin chat");
+    expect(menu?.textContent).toContain("Mark as unread");
+    expect(menu?.textContent).toContain("Archive chat");
+    expect(menu?.textContent).not.toContain("Delete");
+
+    await click(
+      [...document.body.querySelectorAll('[role="menuitem"]')].find((item) => item.textContent === "Pin chat") ?? null,
+    );
+    await harness.waitFor(() => expect(meChatMocks.pinMeChat).toHaveBeenCalledWith(row.chatId, true));
+    expect(currentLocation).toBe("/m/chat");
+  });
+
+  it("keeps the shortcut tray open after a swipe while suppressing the card click", async () => {
+    renderPage(harness, "chat");
+    await harness.waitFor(() => expect(harness.container.textContent).toContain(row.title));
+    const surface = harness.container.querySelector<HTMLElement>("[data-mobile-swipe-surface]");
+    if (!surface) throw new Error("Missing swipe surface");
+    surface.setPointerCapture = vi.fn();
+
+    await act(async () => {
+      surface.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          pointerId: 1,
+          pointerType: "touch",
+          clientX: 320,
+          clientY: 200,
+        }),
+      );
+      surface.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          pointerId: 1,
+          pointerType: "touch",
+          clientX: 100,
+          clientY: 202,
+        }),
+      );
+      surface.dispatchEvent(
+        new PointerEvent("pointerup", {
+          bubbles: true,
+          pointerId: 1,
+          pointerType: "touch",
+          clientX: 100,
+          clientY: 202,
+        }),
+      );
+      // Browsers emit a synthetic click after pointerup. It must be swallowed
+      // without immediately closing the tray the swipe just opened.
+      surface.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    const translatedX = Number.parseFloat(surface.style.transform.match(/translate3d\(([^,]+)/)?.[1] ?? "0");
+    expect(translatedX).toBe(-3 * 68);
+    expect(surface.previousElementSibling?.getAttribute("aria-hidden")).toBe("false");
+    expect(currentLocation).toBe("/m/chat");
+  });
+
+  it("opens the question over Now, sends the answer, and never navigates into detail", async () => {
+    renderPage(harness, "now");
+    await harness.waitFor(() => expect(harness.container.textContent).toContain(row.title));
+
+    await click(harness.container.querySelector("[data-mobile-primary-action]"));
+    await harness.waitFor(() =>
+      expect(document.body.querySelector('[role="dialog"]')?.getAttribute("aria-label")).toBe(
+        "Question from gandy-coder",
+      ),
+    );
+    expect(currentLocation).toBe("/m/now");
+    expect(document.body.textContent).toContain("Which rollout should we use?");
+
+    await click(
+      [...document.body.querySelectorAll('button[role="radio"]')].find((item) =>
+        item.textContent?.includes("Ship now"),
+      ) ?? null,
+    );
+    await click([...document.body.querySelectorAll("button")].find((item) => item.textContent === "Reply") ?? null);
+
+    await harness.waitFor(() =>
+      expect(chatMocks.sendChatMessage).toHaveBeenCalledWith(row.chatId, "Ship now", ["agent-1"], {
+        inReplyTo: request.id,
+        resolves: { request: request.id, kind: "answered" },
+      }),
+    );
+    expect(currentLocation).toBe("/m/now");
+    await harness.waitFor(() => expect(document.body.querySelector("[data-mobile-ask-sheet]")).toBeNull());
+  });
+
+  it("lets the feed sheet close without resolving the question", async () => {
+    renderPage(harness, "now");
+    await harness.waitFor(() => expect(harness.container.textContent).toContain(row.title));
+    await click(harness.container.querySelector("[data-mobile-primary-action]"));
+    await harness.waitFor(() => expect(document.body.querySelector('[aria-label="Close question"]')).not.toBeNull());
+
+    await click(document.body.querySelector('[aria-label="Close question"]'));
+    expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
+    expect(document.body.querySelector("[data-mobile-ask-sheet]")).toBeNull();
+    expect(currentLocation).toBe("/m/now");
+  });
+});

--- a/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import type { ChatDetail, MeChatRow, Message } from "@first-tree/shared";
+import type { ChatDetail, ListMeChatsResponse, MeChatRow, Message } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
@@ -133,14 +133,23 @@ const detail: ChatDetail = {
 };
 
 let currentLocation = "";
+let listResponse: ListMeChatsResponse;
 function LocationProbe() {
   const location = useLocation();
   currentLocation = `${location.pathname}${location.search}`;
   return null;
 }
 
-function renderPage(harness: DomHarness, page: "now" | "chat") {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function renderPage(harness: DomHarness, page: "now" | "chat"): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Number.POSITIVE_INFINITY } },
+  });
+  queryClient.setQueryData(["chat-open-requests", row.chatId], { items: [request] });
+  queryClient.setQueryData(["chat-detail", row.chatId], detail);
+  queryClient.setQueryData(
+    page === "now" ? ["me", "chats", "mobile", "now"] : ["me", "chats", "mobile", "chats", "all"],
+    listResponse,
+  );
   harness.render(
     <MemoryRouter initialEntries={[`/m/${page}`]}>
       <QueryClientProvider client={queryClient}>
@@ -154,6 +163,7 @@ function renderPage(harness: DomHarness, page: "now" | "chat") {
       </QueryClientProvider>
     </MemoryRouter>,
   );
+  return queryClient;
 }
 
 async function click(element: Element | null): Promise<void> {
@@ -172,11 +182,12 @@ describe("mobile card actions", () => {
     currentLocation = "";
     for (const mock of Object.values(meChatMocks)) mock.mockReset();
     for (const mock of Object.values(chatMocks)) mock.mockReset();
-    meChatMocks.listMeChats.mockResolvedValue({
+    listResponse = {
       rows: [row],
       priorityRows: { attention: [], pinned: [] },
       nextCursor: null,
-    });
+    };
+    meChatMocks.listMeChats.mockResolvedValue(listResponse);
     meChatMocks.pinMeChat.mockResolvedValue({ chatId: row.chatId, pinnedAt: "2026-07-14T12:00:00.000Z" });
     meChatMocks.markMeChatUnread.mockResolvedValue({ chatId: row.chatId, unreadMentionCount: 1 });
     chatMocks.patchChatEngagement.mockResolvedValue({ chatId: row.chatId, engagementStatus: "archived" });
@@ -204,6 +215,34 @@ describe("mobile card actions", () => {
     );
     await harness.waitFor(() => expect(meChatMocks.pinMeChat).toHaveBeenCalledWith(row.chatId, true));
     expect(currentLocation).toBe("/m/chat");
+  });
+
+  it("renders and hoists a pinned chat that exists only in the server priority projection", async () => {
+    const recent = {
+      ...row,
+      chatId: "recent",
+      title: "Newest ordinary chat",
+      openRequestCount: 0,
+      lastMessageAt: "2026-07-14T12:00:00.000Z",
+    };
+    const pinnedOnly = {
+      ...row,
+      chatId: "pinned-only",
+      title: "Older pinned chat",
+      openRequestCount: 0,
+      pinnedAt: "2026-07-14T11:00:00.000Z",
+      lastMessageAt: "2026-06-01T12:00:00.000Z",
+    };
+    listResponse = {
+      rows: [recent],
+      priorityRows: { attention: [], pinned: [pinnedOnly] },
+      nextCursor: null,
+    } satisfies ListMeChatsResponse;
+
+    renderPage(harness, "chat");
+    await harness.waitFor(() => expect(harness.container.textContent).toContain(recent.title));
+    const titles = [...harness.container.querySelectorAll("[data-mobile-card-title]")].map((node) => node.textContent);
+    expect(titles).toEqual([pinnedOnly.title, recent.title]);
   });
 
   it("keeps the shortcut tray open after a swipe while suppressing the card click", async () => {
@@ -253,7 +292,7 @@ describe("mobile card actions", () => {
   });
 
   it("opens the question over Now, sends the answer, and never navigates into detail", async () => {
-    renderPage(harness, "now");
+    const queryClient = renderPage(harness, "now");
     await harness.waitFor(() => expect(harness.container.textContent).toContain(row.title));
 
     await click(harness.container.querySelector("[data-mobile-primary-action]"));
@@ -280,6 +319,24 @@ describe("mobile card actions", () => {
     );
     expect(currentLocation).toBe("/m/now");
     await harness.waitFor(() => expect(document.body.querySelector("[data-mobile-ask-sheet]")).toBeNull());
+    await harness.waitFor(() => expect(harness.container.textContent).not.toContain(row.title));
+
+    // Simulate delayed stale projections arriving after the sheet closed. The
+    // row may briefly expose Answer again, but the request-id tombstone keeps
+    // the resolved request inert and prevents a second transport submission.
+    queryClient.setQueryData(["chat-open-requests", row.chatId], { items: [request] });
+    queryClient.setQueryData<ListMeChatsResponse>(["me", "chats", "mobile", "now"], {
+      rows: [row],
+      priorityRows: { attention: [row], pinned: [] },
+      nextCursor: null,
+    });
+    await harness.waitFor(() => expect(harness.container.textContent).toContain(row.title));
+    await click(harness.container.querySelector("[data-mobile-primary-action]"));
+    await harness.waitFor(() =>
+      expect(document.body.querySelector('[role="dialog"]')?.getAttribute("aria-label")).toBe("Question unavailable"),
+    );
+    expect(document.body.textContent).toContain("Question already handled");
+    expect(chatMocks.sendChatMessage).toHaveBeenCalledTimes(1);
   });
 
   it("lets the feed sheet close without resolving the question", async () => {

--- a/packages/web/src/pages/mobile/__tests__/data.test.ts
+++ b/packages/web/src/pages/mobile/__tests__/data.test.ts
@@ -1,12 +1,12 @@
 import type { MeChatRow } from "@first-tree/shared";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   countAttentionRows,
   countUnreadRows,
+  formatMobileAge,
   isNowFeedRow,
   mobileChatPreview,
   mobileChatSignal,
-  mobileFeedReasonLabel,
   sortMobileChats,
 } from "../data.js";
 
@@ -88,32 +88,6 @@ describe("mobile chat projection", () => {
     expect(mobileChatSignal(explicitMention).label).toBe("Unread");
     expect(mobileChatSignal(explicitMention).attention).toBe(false);
   });
-
-  it("does not infer the requester from chat participants", () => {
-    expect(
-      mobileFeedReasonLabel(
-        chatRow({
-          openRequestCount: 1,
-          participants: [
-            {
-              agentId: "human-agent-self",
-              displayName: "Gandy",
-              type: "human",
-              avatarColorToken: null,
-              avatarImageUrl: null,
-            },
-            {
-              agentId: "unrelated-agent",
-              displayName: "Unrelated agent",
-              type: "agent",
-              avatarColorToken: null,
-              avatarImageUrl: null,
-            },
-          ],
-        }),
-      ),
-    ).toBe("Question waiting");
-  });
 });
 
 describe("isNowFeedRow (needs-attention admission)", () => {
@@ -171,5 +145,33 @@ describe("mobileChatPreview", () => {
     expect(mobileChatPreview(chatRow({ description: null, lastMessagePreview: "![](https://x/y.png)" }))).toBe(
       "No messages yet.",
     );
+  });
+});
+
+describe("formatMobileAge", () => {
+  it("keeps waiting time relative and never rounds into the next unit early", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-14T12:00:00.000Z"));
+    try {
+      expect(formatMobileAge("2026-07-14T11:59:30.000Z")).toBe("now");
+      expect(formatMobileAge("2026-07-14T11:00:01.000Z")).toBe("59m");
+      expect(formatMobileAge("2026-07-13T12:00:01.000Z")).toBe("23h");
+      expect(formatMobileAge("2026-07-10T12:00:00.000Z")).toBe("4d");
+      expect(formatMobileAge("2026-06-30T12:00:00.000Z")).toBe("2w");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("omits invalid values and treats clock-skewed future timestamps as now", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-14T12:00:00.000Z"));
+    try {
+      expect(formatMobileAge(null)).toBe("");
+      expect(formatMobileAge("not-a-date")).toBe("");
+      expect(formatMobileAge("2026-07-14T12:05:00.000Z")).toBe("now");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/web/src/pages/mobile/__tests__/data.test.ts
+++ b/packages/web/src/pages/mobile/__tests__/data.test.ts
@@ -1,4 +1,4 @@
-import type { MeChatRow } from "@first-tree/shared";
+import type { ListMeChatsResponse, MeChatRow } from "@first-tree/shared";
 import { describe, expect, it, vi } from "vitest";
 import {
   countAttentionRows,
@@ -7,6 +7,7 @@ import {
   isNowFeedRow,
   mobileChatPreview,
   mobileChatSignal,
+  mobileRowsFromList,
   sortMobileChats,
 } from "../data.js";
 
@@ -43,8 +44,8 @@ function chatRow(overrides: Partial<MeChatRow> = {}): MeChatRow {
     failedAgentIds: overrides.failedAgentIds ?? [],
     busyAgentIds: overrides.busyAgentIds ?? [],
     chatHasExplicitMentionToMe: overrides.chatHasExplicitMentionToMe ?? false,
-    pinnedAt: null,
-    activityAt: null,
+    pinnedAt: overrides.pinnedAt ?? null,
+    activityAt: overrides.activityAt ?? null,
   };
 }
 
@@ -71,6 +72,31 @@ describe("mobile chat projection", () => {
       "working",
       "unread",
     ]);
+  });
+
+  it("includes priority-only pinned chats, de-duplicates additive rows, and keeps priority order", () => {
+    const failed = chatRow({ chatId: "failed", failedAgentIds: ["agent-1"] });
+    const pinnedOnly = chatRow({
+      chatId: "pinned-only",
+      pinnedAt: "2026-07-09T09:00:00.000Z",
+      lastMessageAt: "2026-06-01T09:00:00.000Z",
+    });
+    const olderPin = chatRow({
+      chatId: "older-pin",
+      pinnedAt: "2026-07-08T09:00:00.000Z",
+      lastMessageAt: "2026-07-09T12:00:00.000Z",
+    });
+    const newer = chatRow({ chatId: "newer", lastMessageAt: "2026-07-09T11:00:00.000Z" });
+    const duplicatePinned = { ...pinnedOnly, title: "Wrong additive copy" };
+    const response: ListMeChatsResponse = {
+      priorityRows: { attention: [failed], pinned: [pinnedOnly, olderPin] },
+      rows: [newer, duplicatePinned, failed],
+      nextCursor: null,
+    };
+
+    const rows = sortMobileChats(mobileRowsFromList(response));
+    expect(rows.map((row) => row.chatId)).toEqual(["failed", "pinned-only", "older-pin", "newer"]);
+    expect(rows.find((row) => row.chatId === "pinned-only")?.title).toBe(pinnedOnly.title);
   });
 
   it("counts attention and unread rows separately for mobile tab badges", () => {

--- a/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactElement } from "react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider } from "../../../components/ui/toast.js";
 import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
 import { MobileChatPage } from "../chat.js";
 import { MobileNowPage } from "../now.js";
@@ -99,10 +100,12 @@ function renderWithClient(harness: DomHarness, element: ReactElement, path: stri
   harness.render(
     <MemoryRouter initialEntries={[path]}>
       <QueryClientProvider client={queryClient}>
-        <Routes>
-          <Route path="/m/now" element={element} />
-          <Route path="/m/chat" element={element} />
-        </Routes>
+        <ToastProvider>
+          <Routes>
+            <Route path="/m/now" element={element} />
+            <Route path="/m/chat" element={element} />
+          </Routes>
+        </ToastProvider>
       </QueryClientProvider>
     </MemoryRouter>,
   );
@@ -147,7 +150,7 @@ describe("mobile density tiers", () => {
   it("renders Now work as one priority feed without section grouping", async () => {
     renderWithClient(harness, <MobileNowPage />, "/m/now");
     await harness.waitFor(() => expect(harness.container.textContent).toContain("Release readiness"));
-    expect(harness.container.textContent).toContain("Work feed");
+    expect(harness.container.textContent).toContain("Now");
     expect(harness.container.textContent).not.toContain("need attention");
 
     const sectionHeadings = [...harness.container.querySelectorAll("h2")].map((heading) => heading.textContent);
@@ -162,12 +165,12 @@ describe("mobile density tiers", () => {
     // the question (priority) and working (feed) cards.
     expect(feedCards).toHaveLength(2);
     expect(feedCards[0]?.textContent).toContain("Release readiness");
-    expect(feedCards[0]?.getAttribute("style")).toContain("min-height: var(--sp-45)");
-    expect(feedCards[1]?.getAttribute("style")).toContain("min-height: var(--sp-35)");
+    expect(feedCards[0]?.getAttribute("style")).toContain("min-height: var(--sp-35)");
+    expect(feedCards[1]?.getAttribute("style")).toContain("min-height: var(--sp-20)");
     expect(feedCards[0]?.querySelector("[data-mobile-card-title]")?.className).toContain("text-mobile-title");
     expect(feedCards[0]?.querySelector("[data-mobile-card-preview]")?.className).toContain("text-mobile-body");
     const labels = [...feed.querySelectorAll("[data-mobile-signal-label]")].map((label) => label.textContent);
-    expect(labels).toEqual(["Question waiting", "Working now"]);
+    expect(labels).toEqual(["Needs your answer", "Working now"]);
     expect(feedCards[0]?.querySelector("[data-mobile-signal-label]")?.className).toContain("truncate");
     expect(feedCards[0]?.querySelector("[data-mobile-primary-action]")?.textContent).toContain("Answer");
     expect(feedCards[1]?.querySelector("[data-mobile-primary-action]")).toBeNull();

--- a/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
@@ -143,6 +143,7 @@ describe("mobile density tiers", () => {
         chatRow({ chatId: "working", title: "Context docs", busyAgentIds: ["agent-1"] }),
         chatRow({ chatId: "recent", title: "Team roster polish" }),
       ],
+      priorityRows: { attention: [], pinned: [] },
       nextCursor: null,
     });
   });
@@ -200,6 +201,7 @@ describe("mobile density tiers", () => {
           description: "**Task:** run the seed (`first-tree-seed`)",
         }),
       ],
+      priorityRows: { attention: [], pinned: [] },
       nextCursor: null,
     });
     renderWithClient(harness, <MobileNowPage />, "/m/now");

--- a/packages/web/src/pages/mobile/__tests__/realtime-cache.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/realtime-cache.test.tsx
@@ -18,7 +18,11 @@ describe("mobile projections share the realtime invalidation prefix", () => {
   beforeEach(() => {
     harness = createDomHarness();
     meChatMocks.listMeChats.mockReset();
-    meChatMocks.listMeChats.mockResolvedValue({ rows: [] });
+    meChatMocks.listMeChats.mockResolvedValue({
+      rows: [],
+      priorityRows: { attention: [], pinned: [] },
+      nextCursor: null,
+    });
   });
 
   it("refetches Now when ['me','chats'] is invalidated (answer / new message / failure)", async () => {

--- a/packages/web/src/pages/mobile/answer-cache.ts
+++ b/packages/web/src/pages/mobile/answer-cache.ts
@@ -1,0 +1,77 @@
+import type { ListMeChatsResponse, MeChatRow, Message } from "@first-tree/shared";
+import type { InfiniteData, QueryClient } from "@tanstack/react-query";
+
+type MeChatsCache = ListMeChatsResponse | InfiniteData<ListMeChatsResponse>;
+
+export function mobileResolvedRequestKey(chatId: string): readonly string[] {
+  return ["mobile-resolved-requests", chatId];
+}
+
+export function locallyResolvedRequestIds(queryClient: QueryClient, chatId: string): ReadonlySet<string> {
+  return new Set(queryClient.getQueryData<string[]>(mobileResolvedRequestKey(chatId)) ?? []);
+}
+
+/**
+ * Commit the local projection of a successful mobile answer before closing the
+ * sheet. The server projections are eventually consistent, so merely firing a
+ * refetch leaves a window where the same cached request can be opened and sent
+ * twice. A session-local request-id tombstone remains authoritative against a
+ * delayed stale response, while the list/open-request caches update
+ * synchronously so Now removes the resolved signal immediately.
+ */
+export async function commitMobileAskResolution(
+  queryClient: QueryClient,
+  chatId: string,
+  requestId: string,
+): Promise<void> {
+  await Promise.all([
+    queryClient.cancelQueries({ queryKey: ["chat-open-requests", chatId] }),
+    queryClient.cancelQueries({ queryKey: ["me", "chats"] }),
+  ]);
+
+  queryClient.setQueryData<string[]>(mobileResolvedRequestKey(chatId), (previous = []) =>
+    previous.includes(requestId) ? previous : [...previous, requestId],
+  );
+  queryClient.setQueryData<{ items: Message[] }>(["chat-open-requests", chatId], (previous) =>
+    previous ? { ...previous, items: previous.items.filter((item) => item.id !== requestId) } : previous,
+  );
+  queryClient.setQueriesData<MeChatsCache>({ queryKey: ["me", "chats"] }, (previous) =>
+    previous ? patchMeChatsCache(previous, chatId) : previous,
+  );
+
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["chat-open-requests", chatId], refetchType: "none" }),
+    queryClient.invalidateQueries({ queryKey: ["me", "chats"], refetchType: "none" }),
+    queryClient.invalidateQueries({ queryKey: ["chat-messages", chatId] }),
+  ]);
+}
+
+function patchMeChatsCache(data: MeChatsCache, chatId: string): MeChatsCache {
+  if ("pages" in data) {
+    return { ...data, pages: data.pages.map((page) => patchMeChatsResponse(page, chatId)) };
+  }
+  return patchMeChatsResponse(data, chatId);
+}
+
+function patchMeChatsResponse(data: ListMeChatsResponse, chatId: string): ListMeChatsResponse {
+  const patchRow = (row: MeChatRow): MeChatRow =>
+    row.chatId === chatId ? { ...row, openRequestCount: Math.max(0, row.openRequestCount - 1) } : row;
+
+  let demoted: MeChatRow | undefined;
+  const attention = data.priorityRows.attention.flatMap((row) => {
+    const patched = patchRow(row);
+    if (row.chatId === chatId && patched.openRequestCount === 0 && patched.failedAgentIds.length === 0) {
+      demoted = patched;
+      return [];
+    }
+    return [patched];
+  });
+  let pinned = data.priorityRows.pinned.map(patchRow);
+  if (demoted?.pinnedAt && !pinned.some((row) => row.chatId === chatId)) pinned = [demoted, ...pinned];
+
+  return {
+    ...data,
+    priorityRows: { attention, pinned },
+    rows: data.rows.map(patchRow),
+  };
+}

--- a/packages/web/src/pages/mobile/ask-sheet.tsx
+++ b/packages/web/src/pages/mobile/ask-sheet.tsx
@@ -1,0 +1,200 @@
+import type { AttachmentRef, RequestResolution } from "@first-tree/shared";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { uploadAttachment, uploadMimeFor } from "../../api/attachments.js";
+import {
+  getChat,
+  type ImageRefContent,
+  listChatOpenRequests,
+  readFileAsBase64,
+  sendChatMessage,
+  sendFileMessageBatch,
+} from "../../api/chats.js";
+import { putImage } from "../../api/image-store.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { type AskAnswer, AskTakeover } from "../../components/chat/ask-takeover.js";
+import { findBlockingRequest, readRequestPayload } from "../../components/chat/request-state.js";
+import type { MentionCandidate } from "../../components/mention-autocomplete.js";
+import { useToast } from "../../components/ui/toast.js";
+import { MobileSystemState } from "./components.js";
+
+export function MobileAskSheet({ chatId, onClose }: { chatId: string; onClose: () => void }) {
+  const { agentId } = useAuth();
+  const queryClient = useQueryClient();
+  const { addToast } = useToast();
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requestsQuery = useQuery({
+    queryKey: ["chat-open-requests", chatId],
+    queryFn: () => listChatOpenRequests(chatId),
+    refetchInterval: 5_000,
+  });
+  const detailQuery = useQuery({
+    queryKey: ["chat-detail", chatId],
+    queryFn: () => getChat(chatId),
+    staleTime: 10_000,
+  });
+
+  const request = useMemo(() => {
+    const ordered = [...(requestsQuery.data?.items ?? [])].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    return findBlockingRequest(ordered, agentId ?? null);
+  }, [agentId, requestsQuery.data?.items]);
+  const payload = request ? readRequestPayload(request.metadata) : null;
+  const askerName = request
+    ? (detailQuery.data?.participants.find((participant) => participant.agentId === request.senderId)?.displayName ??
+      undefined)
+    : undefined;
+  const mentionCandidates = useMemo<MentionCandidate[]>(
+    () =>
+      (detailQuery.data?.participants ?? [])
+        .filter((participant) => participant.agentId !== agentId && participant.name)
+        .map((participant) => ({
+          agentId: participant.agentId,
+          name: participant.name,
+          displayName: participant.displayName,
+          managedByMe: false,
+          avatarImageUrl: participant.avatarImageUrl,
+          avatarColorToken: participant.avatarColorToken,
+        })),
+    [agentId, detailQuery.data?.participants],
+  );
+
+  const submit = async (answer: AskAnswer): Promise<void> => {
+    if (!request || sending) return;
+    setError(null);
+    setSending(true);
+    const routedMentions = [...new Set([request.senderId, ...answer.mentions])];
+    const resolves: RequestResolution = { request: request.id, kind: "answered" };
+    try {
+      const documentRefs: AttachmentRef[] = [];
+      for (const attachment of answer.attachments ?? []) {
+        const uploaded = await uploadAttachment(attachment.file);
+        documentRefs.push({
+          attachmentId: uploaded.id,
+          kind: attachment.kind,
+          mimeType: uploadMimeFor(attachment.file),
+          filename: attachment.file.name,
+          size: attachment.file.size,
+        });
+      }
+
+      if (answer.images.length > 0) {
+        const imageRefs: ImageRefContent[] = [];
+        for (const file of answer.images) {
+          const uploaded = await uploadAttachment(file);
+          try {
+            await putImage({ imageId: uploaded.id, base64: await readFileAsBase64(file), mimeType: file.type });
+          } catch {
+            // The server attachment is authoritative; IndexedDB is only a
+            // best-effort cache that makes the sender's thumbnail immediate.
+          }
+          imageRefs.push({ imageId: uploaded.id, mimeType: file.type, filename: file.name, size: file.size });
+        }
+        await sendFileMessageBatch(
+          chatId,
+          { ...(answer.content ? { caption: answer.content } : {}), attachments: imageRefs },
+          { mentions: routedMentions, ...(documentRefs.length > 0 ? { attachments: documentRefs } : {}) },
+          { inReplyTo: request.id, resolves },
+        );
+      } else {
+        await sendChatMessage(chatId, answer.content, routedMentions, {
+          inReplyTo: request.id,
+          resolves,
+          ...(documentRefs.length > 0 ? { attachments: documentRefs } : {}),
+        });
+      }
+
+      void queryClient.invalidateQueries({ queryKey: ["chat-open-requests", chatId] });
+      void queryClient.invalidateQueries({ queryKey: ["chat-messages", chatId] });
+      void queryClient.invalidateQueries({ queryKey: ["me", "chats"] });
+      addToast({ title: "Answer sent" });
+      onClose();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Failed to send your answer");
+      setSending(false);
+    }
+  };
+
+  if (request && payload) {
+    return (
+      <div className="fixed inset-0" style={{ zIndex: 70 }} data-mobile-ask-sheet>
+        <AskTakeover
+          key={request.id}
+          body={typeof request.content === "string" ? request.content : ""}
+          payload={payload}
+          askerName={askerName}
+          sending={sending}
+          error={error ?? undefined}
+          mentionCandidates={mentionCandidates}
+          mobile
+          onDismiss={onClose}
+          onReply={(answer) => {
+            void submit(answer);
+          }}
+          onSkip={() => {
+            void submit({ content: "(Skipped — no answer provided.)", mentions: [], images: [] });
+          }}
+        />
+      </div>
+    );
+  }
+
+  const loading = requestsQuery.isLoading || detailQuery.isLoading;
+  const loadError = requestsQuery.error ?? detailQuery.error;
+  return (
+    <div
+      className="fixed inset-0 flex items-end"
+      style={{ zIndex: 70, background: "color-mix(in oklch, var(--fg) 10%, transparent)" }}
+      data-mobile-ask-sheet
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-label={loading ? "Loading question" : "Question unavailable"}
+        className="relative w-full"
+        style={{
+          minHeight: "var(--sp-35)",
+          padding: "var(--sp-6) var(--sp-4) calc(var(--sp-6) + env(safe-area-inset-bottom))",
+          borderTop: "var(--hairline) solid var(--border)",
+          borderRadius: "var(--radius-dialog) var(--radius-dialog) 0 0",
+          background: "var(--bg-raised)",
+          boxShadow: "var(--shadow-md)",
+        }}
+      >
+        <button
+          type="button"
+          aria-label="Close question"
+          onClick={onClose}
+          className="absolute inline-flex items-center justify-center"
+          style={{
+            top: "var(--sp-2)",
+            right: "var(--sp-2)",
+            width: 44,
+            height: 44,
+            border: 0,
+            borderRadius: "var(--radius-input)",
+            background: "transparent",
+            color: "var(--fg-3)",
+          }}
+        >
+          <X aria-hidden className="h-5 w-5" />
+        </button>
+        <MobileSystemState
+          title={loading ? "Loading question" : loadError ? "Couldn't load question" : "Question already handled"}
+          detail={
+            loading
+              ? undefined
+              : loadError
+                ? loadError instanceof Error
+                  ? loadError.message
+                  : String(loadError)
+                : "The feed will refresh automatically."
+          }
+          tone={loadError ? "error" : "idle"}
+        />
+      </section>
+    </div>
+  );
+}

--- a/packages/web/src/pages/mobile/ask-sheet.tsx
+++ b/packages/web/src/pages/mobile/ask-sheet.tsx
@@ -1,22 +1,14 @@
-import type { AttachmentRef, RequestResolution } from "@first-tree/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { useMemo, useState } from "react";
-import { uploadAttachment, uploadMimeFor } from "../../api/attachments.js";
-import {
-  getChat,
-  type ImageRefContent,
-  listChatOpenRequests,
-  readFileAsBase64,
-  sendChatMessage,
-  sendFileMessageBatch,
-} from "../../api/chats.js";
-import { putImage } from "../../api/image-store.js";
+import { getChat, listChatOpenRequests } from "../../api/chats.js";
 import { useAuth } from "../../auth/auth-context.js";
+import { sendAskAnswer } from "../../components/chat/ask-answer-transport.js";
 import { type AskAnswer, AskTakeover } from "../../components/chat/ask-takeover.js";
 import { findBlockingRequest, readRequestPayload } from "../../components/chat/request-state.js";
 import type { MentionCandidate } from "../../components/mention-autocomplete.js";
 import { useToast } from "../../components/ui/toast.js";
+import { commitMobileAskResolution, locallyResolvedRequestIds } from "./answer-cache.js";
 import { MobileSystemState } from "./components.js";
 
 export function MobileAskSheet({ chatId, onClose }: { chatId: string; onClose: () => void }) {
@@ -38,9 +30,12 @@ export function MobileAskSheet({ chatId, onClose }: { chatId: string; onClose: (
   });
 
   const request = useMemo(() => {
-    const ordered = [...(requestsQuery.data?.items ?? [])].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    const locallyResolved = locallyResolvedRequestIds(queryClient, chatId);
+    const ordered = [...(requestsQuery.data?.items ?? [])]
+      .filter((item) => !locallyResolved.has(item.id))
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
     return findBlockingRequest(ordered, agentId ?? null);
-  }, [agentId, requestsQuery.data?.items]);
+  }, [agentId, chatId, queryClient, requestsQuery.data?.items]);
   const payload = request ? readRequestPayload(request.metadata) : null;
   const askerName = request
     ? (detailQuery.data?.participants.find((participant) => participant.agentId === request.senderId)?.displayName ??
@@ -65,50 +60,9 @@ export function MobileAskSheet({ chatId, onClose }: { chatId: string; onClose: (
     if (!request || sending) return;
     setError(null);
     setSending(true);
-    const routedMentions = [...new Set([request.senderId, ...answer.mentions])];
-    const resolves: RequestResolution = { request: request.id, kind: "answered" };
     try {
-      const documentRefs: AttachmentRef[] = [];
-      for (const attachment of answer.attachments ?? []) {
-        const uploaded = await uploadAttachment(attachment.file);
-        documentRefs.push({
-          attachmentId: uploaded.id,
-          kind: attachment.kind,
-          mimeType: uploadMimeFor(attachment.file),
-          filename: attachment.file.name,
-          size: attachment.file.size,
-        });
-      }
-
-      if (answer.images.length > 0) {
-        const imageRefs: ImageRefContent[] = [];
-        for (const file of answer.images) {
-          const uploaded = await uploadAttachment(file);
-          try {
-            await putImage({ imageId: uploaded.id, base64: await readFileAsBase64(file), mimeType: file.type });
-          } catch {
-            // The server attachment is authoritative; IndexedDB is only a
-            // best-effort cache that makes the sender's thumbnail immediate.
-          }
-          imageRefs.push({ imageId: uploaded.id, mimeType: file.type, filename: file.name, size: file.size });
-        }
-        await sendFileMessageBatch(
-          chatId,
-          { ...(answer.content ? { caption: answer.content } : {}), attachments: imageRefs },
-          { mentions: routedMentions, ...(documentRefs.length > 0 ? { attachments: documentRefs } : {}) },
-          { inReplyTo: request.id, resolves },
-        );
-      } else {
-        await sendChatMessage(chatId, answer.content, routedMentions, {
-          inReplyTo: request.id,
-          resolves,
-          ...(documentRefs.length > 0 ? { attachments: documentRefs } : {}),
-        });
-      }
-
-      void queryClient.invalidateQueries({ queryKey: ["chat-open-requests", chatId] });
-      void queryClient.invalidateQueries({ queryKey: ["chat-messages", chatId] });
-      void queryClient.invalidateQueries({ queryKey: ["me", "chats"] });
+      await sendAskAnswer({ chatId, request, answer });
+      await commitMobileAskResolution(queryClient, chatId, request.id);
       addToast({ title: "Answer sent" });
       onClose();
     } catch (cause) {

--- a/packages/web/src/pages/mobile/chat-card-actions.tsx
+++ b/packages/web/src/pages/mobile/chat-card-actions.tsx
@@ -1,0 +1,338 @@
+import type { MeChatRow } from "@first-tree/shared";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Archive, Mail, MoreHorizontal, Pin } from "lucide-react";
+import { type ReactNode, type PointerEvent as ReactPointerEvent, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { patchChatEngagement } from "../../api/chats.js";
+import { markMeChatUnread, pinMeChat } from "../../api/me-chats.js";
+import { useToast } from "../../components/ui/toast.js";
+
+export type MobileChatAction = {
+  key: "pin" | "mark-unread" | "archive";
+  label: string;
+  shortLabel: string;
+  icon: typeof Pin;
+  disabled: boolean;
+  onSelect: () => void;
+};
+
+/**
+ * The deliberately small mobile triage set. Destructive deletion and other
+ * desktop management controls stay out of the phone surface; these three
+ * reversible actions are the shortcuts approved for Now / Chat cards.
+ */
+export function useMobileChatActions(row: MeChatRow): MobileChatAction[] {
+  const queryClient = useQueryClient();
+  const { addToast } = useToast();
+  const invalidate = (): void => {
+    void queryClient.invalidateQueries({ queryKey: ["me", "chats"] });
+    void queryClient.invalidateQueries({ queryKey: ["chat-detail", row.chatId] });
+  };
+
+  const pinMutation = useMutation({
+    scope: { id: `mobile-chat-pin:${row.chatId}` },
+    mutationFn: (nextPinned: boolean) => pinMeChat(row.chatId, nextPinned),
+    onSuccess: (_data, nextPinned) => {
+      addToast({ title: nextPinned ? "Pinned" : "Unpinned" });
+      invalidate();
+    },
+    onError: (_error, nextPinned) => {
+      addToast({
+        title: nextPinned ? "Couldn't pin" : "Couldn't unpin",
+        description: "The change wasn't saved — try again.",
+      });
+    },
+  });
+  const unreadMutation = useMutation({
+    mutationFn: () => markMeChatUnread(row.chatId),
+    onSuccess: () => {
+      addToast({ title: "Marked as unread" });
+      invalidate();
+    },
+    onError: () => {
+      addToast({ title: "Couldn't mark as unread", description: "The change wasn't saved — try again." });
+    },
+  });
+  const archiveMutation = useMutation({
+    mutationFn: () => patchChatEngagement(row.chatId, "archived"),
+    onSuccess: () => {
+      addToast({ title: "Archived" });
+      invalidate();
+    },
+    onError: () => {
+      addToast({ title: "Couldn't archive", description: "The change wasn't saved — try again." });
+    },
+  });
+
+  return useMemo(
+    () => [
+      {
+        key: "pin",
+        label: row.pinnedAt ? "Unpin chat" : "Pin chat",
+        shortLabel: row.pinnedAt ? "Unpin" : "Pin",
+        icon: Pin,
+        disabled: pinMutation.isPending,
+        onSelect: () => pinMutation.mutate(row.pinnedAt === null),
+      },
+      {
+        key: "mark-unread",
+        label: "Mark as unread",
+        shortLabel: "Unread",
+        icon: Mail,
+        disabled: row.unreadMentionCount > 0 || unreadMutation.isPending,
+        onSelect: () => unreadMutation.mutate(),
+      },
+      {
+        key: "archive",
+        label: "Archive chat",
+        shortLabel: "Archive",
+        icon: Archive,
+        disabled: archiveMutation.isPending,
+        onSelect: () => archiveMutation.mutate(),
+      },
+    ],
+    [
+      archiveMutation.isPending,
+      archiveMutation.mutate,
+      pinMutation.isPending,
+      pinMutation.mutate,
+      row.pinnedAt,
+      row.unreadMentionCount,
+      unreadMutation.isPending,
+      unreadMutation.mutate,
+    ],
+  );
+}
+
+/** A touch-minimum kebab that opens a thumb-reachable action sheet, not a tiny popover. */
+export function MobileCardActionsMenu({ actions, title }: { actions: MobileChatAction[]; title: string }) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      setOpen(false);
+      requestAnimationFrame(() => triggerRef.current?.focus());
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={`Manage ${title}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-mobile-card-menu
+        onClick={(event) => {
+          event.stopPropagation();
+          setOpen((value) => !value);
+        }}
+        className="inline-flex shrink-0 items-center justify-center transition-colors active:translate-y-px"
+        style={{
+          width: 44,
+          height: 44,
+          margin: "calc(var(--sp-2) * -1)",
+          border: 0,
+          borderRadius: "var(--radius-input)",
+          background: "transparent",
+          color: "var(--fg-3)",
+        }}
+      >
+        <MoreHorizontal aria-hidden className="h-5 w-5" />
+      </button>
+      {open && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              role="presentation"
+              className="fixed inset-0"
+              style={{ zIndex: 80, background: "color-mix(in oklch, var(--fg) 10%, transparent)" }}
+              onPointerDown={(event) => {
+                if (event.target !== event.currentTarget) return;
+                setOpen(false);
+                requestAnimationFrame(() => triggerRef.current?.focus());
+              }}
+            >
+              <div
+                role="menu"
+                aria-label={`Manage ${title}`}
+                className="absolute left-0 right-0"
+                style={{
+                  bottom: 0,
+                  padding: "var(--sp-2) var(--sp-3) calc(var(--sp-3) + env(safe-area-inset-bottom))",
+                  background: "var(--bg-raised)",
+                  borderTop: "var(--hairline) solid var(--border)",
+                  borderRadius: "var(--radius-dialog) var(--radius-dialog) 0 0",
+                  boxShadow: "var(--shadow-md)",
+                }}
+              >
+                <p
+                  className="text-mobile-caption truncate"
+                  style={{ margin: "0 var(--sp-2) var(--sp-2)", color: "var(--fg-4)" }}
+                >
+                  {title}
+                </p>
+                {actions.map((action) => (
+                  <button
+                    key={action.key}
+                    type="button"
+                    role="menuitem"
+                    disabled={action.disabled}
+                    onClick={() => {
+                      setOpen(false);
+                      action.onSelect();
+                    }}
+                    className="flex w-full items-center text-left transition-colors active:translate-y-px disabled:opacity-50"
+                    style={{
+                      minHeight: 48,
+                      gap: "var(--sp-3)",
+                      padding: "0 var(--sp-3)",
+                      border: 0,
+                      borderRadius: "var(--radius-input)",
+                      background: "transparent",
+                      color: "var(--fg)",
+                    }}
+                  >
+                    <action.icon aria-hidden className="h-4 w-4" />
+                    <span className="text-mobile-body">{action.label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}
+
+const SWIPE_ACTION_WIDTH = 68;
+const SWIPE_OPEN_THRESHOLD = 40;
+
+/**
+ * Progressive shortcut for repeat users: a horizontal swipe exposes the same
+ * three actions as the kebab. Vertical scrolling keeps browser ownership via
+ * `touchAction: pan-y`; a completed swipe suppresses the synthetic card click.
+ */
+export function MobileSwipeCard({ actions, children }: { actions: MobileChatAction[]; children: ReactNode }) {
+  const trayWidth = actions.length * SWIPE_ACTION_WIDTH;
+  const [open, setOpen] = useState(false);
+  const [dragOffset, setDragOffset] = useState<number | null>(null);
+  const gestureRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    startOffset: number;
+    lastOffset: number;
+    horizontal: boolean;
+  } | null>(null);
+  const suppressClickRef = useRef(false);
+  const offset = dragOffset ?? (open ? -trayWidth : 0);
+
+  const finishGesture = (event: ReactPointerEvent<HTMLDivElement>): void => {
+    const gesture = gestureRef.current;
+    if (!gesture || gesture.pointerId !== event.pointerId) return;
+    if (gesture.horizontal) {
+      const moved = gesture.lastOffset - gesture.startOffset;
+      setOpen(moved < -SWIPE_OPEN_THRESHOLD || (gesture.startOffset < 0 && moved < SWIPE_OPEN_THRESHOLD));
+      suppressClickRef.current = Math.abs(moved) > 8;
+    }
+    setDragOffset(null);
+    gestureRef.current = null;
+  };
+
+  return (
+    <div className="relative" style={{ borderRadius: "var(--radius-dialog)", overflow: "hidden" }}>
+      <div className="absolute inset-y-0 right-0 flex" aria-hidden={!open}>
+        {actions.map((action) => (
+          <button
+            key={action.key}
+            type="button"
+            tabIndex={open ? 0 : -1}
+            disabled={action.disabled}
+            aria-label={action.label}
+            onClick={() => {
+              setOpen(false);
+              action.onSelect();
+            }}
+            className="flex flex-col items-center justify-center disabled:opacity-50"
+            style={{
+              width: SWIPE_ACTION_WIDTH,
+              gap: "var(--sp-1)",
+              border: 0,
+              borderLeft: "var(--hairline) solid var(--border-faint)",
+              background: "var(--bg-active)",
+              color: "var(--fg-2)",
+            }}
+          >
+            <action.icon aria-hidden className="h-4 w-4" />
+            <span className="text-mobile-caption">{action.shortLabel}</span>
+          </button>
+        ))}
+      </div>
+      <div
+        data-mobile-swipe-surface
+        onPointerDown={(event) => {
+          if (event.pointerType === "mouse" && event.button !== 0) return;
+          gestureRef.current = {
+            pointerId: event.pointerId,
+            startX: event.clientX,
+            startY: event.clientY,
+            startOffset: open ? -trayWidth : 0,
+            lastOffset: open ? -trayWidth : 0,
+            horizontal: false,
+          };
+        }}
+        onPointerMove={(event) => {
+          const gesture = gestureRef.current;
+          if (!gesture || gesture.pointerId !== event.pointerId) return;
+          const dx = event.clientX - gesture.startX;
+          const dy = event.clientY - gesture.startY;
+          if (!gesture.horizontal) {
+            if (Math.abs(dx) < 8 && Math.abs(dy) < 8) return;
+            if (Math.abs(dy) >= Math.abs(dx)) {
+              gestureRef.current = null;
+              return;
+            }
+            gesture.horizontal = true;
+            event.currentTarget.setPointerCapture(event.pointerId);
+          }
+          event.preventDefault();
+          const nextOffset = Math.max(-trayWidth, Math.min(0, gesture.startOffset + dx));
+          gesture.lastOffset = nextOffset;
+          setDragOffset(nextOffset);
+        }}
+        onPointerUp={finishGesture}
+        onPointerCancel={finishGesture}
+        onClickCapture={(event) => {
+          if (suppressClickRef.current) {
+            event.preventDefault();
+            event.stopPropagation();
+            suppressClickRef.current = false;
+            return;
+          }
+          if (open) {
+            event.preventDefault();
+            event.stopPropagation();
+            setOpen(false);
+          }
+        }}
+        style={{
+          position: "relative",
+          zIndex: 1,
+          transform: `translate3d(${offset}px, 0, 0)`,
+          transition: dragOffset === null ? "transform 180ms ease-out" : "none",
+          touchAction: "pan-y",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/pages/mobile/chat.tsx
+++ b/packages/web/src/pages/mobile/chat.tsx
@@ -9,8 +9,8 @@ import { ActivityDots } from "../../components/chat/activity-dots.js";
 import { ChatRowAvatar } from "../../components/chat/chat-row-avatar.js";
 import { DocPreviewDrawer } from "../../components/doc-preview-drawer.js";
 import { Button } from "../../components/ui/button.js";
-import { formatRowTime } from "../../lib/utils.js";
 import { CenterPanel } from "../workspace/center/index.js";
+import { MobileCardActionsMenu, MobileSwipeCard, useMobileChatActions } from "./chat-card-actions.js";
 import {
   MobilePage,
   MobileSegmentedControl,
@@ -18,7 +18,7 @@ import {
   MobileSystemState,
   mobileCardStyle,
 } from "./components.js";
-import { mobileChatPreview, mobileChatSignal, sortMobileChats } from "./data.js";
+import { formatMobileAge, mobileChatPreview, mobileChatSignal, sortMobileChats } from "./data.js";
 
 type MobileChatView = "all" | "unread" | "watching";
 
@@ -137,67 +137,76 @@ function MobileChatRow({
   onSelect: (chatId: string) => void;
 }) {
   const signal = mobileChatSignal(row);
+  const actions = useMobileChatActions(row);
   return (
-    <button
-      type="button"
-      onClick={() => onSelect(row.chatId)}
-      className="w-full text-left transition-colors hover:bg-[var(--bg-hover)]"
-      style={{
-        ...mobileCardStyle("list"),
-      }}
-      data-mobile-card="list"
-    >
-      <div className="flex items-start" style={{ gap: "var(--sp-3)" }}>
-        <ChatRowAvatar
-          title={row.title}
-          type={row.type}
-          participants={row.participants}
-          selfAgentId={selfAgentId}
-          unreadCount={row.unreadMentionCount}
-          failed={row.failedAgentIds.length > 0}
-          needsYou={row.openRequestCount > 0}
-          size={34}
-          muted
-          badge={false}
-          statusDot
-        />
-        <div className="min-w-0" style={{ flex: 1 }}>
-          <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
-            <span
-              className="text-mobile-subtitle truncate"
-              style={{ color: "var(--fg)", flex: 1 }}
-              data-mobile-card-title
-            >
-              {row.title}
-            </span>
-            {row.busyAgentIds.length > 0 ? (
-              <ActivityDots />
-            ) : row.lastMessageAt ? (
-              <span className="mono text-mobile-caption shrink-0" style={{ color: "var(--fg-4)" }}>
-                {formatRowTime(row.lastMessageAt)}
-              </span>
-            ) : null}
+    <MobileSwipeCard actions={actions}>
+      <article
+        className="relative transition-colors hover:bg-[var(--bg-hover)]"
+        style={mobileCardStyle("list")}
+        data-mobile-card="list"
+      >
+        <button
+          type="button"
+          onClick={() => onSelect(row.chatId)}
+          aria-label={`Open ${row.title}`}
+          className="w-full border-0 bg-transparent p-0 text-left"
+        >
+          <div className="flex items-start" style={{ gap: "var(--sp-3)" }}>
+            <ChatRowAvatar
+              title={row.title}
+              type={row.type}
+              participants={row.participants}
+              selfAgentId={selfAgentId}
+              unreadCount={row.unreadMentionCount}
+              failed={false}
+              needsYou={false}
+              size={34}
+              muted
+              badge={false}
+              statusDot
+            />
+            <div className="min-w-0" style={{ flex: 1, paddingRight: "var(--sp-8)" }}>
+              <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
+                <span
+                  className="text-mobile-subtitle truncate"
+                  style={{ color: "var(--fg)", flex: 1 }}
+                  data-mobile-card-title
+                >
+                  {row.title}
+                </span>
+                {row.busyAgentIds.length > 0 ? (
+                  <ActivityDots />
+                ) : row.lastMessageAt ? (
+                  <span className="mono text-mobile-caption shrink-0" style={{ color: "var(--fg-4)" }}>
+                    {formatMobileAge(row.lastMessageAt)}
+                  </span>
+                ) : null}
+              </div>
+              <div className="flex items-center" style={{ gap: "var(--sp-2)", marginTop: "var(--sp-1)" }}>
+                <MobileSignalChip signal={signal} />
+              </div>
+              <p
+                className="text-mobile-body"
+                style={{
+                  color: "var(--fg-3)",
+                  margin: "var(--sp-2) 0 0",
+                  display: "-webkit-box",
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: "vertical",
+                  overflow: "hidden",
+                }}
+                data-mobile-card-preview
+              >
+                {mobileChatPreview(row)}
+              </p>
+            </div>
           </div>
-          <div className="flex items-center" style={{ gap: "var(--sp-2)", marginTop: "var(--sp-1)" }}>
-            <MobileSignalChip signal={signal} />
-          </div>
-          <p
-            className="text-mobile-body"
-            style={{
-              color: "var(--fg-3)",
-              margin: "var(--sp-2) 0 0",
-              display: "-webkit-box",
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: "vertical",
-              overflow: "hidden",
-            }}
-            data-mobile-card-preview
-          >
-            {mobileChatPreview(row)}
-          </p>
-        </div>
-      </div>
-    </button>
+        </button>
+        <span className="absolute" style={{ top: "var(--sp-2)", right: "var(--sp-2)" }}>
+          <MobileCardActionsMenu actions={actions} title={row.title} />
+        </span>
+      </article>
+    </MobileSwipeCard>
   );
 }
 

--- a/packages/web/src/pages/mobile/chat.tsx
+++ b/packages/web/src/pages/mobile/chat.tsx
@@ -18,7 +18,7 @@ import {
   MobileSystemState,
   mobileCardStyle,
 } from "./components.js";
-import { formatMobileAge, mobileChatPreview, mobileChatSignal, sortMobileChats } from "./data.js";
+import { formatMobileAge, mobileChatPreview, mobileChatSignal, mobileRowsFromList, sortMobileChats } from "./data.js";
 
 type MobileChatView = "all" | "unread" | "watching";
 
@@ -87,7 +87,7 @@ function MobileChatList({ onSelectChat }: { onSelectChat: (chatId: string) => vo
       }),
     refetchInterval: 30_000,
   });
-  const rows = sortMobileChats(chatsQuery.data?.rows ?? []);
+  const rows = sortMobileChats(mobileRowsFromList(chatsQuery.data));
 
   return (
     <MobilePage className="flex flex-col" padded>

--- a/packages/web/src/pages/mobile/components.tsx
+++ b/packages/web/src/pages/mobile/components.tsx
@@ -1,6 +1,7 @@
 import { Activity, CircleUserRound, MessageSquareText, UsersRound } from "lucide-react";
 import type { CSSProperties, ReactNode } from "react";
 import { NavLink } from "react-router";
+import { StatusGlyph } from "../../components/ui/status-glyph.js";
 import { cn } from "../../lib/utils.js";
 import type { MobileChatSignal, MobileChatSignalTone } from "./data.js";
 
@@ -20,15 +21,21 @@ const BASE_CARD_STYLE = {
 export function mobileCardStyle(tier: MobileCardTier): CSSProperties {
   switch (tier) {
     case "priorityFeed":
-      return {
-        ...BASE_CARD_STYLE,
-        minHeight: "var(--sp-45)",
-        padding: "var(--sp-4)",
-      };
-    case "feed":
+      // Priority cards earn a floor (so an action always has room) but a shorter
+      // one than before — the old taller floor left dead space and slowed the
+      // scan. Content sizes above it; the 2-line preview + action land near here.
       return {
         ...BASE_CARD_STYLE,
         minHeight: "var(--sp-35)",
+        padding: "var(--sp-4)",
+      };
+    case "feed":
+      // Non-priority cards keep a short floor (so a sparse card holds tap weight)
+      // and otherwise size to content — a tighter, scannable rhythm than the old
+      // uniform tall cards, which left dead space under a 2-line preview.
+      return {
+        ...BASE_CARD_STYLE,
+        minHeight: "var(--sp-20)",
         padding: "var(--sp-4)",
       };
     case "list":
@@ -132,27 +139,40 @@ export function MobileSystemState({
   );
 }
 
+// State pill: a `-soft` fill + `-strong` text capsule (the design system's
+// blessed open-question REQUEST-chip form), replacing the old bare mono dot +
+// label. Reads as an intentional status tag rather than a technical readout,
+// and — with the left-edge accent on the card — lets a single glance sort the
+// feed by priority before any word is read. `working` carries the canonical
+// pulsing liveness dot so it is told apart from a static state by form, not hue.
 export function MobileSignalChip({ signal, label = signal.label }: { signal: MobileChatSignal; label?: string }) {
-  const color = toneColor(signal.tone);
+  const chip = toneChipStyle(signal.tone);
   return (
     <span
-      className="mono inline-flex min-w-0 max-w-full items-center text-mobile-caption"
+      className="text-mobile-label inline-flex min-w-0 max-w-full items-center"
       style={{
         gap: "var(--sp-1)",
-        color,
+        padding: "var(--sp-0_5) var(--sp-2)",
+        borderRadius: "var(--radius-full)",
+        background: chip.soft,
+        color: chip.fg,
         whiteSpace: "nowrap",
       }}
     >
-      <span
-        aria-hidden
-        style={{
-          width: "var(--sp-1_5)",
-          height: "var(--sp-1_5)",
-          borderRadius: "var(--radius-full)",
-          background: color,
-          flexShrink: 0,
-        }}
-      />
+      {signal.tone === "working" ? (
+        <StatusGlyph colorVar="var(--state-working)" shape="dot" pulse="working" size={6} />
+      ) : (
+        <span
+          aria-hidden
+          style={{
+            width: "var(--sp-1_5)",
+            height: "var(--sp-1_5)",
+            borderRadius: "var(--radius-full)",
+            background: chip.dot,
+            flexShrink: 0,
+          }}
+        />
+      )}
       <span className="truncate" data-mobile-signal-label>
         {label}
       </span>
@@ -282,5 +302,40 @@ function toneColor(tone: MobileChatSignalTone): string {
       return "var(--state-working)";
     case "idle":
       return "var(--fg-3)";
+  }
+}
+
+type ChipStyle = { fg: string; soft: string; dot: string };
+
+// Pill fill / text / dot per tone. `-soft` fill + `-strong` text is the AA
+// callout pairing from the design system; `idle` stays a quiet neutral (no
+// fill) since it is an at-rest awareness cue, not attention.
+function toneChipStyle(tone: MobileChatSignalTone): ChipStyle {
+  switch (tone) {
+    case "needs-you":
+      return { fg: "var(--fg-needs-you-strong)", soft: "var(--state-needs-you-soft)", dot: "var(--state-needs-you)" };
+    case "error":
+      return { fg: "var(--fg-error-strong)", soft: "var(--state-error-soft)", dot: "var(--state-error)" };
+    case "unread":
+      return { fg: "var(--fg-error-strong)", soft: "var(--state-error-soft)", dot: "var(--state-unread)" };
+    case "working":
+      return { fg: "var(--fg-success-strong)", soft: "var(--state-working-soft)", dot: "var(--state-working)" };
+    case "idle":
+      return { fg: "var(--fg-3)", soft: "transparent", dot: "var(--fg-4)" };
+  }
+}
+
+// Left-edge accent color for a priority card (failed / needs-you). One
+// pre-attentive signal that sorts the feed by weight before any text is read —
+// replacing the old triple-encoding (avatar red mark + chip + colored button).
+// Returns null for non-priority tones, which carry no accent.
+export function mobileAccentColor(tone: MobileChatSignalTone): string | null {
+  switch (tone) {
+    case "error":
+      return "var(--state-error)";
+    case "needs-you":
+      return "var(--state-needs-you)";
+    default:
+      return null;
   }
 }

--- a/packages/web/src/pages/mobile/data.ts
+++ b/packages/web/src/pages/mobile/data.ts
@@ -16,7 +16,7 @@ export function mobileChatSignal(row: MeChatRow): MobileChatSignal {
   if (attentionReason === "failed") {
     return {
       tone: "error",
-      label: row.failedAgentIds.length === 1 ? "Failed" : `${row.failedAgentIds.length} failed`,
+      label: row.failedAgentIds.length === 1 ? "Run failed" : `${row.failedAgentIds.length} runs failed`,
       rank: 0,
       attention: true,
     };
@@ -24,7 +24,7 @@ export function mobileChatSignal(row: MeChatRow): MobileChatSignal {
   if (attentionReason === "request") {
     return {
       tone: "needs-you",
-      label: row.openRequestCount === 1 ? "Needs answer" : `${row.openRequestCount} questions`,
+      label: row.openRequestCount === 1 ? "Needs your answer" : `${row.openRequestCount} questions`,
       rank: 1,
       attention: true,
     };
@@ -41,7 +41,7 @@ export function mobileChatSignal(row: MeChatRow): MobileChatSignal {
   if (row.busyAgentIds.length > 0 || row.liveActivity !== null) {
     return {
       tone: "working",
-      label: row.liveActivity?.label ?? "Working",
+      label: row.liveActivity?.label ?? "Working now",
       rank: 2,
       attention: false,
     };
@@ -64,27 +64,31 @@ export function mobileChatPreview(row: MeChatRow): string {
   return stripped || "No messages yet.";
 }
 
-export function mobileFeedReasonLabel(row: MeChatRow): string {
-  const attentionReason = rowAttentionReason(row);
-  if (attentionReason === "failed") {
-    return row.failedAgentIds.length === 1 ? "Failed run" : `${row.failedAgentIds.length} failed runs`;
-  }
-  if (attentionReason === "request") {
-    if (row.openRequestCount === 1) {
-      return "Question waiting";
-    }
-    return `${row.openRequestCount} questions waiting`;
-  }
-  if (row.chatHasExplicitMentionToMe || row.unreadMentionCount > 0) {
-    return row.unreadMentionCount > 1 ? `${row.unreadMentionCount} unread mentions` : "Unread mention";
-  }
-  if (row.busyAgentIds.length > 0 || row.liveActivity !== null) {
-    return "Working now";
-  }
-  if (row.membershipKind === "watching") {
-    return "Watching";
-  }
-  return "Recent update";
+const AGE_MINUTE_MS = 60_000;
+const AGE_HOUR_MS = 3_600_000;
+const AGE_DAY_MS = 86_400_000;
+const AGE_WEEK_MS = 7 * AGE_DAY_MS;
+const AGE_MONTH_MS = 30 * AGE_DAY_MS;
+
+/**
+ * Ultra-compact age for the attention feed: "now", "5m", "3h", "4d", "2w",
+ * "3mo". Unlike `formatRowTime`, it never falls back to an absolute `MM/DD`
+ * date — on a needs-attention surface, how long a question has been waiting
+ * or a failure has sat unhandled is itself the signal; a dead date reads as
+ * neither urgent nor stale. Returns "" for null/invalid input so the card
+ * simply omits the slot.
+ */
+export function formatMobileAge(iso: string | null): string {
+  if (!iso) return "";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  const age = Date.now() - t;
+  if (age < AGE_MINUTE_MS) return "now";
+  if (age < AGE_HOUR_MS) return `${Math.floor(age / AGE_MINUTE_MS)}m`;
+  if (age < AGE_DAY_MS) return `${Math.floor(age / AGE_HOUR_MS)}h`;
+  if (age < AGE_WEEK_MS) return `${Math.floor(age / AGE_DAY_MS)}d`;
+  if (age < AGE_MONTH_MS) return `${Math.floor(age / AGE_WEEK_MS)}w`;
+  return `${Math.floor(age / AGE_MONTH_MS)}mo`;
 }
 
 export function sortMobileChats(rows: readonly MeChatRow[]): MeChatRow[] {

--- a/packages/web/src/pages/mobile/data.ts
+++ b/packages/web/src/pages/mobile/data.ts
@@ -1,4 +1,4 @@
-import type { MeChatRow } from "@first-tree/shared";
+import type { ListMeChatsResponse, MeChatRow } from "@first-tree/shared";
 import { stripInlineMarkdown } from "../../lib/strip-inline-markdown.js";
 import { rowAttentionReason } from "../workspace/conversations/group-rows.js";
 
@@ -91,12 +91,43 @@ export function formatMobileAge(iso: string | null): string {
   return `${Math.floor(age / AGE_MONTH_MS)}mo`;
 }
 
+/**
+ * Materialize the server's priority projection for a finite mobile list.
+ * Priority rows cover the full filtered result set while `rows` is only the
+ * loaded recency page, and the latter deliberately remains additive for older
+ * clients. Preserve the contract's attention > pinned > recency precedence
+ * while de-duplicating every chat id.
+ */
+export function mobileRowsFromList(data: ListMeChatsResponse | undefined): MeChatRow[] {
+  if (!data) return [];
+  const seen = new Set<string>();
+  return [...data.priorityRows.attention, ...data.priorityRows.pinned, ...data.rows].filter((row) => {
+    if (seen.has(row.chatId)) return false;
+    seen.add(row.chatId);
+    return true;
+  });
+}
+
 export function sortMobileChats(rows: readonly MeChatRow[]): MeChatRow[] {
   return [...rows].sort((a, b) => {
-    const signalDelta = mobileChatSignal(a).rank - mobileChatSignal(b).rank;
+    const signalA = mobileChatSignal(a);
+    const signalB = mobileChatSignal(b);
+    const priorityDelta = mobilePriorityRank(a, signalA) - mobilePriorityRank(b, signalB);
+    if (priorityDelta !== 0) return priorityDelta;
+    if (a.pinnedAt && b.pinnedAt && !signalA.attention && !signalB.attention) {
+      return timestampValue(b.pinnedAt) - timestampValue(a.pinnedAt);
+    }
+    const signalDelta = signalA.rank - signalB.rank;
     if (signalDelta !== 0) return signalDelta;
-    return timestampValue(b.lastMessageAt) - timestampValue(a.lastMessageAt);
+    return timestampValue(b.activityAt ?? b.lastMessageAt) - timestampValue(a.activityAt ?? a.lastMessageAt);
   });
+}
+
+function mobilePriorityRank(row: MeChatRow, signal: MobileChatSignal): number {
+  // Failed/request attention always wins, even when the chat is also pinned.
+  if (signal.attention) return 0;
+  if (row.pinnedAt) return 1;
+  return 2;
 }
 
 /**

--- a/packages/web/src/pages/mobile/now.tsx
+++ b/packages/web/src/pages/mobile/now.tsx
@@ -10,7 +10,14 @@ import { Button } from "../../components/ui/button.js";
 import { MobileAskSheet } from "./ask-sheet.js";
 import { MobileCardActionsMenu, MobileSwipeCard, useMobileChatActions } from "./chat-card-actions.js";
 import { MobilePage, MobileSignalChip, MobileSystemState, mobileAccentColor, mobileCardStyle } from "./components.js";
-import { formatMobileAge, isNowFeedRow, mobileChatPreview, mobileChatSignal, sortMobileChats } from "./data.js";
+import {
+  formatMobileAge,
+  isNowFeedRow,
+  mobileChatPreview,
+  mobileChatSignal,
+  mobileRowsFromList,
+  sortMobileChats,
+} from "./data.js";
 
 export function MobileNowPage() {
   const { agentId } = useAuth();
@@ -29,7 +36,7 @@ export function MobileNowPage() {
   // with an AUTHORITATIVE active signal (see isNowFeedRow — failed agent, open
   // request, explicit @me, or an in-flight turn), then keep the canonical
   // attention order. Quiet / watching-only chats live in the Chat tab.
-  const sortedRows = sortMobileChats(chatsQuery.data?.rows ?? []).filter(isNowFeedRow);
+  const sortedRows = sortMobileChats(mobileRowsFromList(chatsQuery.data)).filter(isNowFeedRow);
 
   return (
     <>

--- a/packages/web/src/pages/mobile/now.tsx
+++ b/packages/web/src/pages/mobile/now.tsx
@@ -1,17 +1,21 @@
 import type { MeChatRow } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, Plus } from "lucide-react";
-import { Link } from "react-router";
+import { useState } from "react";
+import { Link, useNavigate } from "react-router";
 import { listMeChats } from "../../api/me-chats.js";
 import { useAuth } from "../../auth/auth-context.js";
 import { ChatRowAvatar } from "../../components/chat/chat-row-avatar.js";
 import { Button } from "../../components/ui/button.js";
-import { formatRowTime } from "../../lib/utils.js";
-import { MobilePage, MobileSignalChip, MobileSystemState, mobileCardStyle } from "./components.js";
-import { isNowFeedRow, mobileChatPreview, mobileChatSignal, mobileFeedReasonLabel, sortMobileChats } from "./data.js";
+import { MobileAskSheet } from "./ask-sheet.js";
+import { MobileCardActionsMenu, MobileSwipeCard, useMobileChatActions } from "./chat-card-actions.js";
+import { MobilePage, MobileSignalChip, MobileSystemState, mobileAccentColor, mobileCardStyle } from "./components.js";
+import { formatMobileAge, isNowFeedRow, mobileChatPreview, mobileChatSignal, sortMobileChats } from "./data.js";
 
 export function MobileNowPage() {
   const { agentId } = useAuth();
+  const navigate = useNavigate();
+  const [answeringChatId, setAnsweringChatId] = useState<string | null>(null);
   const chatsQuery = useQuery({
     // Nested under ["me", "chats"] so the shared realtime invalidation
     // (useAdminWs WS events + chat send / ask-answer / new-chat mutations)
@@ -28,52 +32,76 @@ export function MobileNowPage() {
   const sortedRows = sortMobileChats(chatsQuery.data?.rows ?? []).filter(isNowFeedRow);
 
   return (
-    <MobilePage className="flex flex-col" padded>
-      <div className="flex items-center" style={{ gap: "var(--sp-2)", marginBottom: "var(--sp-4)" }}>
-        <div className="min-w-0" style={{ flex: 1 }}>
-          <h1 className="text-mobile-title" style={{ color: "var(--fg)", margin: 0 }}>
-            Work feed
-          </h1>
+    <>
+      <MobilePage className="flex flex-col" padded>
+        <div className="flex items-center" style={{ gap: "var(--sp-2)", marginBottom: "var(--sp-4)" }}>
+          <div className="min-w-0" style={{ flex: 1 }}>
+            <h1 className="text-mobile-title" style={{ color: "var(--fg)", margin: 0 }}>
+              Now
+            </h1>
+          </div>
+          <Button asChild variant="cta" size="sm">
+            <Link to="/m/chat?c=draft">
+              <Plus className="h-3.5 w-3.5" />
+              New
+            </Link>
+          </Button>
         </div>
-        <Button asChild variant="cta" size="sm">
-          <Link to="/m/chat?c=draft">
-            <Plus className="h-3.5 w-3.5" />
-            New
-          </Link>
-        </Button>
-      </div>
 
-      {chatsQuery.isLoading && sortedRows.length === 0 ? (
-        <MobileSystemState title="Loading work" />
-      ) : chatsQuery.error ? (
-        <MobileSystemState title="Failed to load work" detail={formatError(chatsQuery.error)} tone="error" />
-      ) : sortedRows.length === 0 ? (
-        <MobileSystemState
-          title="You're all caught up"
-          detail="Asks, failures, and updates show up here. Find every chat in Chat."
-        />
-      ) : (
-        <div className="flex flex-col" style={{ gap: "var(--sp-2)" }} data-mobile-feed>
-          {sortedRows.map((row) => (
-            <MobileAttentionCard key={row.chatId} row={row} selfAgentId={agentId ?? ""} />
-          ))}
-        </div>
-      )}
-    </MobilePage>
+        {chatsQuery.isLoading && sortedRows.length === 0 ? (
+          <MobileSystemState title="Loading work" />
+        ) : chatsQuery.error ? (
+          <MobileSystemState title="Failed to load work" detail={formatError(chatsQuery.error)} tone="error" />
+        ) : sortedRows.length === 0 ? (
+          <MobileSystemState
+            title="You're all caught up"
+            detail="Asks, failures, and updates show up here. Find every chat in Chat."
+          />
+        ) : (
+          <div className="flex flex-col" style={{ gap: "var(--sp-2)" }} data-mobile-feed>
+            {sortedRows.map((row) => (
+              <MobileAttentionCard
+                key={row.chatId}
+                row={row}
+                selfAgentId={agentId ?? ""}
+                onOpenChat={(chatId) => navigate(`/m/chat?c=${encodeURIComponent(chatId)}`)}
+                onOpenAnswer={setAnsweringChatId}
+              />
+            ))}
+          </div>
+        )}
+      </MobilePage>
+      {answeringChatId ? <MobileAskSheet chatId={answeringChatId} onClose={() => setAnsweringChatId(null)} /> : null}
+    </>
   );
 }
 
-function MobileAttentionCard({ row, selfAgentId }: { row: MeChatRow; selfAgentId: string }) {
+function MobileAttentionCard({
+  row,
+  selfAgentId,
+  onOpenChat,
+  onOpenAnswer,
+}: {
+  row: MeChatRow;
+  selfAgentId: string;
+  onOpenChat: (chatId: string) => void;
+  onOpenAnswer: (chatId: string) => void;
+}) {
   const signal = mobileChatSignal(row);
   const preview = mobileChatPreview(row);
   const actionLabel = primaryActionLabel(signal.tone);
-  const reasonLabel = mobileFeedReasonLabel(row);
+  const accent = mobileAccentColor(signal.tone);
+  const actions = useMobileChatActions(row);
   const cardStyle = {
     ...mobileCardStyle(actionLabel ? "priorityFeed" : "feed"),
     textDecoration: "none",
+    position: "relative" as const,
+    // One pre-attentive priority cue: a left-edge accent in the state hue,
+    // replacing the avatar red mark + chip + colored button triple-encoding.
+    ...(accent ? { boxShadow: `inset var(--hairline-bold) 0 0 0 ${accent}` } : {}),
   };
   const content = (
-    <div className="flex h-full flex-col" style={{ gap: "var(--sp-3)" }}>
+    <div className="relative flex h-full flex-col" style={{ gap: "var(--sp-3)", zIndex: 1, pointerEvents: "none" }}>
       <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
         <ChatRowAvatar
           title={row.title}
@@ -81,21 +109,24 @@ function MobileAttentionCard({ row, selfAgentId }: { row: MeChatRow; selfAgentId
           participants={row.participants}
           selfAgentId={selfAgentId}
           unreadCount={row.unreadMentionCount}
-          failed={row.failedAgentIds.length > 0}
-          needsYou={row.openRequestCount > 0}
+          failed={false}
+          needsYou={false}
           size={36}
           muted
           badge={false}
           statusDot
         />
         <div className="min-w-0" style={{ flex: 1 }}>
-          <MobileSignalChip signal={signal} label={reasonLabel} />
+          <MobileSignalChip signal={signal} />
         </div>
         {row.lastMessageAt ? (
           <span className="mono text-mobile-caption shrink-0" style={{ color: "var(--fg-4)" }}>
-            {formatRowTime(row.lastMessageAt)}
+            {formatMobileAge(row.lastMessageAt)}
           </span>
         ) : null}
+        <span style={{ pointerEvents: "auto" }}>
+          <MobileCardActionsMenu actions={actions} title={row.title} />
+        </span>
       </div>
       <p
         className="text-mobile-title"
@@ -117,7 +148,7 @@ function MobileAttentionCard({ row, selfAgentId }: { row: MeChatRow; selfAgentId
           color: "var(--fg-3)",
           margin: 0,
           display: "-webkit-box",
-          WebkitLineClamp: 3,
+          WebkitLineClamp: 2,
           WebkitBoxOrient: "vertical",
           overflow: "hidden",
         }}
@@ -126,35 +157,38 @@ function MobileAttentionCard({ row, selfAgentId }: { row: MeChatRow; selfAgentId
         {preview}
       </p>
       {actionLabel ? (
-        <div className="flex items-center" style={{ marginTop: "auto" }}>
-          <Button asChild variant="cta" size="sm" data-mobile-primary-action>
-            <Link to={`/m/chat?c=${encodeURIComponent(row.chatId)}`}>
-              {actionLabel}
-              <ArrowRight aria-hidden className="h-3.5 w-3.5" />
-            </Link>
+        <div className="flex items-center" style={{ marginTop: "auto", pointerEvents: "auto" }}>
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            data-mobile-primary-action
+            onClick={() => {
+              if (signal.tone === "needs-you") onOpenAnswer(row.chatId);
+              else onOpenChat(row.chatId);
+            }}
+          >
+            {actionLabel}
+            <ArrowRight aria-hidden className="h-3.5 w-3.5" />
           </Button>
         </div>
       ) : null}
     </div>
   );
 
-  if (actionLabel) {
-    return (
+  return (
+    <MobileSwipeCard actions={actions}>
       <article style={cardStyle} data-mobile-card="feed">
+        <button
+          type="button"
+          aria-label={`Open ${row.title}`}
+          onClick={() => onOpenChat(row.chatId)}
+          className="absolute inset-0 cursor-pointer border-0 bg-transparent"
+          style={{ zIndex: 0 }}
+        />
         {content}
       </article>
-    );
-  }
-
-  return (
-    <Link
-      to={`/m/chat?c=${encodeURIComponent(row.chatId)}`}
-      className="block transition-colors hover:bg-[var(--bg-hover)]"
-      style={cardStyle}
-      data-mobile-card="feed"
-    >
-      {content}
-    </Link>
+    </MobileSwipeCard>
   );
 }
 

--- a/packages/web/src/pages/mobile/shell.tsx
+++ b/packages/web/src/pages/mobile/shell.tsx
@@ -6,7 +6,7 @@ import { TeamSwitchOverlay } from "../../components/team-switch-overlay.js";
 import { useAdminWs } from "../../hooks/use-admin-ws.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
 import { MobileBottomTabs } from "./components.js";
-import { countAttentionRows, countUnreadRows } from "./data.js";
+import { countAttentionRows, countUnreadRows, mobileRowsFromList } from "./data.js";
 import { InstallGuideSheet } from "./install-guide-sheet.js";
 import { useInstallGuideAuto } from "./use-install-guide.js";
 
@@ -35,7 +35,7 @@ export function MobileShell() {
 
   const selectedChatId = searchParams.get("c");
   const immersiveChat = location.pathname === "/m/chat" && selectedChatId !== null;
-  const rows = tabCountsQuery.data?.rows ?? [];
+  const rows = mobileRowsFromList(tabCountsQuery.data);
 
   // Kept above the onboarding early-return so hook order stays unconditional.
   const installGuide = useInstallGuideAuto({ hasContent: rows.length > 0, immersive: immersiveChat });

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -83,6 +83,7 @@ import { useAuth } from "../../../auth/auth-context.js";
 import { AddParticipantDropdown } from "../../../components/add-participant-dropdown.js";
 import { Avatar as RealAvatar } from "../../../components/avatar.js";
 import { AgentHovercard } from "../../../components/chat/agent-hovercard.js";
+import { sendAskAnswer } from "../../../components/chat/ask-answer-transport.js";
 import { type AskAnswer, AskTakeover } from "../../../components/chat/ask-takeover.js";
 import { awaitedAgentsFromMessage, ChatOfflineNotice } from "../../../components/chat/chat-offline-notice.js";
 import { ComposeStatusBar } from "../../../components/chat/compose-status-bar.js";
@@ -2346,49 +2347,8 @@ export function ChatView({
     if (askBusy) return;
     setAskError(null);
     setAskBusy(true);
-    // Route to the asker PLUS anyone the free text @mentioned (deduped).
-    const routedMentions = [...new Set([request.senderId, ...answer.mentions])];
-    const resolves: RequestResolution = { request: request.id, kind: "answered" };
-    const docs = answer.attachments ?? [];
     try {
-      const docRefs: AttachmentRef[] = [];
-      for (const doc of docs) {
-        const uploaded = await uploadAttachment(doc.file);
-        docRefs.push({
-          attachmentId: uploaded.id,
-          kind: doc.kind,
-          mimeType: uploadMimeFor(doc.file),
-          filename: doc.file.name,
-          size: doc.file.size,
-        });
-      }
-
-      if (answer.images.length > 0) {
-        const refs: ImageRefContent[] = [];
-        for (const file of answer.images) {
-          const uploaded = await uploadAttachment(file);
-          // Warm the per-browser cache so the sender renders its own image
-          // instantly. Best-effort — the render path re-fetches on a miss.
-          try {
-            await putImage({ imageId: uploaded.id, base64: await readFileAsBase64(file), mimeType: file.type });
-          } catch {
-            // IndexedDB quota / availability — ignore, fall back to server fetch.
-          }
-          refs.push({ imageId: uploaded.id, mimeType: file.type, filename: file.name, size: file.size });
-        }
-        await sendFileMessageBatch(
-          chatId,
-          { ...(answer.content ? { caption: answer.content } : {}), attachments: refs },
-          { mentions: routedMentions, ...(docRefs.length > 0 ? { attachments: docRefs } : {}) },
-          { inReplyTo: request.id, resolves },
-        );
-      } else {
-        await sendChatMessage(chatId, answer.content, routedMentions, {
-          inReplyTo: request.id,
-          resolves,
-          ...(docRefs.length > 0 ? { attachments: docRefs } : {}),
-        });
-      }
+      await sendAskAnswer({ chatId, request, answer });
       queryClient.invalidateQueries({ queryKey: messagesQueryKey });
       queryClient.invalidateQueries({ queryKey: agentSessionsQueryKey(agentId) });
       scrollToBottom("smooth");


### PR DESCRIPTION
## Summary

- refresh the mobile Now and Chat cards around a single scannable state signal: compact age, state pill, priority-only left accent, denser two-line preview, and neutral repeated actions
- keep chat detail available from the full card while adding thumb-reachable pin/unpin, mark-unread, and archive shortcuts through both a kebab sheet and left swipe
- open the oldest blocking question in a bottom sheet over Now, preserving the full question/options and existing Reply/Skip resolution semantics without a route change; dismissing the sheet leaves the question open
- single-source answer transport with Chat detail, render the server's full attention/pinned priority projection, and tombstone successful mobile resolutions so delayed stale projections cannot submit the same answer twice
- keep the dev-only mobile preview interaction-complete so reviewers can exercise the card, swipe, filters, detail navigation, and answer sheet without authentication

This is PR 1 of 2 for the approved mobile card work. PR 2 will adapt shared chat-timeline cards for phone widths and fix AskTakeover overflow/Markdown rendering defects.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the monorepo run hit one unrelated 5s timeout in the client runtime-binary probe under concurrent load; the complete affected suites then passed independently:
  - `pnpm --filter @first-tree/web test` — 1,445 passed
  - `pnpm --filter @first-tree/client test` — 1,506 passed, 3 skipped (including the previously-timed-out probe)
- [x] card-action DOM test passed 15 consecutive focused runs after replacing the async loading race with deterministic Query cache fixtures
- [x] Playwright CLI E2E at 390×844 against `/preview/mobile`: card menu, answer selection/reply, dismiss-without-resolution, detail open/back, Chat tab, and bottom safe-area footer
- [x] light and dark mobile visual QA; final browser console: 0 errors, 0 warnings
- [x] API-backed DOM coverage for priority-only pinned rows, de-duplication/order, swipe click suppression, shared resolving transport, synchronous cache projection, delayed-stale re-entry protection, and dismiss semantics

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: mobile preview and focused DOM/data/density tests updated; new shared transport and answer-cache coverage added
- follow-up work: shared chat timeline mobile adaptation and AskTakeover content bugs in PR 2
- mobile scope decision: [first-tree-context#735](https://github.com/agent-team-foundation/first-tree-context/pull/735) (draft; merge code first, then reconcile and mark ready)
