### PR TITLE
fix(web): clear browser data on logout

### DIFF
--- a/packages/web/src/api/__tests__/browser-stores.test.ts
+++ b/packages/web/src/api/__tests__/browser-stores.test.ts
@@ -123,6 +123,20 @@ describe("image-store", () => {
     await expect(getImage("missing")).resolves.toBeNull();
   });
 
+  it("does not expose one account's image cache to another account", async () => {
+    vi.resetModules();
+    globalThis.indexedDB = new IDBFactory();
+    const scope = await import("../../lib/browser-storage-scope.js");
+    scope.setBrowserStorageUser("user-1");
+    const { getImage, putImage } = await import("../image-store.js");
+
+    await putImage({ imageId: "shared-image-id", base64: "secret", mimeType: "image/png" });
+    scope.setBrowserStorageUser("user-2");
+    await expect(getImage("shared-image-id")).resolves.toBeNull();
+    scope.setBrowserStorageUser("user-1");
+    await expect(getImage("shared-image-id")).resolves.toEqual({ base64: "secret", mimeType: "image/png" });
+  });
+
   it("rejects writes and returns null when IndexedDB is unavailable", async () => {
     vi.resetModules();
     delete (globalThis as { indexedDB?: unknown }).indexedDB;

--- a/packages/web/src/api/__tests__/browser-stores.test.ts
+++ b/packages/web/src/api/__tests__/browser-stores.test.ts
@@ -201,6 +201,38 @@ describe("image-store", () => {
     await expect(purge).rejects.toThrow("is still open");
   });
 
+  it("invalidates the issuing scope in memory when storage and broadcast transport are unavailable", async () => {
+    vi.resetModules();
+    const originalBroadcastChannel = globalThis.BroadcastChannel;
+    const originalLocalStorage = globalThis.localStorage;
+    const deniedStorage = {
+      getItem: () => {
+        throw new Error("storage denied");
+      },
+      setItem: () => {
+        throw new Error("storage denied");
+      },
+      removeItem: () => {
+        throw new Error("storage denied");
+      },
+    } as unknown as Storage;
+    Object.defineProperty(globalThis, "localStorage", { configurable: true, value: deniedStorage });
+    Object.defineProperty(globalThis, "BroadcastChannel", { configurable: true, value: undefined });
+    try {
+      const scope = await import("../../lib/browser-storage-scope.js");
+      scope.setBrowserStorageUser("storage-denied-user");
+      const captured = scope.captureBrowserStorageScope();
+      scope.invalidateBrowserStorageScope(captured);
+      expect(scope.isBrowserStorageScopeCurrent(captured)).toBe(false);
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", { configurable: true, value: originalLocalStorage });
+      Object.defineProperty(globalThis, "BroadcastChannel", {
+        configurable: true,
+        value: originalBroadcastChannel,
+      });
+    }
+  });
+
   it("rejects writes and returns null when IndexedDB is unavailable", async () => {
     vi.resetModules();
     delete (globalThis as { indexedDB?: unknown }).indexedDB;

--- a/packages/web/src/api/__tests__/browser-stores.test.ts
+++ b/packages/web/src/api/__tests__/browser-stores.test.ts
@@ -178,6 +178,29 @@ describe("image-store", () => {
     expect(databaseNames.some((name) => name?.endsWith(`:${accountB.key}`))).toBe(true);
   });
 
+  it("rejects promptly when a scoped database deletion is blocked", async () => {
+    vi.resetModules();
+    const deleteRequest: {
+      onsuccess: (() => void) | null;
+      onerror: (() => void) | null;
+      onblocked: (() => void) | null;
+    } = {
+      onsuccess: null,
+      onerror: null,
+      onblocked: null,
+    };
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: { deleteDatabase: () => deleteRequest },
+    });
+    const scope = await import("../../lib/browser-storage-scope.js");
+    scope.setBrowserStorageUser("blocked-user");
+    const purge = scope.clearPersistentBrowserStorage(scope.captureBrowserStorageScope());
+    deleteRequest.onblocked?.();
+
+    await expect(purge).rejects.toThrow("is still open");
+  });
+
   it("rejects writes and returns null when IndexedDB is unavailable", async () => {
     vi.resetModules();
     delete (globalThis as { indexedDB?: unknown }).indexedDB;

--- a/packages/web/src/api/__tests__/browser-stores.test.ts
+++ b/packages/web/src/api/__tests__/browser-stores.test.ts
@@ -137,6 +137,47 @@ describe("image-store", () => {
     await expect(getImage("shared-image-id")).resolves.toEqual({ base64: "secret", mimeType: "image/png" });
   });
 
+  it("purges only the departing account scope and legacy stores", async () => {
+    vi.resetModules();
+    globalThis.indexedDB = new IDBFactory();
+    const storage = new Map<string, string>();
+    const local = {
+      get length() {
+        return storage.size;
+      },
+      clear: () => storage.clear(),
+      getItem: (key: string) => storage.get(key) ?? null,
+      key: (index: number) => [...storage.keys()][index] ?? null,
+      removeItem: (key: string) => storage.delete(key),
+      setItem: (key: string, value: string) => storage.set(key, value),
+    } satisfies Storage;
+    Object.defineProperty(globalThis, "localStorage", { configurable: true, value: local });
+    Object.defineProperty(globalThis, "sessionStorage", { configurable: true, value: local });
+
+    const scope = await import("../../lib/browser-storage-scope.js");
+    const { getImage, putImage } = await import("../image-store.js");
+    scope.setBrowserStorageUser("user-a");
+    const accountA = scope.captureBrowserStorageScope();
+    await putImage({ imageId: "a-image", base64: "a", mimeType: "image/png" }, accountA);
+    local.setItem(scope.scopedStorageKey("first-tree:chat-drafts:v1", accountA), "a-draft");
+    scope.setBrowserStorageUser("user-b");
+    const accountB = scope.captureBrowserStorageScope();
+    await putImage({ imageId: "b-image", base64: "b", mimeType: "image/png" }, accountB);
+    local.setItem(scope.scopedStorageKey("first-tree:chat-drafts:v1", accountB), "b-draft");
+    local.setItem("other-app:key", "keep");
+
+    await scope.clearPersistentBrowserStorage(accountA);
+
+    expect(local.getItem(scope.scopedStorageKey("first-tree:chat-drafts:v1", accountA))).toBeNull();
+    expect(local.getItem(scope.scopedStorageKey("first-tree:chat-drafts:v1", accountB))).toBe("b-draft");
+    expect(local.getItem("other-app:key")).toBe("keep");
+    await expect(getImage("a-image", accountA)).resolves.toBeNull();
+    await expect(getImage("b-image", accountB)).resolves.toEqual({ base64: "b", mimeType: "image/png" });
+    const databaseNames = (await globalThis.indexedDB.databases()).map((database) => database.name);
+    expect(databaseNames.some((name) => name?.endsWith(`:${accountA.key}`))).toBe(false);
+    expect(databaseNames.some((name) => name?.endsWith(`:${accountB.key}`))).toBe(true);
+  });
+
   it("rejects writes and returns null when IndexedDB is unavailable", async () => {
     vi.resetModules();
     delete (globalThis as { indexedDB?: unknown }).indexedDB;
@@ -220,6 +261,19 @@ describe("read-state-store", () => {
     });
 
     await clearReadState("chat-1");
+    await expect(getReadState("chat-1")).resolves.toBeNull();
+  });
+
+  it("does not write read state after the account scope changes", async () => {
+    const { getReadState, setReadState } = await loadReadStateStore();
+    const scope = await import("../../lib/browser-storage-scope.js");
+    scope.setBrowserStorageUser("user-a");
+    const accountA = scope.captureBrowserStorageScope();
+    scope.setBrowserStorageUser("user-b");
+
+    await setReadState("chat-1", "msg-a", "msg-a", accountA);
+    await expect(getReadState("chat-1")).resolves.toBeNull();
+    scope.setBrowserStorageUser("user-a");
     await expect(getReadState("chat-1")).resolves.toBeNull();
   });
 

--- a/packages/web/src/api/__tests__/client-request.test.ts
+++ b/packages/web/src/api/__tests__/client-request.test.ts
@@ -102,6 +102,33 @@ describe("api client request flow", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("does not clear replacement credentials when an old refreshed retry returns 401", async () => {
+    const { api, clearStoredTokens, getStoredTokens, setStoredTokens } = await import("../client.js");
+    setStoredTokens({ accessToken: "a-expired", refreshToken: "a-refresh" });
+    let resolveRetry!: (value: Response) => void;
+    const retryResponse = new Promise<Response>((resolve) => {
+      resolveRetry = resolve;
+    });
+    fetchMock
+      .mockResolvedValueOnce(response(401, { error: "expired" }))
+      .mockResolvedValueOnce(response(200, { accessToken: "a-new", refreshToken: "a-refresh-2" }))
+      .mockReturnValueOnce(retryResponse);
+
+    const pending = api.get("/me");
+    for (let i = 0; i < 10 && fetchMock.mock.calls.length < 3; i += 1) {
+      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    clearStoredTokens();
+    setStoredTokens({ accessToken: "b-access", refreshToken: "b-refresh" });
+    resolveRetry(response(401, { error: "old account rejected" }));
+
+    await expect(pending).rejects.toMatchObject({ status: 401 });
+    expect(getStoredTokens()).toEqual({ accessToken: "b-access", refreshToken: "b-refresh" });
+  });
+
   it("throws ApiError with validation issues and dispatches auth logout on unrecovered 401", async () => {
     const { api, getStoredTokens, setStoredTokens } = await import("../client.js");
     setStoredTokens({ accessToken: "bad", refreshToken: "refresh-bad" });

--- a/packages/web/src/api/__tests__/client-request.test.ts
+++ b/packages/web/src/api/__tests__/client-request.test.ts
@@ -79,6 +79,29 @@ describe("api client request flow", () => {
     expect(getStoredTokens()).toEqual({ accessToken: "access-2", refreshToken: "refresh-2" });
   });
 
+  it("does not resurrect an old account when refresh resolves after logout", async () => {
+    const { api, clearStoredTokens, getStoredTokens, setStoredTokens } = await import("../client.js");
+    setStoredTokens({ accessToken: "a-expired", refreshToken: "a-refresh" });
+    let resolveRefresh!: (value: Response) => void;
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    fetchMock.mockResolvedValueOnce(response(401, { error: "expired" })).mockReturnValueOnce(refreshResponse);
+
+    const pending = api.get("/me");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    clearStoredTokens();
+    setStoredTokens({ accessToken: "b-access", refreshToken: "b-refresh" });
+    resolveRefresh(response(200, { accessToken: "a-new", refreshToken: "a-new-refresh" }));
+
+    await expect(pending).rejects.toMatchObject({ status: 401 });
+    expect(getStoredTokens()).toEqual({ accessToken: "b-access", refreshToken: "b-refresh" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("throws ApiError with validation issues and dispatches auth logout on unrecovered 401", async () => {
     const { api, getStoredTokens, setStoredTokens } = await import("../client.js");
     setStoredTokens({ accessToken: "bad", refreshToken: "refresh-bad" });

--- a/packages/web/src/api/__tests__/message-store.test.ts
+++ b/packages/web/src/api/__tests__/message-store.test.ts
@@ -94,6 +94,19 @@ describe("message-store / cacheMessages", () => {
     expect(rows.map((m) => m.id)).toEqual(["a"]);
     expect(await getCachedMessages("chat-other")).toEqual([]);
   });
+
+  it("rejects a stale account write instead of opening the current account database", async () => {
+    const { cacheMessages, getCachedMessages } = await loadStore();
+    const scope = await import("../../lib/browser-storage-scope.js");
+    scope.setBrowserStorageUser("user-a");
+    const accountA = scope.captureBrowserStorageScope();
+    scope.setBrowserStorageUser("user-b");
+
+    await cacheMessages("chat-1", [msg("secret", T(1))], accountA);
+    await expect(getCachedMessages("chat-1")).resolves.toEqual([]);
+    scope.setBrowserStorageUser("user-a");
+    await expect(getCachedMessages("chat-1")).resolves.toEqual([]);
+  });
 });
 
 describe("message-store / clearChatCache", () => {

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -84,10 +84,12 @@ export function getStoredTokens(): StoredTokens | null {
 
 export function setStoredTokens(tokens: StoredTokens): void {
   localStorage.setItem(TOKEN_KEY, JSON.stringify(tokens));
+  authGeneration += 1;
 }
 
 export function clearStoredTokens(): void {
   localStorage.removeItem(TOKEN_KEY);
+  authGeneration += 1;
 }
 
 /**
@@ -117,7 +119,8 @@ export class ApiError extends Error {
   }
 }
 
-let refreshPromise: Promise<StoredTokens | null> | null = null;
+let authGeneration = 0;
+let refreshInFlight: { refreshToken: string; generation: number; promise: Promise<StoredTokens | null> } | null = null;
 
 /**
  * Refresh the stored access token via `/auth/refresh`. Reads the current
@@ -136,10 +139,11 @@ export async function refreshAccessToken(): Promise<StoredTokens | null> {
 }
 
 async function tryRefresh(refreshToken: string): Promise<StoredTokens | null> {
-  // Deduplicate concurrent refresh attempts
-  if (refreshPromise) return refreshPromise;
-
-  refreshPromise = (async () => {
+  // Deduplicate only callers for the same credential. A new account must not
+  // inherit a refresh promise started by the previous account.
+  if (refreshInFlight?.refreshToken === refreshToken) return refreshInFlight.promise;
+  const generation = authGeneration;
+  const promise = (async () => {
     try {
       const res = await fetch(`${BASE_URL}/auth/refresh`, {
         method: "POST",
@@ -156,16 +160,22 @@ async function tryRefresh(refreshToken: string): Promise<StoredTokens | null> {
         accessToken: body.accessToken,
         refreshToken: body.refreshToken ?? refreshToken,
       };
+      // Logout/login/adoptTokens may have replaced the credential while the
+      // provider request was in flight. Discard the old response before it can
+      // repopulate storage or be used for a retry under the new account.
+      if (generation !== authGeneration || getStoredTokens()?.refreshToken !== refreshToken) return null;
       setStoredTokens(updated);
       return updated;
     } catch {
       return null;
     } finally {
-      refreshPromise = null;
+      if (refreshInFlight?.refreshToken === refreshToken && refreshInFlight.generation === generation) {
+        refreshInFlight = null;
+      }
     }
   })();
-
-  return refreshPromise;
+  refreshInFlight = { refreshToken, generation, promise };
+  return promise;
 }
 
 async function request<T>(
@@ -192,13 +202,19 @@ async function request<T>(
   };
 
   const tokens = getStoredTokens();
+  const requestGeneration = authGeneration;
   let res = await doFetch(tokens?.accessToken);
 
   // Attempt token refresh on 401
   if (res.status === 401 && tokens?.refreshToken) {
     const refreshed = await tryRefresh(tokens.refreshToken);
     if (refreshed) {
+      if (getStoredTokens()?.accessToken !== refreshed.accessToken) {
+        throw new ApiError(401, "Authentication changed while refreshing");
+      }
       res = await doFetch(refreshed.accessToken);
+    } else if (authGeneration !== requestGeneration) {
+      throw new ApiError(401, "Authentication changed while refreshing");
     }
   }
 
@@ -249,12 +265,18 @@ export async function apiFetchRaw(
   };
 
   const tokens = getStoredTokens();
+  const requestGeneration = authGeneration;
   let res = await doFetch(tokens?.accessToken);
 
   if (res.status === 401 && tokens?.refreshToken) {
     const refreshed = await tryRefresh(tokens.refreshToken);
     if (refreshed) {
+      if (getStoredTokens()?.accessToken !== refreshed.accessToken) {
+        throw new ApiError(401, "Authentication changed while refreshing");
+      }
       res = await doFetch(refreshed.accessToken);
+    } else if (authGeneration !== requestGeneration) {
+      throw new ApiError(401, "Authentication changed while refreshing");
     }
   }
 

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -1,3 +1,5 @@
+import { BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT } from "../lib/browser-storage-scope.js";
+
 const BASE_URL = "/api/v1";
 const TOKEN_KEY = "first-tree:tokens";
 
@@ -122,6 +124,13 @@ export class ApiError extends Error {
 let authGeneration = 0;
 let refreshInFlight: { refreshToken: string; generation: number; promise: Promise<StoredTokens | null> } | null = null;
 
+if (typeof window !== "undefined") {
+  window.addEventListener(BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT, () => {
+    authGeneration += 1;
+    refreshInFlight = null;
+  });
+}
+
 /**
  * Refresh the stored access token via `/auth/refresh`. Reads the current
  * refresh token from `localStorage` and persists the new pair on success.
@@ -203,6 +212,8 @@ async function request<T>(
 
   const tokens = getStoredTokens();
   const requestGeneration = authGeneration;
+  let responseGeneration = requestGeneration;
+  let responseAccessToken = tokens?.accessToken;
   let res = await doFetch(tokens?.accessToken);
 
   // Attempt token refresh on 401
@@ -212,6 +223,8 @@ async function request<T>(
       if (getStoredTokens()?.accessToken !== refreshed.accessToken) {
         throw new ApiError(401, "Authentication changed while refreshing");
       }
+      responseGeneration = authGeneration;
+      responseAccessToken = refreshed.accessToken;
       res = await doFetch(refreshed.accessToken);
     } else if (authGeneration !== requestGeneration) {
       throw new ApiError(401, "Authentication changed while refreshing");
@@ -220,6 +233,10 @@ async function request<T>(
 
   if (!res.ok) {
     if (res.status === 401) {
+      const current = getStoredTokens();
+      if (authGeneration !== responseGeneration || current?.accessToken !== responseAccessToken) {
+        throw new ApiError(401, "Authentication changed while requesting");
+      }
       clearStoredTokens();
       window.dispatchEvent(new CustomEvent("auth:logout"));
     }
@@ -266,6 +283,8 @@ export async function apiFetchRaw(
 
   const tokens = getStoredTokens();
   const requestGeneration = authGeneration;
+  let responseGeneration = requestGeneration;
+  let responseAccessToken = tokens?.accessToken;
   let res = await doFetch(tokens?.accessToken);
 
   if (res.status === 401 && tokens?.refreshToken) {
@@ -274,6 +293,8 @@ export async function apiFetchRaw(
       if (getStoredTokens()?.accessToken !== refreshed.accessToken) {
         throw new ApiError(401, "Authentication changed while refreshing");
       }
+      responseGeneration = authGeneration;
+      responseAccessToken = refreshed.accessToken;
       res = await doFetch(refreshed.accessToken);
     } else if (authGeneration !== requestGeneration) {
       throw new ApiError(401, "Authentication changed while refreshing");
@@ -282,6 +303,10 @@ export async function apiFetchRaw(
 
   if (!res.ok) {
     if (res.status === 401) {
+      const current = getStoredTokens();
+      if (authGeneration !== responseGeneration || current?.accessToken !== responseAccessToken) {
+        throw new ApiError(401, "Authentication changed while requesting");
+      }
       clearStoredTokens();
       window.dispatchEvent(new CustomEvent("auth:logout"));
     }

--- a/packages/web/src/api/image-store.ts
+++ b/packages/web/src/api/image-store.ts
@@ -7,7 +7,13 @@
  * dead-end like the old IndexedDB-only design.
  */
 
-import { getBrowserStorageRevision, scopedDatabaseName } from "../lib/browser-storage-scope.js";
+import {
+  type BrowserStorageScope,
+  captureBrowserStorageScope,
+  getBrowserStorageRevision,
+  isBrowserStorageScopeCurrent,
+  scopedDatabaseName,
+} from "../lib/browser-storage-scope.js";
 
 const DB_NAME = "first-tree-images";
 const DB_VERSION = 1;
@@ -23,7 +29,7 @@ type Stored = {
 let dbPromise: Promise<IDBDatabase | null> | null = null;
 let dbRevision = -1;
 
-function openDb(): Promise<IDBDatabase | null> {
+function openDb(scope: BrowserStorageScope): Promise<IDBDatabase | null> {
   const revision = getBrowserStorageRevision();
   if (dbPromise && dbRevision === revision) return dbPromise;
   dbRevision = revision;
@@ -32,7 +38,7 @@ function openDb(): Promise<IDBDatabase | null> {
       resolve(null);
       return;
     }
-    const req = indexedDB.open(scopedDatabaseName(DB_NAME), DB_VERSION);
+    const req = indexedDB.open(scopedDatabaseName(DB_NAME, scope), DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(STORE)) {
@@ -56,11 +62,16 @@ function openDb(): Promise<IDBDatabase | null> {
  * so a rejection is non-fatal — callers should swallow it and let the render
  * path re-fetch from the server on the next view.
  */
-export async function putImage(params: { imageId: string; base64: string; mimeType: string }): Promise<void> {
-  const db = await openDb();
+export async function putImage(
+  params: { imageId: string; base64: string; mimeType: string },
+  scope: BrowserStorageScope = captureBrowserStorageScope(),
+): Promise<void> {
+  if (!isBrowserStorageScopeCurrent(scope)) return;
+  const db = await openDb(scope);
   if (!db) {
     throw new Error("Image storage unavailable (IndexedDB disabled or blocked)");
   }
+  if (!isBrowserStorageScopeCurrent(scope)) return;
   await new Promise<void>((resolve, reject) => {
     const tx = db.transaction(STORE, "readwrite");
     const store = tx.objectStore(STORE);
@@ -77,14 +88,23 @@ export async function putImage(params: { imageId: string; base64: string; mimeTy
   });
 }
 
-export async function getImage(imageId: string): Promise<{ base64: string; mimeType: string } | null> {
-  const db = await openDb();
+export async function getImage(
+  imageId: string,
+  scope: BrowserStorageScope = captureBrowserStorageScope(),
+): Promise<{ base64: string; mimeType: string } | null> {
+  if (!isBrowserStorageScopeCurrent(scope)) return null;
+  const db = await openDb(scope);
   if (!db) return null;
+  if (!isBrowserStorageScopeCurrent(scope)) return null;
   return new Promise((resolve) => {
     const tx = db.transaction(STORE, "readonly");
     const store = tx.objectStore(STORE);
     const req = store.get(imageId);
     req.onsuccess = () => {
+      if (!isBrowserStorageScopeCurrent(scope)) {
+        resolve(null);
+        return;
+      }
       const row = req.result as Stored | undefined;
       if (!row) {
         resolve(null);

--- a/packages/web/src/api/image-store.ts
+++ b/packages/web/src/api/image-store.ts
@@ -7,6 +7,8 @@
  * dead-end like the old IndexedDB-only design.
  */
 
+import { getBrowserStorageRevision, scopedDatabaseName } from "../lib/browser-storage-scope.js";
+
 const DB_NAME = "first-tree-images";
 const DB_VERSION = 1;
 const STORE = "images";
@@ -19,22 +21,28 @@ type Stored = {
 };
 
 let dbPromise: Promise<IDBDatabase | null> | null = null;
+let dbRevision = -1;
 
 function openDb(): Promise<IDBDatabase | null> {
-  if (dbPromise) return dbPromise;
+  const revision = getBrowserStorageRevision();
+  if (dbPromise && dbRevision === revision) return dbPromise;
+  dbRevision = revision;
   dbPromise = new Promise((resolve) => {
     if (typeof indexedDB === "undefined") {
       resolve(null);
       return;
     }
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    const req = indexedDB.open(scopedDatabaseName(DB_NAME), DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(STORE)) {
         db.createObjectStore(STORE, { keyPath: "imageId" });
       }
     };
-    req.onsuccess = () => resolve(req.result);
+    req.onsuccess = () => {
+      req.result.onversionchange = () => req.result.close();
+      resolve(req.result);
+    };
     req.onerror = () => resolve(null);
     req.onblocked = () => resolve(null);
   });

--- a/packages/web/src/api/message-store.ts
+++ b/packages/web/src/api/message-store.ts
@@ -22,7 +22,13 @@
  * issue first-tree-all 119 under parent first-tree-all 118.
  */
 
-import { getBrowserStorageRevision, scopedDatabaseName } from "../lib/browser-storage-scope.js";
+import {
+  type BrowserStorageScope,
+  captureBrowserStorageScope,
+  getBrowserStorageRevision,
+  isBrowserStorageScopeCurrent,
+  scopedDatabaseName,
+} from "../lib/browser-storage-scope.js";
 import type { MessageWithDelivery } from "./chats.js";
 
 const DB_NAME = "first-tree-chat-cache";
@@ -53,7 +59,7 @@ type StoredMessage = {
 let dbPromise: Promise<IDBDatabase | null> | null = null;
 let dbRevision = -1;
 
-function openDb(): Promise<IDBDatabase | null> {
+function openDb(scope: BrowserStorageScope): Promise<IDBDatabase | null> {
   const revision = getBrowserStorageRevision();
   if (dbPromise && dbRevision === revision) return dbPromise;
   dbRevision = revision;
@@ -62,7 +68,7 @@ function openDb(): Promise<IDBDatabase | null> {
       resolve(null);
       return;
     }
-    const req = indexedDB.open(scopedDatabaseName(DB_NAME), DB_VERSION);
+    const req = indexedDB.open(scopedDatabaseName(DB_NAME, scope), DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(STORE)) {
@@ -91,9 +97,14 @@ function openDb(): Promise<IDBDatabase | null> {
  * (oldest first, matching the timeline render order). Returns an empty
  * array on cache miss or if IndexedDB is unavailable — never throws.
  */
-export async function getCachedMessages(chatId: string): Promise<MessageWithDelivery[]> {
-  const db = await openDb();
+export async function getCachedMessages(
+  chatId: string,
+  scope: BrowserStorageScope = captureBrowserStorageScope(),
+): Promise<MessageWithDelivery[]> {
+  if (!isBrowserStorageScopeCurrent(scope)) return [];
+  const db = await openDb(scope);
   if (!db) return [];
+  if (!isBrowserStorageScopeCurrent(scope)) return [];
   return new Promise((resolve) => {
     const tx = db.transaction(STORE, "readonly");
     const store = tx.objectStore(STORE);
@@ -110,9 +121,9 @@ export async function getCachedMessages(chatId: string): Promise<MessageWithDeli
       out.push(row.payload);
       cursor.continue();
     };
-    tx.oncomplete = () => resolve(out);
-    tx.onerror = () => resolve(out);
-    tx.onabort = () => resolve(out);
+    tx.oncomplete = () => resolve(isBrowserStorageScopeCurrent(scope) ? out : []);
+    tx.onerror = () => resolve(isBrowserStorageScopeCurrent(scope) ? out : []);
+    tx.onabort = () => resolve(isBrowserStorageScopeCurrent(scope) ? out : []);
   });
 }
 
@@ -125,10 +136,16 @@ export async function getCachedMessages(chatId: string): Promise<MessageWithDeli
  * Returns silently on IndexedDB unavailability so write-through can be
  * fire-and-forget (`void cacheMessages(...)`) at the call site.
  */
-export async function cacheMessages(chatId: string, messages: readonly MessageWithDelivery[]): Promise<void> {
+export async function cacheMessages(
+  chatId: string,
+  messages: readonly MessageWithDelivery[],
+  scope: BrowserStorageScope = captureBrowserStorageScope(),
+): Promise<void> {
   if (messages.length === 0) return;
-  const db = await openDb();
+  if (!isBrowserStorageScopeCurrent(scope)) return;
+  const db = await openDb(scope);
   if (!db) return;
+  if (!isBrowserStorageScopeCurrent(scope)) return;
   await new Promise<void>((resolve) => {
     const tx = db.transaction(STORE, "readwrite");
     const store = tx.objectStore(STORE);
@@ -155,9 +172,14 @@ export async function cacheMessages(chatId: string, messages: readonly MessageWi
  * debug use today (e.g. clearing a corrupt cache); not wired into the
  * UI. Resolves silently on IndexedDB unavailability.
  */
-export async function clearChatCache(chatId: string): Promise<void> {
-  const db = await openDb();
+export async function clearChatCache(
+  chatId: string,
+  scope: BrowserStorageScope = captureBrowserStorageScope(),
+): Promise<void> {
+  if (!isBrowserStorageScopeCurrent(scope)) return;
+  const db = await openDb(scope);
   if (!db) return;
+  if (!isBrowserStorageScopeCurrent(scope)) return;
   await new Promise<void>((resolve) => {
     const tx = db.transaction(STORE, "readwrite");
     const store = tx.objectStore(STORE);

--- a/packages/web/src/api/message-store.ts
+++ b/packages/web/src/api/message-store.ts
@@ -22,6 +22,7 @@
  * issue first-tree-all 119 under parent first-tree-all 118.
  */
 
+import { getBrowserStorageRevision, scopedDatabaseName } from "../lib/browser-storage-scope.js";
 import type { MessageWithDelivery } from "./chats.js";
 
 const DB_NAME = "first-tree-chat-cache";
@@ -50,15 +51,18 @@ type StoredMessage = {
 };
 
 let dbPromise: Promise<IDBDatabase | null> | null = null;
+let dbRevision = -1;
 
 function openDb(): Promise<IDBDatabase | null> {
-  if (dbPromise) return dbPromise;
+  const revision = getBrowserStorageRevision();
+  if (dbPromise && dbRevision === revision) return dbPromise;
+  dbRevision = revision;
   dbPromise = new Promise((resolve) => {
     if (typeof indexedDB === "undefined") {
       resolve(null);
       return;
     }
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    const req = indexedDB.open(scopedDatabaseName(DB_NAME), DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(STORE)) {
@@ -72,7 +76,10 @@ function openDb(): Promise<IDBDatabase | null> {
         db.createObjectStore(READ_STATE_STORE, { keyPath: "chatId" });
       }
     };
-    req.onsuccess = () => resolve(req.result);
+    req.onsuccess = () => {
+      req.result.onversionchange = () => req.result.close();
+      resolve(req.result);
+    };
     req.onerror = () => resolve(null);
     req.onblocked = () => resolve(null);
   });

--- a/packages/web/src/api/read-state-store.ts
+++ b/packages/web/src/api/read-state-store.ts
@@ -29,6 +29,8 @@
  * 120.
  */
 
+import { getBrowserStorageRevision, scopedDatabaseName } from "../lib/browser-storage-scope.js";
+
 const DB_NAME = "first-tree-chat-cache";
 const DB_VERSION = 2;
 const MESSAGES_STORE = "messages";
@@ -64,15 +66,18 @@ export type ReadState = {
 };
 
 let dbPromise: Promise<IDBDatabase | null> | null = null;
+let dbRevision = -1;
 
 function openDb(): Promise<IDBDatabase | null> {
-  if (dbPromise) return dbPromise;
+  const revision = getBrowserStorageRevision();
+  if (dbPromise && dbRevision === revision) return dbPromise;
+  dbRevision = revision;
   dbPromise = new Promise((resolve) => {
     if (typeof indexedDB === "undefined") {
       resolve(null);
       return;
     }
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    const req = indexedDB.open(scopedDatabaseName(DB_NAME), DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(MESSAGES_STORE)) {
@@ -83,7 +88,10 @@ function openDb(): Promise<IDBDatabase | null> {
         db.createObjectStore(READ_STATE_STORE, { keyPath: "chatId" });
       }
     };
-    req.onsuccess = () => resolve(req.result);
+    req.onsuccess = () => {
+      req.result.onversionchange = () => req.result.close();
+      resolve(req.result);
+    };
     req.onerror = () => resolve(null);
     req.onblocked = () => resolve(null);
   });

--- a/packages/web/src/api/read-state-store.ts
+++ b/packages/web/src/api/read-state-store.ts
@@ -29,7 +29,13 @@
  * 120.
  */
 
-import { getBrowserStorageRevision, scopedDatabaseName } from "../lib/browser-storage-scope.js";
+import {
+  type BrowserStorageScope,
+  captureBrowserStorageScope,
+  getBrowserStorageRevision,
+  isBrowserStorageScopeCurrent,
+  scopedDatabaseName,
+} from "../lib/browser-storage-scope.js";
 
 const DB_NAME = "first-tree-chat-cache";
 const DB_VERSION = 2;
@@ -68,7 +74,7 @@ export type ReadState = {
 let dbPromise: Promise<IDBDatabase | null> | null = null;
 let dbRevision = -1;
 
-function openDb(): Promise<IDBDatabase | null> {
+function openDb(scope: BrowserStorageScope): Promise<IDBDatabase | null> {
   const revision = getBrowserStorageRevision();
   if (dbPromise && dbRevision === revision) return dbPromise;
   dbRevision = revision;
@@ -77,7 +83,7 @@ function openDb(): Promise<IDBDatabase | null> {
       resolve(null);
       return;
     }
-    const req = indexedDB.open(scopedDatabaseName(DB_NAME), DB_VERSION);
+    const req = indexedDB.open(scopedDatabaseName(DB_NAME, scope), DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(MESSAGES_STORE)) {
@@ -103,16 +109,21 @@ function openDb(): Promise<IDBDatabase | null> {
  * cache miss, on IndexedDB unavailability, or on any read error —
  * never throws.
  */
-export async function getReadState(chatId: string): Promise<ReadState | null> {
-  const db = await openDb();
+export async function getReadState(
+  chatId: string,
+  scope: BrowserStorageScope = captureBrowserStorageScope(),
+): Promise<ReadState | null> {
+  if (!isBrowserStorageScopeCurrent(scope)) return null;
+  const db = await openDb(scope);
   if (!db) return null;
+  if (!isBrowserStorageScopeCurrent(scope)) return null;
   return new Promise((resolve) => {
     const tx = db.transaction(READ_STATE_STORE, "readonly");
     const store = tx.objectStore(READ_STATE_STORE);
     const req = store.get(chatId);
     req.onsuccess = () => {
       const row = req.result as ReadState | undefined;
-      resolve(row ?? null);
+      resolve(isBrowserStorageScopeCurrent(scope) ? (row ?? null) : null);
     };
     req.onerror = () => resolve(null);
     tx.onabort = () => resolve(null);
@@ -133,9 +144,12 @@ export async function setReadState(
   chatId: string,
   bottomVisibleMessageId: string,
   latestKnownMessageId: string,
+  scope: BrowserStorageScope = captureBrowserStorageScope(),
 ): Promise<void> {
-  const db = await openDb();
+  if (!isBrowserStorageScopeCurrent(scope)) return;
+  const db = await openDb(scope);
   if (!db) return;
+  if (!isBrowserStorageScopeCurrent(scope)) return;
   await new Promise<void>((resolve) => {
     const tx = db.transaction(READ_STATE_STORE, "readwrite");
     const store = tx.objectStore(READ_STATE_STORE);
@@ -157,9 +171,14 @@ export async function setReadState(
  * diagnostic / debug use today; the production UI never calls this.
  * Resolves silently on IndexedDB unavailability.
  */
-export async function clearReadState(chatId: string): Promise<void> {
-  const db = await openDb();
+export async function clearReadState(
+  chatId: string,
+  scope: BrowserStorageScope = captureBrowserStorageScope(),
+): Promise<void> {
+  if (!isBrowserStorageScopeCurrent(scope)) return;
+  const db = await openDb(scope);
   if (!db) return;
+  if (!isBrowserStorageScopeCurrent(scope)) return;
   await new Promise<void>((resolve) => {
     const tx = db.transaction(READ_STATE_STORE, "readwrite");
     const store = tx.objectStore(READ_STATE_STORE);

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -311,22 +311,25 @@ describe("AuthProvider", () => {
   it("clears persisted browser data on logout before a returning sign-in", async () => {
     // /me's default (most-recent) is org-1, but the user last used org-2.
     localStorage.setItem("first-tree:selectedOrganizationId:user-1", "org-2");
-    localStorage.setItem("first-tree:chat-drafts:v1:chat-cache", JSON.stringify({ draft: "secret" }));
-    sessionStorage.setItem("first-tree:pending-image", "secret-image");
     apiMocks.getStoredTokens.mockReturnValue({ accessToken: "access", refreshToken: "refresh" });
 
     await renderAuth();
     expect(latestAuth?.currentMembership?.organizationId).toBe("org-2");
+    const storageScope = await import("../../lib/browser-storage-scope.js");
+    const departingScope = storageScope.captureBrowserStorageScope();
+    const draftKey = storageScope.scopedStorageKey("first-tree:chat-drafts:v1", departingScope);
+    localStorage.setItem(draftKey, JSON.stringify({ draft: "secret" }));
+    localStorage.setItem("other-app:key", "keep");
 
-    // Logout clears all browser-local app data; a returning sign-in starts
-    // from the server's current default rather than stale local state.
+    // Logout clears the departing account's browser-local data; a returning
+    // sign-in starts from the server's current default rather than stale state.
     await act(async () => {
       window.dispatchEvent(new CustomEvent("auth:logout"));
     });
     expect(latestAuth?.isAuthenticated).toBe(false);
     expect(localStorage.getItem("first-tree:selectedOrganizationId:user-1")).toBeNull();
-    expect(localStorage.getItem("first-tree:chat-drafts:v1:chat-cache")).toBeNull();
-    expect(sessionStorage.getItem("first-tree:pending-image")).toBeNull();
+    expect(localStorage.getItem(draftKey)).toBeNull();
+    expect(localStorage.getItem("other-app:key")).toBe("keep");
 
     // Returning sign-in uses the server default org-1.
     apiMocks.setApiSelectedOrganizationId.mockClear();

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -400,6 +400,7 @@ describe("AuthProvider", () => {
 
     expect(apiMocks.clearStoredTokens).not.toHaveBeenCalled();
     expect(latestAuth?.isAuthenticated).toBe(false);
+    expect(container?.querySelectorAll('[role="status"]').length).toBe(0);
     delete (globalThis as { indexedDB?: unknown }).indexedDB;
   });
 

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -204,6 +204,28 @@ describe("AuthProvider", () => {
     expect(latestAuth?.currentMembership?.organizationId).toBe("org-2");
   });
 
+  it("keeps the token-derived scope when /me is temporarily unavailable so logout purges it", async () => {
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+    apiMocks.apiGet.mockRejectedValueOnce(new Error("offline"));
+
+    await renderAuth();
+    const storageScope = await import("../../lib/browser-storage-scope.js");
+    const departingScope = storageScope.captureBrowserStorageScope();
+    const draftKey = storageScope.scopedStorageKey("first-tree:chat-drafts:v1", departingScope);
+    localStorage.setItem(draftKey, "secret");
+    expect(departingScope.userId).toBe("user-1");
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("auth:logout"));
+    });
+
+    expect(localStorage.getItem(draftKey)).toBeNull();
+    expect(latestAuth?.isAuthenticated).toBe(false);
+  });
+
   it("ignores unreadable persisted organization storage and rolls back failed dismiss", async () => {
     const throwingStorage = {
       get length() {
@@ -306,6 +328,30 @@ describe("AuthProvider", () => {
     expect(apiMocks.clearStoredTokens).toHaveBeenCalled();
     expect(flagsMocks.clearOnboardingSessionFlags).toHaveBeenCalled();
     expect(latestAuth?.isAuthenticated).toBe(false);
+  });
+
+  it("invalidates the active account when another tab publishes a storage-scope logout", async () => {
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+    await renderAuth();
+    const scope = await import("../../lib/browser-storage-scope.js");
+    const account = scope.captureBrowserStorageScope();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "first-tree:invalidated-scopes:v1",
+          newValue: JSON.stringify([account.key]),
+        }),
+      );
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(latestAuth?.isAuthenticated).toBe(false);
+    expect(scope.isBrowserStorageScopeCurrent(account)).toBe(false);
   });
 
   it("clears persisted browser data on logout before a returning sign-in", async () => {

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -151,6 +151,7 @@ async function renderAuth(children?: ReactNode): Promise<void> {
 
 beforeEach(() => {
   vi.resetModules();
+  vi.stubGlobal("BroadcastChannel", undefined);
   setupDom();
   document.body.innerHTML = "";
   latestAuth = null;
@@ -178,6 +179,7 @@ afterEach(async () => {
     await act(async () => root?.unmount());
   }
   document.body.innerHTML = "";
+  vi.unstubAllGlobals();
 });
 
 describe("AuthProvider", () => {
@@ -401,6 +403,49 @@ describe("AuthProvider", () => {
     delete (globalThis as { indexedDB?: unknown }).indexedDB;
   });
 
+  it("does not finalize an older local logout after adopting replacement credentials", async () => {
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh-a",
+    });
+    await renderAuth();
+    const requests: Array<{ onsuccess: (() => void) | null }> = [];
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: {
+        deleteDatabase: () => {
+          const request = { onsuccess: null as (() => void) | null };
+          requests.push(request);
+          return request;
+        },
+      },
+    });
+
+    let logoutResult: Promise<boolean> = Promise.resolve(false);
+    await act(async () => {
+      logoutResult = latestAuth?.logout({ broadcast: false }) ?? Promise.resolve(false);
+      await Promise.resolve();
+    });
+    expect(requests.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      await latestAuth?.adoptTokens({
+        accessToken: tokenWithPayload({ sub: "user-2" }),
+        refreshToken: "refresh-b",
+      });
+    });
+    expect(latestAuth?.isAuthenticated).toBe(true);
+    await act(async () => {
+      for (const request of requests) request.onsuccess?.();
+      await logoutResult;
+    });
+
+    await expect(logoutResult).resolves.toBe(false);
+    expect(latestAuth?.isAuthenticated).toBe(true);
+    expect(apiMocks.clearStoredTokens).not.toHaveBeenCalled();
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+  });
+
   it("keeps the session available for retry when logout purge is blocked", async () => {
     apiMocks.getStoredTokens.mockReturnValue({
       accessToken: tokenWithPayload({ sub: "user-1" }),
@@ -467,6 +512,19 @@ describe("AuthProvider", () => {
     expect(latestAuth?.isAuthenticated).toBe(false);
     expect(latestAuth?.logoutStatus).toBe("incomplete");
     expect(document.body.textContent).toContain("Sign out incomplete");
+    const firstRequestCount = requests.length;
+    const retry = [...document.querySelectorAll("button")].find((button) => button.textContent?.includes("Retry"));
+    await act(async () => {
+      retry?.click();
+      await Promise.resolve();
+    });
+    expect(requests.length).toBeGreaterThan(firstRequestCount);
+    await act(async () => {
+      for (const request of requests.slice(firstRequestCount)) request.onblocked?.();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container?.querySelectorAll('[role="status"]').length).toBe(1);
     delete (globalThis as { indexedDB?: unknown }).indexedDB;
   });
 

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -394,12 +394,18 @@ describe("AuthProvider", () => {
       refreshToken: "refresh-b",
     };
     await act(async () => {
+      await latestAuth?.adoptTokens({
+        accessToken: currentTokens.accessToken,
+        refreshToken: currentTokens.refreshToken,
+      });
+    });
+    await act(async () => {
       for (const request of requests) request.onsuccess?.();
       await Promise.resolve();
     });
 
     expect(apiMocks.clearStoredTokens).not.toHaveBeenCalled();
-    expect(latestAuth?.isAuthenticated).toBe(false);
+    expect(latestAuth?.isAuthenticated).toBe(true);
     expect(container?.querySelectorAll('[role="status"]').length).toBe(0);
     delete (globalThis as { indexedDB?: unknown }).indexedDB;
   });

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -308,30 +308,34 @@ describe("AuthProvider", () => {
     expect(latestAuth?.isAuthenticated).toBe(false);
   });
 
-  it("keeps the persisted org across logout so a returning sign-in lands back in the last-used org", async () => {
+  it("clears persisted browser data on logout before a returning sign-in", async () => {
     // /me's default (most-recent) is org-1, but the user last used org-2.
     localStorage.setItem("first-tree:selectedOrganizationId:user-1", "org-2");
+    localStorage.setItem("first-tree:chat-drafts:v1:chat-cache", JSON.stringify({ draft: "secret" }));
+    sessionStorage.setItem("first-tree:pending-image", "secret-image");
     apiMocks.getStoredTokens.mockReturnValue({ accessToken: "access", refreshToken: "refresh" });
 
     await renderAuth();
     expect(latestAuth?.currentMembership?.organizationId).toBe("org-2");
 
-    // Logout must NOT wipe the persisted org — it's how a returning sign-in
-    // restores the last-used org instead of jumping to the most-recent one.
+    // Logout clears all browser-local app data; a returning sign-in starts
+    // from the server's current default rather than stale local state.
     await act(async () => {
       window.dispatchEvent(new CustomEvent("auth:logout"));
     });
     expect(latestAuth?.isAuthenticated).toBe(false);
-    expect(localStorage.getItem("first-tree:selectedOrganizationId:user-1")).toBe("org-2");
+    expect(localStorage.getItem("first-tree:selectedOrganizationId:user-1")).toBeNull();
+    expect(localStorage.getItem("first-tree:chat-drafts:v1:chat-cache")).toBeNull();
+    expect(sessionStorage.getItem("first-tree:pending-image")).toBeNull();
 
-    // Returning sign-in: fetchMe restores org-2, not the server default org-1.
+    // Returning sign-in uses the server default org-1.
     apiMocks.setApiSelectedOrganizationId.mockClear();
     await act(async () => {
       await latestAuth?.adoptTokens({ accessToken: "access-2", refreshToken: "refresh-2" });
     });
     await flush();
-    expect(latestAuth?.currentMembership?.organizationId).toBe("org-2");
-    expect(apiMocks.setApiSelectedOrganizationId).toHaveBeenLastCalledWith("org-2");
+    expect(latestAuth?.currentMembership?.organizationId).toBe("org-1");
+    expect(apiMocks.setApiSelectedOrganizationId).toHaveBeenLastCalledWith("org-1");
   });
 
   it("falls back to the server default when the persisted org is no longer a membership", async () => {

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -409,12 +409,12 @@ describe("AuthProvider", () => {
       refreshToken: "refresh-a",
     });
     await renderAuth();
-    const requests: Array<{ onsuccess: (() => void) | null }> = [];
+    const requests: Array<{ onsuccess: (() => void) | null; onblocked: (() => void) | null }> = [];
     Object.defineProperty(globalThis, "indexedDB", {
       configurable: true,
       value: {
         deleteDatabase: () => {
-          const request = { onsuccess: null as (() => void) | null };
+          const request = { onsuccess: null as (() => void) | null, onblocked: null as (() => void) | null };
           requests.push(request);
           return request;
         },
@@ -422,8 +422,13 @@ describe("AuthProvider", () => {
     });
 
     let logoutResult: Promise<"completed" | "incomplete" | "superseded"> = Promise.resolve("incomplete");
+    let retryOperation: (() => Promise<"completed" | "incomplete" | "superseded">) | undefined;
     await act(async () => {
-      logoutResult = latestAuth?.logout({ broadcast: false }) ?? Promise.resolve("incomplete");
+      logoutResult =
+        latestAuth?.logout({
+          broadcast: false,
+          onIncomplete: (retry) => (retryOperation = retry),
+        }) ?? Promise.resolve("incomplete");
       await Promise.resolve();
     });
     expect(requests.length).toBeGreaterThan(0);
@@ -436,24 +441,38 @@ describe("AuthProvider", () => {
     });
     expect(latestAuth?.isAuthenticated).toBe(true);
     await act(async () => {
-      for (const request of requests) request.onsuccess?.();
+      for (const request of requests) request.onblocked?.();
       await logoutResult;
     });
 
-    await expect(logoutResult).resolves.toBe("superseded");
+    await expect(logoutResult).resolves.toBe("incomplete");
+    expect(retryOperation).toBeDefined();
     expect(latestAuth?.isAuthenticated).toBe(true);
-    const firstRequestCount = requests.length;
-    let retryResult: Promise<"completed" | "incomplete" | "superseded"> = Promise.resolve("incomplete");
+    const beforeBLogout = requests.length;
+    let bLogout: Promise<"completed" | "incomplete" | "superseded"> = Promise.resolve("incomplete");
     await act(async () => {
-      retryResult = latestAuth?.retryLogout?.() ?? Promise.resolve("incomplete");
+      bLogout = latestAuth?.logout({ broadcast: false }) ?? Promise.resolve("incomplete");
       await Promise.resolve();
     });
-    expect(requests.length).toBeGreaterThan(firstRequestCount);
+    const beforeRetry = requests.length;
+    expect(beforeRetry).toBeGreaterThan(beforeBLogout);
+    let retryResult: Promise<"completed" | "incomplete" | "superseded"> = Promise.resolve("incomplete");
     await act(async () => {
-      for (const request of requests.slice(firstRequestCount)) request.onsuccess?.();
+      retryResult = retryOperation?.() ?? Promise.resolve("incomplete");
+      await Promise.resolve();
+    });
+    expect(requests.length).toBeGreaterThan(beforeRetry);
+    await act(async () => {
+      for (const request of requests.slice(beforeRetry)) request.onsuccess?.();
       await retryResult;
     });
     await expect(retryResult).resolves.toBe("superseded");
+    expect(latestAuth?.isAuthenticated).toBe(true);
+    await act(async () => {
+      for (const request of requests.slice(beforeBLogout, beforeRetry)) request.onblocked?.();
+      await bLogout;
+    });
+    await expect(bLogout).resolves.toBe("incomplete");
     expect(latestAuth?.isAuthenticated).toBe(true);
     expect(apiMocks.clearStoredTokens).not.toHaveBeenCalled();
     delete (globalThis as { indexedDB?: unknown }).indexedDB;

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider } from "../../components/ui/toast.js";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -137,9 +138,11 @@ async function renderAuth(children?: ReactNode): Promise<void> {
   await act(async () => {
     root?.render(
       <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <Probe />
-        </AuthProvider>
+        <ToastProvider>
+          <AuthProvider>
+            <Probe />
+          </AuthProvider>
+        </ToastProvider>
       </QueryClientProvider>,
     );
   });
@@ -418,7 +421,7 @@ describe("AuthProvider", () => {
 
     let result: Promise<boolean> = Promise.resolve(false);
     await act(async () => {
-      result = latestAuth?.logout() ?? Promise.resolve(false);
+      result = latestAuth?.logout({ broadcast: false }) ?? Promise.resolve(false);
       await Promise.resolve();
     });
     await flush();
@@ -429,6 +432,86 @@ describe("AuthProvider", () => {
     });
     expect(latestAuth?.isAuthenticated).toBe(true);
     expect(apiMocks.clearStoredTokens).not.toHaveBeenCalled();
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+  });
+
+  it("resets local state and shows recovery when an auth failure purge is blocked", async () => {
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+    await renderAuth();
+    const requests: Array<{ onblocked: (() => void) | null }> = [];
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: {
+        deleteDatabase: () => {
+          const request = { onblocked: null as (() => void) | null };
+          requests.push(request);
+          return request;
+        },
+      },
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("auth:logout"));
+      await Promise.resolve();
+    });
+    expect(requests.length).toBeGreaterThan(0);
+    await act(async () => {
+      for (const request of requests) request.onblocked?.();
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(latestAuth?.isAuthenticated).toBe(false);
+    expect(latestAuth?.logoutStatus).toBe("incomplete");
+    expect(document.body.textContent).toContain("Sign out incomplete");
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+  });
+
+  it("resets stale local state while preserving replacement credentials on a blocked remote purge", async () => {
+    let currentTokens = {
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh-a",
+    };
+    apiMocks.getStoredTokens.mockImplementation(() => currentTokens);
+    await renderAuth();
+    const scope = await import("../../lib/browser-storage-scope.js");
+    const account = scope.captureBrowserStorageScope();
+    const requests: Array<{ onblocked: (() => void) | null }> = [];
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: {
+        deleteDatabase: () => {
+          const request = { onblocked: null as (() => void) | null };
+          requests.push(request);
+          return request;
+        },
+      },
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(scope.BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT, { detail: { scope: account } }),
+      );
+      await Promise.resolve();
+    });
+    currentTokens = {
+      accessToken: tokenWithPayload({ sub: "user-2" }),
+      refreshToken: "refresh-b",
+    };
+    expect(requests.length).toBeGreaterThan(0);
+    await act(async () => {
+      for (const request of requests) request.onblocked?.();
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(latestAuth?.isAuthenticated).toBe(false);
+    expect(latestAuth?.logoutStatus).toBe("incomplete");
+    expect(apiMocks.clearStoredTokens).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Sign out incomplete");
     delete (globalThis as { indexedDB?: unknown }).indexedDB;
   });
 

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -354,6 +354,84 @@ describe("AuthProvider", () => {
     expect(scope.isBrowserStorageScopeCurrent(account)).toBe(false);
   });
 
+  it("does not clear replacement credentials when a cross-tab purge completes late", async () => {
+    let currentTokens = {
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh-a",
+    };
+    apiMocks.getStoredTokens.mockImplementation(() => currentTokens);
+    await renderAuth();
+    const scope = await import("../../lib/browser-storage-scope.js");
+    const account = scope.captureBrowserStorageScope();
+    const requests: Array<{ onsuccess: (() => void) | null }> = [];
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: {
+        deleteDatabase: () => {
+          const request = { onsuccess: null as (() => void) | null };
+          requests.push(request);
+          return request;
+        },
+      },
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(scope.BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT, { detail: { scope: account } }),
+      );
+      await Promise.resolve();
+    });
+    await flush();
+    expect(requests.length).toBeGreaterThan(0);
+
+    currentTokens = {
+      accessToken: tokenWithPayload({ sub: "user-2" }),
+      refreshToken: "refresh-b",
+    };
+    await act(async () => {
+      for (const request of requests) request.onsuccess?.();
+      await Promise.resolve();
+    });
+
+    expect(apiMocks.clearStoredTokens).not.toHaveBeenCalled();
+    expect(latestAuth?.isAuthenticated).toBe(false);
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+  });
+
+  it("keeps the session available for retry when logout purge is blocked", async () => {
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+    await renderAuth();
+    const requests: Array<{ onblocked: (() => void) | null }> = [];
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: {
+        deleteDatabase: () => {
+          const request = { onblocked: null as (() => void) | null };
+          requests.push(request);
+          return request;
+        },
+      },
+    });
+
+    let result: Promise<boolean> = Promise.resolve(false);
+    await act(async () => {
+      result = latestAuth?.logout() ?? Promise.resolve(false);
+      await Promise.resolve();
+    });
+    await flush();
+    expect(requests.length).toBeGreaterThan(0);
+    await act(async () => {
+      for (const request of requests) request.onblocked?.();
+      await result;
+    });
+    expect(latestAuth?.isAuthenticated).toBe(true);
+    expect(apiMocks.clearStoredTokens).not.toHaveBeenCalled();
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+  });
+
   it("clears persisted browser data on logout before a returning sign-in", async () => {
     // /me's default (most-recent) is org-1, but the user last used org-2.
     localStorage.setItem("first-tree:selectedOrganizationId:user-1", "org-2");

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -421,9 +421,9 @@ describe("AuthProvider", () => {
       },
     });
 
-    let logoutResult: Promise<boolean> = Promise.resolve(false);
+    let logoutResult: Promise<"completed" | "incomplete" | "superseded"> = Promise.resolve("incomplete");
     await act(async () => {
-      logoutResult = latestAuth?.logout({ broadcast: false }) ?? Promise.resolve(false);
+      logoutResult = latestAuth?.logout({ broadcast: false }) ?? Promise.resolve("incomplete");
       await Promise.resolve();
     });
     expect(requests.length).toBeGreaterThan(0);
@@ -440,7 +440,20 @@ describe("AuthProvider", () => {
       await logoutResult;
     });
 
-    await expect(logoutResult).resolves.toBe(false);
+    await expect(logoutResult).resolves.toBe("superseded");
+    expect(latestAuth?.isAuthenticated).toBe(true);
+    const firstRequestCount = requests.length;
+    let retryResult: Promise<"completed" | "incomplete" | "superseded"> = Promise.resolve("incomplete");
+    await act(async () => {
+      retryResult = latestAuth?.retryLogout?.() ?? Promise.resolve("incomplete");
+      await Promise.resolve();
+    });
+    expect(requests.length).toBeGreaterThan(firstRequestCount);
+    await act(async () => {
+      for (const request of requests.slice(firstRequestCount)) request.onsuccess?.();
+      await retryResult;
+    });
+    await expect(retryResult).resolves.toBe("superseded");
     expect(latestAuth?.isAuthenticated).toBe(true);
     expect(apiMocks.clearStoredTokens).not.toHaveBeenCalled();
     delete (globalThis as { indexedDB?: unknown }).indexedDB;
@@ -464,9 +477,9 @@ describe("AuthProvider", () => {
       },
     });
 
-    let result: Promise<boolean> = Promise.resolve(false);
+    let result: Promise<"completed" | "incomplete" | "superseded"> = Promise.resolve("incomplete");
     await act(async () => {
-      result = latestAuth?.logout({ broadcast: false }) ?? Promise.resolve(false);
+      result = latestAuth?.logout({ broadcast: false }) ?? Promise.resolve("incomplete");
       await Promise.resolve();
     });
     await flush();

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -12,6 +12,7 @@ import {
   setStoredTokens,
 } from "../api/client.js";
 import { markOnboardingCompleted as postOnboardingCompleted } from "../api/onboarding-events.js";
+import { clearPersistentBrowserStorage, setBrowserStorageUser } from "../lib/browser-storage-scope.js";
 import { clearOnboardingJoinPath, clearOnboardingSessionFlags } from "../utils/onboarding-flags.js";
 
 type MeUser = {
@@ -237,19 +238,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // below — RequireAuth only blocks the loading frame when the user IS
   // authenticated.
   const [meLoaded, setMeLoaded] = useState(false);
+  const authGenerationRef = useRef(0);
   // In-flight org-switch target (drives the switcher's optimistic anchor, the
   // row spinner, and the global transition veil). Lives here so the veil
   // (mounted in the layout) and the switcher (in the header) read one source.
   const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
 
   const logout = useCallback(() => {
+    authGenerationRef.current += 1;
+    setBrowserStorageUser(null);
     clearStoredTokens();
-    // Keep the persisted last-used org (no writeSelectedOrgId(null) here) so a
-    // returning sign-in lands back in the org this user left rather than their
-    // most-recently-joined one. It's stored per-user (keyed by the token's
-    // `sub`), so a different account on the same browser can never inherit it.
-    // Clear only the in-memory + API-client selection so nothing org-scoped
-    // fires before the next fetchMe reconciles.
     setApiSelectedOrganizationId(null);
     queryClient.clear();
     // Drop per-tab onboarding flags so the next login (different user, or
@@ -267,11 +265,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setDocsEnabled(false);
     setMeLoaded(false);
     setSwitchingOrg(null);
+    void clearPersistentBrowserStorage();
   }, [queryClient]);
 
   const fetchMe = useCallback(async () => {
+    const generation = authGenerationRef.current;
     try {
       const data = await api.get<MeResponse>("/me");
+      if (generation !== authGenerationRef.current) return;
+      setBrowserStorageUser(data.user?.id ?? null);
       setUser(data.user ?? null);
       const ms = data.memberships ?? [];
       setMemberships(ms);
@@ -311,31 +313,41 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return fallback;
       });
     } catch {
+      if (generation !== authGenerationRef.current) return;
+      setBrowserStorageUser(null);
       // If /me fails, the UI falls back to hiding admin features.
     } finally {
-      // Always flip the gate — even on error — so RequireAuth doesn't hang
-      // the dashboard forever if /me is briefly unreachable.
-      setMeLoaded(true);
+      if (generation === authGenerationRef.current) {
+        // Always flip the gate — even on error — so RequireAuth doesn't hang
+        // the dashboard forever if /me is briefly unreachable.
+        setMeLoaded(true);
+      }
     }
   }, []);
 
   const login = useCallback(
     async (username: string, password: string) => {
       const tokens = await loginApi(username, password);
+      setBrowserStorageUser(null);
+      queryClient.clear();
       setStoredTokens({ accessToken: tokens.accessToken, refreshToken: tokens.refreshToken });
+      authGenerationRef.current += 1;
       setIsAuthenticated(true);
       await fetchMe();
     },
-    [fetchMe],
+    [fetchMe, queryClient],
   );
 
   const adoptTokens = useCallback(
     async (tokens: { accessToken: string; refreshToken: string }) => {
+      setBrowserStorageUser(null);
+      queryClient.clear();
       setStoredTokens(tokens);
+      authGenerationRef.current += 1;
       setIsAuthenticated(true);
       await fetchMe();
     },
-    [fetchMe],
+    [fetchMe, queryClient],
   );
 
   const selectOrganization = useCallback(
@@ -501,7 +513,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Listen for auth failure dispatched by the API client
   useEffect(() => {
-    const handler = () => logout();
+    const handler = () => {
+      void logout();
+    };
     window.addEventListener("auth:logout", handler);
     return () => window.removeEventListener("auth:logout", handler);
   }, [logout]);

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -169,12 +169,14 @@ type AuthContextValue = {
   switchingOrg: OrgBrief | null;
   setSwitchingOrg: (org: OrgBrief | null) => void;
   refreshMe: () => Promise<void>;
-  logout: (options?: LogoutOptions) => void | Promise<void>;
+  logout: (options?: LogoutOptions) => undefined | Promise<boolean>;
+  logoutStatus?: "idle" | "purging" | "incomplete";
 };
 
 type LogoutOptions = {
   broadcast?: boolean;
   clearTokens?: boolean;
+  protectReplacementTokens?: boolean;
   scope?: BrowserStorageScope;
 };
 
@@ -260,12 +262,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // row spinner, and the global transition veil). Lives here so the veil
   // (mounted in the layout) and the switcher (in the header) read one source.
   const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
+  const [logoutStatus, setLogoutStatus] = useState<"idle" | "purging" | "incomplete">("idle");
 
   const logout = useCallback(
-    async (options: LogoutOptions = {}) => {
+    async (options: LogoutOptions = {}): Promise<boolean> => {
       const departingScope = options.scope ?? captureBrowserStorageScope();
       if (options.broadcast !== false) invalidateBrowserStorageScope(departingScope);
       authGenerationRef.current += 1;
+      setLogoutStatus("purging");
+      try {
+        await clearPersistentBrowserStorage(departingScope);
+      } catch {
+        setLogoutStatus("incomplete");
+        return false;
+      }
       setApiSelectedOrganizationId(null);
       queryClient.clear();
       // Drop per-tab onboarding flags so the next login (different user, or
@@ -273,9 +283,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // confirmed" / "Step 3 dismissed" / agent uuid / draft from the prior
       // identity.
       clearOnboardingSessionFlags();
-      await clearPersistentBrowserStorage(departingScope);
       setBrowserStorageUser(null);
-      if (options.clearTokens !== false) clearStoredTokens();
+      // A different tab may have installed a replacement account while this
+      // tab was purging the departing scope. Never clear that newer account's
+      // credential as a side effect of the old logout.
+      const currentTokenOwner = userIdFromToken();
+      const canClearCredential =
+        !options.protectReplacementTokens || !departingScope.userId || currentTokenOwner === departingScope.userId;
+      if (options.clearTokens !== false && canClearCredential) {
+        clearStoredTokens();
+      }
       setIsAuthenticated(false);
       setUser(null);
       setMemberships([]);
@@ -286,6 +303,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setDocsEnabled(false);
       setMeLoaded(false);
       setSwitchingOrg(null);
+      setLogoutStatus("idle");
+      return true;
     },
     [queryClient],
   );
@@ -355,6 +374,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setBrowserStorageUser(null);
       queryClient.clear();
       setStoredTokens({ accessToken: tokens.accessToken, refreshToken: tokens.refreshToken });
+      setLogoutStatus("idle");
       authGenerationRef.current += 1;
       setIsAuthenticated(true);
       await fetchMe();
@@ -369,6 +389,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setBrowserStorageUser(null);
       queryClient.clear();
       setStoredTokens(tokens);
+      setLogoutStatus("idle");
       authGenerationRef.current += 1;
       setIsAuthenticated(true);
       await fetchMe();
@@ -540,7 +561,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Listen for auth failure dispatched by the API client
   useEffect(() => {
     const handler = () => {
-      void logout();
+      void Promise.resolve(logout());
     };
     window.addEventListener("auth:logout", handler);
     return () => window.removeEventListener("auth:logout", handler);
@@ -549,7 +570,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const handler = (event: Event) => {
       const scope = (event as CustomEvent<{ scope?: BrowserStorageScope }>).detail?.scope;
-      void logout({ broadcast: false, scope });
+      void Promise.resolve(logout({ broadcast: false, protectReplacementTokens: true, scope }));
     };
     window.addEventListener(BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT, handler);
     return () => window.removeEventListener(BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT, handler);
@@ -585,6 +606,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setSwitchingOrg,
         refreshMe: fetchMe,
         logout,
+        logoutStatus,
       }}
     >
       {children}

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -12,7 +12,11 @@ import {
   setStoredTokens,
 } from "../api/client.js";
 import { markOnboardingCompleted as postOnboardingCompleted } from "../api/onboarding-events.js";
-import { clearPersistentBrowserStorage, setBrowserStorageUser } from "../lib/browser-storage-scope.js";
+import {
+  captureBrowserStorageScope,
+  clearPersistentBrowserStorage,
+  setBrowserStorageUser,
+} from "../lib/browser-storage-scope.js";
 import { clearOnboardingJoinPath, clearOnboardingSessionFlags } from "../utils/onboarding-flags.js";
 
 type MeUser = {
@@ -162,7 +166,7 @@ type AuthContextValue = {
   switchingOrg: OrgBrief | null;
   setSwitchingOrg: (org: OrgBrief | null) => void;
   refreshMe: () => Promise<void>;
-  logout: () => void;
+  logout: () => void | Promise<void>;
 };
 
 // Exported so DEV-only preview pages (e.g. /preview/resources) can render real
@@ -223,7 +227,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [memberships, setMemberships] = useState<MeMembership[]>([]);
   const [docsEnabled, setDocsEnabled] = useState(false);
   const [selectedOrgId, setSelectedOrgId] = useState<string | null>(() => {
-    const init = readSelectedOrgId(userIdFromToken());
+    const tokenUserId = userIdFromToken();
+    // Seed the browser cache scope from the JWT before /me resolves so an
+    // early 401/logout can still purge the departing account's stores.
+    setBrowserStorageUser(tokenUserId);
+    const init = readSelectedOrgId(tokenUserId);
     // Sync the API client's module-level override on first paint so the
     // first wave of requests (made before fetchMe resolves) already carries
     // the correct `?organizationId=` query (codex P1 #2 fix).
@@ -244,7 +252,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // (mounted in the layout) and the switcher (in the header) read one source.
   const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
 
-  const logout = useCallback(() => {
+  const logout = useCallback(async () => {
+    const departingScope = captureBrowserStorageScope();
     authGenerationRef.current += 1;
     setBrowserStorageUser(null);
     clearStoredTokens();
@@ -265,7 +274,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setDocsEnabled(false);
     setMeLoaded(false);
     setSwitchingOrg(null);
-    void clearPersistentBrowserStorage();
+    await clearPersistentBrowserStorage(departingScope);
   }, [queryClient]);
 
   const fetchMe = useCallback(async () => {
@@ -292,8 +301,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       // Reconcile selectedOrgId, each candidate only if it's still an active
       // membership: (1) the in-memory selection, (2) this user's persisted
-      // last-used org — survives logout so a returning user lands back in the
-      // org they left — then (3) /me's `defaultOrganizationId` (most-recent),
+      // last-used org — if still present — then (3) /me's
+      // `defaultOrganizationId` (most-recent),
       // (4) the first active membership.
       const userId = data.user?.id ?? null;
       setSelectedOrgId((prev) => {

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -13,8 +13,11 @@ import {
 } from "../api/client.js";
 import { markOnboardingCompleted as postOnboardingCompleted } from "../api/onboarding-events.js";
 import {
+  BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT,
+  type BrowserStorageScope,
   captureBrowserStorageScope,
   clearPersistentBrowserStorage,
+  invalidateBrowserStorageScope,
   setBrowserStorageUser,
 } from "../lib/browser-storage-scope.js";
 import { clearOnboardingJoinPath, clearOnboardingSessionFlags } from "../utils/onboarding-flags.js";
@@ -166,7 +169,13 @@ type AuthContextValue = {
   switchingOrg: OrgBrief | null;
   setSwitchingOrg: (org: OrgBrief | null) => void;
   refreshMe: () => Promise<void>;
-  logout: () => void | Promise<void>;
+  logout: (options?: LogoutOptions) => void | Promise<void>;
+};
+
+type LogoutOptions = {
+  broadcast?: boolean;
+  clearTokens?: boolean;
+  scope?: BrowserStorageScope;
 };
 
 // Exported so DEV-only preview pages (e.g. /preview/resources) can render real
@@ -252,30 +261,34 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // (mounted in the layout) and the switcher (in the header) read one source.
   const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
 
-  const logout = useCallback(async () => {
-    const departingScope = captureBrowserStorageScope();
-    authGenerationRef.current += 1;
-    setBrowserStorageUser(null);
-    clearStoredTokens();
-    setApiSelectedOrganizationId(null);
-    queryClient.clear();
-    // Drop per-tab onboarding flags so the next login (different user, or
-    // same user post-DB-reset in dev) doesn't inherit a stale "Step 1
-    // confirmed" / "Step 3 dismissed" / agent uuid / draft from the prior
-    // identity.
-    clearOnboardingSessionFlags();
-    setIsAuthenticated(false);
-    setUser(null);
-    setMemberships([]);
-    setSelectedOrgId(null);
-    setOnboardingStep(null);
-    setOnboardingDismissedAt(null);
-    setOnboardingCompletedAt(null);
-    setDocsEnabled(false);
-    setMeLoaded(false);
-    setSwitchingOrg(null);
-    await clearPersistentBrowserStorage(departingScope);
-  }, [queryClient]);
+  const logout = useCallback(
+    async (options: LogoutOptions = {}) => {
+      const departingScope = options.scope ?? captureBrowserStorageScope();
+      if (options.broadcast !== false) invalidateBrowserStorageScope(departingScope);
+      authGenerationRef.current += 1;
+      setApiSelectedOrganizationId(null);
+      queryClient.clear();
+      // Drop per-tab onboarding flags so the next login (different user, or
+      // same user post-DB-reset in dev) doesn't inherit a stale "Step 1
+      // confirmed" / "Step 3 dismissed" / agent uuid / draft from the prior
+      // identity.
+      clearOnboardingSessionFlags();
+      await clearPersistentBrowserStorage(departingScope);
+      setBrowserStorageUser(null);
+      if (options.clearTokens !== false) clearStoredTokens();
+      setIsAuthenticated(false);
+      setUser(null);
+      setMemberships([]);
+      setSelectedOrgId(null);
+      setOnboardingStep(null);
+      setOnboardingDismissedAt(null);
+      setOnboardingCompletedAt(null);
+      setDocsEnabled(false);
+      setMeLoaded(false);
+      setSwitchingOrg(null);
+    },
+    [queryClient],
+  );
 
   const fetchMe = useCallback(async () => {
     const generation = authGenerationRef.current;
@@ -323,8 +336,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       });
     } catch {
       if (generation !== authGenerationRef.current) return;
-      setBrowserStorageUser(null);
-      // If /me fails, the UI falls back to hiding admin features.
+      // Keep the JWT-derived scope while a non-auth /me failure is retryable;
+      // logout must still know which account's browser data to purge.
     } finally {
       if (generation === authGenerationRef.current) {
         // Always flip the gate — even on error — so RequireAuth doesn't hang
@@ -337,6 +350,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = useCallback(
     async (username: string, password: string) => {
       const tokens = await loginApi(username, password);
+      const departingScope = captureBrowserStorageScope();
+      if (departingScope.userId) invalidateBrowserStorageScope(departingScope);
       setBrowserStorageUser(null);
       queryClient.clear();
       setStoredTokens({ accessToken: tokens.accessToken, refreshToken: tokens.refreshToken });
@@ -349,6 +364,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const adoptTokens = useCallback(
     async (tokens: { accessToken: string; refreshToken: string }) => {
+      const departingScope = captureBrowserStorageScope();
+      if (departingScope.userId) invalidateBrowserStorageScope(departingScope);
       setBrowserStorageUser(null);
       queryClient.clear();
       setStoredTokens(tokens);
@@ -527,6 +544,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
     window.addEventListener("auth:logout", handler);
     return () => window.removeEventListener("auth:logout", handler);
+  }, [logout]);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const scope = (event as CustomEvent<{ scope?: BrowserStorageScope }>).detail?.scope;
+      void logout({ broadcast: false, scope });
+    };
+    window.addEventListener(BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT, handler);
+    return () => window.removeEventListener(BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT, handler);
   }, [logout]);
 
   return (

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -313,7 +313,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       if (authGenerationRef.current !== logoutGeneration) {
         setLogoutStatus("idle");
-        if (options.recovery) publishLogoutIncomplete(retry);
         return "superseded";
       }
       commitLocalLogoutState();

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -21,7 +21,7 @@ import {
   setBrowserStorageUser,
 } from "../lib/browser-storage-scope.js";
 import { clearOnboardingJoinPath, clearOnboardingSessionFlags } from "../utils/onboarding-flags.js";
-import { publishLogoutIncomplete } from "./logout-recovery.js";
+import { type LogoutResult, publishLogoutIncomplete } from "./logout-recovery.js";
 
 type MeUser = {
   id: string;
@@ -170,7 +170,8 @@ type AuthContextValue = {
   switchingOrg: OrgBrief | null;
   setSwitchingOrg: (org: OrgBrief | null) => void;
   refreshMe: () => Promise<void>;
-  logout: (options?: LogoutOptions) => undefined | Promise<boolean>;
+  logout: (options?: LogoutOptions) => undefined | Promise<LogoutResult>;
+  retryLogout?: () => Promise<LogoutResult>;
   logoutStatus?: "idle" | "purging" | "incomplete";
 };
 
@@ -179,6 +180,7 @@ export type LogoutOptions = {
   clearTokens?: boolean;
   recovery?: boolean;
   protectReplacementTokens?: boolean;
+  generation?: number;
   scope?: BrowserStorageScope;
 };
 
@@ -265,6 +267,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // (mounted in the layout) and the switcher (in the header) read one source.
   const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
   const [logoutStatus, setLogoutStatus] = useState<"idle" | "purging" | "incomplete">("idle");
+  const retryLogoutRef = useRef<(() => Promise<LogoutResult>) | null>(null);
 
   const commitLocalLogoutState = useCallback(() => {
     setApiSelectedOrganizationId(null);
@@ -284,35 +287,34 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [queryClient]);
 
   const logout = useCallback(
-    async (options: LogoutOptions = {}): Promise<boolean> => {
+    async (options: LogoutOptions = {}): Promise<LogoutResult> => {
       const departingScope = options.scope ?? captureBrowserStorageScope();
       if (options.broadcast !== false) invalidateBrowserStorageScope(departingScope);
-      authGenerationRef.current += 1;
-      const logoutGeneration = authGenerationRef.current;
-      setLogoutStatus("purging");
+      const logoutGeneration = options.generation ?? authGenerationRef.current + 1;
+      const canFinalize = options.generation === undefined || options.generation === authGenerationRef.current;
+      if (options.generation === undefined) authGenerationRef.current = logoutGeneration;
+      const retry = () => logout({ ...options, generation: logoutGeneration, recovery: false, scope: departingScope });
+      retryLogoutRef.current = retry;
+      if (canFinalize) setLogoutStatus("purging");
       try {
         await clearPersistentBrowserStorage(departingScope);
       } catch {
-        if (authGenerationRef.current !== logoutGeneration) {
+        if (!canFinalize || authGenerationRef.current !== logoutGeneration) {
           setLogoutStatus("idle");
-          if (options.recovery) {
-            publishLogoutIncomplete(() => logout({ ...options, recovery: false, scope: departingScope }));
-          }
-          return false;
+          if (options.recovery) publishLogoutIncomplete(retry);
+          return "incomplete";
         }
         setLogoutStatus("incomplete");
         if (options.recovery) {
           commitLocalLogoutState();
-          publishLogoutIncomplete(() => logout({ ...options, recovery: false, scope: departingScope }));
+          publishLogoutIncomplete(retry);
         }
-        return false;
+        return "incomplete";
       }
       if (authGenerationRef.current !== logoutGeneration) {
         setLogoutStatus("idle");
-        if (options.recovery) {
-          publishLogoutIncomplete(() => logout({ ...options, recovery: false, scope: departingScope }));
-        }
-        return false;
+        if (options.recovery) publishLogoutIncomplete(retry);
+        return "superseded";
       }
       commitLocalLogoutState();
       // A different tab may have installed a replacement account while this
@@ -325,10 +327,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         clearStoredTokens();
       }
       setLogoutStatus("idle");
-      return true;
+      return "completed";
     },
     [commitLocalLogoutState],
   );
+
+  const retryLogout = useCallback(() => retryLogoutRef.current?.() ?? Promise.resolve("incomplete" as const), []);
 
   const fetchMe = useCallback(async () => {
     const generation = authGenerationRef.current;
@@ -627,6 +631,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setSwitchingOrg,
         refreshMe: fetchMe,
         logout,
+        retryLogout,
         logoutStatus,
       }}
     >

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -21,6 +21,7 @@ import {
   setBrowserStorageUser,
 } from "../lib/browser-storage-scope.js";
 import { clearOnboardingJoinPath, clearOnboardingSessionFlags } from "../utils/onboarding-flags.js";
+import { publishLogoutIncomplete } from "./logout-recovery.js";
 
 type MeUser = {
   id: string;
@@ -176,6 +177,7 @@ type AuthContextValue = {
 type LogoutOptions = {
   broadcast?: boolean;
   clearTokens?: boolean;
+  recovery?: boolean;
   protectReplacementTokens?: boolean;
   scope?: BrowserStorageScope;
 };
@@ -264,6 +266,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
   const [logoutStatus, setLogoutStatus] = useState<"idle" | "purging" | "incomplete">("idle");
 
+  const commitLocalLogoutState = useCallback(() => {
+    setApiSelectedOrganizationId(null);
+    queryClient.clear();
+    clearOnboardingSessionFlags();
+    setBrowserStorageUser(null);
+    setIsAuthenticated(false);
+    setUser(null);
+    setMemberships([]);
+    setSelectedOrgId(null);
+    setOnboardingStep(null);
+    setOnboardingDismissedAt(null);
+    setOnboardingCompletedAt(null);
+    setDocsEnabled(false);
+    setMeLoaded(false);
+    setSwitchingOrg(null);
+  }, [queryClient]);
+
   const logout = useCallback(
     async (options: LogoutOptions = {}): Promise<boolean> => {
       const departingScope = options.scope ?? captureBrowserStorageScope();
@@ -274,16 +293,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         await clearPersistentBrowserStorage(departingScope);
       } catch {
         setLogoutStatus("incomplete");
+        if (options.recovery) {
+          commitLocalLogoutState();
+          publishLogoutIncomplete(() => logout({ ...options, scope: departingScope }));
+        }
         return false;
       }
-      setApiSelectedOrganizationId(null);
-      queryClient.clear();
-      // Drop per-tab onboarding flags so the next login (different user, or
-      // same user post-DB-reset in dev) doesn't inherit a stale "Step 1
-      // confirmed" / "Step 3 dismissed" / agent uuid / draft from the prior
-      // identity.
-      clearOnboardingSessionFlags();
-      setBrowserStorageUser(null);
+      commitLocalLogoutState();
       // A different tab may have installed a replacement account while this
       // tab was purging the departing scope. Never clear that newer account's
       // credential as a side effect of the old logout.
@@ -293,20 +309,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (options.clearTokens !== false && canClearCredential) {
         clearStoredTokens();
       }
-      setIsAuthenticated(false);
-      setUser(null);
-      setMemberships([]);
-      setSelectedOrgId(null);
-      setOnboardingStep(null);
-      setOnboardingDismissedAt(null);
-      setOnboardingCompletedAt(null);
-      setDocsEnabled(false);
-      setMeLoaded(false);
-      setSwitchingOrg(null);
       setLogoutStatus("idle");
       return true;
     },
-    [queryClient],
+    [commitLocalLogoutState],
   );
 
   const fetchMe = useCallback(async () => {
@@ -561,7 +567,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Listen for auth failure dispatched by the API client
   useEffect(() => {
     const handler = () => {
-      void Promise.resolve(logout());
+      void Promise.resolve(logout({ recovery: true }));
     };
     window.addEventListener("auth:logout", handler);
     return () => window.removeEventListener("auth:logout", handler);
@@ -570,7 +576,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const handler = (event: Event) => {
       const scope = (event as CustomEvent<{ scope?: BrowserStorageScope }>).detail?.scope;
-      void Promise.resolve(logout({ broadcast: false, protectReplacementTokens: true, scope }));
+      void Promise.resolve(logout({ broadcast: false, protectReplacementTokens: true, recovery: true, scope }));
     };
     window.addEventListener(BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT, handler);
     return () => window.removeEventListener(BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT, handler);

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -174,7 +174,7 @@ type AuthContextValue = {
   logoutStatus?: "idle" | "purging" | "incomplete";
 };
 
-type LogoutOptions = {
+export type LogoutOptions = {
   broadcast?: boolean;
   clearTokens?: boolean;
   recovery?: boolean;
@@ -288,14 +288,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const departingScope = options.scope ?? captureBrowserStorageScope();
       if (options.broadcast !== false) invalidateBrowserStorageScope(departingScope);
       authGenerationRef.current += 1;
+      const logoutGeneration = authGenerationRef.current;
       setLogoutStatus("purging");
       try {
         await clearPersistentBrowserStorage(departingScope);
       } catch {
+        if (authGenerationRef.current !== logoutGeneration) {
+          setLogoutStatus("idle");
+          if (options.recovery) {
+            publishLogoutIncomplete(() => logout({ ...options, recovery: false, scope: departingScope }));
+          }
+          return false;
+        }
         setLogoutStatus("incomplete");
         if (options.recovery) {
           commitLocalLogoutState();
-          publishLogoutIncomplete(() => logout({ ...options, scope: departingScope }));
+          publishLogoutIncomplete(() => logout({ ...options, recovery: false, scope: departingScope }));
+        }
+        return false;
+      }
+      if (authGenerationRef.current !== logoutGeneration) {
+        setLogoutStatus("idle");
+        if (options.recovery) {
+          publishLogoutIncomplete(() => logout({ ...options, recovery: false, scope: departingScope }));
         }
         return false;
       }

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -171,7 +171,6 @@ type AuthContextValue = {
   setSwitchingOrg: (org: OrgBrief | null) => void;
   refreshMe: () => Promise<void>;
   logout: (options?: LogoutOptions) => undefined | Promise<LogoutResult>;
-  retryLogout?: () => Promise<LogoutResult>;
   logoutStatus?: "idle" | "purging" | "incomplete";
 };
 
@@ -181,6 +180,7 @@ export type LogoutOptions = {
   recovery?: boolean;
   protectReplacementTokens?: boolean;
   generation?: number;
+  onIncomplete?: (retry: () => Promise<LogoutResult>) => void;
   scope?: BrowserStorageScope;
 };
 
@@ -267,7 +267,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // (mounted in the layout) and the switcher (in the header) read one source.
   const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
   const [logoutStatus, setLogoutStatus] = useState<"idle" | "purging" | "incomplete">("idle");
-  const retryLogoutRef = useRef<(() => Promise<LogoutResult>) | null>(null);
 
   const commitLocalLogoutState = useCallback(() => {
     setApiSelectedOrganizationId(null);
@@ -294,17 +293,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const canFinalize = options.generation === undefined || options.generation === authGenerationRef.current;
       if (options.generation === undefined) authGenerationRef.current = logoutGeneration;
       const retry = () => logout({ ...options, generation: logoutGeneration, recovery: false, scope: departingScope });
-      retryLogoutRef.current = retry;
       if (canFinalize) setLogoutStatus("purging");
       try {
         await clearPersistentBrowserStorage(departingScope);
       } catch {
         if (!canFinalize || authGenerationRef.current !== logoutGeneration) {
           setLogoutStatus("idle");
+          options.onIncomplete?.(retry);
           if (options.recovery) publishLogoutIncomplete(retry);
           return "incomplete";
         }
         setLogoutStatus("incomplete");
+        options.onIncomplete?.(retry);
         if (options.recovery) {
           commitLocalLogoutState();
           publishLogoutIncomplete(retry);
@@ -331,8 +331,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     },
     [commitLocalLogoutState],
   );
-
-  const retryLogout = useCallback(() => retryLogoutRef.current?.() ?? Promise.resolve("incomplete" as const), []);
 
   const fetchMe = useCallback(async () => {
     const generation = authGenerationRef.current;
@@ -631,7 +629,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setSwitchingOrg,
         refreshMe: fetchMe,
         logout,
-        retryLogout,
         logoutStatus,
       }}
     >

--- a/packages/web/src/auth/logout-recovery.ts
+++ b/packages/web/src/auth/logout-recovery.ts
@@ -1,7 +1,14 @@
 import type { ToastInput } from "../components/ui/toast.js";
 
 type AddToast = (toast: ToastInput) => void;
-type RetryLogout = () => undefined | boolean | Promise<boolean>;
+export type RetryLogout = () => undefined | boolean | Promise<boolean>;
+export const LOGOUT_INCOMPLETE_EVENT = "auth:logout-incomplete";
+
+export function publishLogoutIncomplete(retry: RetryLogout): void {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent(LOGOUT_INCOMPLETE_EVENT, { detail: { retry } }));
+  }
+}
 
 export function showLogoutIncompleteToast(addToast: AddToast, retry: RetryLogout): void {
   addToast({

--- a/packages/web/src/auth/logout-recovery.ts
+++ b/packages/web/src/auth/logout-recovery.ts
@@ -1,7 +1,8 @@
 import type { ToastInput } from "../components/ui/toast.js";
 
 type AddToast = (toast: ToastInput) => void;
-export type RetryLogout = () => undefined | boolean | Promise<boolean>;
+export type LogoutResult = "completed" | "incomplete" | "superseded";
+export type RetryLogout = () => undefined | LogoutResult | Promise<LogoutResult>;
 export const LOGOUT_INCOMPLETE_EVENT = "auth:logout-incomplete";
 
 export function publishLogoutIncomplete(retry: RetryLogout): void {
@@ -19,7 +20,9 @@ export function showLogoutIncompleteToast(addToast: AddToast, retry: RetryLogout
       onClick: () => {
         void Promise.resolve(retry())
           .then((completed) => {
-            if (completed !== true) showLogoutIncompleteToast(addToast, retry);
+            if (completed !== "completed" && completed !== "superseded") {
+              showLogoutIncompleteToast(addToast, retry);
+            }
           })
           .catch(() => showLogoutIncompleteToast(addToast, retry));
       },

--- a/packages/web/src/auth/logout-recovery.ts
+++ b/packages/web/src/auth/logout-recovery.ts
@@ -1,0 +1,22 @@
+import type { ToastInput } from "../components/ui/toast.js";
+
+type AddToast = (toast: ToastInput) => void;
+type RetryLogout = () => undefined | boolean | Promise<boolean>;
+
+export function showLogoutIncompleteToast(addToast: AddToast, retry: RetryLogout): void {
+  addToast({
+    title: "Sign out incomplete",
+    description: "Close other First Tree tabs and retry to finish clearing local data.",
+    action: {
+      label: "Retry",
+      onClick: () => {
+        void Promise.resolve(retry())
+          .then((completed) => {
+            if (completed !== true) showLogoutIncompleteToast(addToast, retry);
+          })
+          .catch(() => showLogoutIncompleteToast(addToast, retry));
+      },
+    },
+    durationMs: null,
+  });
+}

--- a/packages/web/src/components/chat/__tests__/ask-answer-transport.test.ts
+++ b/packages/web/src/components/chat/__tests__/ask-answer-transport.test.ts
@@ -74,11 +74,14 @@ describe("sendAskAnswer", () => {
       answer: { content: "Evidence attached", mentions: ["reviewer-1"], images: [image] },
     });
 
-    expect(imageStoreMocks.putImage).toHaveBeenCalledWith({
-      imageId: "uploaded-proof.png",
-      base64: "base64-image",
-      mimeType: "image/png",
-    });
+    expect(imageStoreMocks.putImage).toHaveBeenCalledWith(
+      {
+        imageId: "uploaded-proof.png",
+        base64: "base64-image",
+        mimeType: "image/png",
+      },
+      expect.objectContaining({ key: expect.any(String), revision: expect.any(Number) }),
+    );
     expect(chatMocks.sendFileMessageBatch).toHaveBeenCalledWith(
       "chat-1",
       {

--- a/packages/web/src/components/chat/ask-answer-transport.ts
+++ b/packages/web/src/components/chat/ask-answer-transport.ts
@@ -2,6 +2,7 @@ import type { AttachmentRef, RequestResolution } from "@first-tree/shared";
 import { uploadAttachment, uploadMimeFor } from "../../api/attachments.js";
 import { type ImageRefContent, readFileAsBase64, sendChatMessage, sendFileMessageBatch } from "../../api/chats.js";
 import { putImage } from "../../api/image-store.js";
+import { captureBrowserStorageScope } from "../../lib/browser-storage-scope.js";
 import type { AskAnswer } from "./ask-takeover.js";
 
 export type AskAnswerRequestRef = {
@@ -26,6 +27,7 @@ export async function sendAskAnswer({
   request: AskAnswerRequestRef;
   answer: AskAnswer;
 }): Promise<void> {
+  const storageScope = captureBrowserStorageScope();
   const routedMentions = [...new Set([request.senderId, ...answer.mentions])];
   const resolves: RequestResolution = { request: request.id, kind: "answered" };
   const documentRefs: AttachmentRef[] = [];
@@ -46,7 +48,10 @@ export async function sendAskAnswer({
     for (const file of answer.images) {
       const uploaded = await uploadAttachment(file);
       try {
-        await putImage({ imageId: uploaded.id, base64: await readFileAsBase64(file), mimeType: file.type });
+        await putImage(
+          { imageId: uploaded.id, base64: await readFileAsBase64(file), mimeType: file.type },
+          storageScope,
+        );
       } catch {
         // The server attachment is authoritative; IndexedDB only makes the
         // sender's thumbnail immediate and must never block resolution.

--- a/packages/web/src/components/ui/toast.tsx
+++ b/packages/web/src/components/ui/toast.tsx
@@ -64,6 +64,10 @@ export function useToast(): ToastContextValue {
   return ctx;
 }
 
+export function useOptionalToast(): ToastContextValue {
+  return useContext(ToastContext) ?? { addToast: () => undefined };
+}
+
 function Toaster({ toasts, onDismiss }: { toasts: Toast[]; onDismiss: (id: string) => void }) {
   if (toasts.length === 0) return null;
   return (

--- a/packages/web/src/components/ui/toast.tsx
+++ b/packages/web/src/components/ui/toast.tsx
@@ -1,5 +1,6 @@
 import { X } from "lucide-react";
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { LOGOUT_INCOMPLETE_EVENT, type RetryLogout, showLogoutIncompleteToast } from "../../auth/logout-recovery.js";
 
 /**
  * Minimal toast system — used for transient informational nudges (e.g.
@@ -49,6 +50,15 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const value: ToastContextValue = { addToast };
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const retry = (event as CustomEvent<{ retry?: RetryLogout }>).detail?.retry;
+      if (retry) showLogoutIncompleteToast(addToast, retry);
+    };
+    window.addEventListener(LOGOUT_INCOMPLETE_EVENT, handler);
+    return () => window.removeEventListener(LOGOUT_INCOMPLETE_EVENT, handler);
+  }, [addToast]);
 
   return (
     <ToastContext.Provider value={value}>

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -2,6 +2,7 @@ import { LogOut } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "../auth/auth-context.js";
 import { showLogoutIncompleteToast } from "../auth/logout-recovery.js";
+import { captureBrowserStorageScope } from "../lib/browser-storage-scope.js";
 import { Avatar } from "./avatar.js";
 import { useOptionalToast } from "./ui/toast.js";
 
@@ -93,13 +94,16 @@ export function UserMenu() {
                 setOpen(false);
                 void (async () => {
                   let completed = false;
+                  const departingScope = captureBrowserStorageScope();
                   try {
-                    completed = (await Promise.resolve(logout())) === true;
+                    completed = (await Promise.resolve(logout({ scope: departingScope }))) === true;
                   } catch {
                     completed = false;
                   }
                   if (!completed) {
-                    showLogoutIncompleteToast(addToast, logout);
+                    showLogoutIncompleteToast(addToast, () =>
+                      logout({ protectReplacementTokens: true, scope: departingScope }),
+                    );
                     return;
                   }
                   // Leave the app on the marketing site rather than an app

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -21,7 +21,7 @@ const PARENT_URL = "https://first-tree.ai";
  * surfaces (team on the left, account on the right).
  */
 export function UserMenu() {
-  const { user, logout, retryLogout } = useAuth();
+  const { user, logout } = useAuth();
   const { addToast } = useOptionalToast();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -94,16 +94,19 @@ export function UserMenu() {
                 setOpen(false);
                 void (async () => {
                   let result: "completed" | "incomplete" | "superseded" | undefined;
+                  let retryOperation: (() => Promise<"completed" | "incomplete" | "superseded">) | undefined;
                   const departingScope = captureBrowserStorageScope();
                   try {
-                    result = await Promise.resolve(logout({ scope: departingScope }));
+                    result = await Promise.resolve(
+                      logout({ scope: departingScope, onIncomplete: (retry) => (retryOperation = retry) }),
+                    );
                   } catch {
                     result = "incomplete";
                   }
                   if (result === "incomplete" || result === undefined) {
                     showLogoutIncompleteToast(
                       addToast,
-                      retryLogout ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
+                      retryOperation ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
                     );
                     return;
                   }

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -1,8 +1,9 @@
 import { LogOut } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "../auth/auth-context.js";
+import { showLogoutIncompleteToast } from "../auth/logout-recovery.js";
 import { Avatar } from "./avatar.js";
-import { useToast } from "./ui/toast.js";
+import { useOptionalToast } from "./ui/toast.js";
 
 // Marketing site — where an explicit sign-out lands the browser, so the user
 // leaves the app on the parent brand surface rather than an app route (which
@@ -20,7 +21,7 @@ const PARENT_URL = "https://first-tree.ai";
  */
 export function UserMenu() {
   const { user, logout } = useAuth();
-  const { addToast } = useToast();
+  const { addToast } = useOptionalToast();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -91,22 +92,20 @@ export function UserMenu() {
               onClick={() => {
                 setOpen(false);
                 void (async () => {
+                  let completed = false;
                   try {
-                    await logout();
-                    // Leave the app on the marketing site rather than an app
-                    // route — `logout()` clears local auth state, so staying in
-                    // the SPA would just redirect to the login page.
-                    window.location.href = PARENT_URL;
+                    completed = (await Promise.resolve(logout())) === true;
                   } catch {
-                    // Keep the app open when browser persistence could not be
-                    // purged; navigating away would violate the logout boundary.
-                    addToast({
-                      title: "Sign out incomplete",
-                      description: "Close other First Tree tabs and retry to finish clearing local data.",
-                      action: { label: "Retry", onClick: () => void logout() },
-                      durationMs: null,
-                    });
+                    completed = false;
                   }
+                  if (!completed) {
+                    showLogoutIncompleteToast(addToast, logout);
+                    return;
+                  }
+                  // Leave the app on the marketing site rather than an app
+                  // route — `logout()` clears local auth state, so staying in
+                  // the SPA would just redirect to the login page.
+                  window.location.href = PARENT_URL;
                 })();
               }}
               className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -88,11 +88,18 @@ export function UserMenu() {
               role="menuitem"
               onClick={() => {
                 setOpen(false);
-                logout();
-                // Leave the app on the marketing site rather than an app
-                // route — `logout()` clears local auth state, so staying in
-                // the SPA would just redirect to the login page.
-                window.location.href = PARENT_URL;
+                void (async () => {
+                  try {
+                    await logout();
+                    // Leave the app on the marketing site rather than an app
+                    // route — `logout()` clears local auth state, so staying in
+                    // the SPA would just redirect to the login page.
+                    window.location.href = PARENT_URL;
+                  } catch {
+                    // Keep the app open when browser persistence could not be
+                    // purged; navigating away would violate the logout boundary.
+                  }
+                })();
               }}
               className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
               style={{ color: "var(--fg)" }}

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -2,6 +2,7 @@ import { LogOut } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "../auth/auth-context.js";
 import { Avatar } from "./avatar.js";
+import { useToast } from "./ui/toast.js";
 
 // Marketing site — where an explicit sign-out lands the browser, so the user
 // leaves the app on the parent brand surface rather than an app route (which
@@ -19,6 +20,7 @@ const PARENT_URL = "https://first-tree.ai";
  */
 export function UserMenu() {
   const { user, logout } = useAuth();
+  const { addToast } = useToast();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -98,6 +100,12 @@ export function UserMenu() {
                   } catch {
                     // Keep the app open when browser persistence could not be
                     // purged; navigating away would violate the logout boundary.
+                    addToast({
+                      title: "Sign out incomplete",
+                      description: "Close other First Tree tabs and retry to finish clearing local data.",
+                      action: { label: "Retry", onClick: () => void logout() },
+                      durationMs: null,
+                    });
                   }
                 })();
               }}

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -21,7 +21,7 @@ const PARENT_URL = "https://first-tree.ai";
  * surfaces (team on the left, account on the right).
  */
 export function UserMenu() {
-  const { user, logout } = useAuth();
+  const { user, logout, retryLogout } = useAuth();
   const { addToast } = useOptionalToast();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -93,19 +93,21 @@ export function UserMenu() {
               onClick={() => {
                 setOpen(false);
                 void (async () => {
-                  let completed = false;
+                  let result: "completed" | "incomplete" | "superseded" | undefined;
                   const departingScope = captureBrowserStorageScope();
                   try {
-                    completed = (await Promise.resolve(logout({ scope: departingScope }))) === true;
+                    result = await Promise.resolve(logout({ scope: departingScope }));
                   } catch {
-                    completed = false;
+                    result = "incomplete";
                   }
-                  if (!completed) {
-                    showLogoutIncompleteToast(addToast, () =>
-                      logout({ protectReplacementTokens: true, scope: departingScope }),
+                  if (result === "incomplete" || result === undefined) {
+                    showLogoutIncompleteToast(
+                      addToast,
+                      retryLogout ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
                     );
                     return;
                   }
+                  if (result === "superseded") return;
                   // Leave the app on the marketing site rather than an app
                   // route — `logout()` clears local auth state, so staying in
                   // the SPA would just redirect to the login page.

--- a/packages/web/src/hooks/use-read-tracker.ts
+++ b/packages/web/src/hooks/use-read-tracker.ts
@@ -27,6 +27,7 @@
 
 import { type RefObject, useEffect, useRef } from "react";
 import { setReadState } from "../api/read-state-store.js";
+import { captureBrowserStorageScope } from "../lib/browser-storage-scope.js";
 
 type Message = { id: string; createdAt: string };
 
@@ -146,6 +147,7 @@ export function useReadTracker({
   onBottomVisibleChange,
   writeDebounceMs = 600,
 }: UseReadTrackerOptions): void {
+  const storageScopeRef = useRef(captureBrowserStorageScope());
   // Latest computed bottom-visible id. Kept in a ref so write/flush
   // paths can read it without depending on React state churn.
   const bottomVisibleIdRef = useRef<string | null>(null);
@@ -249,7 +251,9 @@ export function useReadTracker({
         const bv = bottomVisibleIdRef.current;
         const lkAtFire = latestKnownIdRef.current;
         if (!bv || !lkAtFire) return;
-        void setReadState(chatId, bv, lkAtFire).then(() => onWriteRef.current?.(chatId, bv, lkAtFire));
+        void setReadState(chatId, bv, lkAtFire, storageScopeRef.current).then(() =>
+          onWriteRef.current?.(chatId, bv, lkAtFire),
+        );
       }, writeDebounceMs);
     };
 
@@ -292,7 +296,7 @@ export function useReadTracker({
       const bv = bottomVisibleIdRef.current;
       const lk = latestKnownIdRef.current;
       if (!bv || !lk) return;
-      void setReadState(chatId, bv, lk).then(() => onWriteRef.current?.(chatId, bv, lk));
+      void setReadState(chatId, bv, lk, storageScopeRef.current).then(() => onWriteRef.current?.(chatId, bv, lk));
     };
     const onVis = () => {
       if (document.visibilityState === "hidden") flushNow();

--- a/packages/web/src/lib/__tests__/draft-store.test.ts
+++ b/packages/web/src/lib/__tests__/draft-store.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { beforeEach, describe, expect, it } from "vitest";
+import { scopedStorageKey } from "../browser-storage-scope.js";
 import {
   chatDraftScope,
   clearDraft,
@@ -10,7 +11,7 @@ import {
   saveDraft,
 } from "../draft-store.js";
 
-const STORAGE_KEY = "first-tree:chat-drafts:v1";
+const STORAGE_KEY = scopedStorageKey("first-tree:chat-drafts:v1");
 
 beforeEach(() => {
   window.localStorage.clear();

--- a/packages/web/src/lib/__tests__/draft-store.test.ts
+++ b/packages/web/src/lib/__tests__/draft-store.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment happy-dom
 
 import { beforeEach, describe, expect, it } from "vitest";
-import { scopedStorageKey } from "../browser-storage-scope.js";
+import {
+  captureBrowserStorageScope,
+  invalidateBrowserStorageScope,
+  scopedStorageKey,
+  setBrowserStorageUser,
+} from "../browser-storage-scope.js";
 import {
   chatDraftScope,
   clearDraft,
@@ -18,6 +23,17 @@ beforeEach(() => {
 });
 
 describe("saveDraft / loadDraft", () => {
+  it("does not persist a draft after its captured browser scope is invalidated", () => {
+    setBrowserStorageUser("user-a");
+    const browserScope = captureBrowserStorageScope();
+    invalidateBrowserStorageScope(browserScope);
+
+    saveDraft("chat-1", { text: "stale secret" }, Date.now(), browserScope);
+
+    expect(localStorage.getItem(scopedStorageKey("first-tree:chat-drafts:v1", browserScope))).toBeNull();
+    setBrowserStorageUser(null);
+  });
+
   it("round-trips body text for a chat scope", () => {
     saveDraft("chat-1", { text: "hello world" });
     expect(loadDraft("chat-1")).toEqual({ text: "hello world", participantIds: [] });

--- a/packages/web/src/lib/__tests__/use-chat-draft-text.test.tsx
+++ b/packages/web/src/lib/__tests__/use-chat-draft-text.test.tsx
@@ -3,6 +3,7 @@
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createDomHarness, type DomHarness } from "../../test-utils/dom-harness.js";
+import { setBrowserStorageUser } from "../browser-storage-scope.js";
 import { chatDraftScope, loadDraft, saveDraft } from "../draft-store.js";
 import { useChatDraftText } from "../use-chat-draft-text.js";
 
@@ -10,6 +11,8 @@ let h: DomHarness;
 
 beforeEach(() => {
   window.localStorage.clear();
+  setBrowserStorageUser(null);
+  setBrowserStorageUser("user-1");
   h = createDomHarness();
 });
 afterEach(() => h.cleanup());

--- a/packages/web/src/lib/browser-storage-scope.ts
+++ b/packages/web/src/lib/browser-storage-scope.ts
@@ -12,6 +12,8 @@ const KNOWN_DATABASES_KEY = "first-tree:browser-databases:v1";
 const INVALIDATED_SCOPES_KEY = "first-tree:invalidated-scopes:v1";
 export const BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT = "first-tree:browser-scope-invalidated";
 const SCOPE_CHANNEL = "first-tree-browser-scope";
+const invalidatedScopes = new Set<string>();
+let scopeChannel: BroadcastChannel | null = null;
 
 export type BrowserStorageScope = {
   key: string;
@@ -52,6 +54,7 @@ export function isBrowserStorageScopeCurrent(scope: BrowserStorageScope): boolea
 }
 
 function isScopeInvalidated(key: string): boolean {
+  if (invalidatedScopes.has(key)) return true;
   try {
     const raw = typeof localStorage !== "undefined" ? localStorage.getItem(INVALIDATED_SCOPES_KEY) : null;
     const invalidated = raw ? (JSON.parse(raw) as unknown) : [];
@@ -62,6 +65,7 @@ function isScopeInvalidated(key: string): boolean {
 }
 
 function clearInvalidatedScope(key: string): void {
+  invalidatedScopes.delete(key);
   try {
     if (typeof localStorage === "undefined") return;
     const raw = localStorage.getItem(INVALIDATED_SCOPES_KEY);
@@ -77,6 +81,7 @@ function clearInvalidatedScope(key: string): void {
 
 function invalidateScopeFromOtherDocument(scope: BrowserStorageScope): void {
   if (scope.key !== getBrowserStorageScope() || userId === null) return;
+  invalidatedScopes.add(scope.key);
   window.dispatchEvent(new CustomEvent(BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT, { detail: { scope } }));
 }
 
@@ -89,6 +94,7 @@ function handleScopeInvalidationMessage(value: unknown): void {
 }
 
 export function invalidateBrowserStorageScope(scope: BrowserStorageScope): void {
+  invalidatedScopes.add(scope.key);
   try {
     const raw = typeof localStorage !== "undefined" ? localStorage.getItem(INVALIDATED_SCOPES_KEY) : null;
     const invalidated = raw ? (JSON.parse(raw) as unknown) : [];
@@ -102,11 +108,7 @@ export function invalidateBrowserStorageScope(scope: BrowserStorageScope): void 
     // BroadcastChannel below still covers modern browsers if storage is denied.
   }
   try {
-    if (typeof BroadcastChannel !== "undefined") {
-      const channel = new BroadcastChannel(SCOPE_CHANNEL);
-      channel.postMessage({ scope });
-      channel.close();
-    }
+    if (scopeChannel) scopeChannel.postMessage({ scope });
   } catch {
     // Storage event is the fallback transport.
   }
@@ -127,8 +129,8 @@ if (typeof window !== "undefined") {
   });
   try {
     if (typeof BroadcastChannel !== "undefined") {
-      const channel = new BroadcastChannel(SCOPE_CHANNEL);
-      channel.onmessage = (event) => handleScopeInvalidationMessage(event.data);
+      scopeChannel = new BroadcastChannel(SCOPE_CHANNEL);
+      scopeChannel.onmessage = (event) => handleScopeInvalidationMessage(event.data);
     }
   } catch {
     // BroadcastChannel is optional; storage events remain available.

--- a/packages/web/src/lib/browser-storage-scope.ts
+++ b/packages/web/src/lib/browser-storage-scope.ts
@@ -10,6 +10,12 @@ let userId: string | null = null;
 let revision = 0;
 const KNOWN_DATABASES_KEY = "first-tree:browser-databases:v1";
 
+export type BrowserStorageScope = {
+  key: string;
+  revision: number;
+  userId: string | null;
+};
+
 function serverOrigin(): string {
   if (typeof window !== "undefined" && window.location?.origin) return window.location.origin;
   if (typeof globalThis.location !== "undefined" && globalThis.location?.origin) return globalThis.location.origin;
@@ -33,12 +39,20 @@ export function getBrowserStorageScope(): string {
   return `${encode(serverOrigin())}:${encode(userId ?? "anonymous")}`;
 }
 
-export function scopedStorageKey(base: string): string {
-  return `${base}:${getBrowserStorageScope()}`;
+export function captureBrowserStorageScope(): BrowserStorageScope {
+  return { key: getBrowserStorageScope(), revision, userId };
 }
 
-export function scopedDatabaseName(base: string): string {
-  const name = `${base}:${getBrowserStorageScope()}`;
+export function isBrowserStorageScopeCurrent(scope: BrowserStorageScope): boolean {
+  return scope.revision === revision && scope.key === getBrowserStorageScope();
+}
+
+export function scopedStorageKey(base: string, scope: BrowserStorageScope = captureBrowserStorageScope()): string {
+  return `${base}:${scope.key}`;
+}
+
+export function scopedDatabaseName(base: string, scope: BrowserStorageScope = captureBrowserStorageScope()): string {
+  const name = `${base}:${scope.key}`;
   try {
     const raw = typeof localStorage !== "undefined" ? localStorage.getItem(KNOWN_DATABASES_KEY) : null;
     const names = raw ? (JSON.parse(raw) as unknown) : [];
@@ -58,26 +72,33 @@ export function scopedDatabaseName(base: string): string {
  * best-effort: logout must complete even when storage is unavailable or a
  * browser does not expose the IndexedDB enumeration API.
  */
-export async function clearPersistentBrowserStorage(): Promise<void> {
+export async function clearPersistentBrowserStorage(scope: BrowserStorageScope): Promise<void> {
   const names = new Set<string>();
+  const deletedNames = new Set<string>();
+  const scopedSuffix = `:${scope.key}`;
+  const legacyDatabaseNames = new Set(["first-tree-chat-cache", "first-tree-images"]);
+  const registryNames: string[] = [];
   try {
     const raw = typeof localStorage !== "undefined" ? localStorage.getItem(KNOWN_DATABASES_KEY) : null;
     const known = raw ? (JSON.parse(raw) as unknown) : [];
     if (Array.isArray(known)) {
       for (const name of known) {
-        if (typeof name === "string" && name.startsWith("first-tree-")) names.add(name);
+        if (typeof name !== "string") continue;
+        registryNames.push(name);
+        if (name.endsWith(scopedSuffix) || legacyDatabaseNames.has(name)) names.add(name);
       }
     }
   } catch {
     // Fall through to the known database names below.
   }
   try {
-    if (typeof localStorage !== "undefined") localStorage.clear();
-  } catch {
-    // Storage can be denied in private mode or by browser policy.
-  }
-  try {
-    if (typeof sessionStorage !== "undefined") sessionStorage.clear();
+    if (typeof localStorage !== "undefined") {
+      localStorage.removeItem(scopedStorageKey("first-tree:chat-drafts:v1", scope));
+      // This legacy key was shared by all accounts and therefore cannot be
+      // safely attributed; remove it as an explicitly named legacy store.
+      localStorage.removeItem("first-tree:chat-drafts:v1");
+      if (scope.userId) localStorage.removeItem(`first-tree:selectedOrganizationId:${scope.userId}`);
+    }
   } catch {
     // Storage can be denied in private mode or by browser policy.
   }
@@ -87,27 +108,43 @@ export async function clearPersistentBrowserStorage(): Promise<void> {
     const databases = indexedDB.databases;
     if (typeof databases === "function") {
       for (const database of await databases.call(indexedDB)) {
-        if (database.name?.startsWith("first-tree-")) names.add(database.name);
+        if (database.name && (database.name.endsWith(scopedSuffix) || legacyDatabaseNames.has(database.name))) {
+          names.add(database.name);
+        }
       }
     }
   } catch {
     // Fall through to the known database names below.
   }
-  // Older browsers do not expose indexedDB.databases(). These deletes are
-  // harmless when the database does not exist and cover the shipped bases.
-  names.add("first-tree-chat-cache");
-  names.add("first-tree-images");
+  // Older browsers do not expose indexedDB.databases(). These deletes cover
+  // only the departing scope and explicitly named legacy databases.
+  for (const name of legacyDatabaseNames) names.add(name);
   await Promise.all(
     [...names].map(
       (name) =>
-        new Promise<void>((resolve) => {
+        new Promise<void>((resolve, reject) => {
           try {
             const request = indexedDB.deleteDatabase(name);
-            request.onsuccess = request.onerror = request.onblocked = () => resolve();
+            request.onsuccess = () => {
+              deletedNames.add(name);
+              resolve();
+            };
+            request.onerror = () => reject(request.error ?? new Error(`Failed to delete IndexedDB database ${name}`));
+            // A blocked request is still pending. Open connections receive
+            // `versionchange` and close; only onsuccess proves deletion.
+            request.onblocked = () => undefined;
           } catch {
-            resolve();
+            reject(new Error(`Failed to delete IndexedDB database ${name}`));
           }
         }),
     ),
   );
+  try {
+    if (typeof localStorage !== "undefined") {
+      const remaining = registryNames.filter((name) => !deletedNames.has(name));
+      localStorage.setItem(KNOWN_DATABASES_KEY, JSON.stringify(remaining));
+    }
+  } catch {
+    // Registry maintenance is best-effort after the data deletion succeeds.
+  }
 }

--- a/packages/web/src/lib/browser-storage-scope.ts
+++ b/packages/web/src/lib/browser-storage-scope.ts
@@ -1,0 +1,113 @@
+/**
+ * Identity scope for browser-local application data.
+ *
+ * Sensitive caches must never be addressable by a chat or image id alone:
+ * those ids are server data and can collide across accounts or deployments.
+ * The scope is updated by AuthProvider as the authenticated member changes.
+ */
+
+let userId: string | null = null;
+let revision = 0;
+const KNOWN_DATABASES_KEY = "first-tree:browser-databases:v1";
+
+function serverOrigin(): string {
+  if (typeof window !== "undefined" && window.location?.origin) return window.location.origin;
+  if (typeof globalThis.location !== "undefined" && globalThis.location?.origin) return globalThis.location.origin;
+  return "unknown-origin";
+}
+
+function encode(value: string): string {
+  return encodeURIComponent(value).replace(/%/g, "_");
+}
+
+export function setBrowserStorageUser(user: string | null): void {
+  if (userId !== user) revision += 1;
+  userId = user;
+}
+
+export function getBrowserStorageRevision(): number {
+  return revision;
+}
+
+export function getBrowserStorageScope(): string {
+  return `${encode(serverOrigin())}:${encode(userId ?? "anonymous")}`;
+}
+
+export function scopedStorageKey(base: string): string {
+  return `${base}:${getBrowserStorageScope()}`;
+}
+
+export function scopedDatabaseName(base: string): string {
+  const name = `${base}:${getBrowserStorageScope()}`;
+  try {
+    const raw = typeof localStorage !== "undefined" ? localStorage.getItem(KNOWN_DATABASES_KEY) : null;
+    const names = raw ? (JSON.parse(raw) as unknown) : [];
+    const known = Array.isArray(names) ? names.filter((value): value is string => typeof value === "string") : [];
+    if (!known.includes(name) && typeof localStorage !== "undefined") {
+      localStorage.setItem(KNOWN_DATABASES_KEY, JSON.stringify([...known, name]));
+    }
+  } catch {
+    // The registry is only a compatibility fallback for browsers without
+    // indexedDB.databases(); a storage failure must not block cache access.
+  }
+  return name;
+}
+
+/**
+ * Remove all browser-local data owned by the web app. This is deliberately
+ * best-effort: logout must complete even when storage is unavailable or a
+ * browser does not expose the IndexedDB enumeration API.
+ */
+export async function clearPersistentBrowserStorage(): Promise<void> {
+  const names = new Set<string>();
+  try {
+    const raw = typeof localStorage !== "undefined" ? localStorage.getItem(KNOWN_DATABASES_KEY) : null;
+    const known = raw ? (JSON.parse(raw) as unknown) : [];
+    if (Array.isArray(known)) {
+      for (const name of known) {
+        if (typeof name === "string" && name.startsWith("first-tree-")) names.add(name);
+      }
+    }
+  } catch {
+    // Fall through to the known database names below.
+  }
+  try {
+    if (typeof localStorage !== "undefined") localStorage.clear();
+  } catch {
+    // Storage can be denied in private mode or by browser policy.
+  }
+  try {
+    if (typeof sessionStorage !== "undefined") sessionStorage.clear();
+  } catch {
+    // Storage can be denied in private mode or by browser policy.
+  }
+
+  if (typeof indexedDB === "undefined") return;
+  try {
+    const databases = indexedDB.databases;
+    if (typeof databases === "function") {
+      for (const database of await databases.call(indexedDB)) {
+        if (database.name?.startsWith("first-tree-")) names.add(database.name);
+      }
+    }
+  } catch {
+    // Fall through to the known database names below.
+  }
+  // Older browsers do not expose indexedDB.databases(). These deletes are
+  // harmless when the database does not exist and cover the shipped bases.
+  names.add("first-tree-chat-cache");
+  names.add("first-tree-images");
+  await Promise.all(
+    [...names].map(
+      (name) =>
+        new Promise<void>((resolve) => {
+          try {
+            const request = indexedDB.deleteDatabase(name);
+            request.onsuccess = request.onerror = request.onblocked = () => resolve();
+          } catch {
+            resolve();
+          }
+        }),
+    ),
+  );
+}

--- a/packages/web/src/lib/browser-storage-scope.ts
+++ b/packages/web/src/lib/browser-storage-scope.ts
@@ -9,6 +9,9 @@
 let userId: string | null = null;
 let revision = 0;
 const KNOWN_DATABASES_KEY = "first-tree:browser-databases:v1";
+const INVALIDATED_SCOPES_KEY = "first-tree:invalidated-scopes:v1";
+export const BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT = "first-tree:browser-scope-invalidated";
+const SCOPE_CHANNEL = "first-tree-browser-scope";
 
 export type BrowserStorageScope = {
   key: string;
@@ -29,6 +32,7 @@ function encode(value: string): string {
 export function setBrowserStorageUser(user: string | null): void {
   if (userId !== user) revision += 1;
   userId = user;
+  if (user) clearInvalidatedScope(getBrowserStorageScope());
 }
 
 export function getBrowserStorageRevision(): number {
@@ -44,7 +48,91 @@ export function captureBrowserStorageScope(): BrowserStorageScope {
 }
 
 export function isBrowserStorageScopeCurrent(scope: BrowserStorageScope): boolean {
-  return scope.revision === revision && scope.key === getBrowserStorageScope();
+  return scope.revision === revision && scope.key === getBrowserStorageScope() && !isScopeInvalidated(scope.key);
+}
+
+function isScopeInvalidated(key: string): boolean {
+  try {
+    const raw = typeof localStorage !== "undefined" ? localStorage.getItem(INVALIDATED_SCOPES_KEY) : null;
+    const invalidated = raw ? (JSON.parse(raw) as unknown) : [];
+    return Array.isArray(invalidated) && invalidated.includes(key);
+  } catch {
+    return false;
+  }
+}
+
+function clearInvalidatedScope(key: string): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    const raw = localStorage.getItem(INVALIDATED_SCOPES_KEY);
+    const invalidated = raw ? (JSON.parse(raw) as unknown) : [];
+    if (!Array.isArray(invalidated)) return;
+    const remaining = invalidated.filter((value): value is string => typeof value === "string" && value !== key);
+    if (remaining.length === 0) localStorage.removeItem(INVALIDATED_SCOPES_KEY);
+    else localStorage.setItem(INVALIDATED_SCOPES_KEY, JSON.stringify(remaining));
+  } catch {
+    // Storage can be denied in private mode; the in-memory revision remains.
+  }
+}
+
+function invalidateScopeFromOtherDocument(scope: BrowserStorageScope): void {
+  if (scope.key !== getBrowserStorageScope() || userId === null) return;
+  window.dispatchEvent(new CustomEvent(BROWSER_STORAGE_SCOPE_INVALIDATED_EVENT, { detail: { scope } }));
+}
+
+function handleScopeInvalidationMessage(value: unknown): void {
+  if (typeof value !== "object" || value === null || !("scope" in value)) return;
+  const scope = value.scope;
+  if (typeof scope !== "object" || scope === null) return;
+  if (!("key" in scope) || !("userId" in scope) || typeof scope.key !== "string") return;
+  invalidateScopeFromOtherDocument(scope as BrowserStorageScope);
+}
+
+export function invalidateBrowserStorageScope(scope: BrowserStorageScope): void {
+  try {
+    const raw = typeof localStorage !== "undefined" ? localStorage.getItem(INVALIDATED_SCOPES_KEY) : null;
+    const invalidated = raw ? (JSON.parse(raw) as unknown) : [];
+    const next = Array.isArray(invalidated)
+      ? invalidated.filter((value): value is string => typeof value === "string")
+      : [];
+    if (!next.includes(scope.key) && typeof localStorage !== "undefined") {
+      localStorage.setItem(INVALIDATED_SCOPES_KEY, JSON.stringify([...next, scope.key]));
+    }
+  } catch {
+    // BroadcastChannel below still covers modern browsers if storage is denied.
+  }
+  try {
+    if (typeof BroadcastChannel !== "undefined") {
+      const channel = new BroadcastChannel(SCOPE_CHANNEL);
+      channel.postMessage({ scope });
+      channel.close();
+    }
+  } catch {
+    // Storage event is the fallback transport.
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key !== INVALIDATED_SCOPES_KEY || !event.newValue) return;
+    try {
+      const invalidated = JSON.parse(event.newValue) as unknown;
+      if (Array.isArray(invalidated) && invalidated.includes(getBrowserStorageScope())) {
+        const scope = captureBrowserStorageScope();
+        invalidateScopeFromOtherDocument(scope);
+      }
+    } catch {
+      // Ignore malformed cross-document markers.
+    }
+  });
+  try {
+    if (typeof BroadcastChannel !== "undefined") {
+      const channel = new BroadcastChannel(SCOPE_CHANNEL);
+      channel.onmessage = (event) => handleScopeInvalidationMessage(event.data);
+    }
+  } catch {
+    // BroadcastChannel is optional; storage events remain available.
+  }
 }
 
 export function scopedStorageKey(base: string, scope: BrowserStorageScope = captureBrowserStorageScope()): string {
@@ -75,8 +163,11 @@ export function scopedDatabaseName(base: string, scope: BrowserStorageScope = ca
 export async function clearPersistentBrowserStorage(scope: BrowserStorageScope): Promise<void> {
   const names = new Set<string>();
   const deletedNames = new Set<string>();
-  const scopedSuffix = `:${scope.key}`;
   const legacyDatabaseNames = new Set(["first-tree-chat-cache", "first-tree-images"]);
+  const scopedDatabaseNames = new Set([
+    scopedDatabaseName("first-tree-chat-cache", scope),
+    scopedDatabaseName("first-tree-images", scope),
+  ]);
   const registryNames: string[] = [];
   try {
     const raw = typeof localStorage !== "undefined" ? localStorage.getItem(KNOWN_DATABASES_KEY) : null;
@@ -85,7 +176,7 @@ export async function clearPersistentBrowserStorage(scope: BrowserStorageScope):
       for (const name of known) {
         if (typeof name !== "string") continue;
         registryNames.push(name);
-        if (name.endsWith(scopedSuffix) || legacyDatabaseNames.has(name)) names.add(name);
+        if (scopedDatabaseNames.has(name) || legacyDatabaseNames.has(name)) names.add(name);
       }
     }
   } catch {
@@ -108,7 +199,7 @@ export async function clearPersistentBrowserStorage(scope: BrowserStorageScope):
     const databases = indexedDB.databases;
     if (typeof databases === "function") {
       for (const database of await databases.call(indexedDB)) {
-        if (database.name && (database.name.endsWith(scopedSuffix) || legacyDatabaseNames.has(database.name))) {
+        if (database.name && (scopedDatabaseNames.has(database.name) || legacyDatabaseNames.has(database.name))) {
           names.add(database.name);
         }
       }
@@ -118,6 +209,7 @@ export async function clearPersistentBrowserStorage(scope: BrowserStorageScope):
   }
   // Older browsers do not expose indexedDB.databases(). These deletes cover
   // only the departing scope and explicitly named legacy databases.
+  for (const name of scopedDatabaseNames) names.add(name);
   for (const name of legacyDatabaseNames) names.add(name);
   await Promise.all(
     [...names].map(
@@ -130,9 +222,10 @@ export async function clearPersistentBrowserStorage(scope: BrowserStorageScope):
               resolve();
             };
             request.onerror = () => reject(request.error ?? new Error(`Failed to delete IndexedDB database ${name}`));
-            // A blocked request is still pending. Open connections receive
-            // `versionchange` and close; only onsuccess proves deletion.
-            request.onblocked = () => undefined;
+            // Treat a blocked request as an incomplete purge so callers can
+            // keep the session available and offer a retry. Only onsuccess
+            // proves deletion.
+            request.onblocked = () => reject(new Error(`IndexedDB database ${name} is still open`));
           } catch {
             reject(new Error(`Failed to delete IndexedDB database ${name}`));
           }

--- a/packages/web/src/lib/draft-store.ts
+++ b/packages/web/src/lib/draft-store.ts
@@ -13,6 +13,8 @@
  * scanning every key in the namespace.
  */
 
+import { scopedStorageKey } from "./browser-storage-scope.js";
+
 const STORAGE_KEY = "first-tree:chat-drafts:v1";
 
 /** Cap on retained drafts; oldest-by-`updatedAt` are pruned past this. Drafts
@@ -47,7 +49,7 @@ function isStoredDraft(v: unknown): v is StoredDraft {
 function readMap(): DraftMap {
   if (typeof window === "undefined") return {};
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const raw = window.localStorage.getItem(scopedStorageKey(STORAGE_KEY));
     if (!raw) return {};
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null) return {};
@@ -65,7 +67,7 @@ function readMap(): DraftMap {
 function writeMap(map: DraftMap): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+    window.localStorage.setItem(scopedStorageKey(STORAGE_KEY), JSON.stringify(map));
   } catch {
     // localStorage may be unavailable (private mode) or full; drafts are a
     // best-effort convenience, so a write failure is silently ignored.
@@ -81,9 +83,8 @@ function prune(map: DraftMap): DraftMap {
 }
 
 /** Per-user prefix so a shared browser never restores another account's draft
- *  after a logout/login on the same profile — `logout()` clears tokens and
- *  query state, not this store. Mirrors the userId-bucketed selected-org
- *  storage in auth-context (`first-tree:selectedOrganizationId:<userId>`). */
+ *  after a logout/login on the same profile. The storage key itself is also
+ *  scoped by account and server origin; logout removes it with other app data. */
 function userPrefix(userId: string | null): string {
   return `u:${userId ?? "anon"}`;
 }

--- a/packages/web/src/lib/draft-store.ts
+++ b/packages/web/src/lib/draft-store.ts
@@ -13,7 +13,12 @@
  * scanning every key in the namespace.
  */
 
-import { scopedStorageKey } from "./browser-storage-scope.js";
+import {
+  type BrowserStorageScope,
+  captureBrowserStorageScope,
+  isBrowserStorageScopeCurrent,
+  scopedStorageKey,
+} from "./browser-storage-scope.js";
 
 const STORAGE_KEY = "first-tree:chat-drafts:v1";
 
@@ -46,10 +51,11 @@ function isStoredDraft(v: unknown): v is StoredDraft {
   return true;
 }
 
-function readMap(): DraftMap {
+function readMap(browserScope: BrowserStorageScope): DraftMap {
   if (typeof window === "undefined") return {};
+  if (!isBrowserStorageScopeCurrent(browserScope)) return {};
   try {
-    const raw = window.localStorage.getItem(scopedStorageKey(STORAGE_KEY));
+    const raw = window.localStorage.getItem(scopedStorageKey(STORAGE_KEY, browserScope));
     if (!raw) return {};
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null) return {};
@@ -64,10 +70,11 @@ function readMap(): DraftMap {
   }
 }
 
-function writeMap(map: DraftMap): void {
+function writeMap(map: DraftMap, browserScope: BrowserStorageScope): void {
   if (typeof window === "undefined") return;
+  if (!isBrowserStorageScopeCurrent(browserScope)) return;
   try {
-    window.localStorage.setItem(scopedStorageKey(STORAGE_KEY), JSON.stringify(map));
+    window.localStorage.setItem(scopedStorageKey(STORAGE_KEY, browserScope), JSON.stringify(map));
   } catch {
     // localStorage may be unavailable (private mode) or full; drafts are a
     // best-effort convenience, so a write failure is silently ignored.
@@ -106,8 +113,11 @@ export function newChatDraftScope(
 }
 
 /** Read the stored draft for `scope`, or `null` when none is stored. */
-export function loadDraft(scope: string): DraftSnapshot | null {
-  const entry = readMap()[scope];
+export function loadDraft(
+  scope: string,
+  browserScope: BrowserStorageScope = captureBrowserStorageScope(),
+): DraftSnapshot | null {
+  const entry = readMap(browserScope)[scope];
   if (!entry) return null;
   return { text: entry.text, participantIds: entry.participantIds ?? [] };
 }
@@ -122,27 +132,28 @@ export function saveDraft(
   scope: string,
   draft: { text: string; participantIds?: readonly string[] },
   now: number = Date.now(),
+  browserScope: BrowserStorageScope = captureBrowserStorageScope(),
 ): void {
-  const map = readMap();
+  const map = readMap(browserScope);
   if (draft.text.trim().length === 0) {
     if (scope in map) {
       delete map[scope];
-      writeMap(map);
+      writeMap(map, browserScope);
     }
     return;
   }
   const participantIds =
     draft.participantIds && draft.participantIds.length > 0 ? [...draft.participantIds] : undefined;
   map[scope] = { text: draft.text, participantIds, updatedAt: now };
-  writeMap(prune(map));
+  writeMap(prune(map), browserScope);
 }
 
 /** Remove any stored draft for `scope` (used on successful send). */
-export function clearDraft(scope: string): void {
-  const map = readMap();
+export function clearDraft(scope: string, browserScope: BrowserStorageScope = captureBrowserStorageScope()): void {
+  const map = readMap(browserScope);
   if (scope in map) {
     delete map[scope];
-    writeMap(map);
+    writeMap(map, browserScope);
   }
 }
 
@@ -162,12 +173,13 @@ export function parkFailedDraftIfSwitched(
   sendChatId: string,
   currentChatId: string,
   text: string,
+  browserScope: BrowserStorageScope = captureBrowserStorageScope(),
 ): boolean {
   if (currentChatId === sendChatId) return false;
   const scope = chatDraftScope(userId, sendChatId);
   // Park the rejected text in the originating chat, but never clobber a newer
   // draft the user has since typed there (mirrors the same-chat rollback's
   // "only restore into an empty composer" guard). saveDraft no-ops on empty.
-  if (loadDraft(scope) === null) saveDraft(scope, { text });
+  if (loadDraft(scope, browserScope) === null) saveDraft(scope, { text }, Date.now(), browserScope);
   return true;
 }

--- a/packages/web/src/lib/use-chat-draft-text.ts
+++ b/packages/web/src/lib/use-chat-draft-text.ts
@@ -1,4 +1,5 @@
 import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
+import { captureBrowserStorageScope } from "./browser-storage-scope.js";
 import { chatDraftScope, loadDraft, saveDraft } from "./draft-store.js";
 
 /**
@@ -19,7 +20,8 @@ import { chatDraftScope, loadDraft, saveDraft } from "./draft-store.js";
  */
 export function useChatDraftText(userId: string | null, chatId: string): [string, Dispatch<SetStateAction<string>>] {
   const scope = chatDraftScope(userId, chatId);
-  const [draft, setDraft] = useState<string>(() => loadDraft(scope)?.text ?? "");
+  const browserScopeRef = useRef(captureBrowserStorageScope());
+  const [draft, setDraft] = useState<string>(() => loadDraft(scope, browserScopeRef.current)?.text ?? "");
   // The scope the current `draft` value belongs to. Lets the persist effect
   // write under the right scope and detect a switch (the scope changes a
   // render before the state catches up).
@@ -28,11 +30,11 @@ export function useChatDraftText(userId: string | null, chatId: string): [string
   useEffect(() => {
     if (scopeRef.current === scope) return;
     scopeRef.current = scope;
-    setDraft(loadDraft(scope)?.text ?? "");
+    setDraft(loadDraft(scope, browserScopeRef.current)?.text ?? "");
   }, [scope]);
 
   useEffect(() => {
-    saveDraft(scopeRef.current, { text: draft });
+    saveDraft(scopeRef.current, { text: draft }, Date.now(), browserScopeRef.current);
   }, [draft]);
 
   return [draft, setDraft];

--- a/packages/web/src/lib/use-image-src.ts
+++ b/packages/web/src/lib/use-image-src.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { fetchAttachmentBase64 } from "../api/attachments.js";
 import { getImage, putImage } from "../api/image-store.js";
+import { captureBrowserStorageScope } from "./browser-storage-scope.js";
 
 /**
  * Resolve a chat image reference to a renderable `data:` URL.
@@ -25,10 +26,11 @@ export function useImageSrc(imageId: string | undefined): ImageSrcState {
       setState({ kind: "miss" });
       return;
     }
+    const storageScope = captureBrowserStorageScope();
     let cancelled = false;
     setState({ kind: "loading" });
     (async () => {
-      const hit = await getImage(imageId);
+      const hit = await getImage(imageId, storageScope);
       if (cancelled) return;
       if (hit) {
         setState({ kind: "hit", src: `data:${hit.mimeType};base64,${hit.base64}` });
@@ -38,7 +40,7 @@ export function useImageSrc(imageId: string | undefined): ImageSrcState {
         const fetched = await fetchAttachmentBase64(imageId);
         if (cancelled) return;
         // Warm the cache for subsequent renders; best-effort.
-        putImage({ imageId, base64: fetched.base64, mimeType: fetched.mimeType }).catch(() => {});
+        putImage({ imageId, base64: fetched.base64, mimeType: fetched.mimeType }, storageScope).catch(() => {});
         setState({ kind: "hit", src: `data:${fetched.mimeType};base64,${fetched.base64}` });
       } catch {
         if (!cancelled) setState({ kind: "miss" });

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1532,6 +1532,19 @@ describe("web DOM interaction coverage", () => {
     api.get = originalGet;
   });
 
+  it("shows a retry when sign-out cannot finish clearing browser data", async () => {
+    const { UserMenu } = await import("../../components/user-menu.js");
+    authMock.value = { ...authMock.value, logout: vi.fn().mockRejectedValueOnce(new Error("blocked")) };
+    const account = await renderDom(<UserMenu />);
+    await click(account.container.querySelector('button[aria-haspopup="menu"]'));
+    await click(
+      [...account.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Sign out")) ??
+        null,
+    );
+    await waitForText("Sign out incomplete", document.body);
+    expect(document.body.textContent).toContain("Close other First Tree tabs and retry");
+  });
+
   it("shows the current team in the header and lists the other teams without a collapse", async () => {
     const { TeamSwitcher } = await import("../../components/team-switcher.js");
     authMock.value = {

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1126,11 +1126,14 @@ describe("web DOM interaction coverage", () => {
     await keyDown(textarea, "Enter");
     await waitForCondition(() => meChatMocks.createMeTaskChat.mock.calls.length > 0, "Expected image task create");
     expect(attachmentMocks.uploadAttachment).toHaveBeenCalledWith(dropped);
-    expect(imageStoreMocks.putImage).toHaveBeenCalledWith({
-      imageId: "uploaded-image",
-      base64: "base64",
-      mimeType: "image/png",
-    });
+    expect(imageStoreMocks.putImage).toHaveBeenCalledWith(
+      {
+        imageId: "uploaded-image",
+        base64: "base64",
+        mimeType: "image/png",
+      },
+      expect.objectContaining({ key: expect.any(String), revision: expect.any(Number) }),
+    );
     expect(meChatMocks.createMeTaskChat).toHaveBeenCalledWith({
       mode: "task",
       initialRecipientAgentIds: ["agent-2"],

--- a/packages/web/src/pages/mobile/me.tsx
+++ b/packages/web/src/pages/mobile/me.tsx
@@ -15,7 +15,7 @@ import { isStandalone } from "./install-guide-state.js";
 import { useInstallPrompt } from "./use-install-guide.js";
 
 export function MobileMePage() {
-  const { user, teamDisplayName, role, logout, retryLogout } = useAuth();
+  const { user, teamDisplayName, role, logout } = useAuth();
   const { addToast } = useOptionalToast();
   const displayName = user?.displayName ?? "Signed-in user";
   const username = user?.username ?? "";
@@ -75,19 +75,20 @@ export function MobileMePage() {
           className="min-h-11 justify-start"
           onClick={() => {
             const departingScope = captureBrowserStorageScope();
-            void Promise.resolve(logout({ scope: departingScope }))
+            let retryOperation: (() => Promise<"completed" | "incomplete" | "superseded">) | undefined;
+            void Promise.resolve(logout({ scope: departingScope, onIncomplete: (retry) => (retryOperation = retry) }))
               .then((completed) => {
                 if (completed === "incomplete" || completed === undefined) {
                   showLogoutIncompleteToast(
                     addToast,
-                    retryLogout ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
+                    retryOperation ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
                   );
                 }
               })
               .catch(() =>
                 showLogoutIncompleteToast(
                   addToast,
-                  retryLogout ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
+                  retryOperation ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
                 ),
               );
           }}

--- a/packages/web/src/pages/mobile/me.tsx
+++ b/packages/web/src/pages/mobile/me.tsx
@@ -7,6 +7,7 @@ import { Avatar } from "../../components/avatar.js";
 import { Button } from "../../components/ui/button.js";
 import { ThemeToggle } from "../../components/ui/theme-toggle.js";
 import { useOptionalToast } from "../../components/ui/toast.js";
+import { captureBrowserStorageScope } from "../../lib/browser-storage-scope.js";
 import { DISCORD_INVITE_URL } from "../../lib/community.js";
 import { MobilePage, MobileSection, mobileCardStyle } from "./components.js";
 import { InstallGuideSheet } from "./install-guide-sheet.js";
@@ -73,11 +74,20 @@ export function MobileMePage() {
           variant="outline"
           className="min-h-11 justify-start"
           onClick={() => {
-            void Promise.resolve(logout())
+            const departingScope = captureBrowserStorageScope();
+            void Promise.resolve(logout({ scope: departingScope }))
               .then((completed) => {
-                if (!completed) showLogoutIncompleteToast(addToast, logout);
+                if (!completed) {
+                  showLogoutIncompleteToast(addToast, () =>
+                    logout({ protectReplacementTokens: true, scope: departingScope }),
+                  );
+                }
               })
-              .catch(() => showLogoutIncompleteToast(addToast, logout));
+              .catch(() =>
+                showLogoutIncompleteToast(addToast, () =>
+                  logout({ protectReplacementTokens: true, scope: departingScope }),
+                ),
+              );
           }}
         >
           <LogOut className="h-4 w-4" />

--- a/packages/web/src/pages/mobile/me.tsx
+++ b/packages/web/src/pages/mobile/me.tsx
@@ -15,7 +15,7 @@ import { isStandalone } from "./install-guide-state.js";
 import { useInstallPrompt } from "./use-install-guide.js";
 
 export function MobileMePage() {
-  const { user, teamDisplayName, role, logout } = useAuth();
+  const { user, teamDisplayName, role, logout, retryLogout } = useAuth();
   const { addToast } = useOptionalToast();
   const displayName = user?.displayName ?? "Signed-in user";
   const username = user?.username ?? "";
@@ -77,15 +77,17 @@ export function MobileMePage() {
             const departingScope = captureBrowserStorageScope();
             void Promise.resolve(logout({ scope: departingScope }))
               .then((completed) => {
-                if (!completed) {
-                  showLogoutIncompleteToast(addToast, () =>
-                    logout({ protectReplacementTokens: true, scope: departingScope }),
+                if (completed === "incomplete" || completed === undefined) {
+                  showLogoutIncompleteToast(
+                    addToast,
+                    retryLogout ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
                   );
                 }
               })
               .catch(() =>
-                showLogoutIncompleteToast(addToast, () =>
-                  logout({ protectReplacementTokens: true, scope: departingScope }),
+                showLogoutIncompleteToast(
+                  addToast,
+                  retryLogout ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
                 ),
               );
           }}

--- a/packages/web/src/pages/mobile/me.tsx
+++ b/packages/web/src/pages/mobile/me.tsx
@@ -2,9 +2,11 @@ import type { MeMembership, OrgBrief } from "@first-tree/shared";
 import { ChevronRight, ExternalLink, HelpCircle, Loader2, LogOut, Palette, Smartphone, X } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "../../auth/auth-context.js";
+import { showLogoutIncompleteToast } from "../../auth/logout-recovery.js";
 import { Avatar } from "../../components/avatar.js";
 import { Button } from "../../components/ui/button.js";
 import { ThemeToggle } from "../../components/ui/theme-toggle.js";
+import { useOptionalToast } from "../../components/ui/toast.js";
 import { DISCORD_INVITE_URL } from "../../lib/community.js";
 import { MobilePage, MobileSection, mobileCardStyle } from "./components.js";
 import { InstallGuideSheet } from "./install-guide-sheet.js";
@@ -13,6 +15,7 @@ import { useInstallPrompt } from "./use-install-guide.js";
 
 export function MobileMePage() {
   const { user, teamDisplayName, role, logout } = useAuth();
+  const { addToast } = useOptionalToast();
   const displayName = user?.displayName ?? "Signed-in user";
   const username = user?.username ?? "";
   const avatarSrc = user?.avatarUrl ?? null;
@@ -65,7 +68,18 @@ export function MobileMePage() {
           />
         </MobileSection>
 
-        <Button type="button" variant="outline" className="min-h-11 justify-start" onClick={() => void logout()}>
+        <Button
+          type="button"
+          variant="outline"
+          className="min-h-11 justify-start"
+          onClick={() => {
+            void Promise.resolve(logout())
+              .then((completed) => {
+                if (!completed) showLogoutIncompleteToast(addToast, logout);
+              })
+              .catch(() => showLogoutIncompleteToast(addToast, logout));
+          }}
+        >
           <LogOut className="h-4 w-4" />
           Sign out
         </Button>

--- a/packages/web/src/pages/mobile/me.tsx
+++ b/packages/web/src/pages/mobile/me.tsx
@@ -65,7 +65,7 @@ export function MobileMePage() {
           />
         </MobileSection>
 
-        <Button type="button" variant="outline" className="min-h-11 justify-start" onClick={logout}>
+        <Button type="button" variant="outline" className="min-h-11 justify-start" onClick={() => void logout()}>
           <LogOut className="h-4 w-4" />
           Sign out
         </Button>

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -31,7 +31,7 @@ import { StepProgress } from "./step-progress.js";
  */
 export function OnboardingShell({ children }: { children: ReactNode }) {
   const { activeStep, finishLater, hasAgent } = useOnboardingFlow();
-  const { logout, memberships } = useAuth();
+  const { logout, retryLogout, memberships } = useAuth();
   const { addToast } = useToast();
   const navigate = useNavigate();
   const [setupAction, setSetupAction] = useState<"create" | "join" | null>(null);
@@ -54,12 +54,18 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
     const departingScope = captureBrowserStorageScope();
     void Promise.resolve(logout({ scope: departingScope }))
       .then((completed) => {
-        if (!completed) {
-          showLogoutIncompleteToast(addToast, () => logout({ protectReplacementTokens: true, scope: departingScope }));
+        if (completed === "incomplete" || completed === undefined) {
+          showLogoutIncompleteToast(
+            addToast,
+            retryLogout ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
+          );
         }
       })
       .catch(() =>
-        showLogoutIncompleteToast(addToast, () => logout({ protectReplacementTokens: true, scope: departingScope })),
+        showLogoutIncompleteToast(
+          addToast,
+          retryLogout ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
+        ),
       );
   };
 

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -9,6 +9,7 @@ import { TeamSwitchOverlay } from "../../components/team-switch-overlay.js";
 import { TeamSwitcher } from "../../components/team-switcher.js";
 import { Button } from "../../components/ui/button.js";
 import { useToast } from "../../components/ui/toast.js";
+import { captureBrowserStorageScope } from "../../lib/browser-storage-scope.js";
 import { COPY, STEP_COPY } from "./copy.js";
 import { useOnboardingFlow } from "./onboarding-flow.js";
 import { StepProgress } from "./step-progress.js";
@@ -50,11 +51,16 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
   // the menu's only destinations would fork them into a second team mid-setup.
   const isMultiTeam = memberships.length > 1;
   const signOut = () => {
-    void Promise.resolve(logout())
+    const departingScope = captureBrowserStorageScope();
+    void Promise.resolve(logout({ scope: departingScope }))
       .then((completed) => {
-        if (!completed) showLogoutIncompleteToast(addToast, logout);
+        if (!completed) {
+          showLogoutIncompleteToast(addToast, () => logout({ protectReplacementTokens: true, scope: departingScope }));
+        }
       })
-      .catch(() => showLogoutIncompleteToast(addToast, logout));
+      .catch(() =>
+        showLogoutIncompleteToast(addToast, () => logout({ protectReplacementTokens: true, scope: departingScope })),
+      );
   };
 
   return (

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -2,6 +2,7 @@ import { Plus, UserPlus } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { useNavigate } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
+import { showLogoutIncompleteToast } from "../../auth/logout-recovery.js";
 import { FirstTreeLogo } from "../../components/first-tree-logo.js";
 import { TeamSetupModal } from "../../components/team-setup-modal.js";
 import { TeamSwitchOverlay } from "../../components/team-switch-overlay.js";
@@ -48,6 +49,13 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
   // First-run users (single membership) keep the deliberately minimal chrome:
   // the menu's only destinations would fork them into a second team mid-setup.
   const isMultiTeam = memberships.length > 1;
+  const signOut = () => {
+    void Promise.resolve(logout())
+      .then((completed) => {
+        if (!completed) showLogoutIncompleteToast(addToast, logout);
+      })
+      .catch(() => showLogoutIncompleteToast(addToast, logout));
+  };
 
   return (
     // h-screen + overflow-hidden pins the app to the viewport, so the page can
@@ -89,12 +97,12 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
           {isMultiTeam ? (
             <>
               <TeamSwitcher />
-              <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={() => void logout()}>
+              <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={signOut}>
                 Sign out
               </Button>
             </>
           ) : (
-            <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={() => void logout()}>
+            <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={signOut}>
               Sign out
             </Button>
           )}

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -89,12 +89,12 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
           {isMultiTeam ? (
             <>
               <TeamSwitcher />
-              <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={logout}>
+              <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={() => void logout()}>
                 Sign out
               </Button>
             </>
           ) : (
-            <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={logout}>
+            <Button type="button" variant="link" className="h-auto p-0 text-label" onClick={() => void logout()}>
               Sign out
             </Button>
           )}

--- a/packages/web/src/pages/onboarding/onboarding-shell.tsx
+++ b/packages/web/src/pages/onboarding/onboarding-shell.tsx
@@ -31,7 +31,7 @@ import { StepProgress } from "./step-progress.js";
  */
 export function OnboardingShell({ children }: { children: ReactNode }) {
   const { activeStep, finishLater, hasAgent } = useOnboardingFlow();
-  const { logout, retryLogout, memberships } = useAuth();
+  const { logout, memberships } = useAuth();
   const { addToast } = useToast();
   const navigate = useNavigate();
   const [setupAction, setSetupAction] = useState<"create" | "join" | null>(null);
@@ -52,19 +52,20 @@ export function OnboardingShell({ children }: { children: ReactNode }) {
   const isMultiTeam = memberships.length > 1;
   const signOut = () => {
     const departingScope = captureBrowserStorageScope();
-    void Promise.resolve(logout({ scope: departingScope }))
+    let retryOperation: (() => Promise<"completed" | "incomplete" | "superseded">) | undefined;
+    void Promise.resolve(logout({ scope: departingScope, onIncomplete: (retry) => (retryOperation = retry) }))
       .then((completed) => {
         if (completed === "incomplete" || completed === undefined) {
           showLogoutIncompleteToast(
             addToast,
-            retryLogout ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
+            retryOperation ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
           );
         }
       })
       .catch(() =>
         showLogoutIncompleteToast(
           addToast,
-          retryLogout ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
+          retryOperation ?? (() => logout({ protectReplacementTokens: true, scope: departingScope })),
         ),
       );
   };

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -127,6 +127,7 @@ import { useChatScroll } from "../../../hooks/use-chat-scroll.js";
 import { useReadTracker } from "../../../hooks/use-read-tracker.js";
 import { useServerChannel } from "../../../hooks/use-server-channel.js";
 import { viewOf } from "../../../lib/agent-status-view.js";
+import { captureBrowserStorageScope } from "../../../lib/browser-storage-scope.js";
 import { attachmentIdFromHref, parseFailedDocHref, wrapFailedDocMentions } from "../../../lib/doc-preview-links.js";
 import { parkFailedDraftIfSwitched } from "../../../lib/draft-store.js";
 import { isNavigableWebHref } from "../../../lib/safe-href.js";
@@ -1795,7 +1796,7 @@ export function ChatView({
   // bounces between chats.
   const { data: cachedMessages } = useQuery({
     queryKey: ["chat-messages-cache", chatId],
-    queryFn: () => getCachedMessages(chatId),
+    queryFn: () => getCachedMessages(chatId, captureBrowserStorageScope()),
     staleTime: Infinity,
     refetchOnWindowFocus: false,
   });
@@ -1822,8 +1823,9 @@ export function ChatView({
   const { data: messagesData } = useQuery({
     queryKey: ["chat-messages", chatId],
     queryFn: async () => {
+      const storageScope = captureBrowserStorageScope();
       const fresh = await listChatMessages(chatId, { limit: 50 });
-      void cacheMessages(chatId, fresh.items);
+      void cacheMessages(chatId, fresh.items, storageScope);
       return fresh;
     },
     refetchInterval: 5_000,
@@ -2026,13 +2028,28 @@ export function ChatView({
     // round-trip + follow-up GET take 1–2s. The ctx returned here is threaded
     // to onError / onSuccess so we can reconcile with the server row.
     onMutate: async ({ content, mentions, inReplyTo, resolves }) => {
+      const storageScope = captureBrowserStorageScope();
       await queryClient.cancelQueries({ queryKey: messagesQueryKey });
       const previousDraft = draft;
       setDraft("");
       const optimistic = buildOptimisticTextMessage(content, { mentions, inReplyTo, resolves });
-      if (!optimistic) return { tempId: null, previousDraft, sendChatId: chatId, sendUserId: user?.id ?? null };
+      if (!optimistic) {
+        return {
+          tempId: null,
+          previousDraft,
+          sendChatId: chatId,
+          sendUserId: user?.id ?? null,
+          storageScope,
+        };
+      }
       insertOwnOptimisticMessage(optimistic);
-      return { tempId: optimistic.id, previousDraft, sendChatId: chatId, sendUserId: user?.id ?? null };
+      return {
+        tempId: optimistic.id,
+        previousDraft,
+        sendChatId: chatId,
+        sendUserId: user?.id ?? null,
+        storageScope,
+      };
     },
     onSuccess: (saved, _content, ctx) => {
       if (ctx?.tempId) replaceOptimisticMessage(ctx.tempId, saved);
@@ -2058,7 +2075,7 @@ export function ChatView({
         updatedAt: Date.now(),
       };
       queryClient.setQueryData<ReadState>(["chat-read-state", chatId], ownSendReadState);
-      void setReadState(chatId, saved.id, saved.id);
+      void setReadState(chatId, saved.id, saved.id, ctx?.storageScope);
       // Pre-advance the in-memory high water to the new message id
       // BEFORE initiating the smooth scroll. By the time the new
       // message commits to `mergedMessages`, `sessionHighestIdx`
@@ -2176,6 +2193,7 @@ export function ChatView({
       const previousDraft = draft;
       const sendChatId = chatId;
       const sendUserId = user?.id ?? null;
+      const storageScope = captureBrowserStorageScope();
       setDraft("");
       clearAttachments();
       await queryClient.cancelQueries({ queryKey: messagesQueryKey });
@@ -2200,7 +2218,7 @@ export function ChatView({
           // falls back to fetching from the server.
           try {
             const data = await readFileAsBase64(img.file);
-            await putImage({ imageId: uploaded.id, base64: data, mimeType: img.file.type });
+            await putImage({ imageId: uploaded.id, base64: data, mimeType: img.file.type }, storageScope);
           } catch {
             // Cache warm is best-effort; ignore IndexedDB quota / availability
             // failures and let the render path fetch from the server.
@@ -2314,7 +2332,7 @@ export function ChatView({
             updatedAt: Date.now(),
           };
           queryClient.setQueryData<ReadState>(["chat-read-state", chatId], ownSendReadState);
-          void setReadState(chatId, lastSentMessageId, lastSentMessageId);
+          void setReadState(chatId, lastSentMessageId, lastSentMessageId, storageScope);
           setPendingHighWaterAdvance({ chatId, messageId: lastSentMessageId });
         }
         // Same scroll-on-send as sendMut.onSuccess — the file-send
@@ -2629,7 +2647,7 @@ export function ChatView({
   // chat re-open does not block on IDB.
   const { data: readState } = useQuery({
     queryKey: ["chat-read-state", chatId],
-    queryFn: () => getReadState(chatId),
+    queryFn: () => getReadState(chatId, captureBrowserStorageScope()),
     staleTime: Infinity,
     refetchOnWindowFocus: false,
   });

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -2105,7 +2105,13 @@ export function ChatView({
       // React's commit so we don't race the textarea's controlled value.
       if (
         ctx?.previousDraft &&
-        !parkFailedDraftIfSwitched(ctx.sendUserId, ctx.sendChatId, chatIdRef.current, ctx.previousDraft)
+        !parkFailedDraftIfSwitched(
+          ctx.sendUserId,
+          ctx.sendChatId,
+          chatIdRef.current,
+          ctx.previousDraft,
+          ctx.storageScope,
+        )
       ) {
         setDraft((current) => (current === "" ? ctx.previousDraft : current));
       }
@@ -2348,7 +2354,10 @@ export function ChatView({
         // Only restore the pre-send draft if the user hasn't already started
         // typing something new during the upload window (PR review
         // observation #1).
-        if (previousDraft && !parkFailedDraftIfSwitched(sendUserId, sendChatId, chatIdRef.current, previousDraft)) {
+        if (
+          previousDraft &&
+          !parkFailedDraftIfSwitched(sendUserId, sendChatId, chatIdRef.current, previousDraft, storageScope)
+        ) {
           setDraft((current) => (current === "" ? previousDraft : current));
         }
       } finally {

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -25,6 +25,7 @@ import {
   useMentionAutocomplete,
 } from "../../../components/mention-autocomplete.js";
 import { FileChip } from "../../../components/ui/file-chip.js";
+import { captureBrowserStorageScope } from "../../../lib/browser-storage-scope.js";
 import { clearDraft, type DraftSnapshot, loadDraft, newChatDraftScope, saveDraft } from "../../../lib/draft-store.js";
 import { useAgentIdentityMap } from "../../../lib/use-agent-name-map.js";
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
@@ -441,6 +442,7 @@ export function NewChatDraft({
       docs: PendingAttachment[];
       mentions: string[];
     }) => {
+      const storageScope = captureBrowserStorageScope();
       const trimmed = text.trim();
       const contextParticipantAgentIds = participantIds.filter((id) => !mentions.includes(id));
 
@@ -469,7 +471,7 @@ export function NewChatDraft({
           // miss is recoverable on the render path.
           try {
             const data = await readFileAsBase64(img.file);
-            await putImage({ imageId: uploaded.id, base64: data, mimeType: img.file.type });
+            await putImage({ imageId: uploaded.id, base64: data, mimeType: img.file.type }, storageScope);
           } catch {
             // ignore — render path re-fetches from the server on miss
           }

--- a/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
+++ b/packages/web/src/pages/workspace/conversations/new-chat-draft.tsx
@@ -98,6 +98,7 @@ export function NewChatDraft({
   const queryClient = useQueryClient();
   const { agentId: myAgentId, memberId: myMemberId, organizationId, user } = useAuth();
   const agentIdentity = useAgentIdentityMap();
+  const browserScopeRef = useRef(captureBrowserStorageScope());
 
   // Browser-local unsent-draft cache for this compose context (user + org +
   // seed participants, mirroring the center-panel remount key). User-scoped so
@@ -109,7 +110,7 @@ export function NewChatDraft({
   );
   const initialDraftRef = useRef<DraftSnapshot | null | undefined>(undefined);
   if (initialDraftRef.current === undefined) {
-    initialDraftRef.current = loadDraft(draftScope);
+    initialDraftRef.current = loadDraft(draftScope, browserScopeRef.current);
   }
   const restoredDraft = initialDraftRef.current;
   const cachedDefaultAgentId = useMemo(
@@ -367,7 +368,7 @@ export function NewChatDraft({
   // emptying the body clears the entry; we also clear explicitly on send below
   // because onCreated unmounts this component before the effect could flush.
   useEffect(() => {
-    saveDraft(draftScope, { text: draft, participantIds: chips });
+    saveDraft(draftScope, { text: draft, participantIds: chips }, Date.now(), browserScopeRef.current);
   }, [draftScope, draft, chips]);
 
   const bodyMentions = useMemo(() => {
@@ -524,7 +525,7 @@ export function NewChatDraft({
     },
     onSuccess: ({ chatId, cacheableStarterAgentId }) => {
       saveNewChatDefaultAgentId(user?.id ?? null, organizationId, cacheableStarterAgentId);
-      clearDraft(draftScope);
+      clearDraft(draftScope, browserScopeRef.current);
       setDraft("");
       setChips([]);
       clearAttachments();


### PR DESCRIPTION
## Summary

- clear the departing account's browser-local data on logout, including its localStorage draft/org key and scoped IndexedDB caches
- preserve other accounts' scoped data and unrelated same-origin keys; remove only explicitly named legacy unscoped stores
- await IndexedDB deletion before the explicit sign-out redirect; blocked/error deletion rejects promptly and leaves a visible retry path
- propagate logout/account replacement across tabs with storage-scope invalidation so stale IndexedDB and draft writers cannot recreate the old account's data
- bind message, read-state, image, draft, and delayed send work to immutable account/server scopes
- retain the token-derived scope across transient `/me` failures so a later logout purges the correct account
- discard stale refresh responses and stale post-refresh 401s without clearing replacement credentials
- commit React/API logout state only after purge success; preserve replacement credentials during delayed remote purges
- keep an in-memory invalidation tombstone when storage is denied and use one reusable BroadcastChannel per document
- expose a shared purge status/result and route desktop, mobile, onboarding, auth-failure, and cross-tab failures through retry recovery
- mount the recovery bridge inside `ToastProvider`; event-driven API and cross-tab purge failures reset stale local identity while preserving replacement credentials
- pin direct logout and retry flows to the initiating scope/generation so a local A purge cannot finalize over an adopted B session
- cover account isolation, cross-tab invalidation, deferred stale writes, scoped purge, blocked deletion, `/me` failure, refresh races, and the migrated draft fixture

## Verification

- `pnpm --filter @first-tree/web exec tsc --noEmit`
- `pnpm exec biome check` on changed files
- `NODE_OPTIONS=--localstorage-file=/tmp/sec042-final2.localstorage pnpm --filter @first-tree/web exec vitest run --maxWorkers=1 --minWorkers=1 ...` (`138/138` focused and interaction tests)
- `pnpm --filter @first-tree/web build`

Closes #1647
