### PR TITLE
Render sent chat mentions with display names

### DIFF
--- a/packages/server/src/__tests__/admin-agents.test.ts
+++ b/packages/server/src/__tests__/admin-agents.test.ts
@@ -262,6 +262,27 @@ describe("Admin Agents API", () => {
     expect(res.json().displayName).toBe("New Name");
   });
 
+  it("rejects display-name PATCHes that bypass membership-backed human identity", async () => {
+    const app = getApp();
+    const { req, ctx } = await authedRequest(app);
+    const [before] = await app.db
+      .select({ displayName: agents.displayName })
+      .from(agents)
+      .where(eq(agents.uuid, ctx.humanAgentUuid));
+
+    const res = await req("PATCH", `/api/v1/agents/${ctx.humanAgentUuid}`, {
+      displayName: "Drifted Human",
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(/member or profile endpoint/i);
+    const [after] = await app.db
+      .select({ displayName: agents.displayName })
+      .from(agents)
+      .where(eq(agents.uuid, ctx.humanAgentUuid));
+    expect(after?.displayName).toBe(before?.displayName);
+  });
+
   it("rejects user-supplied internal runtime metadata on PATCH", async () => {
     const app = getApp();
     const { req } = await authedRequest(app);

--- a/packages/server/src/__tests__/agent-delegate-self-only.test.ts
+++ b/packages/server/src/__tests__/agent-delegate-self-only.test.ts
@@ -73,7 +73,7 @@ describe("PATCH /agents/:uuid — delegateMention is self-only", () => {
     expect(res.json().delegateMention).toBe(targetUuid);
   });
 
-  it("still lets an admin edit another member's non-delegate fields (200)", async () => {
+  it("still lets an admin edit another member's non-identity fields (200)", async () => {
     const app = getApp();
     const a = await createTestAdmin(app);
     const b = await createTestAdmin(app);
@@ -82,10 +82,10 @@ describe("PATCH /agents/:uuid — delegateMention is self-only", () => {
       method: "PATCH",
       url: `/api/v1/agents/${b.humanAgentUuid}`,
       headers: { authorization: `Bearer ${a.accessToken}` },
-      payload: { displayName: "Renamed by admin" },
+      payload: { avatarColorToken: "hue-3" },
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json().displayName).toBe("Renamed by admin");
+    expect(res.json().avatarColorToken).toBe("hue-3");
   });
 });

--- a/packages/server/src/__tests__/members.test.ts
+++ b/packages/server/src/__tests__/members.test.ts
@@ -483,6 +483,54 @@ describe("Members API", () => {
       expect(row?.role).toBe("member");
     });
 
+    it("updateMember keeps every human mirror aligned for a multi-org user", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `mirror-admin-${randomUUID().slice(0, 8)}` });
+      const target = await memberService.createMember(app.db, admin.organizationId, {
+        username: `mirror-target-${randomUUID().slice(0, 8)}`,
+        displayName: "Original Name",
+        role: "member",
+      });
+      const sideOrg = await createOrganization(app.db, {
+        name: `mirror-side-${randomUUID().slice(0, 8)}`,
+        displayName: "Mirror Side",
+      });
+      const sideMemberId = randomUUID();
+      let sideAgentId = "";
+      await app.db.transaction(async (tx) => {
+        const sideHuman = await createAgent(tx as unknown as typeof app.db, {
+          name: `mirror-human-${randomUUID().slice(0, 8)}`,
+          type: "human",
+          displayName: "Original Name",
+          managerId: sideMemberId,
+          organizationId: sideOrg.id,
+        });
+        sideAgentId = sideHuman.uuid;
+        await tx.insert(membersTable).values({
+          id: sideMemberId,
+          userId: target.userId,
+          organizationId: sideOrg.id,
+          agentId: sideAgentId,
+          role: "member",
+        });
+      });
+
+      await memberService.updateMember(app.db, target.id, { displayName: "Unified Name" }, admin.organizationId);
+
+      const [user] = await app.db
+        .select({ displayName: usersTable.displayName })
+        .from(usersTable)
+        .where(eq(usersTable.id, target.userId))
+        .limit(1);
+      const mirrors = await app.db
+        .select({ uuid: agentsTable.uuid, displayName: agentsTable.displayName })
+        .from(agentsTable)
+        .where(inArray(agentsTable.uuid, [target.agentId, sideAgentId]));
+      expect(user?.displayName).toBe("Unified Name");
+      expect(mirrors).toHaveLength(2);
+      expect(mirrors.every((mirror) => mirror.displayName === "Unified Name")).toBe(true);
+    });
+
     it("createMember rejects an existing row with an unsupported lifecycle status", async () => {
       const app = getApp();
       const admin = await createTestAdmin(app, { username: `unsupported-admin-${randomUUID().slice(0, 8)}` });

--- a/packages/server/src/__tests__/members.test.ts
+++ b/packages/server/src/__tests__/members.test.ts
@@ -746,6 +746,92 @@ describe("Members API", () => {
       }
     });
 
+    it("rejects a stale admin restore after a concurrent self rejoin wins", async () => {
+      const app = getApp();
+      const databaseUrl = process.env.DATABASE_URL ?? "";
+      if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+      const admin = await createTestAdmin(app, { username: `restore-race-admin-${randomUUID().slice(0, 8)}` });
+      const target = await memberService.createMember(app.db, admin.organizationId, {
+        username: `restore-race-target-${randomUUID().slice(0, 8)}`,
+        displayName: "Self Rejoin Identity",
+        role: "member",
+      });
+      await app.db.update(membersTable).set({ status: "left" }).where(eq(membersTable.id, target.id));
+      await app.db.update(agentsTable).set({ status: "suspended" }).where(eq(agentsTable.uuid, target.agentId));
+
+      const suffix = randomUUID().slice(0, 8);
+      const rejoiningApplicationName = `membership_self_rejoin_${suffix}`;
+      const restoringApplicationName = `membership_admin_restore_${suffix}`;
+      const rejoiningDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, rejoiningApplicationName));
+      const restoringDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, restoringApplicationName));
+      const memberBlocker = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      let memberBlockerCommitted = false;
+      try {
+        await memberBlocker`BEGIN`;
+        await memberBlocker`SELECT id FROM members WHERE id = ${target.id} FOR UPDATE`;
+
+        // The real self-service ensure path takes the user lock first, then
+        // pauses on this member-row blocker before it can publish the rejoin.
+        const rejoining = ensureMembership(rejoiningDb, {
+          userId: target.userId,
+          organizationId: admin.organizationId,
+          role: "member",
+          displayName: "Self Rejoin Identity",
+          username: target.username,
+        });
+        await waitForPostgresLockWait(observer, rejoiningApplicationName);
+
+        const restoring = memberService
+          .createMember(restoringDb, admin.organizationId, {
+            username: target.username,
+            displayName: "Stale Admin Rename",
+            role: "admin",
+          })
+          .then(
+            (value) => ({ status: "fulfilled" as const, value }),
+            (error: unknown) => ({ status: "rejected" as const, error }),
+          );
+        await waitForPostgresLockWait(observer, restoringApplicationName);
+
+        // Releasing the member row lets self-rejoin commit first. The waiting
+        // admin restore must then re-read the active lifecycle state while it
+        // owns the user lock rather than applying its stale pre-lock snapshot.
+        await memberBlocker`COMMIT`;
+        memberBlockerCommitted = true;
+        await expect(rejoining).resolves.toMatchObject({ id: target.id, status: "active" });
+
+        const restoreResult = await restoring;
+        expect(restoreResult.status).toBe("rejected");
+        if (restoreResult.status === "rejected") {
+          expect(restoreResult.error).toBeInstanceOf(Error);
+          expect((restoreResult.error as Error).message).toMatch(/already a member/i);
+        }
+
+        const [user] = await app.db
+          .select({ displayName: usersTable.displayName })
+          .from(usersTable)
+          .where(eq(usersTable.id, target.userId));
+        const [member] = await app.db
+          .select({ role: membersTable.role, status: membersTable.status })
+          .from(membersTable)
+          .where(eq(membersTable.id, target.id));
+        const [mirror] = await app.db
+          .select({ displayName: agentsTable.displayName, status: agentsTable.status })
+          .from(agentsTable)
+          .where(eq(agentsTable.uuid, target.agentId));
+        expect(user?.displayName).toBe("Self Rejoin Identity");
+        expect(member).toMatchObject({ role: "member", status: "active" });
+        expect(mirror).toMatchObject({ displayName: "Self Rejoin Identity", status: "active" });
+      } finally {
+        if (!memberBlockerCommitted) await memberBlocker`ROLLBACK`;
+        await rejoiningDb.end();
+        await restoringDb.end();
+        await memberBlocker.end();
+        await observer.end();
+      }
+    });
+
     it("locks the user before claiming a new membership's unique slot", async () => {
       const app = getApp();
       const databaseUrl = process.env.DATABASE_URL ?? "";
@@ -908,6 +994,80 @@ describe("Members API", () => {
         if (!blockerCommitted) await blocker`ROLLBACK`;
         await repairDb.end();
         await blocker.end();
+        await observer.end();
+      }
+    });
+
+    it("does not deadlock startup repair with concurrent member removal", async () => {
+      const app = getApp();
+      const databaseUrl = process.env.DATABASE_URL ?? "";
+      if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+      const organization = await createOrganization(app.db, {
+        name: `repair-removal-${randomUUID().slice(0, 8)}`,
+        displayName: "Repair Removal",
+      });
+      // Create the ordinary member first so repair reaches and locks it before
+      // the later admin row in its stable user-id order.
+      const target = await memberService.createMember(app.db, organization.id, {
+        username: `repair-removal-target-${randomUUID().slice(0, 8)}`,
+        displayName: "Repair Removal Target",
+        role: "member",
+      });
+      const admin = await memberService.createMember(app.db, organization.id, {
+        username: `repair-removal-admin-${randomUUID().slice(0, 8)}`,
+        displayName: "Repair Removal Admin",
+        role: "admin",
+      });
+      expect(target.userId < admin.userId).toBe(true);
+
+      const suffix = randomUUID().slice(0, 8);
+      const repairApplicationName = `membership_repair_removal_${suffix}`;
+      const removalApplicationName = `membership_remove_repair_${suffix}`;
+      const repairDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, repairApplicationName));
+      const removalDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, removalApplicationName));
+      const mirrorBlocker = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      let mirrorBlockerCommitted = false;
+      try {
+        await mirrorBlocker`BEGIN`;
+        await mirrorBlocker`SELECT uuid FROM agents WHERE uuid = ${target.agentId} FOR UPDATE`;
+
+        const repair = repairMembershipHumanMirrors(repairDb).then(
+          (value) => ({ status: "fulfilled" as const, value }),
+          (error: unknown) => ({ status: "rejected" as const, error }),
+        );
+        await waitForPostgresLockWait(observer, repairApplicationName);
+
+        // Removal locks the active admin first and then waits for the target
+        // member held by repair. A table-wide repair transaction would next
+        // wait for that admin while retaining the target, forming a cycle.
+        const removal = memberService.deleteMember(removalDb, target.id, organization.id).then(
+          (value) => ({ status: "fulfilled" as const, value }),
+          (error: unknown) => ({ status: "rejected" as const, error }),
+        );
+        await waitForPostgresLockWait(observer, removalApplicationName);
+
+        await mirrorBlocker`COMMIT`;
+        mirrorBlockerCommitted = true;
+        const [repairResult, removalResult] = await Promise.all([repair, removal]);
+        expect(repairResult.status).toBe("fulfilled");
+        expect(removalResult.status).toBe("fulfilled");
+
+        const [member] = await app.db
+          .select({ status: membersTable.status })
+          .from(membersTable)
+          .where(eq(membersTable.id, target.id));
+        const [mirror] = await app.db
+          .select({ status: agentsTable.status })
+          .from(agentsTable)
+          .where(eq(agentsTable.uuid, target.agentId));
+        expect(member?.status).toBe("removed");
+        expect(mirror?.status).toBe("suspended");
+      } finally {
+        if (!mirrorBlockerCommitted) await mirrorBlocker`ROLLBACK`;
+        await repairDb.end();
+        await removalDb.end();
+        await mirrorBlocker.end();
         await observer.end();
       }
     });

--- a/packages/server/src/__tests__/members.test.ts
+++ b/packages/server/src/__tests__/members.test.ts
@@ -1,16 +1,39 @@
 import { randomUUID } from "node:crypto";
 import { and, eq, inArray } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
+import postgres from "postgres";
 import { describe, expect, it } from "vitest";
+import { connectDatabase, sslOptions } from "../db/connection.js";
 import { agents as agentsTable } from "../db/schema/agents.js";
 import { members as membersTable } from "../db/schema/members.js";
 import { organizations as organizationsTable } from "../db/schema/organizations.js";
 import { users as usersTable } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
 import * as memberService from "../services/member.js";
-import { repairMembershipHumanMirrors, selfCreateOrganization } from "../services/membership.js";
+import { ensureMembership, repairMembershipHumanMirrors, selfCreateOrganization } from "../services/membership.js";
 import { createOrganization } from "../services/organization.js";
 import { createTestAdmin, useTestApp } from "./helpers.js";
