### PR TITLE
fix(web): truncate long agent names across people pickers

### DIFF
--- a/packages/web/src/components/__tests__/mention-autocomplete.test.ts
+++ b/packages/web/src/components/__tests__/mention-autocomplete.test.ts
@@ -8,6 +8,7 @@ import {
   fieldOutOfScrollport,
   groupAndSortCandidates,
   type MentionCandidate,
+  mentionOptionTitle,
   portalPanelPlacement,
   rankCandidates,
 } from "../mention-autocomplete.js";
@@ -428,5 +429,29 @@ describe("portalPanelPlacement", () => {
 
   it("dismisses (null) when there isn't room above the field for even one row", () => {
     expect(portalPanelPlacement({ field: { top: 30, bottom: 70 }, port, viewportTop: 0 })).toBeNull();
+  });
+});
+
+describe("mentionOptionTitle", () => {
+  it("combines display name and handle when they differ", () => {
+    expect(mentionOptionTitle(cand({ agentId: "a1", name: "codex-assistant", displayName: "白晓航的个人助理" }))).toBe(
+      "白晓航的个人助理 (@codex-assistant)",
+    );
+  });
+
+  it("collapses to the handle alone when the display name matches it", () => {
+    expect(mentionOptionTitle(cand({ agentId: "a1", name: "ux-expert", displayName: "ux-expert" }))).toBe("@ux-expert");
+  });
+
+  it("falls back to the handle when there is no display name", () => {
+    expect(mentionOptionTitle(cand({ agentId: "a1", name: "ux-expert", displayName: null }))).toBe("@ux-expert");
+  });
+
+  it("falls back to the display name when there is no handle", () => {
+    expect(mentionOptionTitle(cand({ agentId: "a1", name: null, displayName: "Soft Deleted" }))).toBe("Soft Deleted");
+  });
+
+  it("returns undefined when neither field is set", () => {
+    expect(mentionOptionTitle(cand({ agentId: "a1", name: null, displayName: null }))).toBeUndefined();
   });
 });

