### PR TITLE
Sync GitLab main through the GitHub gate

### DIFF
--- a/packages/server/src/__tests__/chat-archive.test.ts
+++ b/packages/server/src/__tests__/chat-archive.test.ts
@@ -2,10 +2,10 @@
  * Unit tests for the chat auto-archive sweeper (`sweepChatArchive`). Covers
  * the two SCM-source branches the sweeper owns:
  *
- *   Mapped branch — provider-owned chats with matching SCM mappings: archive
- *                   when every mapped entity is terminal AND
+ *   Mapped branch — SCM-origin chats with complete attention lines: archive
+ *                   when every active GitHub/GitLab entity is terminal AND
  *                   `last_message_at` is older than the SCM idle threshold.
- *   No-mapping branch — provider-owned chats without an SCM mapping: archive
+ *   No-mapping branch — SCM-origin chats without an SCM mapping: archive
  *                       acknowledged (chat, user) pairs after the same idle
  *                       threshold.
  *
@@ -35,6 +35,17 @@ type ChatMetadata = Record<string, unknown>;
 function githubMetadata(key = `owner/repo#${randomUUID().slice(0, 8)}`): ChatMetadata {
   return { source: "github", entityType: "pull_request", entityKey: key };
 }
+
+function gitlabMetadata(iid: number): ChatMetadata {
+  return {
+    source: "gitlab",
+    entityType: "pull_request",
+    entityKey: `701:pull_request:${iid}`,
+    entityUrl: `https://gitlab.internal/acme/archive/-/merge_requests/${iid}`,
+  };
+}
+
+let nextGitlabEntityIid = 10_000;
 
 async function seedHumanAgent(app: App, orgId: string, memberId: string): Promise<string> {
   const uuid = randomUUID();
@@ -88,6 +99,54 @@ async function addHumanMember(app: App, chatId: string, agentId: string): Promis
     role: "member",
     accessMode: "speaker",
     source: "manual",
+  });
+}
+
+async function seedGitlabConnection(app: App, organizationId: string, memberId: string): Promise<string> {
+  const connection = await createGitlabConnection(app.db, {
+    organizationId,
+    memberId,
+    displayName: `Archive GitLab ${randomUUID().slice(0, 8)}`,
+    instanceOrigin: "https://gitlab.internal",
+  });
+  return connection.connectionId;
+}
+
+async function seedGitlabMapping(
+  app: App,
+  input: {
+    organizationId: string;
+    connectionId: string;
+    chatId: string;
+    declaredByAgentId: string;
+    humanAgentId?: string | null;
+    delegateAgentId?: string | null;
+    entityState: string;
+    active?: boolean;
+  },
+): Promise<void> {
+  const iid = nextGitlabEntityIid++;
+  const hasCompletePair = input.humanAgentId != null && input.delegateAgentId != null;
+  await app.db.insert(gitlabEntityChatMappings).values({
+    id: randomUUID(),
+    organizationId: input.organizationId,
+    connectionId: input.connectionId,
+    chatId: input.chatId,
+    declaredByAgentId: input.declaredByAgentId,
+    boundVia: "agent_declared",
+    humanAgentId: input.humanAgentId ?? null,
+    delegateAgentId: input.delegateAgentId ?? null,
+    attentionMode: hasCompletePair ? "paired" : "legacy_route_only",
+    attentionBackfillVersion: hasCompletePair ? 1 : 0,
+    active: input.active ?? true,
+    entityType: "pull_request",
+    entityIid: iid,
+    projectId: 701,
+    projectPath: "acme/archive",
+    projectPathNormalized: "acme/archive",
+    entityUrl: `https://gitlab.internal/acme/archive/-/merge_requests/${iid}`,
+    title: `Archive MR ${iid}`,
+    entityState: input.entityState,
   });
 }
 
@@ -231,11 +290,116 @@ describe("sweepChatArchive — mapped SCM branch", () => {
     expect(await getEngagement(app, chatId, admin.humanAgentUuid)).toBeNull();
   });
 
