### PR TITLE
Sync GitLab staging development changes

### DIFF
--- a/packages/qa/cases/cross-surface/agent-code-access-navigation.md
+++ b/packages/qa/cases/cross-surface/agent-code-access-navigation.md
@@ -1,6 +1,6 @@
 ---
 id: agent-code-access-navigation
-description: Validate that Team repository access stays provider-neutral across Settings and Agent Detail, including reliable deep-link positioning from a scrolled Agent page.
+description: Validate the independent Repositories settings page, its code and Context Tree sections, and reliable Agent Detail deep-link positioning.
 areas: [cross-surface]
 surfaces: [web]
 ---
@@ -9,69 +9,78 @@ surfaces: [web]
 
 ## Goal
 
-Confirm that Team repository access is one provider-neutral catalog shared by
-agents, while GitHub and GitLab connections remain separate event, identity,
-and webhook controls. Validate the real Agent Detail → Settings navigation
-through the Web shell's persistent scroll container; deterministic DOM tests
-own the URL and hash-effect branches, while this case owns the assembled
-browser positioning and cross-page information hierarchy.
+Confirm that Settings → Repositories is the provider-neutral home for both
+Team code repositories and the separate Context Tree repository binding. The
+two models share one repository-oriented destination without sharing state or
+credentials. GitHub and GitLab tabs remain connection-only. Validate the real
+Agent Detail → Settings navigation through the Web shell's persistent scroll
+container and the assembled page's heading hierarchy.
 
 ## Preconditions
 
 - Run the target ref in the isolated Docker plus temporary-worktree QA cell.
 - Prepare one Team admin, one ordinary member, and a manageable non-human
-  agent. Seed at least four recommended Team repository resources using a mix
-  of GitHub, GitLab, and another valid Git-server URL.
-- The provider connection states may be connected or disconnected, but record
-  them before the run. Do not place real private-repository credentials in the
-  Team resource payload or QA artifacts.
+  agent. Seed at least four recommended Team code repositories using a mix of
+  GitHub, GitLab, and another valid Git-server URL.
+- Bind a Context Tree repository on its default branch and configure an active
+  reviewer agent. Provider connections may be connected or disconnected, but
+  record their states before the run. Do not place real private-repository
+  credentials in Team resource payloads or QA artifacts.
 
 ## Operate and Observe
 
-- As the admin, open Settings → Integrations under both the GitHub and GitLab
-  tabs. Confirm **Code available to agents** is above **Connections**, shows
-  the same Team repository catalog on both routes, and does not move into or
-  duplicate inside either provider tab.
-- Confirm the first three repositories are visible and the fourth is hidden
-  behind **View all (4)**. Expand and collapse the list, then add or edit a
-  repository with a full non-GitHub URL and verify the shared catalog updates
-  without requiring a GitHub App or GitLab webhook connection.
-- As the ordinary member, confirm the same shared catalog is readable while
-  add, edit, and retire controls remain unavailable. Provider connection
-  controls must retain their existing role boundary.
+- As the admin, open Settings → Repositories. Confirm the page has no repeated
+  visible **Repositories** heading. **Code repositories** and **Context Tree**
+  must be the only peer section headings; repository names and **Automatic PR
+  review** must read as lower-level row labels, with URLs, branch, and reviewer
+  rendered as quieter metadata.
+- Confirm **Code repositories** appears first, with the first three rows visible
+  and the fourth behind **View all (4)**. Expand and collapse the list, then add
+  or edit a full non-GitHub URL. Verify the catalog updates without requiring a
+  GitHub App or GitLab webhook connection.
+- In **Context Tree**, confirm the compact binding row shows the repository
+  name, full URL, and default branch, with **Edit** and **Open Context** as
+  secondary actions. Confirm **Automatic PR review** is a row in this same
+  section, not a third section heading, and its saved reviewer is metadata that
+  can open the selector.
+- Open Settings → Integrations under GitHub and GitLab. Confirm the catalog and
+  Context Tree binding do not appear there; the surface contains only
+  **Connections** and provider-specific controls.
+- As the ordinary member, confirm both Repositories sections remain readable,
+  while add, edit, retire, and reviewer mutation controls are unavailable.
 - Open the agent's repository-management surface, scroll the persistent main
-  pane far enough that preserving the old offset would skip the top of the
-  Settings page, and choose **Manage Team code access**. Confirm navigation
-  lands with the shared code section visibly positioned and focused rather
-  than leaving the viewport below it. Repeat after visiting both a GitHub and
-  a GitLab connection tab.
-- Confirm the agent's effective repository list reflects recommended Team
+  pane far enough that preserving the old offset would skip the destination,
+  and choose **Manage Team repositories**. Confirm navigation lands on and
+  focuses **Code repositories**. Repeat with the legacy Settings → Context URL
+  and confirm it lands on and focuses **Context Tree**.
+- Confirm the agent's effective repository list reflects recommended Team code
   resources independently of provider connection state. The UI may explain
-  that private clone access uses Git credentials on the agent computer; it
-  must not imply that webhook or provider-connection credentials clone code.
+  that private clone access uses Git credentials on the agent computer; it must
+  not imply that provider connection credentials clone code.
 
 ## Evidence
 
-Capture the before-navigation Agent viewport and the positioned Settings
-destination, both provider-tab routes with the same catalog, compact and
-expanded list states, and admin-versus-member controls. Record only redacted
+Capture the Repositories page hierarchy, compact and expanded code lists, the
+Context Tree row, both provider-only Integrations tabs, admin-versus-member
+controls, and the positioned deep-link destinations. Record only redacted
 repository coordinates and connection summaries; never retain Git tokens,
 private clone credentials, or one-time webhook bearers.
 
 ## Expected Result
 
-`PASS`: one provider-neutral Team repository catalog appears above provider
-connections, role boundaries are preserved, the compact list behaves as
-described, and the Agent shortcut reliably positions the shared section from
-a deeply scrolled origin page.
+`PASS`: one independent Repositories page presents exactly two visible section
+headings in the intended order, preserves both models' role boundaries, keeps
+provider tabs connection-only, and reliably positions both current and legacy
+deep links.
 
-`FAIL`: repository management is provider-bound or duplicated, connection
-state changes catalog availability, a member gains write controls, or the
-Agent shortcut preserves an offset that hides the destination.
+`FAIL`: the page repeats its own title, promotes a row to section-heading level,
+mixes the two repository models, duplicates repository management under a
+provider, grants member write controls, or leaves a deep-link destination out
+of view.
 
 `BLOCKED`: the isolated run cell cannot create the required Team roles,
-manageable agent, or repository fixtures.
+manageable agent, repository fixtures, or Context Tree binding.
 
-`INCONCLUSIVE`: source inspection or unit-test output exists, but the real
-persistent-scroll navigation and assembled Settings hierarchy were not
-observed in a browser.
+`INCONCLUSIVE`: source inspection or unit-test output exists, but the assembled
+Settings hierarchy and persistent-scroll navigation were not observed in a
+browser.

--- a/packages/qa/cases/cross-surface/people-picker-long-identities.md
+++ b/packages/qa/cases/cross-surface/people-picker-long-identities.md
@@ -1,0 +1,81 @@
+---
+id: people-picker-long-identities
+description: Verify long agent display names and handles stay single-line, readable, and viewport-safe across people-picker surfaces.
+areas: [cross-surface]
+surfaces: [web]
+---
+
+# Long identities across people pickers
+
+## Goal
+
+Verify that every Web surface used to find or select a person applies the same
+single-line identity contract: display names and `@handles` ellipsize instead
+of wrapping or widening their panel, selected chips remain bounded, and the
+full identity is available from the row or chip title. The new-chat `[+]`
+picker must remain fully reachable even when preceding recipient chips push its
+inline trigger toward the viewport edge.
+
+Deterministic product tests own identity-title formatting and placement math.
+This case owns rendered geometry across the assembled responsive surfaces,
+where DOM-only tests cannot prove clipping, wrapping, or horizontal overflow.
+
+## Preconditions
+
+- Use an isolated Docker plus temporary-worktree QA run cell with the Web app,
+  server, database, and a real browser available.
+- Seed at least four active, selectable agents: a short display name/handle, a
+  long CJK display name with a long handle, a long unbroken Latin display name,
+  and two agents sharing the same display name so handle disambiguation renders.
+- Open the same data at desktop width, 390px, and the supported 320px mobile
+  baseline. Do not rely on browser zoom as a substitute for actual viewport
+  dimensions.
+
+## Operate and observe
+
+- Open the chat-header/right-sidebar add-participant picker, composer `@`
+  suggestions, new-chat recipient picker and selected chips, Team delegate
+  selector, and Workspace People filter. Confirm every identity label stays on
+  one line; ellipses appear where needed; handles never break mid-token; rows
+  keep their normal height; and the panel/page gains no horizontal scrollbar.
+- Hover or otherwise inspect each truncated row and selected chip. Its title
+  must expose the complete `Display name (@handle)` identity without duplicate
+  text when display name and handle are the same.
+- In New Chat at 390px, select a short-name recipient, reopen `[+]`, then repeat
+  after selecting a long-name recipient and after selecting both. Confirm the
+  picker is portalled above clipping ancestors, its left and right borders are
+  visible, search and every option remain reachable, and choosing an option
+  still commits it.
+- Repeat that chip-offset scenario at 320px. Confirm both panel edges retain an
+  inset from the visual viewport and the panel neither clips nor creates page
+  horizontal scroll. Resize/orient the viewport while it is open and confirm it
+  re-clamps to the new visual viewport.
+- Use keyboard navigation in the open new-chat picker: focus lands in search,
+  Arrow keys move the active option, Enter selects it, Escape closes it, and an
+  outside click closes it without making portal rows unclickable.
+
+## Evidence
+
+Keep screenshots for each surface with the long CJK and unbroken Latin
+identities, plus before/after screenshots of the 390px and 320px new-chat
+chip-offset scenarios showing both picker borders. Record viewport dimensions,
+panel bounding rectangles, `documentElement.scrollWidth/clientWidth`, visible
+row heights, title values, and any browser console errors. Do not capture
+private profile content beyond the synthetic seeded identities.
+
+## Expected result
+
+`PASS`: all picker rows and chips follow the one-line contract; full identities
+remain discoverable; no tested surface widens, wraps, or gains horizontal
+scroll; and the new-chat picker stays fully inside both 390px and 320px visual
+viewports before and after chip offsets and resize.
+
+`FAIL`: any identity wraps or breaks mid-token, a title loses identity data, a
+panel/page overflows horizontally, either new-chat picker edge becomes
+unreachable, or portal positioning breaks mouse or keyboard selection.
+
+`BLOCKED`: the isolated run cell cannot seed agents, start the Web surface, or
+drive a real browser at the required viewport sizes.
+
+`INCONCLUSIVE`: geometry or title evidence is missing, unstable, or cannot be
+attributed to the tested ref.

--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -84,7 +84,10 @@ vi.mock("../pages/settings.js", async () => {
   };
 });
 vi.mock("../pages/settings/computers.js", () => ({ SettingsComputersPage: () => <div>settings computers</div> }));
