### PR TITLE
release: bump apps/cli to v0.5.15

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

- Bump the source-tree CLI version from `0.5.14` to `0.5.15`.
- Keep the source package identity as `first-tree-dev`; CI remains responsible for the production package rewrite and trusted publish.
- Reserve the matching stable release coordinate `v0.5.15` for the two fixes merged after `v0.5.14`.

## Draft GitHub Release

**Title:** `v0.5.15 — Stable agent briefings and focused mobile chat cards`

### Draft release notes

## Highlights

- Keep the full agent briefing checked in and session-stable across runtimes, with compact GitHub and GitLab guidance available without per-session capability drift.

## Notable fixes

- Preserve correct GitHub issue and pull-request routing while simplifying GitLab operations around native `glab` guidance instead of a bundled GitLab skill.
- Restore mobile Chat to compact conversation rows and remove unintended management gestures and controls from mobile Now and Chat cards that could stretch rows or expose unsupported actions.

## Release preflight

- Base commit: `ae321d5ab28688c0c31e3738381b9552e2e60ab2` (`origin/main`).
- Release range after `v0.5.14`: PR #1777 (`079f724d`) and PR #1757 (`ae321d5a`).
- Current source and production npm version: `0.5.14`; current staging version: `0.5.15-staging.859.1`.
- Confirmed absent before this PR: remote tag `v0.5.15`, GitHub Release `v0.5.15`, npm package `first-tree@0.5.15`, and remote release branch.
- Main CI, Docker, and staging npm/portable publishing are green for the base commit.
- This release range has no database migration, schema change, or persisted core-data-structure change.
- Durable context reconciliation is complete: [`first-tree-context#743`](https://github.com/agent-team-foundation/first-tree-context/pull/743) records the final GitLab briefing/provider-attention contract and merged at `4ae7aad93cb8d741105fade9bbc65437303e5597`; the mobile boundary was already reconciled by `first-tree-context#742`.
- PR #1757 changes the runtime briefing/boot path. Its deterministic coverage and main CI are green; its earlier selected live eval attempt was blocked by provider HTTP 401 before a model turn, and formal cross-surface QA has not been run.

## Verification

- `pnpm install --frozen-lockfile` — passed.
- `pnpm check` — passed with the repository's existing 2 warnings and 1 informational diagnostic.
- `pnpm typecheck` — passed (10/10 tasks).
- `git diff --check` — passed.
- `pnpm test` — one unrelated `@first-tree/skill-evals` provider test exceeded its 5-second timeout under the full concurrent Turbo run; the same file passed immediately in isolation (4/4 tests, 1.18 seconds). The base commit's GitHub CI is green, and this PR's CI will rerun the complete gate.

## Post-merge

1. Resolve the release PR merge commit and wait for main CI, Docker, and staging npm/portable publishing.
2. Reconcile these notes against the final merged range.
3. Obtain maintainer confirmation of the exact version, tag, target SHA, release title, and release body.
4. Create GitHub Release `v0.5.15` at that exact SHA and verify production npm, portable assets, Docker publishing, and the website changelog rebuild.
