### PR TITLE
fix: attribute trusted SCM cards as system in agent prompts

### DIFF
--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -60,6 +60,41 @@ function reviewPacket() {
   };
 }
 
+const githubCard = {
+  type: "github_event",
+  reason: "subscribed",
+  event: "issues",
+  action: "opened",
+  kind: "opened",
+  repository: "acme/widgets",
+  sender: "octocat",
+  title: "Issue #42: Broken widget",
+  body: "Please investigate",
+  url: "https://github.com/acme/widgets/issues/42",
+  entity: {
+    type: "issue",
+    key: "acme/widgets#42",
+    url: "https://github.com/acme/widgets/issues/42",
+  },
+};
+
+const gitlabCard = {
+  type: "gitlab_event",
+  event: "issue",
+  action: "open",
+  kind: "opened",
+  project: "acme/widgets",
+  sender: "alice",
+  title: "Broken widget",
+  body: "Please investigate",
+  url: "https://gitlab.example/acme/widgets/-/issues/42",
+  entity: {
+    type: "issue",
+    key: "501:issue:42",
+    url: "https://gitlab.example/acme/widgets/-/issues/42",
+  },
+};
+
 afterEach(() => {
   setCliBinding({ binName: "first-tree", packageName: "first-tree" });
 });
@@ -185,6 +220,47 @@ describe("formatInboundContent", () => {
       metadata: { systemSender: "github" },
     };
     expect(await formatInboundContent(msg, cache)).toBe("[From: alice · type=agent]\n\nPR opened");
+  });
+
+  it.each([
+    ["GitHub", "github", githubCard],
+    ["GitLab", "gitlab", gitlabCard],
+  ])("attributes a trusted %s dispatcher card as system", async (name, source, content) => {
+    const cache = createParticipantCache(
+      mkSdk(async () => participants),
+      "chat-1",
+      () => {},
+    );
+    const msg: SessionMessage = {
+      id: "m1",
+      chatId: "chat-1",
+      senderId: "agent-a",
+      source,
+      format: "card",
+      content,
+      metadata: { systemSender: source },
+    };
+
+    expect(await formatInboundContent(msg, cache)).toBe(`[From: ${name} · type=system]\n\n${JSON.stringify(content)}`);
+  });
+
+  it("does not trust a caller-provided systemSender marker", async () => {
+    const cache = createParticipantCache(
+      mkSdk(async () => participants),
+      "chat-1",
+      () => {},
+    );
+    const msg: SessionMessage = {
+      id: "m1",
+      chatId: "chat-1",
+      senderId: "agent-a",
+      source: "api",
+      format: "card",
+      content: githubCard,
+      metadata: { systemSender: "github" },
+    };
+
+    expect(await formatInboundContent(msg, cache)).toBe(`[From: alice · type=agent]\n\n${JSON.stringify(githubCard)}`);
   });
 
   it("renders a schema-validated Context Review task as explicitly untrusted context", async () => {
@@ -600,6 +676,50 @@ describe("formatInboundContent", () => {
     expect(out).toContain(
       `[From: alice · type=agent · sent=2026-01-01T00:00:00.000Z] ${JSON.stringify({ title: "earlier" })}`,
     );
+  });
+
+  it("preserves trusted SCM system attribution in preceding silent context", async () => {
+    const ps = [mkParticipant("agent-a", "alice"), mkParticipant("agent-b", "bob")];
+    const cache = createParticipantCache(
+      mkSdk(async () => ps),
+      "chat-1",
+      () => {},
+    );
+    const msg: SessionMessage = {
+      id: "m3",
+      chatId: "chat-1",
+      senderId: "agent-b",
+      source: "api",
+      format: "text",
+      content: "please review",
+      metadata: null,
+      precedingMessages: [
+        {
+          id: "m1",
+          senderId: "agent-a",
+          source: "github",
+          format: "card",
+          content: githubCard,
+          metadata: { systemSender: "github" },
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: "m2",
+          senderId: "agent-a",
+          source: "gitlab",
+          format: "card",
+          content: gitlabCard,
+          metadata: { systemSender: "gitlab" },
+          createdAt: "2026-01-01T00:00:01.000Z",
+        },
+      ],
+    };
+
+    const out = await formatInboundContent(msg, cache);
+
+    expect(out).toContain("[From: GitHub · type=system · sent=2026-01-01T00:00:00.000Z]");
+    expect(out).toContain("[From: GitLab · type=system · sent=2026-01-01T00:00:01.000Z]");
+    expect(out).toContain("[From: bob · type=agent]\n\nplease review");
   });
 
   it("omits the [Earlier in chat] block when precedingMessages is empty / absent", async () => {

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -9,6 +9,8 @@ import {
   type ImageRefContent,
   isImageBatchRefContent,
   isImageRefContent,
+  resolveTrustedSystemSender,
+  TRUSTED_SYSTEM_SENDER_NAMES,
 } from "@first-tree/shared";
 import type { FirstTreeHubSDK } from "../sdk.js";
 import { findAttachmentFile } from "./attachment-store.js";
@@ -267,6 +269,29 @@ export function formatFromHeaderLine(
   return `[From: ${parts.join(" · ")}]`;
 }
 
+type AttributedMessage = {
+  senderId: string;
+  source?: string | null;
+  format: string;
+  content: unknown;
+  metadata: Record<string, unknown> | null;
+  createdAt?: string;
+};
+
+/**
+ * Format one inbound sender header using the shared trusted-system gate.
+ * The persisted participant `senderId` remains the delivery carrier; only
+ * the agent-visible attribution changes for server-authored SCM messages.
+ */
+export function formatMessageFromHeaderLine(message: AttributedMessage, participants: ChatParticipantDetail[]): string {
+  const systemSender = resolveTrustedSystemSender(message);
+  if (!systemSender) return formatFromHeaderLine(message.senderId, message.createdAt, participants);
+
+  const parts = [TRUSTED_SYSTEM_SENDER_NAMES[systemSender], "type=system"];
+  if (message.createdAt) parts.push(`sent=${message.createdAt}`);
+  return `[From: ${parts.join(" · ")}]`;
+}
+
 /**
  * SessionContext-facing wrapper: resolve the participant cache and build the
  * `[From: …]` header for `message`, or `""` when it has no sender. Shared by
@@ -275,7 +300,7 @@ export function formatFromHeaderLine(
  */
 export async function buildFromHeader(message: SessionMessage, participants: ParticipantCache): Promise<string> {
   if (!message.senderId) return "";
-  return formatFromHeaderLine(message.senderId, message.createdAt, await participants.get());
+  return formatMessageFromHeaderLine(message, await participants.get());
 }
 
 /**
@@ -426,17 +451,14 @@ export async function formatInboundContent(message: SessionMessage, participants
     for (const p of preceding) {
       const text = typeof p.content === "string" ? p.content : JSON.stringify(p.content);
       const taskContext = renderAgentTaskContextForLLM(p.metadata);
-      lines.push(
-        `${formatFromHeaderLine(p.senderId, p.createdAt, ps)} ${text}${taskContext ? `\n\n${taskContext}` : ""}`,
-      );
+      lines.push(`${formatMessageFromHeaderLine(p, ps)} ${text}${taskContext ? `\n\n${taskContext}` : ""}`);
     }
     lines.push("", "[Now — message that woke you]");
     header = `${lines.join("\n")}\n\n`;
   }
 
-  const base = message.senderId
-    ? `${header}${formatFromHeaderLine(message.senderId, message.createdAt, await participants.get())}\n\n${rawContent}`
-    : `${header}${rawContent}`;
+  const currentHeader = await buildFromHeader(message, participants);
+  const base = currentHeader ? `${header}${currentHeader}\n\n${rawContent}` : `${header}${rawContent}`;
 
   return base;
 }

--- a/packages/client/src/runtime/handler.ts
+++ b/packages/client/src/runtime/handler.ts
@@ -257,6 +257,8 @@ export type SessionMessage = {
   content: string | Record<string, unknown>;
   /** Optional metadata. */
   metadata: Record<string, unknown> | null;
+  /** Server-stamped message provenance used by trusted attribution gates. */
+  source?: string | null;
   /**
    * Server-stamped message creation time (ISO 8601). Carried so the
    * `[From: …]` attribution header can annotate when a message was sent —
@@ -281,6 +283,8 @@ export type PrecedingMessage = {
   format: string;
   content: unknown;
   metadata: Record<string, unknown>;
+  /** Optional for compatibility with preceding context from older servers. */
+  source?: string | null;
   createdAt: string;
 };
 

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -2492,6 +2492,7 @@ export class SessionManager {
       format: msg.format,
       content: msg.content as string | Record<string, unknown>,
       metadata: msg.metadata,
+      source: msg.source,
       createdAt: msg.createdAt,
       precedingMessages: msg.precedingMessages ?? [],
     };

--- a/packages/qa/cases/cross-surface/github-webhook-routing-regression.md
+++ b/packages/qa/cases/cross-surface/github-webhook-routing-regression.md
@@ -26,7 +26,9 @@ together without a GitHub-specific post-delivery branch.
 ## Operate and Observe
 
 - Deliver a valid HMAC-signed webhook for the followed entity with a stable `X-GitHub-Delivery` value. Observe one GitHub
-  card in the followed chat and, for an explicit target, the expected delegate inbox/session wake.
+  card in the followed chat and, for an explicit target, the expected delegate inbox/session wake. Inspect the delegate's
+  assembled turn input and confirm both a current webhook card and a card carried as preceding silent context use
+  `[From: GitHub · type=system ...]`, never the representative human carrier.
 - Redeliver the same signed body with the same stable delivery id. Observe a successful deduplicated response and no
   second card or wake.
 - Deliver an equivalent supported event without `X-GitHub-Delivery`. Confirm it is accepted without creating a
@@ -40,7 +42,8 @@ together without a GitHub-specific post-delivery branch.
 
 `PASS`: signed events resolve through the bound installation, reach the expected chat and wake path, stable delivery ids
 deduplicate the whole request, missing delivery ids do not claim, invalid signatures have no side effects, and optional
-Context Reviewer behavior remains dedicated and claim-covered.
+Context Reviewer behavior remains dedicated and claim-covered. Agent-visible webhook attribution is GitHub/system while
+the existing participant sender, routing, and wake behavior remains unchanged.
 
 `FAIL`: a reproducible regression in authentication, tenant resolution, followed-chat/card delivery, wake routing,
 whole-request deduplication, or Context Reviewer claim coverage.

--- a/packages/qa/cases/cross-surface/gitlab-webhook-basic-card.md
+++ b/packages/qa/cases/cross-surface/gitlab-webhook-basic-card.md
@@ -37,7 +37,8 @@ completed until a customer-side source mapping exists in a later phase.
 - Confirm the event sent before any follow left no standalone entity record and produced no mapping. Deliver the next
   Issue, Merge Request, and Note events for the followed entity. Confirm each pending declaration binds only
   when project path, numeric project id, entity type, and iid are consistent, and each processing pass writes at most one
-  GitLab card to the existing chat.
+  GitLab card to the existing chat. Inspect the delegate's assembled turn input and confirm both a current GitLab card and
+  a card carried as preceding silent context use `[From: GitLab · type=system ...]`, never the human routing carrier.
 - Before that matching webhook, run `first-tree gitlab following` in both chats and confirm the stable public projection
   reports `pending` without connection, organization, mapping, actor, normalized-path, or timestamp fields. After the
   webhook, confirm both independent chat declarations report `active`, the latest URL/title/state projection is visible,
@@ -111,8 +112,8 @@ stable ids are connection-scoped, exact active identities route to the current e
 a generic at-least-once wake, explicit lines wake on ordinary subscribed events, pair-aware rebind moves rather than
 duplicates a line, agent follow/list/unfollow expose only the stable URL contract, chat-scoped unfollow removes automatic
 and manual bindings while later directed events may route afresh, lifecycle-only observations safely refresh public
-state/topic, terminal chats archive only after all safety guards pass, anomalies fail closed, and no source-review state
-is claimed.
+state/topic, terminal chats archive only after all safety guards pass, webhook turn input identifies GitLab/system without
+changing participant routing, anomalies fail closed, and no source-review state is claimed.
 
 `FAIL`: cross-Team resolution, secret exposure, any outbound request to GitLab, incorrect pending binding, duplicate cards
 for one chat within one pass, a fuzzy personnel match, new personnel routing after its authority was removed, reviewer

--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -224,6 +224,7 @@ describe("inbox WS data-plane claim helpers", () => {
       "second silent",
       "third silent",
     ]);
+    expect(entry.message.precedingMessages.map((p) => p.source)).toEqual(["api", "api", "api"]);
 
     // Bundling is not consumption: same-socket recovery can still rebuild
     // the preceding block until the notify trigger is ACKed.

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -1,4 +1,9 @@
-import { type InboxEntryWithMessage, inboxEntryStatusSchema, type PrecedingMessage } from "@first-tree/shared";
+import {
+  type InboxEntryWithMessage,
+  inboxEntryStatusSchema,
+  messageSourceSchema,
+  type PrecedingMessage,
+} from "@first-tree/shared";
 import { and, asc, desc, eq, gt, inArray, isNull, lt, sql } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
@@ -530,6 +535,7 @@ async function collectPrecedingContext(
           format: messages.format,
           content: messages.content,
           metadata: messages.metadata,
+          source: messages.source,
           createdAt: messages.createdAt,
         })
         .from(inboxEntries)
@@ -557,6 +563,7 @@ async function collectPrecedingContext(
           format: r.format,
           content: r.content,
           metadata: (r.metadata ?? {}) as Record<string, unknown>,
+          source: messageSourceSchema.nullable().catch(null).parse(r.source),
           createdAt: r.createdAt.toISOString(),
         }))
         .reverse();

