### PR TITLE
fix(client): delta Claude token usage snapshots

### DIFF
--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -488,6 +488,101 @@ describe("claude-code handler startup inject queue", () => {
     await handler.shutdown();
   });
 
+  it("emits per-turn token deltas from cumulative model usage snapshots", async () => {
+    const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
+    state.resultMessagesForInput = (turn) => [
+      {
+        type: "result",
+        subtype: "success",
+        result: `reply ${turn}`,
+        modelUsage:
+          turn === 1
+            ? {
+                "claude-sonnet-4-5": {
+                  inputTokens: 10,
+                  cacheCreationInputTokens: 4,
+                  cacheReadInputTokens: 100,
+                  outputTokens: 2,
+                },
+                "claude-haiku-4-5": {
+                  inputTokens: 3,
+                  cacheCreationInputTokens: 0,
+                  cacheReadInputTokens: 20,
+                  outputTokens: 1,
+                },
+              }
+            : {
+                "claude-sonnet-4-5": {
+                  inputTokens: 15,
+                  cacheCreationInputTokens: 7,
+                  cacheReadInputTokens: 160,
+                  outputTokens: 5,
+                },
+                // Unchanged models remain in Claude's cumulative snapshot but
+                // must not produce another usage event for this turn.
+                "claude-haiku-4-5": {
+                  inputTokens: 3,
+                  cacheCreationInputTokens: 0,
+                  cacheReadInputTokens: 20,
+                  outputTokens: 1,
+                },
+              },
+      },
+    ];
+    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const ctx = makeContext(() => {});
+    ctx.emitEvent = (event) => {
+      events.push(event);
+    };
+    state.resolveChatContext?.({
+      chatId: "chat-claude-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "first usage turn"), ctx);
+    await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 1);
+    handler.inject(makeMessage("m2", "second usage turn"));
+    await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 2);
+
+    expect(events.filter((event) => event.kind === "token_usage")).toEqual([
+      {
+        kind: "token_usage",
+        payload: {
+          provider: "claude-code",
+          model: "claude-sonnet-4-5",
+          inputTokens: 14,
+          cachedInputTokens: 100,
+          outputTokens: 2,
+        },
+      },
+      {
+        kind: "token_usage",
+        payload: {
+          provider: "claude-code",
+          model: "claude-haiku-4-5",
+          inputTokens: 3,
+          cachedInputTokens: 20,
+          outputTokens: 1,
+        },
+      },
+      {
+        kind: "token_usage",
+        payload: {
+          provider: "claude-code",
+          model: "claude-sonnet-4-5",
+          inputTokens: 8,
+          cachedInputTokens: 60,
+          outputTokens: 3,
+        },
+      },
+    ]);
+
+    await handler.shutdown();
+  });
+
   it("reports forwardResult failures as terminal runtime turn errors", async () => {
     const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
     const logs: string[] = [];

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -583,6 +583,96 @@ describe("claude-code handler startup inject queue", () => {
     await handler.shutdown();
   });
 
+  it("treats a cumulative counter rollback within one Query as a fresh counter", async () => {
+    const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
+    state.resultMessagesForInput = (turn) => [
+      {
+        type: "result",
+        subtype: "success",
+        result: `reply ${turn}`,
+        modelUsage: {
+          "claude-sonnet-4-5": {
+            inputTokens: turn === 1 ? 10 : 4,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            outputTokens: 0,
+          },
+        },
+      },
+    ];
+    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const ctx = makeContext(() => {});
+    ctx.emitEvent = (event) => {
+      events.push(event);
+    };
+    state.resolveChatContext?.({
+      chatId: "chat-claude-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    await handler.start(makeMessage("m1", "before counter rollback"), ctx);
+    await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 1);
+    handler.inject(makeMessage("m2", "after counter rollback"));
+    await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 2);
+
+    expect(
+      events
+        .filter((event) => event.kind === "token_usage")
+        .map((event) => (event.kind === "token_usage" ? event.payload.inputTokens : null)),
+    ).toEqual([10, 4]);
+
+    await handler.shutdown();
+  });
+
+  it("starts a fresh cumulative usage baseline for a replacement Query", async () => {
+    const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
+    state.resultMessagesForInput = (turn) => [
+      {
+        type: "result",
+        subtype: "success",
+        result: `reply ${turn}`,
+        modelUsage: {
+          "claude-sonnet-4-5": {
+            inputTokens: turn === 1 ? 10 : 14,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            outputTokens: 0,
+          },
+        },
+      },
+    ];
+    const handler = createClaudeCodeHandler({ workspaceRoot });
+    const ctx = makeContext(() => {});
+    ctx.emitEvent = (event) => {
+      events.push(event);
+    };
+    state.resolveChatContext?.({
+      chatId: "chat-claude-startup-race",
+      title: "startup race",
+      topic: null,
+      description: null,
+      participants: [],
+    });
+
+    const started = await handler.start(makeMessage("m1", "first Query"), ctx);
+    await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 1);
+    await handler.suspend();
+    const sessionId = typeof started === "string" ? started : started.sessionId;
+    await handler.resume(makeMessage("m2", "replacement Query"), sessionId, ctx);
+    await waitFor(() => events.filter((event) => event.kind === "turn_end").length === 2);
+
+    expect(
+      events
+        .filter((event) => event.kind === "token_usage")
+        .map((event) => (event.kind === "token_usage" ? event.payload.inputTokens : null)),
+    ).toEqual([10, 14]);
+
+    await handler.shutdown();
+  });
+
   it("reports forwardResult failures as terminal runtime turn errors", async () => {
     const events: Array<Parameters<SessionContext["emitEvent"]>[0]> = [];
     const logs: string[] = [];

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -288,12 +288,13 @@ type ResultMessage = {
   total_cost_usd?: number;
   num_turns?: number;
   session_id?: string;
-  // Per-model token usage for this turn. Anthropic's Claude Agent SDK populates
-  // this on every ResultMessage (success and error subtypes). A single turn can
-  // span multiple models (e.g. fast-mode), so we emit one `token_usage` event
-  // per entry. Keys are model identifiers (e.g. "claude-opus-4-7"). Older SDK
-  // versions may omit the field entirely — treat absence as "no usage to emit"
-  // rather than an error.
+  // Per-model cumulative token usage for the current SDK Query. Anthropic's
+  // Claude Agent SDK populates this on every ResultMessage (success and error
+  // subtypes). A single turn can span multiple models (e.g. fast-mode), so the
+  // handler diffs consecutive snapshots and emits one `token_usage` delta per
+  // changed model. Keys are model identifiers (e.g. "claude-opus-4-7"). Older
+  // SDK versions may omit the field entirely — treat absence as "no usage to
+  // emit" rather than an error.
   modelUsage?: Record<
     string,
     {
@@ -303,6 +304,13 @@ type ResultMessage = {
       cacheCreationInputTokens?: number;
     }
   >;
+};
+
+type ClaudeModelUsageCounters = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
 };
 
 function isResultMessage(message: unknown): message is ResultMessage {
@@ -344,22 +352,45 @@ export function detectClaudeAuthFailure(message: unknown): { rawMessage: string 
 }
 
 /**
- * Emit one `token_usage` event per (model) entry in the result's `modelUsage`.
- * The SDK lumps cache-creation tokens under their own field, but the wire
- * schema folds them into `inputTokens` because they bill as input. Best-effort:
- * a missing/empty `modelUsage` is silently skipped (older SDKs and some error
- * subtypes don't populate it). Per-entry emit failures are swallowed so token
- * accounting never blocks the turn close that follows.
+ * Diff a Query's cumulative `modelUsage` snapshots and emit one `token_usage`
+ * event per changed model. The baseline is scoped to the concrete SDK Query:
+ * a respawn/resume starts from an empty baseline because the new native process
+ * owns a fresh cumulative counter. The SDK lumps cache-creation tokens under
+ * their own field, but the wire schema folds their delta into `inputTokens`
+ * because they bill as input.
+ *
+ * Best-effort: a missing/empty `modelUsage` is silently skipped (older SDKs
+ * and some error subtypes don't populate it). Per-entry emit failures are
+ * swallowed so token accounting never blocks the turn close that follows.
  */
-function emitTokenUsageFromResult(message: ResultMessage, sessionCtx: SessionContext): void {
+function emitTokenUsageFromResult(
+  message: ResultMessage,
+  sessionCtx: SessionContext,
+  baseline: Map<string, ClaudeModelUsageCounters>,
+): void {
   const usage = message.modelUsage;
   if (!usage) return;
   for (const [model, m] of Object.entries(usage)) {
     if (!m) continue;
-    const cacheCreation = m.cacheCreationInputTokens ?? 0;
-    const cachedRead = m.cacheReadInputTokens ?? 0;
-    const inputTokens = (m.inputTokens ?? 0) + cacheCreation;
-    const outputTokens = m.outputTokens ?? 0;
+    const current: ClaudeModelUsageCounters = {
+      inputTokens: m.inputTokens ?? 0,
+      outputTokens: m.outputTokens ?? 0,
+      cacheReadInputTokens: m.cacheReadInputTokens ?? 0,
+      cacheCreationInputTokens: m.cacheCreationInputTokens ?? 0,
+    };
+    const previous = baseline.get(model);
+    baseline.set(model, current);
+    const delta = (key: keyof ClaudeModelUsageCounters): number => {
+      const value = current[key];
+      const prior = previous?.[key] ?? 0;
+      // Defensive reset handling: if a provider counter ever rolls back within
+      // one Query, treat the new value as the start of a fresh counter rather
+      // than dropping the usage or emitting a negative schema value.
+      return value >= prior ? value - prior : value;
+    };
+    const inputTokens = delta("inputTokens") + delta("cacheCreationInputTokens");
+    const cachedRead = delta("cacheReadInputTokens");
+    const outputTokens = delta("outputTokens");
     if (inputTokens === 0 && cachedRead === 0 && outputTokens === 0) continue;
     try {
       sessionCtx.emitEvent({
@@ -1646,7 +1677,13 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         if (!currentQuery) return;
 
         try {
-          for await (const message of currentQuery) {
+          // `modelUsage` is cumulative only within one concrete Query/native
+          // process. Capture both together so a config hot-switch can start a
+          // new consumer without sharing or clearing the old consumer's
+          // accounting baseline while it drains.
+          const query = currentQuery;
+          const modelUsageBaseline = new Map<string, ClaudeModelUsageCounters>();
+          for await (const message of query) {
             // Every message refreshes lastActivity to prevent idle timeout
             sessionCtx.recordProviderActivity();
 
@@ -1672,7 +1709,7 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
 
             if (isResultMessage(message)) {
               const providerEnteredPrefix = pendingProviderEnteredPrefix();
-              emitTokenUsageFromResult(message, sessionCtx);
+              emitTokenUsageFromResult(message, sessionCtx, modelUsageBaseline);
               const providerFailure = mergeClaudeProviderFailures({
                 resultFailure: claudeFailureFromSdkResult(message),
                 assistantFailure: pendingAssistantProviderFailure,


### PR DESCRIPTION
## Why

Claude Agent SDK `ResultMessage.modelUsage` is cumulative within one SDK Query, but the Claude Code handler emitted every snapshot as if it were a per-turn delta. The server then sums all `token_usage` events, producing triangular overcounting for long-lived Claude sessions.

A reset-free production sample showed 19 snapshots whose final cumulative processed-token value was 232,609,767, while summing the emitted rows produced 2,846,195,722 (12.24x).

## What

- Track a per-model usage baseline for each concrete Claude SDK Query.
- Diff input, output, cache-read, and cache-creation counters before emitting `token_usage`.
- Keep cache-creation deltas folded into `inputTokens`, preserving the existing wire contract.
- Skip unchanged model entries in cumulative multi-model snapshots.
- Treat an in-Query counter rollback as a fresh counter defensively.
- Bind the baseline to the captured Query/consumer so config hot-switch consumers do not share accounting state.
- Add a two-turn, multi-model regression test that proves cumulative snapshots become per-turn deltas.

This fixes newly emitted usage events. It intentionally does not rewrite already-persisted historical snapshots.

## Verification

- `pnpm check` (passes; existing unrelated warnings/info remain)
- `pnpm typecheck`
- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2 src/__tests__/claude-code-inject-startup-race.test.ts` (10 tests passed)
- `pnpm --filter @first-tree/client exec vitest run --maxWorkers=2` (full Client suite passed)
