### PR TITLE
Collapse live output on strong context transitions

### DIFF
--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -23,7 +23,7 @@ const sessionApiMocks = vi.hoisted(() => ({
 }));
 
 const timelineMocks = vi.hoisted(() => ({
-  scrollToAgentTimeline: vi.fn(),
+  scrollToAgentTimeline: vi.fn(() => true),
 }));
 
 vi.mock("../../../api/agent-status.js", () => ({
@@ -398,7 +398,15 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     );
 
     await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
-    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    const timelineTarget = h.container.querySelector<HTMLElement>('[data-working-agent="agent-nova"]');
+    if (!timelineTarget) throw new Error("Expected timeline target");
+    timelineTarget.tabIndex = -1;
+    timelineMocks.scrollToAgentTimeline.mockImplementationOnce(() => {
+      timelineTarget.focus();
+      return true;
+    });
+    const trigger = h.container.querySelector<HTMLButtonElement>('button[aria-label^="Expand current agent output"]');
+    await click(h, trigger);
     await waitForSettled(h, () =>
       expect(h.container.querySelector('.compose-status-jump[aria-label*="Nova"]')).not.toBeNull(),
     );
@@ -410,6 +418,34 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     await click(h, jump);
 
     expect(timelineMocks.scrollToAgentTimeline).toHaveBeenCalledWith("agent-nova", "working", { focus: true });
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+    expect(h.container.querySelector('[aria-label^="Expand current agent output"]')).toBe(trigger);
+    expect(document.activeElement).toBe(timelineTarget);
+  });
+
+  it("keeps the output expanded if its timeline target disappears before navigation", async () => {
+    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
+      status("agent-nova", {
+        working: true,
+        engagement: "active",
+        activity: activity("agent-nova", { turnText: "Inspect the current turn" }),
+      }),
+    ]);
+    timelineMocks.scrollToAgentTimeline.mockReturnValueOnce(false);
+
+    h.render(
+      withProviders(
+        <>
+          <div data-working-agent="agent-nova" />
+          <ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} />
+        </>,
+      ),
+    );
+
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    await click(h, h.container.querySelector('.compose-status-jump[aria-label*="Nova"]'));
+
     expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
   });
 
@@ -604,13 +640,16 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(trigger?.getAttribute("aria-label")).toContain("3 status updates");
     expect(trigger?.textContent).not.toContain("needs attention");
 
-    for (const [agentId, name] of [
+    const providerAgents = [
       ["agent-waiting", "Waiting Agent"],
       ["agent-retrying", "Retrying Agent"],
       ["agent-warning", "Warning Agent"],
-    ]) {
+    ] as const;
+    for (const [index, [agentId, name]] of providerAgents.entries()) {
       await click(h, h.container.querySelector(`.compose-status-jump[aria-label*="${name}"][aria-label*="timeline"]`));
       expect(timelineMocks.scrollToAgentTimeline).toHaveBeenLastCalledWith(agentId, "reason", { focus: true });
+      expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+      if (index < providerAgents.length - 1) await click(h, trigger);
     }
   });
 

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -509,6 +509,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     const composerInputRef = createRef<HTMLTextAreaElement>();
     const attachButtonRef = createRef<HTMLButtonElement>();
     const externalSurfaceRef = createRef<HTMLDivElement>();
+    const outsideAction = vi.fn();
 
     h.render(
       withProviders(
@@ -516,8 +517,8 @@ describe("ComposeStatusBar extra DOM coverage", () => {
           <ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} />
           <div ref={externalSurfaceRef}>
             <textarea ref={composerInputRef} aria-label="Message composer" />
-            <button ref={attachButtonRef} type="button">
-              Attach file
+            <button ref={attachButtonRef} type="button" onClick={outsideAction}>
+              Timeline action
             </button>
           </div>
         </>,
@@ -534,12 +535,37 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
     expect(document.activeElement).toBe(composerInputRef.current);
 
+    const trigger = h.container.querySelector<HTMLButtonElement>('button[aria-label^="Expand current agent output"]');
+    await act(async () => {
+      trigger?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true }));
+      trigger?.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, cancelable: true }));
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1 }));
+    });
+    await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
+    expect(document.activeElement).toBe(composerInputRef.current);
+
+    await act(async () => {
+      composerInputRef.current?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+    });
+    await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+
     await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     await act(async () => {
       attachButtonRef.current?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true }));
     });
     await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
+    expect(outsideAction).not.toHaveBeenCalled();
+
+    await act(async () => {
+      attachButtonRef.current?.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, cancelable: true }));
+      attachButtonRef.current?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1 }));
+    });
+    await h.flush();
     expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+    expect(outsideAction).toHaveBeenCalledTimes(1);
 
     await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     await act(async () => {
@@ -559,6 +585,14 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     const details = h.container.querySelector("[data-current-agent-output]");
     await act(async () => {
       details?.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true }));
+    });
+    await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
+
+    await act(async () => {
+      details?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true }));
+      externalSurfaceRef.current?.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, cancelable: true }));
+      document.body.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1 }));
     });
     await h.flush();
     expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -498,7 +498,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(document.activeElement).not.toBe(fallbackRef.current);
   });
 
