### PR TITLE
release: bump apps/cli to v0.5.14

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

- Bump the source-tree CLI version from `0.5.13` to `0.5.14`.
- Keep the source package identity as `first-tree-dev`; CI remains responsible for the production package rewrite and trusted publish.
- Reserve the matching stable release coordinate `v0.5.14`.

## Draft GitHub Release

**Title:** `v0.5.14 — Production mobile, Cursor runtime, pinned chats, stricter Context Trees`

### Draft release notes

## Highlights

- Bring the mobile workspace to production, including add-to-home-screen guidance and touch-first chat, triage, and picker improvements.
- Add the external Cursor Agent CLI as a supported runtime provider, with in-product setup, session resume, authentication handling, and replay-safe failure recovery.
- Prioritize conversations with attention and private pinned groups, activity-based ordering, richer filters, and cross-device pin synchronization.
- Let agents send workspace images through `chat send`, with improved image sizing, galleries, and a full-screen lightbox.
- Add agent-scoped Context Tree bindings, strict structural validation, generated governance guidance, and stronger GitHub/GitLab forge setup workflows.

## Notable fixes

- Install Linux daemon services in system scope when the CLI runs as root, while preserving user-scoped systemd behavior for normal users.
- Route user-requested issues and pull requests to the repository the work belongs to instead of accidentally defaulting to First Tree's tracker.
- Improve iOS standalone sizing, mobile card previews, install-guide copy, and narrow-screen timeline layouts.

## Compatibility

- Context Tree validation is now strict and always on. Trees with malformed metadata, unsafe symlinks, invalid `soft_links`, or cross-content-class links must be repaired before their next tree PR can pass.

## Release preflight

- Base commit: `a329276d3b2c68f195f9fb2ae84d32ed43787e62` (`origin/main`).
- Current source and production npm version: `0.5.13`; current staging line: `0.5.14-staging.*`.
- Confirmed absent before this PR: remote tag `v0.5.14`, GitHub Release `v0.5.14`, npm package `first-tree@0.5.14`, and remote release branch.
- Main CI, Docker, and staging npm publish are green for the base commit.
- Database review note: this release range includes migration `0076_lazy_risque.sql` for private chat pins and activity ordering. It runs transactionally on boot, backfills `chats.activity_at`, creates two indexes, and briefly holds an `ACCESS EXCLUSIVE` lock on `chats`; the merged PR reports sub-second runtime at the current table size and full rollback on failure.

## Verification

- `pnpm install --frozen-lockfile` — passed.
- `pnpm check` — passed with the repository's existing 2 warnings and 1 informational diagnostic.
- `pnpm typecheck` — passed (10/10 tasks).
- `git diff --check` — passed.
- `pnpm test` — attempted. The run hit known environment/concurrency failures unrelated to the one-line version bump: the existing mobile-density parallel flake and client-switch fail-closed process detection inside a running First Tree workspace. The mobile-density file passed standalone (3/3); the base commit's GitHub CI is green.

## Post-merge

1. Resolve the release PR merge commit and wait for main CI, Docker, and npm staging workflows.
2. Reconcile these draft notes against the final merged range.
3. Obtain maintainer confirmation of the exact version, tag, target SHA, release title, and release body.
4. Create GitHub Release `v0.5.14` at that exact SHA and verify production npm, portable assets, and Docker publishing.
