### PR TITLE
fix: capture angle-bracketed workspace images

### DIFF
--- a/packages/client/src/__tests__/image-snapshots.test.ts
+++ b/packages/client/src/__tests__/image-snapshots.test.ts
@@ -39,6 +39,7 @@ describe("buildMessageImageSnapshots — capture + strip", () => {
     root = await realpath(await mkdtemp(join(tmpdir(), "img-snap-")));
     await mkdir(join(root, "shots"), { recursive: true });
     await writeFile(join(root, "shots", "filter.png"), PNG);
+    await writeFile(join(root, "shots", "filter with spaces.png"), PNG);
     await writeFile(join(root, "diagram.webp"), PNG);
     await writeFile(join(root, "notes.txt"), Buffer.from("hi"));
   });
@@ -72,6 +73,26 @@ describe("buildMessageImageSnapshots — capture + strip", () => {
     const res = await buildMessageImageSnapshots(`![d](${join(root, "diagram.webp")})`, root, opts(uploader));
     expect(res.imageRefs).toHaveLength(1);
     expect(res.imageRefs[0]?.mimeType).toBe("image/webp");
+    expect(res.strippedText).toBe("");
+  });
+
+  it("captures an angle-bracketed absolute in-workspace path", async () => {
+    const { uploader } = stubUploader();
+    const res = await buildMessageImageSnapshots(`![d](<${join(root, "diagram.webp")}>)`, root, opts(uploader));
+    expect(res.imageRefs).toHaveLength(1);
+    expect(res.imageRefs[0]).toMatchObject({ mimeType: "image/webp", filename: "diagram.webp" });
+    expect(res.strippedText).toBe("");
+  });
+
+  it("captures spaces inside an angle-bracketed path", async () => {
+    const { uploader } = stubUploader();
+    const res = await buildMessageImageSnapshots(
+      `![filter](<${join(root, "shots", "filter with spaces.png")}>)`,
+      root,
+      opts(uploader),
+    );
+    expect(res.imageRefs).toHaveLength(1);
+    expect(res.imageRefs[0]).toMatchObject({ mimeType: "image/png", filename: "filter with spaces.png" });
     expect(res.strippedText).toBe("");
   });
 