-vi.mock("../pages/settings/context-tree.js", () => ({ SettingsContextTreePage: () => <div>settings context</div> }));
+vi.mock("../pages/settings/context-tree.js", async () => {
+  const { Navigate } = await import("react-router");
+  return { SettingsContextTreePage: () => <Navigate to="/settings/repositories#context-tree" replace /> };
+});
 vi.mock("../pages/settings/github.js", () => ({ SettingsGithubPage: () => <div>settings github</div> }));
 vi.mock("../pages/settings/gitlab.js", () => ({ SettingsGitlabPage: () => <div>settings gitlab</div> }));
 vi.mock("../pages/settings/integrations.js", async () => {
@@ -99,6 +102,9 @@ vi.mock("../pages/settings/integrations.js", async () => {
   };
 });
 vi.mock("../pages/settings/onboarding.js", () => ({ SettingsOnboardingPage: () => <div>settings onboarding</div> }));
+vi.mock("../pages/settings/repositories.js", () => ({
+  SettingsRepositoriesPage: () => <div>settings repositories</div>,
+}));
 vi.mock("../pages/settings/resources.js", () => ({ SettingsResourcesPage: () => <div>settings resources</div> }));
 vi.mock("../pages/agent-detail.js", async () => {
   const { Outlet } = await import("react-router");
@@ -248,7 +254,10 @@ describe("App routes", () => {
     expect(await renderAppAt("/settings/setup")).toContain("settings onboarding");
     await resetRenderedApp();
 
-    expect(await renderAppAt("/settings/context")).toContain("settings context");
+    expect(await renderAppAt("/settings/repositories")).toContain("settings repositories");
+    await resetRenderedApp();
+
+    expect(await renderAppAt("/settings/context")).toContain("settings repositories");
     await resetRenderedApp();
 
     expect(await renderAppAt("/settings/resources")).toContain("settings resources");

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -35,6 +35,7 @@ import { SettingsGithubPage } from "./pages/settings/github.js";
 import { SettingsGitlabPage } from "./pages/settings/gitlab.js";
 import { SettingsIntegrationsLayout } from "./pages/settings/integrations.js";
 import { SettingsOnboardingPage } from "./pages/settings/onboarding.js";
+import { SettingsRepositoriesPage } from "./pages/settings/repositories.js";
 import { SettingsResourcesPage } from "./pages/settings/resources.js";
 import { SettingsLayout } from "./pages/settings.js";
 import { TeamPage } from "./pages/team/index.js";
@@ -189,7 +190,7 @@ export function App() {
               ) : null}
               {ContextTreePreviewPage ? (
                 <Route
-                  path="/preview/context-tree"
+                  path="/preview/context-tree/*"
                   element={
                     <Suspense fallback={null}>
                       <ContextTreePreviewPage />
@@ -436,6 +437,7 @@ export function App() {
                   <Route path="settings" element={<SettingsLayout />}>
                     <Route index element={<Navigate to="computers" replace />} />
                     <Route path="team" element={<Navigate to="/settings/computers" replace />} />
+                    <Route path="repositories" element={<SettingsRepositoriesPage />} />
                     <Route path="context" element={<SettingsContextTreePage />} />
                     <Route path="resources" element={<SettingsResourcesPage />} />
                     <Route path="computers" element={<SettingsComputersPage />} />

--- a/packages/web/src/components/__tests__/mention-autocomplete.test.ts
+++ b/packages/web/src/components/__tests__/mention-autocomplete.test.ts
@@ -8,6 +8,7 @@ import {
   fieldOutOfScrollport,
   groupAndSortCandidates,
   type MentionCandidate,
+  mentionOptionTitle,
   portalPanelPlacement,
   rankCandidates,
 } from "../mention-autocomplete.js";
@@ -428,5 +429,29 @@ describe("portalPanelPlacement", () => {
 
   it("dismisses (null) when there isn't room above the field for even one row", () => {
     expect(portalPanelPlacement({ field: { top: 30, bottom: 70 }, port, viewportTop: 0 })).toBeNull();
+  });
+});
+
+describe("mentionOptionTitle", () => {
+  it("combines display name and handle when they differ", () => {
+    expect(mentionOptionTitle(cand({ agentId: "a1", name: "codex-assistant", displayName: "白晓航的个人助理" }))).toBe(
+      "白晓航的个人助理 (@codex-assistant)",
+    );
+  });
+
+  it("collapses to the handle alone when the display name matches it", () => {
+    expect(mentionOptionTitle(cand({ agentId: "a1", name: "ux-expert", displayName: "ux-expert" }))).toBe("@ux-expert");
+  });
+
+  it("falls back to the handle when there is no display name", () => {
+    expect(mentionOptionTitle(cand({ agentId: "a1", name: "ux-expert", displayName: null }))).toBe("@ux-expert");
+  });
+
+  it("falls back to the display name when there is no handle", () => {
+    expect(mentionOptionTitle(cand({ agentId: "a1", name: null, displayName: "Soft Deleted" }))).toBe("Soft Deleted");
+  });
+
+  it("returns undefined when neither field is set", () => {
+    expect(mentionOptionTitle(cand({ agentId: "a1", name: null, displayName: null }))).toBeUndefined();
   });
 });

--- a/packages/web/src/components/add-participant-dropdown.tsx
+++ b/packages/web/src/components/add-participant-dropdown.tsx
@@ -10,6 +10,7 @@ import {
   ambiguousDisplayNames,
   buildPickerSections,
   type MentionCandidate,
+  mentionOptionTitle,
 } from "./mention-autocomplete.js";
 
 /**
@@ -286,9 +287,11 @@ export function AddParticipantDropdown({
           className="absolute z-20 flex flex-col border shadow-[var(--shadow-md)] outline-none"
           style={{
             top: "calc(100% + var(--sp-1))",
-            // Icon trigger sits at the panel's right edge → grow leftward;
+            // Icon trigger sits at the panel's right edge → grow leftward,
+            // capped so one long candidate name cannot stretch the panel;
+            // rows truncate instead.
             // the inline row spans the rail → match its full width.
-            ...(variant === "icon" ? { right: 0, minWidth: 280 } : { left: 0, right: 0 }),
+            ...(variant === "icon" ? { right: 0, minWidth: 280, maxWidth: "var(--sp-90)" } : { left: 0, right: 0 }),
             background: "var(--bg-raised)",
             borderColor: "var(--border)",
             borderRadius: "var(--radius-input)",
@@ -347,12 +350,13 @@ export function AddParticipantDropdown({
                     );
                   }
                   const isInChat = participantSet.has(it.agentId);
+                  const fullTitle = mentionOptionTitle(it);
                   if (isInChat) {
                     return (
                       <div
                         key={it.agentId}
                         role="presentation"
-                        title={it.name ? `@${it.name} — already in this chat` : "Already in this chat"}
+                        title={fullTitle ? `${fullTitle} — already in this chat` : "Already in this chat"}
                         className="flex w-full items-center text-left"
                         style={{
                           padding: "var(--sp-1_75) var(--sp-2)",
@@ -377,7 +381,7 @@ export function AddParticipantDropdown({
                       key={it.agentId}
                       type="button"
                       role="menuitem"
-                      title={it.name ? `@${it.name}` : undefined}
+                      title={fullTitle}
                       onClick={() => commit(it.agentId)}
                       onMouseEnter={() => setHighlight(myIdx)}
                       disabled={addMut.isPending}

--- a/packages/web/src/components/chat/__tests__/agent-hovercard.test.tsx
+++ b/packages/web/src/components/chat/__tests__/agent-hovercard.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   getChat: vi.fn(),
   fetchChatAgentStatuses: vi.fn(),
   getAgent: vi.fn(),
+  authAgentId: "self-human",
 }));
 
 vi.mock("../../../api/chats.js", () => ({ getChat: mocks.getChat }));
@@ -18,13 +19,8 @@ vi.mock("../../../api/agent-status.js", () => ({
   fetchChatAgentStatuses: mocks.fetchChatAgentStatuses,
 }));
 vi.mock("../../../api/agents.js", () => ({ getAgent: mocks.getAgent }));
-vi.mock("../../../lib/use-member-name-map.js", () => ({
-  useMemberNameMap: () => (id: string | null | undefined) => (id === "m1" ? "Gandy" : "—"),
-}));
-vi.mock("../../../lib/use-client-map.js", () => ({
-  useClientMap: () => ({
-    resolve: (id: string | null | undefined) => (id === "c1" ? { hostname: "gandy-mbp" } : null),
-  }),
+vi.mock("../../../auth/auth-context.js", () => ({
+  useAuth: () => ({ agentId: mocks.authAgentId }),
 }));
 
 // Imported after the mocks are registered.
@@ -71,6 +67,7 @@ beforeEach(() => {
   mocks.getChat.mockReset();
   mocks.fetchChatAgentStatuses.mockReset();
   mocks.getAgent.mockReset();
+  mocks.authAgentId = "self-human";
 });
 
 afterEach(() => {
@@ -139,7 +136,7 @@ describe("AgentHovercard", () => {
     expect(document.body.querySelector('[role="dialog"]')).toBeNull();
   });
 
-  it("shows identity, Owner and Runs-on for an agent (Pass B)", async () => {
+  it("shows identity, one chat status, and a calm two-route footer without profile/runtime metadata", async () => {
     seedPassA(
       "chat-1",
       [AGENT_PARTICIPANT],
@@ -166,18 +163,21 @@ describe("AgentHovercard", () => {
     await waitFor(() => {
       expect(card.textContent).toContain("Aria");
       expect(card.textContent).toContain("@aria");
-      expect(card.textContent).toContain("Owner");
-      expect(card.textContent).toContain("Gandy");
-      expect(card.textContent).toContain("Runs on");
-      expect(card.textContent).toContain("claude-code");
-      expect(card.textContent).toContain("gandy-mbp");
-      expect(card.textContent).toContain("Open details");
-      expect(card.textContent).toContain("Chat");
+      expect(card.textContent).toContain("Idle");
+      expect(card.textContent).toContain("New chat");
+      expect(card.textContent).toContain("View profile");
     });
+    expect(card.textContent).not.toContain("Owner");
+    expect(card.textContent).not.toContain("Runs on");
+    expect(card.textContent).not.toContain("claude-code");
+    expect(card.textContent).not.toContain("gandy-mbp");
+    const actions = card.querySelector<HTMLElement>("[data-participant-actions]");
+    expect(actions?.style.gridTemplateColumns).toBe("repeat(2, minmax(0, 1fr))");
+    expect([...card.querySelectorAll("a")].map((a) => a.textContent)).toEqual(["New chat", "View profile"]);
     expect(mocks.getAgent).toHaveBeenCalledWith("a1");
   });
 
-  it("renders a LIVE pill and Working row when the agent is working", async () => {
+  it("renders one Working label without LIVE or activity detail", async () => {
     seedPassA(
       "chat-1",
       [AGENT_PARTICIPANT],
@@ -207,12 +207,14 @@ describe("AgentHovercard", () => {
     await flush();
     const card = await openCard();
     await waitFor(() => {
-      expect(card.textContent).toContain("LIVE");
       expect(card.textContent).toContain("Working");
     });
+    expect(card.textContent?.match(/Working/g)).toHaveLength(1);
+    expect(card.textContent).not.toContain("LIVE");
+    expect(card.textContent).not.toContain("Bash");
   });
 
-  it("navigates to agent details from the Open details action", async () => {
+  it("navigates to agent details from the View profile link", async () => {
     seedPassA("chat-1", [AGENT_PARTICIPANT], []);
     mocks.getAgent.mockResolvedValue(AGENT_DTO);
     render(
@@ -222,19 +224,33 @@ describe("AgentHovercard", () => {
     );
     await flush();
     const card = await openCard();
-    let openDetails: HTMLButtonElement | undefined;
+    let viewProfile: HTMLAnchorElement | undefined;
     await waitFor(() => {
-      openDetails = [...card.querySelectorAll("button")].find((b) => b.textContent?.includes("Open details"));
-      if (!openDetails) throw new Error("Open details not rendered yet");
+      viewProfile = [...card.querySelectorAll("a")].find((a) => a.textContent?.includes("View profile"));
+      if (!viewProfile) throw new Error("View profile not rendered yet");
     });
     await act(async () => {
-      openDetails?.click();
+      viewProfile?.click();
       await Promise.resolve();
     });
     expect(latestPath).toBe("/agents/a1/profile");
   });
 
-  it("renders the human variant with only a Message action (no Pass B)", async () => {
+  it("does not flash View profile while the lazy permission probe is pending", async () => {
+    seedPassA("chat-1", [AGENT_PARTICIPANT], []);
+    mocks.getAgent.mockReturnValue(new Promise(() => undefined));
+    render(
+      <AgentHovercard agentId="a1" chatId="chat-1" name="Aria">
+        <span>Aria</span>
+      </AgentHovercard>,
+    );
+    await flush();
+    const card = await openCard();
+    expect([...card.querySelectorAll("a")].map((a) => a.textContent)).toEqual(["New chat"]);
+    expect(card.textContent).not.toContain("View profile");
+  });
+
+  it("renders the human variant with a Human label and only New chat (no Pass B)", async () => {
     seedPassA("chat-1", [HUMAN_PARTICIPANT], []);
     render(
       <AgentHovercard agentId="h1" chatId="chat-1" name="Gandy">
@@ -246,14 +262,30 @@ describe("AgentHovercard", () => {
     await waitFor(() => {
       expect(card.textContent).toContain("Gandy");
       expect(card.textContent).toContain("@gandy");
-      expect(card.textContent).toContain("Message");
+      expect(card.textContent).toContain("Human");
+      expect(card.textContent).toContain("New chat");
     });
+    expect([...card.querySelectorAll("a")].map((a) => a.textContent)).toEqual(["New chat"]);
     expect(card.textContent).not.toContain("Owner");
     expect(card.textContent).not.toContain("Runs on");
     expect(mocks.getAgent).not.toHaveBeenCalled();
   });
 
-  it("degrades to identity + Chat when the agent is not readable (Pass B 404)", async () => {
+  it("removes the self-chat entry point for the current human", async () => {
+    mocks.authAgentId = "h1";
+    seedPassA("chat-1", [HUMAN_PARTICIPANT], []);
+    render(
+      <AgentHovercard agentId="h1" chatId="chat-1" name="Gandy">
+        <span>Gandy</span>
+      </AgentHovercard>,
+    );
+    await flush();
+    const card = await openCard();
+    expect(card.textContent).toContain("You");
+    expect(card.querySelector("[data-participant-actions]")).toBeNull();
+  });
+
+  it("degrades to identity + New chat when the agent is not readable (Pass B 404)", async () => {
     // A private agent visible via chat membership but not via GET /agents/:uuid.
     seedPassA(
       "chat-1",
@@ -278,16 +310,26 @@ describe("AgentHovercard", () => {
     );
     await flush();
     const card = await openCard();
-    // Wait for the degraded END state, not the loading state: while getAgent is
-    // still pending, detailsAccessible is true and Owner/Runs-on/Open details
-    // render (with skeletons). Fold the negatives + the Chat-only button set
-    // into the waited condition so the assertions run only after the 404 lands.
+    // A failed permission probe never exposes a route that would immediately
+    // land on a 404; the chat-scoped route remains valid.
     await waitFor(() => {
       expect(card.textContent).toContain("Aria");
-      expect([...card.querySelectorAll("button")].map((b) => b.textContent)).toEqual(["Chat"]);
+      expect([...card.querySelectorAll("a")].map((a) => a.textContent)).toEqual(["New chat"]);
       expect(card.textContent).not.toContain("Owner");
       expect(card.textContent).not.toContain("Runs on");
-      expect(card.textContent).not.toContain("Open details");
+      expect(card.textContent).not.toContain("View profile");
     });
+  });
+
+  it("does not invent an @handle from the participant id", async () => {
+    seedPassA("chat-1", [{ ...HUMAN_PARTICIPANT, name: null }], []);
+    render(
+      <AgentHovercard agentId="h1" chatId="chat-1" name="Gandy">
+        <span>Gandy</span>
+      </AgentHovercard>,
+    );
+    await flush();
+    const card = await openCard();
+    expect(card.textContent).not.toContain("@h1");
   });
 });

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -285,6 +285,35 @@ describe("AgentStatusPanel extra DOM coverage", () => {
     await waitForSettled(h, () => expect(sessionApiMocks.suspendSession).toHaveBeenCalledWith("agent-nova", "chat-1"));
   });
 
+  it("keeps working and failed roster statuses static and omits activity detail", async () => {
+    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
+      status("agent-worker", {
+        working: true,
+        engagement: "active",
+        activity: activity("agent-worker", { label: "Bash" }),
+      }),
+      status("agent-failed", { errored: true }),
+    ]);
+
+    h.render(
+      withProviders(
+        <AgentStatusPanel
+          chatId="chat-1"
+          agents={[agent("agent-worker", "Worker Agent"), agent("agent-failed", "Failed Agent")]}
+          canManage={() => false}
+        />,
+        new Set(["agent-worker", "agent-failed"]),
+      ),
+    );
+
+    await waitForSettled(h, () => {
+      expect(h.container.textContent).toContain("Working");
+      expect(h.container.textContent).toContain("Failed");
+    });
+    expect(h.container.textContent).not.toContain("Bash");
+    expect(h.container.querySelector('button[aria-label^="Jump to this agent"]')).toBeNull();
+  });
+
   it("renders missing statuses as empty, and resumes suspended rows", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([status("agent-paused", { engagement: "suspended" })]);
 

--- a/packages/web/src/components/chat/agent-hovercard.tsx
+++ b/packages/web/src/components/chat/agent-hovercard.tsx
@@ -1,33 +1,31 @@
 import type { AgentChatStatus } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, MessageSquare } from "lucide-react";
+import { MessageSquarePlus, UserRound } from "lucide-react";
 import { type ReactNode, useContext } from "react";
-import { useNavigate } from "react-router";
+import { Link } from "react-router";
 import { chatAgentStatusQueryKey, fetchChatAgentStatuses } from "../../api/agent-status.js";
 import { getAgent } from "../../api/agents.js";
 import { getChat } from "../../api/chats.js";
+import { useAuth } from "../../auth/auth-context.js";
 import { reconcileLiveTurn, viewOf } from "../../lib/agent-status-view.js";
-import { useClientMap } from "../../lib/use-client-map.js";
-import { useMemberNameMap } from "../../lib/use-member-name-map.js";
 import { Avatar } from "../avatar.js";
-import { Button } from "../ui/button.js";
 import { HoverCard, type HoverCardPlacement } from "../ui/hover-card.js";
 import { StatusGlyph } from "../ui/status-glyph.js";
 import { LiveTurnAgentsContext } from "./live-turn-context.js";
-import { WorkingChip } from "./working-chip.js";
 
 /**
- * Shared agent identity hovercard. Wraps any trigger (avatar + name cluster) and,
- * on hover/focus, previews the agent's identity + live status + Owner / Runs-on,
- * with `Open details →` / `Chat` actions — so a user in a chat has an in-context
- * door to the agent without leaving the conversation.
+ * Shared participant identity hovercard. Wraps any trigger (avatar + name
+ * cluster) and, on hover or activation, previews identity + one chat-scoped
+ * status with compact `New chat` / `View profile` routes. Durable profile and
+ * runtime metadata stay on Agent Detail rather than turning this card into a
+ * miniature inspector.
  *
  * Two-pass data (never blocks on a fetch):
  *  - Pass A (instant): identity + type/role from the chat participant list and
  *    live status from the chat agent-status — both already cached by ChatView.
- *  - Pass B (lazy on open): Owner + Runs-on from a single getAgent(agentId)
- *    (managerId → member name; runtimeProvider + clientId → hostname). The body
- *    only mounts when the card opens, so this query is naturally lazy.
+ *  - Pass B (lazy on open): getAgent(agentId) verifies that Agent Detail is
+ *    accessible and provides a fallback identity for non-chat entry points.
+ *    The body only mounts when the card opens, so this query is naturally lazy.
  */
 export function AgentHovercard({
   agentId,
@@ -52,12 +50,12 @@ export function AgentHovercard({
   return (
     <HoverCard
       placement={placement}
-      ariaLabel={`${name} — view details`}
+      ariaLabel={`Show details for ${name}`}
       triggerClassName={triggerClassName}
       // Card chrome (background / border / shadow / padding) comes from the
       // HoverCard primitive; only the width is this consumer's call.
       contentStyle={{
-        width: "var(--sp-70)",
+        width: "var(--sp-60)",
         maxWidth: "calc(100vw - var(--sp-4))",
       }}
       content={({ close }) => <AgentHovercardBody agentId={agentId} chatId={chatId} onAction={close} />}
@@ -68,9 +66,7 @@ export function AgentHovercard({
 }
 
 function AgentHovercardBody({ agentId, chatId, onAction }: { agentId: string; chatId: string; onAction: () => void }) {
-  const navigate = useNavigate();
-  const resolveMember = useMemberNameMap();
-  const { resolve: resolveClient } = useClientMap();
+  const { agentId: myAgentId } = useAuth();
 
   // Pass A — cached by ChatView, so these are hits (instant). staleTime keeps a
   // warm cache from refetching on every card open: scanning many names in a busy
@@ -91,7 +87,7 @@ function AgentHovercardBody({ agentId, chatId, onAction }: { agentId: string; ch
   const participant = chatQ.data?.participants.find((p) => p.agentId === agentId);
   const rawStatus: AgentChatStatus | null = statusQ.data?.find((s) => s.agentId === agentId) ?? null;
   // Match the roster row from the same context: a live timeline turn upgrades
-  // `ready → working` (at the axis level) so the card's status dot / LIVE pill
+  // `ready → working` (at the axis level) so the card's status dot / label
   // can't disagree with a visibly-working turn — for every hovercard entry
   // point (roster rows AND message avatars/names) by construction.
   const liveTurnAgentIds = useContext(LiveTurnAgentsContext);
@@ -109,169 +105,139 @@ function AgentHovercardBody({ agentId, chatId, onAction }: { agentId: string; ch
   });
 
   const isHuman = (participant?.type ?? agentQ.data?.type) === "human";
+  const isSelf = isHuman && agentId === myAgentId;
   const displayName = participant?.displayName ?? agentQ.data?.displayName ?? "…";
-  const handle = participant?.name ?? agentQ.data?.name ?? agentId.slice(0, 8);
+  const handle = participant?.name ?? agentQ.data?.name ?? null;
   const avatarImageUrl = participant?.avatarImageUrl ?? agentQ.data?.avatarImageUrl ?? null;
   const avatarColorToken = participant?.avatarColorToken ?? agentQ.data?.avatarColorToken ?? null;
 
-  const main = status?.main;
-  const isWorking = main === "working" || main === "failed";
-  const workingActivity = isWorking ? (status?.activity ?? null) : null;
+  const statusView = status ? viewOf(status.main) : null;
   // Pass B 404s for a private agent visible only via chat membership (getAgent +
-  // the agent-detail route are both visibility-gated). When that happens, drop
-  // the Owner/Runs-on rows and the Open details action rather than show dashes
-  // and route to a page the viewer can't open.
-  const detailsAccessible = !agentQ.isError;
-  const showMeta = detailsAccessible || workingActivity !== null;
-
-  function openDetails() {
-    onAction();
-    navigate(`/agents/${agentId}/profile`);
-  }
-  function openChat() {
-    onAction();
-    // Type-agnostic draft compose (same path as the agent-detail Chat button);
-    // works for agents and humans without an agent-vs-human chat-create fork.
-    navigate(`/?c=draft&with=${encodeURIComponent(agentId)}`);
-  }
+  // the agent-detail route are both visibility-gated). When that happens, hide
+  // the View profile route rather than send the viewer to a page they can't open.
+  // Do not expose a route before the lazy permission probe succeeds. Private
+  // participants and transient failures both keep the always-valid chat route;
+  // the card never flashes an action that may immediately land on a 404.
+  const detailsAccessible = agentQ.isSuccess;
+  const chatPath = `/?c=draft&with=${encodeURIComponent(agentId)}`;
 
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-2_5)" }}>
       {/* Head */}
       <div className="flex items-center" style={{ gap: "var(--sp-2_5)" }}>
-        <span className="relative shrink-0" style={{ width: 38, height: 38 }}>
-          <Avatar src={avatarImageUrl} name={displayName} seed={agentId} colorToken={avatarColorToken} size={38} />
-          {!isHuman && status ? <StatusDot status={status} /> : null}
+        <span className="shrink-0" style={{ width: "var(--sp-10)", height: "var(--sp-10)" }}>
+          <Avatar src={avatarImageUrl} name={displayName} seed={agentId} colorToken={avatarColorToken} size={40} />
         </span>
         <div className="flex min-w-0 flex-1 flex-col" style={{ gap: 1 }}>
-          <div className="truncate text-subtitle" style={{ color: "var(--fg)" }}>
+          <div
+            className="text-subtitle"
+            title={displayName}
+            style={{
+              color: "var(--fg)",
+              display: "-webkit-box",
+              WebkitBoxOrient: "vertical",
+              WebkitLineClamp: 2,
+              overflow: "hidden",
+              overflowWrap: "anywhere",
+            }}
+          >
             {displayName}
           </div>
-          <div className="mono text-caption truncate" style={{ color: "var(--fg-4)" }}>
-            @{handle}
-          </div>
+          {handle ? (
+            <div className="mono text-label truncate" style={{ color: "var(--fg-2)" }} title={`@${handle}`}>
+              @{handle}
+            </div>
+          ) : null}
         </div>
-        {!isHuman && main === "working" ? (
-          <span className="mono text-eyebrow shrink-0" style={{ color: "var(--state-working)" }}>
-            LIVE
-          </span>
-        ) : null}
+        <ParticipantKind isHuman={isHuman} isSelf={isSelf} statusView={statusView} />
       </div>
 
-      {/* Agent-only meta + actions. Humans get just a Message action. */}
-      {isHuman ? (
-        <>
-          <Divider />
-          <Button size="sm" variant="outline" onClick={openChat}>
-            <MessageSquare className="h-4 w-4" />
-            Message
-          </Button>
-        </>
-      ) : (
-        <>
-          {showMeta ? (
-            <>
-              <Divider />
-              <div className="flex flex-col" style={{ gap: "var(--sp-1_5)" }}>
-                {detailsAccessible ? (
-                  <>
-                    <MetaRow label="Owner">
-                      {agentQ.isLoading ? <Skeleton /> : resolveMember(agentQ.data?.managerId)}
-                    </MetaRow>
-                    <MetaRow label="Runs on">
-                      {agentQ.isLoading ? (
-                        <Skeleton />
-                      ) : agentQ.data?.clientId ? (
-                        <span className="mono">
-                          {agentQ.data.runtimeProvider} ·{" "}
-                          {resolveClient(agentQ.data.clientId)?.hostname ?? agentQ.data.clientId}
-                        </span>
-                      ) : (
-                        <span style={{ color: "var(--fg-4)" }}>— not bound</span>
-                      )}
-                    </MetaRow>
-                  </>
-                ) : null}
-                {workingActivity ? (
-                  <MetaRow label="Working">
-                    <WorkingChip activity={workingActivity} showDot={false} />
-                  </MetaRow>
-                ) : null}
-              </div>
-            </>
-          ) : null}
-          <Divider />
-          <div className="flex" style={{ gap: "var(--sp-2)" }}>
-            {detailsAccessible ? (
-              <>
-                <Button size="sm" onClick={openDetails} style={{ flex: 1 }}>
-                  Open details
-                  <ArrowRight className="h-4 w-4" />
-                </Button>
-                <Button size="sm" variant="ghost" onClick={openChat}>
-                  <MessageSquare className="h-4 w-4" />
-                  Chat
-                </Button>
-              </>
-            ) : (
-              // Pass B 404 → a private agent the viewer can see in chat but not
-              // open via /agents/:uuid. Hide Owner/Runs-on + Open details (they'd
-              // 404); keep Chat (they already share this chat).
-              <Button size="sm" variant="outline" onClick={openChat} style={{ flex: 1 }}>
-                <MessageSquare className="h-4 w-4" />
-                Chat
-              </Button>
-            )}
-          </div>
-        </>
+      {/* A single calm footer replaces the old filled-primary + ghost pair.
+          New chat comes first (Workspace first); Agent Detail is an equal,
+          secondary route. A human viewing their own identity gets no dead-end
+          self-chat action. */}
+      {isSelf ? null : (
+        <ParticipantActions
+          chatPath={chatPath}
+          profilePath={!isHuman && detailsAccessible ? `/agents/${agentId}/profile` : null}
+          onAction={onAction}
+        />
       )}
     </div>
   );
 }
 
-function MetaRow({ label, children }: { label: string; children: ReactNode }) {
-  return (
-    <div className="grid items-baseline" style={{ gridTemplateColumns: "var(--sp-16) 1fr", gap: "var(--sp-2)" }}>
-      <div className="text-eyebrow" style={{ color: "var(--fg-4)" }}>
-        {label}
-      </div>
-      <div className="text-caption min-w-0 truncate" style={{ color: "var(--fg-2)" }}>
-        {children}
-      </div>
-    </div>
-  );
-}
-
-function Divider() {
-  return <div style={{ borderTop: "var(--hairline) solid var(--border-faint)" }} />;
-}
-
-function Skeleton() {
+function ParticipantKind({
+  isHuman,
+  isSelf,
+  statusView,
+}: {
+  isHuman: boolean;
+  isSelf: boolean;
+  statusView: ReturnType<typeof viewOf> | null;
+}) {
+  if (isHuman) {
+    return (
+      <span className="text-label shrink-0" style={{ color: "var(--fg-2)" }}>
+        {isSelf ? "You" : "Human"}
+      </span>
+    );
+  }
+  if (!statusView) {
+    return (
+      <span className="text-label shrink-0" style={{ color: "var(--fg-2)" }}>
+        Agent
+      </span>
+    );
+  }
   return (
     <span
-      aria-hidden
-      className="inline-block rounded-[var(--radius-chip)]"
-      style={{ width: "var(--sp-20)", height: "var(--sp-2_5)", background: "var(--bg-sunken)" }}
-    />
+      className="text-label inline-flex shrink-0 items-center"
+      style={{ gap: "var(--sp-1_5)", color: "var(--fg-2)" }}
+    >
+      <StatusGlyph colorVar={statusView.colorVar} shape={statusView.shape} pulse={statusView.pulse} size={7} />
+      {statusView.label}
+    </span>
   );
 }
 
-/**
- * The avatar status dot — same `viewOf` vocabulary (shape / colour / pulse) as
- * the right-sidebar AgentStatusRow, so an agent reads identically in both places.
- */
-function StatusDot({ status }: { status: AgentChatStatus }) {
-  const view = viewOf(status.main);
+function ParticipantActions({
+  chatPath,
+  profilePath,
+  onAction,
+}: {
+  chatPath: string;
+  profilePath: string | null;
+  onAction: () => void;
+}) {
+  const actionClass =
+    "text-label flex min-h-10 min-w-0 items-center justify-center gap-1 px-1 transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--fg)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring active:bg-[var(--bg-active)]";
   return (
-    <span className="absolute" style={{ right: -2, bottom: -3 }}>
-      <StatusGlyph
-        colorVar={view.colorVar}
-        shape={view.shape}
-        pulse={view.pulse}
-        size={9}
-        ariaLabel={view.label}
-        separator
-      />
-    </span>
+    <nav
+      aria-label="Participant actions"
+      className="grid overflow-hidden rounded-[var(--radius-input)]"
+      data-participant-actions
+      style={{
+        gridTemplateColumns: profilePath ? "repeat(2, minmax(0, 1fr))" : "minmax(0, 1fr)",
+        border: "var(--hairline) solid var(--border)",
+        background: "var(--bg-sunken)",
+      }}
+    >
+      <Link to={chatPath} onClick={onAction} className={actionClass} style={{ color: "var(--fg-2)" }}>
+        <MessageSquarePlus className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="truncate">New chat</span>
+      </Link>
+      {profilePath ? (
+        <Link
+          to={profilePath}
+          onClick={onAction}
+          className={actionClass}
+          style={{ color: "var(--fg-2)", borderLeft: "var(--hairline) solid var(--border)" }}
+        >
+          <UserRound className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          <span className="truncate">View profile</span>
+        </Link>
+      ) : null}
+    </nav>
   );
 }

--- a/packages/web/src/components/chat/agent-status-panel.tsx
+++ b/packages/web/src/components/chat/agent-status-panel.tsx
@@ -6,26 +6,21 @@ import { chatAgentStatusQueryKey, fetchChatAgentStatuses } from "../../api/agent
 import { resumeSession, suspendSession } from "../../api/sessions.js";
 import { reconcileLiveTurn, viewOf } from "../../lib/agent-status-view.js";
 import { toneOf } from "../../lib/tones.js";
-import { isJumpable, useMountedAnchors } from "../../lib/use-mounted-anchors.js";
 import { Avatar } from "../avatar.js";
 import { StatusGlyph } from "../ui/status-glyph.js";
 import { AgentHovercard } from "./agent-hovercard.js";
 import { LiveTurnAgentsContext } from "./live-turn-context.js";
-import { TimelineJumpButton } from "./timeline-jump-button.js";
-import { WorkingChip } from "./working-chip.js";
 
 /**
- * AgentStatusPanel — the per-agent composite-status board, shared by the
- * chat right sidebar (always-on) and the compose status bar's expanded view
- * (step 7). One `GET /chats/:chatId/agent-status` call drives every row;
+ * AgentStatusPanel — the chat right sidebar's per-agent composite-status
+ * board. One `GET /chats/:chatId/agent-status` call drives every row;
  * freshness rides the admin WS invalidation of `["chat-agent-status", id]`
  * (see use-admin-ws) — no per-agent poll.
  *
  * Each row reads its main status through the shared `viewOf` vocabulary:
- * a status-point (StatusGlyph) on the avatar + a second line for every state
- * (working → the live activity, failed → a tinted attention pill,
- * idle / paused / offline → the state word in its own colour), so all rows
- * stay uniform / equal-height. The dot carries the shape + colour distinction.
+ * a status-point (StatusGlyph) on the avatar plus one static text label. The
+ * center timeline owns activity/tool detail and error navigation; the sidebar
+ * stays a calm identity + status + lightweight-control surface.
  */
 export function AgentStatusPanel({
   chatId,
@@ -55,7 +50,6 @@ export function AgentStatusPanel({
   // context. `reconcileLiveTurn` uses it to upgrade a stale `ready` row to
   // `working` so the roster can't show Idle while the turn is visibly running.
   const liveTurnAgentIds = useContext(LiveTurnAgentsContext);
-  const mounted = useMountedAnchors();
   // Per the per-chat-runtime authority refactor: working is per-chat
   // freshness stamp the server self-heals from; no local stale-clear ticker
   // needed. The admin-WS delta pushes the recomputed status down.
@@ -81,7 +75,6 @@ export function AgentStatusPanel({
           status={byAgent.get(agent.agentId) ?? null}
           hasLiveTurn={liveTurnAgentIds.has(agent.agentId)}
           canManage={canManage(agent.agentId)}
-          mounted={mounted}
           compact={compact}
         />
       ))}
@@ -110,7 +103,6 @@ function AgentStatusRow({
   status,
   hasLiveTurn,
   canManage,
-  mounted,
   compact,
 }: {
   chatId: string;
@@ -118,7 +110,6 @@ function AgentStatusRow({
   status: AgentChatStatus | null;
   hasLiveTurn: boolean;
   canManage: boolean;
-  mounted: ReadonlySet<string>;
   compact: boolean;
 }) {
   const queryClient = useQueryClient();
@@ -205,7 +196,7 @@ function AgentStatusRow({
         >
           {agent.displayName}
         </AgentHovercard>
-        <SecondLine status={displayStatus} mounted={mounted} />
+        <SecondLine status={displayStatus} />
       </div>
 
       {showPause ? <PauseButton onClick={() => suspendMut.mutate()} isPending={suspendMut.isPending} /> : null}
@@ -215,15 +206,11 @@ function AgentStatusRow({
 }
 
 /**
- * The row's second line — present for every state so all rows stay uniform.
- * Status words are sans (natural language); only technical info (tool name,
- * timer) is mono. The two *attention* states get a subtle tinted pill so they
- * jump out; the quiet states stay dot + plain coloured text:
- *   working            → "Working" (sans, blue) · "Bash · 0s" (mono, live)
- *   failed             → "Failed" pill (red)
- *   idle/paused/offline → the state word in its own colour (sans)
+ * The row's static second line — present for every state so all rows stay
+ * uniform. Working/tool activity and error navigation belong to the center
+ * timeline; this roster intentionally renders status only.
  */
-function SecondLine({ status, mounted }: { status: AgentChatStatus | null; mounted: ReadonlySet<string> }) {
+function SecondLine({ status }: { status: AgentChatStatus | null }) {
   if (!status) {
     return (
       <div className="text-caption" style={{ color: "var(--fg-4)" }}>
@@ -231,43 +218,15 @@ function SecondLine({ status, mounted }: { status: AgentChatStatus | null; mount
       </div>
     );
   }
-  if (status.main === "working" && status.activity) {
-    // "Working" (sans word) · "Bash · 0s" (mono tool + live timer). No leading
-    // pulse dot — the avatar already carries the breathing status dot. The
-    // whole chip is clickable → jumps to this agent's WorkingTurn.
-    return (
-      <TimelineJumpButton
-        agentId={status.agentId}
-        main="working"
-        anchored={isJumpable(mounted, "working", status.agentId)}
-        ariaLabel="Jump to this agent's activity in the timeline"
-        className="text-caption"
-        style={{ color: "var(--state-working)" }}
-      >
-        <span>Working</span>
-        <span aria-hidden="true">·</span>
-        <WorkingChip activity={status.activity} showDot={false} monochrome />
-      </TimelineJumpButton>
-    );
-  }
   if (status.main === "failed") {
-    // Pill is clickable → jumps to this agent's error in the timeline.
     return (
       <div className="flex">
-        <TimelineJumpButton
-          agentId={status.agentId}
-          main="failed"
-          anchored={isJumpable(mounted, "failed", status.agentId)}
-          ariaLabel="Jump to this agent's error in the timeline"
-        >
-          <StatePill tone="error" label="Failed" />
-        </TimelineJumpButton>
+        <StatePill tone="error" label="Failed" />
       </div>
     );
   }
-  // idle / paused / offline → the state word in its own colour, sans. No pill:
-  // these are the quiet, lowest-attention states — a tinted pill would
-  // over-weight them. The dot still carries the shape + colour.
+  // working / idle / paused / offline → the state word in its own colour,
+  // sans. Failed alone keeps the attention pill above.
   const view = viewOf(status.main);
   return (
     <div className="text-caption" style={{ color: view.colorVar }}>

--- a/packages/web/src/components/chat/timeline-jump-button.tsx
+++ b/packages/web/src/components/chat/timeline-jump-button.tsx
@@ -7,9 +7,8 @@ import { cn } from "../../lib/utils.js";
 /**
  * A status element that jumps to the agent's place in the timeline, with a
  * hover-revealed `→` so the affordance is discoverable (the bare
- * `cursor:pointer` alone read as plain text). Shared by the compose rail rows
- * and the AgentRow second-line status (pills / working chip) so the
- * "click a status → jump to its context" interaction is identical in both.
+ * `cursor:pointer` alone read as plain text). Used by the compose activity rail;
+ * the Participants roster intentionally keeps lifecycle labels static.
  *
  * `anchored` gates the affordance: only when the agent's timeline anchor is
  * actually mounted (see `useMountedAnchors`) is the element clickable and the

--- a/packages/web/src/components/mention-autocomplete.tsx
+++ b/packages/web/src/components/mention-autocomplete.tsx
@@ -95,6 +95,13 @@ export function shouldShowHandle(c: MentionCandidate, ambiguous: Set<string>): b
  * `@<handle>` rendering so the format only needs to change in one
  * place.
  *
+ * Overflow contract: both halves are single-line. The display name
+ * truncates with an ellipsis (it shrinks, never wraps — a wrapped or
+ * panel-stretching row is worse than a cut label); the `@<handle>` keeps
+ * its natural width up to 45% of the row, then truncates — it must never
+ * break mid-token. Hover discloses the full label via the row `title`
+ * (see {@link mentionOptionTitle}).
+ *
  * Caller is responsible for the surrounding `<button>` / wrapper
  * (click handlers, `title` attribute, hover/active state) — the label
  * intentionally stays presentational.
@@ -103,14 +110,30 @@ export function MentionLabel({ candidate, ambiguous }: { candidate: MentionCandi
   const fallback = candidate.name ? `@${candidate.name}` : "—";
   return (
     <>
-      <span className="font-medium">{candidate.displayName ?? fallback}</span>
+      <span className="min-w-0 truncate font-medium">{candidate.displayName ?? fallback}</span>
       {shouldShowHandle(candidate, ambiguous) && (
-        <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
+        <span className="mono text-caption shrink-0 truncate" style={{ color: "var(--fg-3)", maxWidth: "45%" }}>
           @{candidate.name}
         </span>
       )}
     </>
   );
+}
+
+/**
+ * Hover `title` for a candidate row: the full untruncated identity. Rows
+ * truncate long labels (see {@link MentionLabel}), so the tooltip carries
+ * whichever parts got cut — `displayName (@name)` when the two differ,
+ * `@name` alone when they're identical or the display name is missing.
+ */
+export function mentionOptionTitle(candidate: Pick<MentionCandidate, "name" | "displayName">): string | undefined {
+  const hasName = typeof candidate.name === "string" && candidate.name.length > 0;
+  const hasDisplay = typeof candidate.displayName === "string" && candidate.displayName.length > 0;
+  if (hasName && hasDisplay && candidate.displayName !== candidate.name) {
+    return `${candidate.displayName} (@${candidate.name})`;
+  }
+  if (hasName) return `@${candidate.name}`;
+  return hasDisplay ? (candidate.displayName ?? undefined) : undefined;
 }
 
 /**
@@ -164,18 +187,24 @@ export function AgentOption({
  * picked agent looks the same everywhere (the new-chat chip was a bare
  * `<span>` label with no avatar before this). Hover reveals the remove
  * `X`; omit `onRemove` for a read-only token.
+ *
+ * A long label truncates on one line (capped at `--sp-60` and at the
+ * host row's width) instead of stretching the chip across — or past —
+ * the composer; hover discloses the full identity via `title`.
  */
 export function AgentToken({ candidate, onRemove }: { candidate: MentionCandidate; onRemove?: () => void }) {
   const label = candidate.displayName ?? candidate.name ?? candidate.agentId.slice(0, 8);
   return (
     <span
       className="group inline-flex items-center text-label"
+      title={mentionOptionTitle(candidate) ?? label}
       style={{
         gap: "var(--sp-1)",
         padding: "var(--sp-0_5) var(--sp-1_5)",
         borderRadius: "var(--radius-chip)",
         background: "var(--bg-sunken)",
         color: "var(--fg)",
+        maxWidth: "min(var(--sp-60), 100%)",
       }}
     >
       <Avatar
@@ -185,7 +214,7 @@ export function AgentToken({ candidate, onRemove }: { candidate: MentionCandidat
         colorToken={candidate.avatarColorToken ?? null}
         size={16}
       />
-      <span>{label}</span>
+      <span className="min-w-0 truncate">{label}</span>
       {onRemove && (
         <button
           type="button"
@@ -742,7 +771,7 @@ export function MentionAutocompletePopover({
         role="option"
         aria-selected={active}
         data-mention-index={i}
-        title={c.name ? `@${c.name}` : undefined}
+        title={mentionOptionTitle(c)}
         onMouseDown={(e) => {
           // preventDefault keeps the textarea focused so `selectionStart`
           // can still be used to compute the insertion point.
@@ -755,7 +784,6 @@ export function MentionAutocompletePopover({
           color: "var(--fg)",
           border: "none",
           cursor: "pointer",
-          whiteSpace: "nowrap",
         }}
       >
         <AgentOption candidate={c} ambiguous={ambiguous} />

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -512,6 +512,7 @@
   --sp-60: 15rem; /* 240px */
   --sp-70: 17.5rem; /* 280px */
   --sp-75: 18.75rem; /* 300px */
+  --sp-90: 22.5rem; /* 360px — people-picker panel width cap (mention popover + participant pickers) */
   --sp-95: 23.75rem; /* 380px — chat-description popover card width (~60ch) */
   --mobile-tabbar-height: 3.5rem; /* 56px */
 
@@ -971,7 +972,7 @@
 }
 .mention-popover {
   min-width: 240px;
-  max-width: 360px;
+  max-width: var(--sp-90);
 }
 .slash-popover {
   min-width: 280px;

--- a/packages/web/src/lib/use-mounted-anchors.ts
+++ b/packages/web/src/lib/use-mounted-anchors.ts
@@ -18,9 +18,8 @@ export function anchorKey(main: AgentMainStatus, agentId: string): string {
 
 /**
  * Whether an agent's status can jump to the timeline right now — i.e. its
- * anchor is in the mounted set. The single predicate every jump affordance
- * gates on (rail row text, rail `Reply ↩`, AgentRow pills/chip) so none can
- * become a clickable no-op. Pure & exported for tests.
+ * anchor is in the mounted set. Compose-rail jump affordances gate on this so
+ * none can become a clickable no-op. Pure & exported for tests.
  */
 export function isJumpable(mounted: ReadonlySet<string>, main: AgentMainStatus, agentId: string): boolean {
   return mounted.has(anchorKey(main, agentId));
@@ -45,16 +44,15 @@ function sameKeys(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
 
 /**
  * Set of `${main}:${agentId}` for every timeline anchor currently mounted in
- * the DOM (working / failed). The status surfaces (compose rail,
- * AgentRow) gate the "jump to timeline" affordance on this so a row is only
- * clickable when its target is actually present — no silent no-op.
+ * the DOM (working / failed). The compose activity rail gates its "jump to
+ * timeline" affordance on this so a row is only clickable when its target is
+ * actually present — no silent no-op.
  *
  * It's computed in an effect (never a render-time DOM read) and refreshed via a
  * MutationObserver, deduped so an unchanged set doesn't re-render. The scan is
- * DOM-driven on purpose: anchors come from two different subtrees (the centre
- * timeline vs. the right-sidebar roster) and from a query keyed per-agent, so
- * observing what's mounted is simpler and more accurate than re-deriving from
- * each source.
+ * DOM-driven on purpose: anchors come from multiple center-timeline row types
+ * and a query keyed per-agent, so observing what's mounted is simpler and more
+ * accurate than re-deriving from each source.
  *
  * ⚠️ Why a gate is needed at all: the chat timeline loads only the latest 50
  * messages (no pagination) and only the primary agent's session events, so a

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -938,8 +938,8 @@ describe("page SSR smoke coverage", () => {
     const { ClientsPage } = await import("../clients.js");
     const { LandingPage } = await import("../landing/index.js");
     const { SettingsComputersPage } = await import("../settings/computers.js");
-    const { SettingsContextTreePage } = await import("../settings/context-tree.js");
     const { SettingsGithubPage } = await import("../settings/github.js");
+    const { SettingsRepositoriesPage } = await import("../settings/repositories.js");
     const { SettingsResourcesPage } = await import("../settings/resources.js");
     const { TeamPage } = await import("../team/index.js");
 
@@ -953,14 +953,16 @@ describe("page SSR smoke coverage", () => {
     // Page titles moved to the Settings layout; assert on stable section
     // content each sub-page renders on its own.
     expect(renderPage(<SettingsGithubPage />)).toContain("GitHub");
-    expect(renderPage(<SettingsContextTreePage />)).toContain("Repository");
+    const repositories = renderPage(<SettingsRepositoriesPage />, "/settings/repositories");
+    expect(repositories).toContain("Code repositories");
+    expect(repositories).toContain("Context Tree");
     expect(renderPage(<SettingsResourcesPage />)).toContain("Loading");
 
     authMock.value = { ...authMock.value, role: "member" };
-    // Settings GitHub, Context tree, and Resources stay visible (read-only)
+    // Settings GitHub, Repositories, and Resources stay visible (read-only)
     // for members.
     expect(renderPage(<SettingsGithubPage />)).toContain("GitHub");
-    expect(renderPage(<SettingsContextTreePage />)).toContain("Repository");
+    expect(renderPage(<SettingsRepositoriesPage />, "/settings/repositories")).toContain("Context Tree");
     expect(renderPage(<SettingsResourcesPage />)).toContain("Loading");
 
     authMock.value = { ...authMock.value, role: null };
@@ -1379,7 +1381,7 @@ describe("page SSR smoke coverage", () => {
       ),
     ).toContain("Join Acme");
     expect(renderPage(<GithubAppInstallationPanel />)).toContain("Connected to");
-    expect(renderPage(<ContextTreeSettingsPanel />)).toContain("Repository");
+    expect(renderPage(<ContextTreeSettingsPanel />)).toContain("Context Tree");
     expect(renderPage(<UserMenu />)).toContain("user-menu");
     expect(() => renderPage(<TeamSetupModal action="create" onClose={() => undefined} />)).not.toThrow();
     expect(renderPage(<SettingsLayout />)).toContain("Settings");

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -298,11 +298,11 @@ describe("extra preview pages", () => {
   it("renders the context-tree preview gallery", async () => {
     const rendered = await renderPreview(<ContextTreePreviewPage />);
 
-    expect(text(rendered.container)).toContain("Context tree");
+    expect(text(rendered.container)).toContain("Repositories");
     expect(text(rendered.container)).toContain("preview");
     expect(text(rendered.container)).toContain("admin, team HAS a tree");
     expect(text(rendered.container)).toContain("member (read-only)");
-    expect(text(rendered.container)).toContain("Context Reviewer");
+    expect(text(rendered.container)).toContain("Automatic PR review");
     expect(text(rendered.container)).toContain("build · 2 agents");
     expect(text(rendered.container)).toContain("bound tree recovery");
     expect(text(rendered.container)).toContain("Work on this in chat");

--- a/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
+++ b/packages/web/src/pages/__tests__/settings-panels-dom.test.tsx
@@ -152,6 +152,7 @@ async function renderDom(
           <Routes>
             <Route path="/settings/*" element={element}>
               <Route path="context" element={<div>Settings child</div>} />
+              <Route path="repositories" element={<div>Repositories child</div>} />
               <Route path="integrations/*" element={<div>Integrations child</div>} />
             </Route>
           </Routes>
@@ -195,7 +196,7 @@ async function click(element: Element | null): Promise<void> {
 }
 
 async function selectOption(container: ParentNode, label: string): Promise<void> {
-  await click(container.querySelector('[aria-label="Context Reviewer agent"]'));
+  await click(container.querySelector('[aria-label="Automatic PR review agent"]'));
   await waitForCondition(
     () => [...document.body.querySelectorAll('[role="option"]')].some((option) => option.textContent?.includes(label)),
     `Expected select option "${label}"`,
@@ -325,6 +326,7 @@ describe("settings panels", () => {
 
     const desktop = await renderDom(<SettingsLayout />, "/settings/integrations/github");
     expect(desktop.container.textContent).toContain("Computers");
+    expect(desktop.container.textContent).toContain("Repositories");
     expect(desktop.container.textContent).toContain("Integrations");
     // The onboarding nav entry is labelled "Setup" (renamed from "Onboarding"
     // so the sidebar label and the page heading no longer drift).
@@ -337,6 +339,7 @@ describe("settings panels", () => {
     const narrow = await renderDom(<SettingsLayout />);
     expect(narrow.container.querySelector("aside")).toBeNull();
     expect(narrow.container.textContent).toContain("Computers");
+    expect(narrow.container.textContent).toContain("Repositories");
     expect(narrow.container.textContent).toContain("Integrations");
     expect(narrow.container.textContent).not.toContain("Setup");
     await act(async () => narrow.root.unmount());
@@ -345,20 +348,31 @@ describe("settings panels", () => {
     const unloaded = await renderDom(<SettingsLayout />);
     expect(unloaded.container.textContent).toBe("");
     await act(async () => unloaded.root.unmount());
+
+    authMock.value = { ...authMock.value, meLoaded: true };
+    viewportMock.value = "xl";
+    const repositories = await renderDom(<SettingsLayout />, "/settings/repositories");
+    const pageHeading = repositories.container.querySelector("h1");
+    expect(pageHeading?.textContent).toBe("Repositories");
+    expect(pageHeading?.classList.contains("sr-only")).toBe(true);
+    expect(repositories.container.textContent).toContain("Repositories child");
+    await act(async () => repositories.root.unmount());
   });
 
   it("renders Context Tree binding configuration and keeps manual editing hidden by default", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
 
-    await waitForText(container, "Repository");
-    // The redundant in-body "Your team's Context Tree" label was removed; the
-    // section title "Repository" now carries that framing.
+    await waitForText(container, "Context Tree");
+    const headings = [...container.querySelectorAll("h2")].map((heading) => heading.textContent);
+    expect(headings).toEqual(["Context Tree"]);
+    expect(headings).not.toContain("Repository");
+    expect(headings).not.toContain("Context Reviewer");
     expect(container.textContent).not.toContain("Your team's Context Tree");
     expect(container.textContent).toContain("https://github.com/acme/context");
-    expect(container.textContent).toContain("branch main");
-    expect(container.textContent).toContain("View on the Context page");
-    expect(container.textContent).toContain("Context Reviewer");
+    expect(container.textContent).toContain("main branch");
+    expect(container.textContent).toContain("Open Context");
+    expect(container.textContent).toContain("Automatic PR review");
     expect(container.querySelectorAll<HTMLButtonElement>('[role="tab"]').length).toBe(0);
     expect(container.textContent).not.toContain("Connect your code & build your Context Tree");
     expect(container.textContent).not.toContain("Repo URL");
@@ -370,7 +384,7 @@ describe("settings panels", () => {
   it("shows and saves manual context tree settings with blank values normalized to null", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "View on the Context page");
+    await waitForText(container, "Open Context");
 
     await click(buttonByText(container, "Edit"));
     await waitForText(container, "Repo URL");
@@ -432,12 +446,11 @@ describe("settings panels", () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     authMock.value = { ...authMock.value, role: "member" };
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "View on the Context page");
+    await waitForText(container, "Open Context");
 
     expect(container.textContent).toContain("https://github.com/acme/context");
-    expect(container.textContent).toContain("branch main");
+    expect(container.textContent).toContain("main branch");
     expect(buttonByText(container, "Edit")).toBeNull();
-    expect(container.textContent).toContain("Context Reviewer");
     expect(container.textContent).toContain("Automatic PR review");
     expect(container.textContent).toContain("Off");
     expect(reviewerSwitch(container)).toBeNull();
@@ -459,7 +472,7 @@ describe("settings panels", () => {
   it("renders Context Reviewer settings without resetting manual binding draft values", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "View on the Context page");
+    await waitForText(container, "Open Context");
 
     await click(buttonByText(container, "Edit"));
     await waitForText(container, "Repo URL");
@@ -467,7 +480,7 @@ describe("settings panels", () => {
     if (!repoInput) throw new Error("Expected repo input");
     await setInputValue(repoInput, "https://github.com/acme/draft-context");
 
-    await waitForText(container, "Context Reviewer");
+    await waitForText(container, "Automatic PR review");
     expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("false");
     expect(settingsMocks.getContextTreeFeaturesSetting).toHaveBeenCalledWith("org-1");
     expect(agentApiMocks.listAllAgents).not.toHaveBeenCalled();
@@ -507,7 +520,7 @@ describe("settings panels", () => {
     );
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Context Reviewer");
+    await waitForText(container, "Automatic PR review");
     await waitForText(container, "Alpha Reviewer");
     expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("true");
 
@@ -523,7 +536,7 @@ describe("settings panels", () => {
   it("does not save when flipping the Switch on (no agent) and back off", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Context Reviewer");
+    await waitForText(container, "Automatic PR review");
 
     await click(reviewerSwitch(container));
     await waitForText(container, "Reviewer agent");
@@ -538,12 +551,12 @@ describe("settings panels", () => {
   it("enables Context Reviewer, filters eligible agents, and saves the selected agent", async () => {
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Context Reviewer");
+    await waitForText(container, "Automatic PR review");
 
     await click(reviewerSwitch(container));
     await waitForText(container, "Reviewer agent");
     await waitForCondition(() => agentApiMocks.listAllAgents.mock.calls.length > 0, "Expected agents to load");
-    await waitForText(container, "Select an agent to enable Context Reviewer.");
+    await waitForText(container, "Select an agent to enable automatic PR review.");
 
     await selectOption(container, "Alpha Reviewer");
     expect(document.body.textContent).not.toContain("Human User");
@@ -564,11 +577,18 @@ describe("settings panels", () => {
     );
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Context Reviewer");
+    await waitForText(container, "Automatic PR review");
 
     await waitForText(container, "Beta Reviewer");
     expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("true");
-    expect(container.textContent).toContain("Beta Reviewer");
+    const reviewerMetadata = buttonByText(container, "Reviewer agent · Beta Reviewer");
+    expect(reviewerMetadata).not.toBeNull();
+    expect(reviewerMetadata?.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector('[aria-label="Automatic PR review agent"]')).toBeNull();
+
+    await click(reviewerMetadata);
+    expect(reviewerMetadata?.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelector('[aria-label="Automatic PR review agent"]')).not.toBeNull();
 
     await act(async () => root.unmount());
   });
@@ -594,7 +614,7 @@ describe("settings panels", () => {
       );
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Context Reviewer");
+    await waitForText(container, "Automatic PR review");
 
     await waitForText(container, "Late Page Reviewer");
     expect(agentApiMocks.listAllAgents).toHaveBeenNthCalledWith(1, { limit: 100 });
@@ -615,11 +635,29 @@ describe("settings panels", () => {
     );
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Context Reviewer");
+    await waitForText(container, "Automatic PR review");
 
     await click(reviewerSwitch(container));
     await waitForText(container, "No active non-human agents are available.");
     expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("true");
+    expect(settingsMocks.putContextTreeFeaturesSetting).not.toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+  });
+
+  it("keeps an unavailable saved reviewer actionable when no replacement agents exist", async () => {
+    settingsMocks.getContextTreeFeaturesSetting.mockResolvedValueOnce(
+      contextTreeFeatures({ enabled: true, agentUuid: "agent-deleted" }),
+    );
+    agentApiMocks.listAllAgents.mockResolvedValueOnce(
+      paginatedAgents([managedAgent({ uuid: "human-only", displayName: "Only Human", type: "human" })]),
+    );
+    const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
+    const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
+
+    await waitForText(container, "No active non-human agents are available.");
+    expect(reviewerSwitch(container)?.getAttribute("aria-checked")).toBe("true");
+    expect(container.textContent).not.toContain("agent-deleted");
     expect(settingsMocks.putContextTreeFeaturesSetting).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
@@ -640,7 +678,7 @@ describe("settings panels", () => {
     );
     const { ContextTreeSettingsPanel } = await import("../context-tree-settings-panel.js");
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
-    await waitForText(container, "Context Reviewer");
+    await waitForText(container, "Automatic PR review");
 
     await waitForText(container, "Other Admin Reviewer");
     expect(container.textContent).not.toContain("Current reviewer is not your active agent.");
@@ -661,7 +699,7 @@ describe("settings panels", () => {
     );
     const { container, root } = await renderPanel(<ContextTreeSettingsPanel />);
 
-    await waitForText(container, "View on the Context page");
+    await waitForText(container, "Open Context");
     await waitForText(container, "Context Reviewer Bot");
     expect(container.textContent).toContain("Automatic PR review");
     expect(container.textContent).toContain("On");
@@ -669,7 +707,7 @@ describe("settings panels", () => {
     expect(settingsMocks.putContextTreeFeaturesSetting).not.toHaveBeenCalled();
     expect(agentApiMocks.listAllAgents).not.toHaveBeenCalled();
     expect(reviewerSwitch(container)).toBeNull();
-    expect(container.querySelector('[aria-label="Context Reviewer agent"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Automatic PR review agent"]')).toBeNull();
 
     await act(async () => root.unmount());
   });
@@ -688,7 +726,7 @@ describe("settings panels", () => {
     expect(container.textContent).not.toContain("agent-deleted");
     expect(agentApiMocks.listAllAgents).not.toHaveBeenCalled();
     expect(reviewerSwitch(container)).toBeNull();
-    expect(container.querySelector('[aria-label="Context Reviewer agent"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Automatic PR review agent"]')).toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -938,11 +938,13 @@ describe("web DOM interaction coverage", () => {
     await waitForText("Nova", second.container);
     expect(agentApiMocks.getNewChatDefaultCandidates).toHaveBeenLastCalledWith({ cachedAgentId: "agent-1" });
     await click(second.container.querySelector('button[aria-label="Add participant"]'));
-    await waitForText("Design Critique", second.container);
+    await waitForText("Design Critique");
+    const participantPicker = document.body.querySelector<HTMLElement>("[data-participant-picker]");
+    expect(participantPicker?.parentElement).toBe(document.body);
+    expect(participantPicker?.style.position).toBe("fixed");
     await click(
-      [...second.container.querySelectorAll("button")].find((button) =>
-        button.textContent?.includes("Design Critique"),
-      ) ?? null,
+      [...document.body.querySelectorAll("button")].find((button) => button.textContent?.includes("Design Critique")) ??
+        null,
     );
     await waitForText("Design Critique", second.container);
     const groupTextarea = second.container.querySelector<HTMLTextAreaElement>("textarea");
@@ -1068,15 +1070,15 @@ describe("web DOM interaction coverage", () => {
     );
 
     await click(rendered.container.querySelector('button[aria-label="Add participant"]'));
-    await waitForText("Nova", rendered.container);
-    const search = rendered.container.querySelector<HTMLInputElement>('input[aria-label="Search agents"]');
+    await waitForText("Nova");
+    const search = document.body.querySelector<HTMLInputElement>('input[aria-label="Search agents"]');
     if (!search) throw new Error("Participant search missing");
     await setValue(search, "nobody");
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 250));
     });
     await flush();
-    await waitForText("No agents match", rendered.container);
+    await waitForText("No agents match");
     await setValue(search, "Nova");
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 250));
@@ -1088,8 +1090,8 @@ describe("web DOM interaction coverage", () => {
     await waitForText("Nova", rendered.container);
 
     await click(rendered.container.querySelector('button[aria-label="Add participant"]'));
-    await waitForText("Design Critique", rendered.container);
-    const designButton = [...rendered.container.querySelectorAll("button")].find((button) =>
+    await waitForText("Design Critique");
+    const designButton = [...document.body.querySelectorAll("button")].find((button) =>
       button.textContent?.includes("Design Critique"),
     );
     await act(async () => {
@@ -1098,10 +1100,10 @@ describe("web DOM interaction coverage", () => {
     await click(designButton ?? null);
     await waitForText("Design Critique", rendered.container);
     await click(rendered.container.querySelector('button[aria-label="Add participant"]'));
-    expect(rendered.container.querySelector('[title*="already in this draft"]')).toBeTruthy();
-    expect(rendered.container.querySelector('[aria-label="Already in draft"]')).toBeTruthy();
+    expect(document.body.querySelector('[title*="already in this draft"]')).toBeTruthy();
+    expect(document.body.querySelector('[aria-label="Already in draft"]')).toBeTruthy();
     await keyDown(
-      rendered.container.querySelector<HTMLInputElement>('input[aria-label="Search agents"]') ?? search,
+      document.body.querySelector<HTMLInputElement>('input[aria-label="Search agents"]') ?? search,
       "Escape",
     );
 

--- a/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/resources-tab-dom.test.tsx
@@ -407,11 +407,11 @@ describe("ResourcesTab", () => {
     expect(buttonByText(document.body, "Opt-in repo")).toBeNull();
     expect(document.body.textContent).not.toContain("Enable from team");
     // …but the menu stays actionable: add a private repo or jump to the
-    // provider-neutral Team code-access area in Settings. Skill/MCP/prompt
+    // provider-neutral Team repositories area in Settings. Skill/MCP/prompt
     // menus keep the Resources destination.
     expect(buttonByText(document.body, "Add agent repo")).toBeTruthy();
-    await click(buttonByText(document.body, "Manage Team code access"));
-    expect(onNavigateAway).toHaveBeenCalledWith("/settings/integrations/github#code-access");
+    await click(buttonByText(document.body, "Manage Team repositories"));
+    expect(onNavigateAway).toHaveBeenCalledWith("/settings/repositories#code-repositories");
     expect(buttonByText(document.body, "Manage in Settings → Resources")).toBeNull();
   });
 

--- a/packages/web/src/pages/agent-detail/capability-section.tsx
+++ b/packages/web/src/pages/agent-detail/capability-section.tsx
@@ -225,12 +225,11 @@ function AddCapabilityMenu(props: {
   onNavigateAway?: (to: string) => void;
 }) {
   const navigate = useNavigate();
-  // Team repos are managed in the provider-neutral code-access area on
-  // Settings → Integrations; the other resource types stay on Settings →
-  // Resources. The anchor makes this exit land on the shared section rather
-  // than implying that Team code belongs to the active GitHub connection.
-  const settingsPath = props.type === "repo" ? "/settings/integrations/github#code-access" : "/settings/resources";
-  const settingsLabel = props.type === "repo" ? "Manage Team code access" : "Manage in Settings → Resources";
+  // Team repos are managed on the provider-neutral Settings → Repositories
+  // page; the other resource types stay on Settings → Resources. The anchor
+  // makes this exit deterministic even from a deeply scrolled Agent page.
+  const settingsPath = props.type === "repo" ? "/settings/repositories#code-repositories" : "/settings/resources";
+  const settingsLabel = props.type === "repo" ? "Manage Team repositories" : "Manage in Settings → Resources";
   const goToSettings = () => (props.onNavigateAway ?? navigate)(settingsPath);
   return (
     <Popover

--- a/packages/web/src/pages/context-tree-preview.tsx
+++ b/packages/web/src/pages/context-tree-preview.tsx
@@ -4,12 +4,12 @@ import { Route, Routes } from "react-router";
 import { AuthContext } from "../auth/auth-context.js";
 import { PageHeader } from "../components/ui/page-header.js";
 import { ContextTreeBuildEntry } from "./context-tree-build-entry.js";
-import { SettingsContextTreePage } from "./settings/context-tree.js";
+import { SettingsRepositoriesPage } from "./settings/repositories.js";
 import { SettingsLayout } from "./settings.js";
 
 /**
  * DEV-only visual preview for the chat-first Context setup. Renders the REAL
- * full Settings → Context tree page (sidebar + header + panel) in each state,
+ * full Settings → Repositories page (sidebar + header + both repo models) in each state,
  * plus the Context tab's single build entry. Mounted with a seeded React Query
  * cache + a mock AuthContext so the real components render with no backend.
  * Visual review only — buttons hit dead mocks.
@@ -42,8 +42,38 @@ const FEATURES_ENABLED = { contextReviewer: { enabled: true, agentUuid: "0192bbb
 const FEATURES_ENABLED_MISSING = { contextReviewer: { enabled: true, agentUuid: "0192ffff-gone" } };
 const BOUND = { repo: "https://github.com/acme/acme-context", branch: "main" };
 const UNBOUND = { repo: null, branch: null };
-// The Context Reviewer section loads candidate agents from this key once on.
-const REVIEWER_AGENTS_KEY = ["context-reviewer", "managed-agents", ORG] as const;
+const CODE_REPOSITORIES = [
+  {
+    id: "repo-web",
+    organizationId: ORG,
+    type: "repo",
+    scope: "team",
+    ownerAgentId: null,
+    name: "first-tree",
+    repoCanonicalKey: "github.com/acme/first-tree",
+    defaultEnabled: "recommended",
+    status: "active",
+    payload: { url: "https://github.com/acme/first-tree.git", defaultBranch: "main" },
+    createdBy: "member-preview",
+    updatedBy: "member-preview",
+    createdAt: "2026-07-16T00:00:00.000Z",
+    updatedAt: "2026-07-16T00:00:00.000Z",
+  },
+];
+const GITHUB_APP_READY = {
+  installationId: 42,
+  accountLogin: "acme",
+  accountType: "Organization",
+  accountGithubId: 42,
+  repositorySelection: "selected",
+  permissions: { metadata: "read", pull_requests: "write" },
+  events: ["pull_request"],
+  suspended: false,
+  manageUrl: "https://github.com/organizations/acme/settings/installations/42",
+  createdAt: "2026-07-16T00:00:00.000Z",
+  updatedAt: "2026-07-16T00:00:00.000Z",
+};
+const REVIEWER_AGENTS_KEY = ["context-reviewer", "org-agents", ORG] as const;
 
 type Seed = ReadonlyArray<readonly [readonly unknown[], unknown]>;
 
@@ -65,7 +95,7 @@ function mockAuth(role: string, onboardingCompletedAt: string | null): ContextTy
   >;
 }
 
-/** The REAL Settings → Context tree page (sidebar + header + panel) for one state. */
+/** The REAL Settings → Repositories page (sidebar + header + panels) for one state. */
 function FullPageCase({ title, authRole, seed }: { title: string; authRole: string; seed: Seed }) {
   const qc = useSeededClient(seed);
   const auth = mockAuth(authRole, "2026-01-01T00:00:00.000Z");
@@ -85,8 +115,8 @@ function FullPageCase({ title, authRole, seed }: { title: string; authRole: stri
         <QueryClientProvider client={qc}>
           <AuthContext.Provider value={auth}>
             <Routes>
-              <Route element={<SettingsLayout />}>
-                <Route path="*" element={<SettingsContextTreePage />} />
+              <Route element={<SettingsLayout activePathname="/settings/repositories" />}>
+                <Route path="*" element={<SettingsRepositoriesPage />} />
               </Route>
             </Routes>
           </AuthContext.Provider>
@@ -132,60 +162,74 @@ function BuildEntryCase({
 export function ContextTreePreviewPage() {
   return (
     <div style={{ minHeight: "100vh", background: "var(--bg)", padding: "var(--sp-6)" }}>
-      <PageHeader title="Context tree — preview" subtitle="DEV-only visual review of chat-first Context setup." />
+      <PageHeader title="Repositories — preview" subtitle="DEV-only visual review of repository settings." />
 
       <div style={{ marginTop: "var(--sp-5)" }}>
         <FullPageCase
-          title="Settings → Context tree · admin, team HAS a tree (the bug fix — no more build CTA)"
+          title="Settings → Repositories · admin, team HAS a tree"
           authRole="admin"
           seed={[
-            [["org-setting", ORG, "context_tree"], BOUND],
+            [["team-resources"], CODE_REPOSITORIES],
+            [["org-setting", ORG, "context_tree", "raw"], BOUND],
+            [["org-setting", ORG, "context_tree_features"], FEATURES_DISABLED],
+            [["github-app-installation", ORG], GITHUB_APP_READY],
+          ]}
+        />
+        <FullPageCase
+          title="Settings → Repositories · admin, no Context Tree yet"
+          authRole="admin"
+          seed={[
+            [["team-resources"], CODE_REPOSITORIES],
+            [["org-setting", ORG, "context_tree", "raw"], UNBOUND],
             [["org-setting", ORG, "context_tree_features"], FEATURES_DISABLED],
           ]}
         />
         <FullPageCase
-          title="Settings → Context tree · admin, no tree yet"
-          authRole="admin"
-          seed={[
-            [["org-setting", ORG, "context_tree"], UNBOUND],
-            [["org-setting", ORG, "context_tree_features"], FEATURES_DISABLED],
-          ]}
-        />
-        <FullPageCase
-          title="Settings → Context tree · member (read-only)"
+          title="Settings → Repositories · member (read-only)"
           authRole="member"
-          seed={[[["org-setting", ORG, "context_tree"], BOUND]]}
+          seed={[
+            [["team-resources"], CODE_REPOSITORIES],
+            [["org-setting", ORG, "context_tree", "safe"], BOUND],
+            [["org-setting", ORG, "context_tree_features"], FEATURES_DISABLED],
+            [["github-app-installation", ORG], GITHUB_APP_READY],
+          ]}
         />
       </div>
 
       <div className="text-eyebrow" style={{ color: "var(--fg-3)", margin: "var(--sp-4) 0 var(--sp-3)" }}>
-        Context Reviewer · immediate-save Switch (replaces the old checkbox + Save). Toggle on/off to see setup ↔ saved.
+        Automatic PR review · immediate-save Switch. Toggle on/off to see setup ↔ saved.
       </div>
       <div style={{ marginTop: "var(--sp-2)" }}>
         <FullPageCase
-          title="Context Reviewer · OFF (flip the Switch on → agent selector appears, pick one to enable)"
+          title="Automatic PR review · OFF (flip the Switch on → choose a reviewer)"
           authRole="admin"
           seed={[
-            [["org-setting", ORG, "context_tree"], BOUND],
+            [["team-resources"], CODE_REPOSITORIES],
+            [["org-setting", ORG, "context_tree", "raw"], BOUND],
             [["org-setting", ORG, "context_tree_features"], FEATURES_DISABLED],
+            [["github-app-installation", ORG], GITHUB_APP_READY],
             [REVIEWER_AGENTS_KEY, AGENTS],
           ]}
         />
         <FullPageCase
-          title="Context Reviewer · ON with a selected agent (Switch on, agent in the Select)"
+          title="Automatic PR review · ON with a selected reviewer"
           authRole="admin"
           seed={[
-            [["org-setting", ORG, "context_tree"], BOUND],
+            [["team-resources"], CODE_REPOSITORIES],
+            [["org-setting", ORG, "context_tree", "raw"], BOUND],
             [["org-setting", ORG, "context_tree_features"], FEATURES_ENABLED],
+            [["github-app-installation", ORG], GITHUB_APP_READY],
             [REVIEWER_AGENTS_KEY, AGENTS],
           ]}
         />
         <FullPageCase
-          title="Context Reviewer · ON but saved reviewer no longer available (warning + re-pick / turn off)"
+          title="Automatic PR review · saved reviewer unavailable"
           authRole="admin"
           seed={[
-            [["org-setting", ORG, "context_tree"], BOUND],
+            [["team-resources"], CODE_REPOSITORIES],
+            [["org-setting", ORG, "context_tree", "raw"], BOUND],
             [["org-setting", ORG, "context_tree_features"], FEATURES_ENABLED_MISSING],
+            [["github-app-installation", ORG], GITHUB_APP_READY],
             [REVIEWER_AGENTS_KEY, AGENTS],
           ]}
         />

--- a/packages/web/src/pages/context-tree-settings-panel.tsx
+++ b/packages/web/src/pages/context-tree-settings-panel.tsx
@@ -1,3 +1,4 @@
+import { deriveRepoLocalPath } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight } from "lucide-react";
 import { type FormEvent, useEffect, useId, useMemo, useState } from "react";
@@ -21,8 +22,8 @@ import { titleWithSemantics, useJustSaved } from "./agent-detail/save-semantics.
 import { fetchAllAgents } from "./team/index.js";
 
 /**
- * Settings → Context tree. Per-org Context Tree **configuration**: which repo /
- * branch the team's tree is bound to, plus the Context Reviewer feature.
+ * Context Tree block on Settings → Repositories. It owns the per-org repo /
+ * branch binding plus the separate Context Reviewer feature.
  *
  * This page is config, not status — the live "is the tree fresh / who reads &
  * writes it" view is the top-level Context tab, and building a team's first tree
@@ -88,12 +89,9 @@ export function ContextTreeSettingsPanel() {
   };
 
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-6)" }}>
-      <Section
-        title="Repository"
-        description="The repository your team's Context Tree lives in. Changes apply to new agent sessions — members should restart their agents to pick up the change."
-      >
-        <div style={{ paddingTop: "var(--sp-4)" }}>
+    <Section title="Context Tree" description="The repository that stores your team's shared context.">
+      <div>
+        <div style={{ padding: "var(--sp-3) 0", borderBottom: "var(--hairline) solid var(--border-faint)" }}>
           {settingQuery.isLoading ? (
             <div className="text-body" style={{ color: "var(--fg-3)" }}>
               Loading…
@@ -151,10 +149,9 @@ export function ContextTreeSettingsPanel() {
             </form>
           ) : null}
         </div>
-      </Section>
-
-      <ContextReviewerSection hasBinding={hasBinding} isAdmin={isAdmin} />
-    </div>
+        <ContextReviewerSection hasBinding={hasBinding} isAdmin={isAdmin} />
+      </div>
+    </Section>
   );
 }
 
@@ -175,26 +172,43 @@ function BoundTree({
   onToggleEdit: () => void;
   onViewContext: () => void;
 }) {
+  const name = deriveRepoLocalPath(repo) || repo;
   return (
     <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-      {isAdmin ? (
-        <div className="flex justify-end">
-          <Button type="button" variant="link" className="h-auto p-0" onClick={onToggleEdit}>
-            {editing ? "Close" : "Edit"}
+      <div className="flex flex-col sm:flex-row sm:items-start" style={{ gap: "var(--sp-3)" }}>
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-baseline" style={{ gap: "var(--sp-3)" }}>
+            <span className="text-body font-medium truncate" style={{ color: "var(--fg)" }} title={name}>
+              {name}
+            </span>
+            <span className="text-label shrink-0" style={{ color: "var(--fg-3)" }}>
+              {branch} branch
+            </span>
+          </div>
+          <div
+            className="text-caption"
+            style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)", wordBreak: "break-all" }}
+          >
+            {repo}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center" style={{ gap: "var(--sp-4)" }}>
+          {isAdmin ? (
+            <Button
+              type="button"
+              variant="link"
+              className="h-auto p-0"
+              style={{ color: "var(--fg-3)" }}
+              onClick={onToggleEdit}
+            >
+              {editing ? "Close" : "Edit"}
+            </Button>
+          ) : null}
+          <Button type="button" variant="link" className="h-auto p-0" onClick={onViewContext}>
+            <span>Open Context</span>
+            <ArrowRight className="h-4 w-4" />
           </Button>
         </div>
-      ) : null}
-      <span className="text-body mono" style={{ color: "var(--fg)", wordBreak: "break-all" }}>
-        {repo}
-      </span>
-      <span className="text-label" style={{ color: "var(--fg-3)" }}>
-        branch <span className="mono">{branch}</span>
-      </span>
-      <div style={{ marginTop: "var(--sp-1)" }}>
-        <Button type="button" variant="link" className="h-auto p-0" onClick={onViewContext}>
-          <span>View on the Context page</span>
-          <ArrowRight className="h-4 w-4" />
-        </Button>
       </div>
     </div>
   );
@@ -248,7 +262,9 @@ function NoTree({
 }
 
 /** Context Reviewer: assign an agent to auto-review Context Tree PRs. Meaningful
- *  only once a tree is bound. Was the old "Features" tab; now a plain section.
+ *  only once a tree is bound. It is a row inside the Context Tree section, not
+ *  a peer heading: the binding and reviewer are one visible chapter but remain
+ *  separate settings models.
  *
  *  This is an immediate-save config block (no page-level Save), mirroring the
  *  Agent Detail Switch rows: flipping the Switch or picking an agent persists at
@@ -310,7 +326,7 @@ function ContextReviewerSection({ hasBinding, isAdmin }: { hasBinding: boolean; 
   const selectedIsCandidate = reviewerCandidates.some((agent) => agent.uuid === serverAgentUuid);
   // Enabled, but the saved reviewer is no longer an active agent this admin can
   // see: keep the Switch on, warn, and let them re-pick or turn it off.
-  const reviewerMissing = serverEnabled && !selectedIsCandidate && !agentsLoading && reviewerCandidates.length > 0;
+  const reviewerMissing = serverEnabled && !selectedIsCandidate && !agentsLoading;
   // Switch is on for setup but no agent chosen yet — prompt for the pick that
   // actually enables the feature.
   const awaitingAgent = setupOpen && !serverEnabled && !agentsLoading && reviewerCandidates.length > 0;
@@ -343,125 +359,135 @@ function ContextReviewerSection({ hasBinding, isAdmin }: { hasBinding: boolean; 
     featuresMutation.mutate({ enabled: true, agentUuid: uuid });
   };
 
+  const selectedReviewer = reviewerCandidates.find((agent) => agent.uuid === serverAgentUuid) ?? null;
+
   return (
-    <Section
-      title={titleWithSemantics("Context Reviewer", justSaved)}
-      description="Assign an agent to review Context Tree PRs."
-    >
-      <div style={{ paddingTop: "var(--sp-4)" }}>
-        {!hasBinding ? (
-          <div className="text-body" style={{ color: "var(--fg-3)" }}>
-            Available once your team has a Context Tree.
-          </div>
-        ) : featuresQuery.isLoading ? (
-          <div className="text-body" style={{ color: "var(--fg-3)" }}>
-            Loading…
-          </div>
-        ) : featuresQuery.error ? (
-          <div className="text-body" style={{ color: "var(--state-error)" }}>
-            {featuresQuery.error instanceof Error ? featuresQuery.error.message : "Failed to load feature settings"}
-          </div>
-        ) : (
-          <div className="flex flex-col" style={{ gap: "var(--sp-4)" }}>
-            {isAdmin ? (
-              <div className="flex items-center justify-between" style={{ gap: "var(--sp-3)" }}>
+    <div className="flex flex-col" style={{ gap: "var(--sp-3)", padding: "var(--sp-3) 0" }}>
+      {!hasBinding ? (
+        <div className="text-body" style={{ color: "var(--fg-3)" }}>
+          Available once your team has a Context Tree.
+        </div>
+      ) : featuresQuery.isLoading ? (
+        <div className="text-body" style={{ color: "var(--fg-3)" }}>
+          Loading…
+        </div>
+      ) : featuresQuery.error ? (
+        <div className="text-body" style={{ color: "var(--state-error)" }}>
+          {featuresQuery.error instanceof Error ? featuresQuery.error.message : "Failed to load feature settings"}
+        </div>
+      ) : (
+        <div className="flex flex-col" style={{ gap: "var(--sp-3)" }}>
+          {isAdmin ? (
+            <div className="flex items-center justify-between" style={{ gap: "var(--sp-3)" }}>
+              <div className="min-w-0">
                 <span id={toggleLabelId} className="text-body font-medium" style={{ color: "var(--fg)" }}>
-                  Automatic PR review
+                  {titleWithSemantics("Automatic PR review", justSaved)}
                 </span>
-                <Switch
-                  checked={switchOn}
-                  onCheckedChange={handleToggle}
-                  disabled={saving || (!serverEnabled && !appReviewReady)}
-                  aria-labelledby={toggleLabelId}
-                />
+                {serverEnabled && selectedReviewer ? (
+                  <button
+                    type="button"
+                    className="block rounded-[var(--radius-input)] border-0 bg-transparent p-0 text-left text-label focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}
+                    aria-expanded={setupOpen}
+                    onClick={() => setSetupOpen((open) => !open)}
+                  >
+                    Reviewer agent · {agentLabel(selectedReviewer)}
+                  </button>
+                ) : null}
               </div>
-            ) : (
-              <ContextReviewerReadOnly
-                contextReviewer={
-                  featuresQuery.data?.contextReviewer ?? { enabled: false, agentUuid: null, reviewerAgent: null }
-                }
+              <Switch
+                checked={switchOn}
+                onCheckedChange={handleToggle}
+                disabled={saving || (!serverEnabled && !appReviewReady)}
+                aria-labelledby={toggleLabelId}
               />
-            )}
+            </div>
+          ) : (
+            <ContextReviewerReadOnly
+              contextReviewer={
+                featuresQuery.data?.contextReviewer ?? { enabled: false, agentUuid: null, reviewerAgent: null }
+              }
+            />
+          )}
 
-            {isAdmin && switchOn ? (
-              <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-                <span className="text-label font-medium" style={{ color: "var(--fg)" }}>
-                  Reviewer agent
+          {isAdmin && (setupOpen || reviewerMissing) ? (
+            <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+              <span className="text-label font-medium" style={{ color: "var(--fg)" }}>
+                Reviewer agent
+              </span>
+              {agentsLoading ? (
+                <div className="text-body" style={{ color: "var(--fg-3)" }}>
+                  Loading agents…
+                </div>
+              ) : reviewerCandidates.length === 0 ? (
+                <div className="text-body" style={{ color: "var(--fg-3)" }}>
+                  No active non-human agents are available.
+                </div>
+              ) : (
+                <Select
+                  aria-label="Automatic PR review agent"
+                  value={serverEnabled && selectedIsCandidate ? (serverAgentUuid ?? "") : ""}
+                  onChange={handleSelectAgent}
+                  disabled={saving}
+                  options={[
+                    { value: "", label: "Select an agent", disabled: true },
+                    ...reviewerCandidates.map((agent) => ({
+                      value: agent.uuid,
+                      label: agentLabel(agent),
+                      hint: agent.name || undefined,
+                    })),
+                  ]}
+                  placeholder="Select an agent"
+                  searchable={reviewerCandidates.length > 6}
+                />
+              )}
+              {awaitingAgent ? (
+                <div className="text-label" style={{ color: "var(--fg-3)" }}>
+                  Select an agent to enable automatic PR review.
+                </div>
+              ) : null}
+              {reviewerMissing && reviewerCandidates.length > 0 ? (
+                <div className="text-label" style={{ color: "var(--fg-3)" }}>
+                  Current reviewer is not an active organization agent. Choose another agent, or turn automatic PR
+                  review off.
+                </div>
+              ) : null}
+              {managedAgentsQuery.error ? (
+                <div className="text-body" style={{ color: "var(--state-error)" }}>
+                  {managedAgentsQuery.error instanceof Error
+                    ? managedAgentsQuery.error.message
+                    : "Failed to load agents"}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {appReviewActionRequired ? (
+            <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
+              <span className="text-body" style={{ color: "var(--warning)" }}>
+                Action required: the GitHub App installation must be active and grant Pull requests: write before it can
+                publish automatic review results.
+              </span>
+              {installation?.manageUrl ? (
+                <a className="text-label" href={installation.manageUrl} target="_blank" rel="noreferrer">
+                  Manage on GitHub
+                </a>
+              ) : (
+                <span className="text-label" style={{ color: "var(--fg-3)" }}>
+                  Connect the installation in Settings → Integrations → GitHub.
                 </span>
-                {agentsLoading ? (
-                  <div className="text-body" style={{ color: "var(--fg-3)" }}>
-                    Loading agents…
-                  </div>
-                ) : reviewerCandidates.length === 0 ? (
-                  <div className="text-body" style={{ color: "var(--fg-3)" }}>
-                    No active non-human agents are available.
-                  </div>
-                ) : (
-                  <Select
-                    aria-label="Context Reviewer agent"
-                    value={serverEnabled && selectedIsCandidate ? (serverAgentUuid ?? "") : ""}
-                    onChange={handleSelectAgent}
-                    disabled={saving}
-                    options={[
-                      { value: "", label: "Select an agent", disabled: true },
-                      ...reviewerCandidates.map((agent) => ({
-                        value: agent.uuid,
-                        label: agentLabel(agent),
-                        hint: agent.name || undefined,
-                      })),
-                    ]}
-                    placeholder="Select an agent"
-                    searchable={reviewerCandidates.length > 6}
-                  />
-                )}
-                {awaitingAgent ? (
-                  <div className="text-label" style={{ color: "var(--fg-3)" }}>
-                    Select an agent to enable Context Reviewer.
-                  </div>
-                ) : null}
-                {reviewerMissing ? (
-                  <div className="text-label" style={{ color: "var(--fg-3)" }}>
-                    Current reviewer is not an active organization agent. Choose another agent, or turn Context Reviewer
-                    off.
-                  </div>
-                ) : null}
-                {managedAgentsQuery.error ? (
-                  <div className="text-body" style={{ color: "var(--state-error)" }}>
-                    {managedAgentsQuery.error instanceof Error
-                      ? managedAgentsQuery.error.message
-                      : "Failed to load agents"}
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
+              )}
+            </div>
+          ) : null}
 
-            {appReviewActionRequired ? (
-              <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
-                <span className="text-body" style={{ color: "var(--warning)" }}>
-                  Action required: the GitHub App installation must be active and grant Pull requests: write before it
-                  can publish Context Reviewer results.
-                </span>
-                {installation?.manageUrl ? (
-                  <a className="text-label" href={installation.manageUrl} target="_blank" rel="noreferrer">
-                    Manage on GitHub
-                  </a>
-                ) : (
-                  <span className="text-label" style={{ color: "var(--fg-3)" }}>
-                    Connect the installation in Settings → GitHub.
-                  </span>
-                )}
-              </div>
-            ) : null}
-
-            {featuresMutation.error instanceof Error ? (
-              <div className="text-body" style={{ color: "var(--state-error)" }}>
-                {featuresMutation.error.message}
-              </div>
-            ) : null}
-          </div>
-        )}
-      </div>
-    </Section>
+          {featuresMutation.error instanceof Error ? (
+            <div className="text-body" style={{ color: "var(--state-error)" }}>
+              {featuresMutation.error.message}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -485,25 +511,20 @@ function ContextReviewerReadOnly({
     : null;
 
   return (
-    <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
-      <div className="flex items-center justify-between" style={{ gap: "var(--sp-3)" }}>
+    <div className="flex items-center justify-between" style={{ gap: "var(--sp-3)" }}>
+      <div className="min-w-0">
         <span className="text-body font-medium" style={{ color: "var(--fg)" }}>
           Automatic PR review
         </span>
-        <span className="text-label" style={{ color: contextReviewer.enabled ? "var(--success)" : "var(--fg-3)" }}>
-          {contextReviewer.enabled ? "On" : "Off"}
-        </span>
+        {contextReviewer.enabled ? (
+          <div className="text-label" style={{ color: "var(--fg-3)", marginTop: "var(--sp-0_5)" }}>
+            {reviewerLabel ? `Reviewer agent · ${reviewerLabel}` : "Configured reviewer is no longer available."}
+          </div>
+        ) : null}
       </div>
-      {contextReviewer.enabled ? (
-        <div className="flex flex-col" style={{ gap: "var(--sp-1)" }}>
-          <span className="text-label font-medium" style={{ color: "var(--fg)" }}>
-            Reviewer agent
-          </span>
-          <span className="text-body" style={{ color: reviewerLabel ? "var(--fg)" : "var(--fg-3)" }}>
-            {reviewerLabel ?? "Configured reviewer is no longer available."}
-          </span>
-        </div>
-      ) : null}
+      <span className="text-label" style={{ color: contextReviewer.enabled ? "var(--success)" : "var(--fg-3)" }}>
+        {contextReviewer.enabled ? "On" : "Off"}
+      </span>
     </div>
   );
 }

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -42,13 +42,13 @@ import { cn } from "../lib/utils.js";
  * Sub-routes:
  *   Computers     — user-scoped: machines connected to First Tree (most-frequent
  *                   entry point — placed first)
- *   Context tree  — org-scoped Context Tree binding (repo / branch). Visible
- *                   to all members (read-only); only admins can edit.
+ *   Repositories  — provider-neutral Team code resources plus the separate
+ *                   org-scoped Context Tree binding. Visible to all members
+ *                   (read-only); only admins can edit.
  *   Resources     — org-scoped runtime resources (prompt / skill / mcp).
  *                   Visible to all members (read-only); only admins can manage.
- *   Integrations  — Team code access plus provider-specific GitHub/GitLab
- *                   connections. Visible to all members (read-only); only
- *                   admins can mutate them.
+ *   Integrations  — provider-specific GitHub/GitLab connections for events,
+ *                   identity, and webhooks.
  *   Setup         — guided-setup stepper enable/disable (hidden once
  *                   onboarding is permanently completed)
  */
@@ -68,9 +68,9 @@ type Item = {
 const ITEMS: Item[] = [
   { to: "/settings/computers", label: "Computers" },
   {
-    to: "/settings/context",
-    label: "Context tree",
-    description: "The shared knowledge tree your team's agents read from.",
+    to: "/settings/repositories",
+    label: "Repositories",
+    description: "Manage code available to agents and the repository backing your team's Context Tree.",
   },
   {
     to: "/settings/resources",
@@ -80,15 +80,19 @@ const ITEMS: Item[] = [
   {
     to: "/settings/integrations",
     label: "Integrations",
-    description: "Choose the code agents can access and connect providers for events and identity.",
+    description: "Connect providers for webhooks, identity, and event routing.",
   },
   { to: "/settings/onboarding", label: "Setup" },
 ];
 
-export function SettingsLayout() {
+export function SettingsLayout({ activePathname }: { activePathname?: string } = {}) {
   const { onboardingCompletedAt, meLoaded } = useAuth();
   const viewport = useWorkspaceViewport();
-  const { pathname } = useLocation();
+  const { pathname: routePathname } = useLocation();
+  // DEV preview galleries render this real layout below their own route. Let
+  // those galleries supply the path whose heading/nav state they are showing;
+  // production always follows the actual router location.
+  const pathname = activePathname ?? routePathname;
   // Wait for `/me` to resolve before rendering the nav so role-dependent
   // entries such as Onboarding do not flicker during a fresh page load.
   if (!meLoaded) {
@@ -133,7 +137,12 @@ export function SettingsLayout() {
           }}
         >
           {visible.map((item) => (
-            <PillLink key={item.to} to={item.to} label={item.label} />
+            <PillLink
+              key={item.to}
+              to={item.to}
+              label={item.label}
+              activeOverride={activePathname === undefined ? undefined : pathname.startsWith(item.to)}
+            />
           ))}
         </nav>
         <div className="flex-1 min-w-0">
@@ -162,7 +171,12 @@ export function SettingsLayout() {
       >
         <nav className="flex flex-col" style={{ gap: "var(--sp-0_5)" }}>
           {visible.map((item) => (
-            <SidebarLink key={item.to} to={item.to} label={item.label} />
+            <SidebarLink
+              key={item.to}
+              to={item.to}
+              label={item.label}
+              activeOverride={activePathname === undefined ? undefined : pathname.startsWith(item.to)}
+            />
           ))}
         </nav>
       </aside>
@@ -200,7 +214,7 @@ function SettingsHeader({ item }: { item: Item | undefined }) {
   );
 }
 
-function SidebarLink({ to, label }: { to: string; label: string }) {
+function SidebarLink({ to, label, activeOverride }: { to: string; label: string; activeOverride?: boolean }) {
   return (
     <NavLink
       to={to}
@@ -209,24 +223,27 @@ function SidebarLink({ to, label }: { to: string; label: string }) {
         "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
       )}
     >
-      {({ isActive }) => (
-        <span
-          className={cn("block", isActive && "font-medium")}
-          style={{
-            padding: "var(--sp-2) var(--sp-3)",
-            borderRadius: "var(--radius-input)",
-            color: isActive ? "var(--fg)" : "var(--fg-3)",
-            background: isActive ? "var(--bg-hover)" : "transparent",
-          }}
-        >
-          {label}
-        </span>
-      )}
+      {({ isActive }) => {
+        const active = activeOverride ?? isActive;
+        return (
+          <span
+            className={cn("block", active && "font-medium")}
+            style={{
+              padding: "var(--sp-2) var(--sp-3)",
+              borderRadius: "var(--radius-input)",
+              color: active ? "var(--fg)" : "var(--fg-3)",
+              background: active ? "var(--bg-hover)" : "transparent",
+            }}
+          >
+            {label}
+          </span>
+        );
+      }}
     </NavLink>
   );
 }
 
-function PillLink({ to, label }: { to: string; label: string }) {
+function PillLink({ to, label, activeOverride }: { to: string; label: string; activeOverride?: boolean }) {
   return (
     <NavLink
       to={to}
@@ -235,19 +252,22 @@ function PillLink({ to, label }: { to: string; label: string }) {
         "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
       )}
     >
-      {({ isActive }) => (
-        <span
-          className={cn("inline-block whitespace-nowrap", isActive && "font-medium")}
-          style={{
-            padding: "var(--sp-1_5) var(--sp-3)",
-            borderRadius: "var(--radius-input)",
-            color: isActive ? "var(--fg)" : "var(--fg-3)",
-            background: isActive ? "var(--bg-hover)" : "transparent",
-          }}
-        >
-          {label}
-        </span>
-      )}
+      {({ isActive }) => {
+        const active = activeOverride ?? isActive;
+        return (
+          <span
+            className={cn("inline-block whitespace-nowrap", active && "font-medium")}
+            style={{
+              padding: "var(--sp-1_5) var(--sp-3)",
+              borderRadius: "var(--radius-input)",
+              color: active ? "var(--fg)" : "var(--fg-3)",
+              background: active ? "var(--bg-hover)" : "transparent",
+            }}
+          >
+            {label}
+          </span>
+        );
+      }}
     </NavLink>
   );
 }

--- a/packages/web/src/pages/settings/__tests__/integrations-layout-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/integrations-layout-dom.test.tsx
@@ -2,35 +2,15 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter, Route, Routes } from "react-router";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, describe, expect, it } from "vitest";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
-let scrollIntoView: ReturnType<typeof vi.fn>;
-
-vi.mock("../resource-sections.js", () => ({
-  ResourceTypeSections: (props: {
-    types: string[];
-    titleFor?: (type: "repo") => string;
-    descriptionFor?: (type: "repo") => string;
-    addLabelFor?: (type: "repo") => string;
-    emptyLabelFor?: (type: "repo") => string;
-    compactLimit?: number;
-  }) => (
-    <div
-      data-testid="resource-sections"
-      data-types={props.types.join(",")}
-      data-compact-limit={props.compactLimit}
-      data-add-label={props.addLabelFor?.("repo")}
-      data-empty-label={props.emptyLabelFor?.("repo")}
-    >
-      <span>{props.titleFor?.("repo")}</span>
-      <span>{props.descriptionFor?.("repo")}</span>
-    </div>
-  ),
-}));
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="repository-destination">{`${location.pathname}${location.hash}`}</div>;
+}
 
 async function renderLayout(path = "/settings/integrations/github"): Promise<{ container: HTMLElement; root: Root }> {
   const { SettingsIntegrationsLayout } = await import("../integrations.js");
@@ -45,6 +25,7 @@ async function renderLayout(path = "/settings/integrations/github"): Promise<{ c
             <Route path="github" element={<div>GitHub connection content</div>} />
             <Route path="gitlab" element={<div>GitLab connection content</div>} />
           </Route>
+          <Route path="/settings/repositories" element={<LocationProbe />} />
         </Routes>
       </MemoryRouter>,
     );
@@ -52,46 +33,31 @@ async function renderLayout(path = "/settings/integrations/github"): Promise<{ c
   return { container, root };
 }
 
-beforeEach(() => {
-  originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
-  scrollIntoView = vi.fn();
-  HTMLElement.prototype.scrollIntoView = scrollIntoView;
-});
-
 afterEach(() => {
-  HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
   document.body.innerHTML = "";
-  vi.restoreAllMocks();
 });
 
 describe("SettingsIntegrationsLayout", () => {
-  it("places provider-neutral Team code access above provider connections", async () => {
+  it("keeps Integrations focused on provider connections", async () => {
     const { container, root } = await renderLayout();
-    const resourceSections = container.querySelector<HTMLElement>('[data-testid="resource-sections"]');
-    expect(resourceSections?.dataset.types).toBe("repo");
-    expect(resourceSections?.dataset.compactLimit).toBe("3");
-    expect(resourceSections?.dataset.addLabel).toBe("Add code repository");
-    expect(resourceSections?.dataset.emptyLabel).toBe("No code repositories configured yet.");
-    expect(resourceSections?.textContent).toContain("Code available to agents");
-    expect(resourceSections?.textContent).toContain("GitHub, GitLab, or any Git server");
-    expect(resourceSections?.textContent).toContain("Git credentials on each agent's computer");
 
-    const text = container.textContent ?? "";
-    expect(text.indexOf("Code available to agents")).toBeLessThan(text.indexOf("Connections"));
-    expect(text.indexOf("Connections")).toBeLessThan(text.indexOf("GitHub connection content"));
+    expect(container.querySelector("h2")?.textContent).toBe("Connections");
+    expect(container.textContent).toContain("Connect providers for webhooks, identity, and event routing.");
+    expect(container.textContent).toContain("GitHub connection content");
+    expect(container.textContent).not.toContain("Code repositories");
 
     const nav = container.querySelector('nav[aria-label="Connection provider"]');
     expect(nav).not.toBeNull();
     expect(nav?.querySelector('a[href="/settings/integrations/github"]')?.getAttribute("aria-current")).toBe("page");
     expect(nav?.querySelector('a[href="/settings/integrations/gitlab"]')).not.toBeNull();
-    expect(scrollIntoView).not.toHaveBeenCalled();
     await act(async () => root.unmount());
   });
 
-  it("keeps the shared code area above the long GitLab connection surface", async () => {
+  it("marks GitLab active without adding repository management to the provider surface", async () => {
     const { container, root } = await renderLayout("/settings/integrations/gitlab");
-    const text = container.textContent ?? "";
-    expect(text.indexOf("Code available to agents")).toBeLessThan(text.indexOf("GitLab connection content"));
+
+    expect(container.textContent).toContain("GitLab connection content");
+    expect(container.textContent).not.toContain("Code repositories");
     expect(
       container
         .querySelector('nav[aria-label="Connection provider"] a[href="/settings/integrations/gitlab"]')
@@ -100,15 +66,12 @@ describe("SettingsIntegrationsLayout", () => {
     await act(async () => root.unmount());
   });
 
-  it("positions and focuses the shared code section when the Agent shortcut supplies its hash", async () => {
+  it("redirects the former code-access fragment to the new Repositories section", async () => {
     const { container, root } = await renderLayout("/settings/integrations/github#code-access");
-    const target = container.querySelector<HTMLElement>("#code-access");
-    expect(target?.tagName).toBe("SECTION");
-    expect(target?.getAttribute("aria-label")).toBe("Code available to agents");
-    expect(target?.tabIndex).toBe(-1);
-    expect(scrollIntoView).toHaveBeenCalledOnce();
-    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
-    expect(document.activeElement).toBe(target);
+
+    expect(container.querySelector('[data-testid="repository-destination"]')?.textContent).toBe(
+      "/settings/repositories#code-repositories",
+    );
     await act(async () => root.unmount());
   });
 });

--- a/packages/web/src/pages/settings/__tests__/repositories-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/repositories-page-dom.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const authMock = vi.hoisted(() => ({ role: "admin" as "admin" | "member" | null }));
+
+vi.mock("../../../auth/auth-context.js", () => ({
+  useAuth: () => ({ role: authMock.role }),
+}));
+
+vi.mock("../../context-tree-settings-panel.js", () => ({
+  ContextTreeSettingsPanel: () => (
+    <section data-testid="context-tree-panel">
+      <h2>Context Tree</h2>
+      <div>Context Tree rows</div>
+    </section>
+  ),
+}));
+
+vi.mock("../resource-sections.js", () => ({
+  ResourceTypeSections: (props: {
+    types: string[];
+    titleFor?: (type: "repo") => string;
+    descriptionFor?: (type: "repo") => string;
+    addLabelFor?: (type: "repo") => string;
+    emptyLabelFor?: (type: "repo") => string;
+    compactLimit?: number;
+  }) => (
+    <section
+      data-testid="resource-sections"
+      data-types={props.types.join(",")}
+      data-compact-limit={props.compactLimit}
+      data-add-label={props.addLabelFor?.("repo")}
+      data-empty-label={props.emptyLabelFor?.("repo")}
+    >
+      <h2>{props.titleFor?.("repo")}</h2>
+      <p>{props.descriptionFor?.("repo")}</p>
+    </section>
+  ),
+}));
+
+let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
+let scrollIntoView: ReturnType<typeof vi.fn>;
+
+async function renderPage(path = "/settings/repositories"): Promise<{ container: HTMLElement; root: Root }> {
+  const { SettingsRepositoriesPage } = await import("../repositories.js");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[path]}>
+        <SettingsRepositoriesPage />
+      </MemoryRouter>,
+    );
+  });
+  return { container, root };
+}
+
+beforeEach(() => {
+  authMock.role = "admin";
+  originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+  scrollIntoView = vi.fn();
+  HTMLElement.prototype.scrollIntoView = scrollIntoView;
+});
+
+afterEach(() => {
+  HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("SettingsRepositoriesPage", () => {
+  it("composes the two repository models with only two visible section headings", async () => {
+    const { container, root } = await renderPage();
+    const resources = container.querySelector<HTMLElement>('[data-testid="resource-sections"]');
+
+    expect(resources?.dataset.types).toBe("repo");
+    expect(resources?.dataset.compactLimit).toBe("3");
+    expect(resources?.dataset.addLabel).toBe("Add repository");
+    expect(resources?.dataset.emptyLabel).toBe("No code repositories configured yet.");
+    expect(resources?.textContent).toContain("Repositories your agents can read and change.");
+    expect(resources?.textContent).toContain("Git credentials on each agent computer");
+
+    const headings = [...container.querySelectorAll("h2")].map((heading) => heading.textContent);
+    expect(headings).toEqual(["Code repositories", "Context Tree"]);
+    expect(container.querySelector("h1")).toBeNull();
+    expect((container.textContent ?? "").indexOf("Code repositories")).toBeLessThan(
+      (container.textContent ?? "").indexOf("Context Tree"),
+    );
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    await act(async () => root.unmount());
+  });
+
+  it.each([
+    ["#code-repositories", "Code repositories"],
+    ["#context-tree", "Context Tree"],
+  ])("positions and focuses %s", async (hash, label) => {
+    const { container, root } = await renderPage(`/settings/repositories${hash}`);
+    const target = container.querySelector<HTMLElement>(hash);
+
+    expect(target?.tagName).toBe("SECTION");
+    expect(target?.getAttribute("aria-label")).toBe(label);
+    expect(target?.tabIndex).toBe(-1);
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(document.activeElement).toBe(target);
+    await act(async () => root.unmount());
+  });
+
+  it("waits for role resolution before rendering either settings model", async () => {
+    authMock.role = null;
+    const { container, root } = await renderPage();
+
+    expect(container.textContent).toContain("Loading...");
+    expect(container.querySelector("h2")).toBeNull();
+    await act(async () => root.unmount());
+  });
+});

--- a/packages/web/src/pages/settings/__tests__/resource-sections-compact-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/resource-sections-compact-dom.test.tsx
@@ -67,9 +67,9 @@ async function renderSections(): Promise<{ container: HTMLElement; root: Root }>
         <ToastProvider>
           <ResourceTypeSections
             types={["repo"]}
-            titleFor={() => "Code available to agents"}
-            descriptionFor={() => "Choose the code your agents can read and change."}
-            addLabelFor={() => "Add code repository"}
+            titleFor={() => "Code repositories"}
+            descriptionFor={() => "Repositories your agents can read and change."}
+            addLabelFor={() => "Add repository"}
             emptyLabelFor={() => "No code repositories configured yet."}
             compactLimit={3}
           />
@@ -102,9 +102,9 @@ afterEach(() => {
 describe("ResourceTypeSections compact mode", () => {
   it("shows three rows until an accessible View all control expands the section", async () => {
     const { container, root } = await renderSections();
-    expect(container.textContent).toContain("Code available to agents");
-    expect(container.textContent).toContain("Choose the code your agents can read and change.");
-    expect(container.querySelector('button[aria-label="Add code repository"]')).not.toBeNull();
+    expect(container.textContent).toContain("Code repositories");
+    expect(container.textContent).toContain("Repositories your agents can read and change.");
+    expect(container.querySelector('button[aria-label="Add repository"]')).not.toBeNull();
     expect(container.textContent).toContain("alpha");
     expect(container.textContent).toContain("beta");
     expect(container.textContent).toContain("gamma");
@@ -130,7 +130,7 @@ describe("ResourceTypeSections compact mode", () => {
     resourceMocks.listTeamResources.mockResolvedValue([]);
     const { container, root } = await renderSections();
     expect(container.textContent).toContain("No code repositories configured yet.");
-    expect(container.querySelector('button[aria-label="Add code repository"]')).not.toBeNull();
+    expect(container.querySelector('button[aria-label="Add repository"]')).not.toBeNull();
     expect(container.textContent).not.toContain("View all");
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/settings/context-tree.tsx
+++ b/packages/web/src/pages/settings/context-tree.tsx
@@ -1,34 +1,9 @@
-import { useAuth } from "../../auth/auth-context.js";
-import { ContextTreeSettingsPanel } from "../context-tree-settings-panel.js";
+import { Navigate } from "react-router";
 
 /**
- * Settings → Context tree. The per-org Context Tree binding (repo / branch).
- *
- * Visible to all members, not just admins: the `context_tree` org-settings
- * namespace is `readPolicy: "member"`, so members can GET the binding to see
- * which tree their agents read from. Only admins can edit it (PUT/DELETE are
- * admin-gated server-side), so the panel renders a read-only form for members.
- * That's why this page does NOT redirect non-admins.
- *
- * Named "Context tree" (not just "Context") to distinguish it from the
- * top-level Context page, which browses tree *contents* — this page configures
- * the *binding*.
+ * Compatibility entry for the former Settings → Context tree page. Repository
+ * resources and the Context Tree binding now share Settings → Repositories.
  */
 export function SettingsContextTreePage() {
-  const { role } = useAuth();
-
-  if (role === null) {
-    return (
-      <div className="text-body" style={{ padding: "var(--sp-5)", color: "var(--fg-3)" }}>
-        Loading...
-      </div>
-    );
-  }
-
-  // Page heading + lead are owned by the Settings layout (see settings.tsx).
-  return (
-    <div style={{ padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
-      <ContextTreeSettingsPanel />
-    </div>
-  );
+  return <Navigate to="/settings/repositories#context-tree" replace />;
 }

--- a/packages/web/src/pages/settings/integrations.tsx
+++ b/packages/web/src/pages/settings/integrations.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useRef } from "react";
-import { NavLink, Outlet, useLocation } from "react-router";
+import { Navigate, NavLink, Outlet, useLocation } from "react-router";
 import { cn } from "../../lib/utils.js";
-import { ResourceTypeSections } from "./resource-sections.js";
 
 const PROVIDERS = [
   { to: "/settings/integrations/github", label: "GitHub" },
@@ -9,49 +7,22 @@ const PROVIDERS = [
 ] as const;
 
 /**
- * One Settings information architecture: provider-neutral code access first,
- * then provider-specific event/identity connections. Repositories deliberately
- * sit outside the provider tabs because their runtime availability does not
- * depend on a GitHub App or GitLab webhook connection.
+ * Provider-specific event, identity, and webhook connections. Team code
+ * resources live on Settings → Repositories because runtime clone access does
+ * not depend on either provider connection.
  */
 export function SettingsIntegrationsLayout() {
   const location = useLocation();
-  const codeAccessRef = useRef<HTMLElement>(null);
 
-  // React Router updates the URL fragment but does not scroll the app's
-  // persistent overflow container. Position and focus the shared section
-  // explicitly so exits from a deeply scrolled Agent page cannot land below
-  // the intended destination.
-  useEffect(() => {
-    if (location.hash !== "#code-access") return;
-    const target = codeAccessRef.current;
-    if (!target) return;
-    target.scrollIntoView({ block: "start" });
-    target.focus({ preventScroll: true });
-  }, [location.hash]);
+  // Preserve deep links created while Team code access lived above the
+  // provider tabs. The Repositories page owns the new focus/scroll contract.
+  if (location.hash === "#code-access") {
+    return <Navigate to="/settings/repositories#code-repositories" replace />;
+  }
 
   return (
     <div>
-      <section
-        ref={codeAccessRef}
-        id="code-access"
-        tabIndex={-1}
-        aria-label="Code available to agents"
-        style={{ padding: "var(--sp-2) var(--sp-5) 0", scrollMarginTop: "var(--sp-4)" }}
-      >
-        <ResourceTypeSections
-          types={["repo"]}
-          titleFor={() => "Code available to agents"}
-          descriptionFor={() =>
-            "Choose the code your agents can read and change. GitHub, GitLab, or any Git server; private access uses Git credentials on each agent's computer."
-          }
-          addLabelFor={() => "Add code repository"}
-          emptyLabelFor={() => "No code repositories configured yet."}
-          compactLimit={3}
-        />
-      </section>
-
-      <div style={{ padding: "var(--sp-7) var(--sp-5) 0" }}>
+      <div style={{ padding: "var(--sp-2) var(--sp-5) 0" }}>
         <h2 className="text-title font-semibold m-0" style={{ color: "var(--fg)" }}>
           Connections
         </h2>

--- a/packages/web/src/pages/settings/repositories.tsx
+++ b/packages/web/src/pages/settings/repositories.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router";
+import { useAuth } from "../../auth/auth-context.js";
+import { ContextTreeSettingsPanel } from "../context-tree-settings-panel.js";
+import { ResourceTypeSections } from "./resource-sections.js";
+
+const CODE_REPOSITORIES_HASH = "#code-repositories";
+const CONTEXT_TREE_HASH = "#context-tree";
+
+/**
+ * Settings → Repositories. One provider-neutral home for the repositories
+ * available to agents and the separate organization Context Tree binding.
+ *
+ * The two models deliberately share a page without sharing state: Team repo
+ * resources are runtime inputs, while `context_tree` remains the single
+ * organization pointer used by Context and agent startup.
+ */
+export function SettingsRepositoriesPage() {
+  const { role } = useAuth();
+  const location = useLocation();
+  const codeRepositoriesRef = useRef<HTMLElement>(null);
+  const contextTreeRef = useRef<HTMLElement>(null);
+
+  // React Router updates the fragment but not the app shell's persistent
+  // overflow container. Position and focus either section explicitly so old
+  // Context links and Agent Detail exits remain deterministic.
+  useEffect(() => {
+    if (role === null) return;
+    const target =
+      location.hash === CODE_REPOSITORIES_HASH
+        ? codeRepositoriesRef.current
+        : location.hash === CONTEXT_TREE_HASH
+          ? contextTreeRef.current
+          : null;
+    if (!target) return;
+    target.scrollIntoView({ block: "start" });
+    target.focus({ preventScroll: true });
+  }, [location.hash, role]);
+
+  if (role === null) {
+    return (
+      <div className="text-body" style={{ padding: "var(--sp-5)", color: "var(--fg-3)" }}>
+        Loading...
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: "var(--sp-2) var(--sp-5) var(--sp-7)" }}>
+      <section
+        ref={codeRepositoriesRef}
+        id={CODE_REPOSITORIES_HASH.slice(1)}
+        tabIndex={-1}
+        aria-label="Code repositories"
+        style={{ scrollMarginTop: "var(--sp-4)" }}
+      >
+        <ResourceTypeSections
+          types={["repo"]}
+          titleFor={() => "Code repositories"}
+          descriptionFor={() =>
+            "Repositories your agents can read and change. Private access uses Git credentials on each agent computer."
+          }
+          addLabelFor={() => "Add repository"}
+          emptyLabelFor={() => "No code repositories configured yet."}
+          compactLimit={3}
+        />
+      </section>
+
+      <section
+        ref={contextTreeRef}
+        id={CONTEXT_TREE_HASH.slice(1)}
+        tabIndex={-1}
+        aria-label="Context Tree"
+        style={{ marginTop: "var(--sp-7)", scrollMarginTop: "var(--sp-4)" }}
+      >
+        <ContextTreeSettingsPanel />
+      </section>
+    </div>
+  );
+}

--- a/packages/web/src/pages/settings/resource-sections.tsx
+++ b/packages/web/src/pages/settings/resource-sections.tsx
@@ -30,9 +30,8 @@ import { ResourcePreviewDialog } from "./resource-preview-dialog.js";
  * Section list for a subset of the team's runtime resource types, extracted
  * from the Settings → Resources page so a type can live on a different
  * Settings page without duplicating the list/editor/retire machinery. The
- * `repo` type renders in the provider-neutral code-access area on Settings →
- * Integrations; prompt, skill, and MCP resources remain on Settings →
- * Resources.
+ * `repo` type renders on the provider-neutral Settings → Repositories page;
+ * prompt, skill, and MCP resources remain on Settings → Resources.
  *
  * Behaviour matches the Resources page: everyone can open the read-only
  * preview (the eye icon); only admins see add / edit / retire affordances.
@@ -109,7 +108,7 @@ export function ResourceTypeSections({
         types.map((type) => {
           // When the host overrides a section's title, derive fallback copy from
           // that title so the surface stays coherent. Hosts with sentence-like
-          // titles (for example "Code available to agents") can supply explicit
+          // titles (for example "Code repositories") can supply explicit
           // add/empty labels rather than relying on this simple noun fallback.
           const overrideTitle = titleFor?.(type);
           const pluralNoun = overrideTitle ? overrideTitle.toLowerCase() : typeLabelPlural(type).toLowerCase();

--- a/packages/web/src/pages/settings/resources.tsx
+++ b/packages/web/src/pages/settings/resources.tsx
@@ -7,8 +7,8 @@ import { ResourceTypeSections } from "./resource-sections.js";
  * surface), not on the Team roster — see the Settings IA in settings.tsx.
  *
  * The `repo` type is deliberately absent here: Team code repositories render
- * in the provider-neutral "Code available to agents" area on Settings →
- * Integrations, above the GitHub/GitLab connection tabs.
+ * in the provider-neutral "Code repositories" area on Settings →
+ * Repositories.
  *
  * Visible to all members. Everyone can open the read-only preview; only
  * admins see add / edit / retire affordances (see ResourceTypeSections).

--- a/packages/web/src/pages/team/team-table.tsx
+++ b/packages/web/src/pages/team/team-table.tsx
@@ -2,6 +2,7 @@ import type { Agent, PresenceStatus, UsageByAgentRow } from "@first-tree/shared"
 import { Bot, ChevronDown, Link2, Lock, type LucideIcon, User } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { Avatar } from "../../components/avatar.js";
+import { mentionOptionTitle } from "../../components/mention-autocomplete.js";
 import { Button } from "../../components/ui/button.js";
 import { DenseBadge } from "../../components/ui/dense-badge.js";
 import { Popover } from "../../components/ui/popover.js";
@@ -763,7 +764,7 @@ function DelegateCell({
     return (
       <Popover
         align="start"
-        panelStyle={{ minWidth: "var(--sp-75)" }}
+        panelStyle={{ minWidth: "var(--sp-75)", maxWidth: "var(--sp-90)" }}
         trigger={({ open, toggle }) => (
           <button
             type="button"
@@ -881,8 +882,9 @@ function DelegateSelector({
             key={agent.uuid}
             active={current === agent.uuid}
             onClick={() => onPick(agent.uuid)}
+            title={mentionOptionTitle(agent)}
             primary={
-              <span className="inline-flex items-center" style={{ gap: "var(--sp-2)" }}>
+              <span className="inline-flex min-w-0 items-center" style={{ gap: "var(--sp-2)" }}>
                 <Avatar
                   name={agent.displayName}
                   seed={agent.uuid}
@@ -890,12 +892,12 @@ function DelegateSelector({
                   colorToken={agent.avatarColorToken}
                   src={agent.avatarImageUrl}
                 />
-                <span className="inline-flex flex-col leading-tight">
-                  <span className="text-body" style={{ color: "var(--fg)" }}>
+                <span className="inline-flex min-w-0 flex-col leading-tight">
+                  <span className="truncate text-body" style={{ color: "var(--fg)" }}>
                     {agent.displayName}
                   </span>
                   {agent.name && (
-                    <span className="mono text-caption" style={{ color: "var(--fg-3)" }}>
+                    <span className="mono truncate text-caption" style={{ color: "var(--fg-3)" }}>
                       @{agent.name}
                     </span>
                   )}
@@ -909,11 +911,22 @@ function DelegateSelector({
   );
 }
 
-function DelegateOption({ active, onClick, primary }: { active: boolean; onClick: () => void; primary: ReactNode }) {
+function DelegateOption({
+  active,
+  onClick,
+  primary,
+  title,
+}: {
+  active: boolean;
+  onClick: () => void;
+  primary: ReactNode;
+  title?: string;
+}) {
   return (
     <button
       type="button"
       onClick={onClick}
+      title={title}
       className="flex w-full items-center text-left transition-colors hover:bg-[var(--bg-hover)]"
       style={{
         gap: "var(--sp-2)",

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -569,7 +569,7 @@ type MessageRowProps = {
   agentColorTokenFn: (id: string) => string | null;
   mentionParticipants: MentionParticipant[];
   /** Trial surface: render sender avatar/name as plain identity, without the
-   *  AgentHovercard whose actions ("Open details" → /agents/:id, "Chat" →
+   *  AgentHovercard whose actions ("View profile" → /agents/:id, "New chat" →
    *  /?c=draft) would navigate out of the controlled trial conversation. */
   isTrial: boolean;
 };

--- a/packages/web/src/pages/workspace/conversations/__tests__/new-chat-default-cache.test.ts
+++ b/packages/web/src/pages/workspace/conversations/__tests__/new-chat-default-cache.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   firstCacheableStarterAgentId,
   newChatDefaultAgentCacheKey,
+  participantPickerPlacement,
   type StarterAgentCacheCandidate,
 } from "../new-chat-draft.js";
 
@@ -40,5 +41,45 @@ describe("new chat default cache helpers", () => {
     ]);
 
     expect(firstCacheableStarterAgentId(["human-peer", "suspended-agent"], agents)).toBeNull();
+  });
+});
+
+describe("participantPickerPlacement", () => {
+  const viewport = { left: 0, top: 0, width: 390, height: 844 };
+  const panel = { width: 360, height: 280 };
+
+  it("clamps a panel after existing chips against the viewport right edge", () => {
+    const placed = participantPickerPlacement({
+      anchor: { left: 236, top: 120, bottom: 148 },
+      panel,
+      viewport,
+    });
+
+    expect(placed.left).toBe(22);
+    expect(placed.left + placed.width).toBe(382);
+  });
+
+  it("keeps both edges reachable at the narrowest mobile baseline", () => {
+    const narrowViewport = { left: 0, top: 0, width: 320, height: 568 };
+    const placed = participantPickerPlacement({
+      anchor: { left: 180, top: 80, bottom: 108 },
+      panel,
+      viewport: narrowViewport,
+    });
+
+    expect(placed.left).toBe(8);
+    expect(placed.width).toBe(304);
+    expect(placed.left + placed.width).toBe(312);
+  });
+
+  it("honors a shifted visual viewport and flips above when below does not fit", () => {
+    const placed = participantPickerPlacement({
+      anchor: { left: 210, top: 620, bottom: 648 },
+      panel,
+      viewport: { left: 40, top: 20, width: 390, height: 700 },
+    });
+
+    expect(placed.left).toBe(62);
+    expect(placed.top).toBe(336);
   });
 });

--- a/packages/web/src/pages/workspace/conversations/filter-popover.tsx
+++ b/packages/web/src/pages/workspace/conversations/filter-popover.tsx
@@ -143,7 +143,7 @@ export function FilterPopover({
   return (
     <Popover
       align="end"
-      panelStyle={{ minWidth: 240, padding: "var(--sp-2)" }}
+      panelStyle={{ minWidth: 240, maxWidth: "var(--sp-90)", padding: "var(--sp-2)" }}
       trigger={({ open, toggle }) => (
         <button
           type="button"
@@ -312,7 +312,9 @@ function FilterCheckbox({
       >
         {checked && <Check size={10} strokeWidth={3} />}
       </span>
-      <span>{label}</span>
+      <span className="min-w-0 truncate" title={label}>
+        {label}
+      </span>
       <input type="checkbox" checked={checked} onChange={onChange} disabled={disabled} className="sr-only" />
     </label>
   );

--- a/packages/web/src/pages/workspace/conversations/index.tsx
+++ b/packages/web/src/pages/workspace/conversations/index.tsx
@@ -760,8 +760,11 @@ function FilterChip({ label, onClear }: { label: string; onClear: () => void }) 
         background: "var(--bg-sunken)",
         color: "var(--fg-2)",
       }}
+      title={label}
     >
-      <span>{label}</span>
+      <span className="truncate" style={{ maxWidth: "var(--sp-35)" }}>
+        {label}
+      </span>
       <button
         type="button"
         onClick={onClear}

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -7,7 +7,8 @@ import {
 } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowUp, Check, Menu, Paperclip, Plus, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { getNewChatDefaultCandidates } from "../../../api/agents.js";
 import { uploadAttachment, uploadMimeFor } from "../../../api/attachments.js";
 import { type ImageRefContent, readFileAsBase64 } from "../../../api/chats.js";
@@ -22,6 +23,7 @@ import {
   detectMentionTrigger,
   MentionAutocompletePopover,
   type MentionCandidate,
+  mentionOptionTitle,
   useMentionAutocomplete,
 } from "../../../components/mention-autocomplete.js";
 import { FileChip } from "../../../components/ui/file-chip.js";
@@ -415,17 +417,6 @@ export function NewChatDraft({
       return changed ? [...set] : prev;
     });
   }, [bodyMentions]);
-
-  useEffect(() => {
-    if (!pickerOpen) return;
-    const handler = (ev: MouseEvent) => {
-      if (!pickerContainerRef.current) return;
-      if (pickerContainerRef.current.contains(ev.target as Node)) return;
-      setPickerOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [pickerOpen]);
 
   const createMut = useMutation({
     mutationFn: async ({
@@ -912,6 +903,48 @@ export function NewChatDraft({
   );
 }
 
+const PARTICIPANT_PICKER_VIEWPORT_MARGIN = 8;
+const PARTICIPANT_PICKER_TRIGGER_GAP = 4;
+
+/**
+ * Clamp the new-chat participant picker into the visual viewport. The `[+]`
+ * trigger is inline after the selected chips, so its x-coordinate can be
+ * anywhere in the row; a trigger-relative `left: 0` panel therefore overflows
+ * as soon as earlier chips push the trigger near the right edge.
+ *
+ * Pure geometry keeps the collision behavior stable under unit test while the
+ * component supplies live DOMRect / VisualViewport measurements.
+ */
+export function participantPickerPlacement({
+  anchor,
+  panel,
+  viewport,
+  margin = PARTICIPANT_PICKER_VIEWPORT_MARGIN,
+  gap = PARTICIPANT_PICKER_TRIGGER_GAP,
+}: {
+  anchor: { left: number; top: number; bottom: number };
+  panel: { width: number; height: number };
+  viewport: { left: number; top: number; width: number; height: number };
+  margin?: number;
+  gap?: number;
+}): { left: number; top: number; width: number } {
+  const width = Math.min(panel.width, Math.max(0, viewport.width - margin * 2));
+  const minLeft = viewport.left + margin;
+  const maxLeft = Math.max(minLeft, viewport.left + viewport.width - margin - width);
+  const left = Math.max(minLeft, Math.min(anchor.left, maxLeft));
+
+  const minTop = viewport.top + margin;
+  const maxTop = Math.max(minTop, viewport.top + viewport.height - margin - panel.height);
+  const belowTop = anchor.bottom + gap;
+  const aboveTop = anchor.top - panel.height - gap;
+  const fitsBelow = belowTop <= maxTop;
+  const fitsAbove = aboveTop >= minTop;
+  const preferredTop = fitsBelow || !fitsAbove ? belowTop : aboveTop;
+  const top = Math.max(minTop, Math.min(preferredTop, maxTop));
+
+  return { left, top, width };
+}
+
 /** Participant chip row at the top of the composer card. Renders one
  *  pill per chip with `×` revealed on hover, plus a `[+]` button that
  *  anchors a search-driven dropdown. The search input is always shown so
@@ -949,6 +982,8 @@ function ParticipantChips({
   onRemove: (agentId: string) => void;
 }) {
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [panelPosition, setPanelPosition] = useState<{ left: number; top: number; width: number } | null>(null);
   const [highlight, setHighlight] = useState(0);
 
   // Bucket the picker hits into addable (not yet a chip) and already-in
@@ -981,6 +1016,76 @@ function ParticipantChips({
     setHighlight(0);
     inputRef.current?.focus();
   }, [pickerOpen]);
+
+  // The panel is portalled to <body>, so outside-click must treat the trigger
+  // and portal as one interactive region. Otherwise a row mousedown closes and
+  // unmounts the panel before its click can commit the selected participant.
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const handler = (event: MouseEvent): void => {
+      const target = event.target as Node;
+      if (pickerContainerRef.current?.contains(target) || panelRef.current?.contains(target)) return;
+      setPickerOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [pickerOpen, pickerContainerRef, setPickerOpen]);
+
+  // Portal + fixed positioning escapes the draft's clipping ancestors. Clamp
+  // against VisualViewport (not only the layout viewport) so browser zoom and
+  // mobile keyboard/viewport shifts keep both horizontal edges reachable.
+  useLayoutEffect(() => {
+    if (!pickerOpen) {
+      setPanelPosition(null);
+      return;
+    }
+    const anchor = pickerContainerRef.current;
+    const panel = panelRef.current;
+    if (!anchor || !panel) return;
+
+    let frame = 0;
+    const place = (): void => {
+      frame = 0;
+      const anchorRect = anchor.getBoundingClientRect();
+      const panelRect = panel.getBoundingClientRect();
+      const visualViewport = window.visualViewport;
+      const next = participantPickerPlacement({
+        anchor: anchorRect,
+        panel: panelRect,
+        viewport: {
+          left: visualViewport?.offsetLeft ?? 0,
+          top: visualViewport?.offsetTop ?? 0,
+          width: visualViewport?.width ?? window.innerWidth,
+          height: visualViewport?.height ?? window.innerHeight,
+        },
+      });
+      setPanelPosition((current) =>
+        current?.left === next.left && current.top === next.top && current.width === next.width ? current : next,
+      );
+    };
+    const schedule = (): void => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(place);
+    };
+
+    place();
+    window.addEventListener("resize", schedule);
+    window.addEventListener("scroll", schedule, true);
+    window.visualViewport?.addEventListener("resize", schedule);
+    window.visualViewport?.addEventListener("scroll", schedule);
+    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(schedule);
+    observer?.observe(anchor);
+    observer?.observe(panel);
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      observer?.disconnect();
+      window.removeEventListener("resize", schedule);
+      window.removeEventListener("scroll", schedule, true);
+      window.visualViewport?.removeEventListener("resize", schedule);
+      window.visualViewport?.removeEventListener("scroll", schedule);
+    };
+  }, [pickerOpen, pickerContainerRef]);
   // Re-clamp the highlight whenever the candidate set shifts (debounced
   // search lands, chip removed, etc.) so it never points past the end.
   useEffect(() => {
@@ -1061,123 +1166,130 @@ function ParticipantChips({
         >
           <Plus className="h-3 w-3" />
         </button>
-        {pickerOpen && (
-          <div
-            role="listbox"
-            aria-label="Add participant"
-            className="absolute z-20 flex flex-col rounded-[var(--radius-panel)] border shadow-[var(--shadow-md)]"
-            style={{
-              top: "calc(100% + var(--sp-1))",
-              left: 0,
-              minWidth: 280,
-              background: "var(--bg-raised)",
-              borderColor: "var(--border)",
-            }}
-          >
+        {pickerOpen &&
+          createPortal(
             <div
+              ref={panelRef}
+              role="listbox"
+              aria-label="Add participant"
+              data-participant-picker=""
+              className="z-50 flex flex-col rounded-[var(--radius-panel)] border shadow-[var(--shadow-md)]"
               style={{
-                padding: "var(--sp-1_5) var(--sp-2)",
-                borderBottom: "var(--hairline) solid var(--border-faint)",
+                position: "fixed",
+                top: panelPosition?.top ?? -9999,
+                left: panelPosition?.left ?? -9999,
+                visibility: panelPosition ? "visible" : "hidden",
+                width: panelPosition?.width ?? "min(var(--sp-90), calc(100vw - var(--sp-4)))",
+                maxWidth: "var(--sp-90)",
+                boxSizing: "border-box",
+                background: "var(--bg-raised)",
+                borderColor: "var(--border)",
               }}
             >
-              <input
-                ref={inputRef}
-                type="text"
-                value={pickerSearch}
-                onChange={(e) => setPickerSearch(e.target.value)}
-                onKeyDown={onInputKeyDown}
-                placeholder="Search by name…"
-                aria-label="Search agents"
-                className="w-full text-body outline-none"
+              <div
                 style={{
-                  padding: "var(--sp-1) var(--sp-1_5)",
-                  background: "var(--bg-sunken)",
-                  border: "var(--hairline) solid var(--border)",
-                  borderRadius: "var(--radius-input)",
-                  color: "var(--fg)",
+                  padding: "var(--sp-1_5) var(--sp-2)",
+                  borderBottom: "var(--hairline) solid var(--border-faint)",
                 }}
-              />
-            </div>
-            <div className="overflow-auto" style={{ maxHeight: "16rem" }}>
-              {emptyHint !== null ? (
-                <div className="text-body" style={{ padding: "var(--sp-2_5) var(--sp-2)", color: "var(--fg-3)" }}>
-                  {emptyHint}
-                </div>
-              ) : (
-                (() => {
-                  // `addableIdx` walks only addable rows so the keyboard
-                  // highlight lines up with `selectable`. Already-in rows
-                  // skip the counter (display-only ✓).
-                  let addableIdx = -1;
-                  let dividerIdx = 0;
-                  return items.map((item) => {
-                    if ("divider" in item) {
-                      dividerIdx += 1;
+              >
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={pickerSearch}
+                  onChange={(e) => setPickerSearch(e.target.value)}
+                  onKeyDown={onInputKeyDown}
+                  placeholder="Search by name…"
+                  aria-label="Search agents"
+                  className="w-full text-body outline-none"
+                  style={{
+                    padding: "var(--sp-1) var(--sp-1_5)",
+                    background: "var(--bg-sunken)",
+                    border: "var(--hairline) solid var(--border)",
+                    borderRadius: "var(--radius-input)",
+                    color: "var(--fg)",
+                  }}
+                />
+              </div>
+              <div className="overflow-auto" style={{ maxHeight: "16rem" }}>
+                {emptyHint !== null ? (
+                  <div className="text-body" style={{ padding: "var(--sp-2_5) var(--sp-2)", color: "var(--fg-3)" }}>
+                    {emptyHint}
+                  </div>
+                ) : (
+                  (() => {
+                    // `addableIdx` walks only addable rows so the keyboard
+                    // highlight lines up with `selectable`. Already-in rows
+                    // skip the counter (display-only ✓).
+                    let addableIdx = -1;
+                    let dividerIdx = 0;
+                    return items.map((item) => {
+                      if ("divider" in item) {
+                        dividerIdx += 1;
+                        return (
+                          <div
+                            key={`__divider-${dividerIdx}`}
+                            role="presentation"
+                            style={{
+                              height: "var(--hairline)",
+                              background: "var(--border-faint)",
+                              margin: "var(--sp-0_5) var(--sp-3)",
+                            }}
+                          />
+                        );
+                      }
+                      const isInChips = chipSet.has(item.agentId);
+                      const fullTitle = mentionOptionTitle(item);
+                      if (isInChips) {
+                        return (
+                          <div
+                            key={item.agentId}
+                            role="presentation"
+                            title={fullTitle ? `${fullTitle} — already in this draft` : "Already in this draft"}
+                            className="flex w-full items-center px-3 py-1.5 text-left text-body"
+                            style={{
+                              background: "transparent",
+                              color: "var(--fg-3)",
+                              cursor: "default",
+                            }}
+                          >
+                            <AgentOption
+                              candidate={item}
+                              ambiguous={ambiguous}
+                              trailing={<Check className="h-3.5 w-3.5" aria-label="Already in draft" />}
+                            />
+                          </div>
+                        );
+                      }
+                      addableIdx += 1;
+                      const myIdx = addableIdx;
+                      const active = myIdx === highlight;
                       return (
-                        <div
-                          key={`__divider-${dividerIdx}`}
-                          role="presentation"
-                          style={{
-                            height: "var(--hairline)",
-                            background: "var(--border-faint)",
-                            margin: "var(--sp-0_5) var(--sp-3)",
-                          }}
-                        />
-                      );
-                    }
-                    const isInChips = chipSet.has(item.agentId);
-                    if (isInChips) {
-                      return (
-                        <div
+                        <button
                           key={item.agentId}
-                          role="presentation"
-                          title={item.name ? `@${item.name} — already in this draft` : "Already in this draft"}
+                          type="button"
+                          role="option"
+                          aria-selected={active}
+                          title={fullTitle}
+                          onClick={() => onAdd(item.agentId)}
+                          onMouseEnter={() => setHighlight(myIdx)}
                           className="flex w-full items-center px-3 py-1.5 text-left text-body"
                           style={{
-                            background: "transparent",
-                            color: "var(--fg-3)",
-                            cursor: "default",
-                            whiteSpace: "nowrap",
+                            background: active ? "var(--bg-hover)" : "transparent",
+                            color: "var(--fg)",
+                            border: "none",
+                            cursor: "pointer",
                           }}
                         >
-                          <AgentOption
-                            candidate={item}
-                            ambiguous={ambiguous}
-                            trailing={<Check className="h-3.5 w-3.5" aria-label="Already in draft" />}
-                          />
-                        </div>
+                          <AgentOption candidate={item} ambiguous={ambiguous} />
+                        </button>
                       );
-                    }
-                    addableIdx += 1;
-                    const myIdx = addableIdx;
-                    const active = myIdx === highlight;
-                    return (
-                      <button
-                        key={item.agentId}
-                        type="button"
-                        role="option"
-                        aria-selected={active}
-                        title={item.name ? `@${item.name}` : undefined}
-                        onClick={() => onAdd(item.agentId)}
-                        onMouseEnter={() => setHighlight(myIdx)}
-                        className="flex w-full items-center px-3 py-1.5 text-left text-body"
-                        style={{
-                          background: active ? "var(--bg-hover)" : "transparent",
-                          color: "var(--fg)",
-                          border: "none",
-                          cursor: "pointer",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        <AgentOption candidate={item} ambiguous={ambiguous} />
-                      </button>
-                    );
-                  });
-                })()
-              )}
-            </div>
-          </div>
-        )}
+                    });
+                  })()
+                )}
+              </div>
+            </div>,
+            document.body,
+          )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed

- Synchronize the three development changes merged on the temporary GitLab main branch.
- Preserve the GitLab commit ancestry so the two main branches can converge safely.

## Why

First Tree development temporarily moved to the self-managed GitLab staging repository. These changes now need to pass the GitHub pull request and required-check gate before GitHub resumes as the CI and release authority.

## Impact

This includes people-picker viewport fixes, the repositories settings page, and simplified chat participant details and actions.

## Validation

- Commit ancestry verified as a six-commit fast-forward from GitHub main.
- git diff --check passed.
- Required GitHub checks are pending.

## Merge requirement

Use a merge commit after required checks pass. Squash or rebase would rewrite commit ancestry and leave GitHub and GitLab main diverged.