### PR TITLE
feat(runtime): host-local model catalogs for Cursor and Kimi (Phase 1)

### DIFF
--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -8,6 +8,7 @@ import {
   configureClientLoggerForService,
   createLogger,
   discoverClaudeCodeSkills,
+  discoverProviderModels,
   flushClientSentry,
   initClientSentry,
 } from "@first-tree/client";
@@ -364,6 +365,28 @@ export function registerDaemonStartCommand(daemon: Command): void {
             setProviderEntry: (provider, entry) => capabilityRefresher.setProviderEntry(provider, entry),
             log: (symbol, msg) => writeStatus(symbol, msg),
           }).finally(() => capabilityRefresher.endInteractive(command.provider));
+        });
+
+        // Host-local model catalog: web opens Model settings → server asks this
+        // daemon → we discover from the real provider and reply on the WS.
+        runtime.onProviderModelsList((command) => {
+          void (async () => {
+            try {
+              const catalog = await discoverProviderModels(command.provider);
+              runtime.sendProviderModelsResult(command.ref, catalog);
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              writeStatus("⚠️", `provider-models:list failed for ${command.provider}: ${message}`);
+              runtime.sendProviderModelsResult(command.ref, {
+                provider: command.provider,
+                models: [],
+                defaultModelId: null,
+                fetchedAt: new Date().toISOString(),
+                source: "unavailable",
+                error: message,
+              });
+            }
+          })();
         });
 
         await runtime.start();

