### PR TITLE
fix: bound /healthz database probes with a cached probe and route rate limit

### DIFF
--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -321,27 +321,35 @@ describe("small API route handlers", () => {
   });
 
   it("returns health and healthz success and degraded responses", async () => {
-    const { healthRoutes } = await import("../api/health.js");
-    const { healthzRoutes } = await import("../api/healthz.js");
-    const execute = vi.fn().mockResolvedValue(undefined);
-    const { app, routes } = makeApp({ db: { execute } });
+    vi.useFakeTimers();
+    try {
+      const { healthRoutes } = await import("../api/health.js");
+      const { healthzRoutes } = await import("../api/healthz.js");
+      const execute = vi.fn().mockResolvedValue(undefined);
+      const { app, routes } = makeApp({ db: { execute } });
 
-    await healthRoutes(app as never);
-    await healthzRoutes(app as never);
-    await expect(route(routes, "GET", "/health").handler()).resolves.toEqual({ db: "connected", status: "ok" });
+      await healthRoutes(app as never);
+      await healthzRoutes(app as never);
+      await expect(route(routes, "GET", "/health").handler()).resolves.toEqual({ db: "connected", status: "ok" });
 
-    const okReply = makeReply();
-    await route(routes, "GET", "/healthz").handler({}, okReply);
-    expect(okReply).toMatchObject({ body: { status: "ok" }, code: 200 });
+      const okReply = makeReply();
+      await route(routes, "GET", "/healthz").handler({}, okReply);
+      expect(okReply).toMatchObject({ body: { status: "ok" }, code: 200 });
 
-    execute.mockRejectedValueOnce(new Error("db down")).mockRejectedValueOnce(new Error("db down"));
-    await expect(route(routes, "GET", "/health").handler()).resolves.toEqual({
-      db: "disconnected",
-      status: "degraded",
-    });
-    const degradedReply = makeReply();
-    await route(routes, "GET", "/healthz").handler({}, degradedReply);
-    expect(degradedReply).toMatchObject({ body: { message: "database unreachable", status: "error" }, code: 503 });
+      execute.mockRejectedValueOnce(new Error("db down")).mockRejectedValueOnce(new Error("db down"));
+      await expect(route(routes, "GET", "/health").handler()).resolves.toEqual({
+        db: "disconnected",
+        status: "degraded",
+      });
+      // /healthz caches its probe briefly; move past the TTL so the degraded
+      // path re-probes and consumes the second rejection.
+      vi.advanceTimersByTime(1_001);
+      const degradedReply = makeReply();
+      await route(routes, "GET", "/healthz").handler({}, degradedReply);
+      expect(degradedReply).toMatchObject({ body: { message: "database unreachable", status: "error" }, code: 503 });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("serves agent runtime config and context tree info", async () => {

--- a/packages/server/src/__tests__/healthz.test.ts
+++ b/packages/server/src/__tests__/healthz.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { healthzRoutes } from "../api/healthz.js";
+import { createTestApp } from "./helpers.js";
+
+type UnknownFn = (...args: unknown[]) => unknown;
+type CapturedRoute = {
+  method: string;
+  path: string;
+  options: unknown;
+  handler: UnknownFn;
+};
+
+function createApp(overrides: Record<string, unknown> = {}): { app: Record<string, unknown>; routes: CapturedRoute[] } {
+  const routes: CapturedRoute[] = [];
+  const registerRoute = (method: string) => (path: string, optionsOrHandler?: unknown, maybeHandler?: unknown) => {
+    const handler = typeof optionsOrHandler === "function" ? optionsOrHandler : maybeHandler;
+    const options = typeof optionsOrHandler === "function" ? undefined : optionsOrHandler;
+    if (typeof handler !== "function") throw new Error(`Missing handler for ${method} ${path}`);
+    routes.push({ method, path, options, handler: handler as UnknownFn });
+    return app;
+  };
+  const app = {
+    db: { execute: vi.fn(async () => [{ one: 1 }]) },
+    get: registerRoute("GET"),
+    ...overrides,
+  };
+  return { app, routes };
+}
+
+function replyDouble(): { status: ReturnType<typeof vi.fn>; send: ReturnType<typeof vi.fn> } {
+  const reply = {
+    status: vi.fn(() => reply),
+    send: vi.fn((body: unknown) => body),
+  };
+  return reply;
+}
+
+async function registerHealthz(execute: ReturnType<typeof vi.fn>): Promise<CapturedRoute> {
+  const { app, routes } = createApp({ db: { execute } });
+  await healthzRoutes(app as never);
+  const route = routes[0];
+  if (!route) throw new Error("Route was not captured");
+  return route;
+}
+
+describe("/healthz database probe cache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("serves a second request within the TTL from cache without probing again", async () => {
+    const execute = vi.fn(async () => [{ one: 1 }]);
+    const route = await registerHealthz(execute);
+
+    const first = replyDouble();
+    await route.handler({}, first);
+    const second = replyDouble();
+    await route.handler({}, second);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(first.status).toHaveBeenCalledWith(200);
+    expect(second.status).toHaveBeenCalledWith(200);
+  });
+
+  it("re-probes after the TTL expires", async () => {
+    const execute = vi.fn(async () => [{ one: 1 }]);
+    const route = await registerHealthz(execute);
+
+    await route.handler({}, replyDouble());
+    vi.advanceTimersByTime(1_001);
+    await route.handler({}, replyDouble());
+
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches a failed probe for the TTL instead of hammering a down database", async () => {
+    const execute = vi.fn(async (): Promise<unknown> => {
+      throw new Error("connection refused");
+    });
+    const route = await registerHealthz(execute);
+
+    const first = replyDouble();
+    await route.handler({}, first);
+    const second = replyDouble();
+    await route.handler({}, second);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(first.status).toHaveBeenCalledWith(503);
+    expect(second.status).toHaveBeenCalledWith(503);
+
+    // Recovery is visible once the cached failure expires.
+    execute.mockResolvedValue([{ one: 1 }]);
+    vi.advanceTimersByTime(1_001);
+    const third = replyDouble();
+    await route.handler({}, third);
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(third.status).toHaveBeenCalledWith(200);
+  });
+
+  it("shares one in-flight probe between concurrent requests (single-flight)", async () => {
+    let release: (value: unknown) => void = () => {};
+    const execute = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+    );
+    const route = await registerHealthz(execute);
+
+    const firstReply = replyDouble();
+    const secondReply = replyDouble();
+    const first = route.handler({}, firstReply);
+    const second = route.handler({}, secondReply);
+    release([{ one: 1 }]);
+    await Promise.all([first, second]);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(firstReply.status).toHaveBeenCalledWith(200);
+    expect(secondReply.status).toHaveBeenCalledWith(200);
+  });
+});
+
+describe("/healthz rate limit", () => {
+  it("allows 120 requests per minute per IP and rejects the 121st", async () => {
+    const app = await createTestApp();
+    try {
+      const probe = () => app.inject({ method: "GET", url: "/healthz" });
+
+      for (let i = 1; i <= 120; i++) {
+        const res = await probe();
+        expect(res.statusCode).toBe(200);
+      }
+      const limited = await probe();
+      expect(limited.statusCode).toBe(429);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/server/src/api/healthz.ts
+++ b/packages/server/src/api/healthz.ts
@@ -5,14 +5,67 @@ import type { FastifyInstance } from "fastify";
  * Root-level health check endpoint for container orchestration.
  * Returns 200 when healthy, 503 when degraded.
  * Used by Docker HEALTHCHECK, Railway, Fly.io, Kubernetes liveness/readiness probes.
+ *
+ * The endpoint is public, so the database probe is cached for
+ * `DB_PROBE_CACHE_TTL_MS` and the route carries its own rate limit: public
+ * traffic or aggressive probes must not create unbounded PostgreSQL round
+ * trips (issue #1716).
  */
+
+/**
+ * How long a database probe result stays valid. Bounds round trips to at most
+ * one probe per second per process regardless of request rate — including
+ * when the database is down, since failures are cached too. The staleness is
+ * negligible next to the 10s–30s cadence of typical probes (the Dockerfile
+ * HEALTHCHECK polls every 30s).
+ */
+const DB_PROBE_CACHE_TTL_MS = 1_000;
+
+type ProbeCache = {
+  /** Last settled probe plus its expiry, or null before the first probe. */
+  result: { healthy: boolean; expiresAt: number } | null;
+  /** In-flight probe shared by concurrent requests (single-flight). */
+  pending: Promise<boolean> | null;
+};
+
 export async function healthzRoutes(app: FastifyInstance): Promise<void> {
-  app.get("/healthz", { config: { rateLimit: false } }, async (_request, reply) => {
-    try {
-      await app.db.execute(sql`SELECT 1`);
-      return reply.status(200).send({ status: "ok" });
-    } catch {
-      return reply.status(503).send({ status: "error", message: "database unreachable" });
+  // The cache lives in the registration closure, not at module scope: the app
+  // registers this plugin once per process, and tests that register the route
+  // repeatedly each get a fresh cache.
+  const cache: ProbeCache = { result: null, pending: null };
+
+  const probeDatabase = (): Promise<boolean> => {
+    if (cache.result !== null && Date.now() < cache.result.expiresAt) {
+      return Promise.resolve(cache.result.healthy);
     }
-  });
+    if (cache.pending !== null) {
+      return cache.pending;
+    }
+    const pending = app.db
+      .execute(sql`SELECT 1`)
+      .then(() => true)
+      .catch(() => false)
+      .then((healthy) => {
+        cache.result = { healthy, expiresAt: Date.now() + DB_PROBE_CACHE_TTL_MS };
+        cache.pending = null;
+        return healthy;
+      });
+    cache.pending = pending;
+    return pending;
+  };
+
+  app.get(
+    "/healthz",
+    // Independent cheap limit for this public endpoint: 120 req/min per key
+    // (anonymous traffic keys on client IP) is ~2x the fastest reasonable
+    // probe cadence (1s) while capping request volume far below the global
+    // default of 3000/min.
+    { config: { rateLimit: { max: 120, timeWindow: "1 minute" } } },
+    async (_request, reply) => {
+      if (await probeDatabase()) {
+        return reply.status(200).send({ status: "ok" });
+      }
+      return reply.status(503).send({ status: "error", message: "database unreachable" });
+    },
+  );
 }


### PR DESCRIPTION
# fix: bound /healthz database probes (PERF-053)

Fixes #1716

## Problem

`/healthz` opted out of rate limiting (`rateLimit: false`) and executed `SELECT 1` against PostgreSQL on **every** request. The endpoint is public (used by Docker HEALTHCHECK, Railway, Fly.io, Kubernetes probes), so public traffic or overly aggressive probes could create unlimited database round trips — including while the database was already down, where every request still attempted its own failing probe.

## Changes

Scoped to `packages/server/src/api/healthz.ts` plus tests; no contract, deployment, or config-schema changes.

- **Short-TTL cached probe with single-flight** (`healthz.ts`): the `SELECT 1` result — success *and* failure — is cached for 1s per process. Concurrent requests past expiry share one in-flight probe. Database round trips are bounded to **≤ 1 per second per process** regardless of request rate. The cache lives in the route-registration closure (no module-level state), so it is per-app-instance and test-isolated.
- **Independent route-level rate limit**: `rateLimit: false` → `{ max: 120, timeWindow: "1 minute" }`, matching the existing route-override pattern in `api/auth/google.ts` and `api/me-auth-providers.ts`.

### Why 120/min

Per the rate-limiting convention (limits must stay high enough that normal use never sees 429s): the fastest reasonable probe cadence is 1s (60/min); 120/min leaves 2x headroom over that, and is far above the actual consumers here — Dockerfile HEALTHCHECK polls every 30s (2/min), Kubernetes defaults to 10s (6/min per probe type). Anonymous traffic keys on client IP via the existing `keyGenerator`. The value comes from the audit finding itself (#1716), not a reintroduced low route default.

### Behavior notes

- Response contract is unchanged: `200 {status:"ok"}` / `503 {status:"error", message:"database unreachable"}`.
- Health signal can lag reality by at most 1s — negligible against 10s–30s probe periods, and a ≤1s stale *failure* expires long before the next 30s Docker HEALTHCHECK tick.
- A 429 from the limiter reads as "unhealthy" to probe clients; with the headroom above, legitimate probes never approach it.
- The fix is in-process only: no Redis/MQ/shared limiter state, keeping the server stateless. With N replicas each process probes ≤ 1/s independently — bounded and acceptable.
- **Scope:** the issue title says "health checks" (plural). `/readyz` also sets `rateLimit: false` but performs no database access (pure in-memory bootstrap-stage read), and `/api/v1/health` is already covered by the global limiter — neither is in the issue's stated location (`healthz.ts:10-15`), so both are intentionally untouched.
- Endpoint split (the issue's first suggested direction) was deliberately not taken: `/healthz` = process + DB reachability is a deployed contract consumed by the Dockerfile HEALTHCHECK, and `/readyz` already fills the no-DB orchestration-probe role. The issue explicitly allows the cheap-limit/cache alternative, which carries far less behavioral risk.

## Testing

- `packages/server/src/__tests__/healthz.test.ts` (new): TTL cache hit/miss, failure caching + recovery after expiry, single-flight concurrency (one probe for concurrent expired requests), and a full-app integration test asserting request #120/min returns 200 and #121 returns 429.
- Adapted `api-small-routes-extra.test.ts` healthz case to advance past the probe TTL before asserting the degraded response.
- `pnpm --filter @first-tree/server test`, `pnpm check`, `pnpm typecheck` — all green.

## QA

This touches the boot/health path. Existing QA case `packages/qa/cases/cross-surface/release-boot-health.md` covers this surface; its PASS criteria (200 / ready / db-connected payload shape) are unaffected by this change. Formal QA per `skills/first-tree-qa` is warranted before merge.
