### PR TITLE
fix(web): show full computer client versions

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1906,7 +1906,9 @@
   width: 5rem;
 }
 .team-computers-table th:nth-child(4) {
-  width: 6rem;
+  /* Keep the channel/build suffix visible for staging versions such as
+     `0.5.14-staging.841.1`; it is part of the release identity. */
+  width: 12rem;
 }
 .team-computers-table th:nth-child(5) {
   width: 5.5rem;

--- a/packages/web/src/pages/clients.tsx
+++ b/packages/web/src/pages/clients.tsx
@@ -730,16 +730,6 @@ function TeamGroupRow({ label, count, attention = false }: { label: string; coun
 }
 
 /**
- * Trim the build/channel suffix ("0.5.14-staging.841.1" → "0.5.14"). The
- * major.minor.patch is the version signal an admin scans for; the build
- * number is noise on an audit line. The full string stays in the `title`.
- */
-function shortVersion(version: string): string {
-  const dash = version.indexOf("-");
-  return dash === -1 ? version : version.slice(0, dash);
-}
-
-/**
  * Row-status view for a stuck self-update, shown *in place of* the `Ready`
  * pill when the machine is otherwise ready but its last update failed/blocked
  * — so a stuck machine never reads as plain `Ready`. The reason (npm error,
@@ -786,7 +776,7 @@ function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel
   const metaParts: { label: string; value: string }[] = [
     { label: "Owner", value: ownerLabel.text },
     ...(client.os ? [{ label: "OS", value: client.os }] : []),
-    ...(version ? [{ label: "First Tree", value: shortVersion(version) }] : []),
+    ...(version ? [{ label: "First Tree", value: version }] : []),
   ];
   const metaTitle = [ownerFull, client.os, version].filter(Boolean).join(" · ");
   return (
@@ -820,7 +810,7 @@ function TeamComputerRow({ client, ownerLabel }: { client: HubClient; ownerLabel
         style={{ color: "var(--fg-3)" }}
         title={version ?? undefined}
       >
-        {version ? shortVersion(version) : "—"}
+        {version ?? "—"}
       </td>
       <td
         className="team-cell--num text-caption tnum"

--- a/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/clients-page-cards-dom.test.tsx
@@ -52,6 +52,7 @@ vi.mock("../../../lib/visibility-interval.js", () => ({
 }));
 
 const NOW = "2026-05-28T12:00:00.000Z";
+const STAGING_CLIENT_VERSION = "0.5.14-staging.841.1";
 const STAGING_INSTALLER_URL = "https://download.first-tree.ai/releases/staging/install.sh";
 const stagingBootstrapCommand = (token: string): string =>
   `curl -fsSL ${STAGING_INSTALLER_URL} | sh\n~/.local/bin/first-tree-staging login ${token}`;
@@ -166,6 +167,7 @@ const TEAM = client({
   userId: "user-alice",
   hostname: "alice-linux",
   os: "linux",
+  sdkVersion: STAGING_CLIENT_VERSION,
   agentCount: 1,
 });
 // Connected + OK runtime (pill = Ready) but its self-update failed — must
@@ -489,6 +491,9 @@ describe("ClientsPage computer cards", () => {
       [...(teamTable?.querySelectorAll("tr.team-computer-row") ?? [])].find((tr) =>
         tr.querySelector('th[scope="row"]')?.textContent?.includes(hostname),
       );
+    const stagingRow = findRow("alice-linux");
+    expect(stagingRow?.querySelector(".team-computer-row__col-ver")?.textContent).toBe(STAGING_CLIENT_VERSION);
+    expect(stagingRow?.querySelector(".team-computer-row__meta")?.textContent).toContain(STAGING_CLIENT_VERSION);
     expect(findRow("diana-box")?.querySelector(".team-computer-row__col-owner")?.getAttribute("title")).toBe(
       LONG_OWNER_NAME,
     );


### PR DESCRIPTION
## Summary

- render the full server-reported First Tree version in Team computers
- widen the version column so staging release identities remain visible
- cover full staging prerelease versions in the Computers DOM test

## Testing

- `pnpm check`
- `pnpm exec turbo run typecheck --concurrency=2`
- `pnpm exec turbo run test --concurrency=1 -- --maxWorkers=2`
- `pnpm --dir packages/web exec vitest run src/pages/clients/__tests__/clients-page-cards-dom.test.tsx --maxWorkers=2`
