### PR TITLE
fix: stop public health endpoints from issuing unbounded PostgreSQL probes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,15 +34,36 @@ its package script.
 
 - API server: `http://127.0.0.1:8000`
 - Web workspace: `http://127.0.0.1:5173`
-- Liveness check: `http://127.0.0.1:8000/healthz`
+- Liveness check (process only, no DB): `http://127.0.0.1:8000/healthz`
+- Readiness check (boot stages + DB, cached probe): `http://127.0.0.1:8000/readyz`
 - Structured health check: `http://127.0.0.1:8000/api/v1/health`
 
 Useful smoke checks:
 
 ```bash
 curl http://127.0.0.1:8000/healthz
+curl http://127.0.0.1:8000/readyz
 curl http://127.0.0.1:8000/api/v1/health
 ```
+
+### Probe endpoints and cadence
+
+`/healthz` is pure process liveness — it never touches the database, so a
+database outage does not make an orchestrator restart a healthy process.
+Point liveness/restart probes (Docker HEALTHCHECK, K8s `livenessProbe`) here.
+
+`/readyz` is readiness: 200 only when every bootstrap stage is done AND the
+database answers a shared cached probe (5s TTL, single-flight, 2s timeout —
+at most one `SELECT 1` per TTL window per process regardless of traffic).
+Point traffic-gating probes (K8s `readinessProbe`, load-balancer checks)
+here. If an external platform (Railway, Fly.io, K8s) previously used
+`/healthz` for readiness/traffic gating, switch it to `/readyz`; leave
+liveness/restart probes on `/healthz`.
+
+Suggested probe cadence: `period >= 10s`, `timeout <= 5s`,
+`failureThreshold >= 3` — consistent with the 5s result cache and the 2s
+probe timeout, so a transient DB blip is absorbed before a replica is pulled
+out of rotation.
 
 ## Minimal `.env`
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -303,8 +303,9 @@ first-tree status                 # CLI version + service + server + auth + agen
 first-tree daemon doctor          # service + agent configs + WS reachability
 first-tree --help                 # 5 top-level verbs + 7 namespaces
 
-# Server side — usual health check:
+# Server side — liveness (process) and readiness (boot stages + DB):
 curl -sf https://<server-public-url>/healthz | jq
