### PR TITLE
fix: restore multi-human agent follow fallback

### DIFF
--- a/packages/qa/cases/cross-surface/scm-entity-attention-parity.md
+++ b/packages/qa/cases/cross-surface/scm-entity-attention-parity.md
@@ -32,6 +32,9 @@ card significance, lifecycle projection, topic protection, and archive behavior.
   takes precedence over the stable fallback, while multiple explicit links fail closed.
 - Deliver an ordinary subscribed comment/Note. Confirm one card per target chat, notifying Inbox entries for every
   surviving delegate, predictive sessions, and wake delivery. Provider actor attribution must not suppress the delegate.
+  When two agent-issued lines share the same fallback human and chat, suspend one wake agent without deleting its mapping
+  or membership, then redeliver. Confirm the card still lands once, the active sibling is the only native mention and wake,
+  and the suspended sibling receives no notifying Inbox entry.
 - Unfollow in one chat and redeliver an ordinary event. Confirm the old chat stays silent. Then deliver an explicit
   reviewer, assignee, or exact body/comment mention and confirm a fresh route may be established without reviving the
   removed line.

--- a/packages/qa/cases/cross-surface/scm-entity-attention-parity.md
+++ b/packages/qa/cases/cross-surface/scm-entity-attention-parity.md
@@ -24,9 +24,12 @@ card significance, lifecycle projection, topic protection, and archive behavior.
 
 ## Operate and Observe
 
-- For each provider, create an agent explicit follow and a human explicit follow. Confirm the stored public behavior is a
-  complete human/delegate attention line, repeated same-pair follow is idempotent, a second-chat follow conflicts, and
-  `--rebind` atomically moves only that pair.
+- For each provider, create an agent explicit follow in a chat with two active human members where neither human links the
+  caller as delegate. Confirm the follow succeeds, the id-sorted-first active human is the stable line representative, and
+  the calling agent remains the wake target. Then create a human explicit follow with a configured delegate. Confirm both
+  paths store a complete human/wake-agent attention line, repeated same-pair follow is idempotent, a second-chat follow
+  conflicts, and `--rebind` atomically moves only that pair. Also confirm exactly one explicit human-to-agent delegate link
+  takes precedence over the stable fallback, while multiple explicit links fail closed.
 - Deliver an ordinary subscribed comment/Note. Confirm one card per target chat, notifying Inbox entries for every
   surviving delegate, predictive sessions, and wake delivery. Provider actor attribution must not suppress the delegate.
 - Unfollow in one chat and redeliver an ordinary event. Confirm the old chat stays silent. Then deliver an explicit

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -773,7 +773,7 @@ describe("small API route handlers", () => {
         body: { entity: "https://github.com/acme/api/pull/42" },
         params: { chatId: "chat_1" },
       }),
-    ).rejects.toThrow("No eligible (human, delegate) binding pair");
+    ).rejects.toThrow("No eligible (human, wake-agent) binding pair");
     expect(resolveBindingPair).toHaveBeenCalledWith({ name: "db" }, "chat_1", "agent_1");
 
     const followReply = makeReply();

--- a/packages/server/src/__tests__/github-audience.test.ts
+++ b/packages/server/src/__tests__/github-audience.test.ts
@@ -381,13 +381,10 @@ describe("resolveAudience", () => {
     expect(audience[0]?.involveLogin).toBe(humanName.toLowerCase());
   });
 
