### PR TITLE
chore: Add Factory GitHub workflows

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -1,0 +1,31 @@
+name: Droid Auto Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  droid-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Droid Auto Review
+        uses: Factory-AI/droid-action@main
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          automatic_review: true
+          automatic_security_review: true

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -2,7 +2,7 @@ name: Droid Auto Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   droid-review:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -24,9 +24,8 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@e3d1f5e7861c36fe4a9c4dca3edec87b964b2bc4  # v5
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
           automatic_security_review: true
-# refreshed-SHA: 1784607982

--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -29,3 +29,4 @@ jobs:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
           automatic_security_review: true
+# refreshed-SHA: 1784607982

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -1,0 +1,38 @@
+name: Droid Tag
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  droid:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@droid')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@droid')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@droid') || contains(github.event.issue.title, '@droid'))) ||
+      (github.event_name == 'pull_request' && (contains(github.event.pull_request.body, '@droid') || contains(github.event.pull_request.title, '@droid')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Droid Exec
+        uses: Factory-AI/droid-action@main
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -33,6 +33,6 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@main
+        uses: Factory-AI/droid-action@e3d1f5e7861c36fe4a9c4dca3edec87b964b2bc4  # v5
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -32,7 +32,30 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 1
+      - name: Guard against fork PR pwn-request
+        id: fork-guard
+        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
+        run: |
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            if [ -z "$ISSUE_PR_URL" ] || [ "$ISSUE_PR_URL" == "null" ]; then
+              echo "is_fork_pr=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            IS_FORK=$(gh api "$ISSUE_PR_URL" --jq '.head.repo.fork' 2>/dev/null || echo "false")
+          else
+            IS_FORK="$PR_HEAD_FORK"
+          fi
+          echo "is_fork_pr=${IS_FORK}" >> "$GITHUB_OUTPUT"
+          if [[ "$IS_FORK" == "true" ]]; then
+            echo "::warning::@droid mentions on fork PRs are skipped for security (pwn-request prevention)."
+          fi
       - name: Run Droid Exec
+        if: steps.fork-guard.outputs.is_fork_pr != 'true'
         uses: Factory-AI/droid-action@e3d1f5e7861c36fe4a9c4dca3edec87b964b2bc4  # v5
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -34,28 +34,46 @@ jobs:
           fetch-depth: 1
       - name: Guard against fork PR pwn-request
         id: fork-guard
-        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
-          PR_HEAD_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          REPO: ${{ github.repository }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           ISSUE_PR_URL: ${{ github.event.issue.pull_request.url }}
         run: |
-          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
-            if [ -z "$ISSUE_PR_URL" ] || [ "$ISSUE_PR_URL" == "null" ]; then
-              echo "is_fork_pr=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            IS_FORK=$(gh api "$ISSUE_PR_URL" --jq '.head.repo.fork' 2>/dev/null || echo "false")
-          else
-            IS_FORK="$PR_HEAD_FORK"
-          fi
-          echo "is_fork_pr=${IS_FORK}" >> "$GITHUB_OUTPUT"
-          if [[ "$IS_FORK" == "true" ]]; then
-            echo "::warning::@droid mentions on fork PRs are skipped for security (pwn-request prevention)."
+          set -euo pipefail
+          safe=false
+          case "$EVENT_NAME" in
+            issues)
+              # Plain issue event, not PR-backed: no fork checkout risk.
+              safe=true
+              ;;
+            issue_comment)
+              if [ -z "${ISSUE_PR_URL:-}" ] || [ "$ISSUE_PR_URL" = "null" ]; then
+                # Comment on a plain issue, not a PR.
+                safe=true
+              else
+                HEAD_REPO=$(gh api "$ISSUE_PR_URL" --jq '.head.repo.full_name' 2>/dev/null || echo "")
+                if [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" = "$REPO" ]; then
+                  safe=true
+                fi
+              fi
+              ;;
+            pull_request|pull_request_review|pull_request_review_comment)
+              if [ -n "${PR_HEAD_REPO:-}" ] && [ "$PR_HEAD_REPO" = "$REPO" ]; then
+                safe=true
+              fi
+              ;;
+            *)
+              safe=false
+              ;;
+          esac
+          echo "safe_to_run=${safe}" >> "$GITHUB_OUTPUT"
+          if [ "$safe" != "true" ]; then
+            echo "::warning::@droid skipped: PR head is a fork or head repository could not be verified (pwn-request prevention)."
           fi
       - name: Run Droid Exec
-        if: steps.fork-guard.outputs.is_fork_pr != 'true'
+        if: steps.fork-guard.outputs.safe_to_run == 'true'
         uses: Factory-AI/droid-action@e3d1f5e7861c36fe4a9c4dca3edec87b964b2bc4  # v5
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}


### PR DESCRIPTION
Enable Factory Droid automated code review on this repository.

**Scope:** Auto-review and @droid tag responses cover PRs and mentions from repository collaborators with write access on non-fork PRs. External fork-PR authors are not covered. This is enforced by fork guards in both workflows (see below).

What was added:
- `.github/workflows/droid.yml` — responds to `@droid` mentions in issues, PR comments, and review bodies. Includes a preflight fork-guard step that uses the GitHub API to check if the PR head is from a fork before running the Droid action (prevents pwn-request).
- `.github/workflows/droid-review.yml` — automatically reviews every new non-draft PR from non-fork branches (including `synchronize` for updated PRs), with the security-review pass enabled and `review_depth: deep` (default).

Security hardening (addressed review feedback from @baixiaohang and @yuezengwu):
- `Factory-AI/droid-action` pinned to commit `e3d1f5e7861c36fe4a9c4dca3edec87b964b2bc4` (release v5) in both workflows.
- `droid-review.yml`: fork-PR guard via `github.event.pull_request.head.repo.fork == false`.
- `droid.yml`: preflight fork-guard step that uses `gh api` to look up the PR head for `issue_comment` events (payload lacks PR head info), and reads `github.event.pull_request.head.repo.fork` for other PR events. Droid action gated on `steps.fork-guard.outputs.is_fork_pr != 'true'`.
- `synchronize` trigger added to `droid-review.yml` so updated PRs get a fresh review.

Prerequisites already done at the org level:
- Factory Droid GitHub App installed
- `FACTORY_API_KEY` available via org secret

Useful links:
- API key management: https://app.factory.ai/settings/api-keys
- Docs: https://docs.factory.ai