### PR TITLE
fix(server): make webhook claims recoverable

### DIFF
--- a/docs/migration/processed-event-claim-lifecycle.md
+++ b/docs/migration/processed-event-claim-lifecycle.md
@@ -1,0 +1,63 @@
+# Processed-event claim lifecycle migration
+
+Migration `0082_processed_event_claim_lifecycle` adds an expiring `pending` claim and a terminal `done` state to `processed_events`. Existing rows become `done` and retain their current deduplication behavior. The migration is additive, and the existing `(event_id, platform)` uniqueness contract does not change.
+
+## Normal rollout and startup risk
+
+Apply the migration before starting code that writes `pending` claims. The migration runs through Drizzle's transactional migrator. PostgreSQL validates the lifecycle constraint against existing rows, and its partial `(expires_at, id)` index contains only `pending` rows but still scans the existing table while building. Historical `done` retention is currently unbounded, so production tables may be large: the migration can lengthen startup or wait for a conflicting table lock because `CREATE INDEX CONCURRENTLY` cannot run inside its transaction. The optional pre-stage below moves the index build out of startup, but constraint installation still needs its normal migration lock. This migration neither changes nor prunes completed history.
+
+During a forward mixed-version rollout, old webhook workers keep the previous claim-before-work behavior: if one of those workers crashes, its claim can still leak permanently because it cannot write or take over `pending` leases. Drain old workers promptly after the new schema is available; the new recovery contract applies only to deliveries acquired by new workers.
+
+For a large production table, an operator may pre-create the additive columns and index before any instance attempts migration 0082:
+
+```sql
+ALTER TABLE "processed_events" ADD COLUMN IF NOT EXISTS "status" text DEFAULT 'done' NOT NULL;
+ALTER TABLE "processed_events" ADD COLUMN IF NOT EXISTS "expires_at" timestamp with time zone;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_processed_events_pending_expiry"
+  ON "processed_events" USING btree ("expires_at", "id")
+  WHERE "status" = 'pending';
+```
+
+Run the concurrent index statement outside a transaction and let it finish before normal migration starts. Do not manually add the lifecycle constraint or modify Drizzle's ledger during this pre-stage. Migration 0082 uses `IF NOT EXISTS` for the columns and index, then installs the constraint and records its own ledger entry. If a concurrent build is interrupted, verify `pg_index.indisvalid`; drop an invalid index before retrying because `IF NOT EXISTS` will not repair it.
+
+## Recovery boundary
+
+A live lease admits one processing winner for its acquisition generation. If an owner runs beyond expiry, a later redelivery may take over while the stale owner has already emitted side effects; the expiry fence prevents stale completion but cannot retract those effects. The contract is therefore not unconditional exactly-once processing after expiry.
+
+GitHub does not automatically redeliver failed webhook deliveries. Expiry makes a later manual or operator-automated redelivery eligible for takeover; the background sweep only removes expired `pending` rows and never stores or replays payloads.
+
+## Ordinary application rollback
+
+An application rollback should leave the additive columns, constraint, index, and migration ledger entry in place. Older code can keep inserting `(event_id, platform)` because omitted lifecycle values default to `done`.
+
+Before old webhook code accepts traffic, stop ingress to **every** new-version webhook handler and wait for all active handlers to drain. Confirm that no process can acquire or complete another `pending` claim, then run the cleanup below. This ordering is mandatory: an old handler interprets any surviving row as a permanent duplicate, and deleting claims while a new handler is still running can admit duplicate business processing. Capture the returned delivery identifiers so orphaned deliveries can be reconciled or redelivered.
+
+<!-- processed-events-rollback-cleanup:start -->
+```sql
+DELETE FROM "processed_events"
+WHERE "status" = 'pending'
+RETURNING "event_id", "platform", "created_at", "expires_at";
+```
+<!-- processed-events-rollback-cleanup:end -->
+
+Deploy the old application only after cleanup completes. Do not drop the lifecycle columns for an ordinary rollback.
+
+## Full schema reversal
+
+Full reversal is exceptional. Quiesce every new-version handler and perform the same pending cleanup first. Reverse 0082 only when it is the newest applied Drizzle migration: the latest `created_at` in `drizzle.__drizzle_migrations` must be `1784645330777`. If a later migration is present, leave 0082 in place or reverse later migrations in their documented order; deleting an older ledger row alone does not make Drizzle reapply it because the migrator compares only the latest timestamp.
+
+Run the following exact block as one operation. It removes only the lifecycle additions and the corresponding ledger row; existing `done` delivery rows and their uniqueness constraint remain intact.
+
+<!-- processed-events-full-reverse:start -->
+```sql
+BEGIN;--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_processed_events_pending_expiry";--> statement-breakpoint
+ALTER TABLE "processed_events" DROP CONSTRAINT IF EXISTS "ck_processed_events_lifecycle";--> statement-breakpoint
+ALTER TABLE "processed_events" DROP COLUMN IF EXISTS "expires_at";--> statement-breakpoint
+ALTER TABLE "processed_events" DROP COLUMN IF EXISTS "status";--> statement-breakpoint
+DELETE FROM "drizzle"."__drizzle_migrations" WHERE "created_at" = 1784645330777;--> statement-breakpoint
+COMMIT;
+```
+<!-- processed-events-full-reverse:end -->
+
+Verify that exactly the 0082 ledger row was deleted. A later forward rollout can then run migration 0082 again and recreate the lifecycle schema. Never delete the ledger row while leaving the lifecycle schema reversed only partially.

--- a/packages/server/drizzle/0082_processed_event_claim_lifecycle.sql
+++ b/packages/server/drizzle/0082_processed_event_claim_lifecycle.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "processed_events" ADD COLUMN IF NOT EXISTS "status" text DEFAULT 'done' NOT NULL;--> statement-breakpoint
+ALTER TABLE "processed_events" ADD COLUMN IF NOT EXISTS "expires_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "processed_events" ADD CONSTRAINT "ck_processed_events_lifecycle" CHECK (("status" = 'pending' AND "expires_at" IS NOT NULL) OR ("status" = 'done' AND "expires_at" IS NULL));--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_processed_events_pending_expiry" ON "processed_events" USING btree ("expires_at","id") WHERE "status" = 'pending';

--- a/packages/server/drizzle/LATEST
+++ b/packages/server/drizzle/LATEST
@@ -1,1 +1,1 @@
-0081_dizzy_tyrannus
+0082_processed_event_claim_lifecycle

