### PR TITLE
fix: retry transient provider failures after visible output

### DIFF
--- a/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
@@ -16,6 +16,9 @@ const mockState = vi.hoisted(() => ({
   promptAppend: "",
   configModel: "",
   setModelCalls: 0,
+  throwQueryOnCall: 0,
+  closeCalls: [] as number[],
+  lifecycleEvents: [] as string[],
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => {
@@ -35,6 +38,9 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
     query: (args: { prompt: AsyncIterable<{ message?: { content?: unknown } }> }) => {
       mockState.queryCalls += 1;
       const attempt = mockState.queryCalls;
+      if (attempt === mockState.throwQueryOnCall) {
+        throw new Error("config restart query construction failed");
+      }
       const messages = (mockState.messagesByAttempt[attempt - 1] ?? mockState.nextMessages).slice();
       void drainPrompt(args.prompt, attempt);
       return {
@@ -51,7 +57,10 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
             },
           };
         },
-        close: () => {},
+        close: () => {
+          mockState.closeCalls.push(attempt);
+          mockState.lifecycleEvents.push(`close:${attempt}`);
+        },
         setModel: async () => {
           mockState.setModelCalls += 1;
         },
@@ -84,6 +93,9 @@ beforeEach(() => {
   mockState.promptAppend = "";
   mockState.configModel = "";
   mockState.setModelCalls = 0;
+  mockState.throwQueryOnCall = 0;
+  mockState.closeCalls.length = 0;
+  mockState.lifecycleEvents.length = 0;
 });
 
 function buildCache() {
@@ -134,6 +146,12 @@ async function startSingleResultTurn() {
   const emitted: SessionEvent[] = [];
   const completed: Array<{ count: number; outcome: TurnOutcome }> = [];
   const logs: string[] = [];
+  const retryTurn = vi.fn<SessionContext["retryTurn"]>(() => {
+    mockState.lifecycleEvents.push("retry:entered");
+  });
+  const failSessionForRecovery = vi.fn<NonNullable<SessionContext["failSessionForRecovery"]>>(() => {
+    mockState.lifecycleEvents.push("fatal");
+  });
 
   const cache = buildCache();
   await cache.refresh(AGENT_ID);
@@ -156,6 +174,8 @@ async function startSingleResultTurn() {
     emitEvent: (e) => emitted.push(e),
     ...mockCtxPlumbing({ sendMessage }, "chat-claude-provider-error"),
     forwardResult,
+    retryTurn,
+    failSessionForRecovery,
     finishTurn: async (messages, outcome) => {
       completed.push({ count: Array.isArray(messages) ? messages.length : 1, outcome });
     },
@@ -173,7 +193,7 @@ async function startSingleResultTurn() {
     ctx,
   );
 
-  return { handler, cache, sendMessage, forwardResult, emitted, completed, logs };
+  return { handler, cache, sendMessage, forwardResult, emitted, completed, logs, retryTurn, failSessionForRecovery };
 }
 
 async function runSingleResultTurn() {
@@ -481,6 +501,88 @@ describe("claude-code handler — structured provider error result", () => {
       expect(result.logs.some((line) => line.includes("[configHotSwitch] path=restart"))).toBe(true);
 
       await result.handler.suspend();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns custody to session recovery when a config restart fails after cancelling backoff", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    mockState.messagesByAttempt = [
+      [
+        {
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "I started working on this." }],
+          },
+        },
+        {
+          type: "result",
+          subtype: "success",
+          is_error: true,
+          api_error_status: 503,
+          result: TRANSIENT_RESULT,
+        },
+      ],
+    ];
+    mockState.throwQueryOnCall = 2;
+
+    try {
+      const result = await startSingleResultTurn();
+      await waitForCondition(() => providerRetryPayloads(result.emitted).length === 1, "scheduled retry");
+
+      mockState.configVersion = 2;
+      mockState.promptAppend = "updated prompt";
+      await result.cache.refresh(AGENT_ID);
+
+      const processingStarted = vi.fn();
+      const retry = vi.fn(() => {
+        mockState.lifecycleEvents.push("retry:tail");
+      });
+      result.handler.inject(
+        {
+          id: "m2",
+          chatId: "chat-claude-provider-error",
+          senderId: "user-1",
+          format: "text",
+          content: "continue with the updated config",
+          metadata: null,
+        },
+        {
+          processingStarted,
+          complete: vi.fn().mockResolvedValue(undefined),
+          retry,
+          terminalRejected: vi.fn().mockResolvedValue(undefined),
+        },
+      );
+
+      await waitForCondition(() => retry.mock.calls.length === 1, "tail recovery");
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(mockState.queryCalls).toBe(2);
+      expect(mockState.closeCalls).toEqual([1]);
+      expect(processingStarted).not.toHaveBeenCalled();
+      expect(retry).toHaveBeenCalledOnce();
+      expect(retry).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "m2" }),
+        "claude_config_restart_failed_recovery",
+      );
+      expect(result.retryTurn).toHaveBeenCalledOnce();
+      expect(result.retryTurn).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "m1" }),
+        "claude_config_restart_failed_recovery",
+      );
+      expect(result.completed).toHaveLength(0);
+      expect(result.failSessionForRecovery).toHaveBeenCalledOnce();
+      expect(result.failSessionForRecovery).toHaveBeenCalledWith("claude_config_restart_failed", expect.any(String));
+      expect(result.logs).toContain("Auto-resume cancelled during provider retry backoff");
+      expect(result.logs).toContain("maybeSwitchConfig errored: config restart query construction failed");
+      expect(mockState.lifecycleEvents).toEqual(["close:1", "retry:tail", "retry:entered", "fatal"]);
+
+      await result.handler.suspend();
+      expect(mockState.closeCalls).toEqual([1]);
+      expect(retry).toHaveBeenCalledOnce();
+      expect(result.retryTurn).toHaveBeenCalledOnce();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
@@ -235,7 +235,7 @@ describe("claude-code handler — structured provider error result", () => {
     });
   });
 
