### PR TITLE
fix: tail TUI resume transcripts from EOF with bounded async reads

### DIFF
--- a/packages/client/src/__tests__/tui-resume-transcript-skip.test.ts
+++ b/packages/client/src/__tests__/tui-resume-transcript-skip.test.ts
@@ -1,0 +1,193 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatContext } from "../runtime/chat-context.js";
+import type { SessionContext, SessionMessage } from "../runtime/handler.js";
+import { mockCtxPlumbing } from "./test-helpers.js";
+
+const state = vi.hoisted(() => ({
+  workspaceRoot: "",
+  events: [] as string[],
+  lastPasteOrdinal: 0,
+  emittedOrdinals: new Set<number>(),
+  consumed: [] as unknown[],
+  chatContext: {
+    chatId: "chat-tui-resume-transcript-skip",
+    title: "resume transcript skip",
+    topic: null,
+    description: null,
+    participants: [],
+  } satisfies ChatContext,
+}));
+
+vi.mock("../runtime/agent-bootstrap.js", () => ({
+  ensureAgentBootstrap: vi.fn(),
+}));
+
+vi.mock("../runtime/agent-briefing.js", () => ({
+  buildAgentBriefing: vi.fn(() => ""),
+}));
+
+vi.mock("../runtime/chat-context.js", () => ({
+  fetchChatContext: vi.fn(async () => state.chatContext),
+}));
+
+vi.mock("../runtime/context-tree-git-status.js", () => ({
+  createContextTreeGitWriteTracker: vi.fn(() => ({})),
+}));
+
+vi.mock("../runtime/source-repos.js", () => ({
+  currentSourceRepoNamesFromPayload: vi.fn(() => null),
+  declaredSourceRepos: vi.fn(() => []),
+}));
+
+vi.mock("../runtime/workspace.js", () => ({
+  acquireAgentHome: vi.fn(() => state.workspaceRoot),
+  markWorkspaceInitComplete: vi.fn(),
+}));
+
+vi.mock("../handlers/claude-code.js", () => ({
+  createToolCallProcessor: vi.fn(() => ({
+    flush: vi.fn(),
+    onMessage: (entry: unknown) => {
+      state.consumed.push(entry);
+    },
+  })),
+  mapMcpServers: vi.fn(() => []),
+}));
+
+vi.mock("../handlers/claude-executable.js", () => ({
+  resolveClaudeCodeExecutable: vi.fn(() => ({ path: "/bin/claude-fake" })),
+}));
+
+vi.mock("../handlers/claude-code-tui/tmux-session.js", () => ({
+  capturePane: vi.fn(async () => ""),
+  deriveSessionName: vi.fn(() => "ftth-resume-skip-session"),
+  killSession: vi.fn(async () => undefined),
+  listOwnedSessions: vi.fn(async () => []),
+  newSession: vi.fn(async () => undefined),
+  ownedSessionPrefix: vi.fn(() => "ftth-resume-skip-"),
+  pasteText: vi.fn(async (_sessionName: string, _text: string) => {
+    state.events.push("paste");
+    state.lastPasteOrdinal += 1;
+  }),
+  sendKey: vi.fn(async () => undefined),
+  sessionExists: vi.fn(async () => false),
+  waitForReady: vi.fn(async () => undefined),
+}));
+
+vi.mock("../handlers/claude-code-tui/transcript-tail.js", () => ({
+  transcriptPathFor: vi.fn(() => "/tmp/fake-resume-transcript.jsonl"),
+  TranscriptTailer: class {
+    skipToEnd() {
+      state.events.push("skipToEnd");
+    }
+    drainEntries() {
+      state.events.push("drain");
+      if (state.lastPasteOrdinal === 0) {
+        // Simulates a resumed transcript that still holds prior-session
+        // history: any pre-paste read (the old drain-based preflush) would
+        // surface it — and surfacing it means replaying it into this turn.
+        return [
+          {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "HISTORY MUST NOT REPLAY" }] },
+          },
+        ];
+      }
+      const ordinal = state.lastPasteOrdinal;
+      if (state.emittedOrdinals.has(ordinal)) return [];
+      state.emittedOrdinals.add(ordinal);
+      return [
+        {
+          type: "assistant",
+          message: { content: [{ type: "text", text: `reply ${ordinal}` }] },
+        },
+      ];
+    }
+  },
+}));
+
+import { createClaudeCodeTuiHandler } from "../handlers/claude-code-tui/index.js";
+
+const AGENT_ID = "019eca71-0000-7000-8000-000000000002";
+const CHAT_ID = "chat-tui-resume-transcript-skip";
+
+function makeMessage(id: string, content: string): SessionMessage {
+  return {
+    id,
+    chatId: CHAT_ID,
+    senderId: "sender-1",
+    format: "text",
+    content,
+    metadata: {},
+    inboxEntryId: Number(id.replace(/\D/g, "")),
+  };
+}
+
+function makeContext(): { ctx: SessionContext; forwarded: string[] } {
+  const forwarded: string[] = [];
+  const sendMessage = vi.fn().mockResolvedValue(undefined);
+  const plumbing = mockCtxPlumbing({ sendMessage }, CHAT_ID);
+  const ctx: SessionContext = {
+    agent: {
+      agentId: AGENT_ID,
+      inboxId: `inbox_${AGENT_ID}`,
+      displayName: "tui-agent",
+      type: "agent",
+      visibility: "organization",
+      delegateMention: null,
+      metadata: {},
+    },
+    sdk: { serverUrl: "http://test", sendMessage } as unknown as SessionContext["sdk"],
+    chatId: CHAT_ID,
+    log: () => {},
+    recordProviderActivity: () => {},
+    emitEvent: () => {},
+    ...plumbing,
+    forwardResult: async (text: string) => {
+      forwarded.push(text);
+    },
+  };
+  return { ctx, forwarded };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.workspaceRoot = mkdtempSync(join(tmpdir(), "ft-tui-resume-skip-"));
+  state.events.length = 0;
+  state.lastPasteOrdinal = 0;
+  state.emittedOrdinals.clear();
+  state.consumed.length = 0;
+});
+
+afterEach(() => {
+  rmSync(state.workspaceRoot, { recursive: true, force: true });
+});
+
+describe("claude-code-tui resume transcript skip", () => {
+  it("skips (never reads) transcript history before the first paste on resume", async () => {
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const { ctx, forwarded } = makeContext();
+    const resumed = makeMessage("m1", "resumed turn");
+
+    await handler.resume(resumed, "existing-session-id", ctx);
+
+    // The pre-turn flush must be the metadata-only skip: skipToEnd runs
+    // before the first paste, and nothing drains (reads) before it.
+    const firstPaste = state.events.indexOf("paste");
+    expect(firstPaste).toBeGreaterThan(-1);
+    const beforePaste = state.events.slice(0, firstPaste);
+    expect(beforePaste).toContain("skipToEnd");
+    expect(beforePaste).not.toContain("drain");
+
+    // Prior-session history never reaches the turn consumers: neither the
+    // per-turn processor nor the forwarded final text may see it.
+    expect(JSON.stringify(state.consumed)).not.toContain("HISTORY MUST NOT REPLAY");
+    expect(forwarded.join("\n")).not.toContain("HISTORY MUST NOT REPLAY");
+    expect(forwarded.join("\n")).toContain("reply 1");
+
+    await handler.shutdown();
+  }, 15_000);
+});

