### PR TITLE
Adapt shared chat timeline cards for mobile widths

### DIFF
--- a/packages/web/src/components/__tests__/markdown-overflow-wrap.test.tsx
+++ b/packages/web/src/components/__tests__/markdown-overflow-wrap.test.tsx
@@ -40,4 +40,16 @@ describe("Markdown long-token wrapping", () => {
     expect(wrapper).not.toBeNull();
     expect(wrapper?.className).toContain("break-words");
   });
+
+  it("renders headings and bounds fenced code to its own horizontal scroller", () => {
+    renderMarkdown(
+      `## Verification\n\n\`\`\`sh\nfirst-tree-staging tree verify --tree-path /${"long-segment".repeat(20)}\n\`\`\``,
+    );
+    const wrapper = container.querySelector(".prose");
+    expect(container.querySelector("h2")?.textContent).toBe("Verification");
+    expect(container.textContent).not.toContain("## Verification");
+    expect(wrapper?.className).toContain("prose-pre:max-w-full");
+    expect(wrapper?.className).toContain("prose-pre:overflow-x-auto");
+    expect(container.querySelector("pre code")?.textContent).toContain("first-tree-staging tree verify");
+  });
 });

--- a/packages/web/src/components/chat/__tests__/github-event-card.test.tsx
+++ b/packages/web/src/components/chat/__tests__/github-event-card.test.tsx
@@ -114,4 +114,22 @@ describe("GitHub event card", () => {
       expect(html).toContain("@alice");
     }
   });
+
+  it("contains long GitHub tokens without clipping the mobile timeline", () => {
+    const html = renderToStaticMarkup(
+      <GithubEventCardMessage
+        content={card({
+          title: `release-${"unbroken".repeat(20)}`,
+          repository: `organization-${"long".repeat(20)}/repository-${"wide".repeat(20)}`,
+          body: `check-${"unbroken".repeat(40)}`,
+        })}
+      />,
+    );
+
+    expect(html).toContain("data-github-card-title");
+    expect(html).toContain("data-github-card-repository");
+    expect(html).toContain("data-github-card-body");
+    expect(html).toContain("overflow-wrap:anywhere");
+    expect(html).toContain("text-overflow:ellipsis");
+  });
 });

--- a/packages/web/src/components/chat/__tests__/github-event-card.test.tsx
+++ b/packages/web/src/components/chat/__tests__/github-event-card.test.tsx
@@ -116,19 +116,32 @@ describe("GitHub event card", () => {
   });
 
   it("contains long GitHub tokens without clipping the mobile timeline", () => {
+    const commitSha = "abcdef0123456789".repeat(3).slice(0, 40);
+    const longRepository = `organization-${"long".repeat(20)}/repository-${"wide".repeat(20)}`;
     const html = renderToStaticMarkup(
       <GithubEventCardMessage
         content={card({
+          event: "commit_comment",
+          kind: "commit_commented",
           title: `release-${"unbroken".repeat(20)}`,
-          repository: `organization-${"long".repeat(20)}/repository-${"wide".repeat(20)}`,
+          repository: longRepository,
           body: `check-${"unbroken".repeat(40)}`,
+          entity: {
+            type: "commit",
+            key: `${longRepository}@${commitSha}`,
+            url: `https://github.com/acme/web/commit/${commitSha}`,
+          },
         })}
       />,
     );
 
+    expect(html).toContain("data-github-card-entity");
+    expect(html).toContain("data-github-card-entity-number");
     expect(html).toContain("data-github-card-title");
     expect(html).toContain("data-github-card-repository");
     expect(html).toContain("data-github-card-body");
+    expect(html).toContain(`title="@${commitSha}"`);
+    expect(html).toContain("max-width:100%");
     expect(html).toContain("overflow-wrap:anywhere");
     expect(html).toContain("text-overflow:ellipsis");
   });

--- a/packages/web/src/components/chat/__tests__/working-turn-dom.test.tsx
+++ b/packages/web/src/components/chat/__tests__/working-turn-dom.test.tsx
@@ -207,4 +207,26 @@ describe("WorkingTurn", () => {
 
     await act(async () => root.unmount());
   });
