### PR TITLE
[test] draft PR — verify auto code-review trigger (DO NOT MERGE)

### DIFF
--- a/TEST-DRAFT-PR-DO-NOT-MERGE.md
+++ b/TEST-DRAFT-PR-DO-NOT-MERGE.md
@@ -1,0 +1,6 @@
+# Test draft PR — DO NOT MERGE
+
+This is a throwaway PR opened in **draft** state to verify whether First Tree's
+automatic code review (reviewer agents) is triggered for draft pull requests.
+
+It will be closed and its branch deleted once the observation is complete.


### PR DESCRIPTION
## What

Throwaway **draft** PR to empirically verify whether First Tree's automatic code review (reviewer agents **baxiaohang** / **yuezengwu**) is triggered for **draft** pull requests.

Context: 火焰杯 model competition needs competition-issue PRs to skip auto code review (maintainers review + merge manually). We are testing whether keeping PRs in draft state is a sufficient mechanism.

## Expectation to observe

- Does opening this as a draft auto-request/assign the reviewer agents?
- (Follow-up) Does marking it "Ready for review" then trigger them?

**DO NOT MERGE.** Will be closed and branch deleted after observation.
