### PR TITLE
Connect current agent output to the composer

### DIFF
--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -198,7 +198,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(h.container.querySelector('[role="status"]')).toBe(liveStatus);
   });
 
-  it("keeps the collapsed snapshot concise and opens one live activity inspector", async () => {
+  it("keeps the compact row concise and expands the existing full narration inline", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-nova", {
         working: true,
@@ -216,13 +216,13 @@ describe("ComposeStatusBar extra DOM coverage", () => {
       expect(h.container.textContent).toContain("Nova");
       expect(h.container.textContent).toContain("Working");
       expect(h.container.textContent).toContain("Write extra DOM tests");
-      expect(h.container.textContent).toContain("Activity (1)");
     });
     expect(h.container.textContent).not.toContain("Bash");
     expect(h.container.textContent).not.toContain("Cover the status rail.");
+    expect(h.container.textContent).not.toContain("Activity");
 
-    const trigger = h.container.querySelector('button[aria-label^="Open agent activity"]');
-    expect(trigger?.getAttribute("aria-label")).toBe("Open agent activity, 1 actionable agent");
+    const trigger = h.container.querySelector('button[aria-label^="Expand current agent output"]');
+    expect(trigger?.getAttribute("aria-label")).toBe("Expand current agent output, 1 actionable agent");
     const liveStatus = h.container.querySelector('[role="status"]');
     expect(liveStatus?.textContent).toContain("1 actionable agent");
     expect(liveStatus?.textContent).toContain("Nova Working");
@@ -231,18 +231,18 @@ describe("ComposeStatusBar extra DOM coverage", () => {
 
     await click(h, trigger);
     await waitForSettled(h, () => {
-      expect(h.container.querySelector('section[aria-label="Agent activity"]')).not.toBeNull();
-      expect(h.container.textContent).toContain("Agent activity · 1 agent");
-      expect(h.container.textContent).toContain("Bash");
-      expect(h.container.textContent).toContain("doc-page.tsx");
+      expect(h.container.querySelector('section[aria-label="Current agent output"]')).not.toBeNull();
+      expect(h.container.textContent).toContain("Cover the status rail.");
     });
-    // `turnTextFull` is timeline evidence, not duplicated into the live snapshot.
-    expect(h.container.textContent).not.toContain("Cover the status rail.");
+    expect(h.container.querySelector('section[aria-label="Current agent output"]')?.getAttribute("tabindex")).toBe("0");
+    expect(h.container.textContent).not.toContain("Bash");
+    expect(h.container.textContent).not.toContain("doc-page.tsx");
+    expect(h.container.querySelector(".compose-status-narration strong")?.textContent).toBe("extra");
 
-    const focusedControl = document.activeElement;
-    if (!(focusedControl instanceof HTMLElement)) throw new Error("Expected a focused Inspector control");
-    await keyDown(h, focusedControl, "Escape");
-    await waitForSettled(h, () => expect(h.container.querySelector('section[aria-label="Agent activity"]')).toBeNull());
+    await click(h, trigger);
+    await waitForSettled(h, () =>
+      expect(h.container.querySelector('section[aria-label="Current agent output"]')).toBeNull(),
+    );
   });
 
   it("keeps the server-derived main state while presenting status reasons as explanation", async () => {
@@ -285,12 +285,12 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(h.container.textContent).toContain("Idle");
     expect(h.container.textContent).not.toContain("Failed");
 
-    await click(h, h.container.querySelector('button[aria-label^="Open agent activity"]'));
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     await waitForSettled(h, () => expect(h.container.textContent).toContain("Offline Agent"));
     expect(h.container.textContent).toContain("Offline");
   });
 
-  it("shows a current reason in the strip and its detail inside the inspector", async () => {
+  it("shows a current reason in the compact row and its detail inline", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-waiting", {
         statusReason: {
@@ -310,13 +310,13 @@ describe("ComposeStatusBar extra DOM coverage", () => {
 
     await waitForSettled(h, () => expect(h.container.textContent).toContain("Waiting for provider capacity"));
     expect(h.container.textContent).toContain("Waiting");
-    await click(h, h.container.querySelector('button[aria-label^="Open agent activity"]'));
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     await waitForSettled(h, () => expect(h.container.querySelector('[title="capacity queue"]')).not.toBeNull());
     expect(h.container.querySelector('[title="capacity queue"]')).not.toBeNull();
     expect(h.container.querySelector('button[aria-label*="timeline"]')).toBeNull();
   });
 
-  it("opens all agents in one lightly divided inspector without duplicating the lead", async () => {
+  it("opens all agents in one lightly divided inline region without duplicating the lead", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-atlas", { errored: true }),
       status("agent-nova", {
@@ -336,17 +336,17 @@ describe("ComposeStatusBar extra DOM coverage", () => {
       expect(h.container.querySelector(".compose-status-agent-name")?.textContent).toBe("Atlas");
     });
 
-    await click(h, h.container.querySelector('button[aria-label^="Open agent activity"]'));
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     await waitForSettled(h, () => expect(h.container.textContent).toContain("Nova"));
 
-    const inspector = h.container.querySelector("[data-live-activity-inspector]");
+    const inspector = h.container.querySelector("[data-current-agent-output]");
     const atlasCount = inspector?.textContent?.match(/Atlas/g)?.length ?? 0;
     expect(atlasCount).toBe(1);
-    expect(h.container.querySelectorAll("[data-live-activity-inspector]")).toHaveLength(1);
-    expect(h.container.querySelectorAll("[data-live-activity-agent]")).toHaveLength(2);
+    expect(h.container.querySelectorAll("[data-current-agent-output]")).toHaveLength(1);
+    expect(h.container.querySelectorAll("[data-current-output-agent]")).toHaveLength(2);
   });
 
-  it("makes the whole anchored agent item close the inspector and jump to evidence", async () => {
+  it("keeps a quiet timeline jump inside the expanded output", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-nova", {
         working: true,
@@ -364,8 +364,8 @@ describe("ComposeStatusBar extra DOM coverage", () => {
       ),
     );
 
-    await waitForSettled(h, () => expect(h.container.textContent).toContain("Activity (1)"));
-    await click(h, h.container.querySelector('button[aria-label^="Open agent activity"]'));
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     await waitForSettled(h, () =>
       expect(
         h.container.querySelector('button[aria-label*="Nova"][aria-label*="Run the focused suite"]'),
@@ -375,10 +375,10 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     await click(h, h.container.querySelector('button[aria-label*="Nova"][aria-label*="Run the focused suite"]'));
 
     expect(timelineMocks.scrollToAgentTimeline).toHaveBeenCalledWith("agent-nova", "working", { focus: true });
-    expect(h.container.querySelector("[data-live-activity-inspector]")).toBeNull();
+    expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
   });
 
-  it("places the inspector after its trigger and restores trigger focus on Escape", async () => {
+  it("places inline output after its trigger and keeps focus on the disclosure", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-nova", {
         working: true,
@@ -388,27 +388,23 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     ]);
 
     h.render(withProviders(<ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} />));
-    await waitForSettled(h, () => expect(h.container.textContent).toContain("Activity (1)"));
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
 
-    const trigger = h.container.querySelector<HTMLButtonElement>('button[aria-label^="Open agent activity"]');
+    const trigger = h.container.querySelector<HTMLButtonElement>('button[aria-label^="Expand current agent output"]');
     trigger?.focus();
     await click(h, trigger);
-    const inspector = h.container.querySelector<HTMLElement>("[data-live-activity-inspector]");
+    const inspector = h.container.querySelector<HTMLElement>("[data-current-agent-output]");
     expect(inspector).not.toBeNull();
     const domPosition = trigger?.compareDocumentPosition(inspector ?? document.body) ?? 0;
     expect(domPosition & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
-    await waitForSettled(h, () =>
-      expect(document.activeElement?.getAttribute("aria-label")).toBe("Close agent activity"),
-    );
+    expect(document.activeElement).toBe(trigger);
 
-    const focusedControl = document.activeElement;
-    if (!(focusedControl instanceof HTMLElement)) throw new Error("Expected a focused Inspector control");
-    await keyDown(h, focusedControl, "Escape");
-    expect(h.container.querySelector("[data-live-activity-inspector]")).toBeNull();
+    await click(h, trigger);
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
     expect(document.activeElement).toBe(trigger);
   });
 
-  it("leaves Escape to a later focused keyboard layer outside the inspector", async () => {
+  it("leaves Escape to a later focused keyboard layer outside the inline output", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-nova", {
         working: true,
@@ -431,8 +427,8 @@ describe("ComposeStatusBar extra DOM coverage", () => {
         </>,
       ),
     );
-    await waitForSettled(h, () => expect(h.container.textContent).toContain("Activity (1)"));
-    await click(h, h.container.querySelector('button[aria-label^="Open agent activity"]'));
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     const laterLayer = h.container.querySelector<HTMLInputElement>('input[aria-label="Mention autocomplete"]');
     if (!laterLayer) throw new Error("Expected later keyboard layer");
     laterLayer.focus();
@@ -440,8 +436,41 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     await keyDown(h, laterLayer, "Escape");
 
     expect(externalEscape).toHaveBeenCalledTimes(1);
-    expect(h.container.querySelector("[data-live-activity-inspector]")).not.toBeNull();
+    expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
     expect(document.activeElement).toBe(laterLayer);
+  });
+
+  it("does not steal focus after a pointer leaves the status surface", async () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(
+      ["chat-agent-status", "chat-1"],
+      [status("agent-nova", { working: true, engagement: "active", activity: activity("agent-nova") })],
+    );
+    const fallbackRef = createRef<HTMLButtonElement>();
+
+    h.render(
+      withProviders(
+        <>
+          <ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} fallbackFocusRef={fallbackRef} />
+          <button ref={fallbackRef} type="button">
+            Composer fallback
+          </button>
+        </>,
+        queryClient,
+      ),
+    );
+
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
+    const trigger = h.container.querySelector<HTMLButtonElement>('button[aria-label^="Expand current agent output"]');
+    trigger?.focus();
+    await act(async () => {
+      document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+      queryClient.setQueryData(["chat-agent-status", "chat-1"], []);
+    });
+    await h.flush();
+
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).toBeNull());
+    expect(document.activeElement).not.toBe(fallbackRef.current);
   });
 
   it("jumps a ready terminal error to its mounted error evidence", async () => {
@@ -467,8 +496,8 @@ describe("ComposeStatusBar extra DOM coverage", () => {
         </>,
       ),
     );
-    await waitForSettled(h, () => expect(h.container.textContent).toContain("Activity (1)"));
-    await click(h, h.container.querySelector('button[aria-label^="Open agent activity"]'));
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     const row = h.container.querySelector(
       'button[aria-label*="Terminal Agent"][aria-label*="Provider retry exhausted"]',
     );
@@ -531,20 +560,20 @@ describe("ComposeStatusBar extra DOM coverage", () => {
         </>,
       ),
     );
-    await waitForSettled(h, () => expect(h.container.textContent).toContain("Activity (3)"));
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("3 agents"));
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
 
     for (const [agentId, name] of [
       ["agent-waiting", "Waiting Agent"],
       ["agent-retrying", "Retrying Agent"],
       ["agent-warning", "Warning Agent"],
     ]) {
-      await click(h, h.container.querySelector('button[aria-label^="Open agent activity"]'));
       await click(h, h.container.querySelector(`button[aria-label*="${name}"][aria-label*="timeline"]`));
       expect(timelineMocks.scrollToAgentTimeline).toHaveBeenLastCalledWith(agentId, "reason", { focus: true });
     }
   });
 
-  it("keeps focus inside a live-updating inspector, then returns it to the composer fallback", async () => {
+  it("recovers focus from live-updating output, then returns it to the composer fallback", async () => {
     const queryClient = createQueryClient();
     queryClient.setQueryData(
       ["chat-agent-status", "chat-1"],
@@ -573,8 +602,8 @@ describe("ComposeStatusBar extra DOM coverage", () => {
       ),
     );
 
-    await waitForSettled(h, () => expect(h.container.textContent).toContain("Activity (2)"));
-    await click(h, h.container.querySelector('button[aria-label^="Open agent activity"]'));
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("2 agents"));
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     const novaRow = h.container.querySelector<HTMLButtonElement>('button[aria-label*="Nova"]');
     novaRow?.focus();
     expect(document.activeElement).toBe(novaRow);
@@ -587,7 +616,9 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     });
     await h.flush();
     await waitForSettled(h, () =>
-      expect(document.activeElement?.getAttribute("aria-label")).toBe("Close agent activity"),
+      expect(document.activeElement?.getAttribute("aria-label")).toBe(
+        "Collapse current agent output, 1 actionable agent",
+      ),
     );
 
     const atlasRow = h.container.querySelector<HTMLButtonElement>('button[aria-label*="Atlas"]');
@@ -600,7 +631,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(h.container.querySelector("[data-compose-status-bar]")).toBeNull();
   });
 
-  it("moves focus to Close when a focused row loses only its timeline anchor", async () => {
+  it("moves focus to the disclosure when a focused jump loses its timeline anchor", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-nova", { working: true, engagement: "active", activity: activity("agent-nova") }),
     ]);
@@ -618,8 +649,8 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     }
 
     h.render(withProviders(<AnchorHarness />));
-    await waitForSettled(h, () => expect(h.container.textContent).toContain("Activity (1)"));
-    await click(h, h.container.querySelector('button[aria-label^="Open agent activity"]'));
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     const row = h.container.querySelector<HTMLButtonElement>('button[aria-label*="Nova"]');
     row?.focus();
     expect(document.activeElement).toBe(row);
@@ -628,7 +659,9 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     await h.flush();
 
     await waitForSettled(h, () =>
-      expect(document.activeElement?.getAttribute("aria-label")).toBe("Close agent activity"),
+      expect(document.activeElement?.getAttribute("aria-label")).toBe(
+        "Collapse current agent output, 1 actionable agent",
+      ),
     );
     expect(h.container.querySelector('button[aria-label*="Nova"]')).toBeNull();
   });

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -222,7 +222,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(h.container.textContent).not.toContain("Activity");
 
     const trigger = h.container.querySelector('button[aria-label^="Expand current agent output"]');
-    expect(trigger?.getAttribute("aria-label")).toBe("Expand current agent output, 1 actionable agent");
+    expect(trigger?.getAttribute("aria-label")).toBe("Expand current agent output, 1 actionable agent, Nova, Working");
     const liveStatus = h.container.querySelector('[role="status"]');
     expect(liveStatus?.textContent).toContain("1 actionable agent");
     expect(liveStatus?.textContent).toContain("Nova Working");
@@ -237,6 +237,14 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(h.container.querySelector('section[aria-label="Current agent output"]')?.getAttribute("tabindex")).toBe("0");
     expect(h.container.textContent).not.toContain("Bash");
     expect(h.container.textContent).not.toContain("doc-page.tsx");
+    expect(trigger?.textContent).not.toContain("Write extra DOM tests");
+    expect(trigger?.querySelector(".compose-status-state-expanded")?.textContent).toContain("Working");
+    expect(trigger?.getAttribute("aria-label")).toBe(
+      "Collapse current agent output, 1 actionable agent, Nova, Working",
+    );
+    expect(h.container.querySelector("[data-current-output-identity]")).toBeNull();
+    expect(h.container.querySelector("[data-current-agent-output]")?.textContent).not.toContain("Nova");
+    expect(h.container.querySelector("[data-current-agent-output]")?.textContent).not.toContain("Working");
     expect(h.container.querySelector(".compose-status-narration strong")?.textContent).toBe("extra");
 
     await click(h, trigger);
@@ -285,9 +293,12 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(h.container.textContent).toContain("Idle");
     expect(h.container.textContent).not.toContain("Failed");
 
-    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    const trigger = h.container.querySelector('button[aria-label^="Expand current agent output"]');
+    await click(h, trigger);
     await waitForSettled(h, () => expect(h.container.textContent).toContain("Offline Agent"));
     expect(h.container.textContent).toContain("Offline");
+    expect(trigger?.textContent).toContain("2 status updates");
+    expect(trigger?.textContent).not.toContain("failed");
   });
 
   it("shows a current reason in the compact row and its detail inline", async () => {
@@ -310,10 +321,13 @@ describe("ComposeStatusBar extra DOM coverage", () => {
 
     await waitForSettled(h, () => expect(h.container.textContent).toContain("Waiting for provider capacity"));
     expect(h.container.textContent).toContain("Waiting");
-    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    const trigger = h.container.querySelector('button[aria-label^="Expand current agent output"]');
+    expect(trigger?.getAttribute("aria-label")).toContain("Beacon, Idle, Waiting for provider capacity");
+    await click(h, trigger);
     await waitForSettled(h, () => expect(h.container.querySelector('[title="capacity queue"]')).not.toBeNull());
+    expect(trigger?.getAttribute("aria-label")).toContain("Beacon, Idle, Waiting for provider capacity");
     expect(h.container.querySelector('[title="capacity queue"]')).not.toBeNull();
-    expect(h.container.querySelector('button[aria-label*="timeline"]')).toBeNull();
+    expect(h.container.querySelector('.compose-status-jump[aria-label*="timeline"]')).toBeNull();
   });
 
   it("opens all agents in one lightly divided inline region without duplicating the lead", async () => {
@@ -342,8 +356,21 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     const inspector = h.container.querySelector("[data-current-agent-output]");
     const atlasCount = inspector?.textContent?.match(/Atlas/g)?.length ?? 0;
     expect(atlasCount).toBe(1);
+    expect(h.container.querySelector('button[aria-label^="Collapse current agent output"]')?.textContent).toContain(
+      "2 agents",
+    );
+    expect(h.container.querySelector('button[aria-label^="Collapse current agent output"]')?.textContent).toContain(
+      "1 failed",
+    );
+    expect(
+      h.container.querySelector('button[aria-label^="Collapse current agent output"]')?.getAttribute("aria-label"),
+    ).toContain("1 failed");
+    expect(h.container.querySelector('button[aria-label^="Collapse current agent output"]')?.textContent).not.toContain(
+      "Atlas",
+    );
     expect(h.container.querySelectorAll("[data-current-agent-output]")).toHaveLength(1);
     expect(h.container.querySelectorAll("[data-current-output-agent]")).toHaveLength(2);
+    expect(h.container.querySelectorAll("[data-current-output-identity]")).toHaveLength(2);
   });
 
   it("keeps a quiet timeline jump inside the expanded output", async () => {
@@ -368,11 +395,14 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     await waitForSettled(h, () =>
       expect(
-        h.container.querySelector('button[aria-label*="Nova"][aria-label*="Run the focused suite"]'),
+        h.container.querySelector('.compose-status-jump[aria-label*="Nova"][aria-label*="Run the focused suite"]'),
       ).not.toBeNull(),
     );
 
-    await click(h, h.container.querySelector('button[aria-label*="Nova"][aria-label*="Run the focused suite"]'));
+    await click(
+      h,
+      h.container.querySelector('.compose-status-jump[aria-label*="Nova"][aria-label*="Run the focused suite"]'),
+    );
 
     expect(timelineMocks.scrollToAgentTimeline).toHaveBeenCalledWith("agent-nova", "working", { focus: true });
     expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
@@ -499,7 +529,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
     await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     const row = h.container.querySelector(
-      'button[aria-label*="Terminal Agent"][aria-label*="Provider retry exhausted"]',
+      '.compose-status-jump[aria-label*="Terminal Agent"][aria-label*="Provider retry exhausted"]',
     );
     expect(row).not.toBeNull();
     await click(h, row);
@@ -561,14 +591,18 @@ describe("ComposeStatusBar extra DOM coverage", () => {
       ),
     );
     await waitForSettled(h, () => expect(h.container.textContent).toContain("3 agents"));
-    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    const trigger = h.container.querySelector('button[aria-label^="Expand current agent output"]');
+    await click(h, trigger);
+    expect(trigger?.textContent).toContain("3 status updates");
+    expect(trigger?.getAttribute("aria-label")).toContain("3 status updates");
+    expect(trigger?.textContent).not.toContain("needs attention");
 
     for (const [agentId, name] of [
       ["agent-waiting", "Waiting Agent"],
       ["agent-retrying", "Retrying Agent"],
       ["agent-warning", "Warning Agent"],
     ]) {
-      await click(h, h.container.querySelector(`button[aria-label*="${name}"][aria-label*="timeline"]`));
+      await click(h, h.container.querySelector(`.compose-status-jump[aria-label*="${name}"][aria-label*="timeline"]`));
       expect(timelineMocks.scrollToAgentTimeline).toHaveBeenLastCalledWith(agentId, "reason", { focus: true });
     }
   });
@@ -603,8 +637,9 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     );
 
     await waitForSettled(h, () => expect(h.container.textContent).toContain("2 agents"));
-    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
-    const novaRow = h.container.querySelector<HTMLButtonElement>('button[aria-label*="Nova"]');
+    const trigger = h.container.querySelector('button[aria-label^="Expand current agent output"]');
+    await click(h, trigger);
+    const novaRow = h.container.querySelector<HTMLButtonElement>('.compose-status-jump[aria-label*="Nova"]');
     novaRow?.focus();
     expect(document.activeElement).toBe(novaRow);
 
@@ -617,18 +652,66 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     await h.flush();
     await waitForSettled(h, () =>
       expect(document.activeElement?.getAttribute("aria-label")).toBe(
-        "Collapse current agent output, 1 actionable agent",
+        "Collapse current agent output, 1 actionable agent, Atlas, Working",
       ),
     );
 
-    const atlasRow = h.container.querySelector<HTMLButtonElement>('button[aria-label*="Atlas"]');
-    atlasRow?.focus();
+    const atlasRow = h.container.querySelector<HTMLButtonElement>('.compose-status-jump[aria-label*="Atlas"]');
+    if (!atlasRow) throw new Error("Expected Atlas timeline jump");
+    atlasRow.focus();
+    expect(document.activeElement).toBe(atlasRow);
     await act(async () => {
       queryClient.setQueryData(["chat-agent-status", "chat-1"], []);
     });
     await h.flush();
     await waitForSettled(h, () => expect(document.activeElement).toBe(fallbackRef.current));
     expect(h.container.querySelector("[data-compose-status-bar]")).toBeNull();
+  });
+
+  it("keeps a focused surviving timeline jump mounted when a group becomes one agent", async () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(
+      ["chat-agent-status", "chat-1"],
+      [
+        status("agent-nova", { working: true, engagement: "active", activity: activity("agent-nova") }),
+        status("agent-atlas", { working: true, engagement: "active", activity: activity("agent-atlas") }),
+      ],
+    );
+
+    h.render(
+      withProviders(
+        <>
+          <div data-working-agent="agent-nova" />
+          <div data-working-agent="agent-atlas" />
+          <ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova"), agent("agent-atlas", "Atlas")]} />
+        </>,
+        queryClient,
+      ),
+    );
+
+    await waitForSettled(h, () => expect(h.container.textContent).toContain("2 agents"));
+    const trigger = h.container.querySelector('button[aria-label^="Expand current agent output"]');
+    await click(h, trigger);
+    const atlasJump = h.container.querySelector<HTMLButtonElement>('.compose-status-jump[aria-label*="Atlas"]');
+    if (!atlasJump) throw new Error("Expected Atlas timeline jump");
+    atlasJump.focus();
+
+    await act(async () => {
+      queryClient.setQueryData(
+        ["chat-agent-status", "chat-1"],
+        [status("agent-atlas", { working: true, engagement: "active", activity: activity("agent-atlas") })],
+      );
+    });
+    await h.flush();
+
+    await waitForSettled(h, () =>
+      expect(trigger?.getAttribute("aria-label")).toBe(
+        "Collapse current agent output, 1 actionable agent, Atlas, Working",
+      ),
+    );
+    expect(h.container.querySelector('.compose-status-jump[aria-label*="Atlas"]')).toBe(atlasJump);
+    expect(document.activeElement).toBe(atlasJump);
+    expect(h.container.querySelector("[data-current-output-identity]")).toBeNull();
   });
 
   it("moves focus to the disclosure when a focused jump loses its timeline anchor", async () => {
@@ -651,7 +734,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     h.render(withProviders(<AnchorHarness />));
     await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
     await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
-    const row = h.container.querySelector<HTMLButtonElement>('button[aria-label*="Nova"]');
+    const row = h.container.querySelector<HTMLButtonElement>('.compose-status-jump[aria-label*="Nova"]');
     row?.focus();
     expect(document.activeElement).toBe(row);
 
@@ -660,10 +743,10 @@ describe("ComposeStatusBar extra DOM coverage", () => {
 
     await waitForSettled(h, () =>
       expect(document.activeElement?.getAttribute("aria-label")).toBe(
-        "Collapse current agent output, 1 actionable agent",
+        "Collapse current agent output, 1 actionable agent, Nova, Working",
       ),
     );
-    expect(h.container.querySelector('button[aria-label*="Nova"]')).toBeNull();
+    expect(h.container.querySelector('.compose-status-jump[aria-label*="Nova"]')).toBeNull();
   });
 });
 

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -342,7 +342,11 @@ describe("ComposeStatusBar extra DOM coverage", () => {
 
     h.render(
       withProviders(
-        <ComposeStatusBar chatId="chat-1" agents={[agent("agent-atlas", "Atlas"), agent("agent-nova", "Nova")]} />,
+        <>
+          <div data-error-agent="agent-atlas" />
+          <div data-working-agent="agent-nova" />
+          <ComposeStatusBar chatId="chat-1" agents={[agent("agent-atlas", "Atlas"), agent("agent-nova", "Nova")]} />
+        </>,
       ),
     );
 
@@ -371,14 +375,16 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(h.container.querySelectorAll("[data-current-agent-output]")).toHaveLength(1);
     expect(h.container.querySelectorAll("[data-current-output-agent]")).toHaveLength(2);
     expect(h.container.querySelectorAll("[data-current-output-identity]")).toHaveLength(2);
+    expect(h.container.querySelectorAll(".compose-status-narration-with-jump")).toHaveLength(2);
   });
 
   it("keeps a quiet timeline jump inside the expanded output", async () => {
+    const fullNarration = `Run the focused suite\n\n${"Detailed result. ".repeat(110)}`;
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-nova", {
         working: true,
         engagement: "active",
-        activity: activity("agent-nova", { turnText: "Run the focused suite" }),
+        activity: activity("agent-nova", { turnText: "Run the focused suite", turnTextFull: fullNarration }),
       }),
     ]);
 
