### PR TITLE
fix(cli): block path traversal in agent remove/prune deletion paths (SEC-030)

### DIFF
--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -52,6 +52,7 @@ const coreMocks = vi.hoisted(() => ({
   listLiveClientRuntimeMarkers: vi.fn(),
   loadCredentials: vi.fn(),
   PACKAGE_NAME: "first-tree",
+  assertRemovableAgentName: vi.fn(),
   promptAddAgent: vi.fn(),
   readActiveClientIdFromIndex: vi.fn(),
   readActiveRootClientId: vi.fn(),

--- a/apps/cli/src/__tests__/agent-prune.test.ts
+++ b/apps/cli/src/__tests__/agent-prune.test.ts
@@ -193,4 +193,75 @@ describe("findStaleAliases", () => {
     expect(existsSync(join(home, "data", "sessions", "stale.json"))).toBe(false);
     rmSync(home, { recursive: true, force: true });
   });
+
+  it("rejects traversal and non-slug names without touching the filesystem", () => {
+    const home = mkdtempSync(join(tmpdir(), "fthub-remove-home-"));
+    process.env.FIRST_TREE_HOME = home;
+    // Canary outside the deletion roots but reachable via `../` from config/agents.
+    const canary = join(home, "config", "canary");
+    mkdirSync(canary, { recursive: true });
+    writeFileSync(join(canary, "keep.txt"), "safe");
+    mkdirSync(join(home, "config", "agents"), { recursive: true });
+
+    const badNames = [
+      "",
+      ".",
+      "..",
+      "../canary",
+      "../../etc",
+      "a/b",
+      "/abs/path",
+      "a\\b",
+      "Foo",
+      "with space",
+      "x.json",
+    ];
+    for (const name of badNames) {
+      expect(() => removeLocalAgent(name)).toThrow(/Invalid agent name/);
+    }
+
+    // "" would previously have matched config/agents itself; "../canary" the canary.
+    expect(existsSync(join(home, "config", "agents"))).toBe(true);
+    expect(existsSync(join(canary, "keep.txt"))).toBe(true);
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("accepts grandfathered legacy names (leading - or _, up to 100 chars)", () => {
+    const home = mkdtempSync(join(tmpdir(), "fthub-remove-home-"));
+    process.env.FIRST_TREE_HOME = home;
+
+    for (const name of ["_legacy-agent", "-dash-name", `a${"b".repeat(99)}`]) {
+      mkdirSync(join(home, "config", "agents", name), { recursive: true });
+      mkdirSync(join(home, "data", "workspaces", name), { recursive: true });
+      mkdirSync(join(home, "data", "sessions"), { recursive: true });
+      writeFileSync(join(home, "data", "sessions", `${name}.json`), "{}");
+
+      removeLocalAgent(name);
+
+      expect(existsSync(join(home, "config", "agents", name))).toBe(false);
+      expect(existsSync(join(home, "data", "workspaces", name))).toBe(false);
+      expect(existsSync(join(home, "data", "sessions", `${name}.json`))).toBe(false);
+    }
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("unlinks a symlinked alias dir without touching the link target", (ctx) => {
+    const home = mkdtempSync(join(tmpdir(), "fthub-remove-home-"));
+    process.env.FIRST_TREE_HOME = home;
+    const outside = mkdtempSync(join(tmpdir(), "fthub-remove-outside-"));
+    writeFileSync(join(outside, "keep.txt"), "safe");
+    mkdirSync(join(home, "config", "agents"), { recursive: true });
+    try {
+      symlinkSync(outside, join(home, "config", "agents", "linked"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    removeLocalAgent("linked");
+
+    expect(existsSync(join(outside, "keep.txt"))).toBe(true);
+    expect(existsSync(join(home, "config", "agents", "linked"))).toBe(false);
+    rmSync(outside, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  });
 });

--- a/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
@@ -38,6 +38,7 @@ const outputMocks = vi.hoisted(() => ({
 const printLineMock = vi.hoisted(() => vi.fn());
 
 const coreMocks = vi.hoisted(() => ({
+  assertRemovableAgentName: vi.fn(),
   getClientServiceStatus: vi.fn(),
   installClientService: vi.fn(),
   isServiceSupported: vi.fn(),
@@ -431,6 +432,12 @@ describe("agent admin and local commands", () => {
     await runAgent(["remove", "nova"]);
     expect(coreMocks.removeLocalAgent).toHaveBeenCalledWith("nova");
     await expect(runAgent(["remove", "missing"])).rejects.toMatchObject({ code: 1 });
+
+    coreMocks.assertRemovableAgentName.mockImplementationOnce(() => {
+      throw new Error('Invalid agent name "../escape"');
+    });
+    await expect(runAgent(["remove", "../escape"])).rejects.toMatchObject({ code: 1 });
+    expect(coreMocks.removeLocalAgent).not.toHaveBeenCalledWith("../escape");
 
     localAgentMocks.createSdk.mockReturnValueOnce({ register: vi.fn(async () => ({ agentId: "agent-1" })) });
     await runAgent(["debug", "register", "--agent", "nova"]);

--- a/apps/cli/src/commands/agent/remove.ts
+++ b/apps/cli/src/commands/agent/remove.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { defaultConfigDir } from "@first-tree/shared/config";
 import type { Command } from "commander";
-import { removeLocalAgent } from "../../core/index.js";
+import { assertRemovableAgentName, removeLocalAgent } from "../../core/index.js";
 import { print } from "../../core/output.js";
 
 export function registerAgentRemoveCommand(agent: Command): void {
@@ -12,6 +12,16 @@ export function registerAgentRemoveCommand(agent: Command): void {
       "Remove an agent from this client and delete its local runtime data (config dir, workspace, session state)",
     )
     .action((name: string) => {
+      // Validate before any filesystem touch: an unvalidated name both
+      // enables path traversal in removeLocalAgent and turns the existence
+      // probe below into an oracle for paths outside First Tree state.
+      try {
+        assertRemovableAgentName(name);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        print.line(`  Error: ${msg}\n`);
+        process.exit(1);
+      }
       const agentDir = join(defaultConfigDir(), "agents", name);
       if (!existsSync(agentDir)) {
         print.line(`  Agent "${name}" not found.\n`);

--- a/apps/cli/src/commands/agent/remove.ts
+++ b/apps/cli/src/commands/agent/remove.ts
@@ -27,7 +27,13 @@ export function registerAgentRemoveCommand(agent: Command): void {
         print.line(`  Agent "${name}" not found.\n`);
         process.exit(1);
       }
-      removeLocalAgent(name);
+      try {
+        removeLocalAgent(name);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        print.line(`  Error: ${msg}\n`);
+        process.exit(1);
+      }
       print.line(`  Agent "${name}" removed.\n`);
     });
 }

--- a/apps/cli/src/core/agent-prune.ts
+++ b/apps/cli/src/core/agent-prune.ts
@@ -1,5 +1,5 @@
-import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync, rmSync, statSync } from "node:fs";
+import { join, sep } from "node:path";
 import { defaultConfigDir, defaultDataDir } from "@first-tree/shared/config";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
@@ -136,13 +136,71 @@ export function formatStaleReason(reason: StaleAliasReason): string {
 }
 
 /**
+ * Names that may be passed to `removeLocalAgent`. This is the pre-tightening
+ * server-side acceptance set (`z.string().min(1).max(100).regex(/^[a-z0-9_-]+$/)`),
+ * i.e. a superset of the canonical `AGENT_NAME_REGEX`
+ * (`/^[a-z0-9][a-z0-9_-]{0,63}$/` in `@first-tree/shared`). Grandfathered
+ * aliases — names starting with `-`/`_` or 65–100 chars — must stay
+ * removable, otherwise `agent prune` can never clean up such a stale alias.
+ * The charset excludes `.`, `/`, and `\`, so no accepted name can traverse
+ * directories; containment below is the second, hard boundary.
+ */
+const REMOVABLE_AGENT_NAME_REGEX = /^[a-z0-9_-]{1,100}$/;
+
+/**
+ * Reject names that could escape First Tree state directories when joined
+ * into a deletion path. Throws on anything outside the historical slug
+ * charset — including `.`/`..`, path separators, and the empty string (which
+ * would otherwise resolve to the base directory itself).
+ */
+export function assertRemovableAgentName(name: string): void {
+  if (!REMOVABLE_AGENT_NAME_REGEX.test(name)) {
+    throw new Error(
+      `Invalid agent name "${name}": only lowercase letters, digits, hyphens, and underscores (1-100 chars) are allowed.`,
+    );
+  }
+}
+
+/**
+ * Delete `join(baseDir, childName)` only when it stays inside `baseDir`.
+ *
+ * - Missing target: no-op (preserves the old `force: true` semantics).
+ * - Symlink target: plain unlink. Removing a link never touches its target,
+ *   so no containment check is needed — this also keeps power-user layouts
+ *   (e.g. `workspaces/<name>` symlinked to another disk) working, and
+ *   broken symlinks removable.
+ * - Real file/dir: resolve both sides with `realpathSync` immediately before
+ *   the delete and refuse when the resolved target escapes the resolved
+ *   base (e.g. an intermediate symlink pointing outside First Tree state).
+ *
+ * Residual TOCTOU window between the check and the delete is accepted: it
+ * would require an attacker who already has local write access.
+ */
+function rmContained(baseDir: string, childName: string, opts: { recursive: boolean }): void {
+  const target = join(baseDir, childName);
+  const stat = lstatSync(target, { throwIfNoEntry: false });
+  if (stat === undefined) return;
+  if (stat.isSymbolicLink()) {
+    rmSync(target, { force: true });
+    return;
+  }
+  const realBase = realpathSync(baseDir);
+  const realTarget = realpathSync(target);
+  if (!realTarget.startsWith(realBase + sep)) {
+    throw new Error(`Refusing to delete "${target}": resolves to "${realTarget}", outside "${realBase}".`);
+  }
+  rmSync(target, { recursive: opts.recursive, force: true });
+}
+
+/**
  * Remove an agent's local footprint: the YAML alias dir, the workspace
  * tree under `data/workspaces/<name>`, and the session-mapping file under
  * `data/sessions/<name>.json`. Mirrors what `agent remove` does, exposed
  * separately so prune and the post-rotation override cleanup can share it.
  */
 export function removeLocalAgent(name: string): void {
-  rmSync(join(defaultConfigDir(), "agents", name), { recursive: true, force: true });
-  rmSync(join(defaultDataDir(), "workspaces", name), { recursive: true, force: true });
-  rmSync(join(defaultDataDir(), "sessions", `${name}.json`), { force: true });
+  assertRemovableAgentName(name);
+  rmContained(join(defaultConfigDir(), "agents"), name, { recursive: true });
+  rmContained(join(defaultDataDir(), "workspaces"), name, { recursive: true });
+  rmContained(join(defaultDataDir(), "sessions"), `${name}.json`, { recursive: false });
 }

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -1,6 +1,6 @@
 // Local agent alias hygiene (stale alias detection + deletion)
 export type { PinnedAgent, StaleAlias, StaleAliasReason } from "./agent-prune.js";
-export { findStaleAliases, formatStaleReason, removeLocalAgent } from "./agent-prune.js";
+export { assertRemovableAgentName, findStaleAliases, formatStaleReason, removeLocalAgent } from "./agent-prune.js";
 // Bootstrap / credentials
 export {
   AuthRefreshFailedError,


### PR DESCRIPTION
## Summary

Fixes #1636 (SEC-030, High): `agent remove` permitted recursive path traversal.

`removeLocalAgent(name)` joined the unvalidated agent name into three recursively deleted paths (`config/agents/<name>`, `data/workspaces/<name>`, `data/sessions/<name>.json`). A traversal name such as `../../somewhere` made `first-tree agent remove` delete writable directories outside First Tree state — and the `existsSync` probe in `agent remove` doubled as an existence oracle for those paths. The empty string was the worst case: it resolved to the `config/agents` base directory itself.

## Changes

Two layers of defense, both converged in the single deletion point `apps/cli/src/core/agent-prune.ts` (shared by `agent remove` and `agent prune`):

1. **Name validation (fail fast).** New `assertRemovableAgentName` accepts only `^[a-z0-9_-]{1,100}$` — the pre-tightening server-side acceptance set (`.min(1).max(100).regex(/^[a-z0-9_-]+$/)`), i.e. a superset of the canonical `AGENT_NAME_REGEX` (`/^[a-z0-9][a-z0-9_-]{0,63}$/`). The charset excludes `.`, `/`, and `\`, so no accepted name can traverse directories. The superset — rather than the canonical regex alone — keeps grandfathered aliases (names starting with `-`/`_`, or 65–100 chars) removable; otherwise `agent prune` could never clean up such a stale alias. `agent remove` validates before its existence probe and exits 1 with a clear error on invalid names.
2. **Realpath containment immediately before every deletion.** New internal `rmContained` helper:
   - missing target → no-op (preserves the old `force: true` semantics);
   - symlink target → plain unlink. Removing a link never touches its target, so power-user layouts (e.g. `workspaces/<name>` symlinked to another disk) keep working and broken symlinks stay removable;
   - real file/dir → both sides resolved with `realpathSync` immediately before the delete, refused when the resolved target escapes the resolved base (fail closed against intermediate symlinks pointing outside First Tree state).

Residual risk accepted: the TOCTOU window between the containment check and the delete would require an attacker who already has local write access.

## Behavior notes

- Hand-crafted junk alias dirs with non-slug names (e.g. uppercase `Foo`) are now refused by `agent prune` (reported inline as `✗ <name> (...)`) and must be removed manually — the reasonable cost of hardening one shared deletion point.
- Grandfathered names with a leading `-` (e.g. `-dash-name`) need the standard commander separator: `first-tree agent remove -- -dash-name` (otherwise commander parses the name as an option). `agent prune` and the core layer are unaffected.
- No changes to shared schemas, server, or any other command.

## Tests

New cases in `apps/cli/src/__tests__/agent-prune.test.ts`:

- Traversal/non-slug names (`""`, `.`, `..`, `../canary`, `../../etc`, `a/b`, `/abs/path`, `a\\b`, uppercase, spaces, dotted) all throw; an on-disk canary outside the deletion roots and the `config/agents` base itself are verified untouched.
- Grandfathered names (`_legacy-agent`, `-dash-name`, 100-char) still remove all three footprints.
- A symlinked alias dir is unlinked while its outside target is preserved.

Command layer: `agent remove` with an invalid name exits 1 without calling `removeLocalAgent` (core mock factories updated in both command test files).

## Verification

- `pnpm check` — clean (only pre-existing warnings already on main)
- `pnpm typecheck` — clean
- `pnpm --filter first-tree-dev test` (full CLI suite, 21 batches) — green except `client-switch-transaction-extra.test.ts` (7 tests), which fails because the test's daemon-process scan detects the live First Tree client processes of this dev host ("pid=... belongs to another client") — environment contamination, unrelated to this diff (that file and its sources are untouched; failure reproduces without this change).
- Full-monorepo `pnpm test`: server and skill-evals each had failures under the full parallel turbo run, but both pass when re-run standalone (server 2556/2556 except one load-flaky chat-priority case that also passes alone; skill-evals 437/437). Neither package is touched by this diff (CLI-only change), so these are pre-existing environment flakes, not regressions.
