### PR TITLE
fix(web): make source repositories provider-neutral

### DIFF
--- a/packages/qa/cases/cross-surface/agent-code-access-navigation.md
+++ b/packages/qa/cases/cross-surface/agent-code-access-navigation.md
@@ -1,0 +1,77 @@
+---
+id: agent-code-access-navigation
+description: Validate that Team repository access stays provider-neutral across Settings and Agent Detail, including reliable deep-link positioning from a scrolled Agent page.
+areas: [cross-surface]
+surfaces: [web]
+---
+
+# Agent Code Access Navigation
+
+## Goal
+
+Confirm that Team repository access is one provider-neutral catalog shared by
+agents, while GitHub and GitLab connections remain separate event, identity,
+and webhook controls. Validate the real Agent Detail → Settings navigation
+through the Web shell's persistent scroll container; deterministic DOM tests
+own the URL and hash-effect branches, while this case owns the assembled
+browser positioning and cross-page information hierarchy.
+
+## Preconditions
+
+- Run the target ref in the isolated Docker plus temporary-worktree QA cell.
+- Prepare one Team admin, one ordinary member, and a manageable non-human
+  agent. Seed at least four recommended Team repository resources using a mix
+  of GitHub, GitLab, and another valid Git-server URL.
+- The provider connection states may be connected or disconnected, but record
+  them before the run. Do not place real private-repository credentials in the
+  Team resource payload or QA artifacts.
+
+## Operate and Observe
+
+- As the admin, open Settings → Integrations under both the GitHub and GitLab
+  tabs. Confirm **Code available to agents** is above **Connections**, shows
+  the same Team repository catalog on both routes, and does not move into or
+  duplicate inside either provider tab.
+- Confirm the first three repositories are visible and the fourth is hidden
+  behind **View all (4)**. Expand and collapse the list, then add or edit a
+  repository with a full non-GitHub URL and verify the shared catalog updates
+  without requiring a GitHub App or GitLab webhook connection.
+- As the ordinary member, confirm the same shared catalog is readable while
+  add, edit, and retire controls remain unavailable. Provider connection
+  controls must retain their existing role boundary.
+- Open the agent's repository-management surface, scroll the persistent main
+  pane far enough that preserving the old offset would skip the top of the
+  Settings page, and choose **Manage Team code access**. Confirm navigation
+  lands with the shared code section visibly positioned and focused rather
+  than leaving the viewport below it. Repeat after visiting both a GitHub and
+  a GitLab connection tab.
+- Confirm the agent's effective repository list reflects recommended Team
+  resources independently of provider connection state. The UI may explain
+  that private clone access uses Git credentials on the agent computer; it
+  must not imply that webhook or provider-connection credentials clone code.
+
+## Evidence
+
+Capture the before-navigation Agent viewport and the positioned Settings
+destination, both provider-tab routes with the same catalog, compact and
+expanded list states, and admin-versus-member controls. Record only redacted
+repository coordinates and connection summaries; never retain Git tokens,
+private clone credentials, or one-time webhook bearers.
+
+## Expected Result
+
+`PASS`: one provider-neutral Team repository catalog appears above provider
+connections, role boundaries are preserved, the compact list behaves as
+described, and the Agent shortcut reliably positions the shared section from
+a deeply scrolled origin page.
+
+`FAIL`: repository management is provider-bound or duplicated, connection
+state changes catalog availability, a member gains write controls, or the
+Agent shortcut preserves an offset that hides the destination.
+
+`BLOCKED`: the isolated run cell cannot create the required Team roles,
+manageable agent, or repository fixtures.
+
+`INCONCLUSIVE`: source inspection or unit-test output exists, but the real
+persistent-scroll navigation and assembled Settings hierarchy were not
+observed in a browser.