--- a/apps/cli/src/core/client-runtime.ts
+++ b/apps/cli/src/core/client-runtime.ts
@@ -8,6 +8,7 @@ import {
   getChildProcessRegistry,
   getHandlerFactory,
   hasHandler,
+  type ProviderModelsListCommand,
   type RuntimeAuthCommand,
   registerBuiltinHandlers,
   type UpdateHooks,
@@ -17,6 +18,7 @@ import {
   AGENT_BIND_REJECT_REASONS,
   type AgentPinnedMessage,
   type ClientPausedReason,
+  type ProviderModelCatalog,
   type RuntimeProvider,
   runtimeProviderSchema,
 } from "@first-tree/shared";
@@ -282,6 +284,20 @@ export class ClientRuntime {
    */
   onRuntimeAuthStart(callback: (command: RuntimeAuthCommand) => void): void {
     this.connection.on("runtime-auth:start", callback);
+  }
+
+  /**
+   * Register a handler for the server→client `provider-models:list` command.
+   * The daemon discovers models from the host-local provider and replies with
+   * `provider-models:result` on the same connection.
+   */
+  onProviderModelsList(callback: (command: ProviderModelsListCommand) => void): void {
+    this.connection.on("provider-models:list", callback);
+  }
+
+  /** Reply to a correlated `provider-models:list` with the discovered catalog. */
+  sendProviderModelsResult(ref: string, catalog: ProviderModelCatalog): void {
+    this.connection.sendProviderModelsResult(ref, catalog);
   }
 
   addAgent(name: string, config: AgentConfig): void {

--- a/packages/client/src/__tests__/discover-models.test.ts
+++ b/packages/client/src/__tests__/discover-models.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { parseCursorModelsOutput, parseKimiConfigModels } from "../runtime/capabilities/discover-models.js";
+
+describe("parseCursorModelsOutput", () => {
+  it("parses id/label rows and marks the default", () => {
+    const parsed = parseCursorModelsOutput(`Available models
+
+auto - Auto (default)
+gpt-5.2 - GPT-5.2
+composer-2.5 - Composer 2.5
+`);
+    expect(parsed.defaultModelId).toBe("auto");
+    expect(parsed.models).toEqual([
+      { id: "auto", label: "Auto", isDefault: true, hint: "default" },
+      { id: "gpt-5.2", label: "GPT-5.2" },
+      { id: "composer-2.5", label: "Composer 2.5" },
+    ]);
+  });
+});
+
+describe("parseKimiConfigModels", () => {
+  it("reads default_model and [models.\".\"] sections", () => {
+    const parsed = parseKimiConfigModels(`
+default_model = "kimi-code/k3"
+
+[models."kimi-code/kimi-for-coding"]
+provider = "managed:kimi-code"
+model = "kimi-for-coding"
+display_name = "K2.7 Coding"
+
+[models."kimi-code/k3"]
+provider = "managed:kimi-code"
+model = "k3"
+display_name = "K3"
+`);
+    expect(parsed.defaultModelId).toBe("kimi-code/k3");
+    expect(parsed.models).toEqual([
+      { id: "kimi-code/kimi-for-coding", label: "K2.7 Coding" },
+      { id: "kimi-code/k3", label: "K3", isDefault: true, hint: "default" },
+    ]);
+  });
+});

--- a/packages/client/src/client-connection.ts
+++ b/packages/client/src/client-connection.ts
@@ -16,10 +16,14 @@ import {
   inboxDeliverFrameSchema,
   inboxRecoverAcceptedFrameSchema,
   inboxRecoverRejectedFrameSchema,
+  PROVIDER_MODELS_LIST_TYPE,
+  PROVIDER_MODELS_RESULT_TYPE,
+  type ProviderModelCatalog,
   RUNTIME_AUTH_START_TYPE,
   type RuntimeAuthMethod,
   type RuntimeProvider,
   type RuntimeState,
+  providerModelsListCommandSchema,
   runtimeAuthStartCommandSchema,
   type ServerWelcomeFrame,
   type SessionEvent,
@@ -164,6 +168,12 @@ export type RuntimeAuthCommand = {
   ref: string;
 };
 
+/** Server→client command to discover host-local provider models. */
+export type ProviderModelsListCommand = {
+  provider: RuntimeProvider;
+  ref: string;
+};
+
 /**
  * Welcome frame received after `auth:ok`. `isReconnect` is true for every
  * occurrence after the first welcome in the lifetime of this `ClientConnection`
@@ -199,6 +209,7 @@ type ClientConnectionEvents = {
   "agent:pinned": [message: AgentPinnedMessage];
   "session:command": [command: SessionCommand];
   "runtime-auth:start": [command: RuntimeAuthCommand];
+  "provider-models:list": [command: ProviderModelsListCommand];
   "session:reconcile:result": [result: SessionReconcileResult];
   "auth:expired": [];
   /**
@@ -1082,6 +1093,12 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
     this.ws.send(JSON.stringify({ type: "session:reconcile", agentId, chatIds }));
   }
 
+  /** Reply to a `provider-models:list` reverse command with the host catalog. */
+  sendProviderModelsResult(ref: string, catalog: ProviderModelCatalog): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify({ type: PROVIDER_MODELS_RESULT_TYPE, ref, catalog }));
+  }
+
   async disconnect(): Promise<void> {
     this.closing = true;
     this.connectAbort?.abort();
@@ -1575,6 +1592,15 @@ export class ClientConnection extends EventEmitter<ClientConnectionEvents> {
       if (parsed.success) {
         const { provider, method, ref } = parsed.data;
         this.emit("runtime-auth:start", { provider, method, ref });
+      }
+      return;
+    }
+
+    if (type === PROVIDER_MODELS_LIST_TYPE) {
+      const parsed = providerModelsListCommandSchema.safeParse(msg);
+      if (parsed.success) {
+        const { provider, ref } = parsed.data;
+        this.emit("provider-models:list", { provider, ref });
       }
       return;
     }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,6 +1,7 @@
 export type {
   BoundAgent,
   ClientConnectionConfig,
+  ProviderModelsListCommand,
   RuntimeAuthCommand,
   ServerWelcome,
   SessionCommand,
@@ -43,6 +44,12 @@ export {
 } from "./runtime/capabilities/codex.js";
 export { probeCursorCapability } from "./runtime/capabilities/cursor.js";
 export {
+  type DiscoverModelsDeps,
+  discoverProviderModels,
+  parseCursorModelsOutput,
+  parseKimiConfigModels,
+} from "./runtime/capabilities/discover-models.js";
+export {
   CAPABILITY_REFRESH_BASE_MS,
   CAPABILITY_REFRESH_MAX_MS,
   hasNonOkProvider,
@@ -54,6 +61,7 @@ export {
   revalidateCapabilities,
   shouldFullReprobe,
 } from "./runtime/capabilities/index.js";
+
 export type {
   AdoptOptions,
   ChildCategory,

--- a/packages/client/src/runtime/capabilities/discover-models.ts
+++ b/packages/client/src/runtime/capabilities/discover-models.ts
@@ -1,0 +1,201 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readFile } from "node:fs/promises";
+import type { ProviderModelCatalog, ProviderModelOption, RuntimeProvider } from "@first-tree/shared";
+import { findCursorExecutableOnPath } from "../cursor-binary.js";
+import { runCommand } from "./launch-probe.js";
+
+/** Ceiling for `agent models` — account catalog fetch can be network-bound. */
+const CURSOR_MODELS_TIMEOUT_MS = 20_000;
+
+export type DiscoverModelsDeps = {
+  env?: NodeJS.ProcessEnv;
+  now?: () => Date;
+  findCursorBinary?: (env?: Record<string, string | undefined>) => string | null;
+  runCursorModels?: (binary: string, env: NodeJS.ProcessEnv) => Promise<{ ok: boolean; stdout: string; stderr: string }>;
+  readKimiConfig?: () => Promise<string | null>;
+  kimiConfigPath?: string;
+};
+
+function fetchedAt(deps: DiscoverModelsDeps): string {
+  return (deps.now ?? (() => new Date()))().toISOString();
+}
+
+function unavailable(provider: RuntimeProvider, error: string, deps: DiscoverModelsDeps): ProviderModelCatalog {
+  return {
+    provider,
+    models: [],
+    defaultModelId: null,
+    fetchedAt: fetchedAt(deps),
+    source: "unavailable",
+    error,
+  };
+}
+
+/**
+ * Parse `agent models` / `agent --list-models` text:
+ *   Available models
+ *   auto - Auto (default)
+ *   gpt-5.2 - GPT-5.2
+ */
+export function parseCursorModelsOutput(stdout: string): {
+  models: ProviderModelOption[];
+  defaultModelId: string | null;
+} {
+  const models: ProviderModelOption[] = [];
+  let defaultModelId: string | null = null;
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || /^available models$/i.test(line)) continue;
+    const match = /^(\S+)\s+-\s+(.+)$/.exec(line);
+    if (!match) continue;
+    const id = match[1]!;
+    const label = match[2]!.trim();
+    const isDefault = /\(default\)/i.test(label);
+    if (isDefault) defaultModelId = id;
+    models.push({
+      id,
+      label: label.replace(/\s*\(default\)\s*/i, "").trim() || id,
+      ...(isDefault ? { isDefault: true, hint: "default" } : {}),
+    });
+  }
+  return { models, defaultModelId };
+}
+
+/**
+ * Minimal TOML extract for Kimi's `~/.kimi-code/config.toml`:
+ *   default_model = "kimi-code/k3"
+ *   [models."kimi-code/k3"]
+ *   display_name = "K3"
+ *   model = "k3"
+ *
+ * Avoids adding a TOML dependency for a narrow, stable config shape.
+ */
+export function parseKimiConfigModels(toml: string): {
+  models: ProviderModelOption[];
+  defaultModelId: string | null;
+} {
+  const defaultMatch = /^default_model\s*=\s*"([^"]+)"/m.exec(toml);
+  const defaultModelId = defaultMatch?.[1] ?? null;
+
+  const models: ProviderModelOption[] = [];
+  const sectionRe = /^\[models\."([^"]+)"\]\s*$/gm;
+  const sections: Array<{ id: string; headerStart: number; bodyStart: number }> = [];
+  for (const match of toml.matchAll(sectionRe)) {
+    sections.push({
+      id: match[1]!,
+      headerStart: match.index!,
+      bodyStart: match.index! + match[0].length,
+    });
+  }
+  for (let i = 0; i < sections.length; i++) {
+    const section = sections[i]!;
+    const bodyEnd = i + 1 < sections.length ? sections[i + 1]!.headerStart : toml.length;
+    const body = toml.slice(section.bodyStart, bodyEnd);
+    const displayName = /^display_name\s*=\s*"([^"]+)"/m.exec(body)?.[1];
+    const isDefault = defaultModelId === section.id;
+    models.push({
+      id: section.id,
+      ...(displayName ? { label: displayName } : {}),
+      ...(isDefault ? { isDefault: true, hint: "default" } : {}),
+    });
+  }
+  return { models, defaultModelId };
+}
+
+async function discoverCursorModels(deps: DiscoverModelsDeps): Promise<ProviderModelCatalog> {
+  const env = deps.env ?? process.env;
+  const findBinary = deps.findCursorBinary ?? findCursorExecutableOnPath;
+  const binary = findBinary(env);
+  if (!binary) {
+    return unavailable("cursor", "cursor-agent / agent binary not found on this host", deps);
+  }
+  const run =
+    deps.runCursorModels ??
+    (async (bin, processEnv) => {
+      const result = await runCommand(bin, ["models"], { timeoutMs: CURSOR_MODELS_TIMEOUT_MS, env: processEnv });
+      return { ok: result.ok, stdout: result.stdout, stderr: result.stderr };
+    });
+  const result = await run(binary, env);
+  if (!result.ok) {
+    const detail = (result.stderr || result.stdout || "agent models failed").trim();
+    return unavailable("cursor", detail.slice(0, 500), deps);
+  }
+  const parsed = parseCursorModelsOutput(result.stdout);
+  if (parsed.models.length === 0) {
+    return unavailable("cursor", "agent models returned no parseable model rows", deps);
+  }
+  return {
+    provider: "cursor",
+    models: parsed.models,
+    defaultModelId: parsed.defaultModelId,
+    fetchedAt: fetchedAt(deps),
+    source: "provider-cli",
+    error: null,
+  };
+}
+
+async function discoverKimiModels(deps: DiscoverModelsDeps): Promise<ProviderModelCatalog> {
+  const path = deps.kimiConfigPath ?? join(homedir(), ".kimi-code", "config.toml");
+  const read =
+    deps.readKimiConfig ??
+    (async () => {
+      try {
+        return await readFile(path, "utf8");
+      } catch (err) {
+        const code = err && typeof err === "object" && "code" in err ? String((err as { code: unknown }).code) : "";
+        if (code === "ENOENT") return null;
+        throw err;
+      }
+    });
+  let toml: string | null;
+  try {
+    toml = await read();
+  } catch (err) {
+    return unavailable("kimi-code", err instanceof Error ? err.message : String(err), deps);
+  }
+  if (toml == null) {
+    return unavailable("kimi-code", `Kimi config not found at ${path}`, deps);
+  }
+  const parsed = parseKimiConfigModels(toml);
+  if (parsed.models.length === 0) {
+    return unavailable("kimi-code", "Kimi config has no [models.\".\"] entries", deps);
+  }
+  return {
+    provider: "kimi-code",
+    models: parsed.models,
+    defaultModelId: parsed.defaultModelId,
+    fetchedAt: fetchedAt(deps),
+    source: "provider-config",
+    error: null,
+  };
+}
+
+/**
+ * Discover the model catalog for a runtime provider from the host-local
+ * provider. Phase 1 implements Cursor + Kimi; other providers return
+ * `source: "unavailable"` so the web can keep its curated/fallback UI.
+ */
+export async function discoverProviderModels(
+  provider: RuntimeProvider,
+  deps: DiscoverModelsDeps = {},
+): Promise<ProviderModelCatalog> {
+  switch (provider) {
+    case "cursor":
+      return discoverCursorModels(deps);
+    case "kimi-code":
+      return discoverKimiModels(deps);
+    case "claude-code":
+    case "claude-code-tui":
+    case "codex":
+      return unavailable(
+        provider,
+        `Host-local model discovery for ${provider} lands in a later phase`,
+        deps,
+      );
+    default: {
+      const _exhaustive: never = provider;
+      return unavailable(_exhaustive, `Unknown provider: ${String(provider)}`, deps);
+    }
+  }
+}

