### PR TITLE
fix(cli): retire stranded legacy github-scan launchd runner on first run after upgrade

### DIFF
--- a/apps/cli/src/__tests__/cli-entry-and-tree-actions-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-entry-and-tree-actions-extra.test.ts
@@ -31,6 +31,10 @@ const outputMocks = vi.hoisted(() => ({
   setJsonMode: vi.fn(),
 }));
 
+const legacyGithubScanMocks = vi.hoisted(() => ({
+  retireLegacyGithubScanRunner: vi.fn(),
+}));
+
 vi.mock("@first-tree/client", () => clientMocks);
 vi.mock("../commands/agent/index.js", () => ({ registerAgentCommands: registrationMocks.registerAgentCommands }));
 vi.mock("../commands/chat/index.js", () => ({ registerChatCommands: registrationMocks.registerChatCommands }));
@@ -47,6 +51,7 @@ vi.mock("../commands/status.js", () => ({ registerStatusCommand: registrationMoc
 vi.mock("../commands/tree/index.js", () => ({ registerTreeCommands: registrationMocks.registerTreeCommands }));
 vi.mock("../commands/upgrade.js", () => ({ registerUpgradeCommand: registrationMocks.registerUpgradeCommand }));
 vi.mock("../core/output.js", () => outputMocks);
+vi.mock("../core/legacy-github-scan.js", () => legacyGithubScanMocks);
 
 const originalCwd = process.cwd();
 const originalHome = process.env.FIRST_TREE_HOME;
@@ -132,9 +137,12 @@ describe("CLI entry and public exports", () => {
     expect(clientMocks.applyClientLoggerConfig).toHaveBeenLastCalledWith({ level: "error", explicit: true });
     delete process.env.FIRST_TREE_JSON;
 
+    legacyGithubScanMocks.retireLegacyGithubScanRunner.mockClear();
     runPreAction({});
     expect(outputMocks.setJsonMode).toHaveBeenLastCalledWith(false);
     expect(clientMocks.applyClientLoggerConfig).toHaveBeenLastCalledWith({ level: "warn" });
+    // One-shot legacy github-scan runner retirement rides every preAction (issue #995).
+    expect(legacyGithubScanMocks.retireLegacyGithubScanRunner).toHaveBeenCalledTimes(1);
   });
 
   it("loads the programmatic entrypoint exports", async () => {

--- a/apps/cli/src/__tests__/legacy-github-scan.test.ts
+++ b/apps/cli/src/__tests__/legacy-github-scan.test.ts
@@ -1,0 +1,306 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { retireLegacyGithubScanRunner } from "../core/legacy-github-scan.js";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+const userInfoMock = vi.hoisted(() => vi.fn(() => ({ uid: 501, username: "gandy" })));
+const homedirMock = vi.hoisted(() => vi.fn(() => "/Users/gandy"));
+const printMocks = vi.hoisted(() => ({
+  status: vi.fn(),
+  line: vi.fn(),
+}));
+const loggerMocks = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+  execFileSync: execFileSyncMock,
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: homedirMock,
+    userInfo: userInfoMock,
+  };
+});
+
+vi.mock("@first-tree/client", () => ({
+  createLogger: vi.fn(() => loggerMocks),
+}));
+
+vi.mock("../core/output.js", () => ({
+  print: printMocks,
+}));
+
+const RUNNER_LABEL = "com.first-tree.github-scan.runner.gandy.default";
+
+const originalPlatform = process.platform;
+const originalFirstTreeHome = process.env.FIRST_TREE_HOME;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+function legacyLaunchdDir(home: string): string {
+  return join(home, ".first-tree", "github-scan", "runner", "launchd");
+}
+
+function markerPath(stateDir: string): string {
+  return join(stateDir, "legacy-github-scan-runner-retired.json");
+}
+
+function spawnOk(stdout = ""): { status: number; stdout: string; stderr: string } {
+  return { status: 0, stdout, stderr: "" };
+}
+
+function spawnFail(stderr: string, status = 1): { status: number; stdout: string; stderr: string } {
+  return { status, stdout: "", stderr };
+}
+
+/** `launchctl list` row shape: `PID\tStatus\tLabel` (`-` when not running). */
+function launchctlListOutput(labels: string[]): string {
+  return labels.map((label) => `-\t0\t${label}`).join("\n");
+}
+
+function spawnCalls(): string[][] {
+  return spawnSyncMock.mock.calls.map((call) => [call[0], ...(call[1] as string[])]);
+}
+
+function bootoutCalls(): string[][] {
+  return spawnCalls().filter((args) => args[1] === "bootout");
+}
+
+let home: string;
+let stateDir: string;
+
+beforeEach(() => {
+  home = join(tmpdir(), `ft-995-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  stateDir = join(home, "ft-home", "state");
+  mkdirSync(home, { recursive: true });
+  process.env.FIRST_TREE_HOME = join(home, "ft-home");
+  setPlatform("darwin");
+  homedirMock.mockReturnValue(home);
+  userInfoMock.mockReturnValue({ uid: 501, username: "gandy" });
+  spawnSyncMock.mockReset();
+  spawnSyncMock.mockImplementation(() => spawnOk());
+  execFileSyncMock.mockReset();
+  printMocks.status.mockClear();
+  printMocks.line.mockClear();
+  loggerMocks.warn.mockClear();
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  setPlatform(originalPlatform);
+  if (originalFirstTreeHome === undefined) delete process.env.FIRST_TREE_HOME;
+  else process.env.FIRST_TREE_HOME = originalFirstTreeHome;
+});
+
+describe("retireLegacyGithubScanRunner", () => {
+  it("short-circuits on non-darwin with zero I/O", () => {
+    setPlatform("linux");
+    const result = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+    expect(result.checked).toBe(false);
+    expect(result.markerWritten).toBe(false);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    expect(existsSync(markerPath(stateDir))).toBe(false);
+  });
+
+  it("short-circuits when the done-marker already exists, leaving residue untouched", () => {
+    const plistDir = legacyLaunchdDir(home);
+    mkdirSync(plistDir, { recursive: true });
+    writeFileSync(join(plistDir, `${RUNNER_LABEL}.plist`), "<plist/>");
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(markerPath(stateDir), "{}\n");
+
+    const result = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+
+    expect(result.checked).toBe(false);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    expect(existsSync(join(plistDir, `${RUNNER_LABEL}.plist`))).toBe(true);
+  });
+
+  it("writes only the marker when nothing is stranded", () => {
+    const result = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+
+    expect(result).toMatchObject({
+      checked: true,
+      labelsBootedOut: [],
+      plistDirRemoved: false,
+      markerWritten: true,
+      errors: [],
+    });
+    expect(spawnCalls()).toEqual([["launchctl", "list"]]);
+    expect(bootoutCalls()).toEqual([]);
+    expect(printMocks.status).not.toHaveBeenCalled();
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
+
+    const marker = JSON.parse(readFileSync(markerPath(stateDir), "utf-8")) as Record<string, unknown>;
+    expect(marker.version).toBe(1);
+    expect(typeof marker.retiredAt).toBe("string");
+    expect(marker.labelsBootedOut).toEqual([]);
+    expect(marker.plistDirRemoved).toBe(false);
+    expect(statSync(markerPath(stateDir)).mode & 0o777).toBe(0o600);
+  });
+
+  it("boots out the loaded runner and removes the plist dir (incident state from #995)", () => {
+    const plistDir = legacyLaunchdDir(home);
+    mkdirSync(plistDir, { recursive: true });
+    writeFileSync(join(plistDir, `${RUNNER_LABEL}.plist`), "<plist/>");
+    spawnSyncMock.mockImplementation((_cmd: string, args: string[]) =>
+      args[0] === "list" ? spawnOk(launchctlListOutput([RUNNER_LABEL, "com.apple.Spotlight"])) : spawnOk(),
+    );
+
+    const result = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+
+    expect(result).toMatchObject({
+      checked: true,
+      labelsBootedOut: [RUNNER_LABEL],
+      plistDirRemoved: true,
+      markerWritten: true,
+      errors: [],
+    });
+    expect(spawnCalls()).toEqual([
+      ["launchctl", "list"],
+      ["launchctl", "bootout", `gui/501/${RUNNER_LABEL}`],
+    ]);
+    expect(existsSync(plistDir)).toBe(false);
+    expect(printMocks.status).toHaveBeenCalledTimes(1);
+    expect(printMocks.status.mock.calls[0]?.[1]).toMatch(/retired legacy github-scan launchd runner/);
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
+
+    const marker = JSON.parse(readFileSync(markerPath(stateDir), "utf-8")) as Record<string, unknown>;
+    expect(marker.labelsBootedOut).toEqual([RUNNER_LABEL]);
+    expect(marker.plistDirRemoved).toBe(true);
+  });
+
+  it("tolerates a not-loaded service while still removing the plist dir (manual-bootout residue)", () => {
+    const plistDir = legacyLaunchdDir(home);
+    mkdirSync(plistDir, { recursive: true });
+    writeFileSync(join(plistDir, `${RUNNER_LABEL}.plist`), "<plist/>");
+    spawnSyncMock.mockImplementation((_cmd: string, args: string[]) =>
+      args[0] === "bootout"
+        ? spawnFail(`Could not find service "${RUNNER_LABEL}" in domain for user gui: 501`, 113)
+        : spawnOk(),
+    );
+
+    const result = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+
+    expect(result.errors).toEqual([]);
+    expect(result.labelsBootedOut).toEqual([RUNNER_LABEL]);
+    expect(result.plistDirRemoved).toBe(true);
+    expect(result.markerWritten).toBe(true);
+    expect(existsSync(plistDir)).toBe(false);
+  });
+
+  it("boots out a runner found only by the launchd sweep (env-override install, no default plist dir)", () => {
+    spawnSyncMock.mockImplementation((_cmd: string, args: string[]) =>
+      args[0] === "list" ? spawnOk(launchctlListOutput(["com.first-tree.github-scan.runner.octo.default"])) : spawnOk(),
+    );
+
+    const result = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+
+    expect(result.labelsBootedOut).toEqual(["com.first-tree.github-scan.runner.octo.default"]);
+    expect(result.plistDirRemoved).toBe(false);
+    expect(result.markerWritten).toBe(true);
+    expect(bootoutCalls()).toEqual([
+      ["launchctl", "bootout", "gui/501/com.first-tree.github-scan.runner.octo.default"],
+    ]);
+  });
+
+  it("skips the marker when the sweep fails and re-runs detection on the next call", () => {
+    spawnSyncMock.mockImplementation((_cmd: string, args: string[]) =>
+      args[0] === "list" ? spawnFail("launchd simulation failed") : spawnOk(),
+    );
+
+    const first = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+    expect(first.checked).toBe(true);
+    expect(first.markerWritten).toBe(false);
+    expect(first.errors.some((e) => e.includes("launchctl list"))).toBe(true);
+    expect(loggerMocks.warn).toHaveBeenCalled();
+    expect(existsSync(markerPath(stateDir))).toBe(false);
+
+    // Recovery: sweep works again — the next CLI run must redo detection,
+    // not treat the failed pass as done.
+    spawnSyncMock.mockImplementation(() => spawnOk());
+    spawnSyncMock.mockClear();
+    const second = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+    expect(spawnCalls()).toEqual([["launchctl", "list"]]);
+    expect(second.markerWritten).toBe(true);
+    expect(second.errors).toEqual([]);
+  });
+
+  it("keeps removing the plist dir when bootout fails unexpectedly, skips the marker, and recovers on retry", () => {
+    const plistDir = legacyLaunchdDir(home);
+    mkdirSync(plistDir, { recursive: true });
+    writeFileSync(join(plistDir, `${RUNNER_LABEL}.plist`), "<plist/>");
+    spawnSyncMock.mockImplementation((_cmd: string, args: string[]) =>
+      args[0] === "bootout" ? spawnFail("Boot-out failed: 5: Input/output error", 5) : spawnOk(),
+    );
+
+    const first = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+    expect(first.labelsBootedOut).toEqual([]);
+    expect(first.errors.some((e) => e.includes(`bootout ${RUNNER_LABEL}`))).toBe(true);
+    expect(first.plistDirRemoved).toBe(true);
+    expect(first.markerWritten).toBe(false);
+    expect(existsSync(plistDir)).toBe(false);
+
+    spawnSyncMock.mockImplementation(() => spawnOk());
+    const second = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+    expect(second.markerWritten).toBe(true);
+    expect(second.errors).toEqual([]);
+  });
+
+  it("is a no-op on the second consecutive run once the marker exists", () => {
+    const first = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+    expect(first.markerWritten).toBe(true);
+    spawnSyncMock.mockClear();
+
+    const second = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+    expect(second.checked).toBe(false);
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("never boots out non-matching plist files, but still removes the tool-private dir wholesale", () => {
+    const plistDir = legacyLaunchdDir(home);
+    mkdirSync(plistDir, { recursive: true });
+    writeFileSync(join(plistDir, `${RUNNER_LABEL}.plist`), "<plist/>");
+    writeFileSync(join(plistDir, "other.plist"), "<plist/>");
+    writeFileSync(join(plistDir, "notes.txt"), "operator notes");
+
+    const result = retireLegacyGithubScanRunner({ homeDir: home, stateDir });
+
+    expect(result.errors).toEqual([]);
+    expect(bootoutCalls()).toEqual([["launchctl", "bootout", `gui/501/${RUNNER_LABEL}`]]);
+    expect(existsSync(plistDir)).toBe(false);
+    expect(result.markerWritten).toBe(true);
+  });
+
+  it("resolves the default legacy dir from the real home and the marker under the channel home", () => {
+    // No opts: homeDir comes from os.homedir() (mocked to the temp home) and
+    // stateDir from defaultHome() (FIRST_TREE_HOME, set in beforeEach).
+    const plistDir = legacyLaunchdDir(home);
+    mkdirSync(plistDir, { recursive: true });
+    writeFileSync(join(plistDir, `${RUNNER_LABEL}.plist`), "<plist/>");
+    const channelMarkerPath = join(
+      process.env.FIRST_TREE_HOME as string,
+      "state",
+      "legacy-github-scan-runner-retired.json",
+    );
+
+    const result = retireLegacyGithubScanRunner();
+
+    expect(result.markerWritten).toBe(true);
+    expect(existsSync(channelMarkerPath)).toBe(true);
+    expect(existsSync(plistDir)).toBe(false);
+  });
+});

--- a/apps/cli/src/cli/index.ts
+++ b/apps/cli/src/cli/index.ts
@@ -26,6 +26,7 @@ import { registerStatusCommand } from "../commands/status.js";
 import { registerTreeCommands } from "../commands/tree/index.js";
 import { registerUpgradeCommand } from "../commands/upgrade.js";
 import { channelConfig } from "../core/channel.js";
+import { retireLegacyGithubScanRunner } from "../core/legacy-github-scan.js";
 import { setJsonMode } from "../core/output.js";
 import { COMMAND_VERSION } from "../core/version.js";
 
@@ -60,6 +61,14 @@ program
     } else {
       applyClientLoggerConfig({ level: "warn" });
     }
+
+    // One-shot housekeeping (issue #995): retire the pre-#775 legacy
+    // github-scan launchd runner — bootout + plist removal, ending its
+    // KeepAlive crash-loop and freeing port 7878. Runs before every command
+    // so any "first run of a new version" path is covered (manual upgrade,
+    // auto-update restart, daemon refresh-unit, non-daemon usage). Marker
+    // gated: steady-state cost is a single existsSync. Never throws.
+    retireLegacyGithubScanRunner();
   });
 
 // ── Top-level shortcuts (single-command verbs) ──────────────────────────

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -134,6 +134,10 @@ export type { InstallClaudeResult } from "./install-claude-runtime.js";
 export { installClaudeRuntime } from "./install-claude-runtime.js";
 export type { InstallCodexResult } from "./install-codex-runtime.js";
 export { installCodexRuntime } from "./install-codex-runtime.js";
+// One-shot retirement of the pre-#775 legacy github-scan launchd runner
+// (issue #995) — bootout + plist cleanup on first run of a new version.
+export type { LegacyGithubScanRetireResult } from "./legacy-github-scan.js";
+export { retireLegacyGithubScanRunner } from "./legacy-github-scan.js";
 export {
   type MemberOrganizationProfile,
   type MemberOrganizationResolutionCode,

--- a/apps/cli/src/core/legacy-github-scan.ts
+++ b/apps/cli/src/core/legacy-github-scan.ts
@@ -1,0 +1,194 @@
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, userInfo } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "@first-tree/client";
+import { defaultHome } from "@first-tree/shared/config";
+import { print } from "./output.js";
+import { runCapture, runCaptureOut } from "./supervisor/shared.js";
+
+/**
+ * One-shot retirement of the legacy github-scan launchd runner (issue #995).
+ *
+ * The github-scan subsystem was removed from every channel in #775, but its
+ * macOS user agent could outlive the upgrade: the plist pinned
+ * `ProgramArguments` to an absolute binary path with `KeepAlive: true`, so
+ * once the binary moved, launchd kept restarting a job that died instantly
+ * with `MODULE_NOT_FOUND` — an endless crash-loop appending to the runner
+ * log, and a zombie that could keep squatting the legacy default port 7878.
+ *
+ * This housekeeping runs once per machine per channel from the CLI's global
+ * preAction hook: detect any stranded runner and put it down — `launchctl
+ * bootout` the label(s) and remove the plist directory.
+ *
+ * Detection has two sources because the label embeds the operator's GitHub
+ * login (`com.first-tree.github-scan.runner.<login>.<profile>`), which we
+ * cannot recompute locally:
+ *
+ *   1. Plist files under the default runner dir
+ *      `~/.first-tree/github-scan/runner/launchd/*.plist` — the only
+ *      location the legacy installer ever bootstrapped from (no
+ *      `~/Library/LaunchAgents` copy existed). The filename IS the label.
+ *   2. A `launchctl list` sweep for labels with the runner prefix — the only
+ *      way to find runners installed with `GITHUB_SCAN_DIR` /
+ *      `GITHUB_SCAN_HOME` overrides (non-default plist location), and
+ *      runners whose plist was deleted by hand while the service stayed
+ *      loaded. For such non-default paths we bootout by label only; we do
+ *      not hunt for their plist files.
+ *
+ * Why auto-removal is safe here, unlike the `dev.first-tree.client` legacy
+ * label in `supervisor/launchd.ts`: no live or future release of any channel
+ * can own `com.first-tree.github-scan.runner.*` — the subsystem is gone
+ * everywhere, so there is no parallel-install scenario to protect.
+ *
+ * Invariants:
+ *   - Idempotent — with nothing stranded it only writes the marker; repeat
+ *     runs short-circuit on the marker; even without the marker every step
+ *     tolerates the already-clean state (bootout tolerates not-loaded,
+ *     rmSync tolerates a missing dir).
+ *   - Non-fatal — any failure is logged and reported in the result, never
+ *     thrown; the marker is only written on a fully clean pass so the next
+ *     CLI run retries.
+ *   - Cheap — steady state is one `existsSync` per command; the first run
+ *     costs at most two `launchctl` subprocesses.
+ */
+
+const LEGACY_LABEL_PREFIX = "com.first-tree.github-scan.runner.";
+const LEGACY_MARKER_VERSION = 1;
+
+export type LegacyGithubScanRetireResult = {
+  /** false when the pass short-circuited (non-darwin, or marker already present). */
+  checked: boolean;
+  /** Labels guaranteed not loaded after the pass (booted out, or already not loaded). */
+  labelsBootedOut: string[];
+  /** Whether the default runner plist directory was removed. */
+  plistDirRemoved: boolean;
+  /** Whether the done-marker was written. Absent marker ⇒ next CLI run retries. */
+  markerWritten: boolean;
+  /** Non-fatal problems encountered; non-empty means the pass will be retried. */
+  errors: string[];
+};
+
+function legacyLaunchdDir(homeDir: string): string {
+  // Prod-era fixed path: github-scan predates channels, so its state always
+  // lived under ~/.first-tree regardless of which channel's binary is
+  // cleaning up now. Deliberately NOT defaultHome() (channel-dependent).
+  return join(homeDir, ".first-tree", "github-scan", "runner", "launchd");
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function retireLegacyGithubScanRunner(opts?: {
+  homeDir?: string;
+  stateDir?: string;
+}): LegacyGithubScanRetireResult {
+  const result: LegacyGithubScanRetireResult = {
+    checked: false,
+    labelsBootedOut: [],
+    plistDirRemoved: false,
+    markerWritten: false,
+    errors: [],
+  };
+  const logger = createLogger("legacy-github-scan");
+  try {
+    // The legacy subsystem was darwin-only; Linux/Windows never had a unit.
+    if (process.platform !== "darwin") return result;
+
+    const stateDir = opts?.stateDir ?? join(defaultHome(), "state");
+    const markerPath = join(stateDir, "legacy-github-scan-runner-retired.json");
+    if (existsSync(markerPath)) return result;
+    result.checked = true;
+
+    const homeDir = opts?.homeDir ?? homedir();
+    const plistDir = legacyLaunchdDir(homeDir);
+    const labels = new Set<string>();
+
+    // Source 1: plist files in the default runner dir. Filename is the label;
+    // only exact-prefix names are eligible for bootout (the directory itself
+    // is tool-private state and is removed wholesale below).
+    const plistDirPresent = existsSync(plistDir);
+    if (plistDirPresent) {
+      try {
+        for (const entry of readdirSync(plistDir)) {
+          if (!entry.endsWith(".plist")) continue;
+          const label = entry.slice(0, -".plist".length);
+          if (label.startsWith(LEGACY_LABEL_PREFIX)) labels.add(label);
+        }
+      } catch (err) {
+        result.errors.push(`scan ${plistDir}: ${errorMessage(err)}`);
+      }
+    }
+
+    // Source 2: sweep the user's launchd domain for runner labels. `launchctl
+    // list` prints `PID\tStatus\tLabel` with no header; labels are
+    // sanitizeFilename products and contain no spaces, so the last
+    // whitespace-separated field of each line is the label.
+    const sweep = runCaptureOut("launchctl", ["list"], 10_000);
+    if (sweep.ok) {
+      for (const line of sweep.stdout.split(/\r?\n/)) {
+        const fields = line.trim().split(/\s+/);
+        const label = fields[fields.length - 1];
+        if (label?.startsWith(LEGACY_LABEL_PREFIX)) labels.add(label);
+      }
+    } else {
+      // Without the sweep we cannot prove nothing is stranded (e.g. an
+      // env-override install), so block the marker and retry next run.
+      result.errors.push(`launchctl list: ${sweep.stderr || `exit ${sweep.code ?? "unknown"}`}`);
+    }
+
+    const uid = userInfo().uid;
+    for (const label of [...labels].sort()) {
+      const res = runCapture("launchctl", ["bootout", `gui/${uid}/${label}`], 15_000);
+      if (!res.ok && !/not find|no such|not loaded/i.test(res.stderr)) {
+        result.errors.push(`launchctl bootout ${label}: ${res.stderr || `exit ${res.code ?? "unknown"}`}`);
+        continue;
+      }
+      result.labelsBootedOut.push(label);
+    }
+
+    if (plistDirPresent) {
+      try {
+        rmSync(plistDir, { recursive: true, force: true });
+        result.plistDirRemoved = true;
+      } catch (err) {
+        result.errors.push(`remove ${plistDir}: ${errorMessage(err)}`);
+      }
+    }
+
+    if (result.errors.length === 0) {
+      try {
+        mkdirSync(stateDir, { recursive: true });
+        const marker = {
+          version: LEGACY_MARKER_VERSION,
+          retiredAt: new Date().toISOString(),
+          labelsBootedOut: result.labelsBootedOut,
+          plistDirRemoved: result.plistDirRemoved,
+        };
+        writeFileSync(markerPath, `${JSON.stringify(marker, null, 2)}\n`, { mode: 0o600 });
+        result.markerWritten = true;
+      } catch (err) {
+        result.errors.push(`write marker ${markerPath}: ${errorMessage(err)}`);
+      }
+    }
+
+    if (result.labelsBootedOut.length > 0 || result.plistDirRemoved) {
+      const parts: string[] = [];
+      if (result.labelsBootedOut.length > 0) parts.push(`booted out ${result.labelsBootedOut.join(", ")}`);
+      if (result.plistDirRemoved) parts.push(`removed ${plistDir}`);
+      print.status(
+        "✓",
+        `retired legacy github-scan launchd runner (${parts.join("; ")}) — crash-loop stopped, port 7878 released`,
+      );
+    }
+    if (result.errors.length > 0) {
+      logger.warn({ errors: result.errors }, "legacy github-scan runner retirement incomplete; will retry on next run");
+    }
+    return result;
+  } catch (err) {
+    // Housekeeping must never break a CLI command.
+    result.errors.push(errorMessage(err));
+    logger.warn({ err }, "legacy github-scan runner retirement failed; will retry on next run");
+    return result;
+  }
+}

--- a/docs/migration/from-first-tree-v0.md
+++ b/docs/migration/from-first-tree-v0.md
@@ -42,6 +42,15 @@ If your scripts call any of the deleted commands, replace them with:
 
 GitHub Scan is no longer part of the current CLI.
 
+If a pre-retirement github-scan launchd runner is still installed on your
+Mac, no manual `launchctl` surgery is needed: on the first run of a current
+CLI version, the legacy `com.first-tree.github-scan.runner.*` service is
+booted out of launchd and its plist directory under
+`~/.first-tree/github-scan/runner/launchd/` is removed (only runner files
+under this default path are removed; runners installed with a custom
+`GITHUB_SCAN_DIR` / `GITHUB_SCAN_HOME` are booted out by label). This ends
+the KeepAlive crash-loop and releases the legacy default port 7878.
+
 ## What's new in v1.0.0
 
 * Single CLI binary covers Context Tree and agent collaboration.


### PR DESCRIPTION
Closes #995.

## Summary

Upgrading the CLI stranded the pre-#775 github-scan launchd runner (`com.first-tree.github-scan.runner.<login>.default`): its plist pinned `ProgramArguments` to a dead absolute path with `KeepAlive: true`, so launchd crash-looped it forever and a zombie kept squatting `127.0.0.1:7878`.

On the first run of a new version, the CLI now detects the stranded runner and retires it automatically — `launchctl bootout` the service and remove its plist directory — ending the crash-loop and releasing port 7878. No manual `launchctl` surgery, idempotent, covered by tests. No general service-management framework.

## How it works

- **Hook**: global Commander `preAction` in `apps/cli/src/cli/index.ts`, so every "first run of a new version" path is covered — manual `upgrade`, auto-update restart (`exit 75`), `daemon refresh-unit`, and non-daemon usage. Steady-state cost is one `existsSync` per command; never throws.
- **Detection** (`apps/cli/src/core/legacy-github-scan.ts`), two sources because the label embeds the operator's GitHub login, which cannot be recomputed locally:
  1. plist files under `~/.first-tree/github-scan/runner/launchd/` (the only bootstrap location the legacy installer ever used; filename == label; prod-era fixed path, not channel home);
  2. a `launchctl list` sweep for the `com.first-tree.github-scan.runner.` prefix — the only way to find runners installed with `GITHUB_SCAN_DIR`/`GITHUB_SCAN_HOME` overrides, and runners whose plist was deleted by hand while the service stayed loaded.
- **Remediation**: `launchctl bootout gui/<uid>/<label>` per found label (not-loaded tolerated), then remove the tool-private plist dir. Only exact-prefix labels are booted out. Darwin-only (the legacy subsystem never existed elsewhere); everything else under `~/.first-tree/github-scan/` (e.g. a user-edited `config.yaml`) is left alone.
- **Idempotency**: a marker at `<channel home>/state/legacy-github-scan-runner-retired.json` short-circuits subsequent runs; the marker is written only on a fully clean pass, so any failure (sweep error, unexpected bootout error) is retried on the next CLI run.
- **Why auto-removal is safe here** (vs. the `dev.first-tree.client` precedent documented in `supervisor/launchd.ts`): the github-scan subsystem was removed from *every* channel in #775, so no live or parallel install can legitimately own these labels.

## Testing

- 11 new unit tests (`apps/cli/src/__tests__/legacy-github-scan.test.ts`): platform gate, marker short-circuit, clean machine, incident state (loaded + plist), manual-bootout residue, sweep-only detection (env-override install), sweep failure → no marker → retry re-runs detection, unexpected bootout error → dir still removed → recovers on retry, consecutive-run no-op, non-matching files never booted out (dir still removed wholesale), default path resolution. Plus a preAction wiring assertion in `cli-entry-and-tree-actions-extra.test.ts`.
- `pnpm typecheck` ✅, `pnpm check` (biome) ✅, `pnpm build` ✅ for `apps/cli`.
- Real-macOS smoke of the built CLI with `HOME` redirected: clean machine writes only the marker; planted residue gets booted out (not-loaded tolerated), plist dir removed, human hint on stderr, `--json` stdout/stderr stays clean.
- Repo-wide `pnpm test`: everything I touched is green. Pre-existing, environment-dependent failures on this machine reproduce identically on pristine `origin/main` (verified via `git stash`): 7 tests in `apps/cli/src/__tests__/client-switch-transaction-extra.test.ts` (they probe this machine's live daemon state); server/web/skill-evals pass standalone and only flake under turbo parallel load.

## Docs

- `docs/migration/from-first-tree-v0.md`: the `github scan` retirement section now notes the automatic launchd cleanup.