--- a/packages/shared/src/__tests__/trusted-system-message.test.ts
+++ b/packages/shared/src/__tests__/trusted-system-message.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  isTrustedGithubDispatcherMessage,
+  isTrustedGitlabDispatcherMessage,
+  resolveTrustedSystemSender,
+} from "../schemas/trusted-system-message.js";
+
+const githubCard = {
+  type: "github_event",
+  reason: "subscribed",
+  event: "issues",
+  action: "opened",
+  kind: "opened",
+  repository: "acme/widgets",
+  sender: "octocat",
+  title: "Issue #42: Broken widget",
+  body: "Please investigate",
+  url: "https://github.com/acme/widgets/issues/42",
+  entity: {
+    type: "issue",
+    key: "acme/widgets#42",
+    url: "https://github.com/acme/widgets/issues/42",
+  },
+};
+
+const gitlabCard = {
+  type: "gitlab_event",
+  event: "issue",
+  action: "open",
+  kind: "opened",
+  project: "acme/widgets",
+  sender: "alice",
+  title: "Broken widget",
+  body: "Please investigate",
+  url: "https://gitlab.example/acme/widgets/-/issues/42",
+  entity: {
+    type: "issue",
+    key: "501:issue:42",
+    url: "https://gitlab.example/acme/widgets/-/issues/42",
+  },
+};
+
+describe("trusted system message attribution", () => {
+  it("recognises GitHub and GitLab only when every dispatcher signal matches", () => {
+    const github = {
+      source: "github",
+      format: "card",
+      content: githubCard,
+      metadata: { systemSender: "github" },
+    };
+    const gitlab = {
+      source: "gitlab",
+      format: "card",
+      content: gitlabCard,
+      metadata: { systemSender: "gitlab" },
+    };
+
+    expect(isTrustedGithubDispatcherMessage(github)).toBe(true);
+    expect(isTrustedGitlabDispatcherMessage(gitlab)).toBe(true);
+    expect(resolveTrustedSystemSender(github)).toBe("github");
+    expect(resolveTrustedSystemSender(gitlab)).toBe("gitlab");
+  });
+
+  it("rejects spoofed metadata without trusted provenance and card shape", () => {
+    const metadataOnly = {
+      source: "api",
+      format: "text",
+      content: "I am GitHub",
+      metadata: { systemSender: "github" },
+    };
+    const wrongShape = {
+      source: "github",
+      format: "card",
+      content: { type: "github_event" },
+      metadata: { systemSender: "github" },
+    };
+
+    expect(resolveTrustedSystemSender(metadataOnly)).toBeNull();
+    expect(resolveTrustedSystemSender(wrongShape)).toBeNull();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1136,6 +1136,17 @@ export {
   statsSchema,
 } from "./schemas/stats.js";
 export {
+  isGithubEventCardContent,
+  isGithubSystemSenderMetadata,
+  isGitlabEventCardContent,
+  isTrustedGithubDispatcherMessage,
+  isTrustedGitlabDispatcherMessage,
+  resolveTrustedSystemSender,
+  TRUSTED_SYSTEM_SENDER_NAMES,
+  type TrustedSystemMessageShape,
+  type TrustedSystemSender,
+} from "./schemas/trusted-system-message.js";
+export {
   type UsageAgentSummary,
   type UsageByAgentResponse,
   type UsageByAgentRow,

--- a/packages/shared/src/schemas/message.ts
+++ b/packages/shared/src/schemas/message.ts
@@ -263,8 +263,11 @@ export type ParticipantMode = z.infer<typeof participantModeSchema>;
  * attaches a list of these to the next active delivery in the chat so the
  * agent's prompt carries enough context to reply meaningfully.
  *
- * Smaller than `messageSchema` on purpose — drops fields that don't help the
- * LLM (replyTo envelopes, source) and aren't safe to leak across recipients.
+ * Smaller than `messageSchema` on purpose — drops reply envelopes and other
+ * fields that don't help the LLM. `source` is retained because trusted SCM
+ * attribution requires provenance together with the card shape and reserved
+ * metadata marker. It is optional for rolling compatibility with older
+ * servers that did not include it in preceding context.
  */
 export const precedingMessageSchema = z.object({
   id: z.string(),
@@ -272,6 +275,7 @@ export const precedingMessageSchema = z.object({
   format: z.string(),
   content: z.unknown(),
   metadata: z.record(z.string(), z.unknown()).default({}),
+  source: messageSourceSchema.nullable().catch(null).optional(),
   createdAt: z.string(),
 });
 export type PrecedingMessage = z.infer<typeof precedingMessageSchema>;

--- a/packages/shared/src/schemas/trusted-system-message.ts
+++ b/packages/shared/src/schemas/trusted-system-message.ts
@@ -1,0 +1,71 @@
+import { contextReviewManagedMessageMetadataSchema } from "./context-review.js";
+import {
+  type GithubEventCard,
+  type GitlabEventCard,
+  githubEventCardSchema,
+  gitlabEventCardSchema,
+} from "./normalized-event.js";
+
+export const TRUSTED_SYSTEM_SENDER_NAMES = {
+  github: "GitHub",
+  gitlab: "GitLab",
+} as const;
+
+export type TrustedSystemSender = keyof typeof TRUSTED_SYSTEM_SENDER_NAMES;
+
+export type TrustedSystemMessageShape = {
+  source?: string | null;
+  format: string;
+  content: unknown;
+  metadata: unknown;
+};
+
+export function isGithubEventCardContent(content: unknown): content is GithubEventCard {
+  return githubEventCardSchema.safeParse(content).success;
+}
+
+export function isGitlabEventCardContent(content: unknown): content is GitlabEventCard {
+  return gitlabEventCardSchema.safeParse(content).success;
+}
+
+export function isGithubSystemSenderMetadata(metadata: unknown): boolean {
+  return hasSystemSender(metadata, "github");
+}
+
+/**
+ * Conjunctive trust gate for GitHub dispatcher attribution. The metadata
+ * marker alone is deliberately insufficient because ordinary message sends
+ * accept caller-provided metadata.
+ */
+export function isTrustedGithubDispatcherMessage(message: TrustedSystemMessageShape): boolean {
+  if (message.source !== "github") return false;
+  if (message.format === "card") {
+    return isGithubEventCardContent(message.content) && hasSystemSender(message.metadata, "github");
+  }
+  return (
+    message.format === "markdown" &&
+    typeof message.content === "string" &&
+    contextReviewManagedMessageMetadataSchema.safeParse(message.metadata).success
+  );
+}
+
+/** Conjunctive trust gate for GitLab dispatcher attribution. */
+export function isTrustedGitlabDispatcherMessage(message: TrustedSystemMessageShape): boolean {
+  return (
+    message.source === "gitlab" &&
+    message.format === "card" &&
+    isGitlabEventCardContent(message.content) &&
+    hasSystemSender(message.metadata, "gitlab")
+  );
+}
+
+/** Resolve the synthetic sender shown to trusted message readers. */
+export function resolveTrustedSystemSender(message: TrustedSystemMessageShape): TrustedSystemSender | null {
+  if (isTrustedGithubDispatcherMessage(message)) return "github";
+  if (isTrustedGitlabDispatcherMessage(message)) return "gitlab";
+  return null;
+}
+
+function hasSystemSender(metadata: unknown, sender: TrustedSystemSender): boolean {
+  return typeof metadata === "object" && metadata !== null && Reflect.get(metadata, "systemSender") === sender;
+}

--- a/packages/web/src/components/chat/github-event-card.tsx
+++ b/packages/web/src/components/chat/github-event-card.tsx
@@ -1,15 +1,15 @@
 import {
-  contextReviewManagedMessageMetadataSchema,
   type GithubEntityType,
   type GithubEventCard,
-  githubEventCardSchema,
+  isGithubEventCardContent,
+  isGithubSystemSenderMetadata,
+  isTrustedGithubDispatcherMessage,
+  TRUSTED_SYSTEM_SENDER_NAMES,
 } from "@first-tree/shared";
 import { Github } from "lucide-react";
 import type { ReactNode } from "react";
 
-export function isGithubEventCardContent(content: unknown): content is GithubEventCard {
-  return githubEventCardSchema.safeParse(content).success;
-}
+export { isGithubEventCardContent, isGithubSystemSenderMetadata, isTrustedGithubDispatcherMessage };
 
 /**
  * The GitHub-dispatcher delivery path writes `systemSender: "github"` into
@@ -19,44 +19,7 @@ export function isGithubEventCardContent(content: unknown): content is GithubEve
  * next to the card so the metadata flag and the visual override stay in
  * lockstep.
  */
-export const GITHUB_SYSTEM_SENDER_NAME = "GitHub";
-
-export function isGithubSystemSenderMetadata(metadata: unknown): boolean {
-  if (typeof metadata !== "object" || metadata === null) return false;
-  return (metadata as { systemSender?: unknown }).systemSender === "github";
-}
-
-/**
- * Conjunctive trust gate for re-attributing a row to the synthetic
- * "GitHub" sender. Metadata alone is not sufficient — `sendMessageSchema`
- * accepts arbitrary `metadata`, so a malicious agent could otherwise post
- * a normal text message with `{ systemSender: "github" }` and have the UI
- * render it as if from GitHub (sender-impersonation / phishing surface
- * flagged in code review). The ordinary dispatcher path uniquely sets a
- * valid GitHub card plus the metadata marker. Managed Context Review wakes
- * are server-authored Markdown, so they instead require the complete
- * versioned managed-event metadata envelope. The message service reserves
- * `systemSender` and `contextReview*` keys, keeping both branches unavailable
- * to regular agent sends.
- */
-type TrustedGithubMessageShape = {
-  source: string | null | undefined;
-  format: string;
-  content: unknown;
-  metadata: unknown;
-};
-
-export function isTrustedGithubDispatcherMessage(msg: TrustedGithubMessageShape): boolean {
-  if (msg.source !== "github") return false;
-  if (msg.format === "card") {
-    return isGithubEventCardContent(msg.content) && isGithubSystemSenderMetadata(msg.metadata);
-  }
-  return (
-    msg.format === "markdown" &&
-    typeof msg.content === "string" &&
-    contextReviewManagedMessageMetadataSchema.safeParse(msg.metadata).success
-  );
-}
+export const GITHUB_SYSTEM_SENDER_NAME = TRUSTED_SYSTEM_SENDER_NAMES.github;
 
 export function GithubSystemAvatar({ size = 20 }: { size?: number }) {
   const dim = `${size}px`;

--- a/packages/web/src/components/chat/gitlab-event-card.tsx
+++ b/packages/web/src/components/chat/gitlab-event-card.tsx
@@ -1,27 +1,14 @@
-import { type GitlabEventCard, gitlabEventCardSchema } from "@first-tree/shared";
+import {
+  type GitlabEventCard,
+  isGitlabEventCardContent,
+  isTrustedGitlabDispatcherMessage,
+  TRUSTED_SYSTEM_SENDER_NAMES,
+} from "@first-tree/shared";
 import { Gitlab } from "lucide-react";
 
-export const GITLAB_SYSTEM_SENDER_NAME = "GitLab";
+export { isGitlabEventCardContent, isTrustedGitlabDispatcherMessage };
 
-export function isGitlabEventCardContent(content: unknown): content is GitlabEventCard {
-  return gitlabEventCardSchema.safeParse(content).success;
-}
-
-export function isTrustedGitlabDispatcherMessage(msg: {
-  source: string | null | undefined;
-  format: string;
-  content: unknown;
-  metadata: unknown;
-}): boolean {
-  return (
-    msg.source === "gitlab" &&
-    msg.format === "card" &&
-    isGitlabEventCardContent(msg.content) &&
-    typeof msg.metadata === "object" &&
-    msg.metadata !== null &&
-    (msg.metadata as { systemSender?: unknown }).systemSender === "gitlab"
-  );
-}
+export const GITLAB_SYSTEM_SENDER_NAME = TRUSTED_SYSTEM_SENDER_NAMES.gitlab;
 
 export function GitlabSystemAvatar({ size = 20 }: { size?: number }) {
   return (


### PR DESCRIPTION
## Summary

- move the existing conjunctive GitHub/GitLab trusted-message classifiers into `@first-tree/shared` so Web and Client use the same attribution gate
- render trusted SCM cards as `[From: GitHub|GitLab · type=system]` in both the current Agent input and preceding silent context
- carry the existing message `source` into optional preceding-context wire data, with safe fallback when older peers omit it
- add shared, Client, Server, and cross-surface QA coverage for trusted attribution and spoof resistance

## Scope and non-goals

This is the short-term agent-visible attribution mitigation discussed in #1886. It does **not** implement first-class system authorship.

The change intentionally leaves the following semantics unchanged:

- database schema and persisted data
- `message.senderId` and its human carrier behavior
- chat membership, ownership, and routing-owner selection
- mentions, wake targets, fan-out, and sender self-skip
- addressable participants and `chat ask` targets

A future first-class system-author model remains a separate design and migration decision.

## Verification

- `pnpm typecheck` passed across the monorepo
- targeted Shared, Client, Web, and Server suites passed (2 + 46 + 39 + 22 tests)
- affected-file Biome checks and `git diff --check` passed
- broader test run passed Web (1,546), Server (2,557), Client (1,621), Shared (645), and QA suites; only the untouched Context Tree audit skill-eval fixture suite timed out locally at existing 15s/25s thresholds, including on isolated retry
- full `pnpm check` remains blocked by pre-existing unrelated issues in `assistant-text.test.ts`, `workspace-migrations.ts`, and `packages/web/src/index.css`; affected files pass targeted checks

## QA

Formal cross-surface QA is warranted because this changes Agent prompt attribution for provider events. The existing GitHub and GitLab webhook QA cases now require checking both current-message and preceding-context headers.

Related to #1886.