--- a/packages/server/src/__tests__/clients-provider-models.test.ts
+++ b/packages/server/src/__tests__/clients-provider-models.test.ts
@@ -1,0 +1,66 @@
+import crypto from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import type { WebSocket } from "ws";
+import {
+  removeClientConnection,
+  resolveClientReply,
+  setClientConnection,
+} from "../services/connection-manager.js";
+import { createAdminContext, useTestApp } from "./helpers.js";
+
+/**
+ * `GET /api/v1/clients/:clientId/providers/:provider/models` asks the connected
+ * daemon for a host-local model catalog and waits for the correlated reply.
+ */
+describe("GET /clients/:clientId/providers/:provider/models", () => {
+  const getApp = useTestApp();
+
+  it("forwards provider-models:list and returns the daemon catalog", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `pm-${crypto.randomUUID().slice(0, 6)}` });
+    const ws = { readyState: 1, send: vi.fn(), close: vi.fn() };
+    setClientConnection(admin.clientId, ws as unknown as WebSocket);
+    try {
+      const pending = app.inject({
+        method: "GET",
+        url: `/api/v1/clients/${admin.clientId}/providers/cursor/models`,
+        headers: { authorization: `Bearer ${admin.accessToken}` },
+      });
+
+      // Wait briefly for the reverse command to be sent, then resolve the waiter.
+      await vi.waitFor(() => {
+        expect(ws.send).toHaveBeenCalled();
+      });
+      const frame = JSON.parse(String(ws.send.mock.calls[0]?.[0]));
+      expect(frame).toMatchObject({ type: "provider-models:list", provider: "cursor" });
+      expect(typeof frame.ref).toBe("string");
+
+      const catalog = {
+        provider: "cursor" as const,
+        models: [{ id: "auto", label: "Auto", isDefault: true }],
+        defaultModelId: "auto",
+        fetchedAt: new Date().toISOString(),
+        source: "provider-cli" as const,
+        error: null,
+      };
+      expect(resolveClientReply(admin.clientId, frame.ref, catalog)).toBe(true);
+
+      const res = await pending;
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toMatchObject(catalog);
+    } finally {
+      removeClientConnection(admin.clientId, ws as unknown as WebSocket);
+    }
+  });
+
+  it("returns 503 when the daemon is not connected", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app, { username: `pm-${crypto.randomUUID().slice(0, 6)}` });
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/clients/${admin.clientId}/providers/kimi-code/models`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(res.statusCode).toBe(503);
+  });
+});

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -5,6 +5,7 @@ import {
   AUTH_RETRYABLE_CODES,
   type AuthRejectedCode,
   type AuthRetryableCode,
+  PROVIDER_MODELS_RESULT_TYPE,
   agentBindRequestSchema,
   agentPinnedMessageSchema,
   clientRegisterSchema,
@@ -12,6 +13,7 @@ import {
   inboxAckFrameSchema,
   inboxDeliverFrameSchema,
   inboxRecoverFrameSchema,
+  providerModelsResultFrameSchema,
   runtimeStateMessageSchema,
   sessionEventMessageSchema,
   sessionEventRejectedReasonSchema,
@@ -1757,6 +1759,27 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                 await reconcilePinnedAgentsForClient();
               }
               socket.send(JSON.stringify({ type: "heartbeat:ack" }));
+            } else if (type === PROVIDER_MODELS_RESULT_TYPE) {
+              if (!clientId) {
+                socket.send(JSON.stringify({ type: "error", message: "Must register client first" }));
+                return;
+              }
+              const result = providerModelsResultFrameSchema.safeParse(msg);
+              if (!result.success) {
+                socket.send(JSON.stringify({ type: "error", message: "Malformed provider-models:result frame" }));
+                return;
+              }
+              const resolved = connectionManager.resolveClientReply(
+                clientId,
+                result.data.ref,
+                result.data.catalog,
+              );
+              if (!resolved) {
+                app.log.debug(
+                  { clientId, ref: result.data.ref },
+                  "provider-models:result matched no pending HTTP waiter",
+                );
+              }
             }
           } catch (err) {
             const message = err instanceof Error ? err.message : "Internal error";

--- a/packages/server/src/api/clients.ts
+++ b/packages/server/src/api/clients.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import {
+  PROVIDER_MODELS_LIST_TYPE,
   RUNTIME_AUTH_START_TYPE,
+  providerModelCatalogSchema,
   runtimeAuthStartRequestSchema,
+  runtimeProviderSchema,
   updateClientCapabilitiesSchema,
 } from "@first-tree/shared";
 import { getChannelConfig } from "@first-tree/shared/channel";
@@ -11,7 +14,7 @@ import { stampClientResource } from "../observability/request-context.js";
 import { requireUser } from "../scope/require-user.js";
 import { expiryToSeconds } from "../services/auth.js";
 import * as clientService from "../services/client.js";
-import { forceDisconnectClient, sendToClient } from "../services/connection-manager.js";
+import { forceDisconnectClient, rejectPendingRepliesForClient, sendToClient, waitForClientReply } from "../services/connection-manager.js";
 import { serializeDate } from "../utils.js";
 import { clientCommandVersionHint } from "./client-command-version.js";
 
@@ -90,6 +93,45 @@ export async function clientRoutes(app: FastifyInstance): Promise<void> {
     }
     return { ref, started: true as const };
   });
+
+  // Host-local model catalog: ask the connected daemon to discover models from
+  // the real provider on that computer, wait for the correlated reply, and
+  // return the catalog to the web. 503 when the computer is offline or times out.
+  app.get<{ Params: { clientId: string; provider: string } }>(
+    "/:clientId/providers/:provider/models",
+    async (request) => {
+      const { userId } = requireUser(request);
+      const { clientId, provider: rawProvider } = request.params;
+      stampClientResource(request, clientId);
+      await clientService.assertClientOwner(app.db, clientId, { userId });
+      await clientService.assertClientNotRetired(app.db, clientId);
+      const provider = runtimeProviderSchema.parse(rawProvider);
+      const ref = randomUUID();
+      const replyPromise = waitForClientReply(clientId, ref);
+      const delivered = sendToClient(clientId, {
+        type: PROVIDER_MODELS_LIST_TYPE,
+        provider,
+        ref,
+      });
+      if (!delivered) {
+        rejectPendingRepliesForClient(clientId, new Error("Computer not connected"));
+        await replyPromise.catch(() => undefined);
+        throw new ServiceUnavailableError(
+          "Could not list models because this computer is not connected. Make sure the daemon is running, then retry.",
+        );
+      }
+      try {
+        const raw = await replyPromise;
+        return providerModelCatalogSchema.parse(raw);
+      } catch (err) {
+        throw new ServiceUnavailableError(
+          err instanceof Error
+            ? err.message
+            : "Could not list models from this computer. Retry after the daemon is connected.",
+        );
+      }
+    },
+  );
 
   app.post<{ Params: { clientId: string } }>("/:clientId/disconnect", async (request) => {
     const { userId } = requireUser(request);

--- a/packages/server/src/services/connection-manager.ts
+++ b/packages/server/src/services/connection-manager.ts
@@ -168,6 +168,7 @@ export function removeClientConnection(clientId: string, ws: WebSocket): string[
     activeConnections.delete(agentId);
   }
   clientConnections.delete(clientId);
+  rejectPendingRepliesForClient(clientId, new Error("Client disconnected"));
   return agentIds;
 }
 
@@ -222,5 +223,66 @@ export function forceDisconnectClient(clientId: string): string[] {
     activeConnections.delete(agentId);
   }
   clientConnections.delete(clientId);
+  rejectPendingRepliesForClient(clientId, new Error("Client disconnected"));
   return agentIds;
+}
+
+/**
+ * HTTP→daemon request/response correlation. Used by host-local discovery
+ * (provider model catalogs) where the web needs a synchronous answer from the
+ * connected computer rather than fire-and-forget + poll.
+ */
+type PendingClientReply = {
+  clientId: string;
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+const pendingClientReplies = new Map<string, PendingClientReply>();
+
+const DEFAULT_CLIENT_REPLY_TIMEOUT_MS = 25_000;
+
+export function waitForClientReply(
+  clientId: string,
+  ref: string,
+  timeoutMs: number = DEFAULT_CLIENT_REPLY_TIMEOUT_MS,
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    if (pendingClientReplies.has(ref)) {
+      reject(new Error(`Duplicate pending client reply ref: ${ref}`));
+      return;
+    }
+    const timer = setTimeout(() => {
+      pendingClientReplies.delete(ref);
+      reject(new Error("Timed out waiting for the computer to reply"));
+    }, timeoutMs);
+    pendingClientReplies.set(ref, { clientId, resolve, reject, timer });
+  });
+}
+
+export function resolveClientReply(clientId: string, ref: string, value: unknown): boolean {
+  const pending = pendingClientReplies.get(ref);
+  if (!pending || pending.clientId !== clientId) return false;
+  clearTimeout(pending.timer);
+  pendingClientReplies.delete(ref);
+  pending.resolve(value);
+  return true;
+}
+
+export function rejectPendingRepliesForClient(clientId: string, error: Error): void {
+  for (const [ref, pending] of pendingClientReplies) {
+    if (pending.clientId !== clientId) continue;
+    clearTimeout(pending.timer);
+    pendingClientReplies.delete(ref);
+    pending.reject(error);
+  }
+}
+
+/** Test seam: drop every pending reply without resolving. */
+export function clearPendingClientRepliesForTests(): void {
+  for (const pending of pendingClientReplies.values()) {
+    clearTimeout(pending.timer);
+  }
+  pendingClientReplies.clear();
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -975,6 +975,20 @@ export {
   runtimeAuthStartResponseSchema,
 } from "./schemas/runtime-auth.js";
 export {
+  PROVIDER_MODELS_LIST_TYPE,
+  PROVIDER_MODELS_RESULT_TYPE,
+  type ProviderModelCatalog,
+  type ProviderModelCatalogSource,
+  type ProviderModelOption,
+  type ProviderModelsListCommand,
+  type ProviderModelsResultFrame,
+  providerModelCatalogSchema,
+  providerModelCatalogSourceSchema,
+  providerModelOptionSchema,
+  providerModelsListCommandSchema,
+  providerModelsResultFrameSchema,
+} from "./schemas/provider-models.js";
+export {
   DEFAULT_RUNTIME_PROVIDER,
   DISABLED_RUNTIME_PROVIDERS,
   isRuntimeProviderEnabled,

--- a/packages/shared/src/schemas/provider-models.ts
+++ b/packages/shared/src/schemas/provider-models.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import { runtimeProviderSchema } from "./runtime-provider.js";
+
+/**
+ * Host-local model catalog discovery: the daemon asks the real provider on the
+ * computer for the models the operator can pick, and the web renders that list.
+ * First Tree never maintains a global model matrix and never proxies provider
+ * credentials — discovery runs only on the daemon host.
+ *
+ * Wire shape mirrors runtime-auth:
+ *   - Web → Server HTTP `GET /clients/:clientId/providers/:provider/models`
+ *   - Server → daemon reverse command `provider-models:list` (ref-correlated)
+ *   - Daemon → Server reply frame `provider-models:result`
+ *   - Server resolves the pending HTTP request with the catalog
+ */
+
+/** Server→client command: discover models for one runtime provider. */
+export const PROVIDER_MODELS_LIST_TYPE = "provider-models:list" as const;
+
+/** Client→server reply carrying the discovered catalog (or an unavailable stub). */
+export const PROVIDER_MODELS_RESULT_TYPE = "provider-models:result" as const;
+
+export const providerModelOptionSchema = z.object({
+  /** Exact value written to `config.payload.model`. */
+  id: z.string().min(1),
+  /** Human-facing label; defaults to `id` in the UI when absent. */
+  label: z.string().optional(),
+  /** Secondary hint (e.g. "default", "flagship"). */
+  hint: z.string().optional(),
+  /** Provider-reported default; informational — Web still uses empty string for DEFAULT. */
+  isDefault: z.boolean().optional(),
+});
+export type ProviderModelOption = z.infer<typeof providerModelOptionSchema>;
+
+export const providerModelCatalogSourceSchema = z.enum([
+  "provider-cli",
+  "provider-config",
+  "provider-rpc",
+  "provider-cache",
+  "unavailable",
+]);
+export type ProviderModelCatalogSource = z.infer<typeof providerModelCatalogSourceSchema>;
+
+export const providerModelCatalogSchema = z.object({
+  provider: runtimeProviderSchema,
+  models: z.array(providerModelOptionSchema),
+  /** Provider's own default model id when known (Kimi `default_model`, Cursor `auto`, …). */
+  defaultModelId: z.string().nullable().optional(),
+  fetchedAt: z.string(),
+  source: providerModelCatalogSourceSchema,
+  /** Present when discovery failed or the provider is not supported yet. */
+  error: z.string().nullable().optional(),
+});
+export type ProviderModelCatalog = z.infer<typeof providerModelCatalogSchema>;
+
+export const providerModelsListCommandSchema = z.object({
+  type: z.literal(PROVIDER_MODELS_LIST_TYPE),
+  provider: runtimeProviderSchema,
+  /** Correlation id tying command → result → HTTP response. */
+  ref: z.string().min(1),
+});
+export type ProviderModelsListCommand = z.infer<typeof providerModelsListCommandSchema>;
+
+export const providerModelsResultFrameSchema = z.object({
+  type: z.literal(PROVIDER_MODELS_RESULT_TYPE),
+  ref: z.string().min(1),
+  catalog: providerModelCatalogSchema,
+});
+export type ProviderModelsResultFrame = z.infer<typeof providerModelsResultFrameSchema>;

--- a/packages/web/src/api/activity.ts
+++ b/packages/web/src/api/activity.ts
@@ -2,6 +2,7 @@ import type {
   AgentType,
   ClientCapabilities,
   ConnectTokenResponse,
+  ProviderModelCatalog,
   RuntimeAuthMethod,
   RuntimeProvider,
   UpdateAttempt,
@@ -128,6 +129,16 @@ export function startRuntimeAuth(
   body: { provider: RuntimeProvider; method?: RuntimeAuthMethod },
 ): Promise<{ ref: string; started: true }> {
   return api.post(`/clients/${encodeURIComponent(clientId)}/runtime-auth/start`, body);
+}
+
+/**
+ * Ask the connected computer's daemon for the host-local model catalog for
+ * this provider (Cursor `agent models`, Kimi `~/.kimi-code/config.toml`, …).
+ */
+export function getProviderModels(clientId: string, provider: RuntimeProvider): Promise<ProviderModelCatalog> {
+  return api.get(
+    `/clients/${encodeURIComponent(clientId)}/providers/${encodeURIComponent(provider)}/models`,
+  );
 }
 
 export function resetAgentActivity(agentId: string): Promise<{ reset: boolean }> {

--- a/packages/web/src/pages/agent-detail/model-section.tsx
+++ b/packages/web/src/pages/agent-detail/model-section.tsx
@@ -1,5 +1,6 @@
-import type { RuntimeProvider } from "@first-tree/shared";
+import type { ProviderModelCatalog, RuntimeProvider } from "@first-tree/shared";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { getProviderModels } from "../../api/activity.js";
 import { Input } from "../../components/ui/input.js";
 import { Select, type SelectOption } from "../../components/ui/select.js";
 import { ConfigRow } from "./flat-section.js";
@@ -7,6 +8,11 @@ import { ConfigRow } from "./flat-section.js";
 /**
  * Model — an inline dropdown. Selecting a value saves it immediately (onChange),
  * consistent with every other control on the page; there is no draft / Save Bar.
+ *
+ * Phase 1 host-local catalogs (Cursor / Kimi): options come from the bound
+ * computer's real provider. Fallbacks required by product:
+ *   1. DEFAULT (empty string) — inherit the provider's local default config
+ *   2. Custom — free-form exact model id the operator types
  */
 
 export type ModelOption = SelectOption;
@@ -56,15 +62,15 @@ export const CODEX_MODEL_OPTIONS: Array<ModelOption & { value: CodexModelId }> =
   { value: CODEX_MODEL_IDS.GPT_5_2, label: CODEX_MODEL_IDS.GPT_5_2 },
 ];
 
-const MODEL_OPTIONS_BY_PROVIDER: Record<RuntimeProvider, ModelOption[]> = {
+/** Sentinel Select value for the custom free-form path — never written to config. */
+export const CUSTOM_MODEL_SENTINEL = "__custom__";
+
+const HOST_LOCAL_MODEL_PROVIDERS: ReadonlySet<RuntimeProvider> = new Set(["cursor", "kimi-code"]);
+
+const CURATED_OPTIONS_BY_PROVIDER: Partial<Record<RuntimeProvider, ModelOption[]>> = {
   "claude-code": CLAUDE_MODEL_OPTIONS,
   "claude-code-tui": CLAUDE_MODEL_OPTIONS,
   codex: CODEX_MODEL_OPTIONS,
-  // Cursor deliberately has NO curated list: the account-dependent SKU catalog
-  // is large and shifting, so the control is a free-form exact-id input (see
-  // ModelSection) and First Tree does not maintain a model matrix.
-  cursor: [],
-  "kimi-code": [],
 };
 
 const MODEL_HELP_BY_PROVIDER: Record<RuntimeProvider, string> = {
@@ -72,8 +78,9 @@ const MODEL_HELP_BY_PROVIDER: Record<RuntimeProvider, string> = {
   "claude-code-tui": "Applies to new sessions immediately. Model swap restarts the tmux session (~2–4s).",
   codex: "Applies to new sessions immediately. Unset lets the CLI pick by auth mode.",
   cursor:
-    "Exact Cursor model id, passed through verbatim on the next turn. Leave empty for the Cursor default (auto). An id your account can't use fails visibly — no silent fallback.",
-  "kimi-code": "Exact Kimi model id, passed to new sessions. Leave empty to use the model configured in ~/.kimi-code.",
+    "Pick a model from this computer's Cursor account catalog, leave DEFAULT to inherit Cursor's local default (auto), or enter a custom exact model id. An id your account can't use fails visibly — no silent fallback.",
+  "kimi-code":
+    "Pick a model from this computer's ~/.kimi-code config, leave DEFAULT to inherit the local default_model, or enter a custom exact model id.",
 };
 
 export type ModelSectionProps = {
@@ -82,51 +89,227 @@ export type ModelSectionProps = {
   disabled?: boolean;
   /** Runtime this agent runs on — drives the option list and help copy. */
   provider?: RuntimeProvider;
+  /** Bound computer id — required to fetch host-local catalogs (Cursor / Kimi). */
+  clientId?: string | null;
 };
 
-const UNSET_OPTION: ModelOption = { value: "", label: "(unset — inherits local)" };
+const DEFAULT_OPTION: ModelOption = { value: "", label: "DEFAULT", hint: "inherit local" };
 
-export function ModelSection({ value, onChange, disabled, provider = "claude-code" }: ModelSectionProps) {
-  const presetOptions = MODEL_OPTIONS_BY_PROVIDER[provider];
-
-  const items = useMemo<ModelOption[]>(() => {
-    const list: ModelOption[] = [UNSET_OPTION, ...presetOptions];
+export function ModelSection({
+  value,
+  onChange,
+  disabled,
+  provider = "claude-code",
+  clientId = null,
+}: ModelSectionProps) {
+  const usesHostCatalog = HOST_LOCAL_MODEL_PROVIDERS.has(provider);
+  const presetOptions = CURATED_OPTIONS_BY_PROVIDER[provider] ?? [];
+  const curatedItems = useMemo<ModelOption[]>(() => {
+    const list: ModelOption[] = [DEFAULT_OPTION, ...presetOptions];
     if (value !== "" && !presetOptions.some((o) => o.value === value)) {
       list.push({ value, label: value, hint: "custom" });
     }
     return list;
   }, [presetOptions, value]);
 
-  if (provider === "cursor" || provider === "kimi-code") {
+  if (usesHostCatalog) {
     return (
       <ConfigRow label="Model" helpText={MODEL_HELP_BY_PROVIDER[provider]}>
-        <FreeFormModelInput value={value} onChange={onChange} disabled={disabled} provider={provider} />
+        <HostLocalModelPicker
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          provider={provider}
+          clientId={clientId}
+        />
       </ConfigRow>
     );
   }
 
   return (
     <ConfigRow label="Model" helpText={MODEL_HELP_BY_PROVIDER[provider]}>
-      <Select options={items} value={value} onChange={onChange} disabled={disabled} mono aria-label="Model" />
+      <Select
+        options={curatedItems}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        mono
+        aria-label="Model"
+      />
     </ConfigRow>
   );
 }
 
+function HostLocalModelPicker({
+  value,
+  onChange,
+  disabled,
+  provider,
+  clientId,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+  provider: RuntimeProvider;
+  clientId: string | null;
+}) {
+  const [catalog, setCatalog] = useState<ProviderModelCatalog | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [customMode, setCustomMode] = useState(false);
+
+  useEffect(() => {
+    if (!clientId) {
+      setCatalog(null);
+      setLoadError(null);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    void getProviderModels(clientId, provider)
+      .then((next) => {
+        if (cancelled) return;
+        setCatalog(next);
+        if (next.source === "unavailable") {
+          setLoadError(next.error ?? "Could not load models from this computer");
+        }
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setCatalog(null);
+        setLoadError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [clientId, provider]);
+
+  const catalogOptions = useMemo<ModelOption[]>(() => {
+    if (!catalog || catalog.source === "unavailable") return [];
+    return catalog.models.map((m) => ({
+      value: m.id,
+      label: m.label ?? m.id,
+      hint: m.hint,
+    }));
+  }, [catalog]);
+
+  const valueInCatalog = value !== "" && catalogOptions.some((o) => o.value === value);
+  const showCustomInput = customMode || (value !== "" && !valueInCatalog);
+
+  useEffect(() => {
+    if (value !== "" && !valueInCatalog && catalogOptions.length > 0) {
+      setCustomMode(true);
+    }
+    if (value === "") setCustomMode(false);
+  }, [value, valueInCatalog, catalogOptions.length]);
+
+  const selectValue = showCustomInput ? CUSTOM_MODEL_SENTINEL : value;
+
+  const items = useMemo<ModelOption[]>(() => {
+    const list: ModelOption[] = [DEFAULT_OPTION, ...catalogOptions];
+    list.push({ value: CUSTOM_MODEL_SENTINEL, label: "Custom…", hint: "type exact id" });
+    if (value !== "" && !catalogOptions.some((o) => o.value === value) && value !== CUSTOM_MODEL_SENTINEL) {
+      // Keep the current custom id visible in the list while editing.
+      list.splice(list.length - 1, 0, { value, label: value, hint: "custom" });
+    }
+    return list;
+  }, [catalogOptions, value]);
+
+  const onSelectChange = (next: string) => {
+    if (next === CUSTOM_MODEL_SENTINEL) {
+      setCustomMode(true);
+      return;
+    }
+    setCustomMode(false);
+    onChange(next);
+  };
+
+  // No computer bound / catalog unavailable → free-form with DEFAULT empty via clearing.
+  if (!clientId || (catalog?.source === "unavailable" && catalogOptions.length === 0 && !loading)) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-2)" }}>
+        <Select
+          options={[DEFAULT_OPTION, ...(value ? [{ value, label: value, hint: "custom" }] : [])]}
+          value={value === "" || !value ? "" : value}
+          onChange={onChange}
+          disabled={disabled}
+          mono
+          aria-label="Model"
+        />
+        <FreeFormModelInput
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          provider={provider}
+          placeholder={provider === "kimi-code" ? "custom model id (or leave DEFAULT above)" : "custom model id"}
+        />
+        {loadError ? (
+          <p className="text-caption" style={{ color: "var(--fg-3)", margin: 0 }}>
+            {clientId ? `Catalog unavailable: ${loadError}. You can still set DEFAULT or type a custom id.` : null}
+            {!clientId ? "Bind a computer to load its model catalog. DEFAULT and custom id still work." : null}
+          </p>
+        ) : !clientId ? (
+          <p className="text-caption" style={{ color: "var(--fg-3)", margin: 0 }}>
+            Bind a computer to load its model catalog. DEFAULT inherits the local provider default; custom id is always
+            available.
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--sp-2)" }}>
+      <Select
+        options={items}
+        value={selectValue}
+        onChange={onSelectChange}
+        disabled={disabled || loading}
+        searchable={catalogOptions.length > 8}
+        mono
+        aria-label="Model"
+        placeholder={loading ? "Loading models…" : undefined}
+      />
+      {showCustomInput ? (
+        <FreeFormModelInput
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          provider={provider}
+          placeholder={provider === "kimi-code" ? "exact Kimi model id" : "exact Cursor model id"}
+        />
+      ) : null}
+      {loadError && catalogOptions.length > 0 ? (
+        <p className="text-caption" style={{ color: "var(--fg-3)", margin: 0 }}>
+          Catalog warning: {loadError}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 /**
- * Free-form exact-model input (cursor). Commits on blur / Enter rather than
- * per keystroke — every other control on this page saves on change, but a
- * text field saving each character would spam config writes.
+ * Free-form exact-model input. Commits on blur / Enter rather than per
+ * keystroke — every other control on this page saves on change, but a text
+ * field saving each character would spam config writes.
  */
 function FreeFormModelInput({
   value,
   onChange,
   disabled,
   provider,
+  placeholder,
 }: {
   value: string;
   onChange: (v: string) => void;
   disabled?: boolean;
-  provider: "cursor" | "kimi-code";
+  provider: RuntimeProvider;
+  placeholder?: string;
 }) {
   const [draft, setDraft] = useState(value);
   // Latch scoped to ONE Enter→blur sequence: Enter followed by the immediate
@@ -160,9 +343,11 @@ function FreeFormModelInput({
         if (e.key === "Enter") commit();
       }}
       disabled={disabled}
-      placeholder={provider === "kimi-code" ? "local Kimi default" : "auto (Cursor default)"}
+      placeholder={
+        placeholder ?? (provider === "kimi-code" ? "local Kimi default" : "auto (Cursor default)")
+      }
       className="font-mono"
-      aria-label="Model"
+      aria-label="Custom model id"
     />
   );
 }

--- a/packages/web/src/pages/agent-detail/runtime-tab.tsx
+++ b/packages/web/src/pages/agent-detail/runtime-tab.tsx
@@ -78,6 +78,7 @@ export function RuntimeTab() {
               onChange={(v) => configSave.save({ model: v }, { field: "model" })}
               disabled={editsDisabled}
               provider={ctx.setupRuntimeProvider}
+              clientId={ctx.clientStatus?.clientId ?? ctx.agent.clientId}
             />
             {/* Cursor has no separate reasoning-effort channel — effort/fast
                 variants live in the provider-native model id, so the control

--- a/packages/web/src/pages/clients/__tests__/cursor-provider-surfaces.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/cursor-provider-surfaces.test.tsx
@@ -70,15 +70,14 @@ describe("cursor provider — setup card surfaces", () => {
   });
 });
 
-describe("cursor provider — free-form model input", () => {
-  it("renders a text input with the auto hint and commits the exact id on blur", async () => {
+describe("cursor provider — DEFAULT + custom model id fallback", () => {
+  it("renders a custom model id input and commits the exact id on blur", async () => {
     const saved: string[] = [];
     const el = await render(<ModelSection value="" onChange={(v) => saved.push(v)} provider="cursor" />);
 
-    const input = el.querySelector<HTMLInputElement>('input[aria-label="Model"]');
+    const input = el.querySelector<HTMLInputElement>('input[aria-label="Custom model id"]');
     expect(input).not.toBeNull();
     if (!input) throw new Error("unreachable");
-    expect(input.placeholder).toContain("auto");
 
     await act(async () => {
       // React tracks the value setter — go through the native prototype setter
@@ -120,6 +119,6 @@ describe("cursor provider — free-form model input", () => {
 
   it("keeps the dropdown for claude/codex providers (no free-form regression)", async () => {
     const el = await render(<ModelSection value="opus" onChange={() => {}} provider="claude-code" />);
-    expect(el.querySelector('input[aria-label="Model"]')).toBeNull();
+    expect(el.querySelector('input[aria-label="Custom model id"]')).toBeNull();
   });
 });

--- a/packages/web/src/pages/clients/__tests__/kimi-code-provider-surfaces.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/kimi-code-provider-surfaces.test.tsx
@@ -42,13 +42,13 @@ describe("Kimi Code provider surfaces", () => {
     expect(providerInstallHint("kimi-code", "darwin")).toContain("bundled with First Tree");
   });
 
-  it("uses the free-form model field with a local-Kimi default hint", async () => {
+  it("uses the free-form custom model field when no computer catalog is bound", async () => {
     const saved: string[] = [];
     const element = await render(
       <ModelSection value="" onChange={(value) => saved.push(value)} provider="kimi-code" />,
     );
-    const input = element.querySelector<HTMLInputElement>('input[aria-label="Model"]');
-    expect(input?.placeholder).toContain("local Kimi default");
+    const input = element.querySelector<HTMLInputElement>('input[aria-label="Custom model id"]');
+    expect(input).not.toBeNull();
     if (!input) throw new Error("model input missing");
 
     await act(async () => {


### PR DESCRIPTION
## Summary
- Discover Cursor/Kimi model ids from the bound computer (`agent models`, `~/.kimi-code/config.toml`) via a correlated daemon RPC (`provider-models:list` → `provider-models:result`).
- Agent Model picker for Cursor/Kimi uses that catalog, with required fallbacks: **DEFAULT** (empty → inherit local provider default) and **Custom…** free-form exact model id.
- Claude/Codex keep curated lists for now (Phase 2/3).

## Test plan
- [ ] Unit: `discover-models` parsers; ModelSection Cursor/Kimi custom-id fallback; server GET models endpoint
- [ ] With a connected computer running Cursor: open Agent → Runtime → Model; confirm catalog loads, DEFAULT clears model, Custom accepts an exact id
- [ ] With Kimi configured: confirm models from `~/.kimi-code/config.toml` appear; DEFAULT inherits `default_model`
- [ ] Offline / unbound computer: Model still allows DEFAULT + custom free-form without blocking save


Made with [Cursor](https://cursor.com)