-  it("collapses subscribed rows by human (sibling mappings on same chat → one audience target)", async () => {
-    // Once `resolveTargetChat` step (a.5) lands sibling mapping rows
-    // (same chat, different delegate under the same human), naive subscribed
-    // expansion would post the same card to the chat N times. Subscribed
-    // dedup collapses by humanAgentId; sibling rows always share chatId by
-    // construction, so we keep the earliest bound_at row as the
-    // representative.
+  it("preserves distinct wake agents carried by the same human in one chat", async () => {
+    // Each (human, delegate) mapping is a distinct wake line. The audience
+    // must preserve both; the delivery planner, not this resolver, owns
+    // collapsing them into one card for the shared chat.
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegateOriginal = await seedAgent(app, {
@@ -407,11 +404,6 @@ describe("resolveAudience", () => {
     });
     const chatId = await seedChat(app, admin.organizationId, human);
 
-    // Original row first (earlier bound_at), then sibling — simulates the
-    // (a.5) write order. We do not control bound_at directly; the default
-    // `now()` clock + serial insert order suffices because the assertions
-    // only require the representative to be one of the two rows sharing
-    // chatId, and both point at the same chat.
     await seedMapping(app, {
       orgId: admin.organizationId,
       humanId: human,
@@ -440,10 +432,12 @@ describe("resolveAudience", () => {
       }),
     );
 
-    expect(audience).toHaveLength(1);
-    expect(audience[0]?.kind).toBe("existing");
-    expect(audience[0]?.humanAgentId).toBe(human);
-    expect(audience[0]?.chatId).toBe(chatId);
+    expect(audience).toHaveLength(2);
+    expect(audience.every((target) => target.kind === "existing")).toBe(true);
+    expect(audience.every((target) => target.humanAgentId === human && target.chatId === chatId)).toBe(true);
+    expect(new Set(audience.map((target) => target.delegateAgentId))).toEqual(
+      new Set([delegateOriginal, delegateSibling]),
+    );
   });
 
   it("M2: does NOT collapse subscribed rows across different chats for the same human", async () => {
@@ -452,8 +446,9 @@ describe("resolveAudience", () => {
     // `human_fallback` row in chat A under delegateA plus an explicit follow
     // row in chat B under delegateB). Deduping by `humanAgentId` alone kept
     // only the earliest chat and silently dropped the *other* followed chat
-    // from the audience. Dedup is keyed by `(human, chat)`, so BOTH chats
-    // receive the event.
+    // from the audience. Dedup is keyed by `(human, delegate, chat)`, so BOTH
+    // chats receive the event while distinct wake lines inside either chat are
+    // preserved for the delivery planner.
     const app = getApp();
     const admin = await createTestAdmin(app);
     const delegateA = await seedAgent(app, {

--- a/packages/server/src/__tests__/github-binding-invariants.test.ts
+++ b/packages/server/src/__tests__/github-binding-invariants.test.ts
@@ -156,16 +156,17 @@ describe("github binding invariants", () => {
       expect(pair?.delegateAgentId).toBe(delegate);
     });
 
-    it("rejects an ambiguous owner when no delegateMention links the caller", async () => {
+    it("falls back to the id-sorted-first active human when no delegateMention links the caller", async () => {
       const app = getApp();
       const admin = await createTestAdmin(app);
       const delegate = await seedAgent(app, { orgId: admin.organizationId, memberId: admin.memberId, type: "agent" });
       const humanA = await seedAgent(app, { orgId: admin.organizationId, memberId: admin.memberId, type: "human" });
       const humanB = await seedAgent(app, { orgId: admin.organizationId, memberId: admin.memberId, type: "human" });
+      const smallerHuman = humanA < humanB ? humanA : humanB;
       const chatId = await seedChat(app, admin.organizationId, [humanA, humanB, delegate]);
       const pair = await resolveBindingPair(app.db, chatId, delegate);
 
-      expect(pair).toBeNull();
+      expect(pair?.humanAgentId).toBe(smallerHuman);
     });
 
     it("returns null when the caller is not a chat member, or is itself human", async () => {

--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -12,6 +12,7 @@ import { messages } from "../db/schema/messages.js";
 import { users } from "../db/schema/users.js";
 import { type AudienceTarget, resolveGithubAudience } from "../services/github-audience.js";
 import { deliverGithubEvent } from "../services/github-delivery.js";
+import { resolveAgentScmBindingPair } from "../services/scm-attention-line.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
@@ -775,6 +776,93 @@ describe("deliverGithubEvent", () => {
     expect(metadata.reason).toBe("mentioned");
     expect(await notifyCount(app, chatId, delegateA)).toBe(0);
     expect(await notifyCount(app, chatId, delegateB)).toBe(1);
+  });
+
+  it("delivers one card and wakes both unlinked agent followers sharing a human carrier", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const followerA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `follower-a-${randomUUID().slice(0, 6)}`,
+    });
+    const followerB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `follower-b-${randomUUID().slice(0, 6)}`,
+    });
+    const humanA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-a-${randomUUID().slice(0, 6)}`,
+      type: "human",
+    });
+    const humanB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-b-${randomUUID().slice(0, 6)}`,
+      type: "human",
+    });
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
+    await app.db.insert(chatMembership).values(
+      [humanA, humanB, followerA, followerB].map((agentId, index) => ({
+        chatId,
+        agentId,
+        role: index === 0 ? "owner" : "member",
+        accessMode: "speaker" as const,
+        mode: "full" as const,
+        source: "manual" as const,
+      })),
+    );
+
+    const pairA = await resolveAgentScmBindingPair(app.db, chatId, followerA);
+    const pairB = await resolveAgentScmBindingPair(app.db, chatId, followerB);
+    expect(pairA).not.toBeNull();
+    expect(pairB).not.toBeNull();
+    expect(pairB?.humanAgentId).toBe(pairA?.humanAgentId);
+    if (!pairA || !pairB) throw new Error("expected both agent follow pairs to resolve");
+
+    await app.db.insert(githubEntityChatMappings).values([
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: pairA.humanAgentId,
+        delegateAgentId: pairA.wakeAgentId,
+        entityType: "pull_request",
+        entityKey: "owner/repo#209",
+        chatId,
+        boundVia: "agent_declared",
+      },
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: pairB.humanAgentId,
+        delegateAgentId: pairB.wakeAgentId,
+        entityType: "pull_request",
+        entityKey: "owner/repo#209",
+        chatId,
+        boundVia: "agent_declared",
+      },
+    ]);
+
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#209",
+      actorLogin: "outsider",
+      eventType: "issue_comment",
+      action: "created",
+      kind: "commented",
+    });
+    const resolution = await resolveGithubAudience(app.db, event);
+    expect(resolution.targets).toHaveLength(2);
+
+    const stats = await deliverGithubEvent(app, event, resolution.targets);
+    expect(stats).toEqual({ delivered: 1, newChats: 0, failed: 0 });
+    const [message] = await app.db.select().from(messages).where(eq(messages.chatId, chatId));
+    const metadata = message?.metadata as { mentions?: string[] };
+    expect(metadata.mentions).toEqual([followerA, followerB].sort());
+    expect(await notifyCount(app, chatId, followerA)).toBe(1);
+    expect(await notifyCount(app, chatId, followerB)).toBe(1);
   });
 
   it("refreshes chats.topic to match the current entity title on each subsequent event for a github-bound chat", async () => {

--- a/packages/server/src/__tests__/github-delivery.test.ts
+++ b/packages/server/src/__tests__/github-delivery.test.ts
@@ -865,6 +865,96 @@ describe("deliverGithubEvent", () => {
     expect(await notifyCount(app, chatId, followerB)).toBe(1);
   });
 
+  it("keeps a shared card deliverable when one follower is suspended", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const followerA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `follower-active-${randomUUID().slice(0, 6)}`,
+    });
+    const followerB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `follower-suspended-${randomUUID().slice(0, 6)}`,
+    });
+    const humanA = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-a-${randomUUID().slice(0, 6)}`,
+      type: "human",
+    });
+    const humanB = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-b-${randomUUID().slice(0, 6)}`,
+      type: "human",
+    });
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "group" });
+    await app.db.insert(chatMembership).values(
+      [humanA, humanB, followerA, followerB].map((agentId, index) => ({
+        chatId,
+        agentId,
+        role: index === 0 ? "owner" : "member",
+        accessMode: "speaker" as const,
+        mode: "full" as const,
+        source: "manual" as const,
+      })),
+    );
+
+    const pairA = await resolveAgentScmBindingPair(app.db, chatId, followerA);
+    const pairB = await resolveAgentScmBindingPair(app.db, chatId, followerB);
+    if (!pairA || !pairB) throw new Error("expected both agent follow pairs to resolve");
+    expect(pairB.humanAgentId).toBe(pairA.humanAgentId);
+
+    await app.db.insert(githubEntityChatMappings).values([
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: pairA.humanAgentId,
+        delegateAgentId: pairA.wakeAgentId,
+        entityType: "pull_request",
+        entityKey: "owner/repo#210",
+        chatId,
+        boundVia: "agent_declared",
+      },
+      {
+        organizationId: admin.organizationId,
+        humanAgentId: pairB.humanAgentId,
+        delegateAgentId: pairB.wakeAgentId,
+        entityType: "pull_request",
+        entityKey: "owner/repo#210",
+        chatId,
+        boundVia: "agent_declared",
+      },
+    ]);
+
+    // Lifecycle changes do not delete the mapping or speaker membership. The
+    // stale wake line must remain routing evidence for the shared card without
+    // being passed to message preflight as a live native mention.
+    await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, followerB));
+
+    const event = makeEvent({
+      orgId: admin.organizationId,
+      entityType: "pull_request",
+      entityKey: "owner/repo#210",
+      actorLogin: "outsider",
+      eventType: "issue_comment",
+      action: "created",
+      kind: "commented",
+    });
+    const resolution = await resolveGithubAudience(app.db, event);
+    expect(resolution.targets).toHaveLength(2);
+
+    const stats = await deliverGithubEvent(app, event, resolution.targets);
+    expect(stats).toEqual({ delivered: 1, newChats: 0, failed: 0 });
+    const [message] = await app.db.select().from(messages).where(eq(messages.chatId, chatId));
+    const metadata = message?.metadata as { mentions?: string[] };
+    expect(metadata.mentions).toEqual([followerA]);
+    expect(await notifyCount(app, chatId, followerA)).toBe(1);
+    expect(await notifyCount(app, chatId, followerB)).toBe(0);
+  });
+
   it("refreshes chats.topic to match the current entity title on each subsequent event for a github-bound chat", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/message-recipients.test.ts
+++ b/packages/server/src/__tests__/message-recipients.test.ts
@@ -118,4 +118,35 @@ describe("sendMessage returns recipients", () => {
     const rows = await app.db.select().from(inboxEntries).where(eq(inboxEntries.inboxId, suspended.inboxId));
     expect(rows).toHaveLength(0);
   });
+
+  it("lets a trusted internal send drop an inactive mention while preserving active recipients", async () => {
+    const app = getApp();
+    const suffix = crypto.randomUUID().slice(0, 6);
+    const { agent: sender } = await createTestAgent(app, { name: `trusted-src-${suffix}` });
+    const { agent: active } = await createTestAgent(app, { name: `trusted-active-${suffix}` });
+    const { agent: suspended } = await createTestAgent(app, { name: `trusted-suspended-${suffix}` });
+    const chat = await createChat(app.db, sender.uuid, {
+      type: "group",
+      participantIds: [active.uuid, suspended.uuid],
+    });
+    await suspendAgent(app.db, suspended.uuid);
+
+    const result = await sendMessage(
+      app.db,
+      chat.id,
+      sender.uuid,
+      {
+        source: "github",
+        format: "card",
+        content: { type: "github_event" },
+        metadata: { mentions: [active.uuid, suspended.uuid] },
+      },
+      { allowRecipientlessSend: true, dropInactiveMentionTargets: true },
+    );
+
+    expect(result.message.metadata.mentions).toEqual([active.uuid]);
+    expect(result.recipients).toEqual([active.inboxId]);
+    const suspendedRows = await app.db.select().from(inboxEntries).where(eq(inboxEntries.inboxId, suspended.inboxId));
+    expect(suspendedRows).toHaveLength(0);
+  });
 });

