### PR TITLE
fix(cli): retire legacy github-scan launchd runner

### DIFF
--- a/apps/cli/src/__tests__/cli-runtime.test.ts
+++ b/apps/cli/src/__tests__/cli-runtime.test.ts
@@ -1,0 +1,272 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const coreMocks = vi.hoisted(() => ({
+  getClientServiceStatus: vi.fn(),
+  getClientSwitchStartupBlock: vi.fn(() => ({ phase: "qa" })),
+  installClientService: vi.fn(),
+  isServiceSupported: vi.fn(() => false),
+  isServiceUnitDriftDetected: vi.fn(() => false),
+  loadCredentials: vi.fn(),
+  loadDaemonEnv: vi.fn(() => []),
+  refreshClientServiceUnitForUpdate: vi.fn(),
+  restartClientService: vi.fn(),
+}));
+
+const outputMocks = vi.hoisted(() => ({
+  line: vi.fn(),
+  setJsonMode: vi.fn(),
+}));
+
+const statusMocks = vi.hoisted(() => ({
+  renderAgentsBlock: vi.fn(),
+  renderAuthBlock: vi.fn(),
+  renderCliVersionBlock: vi.fn(),
+  renderHubBlock: vi.fn(),
+  renderServiceBlock: vi.fn(),
+}));
+
+vi.mock("../core/index.js", () => coreMocks);
+vi.mock("../core/output.js", () => ({
+  print: { line: outputMocks.line },
+  setJsonMode: outputMocks.setJsonMode,
+}));
+vi.mock("../commands/_shared/status-blocks.js", () => statusMocks);
+
+import { type CliRuntimeDependencies, configureCliRuntime } from "../cli/runtime.js";
+import { registerDaemonEnsureServiceCommand } from "../commands/daemon/ensure-service.js";
+import { registerDaemonRefreshUnitCommand } from "../commands/daemon/refresh-unit.js";
+import { registerDaemonStartCommand } from "../commands/daemon/start.js";
+import { registerStatusCommand } from "../commands/status.js";
+import type {
+  LegacyGithubScanLaunchdRetirementDiagnostic,
+  LegacyGithubScanLaunchdRetirementResult,
+} from "../core/legacy-github-scan-launchd-retirement.js";
+
+type RuntimeHarness = {
+  dependencies: CliRuntimeDependencies;
+  events: string[];
+  info: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  runRetirement: ReturnType<typeof vi.fn>;
+};
+
+function result(
+  status: LegacyGithubScanLaunchdRetirementResult["status"] = "absent",
+): LegacyGithubScanLaunchdRetirementResult {
+  return { status, retired: 0, diagnostics: [] };
+}
+
+function runtimeHarness(outcome: LegacyGithubScanLaunchdRetirementResult = result()): RuntimeHarness {
+  const events: string[] = [];
+  const info = vi.fn();
+  const error = vi.fn();
+  const runRetirement = vi.fn(() => {
+    events.push("migration");
+    return outcome;
+  });
+  return {
+    events,
+    info,
+    error,
+    runRetirement,
+    dependencies: {
+      env: {},
+      setJsonMode: (enabled) => events.push(`json:${enabled}`),
+      applyClientLoggerConfig: (options) => events.push(`logger-config:${options?.level ?? "env"}`),
+      createLogger: () => {
+        events.push("migration-logger");
+        return { info, error };
+      },
+      runLegacyGithubScanLaunchdRetirementOnce: runRetirement,
+    },
+  };
+}
+
+function programFor(harness: RuntimeHarness): Command {
+  const program = new Command();
+  program
+    .name("first-tree-staging")
+    .version("0.0.0-test")
+    .exitOverride()
+    .configureOutput({ writeErr: () => undefined, writeOut: () => undefined });
+  configureCliRuntime(program, harness.dependencies);
+  return program;
+}
+
+function registerMaintenanceCommands(program: Command): void {
+  const daemon = program.command("daemon");
+  registerDaemonStartCommand(daemon);
+  registerDaemonEnsureServiceCommand(daemon);
+  registerDaemonRefreshUnitCommand(daemon);
+}
+
+function parse(program: Command, args: string[]): void {
+  program.parse(["node", "first-tree-staging", ...args]);
+}
+
+describe("CLI runtime migration hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    coreMocks.isServiceSupported.mockReturnValue(false);
+  });
+
+  it("runs synchronously after output normalization and before an ordinary real command action", () => {
+    const harness = runtimeHarness();
+    statusMocks.renderCliVersionBlock.mockImplementationOnce(() => harness.events.push("action:status"));
+    const program = programFor(harness);
+    registerStatusCommand(program);
+
+    parse(program, ["status"]);
+
+    expect(harness.events).toEqual([
+      "json:false",
+      "logger-config:warn",
+      "migration-logger",
+      "migration",
+      "action:status",
+    ]);
+    expect(harness.runRetirement).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs for portable ensure-service before its real registered action", () => {
+    const harness = runtimeHarness();
+    outputMocks.line.mockImplementationOnce(() => harness.events.push("action:ensure-service"));
+    const program = programFor(harness);
+    registerMaintenanceCommands(program);
+
+    parse(program, ["daemon", "ensure-service"]);
+
+    expect(harness.events).toEqual([
+      "json:false",
+      "logger-config:warn",
+      "migration-logger",
+      "migration",
+      "action:ensure-service",
+    ]);
+  });
+
+  it("skips only the old-X refresh child, then a fresh supervisor daemon start migrates", () => {
+    const refreshHarness = runtimeHarness();
+    outputMocks.line.mockImplementationOnce(() => refreshHarness.events.push("action:refresh-unit"));
+    const refreshProgram = programFor(refreshHarness);
+    registerMaintenanceCommands(refreshProgram);
+
+    parse(refreshProgram, ["daemon", "refresh-unit"]);
+
+    expect(refreshHarness.events).toEqual(["json:false", "logger-config:warn", "action:refresh-unit"]);
+    expect(refreshHarness.runRetirement).not.toHaveBeenCalled();
+
+    const restartHarness = runtimeHarness();
+    const restartProgram = programFor(restartHarness);
+    outputMocks.line.mockImplementationOnce(() => restartHarness.events.push("action:daemon-start"));
+    registerMaintenanceCommands(restartProgram);
+
+    parse(restartProgram, ["daemon", "start"]);
+
+    expect(restartHarness.events).toEqual([
+      "json:false",
+      "logger-config:warn",
+      "migration-logger",
+      "migration",
+      "action:daemon-start",
+    ]);
+  });
+
+  it("does not migrate for root, nested, positional help, version, or no-action parsing", () => {
+    const cases = [["--help"], ["daemon", "--help"], ["help", "daemon"], ["--version"], []] as const;
+
+    for (const args of cases) {
+      const harness = runtimeHarness();
+      const program = programFor(harness);
+      registerMaintenanceCommands(program);
+      registerStatusCommand(program);
+
+      try {
+        parse(program, [...args]);
+      } catch {
+        // `exitOverride()` represents Commander's normal help/version exit.
+      }
+
+      expect(harness.runRetirement, args.join(" ") || "no action").not.toHaveBeenCalled();
+      expect(harness.events, args.join(" ") || "no action").toEqual([]);
+    }
+  });
+
+  it("keeps partial failures visible at JSON's error level without blocking the action", () => {
+    const diagnostic: LegacyGithubScanLaunchdRetirementDiagnostic = {
+      stage: "verify",
+      reason: "verification-timeout",
+      label: "com.first-tree.github-scan.runner.qa.default",
+    };
+    const harness = runtimeHarness({
+      status: "partial",
+      retired: 0,
+      diagnostics: [diagnostic],
+      retryAt: 123_456,
+    });
+    harness.dependencies.env.FIRST_TREE_JSON = "1";
+    statusMocks.renderCliVersionBlock.mockImplementationOnce(() => harness.events.push("action:status"));
+    const program = programFor(harness);
+    registerStatusCommand(program);
+
+    parse(program, ["status"]);
+
+    expect(harness.events).toEqual([
+      "json:true",
+      "logger-config:error",
+      "migration-logger",
+      "migration",
+      "action:status",
+    ]);
+    expect(harness.error).toHaveBeenCalledWith(
+      { retired: 0, retryAt: 123_456, diagnostics: [diagnostic] },
+      expect.stringContaining("incomplete"),
+    );
+  });
+
+  it("keeps deferred diagnostics visible in JSON mode while continuing the action", () => {
+    const diagnostic: LegacyGithubScanLaunchdRetirementDiagnostic = {
+      stage: "bootout",
+      reason: "exit-nonzero",
+      label: "com.first-tree.github-scan.runner.qa.default",
+      status: 1,
+    };
+    const harness = runtimeHarness({
+      status: "deferred",
+      retired: 0,
+      diagnostics: [diagnostic],
+      retryAt: 654_321,
+    });
+    harness.dependencies.env.FIRST_TREE_JSON = "1";
+    statusMocks.renderCliVersionBlock.mockImplementationOnce(() => harness.events.push("action:status"));
+    const program = programFor(harness);
+    registerStatusCommand(program);
+
+    parse(program, ["status"]);
+
+    expect(harness.events.at(-1)).toBe("action:status");
+    expect(harness.error).toHaveBeenCalledWith(
+      { retired: 0, retryAt: 654_321, diagnostics: [diagnostic] },
+      expect.stringContaining("deferred"),
+    );
+    expect(harness.info).not.toHaveBeenCalled();
+  });
+
+  it("normalizes unexpected exceptions and continues the selected action", () => {
+    const harness = runtimeHarness();
+    harness.runRetirement.mockImplementationOnce(() => {
+      harness.events.push("migration");
+      throw new Error("do not expose /Users/example/private-path");
+    });
+    statusMocks.renderCliVersionBlock.mockImplementationOnce(() => harness.events.push("action:status"));
+    const program = programFor(harness);
+    registerStatusCommand(program);
+
+    parse(program, ["status"]);
+
+    expect(harness.events.at(-1)).toBe("action:status");
+    expect(harness.error).toHaveBeenCalledWith({ errorType: "Error" }, expect.stringContaining("continuing command"));
+    expect(JSON.stringify(harness.error.mock.calls)).not.toContain("private-path");
+  });
+});

