### PR TITLE
fix(web): purge account session data from browser storage on logout (SEC-042)

### DIFF
--- a/packages/web/src/api/__tests__/browser-stores.test.ts
+++ b/packages/web/src/api/__tests__/browser-stores.test.ts
@@ -261,3 +261,60 @@ describe("read-state-store", () => {
     await expect(clear).resolves.toBeUndefined();
   });
 });
+
+describe("browser stores / storage namespace (SEC-042)", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  it("isolates cached images between account namespaces and rejects writes after purge", async () => {
+    vi.resetModules();
+    globalThis.indexedDB = new IDBFactory();
+    const scope = await import("../storage-scope.js");
+    const { getImage, putImage } = await import("../image-store.js");
+
+    scope.setStorageNamespace("user-a");
+    await putImage({ imageId: "img-1", base64: "a-bytes", mimeType: "image/png" });
+
+    scope.setStorageNamespace("user-b");
+    await expect(getImage("img-1")).resolves.toBeNull();
+
+    // Purge user-b (logout): the namespace is write-blocked — `putImage`
+    // degrades to the IndexedDB-unavailable contract and rejects for callers
+    // to swallow, reads return null.
+    await scope.purgeAccountLocalData("user-b");
+    await expect(putImage({ imageId: "img-2", base64: "b", mimeType: "image/png" })).rejects.toThrow(
+      "Image storage unavailable",
+    );
+    await expect(getImage("img-2")).resolves.toBeNull();
+
+    // user-a's cache is untouched by user-b's purge.
+    scope.setStorageNamespace("user-a");
+    await expect(getImage("img-1")).resolves.toEqual({ base64: "a-bytes", mimeType: "image/png" });
+  });
+
+  it("isolates read state between account namespaces and no-ops after purge", async () => {
+    vi.resetModules();
+    globalThis.indexedDB = new IDBFactory();
+    const scope = await import("../storage-scope.js");
+    const { getReadState, setReadState } = await import("../read-state-store.js");
+
+    scope.setStorageNamespace("user-a");
+    await setReadState("chat-1", "msg-1", "msg-3");
+
+    scope.setStorageNamespace("user-b");
+    await expect(getReadState("chat-1")).resolves.toBeNull();
+
+    // Logout purge of user-b: writes no-op, reads return null — never throws.
+    await scope.purgeAccountLocalData("user-b");
+    await setReadState("chat-1", "msg-9", "msg-9");
+    await expect(getReadState("chat-1")).resolves.toBeNull();
+
+    scope.setStorageNamespace("user-a");
+    await expect(getReadState("chat-1")).resolves.toMatchObject({
+      chatId: "chat-1",
+      bottomVisibleMessageId: "msg-1",
+      latestKnownMessageId: "msg-3",
+    });
+  });
+});

--- a/packages/web/src/api/__tests__/message-store.test.ts
+++ b/packages/web/src/api/__tests__/message-store.test.ts
@@ -116,3 +116,47 @@ describe("message-store / clearChatCache", () => {
     expect(await getCachedMessages("chat-1")).toEqual([]);
   });
 });
+
+describe("message-store / storage namespace (SEC-042)", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  async function loadStoreWithScope() {
+    vi.resetModules();
+    globalThis.indexedDB = new IDBFactory();
+    const scope = await import("../storage-scope.js");
+    const store = await import("../message-store.js");
+    return { scope, store };
+  }
+
+  it("isolates cached messages between account namespaces", async () => {
+    const { scope, store } = await loadStoreWithScope();
+    scope.setStorageNamespace("user-a");
+    await store.cacheMessages("chat-1", [msg("a-1", T(1))]);
+
+    // A different account on the same browser sees none of user-a's rows.
+    scope.setStorageNamespace("user-b");
+    expect(await store.getCachedMessages("chat-1")).toEqual([]);
+    await store.cacheMessages("chat-1", [msg("b-1", T(2))]);
+
+    // ...and switching back and forth keeps each account's cache intact.
+    scope.setStorageNamespace("user-a");
+    expect((await store.getCachedMessages("chat-1")).map((m) => m.id)).toEqual(["a-1"]);
+    scope.setStorageNamespace("user-b");
+    expect((await store.getCachedMessages("chat-1")).map((m) => m.id)).toEqual(["b-1"]);
+  });
+
+  it("drops writes and empties reads once the namespace is purged", async () => {
+    const { scope, store } = await loadStoreWithScope();
+    scope.setStorageNamespace("user-a");
+    await store.cacheMessages("chat-1", [msg("a-1", T(1))]);
+
+    await scope.purgeAccountLocalData("user-a");
+
+    // Late in-flight writes under the purged namespace are dropped, and
+    // reads degrade to empty without throwing.
+    await store.cacheMessages("chat-1", [msg("a-late", T(2))]);
+    expect(await store.getCachedMessages("chat-1")).toEqual([]);
+  });
+});