+curl -sf https://<server-public-url>/readyz | jq
 ```
 
 If `daemon doctor` reports "service installed, inactive" persistently

--- a/packages/qa/cases/cross-surface/release-boot-health.md
+++ b/packages/qa/cases/cross-surface/release-boot-health.md
@@ -43,7 +43,8 @@ If the build tooling or Compose flags differ for the target ref, record the exac
 - `observe container-state`: `docker compose ps` shows server and postgres `Up (healthy)` (the image `HEALTHCHECK`
   probes `/healthz`).
 - `observe http-api`: `/healthz` returns a 200 liveness body (`{"status":"ok"}`).
-- `observe http-api`: `/readyz` returns 200 with `ready: true` and boot stages (including `runMigrations`) marked `done`.
+- `observe http-api`: `/readyz` returns 200 with `ready: true`, boot stages (including `runMigrations`) marked `done`,
+  and the database gate reporting reachable (`db.ok: true`).
 - `observe http-api`: `/api/v1/health` returns 200 with database connectivity (`{"status":"ok","db":"connected"}`). Note
   the real DB-health route lives under the `/api/v1` prefix; bare `/health` correctly falls through to the web SPA.
 - `observe http-api`: `GET /` returns the web SPA `index.html`, confirming the server image serves the built web dist.

--- a/packages/server/src/__tests__/api-route-branch-sweeper.test.ts
+++ b/packages/server/src/__tests__/api-route-branch-sweeper.test.ts
@@ -31,6 +31,7 @@ function createApp(overrides: Record<string, unknown> = {}): { app: Record<strin
   };
   const app = {
     db: { execute: vi.fn(async () => [{ one: 1 }]) },
+    dbHealth: { check: vi.fn(async () => ({ ok: true, checkedAt: "2026-01-01T00:00:00.000Z", latencyMs: 1 })) },
     get: registerRoute("GET"),
     ...overrides,
   };
@@ -74,37 +75,30 @@ describe("API route branch contracts", () => {
   it("reports degraded /health when the database probe fails", async () => {
     const healthy = await registerSingleRoute(healthRoutes);
     await expect(healthy.route.handler({}, replyDouble())).resolves.toEqual({ status: "ok", db: "connected" });
-    expect((healthy.app.db as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
+    expect((healthy.app.dbHealth as { check: ReturnType<typeof vi.fn> }).check).toHaveBeenCalledTimes(1);
 
-    const execute = vi.fn(async () => {
-      throw new Error("db unavailable");
-    });
-    const degraded = await registerSingleRoute(healthRoutes, { db: { execute } });
+    const check = vi.fn(async () => ({ ok: false, checkedAt: "2026-01-01T00:00:00.000Z" }));
+    const degraded = await registerSingleRoute(healthRoutes, { dbHealth: { check } });
 
     await expect(degraded.route.handler({}, replyDouble())).resolves.toEqual({
       status: "degraded",
       db: "disconnected",
     });
-    expect(execute).toHaveBeenCalledTimes(1);
+    expect(check).toHaveBeenCalledTimes(1);
   });
 
-  it("maps /healthz database reachability to explicit status codes", async () => {
-    const ok = await registerSingleRoute(healthzRoutes);
-    const okReply = replyDouble();
-    await ok.route.handler({}, okReply);
-
-    expect(okReply.status).toHaveBeenCalledWith(200);
-    expect(okReply.send).toHaveBeenCalledWith({ status: "ok" });
-
+  it("keeps /healthz at 200 without touching the database", async () => {
     const execute = vi.fn(async () => {
       throw new Error("connection refused");
     });
-    const failing = await registerSingleRoute(healthzRoutes, { db: { execute } });
-    const failingReply = replyDouble();
-    await failing.route.handler({}, failingReply);
+    const { app, route } = await registerSingleRoute(healthzRoutes, { db: { execute } });
+    const reply = replyDouble();
+    await route.handler({}, reply);
 
-    expect(failingReply.status).toHaveBeenCalledWith(503);
-    expect(failingReply.send).toHaveBeenCalledWith({ status: "error", message: "database unreachable" });
+    expect(reply.status).toHaveBeenCalledWith(200);
+    expect(reply.send).toHaveBeenCalledWith({ status: "ok" });
+    expect(execute).not.toHaveBeenCalled();
+    expect((app.dbHealth as { check: ReturnType<typeof vi.fn> }).check).not.toHaveBeenCalled();
   });
 
   it("keeps /readyz unavailable until every bootstrap stage is done", async () => {
@@ -131,6 +125,36 @@ describe("API route branch contracts", () => {
           runMigrations: { status: "failed", error: "migration lock contention" },
         }),
       }),
+    );
+  });
+
+  it("gates /readyz on the shared database probe once all stages are done", async () => {
+    bootstrapState.startedAt = new Date("2026-01-01T00:00:00.000Z");
+    bootstrapState.readyAt = new Date("2026-01-01T00:00:10.000Z");
+    bootstrapState.stages = {
+      initTelemetry: { status: "done" },
+      runMigrations: { status: "done" },
+      buildApp: { status: "done" },
+      appListen: { status: "done" },
+    };
+
+    const check = vi.fn(async () => ({ ok: false, checkedAt: "2026-01-01T00:00:11.000Z" }));
+    const gated = await registerSingleRoute(readyzRoutes, { dbHealth: { check } });
+    const gatedReply = replyDouble();
+    await gated.route.handler({}, gatedReply);
+
+    expect(gatedReply.status).toHaveBeenCalledWith(503);
+    expect(gatedReply.send).toHaveBeenCalledWith(
+      expect.objectContaining({ ready: false, db: expect.objectContaining({ ok: false }) }),
+    );
+
+    const healthy = await registerSingleRoute(readyzRoutes);
+    const healthyReply = replyDouble();
+    await healthy.route.handler({}, healthyReply);
+
+    expect(healthyReply.status).toHaveBeenCalledWith(200);
+    expect(healthyReply.send).toHaveBeenCalledWith(
+      expect.objectContaining({ ready: true, db: expect.objectContaining({ ok: true }) }),
     );
   });
 

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -320,11 +320,12 @@ describe("small API route handlers", () => {
     );
   });
 
-  it("returns health and healthz success and degraded responses", async () => {
+  it("serves /health from the shared probe and keeps /healthz database-free", async () => {
     const { healthRoutes } = await import("../api/health.js");
     const { healthzRoutes } = await import("../api/healthz.js");
     const execute = vi.fn().mockResolvedValue(undefined);
-    const { app, routes } = makeApp({ db: { execute } });
+    const check = vi.fn().mockResolvedValue({ ok: true, checkedAt: "2026-01-01T00:00:00.000Z", latencyMs: 1 });
+    const { app, routes } = makeApp({ db: { execute }, dbHealth: { check } });
 
     await healthRoutes(app as never);
     await healthzRoutes(app as never);
@@ -334,14 +335,16 @@ describe("small API route handlers", () => {
     await route(routes, "GET", "/healthz").handler({}, okReply);
     expect(okReply).toMatchObject({ body: { status: "ok" }, code: 200 });
 
-    execute.mockRejectedValueOnce(new Error("db down")).mockRejectedValueOnce(new Error("db down"));
+    check.mockResolvedValueOnce({ ok: false, checkedAt: "2026-01-01T00:00:05.000Z" });
     await expect(route(routes, "GET", "/health").handler()).resolves.toEqual({
       db: "disconnected",
       status: "degraded",
     });
-    const degradedReply = makeReply();
-    await route(routes, "GET", "/healthz").handler({}, degradedReply);
-    expect(degradedReply).toMatchObject({ body: { message: "database unreachable", status: "error" }, code: 503 });
+
+    const stillOkReply = makeReply();
+    await route(routes, "GET", "/healthz").handler({}, stillOkReply);
+    expect(stillOkReply).toMatchObject({ body: { status: "ok" }, code: 200 });
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it("serves agent runtime config and context tree info", async () => {

--- a/packages/server/src/__tests__/db-health.test.ts
+++ b/packages/server/src/__tests__/db-health.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDbHealthChecker } from "../services/db-health.js";
+
+/**
+ * Pure unit tests for the shared cached DB probe — no app, no real DB.
+ * Uses fake timers; the runner re-uses worker processes (vitest
+ * `isolate: false`), so `afterEach` MUST restore real timers.
+ */
+
+const TTL_MS = 5_000;
+const PROBE_TIMEOUT_MS = 2_000;
+
+function makeDb(execute: ReturnType<typeof vi.fn>) {
+  // The checker only ever calls `db.execute`; a one-method double stands in
+  // for the full Drizzle instance.
+  return { execute } as never;
+}
+
+describe("createDbHealthChecker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("serves cached result within TTL without re-querying", async () => {
+    const execute = vi.fn(async () => [{ one: 1 }]);
+    const checker = createDbHealthChecker(makeDb(execute));
+
+    const first = await checker.check();
+    expect(first).toEqual({ ok: true, checkedAt: expect.any(String), latencyMs: expect.any(Number) });
+
+    const second = await checker.check();
+    expect(second).toBe(first);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-probes after TTL expiry", async () => {
+    const execute = vi.fn(async () => [{ one: 1 }]);
+    const checker = createDbHealthChecker(makeDb(execute));
+
+    await checker.check();
+    await vi.advanceTimersByTimeAsync(TTL_MS + 1);
+    const result = await checker.check();
+
+    expect(result.ok).toBe(true);
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent checks into a single in-flight probe", async () => {
+    let release: ((rows: unknown) => void) | undefined;
+    const execute = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+    );
+    const checker = createDbHealthChecker(makeDb(execute));
+
+    const firstCall = checker.check();
+    const secondCall = checker.check();
+    release?.([{ one: 1 }]);
+    const [first, second] = await Promise.all([firstCall, secondCall]);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+    expect(first.ok).toBe(true);
+  });
+
+  it("caches failure and fails fast within TTL", async () => {
+    const execute = vi.fn(async () => {
+      throw new Error("db unavailable");
+    });
+    const checker = createDbHealthChecker(makeDb(execute));
+
+    const first = await checker.check();
+    expect(first.ok).toBe(false);
+
+    const second = await checker.check();
+    expect(second.ok).toBe(false);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("times out a hanging probe after timeoutMs and reports not ok", async () => {
+    const execute = vi.fn(() => new Promise(() => {}));
+    const checker = createDbHealthChecker(makeDb(execute));
+
+    const pending = checker.check();
+    await vi.advanceTimersByTimeAsync(PROBE_TIMEOUT_MS);
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    expect(result.latencyMs).toBeUndefined();
+  });
+
+  it("does not spawn a second probe while one is in flight across TTL windows", async () => {
+    const execute = vi.fn(() => new Promise(() => {}));
+    const checker = createDbHealthChecker(makeDb(execute));
+
+    // Three callers spread across three TTL windows, all while the first
+    // probe hangs (postgres-js connect_timeout can hold it for ~30s). Each
+    // times out against the SAME probe; none may spawn a second one.
+    for (let window = 0; window < 3; window++) {
+      const pending = checker.check();
+      await vi.advanceTimersByTimeAsync(PROBE_TIMEOUT_MS);
+      expect((await pending).ok).toBe(false);
+      await vi.advanceTimersByTimeAsync(TTL_MS + 1);
+    }
+
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes the settled result to cache after a timed-out probe eventually resolves", async () => {
+    let release: ((rows: { one: number }[]) => void) | undefined;
+    const execute = vi.fn(async () => [{ one: 1 }]);
+    execute.mockImplementationOnce(
+      () =>
+        new Promise<{ one: number }[]>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const checker = createDbHealthChecker(makeDb(execute));
+
+    // Caller times out; the failure is cached but the probe keeps flying.
+    const pending = checker.check();
+    await vi.advanceTimersByTimeAsync(PROBE_TIMEOUT_MS);
+    expect((await pending).ok).toBe(false);
+
+    // The probe settles late: its real result overwrites the cached failure
+    // (last-write-wins) without any new probe being spawned.
+    release?.([{ one: 1 }]);
+    await vi.advanceTimersByTimeAsync(0);
+    const settled = await checker.check();
+    expect(settled.ok).toBe(true);
+    expect(settled.latencyMs).toBe(PROBE_TIMEOUT_MS);
+    expect(execute).toHaveBeenCalledTimes(1);
+
+    // The slot was released on settle: after TTL expiry the next caller can
+    // start a fresh probe again.
+    await vi.advanceTimersByTimeAsync(TTL_MS + 1);
+    const reprobed = await checker.check();
+    expect(reprobed.ok).toBe(true);
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/server/src/__tests__/rate-limit.test.ts
+++ b/packages/server/src/__tests__/rate-limit.test.ts
@@ -154,6 +154,26 @@ describe("Rate limit", () => {
     }
   });
 
+  it("keeps /healthz and /readyz exempt from the global limiter but not /api/v1/health", async () => {
+    const app = await createTestApp({ rateLimit: { max: 2 } });
+    try {
+      // Exempt probes: far past `max` without a 429. `/readyz` may be 503
+      // depending on bootstrap state shared across the worker, so only the
+      // exemption (never 429) is asserted for it.
+      for (let i = 0; i < 5; i++) {
+        expect((await app.inject({ method: "GET", url: "/healthz" })).statusCode).toBe(200);
+        expect((await app.inject({ method: "GET", url: "/readyz" })).statusCode).not.toBe(429);
+      }
+
+      // Not exempt: `/api/v1/health` stays behind the global limiter.
+      expect((await app.inject({ method: "GET", url: "/api/v1/health" })).statusCode).toBe(200);
+      expect((await app.inject({ method: "GET", url: "/api/v1/health" })).statusCode).toBe(200);
+      expect((await app.inject({ method: "GET", url: "/api/v1/health" })).statusCode).toBe(429);
+    } finally {
+      await app.close();
+    }
+  });
+
   it("does not apply the removed 6/min route cap to context snapshots", async () => {
     const app = await createTestApp({ rateLimit: { max: 10 } });
     try {

--- a/packages/server/src/__tests__/readyz.test.ts
+++ b/packages/server/src/__tests__/readyz.test.ts
@@ -50,6 +50,28 @@ describe("/readyz", () => {
     expect(body.ready).toBe(true);
     expect(body.readyAt).toBeTruthy();
     expect(body.stages.appListen?.status).toBe("done");
+    expect(body.db.ok).toBe(true);
+  });
+
+  it("returns 503 with db detail when the database probe reports not ok", async () => {
+    markAllStagesDone();
+    markReady();
+
+    // The test app runs against a live DB, so the only stable way to exercise
+    // the gate is stubbing the decorated checker.
+    const app = getApp();
+    const originalCheck = app.dbHealth.check;
+    app.dbHealth.check = async () => ({ ok: false, checkedAt: new Date().toISOString() });
+    try {
+      const res = await app.inject({ method: "GET", url: "/readyz" });
+      expect(res.statusCode).toBe(503);
+      const body = res.json();
+      expect(body.ready).toBe(false);
+      expect(body.db.ok).toBe(false);
+      expect(body.stages.appListen?.status).toBe("done");
+    } finally {
+      app.dbHealth.check = originalCheck;
+    }
   });
 
   it("returns 503 when any required stage failed", async () => {

--- a/packages/server/src/api/health.ts
+++ b/packages/server/src/api/health.ts
@@ -1,13 +1,8 @@
-import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 
 export async function healthRoutes(app: FastifyInstance): Promise<void> {
   app.get("/health", async () => {
-    try {
-      await app.db.execute(sql`SELECT 1`);
-      return { status: "ok", db: "connected" };
-    } catch {
-      return { status: "degraded", db: "disconnected" };
-    }
+    const db = await app.dbHealth.check();
+    return db.ok ? { status: "ok", db: "connected" } : { status: "degraded", db: "disconnected" };
   });
 }

--- a/packages/server/src/api/healthz.ts
+++ b/packages/server/src/api/healthz.ts
@@ -1,18 +1,15 @@
-import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 
 /**
- * Root-level health check endpoint for container orchestration.
- * Returns 200 when healthy, 503 when degraded.
- * Used by Docker HEALTHCHECK, Railway, Fly.io, Kubernetes liveness/readiness probes.
+ * Process liveness endpoint for container orchestration.
+ * Used by Docker HEALTHCHECK, Railway, Fly.io, Kubernetes liveness probes.
+ * Answers 200 from process memory only — no database round trip — so public
+ * traffic cannot be amplified into PG load and a database outage never makes
+ * an orchestrator restart a healthy process. Database readiness lives in
+ * `/readyz`; a structured status body lives in `/api/v1/health`.
  */
 export async function healthzRoutes(app: FastifyInstance): Promise<void> {
   app.get("/healthz", { config: { rateLimit: false } }, async (_request, reply) => {
-    try {
-      await app.db.execute(sql`SELECT 1`);
-      return reply.status(200).send({ status: "ok" });
-    } catch {
-      return reply.status(503).send({ status: "error", message: "database unreachable" });
-    }
+    return reply.status(200).send({ status: "ok" });
   });
 }

--- a/packages/server/src/api/readyz.ts
+++ b/packages/server/src/api/readyz.ts
@@ -11,20 +11,24 @@ const REQUIRED_STAGES = ["initTelemetry", "runMigrations", "buildApp", "appListe
 
 /**
  * Readiness endpoint — distinct from `/healthz` (liveness). Returns 200 only
- * when every bootstrap stage is done. The body carries the stage detail so
- * operators can see which stage stalled. See
+ * when every bootstrap stage is done AND the database answers the shared
+ * cached probe (`app.dbHealth`, at most one `SELECT 1` per TTL window per
+ * process). The body carries the stage detail plus the `db` probe result so
+ * operators can see which gate failed. See
  * docs/server-bootstrap-resilience-design.md §3 (T6).
  */
 export async function readyzRoutes(app: FastifyInstance): Promise<void> {
   app.get("/readyz", { config: { rateLimit: false } }, async (_request, reply) => {
     const allStagesDone = REQUIRED_STAGES.every((s) => bootstrapState.stages[s]?.status === "done");
-    const ready = allStagesDone && bootstrapState.readyAt !== null;
+    const db = await app.dbHealth.check();
+    const ready = allStagesDone && bootstrapState.readyAt !== null && db.ok;
 
     const body = {
       ready,
       startedAt: bootstrapState.startedAt.toISOString(),
       readyAt: bootstrapState.readyAt?.toISOString() ?? null,
       stages: bootstrapState.stages,
+      db,
     };
     return reply.status(ready ? 200 : 503).send(body);
   });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -95,6 +95,7 @@ import { invalidateChatAudienceLocal, registerChatAudienceDispatcher } from "./s
 import { registerChatMessageDispatcher } from "./services/chat-projection.js";
 import { createCommandVersionPoller } from "./services/command-version-poller.js";
 import { createConfigService } from "./services/config-service.js";
+import { createDbHealthChecker } from "./services/db-health.js";
 import { backfillGitlabAttentionPairs } from "./services/gitlab-attention-backfill.js";
 import { repairMembershipHumanMirrors } from "./services/membership.js";
 import { createNotifier, type Notifier } from "./services/notifier.js";
@@ -276,7 +277,7 @@ export async function buildApp(config: Config) {
     //     We emit a dedicated long-running `ws.connection` span from
     //     `ws-tracing.ts` instead.
     ignoreRoutes: (path: string) => {
-      if (path === "/" || path === "/healthz") return true;
+      if (path === "/" || path === "/healthz" || path === "/readyz") return true;
       if (path.startsWith("/assets/") || path.startsWith("/fonts/")) return true;
       if (path === "/api/v1/agent/ws/client") return true;
       // Org WS upgrade: `/api/v1/orgs/:orgId/ws/`. Use a startsWith check so
@@ -292,6 +293,7 @@ export async function buildApp(config: Config) {
   // Decorate with config and db
   const db = connectDatabase(config.database.url);
   app.decorate("db", db);
+  app.decorate("dbHealth", createDbHealthChecker(db));
   app.decorate("config", config);
 
   // Advisory Command-package version broadcast to every Client via the
@@ -486,8 +488,9 @@ export async function buildApp(config: Config) {
   });
 
   // Root-level health checks for container orchestration (outside /api/v1).
-  // `/healthz` checks process + DB reachability (used by Docker HEALTHCHECK).
-  // `/readyz` checks full readiness — all bootstrap stages done.
+  // `/healthz` is pure process liveness — no DB round trip (used by Docker
+  // HEALTHCHECK). `/readyz` checks full readiness — all bootstrap stages done
+  // and the DB reachable via the shared cached probe (`app.dbHealth`).
   // See docs/server-bootstrap-resilience-design.md §3 (T6).
   await app.register(healthzRoutes);
   await app.register(readyzRoutes);

--- a/packages/server/src/services/db-health.ts
+++ b/packages/server/src/services/db-health.ts
@@ -1,0 +1,92 @@
+import { sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+
+/**
+ * Process-local cached database health probe shared by `/healthz`'s siblings
+ * (`/readyz`, `/api/v1/health`). Caps DB probing at one `SELECT 1` per TTL
+ * window per process regardless of external request rate, so public health
+ * traffic can never be amplified into PG load (issue #1716).
+ *
+ * Concurrency contract:
+ *   - Results (success AND failure) are cached for TTL_MS; callers inside the
+ *     window are answered from memory without touching the DB.
+ *   - Single-flight: at most one probe is ever pending. The in-flight slot is
+ *     released only when the underlying probe settles — callers arriving in
+ *     later TTL windows while a probe hangs (postgres-js connect_timeout can
+ *     hold it for ~30s) await the same probe instead of spawning another.
+ *   - Each caller races the shared probe against its own PROBE_TIMEOUT_MS
+ *     budget. On timeout the caller records a failure in the cache and
+ *     returns, but does not cancel the probe or release the slot; when the
+ *     probe eventually settles, its real result overwrites the cache
+ *     (last-write-wins) and the slot clears.
+ */
+
+/** How long a probe result (success or failure) is served from cache. */
+const TTL_MS = 5_000;
+
+/**
+ * Per-caller budget to wait on the shared probe before reporting failure.
+ * Kept below Docker HEALTHCHECK `--timeout=5s` and the CLI doctor's 3s fetch
+ * timeout so probes receive a definite 503 instead of timing out client-side.
+ */
+const PROBE_TIMEOUT_MS = 2_000;
+
+export type DbHealthResult = {
+  ok: boolean;
+  /** ISO timestamp of when this result was recorded (probe settle or caller timeout). */
+  checkedAt: string;
+  /** Time for the probe to settle. Absent when the entry was recorded by a caller timeout. */
+  latencyMs?: number;
+};
+
+export type DbHealthChecker = { check: () => Promise<DbHealthResult> };
+
+export function createDbHealthChecker(
+  db: Database,
+  opts: { ttlMs?: number; timeoutMs?: number } = {},
+): DbHealthChecker {
+  const ttlMs = opts.ttlMs ?? TTL_MS;
+  const timeoutMs = opts.timeoutMs ?? PROBE_TIMEOUT_MS;
+
+  let cached: { result: DbHealthResult; expiresAt: number } | null = null;
+  let inFlight: Promise<DbHealthResult> | null = null;
+
+  function record(result: DbHealthResult): DbHealthResult {
+    cached = { result, expiresAt: Date.now() + ttlMs };
+    return result;
+  }
+
+  async function probe(): Promise<DbHealthResult> {
+    const startedAt = Date.now();
+    let ok: boolean;
+    try {
+      await db.execute(sql`SELECT 1`);
+      ok = true;
+    } catch {
+      ok = false;
+    }
+    inFlight = null;
+    return record({ ok, checkedAt: new Date().toISOString(), latencyMs: Date.now() - startedAt });
+  }
+
+  async function check(): Promise<DbHealthResult> {
+    if (cached && cached.expiresAt > Date.now()) return cached.result;
+    inFlight ??= probe();
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        inFlight,
+        new Promise<DbHealthResult>((resolve) => {
+          timer = setTimeout(() => {
+            resolve(record({ ok: false, checkedAt: new Date().toISOString() }));
+          }, timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  return { check };
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,6 +1,7 @@
 import type { Database } from "./db/connection.js";
 import type { UserScope } from "./scope/types.js";
 import type { ConfigService } from "./services/config-service.js";
+import type { DbHealthChecker } from "./services/db-health.js";
 import type { Notifier } from "./services/notifier.js";
 import type { ResourcesService } from "./services/resources.js";
 
@@ -15,6 +16,8 @@ export type AgentIdentity = {
 declare module "fastify" {
   interface FastifyInstance {
     db: Database;
+    /** Shared cached DB health probe — see services/db-health.ts. */
+    dbHealth: DbHealthChecker;
     config: import("./config.js").Config;
     notifier: Notifier;
     configService: ConfigService;


### PR DESCRIPTION
Fixes #1716 (PERF-053).

## Problem

`/healthz` is public, unauthenticated, exempt from the global rate limiter (`config: { rateLimit: false }`), and ran `SELECT 1` on every request. Any public traffic translated 1:1 into PostgreSQL round trips, with no upper bound. The pathology was worst exactly when the DB was unhealthy: each probe queued in postgres-js for up to ~30s (`connect_timeout` default) while Docker HEALTHCHECK gave up client-side after 5s, so hung queries and request contexts kept piling up, and recovery released a thundering herd of stale `SELECT 1`s. `/api/v1/health` had the same per-request probe behind a per-IP limit that multi-source traffic can aggregate past, and `/readyz` — the nominal readiness endpoint — never looked at the DB at all.

## Approach

The issue's recommended direction, verbatim:

> Split process liveness from database readiness, restrict readiness at ingress or give it an independent cheap limit/cache, and tune probe cadence.

Mapped to this PR:

1. **Split process liveness from database readiness** — `/healthz` is now pure process liveness: 200 from memory, no DB round trip. Database readiness moves to `/readyz`, which gates on the DB on top of the existing bootstrap-stage checks.
2. **An independent cheap cache for readiness** — both `/readyz` and `/api/v1/health` go through one shared probe (`app.dbHealth`, new `services/db-health.ts`): 5s TTL cache (success and failure alike), single-flight, per-caller 2s timeout. DB probing is capped at one `SELECT 1` per 5s per process regardless of external request rate — cost is decoupled from traffic, and the rate-limit exemption on the probe endpoints becomes harmless.
3. **Probe cadence tuning** — `DEVELOPMENT.md` now documents which probe belongs on which endpoint, the migration step for platforms that pointed readiness/traffic-gating probes at `/healthz`, and suggested cadence (`period >= 10s`, `timeout <= 5s`, `failureThreshold >= 3`, consistent with the 5s TTL / 2s probe timeout).

### Endpoint semantics after this PR

| Endpoint | Semantics | DB access | Rate limit |
|---|---|---|---|
| `GET /healthz` | process liveness: 200 iff the process serves HTTP | none | exempt (unchanged) |
| `GET /readyz` | readiness: 200 iff all boot stages done **and** DB reachable | shared cached probe | exempt (unchanged) |
| `GET /api/v1/health` | structured status, always 200, `db` field | shared cached probe | global limiter (unchanged) |

### Probe concurrency contract (`services/db-health.ts`)

- Results (success and failure) are cached for 5s; callers inside the window never touch the DB.
- Single-flight: at most one probe is ever pending. The in-flight slot is released only when the underlying probe settles — callers arriving in later TTL windows while a probe hangs await the same probe instead of spawning another, so a wedged DB connection can never accumulate queued `SELECT 1`s.
- Each caller races the shared probe against its own 2s budget. On timeout it records a failure in the cache and returns 503-fast, but does not cancel the probe or release the slot; when the probe eventually settles, its real result overwrites the cache (last-write-wins) and the slot clears.
- 2s < Docker HEALTHCHECK `--timeout=5s` and < the CLI doctor's 3s fetch timeout, so probes receive a definite 503 instead of timing out client-side.

Constants are named `const`s with rationale comments; no new env/config surface.

## Why Docker HEALTHCHECK stays on `/healthz`

Deploy-time DB validation is not lost by this split: `runMigrations` runs before `appListen` (`bootstrap-server.ts`), so a broken DB config fails boot, the port never opens, and HEALTHCHECK goes red after `start-period` regardless. The only thing pointing HEALTHCHECK at `/readyz` would add is "runtime DB outage → container unhealthy → restart loop" — and restarting the container cannot fix an external database. That restart loop is precisely the anti-pattern this issue asks to remove, so the Dockerfile is intentionally unchanged.

## Behavior changes (call-outs for operators)

- **`/healthz` no longer reflects DB state.** Anything alerting on "healthz returns 503" as a DB signal should watch `/readyz` or `/api/v1/health` instead.
- **`/readyz` now returns 503 during a DB outage** (previously always 200 after boot). This is the intended readiness contract; the body's new `db` field (`{ ok, checkedAt, latencyMs? }`) is a backward-compatible addition. A repo-wide sweep found no existing traffic-gating consumer of `/readyz`; external platforms that used `/healthz` for readiness gating should switch per the `DEVELOPMENT.md` migration note.
- DB state served from cache may lag reality by ≤5s in both directions — negligible against common 10–30s probe periods, and invisible to `isHubReachable`/CLI doctor/onboard, which only check `res.ok`.
- `latencyMs` in probe results is the time for the underlying probe to settle, not a live latency reading. A probe pinned across a long outage reports its true settle time once it finally lands (observed >100s in QA) — expected telemetry, not an alarm; cache entries written by a caller timeout carry no `latencyMs` at all.
- `/readyz` joins `/healthz` in the tracing `ignoreRoutes` list, so periodic readiness probes stop generating trace noise.

## Changes

- `packages/server/src/services/db-health.ts` (new) — shared TTL + single-flight + timeout probe, `createDbHealthChecker`.
- `packages/server/src/api/healthz.ts` — liveness only; no DB import.
- `packages/server/src/api/readyz.ts` — DB gate + `db` body field; doc comment updated.
- `packages/server/src/api/health.ts` — probes via `app.dbHealth`; response contract unchanged.
- `packages/server/src/app.ts` — `dbHealth` decoration, `/readyz` tracing exemption, health-route comment update.
- `packages/server/src/types.ts` — `dbHealth` on `FastifyInstance`.
- Tests — new `db-health.test.ts` (7 cases: TTL cache, TTL expiry re-probe, concurrent coalescing, failure caching, hanging-probe timeout, no second probe across TTL windows while one is in flight, late-settle last-write-wins + slot release); updated `api-route-branch-sweeper.test.ts` (healthz liveness independence incl. zero DB calls, readyz DB gate both ways, health via probe), `api-small-routes-extra.test.ts`, `readyz.test.ts` (200 asserts `db.ok`, stubbed-probe 503 case), `rate-limit.test.ts` (two-way exemption contract: `/healthz` + `/readyz` never 429 at `max: 2`, `/api/v1/health` hits 429 on the 3rd request).
- Docs / QA — `DEVELOPMENT.md` (probe endpoints, migration note, cadence guidance), `MIGRATION.md` (readyz verification curl), `packages/qa/cases/cross-surface/release-boot-health.md` (`/readyz` expectation now includes `db.ok: true`).

## Validation

```
corepack pnpm check      # pass
corepack pnpm typecheck  # pass (10/10 tasks)
corepack pnpm --filter @first-tree/server test   # 239 files / 2567 tests pass
corepack pnpm exec turbo run test --filter='!@first-tree/skill-evals'  # 10/10 tasks pass
```

`@first-tree/skill-evals` shows pre-existing load-dependent flakiness on the dev machine (a different fixture test fails on each full-suite run — 6, 9, 1, 1 across four runs — and every failing file passes in isolation). The package has zero workspace dependencies and this diff does not touch it, so its inputs are identical to `main`.

## QA

This touches a boot/health path. `packages/qa/cases/cross-surface/release-boot-health.md` is updated in this PR, and formal QA per `packages/qa` was run by fire-fable-reviewer against this branch (isolated run cell, Docker + throwaway worktree at the PR head): **PASS**. Highlights, each backed by artifacts:

- Production image boots, self-migrates (39 tables), both containers healthy, all four surfaces green (`/readyz` with `db.ok: true`), SPA served; volume-reset smoke passes.
- Probe cost ceiling verified DB-side via `log_statement=all`: 300 `/healthz` hits → **0** additional `SELECT 1`; 2400 `/readyz`+`/api/v1/health` requests in 19s → **4** probes (ceiling 5), perfect 5s cadence.
- DB stopped (black-hole topology): `/healthz` 200 at 1.9ms; first uncached `/readyz` 503 at **2.010s** (caller timeout on the dot, no `latencyMs` — the timeout-written entry signature); cached fast-fails at 1.4–1.9ms; `/api/v1/health` 200 degraded; after 70s of outage the container HEALTHCHECK still reports ExitCode 0 / FailingStreak 0 — no restart loop.
- Recovery: `/readyz` back to 200 within **~1.7s** of the DB accepting connections; the single pinned probe settled once (`latencyMs: 109045`), and the DB received **one** probe total across the whole outage plus recovery — no thundering herd.
- Rate-limit boundary at `FIRST_TREE_RATE_LIMIT_MAX=5`: 20× `/healthz` + 20× `/readyz` produce zero 429s and consume no quota; `/api/v1/health` 429s on request #6 with the structured error body.