@@ -394,15 +400,14 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
     await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     await waitForSettled(h, () =>
-      expect(
-        h.container.querySelector('.compose-status-jump[aria-label*="Nova"][aria-label*="Run the focused suite"]'),
-      ).not.toBeNull(),
+      expect(h.container.querySelector('.compose-status-jump[aria-label*="Nova"]')).not.toBeNull(),
     );
+    const jump = h.container.querySelector<HTMLButtonElement>('.compose-status-jump[aria-label*="Nova"]');
+    if (!jump) throw new Error("Expected timeline jump");
+    expect(jump?.getAttribute("aria-label")).toBe("View Nova in the timeline");
+    expect(jump?.getAttribute("aria-label")).not.toContain(fullNarration);
 
-    await click(
-      h,
-      h.container.querySelector('.compose-status-jump[aria-label*="Nova"][aria-label*="Run the focused suite"]'),
-    );
+    await click(h, jump);
 
     expect(timelineMocks.scrollToAgentTimeline).toHaveBeenCalledWith("agent-nova", "working", { focus: true });
     expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
@@ -528,9 +533,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     );
     await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
     await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
-    const row = h.container.querySelector(
-      '.compose-status-jump[aria-label*="Terminal Agent"][aria-label*="Provider retry exhausted"]',
-    );
+    const row = h.container.querySelector('.compose-status-jump[aria-label="View Terminal Agent in the timeline"]');
     expect(row).not.toBeNull();
     await click(h, row);
     expect(timelineMocks.scrollToAgentTimeline).toHaveBeenCalledWith("agent-terminal", "failed", { focus: true });
