### PR TITLE
feat(web): shorten trusted GitLab entity links

### DIFF
--- a/packages/server/src/services/gitlab-entity-follow.ts
+++ b/packages/server/src/services/gitlab-entity-follow.ts
@@ -56,6 +56,9 @@ export function parseGitlabEntityUrl(
     if (parsedPath.reason === "control_character") {
       throw new BadRequestError("GitLab entity URL project path must not contain control characters");
     }
+    if (parsedPath.reason === "bidi_control") {
+      throw new BadRequestError("GitLab entity URL project path must not contain bidirectional control characters");
+    }
     if (parsedPath.reason === "route") {
       throw new BadRequestError("GitLab entity URL must point to an issue or merge request");
     }

--- a/packages/server/src/services/gitlab-entity-follow.ts
+++ b/packages/server/src/services/gitlab-entity-follow.ts
@@ -5,7 +5,7 @@ import type {
   ScmEntityState,
   UnfollowChatGitlabEntityResponse,
 } from "@first-tree/shared";
-import { chatMetadataSchema, normalizeScmEntityState } from "@first-tree/shared";
+import { chatMetadataSchema, normalizeScmEntityState, parseGitlabEntityPath } from "@first-tree/shared";
 import { and, asc, eq, inArray, isNull, or } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
 import { chats } from "../db/schema/chats.js";
@@ -50,24 +50,19 @@ export function parseGitlabEntityUrl(
   }
   // GitLab instances and clients emit both route shapes. Treat them as the
   // same identity, but preserve the submitted shape for the user-facing link.
-  const match = /^\/(.+?)\/(?:-\/)?(issues|merge_requests)\/(\d+)\/?$/.exec(url.pathname);
-  if (!match) throw new BadRequestError("GitLab entity URL must point to an issue or merge request");
-  let projectPath: string;
-  try {
-    projectPath = decodeURIComponent(match[1] ?? "");
-  } catch {
-    throw new BadRequestError("Invalid GitLab entity URL encoding");
-  }
-  if (/\p{Cc}/u.test(projectPath)) {
-    throw new BadRequestError("GitLab entity URL project path must not contain control characters");
-  }
-  const entityIid = Number(match[3]);
-  if (!projectPath || !Number.isSafeInteger(entityIid) || entityIid <= 0)
+  const parsedPath = parseGitlabEntityPath(url.pathname);
+  if (!parsedPath.ok) {
+    if (parsedPath.reason === "encoding") throw new BadRequestError("Invalid GitLab entity URL encoding");
+    if (parsedPath.reason === "control_character") {
+      throw new BadRequestError("GitLab entity URL project path must not contain control characters");
+    }
+    if (parsedPath.reason === "route") {
+      throw new BadRequestError("GitLab entity URL must point to an issue or merge request");
+    }
     throw new BadRequestError("Invalid GitLab entity URL");
+  }
   return {
-    entityType: match[2] === "issues" ? "issue" : "pull_request",
-    entityIid,
-    projectPath,
+    ...parsedPath.value,
     entityUrl: url.toString().replace(/\/$/, ""),
   };
 }

--- a/packages/shared/src/__tests__/gitlab-entity-path.test.ts
+++ b/packages/shared/src/__tests__/gitlab-entity-path.test.ts
@@ -33,4 +33,16 @@ describe("parseGitlabEntityPath", () => {
   ] as const)("rejects %s as %s", (pathname, reason) => {
     expect(parseGitlabEntityPath(pathname)).toEqual({ ok: false, reason });
   });
+
+  it.each([
+    "%D8%9C",
+    "%E2%80%8F",
+    "%E2%80%AE",
+    "%E2%81%A7",
+  ])("rejects percent-encoded Unicode bidi control %s", (control) => {
+    expect(parseGitlabEntityPath(`/group/${control}project/-/issues/1`)).toEqual({
+      ok: false,
+      reason: "bidi_control",
+    });
+  });
 });

--- a/packages/shared/src/__tests__/gitlab-entity-path.test.ts
+++ b/packages/shared/src/__tests__/gitlab-entity-path.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseGitlabEntityPath } from "../gitlab-entity-path.js";
+
+describe("parseGitlabEntityPath", () => {
+  it.each([
+    ["/group/project/-/merge_requests/25", "pull_request", "group/project", 25],
+    ["/group/project/merge_requests/25", "pull_request", "group/project", 25],
+    ["/group/project/-/issues/7", "issue", "group/project", 7],
+    ["/group/project/issues/7/", "issue", "group/project", 7],
+  ] as const)("parses %s", (pathname, entityType, projectPath, entityIid) => {
+    expect(parseGitlabEntityPath(pathname)).toEqual({
+      ok: true,
+      value: { entityType, projectPath, entityIid },
+    });
+  });
+
+  it("decodes nested project paths without confusing project-name route segments", () => {
+    expect(parseGitlabEntityPath("/group/issues/123/project%20name/-/issues/9")).toEqual({
+      ok: true,
+      value: { entityType: "issue", projectPath: "group/issues/123/project name", entityIid: 9 },
+    });
+  });
+
+  it.each([
+    ["/group/project/-/pipelines/1", "route"],
+    ["/-/issues/1", "route"],
+    ["/group/project/-/issues/not-a-number", "route"],
+    ["/group/project/-/issues/1//", "route"],
+    ["/group/%E0%A4%A/-/issues/1", "encoding"],
+    ["/group/%00project/-/issues/1", "control_character"],
+    ["/group/project/-/issues/0", "identity"],
+    [`/group/project/-/issues/${Number.MAX_SAFE_INTEGER}0`, "identity"],
+  ] as const)("rejects %s as %s", (pathname, reason) => {
+    expect(parseGitlabEntityPath(pathname)).toEqual({ ok: false, reason });
+  });
+});