-  it("collapses when the user focuses or drops input into the editable composer", async () => {
+  it("collapses for outside interaction intent while keeping internal scrolling open", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-nova", {
         working: true,
@@ -506,19 +506,15 @@ describe("ComposeStatusBar extra DOM coverage", () => {
         activity: activity("agent-nova", { turnText: "Inspect the current turn" }),
       }),
     ]);
-    const composerSurfaceRef = createRef<HTMLDivElement>();
     const composerInputRef = createRef<HTMLTextAreaElement>();
     const attachButtonRef = createRef<HTMLButtonElement>();
+    const externalSurfaceRef = createRef<HTMLDivElement>();
 
     h.render(
       withProviders(
         <>
-          <ComposeStatusBar
-            chatId="chat-1"
-            agents={[agent("agent-nova", "Nova")]}
-            composerSurfaceRef={composerSurfaceRef}
-          />
-          <div ref={composerSurfaceRef}>
+          <ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} />
+          <div ref={externalSurfaceRef}>
             <textarea ref={composerInputRef} aria-label="Message composer" />
             <button ref={attachButtonRef} type="button">
               Attach file
@@ -539,17 +535,83 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(document.activeElement).toBe(composerInputRef.current);
 
     await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
-    await act(async () => attachButtonRef.current?.focus());
-    await h.flush();
-    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
-    expect(document.activeElement).toBe(attachButtonRef.current);
-
-    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     await act(async () => {
-      composerSurfaceRef.current?.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true }));
+      attachButtonRef.current?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true }));
     });
     await h.flush();
     expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    await act(async () => {
+      externalSurfaceRef.current?.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true }));
+    });
+    await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    await act(async () => {
+      externalSurfaceRef.current?.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true }));
+    });
+    await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    const details = h.container.querySelector("[data-current-agent-output]");
+    await act(async () => {
+      details?.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true }));
+    });
+    await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
+  });
+
+  it("clears status focus ownership when an outside drop unmounts focused output", async () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(
+      ["chat-agent-status", "chat-1"],
+      [status("agent-nova", { working: true, engagement: "active", activity: activity("agent-nova") })],
+    );
+    const fallbackRef = createRef<HTMLButtonElement>();
+    const externalRef = createRef<HTMLButtonElement>();
+    const dropTargetRef = createRef<HTMLDivElement>();
+
+    h.render(
+      withProviders(
+        <>
+          <div data-working-agent="agent-nova" />
+          <ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} fallbackFocusRef={fallbackRef} />
+          <div ref={dropTargetRef}>Drop files here</div>
+          <button ref={externalRef} type="button">
+            Later control
+          </button>
+          <button ref={fallbackRef} type="button">
+            Composer fallback
+          </button>
+        </>,
+        queryClient,
+      ),
+    );
+
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    const jump = h.container.querySelector<HTMLButtonElement>('.compose-status-jump[aria-label*="Nova"]');
+    if (!jump) throw new Error("Expected timeline jump");
+    jump.focus();
+
+    await act(async () => {
+      dropTargetRef.current?.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true }));
+    });
+    await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+
+    externalRef.current?.focus();
+    await act(async () => {
+      queryClient.setQueryData(["chat-agent-status", "chat-1"], []);
+    });
+    await h.flush();
+
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).toBeNull());
+    expect(document.activeElement).toBe(externalRef.current);
+    expect(document.activeElement).not.toBe(fallbackRef.current);
   });
 
   it("places inline output after its trigger and keeps focus on the disclosure", async () => {
@@ -582,7 +644,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(document.activeElement).toBe(trigger);
   });
 
-  it("leaves Escape to a later focused keyboard layer outside the inline output", async () => {
+  it("collapses for a later focused keyboard layer without consuming its Escape", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-nova", {
         working: true,
@@ -609,12 +671,13 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     const laterLayer = h.container.querySelector<HTMLInputElement>('input[aria-label="Mention autocomplete"]');
     if (!laterLayer) throw new Error("Expected later keyboard layer");
-    laterLayer.focus();
+    await act(async () => laterLayer.focus());
+    await h.flush();
 
     await keyDown(h, laterLayer, "Escape");
 
     expect(externalEscape).toHaveBeenCalledTimes(1);
-    expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
     expect(document.activeElement).toBe(laterLayer);
   });
 

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -462,11 +462,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
       withProviders(
         <>
           <div data-working-agent="agent-nova" />
-          <ComposeStatusBar
-            chatId="chat-1"
-            agents={[agent("agent-nova", "Nova")]}
-            fallbackFocusRef={fallbackRef}
-          />
+          <ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} fallbackFocusRef={fallbackRef} />
           <button ref={externalRef} type="button">
             Later control
           </button>

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -509,7 +509,9 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     const composerInputRef = createRef<HTMLTextAreaElement>();
     const attachButtonRef = createRef<HTMLButtonElement>();
     const externalSurfaceRef = createRef<HTMLDivElement>();
-    const outsideAction = vi.fn();
+    const outsideAction = vi.fn(() => {
+      expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
+    });
 
     h.render(
       withProviders(
@@ -561,11 +563,20 @@ describe("ComposeStatusBar extra DOM coverage", () => {
 
     await act(async () => {
       attachButtonRef.current?.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, cancelable: true }));
+      attachButtonRef.current?.focus();
       attachButtonRef.current?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1 }));
     });
     await h.flush();
     expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
     expect(outsideAction).toHaveBeenCalledTimes(1);
+
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    await act(async () => {
+      attachButtonRef.current?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, detail: 0 }));
+    });
+    await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+    expect(outsideAction).toHaveBeenCalledTimes(2);
 
     await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
     await act(async () => {

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -659,6 +659,58 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(document.activeElement).not.toBe(fallbackRef.current);
   });
 
+  it("clears status focus ownership after a click-only outside activation", async () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(
+      ["chat-agent-status", "chat-1"],
+      [status("agent-nova", { working: true, engagement: "active", activity: activity("agent-nova") })],
+    );
+    const fallbackRef = createRef<HTMLButtonElement>();
+    const externalRef = createRef<HTMLButtonElement>();
+    const outsideAction = vi.fn(() => {
+      expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
+    });
+
+    h.render(
+      withProviders(
+        <>
+          <div data-working-agent="agent-nova" />
+          <ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} fallbackFocusRef={fallbackRef} />
+          <button ref={externalRef} type="button" onClick={outsideAction}>
+            External action
+          </button>
+          <button ref={fallbackRef} type="button">
+            Composer fallback
+          </button>
+        </>,
+        queryClient,
+      ),
+    );
+
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    const jump = h.container.querySelector<HTMLButtonElement>('.compose-status-jump[aria-label*="Nova"]');
+    if (!jump) throw new Error("Expected timeline jump");
+    jump.focus();
+
+    await act(async () => {
+      externalRef.current?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, detail: 0 }));
+    });
+    await h.flush();
+    expect(outsideAction).toHaveBeenCalledTimes(1);
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+
+    externalRef.current?.focus();
+    await act(async () => {
+      queryClient.setQueryData(["chat-agent-status", "chat-1"], []);
+    });
+    await h.flush();
+
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).toBeNull());
+    expect(document.activeElement).toBe(externalRef.current);
+    expect(document.activeElement).not.toBe(fallbackRef.current);
+  });
+
   it("places inline output after its trigger and keeps focus on the disclosure", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-nova", {

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -449,6 +449,93 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
   });
 
