### PR TITLE
chore(qa): add GitHub App mock fixtures + environment recipe

### DIFF
--- a/packages/qa/environment/README.md
+++ b/packages/qa/environment/README.md
@@ -41,3 +41,23 @@ operation requires `one-turn-ready`; a binary probe alone cannot prove real agen
 Discover host state first, bridge only the minimum required material, prefer read-only copies/mounts, and use a compatible
 runtime binary for the target platform. Never mount a full host provider home writable. Missing auth, entitlement,
 compatible binaries, or authorized turn capacity is `BLOCKED`, not product `FAIL`.
+
+## Mock GitHub App
+
+The GitHub App surface (install-url, installation-token minting, repository catalog, signed webhook ingest) needs a
+configured App. A real App/webhook secret is often unavailable in an isolated cell, so a run may report those sub-areas
+`BLOCKED`, or mock them to validate First Tree's own request/parse/verify logic. Reusable assets live in
+`fixtures/github-app/` (mock REST API + webhook payloads + full recipe).
+
+- The App config block is all-or-nothing: set every `FIRST_TREE_GITHUB_APP_*` field together (id, client id/secret,
+  private key, webhook secret; plus `_SLUG` for install-url) or the server rejects it at boot. A clean boot omits the
+  "GitHub App not configured" log line and the webhook route stops returning its 501 stub.
+- Generate a throwaway PKCS#8 key at run time (`openssl genpkey -algorithm RSA`); never commit one. `node --env-file`
+  cannot hold a multi-line PEM, so pass the key via a shell export rather than the `.env` file.
+- Redirect REST calls to the mock with `FIRST_TREE_GITHUB_API_BASE_URL`; the mock returns canned token/repo data and does
+  not verify the JWT.
+- Sign webhooks with `x-hub-signature-256: sha256=<HMAC-SHA256(webhook_secret, raw_body)>` and set `x-github-event` /
+  `x-github-delivery`. This exercises signature verification, record-only install recording, and delivery-id dedup.
+
+A mock proves the deployment's request/parse/verify wiring, not github.com's live responses; the real install dialog and
+full followed-chat card delivery stay out of an isolated cell.

--- a/packages/qa/environment/README.md
+++ b/packages/qa/environment/README.md
@@ -49,9 +49,10 @@ configured App. A real App/webhook secret is often unavailable in an isolated ce
 `BLOCKED`, or mock them to validate First Tree's own request/parse/verify logic. Reusable assets live in
 `fixtures/github-app/` (mock REST API + webhook payloads + full recipe).
 
-- The App config block is all-or-nothing: set every `FIRST_TREE_GITHUB_APP_*` field together (id, client id/secret,
-  private key, webhook secret; plus `_SLUG` for install-url) or the server rejects it at boot. A clean boot omits the
-  "GitHub App not configured" log line and the webhook route stops returning its 501 stub.
+- The five core credentials — `FIRST_TREE_GITHUB_APP_ID`, `_CLIENT_ID`, `_CLIENT_SECRET`, `_PRIVATE_KEY`,
+  `_WEBHOOK_SECRET` — are an atomic block: set them together or the server rejects the config at boot. `_SLUG` is separate
+  — optional at boot, required only for `install-url`. A clean boot omits the "GitHub App not configured" log line and the
+  webhook route stops returning its 501 stub.
 - Generate a throwaway PKCS#8 key at run time (`openssl genpkey -algorithm RSA`); never commit one. Pass the multi-line
   PEM via a shell export, or a quoted `--env-file` value (Node 22.13+ supports quoted multi-line env values) — the export
   just avoids the quoting/escaping fuss.

--- a/packages/qa/environment/README.md
+++ b/packages/qa/environment/README.md
@@ -52,10 +52,13 @@ configured App. A real App/webhook secret is often unavailable in an isolated ce
 - The App config block is all-or-nothing: set every `FIRST_TREE_GITHUB_APP_*` field together (id, client id/secret,
   private key, webhook secret; plus `_SLUG` for install-url) or the server rejects it at boot. A clean boot omits the
   "GitHub App not configured" log line and the webhook route stops returning its 501 stub.
