### PR TITLE
release: bump apps/cli to v0.5.16

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

- Bump the source-tree CLI version from `0.5.15` to `0.5.16`.
- Keep the source package identity as `first-tree-dev`; GitHub Actions remains responsible for the production package rewrite and npm trusted publishing.
- Reserve the matching stable release coordinate `v0.5.16` for the changes merged to GitHub `main` after `v0.5.15`.

## Draft GitHub Release

**Title:** `v0.5.16 — GitLab attention, Kimi runtime, Context review and audit`

### Draft release notes

## Highlights

- Add Kimi Code as a first-class agent runtime provider, including capability detection, configuration surfaces, and runtime handling.
- Bring GitLab entity attention alongside GitHub with `follow`, `following`, and `unfollow` CLI commands, connection and identity settings, webhook routing, and native chat cards.
- Ship dedicated Context Tree review and audit skills together with the reusable First Tree QA workflow and cases.
- Add connected Google and GitHub account management plus an install-free quick start for invited team-agent users.

## Notable fixes

- Retry transient provider failures even after visible output and report Claude token usage as accurate deltas.
- Align SCM attention semantics, make repository settings provider-neutral, keep renamed chat titles in sync, and improve participant and people-picker interactions.
- Harden OAuth cookie and credential handling while completing landing-campaign conversion measurement and restoring onboarding and growth analytics delivery.

## Release preflight

- Base commit: `d59c83cbfd5572e11a3f3cdefd1b7df6f92d15b7` (`origin/main`).
- Final release range after `v0.5.15`: 58 commits across 453 files, including the landing-campaign conversion work that merged before the release PR.
- Merged source version: `0.5.16`; current production npm version: `0.5.15`; current staging version: `0.5.16-staging.889.1`.
- Confirmed absent before this PR: remote tag `v0.5.16`, GitHub Release `v0.5.16`, npm package `first-tree@0.5.16`, and remote release branch.
- Base-commit GitHub CI, CodeQL, Docker, and staging npm/portable publishing are all green.
- The release range includes migrations `0077` through `0081`; they are already merged on `main`, whose Docker build and production deployment completed successfully.
- Formal cross-surface QA was not run for this release cut. The merged range adds reusable QA cases for Kimi Code, GitLab attention, connected accounts, onboarding, and SCM attention parity.

## Verification

- `pnpm install --frozen-lockfile` — passed.
- `pnpm check` — passed with the repository's existing 2 warnings and 1 informational diagnostic.
- `pnpm typecheck` — passed.
- `git diff --check` — passed.
- `pnpm test` — not run because the release PR changes only package metadata; the base commit's full GitHub CI is green and this PR will rerun the complete gate.

## Post-merge

1. Resolve the release PR merge commit and wait for main CI, Docker, and staging npm/portable publishing.
2. Reconcile these notes against the final merged range.
3. Obtain maintainer confirmation of the exact version, tag, target SHA, release title, and release body.
4. Create GitHub Release `v0.5.16` at that exact SHA and verify production npm, portable assets, Docker publishing, and the website changelog rebuild.