+  it("clears status focus ownership when a pointer jump unmounts its focused control", async () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(
+      ["chat-agent-status", "chat-1"],
+      [status("agent-nova", { working: true, engagement: "active", activity: activity("agent-nova") })],
+    );
+    const fallbackRef = createRef<HTMLButtonElement>();
+    const externalRef = createRef<HTMLButtonElement>();
+
+    h.render(
+      withProviders(
+        <>
+          <div data-working-agent="agent-nova" />
+          <ComposeStatusBar
+            chatId="chat-1"
+            agents={[agent("agent-nova", "Nova")]}
+            fallbackFocusRef={fallbackRef}
+          />
+          <button ref={externalRef} type="button">
+            Later control
+          </button>
+          <button ref={fallbackRef} type="button">
+            Composer fallback
+          </button>
+        </>,
+        queryClient,
+      ),
+    );
+
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    const jump = h.container.querySelector<HTMLButtonElement>('.compose-status-jump[aria-label*="Nova"]');
+    if (!jump) throw new Error("Expected timeline jump");
+    jump.focus();
+
+    await act(async () => {
+      jump.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1 }));
+    });
+    await h.flush();
+
+    expect(timelineMocks.scrollToAgentTimeline).toHaveBeenCalledWith("agent-nova", "working", { focus: false });
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+    externalRef.current?.focus();
+    await act(async () => {
+      queryClient.setQueryData(["chat-agent-status", "chat-1"], []);
+    });
+    await h.flush();
+
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).toBeNull());
+    expect(document.activeElement).toBe(externalRef.current);
+    expect(document.activeElement).not.toBe(fallbackRef.current);
+  });
+
+  it("collapses when the editable composer receives focus without moving focus away", async () => {
+    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
+      status("agent-nova", {
+        working: true,
+        engagement: "active",
+        activity: activity("agent-nova", { turnText: "Inspect the current turn" }),
+      }),
+    ]);
+    const composerInputRef = createRef<HTMLTextAreaElement>();
+
+    h.render(
+      withProviders(
+        <>
+          <ComposeStatusBar
+            chatId="chat-1"
+            agents={[agent("agent-nova", "Nova")]}
+            composerInputRef={composerInputRef}
+          />
+          <textarea ref={composerInputRef} aria-label="Message composer" />
+        </>,
+      ),
+    );
+
+    await waitForSettled(h, () => expect(h.container.querySelector("[data-compose-status-bar]")).not.toBeNull());
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
+
+    await act(async () => composerInputRef.current?.focus());
+    await h.flush();
+
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+    expect(document.activeElement).toBe(composerInputRef.current);
+  });
+
   it("places inline output after its trigger and keeps focus on the disclosure", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-nova", {

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -502,7 +502,7 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     expect(document.activeElement).not.toBe(fallbackRef.current);
   });
 
