### PR TITLE
chore: Droid review smoke test

### DIFF
--- a/docs/droid-review-smoke-test.md
+++ b/docs/droid-review-smoke-test.md
@@ -1,0 +1,5 @@
+# Droid Review Smoke Test
+
+This file exists only to exercise the Factory Droid automated review workflow
+added in #1908. It contains no functional code and can be deleted after the
+review pipeline is confirmed working.


### PR DESCRIPTION
Small test PR to verify the Factory Droid automated review workflow from #1908 triggers correctly.

Adds a single throwaway doc file (`docs/droid-review-smoke-test.md`). Safe to close/delete once the auto-review run is confirmed.