### PR TITLE
fix(client): give the legacy AGENTS prompt fallback self-contained provenance

### DIFF
--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -214,6 +214,13 @@ describe("buildAgentBriefing — prompt provenance sections", () => {
     expect(briefing).toContain("first-tree agent config prompt set test-agent");
     expect(briefing).toContain("Do NOT copy any of this\nmerged section into your per-agent prompt.");
 
+    // The merged blob can also embed binding-managed agent prompt overrides,
+    // which `prompt set` cannot edit — both the banner and the Source
+    // paragraph must name that class and its Cloud-managed edit path.
+    expect(briefing.match(/binding-managed agent prompt overrides/g)).toHaveLength(2);
+    expect(briefing).toMatch(/binding-managed agent prompt overrides[\s\S]{0,160}?Org Settings →\s+Resources/);
+    expect(briefing).toMatch(/binding-managed agent prompt overrides\s+\(NOT editable with `prompt set`/);
+
     // The banner documents the heading that actually renders on this path —
     // the legacy merged entry replaces the structured three-heading map.
     expect(briefing).toContain("# Agent Prompt (legacy merged) → this agent's prompt configuration");

--- a/packages/client/src/__tests__/agent-briefing.test.ts
+++ b/packages/client/src/__tests__/agent-briefing.test.ts
@@ -53,6 +53,7 @@ function topLevelSection(briefing: string, heading: string): string {
     "# Team Prompt (team-shared — read-only for agents)",
     "# Agent Prompt (this agent only — editable)",
     "# Agent Prompt Overrides (this agent only — managed via resource bindings)",
+    "# Agent Prompt (legacy merged — may include team-shared content)",
     "# Working in First Tree (First Tree Managed)",
     "# Context Tree (First Tree Managed)",
     "# Skills (First Tree Managed)",
@@ -196,13 +197,30 @@ describe("buildAgentBriefing — prompt provenance sections", () => {
     reasoningEffort: "" as const,
   };
 
-  it("renders legacy append only as the legacy fallback", () => {
-    expect(buildAgentBriefing(makeOpts({ payload: null }))).not.toContain("## Agent-Specific Prompt");
+  it("renders legacy append only as the legacy fallback, with self-contained provenance", () => {
+    expect(buildAgentBriefing(makeOpts({ payload: null }))).not.toContain("legacy merged");
 
     const payload = { ...basePayload, prompt: { append: "Follow the local plan." } };
     const briefing = buildAgentBriefing(makeOpts({ payload }));
-    expect(briefing).toContain("## Agent-Specific Prompt\n\nFollow the local plan.");
+    expect(briefing).toContain("# Agent Prompt (legacy merged — may include team-shared content)");
+    expect(briefing).toContain("Follow the local plan.");
+    expect(briefing).not.toContain("## Agent-Specific Prompt");
     expect(briefing).not.toContain("# Agent Prompt (this agent only — editable)");
+
+    // The fallback section itself names its source and both edit entry
+    // points, so the file stays self-contained without the structured trio.
+    expect(briefing).toContain("served as one merged blob");
+    expect(briefing).toContain("first-tree agent config prompt show test-agent --raw");
+    expect(briefing).toContain("first-tree agent config prompt set test-agent");
+    expect(briefing).toContain("Do NOT copy any of this\nmerged section into your per-agent prompt.");
+
+    // The banner documents the heading that actually renders on this path —
+    // the legacy merged entry replaces the structured three-heading map.
+    expect(briefing).toContain("# Agent Prompt (legacy merged) → this agent's prompt configuration");
+    expect(briefing).toContain("NEVER copy the merged section back into prompt set");
+    expect(briefing).not.toContain("# Team Prompt   → team prompt resources");
+    expect(briefing).not.toContain("# Agent Prompt Overrides → agent-specific resource bindings");
+    expect(briefing).toContain("Every other section is First Tree Managed");
   });
 
   it("separates team prompt, editable agent prompt, and non-editable overrides", () => {
@@ -230,6 +248,7 @@ describe("buildAgentBriefing — prompt provenance sections", () => {
     expect(briefing).toContain("## Tone guide\n\nOverride body.");
     expect(briefing).toMatch(/NOT editable with `prompt set`/);
     expect(briefing).not.toContain("## Agent-Specific Prompt");
+    expect(briefing).not.toContain("legacy merged");
   });
 
   it("renders identity, prompt, and path values without HTML escaping", () => {

--- a/packages/client/src/__tests__/codex-bootstrap.test.ts
+++ b/packages/client/src/__tests__/codex-bootstrap.test.ts
@@ -124,11 +124,12 @@ describe("bootstrapWorkspace — codex briefing + workspace marker", () => {
       "/var/lib/context-trees/codex",
     );
 
-    // Section names follow the AGENTS.md restructure: `# Identity`,
-    // `## Agent-Specific Prompt`, `# Working in First Tree`, etc.
+    // Section names follow the AGENTS.md restructure: `# Identity`, the
+    // provenance-labelled legacy prompt fallback, `# Working in First Tree`.
     expect(briefing).toContain("# Identity");
     expect(briefing).toContain("Codex Developer");
-    expect(briefing).toContain("## Agent-Specific Prompt");
+    expect(briefing).toContain("# Agent Prompt (legacy merged — may include team-shared content)");
+    expect(briefing).not.toContain("## Agent-Specific Prompt");
     expect(briefing).toContain("Follow the local implementation plan.");
     expect(briefing).not.toContain("## Current Chat Context");
     expect(briefing).not.toContain("Chat ID: chat-1");

--- a/packages/client/src/runtime/templates/agent-briefing.ejs
+++ b/packages/client/src/runtime/templates/agent-briefing.ejs
@@ -6,9 +6,10 @@
   Where each section comes from, and where to edit it:<% if (legacyPrompt) { %>
     # Agent Prompt (legacy merged) → this agent's prompt configuration,
                       served as ONE merged blob by a First Tree server that
-                      predates per-section provenance; team prompt resources
-                      (Cloud → Org Settings → Resources, managed by team
-                      admins) and this agent's own editable prompt fragment
+                      predates per-section provenance; team prompt resources,
+                      binding-managed agent prompt overrides (both managed in
+                      Cloud → Org Settings → Resources, never via prompt
+                      set), and this agent's own editable prompt fragment
                       are indistinguishable inside it;
                       read (own fragment only):  <%- bin %> agent config prompt show <agent> --raw
                       write (own fragment only): <%- bin %> agent config prompt set <agent> -f <file>
@@ -63,9 +64,10 @@ prompt.*<% for (const row of agentPromptOverrideRows) { %>
 
 *Source: this agent's prompt configuration, served as one merged blob by a
 First Tree server that predates per-section provenance. Team prompt
-resources (managed by team admins in Cloud → Org Settings → Resources) and
-this agent's own editable prompt fragment are indistinguishable here. Read
-the editable fragment alone with
+resources (managed by team admins), binding-managed agent prompt overrides
+(NOT editable with `prompt set` — both managed in Cloud → Org Settings →
+Resources), and this agent's own editable prompt fragment are
+indistinguishable here. Read the editable fragment alone with
 `<%- bin %> agent config prompt show <%- agentId %> --raw`; replace it with
 `<%- bin %> agent config prompt set <%- agentId %>`. Do NOT copy any of this
 merged section into your per-agent prompt.*

--- a/packages/client/src/runtime/templates/agent-briefing.ejs
+++ b/packages/client/src/runtime/templates/agent-briefing.ejs
@@ -3,7 +3,16 @@
   every session start. NEVER copy this file, in whole or in part, back into
   any prompt configuration.
 
-  Where each section comes from, and where to edit it:
+  Where each section comes from, and where to edit it:<% if (legacyPrompt) { %>
+    # Agent Prompt (legacy merged) → this agent's prompt configuration,
+                      served as ONE merged blob by a First Tree server that
+                      predates per-section provenance; team prompt resources
+                      (Cloud → Org Settings → Resources, managed by team
+                      admins) and this agent's own editable prompt fragment
+                      are indistinguishable inside it;
+                      read (own fragment only):  <%- bin %> agent config prompt show <agent> --raw
+                      write (own fragment only): <%- bin %> agent config prompt set <agent> -f <file>
+                      NEVER copy the merged section back into prompt set<% } else { %>
     # Team Prompt   → team prompt resources (Cloud → Org Settings →
                       Resources); managed by team admins; read-only here
     # Agent Prompt  → this agent's own prompt fragment;
@@ -11,7 +20,7 @@
                       write: <%- bin %> agent config prompt set <agent> -f <file>
     # Agent Prompt Overrides → agent-specific resource bindings that
                       replace team prompts; managed in Cloud, NOT via
-                      prompt set
+                      prompt set<% } %>
   Every other section is First Tree Managed — injected by the runtime and
   not editable through any prompt configuration.
 ====================================================================== -->
@@ -50,7 +59,16 @@ prompt.*<% for (const row of agentPromptOverrideRows) { %>
 
 <%- row.body %><% } %><% } %><% if (legacyPrompt) { %>
 
-## Agent-Specific Prompt
+# Agent Prompt (legacy merged — may include team-shared content)
+
+*Source: this agent's prompt configuration, served as one merged blob by a
+First Tree server that predates per-section provenance. Team prompt
+resources (managed by team admins in Cloud → Org Settings → Resources) and
+this agent's own editable prompt fragment are indistinguishable here. Read
+the editable fragment alone with
+`<%- bin %> agent config prompt show <%- agentId %> --raw`; replace it with
+`<%- bin %> agent config prompt set <%- agentId %>`. Do NOT copy any of this
+merged section into your per-agent prompt.*
 
 <%- legacyPrompt %><% } %>
 

--- a/packages/shared/src/__tests__/agent-briefing-guard.test.ts
+++ b/packages/shared/src/__tests__/agent-briefing-guard.test.ts
@@ -43,6 +43,12 @@ describe("findAssembledBriefingFingerprint", () => {
         "## Current Chat Context (First Tree Managed, per-chat)",
         "## Current Chat Context (First Tree Managed, per-chat)",
       ],
+      // The legacy-fallback prompt heading marks a merged blob that embeds
+      // team-shared content; copying it back would freeze team prompts.
+      [
+        "# Agent Prompt (legacy merged — may include team-shared content)",
+        "# Agent Prompt (legacy merged — may include team-shared content)",
+      ],
     ];
     for (const [heading, expectedMatch] of cases) {
       const result = findAssembledBriefingFingerprint(`Some intro.\n\n${heading}\n\nBody.`);
@@ -58,5 +64,11 @@ describe("findAssembledBriefingFingerprint", () => {
     expect(findAssembledBriefingFingerprint("# Working in First Trees\n")).toBeNull();
     // …but a colon/suffix after the exact phrase is still the briefing shape.
     expect(findAssembledBriefingFingerprint("# Required Reading: extras\n")?.kind).toBe("briefing-heading");
+  });
+
+  it("does not flag the structured editable agent-prompt heading", () => {
+    // The structured heading's body is the agent's own fragment — copying it
+    // back is harmless duplication, unlike the legacy merged blob.
+    expect(findAssembledBriefingFingerprint("# Agent Prompt (this agent only — editable)\n")).toBeNull();
   });
 });

--- a/packages/shared/src/agent-briefing-guard.ts
+++ b/packages/shared/src/agent-briefing-guard.ts
@@ -33,6 +33,11 @@ const BRIEFING_HEADING_PATTERNS: ReadonlyArray<RegExp> = [
   /^# Working in First Tree\b.*$/m,
   /^# Required Reading\b.*$/m,
   /^## Current Chat Context\b.*$/m,
+  // The legacy-fallback prompt section merges team-shared content into one
+  // blob, so copying it back would freeze team prompts into agent config.
+  // The structured `# Agent Prompt (this agent only — editable)` heading is
+  // deliberately NOT guarded: its body is the agent's own fragment.
+  /^# Agent Prompt \(legacy merged\b.*$/m,
 ];
 
 export type BriefingFingerprint = {


### PR DESCRIPTION
Closes #1799

## Problem

The generated `AGENTS.md` banner documents `# Team Prompt`, `# Agent Prompt`, and `# Agent Prompt Overrides`, then states every other section is First Tree-managed. On the legacy fallback path (`payload.prompt.append` populated, `payload.prompt.sections` absent — a server that predates per-section provenance), the prompt body rendered under a bare `## Agent-Specific Prompt` heading that the banner never names and that carries no source/edit explanation. A reader could misclassify the agent's prompt as First Tree-managed, or copy the assembled briefing back into the prompt source — the exact failure mode the provenance labels exist to rule out.

## Change

- **Template fallback section** (`agent-briefing.ejs`): renamed to `# Agent Prompt (legacy merged — may include team-shared content)`, opening with a *Source:* paragraph that names the merged-blob origin, states that team prompt resources and the agent's own editable fragment are indistinguishable inside it, gives both edit entry points (`agent config prompt show <agent> --raw` / `prompt set <agent>` for the agent fragment; Cloud → Org Settings → Resources for team prompts), and warns against copying the merged section back.
- **Banner section map**: on the legacy path the banner now documents the legacy merged heading (with the same read/write entry points and never-copy warning) instead of the structured trio, so the banner always describes the headings that actually render. The structured path is unchanged.
- **Write guard** (`agent-briefing-guard.ts`): added `# Agent Prompt (legacy merged…` to the CLI-tier briefing-heading heuristic. The heading exists only in the assembled briefing, and its body embeds team-shared content, so copying it back would freeze team prompts into agent config. The structured `# Agent Prompt (this agent only — editable)` heading stays unguarded on purpose — its body is the agent's own fragment. `--force` remains the escape hatch for legitimate quoting.

## Tests

- `agent-briefing.test.ts`: legacy fallback test now asserts the provenance-labelled heading, the source/edit-entry-point prose, the do-not-copy warning, and the banner swap (structured trio absent on the legacy path); structured-path test asserts the legacy heading never renders there.
- `codex-bootstrap.test.ts`: updated to the new fallback heading; pins that `## Agent-Specific Prompt` is gone.
- `agent-briefing-guard.test.ts`: new heading flagged as heuristic tier; structured editable heading explicitly not flagged.

`pnpm check`, `pnpm typecheck`, and full test suites for `@first-tree/shared`, `@first-tree/client`, and the CLI package pass locally. One pre-existing CLI test (`agent-shared-helpers-extra.test.ts` › "ignores the runtime session token value from the agent subprocess env") fails only when the running shell inherits `FIRST_TREE_RUNTIME_SESSION_TOKEN_FILE` (i.e. inside a live agent env) — it passes with that variable unset and is untouched by this diff; the test could additionally sanitize that variable, left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