--- a/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
+++ b/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
@@ -77,6 +77,9 @@ vi.mock("../handlers/claude-code-tui/tmux-session.js", () => ({
 vi.mock("../handlers/claude-code-tui/transcript-tail.js", () => ({
   transcriptPathFor: vi.fn(() => "/tmp/fake-transcript.jsonl"),
   TranscriptTailer: class {
+    skipToEnd() {
+      // Metadata-only no-op, mirroring the real tailer's pre-turn flush.
+    }
     drainEntries() {
       const ordinal = state.lastPasteOrdinal;
       if (ordinal < 2 || state.emittedOrdinals.has(ordinal)) return [];

--- a/packages/client/src/__tests__/tui-transcript-tail.test.ts
+++ b/packages/client/src/__tests__/tui-transcript-tail.test.ts
@@ -2,7 +2,11 @@ import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "n
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { TranscriptTailer, transcriptPathFor } from "../handlers/claude-code-tui/transcript-tail.js";
+import {
+  type RawTranscriptEntry,
+  TranscriptTailer,
+  transcriptPathFor,
+} from "../handlers/claude-code-tui/transcript-tail.js";
 
 describe("transcriptPathFor", () => {
   it("replaces forward-slashes and dots with dashes and prefixes with dash", () => {
@@ -34,8 +38,8 @@ describe("TranscriptTailer", () => {
     return `${JSON.stringify({ type, message: { content } })}\n`;
   }
 
-  async function drainAll(tailer: TranscriptTailer): Promise<unknown[]> {
-    const all: unknown[] = [];
+  async function drainAll(tailer: TranscriptTailer): Promise<RawTranscriptEntry[]> {
+    const all: RawTranscriptEntry[] = [];
     while (true) {
       const batch = await tailer.drainEntries();
       if (batch.length === 0) return all;
@@ -192,7 +196,7 @@ describe("TranscriptTailer", () => {
     expect(first.length).toBeLessThan(contents.length);
 
     const rest = await drainAll(tailer);
-    const all = [...first, ...rest] as Array<{ message?: { content?: unknown } }>;
+    const all = [...first, ...rest];
     expect(all.map((entry) => entry.message?.content)).toEqual(contents);
   });
 

--- a/packages/client/src/__tests__/tui-transcript-tail.test.ts
+++ b/packages/client/src/__tests__/tui-transcript-tail.test.ts
@@ -30,53 +30,253 @@ describe("TranscriptTailer", () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  it("returns empty when the file does not exist yet", () => {
+  function line(type: string, content: unknown): string {
+    return `${JSON.stringify({ type, message: { content } })}\n`;
+  }
+
+  async function drainAll(tailer: TranscriptTailer): Promise<unknown[]> {
+    const all: unknown[] = [];
+    while (true) {
+      const batch = await tailer.drainEntries();
+      if (batch.length === 0) return all;
+      all.push(...batch);
+    }
+  }
+
+  it("returns empty when the file does not exist yet", async () => {
     const tailer = new TranscriptTailer(filePath);
-    expect(tailer.drainEntries()).toEqual([]);
+    expect(await tailer.drainEntries()).toEqual([]);
   });
 
-  it("returns only new entries on each drain", () => {
+  it("returns only new entries on each drain", async () => {
     mkdirSync(testDir, { recursive: true });
     writeFileSync(filePath, "");
     const tailer = new TranscriptTailer(filePath);
 
-    appendFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "first" } })}\n`);
-    const first = tailer.drainEntries();
+    appendFileSync(filePath, line("user", "first"));
+    const first = await tailer.drainEntries();
     expect(first).toHaveLength(1);
     expect(first[0]).toMatchObject({ type: "user" });
 
-    appendFileSync(filePath, `${JSON.stringify({ type: "assistant", message: { content: [] } })}\n`);
-    const second = tailer.drainEntries();
+    appendFileSync(filePath, line("assistant", []));
+    const second = await tailer.drainEntries();
     expect(second).toHaveLength(1);
     expect(second[0]).toMatchObject({ type: "assistant" });
 
-    expect(tailer.drainEntries()).toEqual([]);
+    expect(await tailer.drainEntries()).toEqual([]);
   });
 
-  it("buffers partial lines across reads", () => {
+  it("buffers partial lines across reads", async () => {
     writeFileSync(filePath, "");
     const tailer = new TranscriptTailer(filePath);
 
     const piece1 = '{"type":"user","message":{"content":"half';
     const piece2 = ' message"}}\n';
     appendFileSync(filePath, piece1);
-    expect(tailer.drainEntries()).toEqual([]);
+    expect(await tailer.drainEntries()).toEqual([]);
 
     appendFileSync(filePath, piece2);
-    const entries = tailer.drainEntries();
+    const entries = await tailer.drainEntries();
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ type: "user", message: { content: "half message" } });
   });
 
-  it("tolerates malformed lines without failing the drain", () => {
+  it("tolerates malformed lines without failing the drain", async () => {
     writeFileSync(filePath, "");
     const tailer = new TranscriptTailer(filePath);
 
     appendFileSync(filePath, "this is not json\n");
-    appendFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "ok" } })}\n`);
+    appendFileSync(filePath, line("user", "ok"));
 
-    const entries = tailer.drainEntries();
+    const entries = await tailer.drainEntries();
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ type: "user" });
+  });
+
+  it("starts at EOF when the file already contains history (resume)", async () => {
+    writeFileSync(filePath, "");
+    for (let i = 0; i < 50; i++) {
+      appendFileSync(filePath, line("user", `old ${i}`));
+    }
+
+    const tailer = new TranscriptTailer(filePath);
+    expect(await tailer.drainEntries()).toEqual([]);
+
+    appendFileSync(filePath, line("assistant", "fresh"));
+    const entries = await tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "assistant", message: { content: "fresh" } });
+  });
+
+  it("does not read a large pre-existing transcript on resume", async () => {
+    // ~10 MiB of history. Behavioural assertion only (no timing, which would
+    // flake under CI load): a tailer that read the file would surface its
+    // thousands of entries; resume-at-EOF surfaces none.
+    const row = line("user", "x".repeat(1024));
+    writeFileSync(filePath, row.repeat(Math.ceil((10 * 1024 * 1024) / row.length)));
+
+    const tailer = new TranscriptTailer(filePath);
+    await tailer.skipToEnd();
+    expect(await tailer.drainEntries()).toEqual([]);
+
+    appendFileSync(filePath, line("assistant", "fresh"));
+    const entries = await tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "assistant", message: { content: "fresh" } });
+  });
+
+  it("skipToEnd discards pending unread data", async () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    appendFileSync(filePath, line("user", "stale 1"));
+    appendFileSync(filePath, line("user", "stale 2"));
+    await tailer.skipToEnd();
+    expect(await tailer.drainEntries()).toEqual([]);
+
+    appendFileSync(filePath, line("assistant", "fresh"));
+    const entries = await tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "assistant" });
+  });
+
+  it("skipToEnd clears a buffered partial line", async () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    appendFileSync(filePath, '{"type":"user","message":{"content":"doomed');
+    expect(await tailer.drainEntries()).toEqual([]);
+
+    await tailer.skipToEnd();
+    appendFileSync(filePath, line("assistant", "fresh"));
+    // A leftover partial would glue onto the new line and corrupt it into an
+    // unparsable blob — the fresh entry must come through intact.
+    const entries = await tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "assistant", message: { content: "fresh" } });
+  });
+
+  it("skipToEnd keeps its position when stat transiently fails", async () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    const history = line("user", "history");
+    appendFileSync(filePath, history);
+    expect(await tailer.drainEntries()).toHaveLength(1);
+
+    rmSync(filePath);
+    await tailer.skipToEnd();
+
+    // The file reappears with the same content: a position reset to 0 would
+    // re-surface (replay) the old entry; the kept position must not.
+    writeFileSync(filePath, history);
+    expect(await tailer.drainEntries()).toEqual([]);
+
+    appendFileSync(filePath, line("assistant", "fresh"));
+    const entries = await tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "assistant" });
+  });
+
+  it("returns bounded batches and preserves order", async () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath, { maxBatchBytes: 64 });
+
+    const contents = ["one", "two", "three", "four", "five"];
+    for (const content of contents) {
+      appendFileSync(filePath, line("user", content));
+    }
+
+    const first = await tailer.drainEntries();
+    expect(first.length).toBeGreaterThan(0);
+    expect(first.length).toBeLessThan(contents.length);
+
+    const rest = await drainAll(tailer);
+    const all = [...first, ...rest] as Array<{ message?: { content?: unknown } }>;
+    expect(all.map((entry) => entry.message?.content)).toEqual(contents);
+  });
+
+  it("reassembles a JSONL line split across chunk boundaries", async () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath, { chunkBytes: 8 });
+
+    const entry = { type: "user", message: { content: "a long line that spans many eight-byte chunks" } };
+    appendFileSync(filePath, `${JSON.stringify(entry)}\n`);
+
+    const entries = await tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject(entry);
+  });
+
+  it("decodes multi-byte UTF-8 split across chunk boundaries", async () => {
+    writeFileSync(filePath, "");
+    // A 3-byte chunk cannot align with the 4-byte emoji sequence, so the
+    // decoder is guaranteed to see a split character.
+    const tailer = new TranscriptTailer(filePath, { chunkBytes: 3 });
+
+    const entry = { type: "assistant", message: { content: "中文🙂 done" } };
+    appendFileSync(filePath, `${JSON.stringify(entry)}\n`);
+
+    const entries = await tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject(entry);
+    expect(JSON.stringify(entries[0])).not.toContain("�");
+  });
+
+  it("decodes a multi-byte character split across separate drains", async () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    const bytes = Buffer.from(line("assistant", "🙂"), "utf-8");
+    const emojiStart = bytes.indexOf(0xf0);
+    expect(emojiStart).toBeGreaterThan(-1);
+
+    // First half of the 4-byte emoji lands in one drain, the rest in the
+    // next: the decoder state must persist across drainEntries() calls, not
+    // just across chunks within one call.
+    appendFileSync(filePath, bytes.subarray(0, emojiStart + 2));
+    expect(await tailer.drainEntries()).toEqual([]);
+
+    appendFileSync(filePath, bytes.subarray(emojiStart + 2));
+    const entries = await tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "assistant", message: { content: "🙂" } });
+    expect(JSON.stringify(entries[0])).not.toContain("�");
+  });
+
+  it("clamps to the new EOF after truncation", async () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    appendFileSync(filePath, line("user", "one"));
+    appendFileSync(filePath, line("user", "two"));
+    expect(await tailer.drainEntries()).toHaveLength(2);
+
+    writeFileSync(filePath, "x\n");
+    expect(await tailer.drainEntries()).toEqual([]);
+
+    appendFileSync(filePath, line("assistant", "after"));
+    const entries = await tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "assistant", message: { content: "after" } });
+  });
+
+  it("truncation clamp clears a buffered partial line", async () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    appendFileSync(filePath, line("user", "one"));
+    appendFileSync(filePath, '{"type":"user","message":{"content":"half');
+    expect(await tailer.drainEntries()).toHaveLength(1);
+
+    writeFileSync(filePath, "x\n");
+    expect(await tailer.drainEntries()).toEqual([]);
+
+    appendFileSync(filePath, line("assistant", "after"));
+    // A leftover partial would glue onto the post-truncation line and turn it
+    // into an unparsable blob — the new entry must come through intact.
+    const entries = await tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "assistant", message: { content: "after" } });
   });
 });

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -379,8 +379,15 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
 
   async function drainAndConsume(sessionCtx: SessionContext, state: TurnState): Promise<void> {
     if (!transcriptTailer) return;
-    for (const entry of transcriptTailer.drainEntries()) {
-      consumeEntry(entry, sessionCtx, state);
+    // Batches are bounded (see TranscriptTailer), so loop until an empty one:
+    // every call site still consumes everything available right now, with an
+    // event-loop yield between batches instead of one unbounded read.
+    while (true) {
+      const entries = await transcriptTailer.drainEntries();
+      if (entries.length === 0) return;
+      for (const entry of entries) {
+        consumeEntry(entry, sessionCtx, state);
+      }
     }
   }
 
@@ -403,9 +410,11 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     let brokeOnIdle = false;
 
     try {
-      // Pre-flush whatever's already in the transcript (the prior turn's
-      // tail end) so it doesn't pollute this turn's text accumulation.
-      transcriptTailer.drainEntries();
+      // Skip whatever's already in the transcript — the prior turn's tail
+      // end, or the entire prior-session history on resume — so it doesn't
+      // pollute this turn's text accumulation. Metadata-only: nothing is
+      // read, so resuming against a huge transcript stays O(1).
+      await transcriptTailer.skipToEnd();
 
       await pasteText(tmuxSessionName, text);
       sessionCtx.recordProviderActivity();

--- a/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
+++ b/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
@@ -18,12 +18,12 @@ import { StringDecoder } from "node:string_decoder";
  * `realpath` here so the tailer points at the same file claude writes,
  * even when the caller's `cwd` argument still contains an unresolved
  * symlink component. Falls back to the input on realpath errors so the
- * tailer can still operate against not-yet-created workspaces (the
- * existsSync guard inside drainEntries handles the missing-file window).
+ * tailer can still operate against not-yet-created workspaces (the stat
+ * ENOENT catch inside drainEntries handles the missing-file window).
  *
  * The file is created lazily by claude on first message flush, so consumers
- * must tolerate `existsSync(path) === false` for a brief window after
- * session start.
+ * must tolerate the file not existing for a brief window after session
+ * start.
  */
 export function transcriptPathFor(cwd: string, sessionId: string): string {
   const absCwd = resolve(cwd);

--- a/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
+++ b/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
@@ -1,6 +1,8 @@
-import { closeSync, existsSync, openSync, readSync, realpathSync, statSync } from "node:fs";
+import { realpathSync, statSync } from "node:fs";
+import { open, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 
 /**
  * Resolve Claude Code's per-session transcript path.
@@ -44,40 +46,137 @@ export type RawTranscriptEntry = {
   [key: string]: unknown;
 };
 
+/** Bytes per read call — one reusable buffer of (at most) this size per drain. */
+const DRAIN_CHUNK_BYTES = 256 * 1024;
+/**
+ * Raw-byte ceiling for a single `drainEntries()` batch. Keeps per-drain memory
+ * constant regardless of how much the transcript grew between polls; callers
+ * loop until an empty batch to fully catch up. Both sizes are deliberately
+ * hard-coded (with test-only overrides): they are private tuning knobs of this
+ * tailer, not user configuration.
+ */
+const MAX_DRAIN_BATCH_BYTES = 4 * 1024 * 1024;
+
+/** Test-only overrides for the read sizes; production paths use the defaults. */
+type TranscriptTailerOptions = {
+  chunkBytes?: number;
+  maxBatchBytes?: number;
+};
+
 /**
  * Tail an append-only JSONL transcript. Each `drainEntries()` returns raw
- * entries appended since the last call. Tolerates the file not yet existing
- * (returns empty), partial lines across reads, and malformed JSON (single
- * bad line is skipped, not fatal).
+ * entries appended since the last call, reading a bounded number of bytes per
+ * call — callers loop until an empty batch to fully catch up. A tailer
+ * constructed over an already-existing file starts at its current EOF (resume
+ * semantics): prior-session history is skipped via metadata only, never read,
+ * because historical entries must not be replayed into the current turn.
+ * Tolerates the file not yet existing (returns empty), partial lines across
+ * reads, and malformed JSON (single bad line is skipped, not fatal).
  *
  * NOT thread-safe across instances — each session should own one tailer.
  */
 export class TranscriptTailer {
   private readonly path: string;
+  private readonly chunkBytes: number;
+  private readonly maxBatchBytes: number;
   private offset = 0;
+  /**
+   * Trailing bytes of the last drained chunk that did not yet end in a
+   * newline. Bounded by the length of a single JSONL line (claude writes one
+   * entry per line), not by file size. There is deliberately no hard cap:
+   * enforcing one would need a skip-until-next-newline recovery state machine,
+   * which today's writer behaviour does not justify.
+   */
   private partial = "";
+  /** Carries multi-byte UTF-8 sequences split across chunk AND drain boundaries. */
+  private decoder = new StringDecoder("utf8");
 
-  constructor(path: string) {
+  constructor(path: string, options?: TranscriptTailerOptions) {
     this.path = path;
+    this.chunkBytes = options?.chunkBytes ?? DRAIN_CHUNK_BYTES;
+    this.maxBatchBytes = options?.maxBatchBytes ?? MAX_DRAIN_BATCH_BYTES;
+    // Resume-at-EOF: when the transcript already exists (resume), start at its
+    // current end. The history was already consumed by the prior session and
+    // must never re-enter this one — see skipToEnd(). A single O(1) metadata
+    // stat per session start.
+    try {
+      this.offset = statSync(path).size;
+    } catch {
+      // Not created yet (claude writes the file lazily) — start at 0.
+    }
   }
 
-  /** Read raw JSONL entries appended since the last call. Best-effort. */
-  drainEntries(): RawTranscriptEntry[] {
-    if (!existsSync(this.path)) return [];
-    const stat = statSync(this.path);
-    if (stat.size <= this.offset) return [];
-
-    const fd = openSync(this.path, "r");
-    let chunk = "";
+  /**
+   * Jump the tail position to the file's current EOF without reading any
+   * content, discarding buffered partial-line state. This is the pre-turn
+   * flush: whatever the prior turn (or, on resume, the prior session) left in
+   * the transcript is dropped in O(1). Historical entries must never reach the
+   * turn consumers — they would be replayed as this turn's output.
+   */
+  async skipToEnd(): Promise<void> {
     try {
-      const buf = Buffer.allocUnsafe(stat.size - this.offset);
-      const read = readSync(fd, buf, 0, buf.length, this.offset);
-      this.offset += read;
-      chunk = this.partial + buf.subarray(0, read).toString("utf-8");
-    } finally {
-      closeSync(fd);
+      this.offset = (await stat(this.path)).size;
+    } catch {
+      // Keep the current offset on stat failure (lazy-creation window, or a
+      // transient error such as EMFILE/EACCES). Resetting to 0 would make the
+      // next drain re-read — and replay — the entire transcript.
+    }
+    this.partial = "";
+    this.decoder = new StringDecoder("utf8");
+  }
+
+  /**
+   * Read raw JSONL entries appended since the last call, up to
+   * `maxBatchBytes` raw bytes per call. Best-effort.
+   */
+  async drainEntries(): Promise<RawTranscriptEntry[]> {
+    let size: number;
+    try {
+      size = (await stat(this.path)).size;
+    } catch {
+      // File not created yet — claude writes it on the first message flush.
+      return [];
     }
 
+    if (size < this.offset) {
+      // The file shrank: external truncation/rotation, never claude's own
+      // append-only writes. Bytes at the old offset no longer mean what they
+      // did, so clamp to the new EOF (mirroring resume-at-EOF) instead of
+      // re-reading from 0, which would replay the rewritten file's content as
+      // this turn's output. All three pieces of tail state reset together.
+      this.offset = size;
+      this.partial = "";
+      this.decoder = new StringDecoder("utf8");
+      return [];
+    }
+    // `partial`/`decoder` must survive this early return: a half-written line
+    // from the previous drain may still be waiting for its terminator.
+    if (size === this.offset) return [];
+
+    const target = Math.min(size, this.offset + this.maxBatchBytes);
+    const buf = Buffer.allocUnsafe(Math.min(this.chunkBytes, target - this.offset));
+    let text = "";
+    const fd = await open(this.path, "r");
+    try {
+      while (this.offset < target) {
+        const wanted = Math.min(buf.length, target - this.offset);
+        // Position is passed explicitly on every read — never rely on the
+        // fd's implicit cursor.
+        const { bytesRead } = await fd.read(buf, 0, wanted, this.offset);
+        // stat→read TOCTOU: a zero-byte read means the file was truncated
+        // after the stat above — treat it as EOF for this batch.
+        if (bytesRead === 0) break;
+        this.offset += bytesRead;
+        // Decode only the freshly read prefix — the buffer's tail still holds
+        // stale bytes from the previous iteration. The decoder buffers a
+        // trailing incomplete UTF-8 sequence instead of emitting U+FFFD.
+        text += this.decoder.write(buf.subarray(0, bytesRead));
+      }
+    } finally {
+      await fd.close();
+    }
+
+    const chunk = this.partial + text;
     const parts = chunk.split("\n");
     this.partial = parts.pop() ?? "";
 


### PR DESCRIPTION
## Summary

Fixes #1679 ([PERF-016][High]). Resuming a `claude-code-tui` session pointed the `TranscriptTailer` at the existing transcript with `offset = 0`, so the first turn's pre-flush synchronously read and parsed the **entire** history just to discard it: an O(file size) stall on the shared client event loop (one process serves all agents), transient ~3× file-size memory amplification, and a hard `ERR_STRING_TOO_LONG` failure for transcripts past ~512 MiB. N agents resuming after a client restart/reconnect multiplied this simultaneously — the "can OOM all agents" scenario from the audit.

This boundary is also about correctness, not just performance: historical entries must **never** reach `consumeEntry` — it feeds the tool-call processor (session events) and accumulates assistant text into `finalTexts`, which `forwardResult` delivers as *this turn's reply*. Letting history near the turn consumers would replay the prior session to the user. The fix therefore skips history via metadata only; it is never read at all.

## Changes

`packages/client/src/handlers/claude-code-tui/transcript-tail.ts`
- **Resume-at-EOF**: the constructor stats the file once (O(1) metadata) and starts at its current size — 0 when the file doesn't exist yet (claude creates it lazily). This is defence in depth: even a future pre-paste drain call site cannot replay history.
- **New `skipToEnd()`** — the pre-turn flush. Jumps the offset to the current EOF without reading and discards buffered partial-line state. On a transient stat failure (`EMFILE`/`EACCES`/lazy-creation window) it **keeps** the current offset: resetting to 0 would make the next drain re-read — and replay — the entire transcript.
- **`drainEntries()` is now async and bounded**: a chunked `FileHandle.read` loop (256 KiB reusable buffer) reading at most 4 MiB raw bytes per batch; callers loop until an empty batch. Every read passes an explicit `position`; `bytesRead === 0` breaks the loop (stat→read TOCTOU truncation); only `subarray(0, bytesRead)` is decoded on short reads. Per-drain memory is constant, independent of file size.
- **`StringDecoder`** carries multi-byte UTF-8 sequences across chunk *and* drain boundaries — fixing a latent bug where the old whole-buffer `toString("utf-8")` emitted U+FFFD when a drain boundary split a multi-byte character, corrupting that line and silently dropping the entry via malformed-skip.
- **Truncation clamp**: if the file shrank (external truncation/rotation only — claude's own writes are append-only), the tailer clamps to the new EOF and resets partial/decoder state together, replacing the old undefined behaviour (stale offset → misaligned garbage reads once the file grows past it again).
- `partial` is bounded by a single JSONL line length (the writer's own behaviour), documented in-code; deliberately no hard cap — enforcing one would need a skip-until-next-newline recovery state machine today's writer doesn't justify.

`packages/client/src/handlers/claude-code-tui/index.ts`
- The pre-turn flush is now `await transcriptTailer.skipToEnd()` — metadata-only, so a resume against a huge transcript is O(1).
- `drainAndConsume` loops batches to exhaustion, preserving "consume everything available right now" semantics at every call site (250 ms poll / grace / final pass), with an event-loop yield between batches.

Constants are hard-coded with test-only constructor overrides — they are private tuning knobs of the tailer, not user configuration. The polling model, turn disposition, `consumeEntry`/processor semantics, and other handlers are unchanged. No history backfill: the pre-flush always discarded history; now it just never reads it.

## Behaviour changes

1. Truncation (`size < offset`) jumps to the new EOF instead of holding a stale offset and later reading misaligned bytes. Append-only transcripts never hit this in practice; undefined behaviour becomes deterministic.
2. Multi-byte characters split across drain/chunk boundaries no longer produce U+FFFD (previously could corrupt and silently drop that entry).
3. One extra O(1) `statSync` per session start (constructor EOF init).
4. A half-written line straddling the pre-turn flush is now dropped instead of leaking into the turn. Previously the flush buffered the line's first half into `partial`, and the first post-paste drain glued it to its second half and consumed it — the prior turn's tail entry entered the current turn's `finalTexts`/reply, the exact pollution the pre-flush exists to prevent. Now `skipToEnd` discards the buffered half; the orphaned second half fails JSON parse on its own and is skipped, and consumption starts cleanly at the next full line.

## Tests

`tui-transcript-tail.test.ts` — 15 `TranscriptTailer` cases (real files via mkdtemp; the pre-existing 4 preserved, awaited):
- resume-at-EOF over existing history; a ~10 MiB pre-existing file surfaces nothing (behavioural asserts only — no timing, which would flake under CI load)
- `skipToEnd` discards unread data; clears a buffered partial line; **keeps its position when stat transiently fails** (the P1 from design review — a regression here would re-read/replay the full history)
- bounded batches preserve order across drains (`maxBatchBytes: 64` injection)
- JSONL reassembly across chunk boundaries (`chunkBytes: 8`); multi-byte UTF-8 across chunk boundaries (`chunkBytes: 3`) and across **separate drains** (decoder persistence between calls — the distinct code path)
- truncation clamp returns empty, resumes from the new EOF, and clears buffered partial state

`tui-resume-transcript-skip.test.ts` (new integration test): on resume, `skipToEnd` runs before the first paste and **nothing drains before it**; a transcript still holding history never leaks into the per-turn processor or the forwarded final text.

`tui-suspend-queued-recovery.test.ts`: the mock tailer gains a no-op `skipToEnd`.

## Verification

- `pnpm check` ✓ (2 pre-existing warnings in server/web code, untouched by this diff)
- `pnpm typecheck` ✓ (10/10)
- `pnpm --filter @first-tree/client test` ✓ (154 files / 1633 tests)
- `pnpm test` ✓ (turbo 11/11). Note: `@first-tree/skill-evals` git-fixture tests run at ~4.2 s against a 5 s timeout even on a clean `main` baseline and can exceed it under parallel machine load; unrelated to this diff (skill-evals has no dependency on `@first-tree/client`).

QA self-check (per repo CLAUDE.md): this touches a client runtime path but is fully deterministically verifiable, so coverage belongs in product tests (above). No matching `packages/qa/cases/runtime/` prose case exists for this path and none is needed.

Design reviewed and signed off by fire-fable-reviewer (design round 1 + revision confirmation) before implementation.
