### PR TITLE
fix: initialize resume transcript tail at EOF to skip full-history read

### DIFF
--- a/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
+++ b/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
@@ -11,6 +11,7 @@ const state = vi.hoisted(() => ({
   pasteTexts: [] as string[],
   lastPasteOrdinal: 0,
   emittedOrdinals: new Set<number>(),
+  seekToEnd: vi.fn(),
   chatContext: {
     chatId: "chat-tui-suspend-queued-recovery",
     title: "queued recovery",
@@ -77,6 +78,7 @@ vi.mock("../handlers/claude-code-tui/tmux-session.js", () => ({
 vi.mock("../handlers/claude-code-tui/transcript-tail.js", () => ({
   transcriptPathFor: vi.fn(() => "/tmp/fake-transcript.jsonl"),
   TranscriptTailer: class {
+    seekToEnd = state.seekToEnd;
     drainEntries() {
       const ordinal = state.lastPasteOrdinal;
       if (ordinal < 2 || state.emittedOrdinals.has(ordinal)) return [];
@@ -189,6 +191,10 @@ describe("claude-code-tui suspend queued recovery", () => {
 
     const start = handler.start(first, ctx);
     await waitFor(() => state.pasteTexts.some((text) => text.includes("active turn")));
+
+    // The run-turn pre-flush seeks past existing transcript content instead
+    // of reading/parsing and discarding it.
+    expect(state.seekToEnd).toHaveBeenCalled();
 
     handler.inject(recovered);
     await handler.suspend();

--- a/packages/client/src/__tests__/tui-transcript-tail.test.ts
+++ b/packages/client/src/__tests__/tui-transcript-tail.test.ts
@@ -79,4 +79,45 @@ describe("TranscriptTailer", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ type: "user" });
   });
+
+  it("seekToEnd skips existing content without parsing it", () => {
+    // Simulate a resumed transcript: a full history, including a malformed
+    // line that would fail JSON.parse if it were read.
+    writeFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "old" } })}\nnot json\n`);
+    const tailer = new TranscriptTailer(filePath);
+
+    tailer.seekToEnd();
+    expect(tailer.drainEntries()).toEqual([]);
+
+    appendFileSync(filePath, `${JSON.stringify({ type: "assistant", message: { content: [] } })}\n`);
+    const entries = tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "assistant" });
+  });
+
+  it("seekToEnd discards a buffered partial line", () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    appendFileSync(filePath, '{"type":"user","message":{"content":"half');
+    expect(tailer.drainEntries()).toEqual([]);
+
+    tailer.seekToEnd();
+
+    // The leftover partial is gone: completing it must not surface the old
+    // fragment, only genuinely new entries are returned.
+    appendFileSync(filePath, ' message"}}\n');
+    expect(tailer.drainEntries()).toEqual([]);
+    appendFileSync(filePath, `${JSON.stringify({ type: "assistant", message: { content: [] } })}\n`);
+    expect(tailer.drainEntries()).toHaveLength(1);
+  });
+
+  it("seekToEnd tolerates a missing file and still tails once it appears", () => {
+    const tailer = new TranscriptTailer(filePath);
+
+    expect(() => tailer.seekToEnd()).not.toThrow();
+
+    writeFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "first" } })}\n`);
+    expect(tailer.drainEntries()).toHaveLength(1);
+  });
 });

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -316,6 +316,10 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     }
 
     transcriptTailer = new TranscriptTailer(transcriptPathFor(cwd, sessionId));
+    // A resumed transcript already holds the full session history — start
+    // the tail at EOF so the first pre-flush doesn't synchronously read and
+    // parse (only to discard) the entire historical file.
+    if (resumeSessionId) transcriptTailer.seekToEnd();
     return sessionId;
   }
 
@@ -405,7 +409,9 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     try {
       // Pre-flush whatever's already in the transcript (the prior turn's
       // tail end) so it doesn't pollute this turn's text accumulation.
-      transcriptTailer.drainEntries();
+      // Seek instead of drain-and-discard: no buffer allocation, read, or
+      // parse for data nobody consumes.
+      transcriptTailer.seekToEnd();
 
       await pasteText(tmuxSessionName, text);
       sessionCtx.recordProviderActivity();

--- a/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
+++ b/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
@@ -61,6 +61,19 @@ export class TranscriptTailer {
     this.path = path;
   }
 
+  /**
+   * Skip everything currently in the file without reading or parsing it.
+   * Used to initialize a resume tail at EOF (the historical transcript is
+   * never consumed) and to pre-flush a prior turn's leftover entries.
+   * A missing file is a no-op — the tailer still starts at offset 0 for
+   * the not-yet-created transcript.
+   */
+  seekToEnd(): void {
+    if (!existsSync(this.path)) return;
+    this.offset = statSync(this.path).size;
+    this.partial = "";
+  }
+
   /** Read raw JSONL entries appended since the last call. Best-effort. */
   drainEntries(): RawTranscriptEntry[] {
     if (!existsSync(this.path)) return [];

--- a/packages/qa/cases/runtime/claude-code-tui-resume-large-transcript.md
+++ b/packages/qa/cases/runtime/claude-code-tui-resume-large-transcript.md
@@ -1,0 +1,47 @@
+---
+id: claude-code-tui-resume-large-transcript
+description: Resuming a claude-code-tui session with a large historical transcript starts the tail at EOF instead of synchronously reading and parsing the whole file.
+areas: [runtime]
+surfaces: [client]
+---
+
+# Claude Code TUI resume with a large transcript
+
+Validate that resuming a Claude Code TUI session whose per-session JSONL
+transcript already holds a large history does not synchronously read, split,
+and parse the entire historical file before the first resumed turn. The
+resume tail must initialize at EOF and only consume data appended after the
+resume.
+
+Use an isolated test agent on the claude-code-tui provider and a scratch
+workspace. Pre-seed or grow a real claude session transcript to a
+representative large size (tens of MB of JSONL history, including a long
+tool-result entry) through real turns, then suspend the handler so the next
+delivery goes through the resume path. Do not hand-craft a transcript at a
+path the provider would not write itself; the file must be one claude
+actually produced for that workspace and session.
+
+Resume the session with a new inbound message and observe the first resumed
+turn end to end. Credible evidence shows the turn's pre-flush completes
+without a stall proportional to the historical file size: the first resumed
+reply arrives in roughly the same time as an equivalent fresh-session reply,
+the Client process does not show a heap spike on the order of the transcript
+size, and other agents sharing the Client process remain responsive (their
+turns and chat deliveries are not blocked by the resume). Client logs or
+tracing that attribute read volume to the transcript tail may support the
+conclusion but are not sufficient on their own.
+
+Confirm correctness alongside performance: the resumed turn's reply reflects
+only the new delivery and any post-resume transcript entries; no historical
+assistant text from before the resume leaks into the resumed turn's
+forwarded result. Repeat the resume once more after appending additional
+history to confirm the behavior does not regress with growth.
+
+Include a boundary branch: resume a session whose transcript file is missing
+or empty (first message never flushed) and confirm the resume still works
+and the first real reply is delivered.
+
+Do not report `PASS` when a large real transcript cannot be produced, the
+resume path cannot be driven, or responsiveness of co-resident agents cannot
+be observed; report `BLOCKED` or `INCONCLUSIVE` with the missing evidence
+instead.


### PR DESCRIPTION
## Summary

Fixes #1679 (PERF-016, High).

A resumed claude-code-tui transcript tail started at offset 0. The first turn's pre-flush allocated a buffer for the entire historical JSONL file, synchronously read it, split and `JSON.parse`d every line — and then discarded the result. Large histories blocked the shared Client event loop and could OOM every agent in the process.

## Changes

- `transcript-tail.ts`: add `TranscriptTailer.seekToEnd()` — skips everything currently in the file with a single `stat` (no allocation, read, or parse), clears any buffered partial line, and no-ops when the file does not exist yet.
- `index.ts` (`startClaude`): when resuming (`resumeSessionId != null`), initialize the tail at EOF right after construction — the historical transcript is never consumed.
- `index.ts` (`runTurn` pre-flush): replace drain-and-discard with `seekToEnd()`. Same discard semantics in O(1); also drops a trailing partial line from the previous turn's end instead of letting it complete mid-turn and leak into this turn's `finalTexts`.

No behavior change for fresh sessions (new transcript file: offset 0 == EOF). The incremental `drainEntries()` read path (partial-line buffering, malformed-line tolerance, missing-file window) is untouched.

## Deviation from the issue's recommended direction

The issue recommends "initialize resume tails at EOF and use bounded streaming chunks only for new data". The first half is implemented as suggested. A fixed chunk-size cap inside `drainEntries()` was considered and intentionally not added: reads are already delta-bounded by the tail offset, and per-poll deltas are small (one turn's appended entries between polls). The audit's core defect is the full-history read on resume, which this PR eliminates; a hard chunk cap would add loop/state complexity for marginal gain.

## Tests

- `tui-transcript-tail.test.ts`: new `seekToEnd` cases — skips existing content without parsing (malformed history never parsed), returns only post-seek appends, discards a buffered partial line, tolerates a missing file. Existing drain tests unchanged and green.
- `tui-suspend-queued-recovery.test.ts`: tailer mock updated with `seekToEnd`, plus a wiring assertion that the run-turn pre-flush seeks instead of draining.

## Verification

- `pnpm check` ✅ / `pnpm typecheck` ✅
- `pnpm --filter @first-tree/client test` ✅
- `pnpm test` (full monorepo) ✅

## QA

This change touches the runtime/provider path. Added a matching prose case `packages/qa/cases/runtime/claude-code-tui-resume-large-transcript.md` (no existing case covered claude-code-tui resume/transcript tail). **Formal QA is warranted** per the repo's testing policy.