+
+  it("wraps long agent names and assistant updates inside a narrow timeline", async () => {
+    const { WorkingTurn } = await import("../working-turn.js");
+    const longName = `agent-${"unbroken".repeat(20)}`;
+    const longBody = `progress-${"unbroken".repeat(40)}`;
+    const { container, root } = await renderDom(
+      <WorkingTurn
+        {...props}
+        agentNameFn={() => longName}
+        defaultOpen={false}
+        events={[event({ id: "assistant-long", seq: 1, kind: "assistant_text", payload: { text: longBody } })]}
+      />,
+    );
+
+    expect(container.querySelector<HTMLElement>("[data-working-turn-header]")?.className).toContain("flex-wrap");
+    expect(container.querySelector<HTMLElement>("[data-working-turn-name]")?.style.overflowWrap).toBe("anywhere");
+    expect(container.querySelector<HTMLElement>("[data-working-turn-body]")?.style.overflowWrap).toBe("anywhere");
+    expect(container.textContent).toContain(longName);
+    expect(container.textContent).toContain(longBody);
+
+    await act(async () => root.unmount());
+  });
 });

--- a/packages/web/src/components/chat/github-event-card.tsx
+++ b/packages/web/src/components/chat/github-event-card.tsx
@@ -282,30 +282,57 @@ export function GithubEventCardMessage({ content }: { content: GithubEventCard }
               href={link}
               target="_blank"
               rel="noopener noreferrer"
+              data-github-card-title
               className="font-medium no-underline hover:underline"
-              style={{ color: "var(--fg)", minWidth: 0, flex: "1 1 auto", textDecoration: "none" }}
+              style={{
+                color: "var(--fg)",
+                minWidth: 0,
+                flex: "1 1 auto",
+                overflowWrap: "anywhere",
+                textDecoration: "none",
+              }}
             >
               {titleText}
             </a>
           ) : (
-            <span className="font-medium" style={{ color: "var(--fg)", minWidth: 0, flex: "1 1 auto" }}>
+            <span
+              data-github-card-title
+              className="font-medium"
+              style={{ color: "var(--fg)", minWidth: 0, flex: "1 1 auto", overflowWrap: "anywhere" }}
+            >
               {titleText}
             </span>
           )
         ) : null}