--- a/apps/cli/src/__tests__/legacy-github-scan-launchd-retirement-adapter.test.ts
+++ b/apps/cli/src/__tests__/legacy-github-scan-launchd-retirement-adapter.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const adapterMocks = vi.hoisted(() => ({
+  userInfo: vi.fn(),
+  spawnSync: vi.fn(() => {
+    throw new Error("production spawn must not run in this test");
+  }),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:os")>();
+  return { ...original, userInfo: adapterMocks.userInfo };
+});
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:child_process")>();
+  return { ...original, spawnSync: adapterMocks.spawnSync };
+});
+
+vi.mock("../core/channel.js", () => ({
+  channelConfig: { channel: "staging" },
+}));
+
+import { runLegacyGithubScanLaunchdRetirementOnce } from "../core/legacy-github-scan-launchd-retirement.js";
+
+describe("legacy github-scan launchd production adapter", () => {
+  const effectiveHome = mkdtempSync(join(tmpdir(), "first-tree-legacy-adapter-"));
+
+  afterAll(() => {
+    rmSync(effectiveHome, { recursive: true, force: true });
+  });
+
+  it("uses the effective-account home and memoizes without touching live launchctl", () => {
+    adapterMocks.userInfo.mockReturnValue({
+      uid: 501,
+      gid: 20,
+      username: "qa",
+      homedir: effectiveHome,
+      shell: "/bin/zsh",
+    });
+
+    const first = runLegacyGithubScanLaunchdRetirementOnce();
+    const second = runLegacyGithubScanLaunchdRetirementOnce();
+
+    expect(first.status).toBe(process.platform === "darwin" ? "absent" : "not-applicable");
+    expect(second).toBe(first);
+    expect(adapterMocks.userInfo).toHaveBeenCalledTimes(1);
+    expect(adapterMocks.spawnSync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/__tests__/legacy-github-scan-launchd-retirement.test.ts
+++ b/apps/cli/src/__tests__/legacy-github-scan-launchd-retirement.test.ts
@@ -1,0 +1,1142 @@
+import {
+  chmodSync,
+  constants,
+  existsSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type LegacyGithubScanLaunchdRetirementOptions,
+  runLegacyGithubScanLaunchdRetirement,
+} from "../core/legacy-github-scan-launchd-retirement.js";
+
+const UID = 501;
+const PREFIX = "com.first-tree.github-scan.runner.";
+const MARKER_NAME = ".legacy-launchd-retirement-v1.json";
+
+type LaunchctlResult = ReturnType<LegacyGithubScanLaunchdRetirementOptions["spawnLaunchctl"]>;
+
+function codedError(code: string): Error & { code: string } {
+  return Object.assign(new Error(code), { code });
+}
+
+function label(login: string): string {
+  return `${PREFIX}${login}.default`;
+}
+
+function plist(labelValue: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>${labelValue}</string>
+  <key>KeepAlive</key><true/>
+</dict></plist>
+`;
+}
+
+function paths(home: string) {
+  const runner = join(home, ".first-tree", "github-scan", "runner");
+  const launchd = join(runner, "launchd");
+  return { runner, launchd, marker: join(runner, MARKER_NAME) };
+}
+
+function createLaunchd(home: string): string {
+  const launchd = paths(home).launchd;
+  mkdirSync(launchd, { recursive: true });
+  return launchd;
+}
+
+function writeCandidate(home: string, login: string, embedded = label(login)): string {
+  const launchd = createLaunchd(home);
+  const path = join(launchd, `${label(login)}.plist`);
+  writeFileSync(path, plist(embedded));
+  return path;
+}
+
+function absentPrint(target: string): LaunchctlResult {
+  const parsed = /^gui\/(\d+)\/(.+)$/.exec(target);
+  if (!parsed) throw new Error(`bad target: ${target}`);
+  return {
+    status: 113,
+    signal: null,
+    stderr: `Bad request.\nCould not find service "${parsed[2]}" in domain for user gui: ${parsed[1]}`,
+  };
+}
+
+function defaultSpawn(args: readonly string[]): LaunchctlResult {
+  if (args[0] === "bootout") return { status: 0, signal: null, stderr: "" };
+  if (args[0] === "print" && args[1]) return absentPrint(args[1]);
+  throw new Error(`unexpected launchctl args: ${args.join(" ")}`);
+}
+
+function parseTestPlistLabel(value: string): string | null {
+  if (value.includes("<![CDATA[")) return null;
+  const labels = [...value.matchAll(/<key>\s*Label\s*<\/key>\s*<string>([^<]*)<\/string>/g)].map((match) => match[1]);
+  return labels.length === 1 ? labels[0] : null;
+}
+
+function run(home: string, overrides: Partial<LegacyGithubScanLaunchdRetirementOptions> = {}) {
+  return runLegacyGithubScanLaunchdRetirement({
+    platform: "darwin",
+    channel: "staging",
+    effectiveHome: home,
+    effectiveUid: UID,
+    spawnLaunchctl: defaultSpawn,
+    parsePlistLabel: parseTestPlistLabel,
+    randomToken: () => "0123456789abcdef",
+    ...overrides,
+  });
+}
+
+function writeMarker(home: string, value: unknown, mode = 0o600): string {
+  const { runner, marker } = paths(home);
+  mkdirSync(runner, { recursive: true });
+  writeFileSync(marker, `${JSON.stringify(value)}\n`, { mode });
+  chmodSync(marker, mode);
+  return marker;
+}
+
+function markerValue(retryAt: number, resumeAfter?: string) {
+  return {
+    version: 1,
+    retryAt,
+    ...(resumeAfter ? { resumeAfter } : {}),
+    diagnostics: [{ stage: "bootout", reason: "exit-nonzero", label: label("alice"), status: 1 }],
+  };
+}
+
+describe("legacy github-scan launchd retirement", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "first-tree-legacy-launchd-"));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it.each([
+    { platform: "linux" as const, channel: "prod" as const },
+    { platform: "darwin" as const, channel: "dev" as const },
+  ])("is not applicable for $platform/$channel without touching launchctl", ({ platform, channel }) => {
+    let calls = 0;
+    let fileSystemCalls = 0;
+    const res = run(home, {
+      platform,
+      channel,
+      spawnLaunchctl: () => {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+      fileSystem: {
+        lstat(path) {
+          fileSystemCalls += 1;
+          return lstatSync(path);
+        },
+      },
+    });
+    expect(res).toEqual({ status: "not-applicable", retired: 0, diagnostics: [] });
+    expect(calls).toBe(0);
+    expect(fileSystemCalls).toBe(0);
+  });
+
+  it("rejects an untrusted effective-home value", () => {
+    const res = run("relative/home");
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics).toEqual([{ stage: "eligibility", reason: "invalid-home" }]);
+  });
+
+  it("is idempotently absent when the fixed namespace or launchd directory is missing", () => {
+    expect(run(home).status).toBe("absent");
+    mkdirSync(paths(home).runner, { recursive: true });
+    expect(run(home).status).toBe("absent");
+    createLaunchd(home);
+    expect(run(home).status).toBe("absent");
+  });
+
+  it("retires a loaded exact label, verifies eviction, then unlinks", () => {
+    const candidate = writeCandidate(home, "alice");
+    const events: string[] = [];
+    const calls: Array<{ args: readonly string[]; timeout: number }> = [];
+    const res = run(home, {
+      spawnLaunchctl: (args, timeout) => {
+        calls.push({ args: [...args], timeout });
+        events.push(args[0]);
+        return defaultSpawn(args);
+      },
+      fileSystem: {
+        unlink(path) {
+          events.push(`unlink:${path}`);
+          unlinkSync(path);
+        },
+      },
+    });
+
+    expect(res).toEqual({ status: "complete", retired: 1, diagnostics: [] });
+    expect(calls).toEqual([
+      { args: ["bootout", `gui/${UID}/${label("alice")}`], timeout: 15_000 },
+      { args: ["print", `gui/${UID}/${label("alice")}`], timeout: 2_000 },
+    ]);
+    expect(events).toEqual(["bootout", "print", `unlink:${candidate}`]);
+    expect(existsSync(candidate)).toBe(false);
+    expect(run(home).status).toBe("absent");
+  });
+
+  it.runIf(process.platform === "darwin")("uses the native plist parser for the historical document shape", () => {
+    const candidate = writeCandidate(home, "native-parser");
+    const res = runLegacyGithubScanLaunchdRetirement({
+      platform: "darwin",
+      channel: "staging",
+      effectiveHome: home,
+      effectiveUid: UID,
+      spawnLaunchctl: defaultSpawn,
+      randomToken: () => "0123456789abcdef",
+    });
+
+    expect(res).toEqual({ status: "complete", retired: 1, diagnostics: [] });
+    expect(existsSync(candidate)).toBe(false);
+  });
+
+  it("also runs for the published prod channel", () => {
+    const candidate = writeCandidate(home, "prod-user");
+    const res = run(home, { channel: "prod" });
+    expect(res).toEqual({ status: "complete", retired: 1, diagnostics: [] });
+    expect(existsSync(candidate)).toBe(false);
+  });
+
+  it("cleans a plist-only service only after exact ESRCH and print absence", () => {
+    const candidate = writeCandidate(home, "plist-only");
+    const res = run(home, {
+      spawnLaunchctl(args) {
+        if (args[0] === "bootout") {
+          return { status: 3, signal: null, stderr: "Boot-out failed: 3: No such process" };
+        }
+        return absentPrint(args[1]);
+      },
+    });
+    expect(res.status).toBe("complete");
+    expect(existsSync(candidate)).toBe(false);
+  });
+
+  it.each([
+    "first-tree.plist",
+    "first-tree-staging.plist",
+    "first-tree-dev.plist",
+    `${PREFIX}alice.custom.plist`,
+    `${PREFIX}alice.default.plist.bak`,
+    `x${PREFIX}alice.default.plist`,
+  ])("never targets current-channel or near-miss entry %s", (filename) => {
+    const launchd = createLaunchd(home);
+    const path = join(launchd, filename);
+    writeFileSync(path, plist("first-tree"));
+    let calls = 0;
+    const res = run(home, {
+      spawnLaunchctl: () => {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+    });
+    expect(res.status).toBe("absent");
+    expect(calls).toBe(0);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it.each([
+    { name: "missing", contents: "<plist><dict></dict></plist>" },
+    { name: "mismatch", contents: plist(label("someone-else")) },
+    { name: "duplicate", contents: `${plist(label("alice"))}<key>Label</key><string>${label("alice")}</string>` },
+    { name: "comment-only", contents: `<!-- <key>Label</key><string>${label("alice")}</string> -->` },
+    { name: "plain label snippet", contents: `<key>Label</key><string>${label("alice")}</string>` },
+    {
+      name: "CDATA label snippet",
+      contents: plist(label("alice")).replace(
+        `<key>Label</key><string>${label("alice")}</string>`,
+        `<![CDATA[<key>Label</key><string>${label("alice")}</string>]]>`,
+      ),
+    },
+    { name: "trailing garbage", contents: `${plist(label("alice"))}garbage` },
+  ])("retains an exact filename with $name Label semantics", ({ contents }) => {
+    const candidate = writeCandidate(home, "alice");
+    writeFileSync(candidate, contents);
+    let calls = 0;
+    const res = run(home, {
+      spawnLaunchctl: () => {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.retired).toBe(0);
+    expect(res.diagnostics).toContainEqual({
+      stage: "candidate-read",
+      reason: "invalid-plist-label",
+      label: label("alice"),
+    });
+    expect(calls).toBe(0);
+    expect(existsSync(candidate)).toBe(true);
+    expect(res.retryAt).toBeTypeOf("number");
+    expect(statSync(paths(home).marker).mode & 0o7777).toBe(0o600);
+  });
+
+  it("reports a semantic plist parser failure without invoking launchctl", () => {
+    const candidate = writeCandidate(home, "alice");
+    let calls = 0;
+    const res = run(home, {
+      parsePlistLabel() {
+        throw codedError("ETIMEDOUT");
+      },
+      spawnLaunchctl() {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics).toContainEqual({
+      stage: "candidate-read",
+      reason: "candidate-unreadable",
+      label: label("alice"),
+      code: "ETIMEDOUT",
+    });
+    expect(calls).toBe(0);
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it.each([
+    ".first-tree",
+    "github-scan",
+    "runner",
+    "launchd",
+  ])("fails closed when fixed component %s is a symlink", (component) => {
+    const target = mkdtempSync(join(tmpdir(), "first-tree-symlink-target-"));
+    try {
+      const firstTree = join(home, ".first-tree");
+      const githubScan = join(firstTree, "github-scan");
+      const runner = join(githubScan, "runner");
+      const launchd = join(runner, "launchd");
+      const selected = { ".first-tree": firstTree, "github-scan": githubScan, runner, launchd }[component];
+      if (!selected) throw new Error(`unexpected component: ${component}`);
+      mkdirSync(join(selected, ".."), { recursive: true });
+      symlinkSync(target, selected);
+      let calls = 0;
+      const res = run(home, {
+        spawnLaunchctl: () => {
+          calls += 1;
+          return { status: 0, signal: null };
+        },
+      });
+      expect(res.status).toBe("partial");
+      expect(res.diagnostics[0]?.reason).toBe("unsafe-ancestor");
+      expect(calls).toBe(0);
+    } finally {
+      rmSync(target, { recursive: true, force: true });
+    }
+  });
+
+  it("treats an exact entry symlink and non-regular entry as unresolved without launchctl", () => {
+    const launchd = createLaunchd(home);
+    const outside = join(home, "outside.plist");
+    writeFileSync(outside, plist(label("link")));
+    symlinkSync(outside, join(launchd, `${label("link")}.plist`));
+    mkdirSync(join(launchd, `${label("directory")}.plist`));
+    let calls = 0;
+    const res = run(home, {
+      spawnLaunchctl: () => {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics.filter((item) => item.reason === "unsafe-candidate")).toHaveLength(2);
+    expect(calls).toBe(0);
+  });
+
+  it("retains an oversize candidate and reports the bounded reason", () => {
+    const candidate = writeCandidate(home, "large");
+    writeFileSync(candidate, Buffer.alloc(64 * 1024 + 1, 0x61));
+    const res = run(home);
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics).toContainEqual({
+      stage: "candidate-read",
+      reason: "candidate-oversize",
+      label: label("large"),
+    });
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it("fails closed when O_NOFOLLOW is unavailable", () => {
+    writeCandidate(home, "alice");
+    const res = run(home, { noFollowFlag: 0 });
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics[0]?.reason).toBe("no-follow-unavailable");
+  });
+
+  it.each([
+    {
+      name: "spawn ENOENT",
+      value: { error: codedError("ENOENT"), status: null, signal: null },
+      reason: "spawn-error",
+      code: "ENOENT",
+    },
+    {
+      name: "spawn ETIMEDOUT",
+      value: { error: codedError("ETIMEDOUT"), status: null, signal: "SIGTERM" },
+      reason: "spawn-error",
+      code: "ETIMEDOUT",
+    },
+    {
+      name: "signal",
+      value: { status: null, signal: "SIGTERM" },
+      reason: "spawn-signal",
+      signal: "SIGTERM",
+    },
+    {
+      name: "blank nonzero",
+      value: { status: 1, signal: null, stderr: "" },
+      reason: "empty-nonzero",
+    },
+    {
+      name: "permission",
+      value: { status: 1, signal: null, stderr: "Operation not permitted" },
+      reason: "exit-nonzero",
+    },
+  ])("retains the plist for bootout $name", ({ value, reason, ...expected }) => {
+    const candidate = writeCandidate(home, "alice");
+    const res = run(home, { spawnLaunchctl: () => value });
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics).toContainEqual(
+      expect.objectContaining({
+        stage: "bootout",
+        reason,
+        label: label("alice"),
+        ...(expected.code ? { code: expected.code } : {}),
+        ...(expected.signal ? { signal: expected.signal } : {}),
+      }),
+    );
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it("does not mistake a broad no-such-service message for exact ESRCH", () => {
+    const candidate = writeCandidate(home, "alice");
+    const res = run(home, {
+      spawnLaunchctl: () => ({ status: 3, signal: null, stderr: "No such service" }),
+    });
+    expect(res.status).toBe("partial");
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it("requires the known bootout ESRCH status as well as its exact message", () => {
+    const candidate = writeCandidate(home, "alice");
+    const res = run(home, {
+      spawnLaunchctl: () => ({ status: 7, signal: null, stderr: "Boot-out failed: 3: No such process" }),
+    });
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics[0]).toEqual(
+      expect.objectContaining({ stage: "bootout", reason: "exit-nonzero", status: 7 }),
+    );
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it("requires print absence to bind the exact label and gui domain", () => {
+    const candidate = writeCandidate(home, "alice");
+    const res = run(home, {
+      spawnLaunchctl(args) {
+        if (args[0] === "bootout") return { status: 0, signal: null };
+        return {
+          status: 113,
+          signal: null,
+          stderr: `Could not find service "${label("bob")}" in domain for user gui: ${UID}`,
+        };
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics[0]).toEqual(expect.objectContaining({ stage: "verify", reason: "exit-nonzero" }));
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it.each([
+    {
+      name: "spawn error",
+      value: { error: codedError("ETIMEDOUT"), status: null, signal: null },
+      reason: "spawn-error",
+    },
+    { name: "signal", value: { status: null, signal: "SIGTERM" }, reason: "spawn-signal" },
+    { name: "blank nonzero", value: { status: 1, signal: null, stderr: "" }, reason: "empty-nonzero" },
+  ])("retains the plist for verification $name", ({ value, reason }) => {
+    const candidate = writeCandidate(home, "alice");
+    const res = run(home, {
+      spawnLaunchctl(args) {
+        return args[0] === "bootout" ? { status: 0, signal: null } : value;
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics).toContainEqual(expect.objectContaining({ stage: "verify", reason, label: label("alice") }));
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it("times out while the exact label remains registered", () => {
+    const candidate = writeCandidate(home, "alice");
+    let now = 1_000;
+    let prints = 0;
+    const res = run(home, {
+      now: () => now,
+      sleep: (ms) => {
+        now += ms;
+      },
+      spawnLaunchctl(args) {
+        if (args[0] === "bootout") return { status: 0, signal: null };
+        prints += 1;
+        return { status: 0, signal: null, stdout: "state = running" };
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics).toContainEqual({
+      stage: "verify",
+      reason: "verification-timeout",
+      label: label("alice"),
+    });
+    expect(prints).toBeGreaterThan(1);
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it("rounds fractional monotonic deadlines before passing timeouts to spawnSync", () => {
+    writeCandidate(home, "fractional");
+    let monotonic = 0.25;
+    const printTimeouts: number[] = [];
+    const res = run(home, {
+      monotonicNow: () => monotonic,
+      sleep: (ms) => {
+        monotonic += ms + 0.5;
+      },
+      spawnLaunchctl(args, timeout) {
+        if (args[0] === "bootout") return { status: 0, signal: null };
+        printTimeouts.push(timeout);
+        return { status: 0, signal: null, stdout: "state = running" };
+      },
+    });
+
+    expect(res.status).toBe("partial");
+    expect(printTimeouts.length).toBeGreaterThan(1);
+    expect(printTimeouts.every((timeout) => Number.isInteger(timeout) && timeout >= 1)).toBe(true);
+    expect(printTimeouts.some((timeout) => timeout < 2_000)).toBe(true);
+  });
+
+  it("gives a later candidate its own budget after an earlier verification timeout", () => {
+    const first = writeCandidate(home, "a");
+    const second = writeCandidate(home, "b");
+    let now = 1_000;
+    const bootouts: string[] = [];
+    const res = run(home, {
+      now: () => now,
+      sleep: (ms) => {
+        now += ms;
+      },
+      spawnLaunchctl(args) {
+        const target = args[1];
+        if (!target) throw new Error("missing launchctl target");
+        if (args[0] === "bootout") {
+          bootouts.push(target);
+          return { status: 0, signal: null };
+        }
+        if (target.endsWith(`/${label("a")}`)) {
+          return { status: 0, signal: null, stdout: "state = running" };
+        }
+        return absentPrint(target);
+      },
+    });
+
+    expect(res.status).toBe("partial");
+    expect(res.retired).toBe(1);
+    expect(bootouts).toEqual([`gui/${UID}/${label("a")}`, `gui/${UID}/${label("b")}`]);
+    expect(existsSync(first)).toBe(true);
+    expect(existsSync(second)).toBe(false);
+  });
+
+  it("reports an unlink failure after verified eviction and retains the plist", () => {
+    const candidate = writeCandidate(home, "alice");
+    const res = run(home, {
+      fileSystem: {
+        unlink(path) {
+          if (path === candidate) throw codedError("EACCES");
+          unlinkSync(path);
+        },
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.retired).toBe(0);
+    expect(res.diagnostics).toContainEqual({
+      stage: "unlink",
+      reason: "unlink-failed",
+      label: label("alice"),
+      code: "EACCES",
+    });
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it("fails closed on a real candidate read error", () => {
+    const candidate = writeCandidate(home, "unreadable");
+    let calls = 0;
+    const res = run(home, {
+      fileSystem: {
+        open(path, flags, mode) {
+          if (path === candidate) throw codedError("EACCES");
+          return openSync(path, flags, mode);
+        },
+      },
+      spawnLaunchctl: () => {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics).toContainEqual({
+      stage: "candidate-read",
+      reason: "candidate-unreadable",
+      label: label("unreadable"),
+      code: "EACCES",
+    });
+    expect(calls).toBe(0);
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it("reports a candidate removed between inventory and inspection as unresolved", () => {
+    const candidate = writeCandidate(home, "removed-before-open");
+    let calls = 0;
+    const res = run(home, {
+      fileSystem: {
+        lstat(path) {
+          if (path === candidate) {
+            unlinkSync(candidate);
+            throw codedError("ENOENT");
+          }
+          return lstatSync(path);
+        },
+      },
+      spawnLaunchctl() {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+    });
+
+    expect(res.status).toBe("partial");
+    expect(res.retired).toBe(0);
+    expect(res.retryAt).toBeUndefined();
+    expect(res.diagnostics).toContainEqual({
+      stage: "candidate-read",
+      reason: "candidate-changed",
+      label: label("removed-before-open"),
+      code: "ENOENT",
+    });
+    expect(calls).toBe(0);
+    expect(existsSync(paths(home).marker)).toBe(false);
+  });
+
+  it("treats concurrent unlink ENOENT after verified eviction as success", () => {
+    const candidate = writeCandidate(home, "alice");
+    const res = run(home, {
+      fileSystem: {
+        unlink(path) {
+          if (path === candidate) {
+            unlinkSync(path);
+            throw codedError("ENOENT");
+          }
+          unlinkSync(path);
+        },
+      },
+    });
+    expect(res).toEqual({ status: "complete", retired: 1, diagnostics: [] });
+  });
+
+  it("does not treat launchd-ancestor disappearance before unlink as candidate success", () => {
+    const candidate = writeCandidate(home, "alice");
+    const movedLaunchd = `${paths(home).launchd}.moved`;
+    const res = run(home, {
+      spawnLaunchctl(args) {
+        if (args[0] === "bootout") return { status: 0, signal: null };
+        renameSync(paths(home).launchd, movedLaunchd);
+        return absentPrint(args[1]);
+      },
+    });
+
+    expect(res.status).toBe("partial");
+    expect(res.retired).toBe(0);
+    expect(res.diagnostics).toContainEqual({
+      stage: "unlink",
+      reason: "ancestor-changed",
+      label: label("alice"),
+      code: "ENOENT",
+    });
+    expect(existsSync(join(movedLaunchd, `${label("alice")}.plist`))).toBe(true);
+    expect(existsSync(candidate)).toBe(false);
+  });
+
+  it("rechecks ancestors when unlink itself reports ENOENT", () => {
+    const candidate = writeCandidate(home, "alice");
+    const movedLaunchd = `${paths(home).launchd}.moved`;
+    const res = run(home, {
+      fileSystem: {
+        unlink(path) {
+          if (path === candidate) {
+            renameSync(paths(home).launchd, movedLaunchd);
+            throw codedError("ENOENT");
+          }
+          unlinkSync(path);
+        },
+      },
+    });
+
+    expect(res.status).toBe("partial");
+    expect(res.retired).toBe(0);
+    expect(res.diagnostics).toContainEqual({
+      stage: "unlink",
+      reason: "ancestor-changed",
+      label: label("alice"),
+      code: "ENOENT",
+    });
+    expect(existsSync(join(movedLaunchd, `${label("alice")}.plist`))).toBe(true);
+  });
+
+  it("persists a bounded 0600 marker and defers only a complete pending inventory", () => {
+    const candidate = writeCandidate(home, "alice", label("wrong"));
+    const now = 10_000;
+    const first = run(home, { now: () => now });
+    expect(first.status).toBe("partial");
+    expect(first.retryAt).toBe(now + 5 * 60 * 1000);
+    expect(statSync(paths(home).marker).mode & 0o7777).toBe(0o600);
+    const stored = JSON.parse(readFileSync(paths(home).marker, "utf8"));
+    expect(stored).toEqual(
+      expect.objectContaining({ version: 1, retryAt: first.retryAt, resumeAfter: label("alice") }),
+    );
+
+    let calls = 0;
+    const deferred = run(home, {
+      now: () => now + 1,
+      spawnLaunchctl: () => {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+    });
+    expect(deferred.status).toBe("deferred");
+    expect(deferred.retryAt).toBe(first.retryAt);
+    expect(calls).toBe(0);
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it("removes a stale marker when no exact candidate remains", () => {
+    const marker = writeMarker(home, markerValue(100_000));
+
+    const res = run(home, { now: () => 50_000 });
+
+    expect(res).toEqual({ status: "absent", retired: 0, diagnostics: [] });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("treats concurrent marker unlink ENOENT as benign only after revalidation", () => {
+    const marker = writeMarker(home, markerValue(0));
+    const res = run(home, {
+      fileSystem: {
+        unlink(path) {
+          if (path === marker) {
+            unlinkSync(path);
+            throw codedError("ENOENT");
+          }
+          unlinkSync(path);
+        },
+      },
+    });
+
+    expect(res).toEqual({ status: "absent", retired: 0, diagnostics: [] });
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("fails closed on a real marker read error", () => {
+    writeCandidate(home, "alice");
+    const marker = writeMarker(home, markerValue(100_000));
+    let calls = 0;
+    const res = run(home, {
+      now: () => 50_000,
+      fileSystem: {
+        open(path, flags, mode) {
+          if (path === marker) throw codedError("EACCES");
+          return openSync(path, flags, mode);
+        },
+      },
+      spawnLaunchctl() {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+    });
+
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics).toContainEqual({
+      stage: "marker-read",
+      reason: "marker-unreadable",
+      code: "EACCES",
+    });
+    expect(calls).toBe(0);
+  });
+
+  it("fails closed when the opened marker identity differs from its path", () => {
+    writeCandidate(home, "alice");
+    writeMarker(home, markerValue(100_000));
+    const decoy = join(home, "marker-decoy");
+    writeFileSync(decoy, "decoy", { mode: 0o600 });
+    let fstats = 0;
+    const res = run(home, {
+      now: () => 50_000,
+      fileSystem: {
+        fstat(fd) {
+          fstats += 1;
+          return fstats === 1 ? statSync(decoy) : fstatSync(fd);
+        },
+      },
+    });
+
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics[0]).toEqual({ stage: "marker-read", reason: "marker-race" });
+  });
+
+  it("rejects a marker retry timestamp beyond the bounded future window", () => {
+    const candidate = writeCandidate(home, "alice");
+    const now = 50_000;
+    const marker = writeMarker(home, markerValue(now + 10 * 60 * 1000 + 1));
+
+    const res = run(home, { now: () => now });
+
+    expect(res.status).toBe("complete");
+    expect(existsSync(candidate)).toBe(false);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it.each([
+    { name: "corrupt", body: "{not-json", mode: 0o600 },
+    { name: "wrong mode", body: JSON.stringify(markerValue(0)), mode: 0o644 },
+    { name: "oversize", body: "x".repeat(16 * 1024 + 1), mode: 0o600 },
+  ])("removes a recoverable $name marker and continues", ({ body, mode }) => {
+    const candidate = writeCandidate(home, "alice");
+    const marker = paths(home).marker;
+    writeFileSync(marker, body, { mode });
+    chmodSync(marker, mode);
+    const res = run(home);
+    expect(res.status).toBe("complete");
+    expect(res.retired).toBe(1);
+    expect(existsSync(candidate)).toBe(false);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("rejects marker diagnostics with extra or unsanitized fields instead of replaying them", () => {
+    const candidate = writeCandidate(home, "alice");
+    writeMarker(home, {
+      ...markerValue(100_000),
+      diagnostics: [
+        {
+          stage: "bootout",
+          reason: "exit-nonzero",
+          label: label("alice"),
+          detail: "unsafe\ntext",
+          arbitrary: "/private/unbounded",
+        },
+      ],
+    });
+
+    const res = run(home, { now: () => 50_000 });
+
+    expect(res.status).toBe("complete");
+    expect(existsSync(candidate)).toBe(false);
+    expect(existsSync(paths(home).marker)).toBe(false);
+    expect(JSON.stringify(res)).not.toContain("unbounded");
+  });
+
+  it.each([
+    { name: "unknown top-level field", extra: { arbitrary: true } },
+    { name: "oversized cursor", extra: { resumeAfter: label("x".repeat(300)) } },
+  ])("rejects a marker with $name", ({ extra }) => {
+    const candidate = writeCandidate(home, "alice");
+    writeMarker(home, { ...markerValue(100_000), ...extra });
+
+    const res = run(home, { now: () => 50_000 });
+
+    expect(res.status).toBe("complete");
+    expect(existsSync(candidate)).toBe(false);
+    expect(existsSync(paths(home).marker)).toBe(false);
+  });
+
+  it("fails closed on a marker symlink", () => {
+    writeCandidate(home, "alice");
+    const outside = join(home, "outside-marker");
+    writeFileSync(outside, "{}");
+    symlinkSync(outside, paths(home).marker);
+    let calls = 0;
+    const res = run(home, {
+      spawnLaunchctl: () => {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics[0]?.reason).toBe("unsafe-marker");
+    expect(calls).toBe(0);
+    expect(lstatSync(paths(home).marker).isSymbolicLink()).toBe(true);
+  });
+
+  it("reports stale-marker removal failure instead of claiming absence", () => {
+    createLaunchd(home);
+    const marker = writeMarker(home, markerValue(0));
+    const res = run(home, {
+      fileSystem: {
+        unlink(path) {
+          if (path === marker) throw codedError("EACCES");
+          unlinkSync(path);
+        },
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.retryAt).toBeUndefined();
+    expect(res.diagnostics[0]).toEqual({
+      stage: "marker-remove",
+      reason: "marker-remove-failed",
+      code: "EACCES",
+    });
+  });
+
+  it("does not expose retryAt when marker persistence fails", () => {
+    writeCandidate(home, "alice", label("wrong"));
+    const res = run(home, {
+      fileSystem: {
+        rename() {
+          throw codedError("EACCES");
+        },
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.retryAt).toBeUndefined();
+    expect(res.diagnostics).toContainEqual(
+      expect.objectContaining({
+        stage: "marker-write",
+        reason: "marker-write-failed",
+        code: "EACCES",
+      }),
+    );
+    expect(existsSync(paths(home).marker)).toBe(false);
+  });
+
+  it("removes its exact temporary marker when durability fails", () => {
+    writeCandidate(home, "alice", label("wrong"));
+    const res = run(home, {
+      fileSystem: {
+        fsync(fd) {
+          fsyncSync(fd);
+          throw codedError("EIO");
+        },
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.retryAt).toBeUndefined();
+    expect(existsSync(paths(home).marker)).toBe(false);
+    expect(readdirSync(paths(home).runner).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+  });
+
+  it("does not persist a cooldown after the last candidate disappears during inspection", () => {
+    const candidate = writeCandidate(home, "alice");
+    const first = run(home, {
+      parsePlistLabel() {
+        unlinkSync(candidate);
+        return null;
+      },
+    });
+    expect(first.status).toBe("partial");
+    expect(first.retryAt).toBeUndefined();
+    expect(first.diagnostics).toContainEqual({
+      stage: "candidate-read",
+      reason: "invalid-plist-label",
+      label: label("alice"),
+    });
+    expect(existsSync(paths(home).marker)).toBe(false);
+    expect(run(home).status).toBe("absent");
+  });
+
+  it("advances past four permanent failures so a fifth valid service is retired", () => {
+    for (const name of ["a", "b", "c", "d", "e"]) writeCandidate(home, name);
+    let now = 1_000;
+    const attempted: string[] = [];
+    const spawn = (args: readonly string[]): LaunchctlResult => {
+      if (args[0] === "bootout") {
+        const targetLabel = args[1].split("/").at(-1);
+        if (!targetLabel) throw new Error("missing launchctl label");
+        attempted.push(targetLabel);
+        if (targetLabel !== label("e")) return { status: 1, signal: null, stderr: "Operation not permitted" };
+        return { status: 0, signal: null };
+      }
+      return absentPrint(args[1]);
+    };
+
+    const first = run(home, { now: () => now, spawnLaunchctl: spawn });
+    expect(first.status).toBe("partial");
+    expect(first.retired).toBe(0);
+    expect(attempted).toEqual([label("a"), label("b"), label("c"), label("d")]);
+    expect(first.diagnostics).toContainEqual({ stage: "inventory", reason: "candidate-cap" });
+
+    now = (first.retryAt ?? 0) + 1;
+    attempted.length = 0;
+    const second = run(home, { now: () => now, spawnLaunchctl: spawn });
+    expect(second.status).toBe("partial");
+    expect(second.retired).toBe(1);
+    expect(attempted[0]).toBe(label("e"));
+    expect(existsSync(join(paths(home).launchd, `${label("e")}.plist`))).toBe(false);
+
+    now = (second.retryAt ?? 0) + 1;
+    attempted.length = 0;
+    run(home, { now: () => now, spawnLaunchctl: spawn });
+    expect(attempted[0]).toBe(label("d"));
+    expect(attempted).toContain(label("a"));
+  });
+
+  it("advances past malformed exact entries and reaches a later valid candidate", () => {
+    for (const name of ["a", "b", "c", "d"]) writeCandidate(home, name, label("wrong"));
+    const fifth = writeCandidate(home, "e");
+    let now = 50_000;
+    const first = run(home, { now: () => now });
+    expect(first.status).toBe("partial");
+    expect(first.retired).toBe(0);
+    now = (first.retryAt ?? 0) + 1;
+    const second = run(home, { now: () => now });
+    expect(second.retired).toBe(1);
+    expect(existsSync(fifth)).toBe(false);
+  });
+
+  it("treats exactly four successfully retired candidates as complete, not cap exhaustion", () => {
+    for (const name of ["a", "b", "c", "d"]) writeCandidate(home, name);
+    const res = run(home);
+    expect(res).toEqual({ status: "complete", retired: 4, diagnostics: [] });
+    expect(existsSync(paths(home).marker)).toBe(false);
+  });
+
+  it("makes entry-budget overflow mutation-free and never defers from a fresh marker", () => {
+    const candidate = writeCandidate(home, "z");
+    const now = 100_000;
+    const marker = writeMarker(home, markerValue(now + 60_000, label("a")));
+    const markerBefore = readFileSync(marker);
+    for (let index = 0; index < 256; index += 1) {
+      writeFileSync(join(paths(home).launchd, `unrelated-${String(index).padStart(3, "0")}`), "x");
+    }
+    let calls = 0;
+    const res = run(home, {
+      now: () => now,
+      spawnLaunchctl: () => {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+    });
+    expect(res).toEqual({
+      status: "partial",
+      retired: 0,
+      diagnostics: [{ stage: "inventory", reason: "inventory-overflow" }],
+    });
+    expect(calls).toBe(0);
+    expect(existsSync(candidate)).toBe(true);
+    expect(readFileSync(marker)).toEqual(markerBefore);
+  });
+
+  it("sanitizes and caps launchctl text in diagnostics and marker data", () => {
+    writeCandidate(home, "alice");
+    const raw = `denied\n\u0000\u0085\u009b${"x".repeat(500)}`;
+    const res = run(home, {
+      spawnLaunchctl: () => ({ status: 1, signal: null, stderr: raw }),
+    });
+    const diagnostic = res.diagnostics.find((item) => item.stage === "bootout");
+    expect(diagnostic?.detail?.length).toBeLessThanOrEqual(160);
+    expect(
+      [...(diagnostic?.detail ?? "")].every((character) => {
+        const codePoint = character.codePointAt(0) ?? 0;
+        return codePoint > 0x1f && !(codePoint >= 0x7f && codePoint <= 0x9f);
+      }),
+    ).toBe(true);
+    expect(readFileSync(paths(home).marker, "utf8")).not.toContain("\u0000");
+  });
+
+  it("revalidates the candidate identity before bootout", () => {
+    const candidate = writeCandidate(home, "alice");
+    let candidateStats = 0;
+    let calls = 0;
+    const res = run(home, {
+      fileSystem: {
+        lstat(path) {
+          if (path === candidate) {
+            candidateStats += 1;
+            if (candidateStats === 2) writeFileSync(candidate, `${plist(label("alice"))}\n`);
+          }
+          return lstatSync(path);
+        },
+      },
+      spawnLaunchctl: () => {
+        calls += 1;
+        return { status: 0, signal: null };
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(res.diagnostics).toContainEqual(expect.objectContaining({ reason: "candidate-changed" }));
+    expect(calls).toBe(0);
+    expect(existsSync(candidate)).toBe(true);
+  });
+
+  it("retains a replacement candidate swapped after verified eviction", () => {
+    const candidate = writeCandidate(home, "alice");
+    const original = `${candidate}.original`;
+    let candidateStats = 0;
+    const res = run(home, {
+      fileSystem: {
+        lstat(path) {
+          if (path === candidate) {
+            candidateStats += 1;
+            if (candidateStats === 3) {
+              renameSync(candidate, original);
+              writeFileSync(candidate, plist(label("alice")));
+            }
+          }
+          return lstatSync(path);
+        },
+      },
+    });
+
+    expect(res.status).toBe("partial");
+    expect(res.retired).toBe(0);
+    expect(res.diagnostics).toContainEqual({
+      stage: "unlink",
+      reason: "candidate-changed",
+      label: label("alice"),
+    });
+    expect(existsSync(candidate)).toBe(true);
+    expect(existsSync(original)).toBe(true);
+  });
+
+  it("uses O_NOFOLLOW for candidate and marker file opens", () => {
+    writeCandidate(home, "alice", label("wrong"));
+    const flags: number[] = [];
+    const res = run(home, {
+      fileSystem: {
+        open(path, openFlags, mode) {
+          flags.push(openFlags);
+          return openSync(path, openFlags, mode);
+        },
+      },
+    });
+    expect(res.status).toBe("partial");
+    expect(flags.length).toBeGreaterThanOrEqual(2);
+    expect(flags.every((value) => (value & constants.O_NOFOLLOW) === constants.O_NOFOLLOW)).toBe(true);
+  });
+});

--- a/apps/cli/src/__tests__/update-glue.test.ts
+++ b/apps/cli/src/__tests__/update-glue.test.ts
@@ -258,6 +258,29 @@ describe("update glue", () => {
     expect(output()).toContain("warning: could not spawn 'daemon refresh-unit': spawn string denied");
   });
 
+  it("keeps healthy status-zero refresh output silent while preserving exit 75", async () => {
+    const { SELF_RESTART_EXIT_CODE, createExecuteUpdate } = await import("../core/update-glue.js");
+    const logs: Array<[level: string, message: string]> = [];
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      signal: null,
+      stderr: "service unit already current\n",
+      stdout: "refresh complete\n",
+    });
+
+    await expect(
+      createExecuteUpdate({
+        managed: true,
+        log: (level, message) => logs.push([level, message]),
+      })({ currentVersion: "0.5.0", targetVersion: "0.6.0" }),
+    ).rejects.toMatchObject({ exitCode: SELF_RESTART_EXIT_CODE });
+
+    expect(exitMock).toHaveBeenCalledWith(SELF_RESTART_EXIT_CODE);
+    expect(logs.filter(([level]) => level === "warn")).toEqual([]);
+    expect(logs.map(([, message]) => message).join("\n")).not.toContain("service unit already current");
+    expect(logs.map(([, message]) => message).join("\n")).not.toContain("refresh complete");
+  });
+
   it("routes managed update output through the injected logger and captures refresh-unit output", async () => {
     const { SELF_RESTART_EXIT_CODE, createExecuteUpdate } = await import("../core/update-glue.js");
     const logs: Array<[level: string, message: string]> = [];

--- a/apps/cli/src/cli/index.ts
+++ b/apps/cli/src/cli/index.ts
@@ -8,7 +8,6 @@
 // import re-introduces the multi-env footgun where staging/dev binaries
 // silently fall back to the prod home and prod CLI name.
 import "../core/channel-env.js";
-import { applyClientLoggerConfig } from "@first-tree/client";
 import { Command } from "commander";
 import { registerAgentCommands } from "../commands/agent/index.js";
 import { registerChatCommands } from "../commands/chat/index.js";
@@ -26,41 +25,17 @@ import { registerStatusCommand } from "../commands/status.js";
 import { registerTreeCommands } from "../commands/tree/index.js";
 import { registerUpgradeCommand } from "../commands/upgrade.js";
 import { channelConfig } from "../core/channel.js";
-import { setJsonMode } from "../core/output.js";
 import { COMMAND_VERSION } from "../core/version.js";
+import { configureCliRuntime } from "./runtime.js";
 
 const program = new Command();
 
 program
   .name(channelConfig.binName)
   .description("First Tree — Context Tree and agent collaboration in one CLI")
-  .version(COMMAND_VERSION)
-  .option("--json", "emit only machine-readable JSON on stdout; silence human status lines on stderr")
-  .option("--verbose", "raise log level to debug (overrides FIRST_TREE_LOG_LEVEL)")
-  .hook("preAction", (thisCommand) => {
-    const opts = thisCommand.optsWithGlobals<{ json?: boolean; verbose?: boolean }>();
-    const json = opts.json === true || process.env.FIRST_TREE_JSON === "1";
-    setJsonMode(json);
+  .version(COMMAND_VERSION);
 
-    // Log-level precedence: --verbose > FIRST_TREE_LOG_LEVEL > mode default.
-    // One-shot commands are noisy by default, so human mode defaults to `warn`,
-    // json mode to `error` — script consumers should get nothing on stderr
-    // unless something actually broke.
-    if (opts.verbose) {
-      applyClientLoggerConfig({ level: "debug", explicit: true });
-    } else if (process.env.FIRST_TREE_LOG_LEVEL) {
-      // Env var already applied at logger init; re-pin as explicit so later
-      // config-driven applies (daemon start reading client.yaml) can't
-      // override what the operator explicitly asked for.
-      applyClientLoggerConfig({ explicit: true });
-    } else if (json) {
-      // --json is an operator choice; pin the level so downstream commands
-      // can't re-introduce info/debug noise on stderr from their saved config.
-      applyClientLoggerConfig({ level: "error", explicit: true });
-    } else {
-      applyClientLoggerConfig({ level: "warn" });
-    }
-  });
+configureCliRuntime(program);
 
 // ── Top-level shortcuts (single-command verbs) ──────────────────────────
 

--- a/apps/cli/src/cli/runtime.ts
+++ b/apps/cli/src/cli/runtime.ts
@@ -1,0 +1,119 @@
+import { applyClientLoggerConfig, createLogger } from "@first-tree/client";
+import type { Command } from "commander";
+import {
+  type LegacyGithubScanLaunchdRetirementResult,
+  runLegacyGithubScanLaunchdRetirementOnce,
+} from "../core/legacy-github-scan-launchd-retirement.js";
+import { setJsonMode } from "../core/output.js";
+
+type CliRuntimeLogger = {
+  info: (context: Record<string, unknown>, message: string) => void;
+  error: (context: Record<string, unknown>, message: string) => void;
+};
+
+export type CliRuntimeDependencies = {
+  env: NodeJS.ProcessEnv;
+  setJsonMode: typeof setJsonMode;
+  applyClientLoggerConfig: typeof applyClientLoggerConfig;
+  createLogger: (module: string) => CliRuntimeLogger;
+  runLegacyGithubScanLaunchdRetirementOnce: () => LegacyGithubScanLaunchdRetirementResult;
+};
+
+const productionDependencies: CliRuntimeDependencies = {
+  env: process.env,
+  setJsonMode,
+  applyClientLoggerConfig,
+  createLogger,
+  runLegacyGithubScanLaunchdRetirementOnce,
+};
+
+/**
+ * Configure process-wide CLI output and one-time machine migrations.
+ *
+ * Keep this hook synchronous: the shipped entrypoint calls `program.parse()`,
+ * and the launchd retirement must finish (or return a bounded partial result)
+ * before the selected action starts.
+ */
+export function configureCliRuntime(
+  program: Command,
+  dependencies: CliRuntimeDependencies = productionDependencies,
+): void {
+  program
+    .option("--json", "emit only machine-readable JSON on stdout; silence human status lines on stderr")
+    .option("--verbose", "raise log level to debug (overrides FIRST_TREE_LOG_LEVEL)")
+    .hook("preAction", (thisCommand, actionCommand) => {
+      const opts = thisCommand.optsWithGlobals<{ json?: boolean; verbose?: boolean }>();
+      const json = opts.json === true || dependencies.env.FIRST_TREE_JSON === "1";
+      dependencies.setJsonMode(json);
+
+      // Log-level precedence: --verbose > FIRST_TREE_LOG_LEVEL > mode default.
+      // One-shot commands are noisy by default, so human mode defaults to
+      // `warn`, while JSON mode keeps stderr for real failures only.
+      if (opts.verbose) {
+        dependencies.applyClientLoggerConfig({ level: "debug", explicit: true });
+      } else if (dependencies.env.FIRST_TREE_LOG_LEVEL) {
+        // The env var was applied at logger init. Re-pin it so later
+        // config-driven applies cannot override the operator's choice.
+        dependencies.applyClientLoggerConfig({ explicit: true });
+      } else if (json) {
+        dependencies.applyClientLoggerConfig({ level: "error", explicit: true });
+      } else {
+        dependencies.applyClientLoggerConfig({ level: "warn" });
+      }
+
+      // The first old-X -> new-Y update handoff already has a 45-second child
+      // timeout loaded in X. Do not spend the retirement budget inside the
+      // hidden refresh child. X refreshes the unit and exits 75; the
+      // supervisor-restarted Y performs this migration from `daemon start`.
+      if (isDaemonRefreshUnitAction(program, actionCommand)) return;
+
+      // Construct the logger only after JSON and log-level normalization.
+      const logger = dependencies.createLogger("legacy-github-scan-retirement");
+      try {
+        const result = dependencies.runLegacyGithubScanLaunchdRetirementOnce();
+        logRetirementResult(logger, result);
+      } catch (error) {
+        // This boundary is deliberately non-throwing: retirement must never
+        // turn an ordinary command or supervisor start into a crash-loop.
+        const errorType = error instanceof Error ? error.name : typeof error;
+        logger.error(
+          { errorType: boundedToken(errorType) },
+          "legacy github-scan launchd retirement failed unexpectedly; continuing command",
+        );
+      }
+    });
+}
+
+function isDaemonRefreshUnitAction(program: Command, actionCommand?: Command): boolean {
+  if (!actionCommand) return false;
+  const daemon = actionCommand.parent;
+  return actionCommand.name() === "refresh-unit" && daemon?.name() === "daemon" && daemon.parent === program;
+}
+
+function logRetirementResult(logger: CliRuntimeLogger, result: LegacyGithubScanLaunchdRetirementResult): void {
+  const context = {
+    retired: result.retired,
+    ...(result.retryAt === undefined ? {} : { retryAt: result.retryAt }),
+    ...(result.diagnostics.length === 0 ? {} : { diagnostics: result.diagnostics }),
+  };
+
+  switch (result.status) {
+    case "complete":
+      logger.info(context, "retired legacy github-scan launchd service");
+      return;
+    case "partial":
+      logger.error(context, "legacy github-scan launchd retirement is incomplete; continuing command");
+      return;
+    case "deferred":
+      logger.error(context, "legacy github-scan launchd retirement is deferred with exact candidates pending");
+      return;
+    case "not-applicable":
+    case "absent":
+      return;
+  }
+}
+
+function boundedToken(value: string): string {
+  const cleaned = value.replace(/[^A-Za-z0-9_.-]/g, "_");
+  return cleaned.slice(0, 64) || "unknown";
+}

--- a/apps/cli/src/core/legacy-github-scan-launchd-retirement.ts
+++ b/apps/cli/src/core/legacy-github-scan-launchd-retirement.ts
@@ -1,0 +1,1166 @@
+import { spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  type Dirent,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  opendirSync,
+  openSync,
+  readSync,
+  renameSync,
+  type Stats,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { userInfo } from "node:os";
+import { basename, dirname, isAbsolute, join, normalize, parse, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import type { ChannelName } from "@first-tree/shared/channel";
+import { channelConfig } from "./channel.js";
+import { sleepSync } from "./supervisor/shared.js";
+
+const LEGACY_LABEL_SOURCE = String.raw`com\.first-tree\.github-scan\.runner\.[A-Za-z0-9._-]+\.default`;
+const LEGACY_LABEL_RE = new RegExp(`^${LEGACY_LABEL_SOURCE}$`);
+const LEGACY_PLIST_RE = new RegExp(`^(${LEGACY_LABEL_SOURCE})\\.plist$`);
+const MARKER_NAME = ".legacy-launchd-retirement-v1.json";
+
+const MAX_DIRECTORY_ENTRIES = 256;
+const MAX_CANDIDATES_PER_RUN = 4;
+const MAX_PLIST_BYTES = 64 * 1024;
+const MAX_MARKER_BYTES = 16 * 1024;
+const MAX_DIAGNOSTICS = 16;
+const MAX_DETAIL_CHARS = 160;
+// NAME_MAX (255) minus the six-byte ".plist" suffix. This is also the
+// largest exact legacy label that can be represented by the canonical file.
+const MAX_LEGACY_LABEL_CHARS = 249;
+const RETRY_DELAY_MS = 5 * 60 * 1000;
+const MAX_MARKER_FUTURE_MS = 10 * 60 * 1000;
+const BOOTOUT_TIMEOUT_MS = 15_000;
+const VERIFY_TIMEOUT_MS = 10_000;
+const PRINT_TIMEOUT_MS = 2_000;
+const POLL_INTERVAL_MS = 200;
+
+export type LegacyGithubScanLaunchdRetirementStatus = "not-applicable" | "absent" | "complete" | "partial" | "deferred";
+
+export type LegacyGithubScanLaunchdRetirementStage =
+  | "eligibility"
+  | "path"
+  | "inventory"
+  | "marker-read"
+  | "marker-remove"
+  | "marker-write"
+  | "candidate-read"
+  | "bootout"
+  | "verify"
+  | "unlink"
+  | "internal";
+
+export type LegacyGithubScanLaunchdRetirementReason =
+  | "invalid-home"
+  | "filesystem-error"
+  | "unsafe-ancestor"
+  | "ancestor-changed"
+  | "inventory-overflow"
+  | "inventory-error"
+  | "unsafe-marker"
+  | "marker-unreadable"
+  | "marker-race"
+  | "marker-remove-failed"
+  | "marker-write-failed"
+  | "marker-rename-failed"
+  | "marker-verify-failed"
+  | "no-follow-unavailable"
+  | "unsafe-candidate"
+  | "candidate-unreadable"
+  | "candidate-oversize"
+  | "candidate-changed"
+  | "invalid-plist-label"
+  | "spawn-error"
+  | "spawn-signal"
+  | "empty-nonzero"
+  | "exit-nonzero"
+  | "verification-timeout"
+  | "unlink-failed"
+  | "candidate-cap"
+  | "unexpected";
+
+/**
+ * Diagnostics intentionally contain no arbitrary path or plist data. Labels
+ * have already passed the exact legacy-label grammar; free-form process text
+ * is control-stripped and capped before it reaches this object.
+ */
+export type LegacyGithubScanLaunchdRetirementDiagnostic = Readonly<{
+  stage: LegacyGithubScanLaunchdRetirementStage;
+  reason: LegacyGithubScanLaunchdRetirementReason;
+  label?: string;
+  code?: string;
+  status?: number;
+  signal?: string;
+  detail?: string;
+}>;
+
+export type LegacyGithubScanLaunchdRetirementResult = Readonly<{
+  status: LegacyGithubScanLaunchdRetirementStatus;
+  retired: number;
+  diagnostics: readonly LegacyGithubScanLaunchdRetirementDiagnostic[];
+  /** Unix epoch milliseconds. Present only after the retry marker is durable. */
+  retryAt?: number;
+}>;
+
+type LaunchctlResult = Readonly<{
+  error?: unknown;
+  status: number | null;
+  signal: string | null;
+  stdout?: string | null;
+  stderr?: string | null;
+}>;
+
+type SyncDirectory = {
+  readSync(): Dirent | null;
+  closeSync(): void;
+};
+
+export type LegacyGithubScanRetirementFileSystem = Readonly<{
+  lstat(path: string): Stats;
+  open(path: string, flags: number, mode?: number): number;
+  fstat(fd: number): Stats;
+  read(fd: number, buffer: Buffer, offset: number, length: number, position: number | null): number;
+  write(fd: number, buffer: Buffer, offset: number, length: number, position: number | null): number;
+  close(fd: number): void;
+  unlink(path: string): void;
+  rename(from: string, to: string): void;
+  openDirectory(path: string): SyncDirectory;
+  fchmod(fd: number, mode: number): void;
+  fsync(fd: number): void;
+}>;
+
+export type LegacyGithubScanLaunchdRetirementOptions = Readonly<{
+  platform: NodeJS.Platform;
+  channel: ChannelName;
+  effectiveHome: string;
+  effectiveUid: number;
+  spawnLaunchctl(args: readonly string[], timeoutMs: number): LaunchctlResult;
+  parsePlistLabel?: (plist: string) => string | null;
+  now?: () => number;
+  monotonicNow?: () => number;
+  sleep?: (ms: number) => void;
+  randomToken?: () => string;
+  noFollowFlag?: number;
+  fileSystem?: Partial<LegacyGithubScanRetirementFileSystem>;
+}>;
+
+const nodeFileSystem: LegacyGithubScanRetirementFileSystem = {
+  lstat: lstatSync,
+  open: openSync,
+  fstat: fstatSync,
+  read: readSync,
+  write: writeSync,
+  close: closeSync,
+  unlink: unlinkSync,
+  rename: renameSync,
+  openDirectory: opendirSync,
+  fchmod: fchmodSync,
+  fsync: fsyncSync,
+};
+
+type DirectoryIdentity = Readonly<{ path: string; dev: number; ino: number }>;
+type FileIdentity = Readonly<{
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+  ctimeMs: number;
+}>;
+
+type MarkerValue = Readonly<{
+  version: 1;
+  retryAt: number;
+  resumeAfter?: string;
+  diagnostics: readonly LegacyGithubScanLaunchdRetirementDiagnostic[];
+}>;
+
+type MarkerInspection =
+  | Readonly<{ kind: "missing" }>
+  | Readonly<{ kind: "valid"; value: MarkerValue; identity: FileIdentity }>
+  | Readonly<{ kind: "recoverable-corrupt"; identity: FileIdentity }>
+  | Readonly<{ kind: "error"; diagnostic: LegacyGithubScanLaunchdRetirementDiagnostic }>;
+
+type InventoryResult =
+  | Readonly<{ kind: "complete"; candidates: readonly Candidate[] }>
+  | Readonly<{ kind: "overflow" }>
+  | Readonly<{ kind: "error"; diagnostic: LegacyGithubScanLaunchdRetirementDiagnostic }>;
+
+type Candidate = Readonly<{ label: string; filename: string; path: string }>;
+
+type OpenCandidate = Readonly<{ fd: number; identity: FileIdentity; plist: string }>;
+
+type Runtime = Readonly<{
+  fs: LegacyGithubScanRetirementFileSystem;
+  noFollowFlag: number;
+  spawnLaunchctl: LegacyGithubScanLaunchdRetirementOptions["spawnLaunchctl"];
+  parsePlistLabel: NonNullable<LegacyGithubScanLaunchdRetirementOptions["parsePlistLabel"]>;
+  now: () => number;
+  monotonicNow: () => number;
+  sleep: (ms: number) => void;
+  randomToken: () => string;
+  uid: number;
+}>;
+
+function result(
+  status: LegacyGithubScanLaunchdRetirementStatus,
+  retired = 0,
+  diagnostics: readonly LegacyGithubScanLaunchdRetirementDiagnostic[] = [],
+  retryAt?: number,
+): LegacyGithubScanLaunchdRetirementResult {
+  return {
+    status,
+    retired,
+    diagnostics: diagnostics.slice(0, MAX_DIAGNOSTICS),
+    ...(retryAt === undefined ? {} : { retryAt }),
+  };
+}
+
+function isLegacyLabel(value: string): boolean {
+  return value.length <= MAX_LEGACY_LABEL_CHARS && LEGACY_LABEL_RE.test(value);
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object" || !("code" in error)) return undefined;
+  const value = String((error as { code: unknown }).code);
+  return /^[A-Za-z0-9_-]{1,32}$/.test(value) ? value : undefined;
+}
+
+function isErrorCode(error: unknown, code: string): boolean {
+  return errorCode(error) === code;
+}
+
+function sanitizeDetail(value: unknown): string | undefined {
+  const withoutControls = [...String(value ?? "")]
+    .map((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character;
+    })
+    .join("");
+  const sanitized = withoutControls.replace(/\s+/g, " ").trim().slice(0, MAX_DETAIL_CHARS);
+  return sanitized || undefined;
+}
+
+function safeSignal(value: unknown): string | undefined {
+  const signal = String(value ?? "");
+  return /^[A-Z0-9]{1,16}$/.test(signal) ? signal : undefined;
+}
+
+function addDiagnostic(
+  diagnostics: LegacyGithubScanLaunchdRetirementDiagnostic[],
+  diagnostic: LegacyGithubScanLaunchdRetirementDiagnostic,
+): void {
+  if (diagnostics.length < MAX_DIAGNOSTICS) diagnostics.push(diagnostic);
+}
+
+function fsDiagnostic(
+  stage: LegacyGithubScanLaunchdRetirementStage,
+  reason: LegacyGithubScanLaunchdRetirementReason,
+  error: unknown,
+  label?: string,
+): LegacyGithubScanLaunchdRetirementDiagnostic {
+  const code = errorCode(error);
+  return { stage, reason, ...(label ? { label } : {}), ...(code ? { code } : {}) };
+}
+
+function identityOf(stat: Stats): FileIdentity {
+  return {
+    dev: stat.dev,
+    ino: stat.ino,
+    size: stat.size,
+    mtimeMs: stat.mtimeMs,
+    ctimeMs: stat.ctimeMs,
+  };
+}
+
+function sameFileIdentity(stat: Stats, identity: FileIdentity): boolean {
+  return (
+    stat.isFile() &&
+    !stat.isSymbolicLink() &&
+    stat.dev === identity.dev &&
+    stat.ino === identity.ino &&
+    stat.size === identity.size &&
+    stat.mtimeMs === identity.mtimeMs &&
+    stat.ctimeMs === identity.ctimeMs
+  );
+}
+
+function sameObjectIdentity(stat: Stats, identity: FileIdentity): boolean {
+  return stat.isFile() && !stat.isSymbolicLink() && stat.dev === identity.dev && stat.ino === identity.ino;
+}
+
+function inspectDirectoryChain(
+  paths: readonly string[],
+  fs: LegacyGithubScanRetirementFileSystem,
+):
+  | Readonly<{ kind: "ok"; identities: readonly DirectoryIdentity[] }>
+  | Readonly<{ kind: "absent" }>
+  | Readonly<{ kind: "error"; diagnostic: LegacyGithubScanLaunchdRetirementDiagnostic }> {
+  const identities: DirectoryIdentity[] = [];
+  for (const path of paths) {
+    let stat: Stats;
+    try {
+      stat = fs.lstat(path);
+    } catch (error) {
+      if (isErrorCode(error, "ENOENT")) return { kind: "absent" };
+      return { kind: "error", diagnostic: fsDiagnostic("path", "filesystem-error", error) };
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      return { kind: "error", diagnostic: { stage: "path", reason: "unsafe-ancestor" } };
+    }
+    identities.push({ path, dev: stat.dev, ino: stat.ino });
+  }
+  return { kind: "ok", identities };
+}
+
+function revalidateDirectories(
+  identities: readonly DirectoryIdentity[],
+  fs: LegacyGithubScanRetirementFileSystem,
+  stage: LegacyGithubScanLaunchdRetirementStage,
+  label?: string,
+): LegacyGithubScanLaunchdRetirementDiagnostic | null {
+  for (const identity of identities) {
+    let stat: Stats;
+    try {
+      stat = fs.lstat(identity.path);
+    } catch (error) {
+      return fsDiagnostic(stage, "ancestor-changed", error, label);
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory() || stat.dev !== identity.dev || stat.ino !== identity.ino) {
+      return { stage, reason: "ancestor-changed", ...(label ? { label } : {}) };
+    }
+  }
+  return null;
+}
+
+function readBoundedFile(
+  fd: number,
+  expectedSize: number,
+  maxBytes: number,
+  fs: LegacyGithubScanRetirementFileSystem,
+): Buffer | null {
+  if (!Number.isSafeInteger(expectedSize) || expectedSize < 0 || expectedSize > maxBytes) return null;
+  const buffer = Buffer.alloc(expectedSize + 1);
+  let offset = 0;
+  while (offset < buffer.length) {
+    const read = fs.read(fd, buffer, offset, buffer.length - offset, offset);
+    if (read === 0) break;
+    offset += read;
+  }
+  if (offset !== expectedSize) return null;
+  return buffer.subarray(0, offset);
+}
+
+function decodeUtf8(buffer: Buffer): string | null {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+  } catch {
+    return null;
+  }
+}
+
+function inspectMarker(
+  markerPath: string,
+  runnerIdentities: readonly DirectoryIdentity[],
+  runtime: Runtime,
+): MarkerInspection {
+  let pathStat: Stats;
+  try {
+    pathStat = runtime.fs.lstat(markerPath);
+  } catch (error) {
+    if (isErrorCode(error, "ENOENT")) return { kind: "missing" };
+    return { kind: "error", diagnostic: fsDiagnostic("marker-read", "marker-unreadable", error) };
+  }
+
+  if (pathStat.isSymbolicLink() || !pathStat.isFile()) {
+    return { kind: "error", diagnostic: { stage: "marker-read", reason: "unsafe-marker" } };
+  }
+  const identity = identityOf(pathStat);
+  if (pathStat.size > MAX_MARKER_BYTES || (pathStat.mode & 0o7777) !== 0o600) {
+    return { kind: "recoverable-corrupt", identity };
+  }
+  if (runtime.noFollowFlag === 0) {
+    return { kind: "error", diagnostic: { stage: "marker-read", reason: "no-follow-unavailable" } };
+  }
+
+  let fd: number | null = null;
+  try {
+    fd = runtime.fs.open(markerPath, constants.O_RDONLY | runtime.noFollowFlag);
+    const opened = runtime.fs.fstat(fd);
+    if (!sameFileIdentity(opened, identity)) {
+      return { kind: "error", diagnostic: { stage: "marker-read", reason: "marker-race" } };
+    }
+    const contents = readBoundedFile(fd, opened.size, MAX_MARKER_BYTES, runtime.fs);
+    const afterRead = runtime.fs.fstat(fd);
+    const changed = !sameFileIdentity(afterRead, identity);
+    const ancestorError = revalidateDirectories(runnerIdentities, runtime.fs, "marker-read");
+    if (ancestorError || changed) {
+      return { kind: "error", diagnostic: ancestorError ?? { stage: "marker-read", reason: "marker-race" } };
+    }
+    if (!contents) return { kind: "recoverable-corrupt", identity };
+    const text = decodeUtf8(contents);
+    const value = text ? parseMarker(text, runtime.now()) : null;
+    return value ? { kind: "valid", value, identity } : { kind: "recoverable-corrupt", identity };
+  } catch (error) {
+    return { kind: "error", diagnostic: fsDiagnostic("marker-read", "marker-unreadable", error) };
+  } finally {
+    if (fd !== null) {
+      try {
+        runtime.fs.close(fd);
+      } catch {
+        // The read result is already fail-closed; a close error has no safe
+        // recovery action and must not make us unlink an unverified marker.
+      }
+    }
+  }
+}
+
+function isDiagnostic(value: unknown): value is LegacyGithubScanLaunchdRetirementDiagnostic {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Record<string, unknown>;
+  const allowedKeys = new Set(["stage", "reason", "label", "code", "status", "signal", "detail"]);
+  if (Object.keys(row).some((key) => !allowedKeys.has(key))) return false;
+  const stages: readonly string[] = [
+    "eligibility",
+    "path",
+    "inventory",
+    "marker-read",
+    "marker-remove",
+    "marker-write",
+    "candidate-read",
+    "bootout",
+    "verify",
+    "unlink",
+    "internal",
+  ];
+  const reasons: readonly string[] = [
+    "invalid-home",
+    "filesystem-error",
+    "unsafe-ancestor",
+    "ancestor-changed",
+    "inventory-overflow",
+    "inventory-error",
+    "unsafe-marker",
+    "marker-unreadable",
+    "marker-race",
+    "marker-remove-failed",
+    "marker-write-failed",
+    "marker-rename-failed",
+    "marker-verify-failed",
+    "no-follow-unavailable",
+    "unsafe-candidate",
+    "candidate-unreadable",
+    "candidate-oversize",
+    "candidate-changed",
+    "invalid-plist-label",
+    "spawn-error",
+    "spawn-signal",
+    "empty-nonzero",
+    "exit-nonzero",
+    "verification-timeout",
+    "unlink-failed",
+    "candidate-cap",
+    "unexpected",
+  ];
+  if (typeof row.stage !== "string" || !stages.includes(row.stage)) return false;
+  if (typeof row.reason !== "string" || !reasons.includes(row.reason)) return false;
+  if (row.label !== undefined && (typeof row.label !== "string" || !isLegacyLabel(row.label))) return false;
+  if (row.code !== undefined && (typeof row.code !== "string" || !/^[A-Za-z0-9_-]{1,32}$/.test(row.code))) return false;
+  if (row.status !== undefined && (!Number.isSafeInteger(row.status) || (row.status as number) < 0)) return false;
+  if (row.signal !== undefined && (typeof row.signal !== "string" || !/^[A-Z0-9]{1,16}$/.test(row.signal)))
+    return false;
+  if (
+    row.detail !== undefined &&
+    (typeof row.detail !== "string" ||
+      row.detail.length > MAX_DETAIL_CHARS ||
+      sanitizeDetail(row.detail) !== row.detail)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function parseMarker(text: string, now: number): MarkerValue | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const row = parsed as Record<string, unknown>;
+  const allowedKeys = new Set(["version", "retryAt", "resumeAfter", "diagnostics"]);
+  if (Object.keys(row).some((key) => !allowedKeys.has(key))) return null;
+  if (row.version !== 1) return null;
+  if (!Number.isSafeInteger(row.retryAt) || (row.retryAt as number) < 0) return null;
+  if ((row.retryAt as number) > now + MAX_MARKER_FUTURE_MS) return null;
+  if (row.resumeAfter !== undefined && (typeof row.resumeAfter !== "string" || !isLegacyLabel(row.resumeAfter))) {
+    return null;
+  }
+  if (!Array.isArray(row.diagnostics) || row.diagnostics.length > MAX_DIAGNOSTICS) return null;
+  if (!row.diagnostics.every(isDiagnostic)) return null;
+  return {
+    version: 1,
+    retryAt: row.retryAt as number,
+    ...(typeof row.resumeAfter === "string" ? { resumeAfter: row.resumeAfter } : {}),
+    diagnostics: row.diagnostics,
+  };
+}
+
+function inventoryCandidates(
+  launchdPath: string,
+  launchdIdentities: readonly DirectoryIdentity[],
+  runtime: Runtime,
+): InventoryResult {
+  let directory: SyncDirectory | null = null;
+  try {
+    directory = runtime.fs.openDirectory(launchdPath);
+    const candidates: Candidate[] = [];
+    let entries = 0;
+    for (;;) {
+      const entry = directory.readSync();
+      if (!entry) break;
+      entries += 1;
+      if (entries > MAX_DIRECTORY_ENTRIES) return { kind: "overflow" };
+      const match = LEGACY_PLIST_RE.exec(entry.name);
+      if (match && isLegacyLabel(match[1])) {
+        candidates.push({ label: match[1], filename: entry.name, path: join(launchdPath, entry.name) });
+      }
+    }
+    const changed = revalidateDirectories(launchdIdentities, runtime.fs, "inventory");
+    if (changed) return { kind: "error", diagnostic: changed };
+    candidates.sort((a, b) => (a.label < b.label ? -1 : a.label > b.label ? 1 : 0));
+    return { kind: "complete", candidates };
+  } catch (error) {
+    return { kind: "error", diagnostic: fsDiagnostic("inventory", "inventory-error", error) };
+  } finally {
+    if (directory) {
+      try {
+        directory.closeSync();
+      } catch {
+        // Enumeration already stopped. Revalidation above prevents mutation
+        // after a detected directory replacement.
+      }
+    }
+  }
+}
+
+function removeMarker(
+  markerPath: string,
+  inspection: Exclude<MarkerInspection, { kind: "missing" } | { kind: "error" }>,
+  runnerIdentities: readonly DirectoryIdentity[],
+  runtime: Runtime,
+): LegacyGithubScanLaunchdRetirementDiagnostic | null {
+  const ancestorError = revalidateDirectories(runnerIdentities, runtime.fs, "marker-remove");
+  if (ancestorError) return ancestorError;
+  try {
+    const stat = runtime.fs.lstat(markerPath);
+    if (!sameFileIdentity(stat, inspection.identity)) {
+      return { stage: "marker-remove", reason: "marker-race" };
+    }
+    runtime.fs.unlink(markerPath);
+    return null;
+  } catch (error) {
+    if (isErrorCode(error, "ENOENT")) {
+      const changed = revalidateDirectories(runnerIdentities, runtime.fs, "marker-remove");
+      if (changed) return changed;
+      try {
+        runtime.fs.lstat(markerPath);
+      } catch (afterError) {
+        if (isErrorCode(afterError, "ENOENT")) return null;
+        return fsDiagnostic("marker-remove", "marker-remove-failed", afterError);
+      }
+    }
+    return fsDiagnostic("marker-remove", "marker-remove-failed", error);
+  }
+}
+
+function orderedBatch(candidates: readonly Candidate[], resumeAfter: string | undefined): readonly Candidate[] {
+  if (candidates.length === 0) return [];
+  let start = 0;
+  if (resumeAfter) {
+    const next = candidates.findIndex((candidate) => candidate.label > resumeAfter);
+    start = next === -1 ? 0 : next;
+  }
+  const rotated = [...candidates.slice(start), ...candidates.slice(0, start)];
+  return rotated.slice(0, MAX_CANDIDATES_PER_RUN);
+}
+
+function hasStrictLegacyPlistEnvelope(plist: string): boolean {
+  const trimmed = plist.trim();
+  const header =
+    /^<\?xml version="1\.0" encoding="UTF-8"\?>\s*<!DOCTYPE plist PUBLIC "-\/\/Apple\/\/DTD PLIST 1\.0\/\/EN" "https?:\/\/www\.apple\.com\/DTDs\/PropertyList-1\.0\.dtd">\s*<plist version="1\.0">/;
+  if (!header.test(trimmed) || !trimmed.endsWith("</plist>")) return false;
+  if ((trimmed.match(/<plist\b/g) ?? []).length !== 1) return false;
+  if ((trimmed.match(/<\/plist>/g) ?? []).length !== 1) return false;
+  return (trimmed.match(/<key>\s*Label\s*<\/key>/g) ?? []).length === 1;
+}
+
+function parsePlistLabelWithPlutil(plist: string): string | null {
+  const parsed = spawnSync("/usr/bin/plutil", ["-extract", "Label", "raw", "-o", "-", "-"], {
+    encoding: "utf8",
+    input: plist,
+    timeout: PRINT_TIMEOUT_MS,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (parsed.error) throw parsed.error;
+  if (parsed.signal) {
+    throw Object.assign(new Error("plutil terminated by signal"), { code: "EINTR" });
+  }
+  if (parsed.status !== 0) return null;
+  const label = String(parsed.stdout ?? "").trim();
+  return isLegacyLabel(label) ? label : null;
+}
+
+function openCandidate(
+  candidate: Candidate,
+  launchdIdentities: readonly DirectoryIdentity[],
+  runtime: Runtime,
+): OpenCandidate | LegacyGithubScanLaunchdRetirementDiagnostic {
+  const ancestorError = revalidateDirectories(launchdIdentities, runtime.fs, "candidate-read", candidate.label);
+  if (ancestorError) return ancestorError;
+  if (runtime.noFollowFlag === 0) {
+    return { stage: "candidate-read", reason: "no-follow-unavailable", label: candidate.label };
+  }
+
+  let pathStat: Stats;
+  try {
+    pathStat = runtime.fs.lstat(candidate.path);
+  } catch (error) {
+    return fsDiagnostic(
+      "candidate-read",
+      isErrorCode(error, "ENOENT") ? "candidate-changed" : "candidate-unreadable",
+      error,
+      candidate.label,
+    );
+  }
+  if (pathStat.isSymbolicLink() || !pathStat.isFile()) {
+    return { stage: "candidate-read", reason: "unsafe-candidate", label: candidate.label };
+  }
+  if (pathStat.size > MAX_PLIST_BYTES) {
+    return { stage: "candidate-read", reason: "candidate-oversize", label: candidate.label };
+  }
+  const identity = identityOf(pathStat);
+
+  let fd: number | null = null;
+  try {
+    fd = runtime.fs.open(candidate.path, constants.O_RDONLY | runtime.noFollowFlag);
+    const opened = runtime.fs.fstat(fd);
+    if (!sameFileIdentity(opened, identity)) {
+      runtime.fs.close(fd);
+      return { stage: "candidate-read", reason: "candidate-changed", label: candidate.label };
+    }
+    const contents = readBoundedFile(fd, opened.size, MAX_PLIST_BYTES, runtime.fs);
+    const afterRead = runtime.fs.fstat(fd);
+    if (!contents || !sameFileIdentity(afterRead, identity)) {
+      runtime.fs.close(fd);
+      return { stage: "candidate-read", reason: "candidate-changed", label: candidate.label };
+    }
+    const plist = decodeUtf8(contents);
+    if (plist === null) {
+      runtime.fs.close(fd);
+      return { stage: "candidate-read", reason: "invalid-plist-label", label: candidate.label };
+    }
+    return { fd, identity, plist };
+  } catch (error) {
+    if (fd !== null) {
+      try {
+        runtime.fs.close(fd);
+      } catch {
+        // Preserve the primary failure below.
+      }
+    }
+    return fsDiagnostic(
+      "candidate-read",
+      isErrorCode(error, "ENOENT") ? "candidate-changed" : "candidate-unreadable",
+      error,
+      candidate.label,
+    );
+  }
+}
+
+function revalidateCandidate(
+  candidate: Candidate,
+  opened: OpenCandidate,
+  launchdIdentities: readonly DirectoryIdentity[],
+  runtime: Runtime,
+  stage: "bootout" | "unlink",
+): LegacyGithubScanLaunchdRetirementDiagnostic | "candidate-gone" | null {
+  const ancestorError = revalidateDirectories(launchdIdentities, runtime.fs, stage, candidate.label);
+  if (ancestorError) return ancestorError;
+  let openedStat: Stats;
+  try {
+    openedStat = runtime.fs.fstat(opened.fd);
+  } catch (error) {
+    return fsDiagnostic(stage, "candidate-changed", error, candidate.label);
+  }
+  let pathStat: Stats;
+  try {
+    pathStat = runtime.fs.lstat(candidate.path);
+  } catch (error) {
+    if (isErrorCode(error, "ENOENT")) return "candidate-gone";
+    return fsDiagnostic(stage, "candidate-changed", error, candidate.label);
+  }
+  if (!sameFileIdentity(openedStat, opened.identity) || !sameFileIdentity(pathStat, opened.identity)) {
+    return { stage, reason: "candidate-changed", label: candidate.label };
+  }
+  return null;
+}
+
+function bootoutAbsence(stderr: string | null | undefined): boolean {
+  const lines = String(stderr ?? "")
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines[0] !== "Boot-out failed: 3: No such process") return false;
+  return (
+    lines.length === 1 ||
+    (lines.length === 2 && lines[1] === "Try running `launchctl bootout` as root for richer errors.")
+  );
+}
+
+function printAbsence(stderr: string | null | undefined, label: string, uid: number): boolean {
+  const expected = `Could not find service "${label}" in domain for user gui: ${uid}`;
+  const lines = String(stderr ?? "")
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim());
+  return (
+    (lines.length === 1 && lines[0] === expected) ||
+    (lines.length === 2 && lines[0] === "Bad request." && lines[1] === expected)
+  );
+}
+
+function processFailure(
+  stage: "bootout" | "verify",
+  label: string,
+  launchctlResult: LaunchctlResult,
+): LegacyGithubScanLaunchdRetirementDiagnostic | null {
+  if (launchctlResult.error) {
+    return fsDiagnostic(stage, "spawn-error", launchctlResult.error, label);
+  }
+  if (launchctlResult.signal) {
+    const signal = safeSignal(launchctlResult.signal);
+    return { stage, reason: "spawn-signal", label, ...(signal ? { signal } : {}) };
+  }
+  if (launchctlResult.status === 0) return null;
+  const detail = sanitizeDetail(launchctlResult.stderr);
+  return {
+    stage,
+    reason: detail ? "exit-nonzero" : "empty-nonzero",
+    label,
+    ...(typeof launchctlResult.status === "number" ? { status: launchctlResult.status } : {}),
+    ...(detail ? { detail } : {}),
+  };
+}
+
+function waitForExactLabelAbsent(label: string, runtime: Runtime): LegacyGithubScanLaunchdRetirementDiagnostic | null {
+  const target = `gui/${runtime.uid}/${label}`;
+  const deadline = runtime.monotonicNow() + VERIFY_TIMEOUT_MS;
+  for (;;) {
+    const remaining = Math.max(1, deadline - runtime.monotonicNow());
+    const printTimeout = Math.max(1, Math.ceil(Math.min(PRINT_TIMEOUT_MS, remaining)));
+    const checked = runtime.spawnLaunchctl(["print", target], printTimeout);
+    if (checked.error || checked.signal) return processFailure("verify", label, checked);
+    if (checked.status !== 0) {
+      if (typeof checked.status === "number" && printAbsence(checked.stderr, label, runtime.uid)) return null;
+      return processFailure("verify", label, checked);
+    }
+    if (runtime.monotonicNow() >= deadline) {
+      return { stage: "verify", reason: "verification-timeout", label };
+    }
+    runtime.sleep(Math.max(1, Math.ceil(Math.min(POLL_INTERVAL_MS, deadline - runtime.monotonicNow()))));
+  }
+}
+
+function retireCandidate(
+  candidate: Candidate,
+  launchdIdentities: readonly DirectoryIdentity[],
+  runtime: Runtime,
+): { retired: boolean; diagnostic?: LegacyGithubScanLaunchdRetirementDiagnostic } {
+  const opened = openCandidate(candidate, launchdIdentities, runtime);
+  if (!("fd" in opened)) return { retired: false, diagnostic: opened };
+
+  try {
+    if (!hasStrictLegacyPlistEnvelope(opened.plist)) {
+      return {
+        retired: false,
+        diagnostic: { stage: "candidate-read", reason: "invalid-plist-label", label: candidate.label },
+      };
+    }
+    let embeddedLabel: string | null;
+    try {
+      embeddedLabel = runtime.parsePlistLabel(opened.plist);
+    } catch (error) {
+      return {
+        retired: false,
+        diagnostic: fsDiagnostic("candidate-read", "candidate-unreadable", error, candidate.label),
+      };
+    }
+    if (embeddedLabel !== candidate.label) {
+      return {
+        retired: false,
+        diagnostic: { stage: "candidate-read", reason: "invalid-plist-label", label: candidate.label },
+      };
+    }
+
+    const beforeBootout = revalidateCandidate(candidate, opened, launchdIdentities, runtime, "bootout");
+    if (beforeBootout === "candidate-gone") {
+      return {
+        retired: false,
+        diagnostic: { stage: "bootout", reason: "candidate-changed", label: candidate.label, code: "ENOENT" },
+      };
+    }
+    if (beforeBootout) return { retired: false, diagnostic: beforeBootout };
+
+    const target = `gui/${runtime.uid}/${candidate.label}`;
+    const bootout = runtime.spawnLaunchctl(["bootout", target], BOOTOUT_TIMEOUT_MS);
+    const bootoutFailure = processFailure("bootout", candidate.label, bootout);
+    if (
+      bootoutFailure &&
+      !(!bootout.error && !bootout.signal && bootout.status === 3 && bootoutAbsence(bootout.stderr))
+    ) {
+      return { retired: false, diagnostic: bootoutFailure };
+    }
+
+    const verifyFailure = waitForExactLabelAbsent(candidate.label, runtime);
+    if (verifyFailure) return { retired: false, diagnostic: verifyFailure };
+
+    const beforeUnlink = revalidateCandidate(candidate, opened, launchdIdentities, runtime, "unlink");
+    // Only disappearance of the exact candidate name is benign after verified
+    // label eviction. An ancestor or held-fd error with ENOENT stays partial.
+    if (beforeUnlink === "candidate-gone") return { retired: true };
+    if (beforeUnlink) return { retired: false, diagnostic: beforeUnlink };
+    try {
+      // Node does not expose unlinkat(2). Holding the O_NOFOLLOW fd and
+      // comparing both its identity and every fixed ancestor immediately
+      // before this exact unlink closes detectable swaps; a same-effective-
+      // user substitution in the final syscall window remains an OS-level
+      // residual race and is not represented as impossible here.
+      runtime.fs.unlink(candidate.path);
+      return { retired: true };
+    } catch (error) {
+      if (isErrorCode(error, "ENOENT")) {
+        const afterUnlinkError = revalidateCandidate(candidate, opened, launchdIdentities, runtime, "unlink");
+        if (afterUnlinkError === "candidate-gone") return { retired: true };
+        if (afterUnlinkError) return { retired: false, diagnostic: afterUnlinkError };
+      }
+      return { retired: false, diagnostic: fsDiagnostic("unlink", "unlink-failed", error, candidate.label) };
+    }
+  } finally {
+    try {
+      runtime.fs.close(opened.fd);
+    } catch {
+      // No mutation follows this close, so there is no unsafe recovery step.
+    }
+  }
+}
+
+function cleanupExactTemp(
+  tempPath: string,
+  identity: FileIdentity | null,
+  created: boolean,
+  runnerIdentities: readonly DirectoryIdentity[],
+  runtime: Runtime,
+): void {
+  // If the initial fstat failed, leave the exact O_EXCL temp fail-closed: a
+  // path-only unlink cannot prove that the object behind the name is ours.
+  if (!created || !identity) return;
+  if (revalidateDirectories(runnerIdentities, runtime.fs, "marker-write")) return;
+  try {
+    const stat = runtime.fs.lstat(tempPath);
+    if (sameObjectIdentity(stat, identity)) runtime.fs.unlink(tempPath);
+  } catch {
+    // Best-effort cleanup of the one exact random temp path only.
+  }
+}
+
+function persistMarker(
+  markerPath: string,
+  runnerIdentities: readonly DirectoryIdentity[],
+  resumeAfter: string | undefined,
+  diagnostics: readonly LegacyGithubScanLaunchdRetirementDiagnostic[],
+  runtime: Runtime,
+): { retryAt?: number; diagnostic?: LegacyGithubScanLaunchdRetirementDiagnostic } {
+  if (runtime.noFollowFlag === 0) {
+    return { diagnostic: { stage: "marker-write", reason: "no-follow-unavailable" } };
+  }
+  const retryAt = runtime.now() + RETRY_DELAY_MS;
+  const value: MarkerValue = {
+    version: 1,
+    retryAt,
+    ...(resumeAfter ? { resumeAfter } : {}),
+    diagnostics: diagnostics.slice(0, MAX_DIAGNOSTICS),
+  };
+  const bytes = Buffer.from(`${JSON.stringify(value)}\n`, "utf8");
+  if (bytes.length > MAX_MARKER_BYTES) {
+    return { diagnostic: { stage: "marker-write", reason: "marker-write-failed" } };
+  }
+
+  const ancestorError = revalidateDirectories(runnerIdentities, runtime.fs, "marker-write");
+  if (ancestorError) return { diagnostic: ancestorError };
+  try {
+    runtime.fs.lstat(markerPath);
+    return { diagnostic: { stage: "marker-write", reason: "marker-race" } };
+  } catch (error) {
+    if (!isErrorCode(error, "ENOENT")) {
+      return { diagnostic: fsDiagnostic("marker-write", "marker-write-failed", error) };
+    }
+  }
+
+  let token: string;
+  try {
+    token = runtime.randomToken();
+  } catch (error) {
+    return { diagnostic: fsDiagnostic("marker-write", "marker-write-failed", error) };
+  }
+  if (!/^[A-Za-z0-9_-]{8,64}$/.test(token)) {
+    return { diagnostic: { stage: "marker-write", reason: "marker-write-failed" } };
+  }
+  const tempPath = join(dirname(markerPath), `.${basename(markerPath)}.${token}.tmp`);
+  let fd: number | null = null;
+  let tempIdentity: FileIdentity | null = null;
+  let tempCreated = false;
+  try {
+    fd = runtime.fs.open(
+      tempPath,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | runtime.noFollowFlag,
+      0o600,
+    );
+    tempCreated = true;
+    const createdStat = runtime.fs.fstat(fd);
+    if (!createdStat.isFile() || createdStat.isSymbolicLink()) {
+      return { diagnostic: { stage: "marker-write", reason: "marker-verify-failed" } };
+    }
+    tempIdentity = identityOf(createdStat);
+    runtime.fs.fchmod(fd, 0o600);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const written = runtime.fs.write(fd, bytes, offset, bytes.length - offset, offset);
+      if (written <= 0) throw Object.assign(new Error("short marker write"), { code: "EIO" });
+      offset += written;
+    }
+    runtime.fs.fsync(fd);
+    const tempStat = runtime.fs.fstat(fd);
+    if (!sameObjectIdentity(tempStat, tempIdentity) || (tempStat.mode & 0o7777) !== 0o600) {
+      return { diagnostic: { stage: "marker-write", reason: "marker-verify-failed" } };
+    }
+    runtime.fs.close(fd);
+    fd = null;
+
+    const changed = revalidateDirectories(runnerIdentities, runtime.fs, "marker-write");
+    if (changed) return { diagnostic: changed };
+    try {
+      runtime.fs.lstat(markerPath);
+      return { diagnostic: { stage: "marker-write", reason: "marker-race" } };
+    } catch (error) {
+      if (!isErrorCode(error, "ENOENT")) {
+        return { diagnostic: fsDiagnostic("marker-write", "marker-write-failed", error) };
+      }
+    }
+
+    runtime.fs.rename(tempPath, markerPath);
+    tempCreated = false;
+    const finalStat = runtime.fs.lstat(markerPath);
+    // rename(2) may update ctime; object identity and exact mode are the
+    // stable post-rename assertions here.
+    if (!sameObjectIdentity(finalStat, tempIdentity) || (finalStat.mode & 0o7777) !== 0o600) {
+      return { diagnostic: { stage: "marker-write", reason: "marker-verify-failed" } };
+    }
+    tempIdentity = null;
+    return { retryAt };
+  } catch (error) {
+    return {
+      diagnostic: fsDiagnostic(
+        "marker-write",
+        errorCode(error) === "EXDEV" ? "marker-rename-failed" : "marker-write-failed",
+        error,
+      ),
+    };
+  } finally {
+    if (fd !== null) {
+      try {
+        runtime.fs.close(fd);
+      } catch {
+        // Preserve the marker operation result.
+      }
+    }
+    cleanupExactTemp(tempPath, tempIdentity, tempCreated, runnerIdentities, runtime);
+  }
+}
+
+function runRetirement(options: LegacyGithubScanLaunchdRetirementOptions): LegacyGithubScanLaunchdRetirementResult {
+  if (options.platform !== "darwin" || (options.channel !== "prod" && options.channel !== "staging")) {
+    return result("not-applicable");
+  }
+  const home = options.effectiveHome;
+  if (
+    !home ||
+    home.includes("\0") ||
+    !isAbsolute(home) ||
+    normalize(home) !== home ||
+    resolve(home) !== home ||
+    home === parse(home).root ||
+    !Number.isSafeInteger(options.effectiveUid) ||
+    options.effectiveUid < 0
+  ) {
+    return result("partial", 0, [{ stage: "eligibility", reason: "invalid-home" }]);
+  }
+
+  const fs: LegacyGithubScanRetirementFileSystem = { ...nodeFileSystem, ...options.fileSystem };
+  const runtime: Runtime = {
+    fs,
+    noFollowFlag: options.noFollowFlag ?? constants.O_NOFOLLOW ?? 0,
+    spawnLaunchctl: options.spawnLaunchctl,
+    parsePlistLabel: options.parsePlistLabel ?? parsePlistLabelWithPlutil,
+    now: options.now ?? Date.now,
+    monotonicNow: options.monotonicNow ?? options.now ?? (() => performance.now()),
+    sleep: options.sleep ?? sleepSync,
+    randomToken: options.randomToken ?? (() => randomBytes(12).toString("hex")),
+    uid: options.effectiveUid,
+  };
+
+  const firstTreePath = join(home, ".first-tree");
+  const githubScanPath = join(firstTreePath, "github-scan");
+  const runnerPath = join(githubScanPath, "runner");
+  const launchdPath = join(runnerPath, "launchd");
+  const markerPath = join(runnerPath, MARKER_NAME);
+
+  const runnerChain = inspectDirectoryChain([firstTreePath, githubScanPath, runnerPath], fs);
+  if (runnerChain.kind === "absent") return result("absent");
+  if (runnerChain.kind === "error") return result("partial", 0, [runnerChain.diagnostic]);
+
+  const marker = inspectMarker(markerPath, runnerChain.identities, runtime);
+  const launchdChain = inspectDirectoryChain([firstTreePath, githubScanPath, runnerPath, launchdPath], fs);
+  if (launchdChain.kind === "error") {
+    return result("partial", 0, [launchdChain.diagnostic, ...(marker.kind === "error" ? [marker.diagnostic] : [])]);
+  }
+
+  const inventory =
+    launchdChain.kind === "absent"
+      ? ({ kind: "complete", candidates: [] } as const)
+      : inventoryCandidates(launchdPath, launchdChain.identities, runtime);
+  if (inventory.kind === "overflow") {
+    // Deliberately mutation-free: a bounded scan that did not see the whole
+    // directory cannot prove absence, success, or a safe cooldown decision.
+    return result("partial", 0, [{ stage: "inventory", reason: "inventory-overflow" }]);
+  }
+  if (inventory.kind === "error") return result("partial", 0, [inventory.diagnostic]);
+  if (marker.kind === "error") return result("partial", 0, [marker.diagnostic]);
+
+  if (inventory.candidates.length === 0) {
+    if (marker.kind !== "missing") {
+      const removeFailure = removeMarker(markerPath, marker, runnerChain.identities, runtime);
+      if (removeFailure) return result("partial", 0, [removeFailure]);
+    }
+    return result("absent");
+  }
+  // A non-empty inventory can only have come from the verified launchd
+  // directory. Keep that invariant explicit for the mutation paths below.
+  if (launchdChain.kind !== "ok") return result("partial", 0, [{ stage: "inventory", reason: "inventory-error" }]);
+
+  const now = runtime.now();
+  if (marker.kind === "valid" && marker.value.retryAt > now) {
+    return result("deferred", 0, marker.value.diagnostics, marker.value.retryAt);
+  }
+  if (marker.kind !== "missing") {
+    const removeFailure = removeMarker(markerPath, marker, runnerChain.identities, runtime);
+    if (removeFailure) return result("partial", 0, [removeFailure]);
+  }
+
+  const resumeAfter = marker.kind === "valid" ? marker.value.resumeAfter : undefined;
+  const selected = orderedBatch(inventory.candidates, resumeAfter);
+  const diagnostics: LegacyGithubScanLaunchdRetirementDiagnostic[] = [];
+  let retired = 0;
+  let lastVisited: string | undefined;
+  for (const candidate of selected) {
+    lastVisited = candidate.label;
+    try {
+      const outcome = retireCandidate(candidate, launchdChain.identities, runtime);
+      if (outcome.retired) retired += 1;
+      if (outcome.diagnostic) addDiagnostic(diagnostics, outcome.diagnostic);
+    } catch (error) {
+      addDiagnostic(diagnostics, fsDiagnostic("internal", "unexpected", error, candidate.label));
+    }
+  }
+
+  if (inventory.candidates.length > selected.length) {
+    addDiagnostic(diagnostics, { stage: "inventory", reason: "candidate-cap" });
+  }
+
+  const finalInventory = inventoryCandidates(launchdPath, launchdChain.identities, runtime);
+  if (finalInventory.kind === "overflow") {
+    addDiagnostic(diagnostics, { stage: "inventory", reason: "inventory-overflow" });
+    return result("partial", retired, diagnostics);
+  }
+  if (finalInventory.kind === "error") {
+    addDiagnostic(diagnostics, finalInventory.diagnostic);
+    return result("partial", retired, diagnostics);
+  }
+  if (finalInventory.candidates.length === 0) {
+    // There is nothing left for a cooldown cursor to suppress. Preserve any
+    // fresh failure as an honest partial result, but do not create a stale
+    // retry marker that would make the next idempotent run look deferred.
+    return diagnostics.length === 0 ? result("complete", retired) : result("partial", retired, diagnostics);
+  }
+  if (diagnostics.length === 0) {
+    addDiagnostic(diagnostics, { stage: "inventory", reason: "candidate-cap" });
+  }
+
+  const persisted = persistMarker(markerPath, runnerChain.identities, lastVisited, diagnostics, runtime);
+  if (persisted.diagnostic) addDiagnostic(diagnostics, persisted.diagnostic);
+  return result("partial", retired, diagnostics, persisted.retryAt);
+}
+
+/**
+ * Repeatable, dependency-injected core. Production code should call the
+ * no-argument once wrapper below so caller-controlled roots can never enter
+ * the real cleanup boundary.
+ */
+export function runLegacyGithubScanLaunchdRetirement(
+  options: LegacyGithubScanLaunchdRetirementOptions,
+): LegacyGithubScanLaunchdRetirementResult {
+  try {
+    return runRetirement(options);
+  } catch (error) {
+    return result("partial", 0, [fsDiagnostic("internal", "unexpected", error)]);
+  }
+}
+
+let productionResult: LegacyGithubScanLaunchdRetirementResult | undefined;
+
+/**
+ * Run the one-time retirement exception against the fixed effective-account
+ * legacy namespace. This intentionally ignores HOME, FIRST_TREE_HOME, channel
+ * homes, and the historical github-scan override variables.
+ */
+export function runLegacyGithubScanLaunchdRetirementOnce(): LegacyGithubScanLaunchdRetirementResult {
+  if (productionResult) return productionResult;
+  try {
+    const account = userInfo();
+    productionResult = runLegacyGithubScanLaunchdRetirement({
+      platform: process.platform,
+      channel: channelConfig.channel,
+      effectiveHome: account.homedir,
+      effectiveUid: account.uid,
+      spawnLaunchctl: (args, timeoutMs) =>
+        spawnSync("launchctl", [...args], {
+          encoding: "utf8",
+          timeout: timeoutMs,
+          stdio: ["ignore", "pipe", "pipe"],
+        }),
+    });
+  } catch (error) {
+    productionResult = result("partial", 0, [fsDiagnostic("internal", "unexpected", error)]);
+  }
+  return productionResult;
+}

--- a/packages/qa/cases/runtime/legacy-github-scan-launchd-retirement.md
+++ b/packages/qa/cases/runtime/legacy-github-scan-launchd-retirement.md
@@ -1,0 +1,146 @@
+---
+id: legacy-github-scan-launchd-retirement
+description: Validate that a published-channel CLI safely retires only a task-owned legacy github-scan launchd runner and releases its listener.
+areas: [runtime]
+surfaces: [cli]
+---
+
+# Legacy GitHub-Scan Launchd Retirement
+
+## Goal
+
+Confirm through the shipped CLI boundary that a published-channel macOS CLI automatically retires the exact stranded
+legacy github-scan launchd runner, removes its canonical plist only after launchd has evicted the label, and releases
+`127.0.0.1:7878` without touching current prod, staging, or dev services. Also confirm that help is read-only and that a
+second eligible action is safe after retirement.
+
+The stable parser, matching, pagination, marker, and failure branches belong in product tests. This case owns the live
+boundary those tests cannot prove: a release-shaped CLI entrypoint, the effective account home, real launchd state, an
+attributable KeepAlive process, and an independently rebindable TCP port.
+
+## Harness And Preconditions
+
+Reach the repository's full `QA READY` gate before selecting this case. Build the exact target ref in a disposable
+Docker-backed cell owned by a run-local bare clone and temporary git worktree, initialize every formal product surface,
+and keep run artifacts outside the tested repository. Launchd is the explicit native macOS bridge; it does not replace
+the Docker cell or reduce its readiness requirements.
+
+Build the CLI with the repository's real release procedure for the staging channel and record the resulting artifact,
+channel identity, version, commit, and digest. Exercise that built `first-tree-staging` entrypoint, not a source module,
+dev-channel build, migration helper, or fake supervisor. Give each CLI invocation a run-local `FIRST_TREE_HOME` outside
+the operator's channel homes and, where the entrypoint permits, a different run-local `HOME`. This isolates normal
+staging state and distinguishes the trusted account lookup from environment-selected homes, but must not redirect the
+migration: independently establish that the legacy root is derived from the effective account's canonical home and
+remains `<effective-home>/.first-tree/github-scan/runner/` despite the overrides.
+
+The native bridge may proceed only after a read-only, recorded preflight establishes all of the following:
+
+- the effective UID, launchd `gui/<uid>` domain, and effective account home are unambiguous, and each existing component
+  from that home through `.first-tree/github-scan/runner/launchd` is the expected directory rather than a symlink;
+- the canonical launchd directory contains no pre-existing filename-valid legacy `.default` target, and the product's
+  fixed retirement marker is absent; never use this case to clean up or probe a real stranded artifact;
+- `127.0.0.1:7878` is free by both listener inspection and an actual temporary bind. If it is occupied, report `BLOCKED`
+  and do not signal or kill the owner;
+- current `first-tree`, `first-tree-staging`, and `first-tree-dev` launchd identities have been snapshotted where present,
+  including exact labels, plist paths and hashes, `launchctl print` state, and attributable PIDs; and
+- every path, label, helper, process, and directory that the run may create has a unique run identifier and is listed in
+  a teardown manifest before the first mutation.
+
+Snapshot any non-target legacy data and leave it byte-for-byte untouched. An unsafe path component, an existing
+retirement marker or exact legacy candidate, an unattributable listener, insufficient permission, or any host state
+that prevents unambiguous fixture ownership is a safety precondition failure. Stop `BLOCKED`; do not rename, repair,
+boot out, unlink, or recursively remove host state to make the case runnable.
+
+## Task-Owned Native Fixture
+
+Create the listener helper and logs under the external QA run root. Create only the missing canonical directories that
+the teardown manifest can prove belong to this run, and write one regular plist at the exact canonical legacy path. Its
+filename and embedded `Label` must be the same unique
+`com.first-tree.github-scan.runner.<run-id>.default` value, where the run identifier uses only the historical label's
+allowed `[A-Za-z0-9._-]` characters. Its launchd domain must be the effective user's `gui/<uid>`, and its KeepAlive
+program must bind only `127.0.0.1:7878` and remain alive until launchd unloads it.
+
+Bootstrap that one label with launchctl. Before invoking the CLI, independently attribute all three views to the same
+fixture:
+
+- `launchctl print gui/<uid>/<label>` reports the exact label and a concrete PID;
+- the PID's executable/arguments identify the run-local listener helper; and
+- socket-owner inspection identifies that same PID as the listener on `127.0.0.1:7878`; when the host has no socket-owner
+  utility, a run-nonce challenge response from the listener must report that same launchctl PID. An independent bind must
+  fail because the fixture owns the port.
+
+Do not continue on label, PID, process, or socket ambiguity. Never kill a PID solely because it occupies port 7878.
+
+## Operate And Observe
+
+First invoke representative root and nested/positional help through the built staging CLI with the run-local
+`FIRST_TREE_HOME`. Help must return without running retirement: the exact fixture label remains loaded with its
+attributed listener, its plist is unchanged, the port is still owned by that PID, and no marker appears. Include version
+or no-action coverage when the target's public CLI contract exposes it without starting unrelated host services.
+
+Then invoke an eligible ordinary action through the same entrypoint, such as `status --json`. Record its exit status and
+stdout/stderr separately. Do not require a success JSON envelope when the current action does not promise one; JSON mode
+must keep stdout machine-clean, while a retained migration failure must remain diagnosable on stderr. The action may use
+the run-local current-channel home, but retirement must act on the effective-home canonical legacy fixture.
+
+Wait within the product's documented bounded settling policy and independently observe this order and outcome:
+
+1. launchd no longer reports the exact `gui/<uid>/<label>` service;
+2. only after that label eviction is the exact canonical fixture plist absent;
+3. the task-owned listener PID exits and no process listens on `127.0.0.1:7878`; and
+4. a fresh process can bind that exact address and port, then closes it cleanly.
+
+Compare the current-channel snapshot after retirement. Present prod, staging, and dev labels must still exist, their
+plist bytes must be unchanged, and no observed service change may be attributable to the migration. If a PID changed
+for an independently explainable reason, retain enough launchd and process evidence to distinguish that external event
+from a migration target; otherwise report `INCONCLUSIVE` rather than assuming non-interference.
+
+Finally run the same eligible action again. It must remain safe with no legacy plist or loaded service, must not reclaim
+port 7878, and must not mutate current-channel services. Keep command-continuation and diagnostics evidence from both
+runs; source inspection or unit-test results are supporting evidence only.
+
+## Teardown Safety
+
+Install fail-closed teardown before bootstrapping the fixture. On every exit path, boot out only the exact run label and
+terminate only a PID that is freshly re-attributed to the run-local helper and that exact launchd label. Unlink only the
+recorded fixture plist, helper, logs, and any product-created marker whose pre-run absence and post-run identity make its
+ownership unambiguous. Remove only directories created by this run, in leaf-to-root order and only when empty; never use
+a glob or recursive deletion.
+
+If identity changes, a path becomes a symlink, port 7878 gains an unknown owner, or the run cannot prove ownership of an
+artifact, stop mutating and preserve evidence. Report `BLOCKED` when the unsafe state existed before product execution,
+or `INCONCLUSIVE` when attribution was lost during or after it. A teardown problem can never be hidden behind a product
+`PASS`, and an unknown process must never be killed to restore the preflight state.
+
+## Expected Result
+
+`PASS` means the complete Docker + temporary-worktree harness reached `QA READY`, the native published-staging bridge
+passed every safety precondition, help left the fixture untouched, an ordinary CLI action retired the exact task-owned
+label and plist in the required order, the attributed listener exited and port 7878 was independently rebindable, a
+repeat action was idempotent, current channel services were untouched, and teardown restored every run-owned host
+mutation.
+
+`FAIL` means real product behavior at the exact target reproducibly violates that contract—for example help triggers
+retirement, an eligible action leaves the exact service/plist/listener unresolved, the plist disappears before label
+eviction, the port cannot be rebound after confirmed cleanup, JSON stdout is polluted, or a current channel service is
+targeted despite valid and attributable fixture state.
+
+`BLOCKED` means the complete harness cannot reach readiness, a release-shaped staging CLI cannot be built, a safe native
+launchd bridge is unavailable, the canonical path contains real or unsafe state, port 7878 is already occupied, or the
+fixture cannot be loaded and attributed without affecting host state.
+
+`INCONCLUSIVE` means the operation ran but label/PID/socket ownership, cleanup order, current-service non-interference,
+artifact identity, or teardown evidence became incomplete, unstable, or attributable to something other than the
+target ref.
+
+## Evidence
+
+Keep the exact target ref, detached worktree identity, Docker image/artifact digests, full readiness record, staging CLI
+build provenance and digest, run-local `FIRST_TREE_HOME`, and redacted effective-home/path preflight. Retain the
+before/after current-service snapshot; fixture plist and helper hashes; exact launchctl domain/label output; PID,
+arguments, and socket-owner or nonce-challenge attribution; help and ordinary-action exit/stream captures; timestamps showing label
+eviction before plist disappearance; listener-exit evidence; port bind probes; the repeat-run observation; and the
+teardown manifest plus final host-state check.
+
+Redact usernames, home paths, unrelated process details, credentials, and private channel data in shared evidence while
+preserving structural paths, exact task labels, target identity, and the facts needed to audit attribution.


### PR DESCRIPTION
## Summary

- Automatically retires stranded legacy `github-scan` launchd runners from the effective account's canonical legacy namespace on eligible prod and staging CLI actions.
- Boots out only an exact `com.first-tree.github-scan.runner.<user>.default` service, confirms launchd eviction, and only then removes the matching regular plist.
- Preserves the existing managed-update handoff by skipping only the hidden `daemon refresh-unit` child; the supervisor-restarted new binary performs retirement from `daemon start`.
- Adds exhaustive deterministic coverage plus a reusable formal QA case for the release-shaped macOS boundary.

Fixes #995.

## Root cause

Older published builds installed a KeepAlive launchd runner in an unchannelled `~/.first-tree/github-scan/runner/launchd` namespace. Removing the command did not unload that service or delete its plist, so launchd could keep restarting the missing runner and retain `127.0.0.1:7878` across CLI upgrades.

## Safety and compatibility

- Runs only on macOS for published prod and staging channels; source/dev and other platforms are no-ops.
- Derives the legacy root from `userInfo().homedir`, never `HOME` or `FIRST_TREE_HOME`, and accepts no caller-supplied root in production.
- Rejects symlinked ancestors and non-regular entries, uses `O_NOFOLLOW`, revalidates ancestor/file identity before mutation, and bounds directory, plist, diagnostic, and candidate work.
- Requires exact filename, historical label grammar, `.default` profile, and embedded plist `Label` agreement.
- Uses exact `launchctl bootout gui/<uid>/<label>`, then polls exact `launchctl print` disappearance before unlinking. Timeouts, permissions, malformed state, and partial cleanup stay diagnosable and retryable without blocking the selected CLI action.
- Persists a `0600` atomic legacy-namespace retry marker with fair cursor progression; inventory overflow fails closed without mutation.
- Current prod/staging/dev daemon labels cannot match the legacy grammar and are table-tested as untargetable.
- Leaves `update-glue.ts`, exit 75, and the old-X 45-second refresh-child contract unchanged. A regression test also locks healthy status-zero refresh output as silent.

## Trigger behavior

The synchronous Commander `preAction` hook runs after JSON/logger normalization for ordinary actions, `daemon ensure-service`, and the supervisor-restarted `daemon start`. Root/nested/positional help, version, no-action parsing, and the structurally exact hidden `daemon refresh-unit` child do not run retirement.

## Validation

- `pnpm check` — passed (only pre-existing unrelated repository warnings)
- `pnpm typecheck` — passed
- `pnpm --filter first-tree-dev typecheck` — passed
- CLI full test runner, all 21 batches — passed in a clean CI-shaped environment
- Focused retirement/runtime/update tests — 91 passed
- Related daemon/update/channel/service regression set — 188 passed
- Monorepo build — passed
- Full non-web test graph — passed, including client 1,621 tests and server 2,563 tests
- Local full graph additionally ran 1,564 web tests; one unchanged focus-preservation test failed reproducibly while the other 1,563 passed. This branch has zero `packages/web` diff and the isolated failure is recorded as an unrelated local baseline gate.
- Biome on every touched TypeScript file and `git diff --check` — passed

Formal QA is warranted because this changes CLI boot/update behavior. The reusable case is `packages/qa/cases/runtime/legacy-github-scan-launchd-retirement.md`; Docker-backed temporary-worktree readiness and the explicit native macOS staging bridge will be completed before competition submission. No live launchd or port-release PASS is claimed yet.

## Rollout note

PR #1892 was rechecked immediately before opening this PR and remains open, approved/green, but 119 commits behind and 7 commits ahead of current main. This implementation was independently derived from the binding acceptance and current main; no commits or implementation text were reused.