-- Generate a throwaway PKCS#8 key at run time (`openssl genpkey -algorithm RSA`); never commit one. `node --env-file`
-  cannot hold a multi-line PEM, so pass the key via a shell export rather than the `.env` file.
-- Redirect REST calls to the mock with `FIRST_TREE_GITHUB_API_BASE_URL`; the mock returns canned token/repo data and does
-  not verify the JWT.
+- Generate a throwaway PKCS#8 key at run time (`openssl genpkey -algorithm RSA`); never commit one. Pass the multi-line
+  PEM via a shell export, or a quoted `--env-file` value (Node 22.13+ supports quoted multi-line env values) — the export
+  just avoids the quoting/escaping fuss.
+- Redirect REST calls with `FIRST_TREE_GITHUB_API_BASE_URL` set to a URL the server can reach (`localhost` only if the
+  mock shares the server's container; otherwise the compose service name or `host.docker.internal`). The mock answers two
+  endpoints only (token + repos), so paths needing other GitHub REST — a real `follow`'s `/repos/:o/:r` +
+  `/repos/:o/:r/issues/:n`, OAuth, org repos — fall through and stay out of scope.
 - Sign webhooks with `x-hub-signature-256: sha256=<HMAC-SHA256(webhook_secret, raw_body)>` and set `x-github-event` /
   `x-github-delivery`. This exercises signature verification, record-only install recording, and delivery-id dedup.
 

--- a/packages/qa/fixtures/github-app/README.md
+++ b/packages/qa/fixtures/github-app/README.md
@@ -27,7 +27,9 @@ delivery needs those extra endpoints mocked plus a following chat — out of sco
 
 ## Enabling the App in the QA run cell
 
-The server's App config block is all-or-nothing — set every field together or the server rejects it at boot:
+The five core credentials (id, client id/secret, private key, webhook secret) are an atomic block — set them together or
+the server rejects the config at boot. `_SLUG` is separate: optional at boot, required only for `install-url` (the recipe
+sets it because it exercises that route).
 
 ```
 FIRST_TREE_GITHUB_APP_ID=123456

--- a/packages/qa/fixtures/github-app/README.md
+++ b/packages/qa/fixtures/github-app/README.md
@@ -1,0 +1,71 @@
+# GitHub App Mock Fixtures
+
+Reusable, non-sensitive assets for exercising the GitHub App surface (install-url, installation-token minting,
+repository catalog, and signed webhook ingest) **without a live GitHub App**. Use these with
+`cases/cross-surface/github-settings-connection-panel.md` and `cases/cross-surface/github-webhook-routing-regression.md`.
+
+## Contents
+
+- `mock-github-api.mjs` — a dependency-free stand-in for the two GitHub REST endpoints the server calls
+  (`POST /app/installations/:id/access_tokens`, `GET /installation/repositories`). It returns canned data and does not
+  verify the app JWT or installation token.
+- `webhook-payloads/` — minimal valid bodies: `ping.json`, `installation-created.json`, `issues-opened.json`.
+
+## Enabling the App in the QA run cell
+
+The server's App config block is all-or-nothing — set every field together or the server rejects it at boot:
+
+```
+FIRST_TREE_GITHUB_APP_ID=123456
+FIRST_TREE_GITHUB_APP_CLIENT_ID=Iv1.mockclientid00
+FIRST_TREE_GITHUB_APP_CLIENT_SECRET=mock_client_secret_0123456789abcdef
+FIRST_TREE_GITHUB_APP_WEBHOOK_SECRET=mock_webhook_secret_topsecret_123
+FIRST_TREE_GITHUB_APP_SLUG=mock-first-tree-app          # needed for install-url
+FIRST_TREE_GITHUB_API_BASE_URL=http://localhost:9000    # redirect REST calls to the mock
+```
+
+The private key must be a real PEM so app-JWT signing does not crash (the mock does not verify it). Generate a throwaway
+key at run time — **do not commit one** (a committed key, even a mock, trips secret scanners):
+
+```bash
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out /tmp/mock-app-key.pem
+```
+
+`node --env-file` cannot hold a multi-line PEM, so pass the key via a shell export rather than the `.env` file:
+
+```bash
+export FIRST_TREE_GITHUB_APP_PRIVATE_KEY="$(cat /tmp/mock-app-key.pem)"
+```
+
+## Running the mock API
+
+```bash
+node mock-github-api.mjs        # listens on :9000 (or `node mock-github-api.mjs 9100`, or MOCK_PORT=9100)
+```
+
+With the App configured and the mock reachable, `GET /orgs/:org/github-app-installation/repositories` mints a token
+against the mock and returns the canned catalog, and `GET .../install-url` returns the `installations/new` URL plus the
+`oauth_state_nonce` cookie.
+
+## Signing a webhook
+
+The receiver checks `x-hub-signature-256: sha256=<HMAC-SHA256(webhook_secret, raw_body)>`. Sign a payload and post it:
+
+```bash
+SECRET=mock_webhook_secret_topsecret_123
+BODY=webhook-payloads/installation-created.json
+SIG="sha256=$(openssl dgst -sha256 -hmac "$SECRET" -binary < "$BODY" | xxd -p -c256 | tr -d '\n')"
+curl -sS -X POST "$BASE/api/v1/webhooks/github-app" \
+  -H "content-type: application/json" \
+  -H "x-github-event: installation" \
+  -H "x-github-delivery: $(uuidgen)" \
+  -H "x-hub-signature-256: $SIG" \
+  --data-binary @"$BODY"
+```
+
+Expected shapes: `ping` → `200 {ok}`; a missing/incorrect signature → `401`; `installation-created` →
+`created:recorded` with a new **unbound** `github_app_installations` row carrying the sender as installer;
+`issues-opened` on an unbound installation → ignored, on a bound installation → normalized (delivering a card needs a
+following chat — see the webhook-routing case). Re-posting the same `x-github-delivery` returns `{deduped:true}`.
+
+Keep the webhook secret and generated key out of committed evidence.

--- a/packages/qa/fixtures/github-app/README.md
+++ b/packages/qa/fixtures/github-app/README.md
@@ -1,15 +1,29 @@
 # GitHub App Mock Fixtures
 
-Reusable, non-sensitive assets for exercising the GitHub App surface (install-url, installation-token minting,
-repository catalog, and signed webhook ingest) **without a live GitHub App**. Use these with
-`cases/cross-surface/github-settings-connection-panel.md` and `cases/cross-surface/github-webhook-routing-regression.md`.
+Reusable, non-sensitive assets for exercising the GitHub App surface **without a live GitHub App**.
+
+## Scope
+
+These fixtures cover the App paths that need only the two REST endpoints below plus HMAC signing:
+
+- App boot config (the all-or-nothing block), `install-url`, installation-token minting, and the repository catalog;
+- signed webhook ingest: signature verification, record-only installation recording, the not-seen / not-bound gates, and
+  delivery-id dedup.
+
+They are the setup half for `cases/cross-surface/github-settings-connection-panel.md`, and they provide the signed-ingest
+primitives shared with `cases/cross-surface/github-webhook-routing-regression.md`. They do **not** deliver that case's
+end-to-end followed-chat card path: `FIRST_TREE_GITHUB_API_BASE_URL` redirects **all** GitHub REST traffic, but this mock
+only answers two endpoints, so a real `follow` (which additionally calls `GET /repos/:owner/:repo` and
+`GET /repos/:owner/:repo/issues/:n`), the OAuth paths, and org-repo listing all fall through to `404`. Full card/inbox
+delivery needs those extra endpoints mocked plus a following chat — out of scope here.
 
 ## Contents
 
 - `mock-github-api.mjs` — a dependency-free stand-in for the two GitHub REST endpoints the server calls
-  (`POST /app/installations/:id/access_tokens`, `GET /installation/repositories`). It returns canned data and does not
-  verify the app JWT or installation token.
-- `webhook-payloads/` — minimal valid bodies: `ping.json`, `installation-created.json`, `issues-opened.json`.
+  (`POST /app/installations/:id/access_tokens`, `GET /installation/repositories`). Returns canned data; does not verify the
+  app JWT or installation token.
+- `webhook-payloads/` — minimal valid bodies: `ping.json`, `installation-created.json`, `issues-opened.json`. The issue
+  payload targets the same installation id (`88800002`) the create payload records, so the two compose.
 
 ## Enabling the App in the QA run cell
 
@@ -21,8 +35,13 @@ FIRST_TREE_GITHUB_APP_CLIENT_ID=Iv1.mockclientid00
 FIRST_TREE_GITHUB_APP_CLIENT_SECRET=mock_client_secret_0123456789abcdef
 FIRST_TREE_GITHUB_APP_WEBHOOK_SECRET=mock_webhook_secret_topsecret_123
 FIRST_TREE_GITHUB_APP_SLUG=mock-first-tree-app          # needed for install-url
-FIRST_TREE_GITHUB_API_BASE_URL=http://localhost:9000    # redirect REST calls to the mock
+FIRST_TREE_GITHUB_API_BASE_URL=http://<mock-host>:9000  # a URL the SERVER can reach — see below
 ```
+
+`FIRST_TREE_GITHUB_API_BASE_URL` must resolve **from inside the server**. If the mock runs in the same container as the
+server, use `http://localhost:9000`; if it runs in a sibling container or on the host, use the compose service name
+(`http://mock:9000`) or `http://host.docker.internal:9000` — `localhost` from inside the server container is that
+container's own loopback, not the host.
 
 The private key must be a real PEM so app-JWT signing does not crash (the mock does not verify it). Generate a throwaway
 key at run time — **do not commit one** (a committed key, even a mock, trips secret scanners):
@@ -31,7 +50,8 @@ key at run time — **do not commit one** (a committed key, even a mock, trips s
 openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out /tmp/mock-app-key.pem
 ```
 
-`node --env-file` cannot hold a multi-line PEM, so pass the key via a shell export rather than the `.env` file:
+Node (22.13+ here) does accept a quoted multi-line value in `--env-file`, so a quoted PEM in `.env` works. A shell export
+is shown here only to sidestep the quoting/escaping fuss:
 
 ```bash
 export FIRST_TREE_GITHUB_APP_PRIVATE_KEY="$(cat /tmp/mock-app-key.pem)"
@@ -40,32 +60,49 @@ export FIRST_TREE_GITHUB_APP_PRIVATE_KEY="$(cat /tmp/mock-app-key.pem)"
 ## Running the mock API
 
 ```bash
-node mock-github-api.mjs        # listens on :9000 (or `node mock-github-api.mjs 9100`, or MOCK_PORT=9100)
+node mock-github-api.mjs        # listens on 0.0.0.0:9000 (or `node mock-github-api.mjs 9100`, or MOCK_PORT=9100)
 ```
 
 With the App configured and the mock reachable, `GET /orgs/:org/github-app-installation/repositories` mints a token
 against the mock and returns the canned catalog, and `GET .../install-url` returns the `installations/new` URL plus the
 `oauth_state_nonce` cookie.
 
-## Signing a webhook
+## Signing and posting a webhook
 
-The receiver checks `x-hub-signature-256: sha256=<HMAC-SHA256(webhook_secret, raw_body)>`. Sign a payload and post it:
+The receiver checks `x-hub-signature-256: sha256=<HMAC-SHA256(webhook_secret, raw_body)>`. Sign the exact bytes you post:
 
 ```bash
 SECRET=mock_webhook_secret_topsecret_123
-BODY=webhook-payloads/installation-created.json
-SIG="sha256=$(openssl dgst -sha256 -hmac "$SECRET" -binary < "$BODY" | xxd -p -c256 | tr -d '\n')"
+sign() { printf 'sha256=%s' "$(openssl dgst -sha256 -hmac "$SECRET" -binary < "$1" | xxd -p -c256 | tr -d '\n')"; }
+
+# Record an installation (unbound). Lifecycle events short-circuit BEFORE the dedup/claim path.
 curl -sS -X POST "$BASE/api/v1/webhooks/github-app" \
-  -H "content-type: application/json" \
-  -H "x-github-event: installation" \
+  -H "content-type: application/json" -H "x-github-event: installation" \
   -H "x-github-delivery: $(uuidgen)" \
-  -H "x-hub-signature-256: $SIG" \
-  --data-binary @"$BODY"
+  -H "x-hub-signature-256: $(sign webhook-payloads/installation-created.json)" \
+  --data-binary @webhook-payloads/installation-created.json
 ```
 
-Expected shapes: `ping` → `200 {ok}`; a missing/incorrect signature → `401`; `installation-created` →
-`created:recorded` with a new **unbound** `github_app_installations` row carrying the sender as installer;
-`issues-opened` on an unbound installation → ignored, on a bound installation → normalized (delivering a card needs a
-following chat — see the webhook-routing case). Re-posting the same `x-github-delivery` returns `{deduped:true}`.
+Expected: `ping` → `200 {ok}`; a missing/incorrect signature → `401`; `installation-created` → `created:recorded` with a
+new **unbound** `github_app_installations` row carrying the sender as installer. `issues-opened` targets that same
+installation (`88800002`): posted before the row is bound it is ignored (`installation not bound`); bind the row (connect
+it from the Settings panel, or stub it via the dev-callback `installationId` param) and post it again and it normalizes.
+
+### Delivery-id dedup
+
+Dedup lives in `processScmWebhookDelivery`, which only **non-lifecycle** events reach (installation lifecycle events
+return before it, so they never claim a delivery id). Demonstrate it with `issues-opened` on the bound installation, and
+capture the delivery id **once** so both posts reuse it:
+
+```bash
+DELIVERY_ID=$(uuidgen)
+SIG=$(sign webhook-payloads/issues-opened.json)
+post() { curl -sS -X POST "$BASE/api/v1/webhooks/github-app" \
+  -H "content-type: application/json" -H "x-github-event: issues" \
+  -H "x-github-delivery: $DELIVERY_ID" -H "x-hub-signature-256: $SIG" \
+  --data-binary @webhook-payloads/issues-opened.json; echo; }
+post   # first: processed (audience_empty without a following chat)
+post   # second, same delivery id: {deduped:true}
+```
 
 Keep the webhook secret and generated key out of committed evidence.

--- a/packages/qa/fixtures/github-app/mock-github-api.mjs
+++ b/packages/qa/fixtures/github-app/mock-github-api.mjs
@@ -1,0 +1,77 @@
+// Minimal stand-in for the GitHub REST endpoints the First Tree server calls
+// when a GitHub App is configured. Point the server at it with
+// `FIRST_TREE_GITHUB_API_BASE_URL=http://localhost:9000` so a QA run can
+// exercise the App-token / repository-catalog paths without a live GitHub App.
+//
+// It answers only the two endpoints the server actually hits:
+//   POST /app/installations/:id/access_tokens  -> a stub installation token
+//   GET  /installation/repositories            -> a stub repository catalog
+//
+// It does NOT verify the app JWT or the installation token — the point is to
+// exercise First Tree's request/parse logic, not GitHub's auth. Everything
+// returned here is canned, non-sensitive test data.
+//
+// Usage: node mock-github-api.mjs [port]   (port also reads MOCK_PORT, default 9000)
+
+import http from "node:http";
+
+const port = Number(process.argv[2] ?? process.env.MOCK_PORT ?? 9000);
+
+// Canned catalog returned by GET /installation/repositories (page 1). Shaped
+// exactly like GitHub's `{ total_count, repositories: [...] }` envelope.
+const REPOSITORIES = [
+  {
+    full_name: "acme-org/backend",
+    clone_url: "https://github.com/acme-org/backend.git",
+    html_url: "https://github.com/acme-org/backend",
+    private: true,
+    default_branch: "main",
+    pushed_at: "2026-07-14T10:00:00Z",
+  },
+  {
+    full_name: "acme-org/frontend",
+    clone_url: "https://github.com/acme-org/frontend.git",
+    html_url: "https://github.com/acme-org/frontend",
+    private: false,
+    default_branch: "main",
+    pushed_at: "2026-07-13T09:00:00Z",
+  },
+];
+
+const server = http.createServer((request, response) => {
+  const url = new URL(request.url ?? "/", "http://localhost");
+  response.setHeader("content-type", "application/json");
+
+  if (request.method === "POST" && /\/app\/installations\/\d+\/access_tokens$/.test(url.pathname)) {
+    response.statusCode = 201;
+    response.end(
+      JSON.stringify({
+        token: "ghs_mockinstalltoken_xyz",
+        expires_at: "2030-01-01T00:00:00Z",
+        permissions: { contents: "read", metadata: "read" },
+        repository_selection: "selected",
+      }),
+    );
+    return;
+  }
+
+  if (request.method === "GET" && url.pathname === "/installation/repositories") {
+    const page = Number(url.searchParams.get("page") ?? "1");
+    response.statusCode = 200;
+    response.end(
+      JSON.stringify(
+        page > 1
+          ? { total_count: REPOSITORIES.length, repositories: [] }
+          : { total_count: REPOSITORIES.length, repositories: REPOSITORIES },
+      ),
+    );
+    return;
+  }
+
+  response.statusCode = 404;
+  response.end(JSON.stringify({ message: `mock: unhandled ${request.method} ${url.pathname}` }));
+});
+
+server.listen(port, "0.0.0.0", () => {
+  console.log(`mock github api listening on :${port}`);
+});

--- a/packages/qa/fixtures/github-app/webhook-payloads/installation-created.json
+++ b/packages/qa/fixtures/github-app/webhook-payloads/installation-created.json
@@ -1,0 +1,10 @@
+{
+  "action": "created",
+  "installation": {
+    "id": 88800002,
+    "account": { "id": 99802, "login": "neworg", "type": "Organization" },
+    "permissions": { "contents": "read", "metadata": "read" },
+    "events": ["push", "pull_request"]
+  },
+  "sender": { "id": 88001, "login": "gh-mockadmin", "type": "User" }
+}

--- a/packages/qa/fixtures/github-app/webhook-payloads/issues-opened.json
+++ b/packages/qa/fixtures/github-app/webhook-payloads/issues-opened.json
@@ -1,0 +1,13 @@
+{
+  "action": "opened",
+  "installation": { "id": 88800001 },
+  "repository": { "full_name": "acme-org/backend", "id": 555, "private": true },
+  "issue": {
+    "number": 9,
+    "title": "Mock issue",
+    "html_url": "https://github.com/acme-org/backend/issues/9",
+    "state": "open",
+    "user": { "login": "gh-mockadmin", "id": 88001 }
+  },
+  "sender": { "login": "gh-mockadmin", "id": 88001 }
+}

--- a/packages/qa/fixtures/github-app/webhook-payloads/issues-opened.json
+++ b/packages/qa/fixtures/github-app/webhook-payloads/issues-opened.json
@@ -1,6 +1,6 @@
 {
   "action": "opened",
-  "installation": { "id": 88800001 },
+  "installation": { "id": 88800002 },
   "repository": { "full_name": "acme-org/backend", "id": 555, "private": true },
   "issue": {
     "number": 9,

--- a/packages/qa/fixtures/github-app/webhook-payloads/ping.json
+++ b/packages/qa/fixtures/github-app/webhook-payloads/ping.json
@@ -1,0 +1,4 @@
+{
+  "zen": "Keep it logically awesome.",
+  "hook_id": 1
+}


### PR DESCRIPTION
## What

Adds reusable, non-sensitive QA assets under `packages/qa/fixtures/github-app/` so the GitHub App surface can be exercised in an isolated run cell **without a live GitHub App**, plus a "Mock GitHub App" recipe in `packages/qa/environment/README.md`.

- `mock-github-api.mjs` — dependency-free stand-in for the two GitHub REST endpoints the server calls (`POST /app/installations/:id/access_tokens`, `GET /installation/repositories`). Returns canned data; does not verify the JWT.
- `webhook-payloads/` — `ping.json`, `installation-created.json`, `issues-opened.json`.
- `README.md` — configure the all-or-nothing App block, generate a throwaway key (**never committed** — `openssl genpkey`), pass the multi-line PEM via shell export (not `--env-file`), run the mock, and HMAC-sign webhooks.

## Why

Distilled from a formal `packages/qa` run of the GitHub App surface (the same work behind the merged `github-settings-connection-panel` case, #1782). These turn what was one-off inline harness into grab-and-run fixtures for future GitHub-App QA. Supports `cases/cross-surface/github-settings-connection-panel.md` and `github-webhook-routing-regression.md`.

## Notes

- Static assets + prose only — no `bin`, runner, CLI, or CI gate added (respects the package boundary).
- Docs/assets only; no product code, schema, or migration changes.
- Verified locally: `biome check` clean on the new JS/JSON, `node --check` on the `.mjs`, and a functional smoke test of the mock (201 token, repos page 1/2, 404 fallthrough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