--- a/packages/shared/src/gitlab-entity-path.ts
+++ b/packages/shared/src/gitlab-entity-path.ts
@@ -1,0 +1,72 @@
+export type GitlabEntityPath = {
+  entityType: "issue" | "pull_request";
+  entityIid: number;
+  projectPath: string;
+};
+
+export type GitlabEntityPathParseResult =
+  | { ok: true; value: GitlabEntityPath }
+  | { ok: false; reason: "route" | "encoding" | "control_character" | "identity" };
+
+const ROUTE_SUFFIXES = [
+  { suffix: "/-/merge_requests", entityType: "pull_request" },
+  { suffix: "/merge_requests", entityType: "pull_request" },
+  { suffix: "/-/issues", entityType: "issue" },
+  { suffix: "/issues", entityType: "issue" },
+] as const;
+
+/**
+ * Parse the pathname portion of a GitLab issue or merge-request URL.
+ *
+ * GitLab emits both the canonical `project/-/…` routes and legacy
+ * `project/…` routes. Keeping this parser browser-safe gives the server and
+ * chat renderer one definition of those route shapes.
+ */
+export function parseGitlabEntityPath(pathname: string): GitlabEntityPathParseResult {
+  let path = pathname;
+  if (path.endsWith("/")) path = path.slice(0, -1);
+
+  const iidSeparator = path.lastIndexOf("/");
+  if (iidSeparator <= 0) return { ok: false, reason: "route" };
+
+  const rawIid = path.slice(iidSeparator + 1);
+  if (!isAsciiDigits(rawIid)) return { ok: false, reason: "route" };
+
+  const route = path.slice(0, iidSeparator);
+  const routeSuffix = ROUTE_SUFFIXES.find(({ suffix }) => route.endsWith(suffix));
+  if (!routeSuffix) return { ok: false, reason: "route" };
+
+  const encodedProjectPath = route.slice(1, -routeSuffix.suffix.length);
+  if (!path.startsWith("/") || !encodedProjectPath) return { ok: false, reason: "route" };
+
+  let projectPath: string;
+  try {
+    projectPath = decodeURIComponent(encodedProjectPath);
+  } catch {
+    return { ok: false, reason: "encoding" };
+  }
+  if (/\p{Cc}/u.test(projectPath)) return { ok: false, reason: "control_character" };
+
+  const entityIid = Number(rawIid);
+  if (!projectPath || !Number.isSafeInteger(entityIid) || entityIid <= 0) {
+    return { ok: false, reason: "identity" };
+  }
+
+  return {
+    ok: true,
+    value: {
+      entityType: routeSuffix.entityType,
+      entityIid,
+      projectPath,
+    },
+  };
+}
+
+function isAsciiDigits(value: string): boolean {
+  if (!value) return false;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code < 48 || code > 57) return false;
+  }
+  return true;
+}