--- a/packages/server/src/__tests__/scm-attention-line.test.ts
+++ b/packages/server/src/__tests__/scm-attention-line.test.ts
@@ -37,9 +37,9 @@ describe("SCM attention binding pair policy", () => {
     });
   });
 
-  it("fails closed when the human delegate is absent or the agent owner is ambiguous", async () => {
+  it("uses a stable active-human fallback for agent follow without relaxing human follow", async () => {
     const app = getApp();
-    const runtime = await createTestAgent(app, { name: `pair-ambiguous-${randomUUID().slice(0, 8)}` });
+    const runtime = await createTestAgent(app, { name: `pair-fallback-${randomUUID().slice(0, 8)}` });
     const other = await createTestAgent(app, { name: `pair-other-${randomUUID().slice(0, 8)}` });
     const { chatId } = await createMeChat(app.db, runtime.humanAgentUuid, runtime.organizationId, {
       participantIds: [runtime.agent.uuid],
@@ -52,6 +52,37 @@ describe("SCM attention binding pair policy", () => {
       role: "member",
       accessMode: "speaker",
     });
+    const representativeHumanId =
+      runtime.humanAgentUuid < other.humanAgentUuid ? runtime.humanAgentUuid : other.humanAgentUuid;
+    await expect(resolveAgentScmBindingPair(app.db, chatId, runtime.agent.uuid)).resolves.toEqual({
+      organizationId: runtime.organizationId,
+      humanAgentId: representativeHumanId,
+      wakeAgentId: runtime.agent.uuid,
+    });
+  });
+
+  it("fails closed when multiple humans explicitly link the same wake agent", async () => {
+    const app = getApp();
+    const runtime = await createTestAgent(app, { name: `pair-linked-${randomUUID().slice(0, 8)}` });
+    const other = await createTestAgent(app, { name: `pair-linked-other-${randomUUID().slice(0, 8)}` });
+    const { chatId } = await createMeChat(app.db, runtime.humanAgentUuid, runtime.organizationId, {
+      participantIds: [runtime.agent.uuid],
+    });
+    await app.db
+      .update(agents)
+      .set({ delegateMention: runtime.agent.uuid })
+      .where(eq(agents.uuid, runtime.humanAgentUuid));
+    await app.db
+      .update(agents)
+      .set({ delegateMention: runtime.agent.uuid })
+      .where(eq(agents.uuid, other.humanAgentUuid));
+    await app.db.insert(chatMembership).values({
+      chatId,
+      agentId: other.humanAgentUuid,
+      role: "member",
+      accessMode: "speaker",
+    });
+
     await expect(resolveAgentScmBindingPair(app.db, chatId, runtime.agent.uuid)).resolves.toBeNull();
   });
 });

--- a/packages/server/src/api/agent/chats.ts
+++ b/packages/server/src/api/agent/chats.ts
@@ -246,7 +246,7 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
   // an agent that wants the entity's events in this chat declares it here,
   // immediately after creation. The human side of the binding pair is the
   // chat's representative human (see `resolveBindingPair`); the caller is
-  // the delegate side.
+  // the wake side.
 
   app.get<{ Params: { chatId: string } }>("/:chatId/github-entities", async (request) => {
     const identity = requireAgent(request);
@@ -265,8 +265,9 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
       const pair = await resolveBindingPair(app.db, request.params.chatId, identity.uuid);
       if (!pair) {
         throw new BadRequestError(
-          "No eligible (human, delegate) binding pair: following from an agent session needs at least one " +
-            "active human member in the chat (and a non-human caller). Humans follow via the web UI instead.",
+          "No eligible (human, wake-agent) binding pair: the caller must be an active same-Team agent speaker, " +
+            "the chat needs an active same-Team human member, and no more than one human may link the caller " +
+            "as delegate. Humans follow via the web UI instead.",
         );
       }
 
@@ -316,8 +317,9 @@ export async function agentChatRoutes(app: FastifyInstance): Promise<void> {
       const pair = await resolveAgentScmBindingPair(app.db, request.params.chatId, identity.uuid);
       if (!pair) {
         throw new BadRequestError(
-          "No eligible (human, wake-agent) attention pair: following from an agent session needs an active " +
-            "non-human caller and at least one active human speaker in the chat.",
+          "No eligible (human, wake-agent) attention pair: the caller must be an active same-Team agent speaker, " +
+            "the chat needs an active same-Team human member, and no more than one human may link the caller " +
+            "as delegate.",
         );
       }
       const result = await declareCurrentGitlabEntityFollow(app.db, {

--- a/packages/server/src/services/github-audience.ts
+++ b/packages/server/src/services/github-audience.ts
@@ -127,12 +127,12 @@ export async function resolveGithubAudience(db: Database, event: NormalizedScmEv
       ),
     );
 
-  // Dedup subscribed rows by `(humanAgentId, chatId)` (keep earliest
-  // `bound_at`). A single `(human, entity)` pair can carry multiple mapping
-  // rows pointing at the *same* chat (one per delegate that ever drove an
-  // event for this entity under this human); collapsing those to one row is
-  // loss-free and stops `deliverGithubEvent` posting N identical cards
-  // to that chat.
+  // Dedup subscribed rows by `(humanAgentId, delegateAgentId, chatId)` (keep
+  // earliest `bound_at`). Alias entity keys can leave duplicate rows for the
+  // same logical attention line, but distinct delegates are distinct wake
+  // lines even when they share one human carrier and chat. The per-chat
+  // delivery planner collapses those lines into one card and unions every
+  // wake agent.
   //
   // The key MUST include `chatId`. Deduping by `humanAgentId` alone assumed
   // every row for a human shared one chat — false once the same human is
@@ -141,14 +141,16 @@ export async function resolveGithubAudience(db: Database, event: NormalizedScmEv
   // another, each under a different delegate). Collapsing across chats kept
   // only the earliest chat's row and silently dropped every *other* followed
   // chat from the audience — that chat never received the entity's events at
-  // all. "The chat follows, not the person", so the surviving unit is one
-  // row per (human, chat), never one per human.
-  const earliestByHumanChat = new Map<string, (typeof subscribedRows)[number]>();
+  // all. The key also includes `delegateAgentId`: two agent-issued follows can
+  // share the same fallback human and chat while carrying distinct wake
+  // agents. "The chat follows, not the person", so the surviving unit is one
+  // row per (human, delegate, chat).
+  const earliestByAttentionLine = new Map<string, (typeof subscribedRows)[number]>();
   for (const row of subscribedRows) {
-    const key = `${row.humanAgentId}:${row.chatId}`;
-    const current = earliestByHumanChat.get(key);
+    const key = `${row.humanAgentId}:${row.delegateAgentId}:${row.chatId}`;
+    const current = earliestByAttentionLine.get(key);
     if (!current || row.boundAt < current.boundAt) {
-      earliestByHumanChat.set(key, row);
+      earliestByAttentionLine.set(key, row);
     }
   }
   // #766: A `pull_request.opened` delivery reaching a reviewer purely through
@@ -178,19 +180,21 @@ export async function resolveGithubAudience(db: Database, event: NormalizedScmEv
     return row.humanAgentName !== null && involvedLogins.has(row.humanAgentName.toLowerCase());
   };
 
-  const subscribed: AudienceTarget[] = [...earliestByHumanChat.values()].filter(keepSubscribedOpened).map((row) => ({
-    humanAgentId: row.humanAgentId,
-    delegateAgentId: row.delegateAgentId,
-    kind: "existing",
-    chatId: row.chatId,
-    involveReason: null,
-    involveLogin: null,
-    provenance: isDeclaredBoundVia(row.boundVia)
-      ? "explicit"
-      : row.boundVia === "fixes_link"
-        ? "related_entity"
-        : "identity_target",
-  }));
+  const subscribed: AudienceTarget[] = [...earliestByAttentionLine.values()]
+    .filter(keepSubscribedOpened)
+    .map((row) => ({
+      humanAgentId: row.humanAgentId,
+      delegateAgentId: row.delegateAgentId,
+      kind: "existing",
+      chatId: row.chatId,
+      involveReason: null,
+      involveLogin: null,
+      provenance: isDeclaredBoundVia(row.boundVia)
+        ? "explicit"
+        : row.boundVia === "fixes_link"
+          ? "related_entity"
+          : "identity_target",
+    }));
 
   const subscribedByHuman = new Map<string, AudienceTarget[]>();
   for (const target of subscribed) {

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -293,6 +293,18 @@ export type SendMessageOptions = {
    */
   allowRecipientlessSend?: boolean;
   /**
+   * Trusted-internal opt-in that drops suspended or deleted participants from
+   * `metadata.mentions` instead of rejecting the entire send. SCM mappings can
+   * outlive a wake agent's active lifecycle; their cards must still reach the
+   * bound chat and any other active wake agents without a stale sibling line
+   * poisoning the shared delivery. The normalized metadata persists only the
+   * surviving active mentions.
+   *
+   * Keep this off for ordinary human/agent sends: an explicitly addressed
+   * inactive recipient is normally a caller error that should fail closed.
+   */
+  dropInactiveMentionTargets?: boolean;
+  /**
    * When true and `data.content` is a string, prepend `@<name>` tokens for
    * any participant in `metadata.mentions` whose name is missing from the
    * content. Used by the agent endpoint so the rendered message stays in
@@ -412,7 +424,12 @@ export function preflightMessageSendIntent(input: {
     ? explicitMentionsRaw.filter((m): m is string => typeof m === "string")
     : [];
   const participantsById = new Map(participants.map((p) => [p.agentId, p]));
-  const explicitMentions = explicitMentionsRawList.filter((id) => id === senderId || participantsById.has(id));
+  const explicitMentions = explicitMentionsRawList.filter((id) => {
+    if (id === senderId) return true;
+    const participant = participantsById.get(id);
+    if (!participant) return false;
+    return !options.dropInactiveMentionTargets || participant.status === "active";
+  });
 
   const receiverNames = data.receiverNames ?? [];
   const speakersByName = new Map<string, string>();
@@ -492,7 +509,11 @@ export function preflightMessageSendIntent(input: {
     : [];
   const metadataToStore: Record<string, unknown> = {
     ...incomingMeta,
-    ...(mergedMentions.length > 0 ? { mentions: mergedMentions } : {}),
+    ...(options.dropInactiveMentionTargets
+      ? { mentions: mergedMentions }
+      : mergedMentions.length > 0
+        ? { mentions: mergedMentions }
+        : {}),
     ...(addressedAgentIds.length > 0 ? { [ADDRESSED_AGENT_IDS_METADATA_KEY]: addressedAgentIds } : {}),
   };
 

--- a/packages/server/src/services/scm-attention-line.ts
+++ b/packages/server/src/services/scm-attention-line.ts
@@ -91,8 +91,9 @@ export async function executeScmFollowLine<TRecord extends ScmFollowLineRecord>(
  * Resolve the durable attention owner for an agent-issued follow.
  *
  * The selected agent is always the wake side. The human side is its linked
- * active human in the chat, or the chat's sole active human when no explicit
- * delegate relationship exists. Ambiguous ownership fails closed.
+ * active human in the chat, or the id-sorted-first active human when no
+ * explicit delegate relationship exists. Multiple explicit links are
+ * ambiguous and fail closed.
  */
 export async function resolveAgentScmBindingPair(
   db: Database,
@@ -132,7 +133,7 @@ export async function resolveAgentScmBindingPair(
   );
   const linkedHumans = humans.filter((human) => human.delegateMention === wakeAgentId);
   const representative = linkedHumans.length === 1 ? linkedHumans[0] : linkedHumans.length === 0 ? humans[0] : null;
-  if (!representative || (linkedHumans.length === 0 && humans.length !== 1)) return null;
+  if (!representative) return null;
   return {
     organizationId: representative.chatOrganizationId,
     humanAgentId: representative.agentId,

--- a/packages/server/src/services/scm-card-delivery.ts
+++ b/packages/server/src/services/scm-card-delivery.ts
@@ -39,6 +39,7 @@ export async function sendScmSystemCard(
     {
       allowSystemSender: true,
       allowRecipientlessSend: true,
+      dropInactiveMentionTargets: true,
       deferPostCommitEffects: input.deferPostCommitEffects,
     },
   );


### PR DESCRIPTION
## Summary

- restore the shared GitHub/GitLab agent-follow fallback that selects the id-sorted-first active same-Team human member when no human explicitly links the calling agent
- keep exactly-one linked human precedence, multiple-linked ambiguity fail-closed, and the calling agent as declaration provenance and wake target
- preserve distinct GitHub wake lines when multiple agent followers share one human carrier and chat; the shared planner still emits one card and unions every eligible wake agent
- prevent a suspended or deleted sibling wake line from rejecting the shared card: trusted SCM sends retain the card/attention line while persisting and notifying only active native mentions
- leave human-issued follow, mapping schema, database state, sender selection, echo pruning, and delivery planning unchanged
- align route errors and the cross-provider QA case with the resulting contract

This intentionally implements the minimal pre-SCM-refactor behavior restoration approved for Issue #1887. It does not introduce first-class agent-owned attention lines or a database migration.

PR #1891 is included in this branch base. Its trusted SCM system attribution remains compatible: persisted `message.senderId` continues to use the human carrier while Web and Agent prompt surfaces render trusted provider cards as system messages.

## Context Tree

Draft decision update: https://github.com/agent-team-foundation/first-tree-context/pull/791

The code PR should merge first; the Tree PR can then be reconciled and marked ready.

## Verification

- targeted Server audience/follow/delivery suites: 66 tests passed on the post-#1891 base
- regression proves two unlinked agent followers sharing one human carrier receive one card with both wake IDs in `metadata.mentions` and both Inbox notifications
- lifecycle regression proves that after one shared-line follower is suspended, the card still lands once, only the active sibling remains in `metadata.mentions`, only that sibling receives a notifying Inbox row, and delivery reports no failure
- latest targeted GitHub delivery, shared message, GitLab deferred-delivery, and system-sender suites: 49 tests passed with `--maxWorkers=2`
- `pnpm --filter @first-tree/server typecheck` passed for the lifecycle successor; earlier monorepo typecheck passed 10/10 tasks
- full Server suite before the final base sync: 238 files / 2,558 tests passed with maxWorkers 2
- affected-file Biome checks and `git diff --check` passed
- matching Context Tree verification passed

## QA

Formal cross-surface QA is warranted because the change affects explicit entity follow behavior across both GitHub and GitLab. The existing SCM entity-attention parity case now covers multi-human no-link fallback, multiple-link fail-closed behavior, and stale suspended wake-line isolation.

Closes #1887.
