### PR TITLE
fix: validate agent names and enforce realpath containment in removeLocalAgent

### DIFF
--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -77,7 +77,12 @@ vi.mock("@first-tree/client", () => clientSdkMocks);
 vi.mock("@first-tree/shared/config", () => configMocks);
 vi.mock("../core/bootstrap.js", () => bootstrapMocks);
 vi.mock("../core/cli-fetch.js", () => ({ cliFetch: cliFetchMock }));
-vi.mock("../core/index.js", () => coreMocks);
+vi.mock("../core/index.js", async () => {
+  // `agent remove` imports the real name validator; the commands under test
+  // here only ever pass valid names, so wire it through unmocked.
+  const prune = await vi.importActual<typeof import("../core/agent-prune.js")>("../core/agent-prune.js");
+  return { ...coreMocks, assertRemovableAgentName: prune.assertRemovableAgentName };
+});
 vi.mock("../cli/output.js", () => outputMocks);
 vi.mock("../core/output.js", () => ({
   print: { line: printLineMock, result: outputMocks.success, fail: outputMocks.fail },

--- a/apps/cli/src/__tests__/agent-prune-command.test.ts
+++ b/apps/cli/src/__tests__/agent-prune-command.test.ts
@@ -1,0 +1,95 @@
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerAgentPruneCommand } from "../commands/agent/prune.js";
+import { print } from "../core/output.js";
+
+/**
+ * `agent prune` over the REAL `removeLocalAgent` (unlike the lifecycle
+ * suite, which mocks it): a stale alias symlink that resolves outside First
+ * Tree state must fail closed — reported inline, non-zero exit code — while
+ * the remaining stale entries are still removed and the symlink's target
+ * stays untouched.
+ */
+
+const sdkMocks = vi.hoisted(() => ({ listMyAgents: vi.fn() }));
+
+vi.mock("@first-tree/client", async (importActual) => ({
+  ...(await importActual<typeof import("@first-tree/client")>()),
+  FirstTreeHubSDK: class {
+    listMyAgents = () => sdkMocks.listMyAgents();
+  },
+}));
+
+vi.mock("../commands/_shared/local-agent.js", () => ({
+  readClientId: () => "client_self",
+}));
+
+describe("agent prune with real removeLocalAgent", () => {
+  let home: string;
+  let outside: string;
+  let printLines: string[];
+  let printSpy: ReturnType<typeof vi.spyOn>;
+  const originalHome = process.env.FIRST_TREE_HOME;
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "fthub-prune-cmd-home-"));
+    outside = mkdtempSync(join(tmpdir(), "fthub-prune-cmd-outside-"));
+    process.env.FIRST_TREE_HOME = home;
+    printLines = [];
+    printSpy = vi.spyOn(print, "line").mockImplementation((text: string) => {
+      printLines.push(text);
+    });
+    sdkMocks.listMyAgents.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    printSpy.mockRestore();
+    rmSync(home, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+    if (originalHome === undefined) delete process.env.FIRST_TREE_HOME;
+    else process.env.FIRST_TREE_HOME = originalHome;
+    process.exitCode = originalExitCode;
+  });
+
+  async function runPrune(): Promise<void> {
+    const program = new Command();
+    const agent = program.command("agent");
+    registerAgentPruneCommand(agent);
+    await program.parseAsync(["node", "test", "agent", "prune", "--yes", "--server", "https://hub.example"]);
+  }
+
+  function writeStaleAlias(agentsDir: string, name: string): void {
+    mkdirSync(join(agentsDir, name), { recursive: true });
+    writeFileSync(join(agentsDir, name, "agent.yaml"), `agentId: 00000000-0000-0000-0000-00000000${name.slice(-4)}\n`);
+  }
+
+  it("keeps pruning past an alias resolving outside First Tree state and exits non-zero", async (ctx) => {
+    const agentsDir = join(home, "config", "agents");
+    writeStaleAlias(agentsDir, "stale-aaaa");
+    writeStaleAlias(agentsDir, "stale-zzzz");
+    mkdirSync(join(outside, "target"), { recursive: true });
+    writeFileSync(join(outside, "target", "data.txt"), "keep");
+    try {
+      symlinkSync(join(outside, "target"), join(agentsDir, "escape"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    await runPrune();
+
+    const output = printLines.join("");
+    expect(output).toContain("✓ removed stale-aaaa");
+    expect(output).toContain("✓ removed stale-zzzz");
+    expect(output).toContain('✗ escape (Refusing to remove "escape": resolves outside First Tree state)');
+    expect(output).toContain("2 pruned, 1 failed");
+    expect(process.exitCode).toBe(1);
+    expect(existsSync(join(agentsDir, "stale-aaaa"))).toBe(false);
+    expect(existsSync(join(agentsDir, "stale-zzzz"))).toBe(false);
+    expect(readdirSync(agentsDir)).toContain("escape");
+    expect(existsSync(join(outside, "target", "data.txt"))).toBe(true);
+  });
+});

--- a/apps/cli/src/__tests__/agent-prune.test.ts
+++ b/apps/cli/src/__tests__/agent-prune.test.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { findStaleAliases, formatStaleReason, type PinnedAgent, removeLocalAgent } from "../core/agent-prune.js";
 
@@ -192,5 +192,115 @@ describe("findStaleAliases", () => {
     expect(existsSync(join(home, "data", "workspaces", "stale"))).toBe(false);
     expect(existsSync(join(home, "data", "sessions", "stale.json"))).toBe(false);
     rmSync(home, { recursive: true, force: true });
+  });
+});
+
+describe("removeLocalAgent path safety", () => {
+  let home: string;
+  let outside: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "fthub-remove-home-"));
+    outside = mkdtempSync(join(tmpdir(), "fthub-remove-outside-"));
+    process.env.FIRST_TREE_HOME = home;
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  function localAgentsDir(): string {
+    return join(home, "config", "agents");
+  }
+
+  function seedFootprint(name: string): void {
+    mkdirSync(join(localAgentsDir(), name), { recursive: true });
+    writeFileSync(join(localAgentsDir(), name, "agent.yaml"), "agentId: 00000000-0000-0000-0000-000000000001\n");
+    mkdirSync(join(home, "data", "workspaces", name), { recursive: true });
+    writeFileSync(join(home, "data", "workspaces", name, "note.txt"), "keep");
+    mkdirSync(join(home, "data", "sessions"), { recursive: true });
+    writeFileSync(join(home, "data", "sessions", `${name}.json`), "{}");
+  }
+
+  it("rejects a traversal name that resolves to an existing directory outside the home", () => {
+    mkdirSync(join(outside, "victim"), { recursive: true });
+    writeFileSync(join(outside, "victim", "data.txt"), "keep");
+    mkdirSync(localAgentsDir(), { recursive: true });
+    const traversal = relative(localAgentsDir(), join(outside, "victim"));
+    expect(traversal.startsWith("..")).toBe(true);
+    expect(() => removeLocalAgent(traversal)).toThrow(/Invalid agent name/);
+    expect(existsSync(join(outside, "victim", "data.txt"))).toBe(true);
+  });
+
+  it("rejects a session traversal name and leaves the outside json intact", () => {
+    writeFileSync(join(outside, "victim.json"), "{}");
+    mkdirSync(join(home, "data", "sessions"), { recursive: true });
+    const traversal = relative(join(home, "data", "sessions"), join(outside, "victim"));
+    expect(() => removeLocalAgent(traversal)).toThrow(/Invalid agent name/);
+    expect(existsSync(join(outside, "victim.json"))).toBe(true);
+  });
+
+  it("rejects empty, dot, separator, absolute, and non-whitelist names without touching state", () => {
+    seedFootprint("keeper");
+    for (const name of ["", ".", "..", "a/b", "a\\b", "/etc/x", "Legit", "a.b", "a".repeat(101)]) {
+      expect(() => removeLocalAgent(name)).toThrow(/Invalid agent name/);
+    }
+    expect(existsSync(join(localAgentsDir(), "keeper"))).toBe(true);
+    expect(existsSync(join(home, "data", "workspaces", "keeper"))).toBe(true);
+    expect(existsSync(join(home, "data", "sessions", "keeper.json"))).toBe(true);
+  });
+
+  it("removes grandfathered names the create-side regex would reject", () => {
+    for (const name of ["_legacy", "-legacy", "a".repeat(100)]) {
+      seedFootprint(name);
+      removeLocalAgent(name);
+      expect(existsSync(join(localAgentsDir(), name))).toBe(false);
+      expect(existsSync(join(home, "data", "workspaces", name))).toBe(false);
+      expect(existsSync(join(home, "data", "sessions", `${name}.json`))).toBe(false);
+    }
+  });
+
+  it("is a no-op for a valid name when base dirs or targets are missing", () => {
+    expect(() => removeLocalAgent("ghost")).not.toThrow();
+    mkdirSync(localAgentsDir(), { recursive: true });
+    expect(() => removeLocalAgent("ghost")).not.toThrow();
+  });
+
+  it("still removes a dangling symlink alias", (ctx) => {
+    mkdirSync(localAgentsDir(), { recursive: true });
+    try {
+      symlinkSync(join(outside, "gone"), join(localAgentsDir(), "dangling"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+    expect(() => removeLocalAgent("dangling")).not.toThrow();
+    expect(readdirSync(localAgentsDir())).not.toContain("dangling");
+  });
+
+  it("removes an alias symlink without following it to the real dir inside the base", (ctx) => {
+    seedFootprint("real");
+    try {
+      symlinkSync(join(localAgentsDir(), "real"), join(localAgentsDir(), "alias"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+    removeLocalAgent("alias");
+    expect(readdirSync(localAgentsDir())).not.toContain("alias");
+    expect(existsSync(join(localAgentsDir(), "real", "agent.yaml"))).toBe(true);
+  });
+
+  it("refuses an alias symlink that resolves outside First Tree state", (ctx) => {
+    mkdirSync(localAgentsDir(), { recursive: true });
+    mkdirSync(join(outside, "target"), { recursive: true });
+    writeFileSync(join(outside, "target", "data.txt"), "keep");
+    try {
+      symlinkSync(join(outside, "target"), join(localAgentsDir(), "escape"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+    expect(() => removeLocalAgent("escape")).toThrow('Refusing to remove "escape": resolves outside First Tree state');
+    expect(existsSync(join(outside, "target", "data.txt"))).toBe(true);
+    expect(readdirSync(localAgentsDir())).toContain("escape");
   });
 });

--- a/apps/cli/src/__tests__/agent-prune.test.ts
+++ b/apps/cli/src/__tests__/agent-prune.test.ts
@@ -290,6 +290,27 @@ describe("removeLocalAgent path safety", () => {
     expect(existsSync(join(localAgentsDir(), "real", "agent.yaml"))).toBe(true);
   });
 
+  it("preflights every target before the first deletion", (ctx) => {
+    // The unsafe target (the alias dir) iterates last; the real workspace
+    // and session state validated before it must survive the refusal —
+    // per-target validate-then-delete would have removed them already.
+    mkdirSync(join(home, "data", "workspaces", "victim"), { recursive: true });
+    writeFileSync(join(home, "data", "workspaces", "victim", "note.txt"), "keep");
+    mkdirSync(join(home, "data", "sessions"), { recursive: true });
+    writeFileSync(join(home, "data", "sessions", "victim.json"), "{}");
+    mkdirSync(localAgentsDir(), { recursive: true });
+    mkdirSync(join(outside, "alias-target"), { recursive: true });
+    try {
+      symlinkSync(join(outside, "alias-target"), join(localAgentsDir(), "victim"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+    expect(() => removeLocalAgent("victim")).toThrow('Refusing to remove "victim": resolves outside First Tree state');
+    expect(existsSync(join(home, "data", "workspaces", "victim", "note.txt"))).toBe(true);
+    expect(existsSync(join(home, "data", "sessions", "victim.json"))).toBe(true);
+    expect(existsSync(join(outside, "alias-target"))).toBe(true);
+  });
+
   it("refuses an alias symlink that resolves outside First Tree state", (ctx) => {
     mkdirSync(localAgentsDir(), { recursive: true });
     mkdirSync(join(outside, "target"), { recursive: true });

--- a/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
@@ -71,7 +71,12 @@ vi.mock("../cli/output.js", () => outputMocks);
 vi.mock("../core/output.js", () => ({
   print: { line: printLineMock, result: outputMocks.success, fail: outputMocks.fail },
 }));
-vi.mock("../core/index.js", () => coreMocks);
+vi.mock("../core/index.js", async () => {
+  // Real name validation so `agent remove <invalid>` exercises the actual
+  // whitelist; everything else stays mocked.
+  const prune = await vi.importActual<typeof import("../core/agent-prune.js")>("../core/agent-prune.js");
+  return { ...coreMocks, assertRemovableAgentName: prune.assertRemovableAgentName };
+});
 vi.mock("@first-tree/client", () => clientMocks);
 vi.mock("../commands/_shared/local-agent.js", () => localAgentMocks);
 
@@ -431,6 +436,12 @@ describe("agent admin and local commands", () => {
     await runAgent(["remove", "nova"]);
     expect(coreMocks.removeLocalAgent).toHaveBeenCalledWith("nova");
     await expect(runAgent(["remove", "missing"])).rejects.toMatchObject({ code: 1 });
+
+    coreMocks.removeLocalAgent.mockClear();
+    await expect(runAgent(["remove", "../../x"])).rejects.toMatchObject({ code: 1 });
+    await expect(runAgent(["remove", ""])).rejects.toMatchObject({ code: 1 });
+    expect(coreMocks.removeLocalAgent).not.toHaveBeenCalled();
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Invalid agent name");
 
     localAgentMocks.createSdk.mockReturnValueOnce({ register: vi.fn(async () => ({ agentId: "agent-1" })) });
     await runAgent(["debug", "register", "--agent", "nova"]);

--- a/apps/cli/src/commands/agent/remove.ts
+++ b/apps/cli/src/commands/agent/remove.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { defaultConfigDir } from "@first-tree/shared/config";
 import type { Command } from "commander";
-import { removeLocalAgent } from "../../core/index.js";
+import { assertRemovableAgentName, removeLocalAgent } from "../../core/index.js";
 import { print } from "../../core/output.js";
 
 export function registerAgentRemoveCommand(agent: Command): void {
@@ -12,6 +12,14 @@ export function registerAgentRemoveCommand(agent: Command): void {
       "Remove an agent from this client and delete its local runtime data (config dir, workspace, session state)",
     )
     .action((name: string) => {
+      // Validate before any filesystem access: an invalid name must fail
+      // closed as a clean CLI error instead of reaching path construction.
+      try {
+        assertRemovableAgentName(name);
+      } catch (error) {
+        print.line(`  ${error instanceof Error ? error.message : String(error)}\n`);
+        process.exit(1);
+      }
       const agentDir = join(defaultConfigDir(), "agents", name);
       if (!existsSync(agentDir)) {
         print.line(`  Agent "${name}" not found.\n`);

--- a/apps/cli/src/core/agent-prune.ts
+++ b/apps/cli/src/core/agent-prune.ts
@@ -198,21 +198,30 @@ function resolveContainedTarget(baseDir: string, entryName: string, agentName: s
  *
  * `name` reaches this function as raw user input, so it is gated twice
  * before anything is deleted: the whitelist rejects every traversal-capable
- * name, and each target must realpath-resolve inside its base dir
- * immediately before deletion, so an alias symlink pointing outside First
- * Tree state is refused rather than removed.
+ * name, and every target must realpath-resolve inside its base dir, so an
+ * alias symlink pointing outside First Tree state is refused rather than
+ * removed.
+ *
+ * All targets are containment-validated before the first `rmSync`, and the
+ * alias dir is deleted last: a refused or failed later target must not
+ * strand workspace/session state behind an already-removed alias, because
+ * the alias dir is what `agent prune` discovers and retries by.
  */
 export function removeLocalAgent(name: string): void {
   assertRemovableAgentName(name);
   const targets: Array<{ baseDir: string; entryName: string; options: RmOptions }> = [
-    { baseDir: join(defaultConfigDir(), "agents"), entryName: name, options: { recursive: true, force: true } },
     { baseDir: join(defaultDataDir(), "workspaces"), entryName: name, options: { recursive: true, force: true } },
     { baseDir: join(defaultDataDir(), "sessions"), entryName: `${name}.json`, options: { force: true } },
+    { baseDir: join(defaultConfigDir(), "agents"), entryName: name, options: { recursive: true, force: true } },
   ];
+  const deletions: Array<{ target: string; options: RmOptions }> = [];
   for (const { baseDir, entryName, options } of targets) {
     // A base dir that does not exist yet (fresh install) has nothing to
     // delete; the remaining targets are still processed independently.
     if (!existsSync(baseDir)) continue;
-    rmSync(resolveContainedTarget(baseDir, entryName, name), options);
+    deletions.push({ target: resolveContainedTarget(baseDir, entryName, name), options });
+  }
+  for (const { target, options } of deletions) {
+    rmSync(target, options);
   }
 }

--- a/apps/cli/src/core/agent-prune.ts
+++ b/apps/cli/src/core/agent-prune.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, type RmOptions, readdirSync, readFileSync, realpathSync, rmSync, statSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { defaultConfigDir, defaultDataDir } from "@first-tree/shared/config";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
@@ -136,13 +136,83 @@ export function formatStaleReason(reason: StaleAliasReason): string {
 }
 
 /**
+ * Deletion-side agent-name gate for `removeLocalAgent`. Intentionally wider
+ * than the create-side `AGENT_NAME_REGEX`: the server grandfathers rows
+ * created under the previous 1–100 rule and `migrateLocalAgentDirs` renames
+ * local dirs to those server-authoritative names, so grandfathered names
+ * must stay removable here. The character set contains no `/`, `\` or `.`,
+ * so a matching name can never form `.`, `..`, an absolute path, or any
+ * other traversal segment.
+ */
+const REMOVABLE_AGENT_NAME_REGEX = /^[a-z0-9_-]{1,100}$/;
+
+/**
+ * Reject names that could steer the deletion paths below outside First Tree
+ * state. `agent remove` also calls this before touching the filesystem so an
+ * invalid name fails as a clean CLI error.
+ */
+export function assertRemovableAgentName(name: string): void {
+  if (!REMOVABLE_AGENT_NAME_REGEX.test(name)) {
+    throw new Error(`Invalid agent name ${JSON.stringify(name)}: expected 1-100 characters of [a-z0-9_-]`);
+  }
+}
+
+// Verbatim copy of the private helper in core/context-tree-read.ts and
+// commands/tree/context-links.ts — keep all three in sync.
+function pathIsInside(root: string, target: string): boolean {
+  const relativePath = relative(root, target);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+/**
+ * Resolve `entryName` against `baseDir` and enforce — lexically and on
+ * realpaths — that the target stays inside `baseDir`; throws without
+ * deleting anything otherwise. `resolve` (not `join`) so an absolute
+ * `entryName` replaces the base wholesale and the lexical check rejects it.
+ *
+ * Returns the resolved path, never its realpath: `rmSync` must operate on
+ * the symlink itself, so unlinking a link that points elsewhere inside
+ * `baseDir` cannot delete the link's target.
+ *
+ * A missing target (including a dangling symlink — `existsSync` follows
+ * links) is checked as its parent's realpath plus its own basename, so
+ * stale links stay removable and `realpathSync` never sees ENOENT here.
+ */
+function resolveContainedTarget(baseDir: string, entryName: string, agentName: string): string {
+  const outsideError = () =>
+    new Error(`Refusing to remove ${JSON.stringify(agentName)}: resolves outside First Tree state`);
+  const candidate = resolve(baseDir, entryName);
+  if (!pathIsInside(baseDir, candidate)) throw outsideError();
+  const realBase = realpathSync(baseDir);
+  const realCandidate = existsSync(candidate)
+    ? realpathSync(candidate)
+    : join(realpathSync(dirname(candidate)), basename(candidate));
+  if (!pathIsInside(realBase, realCandidate)) throw outsideError();
+  return candidate;
+}
+
+/**
  * Remove an agent's local footprint: the YAML alias dir, the workspace
  * tree under `data/workspaces/<name>`, and the session-mapping file under
- * `data/sessions/<name>.json`. Mirrors what `agent remove` does, exposed
- * separately so prune and the post-rotation override cleanup can share it.
+ * `data/sessions/<name>.json`. Shared by `agent remove` and `agent prune`.
+ *
+ * `name` reaches this function as raw user input, so it is gated twice
+ * before anything is deleted: the whitelist rejects every traversal-capable
+ * name, and each target must realpath-resolve inside its base dir
+ * immediately before deletion, so an alias symlink pointing outside First
+ * Tree state is refused rather than removed.
  */
 export function removeLocalAgent(name: string): void {
-  rmSync(join(defaultConfigDir(), "agents", name), { recursive: true, force: true });
-  rmSync(join(defaultDataDir(), "workspaces", name), { recursive: true, force: true });
-  rmSync(join(defaultDataDir(), "sessions", `${name}.json`), { force: true });
+  assertRemovableAgentName(name);
+  const targets: Array<{ baseDir: string; entryName: string; options: RmOptions }> = [
+    { baseDir: join(defaultConfigDir(), "agents"), entryName: name, options: { recursive: true, force: true } },
+    { baseDir: join(defaultDataDir(), "workspaces"), entryName: name, options: { recursive: true, force: true } },
+    { baseDir: join(defaultDataDir(), "sessions"), entryName: `${name}.json`, options: { force: true } },
+  ];
+  for (const { baseDir, entryName, options } of targets) {
+    // A base dir that does not exist yet (fresh install) has nothing to
+    // delete; the remaining targets are still processed independently.
+    if (!existsSync(baseDir)) continue;
+    rmSync(resolveContainedTarget(baseDir, entryName, name), options);
+  }
 }

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -1,6 +1,6 @@
 // Local agent alias hygiene (stale alias detection + deletion)
 export type { PinnedAgent, StaleAlias, StaleAliasReason } from "./agent-prune.js";
-export { findStaleAliases, formatStaleReason, removeLocalAgent } from "./agent-prune.js";
+export { assertRemovableAgentName, findStaleAliases, formatStaleReason, removeLocalAgent } from "./agent-prune.js";
 // Bootstrap / credentials
 export {
   AuthRefreshFailedError,


### PR DESCRIPTION
## Summary

Fixes [SEC-030] `first-tree agent remove` recursive path traversal.

`removeLocalAgent` (`apps/cli/src/core/agent-prune.ts`) deleted three paths built by joining raw user input — `config/agents/<name>` and `data/workspaces/<name>` with `{recursive: true, force: true}`, and `data/sessions/<name>.json` with `{force: true}`. `node:path.join` normalizes `..` segments, so `agent remove '../../../../<dir>'` recursively deleted arbitrary user-writable directories outside First Tree state, and the `.json` template deleted arbitrary `.json` files. The `existsSync` pre-check in `remove.ts` ran on the same traversed path, so it passed whenever the escape target existed. Both `agent remove` and `agent prune` go through `removeLocalAgent`, so both paths are covered by the fix.

## Fix — two independent layers, both inside `removeLocalAgent`

1. **Deletion-side name whitelist.** `assertRemovableAgentName` rejects any name not matching `/^[a-z0-9_-]{1,100}$/`. The character set contains no `/`, `\` or `.`, so a valid name can never form `.`, `..`, an absolute path, or any traversal segment. It is intentionally wider than the create-side `AGENT_NAME_REGEX` (`/^[a-z0-9][a-z0-9_-]{0,63}$/`): the server grandfathers rows created under the previous 1–100 rule, and `migrateLocalAgentDirs` renames local dirs to those server-authoritative names on every client startup, so grandfathered agents (e.g. `_legacy`, 65–100 chars) must stay removable. Reserved names are deliberately not blocked here — that list guards creates; blocking deletes would only produce undeletable junk dirs. The create-side rules are untouched.
2. **Realpath containment before every deletion.** Each target must resolve — lexically and via `realpathSync` — inside its base dir, otherwise removal aborts with `Refusing to remove "<name>": resolves outside First Tree state`. `rmSync` keeps operating on the original candidate path, never the realpath result, so an alias symlink is unlinked in place — an alias pointing at another directory *inside* the base cannot delete that directory. A dangling alias symlink (`existsSync` follows links) is containment-checked as parent realpath + own basename and stays removable. A base dir that does not exist yet (fresh install) is skipped without affecting the other targets. All targets are containment-validated **before the first `rmSync`**, and the config alias dir is deleted **last**, so a refused or failed later target cannot strand workspace/session state behind an already-removed alias — the alias dir is what `agent prune` discovers and retries by.

`agent remove` runs the same validation before any filesystem access and exits 1 with a readable error (no stack trace). `agent prune` needs no code changes: its per-alias try/catch reports a refused entry inline as failed (exit code 1) and keeps pruning the rest. The stale `removeLocalAgent` doc comment referencing a no-longer-existing third caller is corrected.

## Threat-model accuracy

The realpath layer is **not** a fix for a currently reachable symlink-follow deletion: Node's `rm`/`rmSync` treat symlinks with lstat semantics — the link itself is removed, never followed. The layer exists because the issue explicitly requires realpath containment before every deletion, as defense in depth against future changes to the deletion implementation, and as a conservative fail-closed stance on aliases resolving outside First Tree state.

## Known behavior change

Removing an alias symlink whose target exists **outside** First Tree state previously deleted the link and succeeded; it is now refused (fail closed). In `agent prune`, such an entry is reported as failed (exit code 1) while the remaining stale entries are still removed. Dangling symlinks and symlinks pointing inside the base behave exactly as before.

Note (pre-existing Commander behavior, unchanged): grandfathered names starting with `-` need `agent remove -- -legacy` to parse as a positional argument.

## Tests

- `agent-prune.test.ts` — new `removeLocalAgent path safety` suite: traversal names resolving to real outside dirs / outside session `.json` targets rejected with sentinels intact; empty / `.` / `..` / separator / absolute / uppercase / dotted / >100-char names rejected without touching state; grandfathered names (`_legacy`, `-legacy`, 100 chars) still remove all three footprint entries; dangling alias symlink still removed; alias→real symlink removal leaves the real dir intact; outward symlink refused with target preserved; valid names stay idempotent with missing bases/targets; preflight — an unsafe last-iterated target leaves the real workspace/session state validated before it untouched.
- `agent-prune-command.test.ts` (new) — `agent prune` integration over the **real** `removeLocalAgent`: the outward-symlink entry fails inline, exit code is 1, remaining stale entries are still pruned, the link target is untouched.
- `cli-command-matrix-extra.test.ts` — `agent remove '../../x'` and `agent remove ''` exit 1 with `Invalid agent name` and never reach `removeLocalAgent` (the name validator now runs unmocked in the command-layer suites).

## Verification

- `pnpm check` ✅ · `pnpm typecheck` ✅ (10/10)
- CLI package: all touched suites green (53 tests). `client-switch-transaction-extra.test.ts` fails identically on unmodified `main` in my environment — its real-process scan finds the actual First Tree daemon running on this machine — unrelated to this change.
- Standalone: `@first-tree/server` 2557/2557 ✅ · `@first-tree/shared` 645/645 ✅ · `@first-tree/client` ✅ · `@first-tree/qa` ✅. One `@first-tree/skill-evals` git-fixture test is timing-flaky here (a different file fails per run; each passes standalone) — unrelated.
- QA self-check per repo guidelines: local-FS CLI behavior only, no cross-surface/runtime/WS/boot path touched → unit + command-matrix + command-integration coverage suffices; no `packages/qa` case needed.

## Post-submission update (review feedback)

`71ef115` adopts the preflight point from maintainer-side review: all targets are containment-validated before the first `rmSync`, and the config alias dir is deleted last (see Fix §2). Locked by a new test in which the unsafe target iterates last and the real workspace/session state validated before it must survive the refusal. Re-verified: `pnpm check` / `pnpm typecheck` green, all four touched test files pass (54 tests).

Two review points intentionally not taken, for the record:

- **Hard-anchoring managed regions to their canonical lexical location.** Relocating a managed region via symlink (e.g. `data/workspaces` → larger disk) is operator-owned configuration the rest of the CLI already honors: `agent add`/`create` write through it, enumeration and migration read through it. Removal refusing what creation honors would make such state permanently unremovable. It is also not attacker-reachable input: replacing `$FIRST_TREE_HOME/config/agents` (or an ancestor) with a symlink already requires write access to First Tree state, at which point no deletion primitive is needed. The boundary this PR enforces is that the *name* — the only untrusted input — cannot select a target outside whatever the managed regions resolve to. Exact-location anchoring would additionally break environments whose home/tmp ancestors are symlinks (macOS `/var` → `/private/var`).
- **Moving the deletion-side name rule into a shared, named schema.** Agreed in principle; deliberately kept local to keep this security fix minimal (the same call as the two existing private `pathIsInside` copies). Tracked under Follow-ups.

## Follow-ups (out of scope)

- Extract the (now three) verbatim `pathIsInside` copies into a shared helper.
- Consider a shared home for name/path validation if the server ever performs local deletions.

Closes #1636