--- a/packages/shared/src/gitlab-entity-path.ts
+++ b/packages/shared/src/gitlab-entity-path.ts
@@ -6,7 +6,12 @@ export type GitlabEntityPath = {
 
 export type GitlabEntityPathParseResult =
   | { ok: true; value: GitlabEntityPath }
-  | { ok: false; reason: "route" | "encoding" | "control_character" | "identity" };
+  | { ok: false; reason: "route" | "encoding" | "control_character" | "bidi_control" | "identity" };
+
+// Unicode's Bidi_Control property: ALM, LRM/RLM, embeddings/overrides, and
+// isolates. These format characters can make a compact visible label read in
+// a different order than its href, so decoded project paths must reject them.
+const BIDI_CONTROL_RE = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u;
 
 const ROUTE_SUFFIXES = [
   { suffix: "/-/merge_requests", entityType: "pull_request" },
@@ -46,6 +51,7 @@ export function parseGitlabEntityPath(pathname: string): GitlabEntityPathParseRe
     return { ok: false, reason: "encoding" };
   }
   if (/\p{Cc}/u.test(projectPath)) return { ok: false, reason: "control_character" };
+  if (BIDI_CONTROL_RE.test(projectPath)) return { ok: false, reason: "bidi_control" };
 
   const entityIid = Number(rawIid);
   if (!projectPath || !Number.isSafeInteger(entityIid) || entityIid <= 0) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,11 @@ export {
   USERNAME_MAX_LENGTH,
   USERNAME_SUFFIX_RESERVE,
 } from "./external-account.js";
+export {
+  type GitlabEntityPath,
+  type GitlabEntityPathParseResult,
+  parseGitlabEntityPath,
+} from "./gitlab-entity-path.js";
 // -- Mention extraction (shared by the server fan-out resolver and other readers) --
 export { type BarePathMatch, scanBareDocPathTokens, stripDocPathLineSuffix } from "./lib/doc-link-scan.js";
 export {

--- a/packages/web/src/api/__tests__/gitlab-connections.test.ts
+++ b/packages/web/src/api/__tests__/gitlab-connections.test.ts
@@ -4,6 +4,7 @@ const apiMock = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn(), delete: vi.fn()
 vi.mock("../client.js", () => ({
   api: apiMock,
   withOrg: (path: string) => `/orgs/current${path}`,
+  withOrgAt: (organizationId: string, path: string) => `/orgs/${organizationId}${path}`,
 }));
 
 describe("GitLab Settings API", () => {
@@ -17,6 +18,7 @@ describe("GitLab Settings API", () => {
   it("uses org-scoped collection routes and resource-scoped lifecycle routes", async () => {
     const gitlab = await import("../gitlab-connections.js");
     await gitlab.listGitlabConnections();
+    await gitlab.listGitlabConnectionsAt("chat-team");
     await gitlab.createGitlabConnection({ displayName: "Private", instanceOrigin: "https://gitlab.internal" });
     await gitlab.regenerateGitlabBearer("connection/id");
     await gitlab.replaceGitlabConnection("connection/id", {
@@ -34,6 +36,7 @@ describe("GitLab Settings API", () => {
     await gitlab.removeGitlabIdentityLink("link/id");
 
     expect(apiMock.get).toHaveBeenCalledWith("/orgs/current/gitlab-connections");
+    expect(apiMock.get).toHaveBeenCalledWith("/orgs/chat-team/gitlab-connections");
     expect(apiMock.post).toHaveBeenCalledWith("/orgs/current/gitlab-connections", {
       displayName: "Private",
       instanceOrigin: "https://gitlab.internal",

--- a/packages/web/src/api/gitlab-connections.ts
+++ b/packages/web/src/api/gitlab-connections.ts
@@ -5,13 +5,21 @@ import type {
   GitlabIdentityLinkCreate,
   GitlabIdentityLinkSummary,
 } from "@first-tree/shared";
-import { api, withOrg } from "./client.js";
+import { api, withOrg, withOrgAt } from "./client.js";
 
 export const gitlabConnectionsQueryKey = (organizationId: string | null) =>
   ["gitlab-connections", organizationId] as const;
 
 export async function listGitlabConnections(): Promise<GitlabConnectionSummary[]> {
   const response = await api.get<{ connections: GitlabConnectionSummary[] }>(withOrg("/gitlab-connections"));
+  return response.connections;
+}
+
+/** Read the connection for a known Team instead of the currently selected shell Team. */
+export async function listGitlabConnectionsAt(organizationId: string): Promise<GitlabConnectionSummary[]> {
+  const response = await api.get<{ connections: GitlabConnectionSummary[] }>(
+    withOrgAt(organizationId, "/gitlab-connections"),
+  );
   return response.connections;
 }
 

--- a/packages/web/src/api/gitlab-connections.ts
+++ b/packages/web/src/api/gitlab-connections.ts
@@ -7,6 +7,9 @@ import type {
 } from "@first-tree/shared";
 import { api, withOrg } from "./client.js";
 
+export const gitlabConnectionsQueryKey = (organizationId: string | null) =>
+  ["gitlab-connections", organizationId] as const;
+
 export async function listGitlabConnections(): Promise<GitlabConnectionSummary[]> {
   const response = await api.get<{ connections: GitlabConnectionSummary[] }>(withOrg("/gitlab-connections"));
   return response.connections;

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -45,7 +45,7 @@ import {
 } from "../mention-autocomplete.js";
 import { MentionHighlightOverlay } from "../mention-highlight-overlay.js";
 import { FileChip } from "../ui/file-chip.js";
-import { Markdown } from "../ui/markdown.js";
+import { Markdown, type MarkdownProps } from "../ui/markdown.js";
 import { allRequiredAnswered, buildResolveAnswer } from "./request-state.js";
 
 /**
@@ -112,6 +112,7 @@ export function AskTakeover({
   askerName,
   sending = false,
   mentionCandidates = [],
+  markdownComponents,
   error,
   onReply,
   onSkip,
@@ -135,6 +136,8 @@ export function AskTakeover({
    *  (self-excluded, same source as the composer). Empty → no autocomplete and
    *  every `@<token>` stays plain text. */
   mentionCandidates?: MentionCandidate[];
+  /** Host-provided link presentation shared with the message timeline. */
+  markdownComponents?: MarkdownProps["components"];
   /** A host-side send failure to surface in the card (the composer is covered,
    *  so a failed resolve must show here or it looks like nothing happened). */
   error?: string;
@@ -630,7 +633,7 @@ export function AskTakeover({
               lineHeight: 1.6,
             }}
           >
-            <Markdown>{body}</Markdown>
+            <Markdown components={markdownComponents}>{body}</Markdown>
           </div>
 
           {/* Answer surface — options + Other (or a single free-text box),

--- a/packages/web/src/hooks/use-gitlab-entity-presentation.tsx
+++ b/packages/web/src/hooks/use-gitlab-entity-presentation.tsx
@@ -1,0 +1,51 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { Components } from "react-markdown";
+import { gitlabConnectionsQueryKey, listGitlabConnectionsAt } from "../api/gitlab-connections.js";
+import { gitlabEntityLinkPresentation } from "../lib/gitlab-entity-link.js";
+import { isNavigableWebHref } from "../lib/safe-href.js";
+
+const GITLAB_CONNECTION_REFRESH_MS = 30_000;
+
+/**
+ * Resolve GitLab link presentation against the rendered chat's Team. Both
+ * workspace and Mobile Now use this hook so their blocking-request surfaces
+ * share the same trust boundary and bounded connection refresh.
+ */
+export function useGitlabEntityPresentation(organizationId: string | null): {
+  instanceOrigin: string | null;
+  markdownComponents: Components;
+} {
+  const connections = useQuery({
+    queryKey: gitlabConnectionsQueryKey(organizationId),
+    queryFn: () => (organizationId ? listGitlabConnectionsAt(organizationId) : Promise.resolve([])),
+    enabled: !!organizationId,
+    staleTime: GITLAB_CONNECTION_REFRESH_MS,
+    refetchInterval: GITLAB_CONNECTION_REFRESH_MS,
+  });
+  const instanceOrigin = connections.data?.[0]?.instanceOrigin ?? null;
+  const markdownComponents = useMemo<Components>(
+    () => ({
+      a: ({ node, href, children, ...props }) => {
+        void node;
+        if (!isNavigableWebHref(href)) return <>{children}</>;
+        const presentation =
+          typeof children === "string" && children === href ? gitlabEntityLinkPresentation(href, instanceOrigin) : null;
+        return (
+          <a
+            {...props}
+            href={href}
+            title={presentation?.title ?? props.title}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {presentation?.label ?? children}
+          </a>
+        );
+      },
+    }),
+    [instanceOrigin],
+  );
+
+  return { instanceOrigin, markdownComponents };
+}

--- a/packages/web/src/lib/__tests__/gitlab-entity-link.test.ts
+++ b/packages/web/src/lib/__tests__/gitlab-entity-link.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { gitlabEntityLinkPresentation } from "../gitlab-entity-link.js";
+
+describe("gitlabEntityLinkPresentation", () => {
+  it.each([
+    ["https://gitlab.example/acme/web/-/merge_requests/25", "acme/web!25"],
+    ["https://gitlab.example/acme/web/merge_requests/25", "acme/web!25"],
+    ["https://gitlab.example/acme/web/-/issues/7", "acme/web#7"],
+    ["https://gitlab.example/acme/web/issues/7", "acme/web#7"],
+  ])("formats %s", (href, label) => {
+    expect(gitlabEntityLinkPresentation(href, "https://gitlab.example")).toEqual({ label, title: href });
+  });
+
+  it("decodes the visible project path while preserving the original href as its title", () => {
+    const href = "https://gitlab.example/acme/design%20system/-/merge_requests/3";
+    expect(gitlabEntityLinkPresentation(href, "https://gitlab.example")).toEqual({
+      label: "acme/design system!3",
+      title: href,
+    });
+  });
+
+  it.each([
+    ["https://other.example/acme/web/-/merge_requests/25", "https://gitlab.example"],
+    ["https://gitlab.example/acme/web/-/pipelines/25", "https://gitlab.example"],
+    ["https://gitlab.example/acme/web/-/issues/7?tab=notes", "https://gitlab.example"],
+    ["not a URL", "https://gitlab.example"],
+    ["https://gitlab.example/acme/web/-/issues/7", null],
+  ])("does not format untrusted or unsupported input %s", (href, origin) => {
+    expect(gitlabEntityLinkPresentation(href, origin)).toBeNull();
+  });
+});

--- a/packages/web/src/lib/gitlab-entity-link.ts
+++ b/packages/web/src/lib/gitlab-entity-link.ts
@@ -1,0 +1,34 @@
+import { parseGitlabEntityPath } from "@first-tree/shared";
+
+export type GitlabEntityLinkPresentation = {
+  label: string;
+  title: string;
+};
+
+/**
+ * Build the compact label for a bare GitLab entity URL from the Team's
+ * connected instance. The href itself is never rewritten.
+ */
+export function gitlabEntityLinkPresentation(
+  href: string | undefined,
+  connectedInstanceOrigin: string | null,
+): GitlabEntityLinkPresentation | null {
+  if (!href || !connectedInstanceOrigin) return null;
+
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  if (url.origin !== connectedInstanceOrigin || url.username || url.password || url.search || url.hash) return null;
+
+  const parsed = parseGitlabEntityPath(url.pathname);
+  if (!parsed.ok) return null;
+
+  const sigil = parsed.value.entityType === "pull_request" ? "!" : "#";
+  return {
+    label: `${parsed.value.projectPath}${sigil}${parsed.value.entityIid}`,
+    title: href,
+  };
+}

--- a/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
@@ -24,10 +24,15 @@ const chatMocks = vi.hoisted(() => ({
   sendFileMessageBatch: vi.fn(),
   patchChatEngagement: vi.fn(),
 }));
+const gitlabMocks = vi.hoisted(() => ({ listGitlabConnectionsAt: vi.fn() }));
 
 vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => ({ agentId: "human-agent-self" }) }));
 vi.mock("../../../api/me-chats.js", () => meChatMocks);
 vi.mock("../../../api/chats.js", () => chatMocks);
+vi.mock("../../../api/gitlab-connections.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../api/gitlab-connections.js")>()),
+  listGitlabConnectionsAt: gitlabMocks.listGitlabConnectionsAt,
+}));
 
 const row: MeChatRow = {
   chatId: "question",
@@ -217,6 +222,7 @@ describe("mobile card behavior", () => {
     currentLocation = "";
     for (const mock of Object.values(meChatMocks)) mock.mockReset();
     for (const mock of Object.values(chatMocks)) mock.mockReset();
+    gitlabMocks.listGitlabConnectionsAt.mockReset();
     listResponse = {
       rows: [row],
       priorityRows: { attention: [], pinned: [] },
@@ -225,6 +231,7 @@ describe("mobile card behavior", () => {
     meChatMocks.listMeChats.mockResolvedValue(listResponse);
     chatMocks.listChatOpenRequests.mockResolvedValue({ items: [request] });
     chatMocks.getChat.mockResolvedValue(detail);
+    gitlabMocks.listGitlabConnectionsAt.mockResolvedValue([]);
     chatMocks.sendChatMessage.mockResolvedValue({ ...request, id: "answer-1", format: "text", content: "Ship now" });
     chatMocks.sendFileMessageBatch.mockResolvedValue({ ...request, id: "answer-file-1", format: "file" });
     chatMocks.patchChatEngagement.mockImplementation(async (chatId: string, engagementStatus: string) => ({
@@ -413,6 +420,29 @@ describe("mobile card behavior", () => {
     );
     expect(document.body.textContent).toContain("Question already handled");
     expect(chatMocks.sendChatMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("compacts trusted bare GitLab links in the Mobile Now ask sheet", async () => {
+    const canonical = "https://gitlab.internal/acme/web/-/merge_requests/42";
+    const customLabel = `[Review the MR](${canonical})`;
+    const queryClient = renderPage(harness, "now");
+    queryClient.setQueryData(["chat-open-requests", row.chatId], {
+      items: [{ ...request, content: [canonical, customLabel].join("\n\n") }],
+    });
+    queryClient.setQueryData(
+      ["gitlab-connections", detail.organizationId],
+      [{ instanceOrigin: "https://gitlab.internal" }],
+    );
+
+    await harness.waitFor(() => expect(harness.container.textContent).toContain(row.title));
+    await click(harness.container.querySelector("[data-mobile-primary-action]"));
+    await harness.waitFor(() => expect(document.body.querySelector('[role="dialog"] a')).not.toBeNull());
+
+    const anchors = [...document.body.querySelectorAll<HTMLAnchorElement>('[role="dialog"] a')];
+    const compact = anchors.find((anchor) => anchor.textContent === "acme/web!42");
+    expect(compact?.getAttribute("href")).toBe(canonical);
+    expect(compact?.title).toBe(canonical);
+    expect(anchors.find((anchor) => anchor.textContent === "Review the MR")?.getAttribute("href")).toBe(canonical);
   });
 
   it("lets the feed sheet close without resolving the question", async () => {

--- a/packages/web/src/pages/mobile/ask-sheet.tsx
+++ b/packages/web/src/pages/mobile/ask-sheet.tsx
@@ -8,6 +8,7 @@ import { type AskAnswer, AskTakeover } from "../../components/chat/ask-takeover.
 import { findBlockingRequest, readRequestPayload } from "../../components/chat/request-state.js";
 import type { MentionCandidate } from "../../components/mention-autocomplete.js";
 import { useToast } from "../../components/ui/toast.js";
+import { useGitlabEntityPresentation } from "../../hooks/use-gitlab-entity-presentation.js";
 import { commitMobileAskResolution, locallyResolvedRequestIds } from "./answer-cache.js";
 import { MobileSystemState } from "./components.js";
 
@@ -28,6 +29,7 @@ export function MobileAskSheet({ chatId, onClose }: { chatId: string; onClose: (
     queryFn: () => getChat(chatId),
     staleTime: 10_000,
   });
+  const { markdownComponents } = useGitlabEntityPresentation(detailQuery.data?.organizationId ?? null);
 
   const request = useMemo(() => {
     const locallyResolved = locallyResolvedRequestIds(queryClient, chatId);
@@ -82,6 +84,7 @@ export function MobileAskSheet({ chatId, onClose }: { chatId: string; onClose: (
           sending={sending}
           error={error ?? undefined}
           mentionCandidates={mentionCandidates}
+          markdownComponents={markdownComponents}
           mobile
           onDismiss={onClose}
           onReply={(answer) => {

--- a/packages/web/src/pages/settings/__tests__/gitlab-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/gitlab-page-dom.test.tsx
@@ -14,6 +14,7 @@ const authMock = vi.hoisted(() => ({
   value: { role: "admin" as string | null, organizationId: "org-1" as string | null },
 }));
 const apiMocks = vi.hoisted(() => ({
+  gitlabConnectionsQueryKey: (organizationId: string | null) => ["gitlab-connections", organizationId] as const,
   listGitlabConnections: vi.fn(),
   createGitlabConnection: vi.fn(),
   regenerateGitlabBearer: vi.fn(),

--- a/packages/web/src/pages/settings/gitlab.tsx
+++ b/packages/web/src/pages/settings/gitlab.tsx
@@ -7,6 +7,7 @@ import {
   createGitlabConnection,
   createGitlabIdentityLink,
   deleteGitlabConnection,
+  gitlabConnectionsQueryKey,
   listGitlabConnections,
   listGitlabIdentityLinks,
   reconfirmGitlabIdentityLink,
@@ -30,7 +31,6 @@ import { Label } from "../../components/ui/label.js";
 import { Section } from "../../components/ui/section.js";
 import { useToast } from "../../components/ui/toast.js";
 
-const connectionKey = (organizationId: string | null) => ["gitlab-connections", organizationId] as const;
 const identityKey = (organizationId: string | null) => ["gitlab-identity-links", organizationId] as const;
 
 type ConnectionDialog = "create" | "replace" | null;
@@ -64,7 +64,7 @@ function OrganizationScopedGitlabPage(props: { role: string | null; organization
   const [secretActionError, setSecretActionError] = useState<unknown>(null);
 
   const connections = useQuery({
-    queryKey: connectionKey(organizationId),
+    queryKey: gitlabConnectionsQueryKey(organizationId),
     queryFn: listGitlabConnections,
     enabled: !!organizationId,
   });
@@ -81,7 +81,7 @@ function OrganizationScopedGitlabPage(props: { role: string | null; organization
   });
   const refresh = async (): Promise<void> => {
     await Promise.all([
-      queryClient.invalidateQueries({ queryKey: connectionKey(organizationId) }),
+      queryClient.invalidateQueries({ queryKey: gitlabConnectionsQueryKey(organizationId) }),
       queryClient.invalidateQueries({ queryKey: identityKey(organizationId) }),
     ]);
   };

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -2410,6 +2410,92 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("binds compact GitLab links to the rendered chat Team while the shell still points elsewhere", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    authMock.value = {
+      agentId: "human-agent-self",
+      memberId: "member-self",
+      organizationId: "shell-org",
+      role: "admin",
+    };
+    const chatOriginUrl = "https://chat-gitlab.example/acme/web/-/merge_requests/42";
+    const shellOriginUrl = "https://shell-gitlab.example/acme/web/-/merge_requests/9";
+    const page = messages([
+      message({
+        id: "msg-cross-org-gitlab",
+        senderId: "agent-1",
+        source: "api",
+        content: [chatOriginUrl, shellOriginUrl].join("\n\n"),
+        createdAt: "2026-05-28T11:59:00.000Z",
+      }),
+    ]);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (queryClient) => {
+        seedChat(queryClient, chatDetail({ organizationId: "chat-org" }), page);
+        queryClient.setQueryData(
+          ["gitlab-connections", "shell-org"],
+          [{ instanceOrigin: "https://shell-gitlab.example" }],
+        );
+        queryClient.setQueryData(
+          ["gitlab-connections", "chat-org"],
+          [{ instanceOrigin: "https://chat-gitlab.example" }],
+        );
+      },
+      "/",
+    );
+
+    await waitForText(container, "acme/web!42");
+    const anchors = [...container.querySelectorAll<HTMLAnchorElement>("a")];
+    expect(anchors.find((anchor) => anchor.textContent === "acme/web!42")?.href).toBe(chatOriginUrl);
+    expect(anchors.find((anchor) => anchor.textContent === shellOriginUrl)?.href).toBe(shellOriginUrl);
+
+    await act(async () => root.unmount());
+  });
+
+  it("uses the same compact GitLab presentation in the blocking request body", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const canonical = "https://gitlab.internal/acme/web/-/merge_requests/42";
+    const request = message({
+      id: "req-gitlab-link",
+      senderId: "agent-1",
+      format: "request",
+      content: [canonical, `[Review the MR](${canonical})`].join("\n\n"),
+      metadata: {
+        mentions: ["human-agent-self"],
+        request: {
+          options: [
+            { label: "Approve", description: "ship it" },
+            { label: "Hold", description: "wait" },
+          ],
+        },
+      },
+      source: "api",
+      createdAt: "2026-05-28T11:59:00.000Z",
+    });
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (queryClient) => {
+        seedChat(queryClient, chatDetail(), messages([request]));
+        queryClient.setQueryData(["gitlab-connections", "org-1"], [{ instanceOrigin: "https://gitlab.internal" }]);
+      },
+      "/",
+    );
+
+    await waitForCondition(
+      () => container.querySelector('[role="dialog"] a') !== null,
+      "Expected the blocking request body links",
+    );
+    const dialog = container.querySelector('[role="dialog"]');
+    const anchors = [...(dialog?.querySelectorAll<HTMLAnchorElement>("a") ?? [])];
+    const compact = anchors.find((anchor) => anchor.textContent === "acme/web!42");
+    expect(compact?.getAttribute("href")).toBe(canonical);
+    expect(compact?.title).toBe(canonical);
+    expect(anchors.find((anchor) => anchor.textContent === "Review the MR")?.getAttribute("href")).toBe(canonical);
+
+    await act(async () => root.unmount());
+  });
+
   it("opens the image lightbox on thumbnail click and closes on Escape", async () => {
     // BASE_MESSAGES' msg-3 is a one-image message ("preview.png").
     const { ChatView } = await import("../chat-view.js");

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -81,6 +81,7 @@ const authMock = vi.hoisted(() => ({
   value: {
     agentId: "human-agent-self",
     memberId: "member-self",
+    organizationId: "org-1",
     role: "admin",
   },
 }));
@@ -481,6 +482,7 @@ function createClient(): QueryClient {
     },
   });
   queryClient.setQueryData(["agents", "org-list"], { items: ORG_AGENTS, nextCursor: null });
+  queryClient.setQueryData(["gitlab-connections", "org-1"], []);
   queryClient.setQueryData(
     ["chat-agent-status", "chat-1"],
     [
@@ -654,7 +656,12 @@ beforeEach(() => {
   installBrowserStubs();
   document.body.innerHTML = "";
   vi.clearAllMocks();
-  authMock.value = { agentId: "human-agent-self", memberId: "member-self", role: "admin" };
+  authMock.value = {
+    agentId: "human-agent-self",
+    memberId: "member-self",
+    organizationId: "org-1",
+    role: "admin",
+  };
   activityMocks.listClients.mockResolvedValue([
     {
       id: "client-1",
@@ -2363,6 +2370,42 @@ describe("ChatView", () => {
     expect(container.textContent).toContain("worktrees/build-tree");
     // A genuine external link in the same message still renders as an anchor.
     expect(anchorHrefs).toContain("https://example.com/guide");
+
+    await act(async () => root.unmount());
+  });
+
+  it("shortens only bare entity links from the Team's connected GitLab instance", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    const canonical = "https://gitlab.internal/acme/web/-/merge_requests/42";
+    const legacy = "https://gitlab.internal/acme/web/issues/7";
+    const otherOrigin = "https://gitlab.example/acme/web/-/merge_requests/9";
+    const page = messages([
+      message({
+        id: "msg-gitlab-links",
+        senderId: "agent-1",
+        source: "api",
+        content: [canonical, legacy, otherOrigin, `[Review the MR](${canonical})`].join("\n\n"),
+        createdAt: "2026-05-28T11:59:00.000Z",
+      }),
+    ]);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" />,
+      (queryClient) => {
+        seedChat(queryClient, chatDetail(), page);
+        queryClient.setQueryData(["gitlab-connections", "org-1"], [{ instanceOrigin: "https://gitlab.internal" }]);
+      },
+      "/",
+    );
+
+    await waitForText(container, "acme/web!42");
+
+    const anchors = [...container.querySelectorAll<HTMLAnchorElement>("a")];
+    const compactMr = anchors.find((anchor) => anchor.textContent === "acme/web!42");
+    expect(compactMr?.getAttribute("href")).toBe(canonical);
+    expect(compactMr?.title).toBe(canonical);
+    expect(anchors.find((anchor) => anchor.textContent === "acme/web#7")?.getAttribute("href")).toBe(legacy);
+    expect(anchors.find((anchor) => anchor.textContent === otherOrigin)?.getAttribute("href")).toBe(otherOrigin);
+    expect(anchors.find((anchor) => anchor.textContent === "Review the MR")?.getAttribute("href")).toBe(canonical);
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -37,11 +37,13 @@ import {
 } from "lucide-react";
 import {
   type CSSProperties,
+  createContext,
   memo,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
   type RefObject,
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -70,6 +72,7 @@ import {
   sendChatMessage,
   sendFileMessageBatch,
 } from "../../../api/chats.js";
+import { gitlabConnectionsQueryKey, listGitlabConnections } from "../../../api/gitlab-connections.js";
 import { putImage } from "../../../api/image-store.js";
 import { cacheMessages, getCachedMessages } from "../../../api/message-store.js";
 import { getReadState, type ReadState, setReadState } from "../../../api/read-state-store.js";
@@ -136,6 +139,7 @@ import { useReadTracker } from "../../../hooks/use-read-tracker.js";
 import { viewOf } from "../../../lib/agent-status-view.js";
 import { attachmentIdFromHref, parseFailedDocHref, wrapFailedDocMentions } from "../../../lib/doc-preview-links.js";
 import { parkFailedDraftIfSwitched } from "../../../lib/draft-store.js";
+import { gitlabEntityLinkPresentation } from "../../../lib/gitlab-entity-link.js";
 import { isNavigableWebHref } from "../../../lib/safe-href.js";
 import { formatTokenUsageTitle, processedTokenCount } from "../../../lib/token-usage.js";
 import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-name-map.js";
@@ -549,6 +553,8 @@ type MessageRowProps = {
   isTrial: boolean;
 };
 
+const GitlabInstanceOriginContext = createContext<string | null>(null);
+
 type MessageBodyProps = {
   msg: MessageWithDelivery;
   myAgentId: string | null;
@@ -572,6 +578,7 @@ const MessageMarkdown = memo(function MessageMarkdown({ children, components, re
 const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipants }: MessageBodyProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
+  const gitlabInstanceOrigin = useContext(GitlabInstanceOriginContext);
   // Generic attachment refs (doc-preview is the first consumer; kind:
   // "document"). Keyed by attachmentId so the `attachment:<id>` link click can
   // look the ref up and seed the drawer's cache. Old messages (legacy inline
@@ -715,14 +722,35 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
           setSearchParams(next);
         };
 
+        const gitlabPresentation =
+          typeof children === "string" && children === href
+            ? gitlabEntityLinkPresentation(href, gitlabInstanceOrigin)
+            : null;
+
         return (
-          <a {...props} href={href} onClick={onClick} target="_blank" rel="noopener noreferrer">
-            {children}
+          <a
+            {...props}
+            href={href}
+            title={gitlabPresentation?.title ?? props.title}
+            onClick={onClick}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {gitlabPresentation?.label ?? children}
           </a>
         );
       },
     }),
-    [docAttachmentRefs, failedDocMentions, msg.chatId, msg.id, queryClient, searchParams, setSearchParams],
+    [
+      docAttachmentRefs,
+      failedDocMentions,
+      gitlabInstanceOrigin,
+      msg.chatId,
+      msg.id,
+      queryClient,
+      searchParams,
+      setSearchParams,
+    ],
   );
 
   return (
@@ -1516,7 +1544,14 @@ export function ChatView({
    * `ChatRowAvatar` on the left rail (both feed `resolveAvatarHue`).
    */
   const agentColorToken = useCallback((id: string) => agentIdentity(id)?.avatarColorToken ?? null, [agentIdentity]);
-  const { agentId: myAgentId, memberId: myMemberId, user } = useAuth();
+  const { agentId: myAgentId, memberId: myMemberId, organizationId, user } = useAuth();
+  const gitlabConnections = useQuery({
+    queryKey: gitlabConnectionsQueryKey(organizationId),
+    queryFn: listGitlabConnections,
+    enabled: !!organizationId,
+    staleTime: Infinity,
+  });
+  const gitlabInstanceOrigin = gitlabConnections.data?.[0]?.instanceOrigin ?? null;
   // Unsent draft text, cached per user + chat in browser-local storage so it
   // survives chat switches and reloads (ChatView is not remounted on switch).
   // Clearing the draft on send empties its stored entry.
@@ -4681,7 +4716,9 @@ export function ChatView({
       </div>
     </div>
   );
-  return body;
+  return (
+    <GitlabInstanceOriginContext.Provider value={gitlabInstanceOrigin}>{body}</GitlabInstanceOriginContext.Provider>
+  );
 }
 
 function MobileChatDetailsSheet({

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -72,7 +72,6 @@ import {
   sendChatMessage,
   sendFileMessageBatch,
 } from "../../../api/chats.js";
-import { gitlabConnectionsQueryKey, listGitlabConnections } from "../../../api/gitlab-connections.js";
 import { putImage } from "../../../api/image-store.js";
 import { cacheMessages, getCachedMessages } from "../../../api/message-store.js";
 import { getReadState, type ReadState, setReadState } from "../../../api/read-state-store.js";
@@ -135,6 +134,7 @@ import { StatusGlyph } from "../../../components/ui/status-glyph.js";
 import { useToast } from "../../../components/ui/toast.js";
 import { UnreadDivider } from "../../../components/unread-divider.js";
 import { useChatScroll } from "../../../hooks/use-chat-scroll.js";
+import { useGitlabEntityPresentation } from "../../../hooks/use-gitlab-entity-presentation.js";
 import { useReadTracker } from "../../../hooks/use-read-tracker.js";
 import { viewOf } from "../../../lib/agent-status-view.js";
 import { attachmentIdFromHref, parseFailedDocHref, wrapFailedDocMentions } from "../../../lib/doc-preview-links.js";
@@ -1544,14 +1544,7 @@ export function ChatView({
    * `ChatRowAvatar` on the left rail (both feed `resolveAvatarHue`).
    */
   const agentColorToken = useCallback((id: string) => agentIdentity(id)?.avatarColorToken ?? null, [agentIdentity]);
-  const { agentId: myAgentId, memberId: myMemberId, organizationId, user } = useAuth();
-  const gitlabConnections = useQuery({
-    queryKey: gitlabConnectionsQueryKey(organizationId),
-    queryFn: listGitlabConnections,
-    enabled: !!organizationId,
-    staleTime: Infinity,
-  });
-  const gitlabInstanceOrigin = gitlabConnections.data?.[0]?.instanceOrigin ?? null;
+  const { agentId: myAgentId, memberId: myMemberId, user } = useAuth();
   // Unsent draft text, cached per user + chat in browser-local storage so it
   // survives chat switches and reloads (ChatView is not remounted on switch).
   // Clearing the draft on send empties its stored entry.
@@ -1869,6 +1862,14 @@ export function ChatView({
     initialData: initialChatDetail?.id === chatId ? initialChatDetail : undefined,
     staleTime: 10_000,
   });
+
+  // A globally addressed chat may render before the shell finishes switching
+  // Teams. Bind the trust decision to the rendered chat's Team, never to the
+  // transient shell selection, and refresh it so remote connection changes
+  // eventually replace (or remove) the compact-label trust boundary.
+  const chatOrganizationId = chatDetail?.organizationId ?? null;
+  const { instanceOrigin: gitlabInstanceOrigin, markdownComponents: askMarkdownComponents } =
+    useGitlabEntityPresentation(chatOrganizationId);
 
   // Fetch one chat-scoped batch with an independent newest-first window per
   // non-human speaker. Chat membership is the disclosure boundary, so a
@@ -3580,6 +3581,7 @@ export function ChatView({
                 sending={askBusy}
                 error={askError ?? undefined}
                 mentionCandidates={mentionCandidates}
+                markdownComponents={askMarkdownComponents}
                 isTrial={isTrial}
                 mobile={composerMobile}
                 onReply={(answer) => {


### PR DESCRIPTION
## Summary

- add one browser-safe GitLab entity-path parser shared by the server and web client, with canonical and legacy route support
- shorten bare Issue and Merge Request URLs from the Team's connected GitLab instance to `namespace/project#iid` and `namespace/project!iid`
- preserve the original href, full-URL title, custom Markdown labels, and existing neutral link styling
- reuse the GitLab connection query key so Settings mutations refresh the chat presentation cache

## Testing

- `pnpm check`
- `pnpm typecheck`
- `pnpm --dir packages/shared exec vitest run src/__tests__/gitlab-entity-path.test.ts`
- `pnpm --dir packages/server exec vitest run src/__tests__/gitlab-entities-agent-route.test.ts`
- `pnpm --dir packages/web exec vitest run src/pages/settings/__tests__/gitlab-page-dom.test.tsx src/lib/__tests__/gitlab-entity-link.test.ts src/pages/workspace/center/__tests__/chat-view-dom.test.tsx`
- local Playwright QA against a real server, Postgres database, GitLab connection, chat, and message at 1440px and 390px widths; no layout overflow or feature console errors
- `pnpm test` full-monorepo attempt: the concurrent run hit unrelated timeout flakes in existing skill-evals and client tests; every observed timeout passed when rerun in isolation

## Scope

No new CSS, card UI, icons, API endpoints, database changes, webhook changes, or stored-message rewrites.
