### PR TITLE
fix(server): separate liveness from bounded database readiness

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,13 +34,15 @@ its package script.
 
 - API server: `http://127.0.0.1:8000`
 - Web workspace: `http://127.0.0.1:5173`
-- Liveness check: `http://127.0.0.1:8000/healthz`
-- Structured health check: `http://127.0.0.1:8000/api/v1/health`
+- Process liveness check: `http://127.0.0.1:8000/healthz` (does not query PostgreSQL)
+- Bootstrap + database readiness check: `http://127.0.0.1:8000/readyz`
+- Structured database diagnostic: `http://127.0.0.1:8000/api/v1/health`
 
 Useful smoke checks:
 
 ```bash
 curl http://127.0.0.1:8000/healthz
+curl http://127.0.0.1:8000/readyz
 curl http://127.0.0.1:8000/api/v1/health
 ```
 

--- a/packages/qa/cases/cross-surface/release-boot-health.md
+++ b/packages/qa/cases/cross-surface/release-boot-health.md
@@ -43,7 +43,8 @@ If the build tooling or Compose flags differ for the target ref, record the exac
 - `observe container-state`: `docker compose ps` shows server and postgres `Up (healthy)` (the image `HEALTHCHECK`
   probes `/healthz`).
 - `observe http-api`: `/healthz` returns a 200 liveness body (`{"status":"ok"}`).
-- `observe http-api`: `/readyz` returns 200 with `ready: true` and boot stages (including `runMigrations`) marked `done`.
+- `observe http-api`: `/readyz` returns 200 with `ready: true`, `db: "connected"`, and boot stages (including
+  `runMigrations`) marked `done`.
 - `observe http-api`: `/api/v1/health` returns 200 with database connectivity (`{"status":"ok","db":"connected"}`). Note
   the real DB-health route lives under the `/api/v1` prefix; bare `/health` correctly falls through to the web SPA.
 - `observe http-api`: `GET /` returns the web SPA `index.html`, confirming the server image serves the built web dist.