--- a/packages/web/src/api/__tests__/storage-scope.test.ts
+++ b/packages/web/src/api/__tests__/storage-scope.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment happy-dom
+
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MessageWithDelivery } from "../chats.js";
+
+/**
+ * storage-scope is the SEC-042 hub: it derives the `<origin>#<userId>`
+ * namespace every persistent store lives under, write-blocks purged
+ * namespaces, and runs the logout purge. These tests exercise it together
+ * with the REAL message/image/draft stores (same module graph, fresh per
+ * test via `vi.resetModules`) — the account-switching scenario is the
+ * issue 1647 acceptance criterion.
+ */
+
+const DRAFTS_STORAGE_KEY = "first-tree:chat-drafts:v1";
+
+function msg(id: string, createdAt: string): MessageWithDelivery {
+  return {
+    id,
+    chatId: "chat-1",
+    senderId: "user-1",
+    format: "text",
+    content: { text: id },
+    metadata: {},
+    inReplyTo: null,
+    source: "web",
+    createdAt,
+  };
+}
+
+const T = (s: number) => new Date(2026, 0, 1, 0, 0, s).toISOString();
+
+async function loadModules() {
+  vi.resetModules();
+  globalThis.indexedDB = new IDBFactory();
+  const scope = await import("../storage-scope.js");
+  const messages = await import("../message-store.js");
+  const images = await import("../image-store.js");
+  const drafts = await import("../../lib/draft-store.js");
+  return { scope, messages, images, drafts };
+}
+
+/** Create a legacy (pre-namespacing, global-name) database the way an old build would have. */
+async function createLegacyDb(name: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.open(name, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore("legacy");
+    };
+    req.onsuccess = () => {
+      req.result.close();
+      resolve();
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function databaseNames(): Promise<string[]> {
+  const dbs = await indexedDB.databases();
+  return dbs.map((d) => d.name ?? "");
+}
+
+function readRawDraftMap(): Record<string, unknown> {
+  const raw = window.localStorage.getItem(DRAFTS_STORAGE_KEY);
+  if (!raw) return {};
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  globalThis.indexedDB = new IDBFactory();
+});
+
+describe("storage-scope / namespace derivation", () => {
+  it("derives <origin>#<userId> namespaces and scoped db names", async () => {
+    vi.resetModules();
+    const { namespaceForUser, scopedDbName, currentStorageNamespace } = await import("../storage-scope.js");
+    const origin = window.location.origin;
+    expect(namespaceForUser("user-1")).toBe(`${origin}#user-1`);
+    expect(namespaceForUser(null)).toBe(`${origin}#anon`);
+    expect(scopedDbName("first-tree-images", `${origin}#user-1`)).toBe(`first-tree-images@${origin}#user-1`);
+    // The module starts anonymous until fetchMe sets the account.
+    expect(currentStorageNamespace()).toBe(`${origin}#anon`);
+  });
+
+  it("write-blocks purged namespaces; re-login lifts the block, anon stays blocked", async () => {
+    const { scope } = await loadModules();
+    const origin = window.location.origin;
+    scope.setStorageNamespace("user-a");
+    expect(scope.activeScopedDbName("base")).toBe(`base@${origin}#user-a`);
+
+    await scope.purgeAccountLocalData();
+    // Current (user-a) namespace is now purged: stores get no name to open.
+    expect(scope.activeScopedDbName("base")).toBeNull();
+
+    scope.setStorageNamespace(null);
+    expect(scope.activeScopedDbName("base")).toBeNull(); // anon purged by the logout
+    scope.setStorageNamespace("user-b");
+    expect(scope.activeScopedDbName("base")).toBe(`base@${origin}#user-b`); // other account unaffected
+    scope.setStorageNamespace("user-a");
+    expect(scope.activeScopedDbName("base")).toBe(`base@${origin}#user-a`); // explicit re-login re-enables
+  });
+
+  it("never rejects when IndexedDB is unavailable", async () => {
+    vi.resetModules();
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    const { purgeAccountLocalData, purgeLegacyUnscopedStores } = await import("../storage-scope.js");
+    await expect(purgeAccountLocalData("user-a")).resolves.toBeUndefined();
+    await expect(purgeLegacyUnscopedStores()).resolves.toBeUndefined();
+  });
+});
+
+describe("storage-scope / logout purge", () => {
+  it("deletes the legacy global databases", async () => {
+    const { scope } = await loadModules();
+    await createLegacyDb("first-tree-chat-cache");
+    await createLegacyDb("first-tree-images");
+    expect(await databaseNames()).toEqual(expect.arrayContaining(["first-tree-chat-cache", "first-tree-images"]));
+
+    await scope.purgeLegacyUnscopedStores();
+
+    const names = await databaseNames();
+    expect(names).not.toContain("first-tree-chat-cache");
+    expect(names).not.toContain("first-tree-images");
+  });
+
+  it("acceptance: account A's messages, images and drafts do not survive a logout into account B", async () => {
+    const { scope, messages, images, drafts } = await loadModules();
+    // Residue from a pre-namespacing build.
+    await createLegacyDb("first-tree-chat-cache");
+    await createLegacyDb("first-tree-images");
+
+    // --- user A's session: cache messages + image + drafts (current AND legacy format)
+    scope.setStorageNamespace("user-a");
+    await messages.cacheMessages("chat-1", [msg("a-1", T(1))]);
+    await images.putImage({ imageId: "img-a", base64: "a-bytes", mimeType: "image/png" });
+    drafts.saveDraft(drafts.chatDraftScope("user-a", "chat-1"), { text: "A current-format draft" });
+    // Another account's draft on the same browser must survive A's purge.
+    drafts.saveDraft(drafts.chatDraftScope("user-b", "chat-1"), { text: "B draft" });
+    // A pre-SEC-042 legacy-format draft for A, seeded raw so the read-path
+    // migration cannot rewrite it before the purge.
+    const seeded = readRawDraftMap();
+    seeded["u:user-a:chat:chat-9"] = { text: "A legacy-format draft", updatedAt: 1 };
+    window.localStorage.setItem(DRAFTS_STORAGE_KEY, JSON.stringify(seeded));
+
+    // --- logout (mirrors auth-context: purge, then drop to anonymous)
+    await scope.purgeAccountLocalData("user-a");
+
+    // B1: while still under A's (now purged) namespace, late writes are
+    // dropped and reads come back empty.
+    await messages.cacheMessages("chat-1", [msg("a-late", T(2))]);
+    expect(await messages.getCachedMessages("chat-1")).toEqual([]);
+    scope.setStorageNamespace(null);
+    // ...and the anonymous namespace is write-blocked too.
+    await messages.cacheMessages("chat-1", [msg("anon-write", T(3))]);
+    expect(await messages.getCachedMessages("chat-1")).toEqual([]);
+    await expect(images.putImage({ imageId: "img-late", base64: "x", mimeType: "image/png" })).rejects.toThrow(
+      "Image storage unavailable",
+    );
+
+    // --- account B signs in on the same browser profile
+    scope.setStorageNamespace("user-b");
+    // Nothing of A is readable: not the messages, not the image, not the drafts.
+    expect(await messages.getCachedMessages("chat-1")).toEqual([]);
+    expect(await images.getImage("img-a")).toBeNull();
+    expect(drafts.loadDraft(drafts.chatDraftScope("user-a", "chat-1"))).toBeNull();
+    // B's own data is intact and B can read/write normally.
+    expect(drafts.loadDraft(drafts.chatDraftScope("user-b", "chat-1"))?.text).toBe("B draft");
+    await messages.cacheMessages("chat-1", [msg("b-1", T(4))]);
+    expect((await messages.getCachedMessages("chat-1")).map((m) => m.id)).toEqual(["b-1"]);
+
+    // The raw drafts map holds no user-a entries in either scope format.
+    const remainingKeys = Object.keys(readRawDraftMap());
+    expect(remainingKeys.some((k) => k.startsWith("u:user-a:") || k.startsWith("u:user-a@"))).toBe(false);
+
+    // The legacy global databases were deleted by the purge.
+    const names = await databaseNames();
+    expect(names).not.toContain("first-tree-chat-cache");
+    expect(names).not.toContain("first-tree-images");
+
+    // A re-login of A re-enables caching, but the purged content stays gone.
+    scope.setStorageNamespace("user-a");
+    expect(await messages.getCachedMessages("chat-1")).toEqual([]);
+    await messages.cacheMessages("chat-1", [msg("a-new", T(5))]);
+    expect((await messages.getCachedMessages("chat-1")).map((m) => m.id)).toEqual(["a-new"]);
+  });
+
+  it("purges the token-fallback namespace when it differs from the current one", async () => {
+    // One browser profile (one fake IDB), two "sessions" (two module graphs):
+    // the first session leaves data under user-a's namespace; the second
+    // session's /me never resolves, so the namespace is still anonymous and
+    // only the token identifies user-a at logout.
+    const factory = new IDBFactory();
+    vi.resetModules();
+    globalThis.indexedDB = factory;
+    const scope1 = await import("../storage-scope.js");
+    const messages1 = await import("../message-store.js");
+    scope1.setStorageNamespace("user-a");
+    await messages1.cacheMessages("chat-1", [msg("stale", T(1))]);
+
+    vi.resetModules();
+    globalThis.indexedDB = factory;
+    const scope2 = await import("../storage-scope.js");
+    const messages2 = await import("../message-store.js");
+    await scope2.purgeAccountLocalData("user-a");
+
+    scope2.setStorageNamespace("user-b");
+    expect(await messages2.getCachedMessages("chat-1")).toEqual([]);
+    // user-a's namespace was purged even though it was never current in this
+    // session: signing back in as user-a finds nothing.
+    scope2.setStorageNamespace("user-a");
+    expect(await messages2.getCachedMessages("chat-1")).toEqual([]);
+  });
+});
+
+describe("storage-scope / multi-tab deletion (D1)", () => {
+  it("closes the cached connection when another tab deletes the db, then re-opens cleanly", async () => {
+    const { scope, messages } = await loadModules();
+    scope.setStorageNamespace("user-a");
+    await messages.cacheMessages("chat-1", [msg("m-1", T(1))]);
+
+    // Another tab deletes this namespace's database. This tab's cached
+    // connection must close via `onversionchange` so the delete is not
+    // blocked.
+    const name = scope.scopedDbName("first-tree-chat-cache", scope.namespaceForUser("user-a"));
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.deleteDatabase(name);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error ?? new Error("delete failed"));
+      req.onblocked = () => reject(new Error("delete blocked — onversionchange did not close the connection"));
+    });
+
+    // Never-throws read contract: the store must not reuse the closed
+    // connection (InvalidStateError); it re-opens a fresh, empty database.
+    await expect(messages.getCachedMessages("chat-1")).resolves.toEqual([]);
+  });
+});

--- a/packages/web/src/api/__tests__/storage-scope.test.ts
+++ b/packages/web/src/api/__tests__/storage-scope.test.ts
@@ -187,6 +187,41 @@ describe("storage-scope / logout purge", () => {
     expect((await messages.getCachedMessages("chat-1")).map((m) => m.id)).toEqual(["a-new"]);
   });
 
