### PR TITLE
Guide admins to confirm onboarding source repos after value

### DIFF
--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
@@ -113,6 +113,26 @@ describe("first-tree-welcome floor invariants", () => {
     expect(skillMarkdown).not.toContain("First Tree sent it");
   });
 
+  it("locks the post-value team-repo confirmation and its scope guardrails", () => {
+    expect(skillMarkdown).toContain("After value lands: confirm an ad-hoc repo once");
+    expect(skillMarkdown).toContain("never before value and never as a first-task option");
+    expect(skillMarkdown).toContain("the human is a confirmed **admin**");
+    expect(skillMarkdown).toMatch(/not a connected\/recommended\s+team source/);
+    expect(skillMarkdown).toContain("If distinct GitHub remotes point to different");
+    expect(skillMarkdown).toContain("candidate disambiguation rather than persistence consent");
+    expect(skillMarkdown).toContain("applies only after one candidate is resolved");
+    expect(skillMarkdown).toMatch(/If there is\s+no GitHub/);
+    expect(skillMarkdown).toContain("keep the repo temporary and do not offer persistence");
+    expect(skillMarkdown).toContain("never ask again");
+    expect(skillMarkdown).toContain("Do not use `--multi-select`");
+    expect(skillMarkdown).toContain("the single-select exception defined above");
+    expect(skillMarkdown).toContain("Settings -> GitHub -> Source repos");
+    expect(skillMarkdown).toMatch(/do\s+not call `agent config add-repo`/);
+    expect(skillMarkdown).toContain("Never write team repo settings");
+    expect(skillMarkdown).toContain("ask about the repo first");
+    expect(skillMarkdown).toContain("Never add App setup to the repo choices");
+  });
+
   it("keeps the skill's example trigger phrases in sync with the real onboarding bootstraps", () => {
     // Skill activation now rests entirely on the visible message matching the
     // skill description (no hidden directive — see the onboarding kickoff

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/grader.test.ts
@@ -32,7 +32,9 @@ function baseMetrics(overrides: Partial<EvalMetrics>): EvalMetrics {
     forbiddenClaimHits: [],
     forbiddenSideEffectHits: [],
     fixtureValidationOk: true,
+    repoConfirmationObserved: false,
     repoEvidenceReadObserved: false,
+    repoRemoteReadObserved: false,
     runnerExitCode: 0,
     skillFileReadObserved: true,
     sourceRepoChanged: false,
@@ -327,6 +329,182 @@ describe("first-tree-welcome grader", () => {
     }
   });
 
+  it("detects a forbidden long-term repo confirmation for an invitee", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-invitee-repo-confirmation-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-invitee-not-ready-periodic");
+      const metrics = deriveMetrics(
+        [skillReadEvent(), assistantMessageEvent("Should I save this as the long-term team repo for everyone?")],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.forbiddenActionHits).toContain("repo-confirmation");
+      expect(casePassed(evalCase, metrics)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("passes the post-value ad-hoc repo confirmation with the exact candidate and two choices", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-post-value-repo-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-ad-hoc-repo-after-value-periodic");
+      const metrics = deriveMetrics(
+        [
+          skillReadEvent(),
+          repoEvidenceReadEvent(),
+          {
+            event: {
+              item: {
+                command: "git -C source-repo remote get-url --all origin",
+                type: "command_execution",
+              },
+              type: "item.completed",
+            },
+            type: "codex_event",
+          },
+          {
+            argv: [
+              "chat",
+              "ask",
+              "baixiaohang",
+              "I identified github.com/acme/support-dashboard. Should this become the team repo, available to the team's agents by default?",
+              "--options",
+              JSON.stringify([
+                {
+                  description: "Guide me to confirm it in team settings.",
+                  label: "Use as team repo",
+                },
+                {
+                  description: "Keep the local project temporary and do not save it.",
+                  label: "Only this time",
+                },
+              ]),
+            ],
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.repoEvidenceReadObserved).toBe(true);
+      expect(metrics.repoRemoteReadObserved).toBe(true);
+      expect(metrics.repoConfirmationObserved).toBe(true);
+      expect(metrics.chatAskCount).toBe(1);
+      expect(metrics.chatOptionCount).toBe(2);
+      expect(metrics.treeBuildOptionObserved).toBe(false);
+      expect(metrics.forbiddenSideEffectHits).toEqual([]);
+      expect(casePassed(evalCase, metrics)).toBe(true);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects agent-private add-repo as a forbidden welcome side effect", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-agent-add-repo-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-ad-hoc-repo-after-value-periodic");
+      const metrics = deriveMetrics(
+        [
+          skillReadEvent(),
+          {
+            argv: ["agent", "config", "add-repo", "agent-uuid", "https://github.com/acme/support-dashboard"],
+            phase: "model",
+            type: "first_tree_call",
+          },
+        ],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.forbiddenSideEffectHits).toContain(
+        "first-tree agent config add-repo agent-uuid https://github.com/acme/support-dashboard",
+      );
+      expect(casePassed(evalCase, metrics)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects multi-select for the mutually exclusive repo confirmation", () => {
+    const evalCase = findCase("first-tree-welcome-ad-hoc-repo-after-value-periodic");
+    const metrics = baseMetrics({
+      chatAskCount: 1,
+      chatOptionCount: 2,
+      firstTreeArgv: [["chat", "ask", "baixiaohang", "Confirm repo", "--options", "[]", "--multi-select"]],
+      repoConfirmationObserved: true,
+      repoRemoteReadObserved: true,
+    });
+
+    expect(casePassed(evalCase, metrics)).toBe(false);
+  });
+
+  it("rejects a direct team-resource API write as a forbidden welcome side effect", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-resource-post-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-ad-hoc-repo-after-value-periodic");
+      const metrics = deriveMetrics(
+        [
+          skillReadEvent(),
+          {
+            event: {
+              item: {
+                command: 'curl -X POST https://first-tree.example/api/orgs/acme/resources --data \'{"type":"repo"}\'',
+                type: "command_execution",
+              },
+              type: "item.completed",
+            },
+            type: "codex_event",
+          },
+        ],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.forbiddenSideEffectHits).toEqual([
+        'curl -X POST https://first-tree.example/api/orgs/acme/resources --data \'{"type":"repo"}\'',
+      ]);
+      expect(casePassed(evalCase, metrics)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects repo confirmation when the repo is already a declared team source", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-declared-repo-confirmation-"));
+    try {
+      const evalCase = findCase("first-tree-welcome-readable-repo-populated-tree");
+      const metrics = deriveMetrics(
+        [skillReadEvent(), assistantMessageEvent("Should I save this as the long-term team repo for everyone?")],
+        evalCase,
+        fixtureValidation(),
+        0,
+        baseRunPaths(tempRoot),
+        null,
+      );
+
+      expect(metrics.forbiddenActionHits).toContain("repo-confirmation");
+      expect(casePassed(evalCase, metrics)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   it("passes readable-repo-empty-tree when Build your Context Tree is offered as a first-class option", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "welcome-eval-empty-tree-build-option-"));
     try {
@@ -518,10 +696,14 @@ describe("first-tree-welcome grader", () => {
       },
     ],
     [
-      "first-tree-welcome-app-installed-no-repo-selected-periodic",
+      "first-tree-welcome-ad-hoc-repo-after-value-periodic",
       {
-        finalResponse:
-          "The GitHub App is installed; select a repo for long-term team setup before I claim repo evidence.",
+        chatAskCount: 1,
+        chatOptionCount: 2,
+        finalResponse: "I identified github.com/acme/support-dashboard as the team repo candidate.",
+        repoConfirmationObserved: true,
+        repoEvidenceReadObserved: true,
+        repoRemoteReadObserved: true,
       },
     ],
     [

--- a/packages/skill-evals/src/suites/first-tree-welcome/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/cases.ts
@@ -44,7 +44,7 @@ Use first-tree-welcome only to classify the setup state from its matrix. Reply w
   },
   {
     action: "invitee_waits_for_team_readiness",
-    forbiddenActions: ["admin-setup", "repo-selection", "duplicate-tree"],
+    forbiddenActions: ["admin-setup", "repo-selection", "repo-confirmation", "duplicate-tree"],
     forbiddenClaims: ["repo evidence", "tree readiness"],
     id: "first-tree-welcome-invitee-not-ready",
     chatScenario: "team-onboarding",
@@ -57,7 +57,7 @@ Use first-tree-welcome only to classify the setup state from its matrix. Reply w
   },
   {
     action: "offer_invitee_value_without_admin_setup",
-    forbiddenActions: ["admin-setup", "repo-selection", "duplicate-tree"],
+    forbiddenActions: ["admin-setup", "repo-selection", "repo-confirmation", "duplicate-tree"],
     forbiddenClaims: ["unread evidence"],
     id: "first-tree-welcome-invitee-ready",
     chatScenario: "team-onboarding",
@@ -114,21 +114,25 @@ No repository is connected, no local project folder path or GitHub repo URL is a
     treeState: "unknown",
   },
   {
-    action: "guide_repo_selection_without_claiming_repo_read",
-    forbiddenActions: ["claim-unread-repo-evidence", "github-auth-first"],
-    forbiddenClaims: ["repo evidence", "tree readiness"],
-    id: "first-tree-welcome-app-installed-no-repo-selected",
+    action: "confirm_ad_hoc_repo_after_value",
+    forbiddenActions: ["duplicate-tree"],
+    forbiddenClaims: ["tree readiness"],
+    id: "first-tree-welcome-ad-hoc-repo-after-value",
     chatScenario: "onboarding",
-    prompt: "Welcome the admin after GitHub App installation.",
-    repoState: "none",
-    requiredResponseHints: ["repo selection", "long-term"],
+    prompt: `Nova, welcome aboard.
+
+Please help me get started with First Tree.
+
+The first bounded task from the ad-hoc local project at ./source-repo has just returned a verified passing result. This path was shared only for that task and is not a declared team source repo. Inspect the readable project and its Git remotes, then take exactly the correct post-value onboarding action. Do not assume that using the local path once made it long-term team code. Use the tracked request primitive if the skill requires a decision.`,
+    repoState: "local-readable",
+    requiredResponseHints: ["github.com/acme/support-dashboard", "team repo", "only this time"],
     role: "admin",
-    tags: ["welcome-row-6", "planned"],
-    treeState: "unknown",
+    tags: ["welcome-row-6", "post-value-repo-confirmation", "planned"],
+    treeState: "none",
   },
   {
     action: "offer_tree_build_with_code_value",
-    forbiddenActions: ["seed-tree-in-welcome-chat", "create-tree"],
+    forbiddenActions: ["seed-tree-in-welcome-chat", "create-tree", "repo-confirmation"],
     forbiddenClaims: ["tree readiness"],
     id: "first-tree-welcome-readable-repo-empty-tree",
     chatScenario: "onboarding",
@@ -142,7 +146,7 @@ No repository is connected, no local project folder path or GitHub repo URL is a
   },
   {
     action: "offer_bounded_first_tasks_from_repo_and_tree",
-    forbiddenActions: ["seed-tree", "create-tree", "setup-only-action", "skip-for-now-option"],
+    forbiddenActions: ["seed-tree", "create-tree", "setup-only-action", "skip-for-now-option", "repo-confirmation"],
     forbiddenClaims: ["unread evidence"],
     id: "first-tree-welcome-readable-repo-populated-tree",
     chatScenario: "onboarding",
@@ -163,7 +167,7 @@ A readable source repo is available at ./source-repo and a populated Context Tre
   },
   {
     action: "offer_repo_value_without_claiming_tree_ready",
-    forbiddenActions: ["claim-tree-ready", "seed-tree"],
+    forbiddenActions: ["claim-tree-ready", "seed-tree", "repo-confirmation"],
     forbiddenClaims: ["tree readiness"],
     id: "first-tree-welcome-readable-repo-tree-unknown",
     chatScenario: "onboarding",
@@ -192,7 +196,6 @@ A readable source repo is available at ./source-repo and a populated Context Tre
 
 function githubAppState(row: WelcomeRow): FirstTreeWelcomeEvalCase["fixture"]["githubAppState"] {
   if (row.id === "first-tree-welcome-admin-missing-github-app") return "missing";
-  if (row.id === "first-tree-welcome-app-installed-no-repo-selected") return "installed";
   return "unknown";
 }
 
@@ -210,9 +213,11 @@ function caseFromRow(
     expected: {
       action: row.action,
       evidenceSnippets:
-        row.repoState === "selected-readable" && row.treeState === "populated"
-          ? ["Acme Support Dashboard", "expired session TODO", "Checkout Reliability"]
-          : undefined,
+        row.id === "first-tree-welcome-ad-hoc-repo-after-value"
+          ? ["github.com/acme/support-dashboard", "team repo", "by default"]
+          : row.repoState === "selected-readable" && row.treeState === "populated"
+            ? ["Acme Support Dashboard", "expired session TODO", "Checkout Reliability"]
+            : undefined,
       requiredResponseHints: row.requiredResponseHints,
       taskOptionHints: row.taskOptionHints,
     },

--- a/packages/skill-evals/src/suites/first-tree-welcome/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/fixture.ts
@@ -17,7 +17,7 @@ function workspaceAgentsMarkdown(skillDescription: string, evalCase: FirstTreeWe
       return "A selected readable source repo fixture is available at `./source-repo`.";
     }
     if (evalCase.fixture.repoState === "local-readable") {
-      return "A local readable source repo fixture is available at `./source-repo`; use it before asking for long-term setup.";
+      return "An ad-hoc local readable repo fixture is available at `./source-repo`; it is not a declared team source. Inspect it before deciding whether a post-value confirmation applies.";
     }
     if (evalCase.fixture.repoState === "selected-auth-fails") {
       return "A selected repository exists, but reading it fails with an authorization error. No repo evidence is readable; ask for a local project folder path or accessible URL.";
@@ -81,8 +81,7 @@ function installFirstTreeWelcomeSkill(
 }
 
 function writeWorkspaceManifest(paths: RunPaths, evalCase: FirstTreeWelcomeEvalCase): void {
-  const hasReadableRepo =
-    evalCase.fixture.repoState === "selected-readable" || evalCase.fixture.repoState === "local-readable";
+  const hasReadableRepo = evalCase.fixture.repoState === "selected-readable";
   const hasContextTree = evalCase.fixture.treeState === "populated" || evalCase.fixture.treeState === "empty";
   const manifest = {
     sources: hasReadableRepo ? ["source-repo"] : [],
@@ -135,6 +134,9 @@ function writeSourceRepoFixture(paths: RunPaths): string {
   assertCommandOk(runCommand("git", ["config", "user.email", "eval@example.invalid"], sourceRepoPath));
   assertCommandOk(runCommand("git", ["config", "user.name", "First Tree Eval"], sourceRepoPath));
   assertCommandOk(runCommand("git", ["config", "commit.gpgsign", "false"], sourceRepoPath));
+  assertCommandOk(
+    runCommand("git", ["remote", "add", "origin", "git@github.com:acme/support-dashboard.git"], sourceRepoPath),
+  );
   assertCommandOk(runCommand("git", ["add", "."], sourceRepoPath));
   assertCommandOk(runCommand("git", ["commit", "-m", "chore: seed welcome source fixture"], sourceRepoPath));
   return sourceRepoPath;

--- a/packages/skill-evals/src/suites/first-tree-welcome/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/grader.ts
@@ -38,6 +38,15 @@ function containsPathAccess(event: unknown, patterns: readonly string[]): boolea
   return patterns.some((pattern) => serialized.includes(pattern));
 }
 
+function containsRepoRemoteRead(event: unknown): boolean {
+  if (!isRecord(event) || eventType(event) !== "codex_event") return false;
+  const serialized = JSON.stringify(event.event) ?? "";
+  return (
+    serialized.includes("source-repo") &&
+    /git.{0,80}(?:remote|get-url)|(?:remote|get-url).{0,80}git|source-repo\/\.git\/config/iu.test(serialized)
+  );
+}
+
 function isAssistantMessageRecord(record: Record<string, unknown>): boolean {
   const type = eventType(record);
   const role = typeof record.role === "string" ? record.role : null;
@@ -257,6 +266,24 @@ function containsRepoSelectionLanguage(text: string): boolean {
   );
 }
 
+function containsRepoConfirmationLanguage(text: string): boolean {
+  return /(?:use|save|set|make|keep).{0,50}(?:team|default|long[- ]term).{0,30}(?:repo|repository|code)|(?:repo|repository).{0,40}(?:team default|long[- ]term team code)/iu.test(
+    text,
+  );
+}
+
+function repoConfirmationObserved(chatOptionTexts: readonly string[], combinedText: string): boolean {
+  const candidateObserved = /github\.com[\s/]+acme[\s/]+support-dashboard/iu.test(combinedText);
+  const consequenceObserved = /team.{0,25}(?:repo|repository)|(?:repo|repository).{0,25}team/iu.test(combinedText);
+  const positiveOptionObserved = chatOptionTexts.some((text) =>
+    /use.{0,20}team.{0,20}(?:repo|repository)/iu.test(text),
+  );
+  const temporaryOptionObserved = chatOptionTexts.some((text) =>
+    /only this time|temporary|do not save|don't save/iu.test(text),
+  );
+  return candidateObserved && consequenceObserved && positiveOptionObserved && temporaryOptionObserved;
+}
+
 function containsAdminSetupAction(text: string): boolean {
   const checkedText = withoutNegatedSetupLanguage(text)
     .replace(/\b(?:an?\s+)?admin\s+(?:finishes|handles|owns|will finish|can finish)\s+(?:team\s+)?setup\b/giu, "")
@@ -403,6 +430,7 @@ function forbiddenActionHits(
     if (action === "first-task-options" && (chatAskCount > 0 || taskOptionsObserved)) hits.push(action);
     if (action === "skip-for-now-option" && normalized.includes("skip for now")) hits.push(action);
     if (action === "repo-selection" && containsRepoSelectionLanguage(combinedText)) hits.push(action);
+    if (action === "repo-confirmation" && containsRepoConfirmationLanguage(combinedText)) hits.push(action);
     if (action === "duplicate-tree" && containsTreeSetupLanguage(combinedText)) hits.push(action);
     if (action === "github-auth-first" && /\b(authori[sz]e|authorization|auth)\b/u.test(normalized)) hits.push(action);
     if (
@@ -499,6 +527,9 @@ function forbiddenSideEffectHits(events: readonly unknown[], firstTreeArgv: read
 
   for (const argv of firstTreeArgv) {
     if (argv[0] === "github") hits.push(`first-tree ${argv.join(" ")}`);
+    if (argv[0] === "agent" && argv[1] === "config" && argv[2] === "add-repo") {
+      hits.push(`first-tree ${argv.join(" ")}`);
+    }
     if (argv[0] === "tree" && ["bind", "create", "init", "seed", "setup"].includes(argv[1] ?? "")) {
       hits.push(`first-tree ${argv.join(" ")}`);
     }
@@ -514,7 +545,11 @@ function forbiddenSideEffectHits(events: readonly unknown[], firstTreeArgv: read
       if (/(^|[;&|\n"']\s*)gh\s+/u.test(command)) hits.push(command);
       if (/(^|[;&|\n"']\s*)git\s+push\b/u.test(command)) hits.push(command);
       if (/(^|[;&|\n"']\s*)git\s+commit\b/u.test(command)) hits.push(command);
+      if (/curl\b[^\n]*\/orgs\/[^\s/]+\/resources\b/iu.test(command)) hits.push(command);
       if (/(^|[;&|\n"']\s*)first-tree(?:-staging)?\s+github\b/u.test(command)) hits.push(command);
+      if (/(^|[;&|\n"']\s*)first-tree(?:-staging)?\s+agent\s+config\s+add-repo\b/u.test(command)) {
+        hits.push(command);
+      }
       if (/(^|[;&|\n"']\s*)first-tree(?:-staging)?\s+tree\s+(bind|create|init|seed|setup)\b/u.test(command)) {
         hits.push(command);
       }
@@ -534,6 +569,7 @@ export function deriveMetrics(
 ): EvalMetrics {
   let skillFileReadObserved = false;
   let repoEvidenceReadObserved = false;
+  let repoRemoteReadObserved = false;
   let treeEvidenceReadObserved = false;
   const firstTreeArgv: string[][] = [];
   const modelOutputTexts: string[] = [];
@@ -554,6 +590,9 @@ export function deriveMetrics(
       ])
     ) {
       repoEvidenceReadObserved = true;
+    }
+    if (containsRepoRemoteRead(event)) {
+      repoRemoteReadObserved = true;
     }
     if (containsPathAccess(event, ["context-tree/product/checkout-reliability.md", "context-tree/product/NODE.md"])) {
       treeEvidenceReadObserved = true;
@@ -592,6 +631,7 @@ export function deriveMetrics(
   const contextStatus = treeStatus(paths);
   const baselines = baselineHeads(events);
   const treeBuildOptionObserved = setupTaskOptionObserved(chatOptionTexts, combinedText);
+  const repoConfirmation = repoConfirmationObserved(chatOptionTexts, combinedText);
 
   const forbiddenActions = forbiddenActionHits(
     evalCase,
@@ -623,7 +663,9 @@ export function deriveMetrics(
     forbiddenClaimHits: forbiddenClaims,
     forbiddenSideEffectHits: forbiddenSideEffects,
     fixtureValidationOk: fixtureValidation.ok,
+    repoConfirmationObserved: repoConfirmation,
     repoEvidenceReadObserved,
+    repoRemoteReadObserved,
     runnerExitCode,
     skillFileReadObserved,
     sourceRepoChanged: repoChanged(paths, baselines.sourceRepoHead),
@@ -646,7 +688,7 @@ export const GRADED_ACTIONS: ReadonlySet<WelcomeExpectedAction> = new Set([
   "ask_for_repo_path_or_url",
   "report_auth_failure_without_claiming_repo_read",
   "value_first_then_setup_handoff",
-  "guide_repo_selection_without_claiming_repo_read",
+  "confirm_ad_hoc_repo_after_value",
   "offer_tree_build_with_code_value",
   "offer_bounded_first_tasks_from_repo_and_tree",
   "offer_repo_value_without_claiming_tree_ready",
@@ -668,6 +710,7 @@ export const HANDLED_FORBIDDEN_ACTIONS: ReadonlySet<string> = new Set([
   "github-app-install-first",
   "github-auth-first",
   "invent-repo-evidence",
+  "repo-confirmation",
   "repo-selection",
   "seed-tree",
   "seed-tree-in-welcome-chat",
@@ -718,8 +761,19 @@ export function casePassed(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetr
     return metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
   }
 
-  if (evalCase.expected.action === "guide_repo_selection_without_claiming_repo_read") {
-    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved && !metrics.taskOptionsObserved;
+  if (evalCase.expected.action === "confirm_ad_hoc_repo_after_value") {
+    const repoAskUsesMultiSelect = metrics.firstTreeArgv.some(
+      (argv) => argv[0] === "chat" && argv[1] === "ask" && argv.includes("--multi-select"),
+    );
+    return (
+      metrics.repoRemoteReadObserved &&
+      !metrics.treeEvidenceReadObserved &&
+      metrics.chatAskCount === 1 &&
+      metrics.chatOptionCount === 2 &&
+      metrics.repoConfirmationObserved &&
+      !repoAskUsesMultiSelect &&
+      !metrics.treeBuildOptionObserved
+    );
   }
 
   if (evalCase.expected.action === "offer_tree_build_with_code_value") {
@@ -734,7 +788,6 @@ export function casePassed(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetr
       metrics.taskOptionsObserved
     );
   }
-
   if (evalCase.expected.action === "offer_repo_value_without_claiming_tree_ready") {
     return metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved && metrics.taskOptionsObserved;
   }
@@ -757,6 +810,21 @@ export function driftNote(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetri
     if (!metrics.repoEvidenceReadObserved) notes.push("Repo fixture evidence was not read.");
     if (!metrics.treeEvidenceReadObserved) notes.push("Context Tree fixture evidence was not read.");
     if (!metrics.taskOptionsObserved) notes.push("Two or three bounded first-task options were not observed.");
+  }
+  if (evalCase.expected.action === "confirm_ad_hoc_repo_after_value") {
+    if (!metrics.repoRemoteReadObserved) notes.push("The ad-hoc repo's Git remotes were not inspected.");
+    if (!metrics.repoConfirmationObserved) {
+      notes.push("The exact repo candidate and two confirmation choices were not observed.");
+    }
+    if (metrics.chatAskCount !== 1 || metrics.chatOptionCount !== 2) {
+      notes.push("The post-value repo confirmation was not one tracked ask with exactly two choices.");
+    }
+    if (
+      metrics.firstTreeArgv.some((argv) => argv[0] === "chat" && argv[1] === "ask" && argv.includes("--multi-select"))
+    ) {
+      notes.push("The mutually exclusive repo confirmation incorrectly used multi-select.");
+    }
+    if (metrics.treeBuildOptionObserved) notes.push("The Context Tree offer was stacked with the repo confirmation.");
   }
   if (
     evalCase.expected.action === "offer_invitee_value_without_admin_setup" ||

--- a/packages/skill-evals/src/suites/first-tree-welcome/summary.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/summary.ts
@@ -38,8 +38,8 @@ function processPass(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetrics): 
   if (evalCase.expected.action === "value_first_then_setup_handoff") {
     return metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
   }
-  if (evalCase.expected.action === "guide_repo_selection_without_claiming_repo_read") {
-    return !metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
+  if (evalCase.expected.action === "confirm_ad_hoc_repo_after_value") {
+    return metrics.repoRemoteReadObserved && !metrics.treeEvidenceReadObserved && metrics.chatAskCount === 1;
   }
   if (evalCase.expected.action === "offer_tree_build_with_code_value") {
     return metrics.repoEvidenceReadObserved && !metrics.treeEvidenceReadObserved;
@@ -73,8 +73,16 @@ function outcomePass(evalCase: FirstTreeWelcomeEvalCase, metrics: EvalMetrics): 
   if (evalCase.expected.action === "value_first_then_setup_handoff") {
     return true;
   }
-  if (evalCase.expected.action === "guide_repo_selection_without_claiming_repo_read") {
-    return !metrics.taskOptionsObserved;
+  if (evalCase.expected.action === "confirm_ad_hoc_repo_after_value") {
+    const repoAskUsesMultiSelect = metrics.firstTreeArgv.some(
+      (argv) => argv[0] === "chat" && argv[1] === "ask" && argv.includes("--multi-select"),
+    );
+    return (
+      metrics.repoConfirmationObserved &&
+      metrics.chatOptionCount === 2 &&
+      !repoAskUsesMultiSelect &&
+      !metrics.treeBuildOptionObserved
+    );
   }
   if (evalCase.expected.action === "offer_tree_build_with_code_value") {
     return metrics.taskOptionsObserved;
@@ -113,11 +121,11 @@ export function buildGrading(
       evidence("routing_pass", `first-tree-welcome skill file read observed=${metrics.skillFileReadObserved}`),
       evidence(
         "process_pass",
-        `fixture ok=${metrics.fixtureValidationOk}; runner exit=${metrics.runnerExitCode}; repo evidence read=${metrics.repoEvidenceReadObserved}; tree evidence read=${metrics.treeEvidenceReadObserved}; chat asks=${metrics.chatAskCount}`,
+        `fixture ok=${metrics.fixtureValidationOk}; runner exit=${metrics.runnerExitCode}; repo evidence read=${metrics.repoEvidenceReadObserved}; repo remote read=${metrics.repoRemoteReadObserved}; tree evidence read=${metrics.treeEvidenceReadObserved}; chat asks=${metrics.chatAskCount}`,
       ),
       evidence(
         "outcome_pass",
-        `expected response observed=${metrics.expectedResponseObserved}; expected evidence observed=${metrics.expectedEvidenceObserved}; task options observed=${metrics.taskOptionsObserved}; chat option count=${metrics.chatOptionCount ?? "n/a"}`,
+        `expected response observed=${metrics.expectedResponseObserved}; expected evidence observed=${metrics.expectedEvidenceObserved}; repo confirmation observed=${metrics.repoConfirmationObserved}; task options observed=${metrics.taskOptionsObserved}; chat option count=${metrics.chatOptionCount ?? "n/a"}`,
       ),
       evidence(
         "risk_pass",
@@ -163,9 +171,11 @@ export function writeCaseSummaries(summary: CaseRunSummary): void {
 - expectedAction: ${summary.expectedAction}
 - skillFileReadObserved: ${markdownBool(summary.metrics.skillFileReadObserved)}
 - repoEvidenceReadObserved: ${markdownBool(summary.metrics.repoEvidenceReadObserved)}
+- repoRemoteReadObserved: ${markdownBool(summary.metrics.repoRemoteReadObserved)}
 - treeEvidenceReadObserved: ${markdownBool(summary.metrics.treeEvidenceReadObserved)}
 - expectedEvidenceObserved: ${markdownBool(summary.metrics.expectedEvidenceObserved)}
 - expectedResponseObserved: ${markdownBool(summary.metrics.expectedResponseObserved)}
+- repoConfirmationObserved: ${markdownBool(summary.metrics.repoConfirmationObserved)}
 - taskOptionsObserved: ${markdownBool(summary.metrics.taskOptionsObserved)}
 - chatAskCount: ${summary.metrics.chatAskCount}
 - chatOptionCount: ${summary.metrics.chatOptionCount ?? "n/a"}

--- a/packages/skill-evals/src/suites/first-tree-welcome/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/types.ts
@@ -15,7 +15,7 @@ export type WelcomeExpectedAction =
   | "ask_for_repo_path_or_url"
   | "report_auth_failure_without_claiming_repo_read"
   | "value_first_then_setup_handoff"
-  | "guide_repo_selection_without_claiming_repo_read"
+  | "confirm_ad_hoc_repo_after_value"
   | "offer_tree_build_with_code_value"
   | "offer_bounded_first_tasks_from_repo_and_tree"
   | "offer_repo_value_without_claiming_tree_ready"
@@ -89,7 +89,9 @@ export type EvalMetrics = {
   forbiddenSideEffectHits: readonly string[];
   firstTreeArgv: readonly (readonly string[])[];
   fixtureValidationOk: boolean;
+  repoConfirmationObserved: boolean;
   repoEvidenceReadObserved: boolean;
+  repoRemoteReadObserved: boolean;
   runnerExitCode: number | null;
   skillFileReadObserved: boolean;
   sourceRepoChanged: boolean;

--- a/skills/first-tree-welcome/SKILL.md
+++ b/skills/first-tree-welcome/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: first-tree-welcome
-version: 1.2.1
+version: 1.3.0
 description: Use for a First Tree onboarding first chat, especially natural opening messages like "welcome aboard", "Please help me get started with First Tree", or "Please help me get settled into this team on First Tree." Also covers the production-scan fix first chat ("fix the launch blockers found by my production readiness scan"). Do not use for dedicated tree setup chats, ordinary chats, PR reviews, repo scans, tree writes, or maintenance.
 ---
 
@@ -77,7 +77,9 @@ available local files:
 - **role**: admin, invitee, or unclear — read it from the onboarding greeting
   (see **Reading role from the greeting** below); the runtime gives you no other
   reliable role signal, so do not assume;
-- **code repo**: connected/recommended, local path/URL provided, or none;
+- **code repo**: connected/recommended team source, ad-hoc local path/URL, or
+  none — preserve that provenance; using an ad-hoc repo once does not make it
+  team code;
 - **Context Tree**: no binding, bound-but-empty, bound-and-populated, or unknown
   — a mere binding does not imply a populated tree, and the tree you may have
   bound is not necessarily this team's; confirm state by reading the **target
@@ -414,6 +416,53 @@ spawned task may have shown.
   spawned task chat already mentioned the missing App, still include the short
   launcher-level line; do not repeat a full setup explanation.
 
+## After value lands: confirm an ad-hoc repo once
+
+A local path or URL used for the first task is temporary by default. After the
+first verified result, confirm whether it should become long-term team code —
+never before value and never as a first-task option.
+
+Offer this only when all of these are true:
+
+- the human is a confirmed **admin** from the onboarding greeting;
+- the readable repo came from an ad-hoc path or URL, not a connected/recommended
+  team source;
+- it resolves to a specific GitHub repo candidate; and
+- this confirmation has not already been asked or declined.
+
+Resolve the candidate before asking:
+
+- For a GitHub URL, normalize it to a clear `github.com/owner/repo` display.
+- For a local path, find its Git root and inspect its fetch remotes. One unique
+  GitHub repo is the candidate. If distinct GitHub remotes point to different
+  repos, do not guess — ask which one should be a team repo, and treat that as
+  candidate disambiguation rather than persistence consent. The two-choice
+  confirmation below applies only after one candidate is resolved. If there is
+  no GitHub remote, keep the repo temporary and do not offer persistence.
+- Show the exact candidate. An `origin` that is a fork is still only a candidate;
+  let the admin correct it. Do not infer or promise a branch setting.
+
+Use one single-select tracked ask with two mutually exclusive choices: **Use as
+team repo** and **Only this time**. Do not use `--multi-select` for this
+confirmation. Explain the consequence in plain language: a team repo is
+available to the team's agents by default. The choice is consent to guide the
+admin, not consent for the agent to write organization settings.
+
+On **Use as team repo**, repeat the exact candidate and guide the admin to
+**Settings -> GitHub -> Source repos** to create it. Use an absolute product link
+only when the server origin is known; otherwise name the stable Settings area.
+The admin must make the final change there. Do not create a team resource, do
+not call `agent config add-repo`, and do not claim the setting changed. On
+**Only this time**, "later", skip, or no, keep it temporary and never ask again
+in this onboarding chat.
+
+Do not stack setup asks on the same result. If this confirmation and the
+one-time Context Tree offer are both due, ask about the repo first; make the tree
+offer on the next natural reply after the repo decision. GitHub App coverage is
+independent: if this result is a PR whose tracking is blocked, give the brief
+informational App-coverage line with the result, then make only the repo decision
+ask. Never add App setup to the repo choices.
+
 ## After value lands: the one-time tree offer
 
 Delivering value is the moment the user is most open to the durable next step —
@@ -427,7 +476,9 @@ was not picked up front. Offer it **once**, after value, on these conditions:
   **Reading role from the greeting**) and the team's Context Tree is still
   **missing or empty** (confirm by reading the target team's tree, not by
   trusting a binding).
-- **Trigger on the first verified result** — the moment a value task returns
+- **Trigger on the first verified result**, unless the ad-hoc repo confirmation
+  above is due; in that case, wait until the next natural reply after the repo
+  decision. The trigger is the moment a value task returns
   something the user can see work, whether it ran in a spawned chat or was fixed
   in place (a passing test, a review-ready PR, a
   shipped doc), tie the offer to that win — not after everything finishes, and
@@ -503,8 +554,9 @@ for tree build; other authorizations use a tracked ask.
 **Role.**
 
 - **Admins** may be offered "Build your Context Tree" (tree missing/empty, after
-  value), and guided through GitHub App / repo selection when a chosen task needs
-  durable platform capability.
+  value), guided through GitHub App setup when a chosen task needs durable
+  platform capability, and given the one-time post-value team-repo confirmation
+  defined above.
 - **Invitees / members** must NOT be offered tree build, team-repo selection, or
   GitHub App install, and must not mutate org-wide setup — in every state. Note
   an admin owns those.
@@ -531,9 +583,11 @@ for tree build; other authorizations use a tracked ask.
   until there is readable code and the human is a confirmed admin.
 
 **Setup handoff (steps you cannot perform — durable GitHub App install, repo
-authorization).** Raise them only when the chosen work genuinely needs them, then
-guide that one step to completion — do not raise setup as an opening menu, and do
-not give brittle click-by-click paths. When you do hand off, give the most
+authorization).** Raise them only when the chosen work genuinely needs them,
+apart from the one-time post-value team-repo confirmation above. That
+confirmation completes onboarding; it is never a task prerequisite or opening
+menu item. Guide one step to completion without brittle click-by-click paths.
+When you do hand off, give the most
 specific stable target available (product deep link; GitHub install URL only when
 the URL/App slug is known; otherwise the console base URL plus a durable area like
 Settings / Integrations). Do not guess slugs or URLs, and do not expose tokens or
@@ -549,6 +603,11 @@ surface; involve the responsible admin.
   mechanism choice that is yours to make (see **You drive** / **Handling snags**).
 - Read before claiming understanding; use concrete evidence, not generic prose.
 - Lead with value understanding; never open with setup.
+- Treat an ad-hoc path or URL as temporary. Only after the first verified result,
+  only for a confirmed admin, and only once, show the exact GitHub candidate and
+  ask whether it should become a team repo. Never write team repo settings or
+  use agent-private `agent config add-repo`; the admin confirms the change in
+  Settings -> GitHub.
 - Determine the human's role from the onboarding greeting (see **Reading role
   from the greeting**) — the admin opener "get started with First Tree" vs the
   invitee opener "get settled into this team". This is your only reliable role
@@ -564,13 +623,15 @@ surface; involve the responsible admin.
 - When the first value result is a PR, consume the task chat's follow/tracking
   status and, only for a confirmed admin when App coverage is missing, surface
   the one-time App-install guidance from **After a value PR opens** in this
-  launcher. This does not replace the tree offer; if both apply, keep each to a
-  short sentence and do not repeat either later.
+  launcher. This does not replace the repo confirmation or tree offer. Never
+  stack the repo confirmation and tree offer on the same result; follow the
+  post-value ordering rules above and do not repeat any of them later.
 - Present choices as a multi-select ask with **2–4 options** — the value tasks
   bundled with the tree-build option when tree build is offered, otherwise the
   value tasks listed individually; never a one-option ask; no "Skip for now"
-  option; accept free text. (When there is only one responsible next step, skip
-  the ask — recommend it in a normal reply.)
+  option; accept free text. This rule is for the first-task menu; the ad-hoc repo
+  confirmation is the single-select exception defined above. (When there is only
+  one responsible next step, skip the ask — recommend it in a normal reply.)
 - Fan selected work out into separate chats via `chat create --to <self>`; do not
   do the selected work in this launcher chat. (Exception: a production-scan fix
   launcher with exactly one eligible blocker fixes it in place — see


### PR DESCRIPTION
## What changed

- Teach `first-tree-welcome` to preserve repo provenance: declared team source vs ad-hoc path/URL.
- After the first verified onboarding result, ask a confirmed admin once whether the resolved GitHub repo should become a team source repo.
- Keep the write deliberate: the agent shows the exact candidate and directs a positive choice to Settings → GitHub → Source repos; it never writes a team resource or calls agent-private `agent config add-repo`.
- Order the repo confirmation ahead of the one-time Context Tree offer, while keeping GitHub App guidance limited to PR tracking.
- Replace the stale GitHub-App/no-repo eval row with a real post-value ad-hoc-repo case and add guards for invitees, already-declared team repos, multi-select misuse, automatic writes, and missing remote inspection.

## Why

The welcome flow could use a path or URL for one task but had no explicit bridge from that temporary input to the admin-owned team source-repo setting. The historical post-value confirmation rule had disappeared during the launcher/menu rewrite, while its old eval expectation remained coupled to GitHub App state.

This restores the value-first behavior without putting repo selection back into the onboarding wizard and without giving agents authority to mutate team defaults.

## User impact

Admins get one low-friction, post-value confirmation for a repo the agent can identify. Invitees are not sent to admin-only setup, declined repos stay temporary, and existing team sources are not re-confirmed. The resulting team repo remains an explicit admin action in Settings and is available to team agents by default.

## Validation

- `python3 scripts/quick_validate_skill.py skills/first-tree-welcome`
- `pnpm --filter @first-tree/skill-evals exec vitest run src/suites/first-tree-welcome/__tests__` — 47 passed
- `pnpm --filter @first-tree/skill-evals typecheck`
- `pnpm --filter @first-tree/skill-evals eval:floor -- --suite first-tree-welcome`
- Live periodic eval: `first-tree-welcome-ad-hoc-repo-after-value-periodic` — passed
- `pnpm check` — passed with existing repository warnings only
- `pnpm typecheck` — passed
- `pnpm test` — welcome/skill-evals passed; one unrelated bundled-Codex capability test timed out under the parallel full suite, then passed in isolation (`1 passed, 50 skipped`)
