### PR TITLE
docs(skills): add GitLab forge guidance

### DIFF
--- a/packages/skill-evals/package.json
+++ b/packages/skill-evals/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.16.0",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "yaml": "^2.8.3"
   }
 }

--- a/packages/skill-evals/src/core/skills/install.ts
+++ b/packages/skill-evals/src/core/skills/install.ts
@@ -1,9 +1,23 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { parseDocument } from "yaml";
 
 import { writeText } from "../commands.js";
 
 export function parseSkillDescription(skillMarkdown: string): string {
+  const frontmatter = skillMarkdown.match(/^---\n([\s\S]*?)\n---/u)?.[1];
+  if (frontmatter) {
+    try {
+      const description = parseDocument(frontmatter).get("description");
+      if (typeof description === "string" && description.trim() !== "") {
+        return description;
+      }
+    } catch (error: unknown) {
+      void error;
+      // Fall back to the legacy line parser for malformed test fixtures.
+    }
+  }
+
   const match = skillMarkdown.match(/^description:\s*"?(.+?)"?\s*$/mu);
   return match?.[1] ?? "Use this skill when its description applies.";
 }

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/chat-first-fixture.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/chat-first-fixture.test.ts
@@ -58,12 +58,19 @@ describe("first-tree-seed chat-first fixtures", () => {
         cwd: sourceRepoPath,
         encoding: "utf8",
       }).trim();
+      const localHead = execFileSync("git", ["rev-parse", "refs/heads/trunk"], {
+        cwd: sourceRepoPath,
+        encoding: "utf8",
+      }).trim();
       const agentsMarkdown = readFileSync(join(paths.workspacePath, "AGENTS.md"), "utf8");
 
       expect(remoteHead).toBe("refs/remotes/origin/trunk");
       expect(sourceHead).not.toBe("");
+      expect(localHead).not.toBe(sourceHead);
       expect(agentsMarkdown).toContain("Source forge: gitlab");
       expect(agentsMarkdown).toContain("Source default branch: `trunk`");
+      expect(agentsMarkdown).toContain("Declared source ref: `ref=trunk`");
+      expect(agentsMarkdown).toContain("Local source branch state: `stale`");
       expect(agentsMarkdown).toContain("worktree add");
       expect(agentsMarkdown).toContain("origin/trunk");
       expect(agentsMarkdown).not.toContain("origin/main");

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/chat-first-fixture.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/chat-first-fixture.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { createRunPaths } from "../../../core/paths.js";
 import { createEvalReporter } from "../../../core/reporter.js";
 import { FIRST_TREE_SEED_GATE_CASES } from "../cases.js";
-import { setupFixture, validateFixture } from "../fixture.js";
+import { setupFixture, sourceRemoteRef, validateFixture } from "../fixture.js";
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
 