--- a/packages/server/drizzle/meta/0082_snapshot.json
+++ b/packages/server/drizzle/meta/0082_snapshot.json
@@ -1,0 +1,5582 @@
+{
+  "id": "f1410283-8a09-464a-b55e-c886fbdd152c",
+  "prevId": "ed77360a-1de2-4ce5-9f63-dd2d28edbdaf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_chat_sessions": {
+      "name": "agent_chat_sessions",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "runtime_state_at": {
+          "name": "runtime_state_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_chat_sessions_chat_agent": {
+          "name": "idx_agent_chat_sessions_chat_agent",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_chat_sessions_agent_id_agents_uuid_fk": {
+          "name": "agent_chat_sessions_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_chat_sessions",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_chat_sessions_chat_id_chats_id_fk": {
+          "name": "agent_chat_sessions_chat_id_chats_id_fk",
+          "tableFrom": "agent_chat_sessions",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_chat_sessions_agent_id_chat_id_pk": {
+          "name": "agent_chat_sessions_agent_id_chat_id_pk",
+          "columns": [
+            "agent_id",
+            "chat_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_configs": {
+      "name": "agent_configs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_type": {
+          "name": "runtime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sessions": {
+          "name": "total_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_updated_at": {
+          "name": "runtime_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_presence_agent_id_agents_uuid_fk": {
+          "name": "agent_presence_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_presence",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_presence_client_id_clients_id_fk": {
+          "name": "agent_presence_client_id_clients_id_fk",
+          "tableFrom": "agent_presence",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "tableTo": "clients",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_resource_bindings": {
+      "name": "agent_resource_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaces_resource_id": {
+          "name": "replaces_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_prompt_body": {
+          "name": "inline_prompt_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_ref": {
+          "name": "repo_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_local_path": {
+          "name": "repo_local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_resource_bindings_agent": {
+          "name": "idx_agent_resource_bindings_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agent_resource_bindings_resource": {
+          "name": "idx_agent_resource_bindings_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agent_resource_bindings_replaces": {
+          "name": "idx_agent_resource_bindings_replaces",
+          "columns": [
+            {
+              "expression": "replaces_resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_resource_bindings_organization_id_organizations_id_fk": {
+          "name": "agent_resource_bindings_organization_id_organizations_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_resource_bindings_agent_id_agents_uuid_fk": {
+          "name": "agent_resource_bindings_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_resource_bindings",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_resource_bindings_resource_id_resources_id_fk": {
+          "name": "agent_resource_bindings_resource_id_resources_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "tableTo": "resources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_resource_bindings_replaces_resource_id_resources_id_fk": {
+          "name": "agent_resource_bindings_replaces_resource_id_resources_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "columnsFrom": [
+            "replaces_resource_id"
+          ],
+          "tableTo": "resources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_mention": {
+          "name": "delegate_mention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "avatar_color_token": {
+          "name": "avatar_color_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_data": {
+          "name": "avatar_image_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_mime": {
+          "name": "avatar_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_updated_at": {
+          "name": "avatar_image_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_org": {
+          "name": "idx_agents_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agents_manager": {
+          "name": "idx_agents_manager",
+          "columns": [
+            {
+              "expression": "manager_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agents_visibility_org": {
+          "name": "idx_agents_visibility_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agents_client": {
+          "name": "idx_agents_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organizations_id_fk": {
+          "name": "agents_organization_id_organizations_id_fk",
+          "tableFrom": "agents",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "agents_client_id_clients_id_fk": {
+          "name": "agents_client_id_clients_id_fk",
+          "tableFrom": "agents",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "tableTo": "clients",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_inbox_id_unique": {
+          "name": "agents_inbox_id_unique",
+          "columns": [
+            "inbox_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "uq_agents_org_name": {
+          "name": "uq_agents_org_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachments_uploaded_by_idx": {
+          "name": "attachments_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "attachments_created_at_idx": {
+          "name": "attachments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attentions": {
+      "name": "attentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "origin_agent_id": {
+          "name": "origin_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_chat_id": {
+          "name": "origin_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_human_id": {
+          "name": "target_human_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "requires_response": {
+          "name": "requires_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by": {
+          "name": "responded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_reason": {
+          "name": "cancelled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_attentions_target_open": {
+          "name": "idx_attentions_target_open",
+          "columns": [
+            {
+              "expression": "target_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_attentions_chat_open": {
+          "name": "idx_attentions_chat_open",
+          "columns": [
+            {
+              "expression": "origin_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_attentions_origin": {
+          "name": "idx_attentions_origin",
+          "columns": [
+            {
+              "expression": "origin_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_identities": {
+      "name": "auth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_payload": {
+          "name": "credential_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_identities_user": {
+          "name": "idx_auth_identities_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_auth_identities_email": {
+          "name": "idx_auth_identities_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_identities_user_id_users_id_fk": {
+          "name": "auth_identities_user_id_users_id_fk",
+          "tableFrom": "auth_identities",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_auth_identities_provider_identifier": {
+          "name": "uq_auth_identities_provider_identifier",
+          "columns": [
+            "provider",
+            "identifier"
+          ],
+          "nullsNotDistinct": false
+        },
+        "uq_auth_identities_user_provider": {
+          "name": "uq_auth_identities_user_provider",
+          "columns": [
+            "user_id",
+            "provider"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_membership": {
+      "name": "chat_membership",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_membership_agent": {
+          "name": "idx_membership_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_membership_chat_role": {
+          "name": "idx_membership_chat_role",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "access_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_membership_chat_id_agent_id_pk": {
+          "name": "chat_membership_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_user_state": {
+      "name": "chat_user_state",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_mention_count": {
+          "name": "unread_mention_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "open_request_count": {
+          "name": "open_request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_status": {
+          "name": "engagement_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_state_agent": {
+          "name": "idx_user_state_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_user_state_unread": {
+          "name": "idx_user_state_unread",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "unread_mention_count > 0",
+          "concurrently": false
+        },
+        "idx_user_state_open_req": {
+          "name": "idx_user_state_open_req",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "open_request_count > 0",
+          "concurrently": false
+        },
+        "idx_user_state_pinned": {
+          "name": "idx_user_state_pinned",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "pinned_at IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_user_state_chat_id_agent_id_pk": {
+          "name": "chat_user_state_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_updated_at": {
+          "name": "description_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_policy": {
+          "name": "lifecycle_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'persistent'"
+        },
+        "parent_chat_id": {
+          "name": "parent_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_kickoff_key": {
+          "name": "onboarding_kickoff_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chats_org_last_message": {
+          "name": "idx_chats_org_last_message",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"last_message_at\" desc",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_chats_org_activity": {
+          "name": "idx_chats_org_activity",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"activity_at\" desc",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_chats_onboarding_kickoff_key": {
+          "name": "uq_chats_onboarding_kickoff_key",
+          "columns": [
+            {
+              "expression": "onboarding_kickoff_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "chats_organization_id_organizations_id_fk": {
+          "name": "chats_organization_id_organizations_id_fk",
+          "tableFrom": "chats",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disconnected'"
+        },
+        "sdk_version": {
+          "name": "sdk_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_user": {
+          "name": "idx_clients_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_clients_org": {
+          "name": "idx_clients_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "clients_user_id_users_id_fk": {
+          "name": "clients_user_id_users_id_fk",
+          "tableFrom": "clients",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "clients_organization_id_organizations_id_fk": {
+          "name": "clients_organization_id_organizations_id_fk",
+          "tableFrom": "clients",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connect_codes": {
+      "name": "connect_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connect_codes_user": {
+          "name": "idx_connect_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_connect_codes_expires_at": {
+          "name": "idx_connect_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "connect_codes_user_id_users_id_fk": {
+          "name": "connect_codes_user_id_users_id_fk",
+          "tableFrom": "connect_codes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connect_codes_code_hash_unique": {
+          "name": "connect_codes_code_hash_unique",
+          "columns": [
+            "code_hash"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context_tree_io_events": {
+      "name": "context_tree_io_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_session_event_id": {
+          "name": "source_session_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_index": {
+          "name": "source_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_repo_url": {
+          "name": "tree_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_branch": {
+          "name": "tree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_context_tree_io_source": {
+          "name": "uq_context_tree_io_source",
+          "columns": [
+            {
+              "expression": "source_session_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_context_tree_io_org_recent": {
+          "name": "idx_context_tree_io_org_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_context_tree_io_org_action_recent": {
+          "name": "idx_context_tree_io_org_action_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_context_tree_io_org_agent_recent": {
+          "name": "idx_context_tree_io_org_agent_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_context_tree_io_org_target_recent": {
+          "name": "idx_context_tree_io_org_target_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "context_tree_io_events_organization_id_organizations_id_fk": {
+          "name": "context_tree_io_events_organization_id_organizations_id_fk",
+          "tableFrom": "context_tree_io_events",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "context_tree_io_events_agent_id_agents_uuid_fk": {
+          "name": "context_tree_io_events_agent_id_agents_uuid_fk",
+          "tableFrom": "context_tree_io_events",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "context_tree_io_events_chat_id_chats_id_fk": {
+          "name": "context_tree_io_events_chat_id_chats_id_fk",
+          "tableFrom": "context_tree_io_events",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_context_tree_io_action": {
+          "name": "ck_context_tree_io_action",
+          "value": "\"context_tree_io_events\".\"action\" IN ('read', 'write')"
+        },
+        "ck_context_tree_io_target_kind": {
+          "name": "ck_context_tree_io_target_kind",
+          "value": "\"context_tree_io_events\".\"target_kind\" IN ('file', 'directory', 'repo')"
+        },
+        "ck_context_tree_io_target_path_nonempty": {
+          "name": "ck_context_tree_io_target_path_nonempty",
+          "value": "\"context_tree_io_events\".\"target_path\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.doc_comments": {
+      "name": "doc_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_comments_document_status_idx": {
+          "name": "doc_comments_document_status_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "doc_comments_parent_idx": {
+          "name": "doc_comments_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "doc_comments_document_id_doc_documents_id_fk": {
+          "name": "doc_comments_document_id_doc_documents_id_fk",
+          "tableFrom": "doc_comments",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "tableTo": "doc_documents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "doc_comments_parent_id_doc_comments_id_fk": {
+          "name": "doc_comments_parent_id_doc_comments_id_fk",
+          "tableFrom": "doc_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "tableTo": "doc_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_documents": {
+      "name": "doc_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_kind": {
+          "name": "created_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_name": {
+          "name": "created_by_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_documents_org_slug_unique": {
+          "name": "doc_documents_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "doc_documents_org_updated_idx": {
+          "name": "doc_documents_org_updated_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "doc_documents_organization_id_organizations_id_fk": {
+          "name": "doc_documents_organization_id_organizations_id_fk",
+          "tableFrom": "doc_documents",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_versions": {
+      "name": "doc_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_versions_document_number_unique": {
+          "name": "doc_versions_document_number_unique",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "doc_versions_document_id_doc_documents_id_fk": {
+          "name": "doc_versions_document_id_doc_documents_id_fk",
+          "tableFrom": "doc_versions",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "tableTo": "doc_documents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_app_installations": {
+      "name": "github_app_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_github_id": {
+          "name": "account_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installer_github_id": {
+          "name": "installer_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester_github_id": {
+          "name": "requester_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_organization_id": {
+          "name": "hub_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_github_app_installations_installation_id": {
+          "name": "uq_github_app_installations_installation_id",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_github_app_installations_hub_org": {
+          "name": "uq_github_app_installations_hub_org",
+          "columns": [
+            {
+              "expression": "hub_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_github_app_installations_account": {
+          "name": "idx_github_app_installations_account",
+          "columns": [
+            {
+              "expression": "account_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_github_app_installations_installer": {
+          "name": "idx_github_app_installations_installer",
+          "columns": [
+            {
+              "expression": "installer_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_github_app_installations_requester": {
+          "name": "idx_github_app_installations_requester",
+          "columns": [
+            {
+              "expression": "requester_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_hub_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_hub_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "columnsFrom": [
+            "hub_organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_github_app_installations_account_type": {
+          "name": "ck_github_app_installations_account_type",
+          "value": "\"github_app_installations\".\"account_type\" IN ('User', 'Organization')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_entity_chat_mappings": {
+      "name": "github_entity_chat_mappings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "human_agent_id": {
+          "name": "human_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_agent_id": {
+          "name": "delegate_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_key": {
+          "name": "entity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_at": {
+          "name": "bound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "bound_via": {
+          "name": "bound_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_state": {
+          "name": "entity_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "entity_state_updated_at": {
+          "name": "entity_state_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_github_entity_chat_mappings_chat": {
+          "name": "idx_github_entity_chat_mappings_chat",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_github_entity_chat_mappings_chat_state": {
+          "name": "idx_github_entity_chat_mappings_chat_state",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "github_entity_chat_mappings_organization_id_organizations_id_fk": {
+          "name": "github_entity_chat_mappings_organization_id_organizations_id_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "github_entity_chat_mappings_human_agent_id_agents_uuid_fk": {
+          "name": "github_entity_chat_mappings_human_agent_id_agents_uuid_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "columnsFrom": [
+            "human_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "github_entity_chat_mappings_delegate_agent_id_agents_uuid_fk": {
+          "name": "github_entity_chat_mappings_delegate_agent_id_agents_uuid_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "columnsFrom": [
+            "delegate_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "github_entity_chat_mappings_chat_id_chats_id_fk": {
+          "name": "github_entity_chat_mappings_chat_id_chats_id_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_entity_chat_mappings_organization_id_human_agent_id_delegate_agent_id_entity_type_entity_key_pk": {
+          "name": "github_entity_chat_mappings_organization_id_human_agent_id_delegate_agent_id_entity_type_entity_key_pk",
+          "columns": [
+            "organization_id",
+            "human_agent_id",
+            "delegate_agent_id",
+            "entity_type",
+            "entity_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gitlab_connections": {
+      "name": "gitlab_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_origin": {
+          "name": "instance_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_first_seen_at": {
+          "name": "endpoint_first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_valid_inbound_at": {
+          "name": "last_valid_inbound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processing_failure_at": {
+          "name": "last_processing_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processing_failure_code": {
+          "name": "last_processing_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stable_delivery_observed_at": {
+          "name": "stable_delivery_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_version": {
+          "name": "last_observed_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_mode": {
+          "name": "reviewer_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_reviewer_schema_anomaly_at": {
+          "name": "last_reviewer_schema_anomaly_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reviewer_schema_anomaly_code": {
+          "name": "last_reviewer_schema_anomaly_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_member_id": {
+          "name": "created_by_member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_member_id": {
+          "name": "updated_by_member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_gitlab_connections_org": {
+          "name": "uq_gitlab_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_gitlab_connections_token_hash": {
+          "name": "uq_gitlab_connections_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "gitlab_connections_organization_id_organizations_id_fk": {
+          "name": "gitlab_connections_organization_id_organizations_id_fk",
+          "tableFrom": "gitlab_connections",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_connections_created_by_member_id_members_id_fk": {
+          "name": "gitlab_connections_created_by_member_id_members_id_fk",
+          "tableFrom": "gitlab_connections",
+          "columnsFrom": [
+            "created_by_member_id"
+          ],
+          "tableTo": "members",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gitlab_connections_updated_by_member_id_members_id_fk": {
+          "name": "gitlab_connections_updated_by_member_id_members_id_fk",
+          "tableFrom": "gitlab_connections",
+          "columnsFrom": [
+            "updated_by_member_id"
+          ],
+          "tableTo": "members",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_gitlab_connections_reviewer_mode": {
+          "name": "ck_gitlab_connections_reviewer_mode",
+          "value": "\"gitlab_connections\".\"reviewer_mode\" IN ('unknown', 'assignee', 'reviewers')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gitlab_entity_chat_mappings": {
+      "name": "gitlab_entity_chat_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declared_by_agent_id": {
+          "name": "declared_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_via": {
+          "name": "bound_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'agent_declared'"
+        },
+        "identity_link_id": {
+          "name": "identity_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "human_agent_id": {
+          "name": "human_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_agent_id": {
+          "name": "delegate_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attention_mode": {
+          "name": "attention_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy_route_only'"
+        },
+        "attention_backfill_version": {
+          "name": "attention_backfill_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_iid": {
+          "name": "entity_iid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_path_normalized": {
+          "name": "project_path_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_url": {
+          "name": "entity_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_state": {
+          "name": "entity_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_gitlab_entity_pending_pair": {
+          "name": "uq_gitlab_entity_pending_pair",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "human_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delegate_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_path_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "uq_gitlab_entity_observed_pair": {
+          "name": "uq_gitlab_entity_observed_pair",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "human_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delegate_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "uq_gitlab_entity_pending_legacy_chat": {
+          "name": "uq_gitlab_entity_pending_legacy_chat",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_path_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NULL",
+          "concurrently": false
+        },
+        "uq_gitlab_entity_observed_legacy_chat": {
+          "name": "uq_gitlab_entity_observed_legacy_chat",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NULL",
+          "concurrently": false
+        },
+        "uq_gitlab_entity_identity_target": {
+          "name": "uq_gitlab_entity_identity_target",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identity_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" = 'identity_target'",
+          "concurrently": false
+        },
+        "idx_gitlab_entity_observed_lookup": {
+          "name": "idx_gitlab_entity_observed_lookup",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_gitlab_entity_pending_lookup": {
+          "name": "idx_gitlab_entity_pending_lookup",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_path_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NULL",
+          "concurrently": false
+        },
+        "idx_gitlab_entity_chat": {
+          "name": "idx_gitlab_entity_chat",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "gitlab_entity_chat_mappings_organization_id_organizations_id_fk": {
+          "name": "gitlab_entity_chat_mappings_organization_id_organizations_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_connection_id_gitlab_connections_id_fk": {
+          "name": "gitlab_entity_chat_mappings_connection_id_gitlab_connections_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "tableTo": "gitlab_connections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_chat_id_chats_id_fk": {
+          "name": "gitlab_entity_chat_mappings_chat_id_chats_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_declared_by_agent_id_agents_uuid_fk": {
+          "name": "gitlab_entity_chat_mappings_declared_by_agent_id_agents_uuid_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "declared_by_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_identity_link_id_gitlab_identity_links_id_fk": {
+          "name": "gitlab_entity_chat_mappings_identity_link_id_gitlab_identity_links_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "identity_link_id"
+          ],
+          "tableTo": "gitlab_identity_links",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_human_agent_id_agents_uuid_fk": {
+          "name": "gitlab_entity_chat_mappings_human_agent_id_agents_uuid_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "human_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_delegate_agent_id_agents_uuid_fk": {
+          "name": "gitlab_entity_chat_mappings_delegate_agent_id_agents_uuid_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "delegate_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_gitlab_entity_type": {
+          "name": "ck_gitlab_entity_type",
+          "value": "\"gitlab_entity_chat_mappings\".\"entity_type\" IN ('issue', 'pull_request')"
+        },
+        "ck_gitlab_entity_bound_via": {
+          "name": "ck_gitlab_entity_bound_via",
+          "value": "\"gitlab_entity_chat_mappings\".\"bound_via\" IN ('agent_declared', 'human_declared', 'identity_target')"
+        },
+        "ck_gitlab_entity_identity_owner": {
+          "name": "ck_gitlab_entity_identity_owner",
+          "value": "\"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' OR (\"gitlab_entity_chat_mappings\".\"identity_link_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL)"
+        },
+        "ck_gitlab_entity_attention_pair": {
+          "name": "ck_gitlab_entity_attention_pair",
+          "value": "(\"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NULL) OR (\"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL)"
+        },
+        "ck_gitlab_entity_attention_mode": {
+          "name": "ck_gitlab_entity_attention_mode",
+          "value": "\"gitlab_entity_chat_mappings\".\"attention_mode\" IN ('paired', 'legacy_route_only')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gitlab_identity_links": {
+      "name": "gitlab_identity_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_id": {
+          "name": "membership_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_username": {
+          "name": "normalized_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_gitlab_identity_connection_membership": {
+          "name": "uq_gitlab_identity_connection_membership",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_gitlab_identity_connection_username": {
+          "name": "uq_gitlab_identity_connection_username",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_gitlab_identity_org_state": {
+          "name": "idx_gitlab_identity_org_state",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_gitlab_identity_membership_state": {
+          "name": "idx_gitlab_identity_membership_state",
+          "columns": [
+            {
+              "expression": "membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "gitlab_identity_links_organization_id_organizations_id_fk": {
+          "name": "gitlab_identity_links_organization_id_organizations_id_fk",
+          "tableFrom": "gitlab_identity_links",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_identity_links_membership_id_members_id_fk": {
+          "name": "gitlab_identity_links_membership_id_members_id_fk",
+          "tableFrom": "gitlab_identity_links",
+          "columnsFrom": [
+            "membership_id"
+          ],
+          "tableTo": "members",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "gitlab_identity_links_connection_id_gitlab_connections_id_fk": {
+          "name": "gitlab_identity_links_connection_id_gitlab_connections_id_fk",
+          "tableFrom": "gitlab_identity_links",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "tableTo": "gitlab_connections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_gitlab_identity_state": {
+          "name": "ck_gitlab_identity_state",
+          "value": "\"gitlab_identity_links\".\"state\" IN ('active', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inbox_entries": {
+      "name": "inbox_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notify": {
+          "name": "notify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbox_pending": {
+          "name": "idx_inbox_pending",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_inbox_pending_notify": {
+          "name": "idx_inbox_pending_notify",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "status = 'pending' AND notify = true",
+          "concurrently": false
+        },
+        "idx_inbox_chat_silent": {
+          "name": "idx_inbox_chat_silent",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notify",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_inbox_entries_message_status": {
+          "name": "idx_inbox_entries_message_status",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "inbox_entries_message_id_messages_id_fk": {
+          "name": "inbox_entries_message_id_messages_id_fk",
+          "tableFrom": "inbox_entries",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "tableTo": "messages",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_inbox_delivery": {
+          "name": "uq_inbox_delivery",
+          "columns": [
+            "inbox_id",
+            "message_id",
+            "chat_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_inbox_entries_status": {
+          "name": "ck_inbox_entries_status",
+          "value": "\"inbox_entries\".\"status\" IN ('pending', 'delivered', 'acked')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation_redemptions": {
+      "name": "invitation_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invitation_redemptions_invitation": {
+          "name": "idx_invitation_redemptions_invitation",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_invitation_redemptions_user": {
+          "name": "idx_invitation_redemptions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_redemptions_invitation_id_invitations_id_fk": {
+          "name": "invitation_redemptions_invitation_id_invitations_id_fk",
+          "tableFrom": "invitation_redemptions",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "tableTo": "invitations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "invitation_redemptions_user_id_users_id_fk": {
+          "name": "invitation_redemptions_user_id_users_id_fk",
+          "tableFrom": "invitation_redemptions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitations_token": {
+          "name": "idx_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_invitations_org": {
+          "name": "idx_invitations_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "invitations_created_by_users_id_fk": {
+          "name": "invitations_created_by_users_id_fk",
+          "tableFrom": "invitations",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_suppressed_at": {
+          "name": "onboarding_suppressed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_suppressed_reason": {
+          "name": "onboarding_suppressed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_members_user": {
+          "name": "idx_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_members_org": {
+          "name": "idx_members_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "members_agent_id_agents_uuid_fk": {
+          "name": "members_agent_id_agents_uuid_fk",
+          "tableFrom": "members",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_agent_id_unique": {
+          "name": "members_agent_id_unique",
+          "columns": [
+            "agent_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "uq_members_user_org": {
+          "name": "uq_members_user_org",
+          "columns": [
+            "user_id",
+            "organization_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_members_completed_implies_suppressed": {
+          "name": "ck_members_completed_implies_suppressed",
+          "value": "\"members\".\"onboarding_completed_at\" IS NULL OR \"members\".\"onboarding_suppressed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reply_to_inbox": {
+          "name": "reply_to_inbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_chat": {
+          "name": "reply_to_chat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_messages_chat_time": {
+          "name": "idx_messages_chat_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_messages_in_reply_to": {
+          "name": "idx_messages_in_reply_to",
+          "columns": [
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_messages_chat_source_time": {
+          "name": "idx_messages_chat_source_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_messages_mentions": {
+          "name": "idx_messages_mentions",
+          "columns": [
+            {
+              "expression": "((\"metadata\" -> 'mentions')) jsonb_path_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_org_created": {
+          "name": "idx_notifications_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_notifications_org_read": {
+          "name": "idx_notifications_org_read",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_notifications_org_dedup_unread": {
+          "name": "uq_notifications_org_dedup_unread",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "read = false AND dedup_key IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_settings_namespace": {
+          "name": "idx_org_settings_namespace",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_settings_organization_id_organizations_id_fk": {
+          "name": "organization_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "organization_settings_updated_by_users_id_fk": {
+          "name": "organization_settings_updated_by_users_id_fk",
+          "tableFrom": "organization_settings",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_settings_organization_id_namespace_pk": {
+          "name": "organization_settings_organization_id_namespace_pk",
+          "columns": [
+            "organization_id",
+            "namespace"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_agents": {
+          "name": "max_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_messages_per_minute": {
+          "name": "max_messages_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_name_unique": {
+          "name": "organizations_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_questions": {
+      "name": "pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_questions_agent_status": {
+          "name": "idx_pending_questions_agent_status",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_pending_questions_chat_status": {
+          "name": "idx_pending_questions_chat_status",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_agent_id": {
+          "name": "owner_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_canonical_key": {
+          "name": "repo_canonical_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_enabled": {
+          "name": "default_enabled",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resources_org_type_scope": {
+          "name": "idx_resources_org_type_scope",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_resources_owner_agent": {
+          "name": "idx_resources_owner_agent",
+          "columns": [
+            {
+              "expression": "owner_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_resources_repo_key": {
+          "name": "idx_resources_repo_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_resources_team_repo_canonical_active": {
+          "name": "uq_resources_team_repo_canonical_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"resources\".\"type\" = 'repo' AND \"resources\".\"scope\" = 'team' AND \"resources\".\"status\" IN ('active', 'stale') AND \"resources\".\"repo_canonical_key\" IS NOT NULL",
+          "concurrently": false
+        },
+        "uq_resources_agent_repo_canonical_active": {
+          "name": "uq_resources_agent_repo_canonical_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"resources\".\"type\" = 'repo' AND \"resources\".\"scope\" = 'agent' AND \"resources\".\"status\" IN ('active', 'stale') AND \"resources\".\"repo_canonical_key\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "resources_organization_id_organizations_id_fk": {
+          "name": "resources_organization_id_organizations_id_fk",
+          "tableFrom": "resources",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "resources_owner_agent_id_agents_uuid_fk": {
+          "name": "resources_owner_agent_id_agents_uuid_fk",
+          "tableFrom": "resources",
+          "columnsFrom": [
+            "owner_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_instances": {
+      "name": "server_instances",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_events": {
+      "name": "session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_session_events_chat_seq": {
+          "name": "uq_session_events_chat_seq",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_session_events_chat_created": {
+          "name": "idx_session_events_chat_created",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_session_events_context_tree_usage_recent": {
+          "name": "idx_session_events_context_tree_usage_recent",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"session_events\".\"kind\" = 'context_tree_usage'",
+          "concurrently": false
+        },
+        "idx_session_events_context_tree_io_agent_recent": {
+          "name": "idx_session_events_context_tree_io_agent_recent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"session_events\".\"kind\" IN ('context_tree_usage', 'tool_call')",
+          "concurrently": false
+        },
+        "idx_session_events_token_usage_agent_recent": {
+          "name": "idx_session_events_token_usage_agent_recent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"session_events\".\"kind\" = 'token_usage'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1784284070652,
       "tag": "0081_dizzy_tyrannus",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1784645330777,
+      "tag": "0082_processed_event_claim_lifecycle",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/background-tasks-extra.test.ts
+++ b/packages/server/src/__tests__/background-tasks-extra.test.ts
@@ -15,12 +15,14 @@ const serviceMocks = {
   notifyAgentEvent: vi.fn(),
   pruneStaleSilentEntries: vi.fn(),
   sweepChatArchive: vi.fn(),
+  sweepExpiredEventClaims: vi.fn(),
 };
 
 const mockedModules = [
   "../observability/index.js",
   "../services/chat-archive.js",
   "../services/client.js",
+  "../services/event-dedup.js",
   "../services/inbox.js",
   "../services/notification.js",
   "../services/presence.js",
@@ -35,6 +37,9 @@ function mockBackgroundTaskDependencies(): void {
   }));
   vi.doMock("../services/client.js", () => ({
     cleanupStaleClients: serviceMocks.cleanupStaleClients,
+  }));
+  vi.doMock("../services/event-dedup.js", () => ({
+    sweepExpiredEventClaims: serviceMocks.sweepExpiredEventClaims,
   }));
   vi.doMock("../services/inbox.js", () => ({
     pruneStaleSilentEntries: serviceMocks.pruneStaleSilentEntries,
@@ -74,6 +79,7 @@ beforeEach(() => {
   serviceMocks.notifyAgentEvent.mockResolvedValue(undefined);
   serviceMocks.pruneStaleSilentEntries.mockResolvedValue({ ackedDeleted: 0, stalePendingDeleted: 0 });
   serviceMocks.sweepChatArchive.mockResolvedValue({ mappedRowsArchived: 0, unmappedRowsArchived: 0 });
+  serviceMocks.sweepExpiredEventClaims.mockResolvedValue(0);
 });
 
 afterEach(() => {
@@ -85,11 +91,12 @@ afterEach(() => {
 });
 
 describe("createBackgroundTasks", () => {
-  it("runs heartbeat, inbox prune, archive sweep, and stale-agent notification intervals", async () => {
+  it("runs heartbeat, inbox prune, event claim sweep, archive sweep, and stale-agent notification intervals", async () => {
     const { createBackgroundTasks } = await import("../services/background-tasks.js");
     serviceMocks.pruneStaleSilentEntries.mockResolvedValue({ ackedDeleted: 2, stalePendingDeleted: 1 });
     serviceMocks.markStaleAgents.mockResolvedValue(["agent_1", "agent_2"]);
     serviceMocks.sweepChatArchive.mockResolvedValue({ mappedRowsArchived: 1, unmappedRowsArchived: 1 });
+    serviceMocks.sweepExpiredEventClaims.mockResolvedValue(3);
     const app = makeApp(30);
     const tasks = createBackgroundTasks(app, "srv_1");
 
@@ -101,6 +108,7 @@ describe("createBackgroundTasks", () => {
     expect(serviceMocks.cleanupStalePresence).toHaveBeenCalledWith(app.db, 60);
     expect(serviceMocks.cleanupStaleClients).toHaveBeenCalledWith(app.db, 60);
     expect(serviceMocks.pruneStaleSilentEntries).toHaveBeenCalledWith(app.db);
+    expect(serviceMocks.sweepExpiredEventClaims).toHaveBeenCalledWith(app.db);
     expect(serviceMocks.sweepChatArchive).toHaveBeenCalledWith(app.db, { mappedIdleSeconds: 3_600 });
     expect(serviceMocks.notifyAgentEvent).toHaveBeenCalledWith(app.db, "agent_1", "agent_stale", "medium");
     expect(serviceMocks.notifyAgentEvent).toHaveBeenCalledWith(app.db, "agent_2", "agent_stale", "medium");
@@ -116,9 +124,13 @@ describe("createBackgroundTasks", () => {
       { mappedRowsArchived: 1, unmappedRowsArchived: 1 },
       "chat auto-archive sweep flipped rows to archived",
     );
+    expect(loggerMocks.info).toHaveBeenCalledWith({ count: 3 }, "swept expired webhook event claims");
 
+    const eventClaimSweepCalls = serviceMocks.sweepExpiredEventClaims.mock.calls.length;
     tasks.stop();
     expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(serviceMocks.sweepExpiredEventClaims).toHaveBeenCalledTimes(eventClaimSweepCalls);
   });
 
   it("logs timer errors, catches rejected notifications, and allows archive sweep disablement", async () => {
@@ -144,5 +156,51 @@ describe("createBackgroundTasks", () => {
     );
 
     tasks.stop();
+  });
+
+  it("contains a rejected event claim sweep and resets its in-progress guard", async () => {
+    const { createBackgroundTasks } = await import("../services/background-tasks.js");
+    const sweepError = new Error("claim sweep failed");
+    serviceMocks.sweepExpiredEventClaims.mockRejectedValueOnce(sweepError).mockResolvedValueOnce(2);
+    const tasks = createBackgroundTasks(makeApp(0), "srv_claim_error");
+
+    tasks.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(serviceMocks.sweepExpiredEventClaims).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.error).toHaveBeenCalledWith({ err: sweepError }, "failed to sweep expired webhook event claims");
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(serviceMocks.sweepExpiredEventClaims).toHaveBeenCalledTimes(2);
+    expect(loggerMocks.info).toHaveBeenCalledWith({ count: 2 }, "swept expired webhook event claims");
+    tasks.stop();
+  });
+
+  it("suppresses overlapping event claim sweep ticks within one server instance", async () => {
+    const { createBackgroundTasks } = await import("../services/background-tasks.js");
+    let finishFirstSweep = (_count: number): void => {};
+    const firstSweep = new Promise<number>((resolve) => {
+      finishFirstSweep = resolve;
+    });
+    serviceMocks.sweepExpiredEventClaims.mockReturnValueOnce(firstSweep).mockResolvedValueOnce(0);
+    const tasks = createBackgroundTasks(makeApp(0), "srv_claim_overlap");
+
+    try {
+      tasks.start();
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(serviceMocks.sweepExpiredEventClaims).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(serviceMocks.sweepExpiredEventClaims).toHaveBeenCalledTimes(1);
+
+      finishFirstSweep(0);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(serviceMocks.sweepExpiredEventClaims).toHaveBeenCalledTimes(2);
+    } finally {
+      finishFirstSweep(0);
+      tasks.stop();
+    }
   });
 });

--- a/packages/server/src/__tests__/event-dedup.test.ts
+++ b/packages/server/src/__tests__/event-dedup.test.ts
@@ -1,36 +1,345 @@
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { connectDatabase, type Database } from "../db/connection.js";
 import * as eventDedup from "../services/event-dedup.js";
 import { useTestApp } from "./helpers.js";
 
-describe("Event deduplication", () => {
+type ExplainNode = {
+  "Node Type"?: string;
+  "Index Name"?: string;
+  Plans?: ExplainNode[];
+};
+
+function transactionDatabase(tx: unknown): Database {
+  return tx as Database;
+}
+
+function namedDatabase(prefix: string): { db: Database; applicationName: string } {
+  const applicationName = `${prefix}-${randomUUID()}`;
+  const url = new URL(process.env.DATABASE_URL ?? "");
+  url.searchParams.set("application_name", applicationName);
+  return { db: connectDatabase(url.toString()), applicationName };
+}
+
+async function insertExpiredPending(db: Database, eventId: string, platform = "github"): Promise<Date> {
+  const rows = await db.execute<{ expires_at: Date | string }>(sql`
+    INSERT INTO processed_events (event_id, platform, status, expires_at)
+    VALUES (
+      ${eventId},
+      ${platform},
+      'pending',
+      date_trunc('milliseconds', clock_timestamp()) - interval '1 second'
+    )
+    RETURNING expires_at
+  `);
+  const value = rows[0]?.expires_at;
+  if (!value) throw new Error("expired pending fixture was not inserted");
+  return value instanceof Date ? value : new Date(value);
+}
+
+async function waitUntilBlocked(db: Database, applicationName: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const rows = await db.execute<{ blocked: boolean }>(sql`
+      SELECT EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE application_name = ${applicationName}
+          AND cardinality(pg_blocking_pids(pid)) > 0
+      ) AS blocked
+    `);
+    if (rows[0]?.blocked) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`database application ${applicationName} did not enter a lock wait`);
+}
+
+function flattenPlan(node: ExplainNode): ExplainNode[] {
+  return [node, ...(node.Plans ?? []).flatMap(flattenPlan)];
+}
+
+describe("Event claim lifecycle", () => {
   const getApp = useTestApp();
 
-  it("claims an event the first time", async () => {
+  it("acquires, completes, and permanently dedupes only a done event", async () => {
     const app = getApp();
-    const claimed = await eventDedup.claimEvent(app.db, "evt_unique_1", "github");
-    expect(claimed).toBe(true);
+    const acquired = await eventDedup.claimEvent(app.db, "evt_done_1", "github");
+    expect(acquired).toMatchObject({ outcome: "acquired", expiresAt: expect.any(Date) });
+    if (acquired.outcome !== "acquired") throw new Error("claim was not acquired");
+
+    const inFlight = await eventDedup.claimEvent(app.db, "evt_done_1", "github");
+    expect(inFlight).toMatchObject({
+      outcome: "in_flight",
+      expiresAt: acquired.expiresAt,
+      retryAfterSeconds: expect.any(Number),
+    });
+    if (inFlight.outcome !== "in_flight") throw new Error("claim was not in flight");
+    expect(inFlight.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+    expect(inFlight.retryAfterSeconds).toBeLessThanOrEqual(eventDedup.EVENT_CLAIM_TTL_SECONDS);
+
+    await eventDedup.completeEventClaim(app.db, "evt_done_1", "github", acquired.expiresAt);
+    await expect(eventDedup.claimEvent(app.db, "evt_done_1", "github")).resolves.toEqual({ outcome: "done" });
   });
 
-  it("rejects a duplicate event", async () => {
+  it("isolates identical delivery ids by provider", async () => {
     const app = getApp();
-    await eventDedup.claimEvent(app.db, "evt_dup_1", "github");
-    const duplicate = await eventDedup.claimEvent(app.db, "evt_dup_1", "github");
-    expect(duplicate).toBe(false);
+    const [github, gitlab] = await Promise.all([
+      eventDedup.claimEvent(app.db, "evt_cross_1", "github"),
+      eventDedup.claimEvent(app.db, "evt_cross_1", "gitlab"),
+    ]);
+    expect(github.outcome).toBe("acquired");
+    expect(gitlab.outcome).toBe("acquired");
   });
 
-  it("allows same event_id on different platforms", async () => {
+  it("allows exactly one initial acquirer while the generation remains pending", async () => {
     const app = getApp();
-    const r1 = await eventDedup.claimEvent(app.db, "evt_cross_1", "github");
-    const r2 = await eventDedup.claimEvent(app.db, "evt_cross_1", "other");
-    expect(r1).toBe(true);
-    expect(r2).toBe(true);
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () => eventDedup.claimEvent(app.db, "evt_concurrent_initial", "github")),
+    );
+    expect(results.filter((result) => result.outcome === "acquired")).toHaveLength(1);
+    expect(results.filter((result) => result.outcome === "in_flight")).toHaveLength(11);
+    expect(results.filter((result) => result.outcome === "done")).toHaveLength(0);
   });
 
-  it("unclaimEvent allows a re-claim", async () => {
+  it("allows exactly one expired-generation takeover", async () => {
     const app = getApp();
-    await eventDedup.claimEvent(app.db, "evt_unclaim_1", "github");
-    await eventDedup.unclaimEvent(app.db, "evt_unclaim_1", "github");
-    const reclaimed = await eventDedup.claimEvent(app.db, "evt_unclaim_1", "github");
-    expect(reclaimed).toBe(true);
+    await insertExpiredPending(app.db, "evt_concurrent_takeover");
+
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () => eventDedup.claimEvent(app.db, "evt_concurrent_takeover", "github")),
+    );
+    expect(results.filter((result) => result.outcome === "acquired")).toHaveLength(1);
+    expect(results.filter((result) => result.outcome === "in_flight")).toHaveLength(11);
+    expect(results.filter((result) => result.outcome === "done")).toHaveLength(0);
+  });
+
+  it("rejects completion from an owner whose expired generation was taken over", async () => {
+    const app = getApp();
+    const staleExpiry = await insertExpiredPending(app.db, "evt_stale_owner");
+    const takeover = await eventDedup.claimEvent(app.db, "evt_stale_owner", "github");
+    expect(takeover.outcome).toBe("acquired");
+
+    await expect(eventDedup.completeEventClaim(app.db, "evt_stale_owner", "github", staleExpiry)).rejects.toThrow(
+      "lost ownership",
+    );
+    await expect(eventDedup.claimEvent(app.db, "evt_stale_owner", "github")).resolves.toMatchObject({
+      outcome: "in_flight",
+    });
+  });
+
+  it("deletes exactly one 1,000-row expired batch and preserves live pending and done rows", async () => {
+    const app = getApp();
+    await app.db.execute(sql`
+      INSERT INTO processed_events (event_id, platform, status, expires_at)
+      SELECT
+        'expired-' || sequence::text,
+        'github',
+        'pending',
+        statement_timestamp() - interval '1 minute'
+      FROM generate_series(1, 1001) AS sequence
+    `);
+    await app.db.execute(sql`
+      INSERT INTO processed_events (event_id, platform, status, expires_at)
+      VALUES
+        ('live-pending', 'github', 'pending', statement_timestamp() + interval '1 minute'),
+        ('completed', 'github', 'done', NULL)
+    `);
+
+    await expect(eventDedup.sweepExpiredEventClaims(app.db)).resolves.toBe(1_000);
+    await expect(eventDedup.sweepExpiredEventClaims(app.db)).resolves.toBe(1);
+    await expect(eventDedup.sweepExpiredEventClaims(app.db)).resolves.toBe(0);
+
+    const remaining = await app.db.execute<{ event_id: string; status: string }>(sql`
+      SELECT event_id, status
+      FROM processed_events
+      ORDER BY event_id
+    `);
+    expect(remaining).toEqual([
+      expect.objectContaining({ event_id: "completed", status: "done" }),
+      expect.objectContaining({ event_id: "live-pending", status: "pending" }),
+    ]);
+  });
+
+  it("installs the ordered partial index used by the expired-pending sweep", async () => {
+    const app = getApp();
+    const indexes = await app.db.execute<{ indexdef: string }>(sql`
+      SELECT indexdef
+      FROM pg_indexes
+      WHERE schemaname = current_schema()
+        AND tablename = 'processed_events'
+        AND indexname = 'idx_processed_events_pending_expiry'
+    `);
+    expect(indexes).toHaveLength(1);
+    expect(indexes[0]?.indexdef).toContain("USING btree (expires_at, id)");
+    expect(indexes[0]?.indexdef).toMatch(/WHERE \(status = 'pending'::text\)$/);
+
+    await app.db.transaction(async (tx) => {
+      await tx.execute(sql`SET LOCAL enable_seqscan = off`);
+      const planRows = await tx.execute<{ "QUERY PLAN": unknown }>(sql`
+        EXPLAIN (FORMAT JSON, COSTS OFF)
+        WITH sweep_clock AS MATERIALIZED (
+          SELECT statement_timestamp() AS cutoff
+        )
+        SELECT pe.id
+        FROM processed_events AS pe
+        WHERE pe.status = 'pending'
+          AND pe.expires_at <= (SELECT cutoff FROM sweep_clock)
+        ORDER BY pe.expires_at ASC, pe.id ASC
+        FOR UPDATE OF pe SKIP LOCKED
+        LIMIT ${eventDedup.EVENT_CLAIM_SWEEP_BATCH_SIZE}
+      `);
+      const rawPlan = planRows[0]?.["QUERY PLAN"];
+      const parsedPlan = typeof rawPlan === "string" ? (JSON.parse(rawPlan) as unknown) : rawPlan;
+      if (!Array.isArray(parsedPlan) || typeof parsedPlan[0] !== "object" || parsedPlan[0] === null) {
+        throw new Error("PostgreSQL returned an unexpected sweep plan");
+      }
+      const root = (parsedPlan[0] as { Plan?: ExplainNode }).Plan;
+      if (!root) throw new Error("PostgreSQL sweep plan has no root node");
+      const nodes = flattenPlan(root);
+      expect(nodes.some((node) => node["Index Name"] === "idx_processed_events_pending_expiry")).toBe(true);
+      expect(nodes.some((node) => node["Node Type"] === "Sort")).toBe(false);
+    });
+  });
+
+  it("does not let a sweep delete a takeover generation that already holds the row lock", async () => {
+    const app = getApp();
+    await insertExpiredPending(app.db, "evt_takeover_before_sweep");
+    const owner = namedDatabase("takeover-owner");
+    let releaseOwner!: () => void;
+    const release = new Promise<void>((resolve) => {
+      releaseOwner = resolve;
+    });
+    let ownerEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      ownerEntered = resolve;
+    });
+
+    const takeover = owner.db.transaction(async (tx) => {
+      const result = await eventDedup.claimEvent(transactionDatabase(tx), "evt_takeover_before_sweep", "github");
+      ownerEntered();
+      await release;
+      return result;
+    });
+    try {
+      await entered;
+      await expect(eventDedup.sweepExpiredEventClaims(app.db)).resolves.toBe(0);
+      releaseOwner();
+      await expect(takeover).resolves.toMatchObject({ outcome: "acquired" });
+      await expect(eventDedup.claimEvent(app.db, "evt_takeover_before_sweep", "github")).resolves.toMatchObject({
+        outcome: "in_flight",
+      });
+    } finally {
+      releaseOwner();
+      await Promise.allSettled([takeover]);
+      await owner.db.end();
+    }
+  });
+
+  it("lets acquisition insert a fresh generation after a sweep commits first", async () => {
+    const app = getApp();
+    await insertExpiredPending(app.db, "evt_sweep_before_takeover");
+    const sweeper = namedDatabase("held-sweeper");
+    const claimant = namedDatabase("blocked-claimant");
+    let releaseSweep!: () => void;
+    const release = new Promise<void>((resolve) => {
+      releaseSweep = resolve;
+    });
+    let sweepEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      sweepEntered = resolve;
+    });
+    const sweeping = sweeper.db.transaction(async (tx) => {
+      const deleted = await eventDedup.sweepExpiredEventClaims(transactionDatabase(tx));
+      sweepEntered();
+      await release;
+      return deleted;
+    });
+
+    let acquiring: ReturnType<typeof eventDedup.claimEvent> | undefined;
+    try {
+      await entered;
+      acquiring = eventDedup.claimEvent(claimant.db, "evt_sweep_before_takeover", "github");
+      await waitUntilBlocked(app.db, claimant.applicationName);
+      releaseSweep();
+      await expect(sweeping).resolves.toBe(1);
+      await expect(acquiring).resolves.toMatchObject({ outcome: "acquired" });
+    } finally {
+      releaseSweep();
+      await Promise.allSettled([sweeping, ...(acquiring ? [acquiring] : [])]);
+      await Promise.all([sweeper.db.end(), claimant.db.end()]);
+    }
+  });
+
+  it("preserves a completion that locks and marks done before the sweep", async () => {
+    const app = getApp();
+    const expiry = await insertExpiredPending(app.db, "evt_complete_before_sweep");
+    const owner = namedDatabase("completion-owner");
+    let releaseOwner!: () => void;
+    const release = new Promise<void>((resolve) => {
+      releaseOwner = resolve;
+    });
+    let ownerEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      ownerEntered = resolve;
+    });
+    const completion = owner.db.transaction(async (tx) => {
+      await eventDedup.completeEventClaim(transactionDatabase(tx), "evt_complete_before_sweep", "github", expiry);
+      ownerEntered();
+      await release;
+    });
+    try {
+      await entered;
+      await expect(eventDedup.sweepExpiredEventClaims(app.db)).resolves.toBe(0);
+      releaseOwner();
+      await completion;
+      await expect(eventDedup.claimEvent(app.db, "evt_complete_before_sweep", "github")).resolves.toEqual({
+        outcome: "done",
+      });
+    } finally {
+      releaseOwner();
+      await Promise.allSettled([completion]);
+      await owner.db.end();
+    }
+  });
+
+  it("makes an expired owner's completion fail if the sweep commits first", async () => {
+    const app = getApp();
+    const expiry = await insertExpiredPending(app.db, "evt_sweep_before_complete");
+    const sweeper = namedDatabase("completion-sweeper");
+    const owner = namedDatabase("blocked-completer");
+    let releaseSweep!: () => void;
+    const release = new Promise<void>((resolve) => {
+      releaseSweep = resolve;
+    });
+    let sweepEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      sweepEntered = resolve;
+    });
+    const sweeping = sweeper.db.transaction(async (tx) => {
+      const deleted = await eventDedup.sweepExpiredEventClaims(transactionDatabase(tx));
+      sweepEntered();
+      await release;
+      return deleted;
+    });
+    let completion: Promise<{ ok: true } | { ok: false; error: unknown }> | undefined;
+    try {
+      await entered;
+      completion = eventDedup.completeEventClaim(owner.db, "evt_sweep_before_complete", "github", expiry).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
+      await waitUntilBlocked(app.db, owner.applicationName);
+      releaseSweep();
+      await expect(sweeping).resolves.toBe(1);
+      const completionResult = await completion;
+      expect(completionResult.ok).toBe(false);
+      if (completionResult.ok) throw new Error("expired owner unexpectedly completed a swept claim");
+      expect(completionResult.error).toMatchObject({ message: expect.stringContaining("lost ownership") });
+    } finally {
+      releaseSweep();
+      await Promise.allSettled([sweeping, ...(completion ? [completion] : [])]);
+      await Promise.all([sweeper.db.end(), owner.db.end()]);
+    }
   });
 });

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -1,6 +1,6 @@
 import { createHmac, randomUUID } from "node:crypto";
 import { CONTEXT_REVIEW_MANAGED_MARKER } from "@first-tree/shared";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
 import { agents } from "../db/schema/agents.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
@@ -774,7 +774,7 @@ describe("POST /webhooks/github-app", () => {
     }
   });
 
-  it("unclaims a delivery when downstream handling fails and logs unclaim failures", async () => {
+  it("leaves a failed delivery pending so an immediate redelivery receives 503", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     const installationId = 100017;
@@ -783,10 +783,9 @@ describe("POST /webhooks/github-app", () => {
     const audienceSpy = vi
       .spyOn(githubAudienceService, "resolveGithubAudience")
       .mockRejectedValueOnce(new Error("audience down"));
-    const unclaimSpy = vi.spyOn(eventDedupService, "unclaimEvent").mockRejectedValueOnce(new Error("unclaim down"));
 
     try {
-      const res = await postWebhook(
+      const failed = await postWebhook(
         app,
         "issues",
         {
@@ -804,12 +803,44 @@ describe("POST /webhooks/github-app", () => {
         { deliveryId },
       );
 
-      expect(res.statusCode).toBe(500);
-      expect(audienceSpy).toHaveBeenCalled();
-      expect(unclaimSpy).toHaveBeenCalledWith(app.db, deliveryId, "github");
+      expect(failed.statusCode).toBe(500);
+      const [pendingClaim] = await app.db.execute<{ status: string; expires_at: Date | null }>(sql`
+        SELECT status, expires_at
+          FROM processed_events
+         WHERE event_id = ${deliveryId}
+           AND platform = 'github'
+      `);
+      expect(pendingClaim?.status).toBe("pending");
+      expect(pendingClaim?.expires_at).not.toBeNull();
+
+      const immediateRedelivery = await postWebhook(
+        app,
+        "issues",
+        {
+          action: "opened",
+          issue: {
+            number: 913,
+            title: "Issue",
+            html_url: "https://github.com/owner/repo/issues/913",
+            body: "",
+          },
+          repository: { full_name: "owner/repo" },
+          sender: { login: "author", type: "User" },
+          installation: { id: installationId },
+        },
+        { deliveryId },
+      );
+      expect(immediateRedelivery.statusCode).toBe(503);
+      expect(immediateRedelivery.json()).toMatchObject({
+        ok: false,
+        event: "issues",
+        outcome: "in_flight",
+        retryAfterSeconds: expect.any(Number),
+      });
+      expect(immediateRedelivery.headers["retry-after"]).toMatch(/^[1-9]\d*$/);
+      expect(audienceSpy).toHaveBeenCalledOnce();
     } finally {
       audienceSpy.mockRestore();
-      unclaimSpy.mockRestore();
     }
   });
 
@@ -1746,6 +1777,18 @@ describe("POST /webhooks/github-app", () => {
         .where(eq(inboxEntries.messageId, committedEvent?.id ?? "missing")),
     ).toHaveLength(1);
 
+    const inFlight = await postWebhook(app, "pull_request", synchronizePayload, { deliveryId });
+    expect(inFlight.statusCode).toBe(503);
+    expect(inFlight.json()).toMatchObject({ outcome: "in_flight" });
+    expect(inFlight.headers["retry-after"]).toMatch(/^[1-9]\d*$/);
+
+    await app.db.execute(sql`
+      UPDATE processed_events
+         SET expires_at = statement_timestamp() - interval '1 second'
+       WHERE event_id = ${deliveryId}
+         AND platform = 'github'
+         AND status = 'pending'
+    `);
     const synchronize = await postWebhook(app, "pull_request", synchronizePayload, { deliveryId });
     expect(synchronize.statusCode).toBe(200);
     expect(synchronize.json()).toMatchObject({
@@ -2037,6 +2080,140 @@ describe("POST /webhooks/github-app", () => {
     const second = await postWebhook(app, "issues", payload, { deliveryId });
     expect(second.statusCode).toBe(200);
     expect(second.json().deduped).toBe(true);
+  });
+
+  it("returns 503 for a concurrent signed delivery until the first request completes", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100044;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+    const deliveryId = randomUUID();
+    const payload = {
+      action: "opened",
+      issue: {
+        number: 944,
+        title: "Concurrent webhook",
+        html_url: "https://github.com/owner/repo/issues/944",
+        body: "",
+        assignees: [],
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "external", type: "User" },
+      installation: { id: installationId },
+    };
+    let signalAudienceEntered = (): void => undefined;
+    const audienceEntered = new Promise<void>((resolve) => {
+      signalAudienceEntered = resolve;
+    });
+    let releaseAudience = (): void => undefined;
+    const audienceGate = new Promise<void>((resolve) => {
+      releaseAudience = resolve;
+    });
+    const audienceSpy = vi.spyOn(githubAudienceService, "resolveGithubAudience").mockImplementationOnce(async () => {
+      signalAudienceEntered();
+      await audienceGate;
+      return { targets: [], actorHumanId: null };
+    });
+    const firstRequest = postWebhook(app, "issues", payload, { deliveryId });
+
+    try {
+      // resolveGithubAudience runs after the durable claim, so holding it open
+      // gives the second signed HTTP request a deterministic in-flight window.
+      await audienceEntered;
+      const concurrent = await postWebhook(app, "issues", payload, { deliveryId });
+
+      expect(concurrent.statusCode).toBe(503);
+      expect(concurrent.json()).toEqual({
+        ok: false,
+        event: "issues",
+        outcome: "in_flight",
+        retryAfterSeconds: expect.any(Number),
+      });
+      const retryAfter = concurrent.headers["retry-after"];
+      expect(retryAfter).toMatch(/^[1-9]\d*$/);
+      expect(Number(retryAfter)).toBeLessThanOrEqual(300);
+      expect(audienceSpy).toHaveBeenCalledOnce();
+
+      releaseAudience();
+      const first = await firstRequest;
+      expect(first.statusCode).toBe(200);
+
+      const completedReplay = await postWebhook(app, "issues", payload, { deliveryId });
+      expect(completedReplay.statusCode).toBe(200);
+      expect(completedReplay.json()).toMatchObject({ ok: true, event: "issues", deduped: true });
+      expect(audienceSpy).toHaveBeenCalledOnce();
+    } finally {
+      releaseAudience();
+      await firstRequest.catch(() => undefined);
+      audienceSpy.mockRestore();
+    }
+  });
+
+  it("recovers a committed pending claim left by a crashed handler after its lease expires", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const installationId = 100045;
+    await seedInstallation(app, { installationId, orgId: admin.organizationId });
+    const deliveryId = randomUUID();
+    const payload = {
+      action: "opened",
+      issue: {
+        number: 945,
+        title: "Recover crashed webhook",
+        html_url: "https://github.com/owner/repo/issues/945",
+        body: "",
+        assignees: [],
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "external", type: "User" },
+      installation: { id: installationId },
+    };
+
+    // A process dying after claim commit leaves exactly this durable state:
+    // no handler is alive, but the unexpired pending lease remains.
+    await app.db.execute(sql`
+      INSERT INTO processed_events (event_id, platform, status, expires_at)
+      VALUES (
+        ${deliveryId},
+        'github',
+        'pending',
+        date_trunc('milliseconds', statement_timestamp()) + interval '5 minutes'
+      )
+    `);
+
+    const immediate = await postWebhook(app, "issues", payload, { deliveryId });
+    expect(immediate.statusCode).toBe(503);
+    expect(immediate.json()).toMatchObject({
+      ok: false,
+      event: "issues",
+      outcome: "in_flight",
+      retryAfterSeconds: expect.any(Number),
+    });
+    expect(immediate.json()).not.toHaveProperty("deduped");
+    expect(immediate.headers["retry-after"]).toMatch(/^[1-9]\d*$/);
+
+    await app.db.execute(sql`
+      UPDATE processed_events
+         SET expires_at = statement_timestamp() - interval '1 second'
+       WHERE event_id = ${deliveryId}
+         AND platform = 'github'
+         AND status = 'pending'
+    `);
+
+    const recovered = await postWebhook(app, "issues", payload, { deliveryId });
+    expect(recovered.statusCode).toBe(200);
+    expect(recovered.json()).toMatchObject({ ok: true, event: "issues", audience: 0 });
+    const [completedClaim] = await app.db.execute<{ status: string; expires_at: Date | null }>(sql`
+      SELECT status, expires_at
+        FROM processed_events
+       WHERE event_id = ${deliveryId}
+         AND platform = 'github'
+    `);
+    expect(completedClaim).toEqual({ status: "done", expires_at: null });
+
+    const completedReplay = await postWebhook(app, "issues", payload, { deliveryId });
+    expect(completedReplay.statusCode).toBe(200);
+    expect(completedReplay.json()).toMatchObject({ ok: true, event: "issues", deduped: true });
   });
 
   it("duplicate context reviewer delivery is deduped and does not send another task", async () => {

--- a/packages/server/src/__tests__/gitlab-webhook-stage2a.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-stage2a.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
 import { formatHttpSpanName } from "../app.js";
 import { agents } from "../db/schema/agents.js";
@@ -13,6 +13,7 @@ import { messages } from "../db/schema/messages.js";
 import { processedEvents } from "../db/schema/processed-events.js";
 import { createAgent } from "../services/agent.js";
 import {
+  buildClaimReadyGitlabDeliveryId,
   createGitlabConnection,
   deleteGitlabConnection,
   findActiveGitlabEndpoint,
@@ -31,6 +32,7 @@ import {
 } from "../services/gitlab-entity-follow.js";
 import { createOrganization } from "../services/organization.js";
 import * as scmCardDelivery from "../services/scm-card-delivery.js";
+import { processScmWebhookDelivery } from "../services/scm-webhook-processing.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
@@ -290,6 +292,104 @@ describe("GitLab Stage 2A backend", () => {
     );
     const afterWebhookId = await app.db.select().from(processedEvents).where(eq(processedEvents.platform, "gitlab"));
     expect(afterWebhookId).toHaveLength(before + 1);
+  });
+
+  it("returns 503 for a committed pending delivery without deferred effects or a health failure", async () => {
+    const app = getApp();
+    const first = await connection(app);
+    const stableId = `pending-${randomUUID()}`;
+    const claimReadyId = buildClaimReadyGitlabDeliveryId(first.connectionId, stableId);
+    await app.db.execute(sql`
+      INSERT INTO processed_events (event_id, platform, status, expires_at)
+      VALUES (
+        ${claimReadyId},
+        'gitlab',
+        'pending',
+        date_trunc('milliseconds', statement_timestamp()) + interval '5 minutes'
+      )
+    `);
+    const before = await getGitlabConnectionSummary(app.db, first.connectionId);
+    const effectsSpy = vi.spyOn(scmCardDelivery, "runDeferredScmCardPostCommitEffects");
+
+    try {
+      const response = await postWebhook(app, first.bearer, issuePayload(), { stableId });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json()).toEqual({
+        ok: false,
+        outcome: "in_flight",
+        retryAfterSeconds: expect.any(Number),
+      });
+      expect(response.headers["retry-after"]).toMatch(/^[1-9]\d*$/);
+      expect(Number(response.headers["retry-after"])).toBeLessThanOrEqual(300);
+      expect(effectsSpy).not.toHaveBeenCalled();
+      expect((await getGitlabConnectionSummary(app.db, first.connectionId)).health).toEqual(before.health);
+    } finally {
+      effectsSpy.mockRestore();
+    }
+  });
+
+  it("rolls back the complete claim lifecycle with a failed GitLab ingress transaction", async () => {
+    const app = getApp();
+    const first = await connection(app);
+    const deliveryId = buildClaimReadyGitlabDeliveryId(first.connectionId, `rollback-${randomUUID()}`);
+    const tokenHash = hashGitlabUrlBearer(first.bearer);
+    const before = await app.db
+      .select({
+        endpointFirstSeenAt: gitlabConnections.endpointFirstSeenAt,
+        lastValidInboundAt: gitlabConnections.lastValidInboundAt,
+      })
+      .from(gitlabConnections)
+      .where(eq(gitlabConnections.id, first.connectionId));
+
+    await expect(
+      withGitlabIngressFence(app.db, first.connectionId, tokenHash, async (tx) => {
+        const processed = await processScmWebhookDelivery({
+          db: tx,
+          ingress: {
+            provider: "gitlab",
+            source: { organizationId: first.admin.organizationId, externalId: first.connectionId },
+            stableDeliveryId: deliveryId,
+            ingressAuthority: "url_bearer",
+          },
+          observation: null,
+          event: null,
+          applyObservation: async () => undefined,
+          runProviderWork: async () => {
+            await markGitlabInboundSeen(tx, first.connectionId, tokenHash);
+            return { endpointSeen: true };
+          },
+          resolveAudience: async () => ({ targets: [], actorHumanId: null }),
+          deliver: async () => ({ delivered: 0 }),
+        });
+        expect(processed).toEqual({ outcome: "provider_only", providerResult: { endpointSeen: true } });
+
+        const lifecycleRows = await tx.execute<{ status: string; expires_at: Date | null }>(sql`
+          SELECT status, expires_at
+          FROM processed_events
+          WHERE event_id = ${deliveryId}
+            AND platform = 'gitlab'
+        `);
+        expect(lifecycleRows).toEqual([expect.objectContaining({ status: "done", expires_at: null })]);
+        throw new Error("force GitLab ingress rollback");
+      }),
+    ).rejects.toThrow("force GitLab ingress rollback");
+
+    const lifecycleRows = await app.db.execute(sql`
+      SELECT id
+      FROM processed_events
+      WHERE event_id = ${deliveryId}
+        AND platform = 'gitlab'
+    `);
+    expect(lifecycleRows).toHaveLength(0);
+    const after = await app.db
+      .select({
+        endpointFirstSeenAt: gitlabConnections.endpointFirstSeenAt,
+        lastValidInboundAt: gitlabConnections.lastValidInboundAt,
+      })
+      .from(gitlabConnections)
+      .where(eq(gitlabConnections.id, first.connectionId));
+    expect(after).toEqual(before);
   });
 
   it("resolves a pending follow and delivers one basic card per chat with wake and no outbound fetch", async () => {

--- a/packages/server/src/__tests__/processed-events-migration.test.ts
+++ b/packages/server/src/__tests__/processed-events-migration.test.ts
@@ -1,0 +1,258 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import postgres from "postgres";
+import { expect, it } from "vitest";
+import { sslOptions } from "../db/connection.js";
+
+const MIGRATION_TAG = "0082_processed_event_claim_lifecycle";
+const STATEMENT_BREAKPOINT = "--> statement-breakpoint";
+
+function splitSql(source: string): string[] {
+  return source
+    .split(STATEMENT_BREAKPOINT)
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+}
+
+function extractDocumentedSql(source: string, marker: string): string {
+  const startMarker = `<!-- ${marker}:start -->`;
+  const endMarker = `<!-- ${marker}:end -->`;
+  const markerStart = source.indexOf(startMarker);
+  const markerEnd = source.indexOf(endMarker, markerStart + startMarker.length);
+  if (markerStart < 0 || markerEnd < 0) {
+    throw new Error(`Missing documented SQL markers for ${marker}`);
+  }
+
+  const markedSection = source.slice(markerStart + startMarker.length, markerEnd);
+  const fenceStart = markedSection.indexOf("```sql\n");
+  const sqlStart = fenceStart + "```sql\n".length;
+  const fenceEnd = markedSection.indexOf("```", sqlStart);
+  if (fenceStart < 0 || fenceEnd < 0) {
+    throw new Error(`Missing SQL fence for ${marker}`);
+  }
+  return markedSection.slice(sqlStart, fenceEnd).trim();
+}
+
+function extractLegacyTableDdl(source: string): string {
+  const match = source.match(/CREATE TABLE IF NOT EXISTS "processed_events" \([\s\S]*?\n\);/);
+  if (!match) throw new Error("Migration 0003 is missing the legacy processed_events table DDL");
+  return match[0];
+}
+
+it("migrates and reverses the processed-event claim lifecycle in an isolated schema", async () => {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) throw new Error("PostgreSQL test URL is not configured");
+
+  const migrationPath = resolve(import.meta.dirname, `../../drizzle/${MIGRATION_TAG}.sql`);
+  const legacyMigrationPath = resolve(import.meta.dirname, "../../drizzle/0003_feishu_adapter.sql");
+  const journalPath = resolve(import.meta.dirname, "../../drizzle/meta/_journal.json");
+  const rollbackDocPath = resolve(import.meta.dirname, "../../../../docs/migration/processed-event-claim-lifecycle.md");
+  const [migrationSql, legacyMigrationSql, journalSource, rollbackDoc] = await Promise.all([
+    readFile(migrationPath, "utf8"),
+    readFile(legacyMigrationPath, "utf8"),
+    readFile(journalPath, "utf8"),
+    readFile(rollbackDocPath, "utf8"),
+  ]);
+  const legacyTableDdl = extractLegacyTableDdl(legacyMigrationSql);
+  const cleanupSql = extractDocumentedSql(rollbackDoc, "processed-events-rollback-cleanup");
+  const reverseSql = extractDocumentedSql(rollbackDoc, "processed-events-full-reverse");
+  const journal = JSON.parse(journalSource) as {
+    entries: Array<{ tag: string; when: number }>;
+  };
+  const migrationEntry = journal.entries.find((entry) => entry.tag === MIGRATION_TAG);
+  if (!migrationEntry) throw new Error(`Journal is missing ${MIGRATION_TAG}`);
+
+  const schemaName = `migration_317_${process.pid}_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+  const isolated = postgres(databaseUrl, {
+    max: 1,
+    onnotice: () => {},
+    ...sslOptions(databaseUrl),
+  });
+  let ledgerRow: { id: number; hash: string; created_at: number | string | null } | undefined;
+
+  try {
+    await isolated`CREATE SCHEMA ${isolated(schemaName)}`;
+    await isolated`SELECT set_config('search_path', ${schemaName}, false)`;
+    [ledgerRow] = await isolated<Array<{ id: number; hash: string; created_at: number | string | null }>>`
+      SELECT "id", "hash", "created_at"
+      FROM "drizzle"."__drizzle_migrations"
+      WHERE "created_at" = ${migrationEntry.when}
+    `;
+    expect(ledgerRow).toBeDefined();
+    const [latestLedger] = await isolated<Array<{ created_at: number | string | null }>>`
+      SELECT max("created_at") AS "created_at"
+      FROM "drizzle"."__drizzle_migrations"
+    `;
+    expect(Number(latestLedger?.created_at)).toBe(migrationEntry.when);
+
+    await isolated.unsafe(legacyTableDdl);
+    await isolated`
+        INSERT INTO "processed_events" ("event_id", "platform")
+        VALUES ('legacy-delivery', 'github')
+      `;
+
+    await isolated.begin(async (transaction) => {
+      for (const statement of splitSql(migrationSql)) {
+        await transaction.unsafe(statement);
+      }
+    });
+
+    const [legacyRow] = await isolated<Array<{ eventId: string; status: string; expiresAt: Date | null }>>`
+        SELECT "event_id" AS "eventId", "status", "expires_at" AS "expiresAt"
+        FROM "processed_events"
+        WHERE "event_id" = 'legacy-delivery'
+      `;
+    expect(legacyRow).toEqual({ eventId: "legacy-delivery", status: "done", expiresAt: null });
+
+    await isolated`
+        INSERT INTO "processed_events" ("event_id", "platform")
+        VALUES ('old-shape-delivery', 'github')
+      `;
+    const [oldShapeRow] = await isolated<Array<{ status: string; expiresAt: Date | null }>>`
+        SELECT "status", "expires_at" AS "expiresAt"
+        FROM "processed_events"
+        WHERE "event_id" = 'old-shape-delivery'
+      `;
+    expect(oldShapeRow).toEqual({ status: "done", expiresAt: null });
+    await isolated`
+        INSERT INTO "processed_events" ("event_id", "platform", "status", "expires_at")
+        VALUES ('pending-delivery', 'github', 'pending', now() + interval '5 minutes')
+      `;
+
+    await expect(
+      isolated`
+          INSERT INTO "processed_events" ("event_id", "platform", "status")
+          VALUES ('invalid-status', 'github', 'invalid')
+        `,
+    ).rejects.toMatchObject({ code: "23514" });
+    await expect(
+      isolated`
+          INSERT INTO "processed_events" ("event_id", "platform", "status")
+          VALUES ('pending-without-expiry', 'github', 'pending')
+        `,
+    ).rejects.toMatchObject({ code: "23514" });
+    await expect(
+      isolated`
+          INSERT INTO "processed_events" ("event_id", "platform", "status", "expires_at")
+          VALUES ('done-with-expiry', 'github', 'done', now() + interval '5 minutes')
+        `,
+    ).rejects.toMatchObject({ code: "23514" });
+
+    const columns = await isolated<Array<{ columnName: string; nullable: string; defaultValue: string | null }>>`
+        SELECT
+          "column_name" AS "columnName",
+          "is_nullable" AS "nullable",
+          "column_default" AS "defaultValue"
+        FROM "information_schema"."columns"
+        WHERE "table_schema" = ${schemaName}
+          AND "table_name" = 'processed_events'
+          AND "column_name" IN ('status', 'expires_at')
+        ORDER BY "ordinal_position"
+      `;
+    expect(columns).toEqual([
+      { columnName: "status", nullable: "NO", defaultValue: "'done'::text" },
+      { columnName: "expires_at", nullable: "YES", defaultValue: null },
+    ]);
+
+    const [constraint] = await isolated<Array<{ validated: boolean }>>`
+        SELECT constraint_row."convalidated" AS "validated"
+        FROM "pg_constraint" AS constraint_row
+        JOIN "pg_class" AS table_row ON table_row."oid" = constraint_row."conrelid"
+        JOIN "pg_namespace" AS namespace_row ON namespace_row."oid" = table_row."relnamespace"
+        WHERE constraint_row."conname" = 'ck_processed_events_lifecycle'
+          AND namespace_row."nspname" = ${schemaName}
+          AND table_row."relname" = 'processed_events'
+      `;
+    expect(constraint).toEqual({ validated: true });
+
+    const [pendingIndex] = await isolated<Array<{ definition: string; valid: boolean; partial: boolean }>>`
+        SELECT
+          pg_get_indexdef("indexrelid") AS "definition",
+          "indisvalid" AS "valid",
+          "indpred" IS NOT NULL AS "partial"
+        FROM "pg_index"
+        JOIN "pg_class" ON "pg_class"."oid" = "pg_index"."indexrelid"
+        JOIN "pg_namespace" ON "pg_namespace"."oid" = "pg_class"."relnamespace"
+        WHERE "pg_namespace"."nspname" = ${schemaName}
+          AND "pg_class"."relname" = 'idx_processed_events_pending_expiry'
+      `;
+    expect(pendingIndex?.valid).toBe(true);
+    expect(pendingIndex?.partial).toBe(true);
+    const normalizedIndexDefinition = pendingIndex?.definition.replaceAll('"', "").replace(/\s+/g, " ");
+    expect(normalizedIndexDefinition).toContain("USING btree (expires_at, id)");
+    expect(normalizedIndexDefinition).toContain("WHERE (status = 'pending'::text)");
+
+    const cleanupStatements = splitSql(cleanupSql);
+    expect(cleanupStatements).toHaveLength(1);
+    const cleanupStatement = cleanupStatements[0];
+    if (!cleanupStatement) throw new Error("Documented pending-claim cleanup SQL is empty");
+    const cleanedRows = await isolated.unsafe<Array<{ event_id: string }>>(cleanupStatement);
+    expect(cleanedRows.map((row) => row.event_id).sort()).toEqual(["pending-delivery"]);
+    const [pendingCount] = await isolated<Array<{ count: number }>>`
+        SELECT count(*)::int AS "count"
+        FROM "processed_events"
+        WHERE "status" = 'pending'
+      `;
+    expect(pendingCount?.count).toBe(0);
+
+    for (const statement of splitSql(reverseSql)) {
+      await isolated.unsafe(statement);
+    }
+
+    const remainingColumns = await isolated<Array<{ columnName: string }>>`
+        SELECT "column_name" AS "columnName"
+        FROM "information_schema"."columns"
+        WHERE "table_schema" = ${schemaName}
+          AND "table_name" = 'processed_events'
+        ORDER BY "ordinal_position"
+      `;
+    expect(remainingColumns.map((column) => column.columnName)).toEqual(["id", "event_id", "platform", "created_at"]);
+
+    await isolated`
+        INSERT INTO "processed_events" ("event_id", "platform")
+        VALUES ('post-reversal-delivery', 'github')
+      `;
+    await expect(
+      isolated`
+          INSERT INTO "processed_events" ("event_id", "platform")
+          VALUES ('legacy-delivery', 'github')
+        `,
+    ).rejects.toMatchObject({ code: "23505" });
+
+    const [ledgerCount] = await isolated<Array<{ count: number }>>`
+        SELECT count(*)::int AS "count"
+        FROM "drizzle"."__drizzle_migrations"
+        WHERE "created_at" = ${migrationEntry.when}
+      `;
+    expect(ledgerCount?.count).toBe(0);
+
+    await isolated.begin(async (transaction) => {
+      for (const statement of splitSql(migrationSql)) {
+        await transaction.unsafe(statement);
+      }
+    });
+    const [reappliedRow] = await isolated<Array<{ status: string; expiresAt: Date | null }>>`
+        SELECT "status", "expires_at" AS "expiresAt"
+        FROM "processed_events"
+        WHERE "event_id" = 'post-reversal-delivery'
+      `;
+    expect(reappliedRow).toEqual({ status: "done", expiresAt: null });
+  } finally {
+    try {
+      await isolated.unsafe("ROLLBACK").catch(() => undefined);
+      if (ledgerRow) {
+        await isolated`
+          INSERT INTO "drizzle"."__drizzle_migrations" ("id", "hash", "created_at")
+          VALUES (${ledgerRow.id}, ${ledgerRow.hash}, ${ledgerRow.created_at})
+          ON CONFLICT ("id") DO UPDATE SET
+            "hash" = EXCLUDED."hash",
+            "created_at" = EXCLUDED."created_at"
+        `;
+      }
+      await isolated`DROP SCHEMA IF EXISTS ${isolated(schemaName)} CASCADE`;
+    } finally {
+      await isolated.end();
+    }
+  }
+});

--- a/packages/server/src/__tests__/scm-webhook-processing.test.ts
+++ b/packages/server/src/__tests__/scm-webhook-processing.test.ts
@@ -1,4 +1,5 @@
 import type { NormalizedScmEvent, ScmIngressContext } from "@first-tree/shared";
+import { sql } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
 import { processScmWebhookDelivery } from "../services/scm-webhook-processing.js";
 import { useTestApp } from "./helpers.js";
@@ -97,7 +98,7 @@ describe("processScmWebhookDelivery", () => {
 
   it("applies an observation without resolving audience or delivering a card", async () => {
     const app = getApp();
-    const ingress = makeIngress(null);
+    const ingress = makeIngress("delivery-provider-only");
     const applyObservation = vi.fn(async () => undefined);
     const resolveAudience = vi.fn(async () => ({ targets: ["unexpected"], actorHumanId: null }));
     const deliver = vi.fn(async () => ({ delivered: 1 }));
@@ -126,6 +127,18 @@ describe("processScmWebhookDelivery", () => {
     expect(applyObservation).toHaveBeenCalledOnce();
     expect(resolveAudience).not.toHaveBeenCalled();
     expect(deliver).not.toHaveBeenCalled();
+    await expect(
+      processScmWebhookDelivery({
+        db: app.db,
+        ingress,
+        observation: null,
+        event: null,
+        applyObservation: async () => undefined,
+        runProviderWork: async () => "unexpected",
+        resolveAudience,
+        deliver,
+      }),
+    ).resolves.toEqual({ outcome: "duplicate" });
   });
 
   it("does not suppress semantic delivery when projection refresh fails", async () => {
@@ -155,7 +168,7 @@ describe("processScmWebhookDelivery", () => {
     expect(deliver).toHaveBeenCalledOnce();
   });
 
-  it("best-effort unclaims a stable delivery after an uncaught top-level failure", async () => {
+  it("leaves a failed delivery pending until an expired generation can be taken over", async () => {
     const app = getApp();
     const ingress = makeIngress("delivery-retryable");
     const event = makeEvent(ingress);
@@ -175,7 +188,7 @@ describe("processScmWebhookDelivery", () => {
       }),
     ).rejects.toThrow("audience unavailable");
 
-    const retried = await processScmWebhookDelivery({
+    const immediateRetry = await processScmWebhookDelivery({
       db: app.db,
       ingress,
       observation: null,
@@ -185,7 +198,110 @@ describe("processScmWebhookDelivery", () => {
       resolveAudience: async () => ({ targets: ["target-1"], actorHumanId: null }),
       deliver: async () => ({ delivered: 1 }),
     });
-    expect(retried.outcome).toBe("delivered");
+    expect(immediateRetry).toMatchObject({ outcome: "in_flight", retryAfterSeconds: expect.any(Number) });
+
+    await app.db.execute(sql`
+      UPDATE processed_events
+      SET expires_at = statement_timestamp() - interval '1 second'
+      WHERE event_id = ${ingress.stableDeliveryId}
+        AND platform = 'github'
+        AND status = 'pending'
+    `);
+    const recovered = await processScmWebhookDelivery({
+      db: app.db,
+      ingress,
+      observation: null,
+      event,
+      applyObservation: async () => undefined,
+      runProviderWork: async () => null,
+      resolveAudience: async () => ({ targets: ["target-1"], actorHumanId: null }),
+      deliver: async () => ({ delivered: 1 }),
+    });
+    expect(recovered.outcome).toBe("delivered");
+    await expect(
+      processScmWebhookDelivery({
+        db: app.db,
+        ingress,
+        observation: null,
+        event,
+        applyObservation: async () => undefined,
+        runProviderWork: async () => null,
+        resolveAudience: async () => ({ targets: ["target-1"], actorHumanId: null }),
+        deliver: async () => ({ delivered: 1 }),
+      }),
+    ).resolves.toEqual({ outcome: "duplicate" });
+  });
+
+  it("keeps concurrent work behind the pending generation until the owner completes", async () => {
+    const app = getApp();
+    const ingress = makeIngress("delivery-gated-concurrency");
+    const event = makeEvent(ingress);
+    let releaseOwner!: () => void;
+    const release = new Promise<void>((resolve) => {
+      releaseOwner = resolve;
+    });
+    let ownerEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      ownerEntered = resolve;
+    });
+    const deliver = vi.fn(async () => ({ delivered: 1 }));
+    const resolveAudience = vi.fn(async () => {
+      ownerEntered();
+      await release;
+      return { targets: ["target-1"], actorHumanId: null };
+    });
+    const input = {
+      db: app.db,
+      ingress,
+      observation: null,
+      event,
+      applyObservation: async () => undefined,
+      runProviderWork: async () => null,
+      resolveAudience,
+      deliver,
+    };
+
+    const owner = processScmWebhookDelivery(input);
+    try {
+      await entered;
+      await expect(processScmWebhookDelivery(input)).resolves.toMatchObject({
+        outcome: "in_flight",
+        retryAfterSeconds: expect.any(Number),
+      });
+      expect(resolveAudience).toHaveBeenCalledOnce();
+      expect(deliver).not.toHaveBeenCalled();
+      releaseOwner();
+      await expect(owner).resolves.toMatchObject({ outcome: "delivered" });
+      await expect(processScmWebhookDelivery(input)).resolves.toEqual({ outcome: "duplicate" });
+      expect(resolveAudience).toHaveBeenCalledOnce();
+      expect(deliver).toHaveBeenCalledOnce();
+    } finally {
+      releaseOwner();
+      await Promise.allSettled([owner]);
+    }
+  });
+
+  it("completes an audience-empty terminal result before reporting success", async () => {
+    const app = getApp();
+    const ingress = makeIngress("delivery-audience-empty");
+    const event = makeEvent(ingress);
+    event.targets = [];
+    const input = {
+      db: app.db,
+      ingress,
+      observation: null,
+      event,
+      applyObservation: async () => undefined,
+      runProviderWork: async () => "provider-result",
+      resolveAudience: async () => ({ targets: [], actorHumanId: null }),
+      deliver: async () => ({ delivered: 0 }),
+    };
+
+    await expect(processScmWebhookDelivery(input)).resolves.toMatchObject({
+      outcome: "audience_empty",
+      reason: "audience_empty_no_targets",
+    });
+    await expect(processScmWebhookDelivery(input)).resolves.toEqual({ outcome: "duplicate" });
   });
 
   it("keeps the whole-request claim when provider delivery isolates a per-chat failure", async () => {

--- a/packages/server/src/api/webhooks/github-app.ts
+++ b/packages/server/src/api/webhooks/github-app.ts
@@ -157,12 +157,15 @@ async function handleInstallationLifecycle(app: FastifyInstance, eventType: stri
  *      the normalize pipeline (these events shouldn't fan out as cards)
  *   4. other events → installation.id → hub_organization_id reverse-lookup,
  *      then GitHub normalize → provider-neutral SCM processing seam →
- *      GitHub audience/delivery adapters. The seam best-effort unclaims on
- *      uncaught handler failure so GitHub's retry has a chance to clear.
+ *      GitHub audience/delivery adapters. A delivery already being processed
+ *      returns 503 + Retry-After rather than being acknowledged as a completed
+ *      duplicate. GitHub does not automatically retry failed webhook
+ *      deliveries, so recovery still depends on manual/operator redelivery;
+ *      once the pending claim expires, that redelivery can take it over.
  *
  * Routes return 200 for "ignored" cases (no installation context, not
- * bound, suspended, duplicate delivery) so GitHub doesn't accumulate
- * retries for events the operator can't act on.
+ * bound, suspended, completed duplicate delivery) so GitHub doesn't
+ * accumulate failures for events the operator can't act on.
  */
 export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void> {
   app.addContentTypeParser("application/json", { parseAs: "buffer" }, (_request, body, done) => {
@@ -294,6 +297,14 @@ export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void
     });
 
     switch (result.outcome) {
+      case "in_flight":
+        reply.header("Retry-After", String(result.retryAfterSeconds));
+        return reply.status(503).send({
+          ok: false,
+          event: eventType,
+          outcome: "in_flight",
+          retryAfterSeconds: result.retryAfterSeconds,
+        });
       case "duplicate":
         return reply.status(200).send({ ok: true, event: eventType, deduped: true });
       case "provider_only":

--- a/packages/server/src/api/webhooks/gitlab.ts
+++ b/packages/server/src/api/webhooks/gitlab.ts
@@ -83,7 +83,7 @@ export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
         }
       },
     },
-    async (request) => {
+    async (request, reply) => {
       const endpoint = endpointByRequest.get(request);
       if (!endpoint) throw new NotFoundError("GitLab webhook endpoint not found");
       const eventHeader = eventHeaderByRequest.get(request);
@@ -175,6 +175,14 @@ export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
             return processed;
           },
         );
+        if (result.outcome === "in_flight") {
+          reply.header("Retry-After", String(result.retryAfterSeconds));
+          return reply.status(503).send({
+            ok: false,
+            outcome: "in_flight",
+            retryAfterSeconds: result.retryAfterSeconds,
+          });
+        }
         if (result.outcome === "delivered") {
           for (const effects of result.deliveryStats.postCommitEffects) {
             await runDeferredScmCardPostCommitEffects(app, effects);

--- a/packages/server/src/db/schema/processed-events.ts
+++ b/packages/server/src/db/schema/processed-events.ts
@@ -1,9 +1,12 @@
-import { pgTable, serial, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { check, index, pgTable, serial, text, timestamp, unique } from "drizzle-orm/pg-core";
+
+export type ProcessedEventStatus = "pending" | "done";
 
 /**
- * Webhook event deduplication. External webhook sources (e.g. GitHub) can
- * deliver the same event multiple times; we use INSERT ... ON CONFLICT DO
- * NOTHING to ensure single processing.
+ * Durable webhook claim lifecycle. This legacy table is intentionally kept
+ * out of schema/index.ts because it was introduced by custom SQL rather than
+ * the Drizzle snapshot lineage.
  */
 export const processedEvents = pgTable(
   "processed_events",
@@ -12,6 +15,15 @@ export const processedEvents = pgTable(
     eventId: text("event_id").notNull(),
     platform: text("platform").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    status: text("status").$type<ProcessedEventStatus>().notNull().default("done"),
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
   },
-  (table) => [unique("uq_processed_event").on(table.eventId, table.platform)],
+  (table) => [
+    unique("uq_processed_event").on(table.eventId, table.platform),
+    index("idx_processed_events_pending_expiry").on(table.expiresAt, table.id).where(sql`${table.status} = 'pending'`),
+    check(
+      "ck_processed_events_lifecycle",
+      sql`(${table.status} = 'pending' AND ${table.expiresAt} IS NOT NULL) OR (${table.status} = 'done' AND ${table.expiresAt} IS NULL)`,
+    ),
+  ],
 );

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -2,11 +2,13 @@ import type { FastifyInstance } from "fastify";
 import { createLogger } from "../observability/index.js";
 import * as chatArchiveService from "./chat-archive.js";
 import * as clientService from "./client.js";
+import * as eventDedupService from "./event-dedup.js";
 import * as inboxService from "./inbox.js";
 import * as notificationService from "./notification.js";
 import * as presenceService from "./presence.js";
 
 const log = createLogger("BackgroundTasks");
+const EVENT_CLAIM_SWEEP_INTERVAL_MS = 60_000;
 
 export type BackgroundTasks = {
   start(): void;
@@ -17,6 +19,23 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
   let inboxTimer: ReturnType<typeof setInterval> | null = null;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let archiveSweepTimer: ReturnType<typeof setInterval> | null = null;
+  let eventClaimSweepTimer: ReturnType<typeof setInterval> | null = null;
+  let eventClaimSweepInProgress = false;
+
+  async function runEventClaimSweep(): Promise<void> {
+    if (eventClaimSweepInProgress) return;
+    eventClaimSweepInProgress = true;
+    try {
+      const count = await eventDedupService.sweepExpiredEventClaims(app.db);
+      if (count > 0) {
+        log.info({ count }, "swept expired webhook event claims");
+      }
+    } catch (err) {
+      log.error({ err }, "failed to sweep expired webhook event claims");
+    } finally {
+      eventClaimSweepInProgress = false;
+    }
+  }
 
   return {
     start() {
@@ -40,6 +59,14 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
           log.error({ err }, "failed to prune silent inbox rows");
         }
       }, 60_000);
+
+      // Expired webhook claim GC. Atomic takeover remains the correctness
+      // path for redelivery; this bounded periodic sweep prevents abandoned
+      // pending rows from accumulating. Each server instance may run it, and
+      // the local guard avoids overlapping ticks when one sweep runs long.
+      eventClaimSweepTimer = setInterval(() => {
+        void runEventClaimSweep();
+      }, EVENT_CLAIM_SWEEP_INTERVAL_MS);
 
       // Server instance heartbeat — runs every 30 seconds
       heartbeatTimer = setInterval(async () => {
@@ -101,6 +128,10 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
       if (archiveSweepTimer) {
         clearInterval(archiveSweepTimer);
         archiveSweepTimer = null;
+      }
+      if (eventClaimSweepTimer) {
+        clearInterval(eventClaimSweepTimer);
+        eventClaimSweepTimer = null;
       }
     },
   };

--- a/packages/server/src/services/event-dedup.ts
+++ b/packages/server/src/services/event-dedup.ts
@@ -1,23 +1,173 @@
 import { sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 
-// ── Event deduplication ─────────────────────────────────────────────
+export const EVENT_CLAIM_TTL_SECONDS = 5 * 60;
+export const EVENT_CLAIM_SWEEP_BATCH_SIZE = 1_000;
+
+const MAX_ACQUISITION_ATTEMPTS = 5;
+
+export type EventClaimAcquisition =
+  | { outcome: "acquired"; expiresAt: Date }
+  | { outcome: "in_flight"; expiresAt: Date; retryAfterSeconds: number }
+  | { outcome: "done" };
+
+type AcquiredRow = {
+  expires_at: Date | string;
+};
+
+type ClassifiedRow = {
+  status: string;
+  expires_at: Date | string | null;
+  retry_after_seconds: number | string | null;
+};
 
 /**
- * Attempt to claim an event for processing.
- * Returns true if this is the first time the event is seen, false if duplicate.
+ * Atomically acquire a new event claim or take over an expired pending claim.
+ * Completed events are never reopened. A live pending claim is reported
+ * separately so callers do not acknowledge unfinished work as a duplicate.
  */
-export async function claimEvent(db: Database, eventId: string, platform: string): Promise<boolean> {
-  const result = await db.execute<{ event_id: string }>(
-    sql`INSERT INTO processed_events (event_id, platform) VALUES (${eventId}, ${platform}) ON CONFLICT DO NOTHING RETURNING event_id`,
-  );
-  return result.length > 0;
+export async function claimEvent(db: Database, eventId: string, platform: string): Promise<EventClaimAcquisition> {
+  for (let attempt = 0; attempt < MAX_ACQUISITION_ATTEMPTS; attempt += 1) {
+    const acquired = await db.execute<AcquiredRow>(sql`
+      WITH claim_clock AS MATERIALIZED (
+        SELECT date_trunc('milliseconds', clock_timestamp()) AS acquired_at
+      )
+      INSERT INTO processed_events (event_id, platform, status, expires_at)
+      SELECT
+        ${eventId},
+        ${platform},
+        'pending',
+        acquired_at + ${EVENT_CLAIM_TTL_SECONDS} * interval '1 second'
+      FROM claim_clock
+      ON CONFLICT ON CONSTRAINT uq_processed_event
+      DO UPDATE SET
+        status = 'pending',
+        expires_at = EXCLUDED.expires_at
+      WHERE processed_events.status = 'pending'
+        AND processed_events.expires_at <= (SELECT acquired_at FROM claim_clock)
+      RETURNING processed_events.expires_at
+    `);
+    const acquiredRow = acquired[0];
+    if (acquiredRow) {
+      return { outcome: "acquired", expiresAt: parseDatabaseDate(acquiredRow.expires_at, "acquired expiry") };
+    }
+
+    // A conditional UPSERT returns no row for both completed and live
+    // pending claims. Classify from a fresh READ COMMITTED statement snapshot
+    // using one database clock value. A sweep can remove an expired claim
+    // between statements, in which case acquisition is retried.
+    const classified = await db.execute<ClassifiedRow>(sql`
+      WITH classification_clock AS MATERIALIZED (
+        SELECT clock_timestamp() AS observed_at
+      )
+      SELECT
+        pe.status,
+        pe.expires_at,
+        CASE
+          WHEN pe.status = 'pending' AND pe.expires_at > classification_clock.observed_at
+            THEN GREATEST(
+              1,
+              ceil(EXTRACT(EPOCH FROM (pe.expires_at - classification_clock.observed_at)))::integer
+            )
+          ELSE NULL
+        END AS retry_after_seconds
+      FROM processed_events AS pe
+      CROSS JOIN classification_clock
+      WHERE pe.event_id = ${eventId}
+        AND pe.platform = ${platform}
+    `);
+    const current = classified[0];
+    if (!current) continue;
+
+    if (current.status === "done") {
+      if (current.expires_at !== null) {
+        throw new Error("processed event is done but still has an expiry");
+      }
+      return { outcome: "done" };
+    }
+
+    if (current.status === "pending") {
+      if (current.expires_at === null) {
+        throw new Error("processed event is pending without an expiry");
+      }
+      if (current.retry_after_seconds === null) continue;
+
+      const retryAfterSeconds = Number(current.retry_after_seconds);
+      if (!Number.isInteger(retryAfterSeconds) || retryAfterSeconds < 1) {
+        throw new Error("processed event has an invalid retry interval");
+      }
+      return {
+        outcome: "in_flight",
+        expiresAt: parseDatabaseDate(current.expires_at, "pending expiry"),
+        retryAfterSeconds,
+      };
+    }
+
+    throw new Error(`processed event has invalid status: ${current.status}`);
+  }
+
+  throw new Error("processed event claim state did not stabilize");
 }
 
-/**
- * Remove a claimed event so it can be retried on next delivery.
- * Called when processing fails after claimEvent() succeeded.
- */
-export async function unclaimEvent(db: Database, eventId: string, platform: string): Promise<void> {
-  await db.execute(sql`DELETE FROM processed_events WHERE event_id = ${eventId} AND platform = ${platform}`);
+/** Mark exactly the acquired pending generation as completed. */
+export async function completeEventClaim(
+  db: Database,
+  eventId: string,
+  platform: string,
+  expiresAt: Date,
+): Promise<void> {
+  const expiresAtIso = expiresAt.toISOString();
+  const completed = await db.execute<{ event_id: string }>(sql`
+    UPDATE processed_events
+    SET status = 'done', expires_at = NULL
+    WHERE event_id = ${eventId}
+      AND platform = ${platform}
+      AND status = 'pending'
+      AND expires_at = ${expiresAtIso}::timestamptz
+    RETURNING event_id
+  `);
+  if (completed.length === 0) {
+    throw new Error(`lost ownership of ${platform} event claim ${eventId}`);
+  }
+}
+
+/** Delete one bounded batch of expired pending claims. Completed rows remain. */
+export async function sweepExpiredEventClaims(db: Database): Promise<number> {
+  const result = await db.execute<{ deleted_count: number | string }>(sql`
+    WITH sweep_clock AS MATERIALIZED (
+      SELECT statement_timestamp() AS cutoff
+    ),
+    expired AS MATERIALIZED (
+      SELECT pe.id
+      FROM processed_events AS pe
+      WHERE pe.status = 'pending'
+        AND pe.expires_at <= (SELECT cutoff FROM sweep_clock)
+      ORDER BY pe.expires_at ASC, pe.id ASC
+      FOR UPDATE OF pe SKIP LOCKED
+      LIMIT ${EVENT_CLAIM_SWEEP_BATCH_SIZE}
+    ),
+    deleted AS (
+      DELETE FROM processed_events AS pe
+      USING expired
+      WHERE pe.id = expired.id
+        AND pe.status = 'pending'
+        AND pe.expires_at <= (SELECT cutoff FROM sweep_clock)
+      RETURNING pe.id
+    )
+    SELECT count(*)::integer AS deleted_count
+    FROM deleted
+  `);
+  const deletedCount = Number(result[0]?.deleted_count ?? 0);
+  if (!Number.isInteger(deletedCount) || deletedCount < 0 || deletedCount > EVENT_CLAIM_SWEEP_BATCH_SIZE) {
+    throw new Error("expired event claim sweep returned an invalid count");
+  }
+  return deletedCount;
+}
+
+function parseDatabaseDate(value: Date | string, label: string): Date {
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`processed event has an invalid ${label}`);
+  }
+  return parsed;
 }

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -26,8 +26,8 @@ export type DeliveryStats = {
   newChats: number;
   /**
    * Number of chats whose delivery threw and was caught by the per-chat
-   * guard. These chats did NOT receive a card; the webhook has already been
-   * claimed in `processed_events`, so GitHub will not retry. Surfaced in the
+   * guard. These chats did NOT receive a card; the outer delivery still
+   * completes its claim and does not replay the payload. Surfaced in the
    * response + metric so a regression in single-chat reliability becomes
    * observable instead of silent.
    */
@@ -214,8 +214,8 @@ export async function deliverGithubEvent(
     } catch (err) {
       stats.failed += 1;
       // Per-chat failures are isolated so one bad chat doesn't poison the rest,
-      // but the webhook is already claimed in `processed_events` — GitHub will
-      // not retry. Emit a structured metric line so a regression in single-chat
+      // and the outer delivery completes its claim without replaying the
+      // payload. Emit a structured metric line so a regression in single-chat
       // reliability is observable instead of silently swallowed. See #507.
       log.error(
         {

--- a/packages/server/src/services/scm-webhook-processing.ts
+++ b/packages/server/src/services/scm-webhook-processing.ts
@@ -1,7 +1,7 @@
 import type { NormalizedScmEvent, ScmEntityObservation, ScmIngressContext } from "@first-tree/shared";
 import type { Database } from "../db/connection.js";
 import { createLogger } from "../observability/index.js";
-import { claimEvent, unclaimEvent } from "./event-dedup.js";
+import { claimEvent, completeEventClaim } from "./event-dedup.js";
 
 const log = createLogger("ScmWebhookProcessing");
 
@@ -12,6 +12,7 @@ export type ScmAudienceResolution<TTarget> = {
 
 export type ScmProcessingResult<TDeliveryStats, TProviderResult> =
   | { outcome: "duplicate" }
+  | { outcome: "in_flight"; retryAfterSeconds: number }
   | { outcome: "provider_only"; providerResult: TProviderResult }
   | {
       outcome: "audience_empty";
@@ -38,10 +39,10 @@ type ProcessScmWebhookDeliveryInput<TTarget, TDeliveryStats, TProviderResult> = 
  * Narrow provider-neutral SCM processing seam.
  *
  * The ingress adapter authenticates and normalizes first. This kernel owns
- * only the existing optional whole-request claim, provider work covered by
- * that claim, audience orchestration, and best-effort unclaim on an uncaught
- * top-level failure. Provider payloads, stores, mapping rules, card shapes,
- * and per-chat failure guards remain behind the supplied callbacks.
+ * only the optional whole-request lifecycle claim, provider work covered by
+ * that claim, audience orchestration, and fenced completion. Provider
+ * payloads, stores, mapping rules, card shapes, and per-chat failure guards
+ * remain behind the supplied callbacks.
  */
 export async function processScmWebhookDelivery<TTarget, TDeliveryStats, TProviderResult>(
   input: ProcessScmWebhookDeliveryInput<TTarget, TDeliveryStats, TProviderResult>,
@@ -49,35 +50,46 @@ export async function processScmWebhookDelivery<TTarget, TDeliveryStats, TProvid
   assertEventMatchesIngress(input.ingress, input.event);
 
   const deliveryId = input.ingress.stableDeliveryId;
+  let claimExpiresAt: Date | null = null;
   if (deliveryId) {
-    const claimed = await claimEvent(input.db, deliveryId, input.ingress.provider);
-    if (!claimed) {
-      log.info({ provider: input.ingress.provider, deliveryId }, "duplicate SCM webhook delivery, skipping");
+    const claim = await claimEvent(input.db, deliveryId, input.ingress.provider);
+    if (claim.outcome === "done") {
+      log.info({ provider: input.ingress.provider, deliveryId }, "completed SCM webhook delivery, skipping replay");
       return { outcome: "duplicate" };
     }
+    if (claim.outcome === "in_flight") {
+      log.info(
+        { provider: input.ingress.provider, deliveryId, retryAfterSeconds: claim.retryAfterSeconds },
+        "SCM webhook delivery is already in flight",
+      );
+      return { outcome: "in_flight", retryAfterSeconds: claim.retryAfterSeconds };
+    }
+    claimExpiresAt = claim.expiresAt;
   }
 
-  try {
-    const providerResult = await input.runProviderWork();
-    if (input.observation) {
-      await input.applyObservation(input.observation).catch((err) => {
-        // Projection refresh is deliberately independent from notification
-        // delivery. A temporary projection failure must not suppress an
-        // otherwise valid card or make a provider retry duplicate it.
-        log.error(
-          {
-            err,
-            provider: input.ingress.provider,
-            organizationId: input.ingress.source.organizationId,
-            entityType: input.observation?.entity.type,
-            entityKey: input.observation?.entity.key,
-          },
-          "failed to apply SCM entity observation",
-        );
-      });
-    }
-    if (!input.event) return { outcome: "provider_only", providerResult };
+  const providerResult = await input.runProviderWork();
+  if (input.observation) {
+    await input.applyObservation(input.observation).catch((err) => {
+      // Projection refresh is deliberately independent from notification
+      // delivery. A temporary projection failure must not suppress an
+      // otherwise valid card or make a provider redelivery duplicate it.
+      log.error(
+        {
+          err,
+          provider: input.ingress.provider,
+          organizationId: input.ingress.source.organizationId,
+          entityType: input.observation?.entity.type,
+          entityKey: input.observation?.entity.key,
+        },
+        "failed to apply SCM entity observation",
+      );
+    });
+  }
 
+  let terminalResult: ScmProcessingResult<TDeliveryStats, TProviderResult>;
+  if (!input.event) {
+    terminalResult = { outcome: "provider_only", providerResult };
+  } else {
     const audience = await input.resolveAudience(input.event);
     if (audience.targets.length === 0) {
       const reason = input.event.targets.length > 0 ? "audience_empty_with_targets" : "audience_empty_no_targets";
@@ -93,22 +105,17 @@ export async function processScmWebhookDelivery<TTarget, TDeliveryStats, TProvid
         },
         "SCM webhook audience empty, skipping",
       );
-      return { outcome: "audience_empty", reason, providerResult };
+      terminalResult = { outcome: "audience_empty", reason, providerResult };
+    } else {
+      const deliveryStats = await input.deliver(input.event, audience);
+      terminalResult = { outcome: "delivered", deliveryStats, providerResult };
     }
-
-    const deliveryStats = await input.deliver(input.event, audience);
-    return { outcome: "delivered", deliveryStats, providerResult };
-  } catch (err) {
-    if (deliveryId) {
-      await unclaimEvent(input.db, deliveryId, input.ingress.provider).catch((unclaimErr) => {
-        log.error(
-          { err: unclaimErr, provider: input.ingress.provider, deliveryId },
-          "failed to unclaim SCM webhook delivery after handler error",
-        );
-      });
-    }
-    throw err;
   }
+
+  if (deliveryId && claimExpiresAt) {
+    await completeEventClaim(input.db, deliveryId, input.ingress.provider, claimExpiresAt);
+  }
+  return terminalResult;
 }
 
 function assertEventMatchesIngress(ingress: ScmIngressContext, event: NormalizedScmEvent | null): void {


### PR DESCRIPTION
Fixes #317.

## Summary

- replace claim-before-work plus best-effort deletion with a durable `pending` / `done` lifecycle and an approximately five-minute lease
- atomically acquire first deliveries or take over expired claims, classify live work separately, and fence completion to the acquired expiry generation
- return a distinct `503` with integer `Retry-After` for live in-flight GitHub App and GitLab deliveries; only completed claims are deduped
- leave failed claims recoverable without depending on request cleanup, and garbage-collect expired pending rows in bounded, non-overlapping background sweeps
- add migration 0082, coordinated rollback guidance, and concurrency/crash/redelivery/migration regression coverage

The removed per-organization `/webhooks/github/:orgId` route is intentionally not restored. Current `main` has App-only GitHub ingress (the legacy route was removed in `da2cb15c`), so the GitHub App route and the shared GitLab ingress kernel are the active consumers of this lifecycle.

## Reliability boundary

The database admits one processing winner per live lease generation. A stale owner that runs beyond expiry can already have emitted side effects before a redelivery takes over, so this does not claim unconditional exactly-once behavior after expiry. Completion fencing prevents the stale generation from marking the newer generation done.

GitHub does not automatically redeliver failed webhook deliveries. Expiry makes a later manual or operator-automated redelivery eligible; the sweep is garbage collection only and never stores or replays payloads. See [GitHub's failed-delivery guidance](https://docs.github.com/en/webhooks/using-webhooks/handling-failed-webhook-deliveries).

## Migration and rollback

Migration 0082 is additive and defaults historical and old-shape inserts to `done`. [The operator guide](docs/migration/processed-event-claim-lifecycle.md) covers startup lock/runtime risk for unbounded historical rows, optional concurrent index pre-creation, forward mixed-version risk, coordinated application rollback, and full schema reversal with Drizzle ledger handling.

This branch is frozen on the repository's 0081 migration head. Draft PR #1921 independently uses slot 0082; if it lands first, that external sequencing conflict should be resolved explicitly at merge time rather than by rebasing or silently rewriting this branch.

## QA

Formal QA is warranted because this change touches the GitHub App and GitLab provider webhook paths. It has not been run as part of this PR. Existing cross-surface coverage is documented in [GitHub Webhook Routing Regression](packages/qa/cases/cross-surface/github-webhook-routing-regression.md) and [GitLab Webhook and Personnel Routing](packages/qa/cases/cross-surface/gitlab-webhook-basic-card.md). Deterministic claim-lifecycle behavior is covered by the product tests and CI checks listed below.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm --filter @first-tree/server test` — 239 files / 2,579 tests passed
- targeted lifecycle/kernel 20/20, GitHub App 49/49, GitLab 22/22, background sweep 4/4, and exact migration/reversal 1/1
- `node scripts/check-migrations.mjs`
- partial-index catalog assertion and PostgreSQL plan probe

Context Tree PR: [first-tree-context#800](https://github.com/agent-team-foundation/first-tree-context/pull/800)