-  it("collapses when the editable composer receives focus without moving focus away", async () => {
+  it("collapses when the user focuses or drops input into the editable composer", async () => {
     agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
       status("agent-nova", {
         working: true,
@@ -510,7 +510,9 @@ describe("ComposeStatusBar extra DOM coverage", () => {
         activity: activity("agent-nova", { turnText: "Inspect the current turn" }),
       }),
     ]);
+    const composerSurfaceRef = createRef<HTMLDivElement>();
     const composerInputRef = createRef<HTMLTextAreaElement>();
+    const attachButtonRef = createRef<HTMLButtonElement>();
 
     h.render(
       withProviders(
@@ -518,9 +520,14 @@ describe("ComposeStatusBar extra DOM coverage", () => {
           <ComposeStatusBar
             chatId="chat-1"
             agents={[agent("agent-nova", "Nova")]}
-            composerInputRef={composerInputRef}
+            composerSurfaceRef={composerSurfaceRef}
           />
-          <textarea ref={composerInputRef} aria-label="Message composer" />
+          <div ref={composerSurfaceRef}>
+            <textarea ref={composerInputRef} aria-label="Message composer" />
+            <button ref={attachButtonRef} type="button">
+              Attach file
+            </button>
+          </div>
         </>,
       ),
     );
@@ -534,6 +541,19 @@ describe("ComposeStatusBar extra DOM coverage", () => {
 
     expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
     expect(document.activeElement).toBe(composerInputRef.current);
+
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    await act(async () => attachButtonRef.current?.focus());
+    await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+    expect(document.activeElement).toBe(attachButtonRef.current);
+
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    await act(async () => {
+      composerSurfaceRef.current?.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true }));
+    });
+    await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
   });
 
   it("places inline output after its trigger and keeps focus on the disclosure", async () => {

--- a/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-components-extra.test.tsx
@@ -499,16 +499,18 @@ describe("ComposeStatusBar extra DOM coverage", () => {
   });
 
   it("collapses for outside interaction intent while keeping internal scrolling open", async () => {
-    agentStatusApiMocks.fetchChatAgentStatuses.mockResolvedValue([
-      status("agent-nova", {
-        working: true,
-        engagement: "active",
-        activity: activity("agent-nova", { turnText: "Inspect the current turn" }),
-      }),
-    ]);
+    const queryClient = createQueryClient();
+    const novaStatus = status("agent-nova", {
+      working: true,
+      engagement: "active",
+      activity: activity("agent-nova", { turnText: "Inspect the current turn" }),
+    });
+    queryClient.setQueryData(["chat-agent-status", "chat-1"], [novaStatus]);
     const composerInputRef = createRef<HTMLTextAreaElement>();
     const attachButtonRef = createRef<HTMLButtonElement>();
     const externalSurfaceRef = createRef<HTMLDivElement>();
+    const clipboardFile = new File(["image"], "evidence.png", { type: "image/png" });
+    const pasteAction = vi.fn();
     const outsideAction = vi.fn(() => {
       expect(h.container.querySelector("[data-current-agent-output]")).not.toBeNull();
     });
@@ -516,14 +518,24 @@ describe("ComposeStatusBar extra DOM coverage", () => {
     h.render(
       withProviders(
         <>
-          <ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} />
+          <ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova"), agent("agent-atlas", "Atlas")]} />
           <div ref={externalSurfaceRef}>
-            <textarea ref={composerInputRef} aria-label="Message composer" />
+            <textarea
+              ref={composerInputRef}
+              aria-label="Message composer"
+              onPaste={(event) => {
+                const files = Array.from(event.clipboardData.files);
+                if (files.length === 0) return;
+                event.preventDefault();
+                pasteAction(files);
+              }}
+            />
             <button ref={attachButtonRef} type="button" onClick={outsideAction}>
               Timeline action
             </button>
           </div>
         </>,
+        queryClient,
       ),
     );
 
@@ -551,6 +563,17 @@ describe("ComposeStatusBar extra DOM coverage", () => {
       composerInputRef.current?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
     });
     await h.flush();
+    expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
+
+    await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
+    await act(async () => {
+      const event = new Event("paste", { bubbles: true, cancelable: true });
+      Object.defineProperty(event, "clipboardData", { configurable: true, value: { files: [clipboardFile] } });
+      composerInputRef.current?.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+    });
+    await h.flush();
+    expect(pasteAction).toHaveBeenCalledWith([clipboardFile]);
     expect(h.container.querySelector("[data-current-agent-output]")).toBeNull();
 
     await click(h, h.container.querySelector('button[aria-label^="Expand current agent output"]'));
@@ -602,6 +625,22 @@ describe("ComposeStatusBar extra DOM coverage", () => {
 
     await act(async () => {
       details?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true }));
+      queryClient.setQueryData(
+        ["chat-agent-status", "chat-1"],
+        [
+          novaStatus,
+          status("agent-atlas", {
+            working: true,
+            engagement: "active",
+            activity: activity("agent-atlas", { turnText: "Review the current turn" }),
+          }),
+        ],
+      );
+    });
+    await h.flush();
+    await waitForSettled(h, () => expect(h.container.querySelectorAll("[data-current-output-agent]")).toHaveLength(2));
+
+    await act(async () => {
       externalSurfaceRef.current?.dispatchEvent(new PointerEvent("pointerup", { bubbles: true, cancelable: true }));
       document.body.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1 }));
     });
@@ -676,7 +715,14 @@ describe("ComposeStatusBar extra DOM coverage", () => {
         <>
           <div data-working-agent="agent-nova" />
           <ComposeStatusBar chatId="chat-1" agents={[agent("agent-nova", "Nova")]} fallbackFocusRef={fallbackRef} />
-          <button ref={externalRef} type="button" onClick={outsideAction}>
+          <button
+            ref={externalRef}
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              outsideAction();
+            }}
+          >
             External action
           </button>
           <button ref={fallbackRef} type="button">

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -93,15 +93,12 @@ export function ComposeStatusBar({
   chatId,
   agents,
   fallbackFocusRef,
-  composerSurfaceRef,
 }: {
   chatId: string;
   /** Non-human agent participants, used for stable display-name lookup. */
   agents: ChatParticipantDetail[];
   /** Stable composer control that receives focus if the status surface vanishes. */
   fallbackFocusRef?: RefObject<HTMLElement | null>;
-  /** Editable composer surface whose use signals a switch from monitoring to composing. */
-  composerSurfaceRef?: RefObject<HTMLElement | null>;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [lead, setLead] = useState<{ agentId: string; since: number } | null>(null);
@@ -144,28 +141,21 @@ export function ComposeStatusBar({
   }, [chatId]);
 
   useEffect(() => {
-    if (!composerSurfaceRef) return;
-    const collapseForComposerIntent = (event: Event) => {
-      const target = event.target;
-      if (target instanceof Node && composerSurfaceRef.current?.contains(target)) setExpanded(false);
-    };
-    document.addEventListener("focusin", collapseForComposerIntent);
-    document.addEventListener("drop", collapseForComposerIntent);
-    return () => {
-      document.removeEventListener("focusin", collapseForComposerIntent);
-      document.removeEventListener("drop", collapseForComposerIntent);
-    };
-  }, [composerSurfaceRef]);
-
-  useEffect(() => {
     if (attention.length === 0) return;
-    const clearOutsidePointerFocus = (event: PointerEvent) => {
+    const collapseForOutsideIntent = (event: Event) => {
       const target = event.target;
-      if (target instanceof Node && !surfaceRef.current?.contains(target)) focusWithinRef.current = false;
+      if (!(target instanceof Node) || surfaceRef.current?.contains(target)) return;
+      focusWithinRef.current = false;
+      if (expanded) setExpanded(false);
     };
-    document.addEventListener("pointerdown", clearOutsidePointerFocus, true);
-    return () => document.removeEventListener("pointerdown", clearOutsidePointerFocus, true);
-  }, [attention.length]);
+    const eventTypes = expanded
+      ? (["pointerdown", "focusin", "click", "wheel", "touchstart", "drop"] as const)
+      : (["pointerdown"] as const);
+    for (const type of eventTypes) document.addEventListener(type, collapseForOutsideIntent, true);
+    return () => {
+      for (const type of eventTypes) document.removeEventListener(type, collapseForOutsideIntent, true);
+    };
+  }, [attention.length, expanded]);
 
   useEffect(() => {
     if (attention.length === 0) {

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -93,12 +93,15 @@ export function ComposeStatusBar({
   chatId,
   agents,
   fallbackFocusRef,
+  composerInputRef,
 }: {
   chatId: string;
   /** Non-human agent participants, used for stable display-name lookup. */
   agents: ChatParticipantDetail[];
   /** Stable composer control that receives focus if the status surface vanishes. */
   fallbackFocusRef?: RefObject<HTMLElement | null>;
+  /** Editable composer input whose focus signals that monitoring is finished. */
+  composerInputRef?: RefObject<HTMLTextAreaElement | null>;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [lead, setLead] = useState<{ agentId: string; since: number } | null>(null);
@@ -139,6 +142,15 @@ export function ComposeStatusBar({
     activeChatIdRef.current = chatId;
     setExpanded(false);
   }, [chatId]);
+
+  useEffect(() => {
+    if (!composerInputRef) return;
+    const collapseForComposerFocus = (event: FocusEvent) => {
+      if (event.target === composerInputRef.current) setExpanded(false);
+    };
+    document.addEventListener("focusin", collapseForComposerFocus);
+    return () => document.removeEventListener("focusin", collapseForComposerFocus);
+  }, [composerInputRef]);
 
   useEffect(() => {
     if (attention.length === 0) return;
@@ -231,7 +243,13 @@ export function ComposeStatusBar({
               attention={attention}
               nameOf={nameOf}
               mounted={mounted}
-              onTimelineNavigate={() => setExpanded(false)}
+              onTimelineNavigate={() => {
+                // A pointer jump does not transfer focus to timeline evidence.
+                // Clear ownership before its focused button is unmounted so a
+                // later status removal cannot steal focus back to the composer.
+                focusWithinRef.current = false;
+                setExpanded(false);
+              }}
             />
           ) : null}
         </section>

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -107,6 +107,7 @@ export function ComposeStatusBar({
   const surfaceRef = useRef<HTMLElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const focusWithinRef = useRef(false);
+  const pointerOriginOutsideRef = useRef<boolean | null>(null);
   const { data: rawStatuses } = useQuery({
     queryKey: chatAgentStatusQueryKey(chatId),
     queryFn: () => fetchChatAgentStatuses(chatId),
@@ -142,18 +143,69 @@ export function ComposeStatusBar({
 
   useEffect(() => {
     if (attention.length === 0) return;
-    const collapseForOutsideIntent = (event: Event) => {
+    const isOutside = (event: Event) => {
       const target = event.target;
-      if (!(target instanceof Node) || surfaceRef.current?.contains(target)) return;
+      return target instanceof Node && !surfaceRef.current?.contains(target);
+    };
+    const collapse = () => {
       focusWithinRef.current = false;
       if (expanded) setExpanded(false);
     };
-    const eventTypes = expanded
-      ? (["pointerdown", "focusin", "click", "wheel", "touchstart", "drop"] as const)
-      : (["pointerdown"] as const);
-    for (const type of eventTypes) document.addEventListener(type, collapseForOutsideIntent, true);
+    if (!expanded) {
+      const clearOutsidePointerFocus = (event: PointerEvent) => {
+        if (isOutside(event)) focusWithinRef.current = false;
+      };
+      document.addEventListener("pointerdown", clearOutsidePointerFocus, true);
+      return () => document.removeEventListener("pointerdown", clearOutsidePointerFocus, true);
+    }
+
+    let collapseFrame: number | null = null;
+    const collapseAfterPointerActivation = () => {
+      if (collapseFrame !== null) return;
+      collapseFrame = requestAnimationFrame(() => {
+        collapseFrame = null;
+        collapse();
+      });
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      pointerOriginOutsideRef.current = isOutside(event);
+      if (pointerOriginOutsideRef.current) focusWithinRef.current = false;
+    };
+    const onPointerUp = () => {
+      const startedOutside = pointerOriginOutsideRef.current;
+      pointerOriginOutsideRef.current = null;
+      if (startedOutside) collapseAfterPointerActivation();
+    };
+    const onPointerCancel = () => {
+      const startedOutside = pointerOriginOutsideRef.current;
+      pointerOriginOutsideRef.current = null;
+      if (startedOutside) collapseAfterPointerActivation();
+    };
+    const onFocusIn = (event: FocusEvent) => {
+      if (pointerOriginOutsideRef.current === null && isOutside(event)) collapse();
+    };
+    const onOutsideIntent = (event: Event) => {
+      if (isOutside(event)) collapse();
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("pointerup", onPointerUp, true);
+    document.addEventListener("pointercancel", onPointerCancel, true);
+    document.addEventListener("focusin", onFocusIn, true);
+    document.addEventListener("keydown", onOutsideIntent);
+    document.addEventListener("beforeinput", onOutsideIntent);
+    document.addEventListener("wheel", onOutsideIntent, true);
+    document.addEventListener("drop", onOutsideIntent, true);
     return () => {
-      for (const type of eventTypes) document.removeEventListener(type, collapseForOutsideIntent, true);
+      pointerOriginOutsideRef.current = null;
+      if (collapseFrame !== null) cancelAnimationFrame(collapseFrame);
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("pointerup", onPointerUp, true);
+      document.removeEventListener("pointercancel", onPointerCancel, true);
+      document.removeEventListener("focusin", onFocusIn, true);
+      document.removeEventListener("keydown", onOutsideIntent);
+      document.removeEventListener("beforeinput", onOutsideIntent);
+      document.removeEventListener("wheel", onOutsideIntent, true);
+      document.removeEventListener("drop", onOutsideIntent, true);
     };
   }, [attention.length, expanded]);
 

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -118,6 +118,7 @@ export function ComposeStatusBar({
   // must never resurrect Working after runtime freshness has expired.
   const statuses = rawStatuses ?? [];
   const attention = useMemo(() => selectAttention(statuses), [statuses]);
+  const hasAttention = attention.length > 0;
   const mounted = useMountedAnchors();
   const nameOf = useMemo(() => nameFor(agents), [agents]);
   const announcement = useMemo(() => activityAnnouncement(attention, nameOf), [attention, nameOf]);
@@ -141,8 +142,10 @@ export function ComposeStatusBar({
     setExpanded(false);
   }, [chatId]);
 
+  // Keep the listener lifetime stable while the actionable set changes so a
+  // live 1 -> 2 agent update cannot erase an in-flight pointer origin.
   useEffect(() => {
-    if (attention.length === 0) return;
+    if (!hasAttention) return;
     const isOutside = (event: Event) => {
       const target = event.target;
       return target instanceof Node && !surfaceRef.current?.contains(target);
@@ -189,21 +192,32 @@ export function ComposeStatusBar({
     const onOutsideIntent = (event: Event) => {
       if (isOutside(event)) collapse();
     };
-    const onClick = (event: MouseEvent) => {
+    const onClickCapture = (event: MouseEvent) => {
       const pointerOriginOutside = pointerOriginOutsideRef.current;
-      pointerOriginOutsideRef.current = null;
       if (pointerCompletionFrame !== null) cancelAnimationFrame(pointerCompletionFrame);
       pointerCompletionFrame = null;
-      if (pointerOriginOutside === false) return;
-      if (pointerOriginOutside === true || isOutside(event)) collapse();
+      if (pointerOriginOutside === false) {
+        pointerOriginOutsideRef.current = null;
+        return;
+      }
+      if (pointerOriginOutside !== true && !isOutside(event)) return;
+      focusWithinRef.current = false;
+      // Capture sees Workspace controls that stop click propagation; defer the
+      // layout change until their target action has completed.
+      pointerCompletionFrame = requestAnimationFrame(() => {
+        pointerCompletionFrame = null;
+        pointerOriginOutsideRef.current = null;
+        collapse();
+      });
     };
     document.addEventListener("pointerdown", onPointerDown, true);
     document.addEventListener("pointerup", onPointerUp, true);
     document.addEventListener("pointercancel", onPointerCancel, true);
     document.addEventListener("focusin", onFocusIn, true);
-    document.addEventListener("click", onClick);
+    document.addEventListener("click", onClickCapture, true);
     document.addEventListener("keydown", onOutsideIntent);
     document.addEventListener("beforeinput", onOutsideIntent);
+    document.addEventListener("paste", onOutsideIntent, true);
     document.addEventListener("wheel", onOutsideIntent, true);
     document.addEventListener("drop", onOutsideIntent, true);
     return () => {
@@ -213,13 +227,14 @@ export function ComposeStatusBar({
       document.removeEventListener("pointerup", onPointerUp, true);
       document.removeEventListener("pointercancel", onPointerCancel, true);
       document.removeEventListener("focusin", onFocusIn, true);
-      document.removeEventListener("click", onClick);
+      document.removeEventListener("click", onClickCapture, true);
       document.removeEventListener("keydown", onOutsideIntent);
       document.removeEventListener("beforeinput", onOutsideIntent);
+      document.removeEventListener("paste", onOutsideIntent, true);
       document.removeEventListener("wheel", onOutsideIntent, true);
       document.removeEventListener("drop", onOutsideIntent, true);
     };
-  }, [attention.length, expanded]);
+  }, [expanded, hasAttention]);
 
   useEffect(() => {
     if (attention.length === 0) {

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -226,7 +226,13 @@ export function ComposeStatusBar({
           </button>
 
           {expanded ? (
-            <CurrentOutputDetails id={detailsId} attention={attention} nameOf={nameOf} mounted={mounted} />
+            <CurrentOutputDetails
+              id={detailsId}
+              attention={attention}
+              nameOf={nameOf}
+              mounted={mounted}
+              onTimelineNavigate={() => setExpanded(false)}
+            />
           ) : null}
         </section>
       ) : null}
@@ -308,11 +314,13 @@ function CurrentOutputDetails({
   attention,
   nameOf,
   mounted,
+  onTimelineNavigate,
 }: {
   id: string;
   attention: AgentChatStatus[];
   nameOf: (agentId: string) => string;
   mounted: ReadonlySet<string>;
+  onTimelineNavigate: () => void;
 }) {
   const showIdentity = attention.length > 1;
   return (
@@ -336,6 +344,7 @@ function CurrentOutputDetails({
               name={nameOf(status.agentId)}
               mounted={mounted}
               showIdentity={showIdentity}
+              onTimelineNavigate={onTimelineNavigate}
             />
           </li>
         ))}
@@ -349,11 +358,13 @@ function CurrentOutputItem({
   name,
   mounted,
   showIdentity,
+  onTimelineNavigate,
 }: {
   status: AgentChatStatus;
   name: string;
   mounted: ReadonlySet<string>;
   showIdentity: boolean;
+  onTimelineNavigate: () => void;
 }) {
   const visual = statusVisual(status);
   const snapshot = agentSnapshot(status);
@@ -390,6 +401,7 @@ function CurrentOutputItem({
           target={jumpTarget}
           anchored
           ariaLabel={`View ${name} in the timeline`}
+          onNavigate={onTimelineNavigate}
           className="compose-status-jump"
           interactiveClassName="rounded-[var(--radius-input)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -159,27 +159,29 @@ export function ComposeStatusBar({
       return () => document.removeEventListener("pointerdown", clearOutsidePointerFocus, true);
     }
 
-    let collapseFrame: number | null = null;
-    const collapseAfterPointerActivation = () => {
-      if (collapseFrame !== null) return;
-      collapseFrame = requestAnimationFrame(() => {
-        collapseFrame = null;
-        collapse();
+    let pointerCompletionFrame: number | null = null;
+    const settlePointerAfterActivation = (startedOutside: boolean) => {
+      if (pointerCompletionFrame !== null) cancelAnimationFrame(pointerCompletionFrame);
+      pointerCompletionFrame = requestAnimationFrame(() => {
+        pointerCompletionFrame = null;
+        if (pointerOriginOutsideRef.current !== startedOutside) return;
+        pointerOriginOutsideRef.current = null;
+        if (startedOutside) collapse();
       });
     };
     const onPointerDown = (event: PointerEvent) => {
+      if (pointerCompletionFrame !== null) cancelAnimationFrame(pointerCompletionFrame);
+      pointerCompletionFrame = null;
       pointerOriginOutsideRef.current = isOutside(event);
       if (pointerOriginOutsideRef.current) focusWithinRef.current = false;
     };
     const onPointerUp = () => {
       const startedOutside = pointerOriginOutsideRef.current;
-      pointerOriginOutsideRef.current = null;
-      if (startedOutside) collapseAfterPointerActivation();
+      if (startedOutside !== null) settlePointerAfterActivation(startedOutside);
     };
     const onPointerCancel = () => {
       const startedOutside = pointerOriginOutsideRef.current;
-      pointerOriginOutsideRef.current = null;
-      if (startedOutside) collapseAfterPointerActivation();
+      if (startedOutside !== null) settlePointerAfterActivation(startedOutside);
     };
     const onFocusIn = (event: FocusEvent) => {
       if (pointerOriginOutsideRef.current === null && isOutside(event)) collapse();
@@ -187,21 +189,31 @@ export function ComposeStatusBar({
     const onOutsideIntent = (event: Event) => {
       if (isOutside(event)) collapse();
     };
+    const onClick = (event: MouseEvent) => {
+      const pointerOriginOutside = pointerOriginOutsideRef.current;
+      pointerOriginOutsideRef.current = null;
+      if (pointerCompletionFrame !== null) cancelAnimationFrame(pointerCompletionFrame);
+      pointerCompletionFrame = null;
+      if (pointerOriginOutside === false) return;
+      if (pointerOriginOutside === true || isOutside(event)) collapse();
+    };
     document.addEventListener("pointerdown", onPointerDown, true);
     document.addEventListener("pointerup", onPointerUp, true);
     document.addEventListener("pointercancel", onPointerCancel, true);
     document.addEventListener("focusin", onFocusIn, true);
+    document.addEventListener("click", onClick);
     document.addEventListener("keydown", onOutsideIntent);
     document.addEventListener("beforeinput", onOutsideIntent);
     document.addEventListener("wheel", onOutsideIntent, true);
     document.addEventListener("drop", onOutsideIntent, true);
     return () => {
       pointerOriginOutsideRef.current = null;
-      if (collapseFrame !== null) cancelAnimationFrame(collapseFrame);
+      if (pointerCompletionFrame !== null) cancelAnimationFrame(pointerCompletionFrame);
       document.removeEventListener("pointerdown", onPointerDown, true);
       document.removeEventListener("pointerup", onPointerUp, true);
       document.removeEventListener("pointercancel", onPointerCancel, true);
       document.removeEventListener("focusin", onFocusIn, true);
+      document.removeEventListener("click", onClick);
       document.removeEventListener("keydown", onOutsideIntent);
       document.removeEventListener("beforeinput", onOutsideIntent);
       document.removeEventListener("wheel", onOutsideIntent, true);

--- a/packages/web/src/components/chat/compose-status-bar.tsx
+++ b/packages/web/src/components/chat/compose-status-bar.tsx
@@ -93,15 +93,15 @@ export function ComposeStatusBar({
   chatId,
   agents,
   fallbackFocusRef,
-  composerInputRef,
+  composerSurfaceRef,
 }: {
   chatId: string;
   /** Non-human agent participants, used for stable display-name lookup. */
   agents: ChatParticipantDetail[];
   /** Stable composer control that receives focus if the status surface vanishes. */
   fallbackFocusRef?: RefObject<HTMLElement | null>;
-  /** Editable composer input whose focus signals that monitoring is finished. */
-  composerInputRef?: RefObject<HTMLTextAreaElement | null>;
+  /** Editable composer surface whose use signals a switch from monitoring to composing. */
+  composerSurfaceRef?: RefObject<HTMLElement | null>;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [lead, setLead] = useState<{ agentId: string; since: number } | null>(null);
@@ -144,13 +144,18 @@ export function ComposeStatusBar({
   }, [chatId]);
 
   useEffect(() => {
-    if (!composerInputRef) return;
-    const collapseForComposerFocus = (event: FocusEvent) => {
-      if (event.target === composerInputRef.current) setExpanded(false);
+    if (!composerSurfaceRef) return;
+    const collapseForComposerIntent = (event: Event) => {
+      const target = event.target;
+      if (target instanceof Node && composerSurfaceRef.current?.contains(target)) setExpanded(false);
     };
-    document.addEventListener("focusin", collapseForComposerFocus);
-    return () => document.removeEventListener("focusin", collapseForComposerFocus);
-  }, [composerInputRef]);
+    document.addEventListener("focusin", collapseForComposerIntent);
+    document.addEventListener("drop", collapseForComposerIntent);
+    return () => {
+      document.removeEventListener("focusin", collapseForComposerIntent);
+      document.removeEventListener("drop", collapseForComposerIntent);
+    };
+  }, [composerSurfaceRef]);
 
   useEffect(() => {
     if (attention.length === 0) return;

--- a/packages/web/src/components/chat/timeline-jump-button.tsx
+++ b/packages/web/src/components/chat/timeline-jump-button.tsx
@@ -34,7 +34,7 @@ export function TimelineJumpButton({
   /** Whether this agent's timeline anchor is currently mounted. */
   anchored: boolean;
   ariaLabel: string;
-  /** Runs immediately before the timeline scroll (for example, to close a popover). */
+  /** Runs after the timeline evidence was found and navigation succeeded. */
   onNavigate?: () => void;
   className?: string;
   /** Classes applied only when the element is an actionable button. */
@@ -55,8 +55,8 @@ export function TimelineJumpButton({
     <button
       type="button"
       onClick={(event: MouseEvent<HTMLButtonElement>) => {
-        onNavigate?.();
-        scrollToAgentTimeline(agentId, target, { focus: event.detail === 0 });
+        const navigated = scrollToAgentTimeline(agentId, target, { focus: event.detail === 0 });
+        if (navigated) onNavigate?.();
       }}
       aria-label={ariaLabel}
       className={cn("group inline-flex min-w-0 items-center", className, interactiveClassName)}

--- a/packages/web/src/lib/__tests__/scroll-to-agent-timeline.test.ts
+++ b/packages/web/src/lib/__tests__/scroll-to-agent-timeline.test.ts
@@ -25,7 +25,7 @@ describe("scrollToAgentTimeline", () => {
     first.scrollIntoView = firstScroll;
     latest.scrollIntoView = latestScroll;
 
-    scrollToAgentTimeline("agent-1", "working");
+    expect(scrollToAgentTimeline("agent-1", "working")).toBe(true);
 
     expect(firstScroll).not.toHaveBeenCalled();
     expect(latestScroll).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
@@ -41,7 +41,7 @@ describe("scrollToAgentTimeline", () => {
     target.scrollIntoView = vi.fn();
     document.body.append(target);
 
-    scrollToAgentTimeline("agent-1", "working", { focus: true });
+    expect(scrollToAgentTimeline("agent-1", "working", { focus: true })).toBe(true);
 
     expect(document.activeElement).toBe(target);
     expect(target.tabIndex).toBe(-1);
@@ -64,7 +64,7 @@ describe("scrollToAgentTimeline", () => {
       vi.fn(() => ({ matches: true })),
     );
 
-    scrollToAgentTimeline("agent-1", "working");
+    expect(scrollToAgentTimeline("agent-1", "working")).toBe(true);
 
     expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: "auto", block: "center" });
     vi.unstubAllGlobals();
@@ -79,10 +79,10 @@ describe("scrollToAgentTimeline", () => {
     error.scrollIntoView = vi.fn();
     reason.scrollIntoView = vi.fn();
 
-    scrollToAgentTimeline("agent-1", "failed");
-    scrollToAgentTimeline("agent-1", "reason");
-    scrollToAgentTimeline("agent-1", "ready");
-    scrollToAgentTimeline("missing", "working");
+    expect(scrollToAgentTimeline("agent-1", "failed")).toBe(true);
+    expect(scrollToAgentTimeline("agent-1", "reason")).toBe(true);
+    expect(scrollToAgentTimeline("agent-1", "ready")).toBe(false);
+    expect(scrollToAgentTimeline("missing", "working")).toBe(false);
 
     expect(error.scrollIntoView).toHaveBeenCalledTimes(1);
     expect(reason.scrollIntoView).toHaveBeenCalledTimes(1);

--- a/packages/web/src/lib/scroll-to-agent-timeline.ts
+++ b/packages/web/src/lib/scroll-to-agent-timeline.ts
@@ -20,7 +20,7 @@ export function scrollToAgentTimeline(
   agentId: string,
   main: AgentMainStatus | "reason",
   options: TimelineJumpOptions = {},
-): void {
+): boolean {
   const attr =
     main === "failed"
       ? "data-error-agent"
@@ -29,10 +29,10 @@ export function scrollToAgentTimeline(
         : main === "reason"
           ? "data-status-reason-agent"
           : null;
-  if (!attr) return;
+  if (!attr) return false;
   const els = document.querySelectorAll<HTMLElement>(`[${attr}="${agentId}"]`);
   const target = els[els.length - 1];
-  if (!target) return;
+  if (!target) return false;
 
   const prefersReducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
   target.scrollIntoView({ behavior: prefersReducedMotion ? "auto" : "smooth", block: "center" });
@@ -66,4 +66,5 @@ export function scrollToAgentTimeline(
       { once: true },
     );
   }
+  return true;
 }

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1121,7 +1121,7 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
-  it("lets a later mention layer consume Escape while inline current output stays open", async () => {
+  it("collapses current output on composer focus before the mention layer consumes Escape", async () => {
     const { ChatView } = await import("../chat-view.js");
     const { container, root } = await renderDom(<ChatView agentId="agent-1" chatId="chat-1" />);
 
@@ -1135,6 +1135,10 @@ describe("ChatView", () => {
     await act(async () => textarea.focus());
     await flush();
     await waitForCondition(
+      () => container.querySelector("[data-current-agent-output]") === null,
+      "Expected composer focus to collapse current output",
+    );
+    await waitForCondition(
       () => container.querySelector('[role="listbox"][aria-label="Mention suggestions"]') !== null,
       "Expected mention suggestions to open after focus primed @",
     );
@@ -1145,7 +1149,7 @@ describe("ChatView", () => {
     await flush();
 
     expect(container.querySelector('[role="listbox"][aria-label="Mention suggestions"]')).toBeNull();
-    expect(container.querySelector("[data-current-agent-output]")).not.toBeNull();
+    expect(container.querySelector("[data-current-agent-output]")).toBeNull();
     expect(document.activeElement).toBe(textarea);
 
     await act(async () => root.unmount());

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1753,6 +1753,7 @@ export function ChatView({
   // dialog) rendered over a still-mounted chat can't bubble Enter into it and
   // silently resolve the pinned question in the background.
   const composerFooterRef = useRef<HTMLDivElement | null>(null);
+  const composerInputSurfaceRef = useRef<HTMLDivElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   // Scrollable container that holds the message timeline. Ref is wired
   // up on the corresponding <div> below; consumed by useChatScroll (for
@@ -4055,7 +4056,7 @@ export function ChatView({
                   chatId={chatId}
                   agents={(chatDetail?.participants ?? []).filter((p) => p.type !== "human")}
                   fallbackFocusRef={readOnly ? readOnlyComposerRef : textareaRef}
-                  composerInputRef={readOnly ? undefined : textareaRef}
+                  composerSurfaceRef={readOnly ? undefined : composerInputSurfaceRef}
                 />
                 {readOnly ? (
                   <div
@@ -4104,6 +4105,7 @@ export function ChatView({
                         the composer. */}
                     {/* biome-ignore lint/a11y/noStaticElementInteractions: drop target for image upload */}
                     <div
+                      ref={composerInputSurfaceRef}
                       className="composer-card composer-input"
                       // Phone-only: flatten the card's top corners while a picker
                       // panel (mention or slash) is docked flush above it so the two

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -1753,7 +1753,6 @@ export function ChatView({
   // dialog) rendered over a still-mounted chat can't bubble Enter into it and
   // silently resolve the pinned question in the background.
   const composerFooterRef = useRef<HTMLDivElement | null>(null);
-  const composerInputSurfaceRef = useRef<HTMLDivElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   // Scrollable container that holds the message timeline. Ref is wired
   // up on the corresponding <div> below; consumed by useChatScroll (for
@@ -4056,7 +4055,6 @@ export function ChatView({
                   chatId={chatId}
                   agents={(chatDetail?.participants ?? []).filter((p) => p.type !== "human")}
                   fallbackFocusRef={readOnly ? readOnlyComposerRef : textareaRef}
-                  composerSurfaceRef={readOnly ? undefined : composerInputSurfaceRef}
                 />
                 {readOnly ? (
                   <div
@@ -4105,7 +4103,6 @@ export function ChatView({
                         the composer. */}
                     {/* biome-ignore lint/a11y/noStaticElementInteractions: drop target for image upload */}
                     <div
-                      ref={composerInputSurfaceRef}
                       className="composer-card composer-input"
                       // Phone-only: flatten the card's top corners while a picker
                       // panel (mention or slash) is docked flush above it so the two

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -4055,6 +4055,7 @@ export function ChatView({
                   chatId={chatId}
                   agents={(chatDetail?.participants ?? []).filter((p) => p.type !== "human")}
                   fallbackFocusRef={readOnly ? readOnlyComposerRef : textareaRef}
+                  composerInputRef={readOnly ? undefined : textareaRef}
                 />
                 {readOnly ? (
                   <div


### PR DESCRIPTION
## Summary

- Treat the composer-connected current-output panel as transient detail: interactions inside it keep it open, while completed user interaction elsewhere (pointer/keyboard activation, focus, wheel/touch scroll, or drop) returns vertical space to the conversation.
- Collapse after a timeline jump only when its mounted evidence target is found; keep the panel expanded if that target disappears before activation.
- Preserve focus intent across every collapse path: the destination keeps focus, keyboard jumps focus timeline evidence before unmounting, and outside interaction clears stale status-surface focus ownership.

## Product boundary

Internal reading remains stable: scrolling, selecting, or following Markdown controls inside the expanded output does not collapse it, including a text-selection drag that crosses its boundary or a live nonzero agent-count update during that gesture. Any user interaction that starts outside the output closes it, including composer controls, continued typing or attachment paste in an already-focused composer, timeline/sidebar activation, scrollbar use, and file drop. Pointer- and click-triggered collapse waits until activation completes, including controls that stop propagation, so the layout change cannot move a pressed timeline control before its action runs. Programmatic scrolling does not emit these user-intent events and therefore does not close it. Existing chat-switch, status-clear, and successful-jump transitions remain unchanged.

## Tests

- Focused composer/status and ChatView coverage: 2 files / 73 tests passed.
- Full Web suite: 193 files / 1,588 tests passed.
- `pnpm typecheck`: 10/10 tasks passed, including the Web production build and design-token guardrails.
- The new regression cases cover outside focus, Safari-style pointer activation without button focus, click-only assistive activation through a control that stops propagation, preserved timeline-control activation, already-focused composer typing/Enter and clipboard-file paste, wheel and file-drop intent, internal output scrolling and cross-boundary selection across a live 1-to-2 agent update, failed timeline navigation, keyboard focus transfer, and pointer/drop/click-only collapse followed by a status clear without focus theft.

## QA gap

The current session has no available Browser instance, so real-browser visual/interaction QA could not be captured. The change has no visual styling delta; deterministic DOM coverage verifies the focus and collapse transitions.