--- a/packages/client/src/runtime/image-snapshots.ts
+++ b/packages/client/src/runtime/image-snapshots.ts
@@ -18,14 +18,14 @@ import {
 /**
  * Outbound image capture — the picture sibling of `doc-snapshots.ts`.
  *
- * When an agent's `chat send` body contains a markdown image `![alt](path)`
- * whose target is a local image file inside the sender's own workspace fence,
- * we upload the bytes to the org attachment store and hand the caller an
- * `ImageRefContent` (the exact shape a human image send produces). The caller
- * then converts the message to a `format: "file"` batch: caption = the body
- * with the captured image spans stripped, `attachments` = these refs. Web then
- * renders it identically to a human image send (caption on top, thumbnails
- * below) — zero web/server change.
+ * When an agent's `chat send` body contains a markdown image `![alt](path)` or
+ * `![alt](<path>)` whose target is a local image file inside the sender's own
+ * workspace fence, we upload the bytes to the org attachment store and hand
+ * the caller an `ImageRefContent` (the exact shape a human image send
+ * produces). The caller then converts the message to a `format: "file"` batch:
+ * caption = the body with the captured image spans stripped, `attachments` =
+ * these refs. Web then renders it identically to a human image send (caption on
+ * top, thumbnails below) — zero web/server change.
  *
  * Scope (see the paired design note): we deliberately capture ONLY markdown
  * image syntax (an explicit "show this picture" intent, unlike a bare filename
@@ -219,17 +219,19 @@ function basename(p: string): string {
 }
 
 /**
- * Collect markdown image mentions `![alt](path)` that are LOCAL, supported
- * image embeds. A leading `!` is required (distinguishes an image from a doc
- * link); a `\` before the `!` escapes it (odd-run parity). A web URL target is
- * skipped — an absolute scheme (`http:`, `data:`, …) OR a protocol-relative
- * `//host/…` — since those render inline and are not workspace files. The
- * target must have a supported image extension, so the per-message cap is over
- * eligible images (an unsupported `.txt` target never consumes budget). Mentions
- * inside a block code sample (fenced or indented) are dropped — the agent is
- * SHOWING the markdown, not embedding an image. Inline code (`` `![](x)` ``) is
- * intentionally NOT excluded: a rare place for a full embed, and treating it as
- * live keeps the send side from reproducing the renderer's inline parsing.
+ * Collect markdown image mentions `![alt](path)` and `![alt](<path>)` that are
+ * LOCAL, supported image embeds. Angle-bracket destinations may contain spaces;
+ * the brackets are syntax and are not part of the captured path. A leading `!`
+ * is required (distinguishes an image from a doc link); a `\` before the `!`
+ * escapes it (odd-run parity). A web URL target is skipped — an absolute scheme
+ * (`http:`, `data:`, …) OR a protocol-relative `//host/…` — since those render
+ * inline and are not workspace files. The target must have a supported image
+ * extension, so the per-message cap is over eligible images (an unsupported
+ * `.txt` target never consumes budget). Mentions inside a block code sample
+ * (fenced or indented) are dropped — the agent is SHOWING the markdown, not
+ * embedding an image. Inline code (`` `![](x)` ``) is intentionally NOT
+ * excluded: a rare place for a full embed, and treating it as live keeps the
+ * send side from reproducing the renderer's inline parsing.
  */
 function collectImageOccurrences(text: string): ImageOccurrence[] {
   // Guard: skip capture on an absurdly large body so a pathological message can
@@ -241,12 +243,12 @@ function collectImageOccurrences(text: string): ImageOccurrence[] {
   // (bounded quantifiers keep it linear — an unbounded `[^\]\n]*` would rescan
   // to EOF at every `![`). Only when there IS a candidate do we compute the
   // (more expensive) code ranges — an ordinary text-only send pays nothing here.
-  const re = /!\[[^\]\n]{0,512}\]\(([^\s)"]{1,2048})(?:\s+"[^"]*")?\)/g;
+  const re = /!\[[^\]\n]{0,512}\]\((?:<([^<>\n]{1,2048})>|([^\s)"]{1,2048}))(?:\s+"[^"]*")?\)/g;
   const candidates: ImageOccurrence[] = [];
   let match: RegExpExecArray | null = re.exec(text);
   while (match !== null) {
     const whole = match[0];
-    const target = match[1];
+    const target = match[1] ?? match[2];
     const start = match.index;
     // CommonMark escape parity: `!` is escaped only by an ODD run of
     // backslashes. `\![](x)` is an escaped literal (skip); `\\![](x)` is a


### PR DESCRIPTION
## What changed

- recognize both bare and angle-bracketed local Markdown image destinations during agent `chat send` capture
- unwrap angle-bracket syntax before MIME detection and workspace path resolution
- cover absolute angle-bracketed paths and angle-bracketed paths containing spaces

## Root cause

The bounded image matcher treated `<...>` as part of the destination. A path ending in `.png>` therefore failed the supported-image extension check, so capture was skipped and the original agent-local path was sent as ordinary Markdown. The Web could not read that local filesystem path and rendered a broken image.

## Impact

Agent messages such as `![preview](</workspace/preview.png>)` now follow the existing attachment upload path and render as normal `format: "file"` image messages. The existing bare-path behavior and workspace provenance fence are unchanged.

## Validation

- `pnpm --filter @first-tree/client exec vitest run src/__tests__/image-snapshots.test.ts` — 27 passed
- `pnpm --filter first-tree-dev exec vitest run src/__tests__/image-capture.test.ts` — 10 passed
- `pnpm check` — passed (existing repository warnings only)
- `pnpm typecheck` — passed
- Two independent code reviews completed with no blocking, P1, or P2 findings on the final diff

The full parallel `pnpm test` run hit timeout-only failures in unrelated long-running CLI, capability-probe, and skill-eval tests. Every failing file passed when rerun serially; the affected code is outside this two-file change.