-        <span className="mono text-caption" style={{ color: "var(--fg-4)", marginLeft: "auto", flexShrink: 0 }}>
+        <span
+          data-github-card-repository
+          className="mono text-caption"
+          style={{
+            color: "var(--fg-4)",
+            marginLeft: "auto",
+            minWidth: 0,
+            maxWidth: "100%",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
           {repoShort}
         </span>
       </div>
 
       {/* L2 — action sentence: @actor verb */}
-      <div className="text-caption" style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)" }}>
+      <div
+        className="text-caption"
+        style={{ color: "var(--fg-3)", marginTop: "var(--sp-1)", overflowWrap: "anywhere" }}
+      >
         <span className="mono">@{content.sender}</span> {verb}
       </div>
 
       {/* L3 — quoted body preview */}
       {previewBody ? (
         <div
+          data-github-card-body
           className="text-body"
           style={{
             marginTop: "var(--sp-1)",
@@ -313,6 +340,7 @@ export function GithubEventCardMessage({ content }: { content: GithubEventCard }
             borderLeft: "var(--hairline-bold) solid var(--border)",
             paddingLeft: "var(--sp-2)",
             whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
             display: "-webkit-box",
             WebkitLineClamp: 3,
             WebkitBoxOrient: "vertical",

--- a/packages/web/src/components/chat/github-event-card.tsx
+++ b/packages/web/src/components/chat/github-event-card.tsx
@@ -243,10 +243,13 @@ export function GithubEventCardMessage({ content }: { content: GithubEventCard }
 
   const entityChip = (
     <span
+      data-github-card-entity
       className="mono text-label"
       style={{
         display: "inline-flex",
         alignItems: "center",
+        minWidth: 0,
+        maxWidth: "100%",
         gap: "var(--sp-1)",
         padding: "var(--sp-px) var(--sp-1_5)",
         borderRadius: "var(--radius-chip)",
@@ -256,10 +259,16 @@ export function GithubEventCardMessage({ content }: { content: GithubEventCard }
         lineHeight: 1.4,
       }}
     >
-      <span className="font-semibold" style={{ color: "var(--primary)" }}>
+      <span className="font-semibold" style={{ color: "var(--primary)", flexShrink: 0 }}>
         {tagLabel}
       </span>
-      <span style={{ color: "var(--fg-3)" }}>{entityNumber}</span>
+      <span
+        data-github-card-entity-number
+        title={entityNumber}
+        style={{ color: "var(--fg-3)", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}
+      >
+        {entityNumber}
+      </span>
     </span>
   );
 

--- a/packages/web/src/components/chat/working-turn.tsx
+++ b/packages/web/src/components/chat/working-turn.tsx
@@ -244,8 +244,12 @@ export function WorkingTurn({ events, defaultOpen, agentNameFn, agentAvatarFn, a
   const thinkingCount = processEvents.length - toolCount;
 
   const header = (
-    <div className="flex items-baseline" style={{ gap: 6, minWidth: 0 }}>
-      <span className="mono text-label font-semibold" style={{ color: "var(--primary)", flexShrink: 0 }}>
+    <div data-working-turn-header className="flex flex-wrap items-baseline" style={{ gap: 6, minWidth: 0 }}>
+      <span
+        data-working-turn-name
+        className="mono text-label font-semibold"
+        style={{ color: "var(--primary)", minWidth: 0, maxWidth: "100%", overflowWrap: "anywhere" }}
+      >
         {name}
       </span>
       <span style={{ display: "inline-flex", flexShrink: 0 }}>
@@ -287,7 +291,11 @@ export function WorkingTurn({ events, defaultOpen, agentNameFn, agentAvatarFn, a
           {header}
 
           {bodyText ? (
-            <div className="text-body" style={{ color: "var(--fg)", whiteSpace: "pre-wrap", marginTop: 2 }}>
+            <div
+              data-working-turn-body
+              className="text-body"
+              style={{ color: "var(--fg)", whiteSpace: "pre-wrap", overflowWrap: "anywhere", marginTop: 2 }}
+            >
               {bodyText}
             </div>
           ) : null}

--- a/packages/web/src/components/ui/markdown.tsx
+++ b/packages/web/src/components/ui/markdown.tsx
@@ -159,7 +159,7 @@ export function Markdown({ children, className, components, rehypePlugins }: Mar
         "prose-p:my-2 prose-headings:mt-3 prose-headings:mb-1.5 prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5 prose-pre:my-2 prose-blockquote:my-2 prose-hr:my-3",
         "prose-a:text-[color:var(--primary)] prose-a:no-underline hover:prose-a:underline",
         "prose-code:text-current prose-code:bg-[color:var(--bg-sunken)] prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-[0.9em] prose-code:before:content-none prose-code:after:content-none",
-        "prose-pre:bg-[color:var(--bg-sunken)] prose-pre:text-current prose-pre:border prose-pre:border-[color:var(--border)]",
+        "prose-pre:max-w-full prose-pre:overflow-x-auto prose-pre:bg-[color:var(--bg-sunken)] prose-pre:text-current prose-pre:border prose-pre:border-[color:var(--border)]",
         "prose-hr:border-[color:var(--border)]",
         "prose-blockquote:border-l-[color:var(--border-strong)] prose-blockquote:text-[color:var(--fg-2)]",
         "prose-th:border-[color:var(--border)] prose-td:border-[color:var(--border)]",

--- a/packages/web/src/pages/request-dock-preview.tsx
+++ b/packages/web/src/pages/request-dock-preview.tsx
@@ -1,12 +1,13 @@
-import type { AskRequest } from "@first-tree/shared";
+import type { AskRequest, GithubEventCard } from "@first-tree/shared";
 import { useState } from "react";
 import { AskTakeover } from "../components/chat/ask-takeover.js";
+import { GithubEventCardMessage } from "../components/chat/github-event-card.js";
 
 /**
- * DEV-only visual review for `AskTakeover` — the pop-up answer card for a
- * `format="request"` ask. No backend / no auth — same gating as the other
- * `/preview/*` routes (DEV-only in `app.tsx`). Each mode renders the production
- * card inside a relative box (the card is an absolute scrim that fills it).
+ * DEV-only visual review for `AskTakeover` plus narrow timeline overflow
+ * fixtures. No backend / no auth — same gating as the other `/preview/*`
+ * routes (DEV-only in `app.tsx`). Each ask mode renders the production card
+ * inside a relative box (the card is an absolute scrim that fills it).
  */
 
 const BODY = [
@@ -48,6 +49,25 @@ const MULTI_PAYLOAD: AskRequest = {
         "https://example.invalid/qa/mobile-ask-card-very-long-preview/endpoint?token=abcdefghijklmnopqrstuvwxyz0123456789&scope=read:write:admin&note=this-is-a-deliberately-very-long-single-token-preview-to-exercise-overflow-wrap-and-scroll-clipping",
     },
   ],
+};
+
+const COMMIT_SHA = "abcdef0123456789".repeat(3).slice(0, 40);
+const COMMIT_CARD: GithubEventCard = {
+  type: "github_event",
+  reason: "subscribed",
+  event: "commit_comment",
+  action: "created",
+  kind: "commit_commented",
+  repository: "agent-team-foundation/first-tree",
+  sender: "mobile-reviewer-with-a-long-handle",
+  title: "Commit: Keep the mobile timeline inside its reading column",
+  body: `Verification target ${"unbroken".repeat(30)}`,
+  url: `https://github.com/agent-team-foundation/first-tree/commit/${COMMIT_SHA}`,
+  entity: {
+    type: "commit",
+    key: `agent-team-foundation/first-tree@${COMMIT_SHA}`,
+    url: `https://github.com/agent-team-foundation/first-tree/commit/${COMMIT_SHA}`,
+  },
 };
 
 const MODES: { label: string; payload: AskRequest }[] = [
@@ -132,6 +152,26 @@ export function RequestDockPreviewPage() {
       </p>
       <ModeBlock label="options · single · short" payload={SINGLE_PAYLOAD} height={300} mobile />
       <ModeBlock label="options · multi · short" payload={MULTI_PAYLOAD} height={300} mobile />
+
+      <h2
+        className="mono text-caption font-semibold"
+        style={{ color: "var(--fg-3)", textTransform: "uppercase", marginBottom: "var(--sp-2)" }}
+      >
+        GitHub commit overflow guard
+      </h2>
+      <div
+        data-mobile-github-fixture
+        style={{
+          width: "100%",
+          padding: "var(--sp-3)",
+          border: "var(--hairline) solid var(--border)",
+          borderRadius: "var(--radius-panel)",
+          background: "var(--bg-raised)",
+          overflow: "hidden",
+        }}
+      >
+        <GithubEventCardMessage content={COMMIT_CARD} />
+      </div>
     </div>
   );
 }

--- a/packages/web/src/pages/request-dock-preview.tsx
+++ b/packages/web/src/pages/request-dock-preview.tsx
@@ -18,6 +18,11 @@ const BODY = [
   "### What I'd weigh",
   "- Error budget is healthy; nothing in the dashboards argues against proceeding.",
   "- The billing migration team is waiting on 20% before they cut over.",
+  "",
+  "### Verification command",
+  "```sh",
+  "first-tree-staging tree verify --tree-path /Users/reviewer/first-tree-context/very-long-mobile-verification-worktree",
+  "```",
 ].join("\n");
 
 const SINGLE_PAYLOAD: AskRequest = {
@@ -51,7 +56,17 @@ const MODES: { label: string; payload: AskRequest }[] = [
   { label: "free text", payload: { multiSelect: false } },
 ];
 
-function ModeBlock({ label, payload, height = 560 }: { label: string; payload: AskRequest; height?: number }) {
+function ModeBlock({
+  label,
+  payload,
+  height = 560,
+  mobile = false,
+}: {
+  label: string;
+  payload: AskRequest;
+  height?: number;
+  mobile?: boolean;
+}) {
   const [status, setStatus] = useState<string | null>(null);
   return (
     <section style={{ marginBottom: "var(--sp-6)" }}>
@@ -73,6 +88,7 @@ function ModeBlock({ label, payload, height = 560 }: { label: string; payload: A
           body={BODY}
           payload={payload}
           askerName="deploy-agent"
+          mobile={mobile}
           onReply={(answer) =>
             setStatus(
               `Reply → ${answer.content.replace(/\n/g, " · ")}` +
@@ -114,8 +130,8 @@ export function RequestDockPreviewPage() {
         A short box (the phone case): the answer surface no longer fits, so it scrolls inside the card while the Skip /
         Reply footer stays pinned and visible. Regression guard for the off-screen-button bug.
       </p>
-      <ModeBlock label="options · single · short" payload={SINGLE_PAYLOAD} height={300} />
-      <ModeBlock label="options · multi · short" payload={MULTI_PAYLOAD} height={300} />
+      <ModeBlock label="options · single · short" payload={SINGLE_PAYLOAD} height={300} mobile />
+      <ModeBlock label="options · multi · short" payload={MULTI_PAYLOAD} height={300} mobile />
     </div>
   );
 }

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -803,6 +803,8 @@ describe("ChatView", () => {
     await waitForText(container, "Launch planning");
     await waitForText(container, "Example recoverable runtime error");
     await waitForText(container, "Preview image for");
+    expect(container.querySelector<HTMLElement>("[data-error-header]")?.style.overflowWrap).toBe("anywhere");
+    expect(container.querySelector<HTMLElement>("[data-error-message]")?.style.overflowWrap).toBe("anywhere");
     expect(container.querySelector('[data-mobile-participants-sheet="true"]')).toBeNull();
     expect(container.querySelector('aside[aria-label="Chat details"]')).not.toBeNull();
     expect(container.textContent).toContain("GitHub");
@@ -1967,7 +1969,12 @@ describe("ChatView", () => {
     await waitForText(container, "Send a message to start the conversation");
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
     const send = container.querySelector<HTMLButtonElement>('button[aria-label="Send"]');
-    if (!textarea || !send) throw new Error("Mobile composer missing");
+    const timeline = container.querySelector<HTMLElement>("[data-chat-timeline-scroll]");
+    const footer = container.querySelector<HTMLElement>("[data-chat-composer-footer]");
+    if (!textarea || !send || !timeline || !footer) throw new Error("Mobile composer or timeline missing");
+
+    expect(timeline.style.padding).toContain("var(--sp-4)");
+    expect(footer.style.paddingInline).toBe("var(--sp-4)");
 
     // Resting height is one row: the auto-resize hook measures the `rows`-sized
     // empty box, so `rows` (not just the min-height floor) must drop to 1.
@@ -2008,7 +2015,12 @@ describe("ChatView", () => {
     await waitForText(container, "Send a message to start the conversation");
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
     const send = container.querySelector<HTMLButtonElement>('button[aria-label="Send"]');
-    if (!textarea || !send) throw new Error("Desktop composer missing");
+    const timeline = container.querySelector<HTMLElement>("[data-chat-timeline-scroll]");
+    const footer = container.querySelector<HTMLElement>("[data-chat-composer-footer]");
+    if (!textarea || !send || !timeline || !footer) throw new Error("Desktop composer or timeline missing");
+
+    expect(timeline.style.padding).toContain("var(--sp-6)");
+    expect(footer.style.paddingInline).toBe("var(--sp-6)");
 
     expect(Number(textarea.rows)).toBe(2);
     expect(Number.parseInt(send.style.width, 10)).toBe(28);

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -490,16 +490,18 @@ function ErrorRow({
         borderRadius: "0 var(--radius-input) var(--radius-input) 0",
       }}
     >
-      <div className="mono uppercase text-caption" style={{ color }}>
+      <div data-error-header className="mono uppercase text-caption" style={{ color, overflowWrap: "anywhere" }}>
         {label}
         {agentName ? ` · ${agentName}` : ""} · {payload?.source ?? "unknown"} · {ts}
       </div>
       <div
+        data-error-message
         className="text-label"
         style={{
           marginTop: 2,
           color: "var(--fg-2)",
           whiteSpace: "pre-wrap",
+          overflowWrap: "anywhere",
         }}
       >
         {message}
@@ -863,9 +865,12 @@ const MessageRow = memo(function MessageRow({
         </AgentHovercard>
       )}
       <div className="min-w-0">
-        <div className="flex items-baseline" style={{ gap: 8 }}>
+        <div className="flex flex-wrap items-baseline" style={{ gap: 8 }}>
           {isSystem || isTrial ? (
-            <span className="mono text-body font-semibold" style={{ color: isSelf ? "var(--fg)" : "var(--primary)" }}>
+            <span
+              className="mono text-body font-semibold"
+              style={{ color: isSelf ? "var(--fg)" : "var(--primary)", minWidth: 0, overflowWrap: "anywhere" }}
+            >
               {senderName}
             </span>
           ) : (
@@ -874,9 +879,12 @@ const MessageRow = memo(function MessageRow({
               chatId={msg.chatId}
               name={senderName}
               placement="bottom"
-              triggerClassName="cursor-pointer hover:underline"
+              triggerClassName="min-w-0 max-w-full cursor-pointer text-left hover:underline"
             >
-              <span className="mono text-body font-semibold" style={{ color: isSelf ? "var(--fg)" : "var(--primary)" }}>
+              <span
+                className="mono text-body font-semibold"
+                style={{ color: isSelf ? "var(--fg)" : "var(--primary)", minWidth: 0, overflowWrap: "anywhere" }}
+              >
                 {senderName}
               </span>
             </AgentHovercard>
@@ -1218,6 +1226,7 @@ type TimelineItem =
   | { kind: "workgroup"; at: string; key: string; events: SessionEventRow[] };
 
 type ChatTimelineProps = {
+  mobile: boolean;
   itemCount: number;
   visibleItems: readonly TimelineItem[];
   hiddenByBlock: number;
@@ -1252,6 +1261,7 @@ type ChatTimelineProps = {
 };
 
 const ChatTimeline = memo(function ChatTimeline({
+  mobile,
   itemCount,
   visibleItems,
   hiddenByBlock,
@@ -1288,7 +1298,12 @@ const ChatTimeline = memo(function ChatTimeline({
   );
   return (
     <div ref={overlayContainerRef} className="relative flex-1 flex flex-col min-h-0">
-      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto" style={{ padding: "var(--sp-2_5) var(--sp-6)" }}>
+      <div
+        ref={scrollContainerRef}
+        className="flex-1 overflow-y-auto"
+        data-chat-timeline-scroll
+        style={{ padding: `var(--sp-2_5) ${mobile ? "var(--sp-4)" : "var(--sp-6)"}` }}
+      >
         <div style={{ maxWidth: "clamp(55rem, 75%, 70rem)", margin: "0 auto", width: "100%" }}>
           {itemCount === 0 && (
             <div
@@ -4031,9 +4046,10 @@ export function ChatView({
           Scroll viewport stays full-width so the scrollbar hugs the panel's
           right edge — pushing it inward would float the column. Reading column
           inside is capped via `maxWidth` and centered to align with the
-          composer below into one vertical thread. Side padding (sp-6) prevents
-          content from kissing the panel border on narrow viewports. */}
+          composer below into one vertical thread. Side padding is sp-4 on the
+          phone surface and sp-6 elsewhere. */}
           <ChatTimeline
+            mobile={presentation === "mobile"}
             itemCount={itemCount}
             visibleItems={visibleItems}
             hiddenByBlock={hiddenByBlock}
@@ -4072,8 +4088,11 @@ export function ChatView({
             <div
               ref={composerFooterRef}
               className="shrink-0"
+              data-chat-composer-footer
               style={{
-                padding: "var(--sp-2_5) var(--sp-6) calc(var(--sp-3) + env(safe-area-inset-bottom, 0))",
+                paddingTop: "var(--sp-2_5)",
+                paddingInline: presentation === "mobile" ? "var(--sp-4)" : "var(--sp-6)",
+                paddingBottom: "calc(var(--sp-3) + env(safe-area-inset-bottom, 0))",
               }}
             >
               <div style={{ maxWidth: "clamp(55rem, 75%, 70rem)", margin: "0 auto", width: "100%" }}>


### PR DESCRIPTION
## Summary

Second of the two approved mobile card/timeline PRs; follows #1769 while remaining independently reviewable.

- Reduce the shared chat timeline and composer side gutter from `sp-6` to `sp-4` only for `presentation="mobile"`; desktop keeps its existing spacing.
- Keep long message senders, WorkingTurn updates, runtime errors, and GitHub event cards inside the mobile reading column.
- Bound 40-character commit entity identifiers with visual ellipsis while retaining the complete SHA in the DOM, accessible name, hover title, and commit link.
- Bound fenced Markdown code to a local horizontal scroller so long commands stay readable without widening or clipping the answer card.
- Extend the request-dock preview and focused DOM coverage for long code, long tokens, and mobile-vs-desktop gutter behavior.

## Browser E2E before commit

Playwright against the local Vite app at an iPhone-sized `390 × 844` viewport:

- Verified the page and request card remain exactly 390px / 318px wide with no horizontal overflow.
- Verified a 784px-wide command is contained by a 284px code scroller with `overflow-x: auto`.
- Verified Markdown headings render as headings rather than exposing `##` markers.
- Verified a real 40-character commit identifier stays inside a 314px chip / 340px fixture; the value truncates visually while its full 41-character `@sha` remains available.
- Selected an option and clicked Reply in the cramped 300px mobile fixture; the pinned footer remained reachable.
- Browser console: 0 errors, 0 warnings.

## Validation

- `pnpm --filter @first-tree/web typecheck` — passed, including design-token guardrails.
- Focused affected tests — 59 passed.
- `pnpm --filter @first-tree/web test` — 177 files / 1,438 tests passed.
- `pnpm check` — clean for this diff; repository still reports the 2 existing warnings and 1 info.
- Biome check over all 9 changed files — passed.

## Context

No new Context Tree write is needed for this PR: it implements mobile presentation resilience while preserving the existing mobile scope, chat-detail resolution behavior, and evidence-access contracts.
