### PR TITLE
Sync GitLab main through the GitHub gate

### DIFF
--- a/packages/server/src/__tests__/landing-campaigns-start.test.ts
+++ b/packages/server/src/__tests__/landing-campaigns-start.test.ts
@@ -417,11 +417,11 @@ describe("POST /me/landing-campaigns/start", () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
 
-    const res = await startCampaign(app, admin, "agent-readiness");
+    const res = await startCampaign(app, admin, "unknown-campaign");
 
     expect(res.statusCode).toBe(404);
     expect(res.json()).toMatchObject({
-      error: expect.stringContaining('Landing campaign "agent-readiness" not found'),
+      error: expect.stringContaining('Landing campaign "unknown-campaign" not found'),
     });
     const serviceMembers = await app.db
       .select()
@@ -438,6 +438,52 @@ describe("POST /me/landing-campaigns/start", () => {
         ),
       );
     expect(trialAgents).toHaveLength(0);
+  });
+
+  it("launches agent-readiness with its external skill and isolated trial identity", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await seedOfficialRuntime(app, admin.organizationId);
+
+    const res = await startCampaign(app, admin, "agent-readiness");
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ chatId: string; agentUuid: string; campaign: string; repoCanonicalKey: string }>();
+    expect(body).toMatchObject({
+      campaign: "agent-readiness",
+      repoCanonicalKey: "github.com/acme/backend",
+    });
+
+    const [trialAgent] = await app.db.select().from(agents).where(eq(agents.uuid, body.agentUuid)).limit(1);
+    expect(trialAgent).toMatchObject({
+      name: "agent-team-readiness-scanner",
+      displayName: "Agent Team Readiness Scanner",
+    });
+    expect(parseLandingCampaignTrialAgentMetadata(trialAgent?.metadata)).toMatchObject({
+      landingCampaignTrial: true,
+      campaign: "agent-readiness",
+      skillSetId: "agent-readiness",
+      skillSetVersion: "2026.07.17.1",
+    });
+
+    const [chat] = await app.db.select().from(chats).where(eq(chats.id, body.chatId)).limit(1);
+    expect(chat?.topic).toBe("Agent team readiness scan");
+    expect(parseLandingCampaignTrialChatMetadata(chat?.metadata)).toMatchObject({
+      campaign: "agent-readiness",
+      agentId: body.agentUuid,
+      repo: { canonicalKey: "github.com/acme/backend" },
+      state: "running",
+      inputLocked: false,
+    });
+
+    const [bootstrap] = await app.db.select().from(messages).where(eq(messages.chatId, body.chatId)).limit(1);
+    expect(bootstrap?.content).toContain("clone https://github.com/agent-team-foundation/agent-team-readiness-scan");
+    expect(bootstrap?.content).toContain("run its agent-team-readiness skill on the repo above");
+    expect(bootstrap?.content).toContain("six-dimension score");
+    expect(bootstrap?.metadata).toMatchObject({
+      campaign: "agent-readiness",
+      landingCampaignTrial: true,
+    });
   });
 
   it("rejects invalid or non-GitHub repository URLs before provisioning", async () => {

--- a/packages/server/src/services/landing-campaigns/skills/catalog.ts
+++ b/packages/server/src/services/landing-campaigns/skills/catalog.ts
@@ -34,7 +34,7 @@ export type LandingCampaignSkillSet = {
   retrySummary: string;
 };
 
-const LANDING_CAMPAIGN_SKILL_SET_VERSION = "2026.07.07.1";
+const LANDING_CAMPAIGN_SKILL_SET_VERSION = "2026.07.17.1";
 
 const LANDING_CAMPAIGN_SKILL_SETS: Record<KnownLandingCampaignSlug, Omit<LandingCampaignSkillSet, "id" | "version">> = {
   "production-scan": {
@@ -46,6 +46,17 @@ const LANDING_CAMPAIGN_SKILL_SETS: Record<KnownLandingCampaignSlug, Omit<Landing
     trialSummary:
       "It's giving your code a safe, read-only check before launch — you'll get a score, the problems that actually matter, and the exact fix for each one.",
     retrySummary: "The scan didn't get started, so First Tree has restarted it. Same safe, read-only check on:",
+  },
+  "agent-readiness": {
+    agentName: "agent-team-readiness-scanner",
+    agentDisplayName: "Agent Team Readiness Scanner",
+    chatTopic: "Agent team readiness scan",
+    skillRepoUrl: "https://github.com/agent-team-foundation/agent-team-readiness-scan",
+    skillName: "agent-team-readiness",
+    trialSummary:
+      "It's checking whether your repo gives multiple coding agents the shared instructions, isolation, ownership, context, verification, and handoff structure they need — you'll get a six-dimension score, cited evidence, and review-ready drafts.",
+    retrySummary:
+      "The readiness scan didn't get started, so First Tree has restarted the same safe, read-only check on:",
   },
 };
 

--- a/packages/shared/src/__tests__/landing-campaign-schema.test.ts
+++ b/packages/shared/src/__tests__/landing-campaign-schema.test.ts
@@ -19,6 +19,7 @@ const repo = {
 describe("landing campaign active registry", () => {
   it("distinguishes active campaign slugs from valid historical metadata slugs", () => {
     expect(isKnownLandingCampaignSlug("production-scan")).toBe(true);
+    expect(isKnownLandingCampaignSlug("agent-readiness")).toBe(true);
     expect(isKnownLandingCampaignSlug("seed-api")).toBe(false);
     expect(landingCampaignSlugSchema.safeParse("seed-api").success).toBe(true);
   });
@@ -26,6 +27,10 @@ describe("landing campaign active registry", () => {
   it("validates a trusted campaign + owner/repo action context", () => {
     expect(landingCampaignActionContextSchema.parse({ campaign: "production-scan", repoSlug: "Acme/api.js" })).toEqual({
       campaign: "production-scan",
+      repoSlug: "Acme/api.js",
+    });
+    expect(landingCampaignActionContextSchema.parse({ campaign: "agent-readiness", repoSlug: "Acme/api.js" })).toEqual({
+      campaign: "agent-readiness",
       repoSlug: "Acme/api.js",
     });
     expect(landingCampaignActionContextSchema.safeParse({ campaign: "retired", repoSlug: "acme/api" }).success).toBe(

--- a/packages/shared/src/schemas/landing-campaign.ts
+++ b/packages/shared/src/schemas/landing-campaign.ts
@@ -8,7 +8,7 @@ export const landingCampaignSlugSchema = z
   .regex(/^[a-z0-9][a-z0-9-]*$/u, "Campaign must be a kebab-case slug.");
 
 /** Campaigns that the current Cloud build can actively launch or hand off. */
-export const KNOWN_LANDING_CAMPAIGN_SLUGS = ["production-scan"] as const;
+export const KNOWN_LANDING_CAMPAIGN_SLUGS = ["production-scan", "agent-readiness"] as const;
 export const knownLandingCampaignSlugSchema = z.enum(KNOWN_LANDING_CAMPAIGN_SLUGS);
 export type KnownLandingCampaignSlug = z.infer<typeof knownLandingCampaignSlugSchema>;
 

--- a/packages/web/src/pages/quickstart/__tests__/campaigns.test.ts
+++ b/packages/web/src/pages/quickstart/__tests__/campaigns.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { getCampaign, isKnownCampaign } from "../campaigns.js";
 
 describe("campaign registry", () => {
-  it("knows the production scan campaign and rejects everything else", () => {
+  it("knows both active scan campaigns and rejects everything else", () => {
     expect(isKnownCampaign("production-scan")).toBe(true);
-    expect(isKnownCampaign("agent-readiness")).toBe(false);
+    expect(isKnownCampaign("agent-readiness")).toBe(true);
     expect(isKnownCampaign("nope")).toBe(false);
     expect(isKnownCampaign(null)).toBe(false);
     expect(isKnownCampaign("")).toBe(false);
@@ -16,7 +16,11 @@ describe("campaign registry", () => {
       needsRepo: true,
       action: { queryValue: "fix", topic: "Fix production scan blockers" },
     });
-    expect(getCampaign("agent-readiness")).toBeNull();
+    expect(getCampaign("agent-readiness")).toMatchObject({
+      slug: "agent-readiness",
+      needsRepo: true,
+      action: { queryValue: "fix", topic: "Adopt agent readiness fixes" },
+    });
     expect(getCampaign("unknown")).toBeNull();
     expect(getCampaign(null)).toBeNull();
   });

--- a/packages/web/src/pages/quickstart/__tests__/intent.test.ts
+++ b/packages/web/src/pages/quickstart/__tests__/intent.test.ts
@@ -94,11 +94,17 @@ describe("readCampaignHandoff", () => {
 
   it("returns null for an unknown campaign or a missing/invalid repo", () => {
     expect(readCampaignHandoff({ search: `?campaign=nope&repo=${REPO_ENC}`, hash: "" })).toBeNull();
-    expect(readCampaignHandoff({ search: `?campaign=agent-readiness&repo=${REPO_ENC}`, hash: "" })).toBeNull();
     expect(readCampaignHandoff({ search: "?campaign=production-scan", hash: "" })).toBeNull();
     expect(
       readCampaignHandoff({ search: "?campaign=production-scan&repo=https://gitlab.com/x/y", hash: "" }),
     ).toBeNull();
+  });
+
+  it("reads the agent-readiness campaign from the shared active registry", () => {
+    expect(readCampaignHandoff({ search: `?campaign=agent-readiness&repo=${REPO_ENC}`, hash: "" })).toEqual({
+      ...INTENT,
+      campaign: "agent-readiness",
+    });
   });
 });
 
@@ -193,6 +199,17 @@ describe("readCampaignActionHandoff", () => {
         hash: "",
       }),
     ).toMatchObject({ campaign: "production-scan", action: "fix", repoSlug: "acme/backend" });
+    expect(
+      readCampaignActionHandoff({
+        search: `?campaign=agent-readiness&repo=${REPO_ENC}&action=fix&report=acme-backend-20260716-abcdef12`,
+        hash: "",
+      }),
+    ).toMatchObject({
+      campaign: "agent-readiness",
+      action: "fix",
+      repoSlug: "acme/backend",
+      reportKey: "acme-backend-20260716-abcdef12",
+    });
     expect(
       readCampaignActionHandoff({
         search: `?campaign=production-scan&repo=${REPO_ENC}&action=unknown`,

--- a/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
+++ b/packages/web/src/pages/quickstart/__tests__/quickstart-page.e2e.test.tsx
@@ -169,6 +169,19 @@ describe("QuickstartPage — landing campaign trial flow", () => {
     expect(navigateMock).toHaveBeenCalledWith("/quickstart?c=chat-1", { replace: true });
   });
 
+  it("starts the agent-readiness campaign through the same generic launcher", async () => {
+    seedIntent("agent-readiness");
+    await renderPage();
+
+    expect(landingCampaignMock.startLandingCampaign).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      campaign: "agent-readiness",
+      repoUrl: "https://github.com/acme/backend",
+    });
+    expect(readCampaignIntent()).toBeNull();
+    expect(navigateMock).toHaveBeenCalledWith("/quickstart?c=chat-1", { replace: true });
+  });
+
   it("renders the workspace shell for an existing trial chat and does not restart the trial", async () => {
     seedIntent("production-scan");
     const container = await renderPage(["/quickstart?c=chat-1"]);
@@ -181,7 +194,7 @@ describe("QuickstartPage — landing campaign trial flow", () => {
   it("shows the workspace (no dead-end) for an unsupported campaign handoff", async () => {
     seedIntent("production-scan");
     const container = await renderPage([
-      "/quickstart?campaign=agent-readiness&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend",
+      "/quickstart?campaign=unsupported-campaign&repo=https%3A%2F%2Fgithub.com%2Facme%2Fbackend",
     ]);
 
     expect(container.querySelector('[data-testid="quickstart-trial-chat"]')).not.toBeNull();

--- a/packages/web/src/pages/quickstart/campaigns.ts
+++ b/packages/web/src/pages/quickstart/campaigns.ts
@@ -45,6 +45,20 @@ const CAMPAIGNS: Record<CampaignSlug, CampaignConfig> = {
         "The scan report link didn't carry over, so start by checking access to the repository, then ask me to share the report or re-run the scan.",
     },
   },
+  "agent-readiness": {
+    slug: "agent-readiness",
+    needsRepo: true,
+    action: {
+      queryValue: "fix",
+      topic: "Adopt agent readiness fixes",
+      request: "apply the prioritized fixes from my Agent Team Readiness report",
+      reportBaseUrl: "https://report.first-tree.ai",
+      withReportInstruction:
+        "Start from the machine-readable atr-1 report. Before applying anything, verify that its repository.source normalizes to the requested repository URL; stop and surface any mismatch. Then address the prioritized blockers first. Keep any AGENTS.md or Context Tree change review-first and source-backed; do not turn the report's runtime, permission, or team-behavior unknowns into assumptions. If the findings link has expired, or the repository isn't accessible from here, say exactly what is needed — a re-run of the scan, the narrowest GitHub access, or a local path.",
+      withoutReportInstruction:
+        "The readiness report link didn't carry over, so start by checking access to the repository, then ask me to share the report or re-run the scan.",
+    },
+  },
 };
 
 export function isKnownCampaign(slug: unknown): slug is CampaignSlug {

--- a/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
+++ b/packages/web/src/pages/workspace/center/onboarding/__tests__/bootstrap-prose.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { getCampaign } from "../../../../quickstart/campaigns.js";
 import {
+  buildCampaignActionBootstrap,
   buildInviteeReadyBootstrap,
   buildNoRepoBootstrap,
   buildScanFixBootstrap,
@@ -74,6 +76,31 @@ describe("start-chat bootstrap prose", () => {
     // A brand-new teammate is NOT asked to write to or seed the tree.
     expect(message).not.toContain("first-tree-seed");
     expect(message).not.toContain("reflect them into the tree");
+  });
+});
+
+describe("buildCampaignActionBootstrap for agent-readiness", () => {
+  it("carries the atr-1 report into a review-first direct task", () => {
+    const campaign = getCampaign("agent-readiness");
+    if (!campaign) throw new Error("agent-readiness campaign config is missing");
+
+    const message = buildCampaignActionBootstrap(
+      "Dev",
+      campaign.action,
+      {
+        repoUrl: "https://github.com/octo/app",
+        reportKey: "octo-app-20260716-ab12cd34",
+      },
+      "direct",
+    );
+
+    expect(message).toContain("apply the prioritized fixes from my Agent Team Readiness report");
+    expect(message).toContain(
+      "Machine-readable findings: https://report.first-tree.ai/octo-app-20260716-ab12cd34.json",
+    );
+    expect(message).toContain("verify that its repository.source normalizes to the requested repository URL");
+    expect(message).toContain("Keep any AGENTS.md or Context Tree change review-first and source-backed");
+    expect(message).not.toContain("welcome aboard");
   });
 });
 


### PR DESCRIPTION
## What changed

- Synchronize commits created on the temporary self-managed GitLab main branch.
- Preserve commit ancestry so GitHub and GitLab main can converge without force pushes.

## Safety

- This PR remains a draft while checks run.
- The synchronization guard marks it ready and merges it only after every check passes.
- The repository review requirement is bypassed only for this checked synchronization PR.
- Merge commit is enabled only for the merge window and immediately disabled again.

## Validation

- The guard verified a safe fast-forward relationship or identical file trees.
- GitHub required checks remain authoritative.