@@ -36,6 +36,37 @@ describe("first-tree-seed chat-first fixtures", () => {
 
       expect(manifest.sources).toEqual([]);
       expect(bare).toBe("false");
+      expect(validateFixture(paths, contextTreePath, evalCase, false, reporter).ok).toBe(true);
+    } finally {
+      rmSync(paths.runRoot, { force: true, recursive: true });
+    }
+  }, 20_000);
+
+  it("materializes a GitLab source fixture on its non-main default branch", () => {
+    const evalCase = gateCase("gitlab-non-main-source-worktree-protocol");
+    const paths = createRunPaths({ caseId: evalCase.id, packageRoot, startedAt: new Date().toISOString() });
+
+    try {
+      const reporter = createEvalReporter(evalCase.id, false);
+      const contextTreePath = setupFixture(evalCase, paths, reporter);
+      const sourceRepoPath = join(paths.workspacePath, "source-repos", "source-repo");
+      const remoteHead = execFileSync("git", ["symbolic-ref", "refs/remotes/origin/HEAD"], {
+        cwd: sourceRepoPath,
+        encoding: "utf8",
+      }).trim();
+      const sourceHead = execFileSync("git", ["rev-parse", sourceRemoteRef(evalCase)], {
+        cwd: sourceRepoPath,
+        encoding: "utf8",
+      }).trim();
+      const agentsMarkdown = readFileSync(join(paths.workspacePath, "AGENTS.md"), "utf8");
+
+      expect(remoteHead).toBe("refs/remotes/origin/trunk");
+      expect(sourceHead).not.toBe("");
+      expect(agentsMarkdown).toContain("Source forge: gitlab");
+      expect(agentsMarkdown).toContain("Source default branch: `trunk`");
+      expect(agentsMarkdown).toContain("worktree add");
+      expect(agentsMarkdown).toContain("origin/trunk");
+      expect(agentsMarkdown).not.toContain("origin/main");
       expect(validateFixture(paths, contextTreePath, evalCase, false, reporter).ok).toBe(true);
     } finally {
       rmSync(paths.runRoot, { force: true, recursive: true });

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/chat-first-fixture.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/chat-first-fixture.test.ts
@@ -71,8 +71,9 @@ describe("first-tree-seed chat-first fixtures", () => {
       expect(agentsMarkdown).toContain("Source default branch: `trunk`");
       expect(agentsMarkdown).toContain("Declared source ref: `ref=trunk`");
       expect(agentsMarkdown).toContain("Local source branch state: `stale`");
-      expect(agentsMarkdown).toContain("worktree add");
-      expect(agentsMarkdown).toContain("origin/trunk");
+      expect(agentsMarkdown).toContain("Runtime declaration: ref=trunk");
+      expect(agentsMarkdown).not.toContain("worktree add");
+      expect(agentsMarkdown).not.toContain("origin/trunk");
       expect(agentsMarkdown).not.toContain("origin/main");
       expect(validateFixture(paths, contextTreePath, evalCase, false, reporter).ok).toBe(true);
     } finally {

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
@@ -41,8 +41,10 @@ describe("first-tree-seed floor invariants", () => {
 
   it("materializes declared source worktrees from the resolved source ref, not origin/main", () => {
     expect(skillMarkdown).toContain("declared/pinned ref when one exists");
+    expect(skillMarkdown).toContain('remote_ref="refs/remotes/origin/$source_ref"');
     expect(skillMarkdown).toContain("refs/remotes/origin/HEAD");
     expect(skillMarkdown).toContain("Do not hard-code `origin/main`");
+    expect(skillMarkdown).toContain("Do not pass a branch-like declared");
 
     const sourceWorktreeSection =
       skillMarkdown.match(/### Materialize source read worktrees[\s\S]*?## The Two Phases/u)?.[0] ?? "";
@@ -120,7 +122,13 @@ describe("first-tree-seed floor invariants", () => {
     );
     expect(gitlabNonMain).toMatchObject({
       expected: { action: "materialize_bare_worktree", requireSourceRead: true, requireWorktree: true },
-      fixture: { sourceDefaultBranch: "trunk", sourceForge: "gitlab", sourceRepoState: "bare-readable" },
+      fixture: {
+        sourceDeclaredRef: "trunk",
+        sourceDefaultBranch: "trunk",
+        sourceForge: "gitlab",
+        sourceLocalBranchState: "stale",
+        sourceRepoState: "bare-readable",
+      },
     });
 
     const continuation = FIRST_TREE_SEED_GATE_CASES.find((evalCase) => evalCase.id === "same-chat-phase2-continuation");

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { parseDocument } from "yaml";
 import { FIRST_TREE_SEED_GATE_CASES, FIRST_TREE_SEED_SUITE } from "../cases.js";
 
 const validateFloor = FIRST_TREE_SEED_SUITE.validateFloor;
@@ -22,12 +23,30 @@ describe("first-tree-seed floor invariants", () => {
     expect(skillMarkdown).toMatch(/rather\s+than asking for the First\s+Tree GitHub App/);
   });
 
+  it("ships valid YAML frontmatter", () => {
+    const frontmatter = skillMarkdown.match(/^---\n([\s\S]*?)\n---/u)?.[1] ?? "";
+    const parsed = parseDocument(frontmatter);
+
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.get("description")).toContain("yet: either no tree exists");
+  });
+
   it("supports GitLab sources without inventing GitLab tree provisioning", () => {
     expect(skillMarkdown).toContain("Use `gh` for GitHub and `glab` for GitLab");
     expect(skillMarkdown).toMatch(/Preserve the full GitLab\s+namespace/);
     expect(skillMarkdown).toMatch(/current\s+`first-tree tree init` provisioning is GitHub-only/);
     expect(skillMarkdown).toContain("do not substitute `glab` for this command");
     expect(skillMarkdown).toContain("Never substitute `/settings/github`");
+  });
+
+  it("materializes declared source worktrees from the resolved source ref, not origin/main", () => {
+    expect(skillMarkdown).toContain("declared/pinned ref when one exists");
+    expect(skillMarkdown).toContain("refs/remotes/origin/HEAD");
+    expect(skillMarkdown).toContain("Do not hard-code `origin/main`");
+
+    const sourceWorktreeSection =
+      skillMarkdown.match(/### Materialize source read worktrees[\s\S]*?## The Two Phases/u)?.[0] ?? "";
+    expect(sourceWorktreeSection).not.toContain("worktree add <workspaceRoot>/worktrees/seed-<source> origin/main");
   });
 
   it("checks same-chat Phase 2 continuation before refusing state C", () => {
@@ -95,6 +114,14 @@ describe("first-tree-seed floor invariants", () => {
       fixture: { sourceRepoState: "chat-local-readable", treeState: "empty" },
     });
     expect(chatSource?.forbidden.actions).toContain("require_github_app");
+
+    const gitlabNonMain = FIRST_TREE_SEED_GATE_CASES.find(
+      (evalCase) => evalCase.id === "gitlab-non-main-source-worktree-protocol",
+    );
+    expect(gitlabNonMain).toMatchObject({
+      expected: { action: "materialize_bare_worktree", requireSourceRead: true, requireWorktree: true },
+      fixture: { sourceDefaultBranch: "trunk", sourceForge: "gitlab", sourceRepoState: "bare-readable" },
+    });
 
     const continuation = FIRST_TREE_SEED_GATE_CASES.find((evalCase) => evalCase.id === "same-chat-phase2-continuation");
     expect(continuation).toMatchObject({

--- a/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/__tests__/floor.test.ts
@@ -17,9 +17,17 @@ describe("first-tree-seed floor invariants", () => {
 
   it("keeps chat-provided sources independent of GitHub App setup", () => {
     expect(skillMarkdown).toContain("An empty or absent `manifest.sources` is valid");
-    expect(skillMarkdown).toMatch(/local\s+project folder or GitHub repository URL/);
+    expect(skillMarkdown).toMatch(/local\s+project folder or GitHub\/GitLab repository URL/);
     expect(skillMarkdown).toContain("Do not send them to Settings");
-    expect(skillMarkdown).toMatch(/rather than asking for the First\s+Tree GitHub App/);
+    expect(skillMarkdown).toMatch(/rather\s+than asking for the First\s+Tree GitHub App/);
+  });
+
+  it("supports GitLab sources without inventing GitLab tree provisioning", () => {
+    expect(skillMarkdown).toContain("Use `gh` for GitHub and `glab` for GitLab");
+    expect(skillMarkdown).toMatch(/Preserve the full GitLab\s+namespace/);
+    expect(skillMarkdown).toMatch(/current\s+`first-tree tree init` provisioning is GitHub-only/);
+    expect(skillMarkdown).toContain("do not substitute `glab` for this command");
+    expect(skillMarkdown).toContain("Never substitute `/settings/github`");
   });
 
   it("checks same-chat Phase 2 continuation before refusing state C", () => {
@@ -75,9 +83,9 @@ describe("first-tree-seed floor invariants", () => {
   });
 
   it("delays App coverage guidance until a reviewable milestone", () => {
-    expect(skillMarkdown).toContain("After the Phase 1 PR is open");
-    expect(skillMarkdown).toContain("do not interrupt source resolution, structure");
-    expect(skillMarkdown).toContain("relay only a recovery URL returned");
+    expect(skillMarkdown).toContain("After the Phase 1 PR/MR is open");
+    expect(skillMarkdown).toMatch(/do not interrupt source resolution,\s+structure/);
+    expect(skillMarkdown).toMatch(/Relay only a recovery URL returned/);
   });
 
   it("ships behavioral gates for chat-supplied sources and same-chat Phase 2 continuation", () => {

--- a/packages/skill-evals/src/suites/first-tree-seed/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/cases.ts
@@ -198,8 +198,10 @@ export const FIRST_TREE_SEED_GATE_CASES: readonly FirstTreeSeedEvalCase[] = [
       skeletonHints: ["system", "product", "team-practice", "raw-context", "members"],
     },
     fixture: {
+      sourceDeclaredRef: "trunk",
       sourceDefaultBranch: "trunk",
       sourceForge: "gitlab",
+      sourceLocalBranchState: "stale",
       sourceRepoState: "bare-readable",
       treeState: "empty",
     },
@@ -209,11 +211,11 @@ export const FIRST_TREE_SEED_GATE_CASES: readonly FirstTreeSeedEvalCase[] = [
     },
     id: "gitlab-non-main-source-worktree-protocol",
     prompt:
-      "Use first-tree-seed to inspect the bound GitLab source repo. The source under source-repos/source-repo is a bare clone whose default branch is trunk, so follow the Worktrees protocol without hard-coding origin/main. Leave that managed worktree in place for final eval provenance, and stop after proposing the Phase 1 skeleton for approval.",
+      "Use first-tree-seed to inspect the bound GitLab source repo. The source under source-repos/source-repo is a bare clone whose runtime declaration pins ref=trunk. The local trunk branch is intentionally stale while origin/trunk is current, so follow the Worktrees protocol without hard-coding origin/main or using the stale local branch. Leave that managed worktree in place for final eval provenance, and stop after proposing the Phase 1 skeleton for approval.",
     provider: "codex",
     skill: "first-tree-seed",
     status: "implemented",
-    tags: ["gitlab", "bare-source", "non-main-default", "worktree-protocol"],
+    tags: ["gitlab", "bare-source", "declared-ref", "non-main-default", "stale-local", "worktree-protocol"],
     tier: "gate",
   },
   {

--- a/packages/skill-evals/src/suites/first-tree-seed/cases.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/cases.ts
@@ -190,6 +190,35 @@ export const FIRST_TREE_SEED_GATE_CASES: readonly FirstTreeSeedEvalCase[] = [
   {
     briefingMode: "generated-fixture",
     expected: {
+      action: "materialize_bare_worktree",
+      approvalHints: ["approve", "reply", "confirm", "ON"],
+      requireSourceRead: true,
+      requireWorktree: true,
+      responseHints: ["worktree", "Phase 1", "skeleton"],
+      skeletonHints: ["system", "product", "team-practice", "raw-context", "members"],
+    },
+    fixture: {
+      sourceDefaultBranch: "trunk",
+      sourceForge: "gitlab",
+      sourceRepoState: "bare-readable",
+      treeState: "empty",
+    },
+    forbidden: {
+      actions: ["direct_bare_source_read", "phase2_leaf_content_before_approval", "skip_user_confirmation"],
+      sideEffects: ["tree_write", "tree_pr", "source_write", "github"],
+    },
+    id: "gitlab-non-main-source-worktree-protocol",
+    prompt:
+      "Use first-tree-seed to inspect the bound GitLab source repo. The source under source-repos/source-repo is a bare clone whose default branch is trunk, so follow the Worktrees protocol without hard-coding origin/main. Leave that managed worktree in place for final eval provenance, and stop after proposing the Phase 1 skeleton for approval.",
+    provider: "codex",
+    skill: "first-tree-seed",
+    status: "implemented",
+    tags: ["gitlab", "bare-source", "non-main-default", "worktree-protocol"],
+    tier: "gate",
+  },
+  {
+    briefingMode: "generated-fixture",
+    expected: {
       action: "propose_phase1_skeleton",
       approvalHints: ["approve", "reply", "confirm", "ON"],
       requireSourceRead: true,
@@ -323,8 +352,8 @@ export const FIRST_TREE_SEED_EVAL_CASES: readonly SkillEvalCase[] = [
 function validateFirstTreeSeedFloor(cases: readonly SkillEvalCase[]): readonly string[] {
   const errors: string[] = [];
   const gateCases = cases.filter((evalCase) => evalCase.skill === "first-tree-seed" && evalCase.tier === "gate");
-  if (gateCases.length !== 10) {
-    errors.push(`seed suite must declare 10 gate cases, found ${gateCases.length}.`);
+  if (gateCases.length !== 11) {
+    errors.push(`seed suite must declare 11 gate cases, found ${gateCases.length}.`);
   }
   const periodicCases = cases.filter(
     (evalCase) => evalCase.skill === "first-tree-seed" && evalCase.tier === "periodic",

--- a/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
@@ -19,7 +19,7 @@ export function sourceRemoteRef(evalCase: FirstTreeSeedEvalCase): string {
 }
 
 function sourceWorktreeRef(evalCase: FirstTreeSeedEvalCase): string {
-  return `origin/${sourceDefaultBranch(evalCase)}`;
+  return `origin/${evalCase.fixture.sourceDeclaredRef ?? sourceDefaultBranch(evalCase)}`;
 }
 
 function workspaceAgentsMarkdown(
@@ -31,7 +31,9 @@ function workspaceAgentsMarkdown(
   const sourceWorktreePath = join(workspacePath, "worktrees", "seed-source-repo");
   const chatSourcePath = join(workspacePath, "provided-source");
   const sourceBranch = sourceDefaultBranch(evalCase);
+  const sourceDeclaredRef = evalCase.fixture.sourceDeclaredRef;
   const sourceForge = evalCase.fixture.sourceForge ?? "github";
+  const sourceLocalBranchState = evalCase.fixture.sourceLocalBranchState ?? "fresh";
   const sourceLine =
     evalCase.fixture.sourceRepoState === "missing"
       ? `The manifest source \`source-repo\` is intentionally missing from \`${sourceRepoPath}\`.`
@@ -39,7 +41,7 @@ function workspaceAgentsMarkdown(
         ? `The workspace manifest intentionally declares no sources. The user supplied the readable local Git checkout \`${chatSourcePath}\` in this setup chat; use it directly without requiring GitHub App installation or team-resource registration.`
         : evalCase.fixture.sourceRepoState === "real-first-tree-bare-readable"
           ? `The manifest source \`source-repo\` exists as a bare clone of the current first-tree repo at \`${sourceRepoPath}\`.`
-          : `The manifest source \`source-repo\` exists as a bare clone at \`${sourceRepoPath}\`. Its forge is ${sourceForge}, and its default branch is \`${sourceBranch}\`.`;
+          : `The manifest source \`source-repo\` exists as a bare clone at \`${sourceRepoPath}\`. Its forge is ${sourceForge}, its default branch is \`${sourceBranch}\`${sourceDeclaredRef ? `, and the runtime declaration pins \`ref=${sourceDeclaredRef}\`` : ""}.${sourceLocalBranchState === "stale" ? ` The local branch \`${sourceDeclaredRef ?? sourceBranch}\` is intentionally stale; the freshly fetched remote-tracking ref is current.` : ""}`;
   const treeLine =
     evalCase.fixture.treeState === "unbound"
       ? 'The workspace is NOT bound to a Context Tree yet: `./.first-tree/workspace.json` has no `tree` field and no `./context-tree` exists. Per state A, the tree must be created and bound with `first-tree tree init --title "<team display name>" --dir "<workspaceRoot>/context-tree"` (the `--dir` pin is load-bearing so the created clone lands where the workspace expects it).'
@@ -95,6 +97,8 @@ ${chatHistoryLine ?? ""}
 - Source state: ${evalCase.fixture.sourceRepoState}
 - Source forge: ${sourceForge}
 - Source default branch: \`${sourceBranch}\`
+${sourceDeclaredRef ? `- Declared source ref: \`ref=${sourceDeclaredRef}\`` : ""}
+${sourceLocalBranchState === "stale" ? `- Local source branch state: \`${sourceLocalBranchState}\`` : ""}
 
 ${treeLine}
 ${sourceLine}
@@ -397,6 +401,16 @@ function writeSourceOriginFixture(paths: RunPaths, evalCase: FirstTreeSeedEvalCa
   return sourceOriginPath;
 }
 
+function advanceSourceOriginFixture(sourceOriginPath: string, evalCase: FirstTreeSeedEvalCase): void {
+  if (evalCase.fixture.sourceLocalBranchState !== "stale") return;
+  writeText(
+    join(sourceOriginPath, "docs", "current-remote.md"),
+    "# Current Remote\n\nThis file exists only on the current remote-tracking ref.\n",
+  );
+  assertCommandOk(runCommand("git", ["add", "docs/current-remote.md"], sourceOriginPath));
+  assertCommandOk(runCommand("git", ["commit", "-m", "docs: advance remote source fixture"], sourceOriginPath));
+}
+
 function writeBareSourceFixture(paths: RunPaths, evalCase: FirstTreeSeedEvalCase): string | null {
   if (evalCase.fixture.sourceRepoState === "missing") {
     return null;
@@ -416,6 +430,7 @@ function writeBareSourceFixture(paths: RunPaths, evalCase: FirstTreeSeedEvalCase
   const sourceRepoPath = join(paths.workspacePath, "source-repos", "source-repo");
   mkdirSync(join(paths.workspacePath, "source-repos"), { recursive: true });
   assertCommandOk(runCommand("git", ["clone", "--bare", sourceOriginPath, sourceRepoPath], paths.workspacePath));
+  advanceSourceOriginFixture(sourceOriginPath, evalCase);
   assertCommandOk(
     runCommand("git", ["config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"], sourceRepoPath),
   );

--- a/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
@@ -34,6 +34,12 @@ function workspaceAgentsMarkdown(
   const sourceDeclaredRef = evalCase.fixture.sourceDeclaredRef;
   const sourceForge = evalCase.fixture.sourceForge ?? "github";
   const sourceLocalBranchState = evalCase.fixture.sourceLocalBranchState ?? "fresh";
+  const declaredSourceWorktreeProtocol = sourceDeclaredRef
+    ? `git -C ${sourceRepoPath} fetch origin
+# Runtime declaration: ref=${sourceDeclaredRef}
+# Resolve this raw declaration with the installed first-tree-seed protocol before materializing ${sourceWorktreePath}.
+# Do not pass the local branch name directly when the fetched remote-tracking branch exists.`
+    : null;
   const sourceLine =
     evalCase.fixture.sourceRepoState === "missing"
       ? `The manifest source \`source-repo\` is intentionally missing from \`${sourceRepoPath}\`.`
@@ -117,8 +123,11 @@ directly from \`${sourceRepoPath}\`; it is a git object store, not a
 checkout. To read source, materialize a read worktree:
 
 \`\`\`bash
-git -C ${sourceRepoPath} fetch origin
-git -C ${sourceRepoPath} worktree add ${sourceWorktreePath} ${sourceWorktreeRef(evalCase)}
+${
+  declaredSourceWorktreeProtocol ??
+  `git -C ${sourceRepoPath} fetch origin
+git -C ${sourceRepoPath} worktree add ${sourceWorktreePath} ${sourceWorktreeRef(evalCase)}`
+}
 \`\`\`
 
 Then read files under \`${sourceWorktreePath}\`.`

--- a/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/fixture.ts
@@ -10,6 +10,18 @@ import type { FirstTreeSeedEvalCase, FixtureValidation } from "./types.js";
 
 const SEED_SKILL_NAME = "first-tree-seed";
 
+export function sourceDefaultBranch(evalCase: FirstTreeSeedEvalCase): string {
+  return evalCase.fixture.sourceDefaultBranch ?? "main";
+}
+
+export function sourceRemoteRef(evalCase: FirstTreeSeedEvalCase): string {
+  return `refs/remotes/origin/${sourceDefaultBranch(evalCase)}`;
+}
+
+function sourceWorktreeRef(evalCase: FirstTreeSeedEvalCase): string {
+  return `origin/${sourceDefaultBranch(evalCase)}`;
+}
+
 function workspaceAgentsMarkdown(
   workspacePath: string,
   seedDescription: string,
@@ -18,6 +30,8 @@ function workspaceAgentsMarkdown(
   const sourceRepoPath = join(workspacePath, "source-repos", "source-repo");
   const sourceWorktreePath = join(workspacePath, "worktrees", "seed-source-repo");
   const chatSourcePath = join(workspacePath, "provided-source");
+  const sourceBranch = sourceDefaultBranch(evalCase);
+  const sourceForge = evalCase.fixture.sourceForge ?? "github";
   const sourceLine =
     evalCase.fixture.sourceRepoState === "missing"
       ? `The manifest source \`source-repo\` is intentionally missing from \`${sourceRepoPath}\`.`
@@ -25,7 +39,7 @@ function workspaceAgentsMarkdown(
         ? `The workspace manifest intentionally declares no sources. The user supplied the readable local Git checkout \`${chatSourcePath}\` in this setup chat; use it directly without requiring GitHub App installation or team-resource registration.`
         : evalCase.fixture.sourceRepoState === "real-first-tree-bare-readable"
           ? `The manifest source \`source-repo\` exists as a bare clone of the current first-tree repo at \`${sourceRepoPath}\`.`
-          : `The manifest source \`source-repo\` exists as a bare clone at \`${sourceRepoPath}\`.`;
+          : `The manifest source \`source-repo\` exists as a bare clone at \`${sourceRepoPath}\`. Its forge is ${sourceForge}, and its default branch is \`${sourceBranch}\`.`;
   const treeLine =
     evalCase.fixture.treeState === "unbound"
       ? 'The workspace is NOT bound to a Context Tree yet: `./.first-tree/workspace.json` has no `tree` field and no `./context-tree` exists. Per state A, the tree must be created and bound with `first-tree tree init --title "<team display name>" --dir "<workspaceRoot>/context-tree"` (the `--dir` pin is load-bearing so the created clone lands where the workspace expects it).'
@@ -79,6 +93,8 @@ ${chatHistoryLine ?? ""}
 - Declared source: \`source-repo\`
 - Tree state: ${evalCase.fixture.treeState}
 - Source state: ${evalCase.fixture.sourceRepoState}
+- Source forge: ${sourceForge}
+- Source default branch: \`${sourceBranch}\`
 
 ${treeLine}
 ${sourceLine}
@@ -98,7 +114,7 @@ checkout. To read source, materialize a read worktree:
 
 \`\`\`bash
 git -C ${sourceRepoPath} fetch origin
-git -C ${sourceRepoPath} worktree add ${sourceWorktreePath} origin/main
+git -C ${sourceRepoPath} worktree add ${sourceWorktreePath} ${sourceWorktreeRef(evalCase)}
 \`\`\`
 
 Then read files under \`${sourceWorktreePath}\`.`
@@ -266,8 +282,8 @@ function contextTreeMetadata(): string {
   )}\n`;
 }
 
-function initGitRepo(repoPath: string, message: string): void {
-  assertCommandOk(runCommand("git", ["init", "--initial-branch=main"], repoPath));
+function initGitRepo(repoPath: string, message: string, initialBranch = "main"): void {
+  assertCommandOk(runCommand("git", ["init", `--initial-branch=${initialBranch}`], repoPath));
   assertCommandOk(runCommand("git", ["config", "user.email", "eval@example.invalid"], repoPath));
   assertCommandOk(runCommand("git", ["config", "user.name", "First Tree Eval"], repoPath));
   assertCommandOk(runCommand("git", ["config", "commit.gpgsign", "false"], repoPath));
@@ -365,7 +381,7 @@ durable context separate from implementation details.
 `;
 }
 
-function writeSourceOriginFixture(paths: RunPaths): string {
+function writeSourceOriginFixture(paths: RunPaths, evalCase: FirstTreeSeedEvalCase): string {
   const sourceOriginPath = join(paths.runRoot, "source-origin");
   mkdirSync(sourceOriginPath, { recursive: true });
   writeText(join(sourceOriginPath, "README.md"), sourceReadmeMarkdown());
@@ -377,7 +393,7 @@ function writeSourceOriginFixture(paths: RunPaths): string {
     join(sourceOriginPath, "package.json"),
     `${JSON.stringify({ name: "apollo-console", workspaces: ["apps/*", "packages/*"] }, null, 2)}\n`,
   );
-  initGitRepo(sourceOriginPath, "chore: seed source fixture");
+  initGitRepo(sourceOriginPath, "chore: seed source fixture", sourceDefaultBranch(evalCase));
   return sourceOriginPath;
 }
 
@@ -390,7 +406,7 @@ function writeBareSourceFixture(paths: RunPaths, evalCase: FirstTreeSeedEvalCase
     return writeRealFirstTreeBareSourceFixture(paths);
   }
 
-  const sourceOriginPath = writeSourceOriginFixture(paths);
+  const sourceOriginPath = writeSourceOriginFixture(paths, evalCase);
   if (evalCase.fixture.sourceRepoState === "chat-local-readable") {
     const chatSourcePath = join(paths.workspacePath, "provided-source");
     assertCommandOk(runCommand("git", ["clone", sourceOriginPath, chatSourcePath], paths.workspacePath));
@@ -404,6 +420,8 @@ function writeBareSourceFixture(paths: RunPaths, evalCase: FirstTreeSeedEvalCase
     runCommand("git", ["config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"], sourceRepoPath),
   );
   assertCommandOk(runCommand("git", ["fetch", "origin"], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["remote", "set-head", "origin", sourceDefaultBranch(evalCase)], sourceRepoPath));
+  assertCommandOk(runCommand("git", ["rev-parse", sourceRemoteRef(evalCase)], sourceRepoPath));
   return sourceRepoPath;
 }
 
@@ -478,7 +496,7 @@ export function setupFixture(evalCase: FirstTreeSeedEvalCase, paths: RunPaths, r
         ? null
         : gitHead(
             sourceRepoPath,
-            evalCase.fixture.sourceRepoState === "chat-local-readable" ? "HEAD" : "refs/remotes/origin/main",
+            evalCase.fixture.sourceRepoState === "chat-local-readable" ? "HEAD" : sourceRemoteRef(evalCase),
           ),
     sourceRepoPath,
     type: "fixture_setup_finished",
@@ -523,9 +541,9 @@ function validateSourceRepo(paths: RunPaths, evalCase: FirstTreeSeedEvalCase, er
     errors.push(`source repo is not bare: ${sourceRepoPath}`);
     return false;
   }
-  const remoteMain = runCommand("git", ["rev-parse", "refs/remotes/origin/main"], sourceRepoPath);
-  if (remoteMain.exitCode !== 0) {
-    errors.push(`source repo is missing refs/remotes/origin/main: ${previewText(remoteMain.stderr)}`);
+  const remoteDefault = runCommand("git", ["rev-parse", sourceRemoteRef(evalCase)], sourceRepoPath);
+  if (remoteDefault.exitCode !== 0) {
+    errors.push(`source repo is missing ${sourceRemoteRef(evalCase)}: ${previewText(remoteDefault.stderr)}`);
     return false;
   }
   return true;

--- a/packages/skill-evals/src/suites/first-tree-seed/grader.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/grader.ts
@@ -5,7 +5,7 @@ import { basename, dirname, isAbsolute, join, normalize, relative, resolve, sep 
 import { runCommand } from "../../core/commands.js";
 import { isRecord, isStringArray } from "../../core/events.js";
 import type { RunPaths } from "../../core/types.js";
-import { approvedPhase1ChatHistoryMarkdown } from "./fixture.js";
+import { approvedPhase1ChatHistoryMarkdown, sourceRemoteRef } from "./fixture.js";
 import type { EvalMetrics, FirstTreeSeedEvalCase, FixtureValidation } from "./types.js";
 
 const TEXT_KEYS = ["content", "message", "output_text", "text"];
@@ -532,7 +532,7 @@ function sourceRepoChanged(paths: RunPaths, baselineHead: string | null, evalCas
   if (baselineHead === null) return existsSync(sourceRepoPath);
   if (!existsSync(sourceRepoPath)) return true;
 
-  const currentHead = gitHead(sourceRepoPath, chatLocal ? "HEAD" : "refs/remotes/origin/main");
+  const currentHead = gitHead(sourceRepoPath, chatLocal ? "HEAD" : sourceRemoteRef(evalCase));
   if (currentHead !== baselineHead) return true;
 
   if (chatLocal) {

--- a/packages/skill-evals/src/suites/first-tree-seed/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/types.ts
@@ -5,6 +5,7 @@ import type { CommandResult } from "../../core/types.js";
 export type SeedTreeState = "empty" | "nonempty" | "phase1-approved" | "unbound";
 export type SeedSourceRepoState = "bare-readable" | "chat-local-readable" | "missing" | "real-first-tree-bare-readable";
 export type SeedChatHistoryState = "absent" | "approved-phase1";
+export type SeedSourceForge = "github" | "gitlab";
 export type SeedExpectedAction =
   | "propose_phase1_skeleton"
   | "refuse_nonempty_tree"
@@ -15,6 +16,8 @@ export type SeedExpectedAction =
 
 export type FirstTreeSeedFixture = {
   chatHistoryState?: SeedChatHistoryState;
+  sourceDefaultBranch?: string;
+  sourceForge?: SeedSourceForge;
   sourceRepoState: SeedSourceRepoState;
   treeState: SeedTreeState;
 };

--- a/packages/skill-evals/src/suites/first-tree-seed/types.ts
+++ b/packages/skill-evals/src/suites/first-tree-seed/types.ts
@@ -6,6 +6,7 @@ export type SeedTreeState = "empty" | "nonempty" | "phase1-approved" | "unbound"
 export type SeedSourceRepoState = "bare-readable" | "chat-local-readable" | "missing" | "real-first-tree-bare-readable";
 export type SeedChatHistoryState = "absent" | "approved-phase1";
 export type SeedSourceForge = "github" | "gitlab";
+export type SeedSourceLocalBranchState = "fresh" | "stale";
 export type SeedExpectedAction =
   | "propose_phase1_skeleton"
   | "refuse_nonempty_tree"
@@ -16,8 +17,10 @@ export type SeedExpectedAction =
 
 export type FirstTreeSeedFixture = {
   chatHistoryState?: SeedChatHistoryState;
+  sourceDeclaredRef?: string;
   sourceDefaultBranch?: string;
   sourceForge?: SeedSourceForge;
+  sourceLocalBranchState?: SeedSourceLocalBranchState;
   sourceRepoState: SeedSourceRepoState;
   treeState: SeedTreeState;
 };

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
@@ -109,8 +109,15 @@ describe("first-tree-welcome floor invariants", () => {
     expect(description).not.toContain("local project folder path");
     expect(skillMarkdown).toContain("Treat the opening message as the user's onboarding request.");
     expect(skillMarkdown).toContain("local project folder path");
-    expect(skillMarkdown).toContain("GitHub repo URL");
+    expect(skillMarkdown).toContain("GitHub/GitLab repo URL");
+    expect(skillMarkdown).toContain("`gh auth login` or `glab auth login`");
     expect(skillMarkdown).not.toContain("First Tree sent it");
+  });
+
+  it("keeps GitHub-only follow guidance out of the GitLab MR path", () => {
+    expect(skillMarkdown).toContain("This section is GitHub-only");
+    expect(skillMarkdown).toContain("For a GitLab MR, do not call `first-tree github");
+    expect(skillMarkdown).toContain("A GitLab MR has no documented equivalent here");
   });
 
   it("keeps the skill's example trigger phrases in sync with the real onboarding bootstraps", () => {

--- a/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/first-tree-welcome/__tests__/floor.test.ts
@@ -155,6 +155,10 @@ describe("first-tree-welcome floor invariants", () => {
 
     expect(skillDescription, "SKILL.md must declare a description").not.toBe("");
     expect(yamlDescription, "openai.yaml description must match SKILL.md description").toBe(skillDescription);
+    expect(skillDescription).toContain("PR/MR reviews");
+    expect(yamlDescription).toContain("PR/MR reviews");
+    expect(skillDescription).not.toContain("PR reviews");
+    expect(yamlDescription).not.toContain("PR reviews");
     // Guard the specific retired trigger the drift-guard exists to catch.
     expect(yamlDescription).not.toContain("explicitly names first-tree-welcome");
     expect(yamlDescription).toContain("repo scans");

--- a/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
@@ -33,7 +33,7 @@ describe("MobileChatPage back navigation", () => {
   beforeEach(() => {
     harness = createDomHarness();
     meChatMocks.listMeChats.mockReset();
-    meChatMocks.listMeChats.mockResolvedValue({ rows: [] });
+    meChatMocks.listMeChats.mockResolvedValue({ priorityRows: { attention: [], pinned: [] }, rows: [] });
     lastNavType = "";
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
   packages/web:
     dependencies:
@@ -659,11 +662,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -7626,22 +7629,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
-
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
-
   '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -10306,7 +10293,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -10349,7 +10336,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/skills/first-tree-file-bug/SKILL.md
+++ b/skills/first-tree-file-bug/SKILL.md
@@ -44,7 +44,11 @@ First Tree defect worth filing. If it is ambiguous whether the fault is in
 First Tree or the user's own setup, resolve that first — do not file an
 issue against First Tree for something outside it. If the report is really
 about the user's own project or their bound source repo, this is not the
-skill: file it into that repo with the target repository's forge CLI (`gh issue create --repo <their repo>` for GitHub, or `glab issue create --repo <their repo>` for GitLab) instead of here.
+skill: file it into that repo with the target repository's forge CLI
+(`gh issue create --repo <their repo>` for GitHub, or `glab issue create
+--repo <their repo>` for GitLab) instead of here. If that CLI is not
+authenticated, recover with `gh auth login` for GitHub or `glab auth login`
+for GitLab.
 
 ### 2. Gather the bug context
 

--- a/skills/first-tree-file-bug/SKILL.md
+++ b/skills/first-tree-file-bug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: first-tree-file-bug
-description: File a GitHub issue about a defect in First Tree itself — the CLI, agent runtime, chat, web app, GitHub integration, or Context Tree tooling — onto First Tree's own public tracker (agent-team-foundation/first-tree). Use only when the user reports that First Tree the platform is broken, errored, crashed, or misbehaving and wants it reported (e.g. "First Tree has a bug", "chat send keeps failing", "the CLI crashed", "给 First Tree 开个 issue 反馈这个 bug"). The skill gathers reproduction steps, the First Tree client/CLI version, the chat ID, the reporting user's ID, OS, and error output, then opens the issue with the user's `gh` CLI. NOT for filing an issue into the user's own or bound source repo — that is an ordinary `gh issue create` against that repo, not this skill — and not for bugs in the user's project code or third-party tools.
+description: File a GitHub issue about a defect in First Tree itself — the CLI, agent runtime, chat, web app, GitHub integration, or Context Tree tooling — onto First Tree's own GitHub-hosted public tracker (agent-team-foundation/first-tree). Use only when the user reports that First Tree the platform is broken, errored, crashed, or misbehaving and wants it reported (e.g. "First Tree has a bug", "chat send keeps failing", "the CLI crashed", "给 First Tree 开个 issue 反馈这个 bug"). The skill gathers reproduction steps, the First Tree client/CLI version, the chat ID, the reporting user's ID, OS, and error output, then opens the issue with the user's `gh` CLI. NOT for filing an issue into the user's own or bound source repo — that is an ordinary source-repo issue using the target forge CLI (`gh` for GitHub, `glab` for GitLab), not this skill — and not for bugs in the user's project code or third-party tools.
 ---
 
 # First Tree File Bug
@@ -44,8 +44,7 @@ First Tree defect worth filing. If it is ambiguous whether the fault is in
 First Tree or the user's own setup, resolve that first — do not file an
 issue against First Tree for something outside it. If the report is really
 about the user's own project or their bound source repo, this is not the
-skill: file it into that repo with `gh issue create --repo <their repo>`
-instead of here.
+skill: file it into that repo with the target repository's forge CLI (`gh issue create --repo <their repo>` for GitHub, or `glab issue create --repo <their repo>` for GitLab) instead of here.
 
 ### 2. Gather the bug context
 
@@ -147,7 +146,8 @@ gh issue create \
 ```
 
 `gh` uses the user's own authentication on this host — that is the intended
-"file with the user's gh CLI" path.
+"file with the user's gh CLI" path. This is GitHub-only because First Tree's
+public issue tracker is GitHub-hosted.
 
 ### 7. Open a tracking chat and follow the issue
 
@@ -225,7 +225,8 @@ the fallback) this chat.
 - **If `gh` is missing or unauthenticated**, do not treat it as a First
   Tree platform gap. Present the fully drafted issue (title + body) to the
   user so they can file it manually, and offer the `gh` install / `gh auth
-  login` path.
+  login` path; this recovery is GitHub-specific because the First Tree
+  tracker is on GitHub.
 
 ## CLI binary
 

--- a/skills/first-tree-file-bug/agents/openai.yaml
+++ b/skills/first-tree-file-bug/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "First Tree File Bug"
   short_description: "Report a defect in First Tree itself, not into the user's repo"
-  default_prompt: "Use $first-tree-file-bug ONLY for a defect in First Tree itself, not for filing an issue into the user's own or bound repo. Collect the bug context (repro, version, chat ID, user ID), confirm with the user that this files into First Tree's GitHub-hosted public issue tracker, then open the issue with the user's gh CLI. Ordinary source-repository issues use the CLI for that forge and are outside this skill."
+  default_prompt: "Use $first-tree-file-bug ONLY for a defect in First Tree itself, not for filing an issue into the user's own or bound repo. Collect the bug context (repro, version, chat ID, user ID), confirm with the user that this files into First Tree's GitHub-hosted public issue tracker, then open the issue with the user's gh CLI. Ordinary source-repository issues use gh for GitHub or glab for GitLab and are outside this skill."

--- a/skills/first-tree-file-bug/agents/openai.yaml
+++ b/skills/first-tree-file-bug/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "First Tree File Bug"
   short_description: "Report a defect in First Tree itself, not into the user's repo"
-  default_prompt: "Use $first-tree-file-bug ONLY for a defect in First Tree itself, not for filing an issue into the user's own or bound repo. Collect the bug context (repro, version, chat ID, user ID), confirm with the user that this files into First Tree's own public issue tracker, then open the issue with the user's gh CLI."
+  default_prompt: "Use $first-tree-file-bug ONLY for a defect in First Tree itself, not for filing an issue into the user's own or bound repo. Collect the bug context (repro, version, chat ID, user ID), confirm with the user that this files into First Tree's GitHub-hosted public issue tracker, then open the issue with the user's gh CLI. Ordinary source-repository issues use the CLI for that forge and are outside this skill."

--- a/skills/first-tree-seed/SKILL.md
+++ b/skills/first-tree-seed/SKILL.md
@@ -3,7 +3,7 @@ name: first-tree-seed
 version: 0.3.0
 cliCompat:
   first-tree: ">=0.5.0 <0.6.0"
-description: Bootstrap a team's Context Tree from readable source repos — for an onboarding "build / set up the Context Tree" task on a tree that has no domain structure yet: either no tree exists (creates and binds it) or a bound-but-empty tree (fills it). Uses declared workspace sources when present, otherwise asks for a local Git repo or a GitHub/GitLab repository URL in the setup chat. Proposes an initial top-level + second-level domain structure for approval, then drafts initial leaf content — each as a reviewable PR/MR. Refuses an unrelated re-seed once the tree has domain structure, while allowing the same setup chat to continue Phase 2 after its Phase 1 PR is merged.
+description: Bootstrap a team's Context Tree from readable source repos — for an onboarding "build / set up the Context Tree" task on a tree that has no domain structure yet: either no tree exists (creates and binds it) or a bound-but-empty tree (fills it). Uses declared workspace sources when present, otherwise asks for a local Git repo or a GitHub/GitLab repository URL in the setup chat. Proposes an initial top-level + second-level domain structure for approval, then drafts initial leaf content — each as a reviewable PR/MR. Refuses an unrelated re-seed once the tree has domain structure, while allowing the same setup chat to continue Phase 2 after its Phase 1 PR/MR is merged.
 ---
 
 # First Tree — Seed
@@ -15,7 +15,7 @@ tree has real top + second level structure plus initial leaf nodes drawn
 from readable source repos". It first resolves the tree's state, then — for
 a tree that needs building — creates the repo with `first-tree tree init`
 when none exists (see *Resolve the tree's state*). Every subsequent write —
-one PR at a time, one decision at a time — belongs to `first-tree-write`,
+one PR/MR at a time, one decision at a time — belongs to `first-tree-write`,
 not here.
 
 ## When To Use This Skill
@@ -24,13 +24,13 @@ not here.
 | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | The team has no tree yet, **or** a bound tree with no normal domain structure per the generated policy's content classes | The tree already has a normal domain structure → `first-tree-write` (incremental source-driven write) |
 | First content pass on resolved readable sources                       | Broad maintenance or drift-audit work on an existing tree                                            |
-| Invoked by name — by a human, an agent, or an onboarding kickoff prompt (see Resolve the tree's state) | Not an org admin, or the required forge CLI (`gh` / `glab`) is unauthenticated, and the team has no tree — seed can't create it; surface the gap to a human |
+| Invoked by name — by a human, an agent, or an onboarding kickoff prompt (see Resolve the tree's state) | Not an org admin, or local `gh` is unauthenticated, and the team has no tree — current `tree init` creation is GitHub-only; source reads separately use the CLI for their detected forge |
 
 The skill is **single-shot per tree setup**: once the tree has domain
 structure, a new or unrelated seed request refuses and routes further work
 through `first-tree-write` or a focused maintenance task. The one exception is
-the verified Phase 2 continuation from this setup chat after its Phase 1 PR was
-merged; that is completion of the same seed, not a second seed.
+the verified Phase 2 continuation from this setup chat after its Phase 1 PR/MR
+was merged; that is completion of the same seed, not a second seed.
 
 ## Policy Baseline
 
@@ -54,8 +54,8 @@ that work to `first-tree-write` or a focused maintenance task.
 same seed into Phase 2 only when all of these are true:
 
 1. this setup chat's visible history contains the Phase 1 proposal, user
-   approval, and the Phase 1 PR handoff;
-2. the current user message explicitly says that PR was merged or asks to
+   approval, and the Phase 1 PR/MR handoff;
+2. the current user message explicitly says that PR/MR was merged or asks to
    continue after merging it; and
 3. a fresh fetch confirms the approved top-level structure exists on the tree
    repo's default branch while Phase 2 has not already completed.
@@ -69,58 +69,60 @@ or a populated tree alone.
 `<workspaceRoot>/.first-tree/workspace.json` has no non-empty `tree`
 field, or the team has no `context_tree` binding. This is the
 agent-driven creation path. First resolve readable sources using the section
-below, because owner placement depends on them; then create the tree with the
-user's local forge CLI (`gh` for GitHub, `glab` for GitLab):
+below and detect each source forge from its supplied URL or `origin` remote.
+Source access may use `gh` for GitHub or `glab` for GitLab, but current
+`first-tree tree init` provisioning is GitHub-only and always uses local `gh`;
+do not substitute `glab` for this command:
 
 ```bash
-first-tree tree init --title "<team display name>" --owner "<source-repo-owner>" --dir "<workspaceRoot>/<manifest.tree>"
+first-tree tree init --title "<team display name>" --owner "<tree-github-owner>" --dir "<workspaceRoot>/<manifest.tree>"
 ```
 
-**Home the tree beside its source — pass `--owner`.** Set
-`<source-repo-owner>` to the account that owns the team's **main resolved
-source repo** — an **org or a personal account alike**. Derive it from the
-source's **remote URL, not its directory name**: for a declared source resolve
-`<source-clone>` from the manifest
-(`<workspaceRoot>/<sourcesRoot>/<source>`, per *Materialize source read
-worktrees* below); for an explicit local repo use that repo; then run
-`git -C <source> remote get-url origin` (or use the explicit forge URL) and take
-the `<owner>` / namespace segment of that URL (e.g. `acme` in
-`github.com/acme/app`, or `acme/platform` in `gitlab.com/acme/platform/app`).
-**`manifest.sources` holds directory names (e.g. `first-tree`), not owners** —
-passing a source *name* as `--owner` targets the wrong forge account, so always
-parse the owner or namespace from the clone's remote. With one source that
-account is unambiguous; when several sources share one account, use it;
-when sources span **different accounts**, pick the account or namespace that
-owns most of them, and if that is genuinely a tie, ask the admin which account
-should host the tree rather than guessing. Why: a team's Context Tree belongs
-in the **same forge account/namespace as its source** — that is the account the
-GitHub App lives on for GitHub sources, or the integration surface First Tree
-returns for GitLab sources, to read those sources. When the GitHub App is
-already installed there — the normal GitHub case — `--owner` just matches the
-installation account and nothing changes. When the GitHub App is not installed
-yet, `--owner` lands the tree in that account instead of defaulting to your
-personal `gh` login, so a **later App install on it covers the tree** rather than
-stranding it in an account the install can never reach. The tree lives in one
-forge account/namespace; sources under other accounts stay covered by their own
-hosted integrations as usual. (When the source repo is itself under your personal
-account, `<source-repo-owner>` simply is that account — same result.)
+**Keep source identity separate from the tree host.** For each declared or
+explicit local source, run `git -C <source> remote get-url origin` (or use the
+explicit forge URL), then classify the host and parse its identity:
+
+- GitHub: keep the owner segment, such as `acme` in
+  `github.com/acme/app`, and use `gh` for host access/authentication.
+- GitLab: keep the complete namespace before the repository, such as
+  `acme/platform` in `gitlab.com/acme/platform/app`, and use `glab`. Never
+  flatten a nested namespace to only `acme` or `platform`.
+
+**`manifest.sources` holds directory names (for example `first-tree`), not
+forge identities.** Never infer an owner or namespace from a clone directory.
+The parsed source identity controls source access and metadata lookup; a GitLab
+namespace is not a valid `tree init --owner` value because `tree init` currently
+creates the Context Tree on GitHub.
+
+**Choose the GitHub account that will host the tree — pass `--owner`.** When the
+main resolved source is on GitHub, use its owner. When several GitHub sources
+share one account, use it; when they span different accounts, use the account
+that owns most of them, and ask the admin on a genuine tie. For GitLab-only
+sources, preserve every full GitLab namespace in `resolvedSources`, then ask
+which GitHub organization or personal account should host the Context Tree;
+do not flatten or pass a GitLab namespace to `--owner`. Why: the repo created
+by `tree init` must live under the GitHub account that the team's First Tree
+GitHub App covers. When the App is already installed there, `--owner` matches
+that installation account. When no App is installed yet, the explicit owner
+prevents the tree from silently landing under the personal `gh` login. Sources
+on GitLab remain readable through `glab` or `git` and do not change the tree
+repo's GitHub host.
 
 **If `--owner` can't be honored, stop and surface it — do not silently
 fall back.** Two distinct cases, each with its own recovery:
 
-- **You lack repo-create rights under `<source-repo-owner>`** (no App is
+- **You lack repo-create rights under `<tree-github-owner>`** (no App is
   installed, so nothing overrides `--owner`): prefer asking an admin to
-  grant you create rights there, so the tree still homes beside its source.
-  Only if that is not an option, re-run without `--owner` to build under
-  your personal forge account — flag the cost first: the tree then lives off
-  the source's account/namespace, so a later App or integration install must
-  go on *your* account/namespace, not the source's, to cover it. Before
-  re-running, empty **only** the half-built scaffold this failed run left in
-  `<manifest.tree>` (confirm the directory holds just that — never delete a
+  grant you create rights there. Only if that is not an option, re-run without
+  `--owner` to build under your personal GitHub account — flag the cost first:
+  the tree then lives outside the intended GitHub account, so a later App
+  install must go on *your* account, not the intended host account, to cover
+  it. Before re-running, empty **only** the half-built scaffold this failed run
+  left in `<manifest.tree>` (confirm the directory holds just that — never delete a
   directory that already holds a real tree clone or other content);
   `tree init` refuses a non-empty target.
 - **`--owner` doesn't match an already-installed App account** (the App is
-  installed on a different account than the source's — rare; `tree init`
+  installed on a different account than the requested tree host; `tree init`
   names that account): re-run **without `--owner`** to create under that
   installation account, which is the coverable home anyway. This error
   fires before any local scaffolding, so there is nothing to clear. (Pass
@@ -128,11 +130,11 @@ fall back.** Two distinct cases, each with its own recovery:
 
 `tree init` seeds a minimal valid tree
 (root `NODE.md`, a `members/` index, and the creator's member node),
-pushes, and binds the org's `context_tree` setting. It is **admin-only**
-and needs an authenticated forge CLI (`gh` for GitHub, `glab` for GitLab);
-if the caller is not an org admin, or the required forge CLI is
+pushes, and binds the org's `context_tree` setting. It is **admin-only** and
+needs an authenticated `gh`; if the caller is not an org admin, or `gh` is
 unauthenticated, surface that exact gap and stop (binding a team tree is an
-admin action).
+admin action). A source repo may still use `glab`; that does not change
+`tree init`'s GitHub authentication requirement.
 Take the team display name from the chat context / `first-tree agent
 status`. After it succeeds the tree is bound and in state **B** — proceed.
 
@@ -141,9 +143,9 @@ bind is the sanctioned agent path (a general "tree binding is an operator
 action" note in your briefing does **not** apply to this task) — running it IS
 the task the user asked for, so binding needs no separate go-ahead. You do not
 need to independently "confirm admin" first: `tree init` enforces it
-server-side (it fails closed for a non-admin or unauthenticated forge CLI). So run
+server-side (it fails closed for a non-admin or unauthenticated `gh`). So run
 it; only if it fails on that admin/authentication check do you surface the
-exact gap (not an admin / matching CLI not authenticated) and stop.
+exact gap (not an admin / `gh` not authenticated) and stop.
 
 **Pin the local checkout with `--dir` — this is load-bearing.** `tree
 init` defaults its local clone to `<cwd>/<repo-name>`, but a managed
@@ -263,27 +265,25 @@ setup failed. Give the manual checklist above in plain words so they can add the
 root `CODEOWNERS` mapping and branch rules in GitHub settings. Do not treat this
 setup failure as a reason to delete or recreate the Context Repo.
 
-**Delay App coverage guidance until there is a reviewable milestone — recommend,
-never block.**
-A newly created tree is only visible to the team's web view and the
-Context Tree reviewer once the First Tree GitHub App can read its repo for
-GitHub sources; for GitLab sources, use the integration URL/settings First
-Tree returns. `tree init` creates and binds the tree either way and prints a
-coverage line; capture the result but do not interrupt source resolution,
-structure review, or Phase 1 work with an installation detour. The tree is
-built and bound, so proceed regardless of coverage.
+**Delay integration coverage guidance until there is a reviewable milestone —
+recommend, never block.** Detect the Context Tree repo's forge from its own
+`origin`; do not infer it from a source repo. State A's `tree init` always
+creates a GitHub-hosted tree and prints GitHub App coverage guidance. For a
+pre-existing GitLab-hosted tree in state B, relay an integration URL or settings
+target only when First Tree returns it explicitly; otherwise state that no
+documented First Tree integration path was returned and do not invent one.
+Capture any authoritative result, but do not interrupt source resolution,
+structure review, or Phase 1 work with an installation detour.
 
-**After the Phase 1 PR is open**, or earlier only when the next requested
+**After the Phase 1 PR/MR is open**, or earlier only when the next requested
 operation actually needs Cloud snapshot/reviewer access, surface an uncovered
-repo once in the setup chat. State the capability consequence — "your Context
-Tree is built and bound, but the web view and PR reviewer won't see it until
-the First Tree App can read its repo" — and relay only a recovery URL returned
-by `tree init` or another authoritative command:
+tree repo once in the setup chat. Relay only a recovery URL returned by
+`tree init` or another authoritative First Tree command:
 
-- **A selected-repositories install that excludes the new repo:** `tree init`
+- **GitHub tree, selected-repositories install excludes it:** `tree init`
   prints a GitHub installation-settings URL — an absolute `https://` link, so
   it renders clickable in chat. Relay it and say to add the tree repo there.
-- **No App installed at all:** give the admin a clickable link to the web
+- **GitHub tree, no App installed:** give the admin a clickable link to the web
   console's GitHub settings, built from the server URL the agent knows — take
   the `Server:` value from `first-tree agent status` and append
   `/settings/github` (an absolute `https://…/settings/github` renders
@@ -294,12 +294,15 @@ by `tree init` or another authoritative command:
   destination in words: **Settings → GitHub** in the web app. Do **not**
   fabricate a raw GitHub App install URL yourself — the install must run
   through the web console so it binds back to your org. Add the **placement
-  caveat**: the tree repo was created under the account shown as `<owner>`
-  in `tree init`'s output — the account that owns your source repo (from
-  `--owner`), org or personal — so install the App on **that same
-  account**; installing it on a different account will not cover this repo.
-- **A suspended install:** `tree init` prints the installation-settings URL —
-  relay it and say to reactivate the First Tree App installation there.
+  caveat**: the tree repo was created under the GitHub account shown as
+  `<owner>` in `tree init`'s output, from `--owner`, so install the App on that
+  same account; installing it elsewhere will not cover this repo.
+- **GitHub tree, suspended install:** `tree init` prints the
+  installation-settings URL — relay it and say to reactivate the First Tree App
+  installation there.
+- **GitLab-hosted existing tree:** use only a GitLab integration URL/settings
+  target returned by First Tree. Never substitute `/settings/github`, a GitHub
+  App URL, or an invented GitLab product path.
 
 **B — Bound but unseeded.** The tree is bound and holds at most non-normal
 supporting/member structure under the generated policy's content classes,
@@ -337,10 +340,16 @@ Use one ordered source-resolution rule and call its result
    until they answer. Do not send them to Settings and do not make GitHub App
    installation a prerequisite.
 3. **Validate before reading.** A local folder must exist, be readable, and be
-   a Git repository. A GitHub or GitLab URL must be a repository URL that host
-   `gh`, `glab`, or `git` can access; materialize a task-local read checkout
-   under the workspace `worktrees/` directory. These reads do not register team
-   resources or mutate the source repo.
+   a Git repository. A GitHub or GitLab URL must be a repository URL that the
+   matching host CLI (`gh` or `glab`) or `git` can access; materialize a
+   task-local read checkout under the workspace `worktrees/` directory. These
+   reads do not register team resources or mutate the source repo.
+
+For every resolved source, determine `sourceForge` from the supplied URL or,
+for a local repository, `git remote get-url origin` before choosing host tools.
+Use `gh` for GitHub and `glab` for GitLab; use plain `git` for an unrecognized
+host unless the user supplies its supported CLI. Preserve the full GitLab
+namespace, including nested groups, in source identity and diagnostics.
 
 For a local non-bare repository, read it in place without modifying it. For a
 local bare repository, follow the worktree protocol below. For a GitHub or
@@ -349,11 +358,13 @@ branch. Private URLs may rely on the user's existing `gh` / `glab` / git
 credentials; if access fails, report that exact credential/access gap rather
 than asking for the First Tree GitHub App.
 
-When state A needs `--owner`, parse the owner or namespace from each resolved
-source's remote. If a local repo has no GitHub or GitLab remote, ask which
-forge account or namespace should host the tree; never guess from its directory
-name. Revalidate the same `resolvedSources` before Phase 2 so a later turn
-cannot silently switch inputs.
+When state A needs `--owner`, use a parsed GitHub source owner as the candidate
+GitHub tree host. A parsed GitLab namespace remains source metadata and must
+not be flattened or passed to `tree init`; for GitLab-only sources, ask which
+GitHub account should host the tree. If a local repo has no recognized forge
+remote, ask for the GitHub tree host separately and never guess from its
+directory name. Revalidate the same `resolvedSources` before Phase 2 so a later
+turn cannot silently switch inputs.
 
 **For declared sources, require every clone on disk.** Each source
 clone lives at `<workspaceRoot>/<manifest.sourcesRoot>/<manifest.sources[i]>`
@@ -391,7 +402,7 @@ git -C <source-clone> worktree add <workspaceRoot>/worktrees/seed-<source> origi
 
 Every "read every resolved source" / Tier 0–2 scan in Phase 1 operates on
 these read worktrees, not the bare clone paths. Remove them
-(`git -C <source-clone> worktree remove <path>`) once both PRs are open.
+(`git -C <source-clone> worktree remove <path>`) once both PRs/MRs are open.
 
 ## The Two Phases
 
@@ -399,25 +410,31 @@ Resolving the tree's state comes first; the two phases below are the build
 itself — they run for a tree that needs building (states A and B). State C
 refuses before reaching them.
 
+Before opening either review request, detect the Context Tree repo's forge from
+its own `origin`: use `gh` and PR terminology for GitHub, or `glab` and MR
+terminology for GitLab. Do not infer the tree forge from a source repo. State A
+`tree init` currently creates a GitHub tree, while state B may point at a tree
+that was provisioned separately.
+
 ```
 Phase 1 — Structure  (~3–10 min, main agent only)
   └─ Tiered structural read of every resolved source
   └─ Propose top + second-level domain skeleton
   └─ User approves checklist
   └─ Create NODE.md stubs + members/<owner> + raw-context
-  └─ PR1 on chore/seed-phase1-structure
+  └─ PR/MR 1 on chore/seed-phase1-structure
 
-User merges PR1 ────────────────────────────────────────────────
+User merges PR/MR 1 ────────────────────────────────────────────
 
 Phase 2 — Content    (parallel; ~10–20 min wall-clock per batch)
   └─ Allocate sub-agents (cap 6 concurrent; split big top-levels,
      merge thin ones, batch dispatch when total work units > 6)
   └─ Each sub-agent: deep-read its subtree, draft leaves, report coverage
   └─ Main agent: consolidate + cross-check + collect escalations
-  └─ PR2 on chore/seed-phase2-content
+  └─ PR/MR 2 on chore/seed-phase2-content
 ```
 
-The hand-off point between phases is the merge of PR1. Do not start
+The hand-off point between phases is the merge of PR/MR 1. Do not start
 Phase 2 work before the user has signed off on the structure — the
 sub-agent fan-out is expensive and Phase 2 inherits Phase 1's
 structural decisions.
@@ -584,8 +601,8 @@ Member nodes carry the extended shape required by
 
 ```yaml
 ---
-title: "<github handle>"
-owners: [<github handle>]
+title: "<forge handle>"
+owners: [<forge handle>]
 type: human                # or "agent" — agents only when seeding an agent-team workspace
 role: "Owner"              # neutral default; user adjusts to "Engineer" / "Product" / etc.
 domains:                   # non-empty; default = the list of top-level domains opened in Phase 1
@@ -617,20 +634,20 @@ Notes on defaults:
   reviewed and hides it from future audits.
 - Do **not** set `decisionLocksCode` (defaults false).
 
-### PR1
+### PR/MR 1
 
 - Branch: `chore/seed-phase1-structure`
 - Show the diff to the user before push.
 - Commit message: `chore: seed initial tree structure from <N> source repo(s)`
-- PR title: `Seed Phase 1 — initial tree structure`
-- PR body: enumerate which top + second-level domains were opened
+- PR/MR title: `Seed Phase 1 — initial tree structure`
+- PR/MR body: enumerate which top + second-level domains were opened
   and which were proposed-but-skipped (one line each, with the
-  user's reason if given). Do not list the source PRs / commits — the
+  user's reason if given). Do not list the source PRs/MRs or commits — the
   audit trail is `git log`.
 - Run `first-tree tree verify --tree-path <tree>` locally before
-  opening the PR. Non-zero exit blocks.
-- Stop after the PR is open. Do **not** start Phase 2 work until the
-  user has explicitly merged PR1.
+  opening the PR/MR. Non-zero exit blocks.
+- Stop after the PR/MR is open. Do **not** start Phase 2 work until the
+  user has explicitly merged PR/MR 1.
 
 ---
 
@@ -643,14 +660,14 @@ extracted.
 
 ### Trigger
 
-The user **re-pings this setup chat** after merging PR1 — that ping is the
+The user **re-pings this setup chat** after merging PR/MR 1 — that ping is the
 only sanctioned start signal. The agent does **not** poll the remote,
-the inbox, or any other source between phases; the seed skill is not
-running between PR1 and PR2. This is the Phase 2 continuation checked before
+the inbox, or any other source between phases; the seed skill is not running
+between PR/MR 1 and PR/MR 2. This is the Phase 2 continuation checked before
 normal state C refusal. When the ping arrives, re-resolve the same sources and
-run a fresh self-check that PR1's structure is actually on the tree's default
-branch before dispatching sub-agents — protects against the case where the
-user pinged before merging, merged a different branch, or changed the source
+run a fresh self-check that PR/MR 1's structure is actually on the tree's
+default branch before dispatching sub-agents — protects against the case where
+the user pinged before merging, merged a different branch, or changed the source
 input between turns.
 Resolve the default branch name dynamically rather than hard-coding
 `main` (some tree repos use `master` / `trunk`):
@@ -672,7 +689,7 @@ the required proof is the materialize/read event, not a leftover checkout.
 ### Sub-agent allocation
 
 Phase 2 must balance parallelism against three costs: token spend,
-main-agent consolidation complexity, and the user's PR2 review
+main-agent consolidation complexity, and the user's PR/MR 2 review
 burden. The allocation policy below caps each batch at 6 concurrent
 sub-agents and uses queue-batched dispatch so no approved domain is
 deferred.
@@ -683,7 +700,7 @@ never get one — do not design nested fan-out). Fall back to
 **sequential self-dispatch**: the main agent works through the same
 queue one unit at a time, under the same per-unit contract — subtree
 scope, time budget, stopping discipline, and a coverage report per
-unit. Wall-clock is slower; the outputs and the PR2 shape are
+unit. Wall-clock is slower; the outputs and the PR/MR 2 shape are
 identical. Everything below that says "sub-agent" applies to a
 self-dispatched unit unchanged, except the parallel-write-safety
 rules, which become trivial. **In sequential mode, still defer all
@@ -691,7 +708,7 @@ git commits until after the consolidation pass** — name normalisation
 and the soft_links resolution check happen across every unit's
 output and may rewrite earlier drafts; committing per-unit inline
 would force consolidation fixes into extra commits and blur the
-per-unit `git log` boundaries that PR2 review depends on.
+per-unit `git log` boundaries that PR/MR 2 review depends on.
 
 **Concurrency cap: 6 sub-agents per batch.** Empirical limit.
 Beyond this, wall-clock savings flatten while token cost and
@@ -742,13 +759,13 @@ hits — the files / forge fields that motivated the domain in Phase 1)
 AND ≤ 1 leaf expected **to be drafted by Phase 2 in this seed run**
 (not "ever"). Weigh the **commit-boundary cost** before merging: a
 merged pair lands as one commit spanning two domains, which blurs
-the per-domain review boundary PR2 otherwise preserves. Merge only
+the per-domain review boundary PR/MR 2 otherwise preserves. Merge only
 when both domains are thin enough that the combined commit is still
 trivially reviewable; when in doubt, run the thin domain as its own
 quick work unit instead. A merged sub-agent's authority covers
 **both assigned top-level paths in full** — the
 "sibling = forbidden" rule applies between work units, not inside a
-merged unit's pair. Surface the pairing in the PR2 body so the user
+merged unit's pair. Surface the pairing in the PR/MR 2 body so the user
 sees why one commit spans two domains.
 
 **Batched dispatch when total work units > 6.** Maintain a queue of
@@ -762,7 +779,7 @@ across multiple waves. Wall-clock for a queue of ~12 ends up roughly
 slowest sub-agent in batch N gates the start of batch N+1 only if
 its slot is the last to free.
 
-Record the actual allocation (splits, merges, batches) in the PR2
+Record the actual allocation (splits, merges, batches) in the PR/MR 2
 body so the user can see why each commit covers the subtree it does
 — and so they can spot if the main agent split or merged something
 they would have left alone.
@@ -837,7 +854,7 @@ holds, whichever comes first:
 - **Twelve leaves drafted in this domain.** Empirical cap from
   observing real seed runs; not a hard architectural limit. A single
   seed pass should not create a sixty-leaf domain — defer the rest
-  to `first-tree-write` writes after the user has reviewed PR2.
+  to `first-tree-write` writes after the user has reviewed PR/MR 2.
   Adjust in a future skill version if real usage shows the number is
   consistently too low or too high.
 
@@ -877,7 +894,7 @@ across sub-agents:
 - `(first paragraph)` — only the first paragraph or first H1 block.
 
 The main agent stitches every sub-agent's coverage report into the
-PR2 description so the user can see, at merge time, exactly what was
+PR/MR 2 description so the user can see, at merge time, exactly what was
 and was not covered — and decide whether to accept, manually fill, or
 re-run seed with a focused prompt.
 
@@ -906,19 +923,19 @@ After all sub-agents return:
 
    Where a sub-agent linked to a target that fails this check, drop
    the link and surface it as a known gap.
-3. Aggregate escalations into a single section in the PR2 body
+3. Aggregate escalations into a single section in the PR/MR 2 body
    ("Sub-agents flagged the following as out of their scope; user to
    decide whether to act now or later").
 4. Run `first-tree tree verify --tree-path <tree>` from a clean
    checkout of `chore/seed-phase2-content`. Non-zero blocks.
 
-### PR2
+### PR/MR 2
 
 - Branch: `chore/seed-phase2-content`
 - One commit per sub-agent (preserve domain boundaries for review),
   plus one consolidation commit at the end.
-- PR title: `Seed Phase 2 — initial leaves across <N> domain(s)`
-- PR body sections, in order:
+- PR/MR title: `Seed Phase 2 — initial leaves across <N> domain(s)`
+- PR/MR body sections, in order:
   1. **Coverage report** — concatenated coverage reports from every
      sub-agent.
   2. **Escalations** — items sub-agents flagged as out of scope.
@@ -927,13 +944,13 @@ After all sub-agents return:
      follow-up source-driven writes and describe any broad maintenance
      gaps as focused follow-up tasks.
 
-After PR2 opens, the seed skill is done. Subsequent writes are owned
+After PR/MR 2 opens, the seed skill is done. Subsequent writes are owned
 by `first-tree-write`; subsequent maintenance uses focused tasks with
 explicit scope.
 
-### Recovery path: PR1 merged, Phase 2 abandoned
+### Recovery path: PR/MR 1 merged, Phase 2 abandoned
 
-A user may merge PR1 and then never come back for Phase 2 (life
+A user may merge PR/MR 1 and then never come back for Phase 2 (life
 happens, the team is busy, the kickoff agent crashed). The tree
 ends up with real structure but zero leaves. **This is not a new
 re-seed condition.** A later explicit continuation in the same setup chat can
@@ -947,8 +964,8 @@ files exist, state C) and refuses. For that unrelated path:
   a focused maintenance pass with explicit source scopes; any actual
   writes still go through `first-tree-write` one source at a time.
 
-Communicate this fallback to the user in PR1's body so the choice
-is visible: "If you merge PR1 without coming back for Phase 2, the
+Communicate this fallback to the user in PR/MR 1's body so the choice
+is visible: "If you merge PR/MR 1 without coming back for Phase 2, the
 tree is fully usable but empty; later writes go through
 `first-tree-write` or a focused maintenance follow-up."
 
@@ -964,13 +981,13 @@ These apply the generated Context Tree Policy to the seed-specific surface.
 - **No diffs, no code detail in nodes.** Function signatures,
   request shapes, retry constants stay in the source repo. The tree
   records the durable decision and the rationale.
-- **No PR references in node bodies.** The audit trail for "which
-  PR delivered this seed" lives in `git log`. Nodes carry their
+- **No PR/MR references in node bodies.** The audit trail for "which
+  PR/MR delivered this seed" lives in `git log`. Nodes carry their
   present-tense claim alone.
 - **No history.** Nodes state current truth. Past states live in
   `git log`. Do not preface a node with "Originally we…" or
   "Update 2026-XX-XX:".
-- **`first-tree tree verify` must pass before PR1 and PR2 land.**
+- **`first-tree tree verify` must pass before PR/MR 1 and PR/MR 2 land.**
   Non-zero exit blocks the commit.
 - **Ownership changes go through humans.** Phase 1 sets `owners` to
   the workspace's primary owner as the default; reassignment is the

--- a/skills/first-tree-seed/SKILL.md
+++ b/skills/first-tree-seed/SKILL.md
@@ -399,6 +399,12 @@ default branch. Follow the **Worktrees** protocol in your `AGENTS.md` /
 # for each <source> in manifest.sources, with <source-clone> resolved as above:
 git -C <source-clone> fetch origin
 source_ref="<declared-or-pinned-ref-if-present>"
+if [ -n "$source_ref" ]; then
+  remote_ref="refs/remotes/origin/$source_ref"
+  if git -C <source-clone> rev-parse --verify --quiet "$remote_ref^{commit}" >/dev/null; then
+    source_ref="origin/$source_ref"
+  fi
+fi
 if [ -z "$source_ref" ]; then
   source_ref="$(git -C <source-clone> symbolic-ref --quiet --short refs/remotes/origin/HEAD || true)"
 fi
@@ -410,10 +416,13 @@ git -C <source-clone> worktree add <workspaceRoot>/worktrees/seed-<source> "$sou
 ```
 
 Do not hard-code `origin/main`: GitLab and imported repositories often use
-`master`, `trunk`, or another default branch. Every "read every resolved
-source" / Tier 0–2 scan in Phase 1 operates on these read worktrees, not the
-bare clone paths. Remove them (`git -C <source-clone> worktree remove <path>`)
-once both PRs/MRs are open.
+`master`, `trunk`, or another default branch. Do not pass a branch-like declared
+ref such as `main` or `release` directly to `worktree add`; prefer the freshly
+fetched remote-tracking ref (`origin/main`, `origin/release`) when it exists.
+Preserve pinned SHAs, tags, and fully qualified refs that do not resolve as a
+remote-tracking branch. Every "read every resolved source" / Tier 0–2 scan in
+Phase 1 operates on these read worktrees, not the bare clone paths. Remove them
+(`git -C <source-clone> worktree remove <path>`) once both PRs/MRs are open.
 
 ## The Two Phases
 

--- a/skills/first-tree-seed/SKILL.md
+++ b/skills/first-tree-seed/SKILL.md
@@ -3,7 +3,7 @@ name: first-tree-seed
 version: 0.3.0
 cliCompat:
   first-tree: ">=0.5.0 <0.6.0"
-description: Bootstrap a team's Context Tree from readable source repos — for an onboarding "build / set up the Context Tree" task on a tree that has no domain structure yet: either no tree exists (creates and binds it) or a bound-but-empty tree (fills it). Uses declared workspace sources when present, otherwise asks for a local Git repo or a GitHub/GitLab repository URL in the setup chat. Proposes an initial top-level + second-level domain structure for approval, then drafts initial leaf content — each as a reviewable PR/MR. Refuses an unrelated re-seed once the tree has domain structure, while allowing the same setup chat to continue Phase 2 after its Phase 1 PR/MR is merged.
+description: "Bootstrap a team's Context Tree from readable source repos — for an onboarding \"build / set up the Context Tree\" task on a tree that has no domain structure yet: either no tree exists (creates and binds it) or a bound-but-empty tree (fills it). Uses declared workspace sources when present, otherwise asks for a local Git repo or a GitHub/GitLab repository URL in the setup chat. Proposes an initial top-level + second-level domain structure for approval, then drafts initial leaf content — each as a reviewable PR/MR. Refuses an unrelated re-seed once the tree has domain structure, while allowing the same setup chat to continue Phase 2 after its Phase 1 PR/MR is merged."
 ---
 
 # First Tree — Seed
@@ -391,18 +391,29 @@ optional):
   `<source-clone>` = `<workspaceRoot>/<source>`
 
 Before any structural read, materialize one read worktree per source off
-its latest default branch, following the **Worktrees** protocol in your
-`AGENTS.md` / `CLAUDE.md` briefing:
+its declared/pinned ref when one exists, otherwise off the source's latest
+default branch. Follow the **Worktrees** protocol in your `AGENTS.md` /
+`CLAUDE.md` briefing:
 
 ```bash
 # for each <source> in manifest.sources, with <source-clone> resolved as above:
 git -C <source-clone> fetch origin
-git -C <source-clone> worktree add <workspaceRoot>/worktrees/seed-<source> origin/main
+source_ref="<declared-or-pinned-ref-if-present>"
+if [ -z "$source_ref" ]; then
+  source_ref="$(git -C <source-clone> symbolic-ref --quiet --short refs/remotes/origin/HEAD || true)"
+fi
+if [ -z "$source_ref" ]; then
+  git -C <source-clone> remote set-head origin --auto
+  source_ref="$(git -C <source-clone> symbolic-ref --quiet --short refs/remotes/origin/HEAD)"
+fi
+git -C <source-clone> worktree add <workspaceRoot>/worktrees/seed-<source> "$source_ref"
 ```
 
-Every "read every resolved source" / Tier 0–2 scan in Phase 1 operates on
-these read worktrees, not the bare clone paths. Remove them
-(`git -C <source-clone> worktree remove <path>`) once both PRs/MRs are open.
+Do not hard-code `origin/main`: GitLab and imported repositories often use
+`master`, `trunk`, or another default branch. Every "read every resolved
+source" / Tier 0–2 scan in Phase 1 operates on these read worktrees, not the
+bare clone paths. Remove them (`git -C <source-clone> worktree remove <path>`)
+once both PRs/MRs are open.
 
 ## The Two Phases
 

--- a/skills/first-tree-seed/SKILL.md
+++ b/skills/first-tree-seed/SKILL.md
@@ -3,7 +3,7 @@ name: first-tree-seed
 version: 0.3.0
 cliCompat:
   first-tree: ">=0.5.0 <0.6.0"
-description: Bootstrap a team's Context Tree from readable source repos — for an onboarding "build / set up the Context Tree" task on a tree that has no domain structure yet: either no tree exists (creates and binds it) or a bound-but-empty tree (fills it). Uses declared workspace sources when present, otherwise asks for a local Git repo or GitHub URL in the setup chat. Proposes an initial top-level + second-level domain structure for approval, then drafts initial leaf content — each as a reviewable PR. Refuses an unrelated re-seed once the tree has domain structure, while allowing the same setup chat to continue Phase 2 after its Phase 1 PR is merged.
+description: Bootstrap a team's Context Tree from readable source repos — for an onboarding "build / set up the Context Tree" task on a tree that has no domain structure yet: either no tree exists (creates and binds it) or a bound-but-empty tree (fills it). Uses declared workspace sources when present, otherwise asks for a local Git repo or a GitHub/GitLab repository URL in the setup chat. Proposes an initial top-level + second-level domain structure for approval, then drafts initial leaf content — each as a reviewable PR/MR. Refuses an unrelated re-seed once the tree has domain structure, while allowing the same setup chat to continue Phase 2 after its Phase 1 PR is merged.
 ---
 
 # First Tree — Seed
@@ -24,7 +24,7 @@ not here.
 | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | The team has no tree yet, **or** a bound tree with no normal domain structure per the generated policy's content classes | The tree already has a normal domain structure → `first-tree-write` (incremental source-driven write) |
 | First content pass on resolved readable sources                       | Broad maintenance or drift-audit work on an existing tree                                            |
-| Invoked by name — by a human, an agent, or an onboarding kickoff prompt (see Resolve the tree's state) | Not an org admin, or `gh` unauthenticated, and the team has no tree — seed can't create it; surface the gap to a human |
+| Invoked by name — by a human, an agent, or an onboarding kickoff prompt (see Resolve the tree's state) | Not an org admin, or the required forge CLI (`gh` / `glab`) is unauthenticated, and the team has no tree — seed can't create it; surface the gap to a human |
 
 The skill is **single-shot per tree setup**: once the tree has domain
 structure, a new or unrelated seed request refuses and routes further work
@@ -70,7 +70,7 @@ or a populated tree alone.
 field, or the team has no `context_tree` binding. This is the
 agent-driven creation path. First resolve readable sources using the section
 below, because owner placement depends on them; then create the tree with the
-user's local `gh`:
+user's local forge CLI (`gh` for GitHub, `glab` for GitLab):
 
 ```bash
 first-tree tree init --title "<team display name>" --owner "<source-repo-owner>" --dir "<workspaceRoot>/<manifest.tree>"
@@ -83,26 +83,27 @@ source's **remote URL, not its directory name**: for a declared source resolve
 `<source-clone>` from the manifest
 (`<workspaceRoot>/<sourcesRoot>/<source>`, per *Materialize source read
 worktrees* below); for an explicit local repo use that repo; then run
-`git -C <source> remote get-url origin` (or use the explicit GitHub URL) and take
-the `<owner>` segment of that URL (e.g. `acme` in `github.com/acme/app`, or
-`alice` in `github.com/alice/app`). **`manifest.sources` holds directory
-names (e.g. `first-tree`), not owners** — passing a source *name* as
-`--owner` targets the wrong GitHub account, so always parse the owner from
-the clone's remote. With one source that account is unambiguous; when
-several sources share one account, use it;
-when sources span **different accounts**, pick the account that owns most
-of them, and if that is genuinely a tie, ask the admin which account should
-host the tree rather than guessing. Why: a team's Context Tree belongs in
-the **same account as its source** — that is the account the GitHub App
-lives on (or will) to read those sources. When the App is already installed
-there — the normal case — `--owner` just matches the installation account
-and nothing changes. When the App is not installed yet, `--owner` lands the
-tree in that account instead of defaulting to your personal `gh` login, so
-a **later App install on it covers the tree** rather than stranding it in
-an account the install can never reach. The tree lives in one account;
-sources under other accounts stay covered by their own App installs as
-usual. (When the source repo is itself under your personal account,
-`<source-repo-owner>` simply is that account — same result.)
+`git -C <source> remote get-url origin` (or use the explicit forge URL) and take
+the `<owner>` / namespace segment of that URL (e.g. `acme` in
+`github.com/acme/app`, or `acme/platform` in `gitlab.com/acme/platform/app`).
+**`manifest.sources` holds directory names (e.g. `first-tree`), not owners** —
+passing a source *name* as `--owner` targets the wrong forge account, so always
+parse the owner or namespace from the clone's remote. With one source that
+account is unambiguous; when several sources share one account, use it;
+when sources span **different accounts**, pick the account or namespace that
+owns most of them, and if that is genuinely a tie, ask the admin which account
+should host the tree rather than guessing. Why: a team's Context Tree belongs
+in the **same forge account/namespace as its source** — that is the account the
+GitHub App lives on for GitHub sources, or the integration surface First Tree
+returns for GitLab sources, to read those sources. When the GitHub App is
+already installed there — the normal GitHub case — `--owner` just matches the
+installation account and nothing changes. When the GitHub App is not installed
+yet, `--owner` lands the tree in that account instead of defaulting to your
+personal `gh` login, so a **later App install on it covers the tree** rather than
+stranding it in an account the install can never reach. The tree lives in one
+forge account/namespace; sources under other accounts stay covered by their own
+hosted integrations as usual. (When the source repo is itself under your personal
+account, `<source-repo-owner>` simply is that account — same result.)
 
 **If `--owner` can't be honored, stop and surface it — do not silently
 fall back.** Two distinct cases, each with its own recovery:
@@ -111,12 +112,13 @@ fall back.** Two distinct cases, each with its own recovery:
   installed, so nothing overrides `--owner`): prefer asking an admin to
   grant you create rights there, so the tree still homes beside its source.
   Only if that is not an option, re-run without `--owner` to build under
-  your personal `gh` account — flag the cost first: the tree then lives off
-  the source's account, so a later App install must go on *your* account,
-  not the source's, to cover it. Before re-running, empty **only** the
-  half-built scaffold this failed run left in `<manifest.tree>` (confirm the
-  directory holds just that — never delete a directory that already holds a
-  real tree clone or other content); `tree init` refuses a non-empty target.
+  your personal forge account — flag the cost first: the tree then lives off
+  the source's account/namespace, so a later App or integration install must
+  go on *your* account/namespace, not the source's, to cover it. Before
+  re-running, empty **only** the half-built scaffold this failed run left in
+  `<manifest.tree>` (confirm the directory holds just that — never delete a
+  directory that already holds a real tree clone or other content);
+  `tree init` refuses a non-empty target.
 - **`--owner` doesn't match an already-installed App account** (the App is
   installed on a different account than the source's — rare; `tree init`
   names that account): re-run **without `--owner`** to create under that
@@ -127,9 +129,10 @@ fall back.** Two distinct cases, each with its own recovery:
 `tree init` seeds a minimal valid tree
 (root `NODE.md`, a `members/` index, and the creator's member node),
 pushes, and binds the org's `context_tree` setting. It is **admin-only**
-and needs an authenticated `gh`; if the caller is not an org admin, or
-`gh` is unauthenticated, surface that exact gap and stop (binding a team
-tree is an admin action).
+and needs an authenticated forge CLI (`gh` for GitHub, `glab` for GitLab);
+if the caller is not an org admin, or the required forge CLI is
+unauthenticated, surface that exact gap and stop (binding a team tree is an
+admin action).
 Take the team display name from the chat context / `first-tree agent
 status`. After it succeeds the tree is bound and in state **B** — proceed.
 
@@ -138,9 +141,9 @@ bind is the sanctioned agent path (a general "tree binding is an operator
 action" note in your briefing does **not** apply to this task) — running it IS
 the task the user asked for, so binding needs no separate go-ahead. You do not
 need to independently "confirm admin" first: `tree init` enforces it
-server-side (it fails closed for a non-admin or unauthenticated `gh`). So run
+server-side (it fails closed for a non-admin or unauthenticated forge CLI). So run
 it; only if it fails on that admin/authentication check do you surface the
-exact gap (not an admin / `gh` not authenticated) and stop.
+exact gap (not an admin / matching CLI not authenticated) and stop.
 
 **Pin the local checkout with `--dir` — this is load-bearing.** `tree
 init` defaults its local clone to `<cwd>/<repo-name>`, but a managed
@@ -263,11 +266,12 @@ setup failure as a reason to delete or recreate the Context Repo.
 **Delay App coverage guidance until there is a reviewable milestone — recommend,
 never block.**
 A newly created tree is only visible to the team's web view and the
-Context Tree reviewer once the First Tree GitHub App can read its repo.
-`tree init` creates and binds the tree either way and prints a coverage
-line; capture the result but do not interrupt source resolution, structure
-review, or Phase 1 work with an installation detour. The tree is built and
-bound, so proceed regardless of coverage.
+Context Tree reviewer once the First Tree GitHub App can read its repo for
+GitHub sources; for GitLab sources, use the integration URL/settings First
+Tree returns. `tree init` creates and binds the tree either way and prints a
+coverage line; capture the result but do not interrupt source resolution,
+structure review, or Phase 1 work with an installation detour. The tree is
+built and bound, so proceed regardless of coverage.
 
 **After the Phase 1 PR is open**, or earlier only when the next requested
 operation actually needs Cloud snapshot/reviewer access, surface an uncovered
@@ -328,27 +332,28 @@ Use one ordered source-resolution rule and call its result
    source on disk. Do not let a URL or local path supplied in chat hide a
    half-provisioned declared workspace.
 2. **An empty or absent `manifest.sources` is valid.** Use an explicit local
-   project folder or GitHub repository URL already supplied in this setup chat.
-   If neither exists, ask the user for exactly one of them and stop until they
-   answer. Do not send them to Settings and do not make GitHub App installation
-   a prerequisite.
+   project folder or GitHub/GitLab repository URL already supplied in this
+   setup chat. If neither exists, ask the user for exactly one of them and stop
+   until they answer. Do not send them to Settings and do not make GitHub App
+   installation a prerequisite.
 3. **Validate before reading.** A local folder must exist, be readable, and be
-   a Git repository. A GitHub URL must be a repository URL that host `gh` or
-   `git` can access; materialize a task-local read checkout under the workspace
-   `worktrees/` directory. These reads do not register team resources or mutate
-   the source repo.
+   a Git repository. A GitHub or GitLab URL must be a repository URL that host
+   `gh`, `glab`, or `git` can access; materialize a task-local read checkout
+   under the workspace `worktrees/` directory. These reads do not register team
+   resources or mutate the source repo.
 
 For a local non-bare repository, read it in place without modifying it. For a
-local bare repository, follow the worktree protocol below. For a GitHub URL,
-clone/fetch it into task-local read storage, then read its default branch.
-Private URLs may rely on the user's existing `gh`/git credentials; if access
-fails, report that exact credential/access gap rather than asking for the First
-Tree GitHub App.
+local bare repository, follow the worktree protocol below. For a GitHub or
+GitLab URL, clone/fetch it into task-local read storage, then read its default
+branch. Private URLs may rely on the user's existing `gh` / `glab` / git
+credentials; if access fails, report that exact credential/access gap rather
+than asking for the First Tree GitHub App.
 
-When state A needs `--owner`, parse the owner from each resolved source's
-GitHub remote. If a local repo has no GitHub remote, ask which GitHub account
-should host the tree; never guess from its directory name. Revalidate the same
-`resolvedSources` before Phase 2 so a later turn cannot silently switch inputs.
+When state A needs `--owner`, parse the owner or namespace from each resolved
+source's remote. If a local repo has no GitHub or GitLab remote, ask which
+forge account or namespace should host the tree; never guess from its directory
+name. Revalidate the same `resolvedSources` before Phase 2 so a later turn
+cannot silently switch inputs.
 
 **For declared sources, require every clone on disk.** Each source
 clone lives at `<workspaceRoot>/<manifest.sourcesRoot>/<manifest.sources[i]>`
@@ -433,7 +438,7 @@ tier left a specific question unanswered.
 | Tier | Action                                                                                                                                                                                                                                                                                                            | Cost                  | Yields                                                                                  |
 | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | --------------------------------------------------------------------------------------- |
 | 0    | Filesystem walk over every resolved source checkout (including declared bare-source read worktrees): **one listing pass per source** (a single `find`-style enumeration, depth-capped at 3–4 levels on huge repos), not repeated re-walks. List directories and well-known meta files. Filter out build artefacts (`node_modules`, `dist`, `build`, `.next`, `.turbo`, `.venv`, `target`, `.git`). Count file extensions, package boundaries, presence of `docs/`, `infra/`, `terraform/`, `k8s/`, `.github/workflows/`. | seconds, even on 10k+ files | monorepo shape, package boundaries, docs hierarchy, ops signals, file-type distribution |
-| 1    | First-line / first-paragraph reads of meta files surfaced by Tier 0: top `README.md`, every `packages/*/README.md`, `docs/*.md` first H1, `ARCHITECTURE.md`, `CONTRIBUTING.md`, `AGENTS.md`, `CLAUDE.md`, `SECURITY.md`, `package.json` description fields, `gh repo view --json description,topics,homepageUrl` (skip silently on **any** failure — 4xx, missing token, no network, no `gh` binary; READMEs are the fallback). | 1–3 min total across all sources | one-sentence description per observed concept; product positioning; ops/contrib focus   |
+| 1    | First-line / first-paragraph reads of meta files surfaced by Tier 0: top `README.md`, every `packages/*/README.md`, `docs/*.md` first H1, `ARCHITECTURE.md`, `CONTRIBUTING.md`, `AGENTS.md`, `CLAUDE.md`, `SECURITY.md`, `package.json` description fields, `gh repo view --json description,topics,homepageUrl` / `glab repo view` metadata where available (skip silently on **any** failure — 4xx, missing token, no network, no `gh` / `glab` binary; READMEs are the fallback). | 1–3 min total across all sources | one-sentence description per observed concept; product positioning; ops/contrib focus   |
 | 2    | Surgical content read of a **specific** file that Tier 0+1 left ambiguous (e.g. `packages/foo/` exists, README is empty → read `packages/foo/src/index.ts` head 30 lines). Triggered per uncertainty, not as a blanket sweep.                                                                                       | 1–3 min per question, 0 if not needed | answer one structural question |
 
 **Tier 2 is targeted, not exhaustive.** If you cannot articulate the
@@ -594,8 +599,8 @@ Notes on defaults:
 - **Primary owner** = the most-active recent contributor across the
   resolved sources, computed from `git log --since='6 months ago'
   --format='%aN <%aE>' | sort | uniq -c | sort -rn | head -1`. Use
-  the GitHub handle when `gh repo view` resolves the email; fall
-  back to the `%aN` author name otherwise. Compute this **during
+  the forge handle when `gh repo view` or `glab repo view` resolves the email;
+  fall back to the `%aN` author name otherwise. Compute this **during
   Phase 1 exploration** and surface it in the confirmation checklist
   (see above) — the user's reply to that checklist is the owner
   confirmation; do not ask a second time unless the derivation was
@@ -733,7 +738,7 @@ siblings.
 
 **Merge multiple thin top-levels into one sub-agent** when each
 top-level has ≤ 2 source signals (counted as distinct Tier-1 meta
-hits — the files / `gh` fields that motivated the domain in Phase 1)
+hits — the files / forge fields that motivated the domain in Phase 1)
 AND ≤ 1 leaf expected **to be drafted by Phase 2 in this seed run**
 (not "ever"). Weigh the **commit-boundary cost** before merging: a
 merged pair lands as one commit spanning two domains, which blurs
@@ -976,9 +981,10 @@ These apply the generated Context Tree Policy to the seed-specific surface.
 ## What This Skill Does NOT Do
 
 - Run the Cloud one-click **server** bootstrap. When the team has no tree
-  (state A), seed creates and binds it with `first-tree tree init`
-  (the user's local `gh`), not the server `/initialize` path — the two
-  coexist. Seed does not write the workspace-root `workspace.json`; that
+  (state A), seed creates and binds it with `first-tree tree init` (the user's
+  local `gh`; current tree creation is GitHub-only), not the server
+  `/initialize` path — the two coexist. A GitLab source still uses `glab` for
+  source access. Seed does not write the workspace-root `workspace.json`; that
   stays a runtime concern.
 - Install GitHub automation beyond the bootstrap root `CODEOWNERS` mapping and
   default-branch ruleset applied after a newly created GitHub Context Repo

--- a/skills/first-tree-seed/agents/openai.yaml
+++ b/skills/first-tree-seed/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "First Tree — Seed"
   short_description: "Bootstrap a team's Context Tree from readable source repos"
-  default_prompt: "Use $first-tree-seed to set up the team's Context Tree from readable sources — declared workspace repos, or a local Git repo / GitHub URL supplied in the setup chat. Create + bind it if none exists, otherwise fill a bound-but-empty tree; propose the initial domains for approval, then complete the two-phase seed in this chat."
+  default_prompt: "Use $first-tree-seed to set up the team's Context Tree from readable sources — declared workspace repos, or a local Git repo / remote repository URL supplied in the setup chat. Treat GitHub and GitLab URLs as supported examples. Create + bind it if none exists, otherwise fill a bound-but-empty tree; propose the initial domains for approval, then complete the two-phase seed in this chat."

--- a/skills/first-tree-welcome/SKILL.md
+++ b/skills/first-tree-welcome/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: first-tree-welcome
 version: 1.2.1
-description: Use for a First Tree onboarding first chat, especially natural opening messages like "welcome aboard", "Please help me get started with First Tree", or "Please help me get settled into this team on First Tree." Also covers the production-scan fix first chat ("fix the launch blockers found by my production readiness scan"). Do not use for dedicated tree setup chats, ordinary chats, PR reviews, repo scans, tree writes, or maintenance.
+description: Use for a First Tree onboarding first chat, especially natural opening messages like "welcome aboard", "Please help me get started with First Tree", or "Please help me get settled into this team on First Tree." Also covers the production-scan fix first chat ("fix the launch blockers found by my production readiness scan"). Do not use for dedicated tree setup chats, ordinary chats, PR/MR reviews, repo scans, tree writes, or maintenance.
 ---
 
 # First Tree Welcome

--- a/skills/first-tree-welcome/SKILL.md
+++ b/skills/first-tree-welcome/SKILL.md
@@ -11,7 +11,7 @@ description: Use for a First Tree onboarding first chat, especially natural open
 Use this skill only when the chat is clearly the onboarding first chat created by
 First Tree, including natural messages such as "welcome aboard", "Please help me
 get started with First Tree", or "Please help me get settled into this team on
-First Tree." Do not use it for ordinary chats, PR reviews, repo scans, tree
+First Tree." Do not use it for ordinary chats, PR/MR reviews, repo scans, tree
 writes, or maintenance work.
 
 Two look-alikes that are NOT this launcher, and one that routes by shape:
@@ -82,11 +82,15 @@ available local files:
   — a mere binding does not imply a populated tree, and the tree you may have
   bound is not necessarily this team's; confirm state by reading the **target
   team's** tree (root `NODE.md`), not by trusting a binding;
-- **host `gh` / `glab` / local credentials**: usable or not.
+- **detected source forge**: GitHub, GitLab, another host, or unknown — derive
+  it from the supplied URL or the repository's `origin` remote;
+- **matching host CLI / local credentials**: `gh` for GitHub, `glab` for
+  GitLab, or plain `git` for another host; usable or not.
 
 If state is unknown, first try to resolve it yourself (read the greeting for
-role, attempt the repo read, check the host CLI (`gh` or `glab`); only if it stays genuinely
-unresolvable, name the one specific missing piece and ask for that. Do not
+role, attempt the repo read, check the host CLI, `gh` or `glab`); only if it
+stays genuinely unresolvable, name the one specific missing piece and ask for
+that. Do not
 invent repo access, GitHub/GitLab authorization, or tree readiness.
 
 #### Reading role from the greeting
@@ -195,21 +199,21 @@ When either shape matches:
    - **None eligible to autofix** (everything left is a judgment call or stale)
      → spawn nothing; go straight to surfacing them (below).
    Do not split one blocker into implementation-step chats: code change, tests,
-   verification, and PR for that blocker belong in the same spawned fix chat.
+   verification, and PR/MR for that blocker belong in the same spawned fix chat.
    **Never fan out — or autofix — a judgment call**: a finding that needs product, architecture, or security-design judgment (rate-limiting redesign,
    changing auth), lacks concrete evidence, no longer matches the current repo,
-   or is already covered by existing code or an already-open PR. Surface those
+   or is already covered by existing code or an already-open PR/MR. Surface those
    in this chat for the user to decide or acknowledge.
    Before any spawned fix starts changing code, verify the finding still applies
    against the current repo. If it is already fixed or covered by existing code
-   or an already-open PR, report that and move to the next queued eligible
+   or an already-open PR/MR, report that and move to the next queued eligible
    blocker rather than producing a duplicate fix. Whether a fix runs in a
    spawned chat or here, its brief/target is self-contained: the repository URL,
    the findings JSON URL (when present), the specific finding(s) with their
    evidence and recommended fix, the instruction to verify the finding still
    applies before changing code, what to do when access is missing (diagnose the
-   cause, then the single narrowest recovery — the narrowest GitHub access or a
-   local path), and the completion bar — a verified fix or PR for that blocker,
+   cause, then the single narrowest recovery — the narrowest forge access or a
+   local path), and the completion bar — a verified fix or PR/MR for that blocker,
    with evidence.
 4. If the repository is not readable from this machine, follow the normal
    cannot-read rule: state the exact failure and make the smallest access ask;
@@ -368,9 +372,12 @@ Key mechanics — read these carefully, they are easy to get wrong:
   own. Include: the task, the relevant repo/paths, and how "done" is verified. Do
   NOT write a terse pointer like "do task 1".
 - **For a value task**: the brief states the change and its verification (test,
-  lint, screenshot, doc diff). If the task's likely completion artifact is a PR,
-  include that the task should follow the PR and report whether live tracking is
-  active or blocked by missing GitHub App coverage.
+  lint, screenshot, doc diff). If the likely completion artifact is a PR/MR,
+  choose the review CLI from that repository's remote. For a GitHub PR, include
+  that the task should run `first-tree github follow` and report whether live
+  tracking is active or blocked by missing GitHub App coverage. For a GitLab MR,
+  do not run that GitHub-only command; report the MR URL and only use a GitLab
+  tracking/integration surface when First Tree returns one explicitly.
 - **For "Build your Context Tree"**: the brief is user-visible, so write it in
   plain product language and **name no skill in it** — e.g. "Build our team's
   Context Tree from the connected code — propose an initial structure for me to
@@ -387,16 +394,21 @@ Key mechanics — read these carefully, they are easy to get wrong:
 
 Then, back in THIS launcher chat, post a short line naming the chats you opened
 so the user can see the parallel streams. As each spawned chat produces a result
-(a PR, a passing test, the seed PRs), note it here so the launcher stays the
+(a PR/MR, a passing test, the seed PRs/MRs), note it here so the launcher stays the
 map of what is in flight.
 
-### After a value PR opens: guide App install once
+### After a GitHub value PR opens: guide App install once
 
 A review-ready PR gives the admin a concrete reason to install or update First
 Tree GitHub App coverage: CI results, review comments, and merge state can flow
 back into chat. The welcome launcher owns one concise install/coverage guidance
 at this moment; do not rely only on the generic PR-following failure text that a
 spawned task may have shown.
+
+This section is GitHub-only. For a GitLab MR, do not call `first-tree github
+follow`, send the user to **Settings -> GitHub**, or imply live MR tracking.
+Relay a GitLab integration URL/settings target only when First Tree itself
+returns one; otherwise report the MR without a tracking/setup claim.
 
 - The spawned value task owns following its PR in its own task chat
   (`first-tree github follow <url>`) and reporting whether live tracking is
@@ -435,8 +447,8 @@ was not picked up front. Offer it **once**, after value, on these conditions:
   trusting a binding).
 - **Trigger on the first verified result** — the moment a value task returns
   something the user can see work, whether it ran in a spawned chat or was fixed
-  in place (a passing test, a review-ready PR, a
-  shipped doc), tie the offer to that win — not after everything finishes, and
+  in place (a passing test, a review-ready PR/MR, a shipped doc), tie the offer
+  to that win — not after everything finishes, and
   not before the first win.
 - **When the evidence warrants it** (per **Recommend, don't just list**), make
   this a reasoned recommendation, not a neutral question — e.g. "Test's green.
@@ -496,7 +508,7 @@ the user only for what only they can supply.
   in plain terms, tight.
 
 This does **not** loosen consent: a consequential or irreversible action (repo
-creation, pushes, PRs, authorization) still needs the user's explicit yes. Being
+creation, pushes, PRs/MRs, authorization) still needs the user's explicit yes. Being
 a protagonist is about owning diagnosis, safe/reversible steps, and mechanism
 choices — not about acting on things that are genuinely the user's to allow.
 
@@ -520,7 +532,7 @@ for tree build; other authorizations use a tracked ask.
   admin owns setup rather than routing a possible non-admin into an admin
   surface, and don't lead with "who should be involved?".
 
-**GitHub / repo access.**
+**Forge / repo access.**
 
 - Prefer a local project folder path + the matching host CLI (`gh` for GitHub,
   `glab` for GitLab) for ordinary forge work. A GitHub URL alone is not a reason
@@ -571,11 +583,14 @@ surface; involve the responsible admin.
 - If the admin did not pick the tree up front, re-offer it exactly once when the
   first value task delivers a verified result (see **After value lands**) — tied
   to that win, one line, no repeated nudging.
-- When the first value result is a PR/MR, consume the task chat's follow/tracking
-  status and, only for a confirmed admin when App coverage is missing, surface
-  the one-time App-install guidance from **After a value PR opens** in this
-  launcher. This does not replace the tree offer; if both apply, keep each to a
-  short sentence and do not repeat either later.
+- When the first value result is a GitHub PR, consume the task chat's
+  follow/tracking status and, only for a confirmed admin when App coverage is
+  missing, surface the one-time App-install guidance from **After a GitHub value
+  PR opens** in this launcher. A GitLab MR has no documented equivalent here;
+  use only an authoritative First Tree result and never substitute
+  `first-tree github follow` or **Settings -> GitHub**. This does not replace the
+  tree offer; if both apply, keep each to a short sentence and do not repeat
+  either later.
 - Present choices as a multi-select ask with **2–4 options** — the value tasks
   bundled with the tree-build option when tree build is offered, otherwise the
   value tasks listed individually; never a one-option ask; no "Skip for now"
@@ -592,7 +607,7 @@ surface; involve the responsible admin.
   `first-tree-seed` owns that in the spawned tree chat.
 - Finish each task against its own check and show the evidence; never claim it
   works without verifying.
-- Do not perform authorization, repo creation, pushes, or PR creation without
+- Do not perform authorization, repo creation, pushes, or PR/MR creation without
   explicit consent.
 - Do not surface skill internals or jargon to the user.
 - Do not use retired onboarding skill names such as `first-tree-guide`,

--- a/skills/first-tree-welcome/SKILL.md
+++ b/skills/first-tree-welcome/SKILL.md
@@ -82,12 +82,12 @@ available local files:
   — a mere binding does not imply a populated tree, and the tree you may have
   bound is not necessarily this team's; confirm state by reading the **target
   team's** tree (root `NODE.md`), not by trusting a binding;
-- **host `gh` / local credentials**: usable or not.
+- **host `gh` / `glab` / local credentials**: usable or not.
 
 If state is unknown, first try to resolve it yourself (read the greeting for
-role, attempt the repo read, check `gh`); only if it stays genuinely
+role, attempt the repo read, check the host CLI (`gh` or `glab`); only if it stays genuinely
 unresolvable, name the one specific missing piece and ask for that. Do not
-invent repo access, GitHub authorization, or tree readiness.
+invent repo access, GitHub/GitLab authorization, or tree readiness.
 
 #### Reading role from the greeting
 
@@ -114,15 +114,16 @@ these examples are kept in sync by a test — do not paraphrase them loosely.
 
 ### Your first substantive reply
 
-- **No readable code yet** — no repo connected, no local path, no GitHub URL, and
+- **No readable code yet** — no repo connected, no local path, no GitHub/GitLab URL, and
   no readable team context. Make exactly one minimal ask: request one project
-  entry point — a local project folder path on this machine or a GitHub repo URL
+  entry point — a local project folder path on this machine or a GitHub/GitLab repo URL
   — without faking understanding. Recommended shape: "Share one project entry
-  point: a local project folder path on this machine, or a GitHub repo URL. I'll
+  point: a local project folder path on this machine, or a GitHub/GitLab repo URL. I'll
   inspect it first, then suggest a few concrete starter tasks." If they share a
-  GitHub URL, use host `gh` first. This ask is a legitimate first result. Do not
-  ask for GitHub App authorization first, do not offer the first-task menu yet,
-  and do not mention Context Tree setup yet.
+  GitHub URL, use host `gh` first; if they share a GitLab URL, use `glab` first.
+  This ask is a legitimate first result. Do not ask for GitHub App authorization
+  first, do not offer the first-task menu yet, and do not mention Context Tree
+  setup yet.
 - **Readable code available** — a repo is connected and you can read it, or a
   local path / URL was given and you can read it. (A repo that is connected but
   local credentials cannot read it is the "cannot read it" state below — report
@@ -223,8 +224,8 @@ never fall through silently.
 
 | State | What to do |
 | --- | --- |
-| No project yet (no repo/path/URL) | Ask for one local project folder path or GitHub repo URL. For GitHub URLs try host `gh` / local credentials first. Do not ask for GitHub authorization first, and do not offer tree build (no code to draw it from). |
-| Repo/resource exists but local credentials cannot read it | **Diagnose why** (private repo needing access / `gh` not authenticated / wrong path / network), then give the one specific next step for that cause — `gh auth login` if gh isn't authenticated; for a private repo, the narrowest access, an accessible URL, or a local project folder path; the corrected path if it's mistyped (see **Handling snags**). Do not claim private repo contents, fake understanding, or send a menu; don't just report the read failure and ask for a path/URL/credential all at once. |
+| No project yet (no repo/path/URL) | Ask for one local project folder path or a GitHub/GitLab repo URL. For GitHub URLs try host `gh` / local credentials first; for GitLab URLs try `glab` / local credentials first. Do not ask for GitHub authorization first, and do not offer tree build (no code to draw it from). |
+| Repo/resource exists but local credentials cannot read it | **Diagnose why** (private repo needing access / `gh` or `glab` not authenticated / wrong path / network), then give the one specific next step for that cause — `gh auth login` or `glab auth login` if the matching CLI isn't authenticated; for a private repo, the narrowest access, an accessible URL, or a local project folder path; the corrected path if it's mistyped (see **Handling snags**). Do not claim private repo contents, fake understanding, or send a menu; don't just report the read failure and ask for a path/URL/credential all at once. |
 | Repo readable, tree missing or empty | Show code value, then offer the menu. **For a confirmed admin**, the menu carries BOTH the value-task bundle AND "Build your Context Tree"; otherwise value tasks only. On selection, fan out. |
 | Repo readable, tree already populated | Read both, cite concrete evidence, offer value-task options. Do NOT offer tree build (already built); do not seed the tree here. |
 | Repo readable, tree state unknown | Give repo-based value; do not invent tree readiness. Offer tree build only once you can confirm the tree is missing/empty AND the human is an admin. |
@@ -480,16 +481,17 @@ stop. Find the real cause, take the smallest forward action yourself, and ask
 the user only for what only they can supply.
 
 - **Diagnose to the cause, not the symptom.** "Can't read the repo" is a
-  symptom; the cause is one of — a private repo needing access, `gh` not
+  symptom; the cause is one of — a private repo needing access, `gh` or `glab` not
   authenticated, a mistyped path, a network issue. Name the actual cause and act
   on *that*.
 - **Exhaust what you can safely do before asking.** Retry the specific safe
-  action, try the obvious alternative (host `gh`, a local path), read what you
+  action, try the obvious alternative (host `gh` or `glab`, a local path), read what you
   can. Escalate to the user only when you hit something only they can supply
   (access, a credential, a login, a repo) or a genuine decision.
 - **When you do ask, make it specific and small.** "`gh` isn't logged in — run
-  `gh auth login`, then tell me" beats "I couldn't read it; give me a path, URL,
-  or credentials." One concrete next step, not a menu of possibilities.
+  `gh auth login`, then tell me" or "`glab` isn't logged in — run `glab auth
+  login`, then tell me" beats "I couldn't read it; give me a path, URL, or
+  credentials." One concrete next step, not a menu of possibilities.
 - Never expose raw errors or internal mechanics; say the cause and the next step
   in plain terms, tight.
 
@@ -501,7 +503,7 @@ choices — not about acting on things that are genuinely the user's to allow.
 ## Guardrails, Consent & Setup Handoff
 
 **Consent gates.** Authorization, repo authorization, Context Tree
-creation/binding, `gh repo create`, pushes, PR creation, and destructive actions
+creation/binding, `gh` / `glab` repo create, pushes, PR/MR creation, and destructive actions
 all require explicit user consent. The user's pick in the menu IS that consent
 for tree build; other authorizations use a tracked ask.
 
@@ -520,20 +522,23 @@ for tree build; other authorizations use a tracked ask.
 
 **GitHub / repo access.**
 
-- Prefer a local project folder path + host `gh` for ordinary GitHub work. A
-  GitHub URL alone is not a reason to ask for GitHub App installation — try host
-  `gh` first.
+- Prefer a local project folder path + the matching host CLI (`gh` for GitHub,
+  `glab` for GitLab) for ordinary forge work. A GitHub URL alone is not a reason
+  to ask for GitHub App installation — try host `gh` first; a GitLab URL should
+  try `glab` first.
 - Private repo access depends on the member's local credentials. Do not promise
   access to named private repos until reads actually succeed.
 - If First Tree says no repo is connected: (1) do not ask for GitHub App
-  authorization first; (2) ask for either a local project folder path or a GitHub
+  authorization first; (2) ask for either a local project folder path or a GitHub/GitLab
   repo URL; (3) local path → inspect it and give the evidence-backed menu;
-  (4) GitHub URL → use host `gh` or local git credentials when available; (5) if
-  `gh` is missing / unauthenticated / lacks access, explain that exact gap and
+  (4) GitHub URL → use host `gh` or local git credentials when available; GitLab
+  URL → use `glab` or local git credentials when available; (5) if `gh` or
+  `glab` is missing / unauthenticated / lacks access, explain that exact gap and
   give the single narrowest recovery for that diagnosed cause (e.g. `gh auth
-  login` when it's just unauthenticated; a local project folder path; GitHub CLI
-  install) — one concrete step, not the whole menu; (6) do not offer "Build your Context Tree"
-  until there is readable code and the human is a confirmed admin.
+  login` or `glab auth login` when it's just unauthenticated; a local project
+  folder path; the relevant CLI install) — one concrete step, not the whole menu;
+  (6) do not offer "Build your Context Tree" until there is readable code and
+  the human is a confirmed admin.
 
 **Setup handoff (steps you cannot perform — durable GitHub App install, repo
 authorization).** Raise them only when the chosen work genuinely needs them, then
@@ -566,7 +571,7 @@ surface; involve the responsible admin.
 - If the admin did not pick the tree up front, re-offer it exactly once when the
   first value task delivers a verified result (see **After value lands**) — tied
   to that win, one line, no repeated nudging.
-- When the first value result is a PR, consume the task chat's follow/tracking
+- When the first value result is a PR/MR, consume the task chat's follow/tracking
   status and, only for a confirmed admin when App coverage is missing, surface
   the one-time App-install guidance from **After a value PR opens** in this
   launcher. This does not replace the tree offer; if both apply, keep each to a

--- a/skills/first-tree-welcome/agents/openai.yaml
+++ b/skills/first-tree-welcome/agents/openai.yaml
@@ -1,4 +1,4 @@
 ---
 name: first-tree-welcome
-description: Use for a First Tree onboarding first chat, especially natural opening messages like "welcome aboard", "Please help me get started with First Tree", or "Please help me get settled into this team on First Tree." Also covers the production-scan fix first chat ("fix the launch blockers found by my production readiness scan"). Do not use for dedicated tree setup chats, ordinary chats, PR reviews, repo scans, tree writes, or maintenance.
+description: Use for a First Tree onboarding first chat, especially natural opening messages like "welcome aboard", "Please help me get started with First Tree", or "Please help me get settled into this team on First Tree." Also covers the production-scan fix first chat ("fix the launch blockers found by my production readiness scan"). Do not use for dedicated tree setup chats, ordinary chats, PR/MR reviews, repo scans, tree writes, or maintenance.
 ---

--- a/skills/first-tree-write/SKILL.md
+++ b/skills/first-tree-write/SKILL.md
@@ -3,7 +3,7 @@ name: first-tree-write
 version: 0.9.0
 cliCompat:
   first-tree: ">=0.5.0 <0.6.0"
-description: Source-driven Context Tree write workflow. Use when a concrete source artifact such as a PR, issue, design doc, meeting note, review thread, or pasted source material should be reflected into the Context Tree. If no source artifact is available, there is no write task; ask the user for one.
+description: Source-driven Context Tree write workflow. Use when a concrete source artifact such as a PR/MR, forge Issue, design doc, meeting note, review thread, or pasted source material should be reflected into the Context Tree. If no source artifact is available, there is no write task; ask the user for one.
 ---
 
 # First Tree Write
@@ -20,7 +20,7 @@ only for source artifact -> tree edit work.
 
 Writing is source-driven. Acceptable sources include:
 
-- a PR, issue, commit discussion, or review thread;
+- a PR/MR, forge Issue, commit discussion, or review thread;
 - a design doc, meeting note, decision note, or pasted source material;
 - a source repo change you just completed, when its design decision now needs
   durable tree context.
@@ -40,12 +40,12 @@ relationship.
 
 1. **Read the source artifact.** If you authored the source in this chat and
    still have it in working context, you may rely on that context. Otherwise
-   read the artifact end to end: PR diff plus linked issue/review comments, or
-   the document/note in full.
+   read the artifact end to end: PR/MR diff plus linked Issue/review comments,
+   or the document/note in full.
 2. **Apply the Double Test.** A candidate belongs only when it both establishes
    or changes a decision future agents must respect and remains durable if the
-   triggering commit or PR is rewritten. If nothing passes, write nothing and
-   explain why.
+   triggering commit or PR/MR is rewritten. If nothing passes, write nothing
+   and explain why.
 3. **Select the smallest target.** Prefer editing an existing node. Add a leaf
    only for a distinct decision with its own rationale/constraints. Add a
    directory only when the domain shape justifies it; new top-level domains
@@ -59,10 +59,10 @@ relationship.
    canonical content in one place and use normal-to-normal `soft_links` when a
    cross-domain reader needs navigation.
 6. **Verify.** Run `first-tree tree verify --tree-path <tree>` before commit.
-   Non-zero exit blocks the PR.
-7. **Prepare the PR/MR.** One source artifact maps to one tree PR/MR. Keep the PR/MR
-   description focused on the source and the tree nodes changed; do not put PR
-   IDs, source links, or audit trails into node bodies.
+   Non-zero exit blocks the PR/MR.
+7. **Prepare the PR/MR.** One source artifact maps to one tree PR/MR. Keep the
+   description focused on the source and the tree nodes changed; do not put
+   PR/MR IDs, source links, or audit trails into node bodies.
 
 ## Write Rules
 
@@ -124,7 +124,7 @@ that mirrors source detail.
 ### Worked Examples
 
 In the examples below, **"Trigger: …"** labels what prompted the
-tree-write (a PR, a meeting note, a report). The labels are
+tree-write (a PR/MR, a meeting note, a report). The labels are
 meta-narration in this skill — they are not a body section template;
 no `## Trigger` / `## Source` heading goes into the actual node.
 
@@ -135,7 +135,7 @@ load-bearing. Both forms describe the same underlying boundary —
 what survives in the node vs what stays in the source repo. The
 split is teaching emphasis, not a separate convention.
 
-**Trigger: PR adding a new caching layer.**
+**Trigger: PR/MR adding a new caching layer.**
 Belongs: "Service X owns the cache; other services read through Service
 X's SDK"; "we chose Redis over Memcached because of pubsub support".
 Does not belong: the cache key format, the eviction policy class, the
@@ -144,7 +144,7 @@ retry constants.
 **Trigger: meeting note "we are moving billing to a new repo".**
 Belongs: workspace map gets a new repo; ownership for billing shifts;
 the `billing/` ↔ `platform/` boundary is updated.
-Does not belong: migration timeline, release-day playbook, per-PR
+Does not belong: migration timeline, release-day playbook, per-PR/MR
 checklist.
 
 **Trigger: a reviewer's nit about variable naming.**
@@ -199,7 +199,7 @@ Does not belong: "option A was considered and rejected because…" as
 historical narration. Phrase the surviving constraint, not the
 past-tense rejection.
 
-**Trigger: PR that flips a policy default — e.g. "approvals required"
+**Trigger: PR/MR that flips a policy default — e.g. "approvals required"
 goes from 1 to 0.**
 Belongs: the *current* rule stated as fact ("approvals required = 0");
 the *current* rationale (why 0 is the right number now), present-tense.
@@ -210,21 +210,21 @@ the new current state. The old state stays only in `git log` (and
 any raw-archive domain your tree may have).
 
 **Trigger: an existing tree node already carries a `## Source`
-section that lists the PRs which delivered the decision.**
+section that lists the PRs/MRs which delivered the decision.**
 Pattern: the `## Source` body section is forbidden, but the section often
 hides *substantive* content — open
 follow-ups, known gaps, deferred items, surviving rationale — that
-was tacked onto the bottom of the PR audit trail. Do not just
+was tacked onto the bottom of the PR/MR audit trail. Do not just
 delete the section.
-- *Delete*: the PR-id list, the "Shipped in #X" / "Landed in #Y"
-  annotations, the "PR-by-PR audit trail" framing.
-- *Move to a GitHub Issue*: any actionable work item the section
+- *Delete*: the PR/MR-id list, the "Shipped in #X" / "Landed in #Y"
+  annotations, the review-request audit-trail framing.
+- *Move to a forge Issue*: any actionable work item the section
   carried (a pending fix, a deferred migration, an unresolved
   question, a known gap) — open a present-tense Issue in the
-  relevant repo, dropping the PR id. Active tree nodes do not
-  carry `## Work` or `## Future Work` sections; actionable work
-  lives in Issues (see the team-practice node for the team's own
-  rule on this).
+  relevant repo with its matching CLI (`gh` for GitHub, `glab` for GitLab),
+  dropping the PR/MR id. Active tree nodes do not carry `## Work` or
+  `## Future Work` sections; actionable work lives in Issues (see the
+  team-practice node for the team's own rule on this).
 - *Fold into body sections*: any current-state architectural fact
   (e.g. "the rollback path lives at X") or surviving rationale
   (e.g. "we chose Postgres because the team was familiar with it")

--- a/skills/first-tree-write/SKILL.md
+++ b/skills/first-tree-write/SKILL.md
@@ -27,6 +27,8 @@ Writing is source-driven. Acceptable sources include:
 
 If no concrete source artifact exists, stop and ask for one. Do not invent
 ad-hoc tree edits from memory or from a broad request like "update the tree".
+When the source repo or issue lives on GitHub or GitLab, choose the matching
+forge CLI (`gh` or `glab`) and use PR/MR language accordingly.
 
 Implementation-only material usually produces no tree write. Refactors,
 function signatures, API shapes, request/response examples, build config,
@@ -58,7 +60,7 @@ relationship.
    cross-domain reader needs navigation.
 6. **Verify.** Run `first-tree tree verify --tree-path <tree>` before commit.
    Non-zero exit blocks the PR.
-7. **Prepare the PR.** One source artifact maps to one tree PR. Keep the PR
+7. **Prepare the PR/MR.** One source artifact maps to one tree PR/MR. Keep the PR/MR
    description focused on the source and the tree nodes changed; do not put PR
    IDs, source links, or audit trails into node bodies.
 
@@ -70,7 +72,7 @@ relationship.
   not the implementation.
 - **No history.** Nodes state what is true now and why. Past states live in
   `git log` and non-normal archive/supporting material, not normal nodes.
-- **No Source section.** Do not add `## Source`, `Shipped in #123`, inline PR
+- **No Source section.** Do not add `## Source`, `Shipped in #123`, inline PR/MR
   citations, or delivery-history prose to node bodies.
 - **No actionable future work in normal nodes.** Put follow-up work in an
   issue, source artifact, or human decision.
@@ -248,6 +250,6 @@ writing is small. Today only one command is operationally required:
 A simplified CLI surface (a structural `list`, a `verify`, and an
 `upgrade`) is the design target; until that lands, map the tree with
 standard tooling (`ls`, `Read`, `Grep`) and rely on `tree verify` as
-the write gate. Everything else (opening PRs, fetching code, reading
+the write gate. Everything else (opening PRs/MRs, fetching code, reading
 the workspace binding) goes through standard tools (`git`, `gh`,
-`Read`, etc.).
+`glab`, `Read`, etc.).


### PR DESCRIPTION
## Summary
- add GitLab / `glab` guidance alongside GitHub / `gh` guidance in repo-local skills
- keep current GitHub-only product surfaces explicit, including First Tree tracker, GitHub App coverage, `/settings/github`, and `first-tree github follow`
- update skill eval floor tests for the new forge-neutral language

## Verification
- `git diff --check`
- YAML parsing
- `pnpm typecheck`
- `@first-tree/skill-evals` typecheck
- full skill-evals: 253 tests passed
- Biome on tracked files passed

## Notes
- `first-tree tree init`, GitHub App coverage, and live follow remain documented as GitHub-only based on current product capabilities.
- The worktree still has an unrelated untracked `.pi/` directory that was not staged or committed.