--- a/packages/server/src/__tests__/api-route-branch-sweeper.test.ts
+++ b/packages/server/src/__tests__/api-route-branch-sweeper.test.ts
@@ -30,6 +30,7 @@ function createApp(overrides: Record<string, unknown> = {}): { app: Record<strin
     return app;
   };
   const app = {
+    databaseReadinessProbe: { check: vi.fn(async () => "connected" as const) },
     db: { execute: vi.fn(async () => [{ one: 1 }]) },
     get: registerRoute("GET"),
     ...overrides,
@@ -74,37 +75,35 @@ describe("API route branch contracts", () => {
   it("reports degraded /health when the database probe fails", async () => {
     const healthy = await registerSingleRoute(healthRoutes);
     await expect(healthy.route.handler({}, replyDouble())).resolves.toEqual({ status: "ok", db: "connected" });
-    expect((healthy.app.db as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalledTimes(1);
+    expect((healthy.app.databaseReadinessProbe as { check: ReturnType<typeof vi.fn> }).check).toHaveBeenCalledTimes(1);
 
-    const execute = vi.fn(async () => {
-      throw new Error("db unavailable");
-    });
-    const degraded = await registerSingleRoute(healthRoutes, { db: { execute } });
+    const check = vi.fn(async () => "disconnected" as const);
+    const degraded = await registerSingleRoute(healthRoutes, { databaseReadinessProbe: { check } });
 
     await expect(degraded.route.handler({}, replyDouble())).resolves.toEqual({
       status: "degraded",
       db: "disconnected",
     });
-    expect(execute).toHaveBeenCalledTimes(1);
+    expect(check).toHaveBeenCalledTimes(1);
   });
 
-  it("maps /healthz database reachability to explicit status codes", async () => {
-    const ok = await registerSingleRoute(healthzRoutes);
-    const okReply = replyDouble();
-    await ok.route.handler({}, okReply);
-
-    expect(okReply.status).toHaveBeenCalledWith(200);
-    expect(okReply.send).toHaveBeenCalledWith({ status: "ok" });
-
+  it("keeps /healthz as a database-free liveness check", async () => {
     const execute = vi.fn(async () => {
       throw new Error("connection refused");
     });
-    const failing = await registerSingleRoute(healthzRoutes, { db: { execute } });
-    const failingReply = replyDouble();
-    await failing.route.handler({}, failingReply);
+    const check = vi.fn(async () => "disconnected" as const);
+    const live = await registerSingleRoute(healthzRoutes, {
+      databaseReadinessProbe: { check },
+      db: { execute },
+    });
+    const reply = replyDouble();
+    await live.route.handler({}, reply);
 
-    expect(failingReply.status).toHaveBeenCalledWith(503);
-    expect(failingReply.send).toHaveBeenCalledWith({ status: "error", message: "database unreachable" });
+    expect(live.route.options).toEqual({ config: { rateLimit: false } });
+    expect(reply.status).toHaveBeenCalledWith(200);
+    expect(reply.send).toHaveBeenCalledWith({ status: "ok" });
+    expect(execute).not.toHaveBeenCalled();
+    expect(check).not.toHaveBeenCalled();
   });
 
   it("keeps /readyz unavailable until every bootstrap stage is done", async () => {
@@ -116,14 +115,16 @@ describe("API route branch contracts", () => {
       buildApp: { status: "pending" },
       appListen: { status: "pending" },
     };
-    const { route } = await registerSingleRoute(readyzRoutes);
+    const { app, route } = await registerSingleRoute(readyzRoutes);
     const reply = replyDouble();
 
     await route.handler({}, reply);
 
+    expect(route.options).toEqual({ config: { rateLimit: false } });
     expect(reply.status).toHaveBeenCalledWith(503);
     expect(reply.send).toHaveBeenCalledWith(
       expect.objectContaining({
+        db: "unchecked",
         ready: false,
         startedAt: "2026-01-01T00:00:00.000Z",
         readyAt: null,
@@ -132,6 +133,7 @@ describe("API route branch contracts", () => {
         }),
       }),
     );
+    expect((app.databaseReadinessProbe as { check: ReturnType<typeof vi.fn> }).check).not.toHaveBeenCalled();
   });
 
   it("previews public invitations without exposing tokenless requests", async () => {

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -320,28 +320,36 @@ describe("small API route handlers", () => {
     );
   });
 
-  it("returns health and healthz success and degraded responses", async () => {
+  it("returns database health diagnostics and database-free healthz liveness", async () => {
     const { healthRoutes } = await import("../api/health.js");
     const { healthzRoutes } = await import("../api/healthz.js");
-    const execute = vi.fn().mockResolvedValue(undefined);
-    const { app, routes } = makeApp({ db: { execute } });
+    const check = vi.fn(async (): Promise<"connected" | "disconnected"> => "connected");
+    const execute = vi.fn().mockRejectedValue(new Error("db down"));
+    const { app, routes } = makeApp({ databaseReadinessProbe: { check }, db: { execute } });
 
     await healthRoutes(app as never);
     await healthzRoutes(app as never);
     await expect(route(routes, "GET", "/health").handler()).resolves.toEqual({ db: "connected", status: "ok" });
+    expect(check).toHaveBeenCalledTimes(1);
 
     const okReply = makeReply();
     await route(routes, "GET", "/healthz").handler({}, okReply);
     expect(okReply).toMatchObject({ body: { status: "ok" }, code: 200 });
+    expect(check).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalled();
 
-    execute.mockRejectedValueOnce(new Error("db down")).mockRejectedValueOnce(new Error("db down"));
+    check.mockResolvedValueOnce("disconnected");
     await expect(route(routes, "GET", "/health").handler()).resolves.toEqual({
       db: "disconnected",
       status: "degraded",
     });
-    const degradedReply = makeReply();
-    await route(routes, "GET", "/healthz").handler({}, degradedReply);
-    expect(degradedReply).toMatchObject({ body: { message: "database unreachable", status: "error" }, code: 503 });
+    expect(check).toHaveBeenCalledTimes(2);
+
+    const stillLiveReply = makeReply();
+    await route(routes, "GET", "/healthz").handler({}, stillLiveReply);
+    expect(stillLiveReply).toMatchObject({ body: { status: "ok" }, code: 200 });
+    expect(check).toHaveBeenCalledTimes(2);
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it("serves agent runtime config and context tree info", async () => {

--- a/packages/server/src/__tests__/database-readiness.test.ts
+++ b/packages/server/src/__tests__/database-readiness.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createDatabaseReadinessProbe,
+  DATABASE_READINESS_CACHE_TTL_MS,
+  DATABASE_READINESS_TIMEOUT_MS,
+} from "../services/database-readiness.js";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let reject!: (reason?: unknown) => void;
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("createDatabaseReadinessProbe", () => {
+  let nowMs: number;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    nowMs = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shares one underlying call and one timeout across 100 concurrent callers", async () => {
+    const query = deferred<unknown>();
+    const executeProbe = vi.fn(() => query.promise);
+    const probe = createDatabaseReadinessProbe(executeProbe, { now: () => nowMs });
+
+    const checks = Array.from({ length: 100 }, () => probe.check());
+
+    expect(new Set(checks)).toHaveLength(1);
+    expect(vi.getTimerCount()).toBe(1);
+    await Promise.resolve();
+    expect(executeProbe).toHaveBeenCalledTimes(1);
+
+    query.resolve(undefined);
+    await expect(Promise.all(checks)).resolves.toEqual(Array(100).fill("connected"));
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("times out exactly at 2000 ms and never replaces a still-pending generation", async () => {
+    const query = deferred<unknown>();
+    const executeProbe = vi.fn(() => query.promise);
+    const probe = createDatabaseReadinessProbe(executeProbe, { now: () => nowMs });
+    const firstCheck = probe.check();
+    const observedResult = vi.fn();
+    void firstCheck.then(observedResult);
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(DATABASE_READINESS_TIMEOUT_MS - 1);
+    expect(observedResult).not.toHaveBeenCalled();
+    expect(executeProbe).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(firstCheck).resolves.toBe("disconnected");
+    expect(observedResult).toHaveBeenCalledWith("disconnected");
+    expect(vi.getTimerCount()).toBe(0);
+
+    for (const elapsed of [5_000, 10_000, 15_000, 25_000]) {
+      nowMs = elapsed;
+      const repeatedChecks = Array.from({ length: 100 }, () => probe.check());
+      expect(new Set(repeatedChecks)).toHaveLength(1);
+      await expect(Promise.all(repeatedChecks)).resolves.toEqual(Array(100).fill("disconnected"));
+      expect(executeProbe).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    }
+  });
+
+  it("caches a late success for a full TTL measured from actual settlement", async () => {
+    const query = deferred<unknown>();
+    const executeProbe = vi.fn(() => query.promise);
+    const probe = createDatabaseReadinessProbe(executeProbe, { now: () => nowMs });
+    const timedOutCheck = probe.check();
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(DATABASE_READINESS_TIMEOUT_MS);
+    await expect(timedOutCheck).resolves.toBe("disconnected");
+
+    nowMs = 12_000;
+    query.resolve(undefined);
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(probe.check()).resolves.toBe("connected");
+    expect(executeProbe).toHaveBeenCalledTimes(1);
+
+    nowMs = 12_000 + DATABASE_READINESS_CACHE_TTL_MS - 1;
+    await expect(probe.check()).resolves.toBe("connected");
+    expect(executeProbe).toHaveBeenCalledTimes(1);
+
+    nowMs += 1;
+    const boundaryChecks = Array.from({ length: 100 }, () => probe.check());
+    expect(new Set(boundaryChecks)).toHaveLength(1);
+    await expect(Promise.all(boundaryChecks)).resolves.toEqual(Array(100).fill("connected"));
+    expect(executeProbe).toHaveBeenCalledTimes(2);
+  });
+
+  it("consumes a late rejection and caches it for a full TTL from settlement", async () => {
+    const query = deferred<unknown>();
+    const executeProbe = vi
+      .fn<() => Promise<unknown>>()
+      .mockImplementationOnce(() => query.promise)
+      .mockResolvedValueOnce(undefined);
+    const probe = createDatabaseReadinessProbe(executeProbe, { now: () => nowMs });
+    const unhandledRejection = vi.fn();
+    process.on("unhandledRejection", unhandledRejection);
+
+    try {
+      const timedOutCheck = probe.check();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(DATABASE_READINESS_TIMEOUT_MS);
+      await expect(timedOutCheck).resolves.toBe("disconnected");
+
+      nowMs = 9_000;
+      query.reject(new Error("database unavailable"));
+      await vi.advanceTimersByTimeAsync(0);
+
+      await expect(probe.check()).resolves.toBe("disconnected");
+      expect(executeProbe).toHaveBeenCalledTimes(1);
+      expect(unhandledRejection).not.toHaveBeenCalled();
+
+      nowMs = 9_000 + DATABASE_READINESS_CACHE_TTL_MS - 1;
+      await expect(probe.check()).resolves.toBe("disconnected");
+      expect(executeProbe).toHaveBeenCalledTimes(1);
+
+      nowMs += 1;
+      const boundaryChecks = Array.from({ length: 100 }, () => probe.check());
+      await expect(Promise.all(boundaryChecks)).resolves.toEqual(Array(100).fill("connected"));
+      expect(executeProbe).toHaveBeenCalledTimes(2);
+      expect(unhandledRejection).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", unhandledRejection);
+    }
+  });
+
+  it("starts the full cache TTL when a slow query settles", async () => {
+    const firstQuery = deferred<unknown>();
+    const executeProbe = vi
+      .fn<() => Promise<unknown>>()
+      .mockImplementationOnce(() => firstQuery.promise)
+      .mockResolvedValueOnce(undefined);
+    const probe = createDatabaseReadinessProbe(executeProbe, { now: () => nowMs });
+    const firstCheck = probe.check();
+
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1_500);
+    nowMs = 1_500;
+    firstQuery.resolve(undefined);
+    await expect(firstCheck).resolves.toBe("connected");
+
+    nowMs = 1_500 + DATABASE_READINESS_CACHE_TTL_MS - 1;
+    await expect(probe.check()).resolves.toBe("connected");
+    expect(executeProbe).toHaveBeenCalledTimes(1);
+
+    nowMs += 1;
+    const boundaryChecks = Array.from({ length: 100 }, () => probe.check());
+    expect(new Set(boundaryChecks)).toHaveLength(1);
+    await expect(Promise.all(boundaryChecks)).resolves.toEqual(Array(100).fill("connected"));
+    expect(executeProbe).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("normalizes and caches synchronous throws and quick rejections", async () => {
+    const syncThrow = vi.fn((): Promise<unknown> => {
+      throw new Error("sync failure");
+    });
+    const syncThrowProbe = createDatabaseReadinessProbe(syncThrow, { now: () => nowMs });
+
+    await expect(syncThrowProbe.check()).resolves.toBe("disconnected");
+    nowMs = DATABASE_READINESS_CACHE_TTL_MS - 1;
+    await expect(syncThrowProbe.check()).resolves.toBe("disconnected");
+    expect(syncThrow).toHaveBeenCalledTimes(1);
+
+    nowMs = 0;
+    const quickRejection = vi.fn(() => Promise.reject(new Error("async failure")));
+    const quickRejectionProbe = createDatabaseReadinessProbe(quickRejection, { now: () => nowMs });
+
+    await expect(quickRejectionProbe.check()).resolves.toBe("disconnected");
+    nowMs = DATABASE_READINESS_CACHE_TTL_MS - 1;
+    await expect(quickRejectionProbe.check()).resolves.toBe("disconnected");
+    expect(quickRejection).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("keeps state isolated between independent probe instances", async () => {
+    const firstExecute = vi.fn(async () => undefined);
+    const secondExecute = vi.fn(async () => undefined);
+    const firstProbe = createDatabaseReadinessProbe(firstExecute, { now: () => nowMs });
+    const secondProbe = createDatabaseReadinessProbe(secondExecute, { now: () => nowMs });
+
+    const firstCheck = firstProbe.check();
+    const secondCheck = secondProbe.check();
+    expect(vi.getTimerCount()).toBe(2);
+
+    await expect(Promise.all([firstCheck, secondCheck])).resolves.toEqual(["connected", "connected"]);
+    expect(firstExecute).toHaveBeenCalledTimes(1);
+    expect(secondExecute).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/server/src/__tests__/health-readiness-integration.test.ts
+++ b/packages/server/src/__tests__/health-readiness-integration.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { bootstrapState, markReady, markStage } from "../bootstrap-state.js";
+import { createTestApp } from "./helpers.js";
+
+function resetBootstrapState() {
+  for (const key of Object.keys(bootstrapState.stages)) {
+    delete bootstrapState.stages[key];
+  }
+  bootstrapState.readyAt = null;
+}
+
+function markBootstrapReady() {
+  markStage("initTelemetry", { status: "done", durationMs: 1 });
+  markStage("runMigrations", { status: "done", durationMs: 1 });
+  markStage("buildApp", { status: "done", durationMs: 1 });
+  markStage("appListen", { status: "done", durationMs: 1 });
+  markReady();
+}
+
+function deferred<T>() {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value: T) {
+      if (!resolvePromise) throw new Error("deferred promise was not initialized");
+      resolvePromise(value);
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetBootstrapState();
+});
+
+describe("health and readiness integration", () => {
+  it("serves 100 concurrent liveness requests without a database or readiness probe call", async () => {
+    const app = await createTestApp();
+    try {
+      const execute = vi.spyOn(app.db, "execute");
+      const check = vi.spyOn(app.databaseReadinessProbe, "check");
+
+      const responses = await Promise.all(
+        Array.from({ length: 100 }, () => app.inject({ method: "GET", url: "/healthz" })),
+      );
+
+      for (const response of responses) {
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toEqual({ status: "ok" });
+      }
+      expect(check).not.toHaveBeenCalled();
+      expect(execute).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("coalesces 100 mixed readiness and diagnostic requests into one database query", async () => {
+    const app = await createTestApp();
+    const query = deferred<unknown>();
+    try {
+      markBootstrapReady();
+      const execute = vi.spyOn(app.db, "execute").mockImplementation(() => query.promise as never);
+      const requests = Array.from({ length: 100 }, (_, index) => {
+        const url = index % 2 === 0 ? "/readyz" : "/api/v1/health";
+        return { url, response: app.inject({ method: "GET", url }) };
+      });
+
+      await vi.waitFor(() => {
+        expect(execute).toHaveBeenCalledOnce();
+      });
+      query.resolve(undefined);
+      const responses = await Promise.all(requests.map(({ response }) => response));
+
+      expect(execute).toHaveBeenCalledOnce();
+      for (const [index, response] of responses.entries()) {
+        if (index % 2 === 0) {
+          expect(response.statusCode).toBe(200);
+          expect(response.json()).toEqual({
+            ready: true,
+            db: "connected",
+            startedAt: bootstrapState.startedAt.toISOString(),
+            readyAt: bootstrapState.readyAt?.toISOString(),
+            stages: bootstrapState.stages,
+          });
+        } else {
+          expect(response.statusCode).toBe(200);
+          expect(response.json()).toEqual({ status: "ok", db: "connected" });
+        }
+      }
+    } finally {
+      query.resolve(undefined);
+      await app.close();
+    }
+  });
+
+  it("keeps readiness probe state isolated between independently built apps", async () => {
+    const firstApp = await createTestApp();
+    try {
+      const secondApp = await createTestApp();
+      try {
+        markBootstrapReady();
+        const firstExecute = vi.spyOn(firstApp.db, "execute");
+        const secondExecute = vi.spyOn(secondApp.db, "execute");
+
+        const [firstResponse, secondResponse] = await Promise.all([
+          firstApp.inject({ method: "GET", url: "/readyz" }),
+          secondApp.inject({ method: "GET", url: "/readyz" }),
+        ]);
+
+        const expectedBody = {
+          ready: true,
+          db: "connected",
+          startedAt: bootstrapState.startedAt.toISOString(),
+          readyAt: bootstrapState.readyAt?.toISOString(),
+          stages: bootstrapState.stages,
+        };
+        expect(firstResponse.statusCode).toBe(200);
+        expect(firstResponse.json()).toEqual(expectedBody);
+        expect(secondResponse.statusCode).toBe(200);
+        expect(secondResponse.json()).toEqual(expectedBody);
+        expect(firstExecute).toHaveBeenCalledOnce();
+        expect(secondExecute).toHaveBeenCalledOnce();
+      } finally {
+        await secondApp.close();
+      }
+    } finally {
+      await firstApp.close();
+    }
+  });
+
+  it("exempts liveness and readiness from a low global cap while keeping diagnostics limited", async () => {
+    const app = await createTestApp({ rateLimit: { max: 1 } });
+    try {
+      markBootstrapReady();
+      vi.spyOn(app.databaseReadinessProbe, "check").mockResolvedValue("connected");
+
+      for (let i = 0; i < 3; i++) {
+        const liveness = await app.inject({ method: "GET", url: "/healthz" });
+        expect(liveness.statusCode).toBe(200);
+        expect(liveness.json()).toEqual({ status: "ok" });
+
+        const readiness = await app.inject({ method: "GET", url: "/readyz" });
+        expect(readiness.statusCode).toBe(200);
+        expect(readiness.json()).toEqual({
+          ready: true,
+          db: "connected",
+          startedAt: bootstrapState.startedAt.toISOString(),
+          readyAt: bootstrapState.readyAt?.toISOString(),
+          stages: bootstrapState.stages,
+        });
+      }
+
+      const firstDiagnostic = await app.inject({ method: "GET", url: "/api/v1/health" });
+      expect(firstDiagnostic.statusCode).toBe(200);
+      expect(firstDiagnostic.json()).toEqual({ status: "ok", db: "connected" });
+
+      const rateLimitedDiagnostic = await app.inject({ method: "GET", url: "/api/v1/health" });
+      expect(rateLimitedDiagnostic.statusCode).toBe(429);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/server/src/__tests__/health.test.ts
+++ b/packages/server/src/__tests__/health.test.ts
@@ -1,13 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useTestApp } from "./helpers.js";
 
 describe("GET /api/v1/health", () => {
   const getApp = useTestApp();
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("returns ok with db connected", async () => {
     const app = getApp();
+    const check = vi.spyOn(app.databaseReadinessProbe, "check").mockResolvedValue("connected");
     const res = await app.inject({ method: "GET", url: "/api/v1/health" });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ status: "ok", db: "connected" });
+    expect(check).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the HTTP 200 degraded contract when the database probe is disconnected", async () => {
+    const app = getApp();
+    const check = vi.spyOn(app.databaseReadinessProbe, "check").mockResolvedValue("disconnected");
+
+    const res = await app.inject({ method: "GET", url: "/api/v1/health" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: "degraded", db: "disconnected" });
+    expect(check).toHaveBeenCalledOnce();
   });
 });

--- a/packages/server/src/__tests__/readyz.test.ts
+++ b/packages/server/src/__tests__/readyz.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { bootstrapState, markReady, markStage } from "../bootstrap-state.js";
 import { useTestApp } from "./helpers.js";
 
@@ -28,49 +28,97 @@ describe("/readyz", () => {
     resetState();
   });
   afterEach(() => {
+    vi.restoreAllMocks();
     resetState();
   });
 
-  it("returns 503 with stage detail when stages have not been marked done", async () => {
+  it("returns 503 with unchecked database state and skips the probe before bootstrap completes", async () => {
+    const check = vi
+      .spyOn(getApp().databaseReadinessProbe, "check")
+      .mockRejectedValue(new Error("readiness probe must not run"));
+
     const res = await getApp().inject({ method: "GET", url: "/readyz" });
     expect(res.statusCode).toBe(503);
-    const body = res.json();
-    expect(body.ready).toBe(false);
-    expect(body.readyAt).toBeNull();
-    expect(body.stages).toEqual({});
+    expect(res.json()).toEqual({
+      ready: false,
+      db: "unchecked",
+      startedAt: bootstrapState.startedAt.toISOString(),
+      readyAt: null,
+      stages: {},
+    });
+    expect(check).not.toHaveBeenCalled();
   });
 
-  it("returns 200 when all stages done and readyAt is set", async () => {
+  it("returns 200 with connected database state after bootstrap completes", async () => {
     markAllStagesDone();
     markReady();
+    const check = vi.spyOn(getApp().databaseReadinessProbe, "check").mockResolvedValue("connected");
 
     const res = await getApp().inject({ method: "GET", url: "/readyz" });
     expect(res.statusCode).toBe(200);
-    const body = res.json();
-    expect(body.ready).toBe(true);
-    expect(body.readyAt).toBeTruthy();
-    expect(body.stages.appListen?.status).toBe("done");
+    expect(res.json()).toEqual({
+      ready: true,
+      db: "connected",
+      startedAt: bootstrapState.startedAt.toISOString(),
+      readyAt: bootstrapState.readyAt?.toISOString(),
+      stages: bootstrapState.stages,
+    });
+    expect(check).toHaveBeenCalledOnce();
   });
 
-  it("returns 503 when any required stage failed", async () => {
+  it("returns 503 with unchecked database state and skips the probe when bootstrap failed", async () => {
     markAllStagesDone();
     markStage("runMigrations", { status: "failed", error: "boom" });
     markReady();
+    const check = vi
+      .spyOn(getApp().databaseReadinessProbe, "check")
+      .mockRejectedValue(new Error("readiness probe must not run"));
 
     const res = await getApp().inject({ method: "GET", url: "/readyz" });
     expect(res.statusCode).toBe(503);
-    const body = res.json();
-    expect(body.ready).toBe(false);
-    expect(body.stages.runMigrations?.status).toBe("failed");
-    expect(body.stages.runMigrations?.error).toBe("boom");
+    expect(res.json()).toEqual({
+      ready: false,
+      db: "unchecked",
+      startedAt: bootstrapState.startedAt.toISOString(),
+      readyAt: bootstrapState.readyAt?.toISOString(),
+      stages: bootstrapState.stages,
+    });
+    expect(check).not.toHaveBeenCalled();
   });
 
   it("returns 503 when stages done but markReady has not been called", async () => {
     markAllStagesDone();
     // readyAt left null on purpose
+    const check = vi
+      .spyOn(getApp().databaseReadinessProbe, "check")
+      .mockRejectedValue(new Error("readiness probe must not run"));
 
     const res = await getApp().inject({ method: "GET", url: "/readyz" });
     expect(res.statusCode).toBe(503);
-    expect(res.json().ready).toBe(false);
+    expect(res.json()).toEqual({
+      ready: false,
+      db: "unchecked",
+      startedAt: bootstrapState.startedAt.toISOString(),
+      readyAt: null,
+      stages: bootstrapState.stages,
+    });
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when the bounded database probe reports disconnected after failure or timeout", async () => {
+    markAllStagesDone();
+    markReady();
+    const check = vi.spyOn(getApp().databaseReadinessProbe, "check").mockResolvedValue("disconnected");
+
+    const res = await getApp().inject({ method: "GET", url: "/readyz" });
+    expect(res.statusCode).toBe(503);
+    expect(res.json()).toEqual({
+      ready: false,
+      db: "disconnected",
+      startedAt: bootstrapState.startedAt.toISOString(),
+      readyAt: bootstrapState.readyAt?.toISOString(),
+      stages: bootstrapState.stages,
+    });
+    expect(check).toHaveBeenCalledOnce();
   });
 });

--- a/packages/server/src/api/health.ts
+++ b/packages/server/src/api/health.ts
@@ -1,13 +1,11 @@
-import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 
 export async function healthRoutes(app: FastifyInstance): Promise<void> {
   app.get("/health", async () => {
-    try {
-      await app.db.execute(sql`SELECT 1`);
+    const db = await app.databaseReadinessProbe.check();
+    if (db === "connected") {
       return { status: "ok", db: "connected" };
-    } catch {
-      return { status: "degraded", db: "disconnected" };
     }
+    return { status: "degraded", db: "disconnected" };
   });
 }

--- a/packages/server/src/api/healthz.ts
+++ b/packages/server/src/api/healthz.ts
@@ -1,18 +1,10 @@
-import { sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 
 /**
- * Root-level health check endpoint for container orchestration.
- * Returns 200 when healthy, 503 when degraded.
- * Used by Docker HEALTHCHECK, Railway, Fly.io, Kubernetes liveness/readiness probes.
+ * Root-level process liveness endpoint for container orchestration.
+ * If the event loop can serve this handler, the process is live. Database
+ * reachability belongs to `/readyz` and must not make liveness restart-loop.
  */
 export async function healthzRoutes(app: FastifyInstance): Promise<void> {
-  app.get("/healthz", { config: { rateLimit: false } }, async (_request, reply) => {
-    try {
-      await app.db.execute(sql`SELECT 1`);
-      return reply.status(200).send({ status: "ok" });
-    } catch {
-      return reply.status(503).send({ status: "error", message: "database unreachable" });
-    }
-  });
+  app.get("/healthz", { config: { rateLimit: false } }, (_request, reply) => reply.status(200).send({ status: "ok" }));
 }

--- a/packages/server/src/api/readyz.ts
+++ b/packages/server/src/api/readyz.ts
@@ -11,17 +11,20 @@ const REQUIRED_STAGES = ["initTelemetry", "runMigrations", "buildApp", "appListe
 
 /**
  * Readiness endpoint — distinct from `/healthz` (liveness). Returns 200 only
- * when every bootstrap stage is done. The body carries the stage detail so
- * operators can see which stage stalled. See
- * docs/server-bootstrap-resilience-design.md §3 (T6).
+ * when every bootstrap stage is done and the bounded database probe is
+ * connected. The body carries stage detail so operators can see which stage
+ * stalled without querying PostgreSQL before bootstrap completes.
  */
 export async function readyzRoutes(app: FastifyInstance): Promise<void> {
   app.get("/readyz", { config: { rateLimit: false } }, async (_request, reply) => {
     const allStagesDone = REQUIRED_STAGES.every((s) => bootstrapState.stages[s]?.status === "done");
-    const ready = allStagesDone && bootstrapState.readyAt !== null;
+    const bootstrapReady = allStagesDone && bootstrapState.readyAt !== null;
+    const db = bootstrapReady ? await app.databaseReadinessProbe.check() : "unchecked";
+    const ready = bootstrapReady && db === "connected";
 
     const body = {
       ready,
+      db,
       startedAt: bootstrapState.startedAt.toISOString(),
       readyAt: bootstrapState.readyAt?.toISOString() ?? null,
       stages: bootstrapState.stages,

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -8,6 +8,7 @@ import fastifyStatic from "@fastify/static";
 import websocket from "@fastify/websocket";
 import { getChannelConfig } from "@first-tree/shared/channel";
 import { FIRST_TREE_ATTR, redactUrl } from "@first-tree/shared/observability";
+import { sql } from "drizzle-orm";
 import Fastify, { type FastifyBaseLogger, type FastifyInstance, type FastifyPluginAsync } from "fastify";
 import postgres from "postgres";
 import { ZodError } from "zod";
@@ -95,6 +96,7 @@ import { invalidateChatAudienceLocal, registerChatAudienceDispatcher } from "./s
 import { registerChatMessageDispatcher } from "./services/chat-projection.js";
 import { createCommandVersionPoller } from "./services/command-version-poller.js";
 import { createConfigService } from "./services/config-service.js";
+import { createDatabaseReadinessProbe } from "./services/database-readiness.js";
 import { backfillGitlabAttentionPairs } from "./services/gitlab-attention-backfill.js";
 import { repairMembershipHumanMirrors } from "./services/membership.js";
 import { createNotifier, type Notifier } from "./services/notifier.js";
@@ -276,7 +278,7 @@ export async function buildApp(config: Config) {
     //     We emit a dedicated long-running `ws.connection` span from
     //     `ws-tracing.ts` instead.
     ignoreRoutes: (path: string) => {
-      if (path === "/" || path === "/healthz") return true;
+      if (path === "/" || path === "/healthz" || path === "/readyz") return true;
       if (path.startsWith("/assets/") || path.startsWith("/fonts/")) return true;
       if (path === "/api/v1/agent/ws/client") return true;
       // Org WS upgrade: `/api/v1/orgs/:orgId/ws/`. Use a startsWith check so
@@ -292,6 +294,10 @@ export async function buildApp(config: Config) {
   // Decorate with config and db
   const db = connectDatabase(config.database.url);
   app.decorate("db", db);
+  app.decorate(
+    "databaseReadinessProbe",
+    createDatabaseReadinessProbe(() => db.execute(sql`SELECT 1`)),
+  );
   app.decorate("config", config);
 
   // Advisory Command-package version broadcast to every Client via the
@@ -486,9 +492,8 @@ export async function buildApp(config: Config) {
   });
 
   // Root-level health checks for container orchestration (outside /api/v1).
-  // `/healthz` checks process + DB reachability (used by Docker HEALTHCHECK).
-  // `/readyz` checks full readiness — all bootstrap stages done.
-  // See docs/server-bootstrap-resilience-design.md §3 (T6).
+  // `/healthz` is process liveness (used by Docker HEALTHCHECK).
+  // `/readyz` requires completed bootstrap stages and bounded DB readiness.
   await app.register(healthzRoutes);
   await app.register(readyzRoutes);
 

--- a/packages/server/src/services/database-readiness.ts
+++ b/packages/server/src/services/database-readiness.ts
@@ -1,0 +1,98 @@
+import { performance } from "node:perf_hooks";
+
+export const DATABASE_READINESS_CACHE_TTL_MS = 5_000;
+export const DATABASE_READINESS_TIMEOUT_MS = 2_000;
+
+export type DatabaseReadinessStatus = "connected" | "disconnected";
+
+export type DatabaseReadinessProbe = {
+  check: () => Promise<DatabaseReadinessStatus>;
+};
+
+export type DatabaseReadinessProbeOptions = {
+  cacheTtlMs?: number;
+  timeoutMs?: number;
+  now?: () => number;
+};
+
+type TerminalCache = {
+  expiresAt: number;
+  status: DatabaseReadinessStatus;
+};
+
+type ProbeGeneration = {
+  actualPromise: Promise<DatabaseReadinessStatus>;
+  visiblePromise: Promise<DatabaseReadinessStatus>;
+};
+
+/**
+ * Creates a process-local, bounded database readiness probe.
+ *
+ * Each generation owns one underlying query, one caller-visible timeout race,
+ * and one timer. A timeout fails closed for callers but deliberately leaves
+ * the generation occupied until the real query settles, so a stalled database
+ * can never accumulate replacement probes.
+ */
+export function createDatabaseReadinessProbe(
+  executeProbe: () => Promise<unknown>,
+  options: DatabaseReadinessProbeOptions = {},
+): DatabaseReadinessProbe {
+  const cacheTtlMs = options.cacheTtlMs ?? DATABASE_READINESS_CACHE_TTL_MS;
+  const timeoutMs = options.timeoutMs ?? DATABASE_READINESS_TIMEOUT_MS;
+  const now = options.now ?? (() => performance.now());
+
+  let terminalCache: TerminalCache | undefined;
+  let activeGeneration: ProbeGeneration | undefined;
+
+  function startGeneration(): ProbeGeneration {
+    // Defer execution into a promise so synchronous throws and asynchronous
+    // rejections share the same consumed terminal result.
+    const actualPromise: Promise<DatabaseReadinessStatus> = Promise.resolve()
+      .then(executeProbe)
+      .then(
+        () => "connected",
+        () => "disconnected",
+      );
+
+    let resolveVisible: (status: DatabaseReadinessStatus) => void = () => undefined;
+    const visiblePromise = new Promise<DatabaseReadinessStatus>((resolve) => {
+      resolveVisible = resolve;
+    });
+
+    const generation: ProbeGeneration = { actualPromise, visiblePromise };
+
+    // Publish the generation before the deferred executeProbe can run. Every
+    // concurrent caller now observes the same visible promise and timer.
+    activeGeneration = generation;
+
+    let timer: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
+      timer = undefined;
+      resolveVisible("disconnected");
+    }, timeoutMs);
+
+    void actualPromise.then((status) => {
+      // Only the real query outcome becomes a 5-second terminal cache. A
+      // timeout fallback never releases or replaces an unsettled generation.
+      terminalCache = { status, expiresAt: now() + cacheTtlMs };
+      if (activeGeneration === generation) activeGeneration = undefined;
+
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      resolveVisible(status);
+    });
+
+    return generation;
+  }
+
+  return {
+    check(): Promise<DatabaseReadinessStatus> {
+      if (terminalCache !== undefined && now() < terminalCache.expiresAt) {
+        return Promise.resolve(terminalCache.status);
+      }
+      if (activeGeneration !== undefined) return activeGeneration.visiblePromise;
+      return startGeneration().visiblePromise;
+    },
+  };
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,6 +1,7 @@
 import type { Database } from "./db/connection.js";
 import type { UserScope } from "./scope/types.js";
 import type { ConfigService } from "./services/config-service.js";
+import type { DatabaseReadinessProbe } from "./services/database-readiness.js";
 import type { Notifier } from "./services/notifier.js";
 import type { ResourcesService } from "./services/resources.js";
 
@@ -15,6 +16,7 @@ export type AgentIdentity = {
 declare module "fastify" {
   interface FastifyInstance {
     db: Database;
+    databaseReadinessProbe: DatabaseReadinessProbe;
     config: import("./config.js").Config;
     notifier: Notifier;
     configService: ConfigService;


### PR DESCRIPTION
Fixes #1716.

## Problem

The public, rate-limit-exempt `/healthz` endpoint issued `SELECT 1` for every request. Traffic volume therefore mapped 1:1 to PostgreSQL round trips, including during a database outage. `/api/v1/health` independently issued the same query, while the existing `/readyz` route only reported bootstrap state.

## Design and behavior

This PR makes the endpoint boundaries explicit and gives every DB-sensitive health request one shared, bounded probe per Fastify instance:

| Endpoint | Contract | Database | HTTP/rate-limit behavior |
| --- | --- | --- | --- |
| `GET /healthz` | Process liveness | Never queried | Always `200 {"status":"ok"}` while HTTP is serving; retains `rateLimit:false` |
| `GET /readyz` | Bootstrap + DB readiness | Shared bounded probe after bootstrap only | `200` only when ready and connected; otherwise `503`; retains `rateLimit:false` |
| `GET /api/v1/health` | Backward-compatible structured health | Same shared probe | Retains `200` for both healthy and degraded bodies; continues to inherit the global limiter |

The probe is created and decorated at the `buildApp` root, so both DB-sensitive routes share it while separate Fastify instances remain isolated. It has:

- a 5-second terminal cache, starting when the real query settles;
- single-flight publication before the first asynchronous boundary;
- one underlying query, one caller-visible promise, and one 2-second timer per generation;
- a timeout that fails callers closed without releasing the occupied generation;
- normalized and consumed synchronous throws/asynchronous rejections, including late settlement;
- monotonic `performance.now()` expiry with `now < expiresAt` freshness (equality is expired).

This yields deterministic bounds per Fastify instance (one app per process in production):

- `/healthz`: **0 DB calls for any request volume**;
- at most **1 unsettled underlying DB probe**;
- adjacent query starts are at least **5 seconds apart**;
- in any closed interval of length `W`, starts are at most `floor(W / 5000) + 1`;
- if the driver promise never settles, total starts remain **1**.

## Compatibility and deployment

- Docker HEALTHCHECK and CLI doctor remain on `/healthz`; they now intentionally prove process reachability/liveness, not runtime DB readiness.
- `/readyz` is the existing readiness path and now adds DB state. Before bootstrap completes or after bootstrap fails it returns `db:"unchecked"` and performs zero DB work; `readyAt` continues to mean bootstrap completion time.
- `/api/v1/health` preserves its existing body/status contract exactly.
- `/readyz` joins the existing healthcheck tracing exclusions so a normal high-frequency readiness probe does not create request-proportional OpenTelemetry volume.
- `DEVELOPMENT.md` documents all three routes. The boot/health QA case now requires `db:"connected"` from `/readyz`.
- No Redis/MQ, shared limiter state, environment variables, migrations, or deployment changes are introduced.

An intentionally wedged driver promise leaves `/readyz` at 503 while `/healthz` remains 200. Releasing the slot on the HTTP timeout would reintroduce unbounded queued probes, so safe automatic recovery requires a driver-level timeout/cancellation that actually settles the underlying operation.

## Validation

- `pnpm check` — pass (1,868 files; only pre-existing informational warnings)
- `pnpm typecheck` — pass, 10/10 tasks
- `pnpm build` — pass, 5/5 tasks
- focused health/readiness suite — pass, 8 files / 67 tests
- full server suite — pass, 240 files / 2,570 tests
- changed-file Biome checks and `git diff --check` — pass
- GitHub CI — 11 successful, 1 path-rule skip, 0 failed, 0 pending

The independent competition reviewer also reran the full server suite from the exact PR head: 240 files / 2,570 tests passed with exit code 0, and no P0–P2 actionable findings were reported.

Coverage includes exact 1,999/2,000 ms timeout behavior, timeout across multiple TTL windows, late success/rejection without unhandled rejection, slow settlement with a full post-settlement TTL, sync throw/quick rejection, exact-expiry concurrency, app isolation, bootstrap zero-query paths, low-global-limit route behavior, 100-way liveness concurrency, and 100-way mixed readiness/health concurrency.

A root `pnpm test` attempt overcommitted the local host when all package suites ran concurrently and produced unrelated timeout-only failures. Re-running `@first-tree/skill-evals` alone passed 433/437; the four remaining failures were marginal fixture timeouts unrelated to this server diff. The complete server suite and all affected package checks pass independently.

## Production-image QA evidence

The exact commit was built into the production Docker image and run against isolated PostgreSQL 16:

- image build: 50.13 s; Compose healthy: 9.92 s; migrations created 39 tables;
- 100 concurrent `/healthz`: 100 HTTP 200, PostgreSQL statement log showed **0 `SELECT 1`**;
- after TTL expiry, 100 concurrent `/readyz` + 100 concurrent `/api/v1/health`: expected statuses and exactly **1 `SELECT 1`**;
- PostgreSQL stopped: `/healthz` stayed 200 and the container stayed healthy; `/readyz` returned 503/disconnected at the 2-second budget; `/api/v1/health` remained 200/degraded;
- PostgreSQL restarted: cached failure remained until expiry, then both DB-sensitive routes returned connected.

Formal repository-wide `QA READY` remains blocked by unavailable OAuth/App/provider credentials and cross-platform native/portable harnesses. No formal case was claimed as executed; the exact-candidate Server/Web/PostgreSQL surface above was fully built, driven, observed, measured, reset, and cleaned up.