+  it("blocks the purged account's draft writes until re-login; anon stays blocked", async () => {
+    const { scope, drafts } = await loadModules();
+    scope.setStorageNamespace("user-a");
+    drafts.saveDraft(drafts.chatDraftScope("user-a", "chat-1"), { text: "A draft" });
+
+    // Logout: purge marks user-a AND anon draft-write-blocked synchronously.
+    await scope.purgeAccountLocalData("user-a");
+
+    // Late writes for the purged account are dropped — including an in-flight
+    // failed send being parked after the purge.
+    drafts.saveDraft(drafts.chatDraftScope("user-a", "chat-2"), { text: "late A write" });
+    expect(drafts.loadDraft(drafts.chatDraftScope("user-a", "chat-2"))).toBeNull();
+    expect(drafts.parkFailedDraftIfSwitched("user-a", "chat-1", "chat-2", "failed text")).toBe(true);
+    expect(drafts.loadDraft(drafts.chatDraftScope("user-a", "chat-1"))).toBeNull();
+
+    // Post-logout anonymous state: draft writes are blocked too.
+    scope.setStorageNamespace(null);
+    drafts.saveDraft(drafts.chatDraftScope(null, "chat-1"), { text: "anon write" });
+    expect(drafts.loadDraft(drafts.chatDraftScope(null, "chat-1"))).toBeNull();
+
+    // Another account is unaffected, and anon STAYS blocked after a sign-in.
+    scope.setStorageNamespace("user-b");
+    drafts.saveDraft(drafts.chatDraftScope("user-b", "chat-1"), { text: "B draft" });
+    expect(drafts.loadDraft(drafts.chatDraftScope("user-b", "chat-1"))?.text).toBe("B draft");
+    drafts.saveDraft(drafts.chatDraftScope(null, "chat-1"), { text: "anon still blocked" });
+    expect(drafts.loadDraft(drafts.chatDraftScope(null, "chat-1"))).toBeNull();
+
+    // Re-login of A lifts the block; the purged content stays gone, new
+    // drafts land fresh.
+    scope.setStorageNamespace("user-a");
+    expect(drafts.loadDraft(drafts.chatDraftScope("user-a", "chat-1"))).toBeNull();
+    drafts.saveDraft(drafts.chatDraftScope("user-a", "chat-1"), { text: "A again" });
+    expect(drafts.loadDraft(drafts.chatDraftScope("user-a", "chat-1"))?.text).toBe("A again");
+  });
+
   it("purges the token-fallback namespace when it differs from the current one", async () => {
     // One browser profile (one fake IDB), two "sessions" (two module graphs):
     // the first session leaves data under user-a's namespace; the second

--- a/packages/web/src/api/image-store.ts
+++ b/packages/web/src/api/image-store.ts
@@ -5,7 +5,13 @@
  * authoritative bytes always live server-side, so a cache miss (cross-device,
  * incognito, cleared storage) is recoverable — not a "not available"
  * dead-end like the old IndexedDB-only design.
+ * The database lives under the storage-scope namespace
+ * (`first-tree-images@<origin>#<userId>`) so accounts sharing a browser
+ * profile never see each other's cached images, and logout purges it — see
+ * `api/storage-scope.ts` (SEC-042 / issue 1647).
  */
+
+import { activeScopedDbName, isActiveScopedDbName, registerDatabaseCloseHook } from "./storage-scope.js";
 
 const DB_NAME = "first-tree-images";
 const DB_VERSION = 1;
@@ -19,22 +25,59 @@ type Stored = {
 };
 
 let dbPromise: Promise<IDBDatabase | null> | null = null;
+let dbConnection: IDBDatabase | null = null;
+
+/**
+ * Close the cached connection and forget it. Registered with storage-scope:
+ * runs on namespace switch and on logout purge so a stale handle neither
+ * serves reads for the wrong account nor blocks `deleteDatabase`.
+ */
+function resetCachedDb(): void {
+  dbConnection?.close();
+  dbConnection = null;
+  dbPromise = null;
+}
+
+registerDatabaseCloseHook(resetCachedDb);
 
 function openDb(): Promise<IDBDatabase | null> {
   if (dbPromise) return dbPromise;
+  // null when the current namespace was purged by logout — callers degrade
+  // exactly like the IndexedDB-unavailable path (reads null, writes reject),
+  // and nothing is cached so a later sign-in re-checks fresh.
+  const name = activeScopedDbName(DB_NAME);
+  if (!name) return Promise.resolve(null);
   dbPromise = new Promise((resolve) => {
     if (typeof indexedDB === "undefined") {
       resolve(null);
       return;
     }
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    const req = indexedDB.open(name, DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(STORE)) {
         db.createObjectStore(STORE, { keyPath: "imageId" });
       }
     };
-    req.onsuccess = () => resolve(req.result);
+    req.onsuccess = () => {
+      const db = req.result;
+      // The namespace can switch (or be purged) while this open is in flight;
+      // never hand out a connection to the previous account's database.
+      if (!isActiveScopedDbName(DB_NAME, name)) {
+        db.close();
+        resolve(null);
+        return;
+      }
+      dbConnection = db;
+      // Multi-tab: when another tab deletes (or upgrades) this database, close
+      // so its `deleteDatabase` is not blocked — AND drop the cached promise,
+      // otherwise a later `db.transaction()` on the closed connection throws
+      // InvalidStateError synchronously, breaking the read contract. The next
+      // operation re-opens via `openDb` (or is dropped when the namespace was
+      // purged).
+      db.onversionchange = () => resetCachedDb();
+      resolve(db);
+    };
     req.onerror = () => resolve(null);
     req.onblocked = () => resolve(null);
   });

--- a/packages/web/src/api/message-store.ts
+++ b/packages/web/src/api/message-store.ts
@@ -18,11 +18,17 @@
  *    real-data sizes warrant it.
  *  - Cursor-based pagination of older history (a separate milestone).
  *
+ * The database lives under the storage-scope namespace
+ * (`first-tree-chat-cache@<origin>#<userId>`) so accounts sharing a browser
+ * profile never see each other's cached messages, and logout purges it — see
+ * `api/storage-scope.ts` (SEC-042 / issue 1647).
+ *
  * Origin: proposal `hub-chat-scroll-and-cache.20260509.md` (M1) — see
  * issue first-tree-all 119 under parent first-tree-all 118.
  */
 
 import type { MessageWithDelivery } from "./chats.js";
+import { activeScopedDbName, isActiveScopedDbName, registerDatabaseCloseHook } from "./storage-scope.js";
 
 const DB_NAME = "first-tree-chat-cache";
 // Schema version is shared with read-state-store.ts (M2). Both modules
@@ -50,15 +56,34 @@ type StoredMessage = {
 };
 
 let dbPromise: Promise<IDBDatabase | null> | null = null;
+let dbConnection: IDBDatabase | null = null;
+
+/**
+ * Close the cached connection and forget it. Registered with storage-scope:
+ * runs on namespace switch and on logout purge so a stale handle neither
+ * serves reads for the wrong account nor blocks `deleteDatabase`.
+ */
+function resetCachedDb(): void {
+  dbConnection?.close();
+  dbConnection = null;
+  dbPromise = null;
+}
+
+registerDatabaseCloseHook(resetCachedDb);
 
 function openDb(): Promise<IDBDatabase | null> {
   if (dbPromise) return dbPromise;
+  // null when the current namespace was purged by logout — callers degrade
+  // exactly like the IndexedDB-unavailable path (reads empty, writes no-op),
+  // and nothing is cached so a later sign-in re-checks fresh.
+  const name = activeScopedDbName(DB_NAME);
+  if (!name) return Promise.resolve(null);
   dbPromise = new Promise((resolve) => {
     if (typeof indexedDB === "undefined") {
       resolve(null);
       return;
     }
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    const req = indexedDB.open(name, DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(STORE)) {
@@ -72,7 +97,25 @@ function openDb(): Promise<IDBDatabase | null> {
         db.createObjectStore(READ_STATE_STORE, { keyPath: "chatId" });
       }
     };
-    req.onsuccess = () => resolve(req.result);
+    req.onsuccess = () => {
+      const db = req.result;
+      // The namespace can switch (or be purged) while this open is in flight;
+      // never hand out a connection to the previous account's database.
+      if (!isActiveScopedDbName(DB_NAME, name)) {
+        db.close();
+        resolve(null);
+        return;
+      }
+      dbConnection = db;
+      // Multi-tab: when another tab deletes (or upgrades) this database, close
+      // so its `deleteDatabase` is not blocked — AND drop the cached promise,
+      // otherwise a later `db.transaction()` on the closed connection throws
+      // InvalidStateError synchronously, breaking the never-throws contract.
+      // The next operation re-opens via `openDb` (or is dropped when the
+      // namespace was purged).
+      db.onversionchange = () => resetCachedDb();
+      resolve(db);
+    };
     req.onerror = () => resolve(null);
     req.onblocked = () => resolve(null);
   });

--- a/packages/web/src/api/read-state-store.ts
+++ b/packages/web/src/api/read-state-store.ts
@@ -27,7 +27,13 @@
  * Origin: proposal `hub-chat-scroll-and-cache.20260509.md` (M2),
  * revised through PR 286 manual sign-off. See issue first-tree-all
  * 120.
+ *
+ * Shares the storage-scope-namespaced `first-tree-chat-cache@<origin>#<userId>`
+ * database with message-store; logout purges it (SEC-042 / issue 1647) —
+ * see `api/storage-scope.ts`.
  */
+
+import { activeScopedDbName, isActiveScopedDbName, registerDatabaseCloseHook } from "./storage-scope.js";
 
 const DB_NAME = "first-tree-chat-cache";
 const DB_VERSION = 2;
@@ -64,15 +70,34 @@ export type ReadState = {
 };
 
 let dbPromise: Promise<IDBDatabase | null> | null = null;
+let dbConnection: IDBDatabase | null = null;
+
+/**
+ * Close the cached connection and forget it. Registered with storage-scope:
+ * runs on namespace switch and on logout purge so a stale handle neither
+ * serves reads for the wrong account nor blocks `deleteDatabase`.
+ */
+function resetCachedDb(): void {
+  dbConnection?.close();
+  dbConnection = null;
+  dbPromise = null;
+}
+
+registerDatabaseCloseHook(resetCachedDb);
 
 function openDb(): Promise<IDBDatabase | null> {
   if (dbPromise) return dbPromise;
+  // null when the current namespace was purged by logout — callers degrade
+  // exactly like the IndexedDB-unavailable path (reads null, writes no-op),
+  // and nothing is cached so a later sign-in re-checks fresh.
+  const name = activeScopedDbName(DB_NAME);
+  if (!name) return Promise.resolve(null);
   dbPromise = new Promise((resolve) => {
     if (typeof indexedDB === "undefined") {
       resolve(null);
       return;
     }
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    const req = indexedDB.open(name, DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(MESSAGES_STORE)) {
@@ -83,7 +108,25 @@ function openDb(): Promise<IDBDatabase | null> {
         db.createObjectStore(READ_STATE_STORE, { keyPath: "chatId" });
       }
     };
-    req.onsuccess = () => resolve(req.result);
+    req.onsuccess = () => {
+      const db = req.result;
+      // The namespace can switch (or be purged) while this open is in flight;
+      // never hand out a connection to the previous account's database.
+      if (!isActiveScopedDbName(DB_NAME, name)) {
+        db.close();
+        resolve(null);
+        return;
+      }
+      dbConnection = db;
+      // Multi-tab: when another tab deletes (or upgrades) this database, close
+      // so its `deleteDatabase` is not blocked — AND drop the cached promise,
+      // otherwise a later `db.transaction()` on the closed connection throws
+      // InvalidStateError synchronously, breaking the never-throws contract.
+      // The next operation re-opens via `openDb` (or is dropped when the
+      // namespace was purged).
+      db.onversionchange = () => resetCachedDb();
+      resolve(db);
+    };
     req.onerror = () => resolve(null);
     req.onblocked = () => resolve(null);
   });

--- a/packages/web/src/api/storage-scope.ts
+++ b/packages/web/src/api/storage-scope.ts
@@ -32,7 +32,7 @@
  *     pre-namespacing global DBs. Never rejects — purge is fire-and-forget.
  */
 
-import { clearDraftsForUser } from "../lib/draft-store.js";
+import { blockDraftWritesForUser, clearDraftsForUser, unblockDraftWritesForUser } from "../lib/draft-store.js";
 
 /** Base names of the scoped IndexedDBs, before the `@<namespace>` suffix. */
 const CHAT_CACHE_DB_BASE = "first-tree-chat-cache";
@@ -111,11 +111,16 @@ export function currentStorageNamespace(): string {
 /**
  * Switch the active namespace. Closes every registered cached connection so
  * the stores re-open under the new namespace on their next operation, and —
- * when signing in as a real account — lifts that account's write block.
+ * when signing in as a real account — lifts that account's write block (both
+ * the IndexedDB purged set and the draft-store block). Anonymous sign-out
+ * never lifts anything.
  */
 export function setStorageNamespace(userId: string | null): void {
   const next = namespaceForUser(userId);
-  if (userId !== null) purgedNamespaces.delete(next);
+  if (userId !== null) {
+    purgedNamespaces.delete(next);
+    unblockDraftWritesForUser(userId);
+  }
   if (next === currentNamespace) {
     currentUserId = userId;
     return;
@@ -184,8 +189,9 @@ export async function purgeLegacyUnscopedStores(): Promise<void> {
  * are cleared) when it differs — e.g. a session where `/me` never resolved but
  * a previous session's data still sits under that account's namespace.
  *
- * Marks every target purged synchronously (before the first `await`), then
- * deletes asynchronously. Never rejects.
+ * Marks every target purged synchronously (before the first `await`) and
+ * blocks the accounts' draft writes, then deletes asynchronously. Never
+ * rejects.
  */
 export async function purgeAccountLocalData(fallbackUserId?: string | null): Promise<void> {
   const targetNamespaces = new Set<string>([currentNamespace, namespaceForUser(null)]);
@@ -195,6 +201,12 @@ export async function purgeAccountLocalData(fallbackUserId?: string | null): Pro
   const draftUserIds = new Set<string>();
   if (currentUserId) draftUserIds.add(currentUserId);
   if (fallbackUserId) draftUserIds.add(fallbackUserId);
+  // Block draft writes for every purged account — and for the anonymous
+  // owner — synchronously (before the first await), mirroring the
+  // purged-namespace write-block above. Without it a late
+  // `parkFailedDraftIfSwitched` could re-write drafts the purge just removed.
+  blockDraftWritesForUser(null);
+  for (const userId of draftUserIds) blockDraftWritesForUser(userId);
 
   try {
     runCloseHooks();

--- a/packages/web/src/api/storage-scope.ts
+++ b/packages/web/src/api/storage-scope.ts
@@ -1,0 +1,215 @@
+/**
+ * Account+server namespacing and logout purge for per-browser session data
+ * (SEC-042 / issue 1647).
+ *
+ * Every persistent client-side store that can hold chat content is scoped to a
+ * namespace of `<origin>#<userId>` so a shared browser profile can never leak
+ * one account's data into another account's view — not even into another
+ * deployment served from a different origin. The namespace is module-level
+ * state (mirroring `setApiSelectedOrganizationId` in `api/client.ts`), set by
+ * the auth context, so read/write call sites keep their existing signatures:
+ *
+ *  - `setStorageNamespace(user.id)` runs inside `fetchMe` before `meLoaded`
+ *    flips, so no store write can land in the wrong namespace.
+ *  - `setStorageNamespace(null)` runs on logout; the anonymous namespace has
+ *    no legitimate writer and is purged + write-blocked by every logout.
+ *
+ * Invariant: once `/me` has resolved, the namespace set from `user.id` equals
+ * the one derivable from the access token's `sub` claim (org keying already
+ * relies on this equivalence) — the token is only a purge fallback for
+ * sessions where `/me` never succeeded.
+ *
+ * Logout purge contract (`purgeAccountLocalData`):
+ *  1. Synchronously mark the target namespaces purged, so in-flight or later
+ *     writes re-open no deleted database — store `openDb` entry points check
+ *     the purged set and resolve `null`, which the stores' existing
+ *     degradation contracts already cover (reads return empty, writes no-op).
+ *  2. Run the registered close hooks so this tab's cached connections do not
+ *     block `deleteDatabase` (other tabs close via their `onversionchange`
+ *     handlers; multi-tab converges eventually).
+ *  3. Asynchronously delete the namespaced IndexedDBs, clear the account's
+ *     drafts (both legacy and current scope formats), and drop the legacy
+ *     pre-namespacing global DBs. Never rejects — purge is fire-and-forget.
+ */
+
+import { clearDraftsForUser } from "../lib/draft-store.js";
+
+/** Base names of the scoped IndexedDBs, before the `@<namespace>` suffix. */
+const CHAT_CACHE_DB_BASE = "first-tree-chat-cache";
+const IMAGES_DB_BASE = "first-tree-images";
+const SCOPED_DB_BASES = [CHAT_CACHE_DB_BASE, IMAGES_DB_BASE] as const;
+
+/**
+ * Pre-namespacing builds stored the same caches under these global names.
+ * Their content is unrecoverable-by-account (no user dimension), cache-only
+ * (the server re-hydrates), and readable by any later account on the profile —
+ * so the safe disposition is deletion on startup and on every logout.
+ */
+const LEGACY_UNSCOPED_DBS = [...SCOPED_DB_BASES];
+
+/**
+ * Server identity for scoping. The web app is same-origin with its API
+ * (`BASE_URL = "/api/v1"`), so `window.location.origin` IS the server
+ * identity. SSR / non-DOM test environments fall back to a fixed placeholder.
+ */
+function currentOrigin(): string {
+  if (typeof window === "undefined" || !window.location?.origin) return "unknown-origin";
+  return window.location.origin;
+}
+
+/** Namespace for an account on this server, e.g. `https://app.example#user-1`. */
+export function namespaceForUser(userId: string | null): string {
+  return `${currentOrigin()}#${userId ?? "anon"}`;
+}
+
+/** IndexedDB name for `base` under `namespace`, e.g. `first-tree-images@https://app.example#user-1`. */
+export function scopedDbName(base: string, namespace: string): string {
+  return `${base}@${namespace}`;
+}
+
+let currentUserId: string | null = null;
+let currentNamespace = namespaceForUser(null);
+
+/**
+ * Namespaces whose session data has been purged by a logout. Stores refuse to
+ * open a database under a purged namespace, which cuts the "purge completes,
+ * then an in-flight `cacheMessages`/`putImage` re-opens and rebuilds the DB"
+ * path. A namespace leaves the set only via `setStorageNamespace(userId)` —
+ * an explicit sign-in of that account re-enables caching. The anonymous
+ * namespace never leaves: anonymous state has no legitimate persistent writer.
+ */
+const purgedNamespaces = new Set<string>();
+
+/**
+ * Close hooks registered by the IndexedDB store modules (message-store,
+ * read-state-store, image-store). Registration (rather than direct imports)
+ * keeps the dependency direction one-way: stores import storage-scope, never
+ * the reverse. A hook must close the module's cached connection and drop its
+ * cached open promise so the next `openDb` re-derives name + purged state.
+ */
+const databaseCloseHooks = new Set<() => void>();
+
+export function registerDatabaseCloseHook(hook: () => void): void {
+  databaseCloseHooks.add(hook);
+}
+
+function runCloseHooks(): void {
+  for (const hook of databaseCloseHooks) {
+    try {
+      hook();
+    } catch {
+      // A misbehaving hook must not block the namespace switch or purge.
+    }
+  }
+}
+
+/** The namespace every store read/write currently lands in. */
+export function currentStorageNamespace(): string {
+  return currentNamespace;
+}
+
+/**
+ * Switch the active namespace. Closes every registered cached connection so
+ * the stores re-open under the new namespace on their next operation, and —
+ * when signing in as a real account — lifts that account's write block.
+ */
+export function setStorageNamespace(userId: string | null): void {
+  const next = namespaceForUser(userId);
+  if (userId !== null) purgedNamespaces.delete(next);
+  if (next === currentNamespace) {
+    currentUserId = userId;
+    return;
+  }
+  currentNamespace = next;
+  currentUserId = userId;
+  runCloseHooks();
+}
+
+/**
+ * The IndexedDB name stores should open for `base` right now, or `null` when
+ * the current namespace has been purged (post-logout) — callers treat `null`
+ * like IndexedDB being unavailable, which their existing fallback paths cover.
+ */
+export function activeScopedDbName(base: string): string | null {
+  if (purgedNamespaces.has(currentNamespace)) return null;
+  return scopedDbName(base, currentNamespace);
+}
+
+/** `true` when `name` is the database the stores would open right now. */
+export function isActiveScopedDbName(base: string, name: string): boolean {
+  return activeScopedDbName(base) === name;
+}
+
+/** Best-effort `indexedDB.deleteDatabase` — resolves on every outcome, never rejects. */
+function deleteDatabase(name: string): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof indexedDB === "undefined") {
+      resolve();
+      return;
+    }
+    try {
+      const req = indexedDB.deleteDatabase(name);
+      req.onsuccess = () => resolve();
+      req.onerror = () => resolve();
+      // A blocked delete (a connection elsewhere never closes) must not wedge
+      // the fire-and-forget purge; namespace isolation still bounds any residue
+      // to the account that produced it.
+      req.onblocked = () => resolve();
+    } catch {
+      resolve();
+    }
+  });
+}
+
+/**
+ * Delete the legacy global (`first-tree-chat-cache`, `first-tree-images`)
+ * databases left behind by pre-namespacing builds. Runs once on AuthProvider
+ * mount and again on every logout. Never rejects.
+ */
+export async function purgeLegacyUnscopedStores(): Promise<void> {
+  try {
+    for (const base of LEGACY_UNSCOPED_DBS) {
+      await deleteDatabase(base);
+    }
+  } catch {
+    // Best-effort cleanup; never surfaces.
+  }
+}
+
+/**
+ * Drop every per-browser trace of an account's session data. Targets the
+ * current namespace (set by `fetchMe` from `user.id` — the authoritative
+ * source) plus the anonymous namespace, and additionally the namespace derived
+ * from `fallbackUserId` (the token's `sub`, captured by logout before tokens
+ * are cleared) when it differs — e.g. a session where `/me` never resolved but
+ * a previous session's data still sits under that account's namespace.
+ *
+ * Marks every target purged synchronously (before the first `await`), then
+ * deletes asynchronously. Never rejects.
+ */
+export async function purgeAccountLocalData(fallbackUserId?: string | null): Promise<void> {
+  const targetNamespaces = new Set<string>([currentNamespace, namespaceForUser(null)]);
+  if (fallbackUserId) targetNamespaces.add(namespaceForUser(fallbackUserId));
+  for (const ns of targetNamespaces) purgedNamespaces.add(ns);
+
+  const draftUserIds = new Set<string>();
+  if (currentUserId) draftUserIds.add(currentUserId);
+  if (fallbackUserId) draftUserIds.add(fallbackUserId);
+
+  try {
+    runCloseHooks();
+    const deletions: Promise<void>[] = [];
+    for (const ns of targetNamespaces) {
+      for (const base of SCOPED_DB_BASES) {
+        deletions.push(deleteDatabase(scopedDbName(base, ns)));
+      }
+    }
+    for (const userId of draftUserIds) {
+      clearDraftsForUser(userId);
+    }
+    deletions.push(purgeLegacyUnscopedStores());
+    await Promise.all(deletions);
+  } catch {
+    // Purge is best-effort and fire-and-forget; it must never reject.
+  }
+}

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -11,6 +11,8 @@ import {
   setStoredTokens,
 } from "../api/client.js";
 import { markOnboardingCompleted as postOnboardingCompleted } from "../api/onboarding-events.js";
+import { purgeAccountLocalData, purgeLegacyUnscopedStores, setStorageNamespace } from "../api/storage-scope.js";
+import { clearChatSummaryPrefs } from "../pages/workspace/center/chat-summary.js";
 import { clearOnboardingJoinPath, clearOnboardingSessionFlags } from "../utils/onboarding-flags.js";
 
 type MeUser = {
@@ -242,6 +244,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
 
   const logout = useCallback(() => {
+    // SEC-042: purge this account's per-browser session data (namespaced
+    // message/read-state/image IndexedDBs, drafts in both scope formats,
+    // legacy global DBs). The token's `sub` is captured BEFORE clearing
+    // tokens and passed as the fallback purge target — it only matters when
+    // this session's /me never resolved (storage-scope's namespace is still
+    // stale from a previous session); once /me has resolved, the namespace
+    // set from `user.id` equals the token's (org keying relies on the same
+    // equivalence). Fire-and-forget: target namespaces are write-blocked
+    // synchronously, the deletion itself settles asynchronously.
+    const tokenUserId = userIdFromToken();
+    void purgeAccountLocalData(tokenUserId);
+    // Per-chat summary prefs embed chatIds — account-linked, so they go too.
+    clearChatSummaryPrefs();
+    // Post-logout state is anonymous; the stores' next operations either land
+    // in the (purged, write-blocked) anon namespace or wait for the next
+    // fetchMe to set the new account's namespace.
+    setStorageNamespace(null);
     clearStoredTokens();
     // Keep the persisted last-used org (no writeSelectedOrgId(null) here) so a
     // returning sign-in lands back in the org this user left rather than their
@@ -272,6 +291,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       const data = await api.get<MeResponse>("/me");
       setUser(data.user ?? null);
+      // Point every persistent browser store at this account's namespace
+      // BEFORE meLoaded flips and the gated UI starts firing store
+      // reads/writes — otherwise the first wave would land in the anonymous
+      // (or a previous account's) namespace (SEC-042).
+      setStorageNamespace(data.user?.id ?? null);
       const ms = data.memberships ?? [];
       setMemberships(ms);
       setDocsEnabled(data.features?.docs === true);
@@ -484,6 +508,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       fetchMe();
     }
   }, [isAuthenticated, user, fetchMe]);
+
+  // SEC-042: one-shot cleanup of the pre-namespacing global IndexedDBs
+  // (`first-tree-chat-cache`, `first-tree-images`) left by older builds. Their
+  // content is cache-only (the server re-hydrates) and not attributable to an
+  // account, so the safe disposition is deletion. Fire-and-forget.
+  useEffect(() => {
+    void purgeLegacyUnscopedStores();
+  }, []);
 
   // Listen for auth failure dispatched by the API client
   useEffect(() => {

--- a/packages/web/src/lib/__tests__/draft-store.test.ts
+++ b/packages/web/src/lib/__tests__/draft-store.test.ts
@@ -2,6 +2,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  blockDraftWritesForUser,
   chatDraftScope,
   clearDraft,
   clearDraftsForUser,
@@ -9,6 +10,7 @@ import {
   newChatDraftScope,
   parkFailedDraftIfSwitched,
   saveDraft,
+  unblockDraftWritesForUser,
 } from "../draft-store.js";
 
 const STORAGE_KEY = "first-tree:chat-drafts:v1";
@@ -242,5 +244,54 @@ describe("legacy scope migration (SEC-042)", () => {
     expect(loadDraft(chatDraftScope("user-a", "chat-1"))?.text).toBe("current body");
     const after = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<string, unknown>;
     expect(after["u:user-a:chat:chat-1"]).toBeUndefined();
+  });
+});
+
+// The write-block is module-level state and this file imports the store
+// statically, so every test here uses its own user id (or unblocks before
+// exiting) to keep the block from leaking into other tests.
+describe("draft write-block after purge (SEC-042)", () => {
+  it("drops saveDraft for a blocked user in both scope formats; other users unaffected", () => {
+    blockDraftWritesForUser("blocked-user");
+
+    saveDraft(chatDraftScope("blocked-user", "chat-1"), { text: "blocked current" });
+    // Legacy-format scope of the same blocked user — also dropped.
+    saveDraft("u:blocked-user:chat:chat-2", { text: "blocked legacy" });
+    saveDraft(chatDraftScope("other-user", "chat-1"), { text: "other" });
+
+    expect(loadDraft(chatDraftScope("blocked-user", "chat-1"))).toBeNull();
+    expect(loadDraft(chatDraftScope("other-user", "chat-1"))?.text).toBe("other");
+    const after = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<string, unknown>;
+    expect(Object.keys(after).some((k) => k.startsWith("u:blocked-user:") || k.startsWith("u:blocked-user@"))).toBe(
+      false,
+    );
+    unblockDraftWritesForUser("blocked-user");
+  });
+
+  it("drops parkFailedDraftIfSwitched for a blocked user", () => {
+    blockDraftWritesForUser("blocked-parker");
+
+    // Still reports "user switched" — only the parking write is dropped.
+    expect(parkFailedDraftIfSwitched("blocked-parker", "chat-a", "chat-b", "retry me")).toBe(true);
+    expect(loadDraft(chatDraftScope("blocked-parker", "chat-a"))).toBeNull();
+    unblockDraftWritesForUser("blocked-parker");
+  });
+
+  it("re-enables writes after unblockDraftWritesForUser", () => {
+    blockDraftWritesForUser("returning-user");
+    saveDraft(chatDraftScope("returning-user", "chat-1"), { text: "dropped" });
+    expect(loadDraft(chatDraftScope("returning-user", "chat-1"))).toBeNull();
+
+    unblockDraftWritesForUser("returning-user");
+    saveDraft(chatDraftScope("returning-user", "chat-1"), { text: "kept" });
+    expect(loadDraft(chatDraftScope("returning-user", "chat-1"))?.text).toBe("kept");
+  });
+
+  it("blocks the anonymous owner via blockDraftWritesForUser(null)", () => {
+    blockDraftWritesForUser(null);
+    saveDraft(chatDraftScope(null, "chat-1"), { text: "anon dropped" });
+    expect(loadDraft(chatDraftScope(null, "chat-1"))).toBeNull();
+    // Cleanup: this file shares the module across tests.
+    unblockDraftWritesForUser("anon");
   });
 });

--- a/packages/web/src/lib/__tests__/draft-store.test.ts
+++ b/packages/web/src/lib/__tests__/draft-store.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   chatDraftScope,
   clearDraft,
+  clearDraftsForUser,
   loadDraft,
   newChatDraftScope,
   parkFailedDraftIfSwitched,
@@ -11,6 +12,8 @@ import {
 } from "../draft-store.js";
 
 const STORAGE_KEY = "first-tree:chat-drafts:v1";
+// Draft scopes embed the server identity — see draft-store `userPrefix`.
+const ORIGIN = window.location.origin;
 
 beforeEach(() => {
   window.localStorage.clear();
@@ -107,20 +110,20 @@ describe("robustness", () => {
 });
 
 describe("scope helpers", () => {
-  it("chatDraftScope encodes user + chat", () => {
-    expect(chatDraftScope("user-1", "chat-9")).toBe("u:user-1:chat:chat-9");
+  it("chatDraftScope encodes user + origin + chat", () => {
+    expect(chatDraftScope("user-1", "chat-9")).toBe(`u:user-1@${ORIGIN}:chat:chat-9`);
   });
 
   it("chatDraftScope falls back to anon when no user", () => {
-    expect(chatDraftScope(null, "chat-9")).toBe("u:anon:chat:chat-9");
+    expect(chatDraftScope(null, "chat-9")).toBe(`u:anon@${ORIGIN}:chat:chat-9`);
   });
 
-  it("newChatDraftScope encodes user + org + seed participants", () => {
-    expect(newChatDraftScope("user-1", "org-7", ["a", "b"])).toBe("u:user-1:new:org-7:a,b");
+  it("newChatDraftScope encodes user + origin + org + seed participants", () => {
+    expect(newChatDraftScope("user-1", "org-7", ["a", "b"])).toBe(`u:user-1@${ORIGIN}:new:org-7:a,b`);
   });
 
   it("newChatDraftScope falls back to anon / no-org / empty participants", () => {
-    expect(newChatDraftScope(null, null)).toBe("u:anon:new:no-org:");
+    expect(newChatDraftScope(null, null)).toBe(`u:anon@${ORIGIN}:new:no-org:`);
   });
 
   it("keeps drafts isolated per user (no cross-account leak on a shared browser)", () => {
@@ -165,5 +168,79 @@ describe("parkFailedDraftIfSwitched", () => {
   it("parks under the originating user's scope only", () => {
     parkFailedDraftIfSwitched("user-1", "chat-a", "chat-b", "retry me");
     expect(loadDraft(chatDraftScope("user-2", "chat-a"))).toBeNull();
+  });
+});
+
+describe("clearDraftsForUser (SEC-042)", () => {
+  it("removes only the target user's drafts, in both current and legacy scope formats", () => {
+    saveDraft(chatDraftScope("user-a", "chat-1"), { text: "A current" });
+    saveDraft(chatDraftScope("user-b", "chat-1"), { text: "B current" });
+    // A pre-SEC-042 legacy-format entry for user-a, seeded raw so the
+    // read-path migration cannot rewrite it before the purge runs.
+    const seeded = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<string, unknown>;
+    seeded["u:user-a:chat:chat-9"] = { text: "A legacy", updatedAt: 1 };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(seeded));
+
+    clearDraftsForUser("user-a");
+
+    const after = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<string, unknown>;
+    expect(Object.keys(after).some((k) => k.startsWith("u:user-a:") || k.startsWith("u:user-a@"))).toBe(false);
+    // The other account's draft survives untouched.
+    expect(loadDraft(chatDraftScope("user-b", "chat-1"))?.text).toBe("B current");
+  });
+
+  it("is a no-op for a user with no drafts", () => {
+    saveDraft(chatDraftScope("user-b", "chat-1"), { text: "B" });
+    clearDraftsForUser("user-a");
+    expect(loadDraft(chatDraftScope("user-b", "chat-1"))?.text).toBe("B");
+  });
+});
+
+describe("legacy scope migration (SEC-042)", () => {
+  it("rewrites u:<userId>: entries to the origin-aware format on read", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "u:user-a:chat:chat-1": { text: "legacy body", updatedAt: 7 } }),
+    );
+
+    // The migrated entry is readable through the current-format scope...
+    expect(loadDraft(chatDraftScope("user-a", "chat-1"))?.text).toBe("legacy body");
+
+    // ...and the stored map was rewritten in place: new key present, legacy gone.
+    const after = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<string, unknown>;
+    expect(after[`u:user-a@${ORIGIN}:chat:chat-1`]).toEqual({ text: "legacy body", updatedAt: 7 });
+    expect(after["u:user-a:chat:chat-1"]).toBeUndefined();
+  });
+
+  it("migrates every user's legacy entries (they all belong to this origin)", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        "u:user-a:chat:chat-1": { text: "A", updatedAt: 1 },
+        "u:user-b:chat:chat-2": { text: "B", updatedAt: 2 },
+      }),
+    );
+
+    // Any read triggers the map-wide migration.
+    loadDraft(chatDraftScope("user-a", "chat-1"));
+
+    expect(loadDraft(chatDraftScope("user-a", "chat-1"))?.text).toBe("A");
+    expect(loadDraft(chatDraftScope("user-b", "chat-2"))?.text).toBe("B");
+    const after = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<string, unknown>;
+    expect(Object.keys(after).every((k) => !k.startsWith("u:user-a:") && !k.startsWith("u:user-b:"))).toBe(true);
+  });
+
+  it("keeps the current-format entry when both formats exist for one scope", () => {
+    saveDraft(chatDraftScope("user-a", "chat-1"), { text: "current body" }, 10);
+    const seeded = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<string, unknown>;
+    seeded["u:user-a:chat:chat-1"] = { text: "stale legacy", updatedAt: 1 };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(seeded));
+
+    // Idempotent: repeated reads keep returning the current entry, and the
+    // legacy key never reappears.
+    expect(loadDraft(chatDraftScope("user-a", "chat-1"))?.text).toBe("current body");
+    expect(loadDraft(chatDraftScope("user-a", "chat-1"))?.text).toBe("current body");
+    const after = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<string, unknown>;
+    expect(after["u:user-a:chat:chat-1"]).toBeUndefined();
   });
 });

--- a/packages/web/src/lib/draft-store.ts
+++ b/packages/web/src/lib/draft-store.ts
@@ -113,12 +113,20 @@ function userPrefix(userId: string | null): string {
 
 /**
  * Split a map key into its legacy-vs-current shape. Current keys are
- * `u:<userId>@<origin>:<rest>`; legacy keys are `u:<userId>:<rest>`. The `@`
- * before the first `:` is the discriminator — origins always contain a `:`
- * (`https://…`), so a key whose first `:` comes before any `@` is legacy.
- * Returns null for keys not in the `u:` family (defensive; none exist today).
+ * `u:<userId>@<origin>:<rest>`; legacy keys are `u:<userId>:<rest>`.
+ * The discriminator is the `@` before the first `:`: legacy keys predate the
+ * origin segment, so they contain no `@` at all, while current keys always
+ * carry `@<origin>` right after the userId — so their `@` precedes every
+ * `:` that matters, whether the origin brings its own colons (`https://…`)
+ * or is the colon-less `unknown-origin` fallback.
+ *
+ * Only the legacy branch carries `rest`: the migration rewrite is its sole
+ * consumer, and the current branch has no well-defined `rest` to offer (the
+ * origin's own colons make "the rest after the origin" ambiguous to slice).
  */
-function parseUserScopedKey(key: string): { userId: string; rest: string; legacy: boolean } | null {
+type ParsedUserScopedKey = { userId: string; legacy: true; rest: string } | { userId: string; legacy: false };
+
+function parseUserScopedKey(key: string): ParsedUserScopedKey | null {
   if (!key.startsWith("u:")) return null;
   const body = key.slice(2);
   const at = body.indexOf("@");
@@ -126,11 +134,7 @@ function parseUserScopedKey(key: string): { userId: string; rest: string; legacy
   if (colon === -1) return null;
   const legacy = at === -1 || colon < at;
   if (legacy) return { userId: body.slice(0, colon), rest: body.slice(colon + 1), legacy: true };
-  // Current format: the scope body starts at the first `:` AFTER the origin
-  // (the origin's own `https://` colons come before it).
-  const scopeColon = body.indexOf(":", at);
-  if (scopeColon === -1) return null;
-  return { userId: body.slice(0, at), rest: body.slice(scopeColon + 1), legacy: false };
+  return { userId: body.slice(0, at), legacy: false };
 }
 
 /** Rewrite a legacy `u:<userId>:` map to current `u:<userId>@<origin>:` keys. */
@@ -150,6 +154,38 @@ function migrateLegacyScopes(map: DraftMap): { map: DraftMap; migrated: boolean 
     }
   }
   return { map: migrated ? out : map, migrated };
+}
+
+/**
+ * User ids whose draft writes are blocked after a logout purge (SEC-042).
+ * Mirrors the IndexedDB purged-namespace write-block in `api/storage-scope.ts`:
+ * without it, an in-flight failed send's `parkFailedDraftIfSwitched` (or any
+ * other post-purge `saveDraft`) would re-write the purged account's drafts.
+ * Blocking gates WRITES only — `clearDraft` / `clearDraftsForUser` stay open
+ * so the purge itself can run after the block is in place. The anonymous
+ * owner is tracked as "anon" and, once blocked, never unblocks: anonymous
+ * state has no legitimate draft writer.
+ */
+const blockedDraftUserIds = new Set<string>();
+
+/** Block draft writes for `userId` (`null` → the anonymous owner). */
+export function blockDraftWritesForUser(userId: string | null): void {
+  blockedDraftUserIds.add(userId ?? "anon");
+}
+
+/**
+ * Re-enable draft writes for `userId` after an explicit sign-in (mirrors
+ * storage-scope lifting the IndexedDB write-block on re-login).
+ */
+export function unblockDraftWritesForUser(userId: string): void {
+  blockedDraftUserIds.delete(userId);
+}
+
+/** `true` when the owner of `scope` (current or legacy format) is write-blocked. */
+function isScopeWriteBlocked(scope: string): boolean {
+  const parsed = parseUserScopedKey(scope);
+  if (!parsed) return false;
+  return blockedDraftUserIds.has(parsed.userId);
 }
 
 /** Storage scope for the in-chat composer: per user, per chat. */
@@ -180,12 +216,18 @@ export function loadDraft(scope: string): DraftSnapshot | null {
  * treated as empty and removes the entry — participant chips are remembered
  * only alongside real text, never on their own (an auto-seeded default chip
  * must not masquerade as an unsent draft).
+ *
+ * No-ops when the scope's owner is write-blocked (see
+ * `blockDraftWritesForUser` — the post-logout purge state).
  */
 export function saveDraft(
   scope: string,
   draft: { text: string; participantIds?: readonly string[] },
   now: number = Date.now(),
 ): void {
+  // SEC-042: dropped silently when the scope's owner was purged by a logout —
+  // a late write (e.g. a failed send being parked) must not resurrect drafts.
+  if (isScopeWriteBlocked(scope)) return;
   const map = readMap();
   if (draft.text.trim().length === 0) {
     if (scope in map) {

--- a/packages/web/src/lib/draft-store.ts
+++ b/packages/web/src/lib/draft-store.ts
@@ -55,7 +55,11 @@ function readMap(): DraftMap {
     for (const [k, v] of Object.entries(parsed)) {
       if (isStoredDraft(v)) out[k] = v;
     }
-    return out;
+    // Upgrade pre-SEC-042 `u:<userId>:` scopes to the origin-aware format in
+    // place. Idempotent — after the rewrite nothing matches the legacy shape.
+    const { map: migratedMap, migrated } = migrateLegacyScopes(out);
+    if (migrated) writeMap(migratedMap);
+    return migratedMap;
   } catch {
     // Corrupt JSON or unavailable storage — start from empty rather than throw.
     return {};
@@ -80,12 +84,72 @@ function prune(map: DraftMap): DraftMap {
   return Object.fromEntries(entries.slice(0, MAX_ENTRIES));
 }
 
-/** Per-user prefix so a shared browser never restores another account's draft
- *  after a logout/login on the same profile — `logout()` clears tokens and
- *  query state, not this store. Mirrors the userId-bucketed selected-org
- *  storage in auth-context (`first-tree:selectedOrganizationId:<userId>`). */
+/**
+ * Server identity for draft scoping — the web app is same-origin with its API,
+ * so `window.location.origin` distinguishes drafts written against different
+ * deployments in the same browser profile. Computed locally (rather than
+ * imported from `api/storage-scope.ts`) to keep this module dependency-free:
+ * storage-scope imports THIS module, never the reverse.
+ */
+function currentOrigin(): string {
+  if (typeof window === "undefined" || !window.location?.origin) return "unknown-origin";
+  return window.location.origin;
+}
+
+/**
+ * Per-user, per-server prefix so a shared browser never restores another
+ * account's — or another deployment's — draft after a logout/login on the
+ * same profile. Mirrors the userId-bucketed selected-org storage in
+ * auth-context (`first-tree:selectedOrganizationId:<userId>`).
+ *
+ * Scope format history: pre-SEC-042 scopes were `u:<userId>:...` (no server
+ * dimension). Current scopes are `u:<userId>@<origin>:...`; legacy entries
+ * are migrated forward on read (drafts are user data, so they are rewritten
+ * rather than dropped) and both formats are removed by `clearDraftsForUser`.
+ */
 function userPrefix(userId: string | null): string {
-  return `u:${userId ?? "anon"}`;
+  return `u:${userId ?? "anon"}@${currentOrigin()}`;
+}
+
+/**
+ * Split a map key into its legacy-vs-current shape. Current keys are
+ * `u:<userId>@<origin>:<rest>`; legacy keys are `u:<userId>:<rest>`. The `@`
+ * before the first `:` is the discriminator — origins always contain a `:`
+ * (`https://…`), so a key whose first `:` comes before any `@` is legacy.
+ * Returns null for keys not in the `u:` family (defensive; none exist today).
+ */
+function parseUserScopedKey(key: string): { userId: string; rest: string; legacy: boolean } | null {
+  if (!key.startsWith("u:")) return null;
+  const body = key.slice(2);
+  const at = body.indexOf("@");
+  const colon = body.indexOf(":");
+  if (colon === -1) return null;
+  const legacy = at === -1 || colon < at;
+  if (legacy) return { userId: body.slice(0, colon), rest: body.slice(colon + 1), legacy: true };
+  // Current format: the scope body starts at the first `:` AFTER the origin
+  // (the origin's own `https://` colons come before it).
+  const scopeColon = body.indexOf(":", at);
+  if (scopeColon === -1) return null;
+  return { userId: body.slice(0, at), rest: body.slice(scopeColon + 1), legacy: false };
+}
+
+/** Rewrite a legacy `u:<userId>:` map to current `u:<userId>@<origin>:` keys. */
+function migrateLegacyScopes(map: DraftMap): { map: DraftMap; migrated: boolean } {
+  let migrated = false;
+  const out: DraftMap = {};
+  for (const [key, value] of Object.entries(map)) {
+    const parsed = parseUserScopedKey(key);
+    if (parsed?.legacy) {
+      const nextKey = `u:${parsed.userId}@${currentOrigin()}:${parsed.rest}`;
+      // A current-format entry for the same scope wins — it was written by
+      // newer code and is at least as fresh.
+      if (!(nextKey in map) && !(nextKey in out)) out[nextKey] = value;
+      migrated = true;
+    } else {
+      out[key] = value;
+    }
+  }
+  return { map: migrated ? out : map, migrated };
 }
 
 /** Storage scope for the in-chat composer: per user, per chat. */
@@ -142,6 +206,37 @@ export function clearDraft(scope: string): void {
   if (scope in map) {
     delete map[scope];
     writeMap(map);
+  }
+}
+
+/**
+ * Remove every draft belonging to `userId` — both the current
+ * `u:<userId>@<origin>:` scopes and any not-yet-migrated legacy
+ * `u:<userId>:` ones. Called by the logout purge (SEC-042 /
+ * `api/storage-scope.ts`); other users' drafts are untouched.
+ *
+ * Scans the raw stored object rather than the validated map so malformed
+ * entries (which `readMap` would skip) are purged too — this is a security
+ * path, and skipped entries could still hold the account's plaintext.
+ */
+export function clearDraftsForUser(userId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return;
+    const map = parsed as Record<string, unknown>;
+    let changed = false;
+    for (const key of Object.keys(map)) {
+      if (key.startsWith(`u:${userId}:`) || key.startsWith(`u:${userId}@`)) {
+        delete map[key];
+        changed = true;
+      }
+    }
+    if (changed) window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // Unavailable storage or corrupt JSON — best-effort purge, never throws.
   }
 }
 

--- a/packages/web/src/pages/workspace/center/chat-summary.tsx
+++ b/packages/web/src/pages/workspace/center/chat-summary.tsx
@@ -109,6 +109,28 @@ function clearDismissedVersion(chatId: string, version: string): void {
 }
 
 /**
+ * Drop every `first-tree:chat-summary-*` localStorage key. Called on logout
+ * (SEC-042 / issue 1647): the keys embed chatIds, which are account-linked
+ * session data, so they must not survive into the next account on a shared
+ * browser. Iterates the prefix so future keys added under it are covered
+ * automatically (mirrors `clearOnboardingSessionFlags`).
+ */
+export function clearChatSummaryPrefs(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const ls = window.localStorage;
+    const toRemove: string[] = [];
+    for (let i = 0; i < ls.length; i++) {
+      const k = ls.key(i);
+      if (k?.startsWith("first-tree:chat-summary-")) toRemove.push(k);
+    }
+    for (const k of toRemove) ls.removeItem(k);
+  } catch {
+    // localStorage may be unavailable (private mode); ignore.
+  }
+}
+
+/**
  * Best-effort single-line preview of a markdown description for the collapsed
  * bar. A leading `## 任务` / `## Goals`-style section heading is a structural
  * label, not the summary itself — the real one-line gist is the prose under it.


### PR DESCRIPTION
## Summary

Fixes #1647 (SEC-042, Medium). Logout cleared tokens and React Query but left plaintext messages, images, and drafts in IndexedDB/localStorage, and the persistent stores were not scoped by account — a later account (or anyone with DevTools) on the same browser profile could recover the previous user's conversation data.

Per the GoF scope on the issue: **logout clears local data by default — there is no "keep local data" option.**

## Approach

- **Account+server namespacing** — new `packages/web/src/api/storage-scope.ts` derives a namespace `<origin>#<userId>` (origin = server identity; the web app is same-origin with its API) and holds it as module-level state set by the auth context, mirroring the existing `setApiSelectedOrganizationId` pattern. Store call sites keep their signatures. The namespaced stores:
  - IndexedDB `first-tree-chat-cache@<origin>#<userId>` (messages + read-state)
  - IndexedDB `first-tree-images@<origin>#<userId>`
  - draft scopes `u:<userId>@<origin>:...` inside `first-tree:chat-drafts:v1` (legacy `u:<userId>:` entries migrate forward on read — drafts are user data)
- **Logout purge** (`purgeAccountLocalData`, fire-and-forget from `logout()`): synchronously write-blocks the target namespaces — so an in-flight 5s-polling `cacheMessages`/`putImage` cannot re-open and rebuild a deleted DB — then asynchronously closes connections and `deleteDatabase`s the account's + anonymous namespaces, clears the account's drafts (both formats), prefix-scans `first-tree:chat-summary-*` (they embed chatIds), and deletes the legacy pre-namespacing global DBs. The purge target is the namespace `fetchMe` set from `user.id` (authoritative); the token `sub` is only a fallback for sessions where `/me` never resolved.
- **Multi-tab**: store connections close on `versionchange` (and drop their cached open promise, so a later `transaction()` never throws `InvalidStateError` on a closed handle) — another tab's `deleteDatabase` is never permanently blocked; each tab's own logout purge converges the rest.
- Legacy global DBs (`first-tree-chat-cache`, `first-tree-images`) are also deleted once on `AuthProvider` mount: their content is cache-only (the server re-hydrates) and unattributable to an account.

## Full persistent-storage inventory

| Storage | Content | Disposition | Why |
|---|---|---|---|
| IDB `first-tree-chat-cache@<ns>` | messages, read-state | **deleted on logout** | conversation data |
| IDB `first-tree-images@<ns>` | image bytes | **deleted on logout** | conversation data |
| localStorage `first-tree:chat-drafts:v1` | unsent drafts | **per-account entries removed on logout** (both scope formats) | conversation data |
| localStorage `first-tree:chat-summary-*:<chatId>` | summary expand/dismiss prefs | **prefix-cleared on logout** | embeds account chatIds |
| localStorage `first-tree:tokens` | auth tokens | cleared on logout (pre-existing) | — |
| sessionStorage `onboarding:*`, `first-tree:auth-attempt`, `first-tree:quickstart:intent` | onboarding/analytics/intent | cleared on logout or dies with the tab (pre-existing) | session-scoped |
| localStorage `first-tree:selectedOrganizationId:<userId>` | last-used org | **kept** | already per-user; deliberately survives logout so a returning sign-in lands in the org it left |
| localStorage `theme`, sidebar widths/open state, `first-tree:chat-list-group`, `first-tree:team-agent-filter:v1`, `first-tree:new-chat-default-agent:<user>:<org>`, `first-tree:install-guide`, `first-tree:doc-preview-drawer:width:v1` | pure UI prefs | **kept** | no conversation content; the default-agent key is already per-user+org |

## Acceptance mapping

- *After logout, no messages, images, or drafts belonging to the account remain in any browser storage* → purge above + legacy global DB deletion.
- *All persistent client stores are namespaced by account + server* → `<origin>#<userId>` on every content-bearing store; even residue can never surface across accounts.
- *Account-switching tests* → `storage-scope.test.ts` runs the full A→logout→B scenario against the real message/image/draft stores (fake-indexeddb), plus purged-namespace write-drop, token-fallback purge, and multi-tab deletion. UI non-rendering follows from the single hydration path (`chat-view.tsx` reads only via `getCachedMessages` + server fetch; `queryClient.clear()` + route unmount on logout) — the store-level tests pin the store half of that chain.

- **Draft write-block** — `draft-store` mirrors the IndexedDB purged-namespace guard: logout synchronously blocks `saveDraft`/`parkFailedDraftIfSwitched` for the purged account (and anon), so an in-flight failed send cannot re-write the account's drafts after the purge; re-login lifts the block.

## Verification

- `pnpm check` — pass (only pre-existing CSS warnings from main)
- `pnpm typecheck` — pass (all 10 turbo tasks)
- `pnpm --filter @first-tree/web test` — **193 files / 1580 tests, all pass**

## Known limitations

- **Multi-tab windows converge, they are not instantaneous.** A second tab still holding a live composer/poller can rewrite account A's drafts/IndexedDB rows until that tab's own session ends (401 → its own logout purge) or A's namespace is purged there too. Any such residue is namespaced to account A — it can never surface to another account (acceptance ②③ hold at all times) — and each tab's logout re-purges, so the end state is clean. Single-tab logout is airtight: write-blocks land synchronously before the async deletion.

## Notes

- No schema/migration impact: namespaced IndexedDBs are fresh per account; the legacy global DBs are deleted, not upgraded (cache-only content).
- `logout()` keeps its synchronous signature; the purge is fire-and-forget with synchronous write-blocking, and `deleteDatabase` still completes if the page unloads.
- Competition rules: this PR stays **draft**; submission is signaled via labels (`fire_wip` → `fire_submitted`), never via "ready for review".
