### PR TITLE
fix(client): bound TUI resume transcript tail

### DIFF
--- a/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
+++ b/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
@@ -25,10 +25,12 @@ const state = vi.hoisted(() => ({
   discardStarted: false,
   discardGate: null as Promise<void> | null,
   discardError: null as Error | null,
+  discardErrors: [] as Error[],
   createError: null as Error | null,
   drainResults: [] as MockDrainResult[],
   captureEnqueueResults: [] as MockDrainResult[],
   drainCalls: 0,
+  captureWatermarkCalls: 0,
   drainCallsAtFirstCapture: null as number | null,
   drainForever: false,
   chatContext: {
@@ -114,11 +116,14 @@ vi.mock("../handlers/claude-code-tui/transcript-tail.js", () => ({
       state.callOrder.push("discard:start");
       state.discardStarted = true;
       if (state.discardGate) await state.discardGate;
+      const queuedError = state.discardErrors.shift();
+      if (queuedError) throw queuedError;
       if (state.discardError) throw state.discardError;
       state.callOrder.push("discard:end");
     }
 
     async captureWatermark() {
+      state.captureWatermarkCalls += 1;
       return 1;
     }
 
@@ -234,10 +239,12 @@ beforeEach(() => {
   state.discardStarted = false;
   state.discardGate = null;
   state.discardError = null;
+  state.discardErrors.length = 0;
   state.createError = null;
   state.drainResults.length = 0;
   state.captureEnqueueResults.length = 0;
   state.drainCalls = 0;
+  state.captureWatermarkCalls = 0;
   state.drainCallsAtFirstCapture = null;
   state.drainForever = false;
 });
@@ -352,6 +359,88 @@ describe("claude-code-tui suspend queued recovery", () => {
     await handler.shutdown();
   });
 
+  it.each([
+    "start",
+    "resume",
+  ] as const)("retries the bootstrap prefix and queued suffix when %s preflush fails", async (mode) => {
+    let releaseDiscard!: () => void;
+    state.discardGate = new Promise<void>((resolve) => {
+      releaseDiscard = resolve;
+    });
+    state.discardErrors.push(new Error("first discard denied"));
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+    const firstToken = makeToken();
+    const queuedToken = makeToken();
+    const first = makeMessage("m121", "failed prefix");
+    const queued = makeMessage("m122", "queued suffix");
+
+    const bootstrap =
+      mode === "start"
+        ? handler.start(first, ctx, firstToken)
+        : handler.resume(first, "existing-session", ctx, firstToken);
+    await waitFor(() => state.discardStarted);
+    expect(handler.inject(queued, queuedToken)).toEqual({ kind: "owned", mode: "queued" });
+
+    releaseDiscard();
+    const result = await bootstrap;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(typeof result === "string" ? null : result.route).toEqual({ kind: "owned", mode: "queued" });
+    expect(state.callOrder.filter((call) => call === "discard:start")).toHaveLength(1);
+    expect(state.pasteTexts).toEqual([]);
+    expect(firstToken.processingStarted).not.toHaveBeenCalled();
+    expect(firstToken.complete).not.toHaveBeenCalled();
+    expect(firstToken.retry).toHaveBeenCalledTimes(1);
+    expect(firstToken.retry).toHaveBeenCalledWith([first], "tui_transcript_preflush_failed");
+    expect(queuedToken.processingStarted).not.toHaveBeenCalled();
+    expect(queuedToken.complete).not.toHaveBeenCalled();
+    expect(queuedToken.retry).toHaveBeenCalledTimes(1);
+    expect(queuedToken.retry).toHaveBeenCalledWith(queued, "tui_bootstrap_recovery_required");
+
+    await handler.shutdown();
+    expect(firstToken.retry).toHaveBeenCalledTimes(1);
+    expect(queuedToken.retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a pumped queued prefix and suffix when preflush fails", async () => {
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+    await handler.resume(undefined, "existing-session", ctx);
+
+    let releaseDiscard!: () => void;
+    state.discardGate = new Promise<void>((resolve) => {
+      releaseDiscard = resolve;
+    });
+    state.discardErrors.push(new Error("queued discard denied"));
+    const prefixToken = makeToken();
+    const suffixToken = makeToken();
+    const prefix = makeMessage("m123", "pumped failed prefix");
+    const suffix = makeMessage("m124", "pumped queued suffix");
+
+    expect(handler.inject(prefix, prefixToken)).toEqual({ kind: "owned", mode: "queued" });
+    await waitFor(() => state.discardStarted);
+    expect(handler.inject(suffix, suffixToken)).toEqual({ kind: "owned", mode: "queued" });
+    releaseDiscard();
+
+    await waitFor(() => prefixToken.retry.mock.calls.length === 1 && suffixToken.retry.mock.calls.length === 1);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(state.callOrder.filter((call) => call === "discard:start")).toHaveLength(1);
+    expect(state.pasteTexts).toEqual([]);
+    expect(prefixToken.processingStarted).not.toHaveBeenCalled();
+    expect(prefixToken.complete).not.toHaveBeenCalled();
+    expect(prefixToken.retry).toHaveBeenCalledWith([prefix], "tui_transcript_preflush_failed");
+    expect(suffixToken.processingStarted).not.toHaveBeenCalled();
+    expect(suffixToken.complete).not.toHaveBeenCalled();
+    expect(suffixToken.retry).toHaveBeenCalledWith(suffix, "tui_queued_recovery_required");
+
+    await handler.shutdown();
+    expect(prefixToken.retry).toHaveBeenCalledTimes(1);
+    expect(suffixToken.retry).toHaveBeenCalledTimes(1);
+  });
+
   it("cleans the tmux session when resume EOF initialization fails", async () => {
     state.createError = new Error("transcript stat failed");
     const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
@@ -378,12 +467,15 @@ describe("claude-code-tui suspend queued recovery", () => {
 
     const resume = handler.resume(message, "existing-session", ctx, token);
     await waitFor(() => state.drainCalls >= 3);
-    const callsAtSuspend = state.drainCalls;
-    await handler.suspend();
+    const suspend = handler.suspend();
+    const callsAtClosedFence = state.drainCalls;
+    const capturesAtClosedFence = state.captureWatermarkCalls;
+    await suspend;
     await resume;
     await new Promise<void>((resolve) => setImmediate(resolve));
 
-    expect(state.drainCalls).toBeLessThanOrEqual(callsAtSuspend + 1);
+    expect(state.drainCalls).toBe(callsAtClosedFence);
+    expect(state.captureWatermarkCalls).toBe(capturesAtClosedFence);
     expect(token.processingStarted).toHaveBeenCalledTimes(1);
     expect(token.complete).not.toHaveBeenCalled();
     expect(token.retry).toHaveBeenCalledWith([message], "turn_aborted");
@@ -424,6 +516,98 @@ describe("claude-code-tui suspend queued recovery", () => {
     expect(token.complete).not.toHaveBeenCalled();
     expect(token.retry).toHaveBeenCalledTimes(1);
     expect(token.retry).toHaveBeenCalledWith([expect.objectContaining({ id: "m14" })], "turn_timeout");
+    await handler.shutdown();
+  });
+
+  it("retries without forwarding or completing when final-flush backlog reaches the turn deadline", async () => {
+    state.workingOrdinals.clear();
+    state.emitFromOrdinal = Number.POSITIVE_INFINITY;
+    state.drainResults.push({
+      entries: [
+        {
+          type: "assistant",
+          message: { content: [{ type: "text", text: "partial output before final backlog" }] },
+        },
+      ],
+      bytesRead: 1,
+      hasMore: false,
+      skippedOversizedLines: 0,
+    });
+    state.drainForever = true;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
+      if (state.drainCalls >= 3) return 600_000;
+      if (state.drainCalls >= 2) return 1_500;
+      return 0;
+    });
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+    const forwardResult = vi.fn(async () => undefined);
+    ctx.forwardResult = forwardResult;
+    const token = makeToken();
+    const message = makeMessage("m141", "idle then final backlog");
+
+    try {
+      await handler.resume(message, "existing-session", ctx, token);
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(state.drainCalls).toBe(3);
+    expect(forwardResult).not.toHaveBeenCalled();
+    expect(token.complete).not.toHaveBeenCalled();
+    expect(token.retry).toHaveBeenCalledTimes(1);
+    expect(token.retry).toHaveBeenCalledWith([message], "turn_timeout");
+    await handler.shutdown();
+  });
+
+  it("retries a queued suffix when its provider-entered prefix times out", async () => {
+    state.workingOrdinals.clear();
+    state.emitFromOrdinal = Number.POSITIVE_INFINITY;
+    state.drainResults.push({
+      entries: [
+        {
+          type: "assistant",
+          message: { content: [{ type: "text", text: "partial prefix output" }] },
+        },
+      ],
+      bytesRead: 1,
+      hasMore: false,
+      skippedOversizedLines: 0,
+    });
+    state.drainForever = true;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
+      if (state.drainCalls >= 3) return 600_000;
+      if (state.drainCalls >= 2) return 1_500;
+      return 0;
+    });
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+    const prefixToken = makeToken();
+    const queuedToken = makeToken();
+    const prefix = makeMessage("m142", "timeout prefix");
+    const queued = makeMessage("m143", "must not overtake prefix");
+
+    try {
+      const resume = handler.resume(prefix, "existing-session", ctx, prefixToken);
+      await waitFor(() => state.drainCalls >= 2);
+      expect(handler.inject(queued, queuedToken)).toEqual({ kind: "owned", mode: "queued" });
+      await resume;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(state.pasteTexts).toHaveLength(1);
+    expect(state.pasteTexts[0]).toContain("timeout prefix");
+    expect(state.pasteTexts[0]).not.toContain("must not overtake prefix");
+    expect(prefixToken.complete).not.toHaveBeenCalled();
+    expect(prefixToken.retry).toHaveBeenCalledTimes(1);
+    expect(prefixToken.retry).toHaveBeenCalledWith([prefix], "turn_timeout");
+    expect(queuedToken.processingStarted).not.toHaveBeenCalled();
+    expect(queuedToken.complete).not.toHaveBeenCalled();
+    expect(queuedToken.retry).toHaveBeenCalledTimes(1);
+    expect(queuedToken.retry).toHaveBeenCalledWith(queued, "tui_bootstrap_recovery_required");
     await handler.shutdown();
   });
 

--- a/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
+++ b/packages/client/src/__tests__/tui-suspend-queued-recovery.test.ts
@@ -3,14 +3,34 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatContext } from "../runtime/chat-context.js";
-import type { SessionContext, SessionMessage } from "../runtime/handler.js";
+import type { DeliveryToken, SessionContext, SessionMessage } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
+
+type MockDrainResult = {
+  entries: Array<{ type: string; message: { content: Array<{ type: string; text: string }> } }>;
+  bytesRead: number;
+  hasMore: boolean;
+  skippedOversizedLines: number;
+};
 
 const state = vi.hoisted(() => ({
   workspaceRoot: "",
   pasteTexts: [] as string[],
   lastPasteOrdinal: 0,
   emittedOrdinals: new Set<number>(),
+  emitFromOrdinal: 2,
+  workingOrdinals: new Set([1]),
+  tailerStartPositions: [] as string[],
+  callOrder: [] as string[],
+  discardStarted: false,
+  discardGate: null as Promise<void> | null,
+  discardError: null as Error | null,
+  createError: null as Error | null,
+  drainResults: [] as MockDrainResult[],
+  captureEnqueueResults: [] as MockDrainResult[],
+  drainCalls: 0,
+  drainCallsAtFirstCapture: null as number | null,
+  drainForever: false,
   chatContext: {
     chatId: "chat-tui-suspend-queued-recovery",
     title: "queued recovery",
@@ -59,13 +79,18 @@ vi.mock("../handlers/claude-executable.js", () => ({
 }));
 
 vi.mock("../handlers/claude-code-tui/tmux-session.js", () => ({
-  capturePane: vi.fn(async () => (state.lastPasteOrdinal === 1 ? "esc to interrupt" : "")),
+  capturePane: vi.fn(async () => {
+    state.drainCallsAtFirstCapture ??= state.drainCalls;
+    state.drainResults.push(...state.captureEnqueueResults.splice(0));
+    return state.workingOrdinals.has(state.lastPasteOrdinal) ? "esc to interrupt" : "";
+  }),
   deriveSessionName: vi.fn(() => "ftth-test-session"),
   killSession: vi.fn(async () => undefined),
   listOwnedSessions: vi.fn(async () => []),
   newSession: vi.fn(async () => undefined),
   ownedSessionPrefix: vi.fn(() => "ftth-test-"),
   pasteText: vi.fn(async (_sessionName: string, text: string) => {
+    state.callOrder.push("paste");
     state.pasteTexts.push(text);
     state.lastPasteOrdinal = state.pasteTexts.length;
   }),
@@ -76,25 +101,58 @@ vi.mock("../handlers/claude-code-tui/tmux-session.js", () => ({
 
 vi.mock("../handlers/claude-code-tui/transcript-tail.js", () => ({
   transcriptPathFor: vi.fn(() => "/tmp/fake-transcript.jsonl"),
-  TranscriptTailer: class {
-    drainEntries() {
+  TranscriptTailer: class MockTranscriptTailer {
+    static async create(_path: string, options: { startAt?: string } = {}) {
+      const startAt = options.startAt ?? "start";
+      state.tailerStartPositions.push(startAt);
+      state.callOrder.push(`create:${startAt}`);
+      if (state.createError) throw state.createError;
+      return new MockTranscriptTailer();
+    }
+
+    async discardToEnd() {
+      state.callOrder.push("discard:start");
+      state.discardStarted = true;
+      if (state.discardGate) await state.discardGate;
+      if (state.discardError) throw state.discardError;
+      state.callOrder.push("discard:end");
+    }
+
+    async captureWatermark() {
+      return 1;
+    }
+
+    async drainEntries() {
+      state.drainCalls += 1;
+      const queued = state.drainResults.shift();
+      if (queued) return queued;
+      if (state.drainForever) {
+        return { entries: [], bytesRead: 1, hasMore: true, skippedOversizedLines: 0 };
+      }
       const ordinal = state.lastPasteOrdinal;
-      if (ordinal < 2 || state.emittedOrdinals.has(ordinal)) return [];
+      if (ordinal < state.emitFromOrdinal || state.emittedOrdinals.has(ordinal)) {
+        return { entries: [], bytesRead: 0, hasMore: false, skippedOversizedLines: 0 };
+      }
       state.emittedOrdinals.add(ordinal);
-      return [
-        {
-          type: "assistant",
-          message: {
-            content: [{ type: "text", text: `reply ${ordinal}` }],
+      return {
+        entries: [
+          {
+            type: "assistant",
+            message: {
+              content: [{ type: "text", text: `reply ${ordinal}` }],
+            },
           },
-        },
-      ];
+        ],
+        bytesRead: 1,
+        hasMore: false,
+        skippedOversizedLines: 0,
+      };
     }
   },
 }));
 
 import { createClaudeCodeTuiHandler } from "../handlers/claude-code-tui/index.js";
-import { newSession } from "../handlers/claude-code-tui/tmux-session.js";
+import { killSession, newSession } from "../handlers/claude-code-tui/tmux-session.js";
 
 const AGENT_ID = "019eca71-0000-7000-8000-000000000001";
 const CHAT_ID = "chat-tui-suspend-queued-recovery";
@@ -111,7 +169,9 @@ function makeMessage(id: string, content: string): SessionMessage {
   };
 }
 
-function makeContext(opts: { formatInboundContent?: SessionContext["formatInboundContent"] } = {}): SessionContext {
+function makeContext(
+  opts: { formatInboundContent?: SessionContext["formatInboundContent"]; emitEvent?: SessionContext["emitEvent"] } = {},
+): SessionContext {
   const sendMessage = vi.fn().mockResolvedValue(undefined);
   const plumbing = mockCtxPlumbing({ sendMessage }, CHAT_ID);
   return {
@@ -128,11 +188,28 @@ function makeContext(opts: { formatInboundContent?: SessionContext["formatInboun
     chatId: CHAT_ID,
     log: () => {},
     recordProviderActivity: () => {},
-    emitEvent: () => {},
+    emitEvent: opts.emitEvent ?? (() => {}),
     ...plumbing,
     ...(opts.formatInboundContent ? { formatInboundContent: opts.formatInboundContent } : {}),
     finishTurn: vi.fn(plumbing.finishTurn),
     retryTurn: vi.fn(plumbing.retryTurn),
+  };
+}
+
+function makeToken(): DeliveryToken & {
+  processingStarted: ReturnType<typeof vi.fn>;
+  complete: ReturnType<typeof vi.fn>;
+  retry: ReturnType<typeof vi.fn>;
+} {
+  return {
+    processingStarted: vi.fn(() => state.callOrder.push("processingStarted")),
+    complete: vi.fn(async () => {
+      state.callOrder.push("complete");
+    }),
+    retry: vi.fn(() => {
+      state.callOrder.push("retry");
+    }),
+    terminalRejected: vi.fn(async () => {}),
   };
 }
 
@@ -150,6 +227,19 @@ beforeEach(() => {
   state.pasteTexts.length = 0;
   state.lastPasteOrdinal = 0;
   state.emittedOrdinals.clear();
+  state.emitFromOrdinal = 2;
+  state.workingOrdinals = new Set([1]);
+  state.tailerStartPositions.length = 0;
+  state.callOrder.length = 0;
+  state.discardStarted = false;
+  state.discardGate = null;
+  state.discardError = null;
+  state.createError = null;
+  state.drainResults.length = 0;
+  state.captureEnqueueResults.length = 0;
+  state.drainCalls = 0;
+  state.drainCallsAtFirstCapture = null;
+  state.drainForever = false;
 });
 
 afterEach(() => {
@@ -178,6 +268,205 @@ describe("claude-code-tui suspend queued recovery", () => {
 
     await handler.suspend();
     await start;
+    expect(state.tailerStartPositions).toEqual(["start"]);
+    await handler.shutdown();
+  });
+
+  it("initializes admin resume at EOF without discarding or pasting a turn", async () => {
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+
+    const result = await handler.resume(undefined, "existing-session", ctx, makeToken());
+
+    expect(typeof result === "string" ? result : result.sessionId).toBe("existing-session");
+    expect(state.tailerStartPositions).toEqual(["end"]);
+    expect(state.callOrder).toEqual(["create:end"]);
+    expect(state.pasteTexts).toEqual([]);
+    await handler.shutdown();
+  });
+
+  it("orders discard before processing and paste on a messageful resume", async () => {
+    state.workingOrdinals.clear();
+    state.emitFromOrdinal = 1;
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+    const token = makeToken();
+    const message = makeMessage("m10", "ordered resume");
+
+    const result = await handler.resume(message, "existing-session", ctx, token);
+
+    expect(typeof result === "string" ? null : result.route).toEqual({ kind: "owned", mode: "processing" });
+    expect(state.tailerStartPositions).toEqual(["end"]);
+    expect(state.callOrder.indexOf("discard:end")).toBeLessThan(state.callOrder.indexOf("processingStarted"));
+    expect(state.callOrder.indexOf("processingStarted")).toBeLessThan(state.callOrder.indexOf("paste"));
+    expect(token.complete).toHaveBeenCalledTimes(1);
+    expect(token.retry).not.toHaveBeenCalled();
+    await handler.shutdown();
+  });
+
+  it("retries without provider entry when suspend lands during async preflush", async () => {
+    let releaseDiscard!: () => void;
+    state.discardGate = new Promise<void>((resolve) => {
+      releaseDiscard = resolve;
+    });
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+    const token = makeToken();
+    const message = makeMessage("m11", "suspend during discard");
+
+    const resume = handler.resume(message, "existing-session", ctx, token);
+    await waitFor(() => state.discardStarted);
+    const suspend = handler.suspend();
+    releaseDiscard();
+    await suspend;
+    const result = await resume;
+
+    expect(typeof result === "string" ? null : result.route).toEqual({ kind: "owned", mode: "queued" });
+    expect(state.pasteTexts).toEqual([]);
+    expect(token.processingStarted).not.toHaveBeenCalled();
+    expect(token.complete).not.toHaveBeenCalled();
+    expect(token.retry).toHaveBeenCalledTimes(1);
+    expect(token.retry).toHaveBeenCalledWith([message], "tui_turn_stopped_before_paste");
+    await handler.shutdown();
+  });
+
+  it("retries exactly once when transcript preflush rejects even if error reporting also throws", async () => {
+    state.discardError = new Error("stat denied");
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext({
+      emitEvent: () => {
+        throw new Error("event sink unavailable");
+      },
+    });
+    const token = makeToken();
+    const message = makeMessage("m12", "discard failure");
+
+    const result = await handler.resume(message, "existing-session", ctx, token);
+
+    expect(typeof result === "string" ? null : result.route).toEqual({ kind: "owned", mode: "queued" });
+    expect(state.pasteTexts).toEqual([]);
+    expect(token.processingStarted).not.toHaveBeenCalled();
+    expect(token.complete).not.toHaveBeenCalled();
+    expect(token.retry).toHaveBeenCalledTimes(1);
+    expect(token.retry).toHaveBeenCalledWith([message], "tui_transcript_preflush_failed");
+    await handler.shutdown();
+  });
+
+  it("cleans the tmux session when resume EOF initialization fails", async () => {
+    state.createError = new Error("transcript stat failed");
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+
+    await expect(handler.resume(undefined, "existing-session", ctx, makeToken())).rejects.toThrow(
+      "transcript stat failed",
+    );
+    expect(state.tailerStartPositions).toEqual(["end"]);
+    expect(killSession).toHaveBeenCalledTimes(1);
+    expect(state.pasteTexts).toEqual([]);
+
+    await handler.shutdown();
+    expect(killSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("cooperatively stops a fixed-watermark backlog when the turn is aborted", async () => {
+    state.workingOrdinals.clear();
+    state.drainForever = true;
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+    const token = makeToken();
+    const message = makeMessage("m13", "abort backlog");
+
+    const resume = handler.resume(message, "existing-session", ctx, token);
+    await waitFor(() => state.drainCalls >= 3);
+    const callsAtSuspend = state.drainCalls;
+    await handler.suspend();
+    await resume;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(state.drainCalls).toBeLessThanOrEqual(callsAtSuspend + 1);
+    expect(token.processingStarted).toHaveBeenCalledTimes(1);
+    expect(token.complete).not.toHaveBeenCalled();
+    expect(token.retry).toHaveBeenCalledWith([message], "turn_aborted");
+    await handler.shutdown();
+  });
+
+  it("stops a continuously non-empty fixed watermark when the turn deadline expires", async () => {
+    state.workingOrdinals.clear();
+    state.drainResults.push({
+      entries: [
+        {
+          type: "assistant",
+          message: { content: [{ type: "text", text: "output before deadline" }] },
+        },
+      ],
+      bytesRead: 1,
+      hasMore: true,
+      skippedOversizedLines: 0,
+    });
+    state.drainForever = true;
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
+      now += 100_000;
+      return now;
+    });
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+    const token = makeToken();
+
+    try {
+      await handler.resume(makeMessage("m14", "deadline backlog"), "existing-session", ctx, token);
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(state.drainCalls).toBeGreaterThan(1);
+    expect(state.drainCalls).toBeLessThan(10);
+    expect(token.complete).not.toHaveBeenCalled();
+    expect(token.retry).toHaveBeenCalledTimes(1);
+    expect(token.retry).toHaveBeenCalledWith([expect.objectContaining({ id: "m14" })], "turn_timeout");
+    await handler.shutdown();
+  });
+
+  it("consumes every chunk added after pane idle below one final-flush watermark", async () => {
+    state.workingOrdinals.clear();
+    state.emitFromOrdinal = Number.POSITIVE_INFINITY;
+    state.drainResults.push({
+      entries: [
+        {
+          type: "assistant",
+          message: { content: [{ type: "text", text: "initial chunk" }] },
+        },
+      ],
+      bytesRead: 1,
+      hasMore: false,
+      skippedOversizedLines: 0,
+    });
+    state.captureEnqueueResults.push(
+      { entries: [], bytesRead: 1, hasMore: true, skippedOversizedLines: 0 },
+      { entries: [], bytesRead: 1, hasMore: true, skippedOversizedLines: 0 },
+      { entries: [], bytesRead: 1, hasMore: true, skippedOversizedLines: 0 },
+      {
+        entries: [
+          {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "final chunk" }] },
+          },
+        ],
+        bytesRead: 1,
+        hasMore: false,
+        skippedOversizedLines: 0,
+      },
+    );
+    const handler = createClaudeCodeTuiHandler({ workspaceRoot: state.workspaceRoot, clientId: "client-test" });
+    const ctx = makeContext();
+    const token = makeToken();
+
+    await handler.resume(makeMessage("m15", "large final flush"), "existing-session", ctx, token);
+
+    expect(state.drainCallsAtFirstCapture).toBe(1);
+    expect(state.drainCalls).toBeGreaterThanOrEqual(5);
+    expect(token.complete).toHaveBeenCalledTimes(1);
+    expect(token.retry).not.toHaveBeenCalled();
     await handler.shutdown();
   });
 

--- a/packages/client/src/__tests__/tui-transcript-tail.test.ts
+++ b/packages/client/src/__tests__/tui-transcript-tail.test.ts
@@ -1,8 +1,16 @@
-import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdtempSync, rmSync, truncateSync, writeFileSync } from "node:fs";
+import { type FileHandle, open as openFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { TranscriptTailer, transcriptPathFor } from "../handlers/claude-code-tui/transcript-tail.js";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import {
+  type RawTranscriptEntry,
+  TRANSCRIPT_MAX_LINE_BYTES,
+  TRANSCRIPT_READ_CHUNK_BYTES,
+  type TranscriptDrainResult,
+  TranscriptTailer,
+  transcriptPathFor,
+} from "../handlers/claude-code-tui/transcript-tail.js";
 
 describe("transcriptPathFor", () => {
   it("replaces forward-slashes and dots with dashes and prefixes with dash", () => {
@@ -17,66 +25,350 @@ describe("transcriptPathFor", () => {
   });
 });
 
+type FileHandleReadTarget = { read: FileHandle["read"] };
+
+function hasFileHandleRead(value: unknown): value is FileHandleReadTarget {
+  return typeof value === "object" && value !== null && "read" in value && typeof value.read === "function";
+}
+
+function transcriptLine(type: string, content: string): string {
+  return JSON.stringify({ type, message: { content } });
+}
+
+function exactTranscriptLine(byteLength: number): string {
+  const empty = transcriptLine("user", "");
+  const fillerBytes = byteLength - Buffer.byteLength(empty);
+  if (fillerBytes < 0) throw new Error(`line limit ${byteLength} is too small for the fixture`);
+  const line = transcriptLine("user", "x".repeat(fillerBytes));
+  if (Buffer.byteLength(line) !== byteLength) throw new Error("fixture did not reach the requested byte length");
+  return line;
+}
+
+type DrainSummary = {
+  entries: RawTranscriptEntry[];
+  results: TranscriptDrainResult[];
+  skippedOversizedLines: number;
+};
+
+async function drainWatermark(tailer: TranscriptTailer, watermark: number): Promise<DrainSummary> {
+  const entries: RawTranscriptEntry[] = [];
+  const results: TranscriptDrainResult[] = [];
+  let skippedOversizedLines = 0;
+
+  for (let iteration = 0; iteration < 10_000; iteration += 1) {
+    const result = await tailer.drainEntries(watermark);
+    results.push(result);
+    entries.push(...result.entries);
+    skippedOversizedLines += result.skippedOversizedLines;
+    if (result.bytesRead === 0 || !result.hasMore) return { entries, results, skippedOversizedLines };
+  }
+  throw new Error("tailer did not finish its fixed watermark");
+}
+
+async function drainCurrent(tailer: TranscriptTailer): Promise<DrainSummary> {
+  return drainWatermark(tailer, await tailer.captureWatermark());
+}
+
 describe("TranscriptTailer", () => {
   let testDir: string;
   let filePath: string;
+  let readSpy: MockInstance;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     testDir = mkdtempSync(join(tmpdir(), "tui-tail-"));
     filePath = join(testDir, "session.jsonl");
+
+    // Spy on the real FileHandle prototype so assertions observe the actual
+    // fs content-read calls and requested byte lengths used by the tailer.
+    const probePath = join(testDir, "read-probe");
+    writeFileSync(probePath, "");
+    const handle = await openFile(probePath, "r");
+    const prototype: unknown = Object.getPrototypeOf(handle);
+    await handle.close();
+    if (!hasFileHandleRead(prototype)) throw new Error("FileHandle.read prototype is unavailable");
+    readSpy = vi.spyOn(prototype, "read");
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  it("returns empty when the file does not exist yet", () => {
-    const tailer = new TranscriptTailer(filePath);
-    expect(tailer.drainEntries()).toEqual([]);
+  function requestedReadLengths(): number[] {
+    return readSpy.mock.calls.flatMap((call) => (typeof call[2] === "number" ? [call[2]] : []));
+  }
+
+  it("returns empty when the file does not exist yet", async () => {
+    const tailer = await TranscriptTailer.create(filePath);
+    expect((await drainCurrent(tailer)).entries).toEqual([]);
+    expect(readSpy).not.toHaveBeenCalled();
   });
 
-  it("returns only new entries on each drain", () => {
-    mkdirSync(testDir, { recursive: true });
+  it("returns only new entries on each drain", async () => {
     writeFileSync(filePath, "");
-    const tailer = new TranscriptTailer(filePath);
+    const tailer = await TranscriptTailer.create(filePath);
 
-    appendFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "first" } })}\n`);
-    const first = tailer.drainEntries();
-    expect(first).toHaveLength(1);
-    expect(first[0]).toMatchObject({ type: "user" });
+    appendFileSync(filePath, `${transcriptLine("user", "first")}\n`);
+    const first = await drainCurrent(tailer);
+    expect(first.entries).toHaveLength(1);
+    expect(first.entries[0]).toMatchObject({ type: "user" });
 
-    appendFileSync(filePath, `${JSON.stringify({ type: "assistant", message: { content: [] } })}\n`);
-    const second = tailer.drainEntries();
-    expect(second).toHaveLength(1);
-    expect(second[0]).toMatchObject({ type: "assistant" });
+    appendFileSync(filePath, `${transcriptLine("assistant", "second")}\n`);
+    const second = await drainCurrent(tailer);
+    expect(second.entries).toHaveLength(1);
+    expect(second.entries[0]).toMatchObject({ type: "assistant" });
 
-    expect(tailer.drainEntries()).toEqual([]);
+    expect((await drainCurrent(tailer)).entries).toEqual([]);
   });
 
-  it("buffers partial lines across reads", () => {
+  it("buffers partial lines across separate appends", async () => {
     writeFileSync(filePath, "");
-    const tailer = new TranscriptTailer(filePath);
+    const tailer = await TranscriptTailer.create(filePath);
 
     const piece1 = '{"type":"user","message":{"content":"half';
     const piece2 = ' message"}}\n';
     appendFileSync(filePath, piece1);
-    expect(tailer.drainEntries()).toEqual([]);
+    expect((await drainCurrent(tailer)).entries).toEqual([]);
 
     appendFileSync(filePath, piece2);
-    const entries = tailer.drainEntries();
+    const entries = (await drainCurrent(tailer)).entries;
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ type: "user", message: { content: "half message" } });
   });
 
-  it("tolerates malformed lines without failing the drain", () => {
-    writeFileSync(filePath, "");
-    const tailer = new TranscriptTailer(filePath);
+  it("tolerates blank and malformed lines without failing the drain", async () => {
+    writeFileSync(filePath, `\nthis is not json\n${transcriptLine("user", "ok")}\n`);
+    const tailer = await TranscriptTailer.create(filePath);
 
-    appendFileSync(filePath, "this is not json\n");
-    appendFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "ok" } })}\n`);
-
-    const entries = tailer.drainEntries();
+    const entries = (await drainCurrent(tailer)).entries;
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ type: "user" });
+  });
+
+  it("baselines a large resumed transcript at EOF with zero content reads, allocation, or parse", async () => {
+    writeFileSync(filePath, "");
+    const historyBytes = 32 * 1024 * 1024;
+    truncateSync(filePath, historyBytes);
+    const boundaryHandle = await openFile(filePath, "r+");
+    await boundaryHandle.write(Buffer.from("\n"), 0, 1, historyBytes - 1);
+    await boundaryHandle.close();
+    readSpy.mockClear();
+    const allocationSpy = vi.spyOn(Buffer, "allocUnsafe");
+    const parseSpy = vi.spyOn(JSON, "parse");
+
+    const tailer = await TranscriptTailer.create(filePath, { startAt: "end" });
+    await tailer.discardToEnd();
+    expect((await drainCurrent(tailer)).entries).toEqual([]);
+
+    expect(readSpy).not.toHaveBeenCalled();
+    expect(allocationSpy).not.toHaveBeenCalled();
+    expect(parseSpy).not.toHaveBeenCalled();
+
+    appendFileSync(filePath, `${transcriptLine("assistant", "new after resume")}\n`);
+    const drained = await drainCurrent(tailer);
+    expect(drained.entries).toEqual([{ type: "assistant", message: { content: "new after resume" } }]);
+    expect(requestedReadLengths()).toEqual([
+      1,
+      Buffer.byteLength(`${transcriptLine("assistant", "new after resume")}\n`),
+    ]);
+  });
+
+  it("drops a suffix when an end-started resume baseline itself is a stale partial record", async () => {
+    writeFileSync(filePath, " ");
+    const tailer = await TranscriptTailer.create(filePath, { startAt: "end" });
+    await tailer.discardToEnd();
+
+    const staleSuffix = transcriptLine("assistant", "resumed stale suffix");
+    const fresh = transcriptLine("assistant", "fresh");
+    appendFileSync(filePath, `${staleSuffix}\n${fresh}\n`);
+
+    expect((await drainCurrent(tailer)).entries).toEqual([{ type: "assistant", message: { content: "fresh" } }]);
+  });
+
+  it("treats a missing end-started file as an EOF-zero baseline", async () => {
+    const tailer = await TranscriptTailer.create(filePath, { startAt: "end" });
+    writeFileSync(filePath, `${transcriptLine("assistant", "created later")}\n`);
+
+    expect((await drainCurrent(tailer)).entries).toEqual([
+      { type: "assistant", message: { content: "created later" } },
+    ]);
+  });
+
+  it("uses bounded reads against a fixed watermark and defers concurrent appends", async () => {
+    const maxReadBytes = 37;
+    const initialLines = Array.from({ length: 12 }, (_, index) => transcriptLine("user", `initial-${index}`));
+    writeFileSync(filePath, `${initialLines.join("\n")}\n`);
+    const tailer = await TranscriptTailer.create(filePath, { maxReadBytes });
+    const watermark = await tailer.captureWatermark();
+
+    const first = await tailer.drainEntries(watermark);
+    const lateLine = transcriptLine("assistant", "late-watermark");
+    appendFileSync(filePath, `${lateLine}\n`);
+    const remainder = await drainWatermark(tailer, watermark);
+    const initialEntries = [...first.entries, ...remainder.entries];
+
+    expect(initialEntries.map((entry) => entry.message?.content)).toEqual(
+      initialLines.map((_, index) => `initial-${index}`),
+    );
+    expect(initialEntries.some((entry) => entry.message?.content === "late-watermark")).toBe(false);
+    expect(requestedReadLengths().length).toBeGreaterThan(3);
+    expect(Math.max(...requestedReadLengths())).toBeLessThanOrEqual(maxReadBytes);
+
+    expect((await drainCurrent(tailer)).entries).toEqual([
+      { type: "assistant", message: { content: "late-watermark" } },
+    ]);
+  });
+
+  it("preserves one JSON record and UTF-8 code point across internal chunks", async () => {
+    const content = `prefix-${"x".repeat(80)}-🙂-suffix`;
+    const line = transcriptLine("assistant", content);
+    const bytes = Buffer.from(`${line}\n`);
+    const emojiOffset = bytes.indexOf(Buffer.from("🙂"));
+    const maxReadBytes = emojiOffset + 1;
+    writeFileSync(filePath, bytes);
+    const tailer = await TranscriptTailer.create(filePath, { maxReadBytes });
+
+    const drained = await drainCurrent(tailer);
+    expect(drained.results.length).toBeGreaterThan(1);
+    expect(drained.entries).toEqual([{ type: "assistant", message: { content } }]);
+  });
+
+  it("keeps continuous partial appends ordered and exactly once", async () => {
+    const lineA = transcriptLine("user", "A");
+    const lineB = transcriptLine("user", "B");
+    const lineC = transcriptLine("user", "C");
+    const lineD = transcriptLine("user", "D");
+    const splitB = Math.floor(lineB.length / 2);
+    const splitD = Math.floor(lineD.length / 2);
+    writeFileSync(filePath, `${lineA}\n${lineB.slice(0, splitB)}`);
+    const tailer = await TranscriptTailer.create(filePath, { maxReadBytes: 19 });
+
+    const observed: RawTranscriptEntry[] = [];
+    observed.push(...(await drainCurrent(tailer)).entries);
+    appendFileSync(filePath, `${lineB.slice(splitB)}\n${lineC}\n${lineD.slice(0, splitD)}`);
+    observed.push(...(await drainCurrent(tailer)).entries);
+    appendFileSync(filePath, `${lineD.slice(splitD)}\n`);
+    observed.push(...(await drainCurrent(tailer)).entries);
+
+    expect(observed.map((entry) => entry.message?.content)).toEqual(["A", "B", "C", "D"]);
+  });
+
+  it("accepts an exact-limit line and recovers after an oversized line in the same chunk", async () => {
+    const maxLineBytes = 128;
+    const exactLine = exactTranscriptLine(maxLineBytes);
+    const nextLine = transcriptLine("assistant", "after oversize");
+    writeFileSync(filePath, `${exactLine}\n${"x".repeat(maxLineBytes + 1)}\n${nextLine}\n`);
+    const tailer = await TranscriptTailer.create(filePath, { maxLineBytes, maxReadBytes: 512 });
+
+    const drained = await drainCurrent(tailer);
+    expect(drained.skippedOversizedLines).toBe(1);
+    expect(drained.entries.map((entry) => entry.message?.content)).toEqual([
+      "x".repeat(maxLineBytes - Buffer.byteLength(transcriptLine("user", ""))),
+      "after oversize",
+    ]);
+  });
+
+  it("counts one unterminated oversized line once across chunks and recovers after its newline", async () => {
+    const maxLineBytes = 64;
+    writeFileSync(filePath, "x".repeat(maxLineBytes * 3));
+    const tailer = await TranscriptTailer.create(filePath, { maxLineBytes, maxReadBytes: 11 });
+
+    const oversized = await drainCurrent(tailer);
+    expect(oversized.entries).toEqual([]);
+    expect(oversized.skippedOversizedLines).toBe(1);
+
+    appendFileSync(filePath, `\n${transcriptLine("assistant", "recovered")}\n`);
+    const recovered = await drainCurrent(tailer);
+    expect(recovered.skippedOversizedLines).toBe(0);
+    expect(recovered.entries).toEqual([{ type: "assistant", message: { content: "recovered" } }]);
+  });
+
+  it("discards stale complete and partial data without content I/O before the next turn", async () => {
+    const stalePrefix = '{"type":"assistant","message":{"content":"stale';
+    writeFileSync(filePath, stalePrefix);
+    const tailer = await TranscriptTailer.create(filePath, { maxReadBytes: 17 });
+    expect((await drainCurrent(tailer)).entries).toEqual([]);
+
+    readSpy.mockClear();
+    const allocationSpy = vi.spyOn(Buffer, "allocUnsafe");
+    const parseSpy = vi.spyOn(JSON, "parse");
+    await tailer.discardToEnd();
+    expect(readSpy).not.toHaveBeenCalled();
+    expect(allocationSpy).not.toHaveBeenCalled();
+    expect(parseSpy).not.toHaveBeenCalled();
+
+    appendFileSync(filePath, ` suffix"}}\n${transcriptLine("assistant", "fresh")}\n`);
+    const drained = await drainCurrent(tailer);
+    expect(drained.entries).toEqual([{ type: "assistant", message: { content: "fresh" } }]);
+  });
+
+  it("drops a stale partial suffix even when that record grew before the metadata-only discard", async () => {
+    writeFileSync(filePath, " ");
+    const tailer = await TranscriptTailer.create(filePath);
+    expect((await drainCurrent(tailer)).entries).toEqual([]);
+
+    // More stale bytes arrive before the preflush, but the record remains
+    // unterminated. The stat-only discard cannot inspect them to decide
+    // whether the old line completed.
+    appendFileSync(filePath, "  ");
+    await tailer.discardToEnd();
+
+    const staleSuffix = transcriptLine("assistant", "stale suffix");
+    const fresh = transcriptLine("assistant", "fresh");
+    appendFileSync(filePath, `${staleSuffix}\n${fresh}\n`);
+    expect((await drainCurrent(tailer)).entries).toEqual([{ type: "assistant", message: { content: "fresh" } }]);
+  });
+
+  it("uses the EOF byte when a completed stale line is followed by another stale partial", async () => {
+    writeFileSync(filePath, " ");
+    const tailer = await TranscriptTailer.create(filePath);
+    expect((await drainCurrent(tailer)).entries).toEqual([]);
+
+    appendFileSync(filePath, "\n ");
+    await tailer.discardToEnd();
+
+    const staleSuffix = transcriptLine("assistant", "second stale suffix");
+    const fresh = transcriptLine("assistant", "fresh");
+    appendFileSync(filePath, `${staleSuffix}\n${fresh}\n`);
+    expect((await drainCurrent(tailer)).entries).toEqual([{ type: "assistant", message: { content: "fresh" } }]);
+  });
+
+  it("detects an unobserved stale partial appended after the previous clean drain", async () => {
+    writeFileSync(filePath, `${transcriptLine("assistant", "previous")}\n`);
+    const tailer = await TranscriptTailer.create(filePath);
+    expect((await drainCurrent(tailer)).entries).toHaveLength(1);
+
+    appendFileSync(filePath, " ");
+    await tailer.discardToEnd();
+
+    const staleSuffix = transcriptLine("assistant", "unobserved stale suffix");
+    const fresh = transcriptLine("assistant", "fresh");
+    appendFileSync(filePath, `${staleSuffix}\n${fresh}\n`);
+    expect((await drainCurrent(tailer)).entries).toEqual([{ type: "assistant", message: { content: "fresh" } }]);
+  });
+
+  it("keeps the first fresh record when the stale partial completed before discard", async () => {
+    const stalePrefix = '{"type":"assistant","message":{"content":"stale';
+    writeFileSync(filePath, stalePrefix);
+    const tailer = await TranscriptTailer.create(filePath, { maxReadBytes: 19 });
+    expect((await drainCurrent(tailer)).entries).toEqual([]);
+
+    appendFileSync(filePath, ' completed"}}\n');
+    readSpy.mockClear();
+    await tailer.discardToEnd();
+    expect(readSpy).not.toHaveBeenCalled();
+
+    appendFileSync(filePath, `${transcriptLine("assistant", "fresh")}\n`);
+    expect((await drainCurrent(tailer)).entries).toEqual([{ type: "assistant", message: { content: "fresh" } }]);
+    expect(requestedReadLengths()[0]).toBe(1);
+  });
+
+  it("rejects test overrides that would exceed the production safety bounds", async () => {
+    await expect(TranscriptTailer.create(filePath, { maxReadBytes: TRANSCRIPT_READ_CHUNK_BYTES + 1 })).rejects.toThrow(
+      RangeError,
+    );
+    await expect(TranscriptTailer.create(filePath, { maxLineBytes: TRANSCRIPT_MAX_LINE_BYTES + 1 })).rejects.toThrow(
+      RangeError,
+    );
   });
 });

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -147,7 +147,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
   let cwd: string | null = null;
   let tmuxSessionName: string | null = null;
   let transcriptTailer: TranscriptTailer | null = null;
-  let currentTurnPromise: Promise<void> | null = null;
+  let currentTurnPromise: Promise<unknown> | null = null;
   const lifecycleFence = new TuiLifecycleFence();
   let turnAborted = false;
   // True for the whole span a turn is being prepared/run — start/resume
@@ -309,13 +309,15 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     tmuxSessionName = sessionName;
     try {
       await waitForReady({ name: sessionName, timeoutMs: READY_TIMEOUT_MS });
+      transcriptTailer = await TranscriptTailer.create(transcriptPathFor(cwd, sessionId), {
+        startAt: resumeSessionId === null ? "start" : "end",
+      });
     } catch (err) {
       await killSession(sessionName).catch(() => {});
       tmuxSessionName = null;
+      transcriptTailer = null;
       throw err;
     }
-
-    transcriptTailer = new TranscriptTailer(transcriptPathFor(cwd, sessionId));
     return sessionId;
   }
 
@@ -377,11 +379,25 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     turnProcessor = null;
   }
 
-  async function drainAndConsume(sessionCtx: SessionContext, state: TurnState): Promise<void> {
-    if (!transcriptTailer) return;
-    for (const entry of transcriptTailer.drainEntries()) {
-      consumeEntry(entry, sessionCtx, state);
+  async function drainAndConsume(sessionCtx: SessionContext, state: TurnState, deadline: number): Promise<boolean> {
+    if (!transcriptTailer) return true;
+    const watermark = await transcriptTailer.captureWatermark();
+    while (!turnAborted && !lifecycleFence.stopRequested && Date.now() < deadline) {
+      const drained = await transcriptTailer.drainEntries(watermark);
+      for (const entry of drained.entries) {
+        consumeEntry(entry, sessionCtx, state);
+      }
+      if (drained.skippedOversizedLines > 0) {
+        sessionCtx.log(`tui transcript skipped ${drained.skippedOversizedLines} oversized JSONL record(s)`);
+      }
+      if (!drained.hasMore) return true;
+      if (drained.bytesRead === 0) return false;
+
+      // Keep a large but finite watermark cooperative with pane polling,
+      // suspend, and the turn deadline.
+      await new Promise<void>((resolve) => setImmediate(resolve));
     }
+    return false;
   }
 
   async function runTurn(
@@ -389,11 +405,10 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     sessionCtx: SessionContext,
     messages: readonly SessionMessage[],
     token: DeliveryToken,
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!tmuxSessionName || !transcriptTailer) {
       throw new Error("runTurn called before session was prepared");
     }
-    token.processingStarted(messages);
     turnAborted = false;
 
     const state: TurnState = { finalTexts: [] };
@@ -402,20 +417,50 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     let everSawWorking = false;
     let brokeOnIdle = false;
 
+    // Everything present before paste belongs to an earlier turn. Move the
+    // baseline with metadata only: resume must never read/parse its history.
+    // This await introduces a lifecycle interleaving point, so re-check the
+    // stop fence before handing the message to the provider.
     try {
-      // Pre-flush whatever's already in the transcript (the prior turn's
-      // tail end) so it doesn't pollute this turn's text accumulation.
-      transcriptTailer.drainEntries();
+      await transcriptTailer.discardToEnd();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      sessionCtx.log(`tui transcript preflush failed: ${message}`);
+      try {
+        sessionCtx.emitEvent({
+          kind: "error",
+          payload: { source: "runtime", message: `Transcript preflush failed: ${message}` },
+        });
+      } catch (emitError) {
+        sessionCtx.log(
+          `tui transcript preflush error event failed: ${emitError instanceof Error ? emitError.message : String(emitError)}`,
+        );
+      }
+      token.retry(messages, "tui_transcript_preflush_failed");
+      return false;
+    }
+    if (turnAborted || lifecycleFence.stopRequested) {
+      token.retry(messages, "tui_turn_stopped_before_paste");
+      return false;
+    }
+    token.processingStarted(messages);
 
+    try {
       await pasteText(tmuxSessionName, text);
       sessionCtx.recordProviderActivity();
 
       const startTs = Date.now();
-      while (Date.now() - startTs < TURN_TIMEOUT_MS) {
+      const turnDeadline = startTs + TURN_TIMEOUT_MS;
+      while (Date.now() < turnDeadline) {
         if (turnAborted) break;
         sessionCtx.recordProviderActivity();
 
-        await drainAndConsume(sessionCtx, state);
+        const caughtUp = await drainAndConsume(sessionCtx, state, turnDeadline);
+        if (turnAborted || lifecycleFence.stopRequested) break;
+        // An idle pane is not a clean completion while a fixed transcript
+        // watermark still has unread bytes at the absolute turn deadline.
+        // Settling here would ACK partial output and lose the remainder.
+        if (!caughtUp && Date.now() >= turnDeadline) break;
 
         const pane = await capturePane(tmuxSessionName);
         const working = pane.includes(WORKING_MARKER);
@@ -431,10 +476,13 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           // assistant_text block to the transcript after the working
           // marker disappears.
           const graceUntil = Date.now() + TURN_GRACE_MS;
+          let graceCaughtUp = true;
           while (Date.now() < graceUntil) {
-            await drainAndConsume(sessionCtx, state);
+            graceCaughtUp = await drainAndConsume(sessionCtx, state, Math.min(graceUntil, turnDeadline));
+            if (turnAborted || lifecycleFence.stopRequested) break;
             await sleep(150);
           }
+          if (!graceCaughtUp && Date.now() >= turnDeadline) break;
           brokeOnIdle = true;
           break;
         }
@@ -443,7 +491,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       }
 
       // One last pass in case the timeout-or-break left entries behind.
-      await drainAndConsume(sessionCtx, state);
+      await drainAndConsume(sessionCtx, state, turnDeadline);
 
       // Loop hit the TURN_TIMEOUT ceiling (not a clean idle break, not an
       // explicit abort): claude may still be working. Interrupt it so its
@@ -517,6 +565,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       token.retry(messages, disposition.action.reason);
     }
     resetProcessor();
+    return true;
   }
 
   /**
@@ -698,13 +747,17 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
             deliveryToken.retry(message, "tui_start_stopped_before_turn");
             return hasExplicitDeliveryToken ? { sessionId, route: { kind: "owned", mode: "queued" } } : sessionId;
           }
-          currentTurnPromise = runTurn(inputText, sessionCtx, [message], deliveryToken);
+          const turnPromise = runTurn(inputText, sessionCtx, [message], deliveryToken);
+          currentTurnPromise = turnPromise;
+          let enteredProvider: boolean;
           try {
-            await currentTurnPromise;
+            enteredProvider = await turnPromise;
           } finally {
             currentTurnPromise = null;
           }
-          return hasExplicitDeliveryToken ? { sessionId, route: { kind: "owned", mode: "processing" } } : sessionId;
+          return hasExplicitDeliveryToken
+            ? { sessionId, route: { kind: "owned", mode: enteredProvider ? "processing" : "queued" } }
+            : sessionId;
         } finally {
           turnRunning = false;
           // Drain any messages injected during bootstrap / the first turn.
@@ -763,11 +816,18 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
                 ? { sessionId: restartedId, route: { kind: "owned", mode: "queued" } }
                 : restartedId;
             }
-            currentTurnPromise = runTurn(inputText, sessionCtx, [message], deliveryToken);
+            const turnPromise = runTurn(inputText, sessionCtx, [message], deliveryToken);
+            currentTurnPromise = turnPromise;
+            let enteredProvider: boolean;
             try {
-              await currentTurnPromise;
+              enteredProvider = await turnPromise;
             } finally {
               currentTurnPromise = null;
+            }
+            if (!enteredProvider) {
+              return hasExplicitDeliveryToken
+                ? { sessionId: restartedId, route: { kind: "owned", mode: "queued" } }
+                : restartedId;
             }
           }
           return hasExplicitDeliveryToken

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -336,6 +336,13 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     finalTexts: string[];
   };
 
+  type TurnResult = {
+    /** Whether this delivery crossed the processing/paste boundary. */
+    enteredProvider: boolean;
+    /** Whether later handler-local deliveries may safely overtake this turn. */
+    canPump: boolean;
+  };
+
   function consumeEntry(entry: RawTranscriptEntry, sessionCtx: SessionContext, state: TurnState): void {
     // Feed the shared processor — it emits all the session events we'd
     // otherwise have to reimplement (assistant_text / thinking / tool_call
@@ -381,6 +388,10 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
 
   async function drainAndConsume(sessionCtx: SessionContext, state: TurnState, deadline: number): Promise<boolean> {
     if (!transcriptTailer) return true;
+    // Do not start a new metadata or content I/O operation after the lifecycle
+    // fence or this drain's deadline has already closed. Returning false is
+    // conservative: without a fresh watermark we cannot certify catch-up.
+    if (turnAborted || lifecycleFence.stopRequested || Date.now() >= deadline) return false;
     const watermark = await transcriptTailer.captureWatermark();
     while (!turnAborted && !lifecycleFence.stopRequested && Date.now() < deadline) {
       const drained = await transcriptTailer.drainEntries(watermark);
@@ -405,7 +416,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     sessionCtx: SessionContext,
     messages: readonly SessionMessage[],
     token: DeliveryToken,
-  ): Promise<boolean> {
+  ): Promise<TurnResult> {
     if (!tmuxSessionName || !transcriptTailer) {
       throw new Error("runTurn called before session was prepared");
     }
@@ -437,11 +448,11 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         );
       }
       token.retry(messages, "tui_transcript_preflush_failed");
-      return false;
+      return { enteredProvider: false, canPump: false };
     }
     if (turnAborted || lifecycleFence.stopRequested) {
       token.retry(messages, "tui_turn_stopped_before_paste");
-      return false;
+      return { enteredProvider: false, canPump: false };
     }
     token.processingStarted(messages);
 
@@ -490,8 +501,11 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         await sleep(TURN_POLL_MS);
       }
 
-      // One last pass in case the timeout-or-break left entries behind.
-      await drainAndConsume(sessionCtx, state, turnDeadline);
+      // One last fixed-watermark pass in case the timeout-or-break left entries
+      // behind. Pane idle is only a clean completion when this pass catches up;
+      // otherwise forwarding/ACKing partial output would permanently lose the
+      // unread tail.
+      const finalCaughtUp = await drainAndConsume(sessionCtx, state, turnDeadline);
 
       // Loop hit the TURN_TIMEOUT ceiling (not a clean idle break, not an
       // explicit abort): claude may still be working. Interrupt it so its
@@ -500,7 +514,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       // `turn_end: error`, stays un-acked (so the inbox entries are redelivered
       // for a real retry instead of being silently consumed), and settles the
       // runtime into `error` (see resolveTurnDisposition).
-      if (!brokeOnIdle && !turnAborted) {
+      if ((!brokeOnIdle || !finalCaughtUp) && !turnAborted) {
         timedOut = true;
         sessionCtx.log(`tui turn exceeded ${TURN_TIMEOUT_MS}ms without completing; interrupting claude`);
         try {
@@ -559,13 +573,15 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     // withholds the ack so the message gets a real retry.
     const disposition = resolveTurnDisposition({ aborted: turnAborted, timedOut, turnFailed, forwardFailed });
     sessionCtx.emitEvent({ kind: "turn_end", payload: { status: disposition.status } });
+    let canPump = false;
     if (disposition.action.kind === "complete") {
       await token.complete(messages, disposition.action.outcome);
+      canPump = true;
     } else {
       token.retry(messages, disposition.action.reason);
     }
     resetProcessor();
-    return true;
+    return { enteredProvider: true, canPump };
   }
 
   /**
@@ -588,6 +604,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
     const token = drained[0]?.token;
     if (!token) return;
     turnRunning = true;
+    let queuedTurnCanPump = false;
     const promise = (async () => {
       const inputs: string[] = [];
       let hadFormatFailure = false;
@@ -611,7 +628,8 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         retryDrainedMessagesForRecovery(sessionCtx, drained, "tui_queued_turn_format_failed");
         return;
       }
-      await runTurn(inputs.join("\n\n"), sessionCtx, messages, token);
+      const result = await runTurn(inputs.join("\n\n"), sessionCtx, messages, token);
+      queuedTurnCanPump = result.canPump;
     })();
     currentTurnPromise = promise;
     void promise
@@ -620,6 +638,11 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         retryDrainedMessagesForRecovery(sessionCtx, drained, "tui_queued_turn_failed");
       })
       .finally(() => {
+        // Any retryable prefix (whether pre-provider or after a timeout/abort)
+        // puts this chat into inbox recovery. Retry every later delivery
+        // already accepted into this handler before clearing the serialisation
+        // gate, so no scheduled pump can overtake that prefix.
+        if (!queuedTurnCanPump) retryQueuedMessages("tui_queued_recovery_required");
         turnRunning = false;
         currentTurnPromise = null;
         // Drain anything injected while this turn ran. setImmediate keeps the
@@ -703,6 +726,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         // the session is still being prepared queues instead of racing pump()
         // into a second turn the instant startClaude sets tmuxSessionName.
         turnRunning = true;
+        let bootstrapCanPump = false;
         try {
           await orphanSweep(clientId);
           ctx = sessionCtx;
@@ -749,16 +773,18 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
           }
           const turnPromise = runTurn(inputText, sessionCtx, [message], deliveryToken);
           currentTurnPromise = turnPromise;
-          let enteredProvider: boolean;
+          let turnResult: TurnResult;
           try {
-            enteredProvider = await turnPromise;
+            turnResult = await turnPromise;
           } finally {
             currentTurnPromise = null;
           }
+          bootstrapCanPump = turnResult.canPump;
           return hasExplicitDeliveryToken
-            ? { sessionId, route: { kind: "owned", mode: enteredProvider ? "processing" : "queued" } }
+            ? { sessionId, route: { kind: "owned", mode: turnResult.enteredProvider ? "processing" : "queued" } }
             : sessionId;
         } finally {
+          if (!bootstrapCanPump) retryQueuedMessages("tui_bootstrap_recovery_required");
           turnRunning = false;
           // Drain any messages injected during bootstrap / the first turn.
           setImmediate(pump);
@@ -771,6 +797,7 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
         const hasExplicitDeliveryToken = token !== undefined;
         const deliveryToken = token ?? deliveryTokenFromSessionContext(sessionCtx);
         turnRunning = true;
+        let bootstrapCanPump = false;
         try {
           await orphanSweep(clientId);
           ctx = sessionCtx;
@@ -818,22 +845,28 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
             }
             const turnPromise = runTurn(inputText, sessionCtx, [message], deliveryToken);
             currentTurnPromise = turnPromise;
-            let enteredProvider: boolean;
+            let turnResult: TurnResult;
             try {
-              enteredProvider = await turnPromise;
+              turnResult = await turnPromise;
             } finally {
               currentTurnPromise = null;
             }
-            if (!enteredProvider) {
+            bootstrapCanPump = turnResult.canPump;
+            if (!turnResult.enteredProvider) {
               return hasExplicitDeliveryToken
                 ? { sessionId: restartedId, route: { kind: "owned", mode: "queued" } }
                 : restartedId;
             }
+          } else {
+            // Administrative resume has no provider turn or failed inbox
+            // prefix; queued deliveries may run once bootstrap completes.
+            bootstrapCanPump = true;
           }
           return hasExplicitDeliveryToken
             ? { sessionId: restartedId, route: message ? { kind: "owned", mode: "processing" } : null }
             : restartedId;
         } finally {
+          if (!bootstrapCanPump) retryQueuedMessages("tui_bootstrap_recovery_required");
           turnRunning = false;
           setImmediate(pump);
         }

--- a/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
+++ b/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
@@ -1,6 +1,21 @@
-import { closeSync, existsSync, openSync, readSync, realpathSync, statSync } from "node:fs";
+import { realpathSync } from "node:fs";
+import { type FileHandle, open, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+
+/** Maximum content bytes read by one {@link TranscriptTailer.drainEntries} call. */
+export const TRANSCRIPT_READ_CHUNK_BYTES = 64 * 1024;
+
+/**
+ * Maximum bytes retained for one incomplete JSONL record.
+ *
+ * This is a First Tree ingestion safety limit, not a guarantee made by the
+ * provider. A larger record is skipped through its newline so a corrupt or
+ * unterminated transcript line cannot grow one runtime session without bound.
+ */
+export const TRANSCRIPT_MAX_LINE_BYTES = 8 * 1024 * 1024;
+
+const NEWLINE_BYTE = 0x0a;
 
 /**
  * Resolve Claude Code's per-session transcript path.
@@ -17,11 +32,10 @@ import { join, resolve } from "node:path";
  * even when the caller's `cwd` argument still contains an unresolved
  * symlink component. Falls back to the input on realpath errors so the
  * tailer can still operate against not-yet-created workspaces (the
- * existsSync guard inside drainEntries handles the missing-file window).
+ * missing-file guards inside the tailer handle the lazy-create window).
  *
  * The file is created lazily by claude on first message flush, so consumers
- * must tolerate `existsSync(path) === false` for a brief window after
- * session start.
+ * must tolerate the path not existing for a brief window after session start.
  */
 export function transcriptPathFor(cwd: string, sessionId: string): string {
   const absCwd = resolve(cwd);
@@ -44,52 +58,287 @@ export type RawTranscriptEntry = {
   [key: string]: unknown;
 };
 
+export type TranscriptStartPosition = "start" | "end";
+
+export type TranscriptTailerOptions = {
+  startAt?: TranscriptStartPosition;
+  maxReadBytes?: number;
+  maxLineBytes?: number;
+};
+
+export type TranscriptDrainResult = {
+  entries: RawTranscriptEntry[];
+  bytesRead: number;
+  /** Whether unread bytes remain below the fixed watermark supplied by the caller. */
+  hasMore: boolean;
+  /** Oversized records first encountered in this chunk. Each record is counted once. */
+  skippedOversizedLines: number;
+};
+
+function isErrnoCode(error: unknown, code: string): boolean {
+  return error instanceof Error && "code" in error && error.code === code;
+}
+
+function assertBoundedPositiveInteger(name: string, value: number, upperBound: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0 || value > upperBound) {
+    throw new RangeError(`${name} must be a positive safe integer no greater than ${upperBound}`);
+  }
+}
+
+function isRawTranscriptEntry(value: unknown): value is RawTranscriptEntry {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
- * Tail an append-only JSONL transcript. Each `drainEntries()` returns raw
- * entries appended since the last call. Tolerates the file not yet existing
- * (returns empty), partial lines across reads, and malformed JSON (single
- * bad line is skipped, not fatal).
+ * Tail an append-only JSONL transcript.
  *
- * NOT thread-safe across instances — each session should own one tailer.
+ * Callers freeze an EOF watermark with {@link captureWatermark}, then call
+ * {@link drainEntries} until `hasMore` is false. Every content read is bounded
+ * and relative to that fixed watermark, so a continuously-growing writer
+ * cannot keep one drain pass alive forever. Incomplete records are retained as
+ * byte fragments (not repeatedly-concatenated strings) and are bounded by
+ * {@link TRANSCRIPT_MAX_LINE_BYTES}.
+ *
+ * NOT thread-safe across instances or overlapping drains — each session owns
+ * one tailer and serialises calls through its handler turn loop.
  */
 export class TranscriptTailer {
-  private readonly path: string;
   private offset = 0;
-  private partial = "";
+  private partialFragments: Buffer[] = [];
+  private partialBytes = 0;
+  private droppingOversizedLine = false;
+  private droppingDiscardedLine = false;
+  private discardedBoundaryProbe: number | null = null;
 
-  constructor(path: string) {
-    this.path = path;
-  }
+  private constructor(
+    private readonly path: string,
+    private readonly maxReadBytes: number,
+    private readonly maxLineBytes: number,
+  ) {}
 
-  /** Read raw JSONL entries appended since the last call. Best-effort. */
-  drainEntries(): RawTranscriptEntry[] {
-    if (!existsSync(this.path)) return [];
-    const stat = statSync(this.path);
-    if (stat.size <= this.offset) return [];
+  /**
+   * Create a tailer and, for resume mode, establish its EOF baseline before
+   * returning. ENOENT is the expected lazy-create window; other metadata
+   * failures reject so the handler can tear down the provider session.
+   */
+  static async create(path: string, options: TranscriptTailerOptions = {}): Promise<TranscriptTailer> {
+    const startAt = options.startAt ?? "start";
+    const maxReadBytes = options.maxReadBytes ?? TRANSCRIPT_READ_CHUNK_BYTES;
+    const maxLineBytes = options.maxLineBytes ?? TRANSCRIPT_MAX_LINE_BYTES;
+    assertBoundedPositiveInteger("maxReadBytes", maxReadBytes, TRANSCRIPT_READ_CHUNK_BYTES);
+    assertBoundedPositiveInteger("maxLineBytes", maxLineBytes, TRANSCRIPT_MAX_LINE_BYTES);
 
-    const fd = openSync(this.path, "r");
-    let chunk = "";
-    try {
-      const buf = Buffer.allocUnsafe(stat.size - this.offset);
-      const read = readSync(fd, buf, 0, buf.length, this.offset);
-      this.offset += read;
-      chunk = this.partial + buf.subarray(0, read).toString("utf-8");
-    } finally {
-      closeSync(fd);
-    }
-
-    const parts = chunk.split("\n");
-    this.partial = parts.pop() ?? "";
-
-    const entries: RawTranscriptEntry[] = [];
-    for (const raw of parts) {
-      if (!raw.trim()) continue;
-      try {
-        entries.push(JSON.parse(raw) as RawTranscriptEntry);
-      } catch {
-        // skip malformed line
+    const tailer = new TranscriptTailer(path, maxReadBytes, maxLineBytes);
+    if (startAt === "end") {
+      const size = await tailer.statSize();
+      if (size !== null) {
+        tailer.offset = size;
+        if (size > 0) tailer.discardedBoundaryProbe = size - 1;
       }
     }
-    return entries;
+    return tailer;
+  }
+
+  /**
+   * Freeze the current EOF for one finite catch-up pass.
+   *
+   * A transcript absent during construction is baselined at the then-current
+   * EOF of zero, so bytes created afterward are eligible for the next drain.
+   */
+  async captureWatermark(): Promise<number> {
+    const size = await this.statSize();
+    if (size === null) return this.offset;
+    return size;
+  }
+
+  /**
+   * Discard everything present before a provider turn without reading or
+   * parsing content. This is the turn preflush boundary.
+   */
+  async discardToEnd(): Promise<void> {
+    const previousOffset = this.offset;
+    const hadIncompleteLine =
+      this.partialBytes > 0 ||
+      this.droppingOversizedLine ||
+      this.droppingDiscardedLine ||
+      this.discardedBoundaryProbe !== null;
+    const size = await this.statSize();
+    this.offset = size ?? 0;
+    const needsBoundaryResolution = hadIncompleteLine || this.offset > previousOffset;
+    this.clearParserState();
+
+    // A metadata-only discard cannot tell whether unseen growth, or the new
+    // EOF of an already-observed partial record, ends at a JSONL boundary.
+    // Retain only the final byte's offset, not its content: once fresh bytes
+    // exist, the next bounded drain probes that byte. LF proves the baseline
+    // is at a record boundary; any other byte means a later suffix must be
+    // ignored through its newline. This avoids both stale replay and dropping
+    // the first fresh record in the ambiguous race.
+    if (needsBoundaryResolution && this.offset > 0) {
+      this.discardedBoundaryProbe = this.offset - 1;
+    } else {
+      this.droppingDiscardedLine = needsBoundaryResolution;
+    }
+  }
+
+  /** Read at most one bounded chunk up to a caller-frozen EOF watermark. */
+  async drainEntries(watermark: number): Promise<TranscriptDrainResult> {
+    if (!Number.isSafeInteger(watermark) || watermark < 0) {
+      throw new RangeError("watermark must be a non-negative safe integer");
+    }
+    if (watermark <= this.offset) return this.emptyDrain();
+    const discardedBoundaryProbe = this.discardedBoundaryProbe;
+
+    const readOffset = discardedBoundaryProbe ?? this.offset;
+    const requestedBytes = discardedBoundaryProbe === null ? Math.min(this.maxReadBytes, watermark - this.offset) : 1;
+
+    let handle: FileHandle;
+    try {
+      handle = await open(this.path, "r");
+    } catch (error) {
+      if (isErrnoCode(error, "ENOENT")) {
+        return this.emptyDrain(this.discardedBoundaryProbe !== null || this.offset < watermark);
+      }
+      throw error;
+    }
+
+    let bytesRead = 0;
+    let chunk = Buffer.alloc(0);
+    try {
+      const buffer = Buffer.allocUnsafe(requestedBytes);
+      const result = await handle.read(buffer, 0, requestedBytes, readOffset);
+      bytesRead = result.bytesRead;
+      chunk = buffer.subarray(0, bytesRead);
+    } finally {
+      await handle.close();
+    }
+
+    if (bytesRead === 0) {
+      return this.emptyDrain(this.discardedBoundaryProbe !== null || this.offset < watermark);
+    }
+    if (discardedBoundaryProbe !== null) {
+      this.discardedBoundaryProbe = null;
+      this.droppingDiscardedLine = chunk[0] !== NEWLINE_BYTE;
+      return {
+        entries: [],
+        bytesRead,
+        hasMore: this.offset < watermark,
+        skippedOversizedLines: 0,
+      };
+    }
+
+    this.offset = readOffset + bytesRead;
+    const parsed = this.parseChunk(chunk);
+    return {
+      ...parsed,
+      bytesRead,
+      // Zero progress is handled above. `hasMore` is deliberately relative to
+      // this call's fixed watermark, never a newly-statted live EOF.
+      hasMore: this.offset < watermark,
+    };
+  }
+
+  private async statSize(): Promise<number | null> {
+    try {
+      const metadata = await stat(this.path);
+      return metadata.size;
+    } catch (error) {
+      if (isErrnoCode(error, "ENOENT")) return null;
+      throw error;
+    }
+  }
+
+  private emptyDrain(hasMore = false): TranscriptDrainResult {
+    return { entries: [], bytesRead: 0, hasMore, skippedOversizedLines: 0 };
+  }
+
+  private clearParserState(): void {
+    this.partialFragments = [];
+    this.partialBytes = 0;
+    this.droppingOversizedLine = false;
+    this.droppingDiscardedLine = false;
+    this.discardedBoundaryProbe = null;
+  }
+
+  private dropThroughNewline(chunk: Buffer, cursor: number): number | null {
+    const newline = chunk.indexOf(NEWLINE_BYTE, cursor);
+    if (newline < 0) return null;
+    this.droppingOversizedLine = false;
+    this.droppingDiscardedLine = false;
+    return newline + 1;
+  }
+
+  private parseChunk(chunk: Buffer): Pick<TranscriptDrainResult, "entries" | "skippedOversizedLines"> {
+    const entries: RawTranscriptEntry[] = [];
+    let skippedOversizedLines = 0;
+    let cursor = 0;
+
+    while (cursor < chunk.length) {
+      if (this.droppingOversizedLine || this.droppingDiscardedLine) {
+        const next = this.dropThroughNewline(chunk, cursor);
+        if (next === null) break;
+        cursor = next;
+        continue;
+      }
+
+      const newline = chunk.indexOf(NEWLINE_BYTE, cursor);
+      const segmentEnd = newline < 0 ? chunk.length : newline;
+      const segment = chunk.subarray(cursor, segmentEnd);
+      const remainingLineBytes = this.maxLineBytes - this.partialBytes;
+
+      if (segment.length > remainingLineBytes) {
+        // Count at the first byte beyond the limit, then retain no content
+        // while skipping through this record's newline (possibly in a later
+        // chunk). This makes one oversized record exactly one skip.
+        skippedOversizedLines += 1;
+        this.partialFragments = [];
+        this.partialBytes = 0;
+        if (newline < 0) {
+          this.droppingOversizedLine = true;
+          break;
+        }
+        cursor = newline + 1;
+        continue;
+      }
+
+      if (newline < 0) {
+        if (segment.length > 0) {
+          // Copy only the exact fragment; retaining a subarray would keep the
+          // whole read buffer alive and defeat the incomplete-record bound.
+          this.partialFragments.push(Buffer.from(segment));
+          this.partialBytes += segment.length;
+        }
+        break;
+      }
+
+      const entry = this.parseCompleteLine(segment);
+      if (entry) entries.push(entry);
+      cursor = newline + 1;
+    }
+
+    return { entries, skippedOversizedLines };
+  }
+
+  private parseCompleteLine(finalSegment: Buffer): RawTranscriptEntry | null {
+    const lineBytes = this.partialBytes + finalSegment.length;
+    let line: Buffer;
+    if (this.partialFragments.length === 0) {
+      line = finalSegment;
+    } else {
+      const fragments = finalSegment.length > 0 ? [...this.partialFragments, finalSegment] : this.partialFragments;
+      line = Buffer.concat(fragments, lineBytes);
+    }
+    this.partialFragments = [];
+    this.partialBytes = 0;
+
+    const raw = line.toString("utf-8");
+    if (!raw.trim()) return null;
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return isRawTranscriptEntry(parsed) ? parsed : null;
+    } catch {
+      // One malformed completed line is best-effort skipped, not fatal.
+      return null;
+    }
   }
 }

--- a/packages/qa/cases/runtime/claude-code-tui-large-transcript-resume.md
+++ b/packages/qa/cases/runtime/claude-code-tui-large-transcript-resume.md
@@ -1,0 +1,126 @@
+---
+id: claude-code-tui-large-transcript-resume
+description: Verify a real Claude Code TUI session resumes from a large transcript without rereading or parsing historical records and still consumes only new appends.
+areas: [runtime]
+surfaces: [client, cli, server]
+---
+
+# Claude Code TUI Large-Transcript Resume
+
+## Goal
+
+Confirm that a real `claude-code-tui` session resumed through First Tree establishes its transcript baseline at the
+current EOF without the Client reading, splitting, or parsing historical JSONL, then processes transcript bytes appended
+by the resumed Claude turn in order and exactly once.
+
+This is a live provider/tmux integration and performance case. Pair it with `runtime-provider-readiness`. Stable
+semantics such as the 64 KiB read ceiling, fixed per-drain watermark, partial and UTF-8 boundaries, the 8 MiB incomplete
+record limit, oversize recovery, suspend-fence interleavings, and I/O-failure settlement remain product-test
+responsibilities. This case checks that those mechanics survive the real Client → tmux → Claude Code → transcript
+boundary.
+
+## Preconditions
+
+- Reach `QA READY` with the complete isolated First Tree harness before selecting this case. Use a run-local Client home,
+  agent workspace, server data, tmux socket/state, and disposable chat; never use an operator checkout, production chat,
+  or another live Client's tmux sessions.
+- Run the candidate Client through an explicit native/provider bridge when the TUI cannot credibly run in Docker. The
+  bridge must still use isolated First Tree state and a unique client identity.
+- Install a real on-disk `claude` executable and `tmux` on the Client host. The SDK-bundled Claude binary is not sufficient
+  for `claude-code-tui`.
+- Establish Claude `one-turn-ready` under the same OS user that runs the Client: the TUI can launch, pass its interactive
+  readiness gates, and complete an authenticated turn. Reuse host-local provider authentication without reading,
+  copying, or archiving credential contents.
+- Create a disposable agent configured for `claude-code-tui`, complete an initial real turn, and record the persisted
+  Claude session id, agent cwd, exact transcript path, and owning Client PID.
+- Prepare a large, complete, provider-accepted JSONL history while the handler is suspended. Prefer history produced by a
+  disposable real session or a sanitized fixture verified by a control resume. Record logical and allocated size, line
+  count, hash, and EOF. Do not use sparse holes or NUL padding as the sole workload: an invalid provider transcript would
+  confound Client tail behavior with Claude resume failure.
+- Choose the large-history size in the run-local plan and record why it is material on that host. When practical, retain
+  equivalent small-history and large-history reset points for comparison.
+- Have a host observer that can attribute file metadata operations and content reads to the First Tree Client PID,
+  including path, offset, requested length, returned length, and time. Separately identify Claude and tmux child PIDs so
+  their transcript access is not charged to the Client. Also sample Client-only RSS and one benign operation serviced by
+  the same event loop, such as runtime heartbeat handling or another run-local control probe.
+- If the environment cannot distinguish the Client's transcript reads from the provider's reads, wall-clock timing alone
+  is not enough for `PASS`.
+
+## Checklist
+
+First suspend the real session through the public session-control path and confirm the owned tmux pane is gone while the
+session id remains resumable. Grow the transcript only while the handler is stopped, preserve a recognizable historical
+sentinel in the disposable data, and start the Client file/process observer before resuming.
+
+Exercise an administrative resume with no message using the public CLI/API session-control path. Keep inbound input
+quiescent until the session is reported active and the Client records the resume as complete. During this phase:
+
+- metadata-only inspection of the transcript is allowed;
+- the Client must perform zero content reads from the transcript;
+- no historical transcript entry or sentinel may be emitted as a new First Tree session event or chat result;
+- Client RSS must not show a transient allocation comparable to the historical transcript size;
+- the concurrent Client-owned responsiveness probe must continue to make progress.
+
+After the no-message resume completes, record the transcript's current EOF again because Claude may have appended
+provider-owned startup or summary data. Send a fresh message containing a unique run nonce and ask for a short
+nonce-bearing response. For this turn, define `baseline` as the exact EOF established by the metadata-only discard before
+tmux paste, not the earlier administrative-resume observation. Observe the transcript, Client session events, chat
+result, and inbox settlement through turn completion. After paste, the Client may issue one 1-byte read at
+`baseline - 1` to determine whether the discarded EOF ended on LF; this byte must never be parsed or emitted. Every other
+content read must begin at or after `baseline`, no other read may revisit historical bytes, and every request—including
+the probe—must be no larger than 64 KiB. The new assistant output must be forwarded once, in transcript order, without
+replaying the historical sentinel.
+
+Also exercise the ordinary messageful-resume path from a clean reset point: suspend again, append another block of valid
+historical JSONL, start observation, and send a new message directly to the suspended chat instead of issuing an
+administrative resume first. Capture enough process evidence to order the metadata-only EOF baseline before the tmux
+paste operation. Before that paste, the Client must not content-read the transcript. After the paste, only newly appended
+bytes may be consumed and the delivery must settle exactly once.
+
+Characterize, rather than hide, performance. Record the history workload, resume phase boundaries, Client transcript
+bytes requested/returned, peak Client RSS, responsiveness-probe latency, and provider-ready/turn-complete durations. If a
+small/large pair is available, compare the Client measurements. The primary oracles are zero pre-paste content I/O and
+zero historical record parsing or replay. After paste, the sole permitted historical I/O is one optional 1-byte
+LF-boundary probe at the pre-paste `baseline - 1`. Timing is supporting evidence because Claude itself may read or
+summarize its history during `--resume`.
+
+## Expected Result
+
+`PASS` requires a real authenticated tmux/Claude session and attributable evidence that both no-message and messageful
+resume establish an EOF baseline without pre-paste Client content reads, do not replay historical entries, preserve
+Client event-loop progress, and process a later valid append in order and exactly once through chat delivery and inbox
+settlement. Apart from the optional post-paste 1-byte LF-boundary probe at `baseline - 1`, all Client transcript reads
+are at most 64 KiB and start in the newly appended region.
+
+`FAIL` means a reproducible candidate defect, including the Client reading pre-baseline transcript content beyond the
+single allowed LF-boundary byte, reading that byte before paste, allocating memory proportional to the historical file
+while baselining, emitting historical entries as current-turn output, reading an unbounded chunk, pasting before the
+resume baseline is established, losing or duplicating the new result, or blocking other Client event-loop work in
+proportion to historical size.
+
+`BLOCKED` means the real Claude executable, tmux, authentication, account/network capacity, provider-accepted transcript
+fixture, or isolated native bridge is unavailable. Claude independently rejecting or failing to resume the prepared
+history is an environment/fixture blocker unless the same history resumes successfully outside the candidate Client.
+
+`INCONCLUSIVE` means the turn ran but transcript I/O could not be attributed to Client versus Claude, phase ordering
+could not be recovered, or only wall-clock/RSS observations are available without the content-read evidence.
+
+## Evidence
+
+Keep the target ref and artifact identities; OS, filesystem, Claude, tmux, Node, and First Tree versions; sanitized
+session/cwd/transcript identifiers; history logical and allocated sizes, line count, hash, and baseline offsets; the
+Client-only file-I/O trace; process tree and tmux session identity; Client RSS and responsiveness samples; session event
+and inbox-settlement sequence; nonce-bearing result; and cleanup confirmation.
+
+Do not retain raw private transcript content, prompts, credentials, tokens, keychain material, or tmux paste buffers.
+Hashes, byte ranges, event kinds, redacted markers, and aggregate syscall tables are normally sufficient.
+
+## Limitations
+
+This case covers the current append-only transcript contract. It does not validate truncation, inode replacement, or
+rotation. It also does not claim that Claude Code's own `--resume` work is independent of history size; provider-process
+CPU, memory, and transcript reads must be reported separately from the First Tree Client.
+
+Bounded transcript ingestion does not make the whole turn constant-memory: accumulated valid assistant output can still
+grow `finalTexts`. Exact chunk, line-limit, malformed-line, UTF-8, deadline, abort, and injected-I/O-failure behavior
+belongs in Vitest and must not be inferred from this live case.


### PR DESCRIPTION
Fixes #1679.

## Problem

Resuming a Claude Code TUI session constructed its transcript tail at byte zero. The first pre-provider flush then synchronously allocated, read, split, and parsed the full historical JSONL file before discarding it, so history size directly controlled event-loop latency and memory pressure.

## Design and implementation

- Construct new-session tails at `start` and every resume tail (including administrative resumes without a message) at `end`.
- Establish and refresh the resume EOF baseline with metadata-only async `stat`; the pre-paste discard performs no content read, buffer allocation, line split, or `JSON.parse`.
- Read appended bytes asynchronously in chunks of at most 64 KiB. Each drain freezes one EOF watermark, yields with `setImmediate` between chunks, and checks abort, stop, and deadline fences before starting or continuing I/O, so a live writer cannot make one poll chase an unbounded moving EOF.
- Keep incomplete records as bounded byte fragments and decode only once at newline. A line at the configured limit is accepted; a larger line is counted once, dropped through its newline, and ingestion resumes in the same chunk. The production limit is 8 MiB, and logs contain only counts, never oversized content.
- Resolve a resumed EOF that may end inside a historical partial record with one deferred, post-paste byte probe at `baseline - 1` after fresh bytes exist. The byte is never parsed or emitted; it only decides whether the fresh suffix starts on a record boundary. Pre-paste and idle pre-output work remain content-read-free.
- Preserve append-only semantics. This change does not add truncate, inode replacement, or rotation behavior that the current tail contract does not promise.
- Move `processingStarted()` after successful discard and a renewed suspend fence. Discard I/O failures retry without paste/complete/ACK; initialization failure remains inside tmux cleanup.
- Preserve inbox prefix ordering across retryable turns. If the TUI turn selects retry, or terminal reporting rejects/throws, every later delivery already accepted by this handler is retried before the serialization gate reopens, so it cannot overtake the failed prefix into Claude.
- Require the final fixed-watermark flush to catch up before forwarding output or completing. An unfinished watermark at the absolute turn deadline is classified as `turn_timeout`, with no partial forward or ACK.

The bounded-memory claim is intentionally limited to each read request and cached incomplete transcript record. `finalTexts` still grows with valid assistant output produced during the current turn.

## Regression coverage

- Sparse 32 MiB resume history: observable file-handle reads, `Buffer.allocUnsafe`, and `JSON.parse` prove zero pre-paste historical content work; later append is consumed normally.
- Fixed watermark across more than three chunks, concurrent append deferral, per-read limit, ordering, and exactly-once delivery.
- Partial append, JSON and UTF-8 chunk boundaries, blank/malformed records, exact configured-limit boundary, oversize spanning chunks, no-newline drop state, and same-chunk recovery.
- Final flush over multiple chunks, unfinished-watermark timeout without partial forward/ACK, and bounded abort/deadline termination.
- Deferred discard versus suspend, pre-provider failure, bootstrap and queued suffix recovery, provider-entered timeout with a queued suffix, and a closed-fence assertion proving no new capture/read begins.
- Handler construction modes, administrative resume, discard/paste ordering, and initialization cleanup.

## Verification

Exact successor head: `894e97e8c419d88ce2ef6fdc9d624ba875784093`.

- `VITEST_MAX_FORKS=1 pnpm --filter @first-tree/client exec vitest run src/__tests__/tui-transcript-tail.test.ts src/__tests__/tui-suspend-queued-recovery.test.ts --maxWorkers=1 --minWorkers=1` — 2 files, 39/39 tests passed.
- `pnpm --filter @first-tree/client typecheck` — passed.
- `pnpm typecheck` — 10/10 tasks passed.
- `pnpm build` — 5/5 tasks passed.
- `pnpm check` — passed; only the existing two warnings and one informational diagnostic outside this diff remain.
- `pnpm --filter @first-tree/qa test` — 4/4 lifecycle contract tests passed.

The full Client suite passed 1,643 tests on the first implementation head. On this successor head, the same run passed 1,644 tests while two unchanged 5-second wall-clock tests timed out under local load (`capability-probes` and the >1 MiB `image-snapshots` guard); both files are byte-for-byte identical to `origin/main`. The capability file passed 51/51 in isolation. The image guard still exceeded its fixed wall-clock threshold locally when isolated, so it is reported as an environment-sensitive timeout rather than a pass. The focused TUI tests remained green, and all exact-head GitHub checks passed.

Repository-wide testing on the first head also exposed two unrelated environment/load failures: active First Tree provider markers confused unchanged CLI client-switch process discovery until a sanitized isolated rerun passed 21/21, and an unchanged portable S3 test exceeded its wall-clock limit under full parallel load before passing 12/12 alone. These areas are outside this diff.

## Formal QA

**Formal QA warranted.** Added `packages/qa/cases/runtime/claude-code-tui-large-transcript-resume.md` for a real isolated tmux/Claude resume with attributable I/O, RSS, and event-loop observation.

For exact successor commit `894e97e8c419d88ce2ef6fdc9d624ba875784093`, a **limited readiness preflight** is `BLOCKED before QA READY`, not a product failure and not a complete formal QA run. Docker and an isolated tmux create/list/reset probe succeeded, and Claude Code was binary-launchable, but no safe isolated credential/entitlement bridge was available to prove one real provider turn. No live case, First Tree service, provider turn, transcript mutation, or formal performance measurement was executed, and no provider-backed PASS is claimed.