+
+function databaseUrlWithApplicationName(url: string, applicationName: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("application_name", applicationName);
+  return parsed.toString();
+}
+
+async function waitForPostgresLockWait(observer: ReturnType<typeof postgres>, applicationName: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await observer<{ wait_event_type: string | null }[]>`
+      SELECT wait_event_type
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND application_name = ${applicationName}
+    `;
+    if (rows.some((row) => row.wait_event_type === "Lock")) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for PostgreSQL lock: ${applicationName}`);
+}
 
 describe("Members API", () => {
   const getApp = useTestApp();
@@ -44,6 +67,36 @@ describe("Members API", () => {
       role: "member",
     });
     return { otherOrg, target };
+  }
+
+  async function attachExistingUserToOtherOrg(
+    app: FastifyInstance,
+    input: { userId: string; displayName: string; prefix: string },
+  ) {
+    const organization = await createOrganization(app.db, {
+      name: `${input.prefix}-${randomUUID().slice(0, 8)}`,
+      displayName: "Identity Side",
+    });
+    const memberId = randomUUID();
+    let agentId = "";
+    await app.db.transaction(async (tx) => {
+      const human = await createAgent(tx as unknown as typeof app.db, {
+        name: `${input.prefix}-human-${randomUUID().slice(0, 8)}`,
+        type: "human",
+        displayName: input.displayName,
+        managerId: memberId,
+        organizationId: organization.id,
+      });
+      agentId = human.uuid;
+      await tx.insert(membersTable).values({
+        id: memberId,
+        userId: input.userId,
+        organizationId: organization.id,
+        agentId,
+        role: "member",
+      });
+    });
+    return { organizationId: organization.id, memberId, agentId };
   }
 
   describe("GET /api/v1/members", () => {
@@ -341,7 +394,7 @@ describe("Members API", () => {
 
       await app.db
         .update(agentsTable)
-        .set({ type: "agent", status: "deleted", name: null, clientId: null })
+        .set({ type: "agent", status: "deleted", name: null, displayName: "Drifted Human", clientId: null })
         .where(eq(agentsTable.uuid, admin.humanAgentUuid));
       await app.db.update(agentsTable).set({ status: "active" }).where(eq(agentsTable.uuid, left.agentId));
       await app.db
@@ -358,12 +411,18 @@ describe("Members API", () => {
           type: agentsTable.type,
           status: agentsTable.status,
           name: agentsTable.name,
+          displayName: agentsTable.displayName,
           clientId: agentsTable.clientId,
         })
         .from(agentsTable)
         .where(inArray(agentsTable.uuid, [admin.humanAgentUuid, left.agentId, removed.agentId]));
       const byId = new Map(repairedRows.map((row) => [row.uuid, row]));
-      expect(byId.get(admin.humanAgentUuid)).toMatchObject({ type: "human", status: "active", clientId: null });
+      expect(byId.get(admin.humanAgentUuid)).toMatchObject({
+        type: "human",
+        status: "active",
+        displayName: "Test Admin",
+        clientId: null,
+      });
       expect(byId.get(admin.humanAgentUuid)?.name).not.toBeNull();
       expect(byId.get(left.agentId)).toMatchObject({
         type: "human",
@@ -491,28 +550,10 @@ describe("Members API", () => {
         displayName: "Original Name",
         role: "member",
       });
-      const sideOrg = await createOrganization(app.db, {
-        name: `mirror-side-${randomUUID().slice(0, 8)}`,
-        displayName: "Mirror Side",
-      });
-      const sideMemberId = randomUUID();
-      let sideAgentId = "";
-      await app.db.transaction(async (tx) => {
-        const sideHuman = await createAgent(tx as unknown as typeof app.db, {
-          name: `mirror-human-${randomUUID().slice(0, 8)}`,
-          type: "human",
-          displayName: "Original Name",
-          managerId: sideMemberId,
-          organizationId: sideOrg.id,
-        });
-        sideAgentId = sideHuman.uuid;
-        await tx.insert(membersTable).values({
-          id: sideMemberId,
-          userId: target.userId,
-          organizationId: sideOrg.id,
-          agentId: sideAgentId,
-          role: "member",
-        });
+      const side = await attachExistingUserToOtherOrg(app, {
+        userId: target.userId,
+        displayName: "Original Name",
+        prefix: "mirror-side",
       });
 
       await memberService.updateMember(app.db, target.id, { displayName: "Unified Name" }, admin.organizationId);
@@ -525,10 +566,381 @@ describe("Members API", () => {
       const mirrors = await app.db
         .select({ uuid: agentsTable.uuid, displayName: agentsTable.displayName })
         .from(agentsTable)
-        .where(inArray(agentsTable.uuid, [target.agentId, sideAgentId]));
+        .where(inArray(agentsTable.uuid, [target.agentId, side.agentId]));
       expect(user?.displayName).toBe("Unified Name");
       expect(mirrors).toHaveLength(2);
       expect(mirrors.every((mirror) => mirror.displayName === "Unified Name")).toBe(true);
+    });
+
+    it("treats an unchanged explicit display name as a mirror repair request", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `same-name-admin-${randomUUID().slice(0, 8)}` });
+      const target = await memberService.createMember(app.db, admin.organizationId, {
+        username: `same-name-target-${randomUUID().slice(0, 8)}`,
+        displayName: "Authoritative Name",
+        role: "member",
+      });
+      const side = await attachExistingUserToOtherOrg(app, {
+        userId: target.userId,
+        displayName: "Authoritative Name",
+        prefix: "same-name-side",
+      });
+      await app.db.update(agentsTable).set({ displayName: "Legacy Drift" }).where(eq(agentsTable.uuid, target.agentId));
+
+      await memberService.updateMember(app.db, target.id, { displayName: "Authoritative Name" }, admin.organizationId);
+
+      const mirrors = await app.db
+        .select({ displayName: agentsTable.displayName })
+        .from(agentsTable)
+        .where(inArray(agentsTable.uuid, [target.agentId, side.agentId]));
+      expect(mirrors).toHaveLength(2);
+      expect(mirrors.every((mirror) => mirror.displayName === "Authoritative Name")).toBe(true);
+    });
+
+    it("keeps all mirrors aligned when createMember restores an inactive membership", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `restore-sync-admin-${randomUUID().slice(0, 8)}` });
+      const target = await memberService.createMember(app.db, admin.organizationId, {
+        username: `restore-sync-target-${randomUUID().slice(0, 8)}`,
+        displayName: "Before Restore",
+        role: "member",
+      });
+      const side = await attachExistingUserToOtherOrg(app, {
+        userId: target.userId,
+        displayName: "Before Restore",
+        prefix: "restore-sync-side",
+      });
+      await app.db.update(membersTable).set({ status: "removed" }).where(eq(membersTable.id, target.id));
+      await app.db.update(agentsTable).set({ status: "suspended" }).where(eq(agentsTable.uuid, target.agentId));
+
+      const restored = await memberService.createMember(app.db, admin.organizationId, {
+        username: target.username,
+        displayName: "After Restore",
+        role: "member",
+      });
+
+      expect(restored.id).toBe(target.id);
+      const [user] = await app.db
+        .select({ displayName: usersTable.displayName })
+        .from(usersTable)
+        .where(eq(usersTable.id, target.userId));
+      const mirrors = await app.db
+        .select({ displayName: agentsTable.displayName })
+        .from(agentsTable)
+        .where(inArray(agentsTable.uuid, [target.agentId, side.agentId]));
+      expect(user?.displayName).toBe("After Restore");
+      expect(mirrors.every((mirror) => mirror.displayName === "After Restore")).toBe(true);
+    });
+
+    it("keeps all mirrors aligned when createMember adds an existing user to another organization", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `add-sync-admin-${randomUUID().slice(0, 8)}` });
+      const target = await memberService.createMember(app.db, admin.organizationId, {
+        username: `add-sync-target-${randomUUID().slice(0, 8)}`,
+        displayName: "Before Add",
+        role: "member",
+      });
+      const sideOrg = await createOrganization(app.db, {
+        name: `add-sync-side-${randomUUID().slice(0, 8)}`,
+        displayName: "Add Sync Side",
+      });
+
+      const added = await memberService.createMember(app.db, sideOrg.id, {
+        username: target.username,
+        displayName: "After Add",
+        role: "member",
+      });
+
+      const [user] = await app.db
+        .select({ displayName: usersTable.displayName })
+        .from(usersTable)
+        .where(eq(usersTable.id, target.userId));
+      const mirrors = await app.db
+        .select({ displayName: agentsTable.displayName })
+        .from(agentsTable)
+        .where(inArray(agentsTable.uuid, [target.agentId, added.agentId]));
+      expect(user?.displayName).toBe("After Add");
+      expect(mirrors).toHaveLength(2);
+      expect(mirrors.every((mirror) => mirror.displayName === "After Add")).toBe(true);
+    });
+
+    it("keeps the locked authoritative label when ensureMembership reactivates a membership", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `ensure-sync-admin-${randomUUID().slice(0, 8)}` });
+      const target = await memberService.createMember(app.db, admin.organizationId, {
+        username: `ensure-sync-target-${randomUUID().slice(0, 8)}`,
+        displayName: "Before Ensure",
+        role: "member",
+      });
+      const side = await attachExistingUserToOtherOrg(app, {
+        userId: target.userId,
+        displayName: "Before Ensure",
+        prefix: "ensure-sync-side",
+      });
+      await app.db.update(membersTable).set({ status: "left" }).where(eq(membersTable.id, target.id));
+      await app.db.update(agentsTable).set({ status: "suspended" }).where(eq(agentsTable.uuid, target.agentId));
+
+      await ensureMembership(app.db, {
+        userId: target.userId,
+        organizationId: admin.organizationId,
+        role: "member",
+        displayName: "After Ensure",
+        username: target.username,
+      });
+
+      const [user] = await app.db
+        .select({ displayName: usersTable.displayName })
+        .from(usersTable)
+        .where(eq(usersTable.id, target.userId));
+      const mirrors = await app.db
+        .select({ displayName: agentsTable.displayName })
+        .from(agentsTable)
+        .where(inArray(agentsTable.uuid, [target.agentId, side.agentId]));
+      expect(user?.displayName).toBe("Before Ensure");
+      expect(mirrors.every((mirror) => mirror.displayName === "Before Ensure")).toBe(true);
+    });
+
+    it("keeps reactivation on the user-to-member-to-agent lock order", async () => {
+      const app = getApp();
+      const databaseUrl = process.env.DATABASE_URL ?? "";
+      if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+      const admin = await createTestAdmin(app, { username: `lock-sync-admin-${randomUUID().slice(0, 8)}` });
+      const target = await memberService.createMember(app.db, admin.organizationId, {
+        username: `lock-sync-target-${randomUUID().slice(0, 8)}`,
+        displayName: "Lock Identity",
+        role: "member",
+      });
+      await app.db.update(membersTable).set({ status: "left" }).where(eq(membersTable.id, target.id));
+      await app.db.update(agentsTable).set({ status: "suspended" }).where(eq(agentsTable.uuid, target.agentId));
+
+      const applicationName = `membership_reactivate_${randomUUID().slice(0, 8)}`;
+      const reactivationDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, applicationName));
+      const blocker = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      let blockerCommitted = false;
+      try {
+        await blocker`BEGIN`;
+        await blocker`SELECT id FROM users WHERE id = ${target.userId} FOR NO KEY UPDATE`;
+
+        const reactivation = ensureMembership(reactivationDb, {
+          userId: target.userId,
+          organizationId: admin.organizationId,
+          role: "member",
+          displayName: "Lock Identity",
+          username: target.username,
+        });
+        await waitForPostgresLockWait(observer, applicationName);
+
+        // A reactivation that touched the member before waiting on the user
+        // would deadlock here. The canonical user -> member -> agents order
+        // leaves the lifecycle row available to this holder.
+        await blocker`SELECT id FROM members WHERE id = ${target.id} FOR UPDATE`;
+        await blocker`COMMIT`;
+        blockerCommitted = true;
+        await reactivation;
+      } finally {
+        if (!blockerCommitted) await blocker`ROLLBACK`;
+        await reactivationDb.end();
+        await blocker.end();
+        await observer.end();
+      }
+    });
+
+    it("locks the user before claiming a new membership's unique slot", async () => {
+      const app = getApp();
+      const databaseUrl = process.env.DATABASE_URL ?? "";
+      if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+      const admin = await createTestAdmin(app, { username: `slot-sync-admin-${randomUUID().slice(0, 8)}` });
+      const target = await memberService.createMember(app.db, admin.organizationId, {
+        username: `slot-sync-target-${randomUUID().slice(0, 8)}`,
+        displayName: "Slot Identity",
+        role: "member",
+      });
+      const destination = await createOrganization(app.db, {
+        name: `slot-sync-destination-${randomUUID().slice(0, 8)}`,
+        displayName: "Slot Destination",
+      });
+
+      const applicationName = `membership_slot_${randomUUID().slice(0, 8)}`;
+      const joiningDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, applicationName));
+      const blocker = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      const insertedMemberId = randomUUID();
+      const insertedAgentId = randomUUID();
+      let blockerCommitted = false;
+      try {
+        await blocker`BEGIN`;
+        await blocker`SELECT id FROM users WHERE id = ${target.userId} FOR NO KEY UPDATE`;
+
+        const joining = ensureMembership(joiningDb, {
+          userId: target.userId,
+          organizationId: destination.id,
+          role: "member",
+          displayName: "Slot Identity",
+          username: target.username,
+        });
+        await waitForPostgresLockWait(observer, applicationName);
+
+        // The user-lock holder represents an OAuth invite flow that wins the
+        // same unique membership slot. A contender must still be waiting on
+        // the user rather than holding the unique index entry.
+        await blocker`
+          INSERT INTO agents (uuid, name, organization_id, type, display_name, inbox_id, manager_id)
+          VALUES (
+            ${insertedAgentId},
+            ${`slot-human-${randomUUID().slice(0, 8)}`},
+            ${destination.id},
+            'human',
+            'Slot Identity',
+            ${`inbox_${insertedAgentId}`},
+            ${insertedMemberId}
+          )
+        `;
+        await blocker`
+          INSERT INTO members (id, user_id, organization_id, agent_id, role, status)
+          VALUES (${insertedMemberId}, ${target.userId}, ${destination.id}, ${insertedAgentId}, 'member', 'active')
+        `;
+        await blocker`COMMIT`;
+        blockerCommitted = true;
+
+        const result = await joining;
+        expect(result.id).toBe(insertedMemberId);
+      } finally {
+        if (!blockerCommitted) await blocker`ROLLBACK`;
+        await joiningDb.end();
+        await blocker.end();
+        await observer.end();
+      }
+    });
+
+    it("does not let a stale lifecycle snapshot overwrite a committed profile rename", async () => {
+      const app = getApp();
+      const databaseUrl = process.env.DATABASE_URL ?? "";
+      if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+      const admin = await createTestAdmin(app, { username: `snapshot-sync-admin-${randomUUID().slice(0, 8)}` });
+      const target = await memberService.createMember(app.db, admin.organizationId, {
+        username: `snapshot-sync-target-${randomUUID().slice(0, 8)}`,
+        displayName: "Old Identity",
+        role: "member",
+      });
+      const destination = await createOrganization(app.db, {
+        name: `snapshot-sync-destination-${randomUUID().slice(0, 8)}`,
+        displayName: "Snapshot Destination",
+      });
+
+      const applicationName = `membership_snapshot_${randomUUID().slice(0, 8)}`;
+      const joiningDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, applicationName));
+      const blocker = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      let blockerCommitted = false;
+      try {
+        await blocker`BEGIN`;
+        await blocker`SELECT id FROM users WHERE id = ${target.userId} FOR NO KEY UPDATE`;
+        await blocker`UPDATE users SET display_name = 'New Identity' WHERE id = ${target.userId}`;
+        await blocker`UPDATE agents SET display_name = 'New Identity' WHERE uuid = ${target.agentId}`;
+
+        const joining = ensureMembership(joiningDb, {
+          userId: target.userId,
+          organizationId: destination.id,
+          role: "member",
+          // Represents a label read before the profile rename acquired its lock.
+          displayName: "Old Identity",
+          username: target.username,
+        });
+        await waitForPostgresLockWait(observer, applicationName);
+        await blocker`COMMIT`;
+        blockerCommitted = true;
+
+        const joined = await joining;
+        const [user] = await app.db
+          .select({ displayName: usersTable.displayName })
+          .from(usersTable)
+          .where(eq(usersTable.id, target.userId));
+        const mirrors = await app.db
+          .select({ displayName: agentsTable.displayName })
+          .from(agentsTable)
+          .where(inArray(agentsTable.uuid, [target.agentId, joined.agentId]));
+        expect(user?.displayName).toBe("New Identity");
+        expect(mirrors).toHaveLength(2);
+        expect(mirrors.every((mirror) => mirror.displayName === "New Identity")).toBe(true);
+      } finally {
+        if (!blockerCommitted) await blocker`ROLLBACK`;
+        await joiningDb.end();
+        await blocker.end();
+        await observer.end();
+      }
+    });
+
+    it("does not let startup repair overwrite a concurrently committed rename", async () => {
+      const app = getApp();
+      const databaseUrl = process.env.DATABASE_URL ?? "";
+      if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+      const target = await createTestAdmin(app, { username: `repair-race-${randomUUID().slice(0, 8)}` });
+      const applicationName = `membership_repair_${randomUUID().slice(0, 8)}`;
+      const repairDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, applicationName));
+      const blocker = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+      let blockerCommitted = false;
+      try {
+        await blocker`BEGIN`;
+        await blocker`SELECT id FROM users WHERE id = ${target.userId} FOR NO KEY UPDATE`;
+        await blocker`SELECT uuid FROM agents WHERE uuid = ${target.humanAgentUuid} FOR UPDATE`;
+
+        const repair = repairMembershipHumanMirrors(repairDb);
+        await waitForPostgresLockWait(observer, applicationName);
+        await blocker`UPDATE users SET display_name = 'Concurrent Rename' WHERE id = ${target.userId}`;
+        await blocker`UPDATE agents SET display_name = 'Concurrent Rename' WHERE uuid = ${target.humanAgentUuid}`;
+        await blocker`COMMIT`;
+        blockerCommitted = true;
+        await repair;
+
+        const [user] = await app.db
+          .select({ displayName: usersTable.displayName })
+          .from(usersTable)
+          .where(eq(usersTable.id, target.userId));
+        const [mirror] = await app.db
+          .select({ displayName: agentsTable.displayName })
+          .from(agentsTable)
+          .where(eq(agentsTable.uuid, target.humanAgentUuid));
+        expect(user?.displayName).toBe("Concurrent Rename");
+        expect(mirror?.displayName).toBe("Concurrent Rename");
+      } finally {
+        if (!blockerCommitted) await blocker`ROLLBACK`;
+        await repairDb.end();
+        await blocker.end();
+        await observer.end();
+      }
+    });
+
+    it("uses an idempotent active ensure to repair legacy mirror drift", async () => {
+      const app = getApp();
+      const admin = await createTestAdmin(app, { username: `active-sync-admin-${randomUUID().slice(0, 8)}` });
+      const target = await memberService.createMember(app.db, admin.organizationId, {
+        username: `active-sync-target-${randomUUID().slice(0, 8)}`,
+        displayName: "Active Identity",
+        role: "member",
+      });
+      const side = await attachExistingUserToOtherOrg(app, {
+        userId: target.userId,
+        displayName: "Active Identity",
+        prefix: "active-sync-side",
+      });
+      await app.db.update(agentsTable).set({ displayName: "Legacy Drift" }).where(eq(agentsTable.uuid, side.agentId));
+
+      await ensureMembership(app.db, {
+        userId: target.userId,
+        organizationId: admin.organizationId,
+        role: "member",
+        displayName: "Active Identity",
+        username: target.username,
+      });
+
+      const mirrors = await app.db
+        .select({ displayName: agentsTable.displayName })
+        .from(agentsTable)
+        .where(inArray(agentsTable.uuid, [target.agentId, side.agentId]));
+      expect(mirrors).toHaveLength(2);
+      expect(mirrors.every((mirror) => mirror.displayName === "Active Identity")).toBe(true);
     });
 
     it("createMember rejects an existing row with an unsupported lifecycle status", async () => {

--- a/packages/server/src/__tests__/membership-extra.test.ts
+++ b/packages/server/src/__tests__/membership-extra.test.ts
@@ -40,6 +40,16 @@ describe("membership service edge coverage", () => {
       }),
       transaction: async (callback: (tx: unknown) => Promise<Record<string, unknown>>) => {
         return callback({
+          select: () => ({
+            from: () => ({
+              where: () =>
+                Object.assign(Promise.resolve([]), {
+                  for: () => ({ limit: async () => [{ id: "user-1", displayName: "Retry User" }] }),
+                  limit: async () => [],
+                  orderBy: async () => [],
+                }),
+            }),
+          }),
           insert: () => ({
             values: (value: Record<string, unknown>) => ({
               returning: async () => {
@@ -56,6 +66,9 @@ describe("membership service edge coverage", () => {
                 ];
               },
             }),
+          }),
+          update: () => ({
+            set: () => ({ where: async () => [] }),
           }),
         });
       },

--- a/packages/server/src/services/agent.ts
+++ b/packages/server/src/services/agent.ts
@@ -1061,6 +1061,19 @@ export async function getNewChatDefaultCandidate(
 export async function updateAgent(db: Database, uuid: string, data: UpdateAgent) {
   const agent = await getAgent(db, uuid);
 
+  if (data.displayName !== undefined) {
+    const [membership] = await db
+      .select({ id: members.id })
+      .from(members)
+      .where(eq(members.agentId, agent.uuid))
+      .limit(1);
+    if (membership) {
+      throw new BadRequestError(
+        "Membership-backed human display names must be updated through the member or profile endpoint.",
+      );
+    }
+  }
+
   // `clientId` is one-shot via this generic PATCH entry: NULL → ID is allowed
   // (admin claiming an unbound agent for a known client). Once bound, direct
   // ID → null and ID → another ID updates are rejected; runtime moves must go

--- a/packages/server/src/services/auth-identity.ts
+++ b/packages/server/src/services/auth-identity.ts
@@ -202,7 +202,7 @@ export async function unlinkExternalIdentity(
       .select({ passwordHash: users.passwordHash })
       .from(users)
       .where(eq(users.id, userId))
-      .for("update");
+      .for("no key update");
     if (!user) throw new Error("Cannot disconnect authentication provider for a missing user");
     const identities = await tx
       .select({

--- a/packages/server/src/services/landing-campaigns/start.ts
+++ b/packages/server/src/services/landing-campaigns/start.ts
@@ -30,7 +30,7 @@ import { computeWorking } from "../agent-chat-status.js";
 import { pickDefaultMembership } from "../auth.js";
 import { createChat } from "../chat.js";
 import { sendToClient } from "../connection-manager.js";
-import { MEMBER_STATUSES, reactivateMembership } from "../membership.js";
+import { MEMBER_STATUSES, reactivateMembership, syncCurrentUserDisplayName } from "../membership.js";
 import { sendMessage } from "../message.js";
 import { notifyRecipients } from "../notifier.js";
 import { assertOfficialLandingCampaignClient, assertTrialQuota, isLandingCampaignServiceOrg } from "./guards.js";
@@ -161,7 +161,7 @@ async function ensureServiceMember(
   serviceUserId: string,
 ): Promise<typeof members.$inferSelect> {
   const [serviceUser] = await db
-    .select({ id: users.id, username: users.username, displayName: users.displayName })
+    .select({ id: users.id, username: users.username })
     .from(users)
     .where(eq(users.id, serviceUserId))
     .limit(1);
@@ -169,56 +169,61 @@ async function ensureServiceMember(
     throw new ServiceUnavailableError("Landing campaign service user is not configured");
   }
 
-  const [existing] = await db
-    .select()
-    .from(members)
-    .where(and(eq(members.userId, serviceUserId), eq(members.organizationId, organizationId)))
-    .limit(1);
-  if (existing) {
-    if (existing.status !== MEMBER_STATUSES.ACTIVE) {
-      await reactivateMembership(db, existing, {
-        displayName: serviceUser.displayName,
-        username: serviceUser.username,
-        role: "member",
-        resetOnboarding: false,
-      });
-      return { ...existing, status: MEMBER_STATUSES.ACTIVE, role: "member" };
+  return syncCurrentUserDisplayName(db, serviceUserId, async (effectiveDisplayName) => {
+    const [existing] = await db
+      .select()
+      .from(members)
+      .where(and(eq(members.userId, serviceUserId), eq(members.organizationId, organizationId)))
+      .limit(1);
+    if (existing) {
+      if (existing.status !== MEMBER_STATUSES.ACTIVE) {
+        await reactivateMembership(db, existing, {
+          username: serviceUser.username,
+          role: "member",
+          resetOnboarding: false,
+        });
+        return { ...existing, status: MEMBER_STATUSES.ACTIVE, role: "member" };
+      }
+      if (existing.role !== "member") {
+        const [updated] = await db
+          .update(members)
+          .set({ role: "member" })
+          .where(eq(members.id, existing.id))
+          .returning();
+        if (!updated) throw new Error("Unexpected: service member role update returned no row");
+        return updated;
+      }
+      return existing;
     }
-    if (existing.role !== "member") {
-      const [updated] = await db.update(members).set({ role: "member" }).where(eq(members.id, existing.id)).returning();
-      if (!updated) throw new Error("Unexpected: service member role update returned no row");
-      return updated;
-    }
-    return existing;
-  }
 
-  const memberId = uuidv7();
-  const agentId = uuidv7();
-  const agentName = await resolveAvailableServiceAgentName(db, organizationId);
-  await db.insert(agents).values({
-    uuid: agentId,
-    name: agentName,
-    organizationId,
-    type: "human",
-    displayName: serviceUser.displayName || "First Tree",
-    inboxId: `inbox_${agentId}`,
-    source: "admin-api",
-    visibility: "private",
-    managerId: memberId,
-    metadata: { landingCampaignServiceUser: true },
-  });
-  const [created] = await db
-    .insert(members)
-    .values({
-      id: memberId,
-      userId: serviceUserId,
+    const memberId = uuidv7();
+    const agentId = uuidv7();
+    const agentName = await resolveAvailableServiceAgentName(db, organizationId);
+    await db.insert(agents).values({
+      uuid: agentId,
+      name: agentName,
       organizationId,
-      agentId,
-      role: "member",
-    })
-    .returning();
-  if (!created) throw new Error("Unexpected: INSERT RETURNING produced no service member row");
-  return created;
+      type: "human",
+      displayName: effectiveDisplayName || "First Tree",
+      inboxId: `inbox_${agentId}`,
+      source: "admin-api",
+      visibility: "private",
+      managerId: memberId,
+      metadata: { landingCampaignServiceUser: true },
+    });
+    const [created] = await db
+      .insert(members)
+      .values({
+        id: memberId,
+        userId: serviceUserId,
+        organizationId,
+        agentId,
+        role: "member",
+      })
+      .returning();
+    if (!created) throw new Error("Unexpected: INSERT RETURNING produced no service member row");
+    return created;
+  });
 }
 
 async function createCampaignAgentWithFallbackName(

--- a/packages/server/src/services/member.ts
+++ b/packages/server/src/services/member.ts
@@ -12,7 +12,7 @@ import { uuidv7 } from "../uuid.js";
 import { createAgent } from "./agent.js";
 import { forceDisconnect } from "./connection-manager.js";
 import { suspendGitlabLinksForMembership } from "./gitlab-identities.js";
-import { MEMBER_STATUSES, reactivateMembership } from "./membership.js";
+import { MEMBER_STATUSES, reactivateMembership, syncUserDisplayName } from "./membership.js";
 import * as presenceService from "./presence.js";
 import { recomputeWatchersForAgent, recomputeWatchersForMember } from "./watcher.js";
 
@@ -67,7 +67,6 @@ export async function createMember(db: Database, orgId: string, data: CreateMemb
       }
 
       await db.transaction(async (tx) => {
-        await tx.update(users).set({ displayName: data.displayName }).where(eq(users.id, existingUser.id));
         await reactivateMembership(tx, existingMember, {
           displayName: data.displayName,
           username: data.username,
@@ -103,48 +102,61 @@ export async function createMember(db: Database, orgId: string, data: CreateMemb
       });
     }
 
-    // Compute the member id up-front so we can set `agents.manager_id` to it
-    // at insert time (managerId is NOT NULL since the unified-user-token
-    // milestone). The human agent self-manages.
-    const memberId = uuidv7();
-    const agentName = data.username.replace(/[^a-z0-9_-]/gi, "-").toLowerCase();
-    const agent = await createAgent(tx as unknown as Database, {
-      name: agentName,
-      type: "human",
-      displayName: data.displayName,
-      organizationId: orgId,
-      source: "admin-api",
-      managerId: memberId,
-    });
+    return syncUserDisplayName(tx, userId, data.displayName, async () => {
+      // Another membership lifecycle may have committed while the initial
+      // pre-check waited on this user's identity lock. Re-check under that
+      // lock before touching the unique (user, organization) slot.
+      if (existingUser) {
+        const [membershipCollision] = await tx
+          .select({ id: members.id })
+          .from(members)
+          .where(and(eq(members.userId, userId), eq(members.organizationId, orgId)))
+          .limit(1);
+        if (membershipCollision) {
+          throw new ConflictError(`User "${data.username}" is already a member of this organization`);
+        }
+      }
 
-    const [member] = await tx
-      .insert(members)
-      .values({
-        id: memberId,
-        userId,
+      // Compute the member id up-front so the human mirror self-manages.
+      const memberId = uuidv7();
+      const agentName = data.username.replace(/[^a-z0-9_-]/gi, "-").toLowerCase();
+      const agent = await createAgent(tx as unknown as Database, {
+        name: agentName,
+        type: "human",
+        displayName: data.displayName,
         organizationId: orgId,
-        agentId: agent.uuid,
-        role: data.role ?? "member",
-      })
-      .returning();
+        source: "admin-api",
+        managerId: memberId,
+      });
 
-    if (!member) throw new Error("Unexpected: INSERT RETURNING produced no row");
+      const [member] = await tx
+        .insert(members)
+        .values({
+          id: memberId,
+          userId,
+          organizationId: orgId,
+          agentId: agent.uuid,
+          role: data.role ?? "member",
+        })
+        .returning();
 
-    return {
-      id: member.id,
-      userId: member.userId,
-      organizationId: member.organizationId,
-      agentId: member.agentId,
-      role: member.role,
-      createdAt: member.createdAt.toISOString(),
-      // Freshly created — no messages yet, so no derived activity.
-      lastActiveAt: null,
-      username: data.username,
-      displayName: data.displayName,
-      avatarUrl: existingUser?.avatarUrl ?? null,
-      // Only return password for new users
-      ...(password ? { password } : { notice: "Existing user — use their current password to log in" }),
-    };
+      if (!member) throw new Error("Unexpected: INSERT RETURNING produced no row");
+      return {
+        id: member.id,
+        userId: member.userId,
+        organizationId: member.organizationId,
+        agentId: member.agentId,
+        role: member.role,
+        createdAt: member.createdAt.toISOString(),
+        // Freshly created — no messages yet, so no derived activity.
+        lastActiveAt: null,
+        username: data.username,
+        displayName: data.displayName,
+        avatarUrl: existingUser?.avatarUrl ?? null,
+        // Only return password for new users
+        ...(password ? { password } : { notice: "Existing user — use their current password to log in" }),
+      };
+    });
   });
 }
 
@@ -225,22 +237,19 @@ export async function updateMember(db: Database, id: string, data: UpdateMember,
   }
 
   await db.transaction(async (tx) => {
-    if (data.role !== undefined && data.role !== current.role) {
-      await tx.update(members).set({ role: data.role }).where(eq(members.id, id));
-    }
+    const updateRole = async () => {
+      if (data.role !== undefined && data.role !== current.role) {
+        await tx.update(members).set({ role: data.role }).where(eq(members.id, id));
+      }
+    };
     // displayName is user-global: members have no display_name column and
     // listMembers reads users.display_name. Keep every membership-scoped
     // human agent mirror aligned so chat detail never disagrees with the
     // member/AuthProvider identity after an admin rename in any organization.
-    if (data.displayName !== undefined && data.displayName !== current.displayName) {
-      await tx.update(users).set({ displayName: data.displayName }).where(eq(users.id, current.userId));
-      const memberRows = await tx
-        .select({ agentId: members.agentId })
-        .from(members)
-        .where(eq(members.userId, current.userId));
-      for (const member of memberRows) {
-        await tx.update(agents).set({ displayName: data.displayName }).where(eq(agents.uuid, member.agentId));
-      }
+    if (data.displayName !== undefined) {
+      await syncUserDisplayName(tx, current.userId, data.displayName, updateRole);
+    } else {
+      await updateRole();
     }
   });
 
@@ -256,11 +265,7 @@ export async function updateMember(db: Database, id: string, data: UpdateMember,
  */
 export async function updateOwnProfile(db: Database, userId: string, displayName: string) {
   await db.transaction(async (tx) => {
-    await tx.update(users).set({ displayName }).where(eq(users.id, userId));
-    const memberRows = await tx.select({ agentId: members.agentId }).from(members).where(eq(members.userId, userId));
-    for (const m of memberRows) {
-      await tx.update(agents).set({ displayName }).where(eq(agents.uuid, m.agentId));
-    }
+    await syncUserDisplayName(tx, userId, displayName);
   });
   return { id: userId, displayName };
 }

--- a/packages/server/src/services/member.ts
+++ b/packages/server/src/services/member.ts
@@ -228,14 +228,19 @@ export async function updateMember(db: Database, id: string, data: UpdateMember,
     if (data.role !== undefined && data.role !== current.role) {
       await tx.update(members).set({ role: data.role }).where(eq(members.id, id));
     }
-    // Member displayName is stored on the member's human agent — there is no
-    // `members.display_name` column. Write to the agent directly so the two
-    // views (member list + agent detail) don't drift. `users.display_name`
-    // is treated as the authoritative field the `listMembers` join reads
-    // from, so update it too.
+    // displayName is user-global: members have no display_name column and
+    // listMembers reads users.display_name. Keep every membership-scoped
+    // human agent mirror aligned so chat detail never disagrees with the
+    // member/AuthProvider identity after an admin rename in any organization.
     if (data.displayName !== undefined && data.displayName !== current.displayName) {
       await tx.update(users).set({ displayName: data.displayName }).where(eq(users.id, current.userId));
-      await tx.update(agents).set({ displayName: data.displayName }).where(eq(agents.uuid, current.agentId));
+      const memberRows = await tx
+        .select({ agentId: members.agentId })
+        .from(members)
+        .where(eq(members.userId, current.userId));
+      for (const member of memberRows) {
+        await tx.update(agents).set({ displayName: data.displayName }).where(eq(agents.uuid, member.agentId));
+      }
     }
   });
 

--- a/packages/server/src/services/membership.ts
+++ b/packages/server/src/services/membership.ts
@@ -33,11 +33,99 @@ export type MemberStatus = (typeof MEMBER_STATUSES)[keyof typeof MEMBER_STATUSES
 // biome-ignore lint/suspicious/noExplicitAny: needed for cross-schema compatibility with transaction clients.
 type DbLike = PgDatabase<PgQueryResultHKT, any, any>;
 
+/**
+ * Persist the user-global display label and fan it out to every
+ * membership-backed human mirror. Call this inside the surrounding lifecycle
+ * transaction so no supported member write can leave user and agent identity
+ * projections at different values.
+ */
+export function syncUserDisplayName(db: DbLike, userId: string, displayName: string): Promise<void>;
+export function syncUserDisplayName<T>(
+  db: DbLike,
+  userId: string,
+  displayName: string,
+  mutateIdentityGraph: (effectiveDisplayName: string) => Promise<T>,
+): Promise<T>;
+export async function syncUserDisplayName<T>(
+  db: DbLike,
+  userId: string,
+  displayName: string,
+  mutateIdentityGraph?: (effectiveDisplayName: string) => Promise<T>,
+): Promise<T | undefined> {
+  if (mutateIdentityGraph) {
+    return syncUserDisplayNameInternal(db, userId, displayName, mutateIdentityGraph);
+  }
+  await syncUserDisplayNameInternal(db, userId, displayName);
+  return undefined;
+}
+
+/**
+ * Project the authoritative label already stored on the user into membership
+ * mirrors without treating a caller's pre-lock snapshot as a rename request.
+ */
+export function syncCurrentUserDisplayName<T>(
+  db: DbLike,
+  userId: string,
+  mutateIdentityGraph: (effectiveDisplayName: string) => Promise<T>,
+): Promise<T> {
+  return syncUserDisplayNameInternal(db, userId, undefined, mutateIdentityGraph);
+}
+
+async function syncUserDisplayNameInternal<T>(
+  db: DbLike,
+  userId: string,
+  requestedDisplayName: string | undefined,
+  mutateIdentityGraph: (effectiveDisplayName: string) => Promise<T>,
+): Promise<T>;
+async function syncUserDisplayNameInternal(
+  db: DbLike,
+  userId: string,
+  requestedDisplayName: string | undefined,
+): Promise<void>;
+async function syncUserDisplayNameInternal<T>(
+  db: DbLike,
+  userId: string,
+  requestedDisplayName: string | undefined,
+  mutateIdentityGraph?: (effectiveDisplayName: string) => Promise<T>,
+): Promise<T | undefined> {
+  // Serialize competing membership/name writes for the same global identity.
+  // NO KEY UPDATE remains compatible with the KEY SHARE lock taken by a
+  // concurrent membership FK insert, avoiding a lock-upgrade deadlock while
+  // still making the later contender observe and update the earlier row.
+  const [user] = await db
+    .select({ id: users.id, displayName: users.displayName })
+    .from(users)
+    .where(eq(users.id, userId))
+    .for("no key update")
+    .limit(1);
+  if (!user) throw new NotFoundError(`User "${userId}" not found`);
+  const effectiveDisplayName = requestedDisplayName ?? user.displayName;
+  if (requestedDisplayName !== undefined) {
+    await db.update(users).set({ displayName: effectiveDisplayName }).where(eq(users.id, userId));
+  }
+  // Membership lifecycle callers mutate their unique/member rows here, while
+  // the user lock is held and before any mirror agent lock is acquired. This
+  // gives every supported path one user -> members -> agents lock order.
+  const result = mutateIdentityGraph ? await mutateIdentityGraph(effectiveDisplayName) : undefined;
+  const memberRows = await db
+    .select({ agentId: members.agentId })
+    .from(members)
+    .where(eq(members.userId, userId))
+    .orderBy(asc(members.agentId));
+  for (const member of memberRows) {
+    await db.update(agents).set({ displayName: effectiveDisplayName }).where(eq(agents.uuid, member.agentId));
+  }
+  return result;
+}
+
 type CreateMembershipForUser = {
   userId: string;
   organizationId: string;
   role: "admin" | "member";
-  /** Display name for the human agent — falls back to user's displayName. */
+  /**
+   * Caller snapshot retained for API compatibility. Lifecycle writes ignore
+   * it and read the authoritative user label after taking the identity lock.
+   */
   displayName: string;
   /** Slugged username; used as the human agent's `name`. */
   username: string;
@@ -45,76 +133,68 @@ type CreateMembershipForUser = {
 
 /** Insert (or reactivate) a `members` row for `userId` in `organizationId`. */
 export async function ensureMembership(db: Database, data: CreateMembershipForUser) {
-  const [existing] = await db
-    .select()
-    .from(members)
-    .where(and(eq(members.userId, data.userId), eq(members.organizationId, data.organizationId)))
-    .limit(1);
-
-  if (existing) {
-    if (existing.status === MEMBER_STATUSES.LEFT) {
-      // Re-activate the prior soft-deleted row and its human-agent mirror.
-      //
-      // Rejoin starts a FRESH onboarding lifecycle for this membership: clear
-      // the prior suppress/completion stamps so the auto-entry gate treats
-      // the rejoined member as first-need again. A stale suppress stamp
-      // would otherwise hide setup for what is effectively a newly joined
-      // team — the exact failure mode the membership-scoped gate exists to
-      // prevent.
-      await db.transaction(async (tx) => {
-        await reactivateMembership(tx, existing, {
-          displayName: data.displayName,
-          username: data.username,
-          resetOnboarding: true,
-        });
-      });
-      return {
-        ...existing,
-        status: MEMBER_STATUSES.ACTIVE,
-        onboardingSuppressedAt: null,
-        onboardingSuppressedReason: null,
-        onboardingCompletedAt: null,
-      };
-    }
-    if (existing.status === MEMBER_STATUSES.REMOVED) {
-      throw new ConflictError(
-        `Membership for user "${data.userId}" was removed by an admin and must be restored by an admin.`,
-      );
-    }
-    return existing;
-  }
-
   return db.transaction(async (tx) => {
-    const memberId = uuidv7();
-    const agentName = sanitizeAgentName(data.username);
-    const inboxId = `inbox_${uuidv7()}`;
-    const agentUuid = uuidv7();
+    return syncCurrentUserDisplayName(tx, data.userId, async (effectiveDisplayName) => {
+      const [existing] = await tx
+        .select()
+        .from(members)
+        .where(and(eq(members.userId, data.userId), eq(members.organizationId, data.organizationId)))
+        .limit(1);
 
-    await tx.insert(agents).values({
-      uuid: agentUuid,
-      name: agentName,
-      organizationId: data.organizationId,
-      type: "human",
-      displayName: data.displayName,
-      inboxId,
-      source: "oauth",
-      visibility: "organization",
-      managerId: memberId,
-    });
+      if (existing) {
+        if (existing.status === MEMBER_STATUSES.LEFT) {
+          // Rejoin starts a fresh onboarding lifecycle for this stable row.
+          await reactivateMembershipRows(tx, existing, {
+            username: data.username,
+            resetOnboarding: true,
+          });
+          return {
+            ...existing,
+            status: MEMBER_STATUSES.ACTIVE,
+            onboardingSuppressedAt: null,
+            onboardingSuppressedReason: null,
+            onboardingCompletedAt: null,
+          };
+        }
+        if (existing.status === MEMBER_STATUSES.REMOVED) {
+          throw new ConflictError(
+            `Membership for user "${data.userId}" was removed by an admin and must be restored by an admin.`,
+          );
+        }
+        return existing;
+      }
 
-    const [row] = await tx
-      .insert(members)
-      .values({
-        id: memberId,
-        userId: data.userId,
+      const memberId = uuidv7();
+      const agentName = sanitizeAgentName(data.username);
+      const inboxId = `inbox_${uuidv7()}`;
+      const agentUuid = uuidv7();
+
+      await tx.insert(agents).values({
+        uuid: agentUuid,
+        name: agentName,
         organizationId: data.organizationId,
-        agentId: agentUuid,
-        role: data.role,
-        status: MEMBER_STATUSES.ACTIVE,
-      })
-      .returning();
-    if (!row) throw new Error("Unexpected: INSERT RETURNING produced no row");
-    return row;
+        type: "human",
+        displayName: effectiveDisplayName,
+        inboxId,
+        source: "oauth",
+        visibility: "organization",
+        managerId: memberId,
+      });
+
+      const [row] = await tx
+        .insert(members)
+        .values({
+          id: memberId,
+          userId: data.userId,
+          organizationId: data.organizationId,
+          agentId: agentUuid,
+          role: data.role,
+          status: MEMBER_STATUSES.ACTIVE,
+        })
+        .returning();
+      if (!row) throw new Error("Unexpected: INSERT RETURNING produced no row");
+      return row;
+    });
   });
 }
 
@@ -136,7 +216,8 @@ type ExistingMembershipForLifecycle = {
 };
 
 type ReactivateMembershipOptions = {
-  displayName: string;
+  /** Present only for an explicit admin rename/restore request. */
+  displayName?: string;
   username: string;
   role?: "admin" | "member";
   resetOnboarding?: boolean;
@@ -148,6 +229,26 @@ type ReactivateMembershipOptions = {
  * same stable ids across leave/rejoin and admin restore.
  */
 export async function reactivateMembership(
+  db: DbLike,
+  existing: ExistingMembershipForLifecycle,
+  options: ReactivateMembershipOptions,
+): Promise<void> {
+  const [identity] = await db
+    .select({ userId: members.userId })
+    .from(members)
+    .where(eq(members.id, existing.id))
+    .limit(1);
+  if (!identity) throw new NotFoundError(`Membership "${existing.id}" not found`);
+
+  const mutateRows = async () => reactivateMembershipRows(db, existing, options);
+  if (options.displayName !== undefined) {
+    await syncUserDisplayName(db, identity.userId, options.displayName, mutateRows);
+  } else {
+    await syncCurrentUserDisplayName(db, identity.userId, mutateRows);
+  }
+}
+
+async function reactivateMembershipRows(
   db: DbLike,
   existing: ExistingMembershipForLifecycle,
   options: ReactivateMembershipOptions,
@@ -176,7 +277,6 @@ export async function reactivateMembership(
       .update(agents)
       .set({
         status: AGENT_STATUSES.ACTIVE,
-        displayName: options.displayName,
         name: restoredName,
         clientId: null,
         updatedAt: new Date(),
@@ -187,7 +287,6 @@ export async function reactivateMembership(
       .update(agents)
       .set({
         status: AGENT_STATUSES.ACTIVE,
-        displayName: options.displayName,
         clientId: null,
         updatedAt: new Date(),
       })
@@ -362,34 +461,52 @@ export async function repairMembershipHumanMirrors(db: Database): Promise<Member
     const rows = await tx
       .select({
         memberId: members.id,
-        memberStatus: members.status,
+        userId: members.userId,
         agentId: members.agentId,
-        organizationId: members.organizationId,
-        username: users.username,
-        mirrorType: agents.type,
-        mirrorStatus: agents.status,
-        mirrorName: agents.name,
       })
       .from(members)
-      .innerJoin(users, eq(users.id, members.userId))
-      .innerJoin(agents, eq(agents.uuid, members.agentId))
-      .for("update");
+      .orderBy(asc(members.userId), asc(members.id));
 
     let activeMirrorsRepaired = 0;
     let inactiveMirrorsRepaired = 0;
     for (const row of rows) {
-      const desiredStatus =
-        row.memberStatus === MEMBER_STATUSES.ACTIVE ? AGENT_STATUSES.ACTIVE : AGENT_STATUSES.SUSPENDED;
+      // Re-read each projection under the same user -> member -> agent order
+      // used by live identity writes. Separate READ COMMITTED statements avoid
+      // replaying a stale joined snapshot after waiting on a concurrent rename.
+      const [identity] = await tx
+        .select({ username: users.username, displayName: users.displayName })
+        .from(users)
+        .where(eq(users.id, row.userId))
+        .for("no key update")
+        .limit(1);
+      const [member] = await tx
+        .select({ status: members.status, organizationId: members.organizationId })
+        .from(members)
+        .where(eq(members.id, row.memberId))
+        .for("update")
+        .limit(1);
+      const [mirror] = await tx
+        .select({ type: agents.type, status: agents.status, name: agents.name, displayName: agents.displayName })
+        .from(agents)
+        .where(eq(agents.uuid, row.agentId))
+        .for("update")
+        .limit(1);
+      if (!identity || !member || !mirror) continue;
+
+      const desiredStatus = member.status === MEMBER_STATUSES.ACTIVE ? AGENT_STATUSES.ACTIVE : AGENT_STATUSES.SUSPENDED;
       const needsRepair =
-        row.mirrorType !== AGENT_TYPES.HUMAN || row.mirrorStatus !== desiredStatus || row.mirrorName === null;
+        mirror.type !== AGENT_TYPES.HUMAN ||
+        mirror.status !== desiredStatus ||
+        mirror.name === null ||
+        mirror.displayName !== identity.displayName;
       if (!needsRepair) continue;
 
       const restoredName =
-        row.mirrorName ??
+        mirror.name ??
         (await resolveRestoredAgentName(
           tx,
-          { agentId: row.agentId, organizationId: row.organizationId },
-          row.username,
+          { agentId: row.agentId, organizationId: member.organizationId },
+          identity.username,
         ));
       await tx
         .update(agents)
@@ -397,12 +514,13 @@ export async function repairMembershipHumanMirrors(db: Database): Promise<Member
           type: AGENT_TYPES.HUMAN,
           status: desiredStatus,
           name: restoredName,
+          displayName: identity.displayName,
           clientId: null,
           updatedAt: new Date(),
         })
         .where(eq(agents.uuid, row.agentId));
 
-      if (row.memberStatus === MEMBER_STATUSES.ACTIVE) activeMirrorsRepaired += 1;
+      if (member.status === MEMBER_STATUSES.ACTIVE) activeMirrorsRepaired += 1;
       else inactiveMirrorsRepaired += 1;
     }
 

--- a/packages/server/src/services/membership.ts
+++ b/packages/server/src/services/membership.ts
@@ -240,7 +240,21 @@ export async function reactivateMembership(
     .limit(1);
   if (!identity) throw new NotFoundError(`Membership "${existing.id}" not found`);
 
-  const mutateRows = async () => reactivateMembershipRows(db, existing, options);
+  const mutateRows = async () => {
+    // The caller may have classified this membership before waiting on the
+    // user identity lock. Re-read and lock the lifecycle row now so a
+    // concurrently completed rejoin/restore is observed instead of being
+    // overwritten from that stale snapshot.
+    const [current] = await db.select().from(members).where(eq(members.id, existing.id)).for("update").limit(1);
+    if (!current) throw new NotFoundError(`Membership "${existing.id}" not found`);
+    if (current.status === MEMBER_STATUSES.ACTIVE) {
+      throw new ConflictError(`User "${options.username}" is already a member of this organization`);
+    }
+    if (current.status !== MEMBER_STATUSES.LEFT && current.status !== MEMBER_STATUSES.REMOVED) {
+      throw new ConflictError(`User "${options.username}" has an unsupported membership status`);
+    }
+    await reactivateMembershipRows(db, current, options);
+  };
   if (options.displayName !== undefined) {
     await syncUserDisplayName(db, identity.userId, options.displayName, mutateRows);
   } else {
@@ -457,19 +471,23 @@ export type MembershipMirrorRepairResult = {
  * mirror; inactive memberships keep the mirror named but suspended.
  */
 export async function repairMembershipHumanMirrors(db: Database): Promise<MembershipMirrorRepairResult> {
-  return db.transaction(async (tx) => {
-    const rows = await tx
-      .select({
-        memberId: members.id,
-        userId: members.userId,
-        agentId: members.agentId,
-      })
-      .from(members)
-      .orderBy(asc(members.userId), asc(members.id));
+  const rows = await db
+    .select({
+      memberId: members.id,
+      userId: members.userId,
+      agentId: members.agentId,
+    })
+    .from(members)
+    .orderBy(asc(members.userId), asc(members.id));
 
-    let activeMirrorsRepaired = 0;
-    let inactiveMirrorsRepaired = 0;
-    for (const row of rows) {
+  let activeMirrorsRepaired = 0;
+  let inactiveMirrorsRepaired = 0;
+  for (const row of rows) {
+    // Keep repair transactions scoped to one membership. Accumulating member
+    // locks across users can deadlock with leave/removal, which locks an org's
+    // active admins before its target member. Per-row commits release the
+    // target before repair advances to another user's admin row.
+    const repairedStatus = await db.transaction(async (tx) => {
       // Re-read each projection under the same user -> member -> agent order
       // used by live identity writes. Separate READ COMMITTED statements avoid
       // replaying a stale joined snapshot after waiting on a concurrent rename.
@@ -491,7 +509,7 @@ export async function repairMembershipHumanMirrors(db: Database): Promise<Member
         .where(eq(agents.uuid, row.agentId))
         .for("update")
         .limit(1);
-      if (!identity || !member || !mirror) continue;
+      if (!identity || !member || !mirror) return null;
 
       const desiredStatus = member.status === MEMBER_STATUSES.ACTIVE ? AGENT_STATUSES.ACTIVE : AGENT_STATUSES.SUSPENDED;
       const needsRepair =
@@ -499,7 +517,7 @@ export async function repairMembershipHumanMirrors(db: Database): Promise<Member
         mirror.status !== desiredStatus ||
         mirror.name === null ||
         mirror.displayName !== identity.displayName;
-      if (!needsRepair) continue;
+      if (!needsRepair) return null;
 
       const restoredName =
         mirror.name ??
@@ -520,12 +538,14 @@ export async function repairMembershipHumanMirrors(db: Database): Promise<Member
         })
         .where(eq(agents.uuid, row.agentId));
 
-      if (member.status === MEMBER_STATUSES.ACTIVE) activeMirrorsRepaired += 1;
-      else inactiveMirrorsRepaired += 1;
-    }
+      return member.status;
+    });
 
-    return { activeMirrorsRepaired, inactiveMirrorsRepaired };
-  });
+    if (repairedStatus === MEMBER_STATUSES.ACTIVE) activeMirrorsRepaired += 1;
+    else if (repairedStatus !== null) inactiveMirrorsRepaired += 1;
+  }
+
+  return { activeMirrorsRepaired, inactiveMirrorsRepaired };
 }
 
 type CreatePersonalTeamInput = {

--- a/packages/server/src/services/oauth-bootstrap.ts
+++ b/packages/server/src/services/oauth-bootstrap.ts
@@ -52,7 +52,7 @@ export async function completeExternalAccountBootstrap(
       .select({ id: users.id })
       .from(users)
       .where(eq(users.id, account.userId))
-      .for("update")
+      .for("no key update")
       .limit(1);
     if (!lockedUser) throw new Error("External account bootstrap references a missing user");
 

--- a/packages/web/src/components/__tests__/rehype-mentions.test.ts
+++ b/packages/web/src/components/__tests__/rehype-mentions.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   copyHtmlWithMentionHandles,
   copyTextWithMentionHandles,
@@ -242,6 +242,30 @@ describe("copyTextWithMentionHandles", () => {
     expect(plain).toContain("next paragraph @me");
     expect(plain).not.toContain("Alice Chen");
     expect(rich).toBe("<p>line one<br>line two @alice</p><p>next paragraph @me</p>");
+
+    selection?.removeAllRanges();
+    root.remove();
+  });
+
+  it("preserves the live whitespace semantics around rewritten mentions", () => {
+    const root = document.createElement("div");
+    root.style.whiteSpace = "normal";
+    root.innerHTML =
+      'Please   ask\t<span class="mention-chip" data-mention-name="alice"><span class="mention-chip-display">@Alice Chen</span></span>   today';
+    document.body.append(root);
+
+    const range = document.createRange();
+    range.selectNodeContents(root);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    const appendSpy = vi.spyOn(document.body, "append");
+    expect(copyTextWithMentionHandles(root, selection)).toBe(root.innerText.replace("@Alice Chen", "@alice"));
+    const detachedRenderRoot = appendSpy.mock.calls.at(-1)?.[0];
+    expect(detachedRenderRoot).toBeInstanceOf(HTMLElement);
+    expect((detachedRenderRoot as HTMLElement).style.whiteSpace).toBe("normal");
+    appendSpy.mockRestore();
 
     selection?.removeAllRanges();
     root.remove();

--- a/packages/web/src/components/__tests__/rehype-mentions.test.ts
+++ b/packages/web/src/components/__tests__/rehype-mentions.test.ts
@@ -132,6 +132,21 @@ describe("rehypeMentions", () => {
     expect(children?.[5]?.children).toHaveLength(1);
   });
 
+  it("counts collisions across the roster while allowing only persisted mention identities to resolve", () => {
+    const participants: RenderedMentionParticipant[] = [
+      { agentId: "agent-alice", name: "alice", displayName: "Sam" },
+      { agentId: "agent-bob", name: "bob", displayName: "Sam" },
+    ];
+    const tree = makeRoot(paragraph(text("hi @alice and @bob")));
+    const transform = rehypeMentions(participants, { allowedAgentIds: new Set(["agent-alice"]) })();
+    transform(tree as unknown as Parameters<typeof transform>[0]);
+
+    const children = tree.children?.[0]?.children;
+    expect(visibleChipText(children?.[1])).toBe("@Sam(@alice)");
+    expect(children?.[1]?.children?.[1]?.properties?.className).toEqual(["mention-chip-handle"]);
+    expect(children?.[2]).toEqual(text(" and @bob"));
+  });
+
   it("adds the `is-self` class when the mention resolves to the viewer", () => {
     // Regression: the fix only works if the resolvable participant set
     // passed to the plugin actually includes self. The view layer is

--- a/packages/web/src/components/__tests__/rehype-mentions.test.ts
+++ b/packages/web/src/components/__tests__/rehype-mentions.test.ts
@@ -28,6 +28,13 @@ function text(value: string): TestNode {
   return { type: "text", value };
 }
 
+function visibleChipText(node: TestNode | undefined): string {
+  return (node?.children ?? [])
+    .flatMap((child) => child.children ?? [child])
+    .map((child) => child.value ?? "")
+    .join("");
+}
+
 function inlineCode(value: string): TestNode {
   return { type: "element", tagName: "code", properties: {}, children: [text(value)] };
 }
@@ -70,7 +77,8 @@ describe("rehypeMentions", () => {
     expect(chip?.properties?.["data-mention-display-name"]).toBe("Alice Chen");
     expect(chip?.properties?.title).toBe("@Alice Chen (@alice)");
     expect(chip?.properties?.ariaLabel).toBe("@Alice Chen (@alice)");
-    expect(chip?.children).toEqual([text("@Alice Chen")]);
+    expect(visibleChipText(chip)).toBe("@Alice Chen");
+    expect(chip?.children?.[0]?.properties?.className).toEqual(["mention-chip-display"]);
     expect(para?.children?.[2]).toEqual(text("!"));
   });
 
@@ -85,7 +93,7 @@ describe("rehypeMentions", () => {
     transform(tree as unknown as Parameters<typeof transform>[0]);
 
     const chip = tree.children?.[0]?.children?.[1];
-    expect(chip?.children).toEqual([text("@李坤阳")]);
+    expect(visibleChipText(chip)).toBe("@李坤阳");
     expect(chip?.properties?.title).toBe("@李坤阳 (@1736192959)");
   });
 
@@ -100,7 +108,7 @@ describe("rehypeMentions", () => {
     transform(tree as unknown as Parameters<typeof transform>[0]);
 
     const chip = tree.children?.[0]?.children?.[1];
-    expect(chip?.children).toEqual([text("@fallback")]);
+    expect(visibleChipText(chip)).toBe("@fallback");
     expect(chip?.properties?.title).toBe("@fallback");
   });
 
@@ -115,9 +123,13 @@ describe("rehypeMentions", () => {
     transform(tree as unknown as Parameters<typeof transform>[0]);
 
     const children = tree.children?.[0]?.children;
-    expect(children?.[1]?.children).toEqual([text("@Sam (@alice)")]);
-    expect(children?.[3]?.children).toEqual([text("@Sam (@bob)")]);
-    expect(children?.[5]?.children).toEqual([text("@Carol")]);
+    expect(visibleChipText(children?.[1])).toBe("@Sam(@alice)");
+    expect(children?.[1]?.children?.[0]?.properties?.className).toEqual(["mention-chip-display"]);
+    expect(children?.[1]?.children?.[1]?.properties?.className).toEqual(["mention-chip-handle"]);
+    expect(visibleChipText(children?.[3])).toBe("@Sam(@bob)");
+    expect(children?.[3]?.children?.[1]?.properties?.className).toEqual(["mention-chip-handle"]);
+    expect(visibleChipText(children?.[5])).toBe("@Carol");
+    expect(children?.[5]?.children).toHaveLength(1);
   });
 
   it("adds the `is-self` class when the mention resolves to the viewer", () => {
@@ -190,6 +202,31 @@ describe("copyTextWithMentionHandles", () => {
     expect(copyHtmlWithMentionHandles(root, selection)).toBe(
       '<strong>请</strong> @1736192959 <a href="https://example.com">查看详情</a>',
     );
+
+    selection?.removeAllRanges();
+    root.remove();
+  });
+
+  it("derives multiline plain and rich copy from the same cloned DOM", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<p>line one<br>line two <span class="mention-chip" data-mention-name="alice"><span class="mention-chip-display">@Alice Chen</span></span></p>' +
+      '<p>next paragraph <span class="mention-chip" data-mention-name="me"><span class="mention-chip-display">@Me</span></span></p>';
+    document.body.append(root);
+
+    const range = document.createRange();
+    range.selectNodeContents(root);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    const plain = copyTextWithMentionHandles(root, selection);
+    const rich = copyHtmlWithMentionHandles(root, selection);
+    expect(plain).toContain("line one");
+    expect(plain).toContain("line two @alice");
+    expect(plain).toContain("next paragraph @me");
+    expect(plain).not.toContain("Alice Chen");
+    expect(rich).toBe("<p>line one<br>line two @alice</p><p>next paragraph @me</p>");
 
     selection?.removeAllRanges();
     root.remove();

--- a/packages/web/src/components/__tests__/rehype-mentions.test.ts
+++ b/packages/web/src/components/__tests__/rehype-mentions.test.ts
@@ -1,6 +1,12 @@
-import type { MentionParticipant } from "@first-tree/shared";
+// @vitest-environment happy-dom
+
 import { describe, expect, it } from "vitest";
-import { rehypeMentions } from "../rehype-mentions.js";
+import {
+  copyHtmlWithMentionHandles,
+  copyTextWithMentionHandles,
+  type RenderedMentionParticipant,
+  rehypeMentions,
+} from "../rehype-mentions.js";
 
 type TestNode = {
   type: string;
@@ -26,9 +32,9 @@ function inlineCode(value: string): TestNode {
   return { type: "element", tagName: "code", properties: {}, children: [text(value)] };
 }
 
-const PARTICIPANTS: MentionParticipant[] = [
-  { agentId: "agent-self", name: "me" },
-  { agentId: "agent-other", name: "alice" },
+const PARTICIPANTS: RenderedMentionParticipant[] = [
+  { agentId: "agent-self", name: "me", displayName: "Me" },
+  { agentId: "agent-other", name: "alice", displayName: "Alice Chen" },
 ];
 
 function runPlugin(tree: TestNode, options?: { selfAgentId?: string | null }): TestNode {
@@ -60,8 +66,58 @@ describe("rehypeMentions", () => {
     expect(chip?.tagName).toBe("span");
     expect(chip?.properties?.className).toEqual(["mention-chip"]);
     expect(chip?.properties?.["data-mention-agent-id"]).toBe("agent-other");
-    expect(chip?.children).toEqual([text("@alice")]);
+    expect(chip?.properties?.["data-mention-name"]).toBe("alice");
+    expect(chip?.properties?.["data-mention-display-name"]).toBe("Alice Chen");
+    expect(chip?.properties?.title).toBe("@Alice Chen (@alice)");
+    expect(chip?.properties?.ariaLabel).toBe("@Alice Chen (@alice)");
+    expect(chip?.children).toEqual([text("@Alice Chen")]);
     expect(para?.children?.[2]).toEqual(text("!"));
+  });
+
+  it("renders a numeric handle as its human-readable display name", () => {
+    const participant: RenderedMentionParticipant = {
+      agentId: "agent-human",
+      name: "1736192959",
+      displayName: "李坤阳",
+    };
+    const tree = makeRoot(paragraph(text("请 @1736192959 处理")));
+    const transform = rehypeMentions([participant])();
+    transform(tree as unknown as Parameters<typeof transform>[0]);
+
+    const chip = tree.children?.[0]?.children?.[1];
+    expect(chip?.children).toEqual([text("@李坤阳")]);
+    expect(chip?.properties?.title).toBe("@李坤阳 (@1736192959)");
+  });
+
+  it("falls back to the canonical handle when displayName is blank", () => {
+    const participant: RenderedMentionParticipant = {
+      agentId: "agent-blank",
+      name: "fallback",
+      displayName: "   ",
+    };
+    const tree = makeRoot(paragraph(text("hi @fallback")));
+    const transform = rehypeMentions([participant])();
+    transform(tree as unknown as Parameters<typeof transform>[0]);
+
+    const chip = tree.children?.[0]?.children?.[1];
+    expect(chip?.children).toEqual([text("@fallback")]);
+    expect(chip?.properties?.title).toBe("@fallback");
+  });
+
+  it("shows handles only when duplicate display names need disambiguation", () => {
+    const participants: RenderedMentionParticipant[] = [
+      { agentId: "agent-alice", name: "alice", displayName: "Sam" },
+      { agentId: "agent-bob", name: "bob", displayName: "Sam" },
+      { agentId: "agent-unique", name: "carol", displayName: "Carol" },
+    ];
+    const tree = makeRoot(paragraph(text("hi @alice, @bob, and @carol")));
+    const transform = rehypeMentions(participants)();
+    transform(tree as unknown as Parameters<typeof transform>[0]);
+
+    const children = tree.children?.[0]?.children;
+    expect(children?.[1]?.children).toEqual([text("@Sam (@alice)")]);
+    expect(children?.[3]?.children).toEqual([text("@Sam (@bob)")]);
+    expect(children?.[5]?.children).toEqual([text("@Carol")]);
   });
 
   it("adds the `is-self` class when the mention resolves to the viewer", () => {
@@ -95,5 +151,124 @@ describe("rehypeMentions", () => {
     const tree = makeRoot(paragraph(text("see @nobody for details")));
     runPlugin(tree, { selfAgentId: "agent-self" });
     expect(tree.children?.[0]?.children).toEqual([text("see @nobody for details")]);
+  });
+});
+
+describe("copyTextWithMentionHandles", () => {
+  it("copies rendered display names as canonical pasteable handles", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '请 <span class="mention-chip" data-mention-name="1736192959">@李坤阳</span> 处理，然后通知 ' +
+      '<span class="mention-chip" data-mention-name="alice">@Alice Chen</span>';
+    document.body.append(root);
+
+    const range = document.createRange();
+    range.selectNodeContents(root);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    expect(copyTextWithMentionHandles(root, selection)).toBe("请 @1736192959 处理，然后通知 @alice");
+
+    selection?.removeAllRanges();
+    root.remove();
+  });
+
+  it("preserves rich HTML while rewriting mention chips to handles", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<strong>请</strong> <span class="mention-chip" data-mention-name="1736192959">@李坤阳</span> ' +
+      '<a href="https://example.com">查看详情</a>';
+    document.body.append(root);
+
+    const range = document.createRange();
+    range.selectNodeContents(root);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    expect(copyHtmlWithMentionHandles(root, selection)).toBe(
+      '<strong>请</strong> @1736192959 <a href="https://example.com">查看详情</a>',
+    );
+
+    selection?.removeAllRanges();
+    root.remove();
+  });
+
+  it("leaves native copy untouched when no rendered mention is selected", () => {
+    const root = document.createElement("div");
+    root.textContent = "plain text";
+    document.body.append(root);
+
+    const range = document.createRange();
+    range.selectNodeContents(root);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    expect(copyTextWithMentionHandles(root, selection)).toBeNull();
+
+    selection?.removeAllRanges();
+    root.remove();
+  });
+
+  it("rewrites the selected chip rather than identical ordinary text", () => {
+    const root = document.createElement("div");
+    root.innerHTML =
+      '普通文本 @李坤阳；mention <span class="mention-chip" data-mention-name="1736192959">@李坤阳</span>';
+    document.body.append(root);
+
+    const range = document.createRange();
+    range.selectNodeContents(root);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    expect(copyTextWithMentionHandles(root, selection)).toBe("普通文本 @李坤阳；mention @1736192959");
+
+    selection?.removeAllRanges();
+    root.remove();
+  });
+
+  it("keeps native copy behaviour for a partially selected chip", () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<span class="mention-chip" data-mention-name="1736192959">@李坤阳</span> 后续';
+    document.body.append(root);
+
+    const chipText = root.querySelector("span")?.firstChild;
+    const trailingText = root.lastChild;
+    if (!chipText || !trailingText) throw new Error("expected mention and trailing text nodes");
+    const range = document.createRange();
+    range.setStart(chipText, 1);
+    range.setEndAfter(trailingText);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    expect(copyTextWithMentionHandles(root, selection)).toBeNull();
+
+    selection?.removeAllRanges();
+    root.remove();
+  });
+
+  it("rewrites a chip when its complete text is selected exactly", () => {
+    const root = document.createElement("div");
+    root.innerHTML = '<span class="mention-chip" data-mention-name="1736192959">@李坤阳</span>';
+    document.body.append(root);
+
+    const chipText = root.querySelector("span")?.firstChild;
+    if (!(chipText instanceof Text)) throw new Error("expected mention text node");
+    const range = document.createRange();
+    range.setStart(chipText, 0);
+    range.setEnd(chipText, chipText.data.length);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    expect(copyTextWithMentionHandles(root, selection)).toBe("@1736192959");
+    expect(copyHtmlWithMentionHandles(root, selection)).toBe("@1736192959");
+
+    selection?.removeAllRanges();
+    root.remove();
   });
 });

--- a/packages/web/src/components/rehype-mentions.ts
+++ b/packages/web/src/components/rehype-mentions.ts
@@ -20,9 +20,10 @@ export type RenderedMentionParticipant = MentionParticipant & {
  * formatting and a chip inside a link would double-style.
  *
  * The participant list is captured by closure and resolved
- * case-insensitively, matching the server's `extractMentions` resolver
- * so the chip appears for exactly the same tokens the router would
- * fan out to.
+ * case-insensitively, matching the server's `extractMentions` resolver.
+ * Historical callers can additionally restrict resolution to persisted
+ * recipient IDs without shrinking the full-roster collision universe used to
+ * disambiguate duplicate display names.
  *
  * Returns a function compatible with react-markdown's `rehypePlugins`
  * prop. Local minimal hast types avoid pulling in `@types/hast` and
@@ -150,12 +151,15 @@ function walk(node: HastNode, nameMap: Map<string, RenderedMentionIdentity>, sel
 
 export function rehypeMentions(
   participants: RenderedMentionParticipant[],
-  options?: { selfAgentId?: string | null },
+  options?: { selfAgentId?: string | null; allowedAgentIds?: ReadonlySet<string> },
 ): () => (tree: HastRoot) => void {
   const selfAgentId = options?.selfAgentId ?? null;
+  const allowedAgentIds = options?.allowedAgentIds;
   const nameMap = new Map<string, RenderedMentionIdentity>();
   const displayNameCounts = new Map<string, number>();
 
+  // Count across the full visible speaker roster. A message that mentions only
+  // one of two people called "Sam" still needs to expose that person's handle.
   for (const participant of participants) {
     if (!participant.name) continue;
     const displayName = participant.displayName.trim() || participant.name;
@@ -164,7 +168,10 @@ export function rehypeMentions(
   }
 
   for (const p of participants) {
-    if (p.name) {
+    // Resolution is a separate identity decision. Historical callers allow
+    // only the IDs persisted for this message, so handle reuse cannot relabel
+    // an old token even though the new owner remains in the collision roster.
+    if (p.name && (!allowedAgentIds || allowedAgentIds.has(p.agentId))) {
       const displayName = p.displayName.trim() || p.name;
       nameMap.set(p.name.toLowerCase(), {
         name: p.name,

--- a/packages/web/src/components/rehype-mentions.ts
+++ b/packages/web/src/components/rehype-mentions.ts
@@ -1,6 +1,18 @@
 import { MENTION_REGEX, type MentionParticipant } from "@first-tree/shared";
 
 /**
+ * Chat-scoped identity shape used only by the sent-message renderer.
+ *
+ * Routing and composer parsing deliberately keep using the narrower
+ * {@link MentionParticipant} (`agentId` + immutable `name`). `displayName` is
+ * presentation-only: it may contain spaces, non-ASCII characters, collide
+ * with another participant, or change after the message was sent.
+ */
+export type RenderedMentionParticipant = MentionParticipant & {
+  displayName: string;
+};
+
+/**
  * Rehype plugin: walks the hast tree, finds `@<participant>` tokens
  * inside `text` nodes, and rewrites them to `span.mention-chip` elements.
  * Code regions (`<code>`, `<pre>`) and existing `<a>` link text are
@@ -32,7 +44,19 @@ type HastNode = HastText | HastElement | HastRoot | { type: string; children?: H
 
 const SKIP_TAGS = new Set(["code", "pre", "a"]);
 
-function makeMentionElement(value: string, name: string, agentId: string, isSelf: boolean): HastElement {
+type RenderedMentionIdentity = {
+  name: string;
+  displayName: string;
+  agentId: string;
+  disambiguate: boolean;
+};
+
+function makeMentionElement(identity: RenderedMentionIdentity, isSelf: boolean): HastElement {
+  const displayName = identity.displayName.trim() || identity.name;
+  const displayLabel = `@${displayName}`;
+  const identityLabel = displayName === identity.name ? displayLabel : `${displayLabel} (@${identity.name})`;
+  const visibleLabel = identity.disambiguate ? identityLabel : displayLabel;
+
   return {
     type: "element",
     tagName: "span",
@@ -43,16 +67,19 @@ function makeMentionElement(value: string, name: string, agentId: string, isSelf
       // it. `is-x` matches the repo's existing state-modifier convention
       // (`.context-network-card.is-live`, `.context-usage-feed-row.is-fresh`).
       className: isSelf ? ["mention-chip", "is-self"] : ["mention-chip"],
-      "data-mention-agent-id": agentId,
-      "data-mention-name": name,
+      "data-mention-agent-id": identity.agentId,
+      "data-mention-name": identity.name,
+      "data-mention-display-name": displayName,
+      title: identityLabel,
+      ariaLabel: identityLabel,
     },
-    children: [{ type: "text", value }],
+    children: [{ type: "text", value: visibleLabel }],
   };
 }
 
 function splitTextNode(
   node: HastText,
-  nameMap: Map<string, { name: string; agentId: string }>,
+  nameMap: Map<string, RenderedMentionIdentity>,
   selfAgentId: string | null,
 ): HastNode[] | null {
   const content = node.value;
@@ -67,7 +94,7 @@ function splitTextNode(
     if (m.index > cursor) {
       out.push({ type: "text", value: content.slice(cursor, m.index) });
     }
-    out.push(makeMentionElement(m[0], resolved.name, resolved.agentId, resolved.agentId === selfAgentId));
+    out.push(makeMentionElement(resolved, resolved.agentId === selfAgentId));
     cursor = m.index + m[0].length;
   }
   if (out.length === 0) return null; // no rewrites — leave node intact
@@ -77,11 +104,7 @@ function splitTextNode(
   return out;
 }
 
-function walk(
-  node: HastNode,
-  nameMap: Map<string, { name: string; agentId: string }>,
-  selfAgentId: string | null,
-): void {
+function walk(node: HastNode, nameMap: Map<string, RenderedMentionIdentity>, selfAgentId: string | null): void {
   if (!("children" in node) || !node.children) return;
   const next: HastNode[] = [];
   for (const child of node.children) {
@@ -110,16 +133,143 @@ function walk(
 }
 
 export function rehypeMentions(
-  participants: MentionParticipant[],
+  participants: RenderedMentionParticipant[],
   options?: { selfAgentId?: string | null },
 ): () => (tree: HastRoot) => void {
   const selfAgentId = options?.selfAgentId ?? null;
-  const nameMap = new Map<string, { name: string; agentId: string }>();
+  const nameMap = new Map<string, RenderedMentionIdentity>();
+  const displayNameCounts = new Map<string, number>();
+
+  for (const participant of participants) {
+    if (!participant.name) continue;
+    const displayName = participant.displayName.trim() || participant.name;
+    const key = displayName.toLowerCase();
+    displayNameCounts.set(key, (displayNameCounts.get(key) ?? 0) + 1);
+  }
+
   for (const p of participants) {
-    if (p.name) nameMap.set(p.name.toLowerCase(), { name: p.name, agentId: p.agentId });
+    if (p.name) {
+      const displayName = p.displayName.trim() || p.name;
+      nameMap.set(p.name.toLowerCase(), {
+        name: p.name,
+        displayName,
+        agentId: p.agentId,
+        // displayName is mutable and non-unique. Keep the common case terse,
+        // but make collisions distinguishable on touch devices where a title
+        // tooltip is not discoverable. If the label is already this person's
+        // canonical handle, adding the same handle again would be redundant.
+        disambiguate: (displayNameCounts.get(displayName.toLowerCase()) ?? 0) > 1 && displayName !== p.name,
+      });
+    }
   }
   return () => (tree: HastRoot) => {
     if (nameMap.size === 0) return;
     walk(tree, nameMap, selfAgentId);
   };
+}
+
+/**
+ * Reconstruct the selected plain text with canonical `@name` handles.
+ *
+ * Sent messages render the friendlier `@displayName`, but copied text needs to
+ * remain pasteable into the composer and CLI. Returning `null` means the
+ * selection contains no complete rendered mention and native copy behaviour
+ * should proceed unchanged.
+ */
+type SelectedMention = {
+  start: number;
+  end: number;
+  name: string;
+  visibleText: string;
+};
+
+function selectedMentions(root: HTMLElement, selection: Selection | null): SelectedMention[] | null {
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null;
+  const range = selection.getRangeAt(0);
+  if (!root.contains(range.commonAncestorContainer)) return null;
+
+  const mentions: SelectedMention[] = [];
+  const chips = root.querySelectorAll<HTMLElement>(".mention-chip[data-mention-name]");
+
+  for (const chip of chips) {
+    if (!range.intersectsNode(chip)) continue;
+    const visibleText = chip.textContent;
+    const name = chip.dataset.mentionName;
+    if (!visibleText || !name) continue;
+
+    // Only rewrite a fully selected chip. A selection that begins or ends
+    // inside the visible label should retain the browser's native partial text.
+    // Compare the selection against the chip's textual boundaries, not the
+    // surrounding element boundaries. A user can drag from text offset 0 to
+    // the final offset and visibly select the whole label without selecting
+    // the span node itself.
+    const textWalker = root.ownerDocument.createTreeWalker(chip, 4); // NodeFilter.SHOW_TEXT
+    const firstText = textWalker.nextNode();
+    let lastText = firstText;
+    for (let node = textWalker.nextNode(); node; node = textWalker.nextNode()) lastText = node;
+    if (firstText?.nodeType !== 3 || lastText?.nodeType !== 3) continue;
+
+    const chipRange = root.ownerDocument.createRange();
+    chipRange.setStart(firstText, 0);
+    chipRange.setEnd(lastText, lastText.textContent?.length ?? 0);
+    if (
+      range.compareBoundaryPoints(range.START_TO_START, chipRange) > 0 ||
+      range.compareBoundaryPoints(range.END_TO_END, chipRange) < 0
+    ) {
+      continue;
+    }
+
+    // Measure the chip's exact position within the selected text instead of
+    // replacing by label value. Two people may share a displayName, and the
+    // same visible string may also appear as ordinary text before the chip.
+    const prefixRange = range.cloneRange();
+    prefixRange.setEnd(chipRange.startContainer, chipRange.startOffset);
+    const start = prefixRange.toString().length;
+    mentions.push({ start, end: start + visibleText.length, name, visibleText });
+  }
+
+  return mentions.length > 0 ? mentions : null;
+}
+
+export function copyTextWithMentionHandles(root: HTMLElement, selection: Selection | null): string | null {
+  const mentions = selectedMentions(root, selection);
+  if (!mentions || !selection) return null;
+  mentions.sort((left, right) => right.start - left.start);
+
+  return mentions.reduce(
+    (text, mention) => `${text.slice(0, mention.start)}@${mention.name}${text.slice(mention.end)}`,
+    selection.toString(),
+  );
+}
+
+/**
+ * Preserve native rich-text copy while rewriting complete mention chips to
+ * canonical handles. Consumers should set this alongside the plain-text
+ * payload so pasting into Docs/Notion retains links and emphasis.
+ */
+export function copyHtmlWithMentionHandles(root: HTMLElement, selection: Selection | null): string | null {
+  const mentions = selectedMentions(root, selection);
+  if (!mentions || !selection) return null;
+
+  const fragment = selection.getRangeAt(0).cloneContents();
+  const pending = [...mentions].sort((left, right) => left.start - right.start);
+
+  for (const chip of fragment.querySelectorAll<HTMLElement>(".mention-chip[data-mention-name]")) {
+    const mention = pending[0];
+    if (!mention || chip.dataset.mentionName !== mention.name || chip.textContent !== mention.visibleText) continue;
+    chip.replaceWith(root.ownerDocument.createTextNode(`@${mention.name}`));
+    pending.shift();
+  }
+
+  const container = root.ownerDocument.createElement("div");
+  // When the selection starts and ends directly inside a chip's text node,
+  // cloneContents() has no ancestor span to rewrite. Fall back to escaped
+  // canonical plain text for that boundary-only case instead of leaking the
+  // presentation label back into a rich paste.
+  if (pending.length > 0) {
+    container.textContent = copyTextWithMentionHandles(root, selection) ?? selection.toString();
+    return container.innerHTML;
+  }
+  container.append(fragment);
+  return container.innerHTML;
 }

--- a/packages/web/src/components/rehype-mentions.ts
+++ b/packages/web/src/components/rehype-mentions.ts
@@ -55,7 +55,6 @@ function makeMentionElement(identity: RenderedMentionIdentity, isSelf: boolean):
   const displayName = identity.displayName.trim() || identity.name;
   const displayLabel = `@${displayName}`;
   const identityLabel = displayName === identity.name ? displayLabel : `${displayLabel} (@${identity.name})`;
-  const visibleLabel = identity.disambiguate ? identityLabel : displayLabel;
 
   return {
     type: "element",
@@ -73,7 +72,24 @@ function makeMentionElement(identity: RenderedMentionIdentity, isSelf: boolean):
       title: identityLabel,
       ariaLabel: identityLabel,
     },
-    children: [{ type: "text", value: visibleLabel }],
+    children: [
+      {
+        type: "element",
+        tagName: "span",
+        properties: { className: ["mention-chip-display"] },
+        children: [{ type: "text", value: displayLabel }],
+      },
+      ...(identity.disambiguate
+        ? [
+            {
+              type: "element" as const,
+              tagName: "span",
+              properties: { className: ["mention-chip-handle"] },
+              children: [{ type: "text" as const, value: `(@${identity.name})` }],
+            },
+          ]
+        : []),
+    ],
   };
 }
 
@@ -177,16 +193,15 @@ export function rehypeMentions(
  * should proceed unchanged.
  */
 type SelectedMention = {
-  start: number;
-  end: number;
   name: string;
   visibleText: string;
+  chip: HTMLElement;
 };
 
 function selectedMentions(root: HTMLElement, selection: Selection | null): SelectedMention[] | null {
   if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null;
   const range = selection.getRangeAt(0);
-  if (!root.contains(range.commonAncestorContainer)) return null;
+  if (!range.intersectsNode(root)) return null;
 
   const mentions: SelectedMention[] = [];
   const chips = root.querySelectorAll<HTMLElement>(".mention-chip[data-mention-name]");
@@ -219,27 +234,100 @@ function selectedMentions(root: HTMLElement, selection: Selection | null): Selec
       continue;
     }
 
-    // Measure the chip's exact position within the selected text instead of
-    // replacing by label value. Two people may share a displayName, and the
-    // same visible string may also appear as ordinary text before the chip.
-    const prefixRange = range.cloneRange();
-    prefixRange.setEnd(chipRange.startContainer, chipRange.startOffset);
-    const start = prefixRange.toString().length;
-    mentions.push({ start, end: start + visibleText.length, name, visibleText });
+    mentions.push({ name, visibleText, chip });
   }
 
   return mentions.length > 0 ? mentions : null;
 }
 
-export function copyTextWithMentionHandles(root: HTMLElement, selection: Selection | null): string | null {
+type CanonicalSelectionFragment = {
+  fragment: DocumentFragment;
+  mentions: SelectedMention[];
+  pending: SelectedMention[];
+};
+
+/**
+ * Clone the selected DOM once, then replace every complete mention chip in
+ * document order. Plain and rich clipboard payloads are both derived from this
+ * same clone, so rendered line breaks never become offsets into a different
+ * string representation.
+ */
+function selectionFragmentWithMentionHandles(
+  root: HTMLElement,
+  selection: Selection | null,
+): CanonicalSelectionFragment | null {
   const mentions = selectedMentions(root, selection);
   if (!mentions || !selection) return null;
-  mentions.sort((left, right) => right.start - left.start);
 
-  return mentions.reduce(
-    (text, mention) => `${text.slice(0, mention.start)}@${mention.name}${text.slice(mention.end)}`,
-    selection.toString(),
-  );
+  const markerAttribute = "data-mention-copy-index";
+  const previousMarkers = mentions.map(({ chip }) => chip.getAttribute(markerAttribute));
+  for (const [index, mention] of mentions.entries()) {
+    mention.chip.setAttribute(markerAttribute, String(index));
+  }
+
+  let fragment: DocumentFragment;
+  try {
+    fragment = selection.getRangeAt(0).cloneContents();
+  } finally {
+    for (const [index, mention] of mentions.entries()) {
+      const previous = previousMarkers[index];
+      if (previous === null || previous === undefined) mention.chip.removeAttribute(markerAttribute);
+      else mention.chip.setAttribute(markerAttribute, previous);
+    }
+  }
+
+  const pending = [...mentions];
+  for (const chip of fragment.querySelectorAll<HTMLElement>(`[${markerAttribute}]`)) {
+    const index = Number(chip.getAttribute(markerAttribute));
+    const mention = mentions[index];
+    if (!mention) continue;
+    chip.replaceWith(root.ownerDocument.createTextNode(`@${mention.name}`));
+    const pendingIndex = pending.indexOf(mention);
+    if (pendingIndex >= 0) pending.splice(pendingIndex, 1);
+  }
+
+  return { fragment, mentions, pending };
+}
+
+/** Read a detached selection fragment through the browser's rendered-text
+ * algorithm. The temporary node stays off-screen (rather than display:none)
+ * because `innerText` deliberately ignores layout for non-rendered content. */
+function renderedTextFromFragment(root: HTMLElement, fragment: DocumentFragment): string {
+  const container = root.ownerDocument.createElement("div");
+  container.style.position = "fixed";
+  container.style.left = "-200vw";
+  container.style.top = "0";
+  container.style.width = "100vw";
+  container.style.whiteSpace = "pre-wrap";
+  container.append(fragment);
+
+  const body = root.ownerDocument.body;
+  if (!body) return container.textContent ?? "";
+  body.append(container);
+  try {
+    return container.innerText;
+  } finally {
+    container.remove();
+  }
+}
+
+export function copyTextWithMentionHandles(root: HTMLElement, selection: Selection | null): string | null {
+  const rewritten = selectionFragmentWithMentionHandles(root, selection);
+  if (!rewritten || !selection) return null;
+
+  // A range whose common ancestor is the chip's text node clones only that
+  // text, not its wrapping span/data attributes. This is the sole useful
+  // pending shape: the user selected exactly one complete chip.
+  if (
+    rewritten.pending.length === 1 &&
+    rewritten.mentions.length === 1 &&
+    selection.toString() === rewritten.pending[0]?.visibleText
+  ) {
+    return `@${rewritten.pending[0].name}`;
+  }
+  if (rewritten.pending.length > 0) return null;
+
+  return renderedTextFromFragment(root, rewritten.fragment);
 }
 
 /**
@@ -248,28 +336,42 @@ export function copyTextWithMentionHandles(root: HTMLElement, selection: Selecti
  * payload so pasting into Docs/Notion retains links and emphasis.
  */
 export function copyHtmlWithMentionHandles(root: HTMLElement, selection: Selection | null): string | null {
-  const mentions = selectedMentions(root, selection);
-  if (!mentions || !selection) return null;
-
-  const fragment = selection.getRangeAt(0).cloneContents();
-  const pending = [...mentions].sort((left, right) => left.start - right.start);
-
-  for (const chip of fragment.querySelectorAll<HTMLElement>(".mention-chip[data-mention-name]")) {
-    const mention = pending[0];
-    if (!mention || chip.dataset.mentionName !== mention.name || chip.textContent !== mention.visibleText) continue;
-    chip.replaceWith(root.ownerDocument.createTextNode(`@${mention.name}`));
-    pending.shift();
-  }
-
+  const rewritten = selectionFragmentWithMentionHandles(root, selection);
+  if (!rewritten || !selection) return null;
   const container = root.ownerDocument.createElement("div");
   // When the selection starts and ends directly inside a chip's text node,
   // cloneContents() has no ancestor span to rewrite. Fall back to escaped
   // canonical plain text for that boundary-only case instead of leaking the
   // presentation label back into a rich paste.
-  if (pending.length > 0) {
+  if (rewritten.pending.length > 0) {
     container.textContent = copyTextWithMentionHandles(root, selection) ?? selection.toString();
     return container.innerHTML;
   }
-  container.append(fragment);
+  container.append(rewritten.fragment);
   return container.innerHTML;
+}
+
+/**
+ * Observe copy at the document boundary, where the Clipboard API dispatches
+ * non-editable timeline copies (the focused node may be body, the composer, or
+ * another control). The selection itself is the scope boundary: helpers return
+ * null unless a complete mention inside this timeline is selected.
+ */
+export function installTimelineMentionCopy(ownerDocument: Document, timeline: () => HTMLElement | null): () => void {
+  const handleCopy = (event: ClipboardEvent) => {
+    if (event.defaultPrevented || !event.clipboardData) return;
+    const root = timeline();
+    if (!root) return;
+    const selection = ownerDocument.getSelection();
+    const copiedText = copyTextWithMentionHandles(root, selection);
+    if (copiedText === null) return;
+    const copiedHtml = copyHtmlWithMentionHandles(root, selection);
+
+    event.preventDefault();
+    event.clipboardData.setData("text/plain", copiedText);
+    if (copiedHtml !== null) event.clipboardData.setData("text/html", copiedHtml);
+  };
+
+  ownerDocument.addEventListener("copy", handleCopy);
+  return () => ownerDocument.removeEventListener("copy", handleCopy);
 }

--- a/packages/web/src/components/rehype-mentions.ts
+++ b/packages/web/src/components/rehype-mentions.ts
@@ -305,7 +305,11 @@ function renderedTextFromFragment(root: HTMLElement, fragment: DocumentFragment)
   container.style.left = "-200vw";
   container.style.top = "0";
   container.style.width = "100vw";
-  container.style.whiteSpace = "pre-wrap";
+  // Match the live timeline's whitespace collapsing. Forcing pre-wrap here
+  // would preserve otherwise-collapsible spaces/tabs merely because the
+  // selection contains a mention, changing unrelated copied text.
+  const liveWhiteSpace = root.ownerDocument.defaultView?.getComputedStyle(root).whiteSpace;
+  if (liveWhiteSpace) container.style.whiteSpace = liveWhiteSpace;
   container.append(fragment);
 
   const body = root.ownerDocument.body;

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -2175,15 +2175,18 @@ tr[data-interactive]:hover {
  * (see below) because any horizontal padding / background offset on
  * the mirror chip pushes the visual glyphs out of sync with the
  * textarea's caret position underneath. `white-space: nowrap` keeps
- * `@<name>` from wrapping at a hyphen mid-handle. The hard-coded
- * `999px` radius (instead of `--radius-chip`) gives the full capsule
- * shape without touching the shared chip radius. */
+ * `@<displayName>` from wrapping. Inline-block + ellipsis keeps a very long
+ * display name inside the message column on narrow screens. */
 .mention-chip {
-  display: inline;
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
   background: var(--brand);
   color: var(--fg-on-vivid);
-  padding: 0 6px;
-  border-radius: 999px;
+  padding: 0 var(--sp-1_5);
+  border-radius: var(--radius-full);
   font-weight: 500;
   white-space: nowrap;
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -2174,14 +2174,14 @@ tr[data-interactive]:hover {
  * plugin). The composer mirror overlay uses `.mention-text` instead
  * (see below) because any horizontal padding / background offset on
  * the mirror chip pushes the visual glyphs out of sync with the
- * textarea's caret position underneath. `white-space: nowrap` keeps
- * `@<displayName>` from wrapping. Inline-block + ellipsis keeps a very long
- * display name inside the message column on narrow screens. */
+ * textarea's caret position underneath. The display-name segment stays on one
+ * line and owns ellipsis so a duplicate-name chip can keep its canonical
+ * handle visible on narrow/touch screens. Exceptionally long valid handles
+ * may wrap within their own segment rather than overflowing the viewport. */
 .mention-chip {
-  display: inline-block;
+  display: inline-flex;
   max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  align-items: baseline;
   vertical-align: bottom;
   background: var(--brand);
   color: var(--fg-on-vivid);
@@ -2189,6 +2189,21 @@ tr[data-interactive]:hover {
   border-radius: var(--radius-full);
   font-weight: 500;
   white-space: nowrap;
+}
+
+.mention-chip-display {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mention-chip-handle {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: calc(100% - var(--sp-1));
+  margin-left: var(--sp-1);
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 /* Mention chip — self variant. Highest-priority highlight: when a

--- a/packages/web/src/lib/__tests__/identity-cache.test.ts
+++ b/packages/web/src/lib/__tests__/identity-cache.test.ts
@@ -1,0 +1,35 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import { invalidateDisplayNameQueries } from "../identity-cache.js";
+
+describe("invalidateDisplayNameQueries", () => {
+  it("invalidates every cached projection that carries a mutable display name", async () => {
+    const queryClient = new QueryClient();
+    const identityKeys = [
+      ["members"],
+      ["agents"],
+      ["managed-agents", "member-1"],
+      ["agent", "agent-1"],
+      ["agents-for-delegate", "member-1"],
+      ["context-build", "managed-agents", "org-1"],
+      ["context-reviewer", "org-agents", "org-1"],
+      ["participant-name-cache"],
+      ["mobile", "team", "members"],
+      ["mobile", "team", "agents", "admin"],
+      ["me", "chats"],
+      ["chat-detail", "chat-1"],
+    ] as const;
+    const unrelatedKey = ["repositories", "agent-1"] as const;
+
+    for (const key of [...identityKeys, unrelatedKey]) {
+      queryClient.setQueryData(key, { label: "Old name" });
+    }
+
+    await invalidateDisplayNameQueries(queryClient);
+
+    for (const key of identityKeys) {
+      expect(queryClient.getQueryState(key)?.isInvalidated, key.join("/")).toBe(true);
+    }
+    expect(queryClient.getQueryState(unrelatedKey)?.isInvalidated).toBe(false);
+  });
+});

--- a/packages/web/src/lib/identity-cache.ts
+++ b/packages/web/src/lib/identity-cache.ts
@@ -1,0 +1,25 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+/**
+ * Invalidate every Web projection that carries a mutable identity label.
+ *
+ * `displayName` is copied into chat-detail participants as well as roster and
+ * conversation projections. Keeping this fan-out in one place prevents a
+ * rename surface from refreshing its own form while leaving an already-open
+ * chat timeline on the old label.
+ */
+export async function invalidateDisplayNameQueries(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["members"] }),
+    queryClient.invalidateQueries({ queryKey: ["agents"] }),
+    queryClient.invalidateQueries({ queryKey: ["managed-agents"] }),
+    queryClient.invalidateQueries({ queryKey: ["agent"] }),
+    queryClient.invalidateQueries({ queryKey: ["agents-for-delegate"] }),
+    queryClient.invalidateQueries({ queryKey: ["context-build", "managed-agents"] }),
+    queryClient.invalidateQueries({ queryKey: ["context-reviewer", "org-agents"] }),
+    queryClient.invalidateQueries({ queryKey: ["participant-name-cache"] }),
+    queryClient.invalidateQueries({ queryKey: ["mobile", "team"] }),
+    queryClient.invalidateQueries({ queryKey: ["me", "chats"] }),
+    queryClient.invalidateQueries({ queryKey: ["chat-detail"] }),
+  ]);
+}

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -15,7 +15,6 @@ import {
   updateAgent,
 } from "./../api/agents.js";
 import { ApiError } from "./../api/client.js";
-import { updateMember, updateMyProfile } from "./../api/members.js";
 import { listAgentSessions } from "./../api/sessions.js";
 import { useAuth } from "./../auth/auth-context.js";
 import { Avatar } from "./../components/avatar.js";
@@ -62,7 +61,7 @@ function AgentDetailPageView() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const location = useLocation();
-  const { memberId, role, refreshMe } = useAuth();
+  const { memberId, role } = useAuth();
   // On phones the header drops its secondary metadata line (type · visibility,
   // offline-since) — those are all repeated on the Profile tab — so the
   // avatar, name, presence chip, and action buttons keep their natural size
@@ -131,33 +130,10 @@ function AgentDetailPageView() {
   const [dangerError, setDangerError] = useState<string | null>(null);
 
   const identityUpdateMutation = useMutation({
-    mutationFn: async (patch: Parameters<typeof updateAgent>[1]) => {
-      const target = agentQuery.data;
-      if (patch.displayName === undefined || target?.type !== "human") {
-        return updateAgent(uuid, patch);
-      }
-
-      // A human agent is only a membership-scoped mirror of its user. Keep the
-      // authoritative users.display_name and every applicable mirror aligned by
-      // using the member/profile mutations instead of generic PATCH /agents.
-      if (!target.managerId) throw new Error("Human identity is missing its member owner.");
-      const { displayName, ...agentPatch } = patch;
-      const identityResult =
-        target.managerId === memberId
-          ? await updateMyProfile({ displayName })
-          : await updateMember(target.managerId, { displayName });
-      // Profile fields commit independently today, but preserve any future
-      // combined patch instead of silently dropping non-name agent fields.
-      if (Object.keys(agentPatch).length > 0) await updateAgent(uuid, agentPatch);
-      return identityResult;
-    },
+    mutationFn: (patch: Parameters<typeof updateAgent>[1]) => updateAgent(uuid, patch),
     onSuccess: async (_agent, patch) => {
       if (patch.displayName !== undefined) {
-        const refreshAuthenticatedUser = agentQuery.data?.type === "human" && agentQuery.data.managerId === memberId;
-        await Promise.all([
-          invalidateDisplayNameQueries(queryClient),
-          ...(refreshAuthenticatedUser ? [refreshMe()] : []),
-        ]);
+        await invalidateDisplayNameQueries(queryClient);
         return;
       }
       queryClient.invalidateQueries({ queryKey: ["agent", uuid] });

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -31,6 +31,7 @@ import {
 import { PresenceChip, runtimeStateToPresence } from "./../components/ui/presence-chip.js";
 import { Tab, TabBadge, TabBar } from "./../components/ui/tab-bar.js";
 import { useWorkspaceViewport } from "./../hooks/use-viewport.js";
+import { invalidateDisplayNameQueries } from "./../lib/identity-cache.js";
 import { cn } from "./../lib/utils.js";
 import { canManageAgentDetail } from "./agent-detail/access.js";
 import { isBindableClient } from "./agent-detail/action-state.js";
@@ -130,7 +131,11 @@ function AgentDetailPageView() {
 
   const identityUpdateMutation = useMutation({
     mutationFn: (patch: Parameters<typeof updateAgent>[1]) => updateAgent(uuid, patch),
-    onSuccess: () => {
+    onSuccess: async (_agent, patch) => {
+      if (patch.displayName !== undefined) {
+        await invalidateDisplayNameQueries(queryClient);
+        return;
+      }
       queryClient.invalidateQueries({ queryKey: ["agent", uuid] });
       queryClient.invalidateQueries({ queryKey: ["agents"] });
     },

--- a/packages/web/src/pages/agent-detail.tsx
+++ b/packages/web/src/pages/agent-detail.tsx
@@ -15,6 +15,7 @@ import {
   updateAgent,
 } from "./../api/agents.js";
 import { ApiError } from "./../api/client.js";
+import { updateMember, updateMyProfile } from "./../api/members.js";
 import { listAgentSessions } from "./../api/sessions.js";
 import { useAuth } from "./../auth/auth-context.js";
 import { Avatar } from "./../components/avatar.js";
@@ -61,7 +62,7 @@ function AgentDetailPageView() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const location = useLocation();
-  const { memberId, role } = useAuth();
+  const { memberId, role, refreshMe } = useAuth();
   // On phones the header drops its secondary metadata line (type · visibility,
   // offline-since) — those are all repeated on the Profile tab — so the
   // avatar, name, presence chip, and action buttons keep their natural size
@@ -130,10 +131,33 @@ function AgentDetailPageView() {
   const [dangerError, setDangerError] = useState<string | null>(null);
 
   const identityUpdateMutation = useMutation({
-    mutationFn: (patch: Parameters<typeof updateAgent>[1]) => updateAgent(uuid, patch),
+    mutationFn: async (patch: Parameters<typeof updateAgent>[1]) => {
+      const target = agentQuery.data;
+      if (patch.displayName === undefined || target?.type !== "human") {
+        return updateAgent(uuid, patch);
+      }
+
+      // A human agent is only a membership-scoped mirror of its user. Keep the
+      // authoritative users.display_name and every applicable mirror aligned by
+      // using the member/profile mutations instead of generic PATCH /agents.
+      if (!target.managerId) throw new Error("Human identity is missing its member owner.");
+      const { displayName, ...agentPatch } = patch;
+      const identityResult =
+        target.managerId === memberId
+          ? await updateMyProfile({ displayName })
+          : await updateMember(target.managerId, { displayName });
+      // Profile fields commit independently today, but preserve any future
+      // combined patch instead of silently dropping non-name agent fields.
+      if (Object.keys(agentPatch).length > 0) await updateAgent(uuid, agentPatch);
+      return identityResult;
+    },
     onSuccess: async (_agent, patch) => {
       if (patch.displayName !== undefined) {
-        await invalidateDisplayNameQueries(queryClient);
+        const refreshAuthenticatedUser = agentQuery.data?.type === "human" && agentQuery.data.managerId === memberId;
+        await Promise.all([
+          invalidateDisplayNameQueries(queryClient),
+          ...(refreshAuthenticatedUser ? [refreshMe()] : []),
+        ]);
         return;
       }
       queryClient.invalidateQueries({ queryKey: ["agent", uuid] });

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -36,11 +36,6 @@ const agentMocks = vi.hoisted(() => ({
   updateAgent: vi.fn(),
 }));
 
-const memberMocks = vi.hoisted(() => ({
-  updateMember: vi.fn(),
-  updateMyProfile: vi.fn(),
-}));
-
 const agentResourceMocks = vi.hoisted(() => ({
   getAgentResources: vi.fn(),
   updateAgentResources: vi.fn(),
@@ -56,7 +51,6 @@ const usageMocks = vi.hoisted(() => ({
 }));
 
 const authMock = vi.hoisted(() => ({
-  refreshMe: vi.fn(),
   value: {
     memberId: "member-self",
     role: "admin",
@@ -80,11 +74,6 @@ vi.mock("../../../api/agents.js", async (importOriginal) => ({
   ...agentMocks,
 }));
 
-vi.mock("../../../api/members.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../../api/members.js")>()),
-  ...memberMocks,
-}));
-
 vi.mock("../../../api/agent-resources.js", () => agentResourceMocks);
 
 vi.mock("../../../api/sessions.js", async (importOriginal) => ({
@@ -99,7 +88,7 @@ vi.mock("../../../api/usage.js", async (importOriginal) => ({
 }));
 
 vi.mock("../../../auth/auth-context.js", () => ({
-  useAuth: () => ({ ...authMock.value, refreshMe: authMock.refreshMe }),
+  useAuth: () => authMock.value,
 }));
 
 vi.mock("../../../api/org-settings.js", () => orgSettingsMocks);
@@ -399,20 +388,6 @@ beforeEach(() => {
   agentMocks.listAllAgents.mockResolvedValue(switcherAgents);
   agentMocks.listAgents.mockResolvedValue(switcherAgents);
   agentMocks.updateAgent.mockResolvedValue(agent());
-  memberMocks.updateMember.mockResolvedValue({
-    id: "member-other",
-    userId: "user-other",
-    organizationId: "org-1",
-    agentId: "agent-1",
-    role: "member",
-    createdAt: NOW,
-    username: "other",
-    displayName: "Other Updated",
-    avatarUrl: null,
-    lastActiveAt: null,
-  });
-  memberMocks.updateMyProfile.mockResolvedValue({ id: "user-self", displayName: "Gandy Updated" });
-  authMock.refreshMe.mockResolvedValue(undefined);
   agentMocks.suspendAgent.mockResolvedValue(agent({ status: "suspended" }));
   agentMocks.switchAgentRuntime.mockResolvedValue(agent({ runtimeProvider: "codex" }));
   agentMocks.recoverAgentRuntimeSwitch.mockResolvedValue(agent());
@@ -1119,7 +1094,7 @@ describe("AgentDetailPage", () => {
     await act(async () => view.root.unmount());
   });
 
-  it("updates a self human name through the authoritative profile route", async () => {
+  it("omits human display-name editing and keeps projection edits on the agent route", async () => {
     const { ProfileTab } = await import("../profile-tab.js");
     agentMocks.getAgent.mockResolvedValue(agent({ type: "human", managerId: "member-self", displayName: "Gandy" }));
 
@@ -1127,38 +1102,13 @@ describe("AgentDetailPage", () => {
     await waitForText(view.container, "Identity");
     await click(exactButtonByText(view.container, "Edit"));
     await waitForText(document.body, "Edit profile");
-    const input = document.body.querySelector<HTMLInputElement>("#profile-display");
-    if (!input) throw new Error("Expected profile display-name input");
-    await setValue(input, "Gandy Updated");
-    await click(exactButtonByText(document.body, "Done"));
+    expect(document.body.querySelector("#profile-display")).toBeNull();
 
-    await waitForCondition(() => memberMocks.updateMyProfile.mock.calls.length > 0, "Expected self profile update");
-    expect(memberMocks.updateMyProfile).toHaveBeenCalledWith({ displayName: "Gandy Updated" });
-    expect(agentMocks.updateAgent).not.toHaveBeenCalled();
-    await waitForCondition(() => authMock.refreshMe.mock.calls.length > 0, "Expected authenticated user refresh");
-
-    await act(async () => view.root.unmount());
-  });
-
-  it("updates another human name through the authoritative member route", async () => {
-    const { ProfileTab } = await import("../profile-tab.js");
-    agentMocks.getAgent.mockResolvedValue(
-      agent({ type: "human", managerId: "member-other", displayName: "Other Person" }),
-    );
-
-    const view = await renderDom("/agents/agent-1/profile", <ProfileTab />);
-    await waitForText(view.container, "Identity");
-    await click(exactButtonByText(view.container, "Edit"));
-    await waitForText(document.body, "Edit profile");
-    const input = document.body.querySelector<HTMLInputElement>("#profile-display");
-    if (!input) throw new Error("Expected profile display-name input");
-    await setValue(input, "Other Updated");
-    await click(exactButtonByText(document.body, "Done"));
-
-    await waitForCondition(() => memberMocks.updateMember.mock.calls.length > 0, "Expected member identity update");
-    expect(memberMocks.updateMember).toHaveBeenCalledWith("member-other", { displayName: "Other Updated" });
-    expect(agentMocks.updateAgent).not.toHaveBeenCalled();
-    expect(authMock.refreshMe).not.toHaveBeenCalled();
+    const visibility = document.body.querySelector<HTMLButtonElement>("#profile-visibility");
+    if (!visibility) throw new Error("Expected human visibility control");
+    await chooseSelectOption(visibility, "Private to you");
+    await waitForCondition(() => agentMocks.updateAgent.mock.calls.length > 0, "Expected agent projection update");
+    expect(agentMocks.updateAgent).toHaveBeenCalledWith("agent-1", { visibility: "private" });
 
     await act(async () => view.root.unmount());
   });
@@ -1178,9 +1128,6 @@ describe("AgentDetailPage", () => {
 
     await waitForCondition(() => agentMocks.updateAgent.mock.calls.length > 0, "Expected agent identity update");
     expect(agentMocks.updateAgent).toHaveBeenCalledWith("agent-1", { displayName: "Vega Updated" });
-    expect(memberMocks.updateMember).not.toHaveBeenCalled();
-    expect(memberMocks.updateMyProfile).not.toHaveBeenCalled();
-    expect(authMock.refreshMe).not.toHaveBeenCalled();
 
     await act(async () => view.root.unmount());
   });

--- a/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/agent-detail-page-dom.test.tsx
@@ -36,6 +36,11 @@ const agentMocks = vi.hoisted(() => ({
   updateAgent: vi.fn(),
 }));
 
+const memberMocks = vi.hoisted(() => ({
+  updateMember: vi.fn(),
+  updateMyProfile: vi.fn(),
+}));
+
 const agentResourceMocks = vi.hoisted(() => ({
   getAgentResources: vi.fn(),
   updateAgentResources: vi.fn(),
@@ -51,6 +56,7 @@ const usageMocks = vi.hoisted(() => ({
 }));
 
 const authMock = vi.hoisted(() => ({
+  refreshMe: vi.fn(),
   value: {
     memberId: "member-self",
     role: "admin",
@@ -74,6 +80,11 @@ vi.mock("../../../api/agents.js", async (importOriginal) => ({
   ...agentMocks,
 }));
 
+vi.mock("../../../api/members.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../api/members.js")>()),
+  ...memberMocks,
+}));
+
 vi.mock("../../../api/agent-resources.js", () => agentResourceMocks);
 
 vi.mock("../../../api/sessions.js", async (importOriginal) => ({
@@ -88,7 +99,7 @@ vi.mock("../../../api/usage.js", async (importOriginal) => ({
 }));
 
 vi.mock("../../../auth/auth-context.js", () => ({
-  useAuth: () => authMock.value,
+  useAuth: () => ({ ...authMock.value, refreshMe: authMock.refreshMe }),
 }));
 
 vi.mock("../../../api/org-settings.js", () => orgSettingsMocks);
@@ -388,6 +399,20 @@ beforeEach(() => {
   agentMocks.listAllAgents.mockResolvedValue(switcherAgents);
   agentMocks.listAgents.mockResolvedValue(switcherAgents);
   agentMocks.updateAgent.mockResolvedValue(agent());
+  memberMocks.updateMember.mockResolvedValue({
+    id: "member-other",
+    userId: "user-other",
+    organizationId: "org-1",
+    agentId: "agent-1",
+    role: "member",
+    createdAt: NOW,
+    username: "other",
+    displayName: "Other Updated",
+    avatarUrl: null,
+    lastActiveAt: null,
+  });
+  memberMocks.updateMyProfile.mockResolvedValue({ id: "user-self", displayName: "Gandy Updated" });
+  authMock.refreshMe.mockResolvedValue(undefined);
   agentMocks.suspendAgent.mockResolvedValue(agent({ status: "suspended" }));
   agentMocks.switchAgentRuntime.mockResolvedValue(agent({ runtimeProvider: "codex" }));
   agentMocks.recoverAgentRuntimeSwitch.mockResolvedValue(agent());
@@ -1090,6 +1115,72 @@ describe("AgentDetailPage", () => {
     expect(view.container.textContent).not.toContain("Agent lifecycle");
     expect(view.container.textContent).not.toContain("Deletion");
     expect(view.container.querySelector('button[aria-label="Suspend"]')).toBeNull();
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("updates a self human name through the authoritative profile route", async () => {
+    const { ProfileTab } = await import("../profile-tab.js");
+    agentMocks.getAgent.mockResolvedValue(agent({ type: "human", managerId: "member-self", displayName: "Gandy" }));
+
+    const view = await renderDom("/agents/agent-1/profile", <ProfileTab />);
+    await waitForText(view.container, "Identity");
+    await click(exactButtonByText(view.container, "Edit"));
+    await waitForText(document.body, "Edit profile");
+    const input = document.body.querySelector<HTMLInputElement>("#profile-display");
+    if (!input) throw new Error("Expected profile display-name input");
+    await setValue(input, "Gandy Updated");
+    await click(exactButtonByText(document.body, "Done"));
+
+    await waitForCondition(() => memberMocks.updateMyProfile.mock.calls.length > 0, "Expected self profile update");
+    expect(memberMocks.updateMyProfile).toHaveBeenCalledWith({ displayName: "Gandy Updated" });
+    expect(agentMocks.updateAgent).not.toHaveBeenCalled();
+    await waitForCondition(() => authMock.refreshMe.mock.calls.length > 0, "Expected authenticated user refresh");
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("updates another human name through the authoritative member route", async () => {
+    const { ProfileTab } = await import("../profile-tab.js");
+    agentMocks.getAgent.mockResolvedValue(
+      agent({ type: "human", managerId: "member-other", displayName: "Other Person" }),
+    );
+
+    const view = await renderDom("/agents/agent-1/profile", <ProfileTab />);
+    await waitForText(view.container, "Identity");
+    await click(exactButtonByText(view.container, "Edit"));
+    await waitForText(document.body, "Edit profile");
+    const input = document.body.querySelector<HTMLInputElement>("#profile-display");
+    if (!input) throw new Error("Expected profile display-name input");
+    await setValue(input, "Other Updated");
+    await click(exactButtonByText(document.body, "Done"));
+
+    await waitForCondition(() => memberMocks.updateMember.mock.calls.length > 0, "Expected member identity update");
+    expect(memberMocks.updateMember).toHaveBeenCalledWith("member-other", { displayName: "Other Updated" });
+    expect(agentMocks.updateAgent).not.toHaveBeenCalled();
+    expect(authMock.refreshMe).not.toHaveBeenCalled();
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("keeps non-human display-name edits on the agent route", async () => {
+    const { ProfileTab } = await import("../profile-tab.js");
+    agentMocks.getAgent.mockResolvedValue(agent({ displayName: "Vega" }));
+
+    const view = await renderDom("/agents/agent-1/profile", <ProfileTab />);
+    await waitForText(view.container, "Identity");
+    await click(exactButtonByText(view.container, "Edit"));
+    await waitForText(document.body, "Edit profile");
+    const input = document.body.querySelector<HTMLInputElement>("#profile-display");
+    if (!input) throw new Error("Expected profile display-name input");
+    await setValue(input, "Vega Updated");
+    await click(exactButtonByText(document.body, "Done"));
+
+    await waitForCondition(() => agentMocks.updateAgent.mock.calls.length > 0, "Expected agent identity update");
+    expect(agentMocks.updateAgent).toHaveBeenCalledWith("agent-1", { displayName: "Vega Updated" });
+    expect(memberMocks.updateMember).not.toHaveBeenCalled();
+    expect(memberMocks.updateMyProfile).not.toHaveBeenCalled();
+    expect(authMock.refreshMe).not.toHaveBeenCalled();
 
     await act(async () => view.root.unmount());
   });

--- a/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
+++ b/packages/web/src/pages/agent-detail/__tests__/appearance-identity-options-dom.test.tsx
@@ -690,14 +690,12 @@ describe("ProfileEditDialog (merged identity + appearance)", () => {
     const disabledName = document.body.querySelector<HTMLInputElement>("input.font-mono");
     expect(disabledName?.value).toBe("@bestony");
     expect(disabledName?.disabled).toBe(true);
-    const displayInput = document.body.querySelector<HTMLInputElement>("#profile-display");
     const visibilitySelect = document.body.querySelector<HTMLButtonElement>("#profile-visibility");
     const delegateSelect = document.body.querySelector<HTMLButtonElement>("#profile-delegate");
-    if (!displayInput || !visibilitySelect || !delegateSelect) throw new Error("Expected fields");
+    if (!visibilitySelect || !delegateSelect) throw new Error("Expected human projection fields");
+    expect(document.body.querySelector("#profile-display")).toBeNull();
+    expect(document.body.textContent).not.toContain("Display name");
     // Each field saves on its own commit — no Save button.
-    await setInputValue(displayInput, "Bestony Renamed");
-    await blurInput(displayInput);
-    expect(onSave).toHaveBeenCalledWith({ displayName: "Bestony Renamed" });
     await chooseSelectOption(visibilitySelect, "Visible to your team");
     expect(onSave).toHaveBeenCalledWith({ visibility: "organization" });
     await chooseSelectOption(delegateSelect, "Second Helper");

--- a/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
@@ -28,8 +28,9 @@ import { useJustSaved } from "./save-semantics.js";
  * One "Edit profile" dialog merging the former Identity and Appearance dialogs.
  * Every field saves on its own commit (immediate-save, like the rest of the
  * agent-detail page) — there is no Save button:
- *   - Identity / visibility / fallback color → a partial PATCH /agents/:uuid per
- *     field (`onSave`): display name on blur / Enter, the rest on change. Saves
+ *   - Identity / visibility / fallback color → a partial mutation per field
+ *     (`onSave`): display name on blur / Enter, the rest on change. Human names
+ *     use their member/profile identity route; agent fields use PATCH /agents/:uuid. Saves
  *     serialize — controls + Done disable while one is in flight — so partial
  *     PATCHes never race and the dialog never closes mid-save; a rejected save
  *     surfaces inline. Done just commits any pending name, then closes.
@@ -210,8 +211,9 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
 
   // Every field saves on its own commit (text on blur / Enter, selects + colour
   // on change) — consistent with the rest of the agent-detail page, which has no
-  // Save button. Each save is a partial PATCH /agents/:uuid; the avatar image is
-  // handled eagerly below, separately.
+  // Save button. Each save is a partial identity mutation; the parent routes a
+  // human display name through its member/profile authority and agent fields
+  // through PATCH /agents/:uuid. The avatar image is handled eagerly below.
   async function saveField(patch: UpdateAgent): Promise<boolean> {
     // Serialize: ignore a new save while one is in flight, so overlapping partial
     // PATCHes can't race and leave the server with a stale value.

--- a/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
+++ b/packages/web/src/pages/agent-detail/profile-edit-dialog.tsx
@@ -29,11 +29,12 @@ import { useJustSaved } from "./save-semantics.js";
  * Every field saves on its own commit (immediate-save, like the rest of the
  * agent-detail page) — there is no Save button:
  *   - Identity / visibility / fallback color → a partial mutation per field
- *     (`onSave`): display name on blur / Enter, the rest on change. Human names
- *     use their member/profile identity route; agent fields use PATCH /agents/:uuid. Saves
- *     serialize — controls + Done disable while one is in flight — so partial
- *     PATCHes never race and the dialog never closes mid-save; a rejected save
- *     surfaces inline. Done just commits any pending name, then closes.
+ *     (`onSave`): non-human display name on blur / Enter, the rest on change.
+ *     Human display names belong to Settings / Team member management and are
+ *     not editable from this agent-mirror surface. Saves serialize — controls +
+ *     Done disable while one is in flight — so partial PATCHes never race and
+ *     the dialog never closes mid-save; a rejected save surfaces inline. Done
+ *     just commits any pending non-human name, then closes.
  *   - Avatar image → eager PUT/DELETE /agents/:uuid/avatar on pick/remove
  *     (raw bytes don't share the JSON envelope); never closes the dialog.
  */
@@ -211,9 +212,9 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
 
   // Every field saves on its own commit (text on blur / Enter, selects + colour
   // on change) — consistent with the rest of the agent-detail page, which has no
-  // Save button. Each save is a partial identity mutation; the parent routes a
-  // human display name through its member/profile authority and agent fields
-  // through PATCH /agents/:uuid. The avatar image is handled eagerly below.
+  // Save button. Each save is a partial agent mutation. Human display names are
+  // intentionally absent here because the human agent is a projection of the
+  // user/member identity. The avatar image is handled eagerly below.
   async function saveField(patch: UpdateAgent): Promise<boolean> {
     // Serialize: ignore a new save while one is in flight, so overlapping partial
     // PATCHes can't race and leave the server with a stale value.
@@ -239,6 +240,9 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
   // empty → inline error and no save; changed + valid → save. `savedNameRef`
   // dedupes so a blur immediately followed by Done doesn't fire the PATCH twice.
   async function commitName(): Promise<boolean> {
+    // Human names are globally authoritative user/member identity and have no
+    // editor in this dialog. Keep Done a pure close for that projection.
+    if (isHuman) return true;
     const trimmed = displayName.trim();
     if (!trimmed) {
       setNameError("Display name is required.");
@@ -377,19 +381,21 @@ export function ProfileEditDialog({ agent, open, onOpenChange, onSave, onRefresh
               Agent name is permanent after creation — used in @mentions and CLI commands.
             </p>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="profile-display">Display name</Label>
-            <Input
-              id="profile-display"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              onBlur={() => void commitName()}
-              disabled={editsDisabled}
-              placeholder="How teammates see this agent"
-              maxLength={200}
-            />
-            {nameError && <p className="text-caption text-destructive">{nameError}</p>}
-          </div>
+          {!isHuman && (
+            <div className="space-y-2">
+              <Label htmlFor="profile-display">Display name</Label>
+              <Input
+                id="profile-display"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                onBlur={() => void commitName()}
+                disabled={editsDisabled}
+                placeholder="How teammates see this agent"
+                maxLength={200}
+              />
+              {nameError && <p className="text-caption text-destructive">{nameError}</p>}
+            </div>
+          )}
           <div className="space-y-2">
             <Label htmlFor="profile-visibility">Visibility</Label>
             <Select

--- a/packages/web/src/pages/settings/__tests__/account-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/account-dom.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter } from "react-router";
@@ -46,20 +47,28 @@ async function flush(): Promise<void> {
   });
 }
 
-async function renderAccount(route = "/settings/account"): Promise<HTMLElement> {
+async function renderAccount(
+  route = "/settings/account",
+): Promise<{ container: HTMLElement; queryClient: QueryClient }> {
   const container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity } },
+  });
+  queryClient.setQueryData(["chat-detail", "chat-1"], { id: "chat-1", participants: [] });
   const { SettingsAccountPage } = await import("../account.js");
   await act(async () => {
     root?.render(
-      <MemoryRouter initialEntries={[route]}>
-        <SettingsAccountPage />
-      </MemoryRouter>,
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[route]}>
+          <SettingsAccountPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
   });
   await flush();
-  return container;
+  return { container, queryClient };
 }
 
 async function waitForText(container: ParentNode, text: string): Promise<void> {
@@ -128,7 +137,7 @@ afterEach(async () => {
 
 describe("Settings account", () => {
   it("separates identity from the editable profile and saves a normalized display name", async () => {
-    const container = await renderAccount();
+    const { container, queryClient } = await renderAccount();
     await waitForText(container, "gandy@example.com");
 
     expect(container.textContent).toContain("Gandy");
@@ -166,11 +175,12 @@ describe("Settings account", () => {
 
     expect(memberMocks.updateMyProfile).toHaveBeenCalledWith({ displayName: "Gandy New" });
     expect(authMock.value.refreshMe).toHaveBeenCalled();
+    expect(queryClient.getQueryState(["chat-detail", "chat-1"])?.isInvalidated).toBe(true);
     expect(container.textContent).toContain("Saved");
   });
 
   it("shows callback errors and removes the transient query from browser history", async () => {
-    const container = await renderAccount("/settings/account?error=identity-conflict");
+    const { container } = await renderAccount("/settings/account?error=identity-conflict");
     await waitForText(container, "already connected to another First Tree user");
 
     expect(container.querySelector('[role="alert"]')?.textContent).toContain(

--- a/packages/web/src/pages/settings/account.tsx
+++ b/packages/web/src/pages/settings/account.tsx
@@ -1,4 +1,5 @@
 import type { AuthProvider, AuthProviderConnection } from "@first-tree/shared";
+import { useQueryClient } from "@tanstack/react-query";
 import { Github, Link2, Unlink } from "lucide-react";
 import type { FormEvent } from "react";
 import { useCallback, useEffect, useState } from "react";
@@ -10,6 +11,7 @@ import { Avatar } from "../../components/avatar.js";
 import { Button } from "../../components/ui/button.js";
 import { Section } from "../../components/ui/section.js";
 import { SettingsField, SettingsSaveButton } from "../../components/ui/settings-field.js";
+import { invalidateDisplayNameQueries } from "../../lib/identity-cache.js";
 
 const ERROR_COPY: Record<string, string> = {
   "identity-conflict": "That account is already connected to another First Tree user.",
@@ -26,6 +28,7 @@ type Feedback = {
 
 export function SettingsAccountPage() {
   const { user, refreshMe } = useAuth();
+  const queryClient = useQueryClient();
   const location = useLocation();
   const [displayName, setDisplayName] = useState(user?.displayName ?? "");
   const [providers, setProviders] = useState<AuthProviderConnection[]>([]);
@@ -89,7 +92,7 @@ export function SettingsAccountPage() {
     try {
       await updateMyProfile({ displayName: normalizedDisplayName });
       setDisplayName(normalizedDisplayName);
-      await refreshMe();
+      await Promise.all([refreshMe(), invalidateDisplayNameQueries(queryClient)]);
       setProfileSaved(true);
     } catch (error) {
       setFeedback({ kind: "error", message: error instanceof Error ? error.message : "Could not update profile." });

--- a/packages/web/src/pages/team/__tests__/team-page-dom.test.tsx
+++ b/packages/web/src/pages/team/__tests__/team-page-dom.test.tsx
@@ -60,6 +60,7 @@ const authMock = vi.hoisted(() => ({
     role: "admin" as "admin" | "member",
     memberId: "member-self" as string | null,
   },
+  refreshMe: vi.fn(),
 }));
 
 const routerMocks = vi.hoisted(() => ({
@@ -75,7 +76,7 @@ vi.mock("../../../api/members.js", () => memberMocks);
 vi.mock("../../../api/usage.js", () => usageMocks);
 
 vi.mock("../../../auth/auth-context.js", () => ({
-  useAuth: () => authMock.value,
+  useAuth: () => ({ ...authMock.value, refreshMe: authMock.refreshMe }),
 }));
 
 vi.mock("../../../lib/use-member-name-map.js", () => ({
@@ -395,19 +396,23 @@ async function flush(): Promise<void> {
   });
 }
 
-async function renderDom(element: ReactElement): Promise<{ container: HTMLElement; root: Root }> {
+async function renderDom(
+  element: ReactElement,
+): Promise<{ container: HTMLElement; queryClient: QueryClient; root: Root }> {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
+  const queryClient = createClient();
+  queryClient.setQueryData(["chat-detail", "chat-1"], { id: "chat-1", participants: [] });
   await act(async () => {
     root.render(
       <MemoryRouter>
-        <QueryClientProvider client={createClient()}>{element}</QueryClientProvider>
+        <QueryClientProvider client={queryClient}>{element}</QueryClientProvider>
       </MemoryRouter>,
     );
   });
   await flush();
-  return { container, root };
+  return { container, queryClient, root };
 }
 
 async function waitForText(container: ParentNode, text: string, timeoutMs = 3000): Promise<void> {
@@ -484,6 +489,7 @@ function seedDefaultMocks(): void {
     ...patch,
   }));
   memberMocks.deleteMember.mockResolvedValue(undefined);
+  authMock.refreshMe.mockResolvedValue(undefined);
   usageMocks.getOrgUsageByAgent.mockImplementation(async () => ({
     rows: [usage("agent-1"), usage("agent-private", { turns: 1 }), usage("agent-2", { turns: 2 })],
   }));
@@ -596,7 +602,7 @@ describe("TeamPage", () => {
   it("edits and removes human members through the profile dialog", async () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const { TeamPage } = await import("../index.js");
-    const { container, root } = await renderDom(<TeamPage />);
+    const { container, queryClient, root } = await renderDom(<TeamPage />);
 
     await waitForText(container, "Alice");
     await click(container.querySelector('[aria-label="Open Alice"]'));
@@ -613,12 +619,40 @@ describe("TeamPage", () => {
       displayName: "Alice Updated",
       role: "admin",
     });
+    expect(queryClient.getQueryState(["chat-detail", "chat-1"])?.isInvalidated).toBe(true);
 
     await click(container.querySelector('button[aria-label="Actions for Alice"]'));
     await click(exactButton(container, "Remove from org"));
     await waitForCondition(() => memberMocks.deleteMember.mock.calls.length > 0, "Expected member removal");
     expect(confirmSpy).toHaveBeenCalledWith("Remove Alice from the org? The human agent will be deactivated.");
     expect(memberMocks.deleteMember.mock.calls[0]?.[0]).toBe("member-alice");
+
+    await act(async () => root.unmount());
+  });
+
+  it("refreshes AuthProvider after a combined self rename and role edit", async () => {
+    memberMocks.listMembers.mockResolvedValueOnce([MEMBERS[0], member({ ...MEMBERS[1], role: "admin" })]);
+    const { TeamPage } = await import("../index.js");
+    const { container, queryClient, root } = await renderDom(<TeamPage />);
+
+    await waitForText(container, "Gandy");
+    await click(container.querySelector('[aria-label="Open Gandy"]'));
+    await waitForText(document.body, "Edit profile");
+
+    const displayName = document.body.querySelector<HTMLInputElement>("#member-display");
+    const role = document.body.querySelector<HTMLSelectElement>("#member-role");
+    if (!displayName || !role) throw new Error("Self member form missing");
+    await setInputValue(displayName, "Gandy Updated");
+    await setSelectValue(role, "member");
+    await click(exactButton(document.body, "Save"));
+
+    await waitForCondition(() => memberMocks.updateMember.mock.calls.length > 0, "Expected self member update");
+    expect(memberMocks.updateMember).toHaveBeenCalledWith("member-self", {
+      displayName: "Gandy Updated",
+      role: "member",
+    });
+    expect(authMock.refreshMe).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryState(["chat-detail", "chat-1"])?.isInvalidated).toBe(true);
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/team/index.tsx
+++ b/packages/web/src/pages/team/index.tsx
@@ -27,6 +27,7 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "
 import { Input } from "../../components/ui/input.js";
 import { Label } from "../../components/ui/label.js";
 import { PageHeader } from "../../components/ui/page-header.js";
+import { invalidateDisplayNameQueries } from "../../lib/identity-cache.js";
 import { useMemberNameMap } from "../../lib/use-member-name-map.js";
 import { formatRelative } from "../../lib/utils.js";
 import {
@@ -159,7 +160,16 @@ export function TeamPage() {
   const updateMemberMut = useMutation({
     mutationFn: async (vars: { id: string; patch: { displayName?: string; role?: "admin" | "member" } }) =>
       updateMember(vars.id, vars.patch),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["members"] }),
+    onSuccess: async (_member, vars) => {
+      const refreshProjection =
+        vars.patch.displayName !== undefined
+          ? invalidateDisplayNameQueries(queryClient)
+          : queryClient.invalidateQueries({ queryKey: ["members"] });
+      // A combined self rename + role edit uses this admin route rather than
+      // /me/profile. AuthProvider owns a separate /me snapshot, so refresh it
+      // alongside React Query or the user menu keeps the old identity/role.
+      await Promise.all([refreshProjection, ...(vars.id === memberId ? [refreshMe()] : [])]);
+    },
   });
   // Self-service display-name edit (PATCH /me/profile). Routed here instead of
   // the admin member route so a non-admin can rename themselves; the server
@@ -174,8 +184,7 @@ export function TeamPage() {
       // Refresh both, else the top-right menu shows the old name until the next
       // natural fetchMe.
       await refreshMe();
-      queryClient.invalidateQueries({ queryKey: ["members"] });
-      queryClient.invalidateQueries({ queryKey: ["agents"] });
+      await invalidateDisplayNameQueries(queryClient);
     },
   });
   const deleteMemberMut = useMutation({

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1597,6 +1597,59 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("renders sent mentions with displayName while preserving the stored handle and refreshes after rename", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const numericHuman = participant({
+      agentId: "human-agent-alice",
+      type: "human",
+      name: "1736192959",
+      displayName: "李坤阳",
+    });
+    const detail = chatDetail({
+      participants: [
+        participant({ agentId: "human-agent-self", type: "human", name: "gandy", displayName: "Gandy" }),
+        numericHuman,
+        participant({ agentId: "agent-1", name: "nova", displayName: "Nova" }),
+      ],
+    });
+    const body = "请 @1736192959 处理";
+    const page = messages([
+      message({
+        id: "display-name-mention",
+        senderId: "agent-1",
+        content: body,
+        metadata: { mentions: [numericHuman.agentId] },
+        source: "api",
+      }),
+    ]);
+    const { container, queryClient, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, detail, page),
+      "/",
+    );
+
+    await waitForText(container, "@李坤阳");
+    const chip = container.querySelector<HTMLElement>('.mention-chip[data-mention-name="1736192959"]');
+    expect(chip?.textContent).toBe("@李坤阳");
+    expect(chip?.getAttribute("title")).toBe("@李坤阳 (@1736192959)");
+    expect(chip?.getAttribute("aria-label")).toBe("@李坤阳 (@1736192959)");
+    expect(markdownMocks.render).toHaveBeenCalledWith(body);
+    expect(chatMocks.sendChatMessage).not.toHaveBeenCalled();
+
+    await act(async () => {
+      queryClient.setQueryData(["chat-detail", "chat-1"], {
+        ...detail,
+        participants: detail.participants.map((row) =>
+          row.agentId === numericHuman.agentId ? { ...row, displayName: "李坤阳（新）" } : row,
+        ),
+      });
+    });
+    await waitForText(container, "@李坤阳（新）");
+    expect(chip?.textContent).toBe("@李坤阳（新）");
+
+    await act(async () => root.unmount());
+  });
+
   it("renders a request as a normal message and does not re-render its body when a reply arrives", async () => {
     const { ChatView } = await import("../chat-view.js");
     const request = message({

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -618,6 +618,17 @@ async function setValue(element: HTMLInputElement | HTMLTextAreaElement, value: 
   await flush();
 }
 
+function dispatchCopy(target: Element): { event: Event; payloads: Map<string, string> } {
+  const payloads = new Map<string, string>();
+  const event = new Event("copy", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "clipboardData", {
+    configurable: true,
+    value: { setData: (type: string, value: string) => payloads.set(type, value) },
+  });
+  target.dispatchEvent(event);
+  return { event, payloads };
+}
+
 async function changeFiles(element: HTMLInputElement, files: File[]): Promise<void> {
   Object.defineProperty(element, "files", { configurable: true, value: files });
   await act(async () => {
@@ -1647,6 +1658,186 @@ describe("ChatView", () => {
     await waitForText(container, "@李坤阳（新）");
     expect(chip?.textContent).toBe("@李坤阳（新）");
 
+    await act(async () => root.unmount());
+  });
+
+  it("does not reassign a historical mention when its canonical handle is reused", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const currentOwner = participant({
+      agentId: "agent-new-owner",
+      name: "reused-handle",
+      displayName: "New Owner",
+    });
+    const detail = chatDetail({
+      participants: [
+        participant({ agentId: "human-agent-self", type: "human", name: "gandy", displayName: "Gandy" }),
+        currentOwner,
+        participant({ agentId: "agent-1", name: "nova", displayName: "Nova" }),
+      ],
+    });
+    const page = messages([
+      message({
+        id: "historical-handle-owner",
+        senderId: "agent-1",
+        content: "旧消息 @reused-handle",
+        metadata: {
+          mentions: ["agent-deleted-owner"],
+          // System routing can point at the new owner for reasons unrelated to
+          // this token. Only the explicit token-to-ID mapping may relabel it.
+          addressedAgentIds: [currentOwner.agentId],
+        },
+        source: "api",
+      }),
+      message({
+        id: "current-handle-owner",
+        senderId: "agent-1",
+        content: "新消息 @reused-handle",
+        metadata: { mentions: [currentOwner.agentId] },
+        source: "api",
+      }),
+    ]);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, detail, page),
+      "/",
+    );
+
+    await waitForText(container, "@New Owner");
+    const historical = container.querySelector<HTMLElement>('[data-message-id="historical-handle-owner"]');
+    const current = container.querySelector<HTMLElement>('[data-message-id="current-handle-owner"]');
+    expect(historical?.textContent).toContain("@reused-handle");
+    expect(historical?.querySelector(".mention-chip")).toBeNull();
+    expect(current?.textContent).toContain("@New Owner");
+    expect(current?.querySelector('.mention-chip[data-mention-agent-id="agent-new-owner"]')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it("copies canonical handles when copy targets the composer or body, including cross-message rich text", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const numericHuman = participant({
+      agentId: "human-agent-alice",
+      type: "human",
+      name: "1736192959",
+      displayName: "李坤阳",
+    });
+    const detail = chatDetail({
+      participants: [
+        participant({ agentId: "human-agent-self", type: "human", name: "gandy", displayName: "Gandy" }),
+        numericHuman,
+        participant({ agentId: "agent-1", name: "nova", displayName: "Nova" }),
+      ],
+    });
+    const page = messages([
+      message({
+        id: "copy-display-name-1",
+        senderId: "human-agent-self",
+        content: "**请** 先看  \n下一行 @1736192959\n\n第二段 [查看详情](https://example.com)",
+        metadata: { mentions: [numericHuman.agentId] },
+        createdAt: "2026-05-28T11:55:00.000Z",
+      }),
+      message({
+        id: "copy-display-name-2",
+        senderId: "agent-1",
+        content: "然后通知 @nova",
+        metadata: { mentions: ["agent-1"] },
+        source: "api",
+        createdAt: "2026-05-28T11:56:00.000Z",
+      }),
+    ]);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, detail, page),
+      "/",
+    );
+
+    await waitForText(container, "@李坤阳");
+    const firstBody = container.querySelector<HTMLElement>('[data-message-id="copy-display-name-1"] div.text-body');
+    const firstParagraph = container.querySelector<HTMLElement>('[data-message-id="copy-display-name-1"] p');
+    const secondParagraph = container.querySelector<HTMLElement>('[data-message-id="copy-display-name-2"] p');
+    const composer = container.querySelector<HTMLTextAreaElement>("textarea");
+    const timeline = container.querySelector<HTMLElement>("[data-chat-timeline-scroll]");
+    const numericChip = container.querySelector<HTMLElement>('.mention-chip[data-mention-name="1736192959"]');
+    if (!firstBody || !firstParagraph || !secondParagraph || !composer || !timeline || !numericChip) {
+      throw new Error("Expected copy fixtures and composer");
+    }
+
+    const selection = window.getSelection();
+    const singleRange = document.createRange();
+    singleRange.selectNodeContents(firstBody);
+    // Real non-editable copy keeps the previously focused composer as the
+    // event target while the mouse selection lives in the timeline.
+    composer.focus();
+    selection?.removeAllRanges();
+    selection?.addRange(singleRange);
+    expect(selection?.toString()).toContain("@李坤阳");
+    expect(timeline.contains(singleRange.commonAncestorContainer)).toBe(true);
+    expect(singleRange.intersectsNode(numericChip)).toBe(true);
+
+    const singleCopy = dispatchCopy(composer);
+    expect(singleCopy.event.defaultPrevented).toBe(true);
+    expect(singleCopy.payloads.get("text/plain")).toContain("请 先看");
+    expect(singleCopy.payloads.get("text/plain")).toContain("下一行 @1736192959");
+    expect(singleCopy.payloads.get("text/plain")).toContain("第二段 查看详情");
+    expect(singleCopy.payloads.get("text/html")).toContain("<strong>请</strong>");
+    expect(singleCopy.payloads.get("text/html")).toContain("@1736192959");
+    expect(singleCopy.payloads.get("text/html")).toContain("https://example.com");
+    expect(singleCopy.payloads.get("text/html")).not.toContain("李坤阳");
+
+    const crossRange = document.createRange();
+    crossRange.setStart(firstBody, 0);
+    crossRange.setEnd(secondParagraph, secondParagraph.childNodes.length);
+    selection?.removeAllRanges();
+    selection?.addRange(crossRange);
+
+    const crossCopy = dispatchCopy(document.body);
+    expect(crossCopy.event.defaultPrevented).toBe(true);
+    expect(crossCopy.payloads.get("text/plain")).toContain("@1736192959");
+    expect(crossCopy.payloads.get("text/plain")).toContain("@nova");
+    expect(crossCopy.payloads.get("text/plain")).not.toContain("@李坤阳");
+    expect(crossCopy.payloads.get("text/html")).toContain("<strong>请</strong>");
+    expect(crossCopy.payloads.get("text/html")).toContain("@1736192959");
+    expect(crossCopy.payloads.get("text/html")).toContain("@nova");
+    expect(crossCopy.payloads.get("text/html")).not.toContain("mention-chip");
+
+    const outsideAfter = document.createElement("p");
+    outsideAfter.textContent = "outside after";
+    document.body.append(outsideAfter);
+    const outsideAfterText = outsideAfter.firstChild;
+    if (!outsideAfterText) throw new Error("Expected outside-after text");
+    const insideToOutside = document.createRange();
+    insideToOutside.setStart(firstParagraph, 0);
+    insideToOutside.setEnd(outsideAfterText, outsideAfterText.textContent?.length ?? 0);
+    selection?.removeAllRanges();
+    selection?.addRange(insideToOutside);
+
+    const insideToOutsideCopy = dispatchCopy(document.body);
+    expect(insideToOutsideCopy.event.defaultPrevented).toBe(true);
+    expect(insideToOutsideCopy.payloads.get("text/plain")).toContain("@1736192959");
+    expect(insideToOutsideCopy.payloads.get("text/plain")).toContain("outside after");
+    expect(insideToOutsideCopy.payloads.get("text/html")).not.toContain("李坤阳");
+
+    const outsideBefore = document.createElement("p");
+    outsideBefore.textContent = "outside before";
+    document.body.insertBefore(outsideBefore, document.body.firstChild);
+    const outsideBeforeText = outsideBefore.firstChild;
+    if (!outsideBeforeText) throw new Error("Expected outside-before text");
+    const outsideToInside = document.createRange();
+    outsideToInside.setStart(outsideBeforeText, 0);
+    outsideToInside.setEnd(secondParagraph, secondParagraph.childNodes.length);
+    selection?.removeAllRanges();
+    selection?.addRange(outsideToInside);
+
+    const outsideToInsideCopy = dispatchCopy(composer);
+    expect(outsideToInsideCopy.event.defaultPrevented).toBe(true);
+    expect(outsideToInsideCopy.payloads.get("text/plain")).toContain("outside before");
+    expect(outsideToInsideCopy.payloads.get("text/plain")).toContain("@1736192959");
+    expect(outsideToInsideCopy.payloads.get("text/plain")).toContain("@nova");
+    expect(outsideToInsideCopy.payloads.get("text/html")).not.toContain("mention-chip");
+
+    selection?.removeAllRanges();
+    outsideBefore.remove();
+    outsideAfter.remove();
     await act(async () => root.unmount());
   });
 

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1713,6 +1713,44 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("disambiguates one persisted recipient against duplicate display names in the full chat roster", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const duplicateLabel = "Sam with an intentionally long shared display name for narrow screens";
+    const alice = participant({ agentId: "agent-alice-sam", name: "alice-sam", displayName: duplicateLabel });
+    const bob = participant({ agentId: "agent-bob-sam", name: "bob-sam", displayName: duplicateLabel });
+    const detail = chatDetail({
+      participants: [
+        participant({ agentId: "human-agent-self", type: "human", name: "gandy", displayName: "Gandy" }),
+        alice,
+        bob,
+        participant({ agentId: "agent-1", name: "nova", displayName: "Nova" }),
+      ],
+    });
+    const page = messages([
+      message({
+        id: "duplicate-display-single-recipient",
+        senderId: "agent-1",
+        content: "请 @alice-sam 处理",
+        metadata: { mentions: [alice.agentId] },
+        source: "api",
+      }),
+    ]);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (client) => seedChat(client, detail, page),
+      "/",
+    );
+
+    await waitForText(container, duplicateLabel);
+    const chip = container.querySelector<HTMLElement>('.mention-chip[data-mention-name="alice-sam"]');
+    expect(chip?.querySelector(".mention-chip-display")?.textContent).toBe(`@${duplicateLabel}`);
+    expect(chip?.querySelector(".mention-chip-handle")?.textContent).toBe("(@alice-sam)");
+    expect(chip?.getAttribute("title")).toBe(`@${duplicateLabel} (@alice-sam)`);
+    expect(container.querySelector('.mention-chip[data-mention-name="bob-sam"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
   it("copies canonical handles when copy targets the composer or body, including cross-message rich text", async () => {
     const { ChatView } = await import("../chat-view.js");
     const numericHuman = participant({

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -38,7 +38,6 @@ import {
 import {
   type CSSProperties,
   memo,
-  type ClipboardEvent as ReactClipboardEvent,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
   type RefObject,
@@ -106,6 +105,7 @@ import {
 import {
   findBlockingRequest,
   findThreadableRequestId,
+  readMentions,
   readRequestPayload,
 } from "../../../components/chat/request-state.js";
 import { WorkingTurn } from "../../../components/chat/working-turn.js";
@@ -119,8 +119,7 @@ import {
 import { MentionHighlightOverlay } from "../../../components/mention-highlight-overlay.js";
 import { NewMessagesPill } from "../../../components/new-messages-pill.js";
 import {
-  copyHtmlWithMentionHandles,
-  copyTextWithMentionHandles,
+  installTimelineMentionCopy,
   type RenderedMentionParticipant,
   rehypeMentions,
 } from "../../../components/rehype-mentions.js";
@@ -607,6 +606,18 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
     return attachmentRefsFromMetadata(msg.metadata).filter((ref) => !body.includes(`attachment:${ref.attachmentId}`));
   }, [msg.metadata, msg.content]);
   const failedDocMentions = useMemo(() => failedDocMentionsFromMetadata(msg.metadata), [msg.metadata]);
+  // Resolve a visible label only when this token's persisted mention ID still
+  // identifies the current owner of the canonical handle. System-level
+  // addressedAgentIds can include recipients unrelated to a particular token
+  // and therefore are not identity evidence. Handles can be released and
+  // reused after an agent is deleted; resolving history from the chat's
+  // current name map alone would then visibly reassign the old mention to a
+  // different person. Legacy rows without structured mentions degrade safely
+  // to their original `@handle` text.
+  const historicalMentionParticipants = useMemo(() => {
+    const targetIds = new Set(readMentions(msg.metadata));
+    return mentionParticipants.filter((participant) => targetIds.has(participant.agentId));
+  }, [mentionParticipants, msg.metadata]);
   // Successful doc captures are already explicit `[display](attachment:<id>)`
   // links the runtime rewrote into the message body — web does NOT re-linkify
   // bare tokens any more. The only scanner-driven rewrite left is wrapping the
@@ -634,8 +645,8 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
   // original rendering. `selfAgentId` flips chips that target the viewer
   // into a higher-priority tone — see `.mention-chip.is-self` in index.css.
   const messageRehypePlugins = useMemo(
-    () => [rehypeMentions(mentionParticipants, { selfAgentId: myAgentId })],
-    [mentionParticipants, myAgentId],
+    () => [rehypeMentions(historicalMentionParticipants, { selfAgentId: myAgentId })],
+    [historicalMentionParticipants, myAgentId],
   );
   const markdownComponents = useMemo<Components>(
     () => ({
@@ -731,20 +742,9 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
     [docAttachmentRefs, failedDocMentions, msg.chatId, msg.id, queryClient, searchParams, setSearchParams],
   );
 
-  const handleCopy = useCallback((event: ReactClipboardEvent<HTMLDivElement>) => {
-    const selection = window.getSelection();
-    const copiedText = copyTextWithMentionHandles(event.currentTarget, selection);
-    if (copiedText === null) return;
-    event.preventDefault();
-    event.clipboardData.setData("text/plain", copiedText);
-    const copiedHtml = copyHtmlWithMentionHandles(event.currentTarget, selection);
-    if (copiedHtml !== null) event.clipboardData.setData("text/html", copiedHtml);
-  }, []);
-
   return (
     <div
       className="text-body"
-      onCopy={handleCopy}
       style={{
         color: "var(--fg)",
         marginTop: 2,
@@ -1753,6 +1753,15 @@ export function ChatView({
   // ResizeObserver-stabilised scrolling) and useReadTracker (as the
   // IntersectionObserver root).
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Non-editable selections dispatch `copy` at the focused node (often body or
+  // the composer), not at the message element that contains the selection.
+  // Listen on the owning document so ordinary and cross-message timeline copy
+  // always reaches the canonical-handle rewrite, then scope strictly back to
+  // this chat's scroll container through the selection Range.
+  useEffect(() => {
+    const ownerDocument = scrollContainerRef.current?.ownerDocument ?? document;
+    return installTimelineMentionCopy(ownerDocument, () => scrollContainerRef.current);
+  }, []);
   // Positioning context for the chat-summary floating card: the expanded
   // summary is portaled into the timeline's `relative` wrapper and laid out
   // `absolute; top:0` over the message area, so it never occupies stream space

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -614,10 +614,7 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
   // current name map alone would then visibly reassign the old mention to a
   // different person. Legacy rows without structured mentions degrade safely
   // to their original `@handle` text.
-  const historicalMentionParticipants = useMemo(() => {
-    const targetIds = new Set(readMentions(msg.metadata));
-    return mentionParticipants.filter((participant) => targetIds.has(participant.agentId));
-  }, [mentionParticipants, msg.metadata]);
+  const historicalMentionAgentIds = useMemo(() => new Set(readMentions(msg.metadata)), [msg.metadata]);
   // Successful doc captures are already explicit `[display](attachment:<id>)`
   // links the runtime rewrote into the message body — web does NOT re-linkify
   // bare tokens any more. The only scanner-driven rewrite left is wrapping the
@@ -645,8 +642,13 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
   // original rendering. `selfAgentId` flips chips that target the viewer
   // into a higher-priority tone — see `.mention-chip.is-self` in index.css.
   const messageRehypePlugins = useMemo(
-    () => [rehypeMentions(historicalMentionParticipants, { selfAgentId: myAgentId })],
-    [historicalMentionParticipants, myAgentId],
+    () => [
+      rehypeMentions(mentionParticipants, {
+        selfAgentId: myAgentId,
+        allowedAgentIds: historicalMentionAgentIds,
+      }),
+    ],
+    [historicalMentionAgentIds, mentionParticipants, myAgentId],
   );
   const markdownComponents = useMemo<Components>(
     () => ({

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -38,6 +38,7 @@ import {
 import {
   type CSSProperties,
   memo,
+  type ClipboardEvent as ReactClipboardEvent,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
   type RefObject,
@@ -117,7 +118,12 @@ import {
 } from "../../../components/mention-autocomplete.js";
 import { MentionHighlightOverlay } from "../../../components/mention-highlight-overlay.js";
 import { NewMessagesPill } from "../../../components/new-messages-pill.js";
-import { rehypeMentions } from "../../../components/rehype-mentions.js";
+import {
+  copyHtmlWithMentionHandles,
+  copyTextWithMentionHandles,
+  type RenderedMentionParticipant,
+  rehypeMentions,
+} from "../../../components/rehype-mentions.js";
 import {
   resolveMentionContext,
   SlashCommandPopover,
@@ -542,7 +548,7 @@ type MessageRowProps = {
   agentNameFn: (id: string) => string;
   agentAvatarFn: (id: string) => string | null;
   agentColorTokenFn: (id: string) => string | null;
-  mentionParticipants: MentionParticipant[];
+  mentionParticipants: RenderedMentionParticipant[];
   /** Trial surface: render sender avatar/name as plain identity, without the
    *  AgentHovercard whose actions ("View profile" → /agents/:id, "New chat" →
    *  /?c=draft) would navigate out of the controlled trial conversation. */
@@ -552,7 +558,7 @@ type MessageRowProps = {
 type MessageBodyProps = {
   msg: MessageWithDelivery;
   myAgentId: string | null;
-  mentionParticipants: MentionParticipant[];
+  mentionParticipants: RenderedMentionParticipant[];
 };
 
 type MessageMarkdownProps = {
@@ -725,9 +731,20 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
     [docAttachmentRefs, failedDocMentions, msg.chatId, msg.id, queryClient, searchParams, setSearchParams],
   );
 
+  const handleCopy = useCallback((event: ReactClipboardEvent<HTMLDivElement>) => {
+    const selection = window.getSelection();
+    const copiedText = copyTextWithMentionHandles(event.currentTarget, selection);
+    if (copiedText === null) return;
+    event.preventDefault();
+    event.clipboardData.setData("text/plain", copiedText);
+    const copiedHtml = copyHtmlWithMentionHandles(event.currentTarget, selection);
+    if (copiedHtml !== null) event.clipboardData.setData("text/html", copiedHtml);
+  }, []);
+
   return (
     <div
       className="text-body"
+      onCopy={handleCopy}
       style={{
         color: "var(--fg)",
         marginTop: 2,
@@ -935,14 +952,19 @@ function messageBodyFieldsEqual(a: MessageWithDelivery, b: MessageWithDelivery):
   );
 }
 
-function mentionParticipantsEqual(a: readonly MentionParticipant[], b: readonly MentionParticipant[]): boolean {
+function mentionParticipantsEqual(
+  a: readonly RenderedMentionParticipant[],
+  b: readonly RenderedMentionParticipant[],
+): boolean {
   if (a === b) return true;
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
     const left = a[i];
     const right = b[i];
     if (!left || !right) return false;
-    if (left.agentId !== right.agentId || left.name !== right.name) return false;
+    if (left.agentId !== right.agentId || left.name !== right.name || left.displayName !== right.displayName) {
+      return false;
+    }
   }
   return true;
 }
@@ -1243,7 +1265,7 @@ type ChatTimelineProps = {
   chatId: string;
   /** Non-human agent participants — drives the inline offline notice. */
   agents: ChatParticipantDetail[];
-  mentionParticipants: MentionParticipant[];
+  mentionParticipants: RenderedMentionParticipant[];
   dockRequestId: string | undefined;
   gapAfterMessageId: string | null;
   firstNewItemIdx: number;
@@ -3323,33 +3345,34 @@ export function ChatView({
    * runs its own unresolved-token guard on the agent path (the PR-393
    * anti-hallucination fix); on the human web path it's tolerated by the
    * `mentions.ts` regex excluding npm scoped names from token scans. */
-  // Shared participant projection: drives draftMentions resolution, the
-  // composer's mirror-overlay highlight, and the sent-message rehype
-  // plugin — keeping a single source of truth so the three paths can't
-  // drift on case-sensitivity or filtering.
+  // Composer-only participant projection: routing stays keyed by immutable
+  // `name`, and the mirror overlay must remain byte-for-byte aligned with the
+  // textarea. Sent-message rendering has a separate display-name projection
+  // below so presentation cannot leak back into routing.
   const mentionParticipants = useMemo<MentionParticipant[]>(
     () => mentionCandidates.map((c) => ({ agentId: c.agentId, name: c.name })),
     [mentionCandidates],
   );
-  // Rendered-message variant of the projection above: the rehype plugin
-  // resolves `@<name>` tokens against this list, and it MUST include the
-  // viewer themselves so chips that target them flip to the
-  // `.mention-chip.is-self` attention tone. `mentionCandidates` deliberately
-  // excludes self (the composer's `@` autocomplete should not suggest you
-  // `@` yourself, and `draftMentions` / `MentionHighlightOverlay` keep
-  // that self-exclusive semantics), so we append the viewer here in a
-  // separate projection used only by rendered messages. Source the viewer's
-  // slug from the speaker-only `chatParticipantById` map — NOT from the
-  // org-identity fallback in `chatScopedAgentIdentity` — so a non-speaker
-  // watcher viewing the chat doesn't get their org-wide name pushed into
-  // the resolver, which would paint chips that the server would never
-  // actually route to them.
-  const renderMentionParticipants = useMemo<MentionParticipant[]>(() => {
-    if (!myAgentId) return mentionParticipants;
-    const selfParticipant = chatParticipantById.get(myAgentId);
-    if (!selfParticipant?.name) return mentionParticipants;
-    return [...mentionParticipants, { agentId: myAgentId, name: selfParticipant.name }];
-  }, [mentionParticipants, myAgentId, chatParticipantById]);
+  // Rendered-message projection: all chat speakers (including self) carry
+  // `displayName` for the visible chip while the immutable `name` remains the
+  // resolver key and copy target. Reading directly from chat detail preserves
+  // the membership disclosure boundary for private agents and excludes
+  // non-speaker watchers.
+  const renderMentionParticipants = useMemo<RenderedMentionParticipant[]>(
+    () =>
+      (chatDetail?.participants ?? []).flatMap((participant) =>
+        participant.name
+          ? [
+              {
+                agentId: participant.agentId,
+                name: participant.name,
+                displayName: participant.displayName,
+              },
+            ]
+          : [],
+      ),
+    [chatDetail?.participants],
+  );
   const draftMentions = useMemo(() => extractMentions(draft, mentionParticipants), [draft, mentionParticipants]);
 
   /**


### PR DESCRIPTION
## Summary

- render sent-message mentions with each chat participant's `displayName` while keeping immutable `name` as the resolver key
- visibly disambiguate duplicate display names and fall back to the canonical handle when a display name is blank or no longer resolvable
- preserve canonical handles in both plain-text and rich-text copy without changing composer parsing, stored content, mention metadata, or server routing
- constrain long mention chips on narrow screens and refresh rendered labels after a display-name update

## Validation

- `pnpm --filter @first-tree/web test` — 192 files, 1,574 tests passed
- `pnpm --filter @first-tree/web typecheck`
- `pnpm check`
- focused mention + ChatView DOM tests — 60 tests passed
- Playwright visual QA at 1280×800 and 360×740; no horizontal overflow, long display names ellipsize
- two independent code reviews completed; all correctness and copy regressions found during review were addressed

## Test note

An initial concurrent monorepo `pnpm test` attempt exhausted timing budgets in unrelated `skill-evals` fixtures. The affected Web package was then run independently and passed in full as reported above.