@@ -712,6 +715,45 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(h.container.querySelector('.compose-status-jump[aria-label*="Atlas"]')).toBe(atlasJump);
     expect(document.activeElement).toBe(atlasJump);
     expect(h.container.querySelector("[data-current-output-identity]")).toBeNull();
+  });
+
+  it("keeps focus on a surviving Markdown link without a timeline anchor during a status update", async () => {
+    const queryClient = createQueryClient();
+    const linkedActivity = activity("agent-nova", {
+      label: "Drafting",
+      turnText: "Review the [implementation notes](https://example.com/notes).",
+    });
+    queryClient.setQueryData(
+      ["chat-agent-status", "chat-1"],
+      [status("agent-nova", { working: true, engagement: "active", activity: linkedActivity })],
+    );
+
+    h.render(withProviders(<ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} />, queryClient));
+
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    const link = h.container.querySelector<HTMLAnchorElement>(
+      '.compose-status-narration a[href="https://example.com/notes"]',
+    );
+    if (!link) throw new Error("Expected Markdown link");
+    expect(h.container.querySelector(".compose-status-jump")).toBeNull();
+    link.focus();
+
+    await act(async () => {
+      queryClient.setQueryData(
+        ["chat-agent-status", "chat-1"],
+        [
+          status("agent-nova", {
+            working: true,
+            engagement: "active",
+            activity: { ...linkedActivity, detail: "Refreshing status" },
+          }),
+        ],
+      );
+    });
+    await h.flush();
+
+    expect(document.activeElement).toBe(link);
   });
 
   it("moves focus to the disclosure when a focused jump loses its timeline anchor", async () => {

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -5,24 +5,22 @@ import {
   type LiveActivity,
 } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
-import { Brain, ChevronDown, Pencil, Wrench, X } from "lucide-react";
-import { type Ref, type RefObject, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { Brain, ChevronDown, Pencil, Wrench } from "lucide-react";
+import { type RefObject, useEffect, useId, useMemo, useRef, useState } from "react";
 import { chatAgentStatusQueryKey, fetchChatAgentStatuses } from "../../api/agent-status.js";
 import { viewOf } from "../../lib/agent-status-view.js";
 import { stripInlineMarkdown } from "../../lib/strip-inline-markdown.js";
 import { isJumpable, type TimelineAnchorKind, useMountedAnchors } from "../../lib/use-mounted-anchors.js";
+import { Markdown } from "../ui/markdown.js";
 import { StatusGlyph } from "../ui/status-glyph.js";
 import { TimelineJumpButton } from "./timeline-jump-button.js";
 
 /**
  * ComposeStatusBar is the stable answer to “what are the agents doing now?”.
  *
- * The collapsed strip keeps one invariant structure: lead snapshot on the left,
- * `Activity (N)` on the right. The explicit Activity control always opens the
- * same live inspector, regardless of viewport or agent count. The inspector is
- * intentionally a current-state index, not another timeline: every agent gets
- * one compact item with at most two lines of latest narration plus its current
- * tool/reason. Full narration and activity history remain in the timeline.
+ * The compact row is the top edge of the composer: it shows one live snapshot
+ * and expands in place to the current output for every actionable agent. This
+ * is a status projection, not another timeline or a floating inspector.
  *
  * Only working, failed, waiting, retrying, and terminal-reason states raise the
  * strip. When every participant is quiet, the strip disappears.
@@ -99,24 +97,16 @@ export function ComposeStatusBar({
   chatId: string;
   /** Non-human agent participants, used for stable display-name lookup. */
   agents: ChatParticipantDetail[];
-  /** Stable composer control that receives focus if the activity bar vanishes. */
+  /** Stable composer control that receives focus if the status surface vanishes. */
   fallbackFocusRef?: RefObject<HTMLElement | null>;
 }) {
-  const [inspectorOpen, setInspectorOpen] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const [lead, setLead] = useState<{ agentId: string; since: number } | null>(null);
-  const inspectorId = useId();
+  const detailsId = useId();
   const activeChatIdRef = useRef(chatId);
-  const inspectorRef = useRef<HTMLElement | null>(null);
+  const surfaceRef = useRef<HTMLElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const focusWithinRef = useRef(false);
-  const closeInspector = useCallback(() => {
-    focusWithinRef.current = false;
-    setInspectorOpen(false);
-  }, []);
-  const closeInspectorAndRestoreFocus = useCallback(() => {
-    setInspectorOpen(false);
-    triggerRef.current?.focus();
-  }, []);
   const { data: rawStatuses } = useQuery({
     queryKey: chatAgentStatusQueryKey(chatId),
     queryFn: () => fetchChatAgentStatuses(chatId),
@@ -147,72 +137,39 @@ export function ComposeStatusBar({
   useEffect(() => {
     if (activeChatIdRef.current === chatId) return;
     activeChatIdRef.current = chatId;
-    setInspectorOpen(false);
+    setExpanded(false);
   }, [chatId]);
 
   useEffect(() => {
+    if (attention.length === 0) return;
+    const clearOutsidePointerFocus = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && !surfaceRef.current?.contains(target)) focusWithinRef.current = false;
+    };
+    document.addEventListener("pointerdown", clearOutsidePointerFocus, true);
+    return () => document.removeEventListener("pointerdown", clearOutsidePointerFocus, true);
+  }, [attention.length]);
+
+  useEffect(() => {
     if (attention.length === 0) {
-      setInspectorOpen(false);
+      setExpanded(false);
       if (!focusWithinRef.current) return;
       focusWithinRef.current = false;
       const frame = requestAnimationFrame(() => fallbackFocusRef?.current?.focus());
       return () => cancelAnimationFrame(frame);
     }
-    if (!inspectorOpen || !focusWithinRef.current) return;
+    if (!expanded || !focusWithinRef.current) return;
     const active = document.activeElement;
-    const activeAgentId = active?.closest<HTMLElement>("[data-live-activity-agent]")?.dataset.liveActivityAgent;
+    const activeAgentId = active?.closest<HTMLElement>("[data-current-output-agent]")?.dataset.currentOutputAgent;
     const focusedStatus = attention.find((status) => status.agentId === activeAgentId);
     const focusedRowSurvives =
       focusedStatus !== undefined && isJumpable(mounted, timelineTarget(focusedStatus), focusedStatus.agentId);
-    if (
-      active &&
-      (triggerRef.current?.contains(active) ||
-        (inspectorRef.current?.contains(active) && (activeAgentId === undefined || focusedRowSurvives)))
-    ) {
+    if (active && surfaceRef.current?.contains(active) && (activeAgentId === undefined || focusedRowSurvives)) {
       return;
     }
-    const frame = requestAnimationFrame(() => {
-      inspectorRef.current?.querySelector<HTMLElement>(".compose-status-inspector-close")?.focus();
-    });
+    const frame = requestAnimationFrame(() => triggerRef.current?.focus());
     return () => cancelAnimationFrame(frame);
-  }, [attention, fallbackFocusRef, inspectorOpen, mounted]);
-
-  useEffect(() => {
-    if (!inspectorOpen) return;
-    const frame = requestAnimationFrame(() => {
-      inspectorRef.current?.querySelector<HTMLElement>("button")?.focus();
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [inspectorOpen]);
-
-  useEffect(() => {
-    if (!inspectorOpen) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      const target = event.target;
-      if (
-        !(target instanceof Node) ||
-        (!inspectorRef.current?.contains(target) && !triggerRef.current?.contains(target))
-      ) {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation();
-      closeInspectorAndRestoreFocus();
-    };
-    const onPointerDown = (event: PointerEvent) => {
-      const target = event.target as Node | null;
-      if (!target || inspectorRef.current?.contains(target) || triggerRef.current?.contains(target)) return;
-      closeInspector();
-    };
-    document.addEventListener("keydown", onKeyDown, true);
-    document.addEventListener("pointerdown", onPointerDown, true);
-    return () => {
-      document.removeEventListener("keydown", onKeyDown, true);
-      document.removeEventListener("pointerdown", onPointerDown, true);
-    };
-  }, [closeInspector, closeInspectorAndRestoreFocus, inspectorOpen]);
+  }, [attention, expanded, fallbackFocusRef, mounted]);
 
   const leadRow = (lead && attention.find((status) => status.agentId === lead.agentId)) ?? attention[0];
 
@@ -223,72 +180,46 @@ export function ComposeStatusBar({
       </span>
 
       {leadRow ? (
-        <div
-          className="fade-in"
+        <section
+          ref={surfaceRef}
+          className="compose-status-surface fade-in"
           data-compose-status-bar
           onFocusCapture={() => {
             focusWithinRef.current = true;
           }}
           onBlurCapture={(event) => {
             const next = event.relatedTarget;
-            // Removing the last actionable row temporarily moves browser focus to
-            // body before the fallback-focus effect runs. Preserve the marker for
-            // that removal transition; explicit outside pointer dismissal resets
-            // it through closeInspector.
-            if (next instanceof Node && next !== document.body && !event.currentTarget.contains(next)) {
+            if (next instanceof HTMLElement && next !== document.body && !event.currentTarget.contains(next)) {
               focusWithinRef.current = false;
             }
           }}
-          style={{
-            position: "relative",
-            marginBottom: "var(--sp-1)",
-            paddingBottom: "var(--sp-1)",
-            borderBottom: "var(--hairline) solid var(--border-faint)",
-          }}
         >
-          <div className="flex min-w-0 items-center" style={{ gap: "var(--sp-2)" }}>
+          <button
+            ref={triggerRef}
+            type="button"
+            aria-controls={detailsId}
+            aria-expanded={expanded}
+            aria-label={`${expanded ? "Collapse" : "Expand"} current agent output, ${attention.length} actionable ${attention.length === 1 ? "agent" : "agents"}`}
+            onClick={() => setExpanded((open) => !open)}
+            className="compose-status-summary flex w-full min-w-0 items-center text-left transition-colors hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+          >
             <LeadSnapshot status={leadRow} name={nameOf(leadRow.agentId)} />
-            <button
-              ref={triggerRef}
-              type="button"
-              aria-controls={inspectorId}
-              aria-expanded={inspectorOpen}
-              aria-haspopup="dialog"
-              aria-label={`${inspectorOpen ? "Close" : "Open"} agent activity, ${attention.length} actionable ${attention.length === 1 ? "agent" : "agents"}`}
-              onClick={() => setInspectorOpen((open) => !open)}
-              className="compose-status-activity-trigger text-label inline-flex shrink-0 items-center rounded-[var(--radius-input)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--fg)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              style={{
-                gap: "var(--sp-1)",
-                border: 0,
-                background: inspectorOpen ? "var(--bg-hover)" : "transparent",
-                padding: "0 var(--sp-1_5)",
-                cursor: "pointer",
-                color: "var(--fg-3)",
-              }}
-            >
-              <span>Activity ({attention.length})</span>
-              <ChevronDown
-                aria-hidden="true"
-                className="h-3.5 w-3.5 transition-transform"
-                style={{ transform: inspectorOpen ? "rotate(180deg)" : "none" }}
-              />
-            </button>
-          </div>
-
-          {/* Keep the panel after its disclosure trigger in DOM order. Its visual
-              position is still above the composer, while forward Tab now enters
-              Close → activity rows instead of skipping the panel entirely. */}
-          {inspectorOpen ? (
-            <LiveActivityInspector
-              id={inspectorId}
-              ref={inspectorRef}
-              attention={attention}
-              nameOf={nameOf}
-              mounted={mounted}
-              onClose={closeInspectorAndRestoreFocus}
+            {attention.length > 1 ? (
+              <span className="text-caption shrink-0" style={{ color: "var(--fg-3)" }}>
+                {attention.length} agents
+              </span>
+            ) : null}
+            <ChevronDown
+              aria-hidden="true"
+              className="h-3.5 w-3.5 shrink-0 transition-transform"
+              style={{ color: "var(--fg-3)", transform: expanded ? "rotate(180deg)" : "none" }}
             />
+          </button>
+
+          {expanded ? (
+            <CurrentOutputDetails id={detailsId} attention={attention} nameOf={nameOf} mounted={mounted} />
           ) : null}
-        </div>
+        </section>
       ) : null}
     </>
   );
@@ -304,7 +235,7 @@ function activityAnnouncement(attention: AgentChatStatus[], nameOf: (agentId: st
     .sort((a, b) => a.agentId.localeCompare(b.agentId))
     .map((status) => `${nameOf(status.agentId)} ${visibleStatusReason(status)?.label ?? stateLabel(status)}`)
     .join(". ");
-  return states ? `Agent activity updated: ${count}. ${states}.` : `Agent activity updated: ${count}.`;
+  return states ? `Agent status updated: ${count}. ${states}.` : `Agent status updated: ${count}.`;
 }
 
 function LeadSnapshot({ status, name }: { status: AgentChatStatus; name: string }) {
@@ -332,98 +263,49 @@ function LeadSnapshot({ status, name }: { status: AgentChatStatus; name: string 
   );
 }
 
-const LiveActivityInspector = function LiveActivityInspector({
+function CurrentOutputDetails({
   id,
-  ref,
   attention,
   nameOf,
   mounted,
-  onClose,
 }: {
   id: string;
-  ref: Ref<HTMLElement>;
   attention: AgentChatStatus[];
   nameOf: (agentId: string) => string;
   mounted: ReadonlySet<string>;
-  onClose: () => void;
 }) {
   return (
     <section
       id={id}
-      ref={ref}
-      role="dialog"
-      aria-label="Agent activity"
-      className="fade-in"
-      data-live-activity-inspector
-      style={{
-        position: "absolute",
-        left: 0,
-        right: 0,
-        bottom: "calc(100% + var(--sp-1))",
-        zIndex: 30,
-        overflow: "hidden",
-        background: "var(--bg-raised)",
-        border: "var(--hairline) solid var(--border)",
-        borderRadius: "var(--radius-dialog)",
-        boxShadow: "var(--shadow-md)",
-      }}
+      aria-label="Current agent output"
+      className="compose-status-details fade-in focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+      data-current-agent-output
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: keyboard users need a focus target to scroll long plain-text output.
+      tabIndex={0}
     >
-      <div
-        className="flex items-center"
-        style={{
-          minHeight: "var(--sp-10)",
-          gap: "var(--sp-2)",
-          padding: "var(--sp-1) var(--sp-1) var(--sp-1) var(--sp-2_5)",
-          borderBottom: "var(--hairline) solid var(--border-faint)",
-        }}
-      >
-        <span className="text-label font-semibold" style={{ color: "var(--fg-2)" }}>
-          Agent activity · {attention.length} {attention.length === 1 ? "agent" : "agents"}
-        </span>
-        <button
-          type="button"
-          aria-label="Close agent activity"
-          onClick={onClose}
-          className="compose-status-inspector-close ml-auto inline-flex items-center justify-center rounded-[var(--radius-input)] transition-colors hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          style={{ border: 0, background: "transparent", cursor: "pointer", color: "var(--fg-3)" }}
-        >
-          <X aria-hidden="true" className="h-3.5 w-3.5" />
-        </button>
-      </div>
-      <ul
-        style={{
-          maxHeight: "min(52vh, 20rem)",
-          margin: 0,
-          padding: 0,
-          overflowY: "auto",
-          overscrollBehavior: "contain",
-          listStyle: "none",
-        }}
-      >
+      <ul style={{ margin: 0, padding: 0, listStyle: "none" }}>
         {attention.map((status, index) => (
           <li
             key={status.agentId}
-            data-live-activity-agent={status.agentId}
+            data-current-output-agent={status.agentId}
             style={{ borderTop: index === 0 ? 0 : "var(--hairline) solid var(--border-faint)" }}
           >
-            <InspectorItem status={status} name={nameOf(status.agentId)} mounted={mounted} onNavigate={onClose} />
+            <CurrentOutputItem status={status} name={nameOf(status.agentId)} mounted={mounted} />
           </li>
         ))}
       </ul>
     </section>
   );
-};
+}
 
-function InspectorItem({
+function CurrentOutputItem({
   status,
   name,
   mounted,
-  onNavigate,
 }: {
   status: AgentChatStatus;
   name: string;
   mounted: ReadonlySet<string>;
-  onNavigate: () => void;
 }) {
   const visual = statusVisual(status);
   const snapshot = agentSnapshot(status);
@@ -432,25 +314,16 @@ function InspectorItem({
   const accessibleSummary = [
     name,
     stateLabel(status),
-    snapshot.update,
+    stripInlineMarkdown(snapshot.update),
     snapshot.meta ? formatActivityMeta(snapshot.meta) : null,
     "View in the timeline",
   ]
     .filter((part): part is string => part !== null)
     .join(". ");
   return (
-    <TimelineJumpButton
-      agentId={status.agentId}
-      target={jumpTarget}
-      anchored={anchored}
-      ariaLabel={accessibleSummary}
-      onNavigate={onNavigate}
-      className="w-full text-left"
-      interactiveClassName="transition-colors hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
-      style={{ minHeight: "var(--sp-16)", padding: "var(--sp-2) var(--sp-2_5)" }}
-    >
-      <div className="min-w-0 flex-1">
-        <div className="text-label flex min-w-0 items-center" style={{ gap: "var(--sp-1_5)" }}>
+    <article style={{ padding: "var(--sp-2_5) var(--sp-3)" }} title={snapshot.updateTitle}>
+      <div className="text-label flex min-w-0 items-center" style={{ gap: "var(--sp-1_5)" }}>
+        <div className="flex min-w-0 flex-1 items-center" style={{ gap: "var(--sp-1_5)" }}>
           <StatusGlyph colorVar={visual.colorVar} shape={visual.shape} pulse={visual.pulse} size={7} />
           <span className="font-semibold" style={{ color: "var(--fg-2)", overflowWrap: "anywhere" }}>
             {name}
@@ -459,24 +332,22 @@ function InspectorItem({
             {stateLabel(status)}
           </span>
         </div>
-        <div
-          className="text-body"
-          title={snapshot.updateTitle}
-          style={{
-            display: "-webkit-box",
-            WebkitBoxOrient: "vertical",
-            WebkitLineClamp: 2,
-            marginTop: "var(--sp-0_5)",
-            overflow: "hidden",
-            overflowWrap: "anywhere",
-            color: "var(--fg-2)",
-          }}
-        >
-          {snapshot.update}
-        </div>
-        {snapshot.meta ? <ActivityMetaLine meta={snapshot.meta} /> : null}
+        {anchored ? (
+          <TimelineJumpButton
+            agentId={status.agentId}
+            target={jumpTarget}
+            anchored
+            ariaLabel={accessibleSummary}
+            interactiveClassName="rounded-[var(--radius-input)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <span className="sr-only">View in the timeline</span>
+          </TimelineJumpButton>
+        ) : null}
       </div>
-    </TimelineJumpButton>
+
+      <Markdown className="compose-status-narration text-body">{snapshot.update}</Markdown>
+      {snapshot.meta ? <ActivityMetaLine meta={snapshot.meta} /> : null}
+    </article>
   );
 }
 
@@ -535,9 +406,10 @@ type AgentSnapshot = {
   meta: ActivityMeta | null;
 };
 
-function narrationOf(status: AgentChatStatus): string | null {
-  const narration = status.activity?.turnText;
-  return narration ? stripInlineMarkdown(narration) : null;
+function narrationOf(status: AgentChatStatus, full = false): string | null {
+  const narration = full ? (status.activity?.turnTextFull ?? status.activity?.turnText) : status.activity?.turnText;
+  if (!narration) return null;
+  return full ? narration : stripInlineMarkdown(narration);
 }
 
 function collapsedSummary(status: AgentChatStatus): string | null {
@@ -551,7 +423,7 @@ function collapsedSummary(status: AgentChatStatus): string | null {
 }
 
 function agentSnapshot(status: AgentChatStatus): AgentSnapshot {
-  const narration = narrationOf(status);
+  const narration = narrationOf(status, true);
   const reason = visibleStatusReason(status);
   if (reason) {
     const detail = reason.detail ? stripInlineMarkdown(reason.detail) : undefined;
@@ -575,9 +447,9 @@ function agentSnapshot(status: AgentChatStatus): AgentSnapshot {
 }
 
 function activityMeta(activity: LiveActivity, hasNarration: boolean): ActivityMeta | null {
+  if (hasNarration) return null;
   if (activity.kind === "thinking") return { kind: "thinking", label: "Thinking" };
   if (activity.kind === "assistant_text") {
-    if (hasNarration) return null;
     return {
       kind: "assistant_text",
       label: activity.detail ? stripInlineMarkdown(activity.detail) : "Writing",

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -155,8 +155,8 @@ export function ComposeStatusBar({
       setExpanded(false);
       if (!focusWithinRef.current) return;
       focusWithinRef.current = false;
-      const frame = requestAnimationFrame(() => fallbackFocusRef?.current?.focus());
-      return () => cancelAnimationFrame(frame);
+      fallbackFocusRef?.current?.focus();
+      return;
     }
     if (!expanded || !focusWithinRef.current) return;
     const active = document.activeElement;
@@ -172,6 +172,11 @@ export function ComposeStatusBar({
   }, [attention, expanded, fallbackFocusRef, mounted]);
 
   const leadRow = (lead && attention.find((status) => status.agentId === lead.agentId)) ?? attention[0];
+  const disclosureStatus = leadRow
+    ? expanded && attention.length > 1
+      ? expandedGroupState(attention)
+      : [nameOf(leadRow.agentId), stateLabel(leadRow), visibleStatusReason(leadRow)?.label].filter(Boolean).join(", ")
+    : "";
 
   return (
     <>
@@ -199,12 +204,16 @@ export function ComposeStatusBar({
             type="button"
             aria-controls={detailsId}
             aria-expanded={expanded}
-            aria-label={`${expanded ? "Collapse" : "Expand"} current agent output, ${attention.length} actionable ${attention.length === 1 ? "agent" : "agents"}`}
+            aria-label={`${expanded ? "Collapse" : "Expand"} current agent output, ${attention.length} actionable ${attention.length === 1 ? "agent" : "agents"}, ${disclosureStatus}`}
             onClick={() => setExpanded((open) => !open)}
             className="compose-status-summary flex w-full min-w-0 items-center text-left transition-colors hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
           >
-            <LeadSnapshot status={leadRow} name={nameOf(leadRow.agentId)} />
-            {attention.length > 1 ? (
+            {expanded && attention.length > 1 ? (
+              <ExpandedGroupSnapshot statuses={attention} />
+            ) : (
+              <LeadSnapshot status={leadRow} name={nameOf(leadRow.agentId)} showSummary={!expanded} />
+            )}
+            {!expanded && attention.length > 1 ? (
               <span className="text-caption shrink-0" style={{ color: "var(--fg-3)" }}>
                 {attention.length} agents
               </span>
@@ -238,7 +247,7 @@ function activityAnnouncement(attention: AgentChatStatus[], nameOf: (agentId: st
   return states ? `Agent status updated: ${count}. ${states}.` : `Agent status updated: ${count}.`;
 }
 
-function LeadSnapshot({ status, name }: { status: AgentChatStatus; name: string }) {
+function LeadSnapshot({ status, name, showSummary }: { status: AgentChatStatus; name: string; showSummary: boolean }) {
   const visual = statusVisual(status);
   const summary = collapsedSummary(status);
   return (
@@ -247,11 +256,14 @@ function LeadSnapshot({ status, name }: { status: AgentChatStatus; name: string 
       <span className="compose-status-agent-name shrink-0 font-semibold" style={{ color: "var(--fg-2)" }}>
         {name}
       </span>
-      <span className="compose-status-state inline-flex shrink-0 items-center" style={{ gap: "var(--sp-1_5)" }}>
+      <span
+        className={`compose-status-state inline-flex shrink-0 items-center${showSummary ? "" : " compose-status-state-expanded"}`}
+        style={{ gap: "var(--sp-1_5)" }}
+      >
         <Sep />
         <span style={{ color: "var(--fg-3)" }}>{stateLabel(status)}</span>
       </span>
-      {summary ? (
+      {showSummary && summary ? (
         <>
           <Sep />
           <span className="truncate" title={summary} style={{ color: "var(--fg-2)" }}>
@@ -261,6 +273,34 @@ function LeadSnapshot({ status, name }: { status: AgentChatStatus; name: string 
       ) : null}
     </div>
   );
+}
+
+function ExpandedGroupSnapshot({ statuses }: { statuses: AgentChatStatus[] }) {
+  const lead = statuses[0];
+  if (!lead) return null;
+  const visual = statusVisual(lead);
+  const state = expandedGroupState(statuses);
+
+  return (
+    <div className="text-caption flex min-w-0 flex-1 items-center" style={{ gap: "var(--sp-1_5)" }}>
+      <StatusGlyph colorVar={visual.colorVar} shape={visual.shape} pulse={visual.pulse} size={8} />
+      <span className="shrink-0 font-semibold" style={{ color: "var(--fg-2)" }}>
+        {statuses.length} agents
+      </span>
+      <Sep />
+      <span className="truncate" style={{ color: "var(--fg-3)" }}>
+        {state}
+      </span>
+    </div>
+  );
+}
+
+function expandedGroupState(statuses: AgentChatStatus[]): string {
+  const failures = statuses.filter((status) => status.main === "failed").length;
+  if (failures > 0) return `${failures} failed`;
+  const statusUpdates = statuses.filter((status) => visibleStatusReason(status) !== undefined).length;
+  if (statusUpdates > 0) return `${statusUpdates} status ${statusUpdates === 1 ? "update" : "updates"}`;
+  return "Active";
 }
 
 function CurrentOutputDetails({
@@ -274,6 +314,7 @@ function CurrentOutputDetails({
   nameOf: (agentId: string) => string;
   mounted: ReadonlySet<string>;
 }) {
+  const showIdentity = attention.length > 1;
   return (
     <section
       id={id}
@@ -290,7 +331,12 @@ function CurrentOutputDetails({
             data-current-output-agent={status.agentId}
             style={{ borderTop: index === 0 ? 0 : "var(--hairline) solid var(--border-faint)" }}
           >
-            <CurrentOutputItem status={status} name={nameOf(status.agentId)} mounted={mounted} />
+            <CurrentOutputItem
+              status={status}
+              name={nameOf(status.agentId)}
+              mounted={mounted}
+              showIdentity={showIdentity}
+            />
           </li>
         ))}
       </ul>
@@ -302,10 +348,12 @@ function CurrentOutputItem({
   status,
   name,
   mounted,
+  showIdentity,
 }: {
   status: AgentChatStatus;
   name: string;
   mounted: ReadonlySet<string>;
+  showIdentity: boolean;
 }) {
   const visual = statusVisual(status);
   const snapshot = agentSnapshot(status);
@@ -321,31 +369,49 @@ function CurrentOutputItem({
     .filter((part): part is string => part !== null)
     .join(". ");
   return (
-    <article style={{ padding: "var(--sp-2_5) var(--sp-3)" }} title={snapshot.updateTitle}>
-      <div className="text-label flex min-w-0 items-center" style={{ gap: "var(--sp-1_5)" }}>
-        <div className="flex min-w-0 flex-1 items-center" style={{ gap: "var(--sp-1_5)" }}>
-          <StatusGlyph colorVar={visual.colorVar} shape={visual.shape} pulse={visual.pulse} size={7} />
-          <span className="font-semibold" style={{ color: "var(--fg-2)", overflowWrap: "anywhere" }}>
-            {name}
-          </span>
-          <span className="shrink-0" style={{ color: "var(--fg-3)" }}>
-            {stateLabel(status)}
-          </span>
+    <article
+      className="compose-status-output"
+      style={{ padding: "var(--sp-2_5) var(--sp-3)" }}
+      title={snapshot.updateTitle}
+    >
+      {showIdentity ? (
+        <div
+          key="identity"
+          className="compose-status-identity text-label flex min-w-0 items-center"
+          style={{ gap: "var(--sp-1_5)" }}
+          data-current-output-identity
+        >
+          <div className="flex min-w-0 flex-1 items-center" style={{ gap: "var(--sp-1_5)" }}>
+            <StatusGlyph colorVar={visual.colorVar} shape={visual.shape} pulse={visual.pulse} size={7} />
+            <span className="font-semibold" style={{ color: "var(--fg-2)", overflowWrap: "anywhere" }}>
+              {name}
+            </span>
+            <span className="shrink-0" style={{ color: "var(--fg-3)" }}>
+              {stateLabel(status)}
+            </span>
+          </div>
         </div>
-        {anchored ? (
-          <TimelineJumpButton
-            agentId={status.agentId}
-            target={jumpTarget}
-            anchored
-            ariaLabel={accessibleSummary}
-            interactiveClassName="rounded-[var(--radius-input)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            <span className="sr-only">View in the timeline</span>
-          </TimelineJumpButton>
-        ) : null}
-      </div>
+      ) : null}
+      {anchored ? (
+        <TimelineJumpButton
+          key="timeline-jump"
+          agentId={status.agentId}
+          target={jumpTarget}
+          anchored
+          ariaLabel={accessibleSummary}
+          className="compose-status-jump"
+          interactiveClassName="rounded-[var(--radius-input)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <span className="sr-only">View in the timeline</span>
+        </TimelineJumpButton>
+      ) : null}
 
-      <Markdown className="compose-status-narration text-body">{snapshot.update}</Markdown>
+      <Markdown
+        key="narration"
+        className={`compose-status-narration text-body${!showIdentity && anchored ? " compose-status-narration-with-jump" : ""}`}
+      >
+        {snapshot.update}
+      </Markdown>
       {snapshot.meta ? <ActivityMetaLine meta={snapshot.meta} /> : null}
     </article>
   );

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -160,12 +160,12 @@ export function ComposeStatusBar({
     }
     if (!expanded || !focusWithinRef.current) return;
     const active = document.activeElement;
-    const activeAgentId = active?.closest<HTMLElement>("[data-current-output-agent]")?.dataset.currentOutputAgent;
-    const focusedStatus = attention.find((status) => status.agentId === activeAgentId);
-    const focusedRowSurvives =
-      focusedStatus !== undefined && isJumpable(mounted, timelineTarget(focusedStatus), focusedStatus.agentId);
-    if (active && surfaceRef.current?.contains(active) && (activeAgentId === undefined || focusedRowSurvives)) {
-      return;
+    if (active instanceof HTMLElement && active.isConnected && surfaceRef.current?.contains(active)) {
+      const activeJump = active.closest<HTMLElement>(".compose-status-jump");
+      if (!activeJump) return;
+      const activeAgentId = activeJump.closest<HTMLElement>("[data-current-output-agent]")?.dataset.currentOutputAgent;
+      const focusedStatus = attention.find((status) => status.agentId === activeAgentId);
+      if (focusedStatus && isJumpable(mounted, timelineTarget(focusedStatus), focusedStatus.agentId)) return;
     }
     const frame = requestAnimationFrame(() => triggerRef.current?.focus());
     return () => cancelAnimationFrame(frame);
@@ -359,15 +359,6 @@ function CurrentOutputItem({
   const snapshot = agentSnapshot(status);
   const jumpTarget = timelineTarget(status);
   const anchored = isJumpable(mounted, jumpTarget, status.agentId);
-  const accessibleSummary = [
-    name,
-    stateLabel(status),
-    stripInlineMarkdown(snapshot.update),
-    snapshot.meta ? formatActivityMeta(snapshot.meta) : null,
-    "View in the timeline",
-  ]
-    .filter((part): part is string => part !== null)
-    .join(". ");
   return (
     <article
       className="compose-status-output"
@@ -398,7 +389,7 @@ function CurrentOutputItem({
           agentId={status.agentId}
           target={jumpTarget}
           anchored
-          ariaLabel={accessibleSummary}
+          ariaLabel={`View ${name} in the timeline`}
           className="compose-status-jump"
           interactiveClassName="rounded-[var(--radius-input)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
@@ -408,7 +399,7 @@ function CurrentOutputItem({
 
       <Markdown
         key="narration"
-        className={`compose-status-narration text-body${!showIdentity && anchored ? " compose-status-narration-with-jump" : ""}`}
+        className={`compose-status-narration text-body${anchored ? " compose-status-narration-with-jump" : ""}`}
       >
         {snapshot.update}
       </Markdown>

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -929,7 +929,7 @@
     box-shadow: inset 0 0 0 var(--hairline) var(--fg-info-strong);
   }
   [data-compose-status-bar].fade-in,
-  [data-live-activity-inspector].fade-in {
+  [data-current-agent-output].fade-in {
     animation: none;
   }
 }
@@ -1021,18 +1021,21 @@
 }
 
 .compose-status-identity {
-  padding-right: var(--sp-6);
+  padding-right: var(--sp-8);
 }
 
 .compose-status-jump {
   position: absolute;
   z-index: 1;
-  top: var(--sp-3);
-  right: var(--sp-3);
+  top: var(--sp-2);
+  right: var(--sp-2);
+  width: var(--sp-7);
+  height: var(--sp-7);
+  justify-content: center;
 }
 
 .compose-status-narration-with-jump > :first-child {
-  padding-right: var(--sp-6);
+  padding-right: var(--sp-8);
 }
 
 [data-compose-status-bar] + .composer-card {
@@ -2500,5 +2503,15 @@ tr[data-interactive]:hover {
   }
   .compose-status-summary {
     min-height: var(--sp-11);
+  }
+  .compose-status-identity,
+  .compose-status-narration-with-jump > :first-child {
+    padding-right: var(--sp-11);
+  }
+  .compose-status-jump {
+    top: 0;
+    right: 0;
+    width: var(--sp-11);
+    height: var(--sp-11);
   }
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -1016,6 +1016,25 @@
   border-top: var(--hairline) solid var(--border-faint);
 }
 
+.compose-status-output {
+  position: relative;
+}
+
+.compose-status-identity {
+  padding-right: var(--sp-6);
+}
+
+.compose-status-jump {
+  position: absolute;
+  z-index: 1;
+  top: var(--sp-3);
+  right: var(--sp-3);
+}
+
+.compose-status-narration-with-jump > :first-child {
+  padding-right: var(--sp-6);
+}
+
 [data-compose-status-bar] + .composer-card {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
@@ -2468,7 +2487,7 @@ tr[data-interactive]:hover {
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .compose-status-state {
+  .compose-status-state:not(.compose-status-state-expanded) {
     position: absolute;
     width: 1px;
     height: 1px;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -988,6 +988,39 @@
   border-radius: var(--radius-panel);
 }
 
+/* Live status is the composer's connected top section, not a floating
+   inspector. The composer keeps the shared seam and supplies the lower
+   corners; when no status is present its normal four-corner shape remains. */
+.compose-status-surface {
+  overflow: hidden;
+  background: var(--bg-raised);
+  border: var(--hairline) solid var(--border);
+  border-bottom: 0;
+  border-radius: var(--radius-panel) var(--radius-panel) 0 0;
+}
+
+.compose-status-summary {
+  min-height: var(--sp-10);
+  gap: var(--sp-2);
+  padding: var(--sp-1) var(--sp-3);
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.compose-status-details {
+  max-height: min(42vh, 28rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border-top: var(--hairline) solid var(--border-faint);
+}
+
+[data-compose-status-bar] + .composer-card {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
 /* Shared base for the composer picker popovers — the `@`mention list and the
    `/`slash-command list. Desktop presentation: a compact panel floating just
    above the input. Each keeps its own min/max width below. */
@@ -2420,15 +2453,6 @@ tr[data-interactive]:hover {
   --composer-font-size: var(--text-subtitle);
 }
 
-.compose-status-activity-trigger {
-  min-height: var(--sp-8);
-}
-
-.compose-status-inspector-close {
-  width: var(--sp-8);
-  height: var(--sp-8);
-}
-
 @media (max-width: 47.999rem) {
   input,
   textarea,
@@ -2455,11 +2479,7 @@ tr[data-interactive]:hover {
     white-space: nowrap;
     border: 0;
   }
-  .compose-status-activity-trigger {
+  .compose-status-summary {
     min-height: var(--sp-11);
-  }
-  .compose-status-inspector-close {
-    width: var(--sp-11);
-    height: var(--sp-11);
   }
 }

--- a/packages/web/src/pages/compose-status-bar-preview.tsx
+++ b/packages/web/src/pages/compose-status-bar-preview.tsx
@@ -11,14 +11,14 @@ import { chatAgentStatusQueryKey } from "../api/agent-status.js";
 import { ComposeStatusBar } from "../components/chat/compose-status-bar.js";
 
 /**
- * DEV-only visual review for the stable composer activity strip and its shared
- * live-activity inspector.
+ * DEV-only visual review for the current-output surface connected to the
+ * composer.
  *
  * The rail is `useQuery`-driven (the shared `/agent-status` query), so each
  * variant primes its own entry in a local `QueryClient` cache keyed by a unique
  * `chatId`; the production component is then rendered against it inside a box
  * that mimics the real composer column width, so spacing, truncation, and the
- * snapshot → Activity entry structure is faithful to prod. No backend / no auth — same
+ * collapsed → current-output structure is faithful to prod. No backend / no auth — same
  * gating as `/preview/chat-row-avatar` (DEV-only in `app.tsx`).
  *
  * Covers concise narration, tool-only fallback, markdown stripping, long
@@ -75,7 +75,7 @@ type Variant = {
 const VARIANTS: Variant[] = [
   {
     name: "working · narration + tool",
-    subtitle: "collapsed strip shows narration; Activity opens the current tool as secondary context",
+    subtitle: "collapsed row shows narration; expanded output avoids repeating the tool when text exists",
     chatId: "v-goal-tool",
     agents: [DEV],
     statuses: [
@@ -89,8 +89,8 @@ const VARIANTS: Variant[] = [
     ],
   },
   {
-    name: "working · markdown in narration (stripped)",
-    subtitle: "raw turnText `issue 669` / **hex-color** renders as plain text",
+    name: "working · markdown narration",
+    subtitle: "collapsed text is plain; expanded output preserves Markdown",
     chatId: "v-markdown",
     agents: [DEV],
     statuses: [
@@ -105,7 +105,7 @@ const VARIANTS: Variant[] = [
   },
   {
     name: "working · long narration",
-    subtitle: "the strip truncates; the inspector clamps the latest update to two visual lines",
+    subtitle: "the collapsed row truncates; expanded output keeps the available text without a line clamp",
     chatId: "v-long",
     agents: [DEV],
     statuses: [
@@ -120,9 +120,8 @@ const VARIANTS: Variant[] = [
     ],
   },
   {
-    name: "working · full narration stays in timeline",
-    subtitle:
-      "turnTextFull is deliberately not copied into the inspector; Activity shows only the latest concise snapshot",
+    name: "working · full narration in composer",
+    subtitle: "expanded output uses the existing turnTextFull field and preserves its multi-line structure",
     chatId: "v-expand",
     agents: [DEV],
     statuses: [
@@ -132,7 +131,7 @@ const VARIANTS: Variant[] = [
         detail: "pnpm typecheck",
         turnText: "Reworking the compose status bar so a long narration can expand to its full multi-line form",
         turnTextFull:
-          "Reworking the compose status bar so a long narration can expand to its full multi-line form.\n\nPlan:\n1. Server derives a newline-preserving turnTextFull (capped at 2000), only when it carries more than the one-line goal.\n2. The rail keeps its single line; a dedicated ⌃ chevron opens a floating card.\n3. The card floats over the stream (absolute, out of flow) so the live ~1s refresh never reflows the conversation.",
+          "Reworking the compose status bar so a long narration can expand to its full multi-line form.\n\n**Plan**\n\n1. Keep token usage above the live status.\n2. Connect the current output directly to the composer.\n3. Preserve Markdown and remove the two-line clamp.",
         startedAt: ago(23),
       }),
     ],
@@ -146,7 +145,7 @@ const VARIANTS: Variant[] = [
   },
   {
     name: "working · thinking",
-    subtitle: "narration in the strip; Thinking appears as the current action in Activity",
+    subtitle: "narration is enough context, so the redundant Thinking label stays hidden",
     chatId: "v-thinking",
     agents: [NOVA],
     statuses: [
@@ -190,14 +189,14 @@ const VARIANTS: Variant[] = [
   },
   {
     name: "failed",
-    subtitle: "failure leads the strip; an anchored inspector item jumps to timeline evidence",
+    subtitle: "failure leads the row; expanded output can jump to timeline evidence",
     chatId: "v-failed",
     agents: [RESEARCH],
     statuses: [build({ agentId: "agent-res", errored: true })],
   },
   {
-    name: "multi-agent · one shared inspector",
-    subtitle: "failure leads the stable strip; Activity (3) opens one container with lightly divided agent items",
+    name: "multi-agent · one connected output",
+    subtitle: "failure leads the stable row; expanding shows all actionable agents in one connected section",
     chatId: "v-multi",
     agents: [DEV, NOVA, RESEARCH],
     statuses: [
@@ -251,7 +250,7 @@ export function ComposeStatusBarPreviewPage() {
       <div style={{ background: "var(--bg)", minHeight: "100vh", padding: "var(--sp-6)" }}>
         <div style={{ maxWidth: 980, margin: "0 auto" }}>
           <h1 className="text-title" style={{ color: "var(--fg-2)", marginBottom: "var(--sp-1)" }}>
-            ComposeStatusBar — stable strip + live activity inspector
+            ComposeStatusBar — connected composer
           </h1>
           <p className="text-body" style={{ color: "var(--fg-3)", marginBottom: "var(--sp-6)" }}>
             DEV preview. Each card mimics the composer column; the real component renders against a primed status
@@ -268,21 +267,28 @@ export function ComposeStatusBarPreviewPage() {
                     {v.subtitle}
                   </div>
                 </div>
-                {/* Composer-column mimic: same max-width + raised surface as the
-                    real chat-bottom composer card. */}
+                {/* Composer-column mimic: same token → status → composer order,
+                    width, connected seam and raised surface as the real footer. */}
                 <div
                   style={{
                     maxWidth: "clamp(55rem, 75%, 70rem)",
-                    background: "var(--bg-raised)",
-                    border: "var(--hairline) solid var(--border)",
-                    borderRadius: 6,
-                    padding: "var(--sp-2) var(--sp-3)",
                   }}
                 >
+                  <div
+                    className="mono text-caption"
+                    style={{ color: "var(--fg-4)", padding: "0 var(--sp-0_5) var(--sp-1)" }}
+                  >
+                    18.4K processed tokens in this chat
+                  </div>
                   <ComposeStatusBar chatId={v.chatId} agents={v.agents} />
                   <div
-                    className="text-caption"
-                    style={{ color: "var(--fg-4)", paddingTop: "var(--sp-1)" }}
+                    className="composer-card text-caption"
+                    style={{
+                      color: "var(--fg-4)",
+                      padding: "var(--sp-3)",
+                      background: "var(--bg-raised)",
+                      border: "var(--hairline) solid var(--border)",
+                    }}
                     aria-hidden="true"
                   >
                     Message {v.agents[0]?.displayName ?? "the team"}…

--- a/packages/web/src/pages/mobile/__tests__/viewport-css.test.ts
+++ b/packages/web/src/pages/mobile/__tests__/viewport-css.test.ts
@@ -16,4 +16,18 @@ describe("mobile shell viewport CSS", () => {
     expect(standaloneBlock).toContain(".h-dvh-screen");
     expect(standaloneBlock).toContain("height: 100vh");
   });
+
+  it("reserves the mobile timeline-jump footprint beside current output", () => {
+    const narrationClearance = indexCss.lastIndexOf(".compose-status-narration-with-jump > :first-child");
+    const mobileRule = indexCss.lastIndexOf("@media (max-width: 47.999rem)", narrationClearance);
+    const jumpRule = indexCss.indexOf(".compose-status-jump {", narrationClearance);
+    const clearanceBlock = indexCss.slice(narrationClearance, jumpRule);
+    const jumpBlock = indexCss.slice(jumpRule, jumpRule + 140);
+
+    expect(mobileRule).toBeGreaterThan(-1);
+    expect(narrationClearance).toBeGreaterThan(mobileRule);
+    expect(clearanceBlock).toContain("padding-right: var(--sp-11)");
+    expect(jumpBlock).toContain("width: var(--sp-11)");
+    expect(jumpBlock).toContain("height: var(--sp-11)");
+  });
 });

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1081,7 +1081,7 @@ describe("ChatView", () => {
       "Expected secondary agent timeline evidence",
     );
     await click(container.querySelector('button[aria-label^="Expand current agent output"]'));
-    expect(container.querySelector('button[aria-label*="Design Critique"][aria-label*="Reviewing"]')).not.toBeNull();
+    expect(container.querySelector('button[aria-label="View Design Critique in the timeline"]')).not.toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -981,14 +981,47 @@ describe("ChatView", () => {
       />,
     );
     await waitForText(readOnly.container, "watching");
-    expect(readOnly.container.querySelector("[data-compose-status-bar]")).not.toBeNull();
+    const readOnlyStatus = readOnly.container.querySelector("[data-compose-status-bar]");
+    const readOnlyComposer = readOnly.container.querySelector(".composer-card");
+    expect(readOnlyStatus).not.toBeNull();
+    expect(readOnlyStatus?.nextElementSibling).toBe(readOnlyComposer);
+    expect(readOnlyComposer?.getAttribute("style")).not.toContain("border-radius");
     await waitForText(readOnly.container, "Join failed");
     await click(buttonByText(readOnly.container, "Join to reply"));
     expect(onJoin).toHaveBeenCalledTimes(1);
     await act(async () => readOnly.root.unmount());
   });
 
-  it("loads secondary-agent activity into the timeline so inspector summaries have evidence", async () => {
+  it("places token usage above the connected status and composer surfaces", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />, (queryClient) => {
+      queryClient.setQueryData(["chat-token-usage", "chat-1"], {
+        inputTokens: 100,
+        cachedInputTokens: 250,
+        outputTokens: 50,
+        totalTokens: 400,
+      });
+    });
+
+    await waitForText(container, "400 processed tokens in this chat");
+    const tokenUsage = container.querySelector<HTMLElement>('[title^="Processed 400"]');
+    const statusSurface = container.querySelector<HTMLElement>("[data-compose-status-bar]");
+    const composer = container.querySelector<HTMLElement>(".composer-card");
+    expect(tokenUsage).not.toBeNull();
+    expect(statusSurface).not.toBeNull();
+    expect(composer).not.toBeNull();
+    expect(tokenUsage?.compareDocumentPosition(statusSurface ?? document.body) ?? 0).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(statusSurface?.compareDocumentPosition(composer ?? document.body) ?? 0).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(statusSurface?.nextElementSibling).toBe(composer);
+
+    await act(async () => root.unmount());
+  });
+
+  it("loads secondary-agent activity into the timeline so current-output links have evidence", async () => {
     const { ChatView } = await import("../chat-view.js");
     const secondaryEvents = {
       items: [
@@ -1047,13 +1080,13 @@ describe("ChatView", () => {
       () => container.querySelector('[data-working-agent="agent-2"]') !== null,
       "Expected secondary agent timeline evidence",
     );
-    await click(container.querySelector('button[aria-label^="Open agent activity"]'));
+    await click(container.querySelector('button[aria-label^="Expand current agent output"]'));
     expect(container.querySelector('button[aria-label*="Design Critique"][aria-label*="Reviewing"]')).not.toBeNull();
 
     await act(async () => root.unmount());
   });
 
-  it("uses one Escape to close Activity without also dismissing open chat details", async () => {
+  it("keeps chat details open while current output expands and collapses inline", async () => {
     const { ChatView } = await import("../chat-view.js");
     const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />);
 
@@ -1066,37 +1099,29 @@ describe("ChatView", () => {
       () => container.querySelector('aside[aria-label="Chat details"]') !== null,
       "Expected chat details to be open",
     );
-    await click(container.querySelector('button[aria-label^="Open agent activity"]'));
+    const outputTrigger = container.querySelector('button[aria-label^="Expand current agent output"]');
+    await click(outputTrigger);
     await waitForCondition(
-      () => container.querySelector("[data-live-activity-inspector]") !== null,
-      "Expected Activity Inspector to open",
+      () => container.querySelector("[data-current-agent-output]") !== null,
+      "Expected current output to expand",
     );
-    await waitForCondition(
-      () => document.activeElement?.getAttribute("aria-label") === "Close agent activity",
-      "Expected focus to enter Activity Inspector",
-    );
+    expect(container.querySelector('aside[aria-label="Chat details"]')).not.toBeNull();
 
-    await act(async () => {
-      document.activeElement?.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
-      );
-    });
-    await flush();
-
-    expect(container.querySelector("[data-live-activity-inspector]")).toBeNull();
+    await click(outputTrigger);
+    expect(container.querySelector("[data-current-agent-output]")).toBeNull();
     expect(container.querySelector('aside[aria-label="Chat details"]')).not.toBeNull();
 
     await act(async () => root.unmount());
   });
 
-  it("lets a later mention layer consume Escape before the open Activity Inspector", async () => {
+  it("lets a later mention layer consume Escape while inline current output stays open", async () => {
     const { ChatView } = await import("../chat-view.js");
     const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />);
 
-    await click(container.querySelector('button[aria-label^="Open agent activity"]'));
+    await click(container.querySelector('button[aria-label^="Expand current agent output"]'));
     await waitForCondition(
-      () => container.querySelector("[data-live-activity-inspector]") !== null,
-      "Expected Activity Inspector to open",
+      () => container.querySelector("[data-current-agent-output]") !== null,
+      "Expected current output to expand",
     );
     const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
     if (!textarea) throw new Error("Composer textarea missing");
@@ -1113,7 +1138,7 @@ describe("ChatView", () => {
     await flush();
 
     expect(container.querySelector('[role="listbox"][aria-label="Mention suggestions"]')).toBeNull();
-    expect(container.querySelector("[data-live-activity-inspector]")).not.toBeNull();
+    expect(container.querySelector("[data-current-agent-output]")).not.toBeNull();
     expect(document.activeElement).toBe(textarea);
 
     await act(async () => root.unmount());

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1701,7 +1701,7 @@ export function ChatView({
     if (!detailsOpen || hasDocPreview) return;
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.key !== "Escape") return;
-      // A nested top layer (for example the Activity Inspector) owns the first
+      // A nested top layer (for example a dialog or autocomplete) owns the first
       // Escape and marks it handled. Keep the details rail open until the next
       // Escape instead of dismissing two layers in one keypress.
       if (event.defaultPrevented) return;
@@ -4002,7 +4002,16 @@ export function ChatView({
               }}
             >
               <div style={{ maxWidth: "clamp(55rem, 75%, 70rem)", margin: "0 auto", width: "100%" }}>
-                {/* Live activity is view-only awareness, so watchers keep the
+                {!readOnly && chatTokenUsage && chatProcessedTokens > 0 ? (
+                  <div
+                    className="mono text-caption"
+                    style={{ color: "var(--fg-4)", padding: "0 var(--sp-0_5) var(--sp-1)" }}
+                    title={formatTokenUsageTitle(chatTokenUsage)}
+                  >
+                    {formatTokenCount(chatProcessedTokens)} processed tokens in this chat
+                  </div>
+                ) : null}
+                {/* Live status is view-only awareness, so watchers keep the
                     same stable “what are agents doing?” entry as participants.
                     Reply controls below remain gated by `readOnly`. */}
                 <ComposeStatusBar
@@ -4014,12 +4023,11 @@ export function ChatView({
                   <div
                     ref={readOnlyComposerRef}
                     tabIndex={-1}
-                    className="flex items-center"
+                    className="composer-card flex items-center"
                     style={{
                       gap: "var(--sp-3)",
                       padding: "var(--sp-2) var(--sp-3)",
                       border: "var(--hairline) solid var(--border)",
-                      borderRadius: 6,
                       // Raised surface (`--bg-raised`) so the slot reads as a
                       // distinct input card lifted above the timeline (`--bg`),
                       // sharing the header chrome's surface. Mirrors the editable
@@ -4053,15 +4061,6 @@ export function ChatView({
                   </div>
                 ) : (
                   <>
-                    {chatTokenUsage && chatProcessedTokens > 0 ? (
-                      <div
-                        className="mono text-caption"
-                        style={{ color: "var(--fg-4)", padding: "0 var(--sp-0_5) var(--sp-1)" }}
-                        title={formatTokenUsageTitle(chatTokenUsage)}
-                      >
-                        {formatTokenCount(chatProcessedTokens)} processed tokens in this chat
-                      </div>
-                    ) : null}
                     {/* A blocking question is answered in the full-coverage
                         AskTakeover overlay (rendered over the workspace), not in
                         the composer. */}


### PR DESCRIPTION
## Summary

- move chat token usage above live agent status
- connect the live status surface directly to the composer instead of opening a detached Activity inspector
- expand the existing `turnTextFull ?? turnText` value inline with Markdown, without the former two-line clamp
- remove the duplicated identity header from single-agent expanded output; use an aggregate header for multi-agent output while retaining per-agent ownership in the details
- suppress redundant tool/Thinking metadata when narration already explains the current work, while retaining it as a no-text fallback
- preserve multi-agent states, provider reasons, stable timeline evidence links, keyboard scrolling, responsive state visibility, and focus recovery

## Root cause

The composer rendered token usage between the live status and the input. The expanded status view also read the 120-character `turnText` preview and applied a two-line clamp even though the existing status contract already provides `turnTextFull`.

This patch corrects the Web layout and field usage. It intentionally does not add an API, cache, event contract, session identity, or provider-handler change. The existing server boundary for `turnTextFull` (latest text block, capped at 2,000 characters) remains unchanged.

## Validation

- `pnpm --filter @first-tree/web typecheck`
- full Web suite before the final header refinement: 192 files, 1,561 tests
- final focused `ComposeStatusBar` coverage: 20 tests
- final `ChatView` integration coverage: 44 tests
- two independent read-only reviews covering UI/accessibility and state/focus behavior; all P1/P2 findings fixed and re-reviewed
- real local stack available at `http://localhost:5174/?c=ac1a110d-fe19-4358-928f-8464ab983e5b`

Latest browser-rendered screenshot comparison is pending: the approved browser runtime has no available browser instance in this session. The PR remains draft until that visual QA is complete.
