### PR TITLE
fix(server): add app-wide browser security headers for Fastify/SPA (#1541)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,11 +45,15 @@ FIRST_TREE_HOST=0.0.0.0
 # Analytics origins added to script-src, connect-src, and img-src. The SPA only
 # loads GA4/Clarity on the production hostname, so non-production deployments
 # leave this unset. Production set for the GA4/Clarity bootstrap in
-# packages/web/public/analytics-init.js (verified against a real browser
-# session 2026-07-22): the www.clarity.ms tag loader pulls the actual script
-# from scripts.clarity.ms (script-src) and sends pixels via c.clarity.ms
-# (img-src), so all five hosts are required.
-# FIRST_TREE_CSP_ANALYTICS_ORIGINS="https://www.googletagmanager.com https://www.clarity.ms https://scripts.clarity.ms https://c.clarity.ms https://www.google-analytics.com"
+# packages/web/public/analytics-init.js (verified across two browser QA
+# rounds 2026-07-22, full chain observed with zero violations): the
+# www.clarity.ms tag loader pulls the actual script from scripts.clarity.ms
+# (script-src) and sends pixels via c.clarity.ms and c.bing.com (img-src), so
+# all six hosts are required. Note the knob has no per-directive granularity:
+# the pixel hosts also land in script-src — an accepted, vendor-scoped
+# widening. Clarity's collect endpoint is NOT here — see the extra-connect
+# knob below.
+# FIRST_TREE_CSP_ANALYTICS_ORIGINS="https://www.googletagmanager.com https://www.clarity.ms https://scripts.clarity.ms https://c.clarity.ms https://c.bing.com https://www.google-analytics.com"
 #
 # Avatar origins for img-src. Replaces the built-in default
 # ("https://avatars.githubusercontent.com https://lh3.googleusercontent.com")
@@ -57,11 +61,15 @@ FIRST_TREE_HOST=0.0.0.0
 # FIRST_TREE_CSP_AVATAR_ORIGINS="https://avatars.example-cdn.com"
 #
 # Extra connect-src origins (e.g. the Sentry ingest host matching
-# VITE_SENTRY_DSN above, or an object-storage host). GA4 note: with the
-# cross-domain `linker` config in analytics-init.js, GA collect also POSTs to
-# https://www.google.com — it belongs HERE, not in the analytics knob, so
-# www.google.com is not widened into script-src.
-# FIRST_TREE_CSP_EXTRA_CONNECT_SRC="https://example.ingest.sentry.io https://www.google.com"
+# VITE_SENTRY_DSN above, or an object-storage host). Two analytics collect
+# endpoints belong HERE rather than in the analytics knob, so they are not
+# widened into script-src/img-src: GA4's cross-domain `linker` config POSTs
+# collect to https://www.google.com, and Clarity collects via
+# https://b.clarity.ms (observed 2026-07-22; the collect host may vary by
+# region — vendor docs suggest *.clarity.ms, we enumerate the measured host
+# per least-privilege. If production logs CSP violations for another
+# *.clarity.ms collect host, append it here).
+# FIRST_TREE_CSP_EXTRA_CONNECT_SRC="https://example.ingest.sentry.io https://www.google.com https://b.clarity.ms"
 
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │ Web Sentry (SaaS internal) — Optional                                    │

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,25 @@ FIRST_TREE_HOST=0.0.0.0
 # CORS allowed origins (comma-separated)
 # FIRST_TREE_CORS_ORIGIN=https://app.example.com
 
+# Content-Security-Policy origin tuning (space- or comma-separated origins).
+# The full security header set (enforced CSP, HSTS, nosniff, Referrer-Policy,
+# Permissions-Policy, frame protection) is always emitted; these only widen the
+# CSP for environment-specific origins.
+#
+# Analytics origins added to script-src, connect-src, and img-src. The SPA only
+# loads GA4/Clarity on the production hostname, so non-production deployments
+# leave this unset. Verified production set:
+# FIRST_TREE_CSP_ANALYTICS_ORIGINS="https://www.googletagmanager.com https://www.clarity.ms https://www.google-analytics.com"
+#
+# Avatar origins for img-src. Replaces the built-in default
+# ("https://avatars.githubusercontent.com https://lh3.googleusercontent.com")
+# when set — include those hosts too if OAuth avatars should keep loading.
+# FIRST_TREE_CSP_AVATAR_ORIGINS="https://avatars.example-cdn.com"
+#
+# Extra connect-src origins (e.g. the Sentry ingest host matching
+# VITE_SENTRY_DSN above, or an object-storage host).
+# FIRST_TREE_CSP_EXTRA_CONNECT_SRC="https://example.ingest.sentry.io"
+
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │ Web Sentry (SaaS internal) — Optional                                    │
 # └───────────────────────────────────────────────────────────────────────────┘

--- a/.env.example
+++ b/.env.example
@@ -45,9 +45,11 @@ FIRST_TREE_HOST=0.0.0.0
 # Analytics origins added to script-src, connect-src, and img-src. The SPA only
 # loads GA4/Clarity on the production hostname, so non-production deployments
 # leave this unset. Production set for the GA4/Clarity bootstrap in
-# packages/web/public/analytics-init.js (derived from code analysis; confirm
-# against the browser Network panel on deploy):
-# FIRST_TREE_CSP_ANALYTICS_ORIGINS="https://www.googletagmanager.com https://www.clarity.ms https://www.google-analytics.com"
+# packages/web/public/analytics-init.js (verified against a real browser
+# session 2026-07-22): the www.clarity.ms tag loader pulls the actual script
+# from scripts.clarity.ms (script-src) and sends pixels via c.clarity.ms
+# (img-src), so all five hosts are required.
+# FIRST_TREE_CSP_ANALYTICS_ORIGINS="https://www.googletagmanager.com https://www.clarity.ms https://scripts.clarity.ms https://c.clarity.ms https://www.google-analytics.com"
 #
 # Avatar origins for img-src. Replaces the built-in default
 # ("https://avatars.githubusercontent.com https://lh3.googleusercontent.com")
@@ -55,8 +57,11 @@ FIRST_TREE_HOST=0.0.0.0
 # FIRST_TREE_CSP_AVATAR_ORIGINS="https://avatars.example-cdn.com"
 #
 # Extra connect-src origins (e.g. the Sentry ingest host matching
-# VITE_SENTRY_DSN above, or an object-storage host).
-# FIRST_TREE_CSP_EXTRA_CONNECT_SRC="https://example.ingest.sentry.io"
+# VITE_SENTRY_DSN above, or an object-storage host). GA4 note: with the
+# cross-domain `linker` config in analytics-init.js, GA collect also POSTs to
+# https://www.google.com — it belongs HERE, not in the analytics knob, so
+# www.google.com is not widened into script-src.
+# FIRST_TREE_CSP_EXTRA_CONNECT_SRC="https://example.ingest.sentry.io https://www.google.com"
 
 # ┌───────────────────────────────────────────────────────────────────────────┐
 # │ Web Sentry (SaaS internal) — Optional                                    │

--- a/.env.example
+++ b/.env.example
@@ -44,7 +44,9 @@ FIRST_TREE_HOST=0.0.0.0
 #
 # Analytics origins added to script-src, connect-src, and img-src. The SPA only
 # loads GA4/Clarity on the production hostname, so non-production deployments
-# leave this unset. Verified production set:
+# leave this unset. Production set for the GA4/Clarity bootstrap in
+# packages/web/public/analytics-init.js (derived from code analysis; confirm
+# against the browser Network panel on deploy):
 # FIRST_TREE_CSP_ANALYTICS_ORIGINS="https://www.googletagmanager.com https://www.clarity.ms https://www.google-analytics.com"
 #
 # Avatar origins for img-src. Replaces the built-in default

--- a/packages/server/src/__tests__/security-headers.test.ts
+++ b/packages/server/src/__tests__/security-headers.test.ts
@@ -1,0 +1,243 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it } from "vitest";
+import { buildApp } from "../app.js";
+import type { Config } from "../config.js";
+import { buildSecurityHeaders } from "../security-headers.js";
+import { useTestApp } from "./helpers.js";
+
+/**
+ * App-wide browser security headers (issue #1541).
+ *
+ * Two layers under test:
+ *   1. `buildSecurityHeaders` — pure composition of the header values
+ *      (enforced CSP + HSTS + nosniff + Referrer-Policy + Permissions-Policy
+ *      + frame protection), including config-driven CSP origins.
+ *   2. The root `onSend` hook — headers present on API success, API error,
+ *      rate-limit, and SPA-fallback responses alike.
+ */
+
+const baseConfig: Config = {
+  channel: "dev",
+  growth: {
+    landingPagesEnabled: false,
+    landingCampaignMaxAgentTurns: 1,
+    landingCampaignMaxEstimatedTokens: 120_000,
+    landingCampaignMaxTrialsPerUserPer24Hours: 5,
+  },
+  docs: { enabled: false },
+  database: { url: process.env.DATABASE_URL ?? "", provider: "external" },
+  server: { port: 0, host: "127.0.0.1", publicUrl: undefined },
+  workspace: { root: "/tmp/first-tree-test-workspaces" },
+  secrets: {
+    jwtSecret: "test-jwt-secret-key-for-vitest",
+    encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  },
+  auth: { accessTokenExpiry: "30m", refreshTokenExpiry: "30d", connectTokenExpiry: "10m" },
+  trustProxy: false,
+  connectBootstrap: {
+    portableDownloadBaseUrl: "https://download.first-tree.ai/releases",
+  },
+  observability: { logging: { level: "error", format: "json", bridgeToSpanLevel: "off" } },
+  runtime: {
+    agentHttpTokenEnforcement: false,
+    runtimeSwitchFaultInjection: false,
+    pollingIntervalSeconds: 5,
+    presenceCleanupSeconds: 60,
+    archiveSweepIntervalSeconds: 0,
+    archiveMappedIdleSeconds: 60 * 60,
+    notificationWebhookUrl: undefined,
+  },
+  update: {
+    commandVersion: "test.version",
+    pollIntervalMinutes: 1440,
+    registryUrl: "https://localhost.invalid",
+  },
+  instanceId: "test-instance",
+};
+
+const DEFAULT_CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https://avatars.githubusercontent.com https://lh3.googleusercontent.com",
+  "connect-src 'self'",
+  "font-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+const STATIC_HEADERS: Record<string, string> = {
+  "strict-transport-security": "max-age=31536000; includeSubDomains",
+  "x-content-type-options": "nosniff",
+  "referrer-policy": "strict-origin-when-cross-origin",
+  "permissions-policy": "camera=(), microphone=(), geolocation=(), payment=()",
+  "x-frame-options": "DENY",
+};
+
+function expectSecurityHeaders(headers: Record<string, unknown>, csp = DEFAULT_CSP) {
+  expect(headers["content-security-policy"]).toBe(csp);
+  for (const [name, value] of Object.entries(STATIC_HEADERS)) {
+    expect(headers[name]).toBe(value);
+  }
+}
+
+/** The security group type requires all three keys; default the unset ones. */
+function securityConfig(partial: {
+  cspAnalyticsOrigins?: string;
+  cspAvatarOrigins?: string;
+  cspExtraConnectSrcOrigins?: string;
+}): NonNullable<Config["security"]> {
+  return {
+    cspAnalyticsOrigins: undefined,
+    cspAvatarOrigins: undefined,
+    cspExtraConnectSrcOrigins: undefined,
+    ...partial,
+  };
+}
+
+describe("buildSecurityHeaders — header composition", () => {
+  it("emits the full header set with the default CSP when no security config is set", () => {
+    const headers = buildSecurityHeaders(baseConfig);
+    expect(headers).toEqual({ "content-security-policy": DEFAULT_CSP, ...STATIC_HEADERS });
+    // Acceptance invariants: enforced (not Report-Only), no unsafe-inline /
+    // unsafe-eval in script directives, framing denied two ways.
+    expect(headers["content-security-policy-report-only"]).toBeUndefined();
+    expect(headers["content-security-policy"]).not.toMatch(/script-src[^;]*unsafe-(inline|eval)/);
+    expect(headers["content-security-policy"]).toContain("frame-ancestors 'none'");
+  });
+
+  it("adds analytics origins to script-src, connect-src, and img-src", () => {
+    const headers = buildSecurityHeaders({
+      ...baseConfig,
+      security: securityConfig({ cspAnalyticsOrigins: "https://www.googletagmanager.com, https://www.clarity.ms" }),
+    });
+    const csp = headers["content-security-policy"];
+    expect(csp).toContain("script-src 'self' https://www.googletagmanager.com https://www.clarity.ms");
+    expect(csp).toContain("connect-src 'self' https://www.googletagmanager.com https://www.clarity.ms");
+    expect(csp).toContain(
+      "img-src 'self' data: blob: https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://www.googletagmanager.com https://www.clarity.ms",
+    );
+  });
+
+  it("replaces the built-in avatar origins when cspAvatarOrigins is set", () => {
+    const headers = buildSecurityHeaders({
+      ...baseConfig,
+      security: securityConfig({ cspAvatarOrigins: "https://avatars.example-cdn.com" }),
+    });
+    const csp = headers["content-security-policy"];
+    expect(csp).toContain("img-src 'self' data: blob: https://avatars.example-cdn.com");
+    expect(csp).not.toContain("avatars.githubusercontent.com");
+  });
+
+  it("adds extra connect-src origins without touching other directives", () => {
+    const headers = buildSecurityHeaders({
+      ...baseConfig,
+      security: securityConfig({ cspExtraConnectSrcOrigins: "https://example.ingest.sentry.io" }),
+    });
+    const csp = headers["content-security-policy"];
+    expect(csp).toContain("connect-src 'self' https://example.ingest.sentry.io");
+    expect(csp).toContain("script-src 'self';");
+    expect(csp).not.toContain("img-src 'self' data: blob: https://example.ingest.sentry.io");
+  });
+
+  it("rejects invalid CSP origins loudly", () => {
+    for (const bad of [
+      "not-a-url",
+      "ftp://example.com",
+      "https://example.com/path",
+      "https://example.com/",
+      "https://example.com?q=1",
+    ]) {
+      expect(() =>
+        buildSecurityHeaders({ ...baseConfig, security: securityConfig({ cspExtraConnectSrcOrigins: bad }) }),
+      ).toThrow(/FIRST_TREE_CSP_EXTRA_CONNECT_SRC/);
+    }
+  });
+});
+
+describe("security headers — app-wide onSend hook", () => {
+  const getApp = useTestApp();
+
+  it("sets all headers on an API response", async () => {
+    const res = await getApp().inject({ method: "GET", url: "/healthz" });
+    expect(res.statusCode).toBe(200);
+    expectSecurityHeaders(res.headers);
+  });
+
+  it("sets all headers on an API 404 JSON response", async () => {
+    const res = await getApp().inject({ method: "GET", url: "/api/v1/does-not-exist" });
+    expect(res.statusCode).toBe(404);
+    expect(res.headers["content-type"]).toContain("application/json");
+    expectSecurityHeaders(res.headers);
+  });
+});
+
+describe("security headers — rate-limit responses", () => {
+  const getApp = useTestApp({ rateLimit: { max: 1 } });
+
+  it("sets all headers on a 429 response", async () => {
+    const app = getApp();
+    const first = await app.inject({ method: "GET", url: "/api/v1/health" });
+    expect(first.statusCode).toBe(200);
+    const limited = await app.inject({ method: "GET", url: "/api/v1/health" });
+    expect(limited.statusCode).toBe(429);
+    expectSecurityHeaders(limited.headers);
+  });
+});
+
+describe("security headers — SPA responses", () => {
+  it("sets all headers on static assets and the SPA fallback", async () => {
+    const webRoot = await mkdtemp(join(tmpdir(), "first-tree-web-"));
+    await writeFile(join(webRoot, "index.html"), "<!doctype html><html><body>App shell</body></html>", "utf8");
+
+    let app: FastifyInstance | undefined;
+    try {
+      app = await buildApp({ ...baseConfig, webDistPath: webRoot });
+
+      const shell = await app.inject({ method: "GET", url: "/" });
+      expect(shell.statusCode).toBe(200);
+      expectSecurityHeaders(shell.headers);
+
+      const fallback = await app.inject({ method: "GET", url: "/workspace/deep-link" });
+      expect(fallback.statusCode).toBe(200);
+      expect(fallback.body).toContain("App shell");
+      expectSecurityHeaders(fallback.headers);
+
+      // With the SPA served, /api/* misses are JSON 404s from the not-found
+      // handler — the production API error shape.
+      const apiMiss = await app.inject({ method: "GET", url: "/api/missing" });
+      expect(apiMiss.statusCode).toBe(404);
+      expect(apiMiss.json()).toEqual({ error: "Not found" });
+      expectSecurityHeaders(apiMiss.headers);
+    } finally {
+      if (app) await app.close();
+      await rm(webRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("applies configured CSP origins to served responses", async () => {
+    const webRoot = await mkdtemp(join(tmpdir(), "first-tree-web-"));
+    await writeFile(join(webRoot, "index.html"), "<!doctype html><html><body>App shell</body></html>", "utf8");
+
+    let app: FastifyInstance | undefined;
+    try {
+      app = await buildApp({
+        ...baseConfig,
+        webDistPath: webRoot,
+        security: securityConfig({ cspAnalyticsOrigins: "https://www.googletagmanager.com" }),
+      });
+
+      const res = await app.inject({ method: "GET", url: "/" });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["content-security-policy"]).toContain("script-src 'self' https://www.googletagmanager.com");
+    } finally {
+      if (app) await app.close();
+      await rm(webRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -88,6 +88,7 @@ import {
   reportErrorToRoot,
   rootLogger,
 } from "./observability/index.js";
+import { registerSecurityHeaders } from "./security-headers.js";
 import { broadcastToAdmins } from "./services/admin-broadcast.js";
 import { expiryToSeconds } from "./services/auth.js";
 import { type BackgroundTasks, createBackgroundTasks } from "./services/background-tasks.js";
@@ -391,6 +392,12 @@ export async function buildApp(config: Config) {
   // and only fires on `statusCode >= 400`. Registered globally so any route
   // that flips the flag participates without extra wiring.
   app.addHook("onSend", bodyCaptureOnSendHook);
+
+  // App-wide browser security headers (CSP/HSTS/nosniff/Referrer-Policy/
+  // Permissions-Policy/frame protection). Root-level onSend hook registered
+  // before any route so API routes, static sends, the SPA fallback, and error
+  // responses are all covered. Throws at boot on an invalid CSP origin config.
+  registerSecurityHeaders(app, config);
 
   // Auth hooks
   const userAuth = userAuthHook(db, config.secrets.jwtSecret);

--- a/packages/server/src/security-headers.ts
+++ b/packages/server/src/security-headers.ts
@@ -1,0 +1,137 @@
+import type { FastifyInstance } from "fastify";
+import type { Config } from "./config.js";
+
+/**
+ * App-wide browser security headers (issue #1541).
+ *
+ * The server serves both the API and the SPA, so the header layer lives here
+ * rather than in edge configuration: every environment gets the same testable
+ * guarantee. `buildSecurityHeaders` is the single place where header values
+ * are composed (pure, unit-testable); `registerSecurityHeaders` installs them
+ * as a root-level `onSend` hook — the same precedent as
+ * `bodyCaptureOnSendHook` in app.ts — so API routes, `@fastify/static` sends,
+ * the SPA fallback, and error responses are all covered by one hook.
+ *
+ * The CSP is enforced (not Report-Only) and least-privilege: `index.html`
+ * ships zero inline scripts (see packages/web/public/), so `script-src` needs
+ * no `unsafe-inline`/`unsafe-eval`. Environment-specific origins are
+ * config-driven via the `security` group in server-config.ts.
+ */
+
+/**
+ * Built-in `img-src` avatar origins: the OAuth profile picture hosts our login
+ * providers return (`users.avatar_url` from GitHub, `picture` from Google).
+ * Replaced wholesale by FIRST_TREE_CSP_AVATAR_ORIGINS when configured.
+ */
+const DEFAULT_AVATAR_ORIGINS = ["https://avatars.githubusercontent.com", "https://lh3.googleusercontent.com"];
+
+/** Header name → env var that feeds it, for boot-time error messages. */
+const ENV_NAMES = {
+  analytics: "FIRST_TREE_CSP_ANALYTICS_ORIGINS",
+  avatar: "FIRST_TREE_CSP_AVATAR_ORIGINS",
+  extraConnect: "FIRST_TREE_CSP_EXTRA_CONNECT_SRC",
+} as const;
+
+/**
+ * Parse a space- or comma-separated origin list into deduped origins. Each
+ * entry must be an exact http(s) origin (scheme + host, no path/query/trailing
+ * slash) so the emitted CSP stays predictable. Invalid entries throw — the
+ * call site runs at boot, so a typo fails startup loudly instead of silently
+ * weakening the policy.
+ */
+function parseOriginList(raw: string, envName: string): string[] {
+  const tokens = raw.split(/[\s,]+/).filter((token) => token.length > 0);
+  for (const token of tokens) {
+    let url: URL;
+    try {
+      url = new URL(token);
+    } catch {
+      throw new Error(`${envName}: "${token}" is not a valid URL (expected an origin like https://example.com)`);
+    }
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      throw new Error(`${envName}: "${token}" must use http or https`);
+    }
+    if (url.origin !== token) {
+      throw new Error(
+        `${envName}: "${token}" must be a bare origin (got path/query/trailing slash — e.g. ${url.origin})`,
+      );
+    }
+  }
+  return [...new Set(tokens)];
+}
+
+/** Compose the full security header set from config. Pure — safe to unit-test. */
+export function buildSecurityHeaders(config: Config): Record<string, string> {
+  const security = config.security;
+  const analyticsOrigins = security?.cspAnalyticsOrigins
+    ? parseOriginList(security.cspAnalyticsOrigins, ENV_NAMES.analytics)
+    : [];
+  const avatarOrigins = security?.cspAvatarOrigins
+    ? parseOriginList(security.cspAvatarOrigins, ENV_NAMES.avatar)
+    : DEFAULT_AVATAR_ORIGINS;
+  const extraConnectOrigins = security?.cspExtraConnectSrcOrigins
+    ? parseOriginList(security.cspExtraConnectSrcOrigins, ENV_NAMES.extraConnect)
+    : [];
+
+  const scriptSrc = ["'self'", ...analyticsOrigins];
+  // 'self' covers the same-origin WebSocket (CSP3 matches ws/wss on the same
+  // host). Analytics origins collect beacons; extra connect origins cover
+  // environment services such as Sentry ingest or object storage.
+  const connectSrc = ["'self'", ...analyticsOrigins, ...extraConnectOrigins];
+  // data: — markdown / inline SVG images; blob: — URL.createObjectURL previews
+  // (avatar crop, pending image attachments).
+  const imgSrc = ["'self'", "data:", "blob:", ...avatarOrigins, ...analyticsOrigins];
+
+  const contentSecurityPolicy = [
+    "default-src 'self'",
+    `script-src ${[...new Set(scriptSrc)].join(" ")}`,
+    // React/Radix write style attributes at runtime; script directives stay
+    // free of unsafe-inline/unsafe-eval as required.
+    "style-src 'self' 'unsafe-inline'",
+    `img-src ${[...new Set(imgSrc)].join(" ")}`,
+    `connect-src ${[...new Set(connectSrc)].join(" ")}`,
+    "font-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ].join("; ");
+
+  return {
+    "content-security-policy": contentSecurityPolicy,
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "permissions-policy": "camera=(), microphone=(), geolocation=(), payment=()",
+    "x-frame-options": "DENY",
+  };
+}
+
+/**
+ * Install the security headers on the root instance. Header values are
+ * computed once at boot (config is frozen); an invalid CSP origin therefore
+ * fails startup loudly. Must be called before routes are registered so the
+ * hook propagates to API scopes, static sends, the SPA fallback, and error
+ * responses alike.
+ *
+ * The hook is deliberately SYNCHRONOUS (callback style). An extra async
+ * onSend hook delays the chain by one microtask, which trips a latent fastify
+ * footgun: async handlers that call `reply.send()` bare (without returning
+ * the reply) get re-sent by fastify's wrap-thenable fallback when the
+ * response hasn't ended yet — `settings.ts`'s DELETE 204 double-writes
+ * headers that way. Keeping this hook sync preserves the exact onSend timing
+ * the app had before it existed.
+ */
+export function registerSecurityHeaders(app: FastifyInstance, config: Config): void {
+  const headers = buildSecurityHeaders(config);
+  app.addHook("onSend", (_request, reply, _payload, done) => {
+    for (const [name, value] of Object.entries(headers)) {
+      // Routes may set their own X-Content-Type-Options (attachment downloads
+      // have done so since before this hook existed); same value, so leave
+      // theirs in place.
+      if (reply.hasHeader(name)) continue;
+      reply.header(name, value);
+    }
+    done();
+  });
+}

--- a/packages/server/src/security-headers.ts
+++ b/packages/server/src/security-headers.ts
@@ -126,9 +126,11 @@ export function registerSecurityHeaders(app: FastifyInstance, config: Config): v
   const headers = buildSecurityHeaders(config);
   app.addHook("onSend", (_request, reply, _payload, done) => {
     for (const [name, value] of Object.entries(headers)) {
-      // Routes may set their own X-Content-Type-Options (attachment downloads
-      // have done so since before this hook existed); same value, so leave
-      // theirs in place.
+      // General rule: a route's own value always wins over the app-wide
+      // default (route-level escape hatch). In practice the only route
+      // setting any of these today is attachment downloads, which have set
+      // X-Content-Type-Options: nosniff — the same value — since before this
+      // hook existed.
       if (reply.hasHeader(name)) continue;
       reply.header(name, value);
     }

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -278,6 +278,35 @@ export const serverConfigSchema = defineConfig({
     origin: field(z.string(), { env: "FIRST_TREE_CORS_ORIGIN" }),
   }),
   /**
+   * App-wide browser security headers: CSP origin tuning only. The enforced
+   * header set itself (CSP, HSTS, nosniff, Referrer-Policy, Permissions-Policy,
+   * frame protection) is always emitted — see packages/server/src/security-headers.ts.
+   * These knobs widen the CSP for environment-specific origins so a new
+   * legitimate origin (analytics host, avatar/CDN host, object storage) is a
+   * config change, not a code edit. Values are space- or comma-separated
+   * origin lists; invalid origins fail fast at boot.
+   */
+  security: optional({
+    /**
+     * Analytics origins added to `script-src`, `connect-src`, and `img-src`
+     * (e.g. "https://www.googletagmanager.com https://www.clarity.ms
+     * https://www.google-analytics.com"). Analytics scripts are only loaded on
+     * the production hostname, so non-production deployments leave this unset.
+     */
+    cspAnalyticsOrigins: field(optionalTrimmedStringSchema, { env: "FIRST_TREE_CSP_ANALYTICS_ORIGINS" }),
+    /**
+     * Avatar image origins added to `img-src`. Replaces the built-in default
+     * (GitHub/Google OAuth avatar hosts) when set — include those hosts in the
+     * value if OAuth avatars should keep loading.
+     */
+    cspAvatarOrigins: field(optionalTrimmedStringSchema, { env: "FIRST_TREE_CSP_AVATAR_ORIGINS" }),
+    /**
+     * Extra `connect-src` origins for environment services (e.g. the Sentry
+     * ingest host matching VITE_SENTRY_DSN, or an object-storage host).
+     */
+    cspExtraConnectSrcOrigins: field(optionalTrimmedStringSchema, { env: "FIRST_TREE_CSP_EXTRA_CONNECT_SRC" }),
+  }),
+  /**
    * Trust upstream proxy headers (e.g. `x-forwarded-for`) for `req.ip`. Required
    * in production where First Tree sits behind Cloudflare / a reverse proxy — otherwise
    * unauthenticated rate-limit fallback keys resolve to the proxy. Default false;

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -290,8 +290,14 @@ export const serverConfigSchema = defineConfig({
     /**
      * Analytics origins added to `script-src`, `connect-src`, and `img-src`
      * (e.g. "https://www.googletagmanager.com https://www.clarity.ms
-     * https://www.google-analytics.com"). Analytics scripts are only loaded on
-     * the production hostname, so non-production deployments leave this unset.
+     * https://scripts.clarity.ms https://c.clarity.ms
+     * https://www.google-analytics.com"). The Clarity sub-hosts scripts. and
+     * c. are required — the www.clarity.ms tag loader pulls the real script
+     * and pixels from them (verified in a browser session 2026-07-22).
+     * Analytics scripts are only loaded on the production hostname, so
+     * non-production deployments leave this unset. GA4's linker collect POSTs
+     * to https://www.google.com — configure that via
+     * FIRST_TREE_CSP_EXTRA_CONNECT_SRC instead so it stays out of script-src.
      */
     cspAnalyticsOrigins: field(optionalTrimmedStringSchema, { env: "FIRST_TREE_CSP_ANALYTICS_ORIGINS" }),
     /**

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -290,14 +290,17 @@ export const serverConfigSchema = defineConfig({
     /**
      * Analytics origins added to `script-src`, `connect-src`, and `img-src`
      * (e.g. "https://www.googletagmanager.com https://www.clarity.ms
-     * https://scripts.clarity.ms https://c.clarity.ms
-     * https://www.google-analytics.com"). The Clarity sub-hosts scripts. and
-     * c. are required — the www.clarity.ms tag loader pulls the real script
-     * and pixels from them (verified in a browser session 2026-07-22).
+     * https://scripts.clarity.ms https://c.clarity.ms https://c.bing.com
+     * https://www.google-analytics.com"). The Clarity sub-hosts scripts., c.,
+     * and c.bing.com are required — the www.clarity.ms tag loader pulls the
+     * real script and pixels from them (verified across two browser QA rounds
+     * 2026-07-22). The knob has no per-directive granularity, so the pixel
+     * hosts also land in script-src — an accepted, vendor-scoped widening.
      * Analytics scripts are only loaded on the production hostname, so
-     * non-production deployments leave this unset. GA4's linker collect POSTs
-     * to https://www.google.com — configure that via
-     * FIRST_TREE_CSP_EXTRA_CONNECT_SRC instead so it stays out of script-src.
+     * non-production deployments leave this unset. The collect endpoints
+     * (https://www.google.com for GA4 linker, https://b.clarity.ms for
+     * Clarity) belong to FIRST_TREE_CSP_EXTRA_CONNECT_SRC instead so they
+     * stay out of script-src/img-src.
      */
     cspAnalyticsOrigins: field(optionalTrimmedStringSchema, { env: "FIRST_TREE_CSP_ANALYTICS_ORIGINS" }),
     /**

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -9,72 +9,16 @@
     <link rel="preload" href="/fonts/jetbrains-mono-latin.woff2" as="font" type="font/woff2" crossorigin />
     <title>First Tree</title>
     <!--
-      Google Analytics 4 — same property (G-BHG918MZ02) as first-tree.ai, with
-      cross-domain linking so a visitor who goes marketing-site -> cloud is
-      stitched into one user (that's what makes "click_app -> signup"
-      attributable per repo/campaign). send_page_view is off: this is a
-      react-router SPA, so RouteTracker (src/analytics.tsx) reports page_view on
-      every route change — leaving it on would double-count the first screen.
-
-      PRODUCTION ONLY: the Docker build produces one web dist for every channel,
-      so we gate here on hostname. Without this, dev (127.0.0.1) and staging
-      (dev.cloud.first-tree.ai) would load gtag and write into the shared
-      production property, polluting the attribution dataset. gtag is neither
-      fetched nor configured off the production host. analytics.tsx applies the
-      same host gate before sending, as defense in depth.
+      Analytics (GA4 + Clarity) and the pre-paint theme init live in external
+      files under public/ — never inline. The enforced Content-Security-Policy
+      has no script-src 'unsafe-inline', so an inline script would be blocked.
+      analytics-init.js is hostname-gated to production and deferred; its
+      origins must be allowed via FIRST_TREE_CSP_ANALYTICS_ORIGINS on the
+      server. theme-init.js is synchronous on purpose: it must run before
+      first paint to avoid a theme flash.
     -->
-    <script>
-      (() => {
-        if (window.location.hostname !== "cloud.first-tree.ai") return;
-        window.dataLayer = window.dataLayer || [];
-        // Keep the official gtag queue shape. gtag.js consumes the function's
-        // Arguments object; pushing the rest-parameter Array leaves commands
-        // queued without producing GA collect requests in production.
-        window.gtag = function gtag() {
-          // biome-ignore lint/complexity/noArguments: the official gtag.js queue contract uses Arguments.
-          window.dataLayer.push(arguments);
-        };
-        const tag = document.createElement("script");
-        tag.async = true;
-        tag.src = "https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02";
-        document.head.appendChild(tag);
-        window.gtag("js", new Date());
-        window.gtag("config", "G-BHG918MZ02", {
-          send_page_view: false,
-          linker: { domains: ["first-tree.ai", "cloud.first-tree.ai"] },
-        });
-      })();
-    </script>
-    <!--
-      Microsoft Clarity — session insights for the production Web Console.
-      Like GA4, this is hostname-gated because the Docker build ships one dist
-      across channels; staging/local must not write into the production project.
-      The React app root is masked below so customer/workspace text is not
-      uploaded in Clarity recordings by default.
-    -->
-    <script>
-      (() => {
-        if (window.location.hostname !== "cloud.first-tree.ai") return;
-        window.clarity =
-          window.clarity ||
-          ((...args) => {
-            const queue = window.clarity.q || [];
-            window.clarity.q = queue;
-            queue.push(args);
-          });
-        const tag = document.createElement("script");
-        tag.async = true;
-        tag.src = "https://www.clarity.ms/tag/xj2f9syfng";
-        document.head.appendChild(tag);
-      })();
-    </script>
-    <script>
-      (() => {
-        const t = localStorage.getItem("theme");
-        const m = window.matchMedia("(prefers-color-scheme: dark)").matches;
-        if (t === "dark" || (!t && m)) document.documentElement.classList.add("dark");
-      })();
-    </script>
+    <script src="/theme-init.js"></script>
+    <script src="/analytics-init.js" defer></script>
   </head>
   <body>
     <div id="root" data-clarity-mask="true"></div>

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,7 +36,8 @@
     "react-router": "^7.13.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@sentry/vite-plugin": "^5.3.0",

--- a/packages/web/public/analytics-init.js
+++ b/packages/web/public/analytics-init.js
@@ -1,0 +1,57 @@
+// Analytics bootstrap: Google Analytics 4 + Microsoft Clarity.
+//
+// External file, not an inline script: the enforced Content-Security-Policy
+// ships without script-src 'unsafe-inline'. The origins below must also be
+// present in the server's FIRST_TREE_CSP_ANALYTICS_ORIGINS on the production
+// deployment, otherwise the CSP blocks these tags.
+//
+// Google Analytics 4 — same property (G-BHG918MZ02) as first-tree.ai, with
+// cross-domain linking so a visitor who goes marketing-site -> cloud is
+// stitched into one user (that's what makes "click_app -> signup"
+// attributable per repo/campaign). send_page_view is off: this is a
+// react-router SPA, so RouteTracker (src/analytics.tsx) reports page_view on
+// every route change — leaving it on would double-count the first screen.
+//
+// Microsoft Clarity — session insights for the production Web Console. The
+// React app root is masked (data-clarity-mask on #root) so customer/workspace
+// text is not uploaded in Clarity recordings by default.
+//
+// PRODUCTION ONLY: the Docker build produces one web dist for every channel,
+// so both tags are gated on hostname. Without this, dev (127.0.0.1) and
+// staging (dev.cloud.first-tree.ai) would load gtag/Clarity and write into
+// the shared production datasets, polluting attribution. Neither script is
+// fetched nor configured off the production host; analytics.tsx applies the
+// same host gate before sending, as defense in depth.
+(() => {
+  if (window.location.hostname !== "cloud.first-tree.ai") return;
+
+  // Keep the official gtag queue shape. gtag.js consumes the function's
+  // Arguments object; pushing the rest-parameter Array leaves commands
+  // queued without producing GA collect requests in production.
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = function gtag() {
+    // biome-ignore lint/complexity/noArguments: the official gtag.js queue contract uses Arguments.
+    window.dataLayer.push(arguments);
+  };
+  const gtagScript = document.createElement("script");
+  gtagScript.async = true;
+  gtagScript.src = "https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02";
+  document.head.appendChild(gtagScript);
+  window.gtag("js", new Date());
+  window.gtag("config", "G-BHG918MZ02", {
+    send_page_view: false,
+    linker: { domains: ["first-tree.ai", "cloud.first-tree.ai"] },
+  });
+
+  window.clarity =
+    window.clarity ||
+    ((...args) => {
+      const queue = window.clarity.q || [];
+      window.clarity.q = queue;
+      queue.push(args);
+    });
+  const clarityScript = document.createElement("script");
+  clarityScript.async = true;
+  clarityScript.src = "https://www.clarity.ms/tag/xj2f9syfng";
+  document.head.appendChild(clarityScript);
+})();

--- a/packages/web/public/theme-init.js
+++ b/packages/web/public/theme-init.js
@@ -1,0 +1,12 @@
+// Applies the persisted theme before first paint so the user never sees a
+// flash of the wrong color scheme (FOUC). index.html loads this synchronously
+// from <head> (no async/defer) to preserve that guarantee.
+//
+// External file, not an inline script: the enforced Content-Security-Policy
+// ships without script-src 'unsafe-inline', so every script the SPA runs must
+// come from an allowed origin ('self' here).
+(() => {
+  const t = localStorage.getItem("theme");
+  const m = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  if (t === "dark" || (!t && m)) document.documentElement.classList.add("dark");
+})();

--- a/packages/web/src/__tests__/analytics.test.ts
+++ b/packages/web/src/__tests__/analytics.test.ts
@@ -2,12 +2,15 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { sanitizePath } from "../analytics.js";
 
-const indexHtml = readFileSync(new URL("../../index.html", import.meta.url), "utf8");
+// The bootstrap moved from an inline <script> in index.html to
+// public/analytics-init.js (issue 1541 — the enforced CSP forbids inline
+// scripts). The Arguments-queue contract it guards is unchanged.
+const analyticsInit = readFileSync(new URL("../../public/analytics-init.js", import.meta.url), "utf8");
 
 describe("production gtag bootstrap", () => {
   it("queues the official Arguments object so gtag.js processes commands", () => {
-    expect(indexHtml).toContain("window.dataLayer.push(arguments)");
-    expect(indexHtml).not.toContain("window.dataLayer.push(args)");
+    expect(analyticsInit).toContain("window.dataLayer.push(arguments)");
+    expect(analyticsInit).not.toContain("window.dataLayer.push(args)");
   });
 });
 

--- a/packages/web/src/__tests__/index-html.test.ts
+++ b/packages/web/src/__tests__/index-html.test.ts
@@ -1,0 +1,25 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard for issue 1541: the enforced Content-Security-Policy has
+ * no script-src 'unsafe-inline', so index.html must never ship an inline
+ * <script> block. The analytics bootstrap and the pre-paint theme init live
+ * in external files under public/.
+ */
+describe("index.html — no inline scripts", () => {
+  it("contains no inline <script> block", async () => {
+    const html = await readFile(new URL("../../index.html", import.meta.url), "utf8");
+    const scriptTags = html.match(/<script\b[^>]*>/gi) ?? [];
+    const inlineScripts = scriptTags.filter((tag) => !/\bsrc\s*=/.test(tag));
+    expect(inlineScripts).toEqual([]);
+  });
+
+  it("loads the external analytics and theme init scripts with the intended semantics", async () => {
+    const html = await readFile(new URL("../../index.html", import.meta.url), "utf8");
+    // Theme init must stay synchronous (no async/defer) to run before first paint.
+    expect(html).toContain('<script src="/theme-init.js"></script>');
+    // Analytics is queue-based and safe to defer off the critical path.
+    expect(html).toContain('<script src="/analytics-init.js" defer></script>');
+  });
+});

--- a/packages/web/src/__tests__/zod-jitless.test.ts
+++ b/packages/web/src/__tests__/zod-jitless.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Guards the zod-jitless bootstrap (issue 1541): zod v4 probes eval support
+ * with `new Function(...)` when an object schema is first constructed; under
+ * the enforced CSP (no unsafe-eval) that probe is blocked and reported to the
+ * console. `src/zod-jitless.ts` must configure `jitless: true` before any
+ * shared schema module evaluates.
+ */
+describe("zod-jitless bootstrap", () => {
+  it("configures jitless mode before shared schemas are used", async () => {
+    await import("../zod-jitless.js");
+    const { globalConfig } = await import("zod/v4/core");
+    expect(globalConfig.jitless).toBe(true);
+  });
+
+  it("keeps shared object schemas functional when eval is unavailable", async () => {
+    // Simulate the enforced CSP: any eval-style construction throws.
+    vi.stubGlobal("Function", function blockedFunction(): never {
+      throw new Error("eval blocked by Content-Security-Policy");
+    });
+    try {
+      await import("../zod-jitless.js");
+      const { askRequestSchema } = await import("@first-tree/shared");
+      expect(askRequestSchema.parse({})).toEqual({ multiSelect: false });
+      expect(() => askRequestSchema.parse({ multiSelect: true })).toThrow();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("stays the first import of main.tsx (load order is the contract)", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const mainSource = await readFile(new URL("../main.tsx", import.meta.url), "utf8");
+    const firstImport = mainSource.split("\n").find((line) => line.startsWith("import"));
+    expect(firstImport).toBe('import "./zod-jitless.js";');
+  });
+});

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,3 +1,4 @@
+import "./zod-jitless.js";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app.js";

--- a/packages/web/src/zod-jitless.ts
+++ b/packages/web/src/zod-jitless.ts
@@ -1,0 +1,18 @@
+// Disables zod v4's JIT-compiled object parsers before any shared schema
+// module evaluates.
+//
+// Why this exists: zod v4 probes eval support with `new Function(...)` the
+// first time an object schema is constructed (zod's util.allowsEval). Under
+// the enforced Content-Security-Policy (no script-src 'unsafe-eval') the
+// browser blocks that probe; zod catches it and falls back to jitless, but
+// the CSP violation is still reported to the console — failing the "zero CSP
+// violations" bar for issue 1541. Configuring `jitless: true` up front skips
+// the probe entirely.
+//
+// Load order is the contract: ESM evaluates imports depth-first in
+// declaration order, and main.tsx imports this module first, so the config
+// lands before any @first-tree/shared schema module is evaluated. Do not move
+// it below other imports in main.tsx.
+import { config } from "zod";
+
+config({ jitless: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
     devDependencies:
       '@sentry/vite-plugin':
         specifier: ^5.3.0
@@ -7660,22 +7663,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
-
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
-
   '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -10342,7 +10329,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -10385,7 +10372,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
## Summary

Fixes #1541 — the Fastify server serves both the API and the SPA but had no app-wide browser security header layer (the only header was attachment-route `nosniff`; whatever protection exists lives in invisible edge config). This PR makes the app layer the testable source of truth:

- **New root `onSend` hook** (`packages/server/src/security-headers.ts`) registered before routes, so API routes, `@fastify/static` sends, the SPA fallback, and error responses (404/429) all emit the same set:
  - `Content-Security-Policy` — **enforced** (not Report-Only), least-privilege, no `unsafe-inline`/`unsafe-eval` in script directives
  - `Strict-Transport-Security: max-age=31536000; includeSubDomains`
  - `X-Content-Type-Options: nosniff` (skipped when a route already set it)
  - `Referrer-Policy: strict-origin-when-cross-origin`
  - `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()`
  - `X-Frame-Options: DENY` (+ CSP `frame-ancestors 'none'`)
- **Inline scripts removed from `packages/web/index.html`** (instead of nonces): the pre-paint theme init and the hostname-gated GA4/Clarity bootstrap move verbatim to `packages/web/public/theme-init.js` / `analytics-init.js`. `dist/index.html` ships zero inline scripts, so `script-src 'self'` suffices and the static-serving pipeline is untouched.
- **Config-driven CSP origins** via a new `security` group in `server-config.ts`: `FIRST_TREE_CSP_ANALYTICS_ORIGINS` (script+connect+img), `FIRST_TREE_CSP_AVATAR_ORIGINS` (replaces the built-in GitHub/Google OAuth avatar hosts), `FIRST_TREE_CSP_EXTRA_CONNECT_SRC` (Sentry ingest, future object-storage). Invalid origins fail boot loudly. Adding a legitimate origin is now a config change, not a code edit.
- **`zod-jitless.ts` bootstrap** (first import of `main.tsx`): zod v4 probes eval support with `new Function(...)` at first schema construction; under the enforced CSP that probe is blocked and reported to the console even though zod catches it. `config({ jitless: true })` skips the probe. Web declares `zod` (already a transitive dep, same `^4.0.0` range as shared/server).

The onSend hook is deliberately **synchronous**: a second *async* onSend hook delays the chain one microtask and trips a latent fastify footgun — async handlers that call `reply.send()` bare (e.g. the DELETE 204 in `api/orgs/settings.ts`) get re-sent by fastify's wrap-thenable fallback (`ERR_HTTP_HEADERS_SENT` unhandled rejection, caught in the full suite). The sync hook preserves the exact onSend timing the app had before. The route-level pattern is a pre-existing latent bug worth its own follow-up sweep.

## Validation

- [x] `pnpm check` — 0 errors
- [x] `pnpm typecheck` — 10/10 tasks
- [x] `pnpm test` — 11/11 turbo tasks (server 2573, web 1569, shared 645, …), zero unhandled errors
- [x] `pnpm --filter @first-tree/web build` — `dist/index.html` verified to contain no inline `<script>`
- [x] Live verification against a running instance (postgres in docker, `FIRST_TREE_WEB_DIST_PATH` pointing at the real dist):

```
$ curl -sI http://127.0.0.1:8000/ | grep -iE 'content-security-policy|strict-transport-security|x-content-type-options|referrer-policy|x-frame-options|permissions-policy'
content-security-policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://avatars.githubusercontent.com https://lh3.googleusercontent.com; connect-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
strict-transport-security: max-age=31536000; includeSubDomains
x-content-type-options: nosniff
referrer-policy: strict-origin-when-cross-origin
permissions-policy: camera=(), microphone=(), geolocation=(), payment=()
x-frame-options: DENY
```

Same set verified on `/healthz` (API), `/api/v1/nope` (404), and `/workspace/abc` (SPA fallback); `/theme-init.js` and `/analytics-init.js` serve 200. With `FIRST_TREE_CSP_ANALYTICS_ORIGINS="https://www.googletagmanager.com https://www.clarity.ms https://scripts.clarity.ms https://c.clarity.ms https://c.bing.com https://www.google-analytics.com"` + `FIRST_TREE_CSP_EXTRA_CONNECT_SRC="https://example.ingest.sentry.io"` set, those origins appear in the expected directives; an invalid origin (`not-a-url`) fails boot with a descriptive error.

New tests: `security-headers.test.ts` (header composition + API/404/429/SPA coverage), `index-html.test.ts` (zero-inline-script guard), `zod-jitless.test.ts` (jitless bootstrap + load-order guard); `analytics.test.ts` updated to point at the externalized bootstrap.

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: web gains an explicit `zod@^4.0.0` dependency (already in the tree at 4.3.6 via shared); no new runtime libraries. The lockfile diff also prunes two stale `@vitest/mocker` snapshot variants — pnpm's deterministic re-resolution from `pnpm install`.
- docs or tests updated to match: `.env.example` documents the three new `FIRST_TREE_CSP_*` vars (incl. the verified GA4/Clarity origin set for production).
- follow-up work:
  - **Deployment config** (production): set
    `FIRST_TREE_CSP_ANALYTICS_ORIGINS="https://www.googletagmanager.com https://www.clarity.ms https://scripts.clarity.ms https://c.clarity.ms https://c.bing.com https://www.google-analytics.com"`
    and `FIRST_TREE_CSP_EXTRA_CONNECT_SRC="https://www.google.com https://b.clarity.ms"` (GA4 linker collect + Clarity collect; kept out of the analytics knob so they are not widened into script-src/img-src), plus the Sentry ingest host if `VITE_SENTRY_DSN` is set. This set is browser-verified across two QA rounds (2026-07-22, Chromium 149, hostname gate triggered): the full vendor tag chain fires with zero CSP violations. Clarity's collect host may vary by region — if production logs violations for another `*.clarity.ms` collect host, append it to `FIRST_TREE_CSP_EXTRA_CONNECT_SRC`. Evidence: `/private/tmp/first-tree-qa-runs/1541-r1/artifacts/`.
  - **Functional regression** (per the issue's acceptance checklist) — done on Chromium 149: login, chat send/receive, WebSocket live updates (101 upgrade, same-origin ws covered by `connect-src 'self'`), avatar/attachment images, document preview — zero console CSP violations with the completed origin set. Safari: INCONCLUSIVE (safaridriver session blocked by "Allow remote automation", needs interactive sudo); if same-origin `wss:` ever breaks there, the fallback is config-only via `FIRST_TREE_CSP_EXTRA_CONNECT_SRC`.
  - Methodology lesson from QA: a blocked vendor tag cannot issue its follow-up requests, so the chain reveals itself one hop at a time — R1's "verified" set was truncated by the first blocked hop, and only a run with **zero violations AND every endpoint succeeding** counts as converged. The final set above reached that bar in the QA re-run.
  - Latent route bug found during validation: async handlers that call `reply.send()` bare can double-send once any second async onSend hook exists (fastify wrap-thenable fallback). Deserves its own sweep/fix.
