### PR TITLE
fix: scope Context review merge policy

### DIFF
--- a/packages/skill-evals/src/suites/context-tree-review/__tests__/floor.test.ts
+++ b/packages/skill-evals/src/suites/context-tree-review/__tests__/floor.test.ts
@@ -41,6 +41,8 @@ describe("context-tree-review floor", () => {
     expect(skill).toContain("first-tree github context-review submit");
     expect(skill).toContain('--run "$CONTEXT_REVIEW_RUN_ID"');
     expect(skill).toContain("Never call local `gh api .../reviews`");
+    expect(skill).toContain("The review workflow does not depend on");
+    expect(skill).toContain("strict per-head merge gate");
     expect(cloud).toContain("context-tree-review");
     expect(cloud).not.toContain("gh pr review");
     expect(cloud).not.toContain("tree verify");

--- a/skills/context-tree-review/SKILL.md
+++ b/skills/context-tree-review/SKILL.md
@@ -162,9 +162,11 @@ review`, or another GitHub write as a fallback.
 GitHub does not provide a current-head compare-and-set for review creation. If
 a new push lands after the final view, Cloud may accept a review bound only to
 the inspected old commit; report that exact reviewed commit and let the
-synchronize event create a fresh run. Repository governance must dismiss stale
-approvals (or provide an equivalent current-head rule); this skill neither
-changes nor guarantees that policy.
+synchronize event create a fresh run. The review workflow does not depend on
+repository merge-policy settings. If the repository treats App approval as a
+strict per-head merge gate, its governance must dismiss stale approvals on
+push or provide an equivalent current-head rule; this skill neither changes
+nor guarantees that policy.
 
 Permission upgrade, missing installation/repository access, stale head,
 invalid run/session, and unknown GitHub delivery all fail closed. Never retry


### PR DESCRIPTION
## Summary

- Clarify that the Context Review workflow runs independently of repository merge-policy settings.
- Require stale-approval dismissal or equivalent current-head protection only when a repository uses App approval as a strict per-head merge gate.
- Keep repository ruleset ownership outside the review skill and lock the conditional contract with a static floor test.

## Rationale

The review workflow always binds its verdict to the inspected commit and reruns on `synchronize`. Repository owners may still choose merge rules under which an older approval remains merge-eligible while a new head is being reviewed. That choice weakens the merge gate but does not make Context Review unsupported, so the shipped skill must not describe stale dismissal as an unconditional runtime prerequisite.

This reconciles the shipped skill with the post-merge governance decision being recorded in draft Context Tree PR https://github.com/agent-team-foundation/first-tree-context/pull/733.

## Validation

- Focused Context Review floor: 3/3
- `pnpm validate:skill`: 6/6
- `git diff --check`

The expensive live/model skill eval was not run for this wording-only contract correction.