--- a/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/resource-editors-dom.test.tsx
@@ -108,9 +108,9 @@ async function clickWhenEnabled(text: string): Promise<void> {
 
 async function render(): Promise<{ root: Root }> {
   // Mount the shared sections component with every type: the machinery under
-  // test is type-agnostic, and the page-level split (repo on Settings →
-  // GitHub as "Source Repos", the rest on Settings → Resources) is covered
-  // by the page smoke tests.
+  // test is type-agnostic, and the page-level split (repo in the shared
+  // Integrations code-access area, the rest on Settings → Resources) is
+  // covered by the page smoke tests.
   const { ResourceTypeSections } = await import("../settings/resource-sections.js");
   const { RESOURCE_TYPES } = await import("../settings/resource-editors.js");
   const { ToastProvider } = await import("../../components/ui/toast.js");

--- a/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
@@ -398,11 +398,11 @@ describe("ResourcesTab", () => {
     // The opt-in repo is not enableable, and there's no "Enable from team" list…
     expect(buttonByText(document.body, "Opt-in repo")).toBeNull();
     expect(document.body.textContent).not.toContain("Enable from team");
-    // …but the menu stays actionable: add a private repo or jump to Settings.
-    // Team repos manage on Settings → GitHub (Source Repos live there);
-    // skill/MCP/prompt menus keep the Resources destination.
+    // …but the menu stays actionable: add a private repo or jump to the
+    // provider-neutral Team code-access area in Settings. Skill/MCP/prompt
+    // menus keep the Resources destination.
     expect(buttonByText(document.body, "Add agent repo")).toBeTruthy();
-    expect(buttonByText(document.body, "Manage in Settings → GitHub")).toBeTruthy();
+    expect(buttonByText(document.body, "Manage Team code access")).toBeTruthy();
     expect(buttonByText(document.body, "Manage in Settings → Resources")).toBeNull();
   });
 

--- a/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
@@ -331,6 +331,7 @@ describe("ResourcesTab", () => {
 
   it("renders the repo section (Environment) with rows and an actionable add menu", async () => {
     const { ResourceTypeSection } = await import("../capability-section.js");
+    const onNavigateAway = vi.fn();
     // An enabled team repo to render, plus a legacy team repo still flagged
     // Opt-in (available). Team repos are now always On by default, so the opt-in
     // one must NOT be offered as an "enable from team" option.
@@ -382,7 +383,14 @@ describe("ResourcesTab", () => {
     });
 
     const container = await renderRouted(
-      <ResourceTypeSection type="repo" data={data} canEdit pending={false} onMutate={vi.fn()} />,
+      <ResourceTypeSection
+        type="repo"
+        data={data}
+        canEdit
+        pending={false}
+        onMutate={vi.fn()}
+        onNavigateAway={onNavigateAway}
+      />,
     );
 
     expect(container.textContent).toContain("Repositories");
@@ -402,7 +410,8 @@ describe("ResourcesTab", () => {
     // provider-neutral Team code-access area in Settings. Skill/MCP/prompt
     // menus keep the Resources destination.
     expect(buttonByText(document.body, "Add agent repo")).toBeTruthy();
-    expect(buttonByText(document.body, "Manage Team code access")).toBeTruthy();
+    await click(buttonByText(document.body, "Manage Team code access"));
+    expect(onNavigateAway).toHaveBeenCalledWith("/settings/integrations/github#code-access");
     expect(buttonByText(document.body, "Manage in Settings → Resources")).toBeNull();
   });
 

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -225,11 +225,12 @@ function AddCapabilityMenu(props: {
   onNavigateAway?: (to: string) => void;
 }) {
   const navigate = useNavigate();
-  // Team repos are managed on Settings → GitHub (the "Source Repos" section
-  // lives next to the GitHub connection); the other resource types stay on
-  // Settings → Resources.
-  const settingsPath = props.type === "repo" ? "/settings/integrations/github" : "/settings/resources";
-  const settingsLabel = props.type === "repo" ? "Manage in Settings → GitHub" : "Manage in Settings → Resources";
+  // Team repos are managed in the provider-neutral code-access area on
+  // Settings → Integrations; the other resource types stay on Settings →
+  // Resources. The anchor makes this exit land on the shared section rather
+  // than implying that Team code belongs to the active GitHub connection.
+  const settingsPath = props.type === "repo" ? "/settings/integrations/github#code-access" : "/settings/resources";
+  const settingsLabel = props.type === "repo" ? "Manage Team code access" : "Manage in Settings → Resources";
   const goToSettings = () => (props.onNavigateAway ?? navigate)(settingsPath);
   return (
     <Popover
@@ -408,9 +409,9 @@ function AgentRepoDialog(props: {
   const [error, setError] = useState<string | null>(null);
   function submit(e: FormEvent) {
     e.preventDefault();
-    // Normalize so common paste shapes (github.com/org/repo, org/repo) work
-    // without a scheme, then derive the name — matching the Settings → Resources
-    // repo editor. A repo has no user-meaningful name, so we don't ask for one.
+    // Normalize common paste shapes, then derive the name — matching the Team
+    // code-access editor. A repo has no user-meaningful name, so we don't ask
+    // for one.
     const normalized = normalizeRepoUrl(url);
     if (!normalized) {
       setError("URL is required.");
@@ -431,7 +432,14 @@ function AgentRepoDialog(props: {
           <DialogTitle>Add agent repository</DialogTitle>
         </DialogHeader>
         <form onSubmit={submit} className="space-y-4">
-          <Field id="agent-repo-url" label="URL" value={url} onChange={setUrl} placeholder="github.com/org/repo" mono />
+          <Field
+            id="agent-repo-url"
+            label="URL"
+            value={url}
+            onChange={setUrl}
+            placeholder="https://git.example.com/org/repo.git"
+            mono
+          />
           <Field id="agent-repo-branch" label="Default branch" value={branch} onChange={setBranch} placeholder="main" />
           {error ? (
             <p className="text-body" style={{ color: "var(--state-error)" }}>

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -44,10 +44,11 @@ import { cn } from "../lib/utils.js";
  *                   entry point — placed first)
  *   Context tree  — org-scoped Context Tree binding (repo / branch). Visible
  *                   to all members (read-only); only admins can edit.
- *   Resources     — org-scoped runtime resources (repo / prompt / skill / mcp).
+ *   Resources     — org-scoped runtime resources (prompt / skill / mcp).
  *                   Visible to all members (read-only); only admins can manage.
- *   Integrations  — provider-specific GitHub/GitLab connections. Visible to
- *                   all members (read-only); only admins can mutate them.
+ *   Integrations  — Team code access plus provider-specific GitHub/GitLab
+ *                   connections. Visible to all members (read-only); only
+ *                   admins can mutate them.
  *   Setup         — guided-setup stepper enable/disable (hidden once
  *                   onboarding is permanently completed)
  */
@@ -79,7 +80,7 @@ const ITEMS: Item[] = [
   {
     to: "/settings/integrations",
     label: "Integrations",
-    description: "Connect source providers and control how their events reach your Team.",
+    description: "Choose the code agents can access and connect providers for events and identity.",
   },
   { to: "/settings/onboarding", label: "Setup" },
 ];

--- a/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/github-page-dom.test.tsx
@@ -6,9 +6,9 @@ import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// The GitHub round-trip return is the only logic under test here; stub the heavy
-// children (the installation panel and the repo resource sections) so the test
-// stays focused on the `?from=context` return affordance.
+// The GitHub round-trip return is the only logic under test here; stub the
+// installation panel so the test stays focused on the `?from=context` return
+// affordance. Team code access now belongs to the parent Integrations layout.
 const githubAppMocks = vi.hoisted(() => ({ getGithubAppInstallation: vi.fn() }));
 const authMock = vi.hoisted(() => ({
   value: { role: "admin" as string | null, organizationId: "org-1" as string | null },
@@ -18,9 +18,6 @@ vi.mock("../../../api/github-app.js", () => githubAppMocks);
 vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
 vi.mock("../../github-app-installation-panel.js", () => ({
   GithubAppInstallationPanel: () => <div data-testid="panel-stub">panel</div>,
-}));
-vi.mock("../resource-sections.js", () => ({
-  ResourceTypeSections: () => <div data-testid="resources-stub">resources</div>,
 }));
 
 function createClient(): QueryClient {

--- a/packages/web/src/pages/settings/__tests__/integrations-layout-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/integrations-layout-dom.test.tsx
@@ -3,9 +3,12 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter, Route, Routes } from "react-router";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
+let scrollIntoView: ReturnType<typeof vi.fn>;
 
 vi.mock("../resource-sections.js", () => ({
   ResourceTypeSections: (props: {
@@ -49,7 +52,14 @@ async function renderLayout(path = "/settings/integrations/github"): Promise<{ c
   return { container, root };
 }
 
+beforeEach(() => {
+  originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+  scrollIntoView = vi.fn();
+  HTMLElement.prototype.scrollIntoView = scrollIntoView;
+});
+
 afterEach(() => {
+  HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
   document.body.innerHTML = "";
   vi.restoreAllMocks();
 });
@@ -74,6 +84,7 @@ describe("SettingsIntegrationsLayout", () => {
     expect(nav).not.toBeNull();
     expect(nav?.querySelector('a[href="/settings/integrations/github"]')?.getAttribute("aria-current")).toBe("page");
     expect(nav?.querySelector('a[href="/settings/integrations/gitlab"]')).not.toBeNull();
+    expect(scrollIntoView).not.toHaveBeenCalled();
     await act(async () => root.unmount());
   });
 
@@ -86,6 +97,17 @@ describe("SettingsIntegrationsLayout", () => {
         .querySelector('nav[aria-label="Connection provider"] a[href="/settings/integrations/gitlab"]')
         ?.getAttribute("aria-current"),
     ).toBe("page");
+    await act(async () => root.unmount());
+  });
+
+  it("positions and focuses the shared code section when the Agent shortcut supplies its hash", async () => {
+    const { container, root } = await renderLayout("/settings/integrations/github#code-access");
+    const target = container.querySelector<HTMLElement>("#code-access");
+    expect(target?.getAttribute("aria-label")).toBe("Code available to agents");
+    expect(target?.tabIndex).toBe(-1);
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(document.activeElement).toBe(target);
     await act(async () => root.unmount());
   });
 });

--- a/packages/web/src/pages/settings/__tests__/integrations-layout-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/integrations-layout-dom.test.tsx
@@ -103,6 +103,7 @@ describe("SettingsIntegrationsLayout", () => {
   it("positions and focuses the shared code section when the Agent shortcut supplies its hash", async () => {
     const { container, root } = await renderLayout("/settings/integrations/github#code-access");
     const target = container.querySelector<HTMLElement>("#code-access");
+    expect(target?.tagName).toBe("SECTION");
     expect(target?.getAttribute("aria-label")).toBe("Code available to agents");
     expect(target?.tabIndex).toBe(-1);
     expect(scrollIntoView).toHaveBeenCalledOnce();

--- a/packages/web/src/pages/settings/__tests__/integrations-layout-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/integrations-layout-dom.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("../resource-sections.js", () => ({
+  ResourceTypeSections: (props: {
+    types: string[];
+    titleFor?: (type: "repo") => string;
+    descriptionFor?: (type: "repo") => string;
+    addLabelFor?: (type: "repo") => string;
+    emptyLabelFor?: (type: "repo") => string;
+    compactLimit?: number;
+  }) => (
+    <div
+      data-testid="resource-sections"
+      data-types={props.types.join(",")}
+      data-compact-limit={props.compactLimit}
+      data-add-label={props.addLabelFor?.("repo")}
+      data-empty-label={props.emptyLabelFor?.("repo")}
+    >
+      <span>{props.titleFor?.("repo")}</span>
+      <span>{props.descriptionFor?.("repo")}</span>
+    </div>
+  ),
+}));
+
+async function renderLayout(path = "/settings/integrations/github"): Promise<{ container: HTMLElement; root: Root }> {
+  const { SettingsIntegrationsLayout } = await import("../integrations.js");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/settings/integrations" element={<SettingsIntegrationsLayout />}>
+            <Route path="github" element={<div>GitHub connection content</div>} />
+            <Route path="gitlab" element={<div>GitLab connection content</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+  });
+  return { container, root };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("SettingsIntegrationsLayout", () => {
+  it("places provider-neutral Team code access above provider connections", async () => {
+    const { container, root } = await renderLayout();
+    const resourceSections = container.querySelector<HTMLElement>('[data-testid="resource-sections"]');
+    expect(resourceSections?.dataset.types).toBe("repo");
+    expect(resourceSections?.dataset.compactLimit).toBe("3");
+    expect(resourceSections?.dataset.addLabel).toBe("Add code repository");
+    expect(resourceSections?.dataset.emptyLabel).toBe("No code repositories configured yet.");
+    expect(resourceSections?.textContent).toContain("Code available to agents");
+    expect(resourceSections?.textContent).toContain("GitHub, GitLab, or any Git server");
+    expect(resourceSections?.textContent).toContain("Git credentials on each agent's computer");
+
+    const text = container.textContent ?? "";
+    expect(text.indexOf("Code available to agents")).toBeLessThan(text.indexOf("Connections"));
+    expect(text.indexOf("Connections")).toBeLessThan(text.indexOf("GitHub connection content"));
+
+    const nav = container.querySelector('nav[aria-label="Connection provider"]');
+    expect(nav).not.toBeNull();
+    expect(nav?.querySelector('a[href="/settings/integrations/github"]')?.getAttribute("aria-current")).toBe("page");
+    expect(nav?.querySelector('a[href="/settings/integrations/gitlab"]')).not.toBeNull();
+    await act(async () => root.unmount());
+  });
+
+  it("keeps the shared code area above the long GitLab connection surface", async () => {
+    const { container, root } = await renderLayout("/settings/integrations/gitlab");
+    const text = container.textContent ?? "";
+    expect(text.indexOf("Code available to agents")).toBeLessThan(text.indexOf("GitLab connection content"));
+    expect(
+      container
+        .querySelector('nav[aria-label="Connection provider"] a[href="/settings/integrations/gitlab"]')
+        ?.getAttribute("aria-current"),
+    ).toBe("page");
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/pages/settings/__tests__/resource-sections-compact-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/resource-sections-compact-dom.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+
+import type { ResourceRow } from "@first-tree/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider } from "../../../components/ui/toast.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const authMock = vi.hoisted(() => ({ value: { role: "admin" as "admin" | "member" } }));
+const resourceMocks = vi.hoisted(() => ({
+  listTeamResources: vi.fn(),
+  previewResourceImpact: vi.fn(),
+  retireResource: vi.fn(),
+}));
+
+vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
+vi.mock("../../../api/resources.js", async () => {
+  const actual = await vi.importActual<typeof import("../../../api/resources.js")>("../../../api/resources.js");
+  return { ...actual, ...resourceMocks };
+});
+
+const NOW = "2026-07-16T00:00:00.000Z";
+
+function repo(id: string): ResourceRow {
+  return {
+    id,
+    organizationId: "org-1",
+    type: "repo",
+    scope: "team",
+    ownerAgentId: null,
+    name: id,
+    repoCanonicalKey: `git.example.com/acme/${id}`,
+    defaultEnabled: "recommended",
+    status: "active",
+    payload: { url: `https://git.example.com/acme/${id}.git` },
+    createdBy: "member-1",
+    updatedBy: "member-1",
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function client(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false }, mutations: { retry: false } },
+  });
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function renderSections(): Promise<{ container: HTMLElement; root: Root }> {
+  const { ResourceTypeSections } = await import("../resource-sections.js");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={client()}>
+        <ToastProvider>
+          <ResourceTypeSections
+            types={["repo"]}
+            titleFor={() => "Code available to agents"}
+            descriptionFor={() => "Choose the code your agents can read and change."}
+            addLabelFor={() => "Add code repository"}
+            emptyLabelFor={() => "No code repositories configured yet."}
+            compactLimit={3}
+          />
+        </ToastProvider>
+      </QueryClientProvider>,
+    );
+  });
+  await flush();
+  return { container, root };
+}
+
+async function click(button: HTMLButtonElement | null): Promise<void> {
+  if (!button) throw new Error("Expected button");
+  await act(async () => button.click());
+  await flush();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+  authMock.value = { role: "admin" };
+  resourceMocks.listTeamResources.mockResolvedValue([repo("alpha"), repo("beta"), repo("gamma"), repo("delta")]);
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("ResourceTypeSections compact mode", () => {
+  it("shows three rows until an accessible View all control expands the section", async () => {
+    const { container, root } = await renderSections();
+    expect(container.textContent).toContain("Code available to agents");
+    expect(container.textContent).toContain("Choose the code your agents can read and change.");
+    expect(container.querySelector('button[aria-label="Add code repository"]')).not.toBeNull();
+    expect(container.textContent).toContain("alpha");
+    expect(container.textContent).toContain("beta");
+    expect(container.textContent).toContain("gamma");
+    expect(container.textContent).not.toContain("delta");
+
+    const expand = [...container.querySelectorAll<HTMLButtonElement>("button")].find((item) =>
+      item.textContent?.includes("View all (4)"),
+    );
+    expect(expand?.getAttribute("aria-expanded")).toBe("false");
+    await click(expand ?? null);
+    expect(container.textContent).toContain("delta");
+
+    const collapse = [...container.querySelectorAll<HTMLButtonElement>("button")].find((item) =>
+      item.textContent?.includes("Show less"),
+    );
+    expect(collapse?.getAttribute("aria-expanded")).toBe("true");
+    await click(collapse ?? null);
+    expect(container.textContent).not.toContain("delta");
+    await act(async () => root.unmount());
+  });
+
+  it("uses the host's explicit empty and add copy", async () => {
+    resourceMocks.listTeamResources.mockResolvedValue([]);
+    const { container, root } = await renderSections();
+    expect(container.textContent).toContain("No code repositories configured yet.");
+    expect(container.querySelector('button[aria-label="Add code repository"]')).not.toBeNull();
+    expect(container.textContent).not.toContain("View all");
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/pages/settings/github.tsx
+++ b/packages/web/src/pages/settings/github.tsx
@@ -6,18 +6,12 @@ import { useAuth } from "../../auth/auth-context.js";
 import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
 import { GithubAppInstallationPanel } from "../github-app-installation-panel.js";
-import { ResourceTypeSections } from "./resource-sections.js";
 
 /**
- * Settings → Integrations → GitHub. Members can read the team's GitHub connection and source
- * repo catalog; admin-only actions stay hidden in the panel/resource sections.
- *
- * Two sections:
- *   - GitHub Connection — the GitHub App installation panel (connect /
- *     disconnect / install for admins; read-only state for members).
- *   - Source Repos — the team's `repo` runtime resources, moved here from
- *     Settings → Resources so the repos agents work on sit next to the
- *     GitHub connection their code and events flow through.
+ * Settings → Integrations → GitHub. Members can read the team's GitHub
+ * connection; admin-only actions stay hidden in the installation panel. Team
+ * code access is provider-neutral and lives in the shared Integrations layout
+ * above the GitHub/GitLab connection tabs.
  *
  * `?from=context`: the Context tab is the single place a team builds its
  * Context Tree, but installing + connecting GitHub lives here (the one place
@@ -57,7 +51,6 @@ export function SettingsGithubPage() {
       <Section title="Connection">
         <GithubAppInstallationPanel readOnly={!isAdmin} />
       </Section>
-      <ResourceTypeSections types={["repo"]} titleFor={() => "Source repos"} />
     </div>
   );
 }
@@ -66,7 +59,7 @@ export function SettingsGithubPage() {
  * The Context round-trip return. Before the team is connected it's a quiet line
  * explaining why the user was sent here; once connected it becomes the explicit
  * way back to building (deliberately a button, not an auto-redirect, so the user
- * stays in control and can adjust source repos below first if they want).
+ * stays in control and can adjust shared code access above first if they want).
  */
 function ContextReturn({ connected }: { connected: boolean }) {
   if (!connected) {

--- a/packages/web/src/pages/settings/integrations.tsx
+++ b/packages/web/src/pages/settings/integrations.tsx
@@ -1,19 +1,46 @@
 import { NavLink, Outlet } from "react-router";
 import { cn } from "../../lib/utils.js";
+import { ResourceTypeSections } from "./resource-sections.js";
 
 const PROVIDERS = [
   { to: "/settings/integrations/github", label: "GitHub" },
   { to: "/settings/integrations/gitlab", label: "GitLab" },
 ] as const;
 
-/** One Settings information architecture; providers are children of Integrations. */
+/**
+ * One Settings information architecture: provider-neutral code access first,
+ * then provider-specific event/identity connections. Repositories deliberately
+ * sit outside the provider tabs because their runtime availability does not
+ * depend on a GitHub App or GitLab webhook connection.
+ */
 export function SettingsIntegrationsLayout() {
   return (
     <div>
+      <div id="code-access" style={{ padding: "var(--sp-2) var(--sp-5) 0", scrollMarginTop: "var(--sp-4)" }}>
+        <ResourceTypeSections
+          types={["repo"]}
+          titleFor={() => "Code available to agents"}
+          descriptionFor={() =>
+            "Choose the code your agents can read and change. GitHub, GitLab, or any Git server; private access uses Git credentials on each agent's computer."
+          }
+          addLabelFor={() => "Add code repository"}
+          emptyLabelFor={() => "No code repositories configured yet."}
+          compactLimit={3}
+        />
+      </div>
+
+      <div style={{ padding: "var(--sp-7) var(--sp-5) 0" }}>
+        <h2 className="text-title font-semibold m-0" style={{ color: "var(--fg)" }}>
+          Connections
+        </h2>
+        <p className="text-label m-0" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
+          Connect providers for webhooks, identity, and event routing.
+        </p>
+      </div>
       <nav
-        aria-label="Integration provider"
+        aria-label="Connection provider"
         className="flex"
-        style={{ gap: "var(--sp-1)", padding: "var(--sp-2) var(--sp-5) 0" }}
+        style={{ gap: "var(--sp-1)", padding: "var(--sp-3) var(--sp-5) 0", overflowX: "auto" }}
       >
         {PROVIDERS.map((provider) => (
           <NavLink

--- a/packages/web/src/pages/settings/integrations.tsx
+++ b/packages/web/src/pages/settings/integrations.tsx
@@ -1,4 +1,5 @@
-import { NavLink, Outlet } from "react-router";
+import { useEffect, useRef } from "react";
+import { NavLink, Outlet, useLocation } from "react-router";
 import { cn } from "../../lib/utils.js";
 import { ResourceTypeSections } from "./resource-sections.js";
 
@@ -14,9 +15,30 @@ const PROVIDERS = [
  * depend on a GitHub App or GitLab webhook connection.
  */
 export function SettingsIntegrationsLayout() {
+  const location = useLocation();
+  const codeAccessRef = useRef<HTMLDivElement>(null);
+
+  // React Router updates the URL fragment but does not scroll the app's
+  // persistent overflow container. Position and focus the shared section
+  // explicitly so exits from a deeply scrolled Agent page cannot land below
+  // the intended destination.
+  useEffect(() => {
+    if (location.hash !== "#code-access") return;
+    const target = codeAccessRef.current;
+    if (!target) return;
+    target.scrollIntoView({ block: "start" });
+    target.focus({ preventScroll: true });
+  }, [location.hash]);
+
   return (
     <div>
-      <div id="code-access" style={{ padding: "var(--sp-2) var(--sp-5) 0", scrollMarginTop: "var(--sp-4)" }}>
+      <div
+        ref={codeAccessRef}
+        id="code-access"
+        tabIndex={-1}
+        aria-label="Code available to agents"
+        style={{ padding: "var(--sp-2) var(--sp-5) 0", scrollMarginTop: "var(--sp-4)" }}
+      >
         <ResourceTypeSections
           types={["repo"]}
           titleFor={() => "Code available to agents"}

--- a/packages/web/src/pages/settings/integrations.tsx
+++ b/packages/web/src/pages/settings/integrations.tsx
@@ -16,7 +16,7 @@ const PROVIDERS = [
  */
 export function SettingsIntegrationsLayout() {
   const location = useLocation();
-  const codeAccessRef = useRef<HTMLDivElement>(null);
+  const codeAccessRef = useRef<HTMLElement>(null);
 
   // React Router updates the URL fragment but does not scroll the app's
   // persistent overflow container. Position and focus the shared section
@@ -32,7 +32,7 @@ export function SettingsIntegrationsLayout() {
 
   return (
     <div>
-      <div
+      <section
         ref={codeAccessRef}
         id="code-access"
         tabIndex={-1}
@@ -49,7 +49,7 @@ export function SettingsIntegrationsLayout() {
           emptyLabelFor={() => "No code repositories configured yet."}
           compactLimit={3}
         />
-      </div>
+      </section>
 
       <div style={{ padding: "var(--sp-7) var(--sp-5) 0" }}>
         <h2 className="text-title font-semibold m-0" style={{ color: "var(--fg)" }}>

--- a/packages/web/src/pages/settings/resource-editors.tsx
+++ b/packages/web/src/pages/settings/resource-editors.tsx
@@ -407,8 +407,10 @@ function RepoEditor({ state, save, onClose }: EditorProps) {
 
   // A repo has no user-meaningful name — it's the `owner/repo` of the URL — so we
   // don't ask for one: the display name is derived from the (normalized) URL. The
-  // URL is normalized first so common paste shapes (github.com/org/repo, org/repo)
-  // work without a scheme; the server schema still validates the result. Repos are
+  // URL is normalized first so common full-host paste shapes work without a
+  // scheme; the server schema still validates the result. The owner/repo shorthand
+  // remains GitHub-specific, so the provider-neutral UI prompts for a full host.
+  // Repos are
   // always a team-wide default: pin `defaultEnabled: "recommended"` (editing a
   // legacy Opt-in repo normalizes it to recommended).
   const normalizedUrl = normalizeRepoUrl(url);
@@ -426,7 +428,7 @@ function RepoEditor({ state, save, onClose }: EditorProps) {
         label="Repository URL"
         value={url}
         onChange={setUrl}
-        placeholder="github.com/org/repo"
+        placeholder="https://git.example.com/org/repo.git"
         mono
         required
       />

--- a/packages/web/src/pages/settings/resource-sections.tsx
+++ b/packages/web/src/pages/settings/resource-sections.tsx
@@ -29,9 +29,10 @@ import { ResourcePreviewDialog } from "./resource-preview-dialog.js";
 /**
  * Section list for a subset of the team's runtime resource types, extracted
  * from the Settings → Resources page so a type can live on a different
- * Settings page without duplicating the list/editor/retire machinery — the
- * `repo` type renders on Settings → GitHub as "Source Repos", next to the
- * GitHub App connection those repos flow through.
+ * Settings page without duplicating the list/editor/retire machinery. The
+ * `repo` type renders in the provider-neutral code-access area on Settings →
+ * Integrations; prompt, skill, and MCP resources remain on Settings →
+ * Resources.
  *
  * Behaviour matches the Resources page: everyone can open the read-only
  * preview (the eye icon); only admins see add / edit / retire affordances.
@@ -45,10 +46,22 @@ import { ResourcePreviewDialog } from "./resource-preview-dialog.js";
 export function ResourceTypeSections({
   types,
   titleFor,
+  descriptionFor,
+  addLabelFor,
+  emptyLabelFor,
+  compactLimit,
 }: {
   types: readonly ResourceType[];
   /** Override a section's heading; defaults to the type's plural label. */
   titleFor?: (type: ResourceType) => string;
+  /** Optional explanatory copy beneath a section heading. */
+  descriptionFor?: (type: ResourceType) => string;
+  /** Override the section-local add button's accessible label and tooltip. */
+  addLabelFor?: (type: ResourceType) => string;
+  /** Override the empty-state sentence. */
+  emptyLabelFor?: (type: ResourceType) => string;
+  /** Keep long sections compact until the user explicitly expands them. */
+  compactLimit?: number;
 }) {
   const { role } = useAuth();
   const isAdmin = role === "admin";
@@ -57,6 +70,7 @@ export function ResourceTypeSections({
   const [editor, setEditor] = useState<EditorState | null>(null);
   const [preview, setPreview] = useState<ResourceRow | null>(null);
   const [retireTarget, setRetireTarget] = useState<ResourceRow | null>(null);
+  const [expandedTypes, setExpandedTypes] = useState<ResourceType[]>([]);
   const resourcesQuery = useQuery({ queryKey: ["team-resources"], queryFn: listTeamResources });
   const retireMut = useMutation({
     mutationFn: retireResource,
@@ -93,20 +107,25 @@ export function ResourceTypeSections({
         </p>
       ) : (
         types.map((type) => {
-          // When the host overrides a section's title (e.g. GitHub renders the
-          // `repo` type as "Source repos"), derive the empty-state and add-button
-          // nouns from that title so they read as one surface — instead of the
-          // per-type default ("repos" / "Repo") leaking through. Plural comes
-          // straight from the (already-plural) title; the add label strips a
-          // trailing "s" for a singular.
+          // When the host overrides a section's title, derive fallback copy from
+          // that title so the surface stays coherent. Hosts with sentence-like
+          // titles (for example "Code available to agents") can supply explicit
+          // add/empty labels rather than relying on this simple noun fallback.
           const overrideTitle = titleFor?.(type);
           const pluralNoun = overrideTitle ? overrideTitle.toLowerCase() : typeLabelPlural(type).toLowerCase();
-          const addLabel = overrideTitle ? `Add ${overrideTitle.toLowerCase().replace(/s$/, "")}` : undefined;
+          const addLabel =
+            addLabelFor?.(type) ?? (overrideTitle ? `Add ${overrideTitle.toLowerCase().replace(/s$/, "")}` : undefined);
+          const rows = grouped.get(type) ?? [];
+          const limit = compactLimit !== undefined && compactLimit > 0 ? compactLimit : null;
+          const isExpanded = expandedTypes.includes(type);
+          const isCompactable = limit !== null && rows.length > limit;
+          const visibleRows = isCompactable && !isExpanded ? rows.slice(0, limit) : rows;
           return (
             <Section
               key={type}
               title={overrideTitle ?? typeLabelPlural(type)}
-              count={grouped.get(type)?.length ?? 0}
+              count={rows.length}
+              description={descriptionFor?.(type)}
               action={
                 isAdmin ? (
                   <AddResourceButton type={type} label={addLabel} onClick={() => setEditor({ mode: "create", type })} />
@@ -114,12 +133,12 @@ export function ResourceTypeSections({
               }
             >
               <div>
-                {(grouped.get(type) ?? []).length === 0 ? (
+                {rows.length === 0 ? (
                   <p className="text-body" style={{ color: "var(--fg-4)", padding: "var(--sp-3) 0", margin: 0 }}>
-                    No {pluralNoun} configured yet.
+                    {emptyLabelFor?.(type) ?? `No ${pluralNoun} configured yet.`}
                   </p>
                 ) : (
-                  (grouped.get(type) ?? []).map((resource) => (
+                  visibleRows.map((resource) => (
                     <ResourceListRow
                       key={resource.id}
                       resource={resource}
@@ -130,6 +149,23 @@ export function ResourceTypeSections({
                     />
                   ))
                 )}
+                {isCompactable ? (
+                  <div className="flex justify-start" style={{ paddingTop: "var(--sp-2)" }}>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      aria-expanded={isExpanded}
+                      onClick={() =>
+                        setExpandedTypes((current) =>
+                          current.includes(type) ? current.filter((item) => item !== type) : [...current, type],
+                        )
+                      }
+                    >
+                      {isExpanded ? "Show less" : `View all (${rows.length})`}
+                    </Button>
+                  </div>
+                ) : null}
               </div>
             </Section>
           );

--- a/packages/web/src/pages/settings/resources.tsx
+++ b/packages/web/src/pages/settings/resources.tsx
@@ -6,9 +6,9 @@ import { ResourceTypeSections } from "./resource-sections.js";
  * the team's agents consume. Lives under Settings (an org-admin config
  * surface), not on the Team roster — see the Settings IA in settings.tsx.
  *
- * The `repo` type is deliberately absent here: source repos render on
- * Settings → GitHub as the "Source Repos" section, next to the GitHub App
- * connection their code and events flow through.
+ * The `repo` type is deliberately absent here: Team code repositories render
+ * in the provider-neutral "Code available to agents" area on Settings →
+ * Integrations, above the GitHub/GitLab connection tabs.
  *
  * Visible to all members. Everyone can open the read-only preview; only
  * admins see add / edit / retire affordances (see ResourceTypeSections).


### PR DESCRIPTION
## Summary

- Move Team repository management out of the GitHub tab into a shared **Code available to agents** section above **Connections** in Settings → Integrations.
- Keep GitHub and GitLab tabs focused on provider connections, while repository copy and URL examples support GitHub, GitLab, and any Git server.
- Keep the shared repository list compact at three rows with an accessible View all / Show less control.
- Make the Agent Detail shortcut reliably position and focus the shared section through the app's persistent scroll container.

This removes the misleading implication that GitLab users must configure agent code access inside a GitHub-owned surface. Repository runtime projection remains independent from webhook, identity, and event-routing connections.

Companion Context Tree update: [first-tree-context#758](https://github.com/agent-team-foundation/first-tree-context/pull/758) (draft; merge after this code PR and reconcile before marking ready).

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the local full-suite run hit unrelated runner/environment failures: parallel execution timed out three Context Tree audit fixtures (all 12 passed when rerun alone), while a serial rerun's CLI process-drain tests classified the test runner itself as an unmarked First Tree provider process.
- [x] `pnpm --filter @first-tree/web test` — 186 files, 1,473 tests passed.
- [x] Focused Integrations hash positioning, resource-list, route, editor, and Agent capability DOM coverage passed.
- [x] Companion Context Tree verification passed.

## Formal QA

- [x] Formal QA is warranted because the shortcut crosses Agent Detail and Settings through a persistent scroll container.
- Added `packages/qa/cases/cross-surface/agent-code-access-navigation.md` for the assembled browser flow, provider-neutral catalog, role boundary, and real destination positioning.
- The formal isolated QA run remains human-requested and has not been run for this PR.

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: added DOM coverage for shared placement, provider tabs, compact expansion, empty/add copy, Agent navigation target, and destination scroll/focus; added the matching cross-surface QA case
- follow-up work: none