--- a/packages/web/src/components/add-participant-dropdown.tsx
+++ b/packages/web/src/components/add-participant-dropdown.tsx
@@ -10,6 +10,7 @@ import {
   ambiguousDisplayNames,
   buildPickerSections,
   type MentionCandidate,
+  mentionOptionTitle,
 } from "./mention-autocomplete.js";
 
 /**
@@ -286,9 +287,11 @@ export function AddParticipantDropdown({
           className="absolute z-20 flex flex-col border shadow-[var(--shadow-md)] outline-none"
           style={{
             top: "calc(100% + var(--sp-1))",
-            // Icon trigger sits at the panel's right edge → grow leftward;
+            // Icon trigger sits at the panel's right edge → grow leftward,
+            // capped (same cap as `.mention-popover`'s max-width) so one long
+            // candidate name can't stretch the panel — rows truncate instead;
             // the inline row spans the rail → match its full width.
-            ...(variant === "icon" ? { right: 0, minWidth: 280 } : { left: 0, right: 0 }),
+            ...(variant === "icon" ? { right: 0, minWidth: 280, maxWidth: "var(--sp-90)" } : { left: 0, right: 0 }),
             background: "var(--bg-raised)",
             borderColor: "var(--border)",
             borderRadius: "var(--radius-input)",
@@ -347,12 +350,13 @@ export function AddParticipantDropdown({
                     );
                   }
                   const isInChat = participantSet.has(it.agentId);
+                  const fullTitle = mentionOptionTitle(it);
                   if (isInChat) {
                     return (
                       <div
                         key={it.agentId}
                         role="presentation"
-                        title={it.name ? `@${it.name} — already in this chat` : "Already in this chat"}
+                        title={fullTitle ? `${fullTitle} — already in this chat` : "Already in this chat"}
                         className="flex w-full items-center text-left"
                         style={{
                           padding: "var(--sp-1_75) var(--sp-2)",
@@ -377,7 +381,7 @@ export function AddParticipantDropdown({
                       key={it.agentId}
                       type="button"
                       role="menuitem"
-                      title={it.name ? `@${it.name}` : undefined}
+                      title={fullTitle}
                       onClick={() => commit(it.agentId)}
                       onMouseEnter={() => setHighlight(myIdx)}
                       disabled={addMut.isPending}

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -95,6 +95,13 @@ export function shouldShowHandle(c: MentionCandidate, ambiguous: Set<string>): b
  * `@<handle>` rendering so the format only needs to change in one
  * place.
  *
+ * Overflow contract: both halves are single-line. The display name
+ * truncates with an ellipsis (it shrinks, never wraps — a wrapped or
+ * panel-stretching row is worse than a cut label); the `@<handle>` keeps
+ * its natural width up to 45% of the row, then truncates — it must never
+ * break mid-token. Hover discloses the full label via the row `title`
+ * (see {@link mentionOptionTitle}).
+ *
  * Caller is responsible for the surrounding `<button>` / wrapper
  * (click handlers, `title` attribute, hover/active state) — the label
  * intentionally stays presentational.
@@ -103,14 +110,33 @@ export function MentionLabel({ candidate, ambiguous }: { candidate: MentionCandi
   const fallback = candidate.name ? `@${candidate.name}` : "—";
   return (
     <>
-      <span className="font-medium">{candidate.displayName ?? fallback}</span>
+      <span className="min-w-0 truncate font-medium">{candidate.displayName ?? fallback}</span>
       {shouldShowHandle(candidate, ambiguous) && (
-        <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
+        <span className="mono text-caption shrink-0 truncate" style={{ color: "var(--fg-3)", maxWidth: "45%" }}>
           @{candidate.name}
         </span>
       )}
     </>
   );
+}
+
+/**
+ * Hover `title` for a candidate row: the full untruncated identity. Rows
+ * truncate long labels (see {@link MentionLabel}), so the tooltip must
+ * carry whichever parts got cut — `displayName (@name)` when the two
+ * differ, `@name` alone when they're identical or the display name is
+ * missing. Same shape as `AgentChip`'s computed title, except the
+ * identical-name case collapses here (per `shouldShowHandle`'s "showing
+ * it twice is pure noise" rule) instead of rendering `x (@x)`.
+ */
+export function mentionOptionTitle(candidate: Pick<MentionCandidate, "name" | "displayName">): string | undefined {
+  const hasName = typeof candidate.name === "string" && candidate.name.length > 0;
+  const hasDisplay = typeof candidate.displayName === "string" && candidate.displayName.length > 0;
+  if (hasName && hasDisplay && candidate.displayName !== candidate.name) {
+    return `${candidate.displayName} (@${candidate.name})`;
+  }
+  if (hasName) return `@${candidate.name}`;
+  return hasDisplay ? (candidate.displayName ?? undefined) : undefined;
 }
 
 /**
@@ -164,18 +190,24 @@ export function AgentOption({
  * picked agent looks the same everywhere (the new-chat chip was a bare
  * `<span>` label with no avatar before this). Hover reveals the remove
  * `X`; omit `onRemove` for a read-only token.
+ *
+ * A long label truncates on one line (capped at `--sp-60` and at the
+ * host row's width) instead of stretching the chip across — or past —
+ * the composer; hover discloses the full identity via `title`.
  */
 export function AgentToken({ candidate, onRemove }: { candidate: MentionCandidate; onRemove?: () => void }) {
   const label = candidate.displayName ?? candidate.name ?? candidate.agentId.slice(0, 8);
   return (
     <span
       className="group inline-flex items-center text-label"
+      title={mentionOptionTitle(candidate) ?? label}
       style={{
         gap: "var(--sp-1)",
         padding: "var(--sp-0_5) var(--sp-1_5)",
         borderRadius: "var(--radius-chip)",
         background: "var(--bg-sunken)",
         color: "var(--fg)",
+        maxWidth: "min(var(--sp-60), 100%)",
       }}
     >
       <Avatar
@@ -185,7 +217,7 @@ export function AgentToken({ candidate, onRemove }: { candidate: MentionCandidat
         colorToken={candidate.avatarColorToken ?? null}
         size={16}
       />
-      <span>{label}</span>
+      <span className="min-w-0 truncate">{label}</span>
       {onRemove && (
         <button
           type="button"
@@ -742,7 +774,7 @@ export function MentionAutocompletePopover({
         role="option"
         aria-selected={active}
         data-mention-index={i}
-        title={c.name ? `@${c.name}` : undefined}
+        title={mentionOptionTitle(c)}
         onMouseDown={(e) => {
           // preventDefault keeps the textarea focused so `selectionStart`
           // can still be used to compute the insertion point.
@@ -755,7 +787,6 @@ export function MentionAutocompletePopover({
           color: "var(--fg)",
           border: "none",
           cursor: "pointer",
-          whiteSpace: "nowrap",
         }}
       >
         <AgentOption candidate={c} ambiguous={ambiguous} />

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -512,6 +512,7 @@
   --sp-60: 15rem; /* 240px */
   --sp-70: 17.5rem; /* 280px */
   --sp-75: 18.75rem; /* 300px */
+  --sp-90: 22.5rem; /* 360px — people-picker panel width cap (mention popover + participant pickers) */
   --sp-95: 23.75rem; /* 380px — chat-description popover card width (~60ch) */
   --mobile-tabbar-height: 3.5rem; /* 56px */
 
@@ -971,7 +972,7 @@
 }
 .mention-popover {
   min-width: 240px;
-  max-width: 360px;
+  max-width: var(--sp-90);
 }
 .slash-popover {
   min-width: 280px;

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -2,6 +2,7 @@ import type { Agent, PresenceStatus, UsageByAgentRow } from "@first-tree/shared"
 import { Bot, ChevronDown, Link2, Lock, type LucideIcon, User } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { Avatar } from "../../components/avatar.js";
+import { mentionOptionTitle } from "../../components/mention-autocomplete.js";
 import { Button } from "../../components/ui/button.js";
 import { DenseBadge } from "../../components/ui/dense-badge.js";
 import { Popover } from "../../components/ui/popover.js";
@@ -763,7 +764,7 @@ function DelegateCell({
     return (
       <Popover
         align="start"
-        panelStyle={{ minWidth: "var(--sp-75)" }}
+        panelStyle={{ minWidth: "var(--sp-75)", maxWidth: "var(--sp-90)" }}
         trigger={({ open, toggle }) => (
           <button
             type="button"
@@ -881,8 +882,13 @@ function DelegateSelector({
             key={agent.uuid}
             active={current === agent.uuid}
             onClick={() => onPick(agent.uuid)}
+            title={mentionOptionTitle(agent)}
             primary={
-              <span className="inline-flex items-center" style={{ gap: "var(--sp-2)" }}>
+              // min-w-0 down the chain + truncate on both lines: a long
+              // display name / handle ellipsizes on its own line instead of
+              // stretching the popover panel past its maxWidth. Hover on the
+              // row shows the full identity (mentionOptionTitle).
+              <span className="inline-flex min-w-0 items-center" style={{ gap: "var(--sp-2)" }}>
                 <Avatar
                   name={agent.displayName}
                   seed={agent.uuid}
@@ -890,12 +896,12 @@ function DelegateSelector({
                   colorToken={agent.avatarColorToken}
                   src={agent.avatarImageUrl}
                 />
-                <span className="inline-flex flex-col leading-tight">
-                  <span className="text-body" style={{ color: "var(--fg)" }}>
+                <span className="inline-flex min-w-0 flex-col leading-tight">
+                  <span className="truncate text-body" style={{ color: "var(--fg)" }}>
                     {agent.displayName}
                   </span>
                   {agent.name && (
-                    <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
+                    <span className="mono truncate text-caption" style={{ color: "var(--fg-3)" }}>
                       @{agent.name}
                     </span>
                   )}
@@ -909,11 +915,22 @@ function DelegateSelector({
   );
 }
 
-function DelegateOption({ active, onClick, primary }: { active: boolean; onClick: () => void; primary: ReactNode }) {
+function DelegateOption({
+  active,
+  onClick,
+  primary,
+  title,
+}: {
+  active: boolean;
+  onClick: () => void;
+  primary: ReactNode;
+  title?: string;
+}) {
   return (
     <button
       type="button"
       onClick={onClick}
+      title={title}
       className="flex w-full items-center text-left transition-colors hover:bg-[var(--bg-hover)]"
       style={{
         gap: "var(--sp-2)",

--- a/packages/web/src/pages/workspace/conversations/filter-popover.tsx
+++ b/packages/web/src/pages/workspace/conversations/filter-popover.tsx
@@ -143,7 +143,10 @@ export function FilterPopover({
   return (
     <Popover
       align="end"
-      panelStyle={{ minWidth: 240, padding: "var(--sp-2)" }}
+      // maxWidth caps the shrink-to-fit panel (same cap as `.mention-popover`)
+      // so one long participant name in the People results ellipsizes instead
+      // of stretching the panel toward the viewport edge.
+      panelStyle={{ minWidth: 240, maxWidth: "var(--sp-90)", padding: "var(--sp-2)" }}
       trigger={({ open, toggle }) => (
         <button
           type="button"
@@ -312,7 +315,11 @@ function FilterCheckbox({
       >
         {checked && <Check size={10} strokeWidth={3} />}
       </span>
-      <span>{label}</span>
+      {/* Truncate so a long participant display name can't wrap the row or
+          stretch the popover; hover discloses the full name. */}
+      <span className="min-w-0 truncate" title={label}>
+        {label}
+      </span>
       <input type="checkbox" checked={checked} onChange={onChange} disabled={disabled} className="sr-only" />
     </label>
   );

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -760,8 +760,13 @@ function FilterChip({ label, onClear }: { label: string; onClear: () => void }) 
         background: "var(--bg-sunken)",
         color: "var(--fg-2)",
       }}
+      title={label}
     >
-      <span>{label}</span>
+      {/* Same cap as the popover's selected-people chips: a long participant
+          name ellipsizes instead of overflowing the narrow rail. */}
+      <span className="truncate" style={{ maxWidth: "var(--sp-35)" }}>
+        {label}
+      </span>
       <button
         type="button"
         onClick={onClear}

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -22,6 +22,7 @@ import {
   detectMentionTrigger,
   MentionAutocompletePopover,
   type MentionCandidate,
+  mentionOptionTitle,
   useMentionAutocomplete,
 } from "../../../components/mention-autocomplete.js";
 import { FileChip } from "../../../components/ui/file-chip.js";
@@ -1070,6 +1071,11 @@ function ParticipantChips({
               top: "calc(100% + var(--sp-1))",
               left: 0,
               minWidth: 280,
+              // Cap the shrink-to-fit width (same cap as `.mention-popover`'s
+              // max-width) — without it one long candidate name stretches the
+              // panel arbitrarily wide, past the viewport edge. Rows truncate
+              // instead (see MentionLabel).
+              maxWidth: "var(--sp-90)",
               background: "var(--bg-raised)",
               borderColor: "var(--border)",
             }}
@@ -1126,18 +1132,18 @@ function ParticipantChips({
                       );
                     }
                     const isInChips = chipSet.has(item.agentId);
+                    const fullTitle = mentionOptionTitle(item);
                     if (isInChips) {
                       return (
                         <div
                           key={item.agentId}
                           role="presentation"
-                          title={item.name ? `@${item.name} — already in this draft` : "Already in this draft"}
+                          title={fullTitle ? `${fullTitle} — already in this draft` : "Already in this draft"}
                           className="flex w-full items-center px-3 py-1.5 text-left text-body"
                           style={{
                             background: "transparent",
                             color: "var(--fg-3)",
                             cursor: "default",
-                            whiteSpace: "nowrap",
                           }}
                         >
                           <AgentOption
@@ -1157,7 +1163,7 @@ function ParticipantChips({
                         type="button"
                         role="option"
                         aria-selected={active}
-                        title={item.name ? `@${item.name}` : undefined}
+                        title={fullTitle}
                         onClick={() => onAdd(item.agentId)}
                         onMouseEnter={() => setHighlight(myIdx)}
                         className="flex w-full items-center px-3 py-1.5 text-left text-body"
@@ -1166,7 +1172,6 @@ function ParticipantChips({
                           color: "var(--fg)",
                           border: "none",
                           cursor: "pointer",
-                          whiteSpace: "nowrap",
                         }}
                       >
                         <AgentOption candidate={item} ambiguous={ambiguous} />


### PR DESCRIPTION
## Problem

Agent display names and `@handles` render with no truncation in any people-picker surface. Long names break the layout in three different ways:

- **Add-participant dropdown** (chat header + right sidebar): rows wrap freely — a CJK full-title name wraps to 2+ lines and the mono `@handle` breaks mid-token (`@codex-` / `assistant`).
- **Composer `@` popover** (chat view, ask takeover, new-chat body): rows force `white-space: nowrap`, so a long name makes the whole list scroll horizontally with no ellipsis.
- **New-chat `[+]` recipient picker**: nowrap rows and a panel with `minWidth: 280` but no max — one long name stretches the panel arbitrarily wide, past the viewport edge. The selected-recipient chip (`AgentToken`) had no width cap either.

Team-page delegate selector options and the conversations People-filter labels had the same unbounded-name problem.

## Fix (owner-approved: single-line everywhere)

- `MentionLabel` (the shared label used by every picker row): display name gets `min-w-0 truncate`; the conditional `@handle` gets `shrink-0 truncate` capped at 45% of the row — it keeps its natural width when short, ellipsizes when long, and never breaks mid-token.
- New shared `mentionOptionTitle()` helper: hover `title` is now `DisplayName (@name)`, collapsing to `@name` when the two are identical (same noise rule as `shouldShowHandle`), so a truncated row still discloses the full identity; adopted by the popover, add-participant, new-chat, and delegate-selector rows (title sits on the row control, matching command-palette).
- `AgentToken` recipient chip: single-line truncate capped at `min(var(--sp-60), 100%)`, plus `title`.
- New `--sp-90` token (360px) so the picker-panel width cap lives in one place: `.mention-popover`'s existing max-width now references it, and the add-participant (icon variant), new-chat `[+]`, delegate-selector, and conversations-filter panels adopt it inline.
- Removed the three row-level `white-space: nowrap` declarations — truncation now lives at the label level, so the popover no longer scrolls horizontally.
- `DelegateSelector` option labels, `FilterCheckbox` labels, and the conversations rail `FilterChip` (the persistent chip for a picked People filter, previously unbounded) get the same `min-w-0` + `truncate` + `title` treatment.

Already-correct precedents untouched and now matched: command-palette rows, right-sidebar participant rows, Team-table `DelegateChip`.

Two independent review passes ran on the diff; their findings (filter panel missing the width cap, delegate title format drift and span-level placement, unlinked 360 literals, untokenized chip cap, rail `FilterChip` gap) are folded in.

## Testing

- `pnpm --filter @first-tree/web typecheck` (tsc + lint:tokens) passes.
- `pnpm check` (biome) passes.
- `pnpm --filter @first-tree/web test`: 186 files / 1483 tests pass, including new unit tests for `mentionOptionTitle`.
- Live-verified on a branch dev server proxied to staging, with real org data: composer `@` popover (desktop and 390px mobile), add-participant dropdown, new-chat `[+]` picker, Team delegate selector, People filter — uniform single-line rows, ellipsis on overflow, no horizontal scroll, panels capped at 360px. The original repro row (a CJK full-title display name + long handle) now renders on one line with the handle intact.