-  it("does not replay a transient structured failure after assistant text was emitted", async () => {
+  it("retries a transient structured failure after assistant text was emitted", async () => {
     mockState.nextMessages = [
       {
         type: "assistant",
@@ -253,18 +253,30 @@ describe("claude-code handler — structured provider error result", () => {
     ];
     const { sendMessage, forwardResult, emitted, completed } = await runSingleResultTurn();
 
-    expect(mockState.queryCalls).toBe(1);
+    expect(mockState.queryCalls).toBe(3);
     expect(forwardResult).not.toHaveBeenCalled();
     expect(sendMessage).not.toHaveBeenCalled();
     expect(emitted.some((event) => event.kind === "assistant_text")).toBe(true);
 
     const providerPayloads = providerRetryPayloads(emitted);
+    expect(providerPayloads).toHaveLength(3);
     expect(providerPayloads[0]).toMatchObject({
-      event: "provider_failure_terminal",
+      event: "provider_retry_scheduled",
       provider: "claude-code",
       scope: "provider_turn",
       category: "transient_transport",
-      reasonCode: "unsafe_replay",
+      attempt: 1,
+      replaySafety: "user_visible",
+    });
+    expect(providerPayloads[1]).toMatchObject({
+      event: "provider_retry_scheduled",
+      category: "transient_transport",
+      attempt: 2,
+      replaySafety: "user_visible",
+    });
+    expect(providerPayloads[2]).toMatchObject({
+      event: "provider_retry_exhausted",
+      category: "transient_transport",
       replaySafety: "user_visible",
     });
     expect(formatProviderFailureRuntimeNotice(firstProviderPayload(providerPayloads))).toContain(
@@ -274,7 +286,7 @@ describe("claude-code handler — structured provider error result", () => {
       status: "error",
       terminal: true,
       completion: "consumed",
-      reason: "unsafe_replay",
+      reason: "provider_retry_exhausted",
     });
   });
 

--- a/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
@@ -2,15 +2,20 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type ProviderRetryEventPayload, parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const BILLING_RESULT = "Failed to authenticate. API Error: 403 Insufficient account balance.";
 const TRANSIENT_RESULT =
   "API Error: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()";
 const mockState = vi.hoisted(() => ({
   nextMessages: [] as unknown[],
+  messagesByAttempt: [] as unknown[][],
   queryCalls: 0,
   observedInputMessages: [] as Array<{ attempt: number; content: string }>,
+  configVersion: 1,
+  promptAppend: "",
+  configModel: "",
+  setModelCalls: 0,
 }));
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => {
@@ -30,7 +35,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
     query: (args: { prompt: AsyncIterable<{ message?: { content?: unknown } }> }) => {
       mockState.queryCalls += 1;
       const attempt = mockState.queryCalls;
-      const messages = mockState.nextMessages.slice();
+      const messages = (mockState.messagesByAttempt[attempt - 1] ?? mockState.nextMessages).slice();
       void drainPrompt(args.prompt, attempt);
       return {
         [Symbol.asyncIterator]() {
@@ -47,7 +52,9 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => {
           };
         },
         close: () => {},
-        setModel: async () => {},
+        setModel: async () => {
+          mockState.setModelCalls += 1;
+        },
       };
     },
   };
@@ -71,12 +78,26 @@ afterAll(() => {
   rmSync(workspaceRoot, { recursive: true, force: true });
 });
 
+beforeEach(() => {
+  mockState.messagesByAttempt.length = 0;
+  mockState.configVersion = 1;
+  mockState.promptAppend = "";
+  mockState.configModel = "";
+  mockState.setModelCalls = 0;
+});
+
 function buildCache() {
   const stubSdk = {
     fetchAgentConfig: async () => ({
       agentId: AGENT_ID,
-      version: 1,
-      payload: { prompt: { append: "" }, model: "", mcpServers: [], env: [], gitRepos: [] },
+      version: mockState.configVersion,
+      payload: {
+        prompt: { append: mockState.promptAppend },
+        model: mockState.configModel,
+        mcpServers: [],
+        env: [],
+        gitRepos: [],
+      },
       updatedAt: new Date().toISOString(),
       updatedBy: "test",
     }),
@@ -152,7 +173,7 @@ async function startSingleResultTurn() {
     ctx,
   );
 
-  return { handler, sendMessage, forwardResult, emitted, completed, logs };
+  return { handler, cache, sendMessage, forwardResult, emitted, completed, logs };
 }
 
 async function runSingleResultTurn() {
@@ -354,6 +375,112 @@ describe("claude-code handler — structured provider error result", () => {
       expect(mockState.queryCalls).toBe(1);
       expect(result.logs).toContain("Auto-resume cancelled during provider retry backoff");
       expect(result.completed).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retires a pending retry consumer before a config restart takes ownership", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    mockState.messagesByAttempt = [
+      [
+        {
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "I started working on this." }],
+          },
+        },
+        {
+          type: "result",
+          subtype: "success",
+          is_error: true,
+          api_error_status: 503,
+          result: TRANSIENT_RESULT,
+        },
+      ],
+      [],
+    ];
+
+    try {
+      const result = await startSingleResultTurn();
+      await waitForCondition(() => providerRetryPayloads(result.emitted).length === 1, "scheduled retry");
+
+      mockState.configVersion = 2;
+      mockState.promptAppend = "updated prompt";
+      await result.cache.refresh(AGENT_ID);
+      result.handler.inject({
+        id: "m2",
+        chatId: "chat-claude-provider-error",
+        senderId: "user-1",
+        format: "text",
+        content: "continue with the updated config",
+        metadata: null,
+      });
+
+      await waitForCondition(() => mockState.queryCalls === 2, "config restart query");
+      await waitForCondition(
+        () => result.logs.includes("Auto-resume cancelled during provider retry backoff"),
+        "stale retry consumer cancellation",
+      );
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(mockState.queryCalls).toBe(2);
+      expect(result.completed).toHaveLength(0);
+      expect(result.logs.some((line) => line.includes("[configHotSwitch] path=restart"))).toBe(true);
+
+      await result.handler.suspend();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips an in-flight same-family model switch while retry backoff owns the turn", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    mockState.configModel = "claude-opus-4-5";
+    mockState.messagesByAttempt = [
+      [
+        {
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "I started working on this." }],
+          },
+        },
+        {
+          type: "result",
+          subtype: "success",
+          is_error: true,
+          api_error_status: 503,
+          result: TRANSIENT_RESULT,
+        },
+      ],
+      [],
+    ];
+
+    try {
+      const result = await startSingleResultTurn();
+      await waitForCondition(() => providerRetryPayloads(result.emitted).length === 1, "scheduled retry");
+
+      mockState.configVersion = 2;
+      mockState.configModel = "claude-opus-4-6";
+      await result.cache.refresh(AGENT_ID);
+      result.handler.inject({
+        id: "m2",
+        chatId: "chat-claude-provider-error",
+        senderId: "user-1",
+        format: "text",
+        content: "continue with the new model",
+        metadata: null,
+      });
+
+      await waitForCondition(() => mockState.queryCalls === 2, "config restart query");
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(mockState.setModelCalls).toBe(0);
+      expect(mockState.queryCalls).toBe(2);
+      expect(result.completed).toHaveLength(0);
+      expect(result.logs.some((line) => line.includes("[configHotSwitch] path=restart"))).toBe(true);
+
+      await result.handler.suspend();
     } finally {
       vi.useRealTimers();
     }

--- a/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
+++ b/packages/client/src/__tests__/claude-code-provider-error-result.test.ts
@@ -97,7 +97,15 @@ function firstProviderPayload(payloads: readonly ProviderRetryEventPayload[]): P
   return payload;
 }
 
-async function runSingleResultTurn() {
+async function waitForCondition(predicate: () => boolean, description: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error(`timed out waiting for ${description}`);
+}
+
+async function startSingleResultTurn() {
   mockState.queryCalls = 0;
   mockState.observedInputMessages.length = 0;
   const sendMessage = vi.fn().mockResolvedValue(undefined);
@@ -143,10 +151,16 @@ async function runSingleResultTurn() {
     },
     ctx,
   );
-  await handler.suspend();
+
+  return { handler, sendMessage, forwardResult, emitted, completed, logs };
+}
+
+async function runSingleResultTurn() {
+  const result = await startSingleResultTurn();
+  await result.handler.suspend();
   await new Promise((r) => setImmediate(r));
 
-  return { sendMessage, forwardResult, emitted, completed, logs };
+  return result;
 }
 
 describe("claude-code handler — structured provider error result", () => {
@@ -236,6 +250,7 @@ describe("claude-code handler — structured provider error result", () => {
   });
 
   it("retries a transient structured failure after assistant text was emitted", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     mockState.nextMessages = [
       {
         type: "assistant",
@@ -251,43 +266,97 @@ describe("claude-code handler — structured provider error result", () => {
         result: TRANSIENT_RESULT,
       },
     ];
-    const { sendMessage, forwardResult, emitted, completed } = await runSingleResultTurn();
+    try {
+      const result = await startSingleResultTurn();
+      await waitForCondition(() => providerRetryPayloads(result.emitted).length === 1, "first scheduled retry");
 
-    expect(mockState.queryCalls).toBe(3);
-    expect(forwardResult).not.toHaveBeenCalled();
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(emitted.some((event) => event.kind === "assistant_text")).toBe(true);
+      expect(mockState.queryCalls).toBe(1);
+      await vi.advanceTimersByTimeAsync(499);
+      expect(mockState.queryCalls).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await waitForCondition(() => mockState.queryCalls === 2, "second provider attempt");
 
-    const providerPayloads = providerRetryPayloads(emitted);
-    expect(providerPayloads).toHaveLength(3);
-    expect(providerPayloads[0]).toMatchObject({
-      event: "provider_retry_scheduled",
-      provider: "claude-code",
-      scope: "provider_turn",
-      category: "transient_transport",
-      attempt: 1,
-      replaySafety: "user_visible",
-    });
-    expect(providerPayloads[1]).toMatchObject({
-      event: "provider_retry_scheduled",
-      category: "transient_transport",
-      attempt: 2,
-      replaySafety: "user_visible",
-    });
-    expect(providerPayloads[2]).toMatchObject({
-      event: "provider_retry_exhausted",
-      category: "transient_transport",
-      replaySafety: "user_visible",
-    });
-    expect(formatProviderFailureRuntimeNotice(firstProviderPayload(providerPayloads))).toContain(
-      "provider API connection failed after retry handling",
-    );
-    expect(completed[0]?.outcome).toMatchObject({
-      status: "error",
-      terminal: true,
-      completion: "consumed",
-      reason: "provider_retry_exhausted",
-    });
+      await waitForCondition(() => providerRetryPayloads(result.emitted).length === 2, "second scheduled retry");
+      await vi.advanceTimersByTimeAsync(1499);
+      expect(mockState.queryCalls).toBe(2);
+      await vi.advanceTimersByTimeAsync(1);
+      await waitForCondition(() => mockState.queryCalls === 3, "third provider attempt");
+      await waitForCondition(() => result.completed.length === 1, "retry exhaustion settlement");
+
+      await result.handler.suspend();
+      const { sendMessage, forwardResult, emitted, completed } = result;
+
+      expect(mockState.queryCalls).toBe(3);
+      expect(forwardResult).not.toHaveBeenCalled();
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(emitted.some((event) => event.kind === "assistant_text")).toBe(true);
+
+      const providerPayloads = providerRetryPayloads(emitted);
+      expect(providerPayloads).toHaveLength(3);
+      expect(providerPayloads[0]).toMatchObject({
+        event: "provider_retry_scheduled",
+        provider: "claude-code",
+        scope: "provider_turn",
+        category: "transient_transport",
+        attempt: 1,
+        replaySafety: "user_visible",
+      });
+      expect(providerPayloads[1]).toMatchObject({
+        event: "provider_retry_scheduled",
+        category: "transient_transport",
+        attempt: 2,
+        replaySafety: "user_visible",
+      });
+      expect(providerPayloads[2]).toMatchObject({
+        event: "provider_retry_exhausted",
+        category: "transient_transport",
+        replaySafety: "user_visible",
+      });
+      expect(formatProviderFailureRuntimeNotice(firstProviderPayload(providerPayloads))).toContain(
+        "provider API connection failed after retry handling",
+      );
+      expect(completed[0]?.outcome).toMatchObject({
+        status: "error",
+        terminal: true,
+        completion: "consumed",
+        reason: "provider_retry_exhausted",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels a pending provider retry backoff when the session is suspended", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    mockState.nextMessages = [
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "I started working on this." }],
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        api_error_status: 503,
+        result: TRANSIENT_RESULT,
+      },
+    ];
+
+    try {
+      const result = await startSingleResultTurn();
+      await waitForCondition(() => providerRetryPayloads(result.emitted).length === 1, "scheduled retry");
+
+      await result.handler.suspend();
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(mockState.queryCalls).toBe(1);
+      expect(result.logs).toContain("Auto-resume cancelled during provider retry backoff");
+      expect(result.completed).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps assistant billing_error as the primary classification for a generic 403 result", async () => {

--- a/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
+++ b/packages/client/src/__tests__/claude-code-stream-error-retry-replay.test.ts
@@ -55,9 +55,17 @@ function requiredInputsForAttempt(attempt: number): number {
 }
 
 async function waitForObservedInputs(attempt: number, count: number): Promise<void> {
-  const deadline = Date.now() + 1000;
+  const deadline = Date.now() + 3000;
   while (observedInputMessages.filter((message) => message.attempt === attempt).length < count) {
     if (Date.now() > deadline) throw new Error(`timed out waiting for attempt ${attempt} inputs`);
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+async function waitForCondition(predicate: () => boolean, description: string): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${description}`);
     await new Promise((resolve) => setImmediate(resolve));
   }
 }
@@ -153,6 +161,7 @@ function buildCache() {
 
 describe("claude-code handler — transient stream-error retry replays user message", () => {
   it("re-pushes the original prompt into the rebuilt InputController so the SDK isn't left idle", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     resetSdkMockState();
 
     const sendMessage = vi.fn().mockResolvedValue(undefined);
@@ -185,54 +194,79 @@ describe("claude-code handler — transient stream-error retry replays user mess
       },
     };
 
-    await handler.start(
-      {
-        id: "m1",
-        chatId: "chat-stream-retry",
-        senderId: "user-1",
-        format: "text",
-        content: ORIGINAL_PROMPT,
-        metadata: null,
-      },
-      ctx,
-    );
-    // suspend awaits `consumerDone` so the consumer loop runs through all
-    // retries and the eventual retry-exhausted ack before we assert.
-    await handler.suspend();
-    await new Promise((r) => setImmediate(r));
+    try {
+      await handler.start(
+        {
+          id: "m1",
+          chatId: "chat-stream-retry",
+          senderId: "user-1",
+          format: "text",
+          content: ORIGINAL_PROMPT,
+          metadata: null,
+        },
+        ctx,
+      );
+      await waitForCondition(
+        () => logs.filter((line) => line.includes("Attempting auto-resume")).length === 1,
+        "first scheduled stream retry",
+      );
 
-    // First retry must have been attempted — proves the catch path fired
-    // on the wrapped stream error.
-    expect(logs.some((l) => l.includes("Attempting auto-resume (retry 1/"))).toBe(true);
+      expect(attemptIdx).toBe(1);
+      await vi.advanceTimersByTimeAsync(499);
+      expect(attemptIdx).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await waitForObservedInputs(2, 1);
 
-    // The smoking gun: the rebuilt query (attempt 2) must have received
-    // a user message containing the original prompt. Pre-fix this was
-    // empty and the SDK subprocess hung idle.
-    const attempt2Inputs = observedInputMessages.filter((m) => m.attempt === 2);
-    expect(attempt2Inputs.length).toBeGreaterThan(0);
-    expect(attempt2Inputs.some((m) => m.content.includes(ORIGINAL_PROMPT))).toBe(true);
+      await waitForCondition(
+        () => logs.filter((line) => line.includes("Attempting auto-resume")).length === 2,
+        "second scheduled stream retry",
+      );
+      expect(attemptIdx).toBe(2);
+      await vi.advanceTimersByTimeAsync(1499);
+      expect(attemptIdx).toBe(2);
+      await vi.advanceTimersByTimeAsync(1);
+      await waitForObservedInputs(3, 1);
+      await waitForCondition(() => finishTurnCalled.mock.calls.length === 1, "stream retry exhaustion settlement");
 
-    // And the first attempt also saw the prompt (sanity check that the
-    // mock plumbing works at all).
-    const attempt1Inputs = observedInputMessages.filter((m) => m.attempt === 1);
-    expect(attempt1Inputs.some((m) => m.content.includes(ORIGINAL_PROMPT))).toBe(true);
+      // suspend awaits `consumerDone` after the retry-exhausted settlement.
+      await handler.suspend();
+      await new Promise((r) => setImmediate(r));
 
-    // After both retries fail transient (same wrapped API error every
-    // time), the handler must end in the retry-exhausted / permanent
-    // branch and ack — per PR #612 § "permanent → ack".
-    expect(finishTurnCalled).toHaveBeenCalledTimes(1);
+      // First retry must have been attempted — proves the catch path fired
+      // on the wrapped stream error.
+      expect(logs.some((l) => l.includes("Attempting auto-resume (retry 1/"))).toBe(true);
 
-    // A user-visible error must be surfaced on retry-exhaustion (so the
-    // chat timeline shows what happened), AND the turn must be closed
-    // with status:"error" so the frontend turn-grouping filter doesn't
-    // wait forever for the success boundary.
-    const errors = emitted.filter((e) => e.kind === "error");
-    expect(errors.some((e) => e.kind === "error" && e.payload.source === "sdk")).toBe(true);
-    const turnEnds = emitted.filter((e) => e.kind === "turn_end");
-    expect(turnEnds.length).toBeGreaterThan(0);
-    const lastTurnEnd = turnEnds[turnEnds.length - 1];
-    if (!lastTurnEnd || lastTurnEnd.kind !== "turn_end") throw new Error("expected turn_end event");
-    expect(lastTurnEnd.payload.status).toBe("error");
+      // The smoking gun: the rebuilt query (attempt 2) must have received
+      // a user message containing the original prompt. Pre-fix this was
+      // empty and the SDK subprocess hung idle.
+      const attempt2Inputs = observedInputMessages.filter((m) => m.attempt === 2);
+      expect(attempt2Inputs.length).toBeGreaterThan(0);
+      expect(attempt2Inputs.some((m) => m.content.includes(ORIGINAL_PROMPT))).toBe(true);
+
+      // And the first attempt also saw the prompt (sanity check that the
+      // mock plumbing works at all).
+      const attempt1Inputs = observedInputMessages.filter((m) => m.attempt === 1);
+      expect(attempt1Inputs.some((m) => m.content.includes(ORIGINAL_PROMPT))).toBe(true);
+
+      // After both retries fail transient (same wrapped API error every
+      // time), the handler must end in the retry-exhausted / permanent
+      // branch and ack — per PR #612 § "permanent → ack".
+      expect(finishTurnCalled).toHaveBeenCalledTimes(1);
+
+      // A user-visible error must be surfaced on retry-exhaustion (so the
+      // chat timeline shows what happened), AND the turn must be closed
+      // with status:"error" so the frontend turn-grouping filter doesn't
+      // wait forever for the success boundary.
+      const errors = emitted.filter((e) => e.kind === "error");
+      expect(errors.some((e) => e.kind === "error" && e.payload.source === "sdk")).toBe(true);
+      const turnEnds = emitted.filter((e) => e.kind === "turn_end");
+      expect(turnEnds.length).toBeGreaterThan(0);
+      const lastTurnEnd = turnEnds[turnEnds.length - 1];
+      if (!lastTurnEnd || lastTurnEnd.kind !== "turn_end") throw new Error("expected turn_end event");
+      expect(lastTurnEnd.payload.status).toBe("error");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("replays every provider-entered input in a coalesced transient retry", async () => {

--- a/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-auto-resume-fail.test.ts
@@ -143,6 +143,7 @@ function providerRetryPayloads(emitted: readonly SessionEvent[]): ProviderRetryE
 
 describe("claude-code handler — auto-resume failure surfacing", () => {
   it("emits error + turn_end:error and finishes the in-flight entry when respawnQuery throws", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     resetSdkMockState();
 
     const sendMessage = vi.fn().mockResolvedValue(undefined);
@@ -174,12 +175,19 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       },
     };
 
-    await handler.start(
-      { id: "m1", chatId: "chat-resume-fail", senderId: "u", format: "text", content: "hi", metadata: null },
-      ctx,
-    );
-    await handler.suspend();
-    await new Promise((r) => setImmediate(r));
+    try {
+      await handler.start(
+        { id: "m1", chatId: "chat-resume-fail", senderId: "u", format: "text", content: "hi", metadata: null },
+        ctx,
+      );
+      await waitForCondition("scheduled retry", () => providerRetryPayloads(emitted).length === 1);
+      await vi.advanceTimersByTimeAsync(5000);
+      await waitForCondition("auto-resume failure settlement", () => providerRetryPayloads(emitted).length === 2);
+      await handler.suspend();
+      await new Promise((r) => setImmediate(r));
+    } finally {
+      vi.useRealTimers();
+    }
 
     const errors = emitted.filter(
       (e) => e.kind === "error" && parseProviderRetryEventMessage(e.payload.message) === null,
@@ -226,6 +234,7 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
   });
 
   it("redacts and truncates auto-resume terminal provider previews", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     resetSdkMockState();
     initialCrashMessage = `initial sdk transport crash Authorization: Bearer ${RAW_TOKEN} ${"x".repeat(1200)}`;
     respawnFailureMessage = `respawn build failed: sdk module unavailable api_key=${RAW_TOKEN} ${"y".repeat(1200)}`;
@@ -256,12 +265,19 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       finishTurn: async () => {},
     };
 
-    await handler.start(
-      { id: "m1", chatId: "chat-resume-fail", senderId: "u", format: "text", content: "hi", metadata: null },
-      ctx,
-    );
-    await handler.suspend();
-    await new Promise((r) => setImmediate(r));
+    try {
+      await handler.start(
+        { id: "m1", chatId: "chat-resume-fail", senderId: "u", format: "text", content: "hi", metadata: null },
+        ctx,
+      );
+      await waitForCondition("scheduled retry", () => providerRetryPayloads(emitted).length === 1);
+      await vi.advanceTimersByTimeAsync(5000);
+      await waitForCondition("auto-resume failure settlement", () => providerRetryPayloads(emitted).length === 2);
+      await handler.suspend();
+      await new Promise((r) => setImmediate(r));
+    } finally {
+      vi.useRealTimers();
+    }
 
     const errorMessages = emitted.filter((event) => event.kind === "error").map((event) => event.payload.message);
     expect(errorMessages.every((message) => !message.includes(RAW_TOKEN))).toBe(true);
@@ -286,6 +302,7 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
   });
 
   it("retries an unentered tail after auto-resume failure settles the provider-entered prefix", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     resetSdkMockState();
     requiredInputsBeforeThrowByAttempt.set(1, 1);
     let releaseAttempt1!: () => void;
@@ -344,25 +361,31 @@ describe("claude-code handler — auto-resume failure surfacing", () => {
       failSessionForRecovery,
     };
 
-    await handler.start(
-      { id: "m1", chatId: "chat-resume-fail", senderId: "u", format: "text", content: "hi", metadata: null },
-      ctx,
-    );
-    await waitForObservedInputs(1, 1);
-    handler.inject({
-      id: "m2",
-      chatId: "chat-resume-fail",
-      senderId: "u",
-      format: "text",
-      content: SECOND_PROMPT,
-      metadata: null,
-    });
-    await m2Pushed;
-    releaseAttempt1();
+    try {
+      await handler.start(
+        { id: "m1", chatId: "chat-resume-fail", senderId: "u", format: "text", content: "hi", metadata: null },
+        ctx,
+      );
+      await waitForObservedInputs(1, 1);
+      handler.inject({
+        id: "m2",
+        chatId: "chat-resume-fail",
+        senderId: "u",
+        format: "text",
+        content: SECOND_PROMPT,
+        metadata: null,
+      });
+      await m2Pushed;
+      releaseAttempt1();
 
-    await waitForCondition("auto-resume failed tail recovery", () => retriedBatches.length > 0);
-    await handler.suspend();
-    await new Promise((r) => setImmediate(r));
+      await waitForCondition("scheduled retry", () => providerRetryPayloads(emitted).length === 1);
+      await vi.advanceTimersByTimeAsync(5000);
+      await waitForCondition("auto-resume failed tail recovery", () => retriedBatches.length > 0);
+      await handler.suspend();
+      await new Promise((r) => setImmediate(r));
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(logs.some((l) => l.includes("Auto-resume failed: respawn build failed"))).toBe(true);
     const providerPayloads = providerRetryPayloads(emitted);

--- a/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
+++ b/packages/client/src/__tests__/claude-code-turn-end-retry-exhausted.test.ts
@@ -54,6 +54,14 @@ async function waitForCondition(label: string, predicate: () => boolean): Promis
   }
 }
 
+function scheduledRetryCount(emitted: readonly SessionEvent[]): number {
+  return emitted.filter(
+    (event) =>
+      event.kind === "error" &&
+      parseProviderRetryEventMessage(event.payload.message)?.event === "provider_retry_scheduled",
+  ).length;
+}
+
 function makeFailingQuery(promptIterable: AsyncIterable<{ message: { content: unknown } }>, attempt: number) {
   void (async () => {
     const maxInputsToDrain = requiredInputsForAttempt(attempt);
@@ -124,6 +132,7 @@ function buildCache() {
 
 describe("claude-code handler — retry-exhausted surfacing", () => {
   it("emits error + turn_end:error and finishes the in-flight entry after MAX_RETRIES", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     resetSdkMockState();
 
     const sendMessage = vi.fn().mockResolvedValue(undefined);
@@ -155,12 +164,21 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       },
     };
 
-    await handler.start(
-      { id: "m1", chatId: "chat-retry", senderId: "u", format: "text", content: "hi", metadata: null },
-      ctx,
-    );
-    await handler.suspend();
-    await new Promise((r) => setImmediate(r));
+    try {
+      await handler.start(
+        { id: "m1", chatId: "chat-retry", senderId: "u", format: "text", content: "hi", metadata: null },
+        ctx,
+      );
+      await waitForCondition("first scheduled retry", () => scheduledRetryCount(emitted) === 1);
+      await vi.advanceTimersByTimeAsync(5000);
+      await waitForCondition("second scheduled retry", () => scheduledRetryCount(emitted) === 2);
+      await vi.advanceTimersByTimeAsync(15_000);
+      await waitForCondition("retry exhaustion settlement", () => finishTurnCalled.mock.calls.length === 1);
+      await handler.suspend();
+      await new Promise((r) => setImmediate(r));
+    } finally {
+      vi.useRealTimers();
+    }
 
     // Every iteration threw, so the turn never reached its completion hook;
     // the hook delivers nothing anyway (final-text mirror retired).
@@ -196,6 +214,7 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
   });
 
   it("retries an unentered tail after retry exhaustion settles the provider-entered prefix", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     resetSdkMockState();
     requiredInputsBeforeThrowByAttempt.set(1, 1);
     requiredInputsBeforeThrowByAttempt.set(2, 1);
@@ -268,30 +287,38 @@ describe("claude-code handler — retry-exhausted surfacing", () => {
       failSessionForRecovery,
     };
 
-    await handler.start(
-      { id: "m1", chatId: "chat-retry", senderId: "u", format: "text", content: "hi", metadata: null },
-      ctx,
-    );
-    await waitForObservedInputs(1, 1);
-    handler.inject(
-      {
-        id: "m2",
-        chatId: "chat-retry",
-        senderId: "u",
-        format: "text",
-        content: SECOND_PROMPT,
-        metadata: null,
-      },
-      m2Token,
-    );
-    await m2FormatStarted;
-    releaseAttempt1();
+    try {
+      await handler.start(
+        { id: "m1", chatId: "chat-retry", senderId: "u", format: "text", content: "hi", metadata: null },
+        ctx,
+      );
+      await waitForObservedInputs(1, 1);
+      handler.inject(
+        {
+          id: "m2",
+          chatId: "chat-retry",
+          senderId: "u",
+          format: "text",
+          content: SECOND_PROMPT,
+          metadata: null,
+        },
+        m2Token,
+      );
+      await m2FormatStarted;
+      releaseAttempt1();
 
-    await waitForObservedInputs(3, 1);
-    await waitForCondition("retry-exhausted tail recovery", () => m2Retries.length > 0);
-    releaseM2Format();
-    await handler.suspend();
-    await new Promise((r) => setImmediate(r));
+      await waitForCondition("first scheduled retry", () => scheduledRetryCount(emitted) === 1);
+      await vi.advanceTimersByTimeAsync(5000);
+      await waitForCondition("second scheduled retry", () => scheduledRetryCount(emitted) === 2);
+      await vi.advanceTimersByTimeAsync(15_000);
+      await waitForObservedInputs(3, 1);
+      await waitForCondition("retry-exhausted tail recovery", () => m2Retries.length > 0);
+      releaseM2Format();
+      await handler.suspend();
+      await new Promise((r) => setImmediate(r));
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(logs.some((l) => l.includes("Attempting auto-resume (retry 1/"))).toBe(true);
 

--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { SessionEvent } from "@first-tree/shared";
+import { parseProviderRetryEventMessage, type SessionEvent } from "@first-tree/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexAppServerRpcError, CodexAppServerTransportError } from "../handlers/codex/app-server/client.js";
 import { createCodexAppServerHandler } from "../handlers/codex/app-server/index.js";
@@ -469,6 +469,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllEnvs();
   rmSync(workspaceRoot, { recursive: true, force: true });
 });
@@ -1857,32 +1858,178 @@ describe("codex app-server handler", () => {
     await handler.shutdown();
   });
 
-  it("consumes unsafe replay stops after visible output instead of terminal-rejecting them", async () => {
+  it("retries visible provider capacity failures twice, then exhausts and consumes once", async () => {
     const fake = new FakeAppServerClient();
     const token = makeDeliveryToken();
     const handler = makeHandler(fake);
-    const ctx = makeContext();
+    const settlementOrder: string[] = [];
+    const emitEvent = vi.fn<(event: SessionEvent) => void>((event) => {
+      if (event.kind !== "error") return;
+      const payload = parseProviderRetryEventMessage(event.payload.message);
+      if (payload) settlementOrder.push(payload.event);
+    });
+    token.complete = vi.fn<DeliveryToken["complete"]>(async () => {
+      settlementOrder.push("complete");
+    });
+    const ctx = makeContext({ emitEvent });
     const message = makeMessage("m1", "first");
 
     const startPromise = handler.start(message, ctx, token);
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+    vi.useFakeTimers();
 
-    fake.emit("item/completed", {
-      threadId: "thread-app-server",
-      turnId: "turn-1",
-      item: { type: "agentMessage", id: "item-turn-1", text: "partial answer", phase: null, memoryCitation: null },
-    });
-    fake.close("transport is closed");
+    const failCapacityAttempt = (turnId: string, visible: boolean): void => {
+      if (visible) {
+        fake.emit("item/completed", {
+          threadId: "thread-app-server",
+          turnId,
+          item: {
+            type: "fileChange",
+            id: `file-${turnId}`,
+            status: "completed",
+            changes: [{ path: "src/changed.ts" }],
+          },
+        });
+      }
+      failTurn(fake, turnId, { message: "Selected model is at capacity. Please try a different model." });
+    };
+
+    failCapacityAttempt("turn-1", true);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fake.turnCounter).toBe(2);
+
+    failCapacityAttempt("turn-2", false);
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(fake.turnCounter).toBe(3);
+
+    failCapacityAttempt("turn-3", false);
     await startPromise;
 
+    expect(settlementOrder).toEqual([
+      "provider_retry_scheduled",
+      "provider_retry_scheduled",
+      "provider_retry_exhausted",
+      "complete",
+    ]);
+    expect(token.complete).toHaveBeenCalledTimes(1);
     expect(token.complete).toHaveBeenCalledWith([message], {
       status: "error",
       terminal: true,
       completion: "consumed",
-      reason: "unsafe_replay",
+      reason: "provider_retry_exhausted",
     });
     expect(token.terminalRejected).not.toHaveBeenCalled();
     expect(token.retry).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
+  it("fences an injected tail during provider retry backoff until the retry turn starts", async () => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const tailToken = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+    const message = makeMessage("m1", "first");
+    const tail = makeMessage("m2", "second");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.turnCounter === 1);
+    vi.useFakeTimers();
+
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-1",
+      item: {
+        type: "fileChange",
+        id: "file-turn-1",
+        status: "completed",
+        changes: [{ path: "src/changed.ts" }],
+      },
+    });
+    failTurn(fake, "turn-1", { message: "Selected model is at capacity. Please try a different model." });
+    fake.deferNextSteer();
+    expect(handler.inject(tail, tailToken)).toEqual({ kind: "owned", mode: "queued" });
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(fake.turnCounter).toBe(1);
+    expect(fake.requests.filter((request) => request.method === "turn/steer")).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fake.turnCounter).toBe(2);
+    await vi.runOnlyPendingTimersAsync();
+    expect(fake.requests.filter((request) => request.method === "turn/steer")).toHaveLength(1);
+
+    fake.resolveSteer({ turnId: "turn-2" });
+    await vi.advanceTimersByTimeAsync(0);
+    completeTurn(fake, "turn-2", "done");
+    await startPromise;
+
+    expect(token.complete).toHaveBeenCalledWith([message, tail], { status: "success", terminal: true });
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(tailToken.retry).not.toHaveBeenCalled();
+
+    await handler.shutdown();
+  });
+
+  it.each([
+    "success",
+    "exhausted",
+  ] as const)("carries a successfully steered tail into the provider retry %s settlement", async (outcome) => {
+    const fake = new FakeAppServerClient();
+    const token = makeDeliveryToken();
+    const tailToken = makeDeliveryToken();
+    const handler = makeHandler(fake);
+    const ctx = makeContext();
+    const message = makeMessage("m1", "first");
+    const tail = makeMessage("m2", "second");
+
+    const startPromise = handler.start(message, ctx, token);
+    await waitFor(() => fake.turnCounter === 1);
+
+    expect(handler.inject(tail, tailToken)).toEqual({ kind: "owned", mode: "queued" });
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"));
+    await flushAsync();
+    vi.useFakeTimers();
+
+    fake.emit("item/completed", {
+      threadId: "thread-app-server",
+      turnId: "turn-1",
+      item: {
+        type: "fileChange",
+        id: "file-turn-1",
+        status: "completed",
+        changes: [{ path: "src/changed.ts" }],
+      },
+    });
+    failTurn(fake, "turn-1", { message: "Selected model is at capacity. Please try a different model." });
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fake.turnCounter).toBe(2);
+    if (outcome === "success") {
+      completeTurn(fake, "turn-2", "done");
+    } else {
+      failTurn(fake, "turn-2", { message: "Selected model is at capacity. Please try a different model." });
+      await vi.advanceTimersByTimeAsync(1500);
+      expect(fake.turnCounter).toBe(3);
+      failTurn(fake, "turn-3", { message: "Selected model is at capacity. Please try a different model." });
+    }
+    await startPromise;
+
+    expect(token.complete).toHaveBeenCalledWith(
+      [message, tail],
+      outcome === "success"
+        ? { status: "success", terminal: true }
+        : {
+            status: "error",
+            terminal: true,
+            completion: "consumed",
+            reason: "provider_retry_exhausted",
+          },
+    );
+    expect(token.retry).not.toHaveBeenCalled();
+    expect(tailToken.retry).not.toHaveBeenCalled();
+    expect(tailToken.complete).not.toHaveBeenCalled();
 
     await handler.shutdown();
   });

--- a/packages/client/src/__tests__/provider-attempt.test.ts
+++ b/packages/client/src/__tests__/provider-attempt.test.ts
@@ -78,7 +78,7 @@ describe("ProviderAttempt", () => {
     expect(settled?.messagePreview).toContain("diagnostic: Reconnecting... 2/5");
   });
 
-  it("stops retry when user-visible output makes replay unsafe", () => {
+  it("retries a transient transport failure after user-visible output", () => {
     const a = attempt();
 
     a.markUserVisibleOutput();
@@ -88,9 +88,8 @@ describe("ProviderAttempt", () => {
     });
 
     expect(settled?.decision).toMatchObject({
-      action: "stop",
-      terminalKind: "unsafe_replay",
-      reasonCode: "unsafe_replay",
+      action: "retry",
+      replaySafety: "user_visible",
     });
   });
 });

--- a/packages/client/src/__tests__/provider-retry-policy.test.ts
+++ b/packages/client/src/__tests__/provider-retry-policy.test.ts
@@ -293,6 +293,15 @@ describe("decideProviderRetry", () => {
         retryAfterMs: 120_000,
       }),
     ).toMatchObject({ action: "stop", terminalKind: "exhausted" });
+    expect(
+      decide({
+        category: "provider_capacity",
+        reasonCode: "provider_rate_limited",
+        replaySafety: "user_visible",
+        attempt: 3,
+        retryAfterMs: 25_000,
+      }),
+    ).toMatchObject({ action: "stop", terminalKind: "exhausted" });
   });
 
   it("returns capacity_wait_required for provider-entered long capacity refusals", () => {
@@ -310,18 +319,59 @@ describe("decideProviderRetry", () => {
     });
   });
 
-  it("stops unsafe provider_turn replay before retrying", () => {
+  it("retries classified transient provider_turn failures after user-visible output", () => {
     expect(
       decide({
         category: "transient_transport",
         replaySafety: "user_visible",
         attempt: 1,
       }),
-    ).toMatchObject({ action: "stop", terminalKind: "unsafe_replay" });
+    ).toMatchObject({ action: "retry", delayMs: 500, retryMode: "foreground" });
+    expect(
+      decide({
+        category: "provider_capacity",
+        reasonCode: "provider_overloaded",
+        replaySafety: "user_visible",
+        attempt: 1,
+      }),
+    ).toMatchObject({ action: "retry", delayMs: 500, retryMode: "foreground" });
+    expect(
+      decide({
+        category: "transient_transport",
+        replaySafety: "user_visible",
+        attempt: 3,
+      }),
+    ).toMatchObject({ action: "stop", terminalKind: "exhausted" });
+    expect(
+      decide({
+        category: "provider_capacity",
+        reasonCode: "provider_overloaded",
+        replaySafety: "user_visible",
+        attempt: 3,
+      }),
+    ).toMatchObject({ action: "stop", terminalKind: "exhausted" });
+    expect(
+      decide({
+        category: "provider_capacity",
+        reasonCode: "provider_usage_limit",
+        replaySafety: "user_visible",
+        attempt: 1,
+      }),
+    ).toMatchObject({ action: "stop", terminalKind: "capacity_wait_required" });
+  });
+
+  it("stops provider_turn retry when replay custody is unknown", () => {
     expect(
       decide({
         category: "transient_transport",
         replaySafety: "unknown",
+        attempt: 1,
+      }),
+    ).toMatchObject({ action: "stop", terminalKind: "unsafe_replay" });
+    expect(
+      decide({
+        category: "unknown",
+        replaySafety: "user_visible",
         attempt: 1,
       }),
     ).toMatchObject({ action: "stop", terminalKind: "unsafe_replay" });

--- a/packages/client/src/__tests__/session-manager.test.ts
+++ b/packages/client/src/__tests__/session-manager.test.ts
@@ -118,6 +118,25 @@ function emitCodexTerminalProviderFailure(ctx: SessionContext, messagePreview: s
   });
 }
 
+function emitCodexRetryExhausted(ctx: SessionContext, messagePreview: string): void {
+  ctx.emitEvent({
+    kind: "error",
+    payload: {
+      source: "runtime",
+      message: encodeProviderRetryEventMessage({
+        event: "provider_retry_exhausted",
+        provider: "codex",
+        scope: "provider_turn",
+        category: "provider_capacity",
+        reasonCode: "provider_overloaded_exhausted",
+        replaySafety: "user_visible",
+        userSeverity: "error",
+        messagePreview,
+      }),
+    },
+  });
+}
+
 function emitClaudeProviderFailure(
   ctx: SessionContext,
   input: {
@@ -1965,6 +1984,56 @@ describe("SessionManager ackEntry callback (deferred ack)", () => {
     expect(notice).toContain("credentials need attention");
     expect(notice).toContain("refresh token was revoked");
     expect(ackEntry).toHaveBeenCalledWith(21);
+    const [noticeOrder] = sendMessage.mock.invocationCallOrder;
+    const [ackOrder] = ackEntry.mock.invocationCallOrder;
+    if (noticeOrder === undefined || ackOrder === undefined) throw new Error("expected notice and ack order");
+    expect(noticeOrder).toBeLessThan(ackOrder);
+
+    await sm.shutdown();
+  });
+
+  it("posts a durable runtime notice before ACKing a Codex retry-exhausted turn once", async () => {
+    const ackEntry = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockResolvedValue({ id: "runtime-notice" });
+    const sdk = {
+      register: vi.fn(),
+      sendMessage,
+      sendToAgent: vi.fn().mockResolvedValue({ id: "msg-dm" }),
+    } as unknown as FirstTreeHubSDK;
+    let capturedCtx: SessionContext | undefined;
+    let capturedToken: DeliveryToken | undefined;
+    let capturedMessage: SessionMessage | undefined;
+    const handler = createMockHandler({
+      start: vi.fn(async (message, ctx, token) => {
+        capturedMessage = message;
+        capturedCtx = ctx;
+        capturedToken = token;
+        return { sessionId: "session-id-mock", route: { kind: "owned", mode: "queued" } as const };
+      }),
+    });
+    const sm = createSessionManager({
+      handler,
+      ackEntry,
+      sdk,
+      handlerConfig: { workspaceRoot: "/tmp/test", runtimeProvider: "codex" },
+    });
+
+    await sm.dispatch(
+      mockEntry({ id: 27, chatId: "chat-codex-retry-exhausted", messageId: "msg-codex-retry-exhausted" }),
+    );
+    if (!capturedCtx || !capturedToken || !capturedMessage) throw new Error("delivery was not captured");
+
+    emitCodexRetryExhausted(capturedCtx, "Selected model is at capacity. Please try a different model.");
+    await capturedToken.complete(capturedMessage, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "provider_retry_exhausted",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledWith(27);
     const [noticeOrder] = sendMessage.mock.invocationCallOrder;
     const [ackOrder] = ackEntry.mock.invocationCallOrder;
     if (noticeOrder === undefined || ackOrder === undefined) throw new Error("expected notice and ack order");

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -841,6 +841,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     providerRetryBackoffAbort = null;
   }
 
+  function providerRetryBackoffPending(): boolean {
+    return providerRetryBackoffAbort !== null;
+  }
+
   /**
    * Honor the shared provider retry delay while allowing suspend/shutdown to
    * interrupt the foreground retry chain immediately.
@@ -1489,7 +1493,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       appliedPayload.model !== newPayload.model;
 
     // Path A: same-family model swap → in-flight setModel.
-    if (onlyModelChanged && isSameModelFamily(appliedModel, newPayload.model)) {
+    if (onlyModelChanged && isSameModelFamily(appliedModel, newPayload.model) && !providerRetryBackoffPending()) {
       try {
         await currentQuery.setModel(newPayload.model);
         sessionCtx.log(
@@ -1509,6 +1513,11 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     // still iterating the OLD query and will exit once `oldQuery.close()`
     // drains it, so the new query would otherwise have no reader.
     sessionCtx.log(`[configHotSwitch] path=restart fromVersion=${appliedConfigVersion} toVersion=${cached.version}`);
+    // Path B takes ownership of the unsettled turn. Retire an old consumer
+    // that may be waiting in provider retry backoff before any async restart
+    // preparation can yield; otherwise its timer could later respawn another
+    // query alongside the config-switch consumer.
+    cancelProviderRetryBackoff();
     // Rewrite AGENTS.md (CLAUDE.md symlink) with the new payload so the
     // restarted SDK Query — which reads CLAUDE.md via `settingSources:
     // ["project"]` on construction — picks up the new prompt.append. The

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -784,6 +784,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   let activeProviderEnv: Record<string, string | undefined> | null = null;
   let inputController: InputController<PendingSdkInput> | null = null;
   let abortController: AbortController | null = null;
+  let providerRetryBackoffAbort: AbortController | null = null;
   let consumerDone: Promise<void> | null = null;
   let retryCount = 0;
   let ctx: SessionContext | null = null;
@@ -834,6 +835,42 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
    * tracked separately by `PendingAckMessage.providerEntered`.
    */
   const unclosedSdkInputs: PendingSdkInput[] = [];
+
+  function cancelProviderRetryBackoff(): void {
+    providerRetryBackoffAbort?.abort();
+    providerRetryBackoffAbort = null;
+  }
+
+  /**
+   * Honor the shared provider retry delay while allowing suspend/shutdown to
+   * interrupt the foreground retry chain immediately.
+   */
+  async function waitForProviderRetry(delayMs: number): Promise<boolean> {
+    if (delayMs <= 0) return true;
+
+    cancelProviderRetryBackoff();
+    const backoffAbort = new AbortController();
+    providerRetryBackoffAbort = backoffAbort;
+
+    try {
+      await new Promise<void>((resolveDelay) => {
+        let settled = false;
+        const finish = (): void => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          backoffAbort.signal.removeEventListener("abort", finish);
+          resolveDelay();
+        };
+        const timer = setTimeout(finish, delayMs);
+        backoffAbort.signal.addEventListener("abort", finish, { once: true });
+        if (backoffAbort.signal.aborted) finish();
+      });
+      return !backoffAbort.signal.aborted;
+    } finally {
+      if (providerRetryBackoffAbort === backoffAbort) providerRetryBackoffAbort = null;
+    }
+  }
 
   function emitProviderTurnRetryEvent(
     sessionCtx: SessionContext,
@@ -1611,6 +1648,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
                     emitProviderTurnSettlementEvent(sessionCtx, settlement);
                     sessionCtx.log(`Attempting auto-resume (retry ${retryCount}/${providerTurnMaxRetries})`);
                     toolCallProcessor.flush();
+                    if (!(await waitForProviderRetry(settlement.decision.delayMs))) {
+                      sessionCtx.log("Auto-resume cancelled during provider retry backoff");
+                      return;
+                    }
                     try {
                       respawnQuery(claudeSessionId, sessionCtx);
                     } catch (resumeErr) {
@@ -1878,6 +1919,11 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
           retryCount = decision.attempt;
           emitProviderTurnRetryEvent(sessionCtx, "provider_retry_scheduled", classification, decision, errMsg);
           sessionCtx.log(`Attempting auto-resume (retry ${retryCount}/${providerTurnMaxRetries})`);
+
+          if (!(await waitForProviderRetry(decision.delayMs))) {
+            sessionCtx.log("Auto-resume cancelled during provider retry backoff");
+            return;
+          }
 
           try {
             respawnQuery(claudeSessionId, sessionCtx);
@@ -2272,6 +2318,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
     async suspend(reason?: string) {
       ctx?.log("Suspending session");
+      cancelProviderRetryBackoff();
 
       if (inputController) {
         inputController.end();

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -783,7 +783,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
   let currentQuery: Query | null = null;
   let activeProviderEnv: Record<string, string | undefined> | null = null;
   let inputController: InputController<PendingSdkInput> | null = null;
-  let abortController: AbortController | null = null;
   let providerRetryBackoffAbort: AbortController | null = null;
   let consumerDone: Promise<void> | null = null;
   let retryCount = 0;
@@ -1303,6 +1302,15 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       await maybeSwitchConfig(sessionCtx);
     } catch (err) {
       sessionCtx.log(`maybeSwitchConfig errored: ${err instanceof Error ? err.message : String(err)}`);
+      // Path B may already have retired the provider-retry consumer before a
+      // fallible config-restart step fails. Do not continue into an orphaned
+      // input controller. Retire the provider transport before returning the
+      // provider-entered prefix and unentered tail to runtime recovery so a
+      // fresh handler cannot overlap the abandoned native process.
+      retireProviderTransport();
+      retryBufferedMessages("claude_config_restart_failed_recovery");
+      failFatalSessionForRecovery(sessionCtx, "claude_config_restart_failed");
+      return;
     }
     if (recoverIfInputClosed(item)) return;
 
@@ -1379,6 +1387,28 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     sessionCtx.failSessionForRecovery?.(reason, claudeSessionId ?? undefined);
   }
 
+  function retireProviderTransport(): void {
+    cancelProviderRetryBackoff();
+
+    const controller = inputController;
+    inputController = null;
+    try {
+      controller?.end();
+    } catch {
+      // best-effort transport cleanup
+    }
+
+    const query = currentQuery;
+    currentQuery = null;
+    try {
+      query?.close();
+    } catch {
+      // best-effort transport cleanup
+    }
+
+    activeProviderEnv = null;
+  }
+
   /**
    * Rebuild the SDK query in resume mode AND re-push every input already handed
    * to the previous query's controller for the still-unclosed turn, preserving
@@ -1424,9 +1454,11 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     resume?: string,
     providerEnv?: Record<string, string | undefined>,
   ): void {
-    inputRecoveryReason = null;
-    inputController = new InputController<PendingSdkInput>();
-    abortController = new AbortController();
+    // Construct the replacement locally so a synchronous SDK constructor
+    // failure cannot leave the handler pointing at an orphan controller while
+    // the previous query still owns the unsettled turn.
+    const nextInputController = new InputController<PendingSdkInput>();
+    const nextAbortController = new AbortController();
 
     // Step 6: M1 hard-codes bypassPermissions per PRD §5.1.6 (permission mode
     // is intentionally not exposed to admins).
@@ -1436,14 +1468,14 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
     const childEnv = providerEnv ?? buildEnv(sessionCtx);
 
-    currentQuery = claudeQuery({
-      prompt: providerPromptInputs(inputController.iterable),
+    const nextQuery = claudeQuery({
+      prompt: providerPromptInputs(nextInputController.iterable),
       options: {
         sessionId: resume ? undefined : sessionId,
         resume,
         cwd: cwd ?? undefined,
         persistSession: true,
-        abortController,
+        abortController: nextAbortController,
         permissionMode,
         allowDangerouslySkipPermissions: true,
         // SDK 0.2.84 defaults to isolation mode — no filesystem settings are
@@ -1474,6 +1506,10 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         ...buildClaudeQueryOptions(payload, chatContextForPrompt),
       },
     });
+
+    inputRecoveryReason = null;
+    inputController = nextInputController;
+    currentQuery = nextQuery;
     activeProviderEnv = childEnv;
   }
 
@@ -2327,17 +2363,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
     async suspend(reason?: string) {
       ctx?.log("Suspending session");
-      cancelProviderRetryBackoff();
-
-      if (inputController) {
-        inputController.end();
-        inputController = null;
-      }
-
-      if (currentQuery) {
-        currentQuery.close();
-        currentQuery = null;
-      }
+      retireProviderTransport();
 
       // Wait for consumer loop to finish
       if (consumerDone) {
@@ -2345,8 +2371,6 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         consumerDone = null;
       }
 
-      abortController = null;
-      activeProviderEnv = null;
       // The session is no longer active — any pending replay inputs would be
       // moot. Resume goes through `handler.resume(message, sessionId)`, which
       // builds a fresh replay buffer from its own pushed inputs.

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -143,6 +143,8 @@ type TurnErrorInfo = {
 
 type CurrentTurn = {
   turnId: string;
+  providerAttemptNumber: number;
+  providerRetryChain: boolean;
   status: "inProgress" | "completed" | "failed" | "interrupted";
   primaryToken: DeliveryToken;
   acceptedMessages: SessionMessage[];
@@ -206,6 +208,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   let startupTurnPending = false;
   let turnStartInProgress = false;
   let turnStartAttempt: ProviderAttempt | null = null;
+  let cancelProviderRetryBackoff: (() => void) | null = null;
+  let providerRetryFence = false;
   let pendingDrainInProgress = false;
   let pendingDrainScheduled = false;
   let shutdownRequested = false;
@@ -235,6 +239,30 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     });
   }
 
+  function isExplicitTransientSettlement(settlement: ProviderAttemptSettlement): boolean {
+    return (
+      settlement.classification.category === "provider_capacity" ||
+      settlement.classification.category === "transient_transport"
+    );
+  }
+
+  async function waitForProviderRetry(delayMs: number): Promise<boolean> {
+    if (shutdownRequested) return false;
+    await new Promise<void>((resolveDelay) => {
+      let settled = false;
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (cancelProviderRetryBackoff === finish) cancelProviderRetryBackoff = null;
+        resolveDelay();
+      };
+      const timer = setTimeout(finish, delayMs);
+      cancelProviderRetryBackoff = finish;
+    });
+    return !shutdownRequested;
+  }
+
   function emitProviderSettlementEvent(sessionCtx: SessionContext, settlement: ProviderAttemptSettlement): void {
     sessionCtx.emitEvent({
       kind: "error",
@@ -249,6 +277,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     attempt: ProviderAttempt,
     error: TurnErrorInfo,
     turn?: Pick<CurrentTurn, "userVisibleOutput">,
+    attemptNumber = 1,
   ): ProviderAttemptSettlement | null {
     const diagnostic = isCodexStreamDiagnosticMessage(error.message);
     const classification = attempt.recordSignal({
@@ -266,7 +295,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         attempt.setReplaySafety("pre_visible");
       }
     }
-    return attempt.settle({ attempt: 1 });
+    return attempt.settle({ attempt: attemptNumber });
   }
 
   type AcceptedTurnStopDisposition =
@@ -278,7 +307,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     settlement: ProviderAttemptSettlement,
   ): TurnConsumedErrorReason | null {
     if (settlement.decision.action !== "stop") return null;
-    if (settlement.decision.terminalKind === "exhausted") return null;
+    if (settlement.decision.terminalKind === "exhausted") return "provider_retry_exhausted";
     if (settlement.classification.category === "deterministic_input") {
       return deterministicTerminalRejectionReason(errorInfoForSettlement(error, settlement));
     }
@@ -1009,6 +1038,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     token: DeliveryToken,
     sessionCtx: SessionContext,
     allowStaleRolloutRecovery = true,
+    providerAttemptNumber = 1,
+    providerRetryChain = false,
   ): Promise<boolean> {
     const client = appServer;
     if (!client || !threadId) {
@@ -1046,7 +1077,15 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         pendingChatContextPrompt = promptSnapshot;
         const staleThreadId = extractCodexStaleRolloutThreadId(err) ?? threadId;
         await startFreshThreadAfterStaleRollout(activePayload, sessionCtx, staleThreadId);
-        return runTurnFromText(inputText, messages, token, sessionCtx, false);
+        return runTurnFromText(
+          inputText,
+          messages,
+          token,
+          sessionCtx,
+          false,
+          providerAttemptNumber,
+          providerRetryChain,
+        );
       }
       const attempt = turnStartAttempt ?? createProviderAttempt();
       turnStartAttempt = null;
@@ -1111,7 +1150,14 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     }
 
     recordBufferedHistoricalTokenUsageExcept(turnId);
-    const turn = await createCurrentTurn(turnId, messages, token, sessionCtx);
+    const turn = await createCurrentTurn(
+      turnId,
+      messages,
+      token,
+      sessionCtx,
+      providerAttemptNumber,
+      providerRetryChain,
+    );
     turnStartAttempt = null;
     turnStartInProgress = false;
     schedulePendingDrain();
@@ -1121,12 +1167,23 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     replayBufferedNotifications(turn, sessionCtx);
     await currentTurnPromise;
     turnSettlementInProgress = true;
+    let providerRetrySettlement: ProviderAttemptSettlement | null = null;
     try {
-      await settleTurn(turn, sessionCtx);
+      providerRetrySettlement = await settleTurn(turn, sessionCtx);
     } finally {
       turnSettlementInProgress = false;
+      if (providerRetrySettlement) providerRetryFence = true;
       if (currentTurn === turn) currentTurn = null;
-      schedulePendingDrain();
+      if (!providerRetrySettlement) schedulePendingDrain();
+    }
+    if (providerRetrySettlement?.decision.action === "retry") {
+      const { attempt, delayMs, maxAttempts } = providerRetrySettlement.decision;
+      sessionCtx.log(
+        `codex app-server turn retry ${attempt}/${(maxAttempts ?? attempt) + 1} after ${delayMs}ms; ` +
+          `${providerRetrySettlement.classification.category}: ${providerRetrySettlement.messagePreview}`,
+      );
+      if (!(await waitForProviderRetry(delayMs))) return false;
+      return runTurnFromText(inputText, turn.acceptedMessages, token, sessionCtx, true, attempt + 1, true);
     }
     // Reached the provider (turn/start accepted, turn id assigned), so the
     // notice-bearing input was delivered to the model.
@@ -1151,6 +1208,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     messages: readonly SessionMessage[],
     token: DeliveryToken,
     sessionCtx: SessionContext,
+    providerAttemptNumber: number,
+    providerRetryChain: boolean,
   ): Promise<CurrentTurn> {
     let resolveTerminal: () => void = () => {};
     const terminalPromise = new Promise<void>((resolve) => {
@@ -1160,6 +1219,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     providerAttempt.setReplaySafety("pre_visible");
     const turn: CurrentTurn = {
       turnId,
+      providerAttemptNumber,
+      providerRetryChain,
       status: "inProgress",
       primaryToken: token,
       acceptedMessages: [...messages],
@@ -1180,6 +1241,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       resolveTerminal,
     };
     currentTurn = turn;
+    if (providerRetryChain) providerRetryFence = false;
     token.processingStarted(messages);
     currentTurnPromise = terminalPromise.finally(() => {
       currentTurnPromise = null;
@@ -1209,12 +1271,12 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     await closeAppServerAfterUnknownCustody(sessionCtx, reason, err);
   }
 
-  async function settleTurn(turn: CurrentTurn, sessionCtx: SessionContext): Promise<void> {
+  async function settleTurn(turn: CurrentTurn, sessionCtx: SessionContext): Promise<ProviderAttemptSettlement | null> {
     if (turn.inFlightAppend) await turn.inFlightAppend;
 
     if (turn.stopRequested || shutdownRequested) {
       schedulePendingDrain();
-      return;
+      return null;
     }
 
     const completedSuccessfully = turn.providerCompleted && turn.failure === null && turn.status === "completed";
@@ -1237,6 +1299,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     let retryReason: string | null = null;
     let consumedErrorReason: TurnConsumedErrorReason | null = null;
     let terminalRejectionReason: string | null = null;
+    let providerRetrySettlement: ProviderAttemptSettlement | null = null;
 
     if (completedEmptyCompactFailure) {
       terminalRejectionReason = deterministicTerminalRejectionReason(completedEmptyCompactFailure);
@@ -1300,11 +1363,28 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       }
     } else if (turn.failure) {
       const failure = mergeFailureWithDiagnostic(turn.failure, turn.lastSdkError);
-      const providerSettlement = recordAppServerFailureSignal(turn.providerAttempt, failure, turn);
+      const providerSettlement = recordAppServerFailureSignal(
+        turn.providerAttempt,
+        failure,
+        turn,
+        turn.providerAttemptNumber,
+      );
       const providerStopDisposition = providerSettlement
         ? acceptedTurnStopDisposition(failure, providerSettlement)
         : null;
-      if (providerSettlement && providerStopDisposition) {
+      if (providerSettlement?.decision.action === "retry") {
+        emitProviderSettlementEvent(sessionCtx, providerSettlement);
+        if (
+          isExplicitTransientSettlement(providerSettlement) &&
+          (providerSettlement.decision.replaySafety === "user_visible" || turn.providerRetryChain)
+        ) {
+          providerRetrySettlement = providerSettlement;
+        } else {
+          const kind = classifyAppServerFailure(failure);
+          retryReason = `codex_${kind}_failure`;
+          sessionCtx.log(`codex app-server turn failed (${kind}): ${turn.failure.message}`);
+        }
+      } else if (providerSettlement && providerStopDisposition) {
         emitProviderSettlementEvent(sessionCtx, providerSettlement);
         if (!turn.sdkErrorEmitted) {
           sessionCtx.emitEvent({
@@ -1334,11 +1414,26 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         codexErrorInfo: null,
         additionalDetails: null,
       };
-      const streamEndSettlement = recordAppServerFailureSignal(turn.providerAttempt, streamEndError, turn);
+      const streamEndSettlement = recordAppServerFailureSignal(
+        turn.providerAttempt,
+        streamEndError,
+        turn,
+        turn.providerAttemptNumber,
+      );
       const providerStopDisposition = streamEndSettlement
         ? acceptedTurnStopDisposition(streamEndError, streamEndSettlement)
         : null;
-      if (streamEndSettlement && providerStopDisposition) {
+      if (streamEndSettlement?.decision.action === "retry") {
+        emitProviderSettlementEvent(sessionCtx, streamEndSettlement);
+        if (
+          isExplicitTransientSettlement(streamEndSettlement) &&
+          (streamEndSettlement.decision.replaySafety === "user_visible" || turn.providerRetryChain)
+        ) {
+          providerRetrySettlement = streamEndSettlement;
+        } else {
+          retryReason = "codex_app_server_stream_ended_without_completion";
+        }
+      } else if (streamEndSettlement && providerStopDisposition) {
         emitProviderSettlementEvent(sessionCtx, streamEndSettlement);
         sessionCtx.emitEvent({
           kind: "error",
@@ -1376,6 +1471,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       });
     }
 
+    if (providerRetrySettlement) return providerRetrySettlement;
+
     if (terminalRejectionReason) {
       sessionCtx.emitEvent({ kind: "turn_end", payload: { status: "error" } });
       await turn.primaryToken.terminalRejected(turn.acceptedMessages, terminalRejectionReason, {
@@ -1405,21 +1502,23 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
           sessionCtx.log(`landing trial turn completion confirmation failed after provider completion: ${err.message}`);
           turn.primaryToken.retry(turn.acceptedMessages, LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED);
           await closeAppServerAfterUncommittablePrefix(sessionCtx, LANDING_TRIAL_TURN_COMPLETION_CONFIRM_FAILED);
-          return;
+          return null;
         }
         await turn.primaryToken.complete(turn.acceptedMessages, settlement.action.outcome);
       } else {
         sessionCtx.emitEvent({ kind: "turn_end", payload: { status: settlement.status } });
         turn.primaryToken.retry(turn.acceptedMessages, settlement.action.reason);
         await closeAppServerAfterUncommittablePrefix(sessionCtx, settlement.action.reason);
-        return;
+        return null;
       }
     }
     schedulePendingDrain();
+    return null;
   }
 
   function schedulePendingDrain(): void {
     if (pendingDrainScheduled || pendingDrainInProgress) return;
+    if (providerRetryFence) return;
     if (pendingInputs.length === 0 || shutdownRequested) return;
     if (!appServer || !threadId) return;
     if (turnSettlementInProgress || turnStartInProgress) return;
@@ -1440,6 +1539,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
 
   async function drainPendingInputs(): Promise<void> {
     if (pendingDrainInProgress || pendingInputs.length === 0 || shutdownRequested) return;
+    if (providerRetryFence) return;
     if (!appServer || !threadId) return;
     const sessionCtx = ctx;
     if (!sessionCtx) return;
@@ -1668,6 +1768,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       const hasExplicitDeliveryToken = token !== undefined;
       const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
       shutdownRequested = false;
+      providerRetryFence = false;
       startupTurnPending = true;
       ctx = sessionCtx;
       try {
@@ -1700,6 +1801,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       const hasExplicitDeliveryToken = token !== undefined;
       const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
       shutdownRequested = false;
+      providerRetryFence = false;
       startupTurnPending = message !== undefined;
       ctx = sessionCtx;
       try {
@@ -1766,8 +1868,11 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     },
 
     async suspend() {
+      shutdownRequested = true;
+      providerRetryFence = false;
       startupTurnPending = false;
       turnStartInProgress = false;
+      cancelProviderRetryBackoff?.();
       retryQueuedMessages("codex_suspend_before_terminal");
       await interruptCurrentTurn();
       await appServer?.shutdown();
@@ -1783,6 +1888,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
 
     async shutdown(reason?: string) {
       shutdownRequested = true;
+      providerRetryFence = false;
+      cancelProviderRetryBackoff?.();
       retryQueuedMessages(reason ?? "codex_shutdown_before_terminal");
       await interruptCurrentTurn();
       await appServer?.shutdown();

--- a/packages/client/src/runtime/provider-retry-policy.ts
+++ b/packages/client/src/runtime/provider-retry-policy.ts
@@ -150,7 +150,11 @@ export function decideProviderRetry(input: {
   const attempt = Math.max(1, Math.floor(input.attempt));
   const retryAfterMs = input.retryAfterMs ?? input.classification.retryAfterMs;
 
-  if (input.scope === "provider_turn" && isUnsafeReplay(input.replaySafety)) {
+  if (
+    input.scope === "provider_turn" &&
+    isUnsafeReplay(input.replaySafety) &&
+    !isRetryableUserVisibleFailure(input.classification.category, input.replaySafety)
+  ) {
     return stop("unsafe_replay", "unsafe_replay", input.replaySafety, "warning");
   }
 
@@ -242,23 +246,25 @@ function decideProviderTurnCapacity(
   if (replaySafety === "pre_provider") {
     return decideProviderTurnTransient(reasonCode, attempt, replaySafety);
   }
-  if (reasonCode === "provider_overloaded" && retryAfterMs === undefined && attempt <= PROVIDER_TURN_MAX_RETRIES) {
-    return retry(
-      reasonCode,
-      attempt,
-      PROVIDER_TURN_MAX_RETRIES,
-      PROVIDER_TURN_DELAYS_MS[attempt - 1] ?? 1500,
-      "foreground",
-      replaySafety,
-      "warning",
-    );
+  if (reasonCode === "provider_overloaded" && retryAfterMs === undefined) {
+    if (attempt <= PROVIDER_TURN_MAX_RETRIES) {
+      return retry(
+        reasonCode,
+        attempt,
+        PROVIDER_TURN_MAX_RETRIES,
+        PROVIDER_TURN_DELAYS_MS[attempt - 1] ?? 1500,
+        "foreground",
+        replaySafety,
+        "warning",
+      );
+    }
+    return stop(`${reasonCode}_exhausted`, "exhausted", replaySafety, "error");
   }
-  if (
-    retryAfterMs !== undefined &&
-    retryAfterMs <= PROVIDER_TURN_CAPACITY_SHORT_WAIT_MS &&
-    attempt <= PROVIDER_TURN_MAX_RETRIES
-  ) {
-    return retry(reasonCode, attempt, PROVIDER_TURN_MAX_RETRIES, retryAfterMs, "foreground", replaySafety, "warning");
+  if (retryAfterMs !== undefined && retryAfterMs <= PROVIDER_TURN_CAPACITY_SHORT_WAIT_MS) {
+    if (attempt <= PROVIDER_TURN_MAX_RETRIES) {
+      return retry(reasonCode, attempt, PROVIDER_TURN_MAX_RETRIES, retryAfterMs, "foreground", replaySafety, "warning");
+    }
+    return stop(`${reasonCode}_exhausted`, "exhausted", replaySafety, "error");
   }
   return stop("capacity_wait_required", "capacity_wait_required", replaySafety, "warning");
 }
@@ -337,6 +343,10 @@ function stop(
 
 function isUnsafeReplay(replaySafety: ReplaySafety): boolean {
   return replaySafety === "user_visible" || replaySafety === "unsafe" || replaySafety === "unknown";
+}
+
+function isRetryableUserVisibleFailure(category: ProviderFailureCategory, replaySafety: ReplaySafety): boolean {
+  return replaySafety === "user_visible" && (category === "provider_capacity" || category === "transient_transport");
 }
 
 type ErrorShape = {

--- a/packages/qa/cases/runtime/provider-transient-retry-after-visible-output.md
+++ b/packages/qa/cases/runtime/provider-transient-retry-after-visible-output.md
@@ -1,0 +1,53 @@
+---
+id: provider-transient-retry-after-visible-output
+description: Transient provider failures remain retryable after a turn has emitted visible output or tool effects.
+areas: [runtime]
+surfaces: [client, server]
+---
+
+# Provider transient retry after visible output
+
+Validate that a Codex turn which has already produced assistant output or a
+tool effect remains recoverable when the provider then reports an explicit
+transient capacity or transport failure. The Runtime should route the owned
+delivery through retry/recovery rather than consuming it as an
+`unsafe_replay` terminal failure.
+
+Use an isolated test agent and scratch workspace. The provider or bridge must
+be controllable enough to produce a completed, reversible scratch-file change
+followed by either the exact capacity message `Selected model is at capacity.
+Please try a different model.` or a clear transient transport failure. Do not
+induce failures against a production provider account and do not use external
+or irreversible tool effects merely to satisfy this case.
+
+Observe the turn's session events, Client logs, chat messages, and inbox
+settlement closely enough to establish the sequence. Credible evidence shows
+that the visible/tool event precedes the provider failure, the failure enters
+the bounded retry path without an immediate terminal runtime notice or ACK,
+and resumed agent execution can inspect the already-changed scratch state and
+finish the delivery.
+
+Also hold the same transient failure through the full retry budget. Produce the
+visible scratch-file effect only on the first attempt, then fail the next two
+attempts before they emit new output. The first two failures should schedule
+foreground retries; the third should emit `provider_retry_exhausted`. Its
+durable runtime notice must be posted before the original delivery is
+acknowledged exactly once. No fourth provider attempt or recovery redelivery
+should occur.
+
+During the first retry backoff, inject a second message into the same chat. It
+must remain queued until the original delivery's retry turn has started; it
+must not start a competing turn during the backoff. After the retry turn
+starts, normal steer/drain processing may attach the queued tail.
+
+Repeat with the second message successfully steered into the first attempt
+before that attempt fails. Every later retry attempt and the final success or
+exhausted settlement must retain both messages. The steered tail must not be
+left in processing state or separately retried.
+
+Include a negative branch when the controlled environment supports it: a
+credential, deterministic-input, or unknown-custody failure must still stop
+instead of being treated as a known transient retry. Do not report `PASS` when
+the provider failure cannot be induced deterministically or the inbox
+settlement is not observable; report `BLOCKED` or `INCONCLUSIVE` with the
+missing evidence instead.


### PR DESCRIPTION
## Summary

- allow explicit `provider_capacity` and `transient_transport` failures to remain retryable after user-visible output or tool effects
- keep Codex app-server retries bounded inside the active handler, preserving the retry chain, accepted message prefix, and pending-tail custody across attempts
- exhaust overloaded and short-wait capacity failures after two foreground retries, then persist the terminal runtime notice before the single inbox ACK
- add product regressions and a formal QA case for capacity retry, exhaustion, backoff fencing, and steered-tail settlement

## Context

Codex can report `Selected model is at capacity. Please try a different model.` after assistant output or completed file changes. First Tree previously classified the resulting turn as `unsafe_replay` and consumed it immediately. The retry policy now treats failure classification and replay safety as separate inputs: known transient provider failures can continue through a bounded handler-owned retry chain, while unknown custody and permanent failures still stop.

## Companion Context Tree change

- https://github.com/agent-team-foundation/first-tree-context/pull/755 (draft; merge the code PR first)

## Validation

- `pnpm --filter @first-tree/client test --pool=threads --poolOptions.threads.maxThreads=2 --poolOptions.threads.minThreads=1 --reporter=dot` — 148 files passed, 1577 tests passed, 3 skipped
- targeted Codex app-server suite — 50 tests passed
- `pnpm check` — passed with 3 pre-existing warning/info diagnostics
- `pnpm typecheck` — 10/10 tasks passed
- `first-tree-staging tree verify` — passed for the companion Context Tree change
- shared/server/web/skill-evals suites passed before the final client-only review fixes

The formal provider/bridge QA case was added but not executed because no deterministic controlled provider failure environment was available. The unrelated CLI suite still has two reproducible baseline failures in `update-portable-install.test.ts` where expected fallback shims are absent; this PR does not modify CLI code.