-  it("does not archive mapped chats unless their source is github", async () => {
+  it("keeps a GitLab-origin chat active when GitLab is terminal but GitHub is open", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
     const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const connectionId = await seedGitlabConnection(app, admin.organizationId, admin.memberId);
+    const chatId = await seedChat(app, admin.organizationId, longAgo(), gitlabMetadata(21));
+    await seedGitlabMapping(app, {
+      organizationId: admin.organizationId,
+      connectionId,
+      chatId,
+      declaredByAgentId: delegate,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityState: "merged",
+    });
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "issue",
+      entityKey: "owner/repo#cross-provider-open",
+      chatId,
+      boundVia: "agent_declared",
+      entityState: "open",
+    });
+
+    expect(await sweepChatArchive(app.db)).toMatchObject({ mappedRowsArchived: 0 });
+    expect(await getEngagement(app, chatId, human)).toBeNull();
+  });
+
+  it("keeps a GitHub-origin chat active when GitHub is terminal but GitLab is open", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const connectionId = await seedGitlabConnection(app, admin.organizationId, admin.memberId);
+    const chatId = await seedChat(app, admin.organizationId, longAgo());
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#cross-provider-merged",
+      chatId,
+      boundVia: "direct",
+      entityState: "merged",
+    });
+    await seedGitlabMapping(app, {
+      organizationId: admin.organizationId,
+      connectionId,
+      chatId,
+      declaredByAgentId: delegate,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityState: "open",
+    });
+
+    expect(await sweepChatArchive(app.db)).toMatchObject({ mappedRowsArchived: 0 });
+    expect(await getEngagement(app, chatId, human)).toBeNull();
+  });
+
+  it("archives a GitLab-origin chat whose only complete terminal line is GitHub", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const chatId = await seedChat(app, admin.organizationId, longAgo(), gitlabMetadata(22));
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#opposite-only",
+      chatId,
+      boundVia: "agent_declared",
+      entityState: "closed",
+    });
+
+    expect(await sweepChatArchive(app.db)).toMatchObject({ mappedRowsArchived: 1 });
+    expect(await getEngagement(app, chatId, human)).toBe("archived");
+  });
+
+  it("archives a GitHub-origin chat whose only complete terminal line is GitLab", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const connectionId = await seedGitlabConnection(app, admin.organizationId, admin.memberId);
+    const chatId = await seedChat(app, admin.organizationId, longAgo());
+    await seedGitlabMapping(app, {
+      organizationId: admin.organizationId,
+      connectionId,
+      chatId,
+      declaredByAgentId: delegate,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityState: "merged",
+    });
+
+    expect(await sweepChatArchive(app.db)).toMatchObject({ mappedRowsArchived: 1 });
+    expect(await getEngagement(app, chatId, human)).toBe("archived");
+  });
+
+  it("does not archive mixed-provider mapped chats unless their source is an SCM provider", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const connectionId = await seedGitlabConnection(app, admin.organizationId, admin.memberId);
     const manualChatId = await seedChat(app, admin.organizationId, longAgo(), {});
     const agentChatId = await seedChat(app, admin.organizationId, longAgo(), { source: "agent" });
     await app.db.insert(githubEntityChatMappings).values([
@@ -260,12 +424,164 @@ describe("sweepChatArchive — mapped SCM branch", () => {
         entityState: "merged",
       },
     ]);
+    await seedGitlabMapping(app, {
+      organizationId: admin.organizationId,
+      connectionId,
+      chatId: manualChatId,
+      declaredByAgentId: delegate,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityState: "merged",
+    });
+    await seedGitlabMapping(app, {
+      organizationId: admin.organizationId,
+      connectionId,
+      chatId: agentChatId,
+      declaredByAgentId: delegate,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityState: "merged",
+    });
 
     const result = await sweepChatArchive(app.db);
 
     expect(result.mappedRowsArchived).toBe(0);
     expect(await getEngagement(app, manualChatId, human)).toBeNull();
     expect(await getEngagement(app, agentChatId, human)).toBeNull();
+  });
+
+  it("uses active GitLab legacy route-only rows as state guards without inventing archive targets", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const connectionId = await seedGitlabConnection(app, admin.organizationId, admin.memberId);
+
+    const routeOnlyChatId = await seedChat(app, admin.organizationId, longAgo(), gitlabMetadata(23));
+    await seedGitlabMapping(app, {
+      organizationId: admin.organizationId,
+      connectionId,
+      chatId: routeOnlyChatId,
+      declaredByAgentId: delegate,
+      entityState: "merged",
+    });
+    await addHumanMember(app, routeOnlyChatId, human);
+    await app.db.insert(chatUserState).values({
+      chatId: routeOnlyChatId,
+      agentId: human,
+      engagementStatus: "active",
+      unreadMentionCount: 0,
+      lastReadAt: new Date(Date.now() - 24 * HOURS * 1000),
+    });
+
+    const guardedChatId = await seedChat(
+      app,
+      admin.organizationId,
+      longAgo(),
+      githubMetadata("owner/repo#route-only-guard"),
+    );
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "pull_request",
+      entityKey: "owner/repo#route-only-guard",
+      chatId: guardedChatId,
+      boundVia: "direct",
+      entityState: "merged",
+    });
+    await seedGitlabMapping(app, {
+      organizationId: admin.organizationId,
+      connectionId,
+      chatId: guardedChatId,
+      declaredByAgentId: delegate,
+      entityState: "open",
+    });
+
+    const result = await sweepChatArchive(app.db);
+
+    expect(result.mappedRowsArchived).toBe(0);
+    expect(result.unmappedRowsArchived).toBe(0);
+    expect(await getEngagement(app, routeOnlyChatId, human)).toBe("active");
+    expect(await getEngagement(app, guardedChatId, human)).toBeNull();
+  });
+
+  it.each([
+    "github",
+    "gitlab",
+  ] as const)("applies unread, open-request, working, and blocked guards to complete $provider lines", async (provider) => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
+    const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
+    const connectionId =
+      provider === "gitlab" ? await seedGitlabConnection(app, admin.organizationId, admin.memberId) : null;
+    const guardCases = [
+      { guard: "unread", runtimeState: null },
+      { guard: "open-request", runtimeState: null },
+      { guard: "working", runtimeState: "working" },
+      { guard: "blocked", runtimeState: "blocked" },
+    ] as const;
+    const chatIds: string[] = [];
+
+    for (const [index, guardCase] of guardCases.entries()) {
+      const metadata =
+        provider === "github"
+          ? githubMetadata(`owner/repo#${provider}-guard-${guardCase.guard}`)
+          : gitlabMetadata(30 + index);
+      const chatId = await seedChat(app, admin.organizationId, longAgo(), metadata);
+      chatIds.push(chatId);
+
+      if (provider === "github") {
+        await app.db.insert(githubEntityChatMappings).values({
+          organizationId: admin.organizationId,
+          humanAgentId: human,
+          delegateAgentId: delegate,
+          entityType: "pull_request",
+          entityKey: `owner/repo#${provider}-guard-${guardCase.guard}`,
+          chatId,
+          boundVia: "direct",
+          entityState: "merged",
+        });
+      } else {
+        if (!connectionId) throw new Error("GitLab connection missing");
+        await seedGitlabMapping(app, {
+          organizationId: admin.organizationId,
+          connectionId,
+          chatId,
+          declaredByAgentId: delegate,
+          humanAgentId: human,
+          delegateAgentId: delegate,
+          entityState: "merged",
+        });
+      }
+
+      if (guardCase.guard === "unread" || guardCase.guard === "open-request") {
+        await app.db.insert(chatUserState).values({
+          chatId,
+          agentId: human,
+          engagementStatus: "active",
+          unreadMentionCount: guardCase.guard === "unread" ? 1 : 0,
+          openRequestCount: guardCase.guard === "open-request" ? 1 : 0,
+        });
+      }
+      if (guardCase.runtimeState) {
+        await app.db.insert(agentChatSessions).values({
+          agentId: delegate,
+          chatId,
+          state: "active",
+          runtimeState: guardCase.runtimeState,
+          runtimeStateAt: new Date(),
+        });
+      }
+    }
+
+    expect(await sweepChatArchive(app.db)).toMatchObject({ mappedRowsArchived: 0 });
+    await Promise.all(
+      chatIds.map(async (chatId) => {
+        expect(await getEngagement(app, chatId, human)).not.toBe("archived");
+      }),
+    );
   });
 
   it("does not archive mapped chats while any request in the chat is still open", async () => {
@@ -337,7 +653,7 @@ describe("sweepChatArchive — mapped SCM branch", () => {
     const human = await seedHumanAgent(app, admin.organizationId, admin.memberId);
     const delegate = await seedDelegateAgent(app, admin.organizationId, admin.memberId);
     const chatId = await seedChat(app, admin.organizationId, longAgo());
-    // One merged, one still open → BOOL_AND is false.
+    // One merged, one still open → the non-terminal mapping blocks archive.
     await app.db.insert(githubEntityChatMappings).values([
       {
         organizationId: admin.organizationId,

--- a/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../services/gitlab-identities.js";
 import { applyGitlabPersonnelEvidence, normalizeGitlabWebhook } from "../services/gitlab-webhook.js";
 import { pollInbox } from "../services/inbox.js";
+import { getCallerEngagement, setChatEngagement } from "../services/me-chat.js";
 import { deleteMember } from "../services/member.js";
 import { deactivateMembership, MEMBER_STATUSES, reactivateMembership } from "../services/membership.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
@@ -839,10 +840,48 @@ describe("GitLab Stage 3 personnel routing", () => {
     ).toHaveLength(0);
   });
 
-  it("wakes the stored delegate for an ordinary event on an explicit attention line", async () => {
+  it("revives an archived chat when a GitLab card arrives through the shared message path", async () => {
     const app = getApp();
     const setup = await setupTarget(app);
     const iid = 63;
+    const chat = await createChat(app.db, setup.admin.humanAgentUuid, {
+      type: "group",
+      participantIds: [setup.delegate.uuid],
+      topic: `GitLab revive ${iid}`,
+      metadata: {},
+    });
+    await declareGitlabEntityFollow(app.db, {
+      organizationId: setup.admin.organizationId,
+      connectionId: setup.connection.connectionId,
+      chatId: chat.id,
+      declaredByAgentId: setup.delegate.uuid,
+      humanAgentId: setup.admin.humanAgentUuid,
+      delegateAgentId: setup.delegate.uuid,
+      boundVia: "agent_declared",
+      entityUrl: `https://gitlab.internal/Acme/Reviews/-/merge_requests/${iid}`,
+    });
+    await setChatEngagement(app.db, chat.id, setup.admin.humanAgentUuid, "archived");
+
+    const response = await postMr(
+      app,
+      setup.connection.bearer,
+      mergeRequestPayload({ iid, actor: "another.user", reviewers: [] }),
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(
+      await app.db
+        .select()
+        .from(messages)
+        .where(and(eq(messages.chatId, chat.id), eq(messages.source, "gitlab"))),
+    ).toHaveLength(1);
+    await expect(getCallerEngagement(app.db, chat.id, setup.admin.humanAgentUuid)).resolves.toBe("active");
+  });
+
+  it("wakes the stored delegate for an ordinary event on an explicit attention line", async () => {
+    const app = getApp();
+    const setup = await setupTarget(app);
+    const iid = 64;
     const chat = await createChat(app.db, setup.admin.humanAgentUuid, {
       type: "group",
       participantIds: [setup.delegate.uuid],

--- a/packages/server/src/services/chat-archive.ts
+++ b/packages/server/src/services/chat-archive.ts
@@ -9,10 +9,10 @@
  * eligible for automatic archive. The sweep has two provider-neutral branches,
  * both keyed off `chats.last_message_at` as the idleness anchor:
  *
- *   Mapped branch — chats with at least one matching provider mapping row.
- *     Archive (for every mapped human) once *all* bound entities are
- *     terminal (`entity_state` in `('closed','merged')`) AND the chat has
- *     been silent for `mappedIdleSeconds` (default 1h).
+ *   Mapped branch — chats with at least one complete SCM attention line.
+ *     Archive (for every mapped human) once *all* GitHub mappings and active
+ *     GitLab mappings are terminal (`entity_state` in `('closed','merged')`)
+ *     AND the chat has been silent for `mappedIdleSeconds` (default 1h).
  *
  *   No-mapping branch — SCM-originated chats with no mapping rows. Archive
  *     only acknowledged human views once the chat has been silent for the same
@@ -64,10 +64,15 @@ export async function sweepChatArchive(
 }
 
 /**
- * Mapped branch: SCM-originated chats whose every provider-mapped entity is
- * terminal AND have been silent for at least `idleSeconds`. Archives every
- * (chat, human) pair from the mapping table, minus per-user unread and
- * chat-level open-request guards.
+ * Mapped branch: SCM-originated chats whose every active provider-mapped
+ * entity is terminal AND have been silent for at least `idleSeconds`.
+ * Archives every (chat, human) pair from complete attention lines, minus
+ * per-user unread and chat-level open-request guards.
+ *
+ * Chat origin is only the eligibility gate. Once eligible, entity state and
+ * archive targets are projected across both providers. Active GitLab legacy
+ * route-only rows participate in the entity-state guard but never create an
+ * archive target because they do not identify a human/wake pair.
  *
  * Implemented as a single `INSERT … SELECT … ON CONFLICT` round-trip:
  *  - The CTE enumerates only archivable (chat, human) rows, then applies the
@@ -86,22 +91,37 @@ export async function sweepChatArchive(
  */
 async function sweepMapped(db: Database, idleSeconds: number, batchSize: number): Promise<number> {
   const rows = await db.execute<{ chat_id: string }>(sql`
-    WITH scm_mappings AS (
-      SELECT m.chat_id, m.human_agent_id, m.entity_state
+    WITH scm_chats AS (
+      SELECT c.id AS chat_id
+        FROM chats c
+       WHERE c.metadata->>'source' IN ('github', 'gitlab')
+         AND c.parent_chat_id IS NULL
+    ),
+    scm_entity_states AS (
+      SELECT m.chat_id, m.entity_state
         FROM github_entity_chat_mappings m
-        JOIN chats c ON c.id = m.chat_id
-       WHERE c.metadata->>'source' = 'github'
+        JOIN scm_chats c ON c.chat_id = m.chat_id
       UNION ALL
-      SELECT m.chat_id, m.human_agent_id, m.entity_state
+      SELECT m.chat_id, m.entity_state
         FROM gitlab_entity_chat_mappings m
-        JOIN chats c ON c.id = m.chat_id
-       WHERE c.metadata->>'source' = 'gitlab'
-         AND m.active
+        JOIN scm_chats c ON c.chat_id = m.chat_id
+       WHERE m.active
+    ),
+    scm_archive_targets AS (
+      SELECT m.chat_id, m.human_agent_id
+        FROM github_entity_chat_mappings m
+        JOIN scm_chats c ON c.chat_id = m.chat_id
+      UNION ALL
+      SELECT m.chat_id, m.human_agent_id
+        FROM gitlab_entity_chat_mappings m
+        JOIN scm_chats c ON c.chat_id = m.chat_id
+       WHERE m.active
          AND m.human_agent_id IS NOT NULL
+         AND m.delegate_agent_id IS NOT NULL
     ),
     archivable_rows AS (
       SELECT DISTINCT m.chat_id, m.human_agent_id
-        FROM scm_mappings m
+        FROM scm_archive_targets m
         JOIN chats c ON c.id = m.chat_id
         LEFT JOIN chat_user_state cus
                ON cus.chat_id = m.chat_id AND cus.agent_id = m.human_agent_id
@@ -122,7 +142,7 @@ async function sweepMapped(db: Database, idleSeconds: number, batchSize: number)
          )
          AND NOT EXISTS (
            SELECT 1
-             FROM scm_mappings open_m
+             FROM scm_entity_states open_m
             WHERE open_m.chat_id = m.chat_id
               AND open_m.entity_state NOT IN ('closed', 'merged')
          )

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -474,9 +474,9 @@ export const serverConfigSchema = defineConfig({
       env: "FIRST_TREE_ARCHIVE_SWEEP_INTERVAL_SECONDS",
     }),
     /**
-     * Idle threshold for source=github chats. Mapped chats require every bound
-     * entity to be closed/merged; no-mapping source=github chats use this same
-     * threshold as an orphan/no-binding cleanup.
+     * Idle threshold for SCM-originated chats. Mapped chats require all GitHub
+     * mappings and active GitLab mappings to be closed/merged; no-mapping SCM
+     * chats use this same threshold as an orphan/no-binding cleanup.
      */
     archiveMappedIdleSeconds: field(
       z.coerce


### PR DESCRIPTION
## What changed

- Synchronize commits created on the temporary self-managed GitLab main branch.
- Preserve commit ancestry so GitHub and GitLab main can converge without force pushes.

## Safety

- This PR remains a draft while checks run.
- The synchronization guard marks it ready and merges it only after every check passes.
- The repository review requirement is bypassed only for this checked synchronization PR.
- Merge commit is enabled only for the merge window and immediately disabled again.

## Validation

- The guard verified a safe fast-forward relationship or identical file trees.
- GitHub required checks remain authoritative.