### PR TITLE
fix(cli): install root systemd service in system scope

### DIFF
--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -809,6 +809,50 @@ describe("logout and upgrade commands", () => {
     expect(output).toContain("first-tree-dev daemon stop");
   });
 
+  it("refuses plain logout and purge while root systemd migration is required", async () => {
+    const credentials = join(tempDir, "credentials.json");
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(credentials, "{}");
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.getClientServiceStatus.mockReturnValue({
+      state: "unknown",
+      platform: "systemd",
+      detail:
+        "legacy root systemd user unit requires out-of-service migration: /root/.config/systemd/user/first-tree.service",
+      migrationRequired: "root-systemd-user-to-system",
+    });
+    coreMocks.loadCredentials.mockReturnValue({
+      accessToken: jwt({ sub: "user-old" }),
+      refreshToken: "refresh",
+      serverUrl: "https://first-tree.example",
+    });
+    coreMocks.readActiveRootClientId.mockReturnValue("client-1");
+
+    const { registerLogoutCommand } = await import("../commands/logout.js");
+    await expect(runTopLevel(registerLogoutCommand, ["logout"])).rejects.toMatchObject({
+      code: "DAEMON_MIGRATION_REQUIRED",
+      exitCode: 1,
+    });
+
+    let output = printLineMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("Refusing to remove credentials");
+    expect(output).toContain("first-tree-dev login <code>");
+    expect(coreMocks.stopClientService).not.toHaveBeenCalled();
+    expect(cliFetchMock).not.toHaveBeenCalled();
+    expect(readFileSync(credentials, "utf8")).toBe("{}");
+
+    printLineMock.mockClear();
+    await expect(runTopLevel(registerLogoutCommand, ["logout", "--purge"])).rejects.toMatchObject({
+      code: "DAEMON_MIGRATION_REQUIRED",
+      exitCode: 1,
+    });
+
+    output = printLineMock.mock.calls.map((call) => String(call[0])).join("");
+    expect(output).toContain("Refusing to remove credentials");
+    expect(cliFetchMock).not.toHaveBeenCalled();
+    expect(readFileSync(credentials, "utf8")).toBe("{}");
+  });
+
   it("refuses purge before server retire or local deletion when service state is unknown", async () => {
     const credentials = join(tempDir, "credentials.json");
     const clientYaml = join(tempDir, "client.yaml");

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -450,10 +450,13 @@ describe("daemon start command", () => {
         "legacy root systemd user unit requires out-of-service migration: /root/.config/systemd/user/first-tree.service",
       logDir: "/logs",
       managerScope: "user",
+      migrationRequired: "root-systemd-user-to-system",
     });
 
     await expect(runStart()).rejects.toMatchObject({ exitCode: 1 });
     expect(output()).toContain("legacy root systemd user unit requires out-of-service migration");
+    expect(output()).toContain("Complete the root systemd migration out-of-service with `first-tree-dev login <code>`");
+    expect(output()).not.toContain("--foreground");
     expect(coreMocks.startClientService).not.toHaveBeenCalled();
     expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
   });

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -440,6 +440,22 @@ describe("daemon start command", () => {
 
     await expect(runStart()).rejects.toMatchObject({ exitCode: 1 });
     expect(output()).toContain("Service state could not be determined (launchd).");
+
+    stderrSpy.mockClear();
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({
+      platform: "systemd",
+      state: "unknown",
+      label: "first-tree.service",
+      detail:
+        "legacy root systemd user unit requires out-of-service migration: /root/.config/systemd/user/first-tree.service",
+      logDir: "/logs",
+      managerScope: "user",
+    });
+
+    await expect(runStart()).rejects.toMatchObject({ exitCode: 1 });
+    expect(output()).toContain("legacy root systemd user unit requires out-of-service migration");
+    expect(coreMocks.startClientService).not.toHaveBeenCalled();
+    expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
   });
 
   it("runs inline, reconciles local state, uploads capabilities and skills", async () => {

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -329,6 +329,31 @@ describe("daemon start command", () => {
     expect(output()).toContain("Supervisor fallback: `journalctl --user -u first-tree`");
   });
 
+  it("prints system journal hints for root systemd services", async () => {
+    coreMocks.isServiceSupported.mockReturnValue(true);
+    coreMocks.getClientServiceStatus
+      .mockReturnValueOnce({
+        platform: "systemd",
+        state: "inactive",
+        label: "first-tree.service",
+        logDir: "/logs",
+        managerScope: "system",
+      })
+      .mockReturnValueOnce({
+        platform: "systemd",
+        state: "active",
+        label: "first-tree.service",
+        detail: "pid 123",
+        logDir: "/logs",
+        managerScope: "system",
+      });
+
+    await expect(runStart()).resolves.toBeTruthy();
+    expect(coreMocks.startClientService).toHaveBeenCalled();
+    expect(output()).toContain("Supervisor fallback: `journalctl -u first-tree`");
+    expect(output()).not.toContain("journalctl --user -u first-tree");
+  });
+
   it("starts an inactive launchd service and prints stdout/stderr fallback logs", async () => {
     coreMocks.isServiceSupported.mockReturnValue(true);
     coreMocks.getClientServiceStatus

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -459,6 +459,23 @@ describe("daemon start command", () => {
     expect(output()).not.toContain("--foreground");
     expect(coreMocks.startClientService).not.toHaveBeenCalled();
     expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
+
+    stderrSpy.mockClear();
+    coreMocks.getClientServiceStatus.mockReturnValueOnce({
+      platform: "systemd",
+      state: "unknown",
+      label: "first-tree.service",
+      detail:
+        "legacy root systemd user unit requires out-of-service migration: /root/.config/systemd/user/first-tree.service",
+      logDir: "/logs",
+      managerScope: "user",
+      migrationRequired: "root-systemd-user-to-system",
+    });
+
+    await expect(runStart(["--foreground"])).rejects.toMatchObject({ exitCode: 1 });
+    expect(output()).toContain("Service migration is required before foreground start");
+    expect(output()).toContain("Complete the root systemd migration out-of-service with `first-tree-dev login <code>`");
+    expect(coreMocks.ClientRuntime).not.toHaveBeenCalled();
   });
 
   it("runs inline, reconciles local state, uploads capabilities and skills", async () => {

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -67,6 +67,7 @@ const originalArgv = [...process.argv];
 const originalExecPath = process.execPath;
 const originalCwd = process.cwd;
 const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
+const originalSystemdSystemDir = process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR;
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 
 function setPlatform(platform: NodeJS.Platform): void {
@@ -123,6 +124,7 @@ beforeEach(() => {
   home = tempHome();
   mkdirSync(home, { recursive: true });
   process.env.FIRST_TREE_HOME = join(home, "ft-home");
+  process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR = join(home, "systemd-system");
   process.env.XDG_CONFIG_HOME = join(home, "xdg");
   process.argv = ["node", "/repo/dist/cli/index.mjs"];
   setExecPath("/opt/node/bin/node");
@@ -139,6 +141,8 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
   if (originalFirstTreeHome === undefined) delete process.env.FIRST_TREE_HOME;
   else process.env.FIRST_TREE_HOME = originalFirstTreeHome;
+  if (originalSystemdSystemDir === undefined) delete process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR;
+  else process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR = originalSystemdSystemDir;
   if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
   else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
   process.argv = [...originalArgv];
@@ -199,7 +203,11 @@ describe("service install helpers", () => {
     const unit = renderSystemdUnit({ kind: "bin", program: "/usr/local/bin/first tree" });
     expect(unit).toContain('ExecStart="/usr/local/bin/first tree" daemon start --no-interactive');
     expect(unit).toContain(`Environment=FIRST_TREE_HOME=${process.env.FIRST_TREE_HOME}`);
+    expect(unit).toContain("WantedBy=default.target");
     expect(unit).not.toContain("HTTPS_PROXY");
+
+    const systemUnit = renderSystemdUnit({ kind: "bin", program: "/usr/local/bin/first tree" }, "system");
+    expect(systemUnit).toContain("WantedBy=multi-user.target");
 
     const windowsWrapper = renderWindowsSupervisorCmd({
       kind: "node",
@@ -438,6 +446,47 @@ describe("service install helpers", () => {
       ["systemctl", ["--user", "enable", "--now", channelConfig.serviceUnitFile]],
       ["systemctl", ["--user", "is-active", channelConfig.serviceUnitFile]],
       ["systemctl", ["--user", "show", channelConfig.serviceUnitFile, "-p", "MainPID", "--value"]],
+    ]);
+  });
+
+  it("installs a root systemd system service without a user bus", () => {
+    setPlatform("linux");
+    userInfoMock.mockReturnValue({ uid: 0, username: "root" });
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "active\n", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "987\n", stderr: "" });
+
+    const info = installClientService();
+    const unitPath = join(process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR ?? "", channelConfig.serviceUnitFile);
+    const unit = readFileSync(unitPath, "utf-8");
+
+    expect(info).toMatchObject({
+      platform: "systemd",
+      label: channelConfig.serviceUnitFile,
+      state: "active",
+      pid: 987,
+      unitPath,
+    });
+    expect(unit).toContain("WantedBy=multi-user.target");
+    expect(unit).toContain(`Environment=FIRST_TREE_HOME=${process.env.FIRST_TREE_HOME}`);
+    expect(spawnSyncMock.mock.calls.map((call) => [call[0], call[1]])).toEqual([
+      ["systemctl", ["daemon-reload"]],
+      ["systemctl", ["enable", "--now", channelConfig.serviceUnitFile]],
+      ["systemctl", ["is-active", channelConfig.serviceUnitFile]],
+      ["systemctl", ["show", channelConfig.serviceUnitFile, "-p", "MainPID", "--value"]],
+    ]);
+
+    spawnSyncMock.mockClear();
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: "", stderr: "" });
+    expect(startClientService()).toEqual({ ok: true });
+    expect(stopClientService()).toEqual({ ok: true });
+    expect(restartClientService()).toEqual({ ok: true });
+    expect(spawnSyncMock.mock.calls.map((call) => [call[0], call[1]])).toEqual([
+      ["systemctl", ["start", channelConfig.serviceUnitFile]],
+      ["systemctl", ["stop", channelConfig.serviceUnitFile]],
+      ["systemctl", ["restart", channelConfig.serviceUnitFile]],
     ]);
   });
 
@@ -1244,13 +1293,14 @@ describe("service install helpers", () => {
 
   it("covers systemd install refresh and uninstall fallback messages", () => {
     setPlatform("linux");
-    userInfoMock.mockReturnValueOnce({ uid: 501, username: "" });
+    userInfoMock.mockReturnValue({ uid: 501, username: "" });
     spawnSyncMock
       .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
       .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
       .mockReturnValueOnce({ status: 0, stdout: "inactive\n", stderr: "" });
     expect(installClientService()).toMatchObject({ platform: "systemd", state: "inactive" });
     expect(printMocks.line).toHaveBeenCalledWith(expect.stringContaining("could not determine username"));
+    userInfoMock.mockReturnValue({ uid: 501, username: "gandy" });
 
     spawnSyncMock.mockReset();
     spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "" });

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -69,6 +69,8 @@ const originalCwd = process.cwd;
 const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
 const originalSystemdSystemDir = process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR;
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+const originalXdgRuntimeDir = process.env.XDG_RUNTIME_DIR;
+const originalDbusSessionBusAddress = process.env.DBUS_SESSION_BUS_ADDRESS;
 
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, "platform", { configurable: true, value: platform });
@@ -80,6 +82,18 @@ function setExecPath(value: string): void {
 
 function tempHome(): string {
   return join(tmpdir(), `ft-service-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+function rootHome(): string {
+  return join(home, "root");
+}
+
+function rootUserInfo(): { uid: 0; username: string; homedir: string } {
+  return { uid: 0, username: "root", homedir: rootHome() };
+}
+
+function rootLegacySystemdUserUnitPath(): string {
+  return join(rootHome(), ".config", "systemd", "user", channelConfig.serviceUnitFile);
 }
 
 function windowsProcessIdentityJson(
@@ -145,6 +159,10 @@ afterEach(() => {
   else process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR = originalSystemdSystemDir;
   if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
   else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  if (originalXdgRuntimeDir === undefined) delete process.env.XDG_RUNTIME_DIR;
+  else process.env.XDG_RUNTIME_DIR = originalXdgRuntimeDir;
+  if (originalDbusSessionBusAddress === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
+  else process.env.DBUS_SESSION_BUS_ADDRESS = originalDbusSessionBusAddress;
   process.argv = [...originalArgv];
   setExecPath(originalExecPath);
   process.cwd = originalCwd;
@@ -451,7 +469,7 @@ describe("service install helpers", () => {
 
   it("installs a root systemd system service without a user bus", () => {
     setPlatform("linux");
-    userInfoMock.mockReturnValue({ uid: 0, username: "root" });
+    userInfoMock.mockReturnValue(rootUserInfo());
     spawnSyncMock
       .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
       .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
@@ -493,8 +511,11 @@ describe("service install helpers", () => {
 
   it("migrates a legacy root systemd user unit before enabling the system unit", () => {
     setPlatform("linux");
-    userInfoMock.mockReturnValue({ uid: 0, username: "root" });
-    const legacyUnitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    userInfoMock.mockReturnValue(rootUserInfo());
+    process.env.XDG_CONFIG_HOME = join(home, "sudo-user-xdg");
+    process.env.XDG_RUNTIME_DIR = "/run/user/501";
+    process.env.DBUS_SESSION_BUS_ADDRESS = "unix:path=/run/user/501/bus";
+    const legacyUnitPath = rootLegacySystemdUserUnitPath();
     mkdirSync(dirname(legacyUnitPath), { recursive: true });
     writeFileSync(legacyUnitPath, 'Environment=HTTP_PROXY="http://legacy-proxy:8080"\n');
     spawnSyncMock
@@ -516,12 +537,16 @@ describe("service install helpers", () => {
       ["systemctl", ["enable", "--now", channelConfig.serviceUnitFile]],
       ["systemctl", ["is-active", channelConfig.serviceUnitFile]],
     ]);
+    expect(spawnSyncMock.mock.calls[0][2].env).toMatchObject({
+      XDG_RUNTIME_DIR: "/run/user/0",
+      DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/0/bus",
+    });
   });
 
   it("fails root systemd migration when the legacy user bus is unavailable", () => {
     setPlatform("linux");
-    userInfoMock.mockReturnValue({ uid: 0, username: "root" });
-    const legacyUnitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    userInfoMock.mockReturnValue(rootUserInfo());
+    const legacyUnitPath = rootLegacySystemdUserUnitPath();
     mkdirSync(dirname(legacyUnitPath), { recursive: true });
     writeFileSync(legacyUnitPath, "unit");
     spawnSyncMock.mockReturnValueOnce({
@@ -541,8 +566,8 @@ describe("service install helpers", () => {
 
   it("fails root systemd migration when the legacy user unit cannot be stopped", () => {
     setPlatform("linux");
-    userInfoMock.mockReturnValue({ uid: 0, username: "root" });
-    const legacyUnitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    userInfoMock.mockReturnValue(rootUserInfo());
+    const legacyUnitPath = rootLegacySystemdUserUnitPath();
     mkdirSync(dirname(legacyUnitPath), { recursive: true });
     writeFileSync(legacyUnitPath, "unit");
     spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "access denied" });
@@ -551,6 +576,23 @@ describe("service install helpers", () => {
     expect(existsSync(join(process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR ?? "", channelConfig.serviceUnitFile))).toBe(
       false,
     );
+  });
+
+  it("refuses in-daemon refresh during root user-to-system systemd migration", () => {
+    setPlatform("linux");
+    userInfoMock.mockReturnValue(rootUserInfo());
+    const legacyUnitPath = rootLegacySystemdUserUnitPath();
+    mkdirSync(dirname(legacyUnitPath), { recursive: true });
+    writeFileSync(legacyUnitPath, "unit");
+
+    expect(() => refreshClientServiceUnitForUpdate()).toThrow(
+      `legacy root systemd user unit requires an out-of-service migration before refresh: ${legacyUnitPath}`,
+    );
+    expect(existsSync(legacyUnitPath)).toBe(true);
+    expect(existsSync(join(process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR ?? "", channelConfig.serviceUnitFile))).toBe(
+      false,
+    );
+    expect(spawnSyncMock).not.toHaveBeenCalled();
   });
 
   it("surfaces systemd install and uninstall warnings", () => {

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -468,6 +468,7 @@ describe("service install helpers", () => {
       state: "active",
       pid: 987,
       unitPath,
+      managerScope: "system",
     });
     expect(unit).toContain("WantedBy=multi-user.target");
     expect(unit).toContain(`Environment=FIRST_TREE_HOME=${process.env.FIRST_TREE_HOME}`);
@@ -488,6 +489,78 @@ describe("service install helpers", () => {
       ["systemctl", ["stop", channelConfig.serviceUnitFile]],
       ["systemctl", ["restart", channelConfig.serviceUnitFile]],
     ]);
+  });
+
+  it("migrates a legacy root systemd user unit before enabling the system unit", () => {
+    setPlatform("linux");
+    userInfoMock.mockReturnValue({ uid: 0, username: "root" });
+    const legacyUnitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    mkdirSync(dirname(legacyUnitPath), { recursive: true });
+    writeFileSync(legacyUnitPath, 'Environment=HTTP_PROXY="http://legacy-proxy:8080"\n');
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "inactive\n", stderr: "" });
+
+    expect(installClientService()).toMatchObject({ platform: "systemd", state: "inactive", managerScope: "system" });
+    expect(existsSync(legacyUnitPath)).toBe(false);
+    expect(readFileSync(join(process.env.FIRST_TREE_HOME ?? "", "daemon.env"), "utf-8")).toContain(
+      "HTTP_PROXY=http://legacy-proxy:8080",
+    );
+    expect(spawnSyncMock.mock.calls.map((call) => [call[0], call[1]])).toEqual([
+      ["systemctl", ["--user", "disable", "--now", channelConfig.serviceUnitFile]],
+      ["systemctl", ["--user", "daemon-reload"]],
+      ["systemctl", ["daemon-reload"]],
+      ["systemctl", ["enable", "--now", channelConfig.serviceUnitFile]],
+      ["systemctl", ["is-active", channelConfig.serviceUnitFile]],
+    ]);
+  });
+
+  it("removes a legacy root user unit when the user bus is unavailable", () => {
+    setPlatform("linux");
+    userInfoMock.mockReturnValue({ uid: 0, username: "root" });
+    const legacyUnitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    mkdirSync(dirname(legacyUnitPath), { recursive: true });
+    writeFileSync(legacyUnitPath, "unit");
+    spawnSyncMock
+      .mockReturnValueOnce({
+        status: 1,
+        stdout: "",
+        stderr: "Failed to connect to bus: No such file or directory",
+      })
+      .mockReturnValueOnce({
+        status: 1,
+        stdout: "",
+        stderr: "Failed to connect to bus: No such file or directory",
+      })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
+      .mockReturnValueOnce({ status: 0, stdout: "inactive\n", stderr: "" });
+
+    expect(installClientService()).toMatchObject({ platform: "systemd", state: "inactive", managerScope: "system" });
+    expect(existsSync(legacyUnitPath)).toBe(false);
+    expect(printMocks.line).toHaveBeenCalledWith(
+      expect.stringContaining("legacy root systemd user manager unavailable during migration"),
+    );
+    expect(printMocks.line).toHaveBeenCalledWith(
+      expect.stringContaining("legacy root systemd user daemon-reload skipped"),
+    );
+  });
+
+  it("fails root systemd migration when the legacy user unit cannot be stopped", () => {
+    setPlatform("linux");
+    userInfoMock.mockReturnValue({ uid: 0, username: "root" });
+    const legacyUnitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
+    mkdirSync(dirname(legacyUnitPath), { recursive: true });
+    writeFileSync(legacyUnitPath, "unit");
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "", stderr: "access denied" });
+
+    expect(() => installClientService()).toThrow("legacy root systemd user service migration failed: access denied");
+    expect(existsSync(join(process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR ?? "", channelConfig.serviceUnitFile))).toBe(
+      false,
+    );
   });
 
   it("surfaces systemd install and uninstall warnings", () => {

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -591,6 +591,7 @@ describe("service install helpers", () => {
       state: "unknown",
       unitPath: legacyUnitPath,
       managerScope: "user",
+      migrationRequired: "root-systemd-user-to-system",
       detail: reason,
     });
     expect(isServiceUnitDriftDetected()).toBe(true);
@@ -602,6 +603,7 @@ describe("service install helpers", () => {
       state: "unknown",
       unitPath: legacyUnitPath,
       managerScope: "user",
+      migrationRequired: "root-systemd-user-to-system",
       detail: reason,
     });
     expect(() => refreshClientServiceUnitForUpdate()).toThrow(

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -578,13 +578,32 @@ describe("service install helpers", () => {
     );
   });
 
-  it("refuses in-daemon refresh during root user-to-system systemd migration", () => {
+  it("refuses lifecycle operations during deferred root user-to-system systemd migration", () => {
     setPlatform("linux");
     userInfoMock.mockReturnValue(rootUserInfo());
     const legacyUnitPath = rootLegacySystemdUserUnitPath();
+    const reason = `legacy root systemd user unit requires out-of-service migration: ${legacyUnitPath}`;
     mkdirSync(dirname(legacyUnitPath), { recursive: true });
     writeFileSync(legacyUnitPath, "unit");
 
+    expect(getClientServiceStatus()).toMatchObject({
+      platform: "systemd",
+      state: "unknown",
+      unitPath: legacyUnitPath,
+      managerScope: "user",
+      detail: reason,
+    });
+    expect(isServiceUnitDriftDetected()).toBe(true);
+    expect(startClientService()).toEqual({ ok: false, reason });
+    expect(stopClientService()).toEqual({ ok: false, reason });
+    expect(restartClientService()).toEqual({ ok: false, reason });
+    expect(uninstallClientService()).toMatchObject({
+      platform: "systemd",
+      state: "unknown",
+      unitPath: legacyUnitPath,
+      managerScope: "user",
+      detail: reason,
+    });
     expect(() => refreshClientServiceUnitForUpdate()).toThrow(
       `legacy root systemd user unit requires an out-of-service migration before refresh: ${legacyUnitPath}`,
     );

--- a/apps/cli/src/__tests__/service-install-core.test.ts
+++ b/apps/cli/src/__tests__/service-install-core.test.ts
@@ -518,34 +518,24 @@ describe("service install helpers", () => {
     ]);
   });
 
-  it("removes a legacy root user unit when the user bus is unavailable", () => {
+  it("fails root systemd migration when the legacy user bus is unavailable", () => {
     setPlatform("linux");
     userInfoMock.mockReturnValue({ uid: 0, username: "root" });
     const legacyUnitPath = join(process.env.XDG_CONFIG_HOME ?? "", "systemd", "user", channelConfig.serviceUnitFile);
     mkdirSync(dirname(legacyUnitPath), { recursive: true });
     writeFileSync(legacyUnitPath, "unit");
-    spawnSyncMock
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-        stderr: "Failed to connect to bus: No such file or directory",
-      })
-      .mockReturnValueOnce({
-        status: 1,
-        stdout: "",
-        stderr: "Failed to connect to bus: No such file or directory",
-      })
-      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
-      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" })
-      .mockReturnValueOnce({ status: 0, stdout: "inactive\n", stderr: "" });
+    spawnSyncMock.mockReturnValueOnce({
+      status: 1,
+      stdout: "",
+      stderr: "Failed to connect to bus: No such file or directory",
+    });
 
-    expect(installClientService()).toMatchObject({ platform: "systemd", state: "inactive", managerScope: "system" });
-    expect(existsSync(legacyUnitPath)).toBe(false);
-    expect(printMocks.line).toHaveBeenCalledWith(
-      expect.stringContaining("legacy root systemd user manager unavailable during migration"),
+    expect(() => installClientService()).toThrow(
+      "legacy root systemd user service state is ambiguous: Failed to connect to bus: No such file or directory",
     );
-    expect(printMocks.line).toHaveBeenCalledWith(
-      expect.stringContaining("legacy root systemd user daemon-reload skipped"),
+    expect(existsSync(legacyUnitPath)).toBe(true);
+    expect(existsSync(join(process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR ?? "", channelConfig.serviceUnitFile))).toBe(
+      false,
     );
   });
 

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -195,11 +195,17 @@ export function registerDaemonStartCommand(daemon: Command): void {
             // don't recognise. Falling through to the inline path here would
             // race a still-supervised process for the same client.id, which
             // is exactly the failure mode this whole PR is trying to
-            // eliminate. Refuse and let the operator inspect.
+            // eliminate. Known migration-required states get stricter
+            // guidance because foreground bypass can recreate the duplicate
+            // runtime we are refusing.
             writeLine(
               `\n  Service state could not be determined (${svc.platform}${svc.detail ? `: ${svc.detail}` : ""}).\n`,
             );
-            writeLine(`  Inspect with \`${binName} daemon doctor\`, or pass \`--foreground\` to bypass.\n\n`);
+            if (svc.migrationRequired === "root-systemd-user-to-system") {
+              writeLine(`  Complete the root systemd migration out-of-service with \`${binName} login <code>\`.\n\n`);
+            } else {
+              writeLine(`  Inspect with \`${binName} daemon doctor\`, or pass \`--foreground\` to bypass.\n\n`);
+            }
             process.exit(1);
           }
           // state === "not-installed" → fall through to inline run.

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -180,7 +180,7 @@ export function registerDaemonStartCommand(daemon: Command): void {
             writeLine(`  Logs:  ${join(after.logDir, "client.log")}\n`);
             const supervisorHint =
               after.platform === "systemd"
-                ? `  Supervisor fallback: \`journalctl --user -u ${after.label.replace(/\.service$/, "")}\`\n\n`
+                ? `  Supervisor fallback: \`journalctl ${after.managerScope === "system" ? "" : "--user "}-u ${after.label.replace(/\.service$/, "")}\`\n\n`
                 : after.platform === "task-scheduler"
                   ? `  Supervisor log: ${join(after.logDir, "supervisor.log")}\n  Wrapper fallback: ${join(
                       after.logDir,

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -133,6 +133,16 @@ export function registerDaemonStartCommand(daemon: Command): void {
         // invoking us, run inline" so we don't recursively call systemctl
         // from inside our own ExecStart.
         const wantInline = options.foreground === true || isSupervisorChild;
+        if (options.foreground === true && !isSupervisorChild && isServiceSupported()) {
+          const svc = getClientServiceStatus();
+          if (svc.migrationRequired === "root-systemd-user-to-system") {
+            writeLine(
+              `\n  Service migration is required before foreground start (${svc.platform}${svc.detail ? `: ${svc.detail}` : ""}).\n`,
+            );
+            writeLine(`  Complete the root systemd migration out-of-service with \`${binName} login <code>\`.\n\n`);
+            process.exit(1);
+          }
+        }
         if (!wantInline && isServiceSupported()) {
           const svc = getClientServiceStatus();
           if (svc.state === "active") {

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -191,6 +191,17 @@ export async function runLogout(opts: {
   // 1. Stop daemon (best-effort).
   if (isServiceSupported()) {
     const svc = getClientServiceStatus();
+    if (svc.migrationRequired === "root-systemd-user-to-system") {
+      const detail = svc.detail ? `: ${svc.detail}` : "";
+      print.line(`  Background service requires migration before logout${detail}.\n\n`);
+      print.line("  Refusing to remove credentials while the legacy root daemon may still be running.\n");
+      print.line(`  Complete the migration with \`${channelConfig.binName} login <code>\`, then retry logout.\n\n`);
+      fail(
+        "DAEMON_MIGRATION_REQUIRED",
+        `Cannot safely logout while background service migration is required: ${svc.platform}${detail}`,
+        1,
+      );
+    }
     if (svc.state === "unknown" && opts.purge) {
       const detail = svc.detail ? `: ${svc.detail}` : "";
       print.line(`  Could not determine ${svc.platform} service state${detail}.\n\n`);

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -108,7 +108,7 @@ export {
   uploadAgentSkills,
   uploadClientCapabilities,
 } from "./runtime-provider-reconcile.js";
-// Background service install (launchd / systemd --user)
+// Background service install (launchd / systemd)
 export type { ServiceInfo, ServiceOpResult, ServiceState } from "./service-install.js";
 export {
   getClientServiceStatus,

--- a/apps/cli/src/core/supervisor/index.ts
+++ b/apps/cli/src/core/supervisor/index.ts
@@ -44,9 +44,11 @@ export function installClientService(): ServiceInfo {
  * a child of the current daemon job, and unloading that label can terminate the
  * update handoff before the parent daemon exits with the restart signal.
  *
- * On systemd we keep the install path because the unit explicitly treats exit
- * 75 as restart-forced, and `enable --now` does not unload the running parent
- * process out from under the update callback.
+ * On systemd we keep the in-scope refresh path because the unit explicitly
+ * treats exit 75 as restart-forced, and `enable --now` does not unload the
+ * running parent process out from under the update callback. Root user-to-system
+ * scope migration is intentionally excluded from this in-daemon handoff: it
+ * must run out-of-service so it never stops the containing legacy unit.
  */
 export function refreshClientServiceUnitForUpdate(): ServiceInfo {
   return currentBackend().refreshForUpdate();

--- a/apps/cli/src/core/supervisor/shared.ts
+++ b/apps/cli/src/core/supervisor/shared.ts
@@ -15,11 +15,12 @@ export type ShellOutResult = { ok: true; stdout: string } | { ok: false; stderr:
  * instead of Node's opaque "Command failed". Used for launchctl/systemctl —
  * anywhere the stderr message is diagnostically crucial.
  */
-export function runCapture(program: string, args: string[], timeoutMs: number): ShellResult {
+export function runCapture(program: string, args: string[], timeoutMs: number, env?: NodeJS.ProcessEnv): ShellResult {
   const res = spawnSync(program, args, {
     encoding: "utf-8",
     timeout: timeoutMs,
     stdio: ["ignore", "pipe", "pipe"],
+    ...(env ? { env } : {}),
   });
   if (res.status === 0) return { ok: true };
   // spawnSync returns status === null + signal === 'SIGTERM' on timeout.

--- a/apps/cli/src/core/supervisor/systemd.ts
+++ b/apps/cli/src/core/supervisor/systemd.ts
@@ -38,12 +38,31 @@ function systemctlArgs(scope: SystemdScope, args: string[]): string[] {
   return scope === "user" ? ["--user", ...args] : args;
 }
 
+function systemdUserUnitPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+  return join(xdg, "systemd", "user", SYSTEMD_UNIT);
+}
+
 function systemdUnitPath(scope: SystemdScope = systemdScope()): string {
   if (scope === "system") {
     return join(process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR ?? "/etc/systemd/system", SYSTEMD_UNIT);
   }
-  const xdg = process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
-  return join(xdg, "systemd", "user", SYSTEMD_UNIT);
+  return systemdUserUnitPath();
+}
+
+function rootUserSystemctlEnv(): NodeJS.ProcessEnv {
+  const runtimeDir = process.env.XDG_RUNTIME_DIR ?? "/run/user/0";
+  return {
+    ...process.env,
+    XDG_RUNTIME_DIR: runtimeDir,
+    DBUS_SESSION_BUS_ADDRESS: process.env.DBUS_SESSION_BUS_ADDRESS ?? `unix:path=${runtimeDir}/bus`,
+  };
+}
+
+function isUserBusUnavailable(reason: string): boolean {
+  return /failed to connect to bus|dbus_session_bus_address|xdg_runtime_dir|no medium found|no such file or directory/i.test(
+    reason,
+  );
 }
 
 export function renderSystemdUnit(invocation: ResolvedBinary, scope: SystemdScope = "user"): string {
@@ -160,14 +179,43 @@ function tryEnableLinger(): { ok: true; alreadyOn: boolean } | { ok: false; reas
   return { ok: false, reason: res.stderr || `exit ${res.code ?? "unknown"}` };
 }
 
+function migrateLegacyRootUserUnitToSystemScope(): void {
+  const legacyUnitPath = systemdUserUnitPath();
+  if (!existsSync(legacyUnitPath)) return;
+
+  migrateBakedProxyEnv(extractProxyFromSystemd(readFileSync(legacyUnitPath, "utf-8")));
+
+  const env = rootUserSystemctlEnv();
+  const disableRes = runCapture("systemctl", ["--user", "disable", "--now", SYSTEMD_UNIT], 10_000, env);
+  if (!disableRes.ok) {
+    const reason = disableRes.stderr || `exit ${disableRes.code ?? "unknown"}`;
+    if (!isUserBusUnavailable(reason) && !/not found|no such|not loaded/i.test(reason)) {
+      throw new Error(`legacy root systemd user service migration failed: ${reason}`);
+    }
+    print.line(`    warning: legacy root systemd user manager unavailable during migration: ${reason}\n`);
+  }
+
+  rmSync(legacyUnitPath);
+
+  const reloadRes = runCapture("systemctl", ["--user", "daemon-reload"], 5_000, env);
+  if (!reloadRes.ok) {
+    const reason = reloadRes.stderr || `exit ${reloadRes.code ?? "unknown"}`;
+    if (!isUserBusUnavailable(reason) && !/not found|no such|not loaded/i.test(reason)) {
+      throw new Error(`legacy root systemd user daemon-reload failed: ${reason}`);
+    }
+    print.line(`    warning: legacy root systemd user daemon-reload skipped: ${reason}\n`);
+  }
+}
+
 function installSystemd(): ServiceInfo {
   const scope = systemdScope();
-  // Legacy unit auto-cleanup deliberately not done here — same reason
-  // as `installLaunchd` above. A blanket `disable --now` + `rm` of
-  // a retired or sibling channel service unit would silently wipe a peer
-  // staging/prod install that the
-  // operator hasn't migrated yet. MIGRATION.md Phase 2 documents the
-  // operator-driven `systemctl --user stop` + `rm` snippet instead.
+  if (scope === "system") migrateLegacyRootUserUnitToSystemScope();
+  // Cross-channel legacy cleanup is deliberately not done here — same reason
+  // as `installLaunchd` above. A blanket `disable --now` + `rm` of a retired
+  // or sibling channel service unit would silently wipe a peer staging/prod
+  // install that the operator hasn't migrated yet. Root's same-channel user
+  // unit is the one exception, handled above before the replacement system
+  // unit is enabled.
   const invocation = resolveCliInvocation();
   ensureLogDir();
   const unitPath = systemdUnitPath(scope);
@@ -210,7 +258,7 @@ function installSystemd(): ServiceInfo {
   }
 
   const { state, pid, detail } = systemdState();
-  return systemdInfo(unitPath, state, pid, detail);
+  return systemdInfo(unitPath, scope, state, pid, detail);
 }
 
 function uninstallSystemd(): ServiceInfo {
@@ -235,6 +283,7 @@ function uninstallSystemd(): ServiceInfo {
     unitPath,
     logDir: logDir(),
     state: "not-installed",
+    managerScope: scope,
   };
 }
 
@@ -246,17 +295,25 @@ function systemdUnitDriftDetected(): boolean {
 }
 
 function getSystemdServiceStatus(): ServiceInfo {
+  const scope = systemdScope();
   const { state, pid, detail } = systemdState();
-  return systemdInfo(systemdUnitPath(), state, pid, detail);
+  return systemdInfo(systemdUnitPath(scope), scope, state, pid, detail);
 }
 
-function systemdInfo(unitPath: string, state: ServiceState, pid?: number, detail?: string): ServiceInfo {
+function systemdInfo(
+  unitPath: string,
+  managerScope: SystemdScope,
+  state: ServiceState,
+  pid?: number,
+  detail?: string,
+): ServiceInfo {
   return {
     platform: "systemd",
     label: SYSTEMD_UNIT,
     unitPath,
     logDir: logDir(),
     state,
+    managerScope,
     pid,
     detail,
   };

--- a/apps/cli/src/core/supervisor/systemd.ts
+++ b/apps/cli/src/core/supervisor/systemd.ts
@@ -71,6 +71,17 @@ function isUserBusUnavailable(reason: string): boolean {
   );
 }
 
+function legacyRootUserMigrationDetail(unitPath: string): string {
+  return `legacy root systemd user unit requires out-of-service migration: ${unitPath}`;
+}
+
+function blockingLegacyRootUserUnitPath(scope: SystemdScope = systemdScope()): string | null {
+  if (scope !== "system") return null;
+  if (existsSync(systemdUnitPath("system"))) return null;
+  const legacyUnitPath = rootSystemdUserUnitPath();
+  return existsSync(legacyUnitPath) ? legacyUnitPath : null;
+}
+
 export function renderSystemdUnit(invocation: ResolvedBinary, scope: SystemdScope = "user"): string {
   const execStart: string =
     invocation.kind === "bin"
@@ -124,10 +135,27 @@ WantedBy=${wantedBy}
 `;
 }
 
-function systemdState(): { state: ServiceState; pid?: number; detail?: string } {
+function systemdState(): {
+  state: ServiceState;
+  pid?: number;
+  detail?: string;
+  managerScope?: SystemdScope;
+  unitPath?: string;
+} {
   const scope = systemdScope();
   const unitPath = systemdUnitPath(scope);
-  if (!existsSync(unitPath)) return { state: "not-installed" };
+  if (!existsSync(unitPath)) {
+    const legacyUnitPath = blockingLegacyRootUserUnitPath(scope);
+    if (legacyUnitPath) {
+      return {
+        state: "unknown",
+        detail: legacyRootUserMigrationDetail(legacyUnitPath),
+        managerScope: "user",
+        unitPath: legacyUnitPath,
+      };
+    }
+    return { state: "not-installed" };
+  }
   // Mirror the launchctl fix: keep stderr piped so systemctl's error text
   // ("Failed to connect to bus..." etc.) doesn't leak to the user's terminal.
   const res = spawnSync("systemctl", systemctlArgs(scope, ["is-active", SYSTEMD_UNIT]), {
@@ -225,15 +253,7 @@ function assertNoLegacyRootUserUnitDuringRefresh(): void {
   );
 }
 
-function installSystemd(): ServiceInfo {
-  const scope = systemdScope();
-  if (scope === "system") migrateLegacyRootUserUnitToSystemScope();
-  // Cross-channel legacy cleanup is deliberately not done here — same reason
-  // as `installLaunchd` above. A blanket `disable --now` + `rm` of a retired
-  // or sibling channel service unit would silently wipe a peer staging/prod
-  // install that the operator hasn't migrated yet. Root's same-channel user
-  // unit is the one exception, handled above before the replacement system
-  // unit is enabled.
+function writeAndEnableSystemd(scope: SystemdScope): ServiceInfo {
   const invocation = resolveCliInvocation();
   ensureLogDir();
   const unitPath = systemdUnitPath(scope);
@@ -282,11 +302,33 @@ function installSystemd(): ServiceInfo {
 function refreshSystemdForUpdate(): ServiceInfo {
   const scope = systemdScope();
   if (scope === "system") assertNoLegacyRootUserUnitDuringRefresh();
-  return installSystemd();
+  return writeAndEnableSystemd(scope);
+}
+
+function installSystemd(): ServiceInfo {
+  const scope = systemdScope();
+  if (scope === "system") migrateLegacyRootUserUnitToSystemScope();
+  // Cross-channel legacy cleanup is deliberately not done here — same reason
+  // as `installLaunchd` above. A blanket `disable --now` + `rm` of a retired
+  // or sibling channel service unit would silently wipe a peer staging/prod
+  // install that the operator hasn't migrated yet. Root's same-channel user
+  // unit is the one exception, handled above before the replacement system
+  // unit is enabled.
+  return writeAndEnableSystemd(scope);
 }
 
 function uninstallSystemd(): ServiceInfo {
   const scope = systemdScope();
+  const blockedLegacyUnitPath = blockingLegacyRootUserUnitPath(scope);
+  if (blockedLegacyUnitPath) {
+    return systemdInfo(
+      blockedLegacyUnitPath,
+      "user",
+      "unknown",
+      undefined,
+      legacyRootUserMigrationDetail(blockedLegacyUnitPath),
+    );
+  }
   const unitPath = systemdUnitPath(scope);
   const disableRes = runCapture("systemctl", systemctlArgs(scope, ["disable", "--now", SYSTEMD_UNIT]), 10_000);
   if (!disableRes.ok && !/not found|no such|not loaded/i.test(disableRes.stderr)) {
@@ -313,6 +355,7 @@ function uninstallSystemd(): ServiceInfo {
 
 function systemdUnitDriftDetected(): boolean {
   const scope = systemdScope();
+  if (blockingLegacyRootUserUnitPath(scope)) return true;
   const invocation = resolveCliInvocation();
   const expected = renderSystemdUnit(invocation, scope);
   return readFileOrFlagDrift(systemdUnitPath(scope), expected);
@@ -320,8 +363,8 @@ function systemdUnitDriftDetected(): boolean {
 
 function getSystemdServiceStatus(): ServiceInfo {
   const scope = systemdScope();
-  const { state, pid, detail } = systemdState();
-  return systemdInfo(systemdUnitPath(scope), scope, state, pid, detail);
+  const { state, pid, detail, managerScope, unitPath } = systemdState();
+  return systemdInfo(unitPath ?? systemdUnitPath(scope), managerScope ?? scope, state, pid, detail);
 }
 
 function systemdInfo(
@@ -346,6 +389,8 @@ function systemdInfo(
 /** Start the service. No-op + ok if already running. */
 function startSystemdService(): ServiceOpResult {
   const scope = systemdScope();
+  const legacyUnitPath = blockingLegacyRootUserUnitPath(scope);
+  if (legacyUnitPath) return { ok: false, reason: legacyRootUserMigrationDetail(legacyUnitPath) };
   const res = runCapture("systemctl", systemctlArgs(scope, ["start", SYSTEMD_UNIT]), 15_000);
   if (!res.ok) return { ok: false, reason: res.stderr || `exit ${res.code ?? "unknown"}` };
   return { ok: true };
@@ -361,6 +406,8 @@ function startSystemdService(): ServiceOpResult {
  */
 function stopSystemdService(): ServiceOpResult {
   const scope = systemdScope();
+  const legacyUnitPath = blockingLegacyRootUserUnitPath(scope);
+  if (legacyUnitPath) return { ok: false, reason: legacyRootUserMigrationDetail(legacyUnitPath) };
   const res = runCapture("systemctl", systemctlArgs(scope, ["stop", SYSTEMD_UNIT]), 35_000);
   if (!res.ok) {
     // Mirror the launchd "stop on missing unit = ok" semantics below: a
@@ -376,6 +423,8 @@ function stopSystemdService(): ServiceOpResult {
 /** Restart the service. Equivalent to stop + start, but uses the manager's atomic primitive. */
 function restartSystemdService(): ServiceOpResult {
   const scope = systemdScope();
+  const legacyUnitPath = blockingLegacyRootUserUnitPath(scope);
+  if (legacyUnitPath) return { ok: false, reason: legacyRootUserMigrationDetail(legacyUnitPath) };
   const res = runCapture("systemctl", systemctlArgs(scope, ["restart", SYSTEMD_UNIT]), 45_000);
   if (!res.ok) return { ok: false, reason: res.stderr || `exit ${res.code ?? "unknown"}` };
   return { ok: true };

--- a/apps/cli/src/core/supervisor/systemd.ts
+++ b/apps/cli/src/core/supervisor/systemd.ts
@@ -28,13 +28,25 @@ const SYSTEMD_UNIT = channelConfig.serviceUnitFile;
 // launchd label uses the same identifier convention (bare name), so we
 // reuse it for both.
 const SYSLOG_IDENT = channelConfig.launchdLabel;
+type SystemdScope = "user" | "system";
 
-function systemdUnitPath(): string {
+function systemdScope(): SystemdScope {
+  return userInfo().uid === 0 ? "system" : "user";
+}
+
+function systemctlArgs(scope: SystemdScope, args: string[]): string[] {
+  return scope === "user" ? ["--user", ...args] : args;
+}
+
+function systemdUnitPath(scope: SystemdScope = systemdScope()): string {
+  if (scope === "system") {
+    return join(process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR ?? "/etc/systemd/system", SYSTEMD_UNIT);
+  }
   const xdg = process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
   return join(xdg, "systemd", "user", SYSTEMD_UNIT);
 }
 
-export function renderSystemdUnit(invocation: ResolvedBinary): string {
+export function renderSystemdUnit(invocation: ResolvedBinary, scope: SystemdScope = "user"): string {
   const execStart: string =
     invocation.kind === "bin"
       ? `${shellQuote(invocation.program)} daemon start --no-interactive`
@@ -51,6 +63,7 @@ export function renderSystemdUnit(invocation: ResolvedBinary): string {
   // Put this CLI's Node directory first so npm/nvm-installed shebangs and
   // self-update use the same Node toolchain when supervised.
   const pathEnv = `Environment=PATH=${shellQuote(systemdPathEnv())}\n`;
+  const wantedBy = scope === "system" ? "multi-user.target" : "default.target";
 
   // Restart policy split:
   //   - on-failure  → operator-issued `systemctl stop` (clean exit 0) really stops.
@@ -82,30 +95,35 @@ StandardError=journal
 SyslogIdentifier=${SYSLOG_IDENT}
 ${pathEnv}Environment=FIRST_TREE_SERVICE_MODE=1
 ${homeEnv}[Install]
-WantedBy=default.target
+WantedBy=${wantedBy}
 `;
 }
 
 function systemdState(): { state: ServiceState; pid?: number; detail?: string } {
-  const unitPath = systemdUnitPath();
+  const scope = systemdScope();
+  const unitPath = systemdUnitPath(scope);
   if (!existsSync(unitPath)) return { state: "not-installed" };
   // Mirror the launchctl fix: keep stderr piped so systemctl's error text
   // ("Failed to connect to bus..." etc.) doesn't leak to the user's terminal.
-  const res = spawnSync("systemctl", ["--user", "is-active", SYSTEMD_UNIT], {
+  const res = spawnSync("systemctl", systemctlArgs(scope, ["is-active", SYSTEMD_UNIT]), {
     encoding: "utf-8",
     timeout: 5000,
     stdio: ["ignore", "pipe", "pipe"],
   });
   const out = (res.stdout ?? "").trim();
   if (res.status === 0 && out === "active") {
-    const pid = readSystemdMainPid();
+    const pid = readSystemdMainPid(scope);
     return { state: "active", pid, detail: pid ? `pid ${pid}` : "running" };
   }
   return { state: "inactive", detail: out || "unit present but not active" };
 }
 
-function readSystemdMainPid(): number | undefined {
-  const res = runCaptureOut("systemctl", ["--user", "show", SYSTEMD_UNIT, "-p", "MainPID", "--value"], 5000);
+function readSystemdMainPid(scope: SystemdScope): number | undefined {
+  const res = runCaptureOut(
+    "systemctl",
+    systemctlArgs(scope, ["show", SYSTEMD_UNIT, "-p", "MainPID", "--value"]),
+    5000,
+  );
   if (!res.ok) return undefined;
   const n = Number(res.stdout);
   return Number.isFinite(n) && n > 0 ? n : undefined;
@@ -143,6 +161,7 @@ function tryEnableLinger(): { ok: true; alreadyOn: boolean } | { ok: false; reas
 }
 
 function installSystemd(): ServiceInfo {
+  const scope = systemdScope();
   // Legacy unit auto-cleanup deliberately not done here — same reason
   // as `installLaunchd` above. A blanket `disable --now` + `rm` of
   // a retired or sibling channel service unit would silently wipe a peer
@@ -151,7 +170,7 @@ function installSystemd(): ServiceInfo {
   // operator-driven `systemctl --user stop` + `rm` snippet instead.
   const invocation = resolveCliInvocation();
   ensureLogDir();
-  const unitPath = systemdUnitPath();
+  const unitPath = systemdUnitPath(scope);
   // Upgrade buffer: lift any proxy env a prior version baked into the unit into
   // the user-owned daemon.env before we re-render a proxy-free unit (no-op when
   // there is no prior unit, no baked proxy, or a daemon.env already exists).
@@ -159,31 +178,34 @@ function installSystemd(): ServiceInfo {
     migrateBakedProxyEnv(extractProxyFromSystemd(readFileSync(unitPath, "utf-8")));
   }
   mkdirSync(dirname(unitPath), { recursive: true });
-  writeFileSync(unitPath, renderSystemdUnit(invocation), { mode: 0o644 });
+  writeFileSync(unitPath, renderSystemdUnit(invocation, scope), { mode: 0o644 });
 
-  const reloadRes = runCapture("systemctl", ["--user", "daemon-reload"], 5_000);
+  const reloadRes = runCapture("systemctl", systemctlArgs(scope, ["daemon-reload"]), 5_000);
   if (!reloadRes.ok) {
     throw new Error(
-      `systemctl --user daemon-reload failed: ${reloadRes.stderr || `exit ${reloadRes.code ?? "unknown"}`}`,
+      `systemctl ${scope === "user" ? "--user " : ""}daemon-reload failed: ${reloadRes.stderr || `exit ${reloadRes.code ?? "unknown"}`}`,
     );
   }
 
   // Enable linger BEFORE enable --now so the unit can survive logout from
   // the very first session. Best-effort: if polkit denies it, surface a
   // warning with the manual recovery command rather than failing install.
-  const lingerRes = tryEnableLinger();
-  if (!lingerRes.ok) {
-    print.line(
-      `    warning: loginctl enable-linger failed: ${lingerRes.reason}\n` +
-        `    The service will stop when you log out. Run manually: sudo loginctl enable-linger ${userInfo().username}\n`,
-    );
+  if (scope === "user") {
+    const lingerRes = tryEnableLinger();
+    if (!lingerRes.ok) {
+      print.line(
+        `    warning: loginctl enable-linger failed: ${lingerRes.reason}\n` +
+          `    The service will stop when you log out. Run manually: sudo loginctl enable-linger ${userInfo().username}\n`,
+      );
+    }
   }
 
-  const enableRes = runCapture("systemctl", ["--user", "enable", "--now", SYSTEMD_UNIT], 10_000);
+  const enableRes = runCapture("systemctl", systemctlArgs(scope, ["enable", "--now", SYSTEMD_UNIT]), 10_000);
   if (!enableRes.ok) {
+    const systemctlPrefix = scope === "user" ? "systemctl --user" : "systemctl";
     throw new Error(
-      `systemctl --user enable --now ${SYSTEMD_UNIT} failed: ${enableRes.stderr || `exit ${enableRes.code ?? "unknown"}`}\n` +
-        `    Recovery: \`systemctl --user stop ${SYSTEMD_UNIT}\` then \`${channelConfig.binName} login <code>\`.`,
+      `${systemctlPrefix} enable --now ${SYSTEMD_UNIT} failed: ${enableRes.stderr || `exit ${enableRes.code ?? "unknown"}`}\n` +
+        `    Recovery: \`${systemctlPrefix} stop ${SYSTEMD_UNIT}\` then \`${channelConfig.binName} login <code>\`.`,
     );
   }
 
@@ -192,15 +214,16 @@ function installSystemd(): ServiceInfo {
 }
 
 function uninstallSystemd(): ServiceInfo {
-  const unitPath = systemdUnitPath();
-  const disableRes = runCapture("systemctl", ["--user", "disable", "--now", SYSTEMD_UNIT], 10_000);
+  const scope = systemdScope();
+  const unitPath = systemdUnitPath(scope);
+  const disableRes = runCapture("systemctl", systemctlArgs(scope, ["disable", "--now", SYSTEMD_UNIT]), 10_000);
   if (!disableRes.ok && !/not found|no such|not loaded/i.test(disableRes.stderr)) {
     print.line(
       `    warning: systemctl disable during uninstall: ${disableRes.stderr || `exit ${disableRes.code ?? "unknown"}`}\n`,
     );
   }
   if (existsSync(unitPath)) rmSync(unitPath);
-  const reloadRes = runCapture("systemctl", ["--user", "daemon-reload"], 5_000);
+  const reloadRes = runCapture("systemctl", systemctlArgs(scope, ["daemon-reload"]), 5_000);
   if (!reloadRes.ok) {
     print.line(
       `    warning: systemctl daemon-reload during uninstall: ${reloadRes.stderr || `exit ${reloadRes.code ?? "unknown"}`}\n`,
@@ -216,9 +239,10 @@ function uninstallSystemd(): ServiceInfo {
 }
 
 function systemdUnitDriftDetected(): boolean {
+  const scope = systemdScope();
   const invocation = resolveCliInvocation();
-  const expected = renderSystemdUnit(invocation);
-  return readFileOrFlagDrift(systemdUnitPath(), expected);
+  const expected = renderSystemdUnit(invocation, scope);
+  return readFileOrFlagDrift(systemdUnitPath(scope), expected);
 }
 
 function getSystemdServiceStatus(): ServiceInfo {
@@ -240,7 +264,8 @@ function systemdInfo(unitPath: string, state: ServiceState, pid?: number, detail
 
 /** Start the service. No-op + ok if already running. */
 function startSystemdService(): ServiceOpResult {
-  const res = runCapture("systemctl", ["--user", "start", SYSTEMD_UNIT], 15_000);
+  const scope = systemdScope();
+  const res = runCapture("systemctl", systemctlArgs(scope, ["start", SYSTEMD_UNIT]), 15_000);
   if (!res.ok) return { ok: false, reason: res.stderr || `exit ${res.code ?? "unknown"}` };
   return { ok: true };
 }
@@ -254,7 +279,8 @@ function startSystemdService(): ServiceOpResult {
  * (the bug `Restart=always` had: stop would be immediately undone).
  */
 function stopSystemdService(): ServiceOpResult {
-  const res = runCapture("systemctl", ["--user", "stop", SYSTEMD_UNIT], 35_000);
+  const scope = systemdScope();
+  const res = runCapture("systemctl", systemctlArgs(scope, ["stop", SYSTEMD_UNIT]), 35_000);
   if (!res.ok) {
     // Mirror the launchd "stop on missing unit = ok" semantics below: a
     // concurrent `daemon stop` or a manual `systemctl --user disable` can
@@ -268,7 +294,8 @@ function stopSystemdService(): ServiceOpResult {
 
 /** Restart the service. Equivalent to stop + start, but uses the manager's atomic primitive. */
 function restartSystemdService(): ServiceOpResult {
-  const res = runCapture("systemctl", ["--user", "restart", SYSTEMD_UNIT], 45_000);
+  const scope = systemdScope();
+  const res = runCapture("systemctl", systemctlArgs(scope, ["restart", SYSTEMD_UNIT]), 45_000);
   if (!res.ok) return { ok: false, reason: res.stderr || `exit ${res.code ?? "unknown"}` };
   return { ok: true };
 }

--- a/apps/cli/src/core/supervisor/systemd.ts
+++ b/apps/cli/src/core/supervisor/systemd.ts
@@ -43,6 +43,12 @@ function systemdUserUnitPath(): string {
   return join(xdg, "systemd", "user", SYSTEMD_UNIT);
 }
 
+function rootSystemdUserUnitPath(): string {
+  const info = userInfo();
+  const rootHome = info.uid === 0 && info.homedir ? info.homedir : "/root";
+  return join(rootHome, ".config", "systemd", "user", SYSTEMD_UNIT);
+}
+
 function systemdUnitPath(scope: SystemdScope = systemdScope()): string {
   if (scope === "system") {
     return join(process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR ?? "/etc/systemd/system", SYSTEMD_UNIT);
@@ -51,11 +57,11 @@ function systemdUnitPath(scope: SystemdScope = systemdScope()): string {
 }
 
 function rootUserSystemctlEnv(): NodeJS.ProcessEnv {
-  const runtimeDir = process.env.XDG_RUNTIME_DIR ?? "/run/user/0";
+  const runtimeDir = "/run/user/0";
   return {
     ...process.env,
     XDG_RUNTIME_DIR: runtimeDir,
-    DBUS_SESSION_BUS_ADDRESS: process.env.DBUS_SESSION_BUS_ADDRESS ?? `unix:path=${runtimeDir}/bus`,
+    DBUS_SESSION_BUS_ADDRESS: `unix:path=${runtimeDir}/bus`,
   };
 }
 
@@ -180,7 +186,7 @@ function tryEnableLinger(): { ok: true; alreadyOn: boolean } | { ok: false; reas
 }
 
 function migrateLegacyRootUserUnitToSystemScope(): void {
-  const legacyUnitPath = systemdUserUnitPath();
+  const legacyUnitPath = rootSystemdUserUnitPath();
   if (!existsSync(legacyUnitPath)) return;
 
   migrateBakedProxyEnv(extractProxyFromSystemd(readFileSync(legacyUnitPath, "utf-8")));
@@ -209,6 +215,14 @@ function migrateLegacyRootUserUnitToSystemScope(): void {
       throw new Error(`legacy root systemd user daemon-reload failed: ${reason}`);
     }
   }
+}
+
+function assertNoLegacyRootUserUnitDuringRefresh(): void {
+  const legacyUnitPath = rootSystemdUserUnitPath();
+  if (!existsSync(legacyUnitPath)) return;
+  throw new Error(
+    `legacy root systemd user unit requires an out-of-service migration before refresh: ${legacyUnitPath}`,
+  );
 }
 
 function installSystemd(): ServiceInfo {
@@ -263,6 +277,12 @@ function installSystemd(): ServiceInfo {
 
   const { state, pid, detail } = systemdState();
   return systemdInfo(unitPath, scope, state, pid, detail);
+}
+
+function refreshSystemdForUpdate(): ServiceInfo {
+  const scope = systemdScope();
+  if (scope === "system") assertNoLegacyRootUserUnitDuringRefresh();
+  return installSystemd();
 }
 
 function uninstallSystemd(): ServiceInfo {
@@ -365,7 +385,7 @@ export const systemdBackend: SupervisorBackend = {
   platform: "systemd",
   isSupported: () => true,
   install: installSystemd,
-  refreshForUpdate: installSystemd,
+  refreshForUpdate: refreshSystemdForUpdate,
   isUnitDriftDetected: systemdUnitDriftDetected,
   status: getSystemdServiceStatus,
   start: startSystemdService,

--- a/apps/cli/src/core/supervisor/systemd.ts
+++ b/apps/cli/src/core/supervisor/systemd.ts
@@ -189,10 +189,12 @@ function migrateLegacyRootUserUnitToSystemScope(): void {
   const disableRes = runCapture("systemctl", ["--user", "disable", "--now", SYSTEMD_UNIT], 10_000, env);
   if (!disableRes.ok) {
     const reason = disableRes.stderr || `exit ${disableRes.code ?? "unknown"}`;
-    if (!isUserBusUnavailable(reason) && !/not found|no such|not loaded/i.test(reason)) {
+    if (isUserBusUnavailable(reason)) {
+      throw new Error(`legacy root systemd user service state is ambiguous: ${reason}`);
+    }
+    if (!/not found|no such|not loaded/i.test(reason)) {
       throw new Error(`legacy root systemd user service migration failed: ${reason}`);
     }
-    print.line(`    warning: legacy root systemd user manager unavailable during migration: ${reason}\n`);
   }
 
   rmSync(legacyUnitPath);
@@ -200,10 +202,12 @@ function migrateLegacyRootUserUnitToSystemScope(): void {
   const reloadRes = runCapture("systemctl", ["--user", "daemon-reload"], 5_000, env);
   if (!reloadRes.ok) {
     const reason = reloadRes.stderr || `exit ${reloadRes.code ?? "unknown"}`;
-    if (!isUserBusUnavailable(reason) && !/not found|no such|not loaded/i.test(reason)) {
+    if (isUserBusUnavailable(reason)) {
+      throw new Error(`legacy root systemd user daemon-reload state is ambiguous: ${reason}`);
+    }
+    if (!/not found|no such|not loaded/i.test(reason)) {
       throw new Error(`legacy root systemd user daemon-reload failed: ${reason}`);
     }
-    print.line(`    warning: legacy root systemd user daemon-reload skipped: ${reason}\n`);
   }
 }
 

--- a/apps/cli/src/core/supervisor/systemd.ts
+++ b/apps/cli/src/core/supervisor/systemd.ts
@@ -140,6 +140,7 @@ function systemdState(): {
   pid?: number;
   detail?: string;
   managerScope?: SystemdScope;
+  migrationRequired?: ServiceInfo["migrationRequired"];
   unitPath?: string;
 } {
   const scope = systemdScope();
@@ -151,6 +152,7 @@ function systemdState(): {
         state: "unknown",
         detail: legacyRootUserMigrationDetail(legacyUnitPath),
         managerScope: "user",
+        migrationRequired: "root-systemd-user-to-system",
         unitPath: legacyUnitPath,
       };
     }
@@ -327,6 +329,7 @@ function uninstallSystemd(): ServiceInfo {
       "unknown",
       undefined,
       legacyRootUserMigrationDetail(blockedLegacyUnitPath),
+      "root-systemd-user-to-system",
     );
   }
   const unitPath = systemdUnitPath(scope);
@@ -363,8 +366,8 @@ function systemdUnitDriftDetected(): boolean {
 
 function getSystemdServiceStatus(): ServiceInfo {
   const scope = systemdScope();
-  const { state, pid, detail, managerScope, unitPath } = systemdState();
-  return systemdInfo(unitPath ?? systemdUnitPath(scope), managerScope ?? scope, state, pid, detail);
+  const { state, pid, detail, managerScope, migrationRequired, unitPath } = systemdState();
+  return systemdInfo(unitPath ?? systemdUnitPath(scope), managerScope ?? scope, state, pid, detail, migrationRequired);
 }
 
 function systemdInfo(
@@ -373,6 +376,7 @@ function systemdInfo(
   state: ServiceState,
   pid?: number,
   detail?: string,
+  migrationRequired?: ServiceInfo["migrationRequired"],
 ): ServiceInfo {
   return {
     platform: "systemd",
@@ -381,6 +385,7 @@ function systemdInfo(
     logDir: logDir(),
     state,
     managerScope,
+    migrationRequired,
     pid,
     detail,
   };

--- a/apps/cli/src/core/supervisor/types.ts
+++ b/apps/cli/src/core/supervisor/types.ts
@@ -8,6 +8,8 @@ export type ServiceInfo = {
   state: ServiceState;
   /** PID of the active service process, if running. */
   pid?: number;
+  /** systemd manager scope when platform === "systemd". */
+  managerScope?: "user" | "system";
   detail?: string;
 };
 

--- a/apps/cli/src/core/supervisor/types.ts
+++ b/apps/cli/src/core/supervisor/types.ts
@@ -10,6 +10,8 @@ export type ServiceInfo = {
   pid?: number;
   /** systemd manager scope when platform === "systemd". */
   managerScope?: "user" | "system";
+  /** Structured migration guard for known transitional supervisor states. */
+  migrationRequired?: "root-systemd-user-to-system";
   detail?: string;
 };
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -623,8 +623,12 @@ after scaffolding the tree.
 
 The background service that holds the client WebSocket and runs every
 configured agent on this machine. Installed automatically by `first-tree
-login` on supported desktop platforms: launchd on macOS, `systemd --user`
-on Linux, and a per-user Task Scheduler logon task on Windows.
+login` on supported desktop platforms: launchd on macOS, systemd on
+Linux, and a per-user Task Scheduler logon task on Windows. Linux installs
+use a `systemd --user` unit for normal users; when the CLI is run as root,
+First Tree installs the same channel's unit in system scope instead
+(`/etc/systemd/system/<channel>.service`) so daemon setup does not depend
+on a root user D-Bus session.
 
 On Windows, Task Scheduler only owns per-user logon/start triggering. A hidden
 First Tree supervisor loop owns the daemon child process, exit-code restart

--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -58,7 +58,7 @@ first-tree-dev login <connect-code>
 
 ```bash
 # 1. Run the channel-aware install/login command above. It persists credentials
-#    and installs the background daemon on macOS / Linux.
+#    and installs the background daemon on supported platforms.
 FT_BIN="$HOME/.local/bin/first-tree" # Use first-tree-staging for staging.
 
 # 2. Create the agent record on the server and bind it to this client.
@@ -82,10 +82,13 @@ because an agent is permanently bound to exactly one client machine.
   accepted during rollout.
 - `$FIRST_TREE_HOME/config/client.yaml` — `client.id` (auto-generated
   on first login) and `server.url`.
-- On macOS / Linux / Windows, the background daemon is installed as a
-  per-user service so the machine stays online after login across reboots.
-  Windows uses a per-user Task Scheduler logon task, not a machine-wide
-  Windows Service. Pass `--no-start` to skip the daemon launch.
+- On macOS / Linux / Windows, the background daemon is installed so the
+  machine stays online after login across reboots. macOS uses launchd,
+  Windows uses a per-user Task Scheduler logon task, and Linux uses a
+  `systemd --user` unit for normal users. When the Linux CLI is run as
+  root, First Tree installs the channel's systemd unit in system scope
+  instead of relying on a root user D-Bus session. Windows does not use a
+  machine-wide Windows Service. Pass `--no-start` to skip the daemon launch.
 
 Every agent on this machine authenticates as the signed-in member —
 there are no per-agent bearer tokens.

--- a/docs/troubleshooting/proxy.md
+++ b/docs/troubleshooting/proxy.md
@@ -1,10 +1,11 @@
 # Proxy & network egress (daemon behind a firewall)
 
-First Tree's background daemon (launchd on macOS, systemd `--user` on Linux,
+First Tree's background daemon (launchd on macOS, systemd on Linux,
 and per-user Task Scheduler on Windows) is **compatible with** whatever proxy
-you run — it does not configure, capture, or manage a proxy for you. This page
-explains the one thing you must do so the daemon can reach the network the same
-way your shell does.
+you run — it does not configure, capture, or manage a proxy for you. Linux uses
+`systemd --user` for normal users and a system-scoped unit when the CLI is run
+as root. This page explains the one thing you must do so the daemon can reach
+the network the same way your shell does.
 
 ## Symptom
 

--- a/packages/qa/cases/cross-surface/portable-shell-onboarding.md
+++ b/packages/qa/cases/cross-surface/portable-shell-onboarding.md
@@ -42,10 +42,13 @@ identity, real first login, daemon startup, and server-side client registration.
   database and client state before switching channel configuration.
 - Give each channel a clean writable `HOME`. The runner must have `sh`, `curl`, CA certificates, and the installer's
   normal archive/checksum tools, but no system Node.js requirement; the portable artifact must supply its own runtime.
-- On Linux, give the runner's test user a real systemd user manager and D-Bus user session. Verify that
-  `systemctl --user status` can reach the manager before testing. A plain container without a working user bus cannot
-  validate this case: `login` must install and start the background daemon, so a missing manager or bus is `BLOCKED`.
-  Do not add `--no-start`, mock the supervisor, or accept a credentials-only login as a substitute.
+- On Linux, match the service-manager precondition to the user under test. For a normal user, give the runner a real
+  systemd user manager and D-Bus user session, and verify that `systemctl --user status` can reach the manager before
+  testing. For root, give the runner a working system systemd manager and verify `systemctl status` can reach it; root
+  login installs the channel service in system scope and must not depend on a root user bus. A plain container without
+  the required manager for the chosen user cannot validate this case: `login` must install and start the background
+  daemon, so a missing manager is `BLOCKED`. Do not add `--no-start`, mock the supervisor, or accept a credentials-only
+  login as a substitute.
 - Public network access to `https://download.first-tree.ai` is required. Record the resolved public metadata/version for
   each mutable `install.sh` entry point so the report distinguishes the tested public release from the source target ref.
 - Use throwaway server secrets, databases, users, and connect codes. A non-production QA auth bootstrap may be enabled
@@ -94,8 +97,10 @@ For each of `prod` and `staging`:
   shell profile, and installed metadata identifies the matching channel and portable install mode.
 - `observe cli-output`: the installed executable launches with its bundled Node.js runtime and the first `login` exits
   successfully against the isolated server without `--no-start`.
-- `observe service-state`: login installs and starts the channel-correct systemd user service, and `systemctl --user`
-  reports it active through the runner's real user manager and bus.
+- `observe service-state`: login installs and starts the channel-correct systemd service. For a normal Linux user,
+  `systemctl --user` reports the user unit active through the runner's real user manager and bus. For root,
+  `systemctl status <channel-service-unit>` reports the system unit active, and `journalctl -u <channel-service-unit>`
+  is the supervisor fallback.
 - `observe http-api`: the isolated server reports the newly registered client for the throwaway user after login. Prod
   and staging homes and clients stay isolated; neither flow invokes the other channel's binary.
 
@@ -116,8 +121,9 @@ failure, daemon installation/start failing despite a healthy user manager and bu
 to register against a healthy isolated server.
 
 `BLOCKED`: Docker or public download access is unavailable, QA auth/data bootstrap cannot mint a connect code, a required
-public channel release has not been published, or the Linux runner lacks a reachable systemd user manager and D-Bus user
-session. Do not downgrade this case to `login --no-start`.
+public channel release has not been published, or the Linux runner lacks the reachable systemd manager required for the
+chosen user (user manager + D-Bus user session for normal users, system manager for root). Do not downgrade this case to
+`login --no-start`.
 
 `INCONCLUSIVE`: only one channel completed, the mutable public installer changed during the run, the public artifact
 could not be attributed to the recorded metadata/version, or clipboard, login, daemon, or registration evidence was
@@ -127,6 +133,6 @@ partial or unstable.
 
 Keep redacted API responses, browser screenshots plus clipboard capture, installer, latest metadata, immutable-manifest,
 and `SHA256SUMS` HTTP responses, `sh -n` output, checksum/install logs, installed binary/version/channel evidence, CLI
-login output, systemd user-service state, and server-side client registration. Record the target ref, public artifact
-versions, container image digests, and run-local routing overrides. Never retain connect codes, bearer tokens, cookies,
-or generated client credentials in shared artifacts.
+login output, systemd service state (user scope for normal users, system scope for root), and server-side client
+registration. Record the target ref, public artifact versions, container image digests, and run-local routing overrides.
+Never retain connect codes, bearer tokens, cookies, or generated client credentials in shared artifacts.


### PR DESCRIPTION
## Summary
- install Linux systemd services in system scope when the CLI is running as root, while keeping normal Linux users on systemd user units with linger behavior unchanged
- migrate legacy same-channel root user units only from the out-of-service install path; ambiguous root user-manager state now fails closed before writing/enabling the system unit
- keep `daemon refresh-unit` from stopping its containing legacy root user unit, and force root migration probes to UID 0 paths/bus instead of inherited sudo XDG/D-Bus values
- make systemd manager scope visible to daemon-start output so root installs print `journalctl -u ...` and user installs print `journalctl --user -u ...`
- update source docs/QA guidance and pair the durable Runtime Daemon Context Tree change in draft PR agent-team-foundation/first-tree-context#739

## Verification
- `pnpm --dir apps/cli exec vitest run src/__tests__/service-install-core.test.ts src/__tests__/daemon-start-command.test.ts`
- `pnpm --filter first-tree-dev typecheck`
- `pnpm exec biome check apps/cli/src/core/supervisor/systemd.ts apps/cli/src/core/supervisor/index.ts apps/cli/src/__tests__/service-install-core.test.ts`
- GitHub Actions on the latest pushed commit are green

## Notes
- `pnpm check` previously completed with existing warnings in `packages/client/src/__tests__/assistant-text.test.ts`, `packages/client/src/runtime/workspace-migrations.ts`, and `packages/web/src/index.css`.
- `pnpm test` was previously attempted and failed outside this change: `@first-tree/skill-evals` fixture git commit/timeouts, `@first-tree/web` draft-store `window.localStorage.clear` unavailable, and `first-tree-dev` batch 9 hit an environment-specific client-switch drain timeout before its EXDEV assertion.