### PR TITLE
Fix composer disclosure chevron direction

### DIFF
--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -426,8 +426,11 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
 
     const trigger = h.container.querySelector<HTMLButtonElement>('button[aria-label^="Expand current agent output"]');
+    const chevron = trigger?.querySelector<SVGSVGElement>(".lucide-chevron-down");
+    expect(chevron?.style.transform).toBe("rotate(180deg)");
     trigger?.focus();
     await click(h, trigger);
+    expect(chevron?.style.transform).toBe("none");
     const inspector = h.container.querySelector<HTMLElement>("[data-current-agent-output]");
     expect(inspector).not.toBeNull();
     const domPosition = trigger?.compareDocumentPosition(inspector ?? document.body) ?? 0;
@@ -435,6 +438,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(document.activeElement).toBe(trigger);
 
     await click(h, trigger);
+    expect(chevron?.style.transform).toBe("rotate(180deg)");
     expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
     expect(document.activeElement).toBe(trigger);
   });

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -221,7 +221,7 @@ export function ComposeStatusBar({
             <ChevronDown
               aria-hidden="true"
               className="h-3.5 w-3.5 shrink-0 transition-transform"
-              style={{ color: "var(--fg-3)", transform: expanded ? "rotate(180deg)" : "none" }}
+              style={{ color: "var(--fg-3)", transform: expanded ? "none" : "rotate(180deg)" }}
             />
           </button>
 


### PR DESCRIPTION
## Summary

- point the collapsed composer status disclosure upward, matching the panel's upward expansion from the bottom-docked composer
- point the expanded disclosure downward, matching collapse back toward the composer
- lock the collapsed, expanded, and re-collapsed directions with DOM coverage

## Root cause

The connected status surface inherited the conventional direction for a top-anchored accordion. In this bottom-docked composer layout, that made the disclosure point opposite to the panel's perceived movement.

## Impact

Only the disclosure direction changes. Size, animation, hit area, focus behavior, accessible names, status content, and other chat surfaces remain unchanged.

## Validation

- `pnpm --filter @first-tree/web test` (192 files, 1,564 tests)
- `pnpm --filter @first-tree/web typecheck`
- `pnpm check`
- `pnpm typecheck` (10 tasks across 7 packages)
- two independent code/UI reviews with no findings

## QA note

The real preview route was started locally, but this agent session had no available Browser instance, so browser screenshot QA could not be completed. The disclosure states are covered deterministically in DOM tests.
