### PR TITLE
feat: add Context Tree setup preview

### DIFF
--- a/packages/server/src/__tests__/bootstrap-config.test.ts
+++ b/packages/server/src/__tests__/bootstrap-config.test.ts
@@ -1,3 +1,4 @@
+import { CONNECT_BOOTSTRAP_CODE_PLACEHOLDER } from "@first-tree/shared";
 import { describe, expect, it } from "vitest";
 import { createTestApp, useTestApp } from "./helpers.js";
 
@@ -10,6 +11,7 @@ describe("GET /bootstrap/config", () => {
     const res = await app.inject({
       method: "GET",
       url: "/api/v1/bootstrap/config",
+      headers: { host: "127.0.0.1:8000", "x-forwarded-proto": "http" },
     });
 
     expect(res.statusCode).toBe(200);
@@ -19,6 +21,12 @@ describe("GET /bootstrap/config", () => {
       // Surfaced so the web can gate channel-scoped UI (e.g. the staging-only
       // "hide agent final text" toggle). Test app defaults to the dev channel.
       channel: "dev",
+      connectBootstrapCommandTemplate: {
+        command:
+          "curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh\n" +
+          `FIRST_TREE_SERVER_URL='http://127.0.0.1:8000' ~/.local/bin/first-tree-staging login ${CONNECT_BOOTSTRAP_CODE_PLACEHOLDER}`,
+        codePlaceholder: CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+      },
       growthLandingPagesEnabled: false,
       authProviders: { google: false, github: true },
     });
@@ -28,11 +36,44 @@ describe("GET /bootstrap/config", () => {
 describe("GET /bootstrap/config — non-dev channel", () => {
   const getApp = useTestApp({ channel: "staging" });
 
-  it("reports the server's configured channel verbatim", async () => {
-    const res = await getApp().inject({ method: "GET", url: "/api/v1/bootstrap/config" });
+  it("reports the channel and server-authored staging connect template", async () => {
+    const res = await getApp().inject({
+      method: "GET",
+      url: "/api/v1/bootstrap/config",
+      headers: { host: "dev.cloud.first-tree.ai", "x-forwarded-proto": "https" },
+    });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json().channel).toBe("staging");
+    expect(res.json()).toMatchObject({
+      channel: "staging",
+      connectBootstrapCommandTemplate: {
+        command:
+          "curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh\n" +
+          `~/.local/bin/first-tree-staging login ${CONNECT_BOOTSTRAP_CODE_PLACEHOLDER}`,
+        codePlaceholder: CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+      },
+    });
+  });
+
+  it("carries deployment mirror and public URL overrides into the preview template", async () => {
+    const app = await createTestApp({
+      channel: "staging",
+      connectBootstrap: { portableDownloadBaseUrl: "https://downloads.example.test/releases/$(id)" },
+    });
+    try {
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/v1/bootstrap/config",
+        headers: { host: "staging.example.test", "x-forwarded-proto": "https" },
+      });
+      expect(res.json().connectBootstrapCommandTemplate.command).toBe(
+        "curl -fsSL 'https://downloads.example.test/releases/$(id)/staging/install.sh' | " +
+          "FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL='https://downloads.example.test/releases/$(id)' sh\n" +
+          `FIRST_TREE_SERVER_URL='https://staging.example.test' ~/.local/bin/first-tree-staging login ${CONNECT_BOOTSTRAP_CODE_PLACEHOLDER}`,
+      );
+    } finally {
+      await app.close();
+    }
   });
 });
 
@@ -46,6 +87,7 @@ describe("GET /bootstrap/config — growth landing flag", () => {
     expect(res.json()).toMatchObject({
       channel: "prod",
       growthLandingPagesEnabled: true,
+      connectBootstrapCommandTemplate: null,
     });
   });
 });

--- a/packages/server/src/__tests__/bootstrap-config.test.ts
+++ b/packages/server/src/__tests__/bootstrap-config.test.ts
@@ -58,7 +58,7 @@ describe("GET /bootstrap/config — non-dev channel", () => {
   it("carries deployment mirror and public URL overrides into the preview template", async () => {
     const app = await createTestApp({
       channel: "staging",
-      connectBootstrap: { portableDownloadBaseUrl: "https://downloads.example.test/releases/$(id)" },
+      connectBootstrap: { portableDownloadBaseUrl: "https://downloads.example.test/releases/$(id)////" },
     });
     try {
       const res = await app.inject({
@@ -68,7 +68,7 @@ describe("GET /bootstrap/config — non-dev channel", () => {
       });
       expect(res.json().connectBootstrapCommandTemplate.command).toBe(
         "curl -fsSL 'https://downloads.example.test/releases/$(id)/staging/install.sh' | " +
-          "FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL='https://downloads.example.test/releases/$(id)' sh\n" +
+          "FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL='https://downloads.example.test/releases/$(id)////' sh\n" +
           `FIRST_TREE_SERVER_URL='https://staging.example.test' ~/.local/bin/first-tree-staging login ${CONNECT_BOOTSTRAP_CODE_PLACEHOLDER}`,
       );
     } finally {

--- a/packages/server/src/api/bootstrap/config.ts
+++ b/packages/server/src/api/bootstrap/config.ts
@@ -1,4 +1,6 @@
+import { CONNECT_BOOTSTRAP_CODE_PLACEHOLDER } from "@first-tree/shared";
 import type { FastifyInstance } from "fastify";
+import { buildServerConnectBootstrapCommand } from "../../services/connect-bootstrap-command.js";
 
 export async function bootstrapConfigRoutes(app: FastifyInstance): Promise<void> {
   /**
@@ -9,7 +11,22 @@ export async function bootstrapConfigRoutes(app: FastifyInstance): Promise<void>
    * (see issue #255). A public bootstrap endpoint can't resolve an
    * installation without a caller, so the field is surfaced as `null`.
    */
-  app.get("/config", async () => {
+  app.get("/config", async (request) => {
+    // The public setup preview always models the hosted staging flow. Build
+    // its non-authenticating template from the same server-owned path as real
+    // connect tokens so deployment mirror/public-URL overrides stay exact.
+    const connectBootstrapCommandTemplate =
+      app.config.channel === "prod"
+        ? null
+        : {
+            command: buildServerConnectBootstrapCommand({
+              app,
+              request,
+              token: CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+              channel: "staging",
+            }).bootstrapCommand,
+            codePlaceholder: CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+          };
     return {
       allowedOrg: null as string | null,
       serverCommandVersion: app.commandVersion(),
@@ -17,6 +34,7 @@ export async function bootstrapConfigRoutes(app: FastifyInstance): Promise<void>
       // the web gate channel-scoped affordances (e.g. the staging-only "hide
       // agent final text" view toggle) without shipping prod-visible dev UI.
       channel: app.config.channel,
+      connectBootstrapCommandTemplate,
       // Product flag for growth landing funnels. Kept separate from release
       // channel so staging/dev do not implicitly expose public campaigns.
       growthLandingPagesEnabled: app.config.growth.landingPagesEnabled,

--- a/packages/server/src/api/me.ts
+++ b/packages/server/src/api/me.ts
@@ -26,6 +26,7 @@ import {
 import { resolveAvatarImageUrl } from "../services/agent.js";
 import * as authService from "../services/auth.js";
 import * as clientService from "../services/client.js";
+import { buildServerConnectBootstrapCommand } from "../services/connect-bootstrap-command.js";
 import { GithubApiError, listUserRepos } from "../services/github-oauth.js";
 import { GithubUserTokenError, getFreshGithubUserToken } from "../services/github-user-token.js";
 import { buildInviteUrl, findActiveByToken, getActiveInvitation, recordRedemption } from "../services/invitation.js";
@@ -54,67 +55,6 @@ import { clientCommandVersionHint } from "./client-command-version.js";
 const onboardingTreeSetupStatusQuerySchema = z.object({
   organizationId: z.string().optional(),
 });
-
-function joinUrl(base: string, path: string): string {
-  return `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
-}
-
-function shellArg(value: string): string {
-  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : shellQuote(value);
-}
-
-function normalizeDownloadBaseUrl(value: string): string {
-  return value.replace(/\/+$/, "");
-}
-
-function normalizeCommandServerUrl(value: string): string {
-  try {
-    return new URL(value).origin;
-  } catch {
-    return value.replace(/\/+$/, "");
-  }
-}
-
-function buildLoginCommand(options: {
-  executable: string;
-  tokenArg: string;
-  serverUrl: string;
-  defaultServerUrl: string;
-}): string {
-  const serverUrl = normalizeCommandServerUrl(options.serverUrl);
-  const prefix = serverUrl === options.defaultServerUrl ? "" : `FIRST_TREE_SERVER_URL=${shellQuote(serverUrl)} `;
-  return `${prefix}${options.executable} login ${options.tokenArg}`;
-}
-
-function buildPortableBootstrapCommand(options: {
-  installerUrl: string;
-  portableDownloadBaseUrl: string;
-  defaultPortableDownloadBaseUrl: string;
-  binName: string;
-  token: string;
-  serverUrl: string;
-  defaultServerUrl: string;
-}): string {
-  const isCustomDownloadBase =
-    normalizeDownloadBaseUrl(options.portableDownloadBaseUrl) !==
-    normalizeDownloadBaseUrl(options.defaultPortableDownloadBaseUrl);
-  const installerUrl = isCustomDownloadBase ? shellQuote(options.installerUrl) : options.installerUrl;
-  const installerEnv = isCustomDownloadBase
-    ? `FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL=${shellQuote(options.portableDownloadBaseUrl)} `
-    : "";
-  const loginCommand = buildLoginCommand({
-    executable: `~/.local/bin/${options.binName}`,
-    tokenArg: shellArg(options.token),
-    serverUrl: options.serverUrl,
-    defaultServerUrl: options.defaultServerUrl,
-  });
-
-  return [`curl -fsSL ${installerUrl} | ${installerEnv}sh`, loginCommand].join("\n");
-}
 
 /**
  * `/me` and self-service organization routes (Class A — User-scoped).
@@ -571,47 +511,11 @@ export async function meRoutes(app: FastifyInstance): Promise<void> {
     const { token, expiresIn } = await authService.generateConnectToken(app.db, userId, app.config.auth, issuer);
     // Web surfaces render the server-provided command directly. Dev is
     // source-only; hosted channels always use their public shell installer.
-    const ch = getChannelConfig(app.config.channel);
-    const command = buildLoginCommand({
-      executable: ch.binName,
-      tokenArg: shellArg(token),
-      serverUrl: issuer,
-      defaultServerUrl: ch.defaultServerUrl,
-    });
-    if (app.config.channel === "dev") {
-      return {
-        token,
-        expiresIn,
-        command,
-        bootstrapCommand: command,
-        installerUrl: null,
-        binName: ch.binName,
-      };
-    }
-
-    const installerPath = ch.portable.publicInstallerPath;
-    const defaultPortableDownloadBaseUrl = ch.portable.downloadBaseUrl;
-    if (installerPath === null || defaultPortableDownloadBaseUrl === null) {
-      throw new Error(`Portable installer metadata is missing for the ${app.config.channel} channel`);
-    }
-    const portableDownloadBaseUrl = app.config.connectBootstrap.portableDownloadBaseUrl;
-    const installerUrl = joinUrl(portableDownloadBaseUrl, installerPath);
-    const bootstrapCommand = buildPortableBootstrapCommand({
-      installerUrl,
-      portableDownloadBaseUrl,
-      defaultPortableDownloadBaseUrl,
-      binName: ch.binName,
-      token,
-      serverUrl: issuer,
-      defaultServerUrl: ch.defaultServerUrl,
-    });
+    const bootstrap = buildServerConnectBootstrapCommand({ app, request, token });
     return {
       token,
       expiresIn,
-      command,
-      bootstrapCommand,
-      installerUrl,
-      binName: ch.binName,
+      ...bootstrap,
     };
   });
 

--- a/packages/server/src/services/connect-bootstrap-command.ts
+++ b/packages/server/src/services/connect-bootstrap-command.ts
@@ -11,7 +11,11 @@ export type ServerConnectBootstrapCommand = {
 };
 
 function joinUrl(base: string, path: string): string {
-  return `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+  let baseEnd = base.length;
+  while (baseEnd > 0 && base.charCodeAt(baseEnd - 1) === 47) baseEnd -= 1;
+  let pathStart = 0;
+  while (pathStart < path.length && path.charCodeAt(pathStart) === 47) pathStart += 1;
+  return `${base.slice(0, baseEnd)}/${path.slice(pathStart)}`;
 }
 
 /**

--- a/packages/server/src/services/connect-bootstrap-command.ts
+++ b/packages/server/src/services/connect-bootstrap-command.ts
@@ -1,0 +1,70 @@
+import { buildLoginCommand, buildPortableBootstrapCommand } from "@first-tree/shared";
+import { type ChannelName, getChannelConfig } from "@first-tree/shared/channel";
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import { resolvePublicUrl } from "../utils/public-url.js";
+
+export type ServerConnectBootstrapCommand = {
+  command: string;
+  bootstrapCommand: string;
+  installerUrl: string | null;
+  binName: string;
+};
+
+function joinUrl(base: string, path: string): string {
+  return `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+/**
+ * Build the deployment-authoritative connect command for a request. Both the
+ * real connect-token response and public non-authenticating preview template
+ * use this path so mirror, channel, binary, and public-server overrides cannot
+ * drift between Web and Server.
+ */
+export function buildServerConnectBootstrapCommand(options: {
+  app: FastifyInstance;
+  request: FastifyRequest;
+  token: string;
+  channel?: ChannelName;
+}): ServerConnectBootstrapCommand {
+  const channel = options.channel ?? options.app.config.channel;
+  const channelConfig = getChannelConfig(channel);
+  const issuer = resolvePublicUrl(options.app, options.request);
+  const command = buildLoginCommand({
+    executable: channelConfig.binName,
+    tokenArg: options.token,
+    serverUrl: issuer,
+    defaultServerUrl: channelConfig.defaultServerUrl,
+  });
+
+  if (channel === "dev") {
+    return {
+      command,
+      bootstrapCommand: command,
+      installerUrl: null,
+      binName: channelConfig.binName,
+    };
+  }
+
+  const installerPath = channelConfig.portable.publicInstallerPath;
+  const defaultPortableDownloadBaseUrl = channelConfig.portable.downloadBaseUrl;
+  if (installerPath === null || defaultPortableDownloadBaseUrl === null) {
+    throw new Error(`Portable installer metadata is missing for the ${channel} channel`);
+  }
+  const portableDownloadBaseUrl = options.app.config.connectBootstrap.portableDownloadBaseUrl;
+  const installerUrl = joinUrl(portableDownloadBaseUrl, installerPath);
+  const bootstrapCommand = buildPortableBootstrapCommand({
+    installerUrl,
+    portableDownloadBaseUrl,
+    defaultPortableDownloadBaseUrl,
+    binName: channelConfig.binName,
+    token: options.token,
+    serverUrl: issuer,
+    defaultServerUrl: channelConfig.defaultServerUrl,
+  });
+  return {
+    command,
+    bootstrapCommand,
+    installerUrl,
+    binName: channelConfig.binName,
+  };
+}

--- a/packages/shared/src/__tests__/connect-bootstrap.test.ts
+++ b/packages/shared/src/__tests__/connect-bootstrap.test.ts
@@ -53,6 +53,32 @@ describe("connect bootstrap commands", () => {
     ).toBe("first-tree login 'FT-X; echo injected'");
   });
 
+  it("normalizes repeated trailing slashes in linear time", () => {
+    const trailingSlashes = "/".repeat(10_000);
+    expect(
+      buildLoginCommand({
+        executable: "first-tree-dev",
+        tokenArg: "FT-CODE",
+        serverUrl: `local-server${trailingSlashes}`,
+        defaultServerUrl: "local-server",
+      }),
+    ).toBe("first-tree-dev login FT-CODE");
+    expect(
+      buildPortableBootstrapCommand({
+        installerUrl: "https://download.first-tree.ai/releases/staging/install.sh",
+        portableDownloadBaseUrl: `https://download.first-tree.ai/releases${trailingSlashes}`,
+        defaultPortableDownloadBaseUrl: "https://download.first-tree.ai/releases",
+        binName: "first-tree-staging",
+        token: "FT-CODE",
+        serverUrl: "https://dev.cloud.first-tree.ai",
+        defaultServerUrl: "https://dev.cloud.first-tree.ai",
+      }),
+    ).toBe(
+      "curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh\n" +
+        "~/.local/bin/first-tree-staging login FT-CODE",
+    );
+  });
+
   it("materializes only a single server-authored placeholder", () => {
     const template = {
       command: `first-tree-staging login ${CONNECT_BOOTSTRAP_CODE_PLACEHOLDER}`,

--- a/packages/shared/src/__tests__/connect-bootstrap.test.ts
+++ b/packages/shared/src/__tests__/connect-bootstrap.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLoginCommand,
+  buildPortableBootstrapCommand,
+  CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+  materializeConnectBootstrapCommand,
+} from "../connect-bootstrap.js";
+
+describe("connect bootstrap commands", () => {
+  it("builds the default hosted portable bootstrap", () => {
+    expect(
+      buildPortableBootstrapCommand({
+        installerUrl: "https://download.first-tree.ai/releases/staging/install.sh",
+        portableDownloadBaseUrl: "https://download.first-tree.ai/releases",
+        defaultPortableDownloadBaseUrl: "https://download.first-tree.ai/releases",
+        binName: "first-tree-staging",
+        token: "FT-CODE",
+        serverUrl: "https://dev.cloud.first-tree.ai",
+        defaultServerUrl: "https://dev.cloud.first-tree.ai",
+      }),
+    ).toBe(
+      "curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh\n" +
+        "~/.local/bin/first-tree-staging login FT-CODE",
+    );
+  });
+
+  it("quotes custom deployment authority inputs", () => {
+    expect(
+      buildPortableBootstrapCommand({
+        installerUrl: "https://downloads.example.test/releases/$(id)/staging/install.sh",
+        portableDownloadBaseUrl: "https://downloads.example.test/releases/$(id)",
+        defaultPortableDownloadBaseUrl: "https://download.first-tree.ai/releases",
+        binName: "first-tree-staging",
+        token: "FT-CODE",
+        serverUrl: "https://preview.example.test/path",
+        defaultServerUrl: "https://dev.cloud.first-tree.ai",
+      }),
+    ).toBe(
+      "curl -fsSL 'https://downloads.example.test/releases/$(id)/staging/install.sh' | " +
+        "FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL='https://downloads.example.test/releases/$(id)' sh\n" +
+        "FIRST_TREE_SERVER_URL='https://preview.example.test' ~/.local/bin/first-tree-staging login FT-CODE",
+    );
+  });
+
+  it("keeps login token arguments shell-safe", () => {
+    expect(
+      buildLoginCommand({
+        executable: "first-tree",
+        tokenArg: "FT-X; echo injected",
+        serverUrl: "https://cloud.first-tree.ai",
+        defaultServerUrl: "https://cloud.first-tree.ai",
+      }),
+    ).toBe("first-tree login 'FT-X; echo injected'");
+  });
+
+  it("materializes only a single server-authored placeholder", () => {
+    const template = {
+      command: `first-tree-staging login ${CONNECT_BOOTSTRAP_CODE_PLACEHOLDER}`,
+      codePlaceholder: CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+    } as const;
+    expect(materializeConnectBootstrapCommand(template, "FT-PREVIEW-STAGING-ADMIN")).toBe(
+      "first-tree-staging login FT-PREVIEW-STAGING-ADMIN",
+    );
+    expect(() => materializeConnectBootstrapCommand(template, "FT-X; echo injected")).toThrow(TypeError);
+    expect(() =>
+      materializeConnectBootstrapCommand({ ...template, command: "first-tree-staging login" }, "FT-X"),
+    ).toThrow(TypeError);
+  });
+});

--- a/packages/shared/src/connect-bootstrap.ts
+++ b/packages/shared/src/connect-bootstrap.ts
@@ -1,0 +1,76 @@
+const SAFE_SHELL_ARG_PATTERN = /^[A-Za-z0-9_@%+=:,./-]+$/;
+
+export const CONNECT_BOOTSTRAP_CODE_PLACEHOLDER = "FIRST_TREE_CONNECT_CODE_PLACEHOLDER";
+
+export type ConnectBootstrapCommandTemplate = {
+  command: string;
+  codePlaceholder: typeof CONNECT_BOOTSTRAP_CODE_PLACEHOLDER;
+};
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function shellArg(value: string): string {
+  return SAFE_SHELL_ARG_PATTERN.test(value) ? value : shellQuote(value);
+}
+
+function normalizeDownloadBaseUrl(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function normalizeCommandServerUrl(value: string): string {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return value.replace(/\/+$/, "");
+  }
+}
+
+export function buildLoginCommand(options: {
+  executable: string;
+  tokenArg: string;
+  serverUrl: string;
+  defaultServerUrl: string;
+}): string {
+  const serverUrl = normalizeCommandServerUrl(options.serverUrl);
+  const prefix = serverUrl === options.defaultServerUrl ? "" : `FIRST_TREE_SERVER_URL=${shellQuote(serverUrl)} `;
+  return `${prefix}${options.executable} login ${shellArg(options.tokenArg)}`;
+}
+
+export function buildPortableBootstrapCommand(options: {
+  installerUrl: string;
+  portableDownloadBaseUrl: string;
+  defaultPortableDownloadBaseUrl: string;
+  binName: string;
+  token: string;
+  serverUrl: string;
+  defaultServerUrl: string;
+}): string {
+  const isCustomDownloadBase =
+    normalizeDownloadBaseUrl(options.portableDownloadBaseUrl) !==
+    normalizeDownloadBaseUrl(options.defaultPortableDownloadBaseUrl);
+  const installerUrl = isCustomDownloadBase ? shellQuote(options.installerUrl) : options.installerUrl;
+  const installerEnv = isCustomDownloadBase
+    ? `FIRST_TREE_PORTABLE_DOWNLOAD_BASE_URL=${shellQuote(options.portableDownloadBaseUrl)} `
+    : "";
+  const loginCommand = buildLoginCommand({
+    executable: `~/.local/bin/${options.binName}`,
+    tokenArg: options.token,
+    serverUrl: options.serverUrl,
+    defaultServerUrl: options.defaultServerUrl,
+  });
+
+  return [`curl -fsSL ${installerUrl} | ${installerEnv}sh`, loginCommand].join("\n");
+}
+
+export function materializeConnectBootstrapCommand(template: ConnectBootstrapCommandTemplate, code: string): string {
+  if (!SAFE_SHELL_ARG_PATTERN.test(code)) {
+    throw new TypeError("A shell-safe connect code is required");
+  }
+  const parts = template.command.split(template.codePlaceholder);
+  if (parts.length !== 2) {
+    throw new TypeError("The connect bootstrap template must contain its code placeholder exactly once");
+  }
+  return `${parts[0]}${code}${parts[1]}`;
+}

--- a/packages/shared/src/connect-bootstrap.ts
+++ b/packages/shared/src/connect-bootstrap.ts
@@ -15,15 +15,21 @@ function shellArg(value: string): string {
   return SAFE_SHELL_ARG_PATTERN.test(value) ? value : shellQuote(value);
 }
 
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
+  return value.slice(0, end);
+}
+
 function normalizeDownloadBaseUrl(value: string): string {
-  return value.replace(/\/+$/, "");
+  return stripTrailingSlashes(value);
 }
 
 function normalizeCommandServerUrl(value: string): string {
   try {
     return new URL(value).origin;
   } catch {
-    return value.replace(/\/+$/, "");
+    return stripTrailingSlashes(value);
   }
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,13 @@ export {
   findAssembledBriefingFingerprint,
 } from "./agent-briefing-guard.js";
 export { canonicalGitRepoUrl } from "./canonical-git-repo-url.js";
+export {
+  buildLoginCommand,
+  buildPortableBootstrapCommand,
+  CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+  type ConnectBootstrapCommandTemplate,
+  materializeConnectBootstrapCommand,
+} from "./connect-bootstrap.js";
 // -- Document review (docloop) anchor building / locating --
 export {
   type BuildDocAnchorInput,

--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -23,10 +23,20 @@ vi.mock("../hooks/pulse-context.js", () => ({
 const serverChannelStateMock = vi.hoisted(() => ({
   channel: "prod" as "dev" | "staging" | "prod" | null,
   settled: true,
+  commandTemplate: {
+    command:
+      "curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh\n" +
+      "~/.local/bin/first-tree-staging login FIRST_TREE_CONNECT_CODE_PLACEHOLDER",
+    codePlaceholder: "FIRST_TREE_CONNECT_CODE_PLACEHOLDER",
+  } as {
+    command: string;
+    codePlaceholder: string;
+  } | null,
 }));
 
 vi.mock("../hooks/use-server-channel.js", () => ({
   useServerChannelState: () => serverChannelStateMock,
+  useContextTreeSetupPreviewBootstrapState: () => serverChannelStateMock,
 }));
 
 vi.mock("../components/ui/toast.js", () => ({
@@ -154,7 +164,9 @@ vi.mock("../pages/settings-github-preview.js", () => ({
 }));
 vi.mock("../pages/onboarding-preview.js", () => ({ OnboardingPreviewPage: () => <div>onboarding preview</div> }));
 vi.mock("../pages/context-tree-setup-preview.js", () => ({
-  ContextTreeSetupPreviewPage: () => <div>context tree setup preview</div>,
+  ContextTreeSetupPreviewPage: () => (
+    <div data-testid="context-tree-setup-preview-mock">context tree setup preview</div>
+  ),
 }));
 vi.mock("../pages/team-preview.js", () => ({ TeamPreviewPage: () => <div>team preview</div> }));
 vi.mock("../pages/resources-preview.js", () => ({ ResourcesPreviewPage: () => <div>resources preview</div> }));
@@ -210,6 +222,12 @@ describe("App routes", () => {
     setViewportWidth(1280);
     serverChannelStateMock.channel = "prod";
     serverChannelStateMock.settled = true;
+    serverChannelStateMock.commandTemplate = {
+      command:
+        "curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh\n" +
+        "~/.local/bin/first-tree-staging login FIRST_TREE_CONNECT_CODE_PLACEHOLDER",
+      codePlaceholder: "FIRST_TREE_CONNECT_CODE_PLACEHOLDER",
+    };
   });
 
   afterEach(async () => {
@@ -479,6 +497,23 @@ describe("App routes", () => {
     expect(await renderAppAt("/preview/context-tree-setup", false)).toContain("context tree setup preview");
     await resetRenderedApp();
 
+    serverChannelStateMock.commandTemplate = null;
+    const reloadSpy = vi.spyOn(window.location, "reload").mockImplementation(() => undefined);
+    const missingAuthority = await renderAppAt("/preview/context-tree-setup", false);
+    expect(missingAuthority).toContain("Preview unavailable");
+    expect(document.querySelector('[data-testid="context-tree-setup-preview-mock"]')).toBeNull();
+    const reloadButton = document.querySelector<HTMLButtonElement>("button");
+    expect(reloadButton?.textContent).toBe("Reload preview");
+    await act(async () => reloadButton?.click());
+    expect(reloadSpy).toHaveBeenCalledOnce();
+    reloadSpy.mockRestore();
+    expect(window.location.pathname).toBe("/preview/context-tree-setup");
+    await resetRenderedApp();
+
+    serverChannelStateMock.commandTemplate = {
+      command: "first-tree-staging login FIRST_TREE_CONNECT_CODE_PLACEHOLDER",
+      codePlaceholder: "FIRST_TREE_CONNECT_CODE_PLACEHOLDER",
+    };
     serverChannelStateMock.settled = false;
     const pendingRoute = await renderAppAt("/preview/context-tree-setup", false);
     expect(pendingRoute).not.toContain("context tree setup preview");

--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -153,6 +153,9 @@ vi.mock("../pages/settings-github-preview.js", () => ({
   SettingsGithubPreviewPage: () => <div>settings github preview</div>,
 }));
 vi.mock("../pages/onboarding-preview.js", () => ({ OnboardingPreviewPage: () => <div>onboarding preview</div> }));
+vi.mock("../pages/context-tree-setup-preview.js", () => ({
+  ContextTreeSetupPreviewPage: () => <div>context tree setup preview</div>,
+}));
 vi.mock("../pages/team-preview.js", () => ({ TeamPreviewPage: () => <div>team preview</div> }));
 vi.mock("../pages/resources-preview.js", () => ({ ResourcesPreviewPage: () => <div>resources preview</div> }));
 vi.mock("../pages/agent-detail-preview.js", () => ({ AgentDetailPreviewPage: () => <div>agent detail preview</div> }));
@@ -466,5 +469,34 @@ describe("App routes", () => {
     const productionPreview = await renderAppAt("/preview/styleguide", false);
     expect(productionPreview).toContain("styleguide preview");
     expect(productionPreview).not.toContain("context preview");
+  });
+
+  it("exposes Context Tree setup only in development and on the staging channel", async () => {
+    expect(await renderAppAt("/preview/context-tree-setup")).toContain("context tree setup preview");
+    await resetRenderedApp();
+
+    serverChannelStateMock.channel = "staging";
+    expect(await renderAppAt("/preview/context-tree-setup", false)).toContain("context tree setup preview");
+    await resetRenderedApp();
+
+    serverChannelStateMock.settled = false;
+    const pendingRoute = await renderAppAt("/preview/context-tree-setup", false);
+    expect(pendingRoute).not.toContain("context tree setup preview");
+    expect(window.location.pathname).toBe("/preview/context-tree-setup");
+    await resetRenderedApp();
+
+    serverChannelStateMock.settled = true;
+    serverChannelStateMock.channel = null;
+    const unknownRoute = await renderAppAt("/preview/context-tree-setup", false);
+    expect(unknownRoute).toContain("workspace page");
+    expect(unknownRoute).not.toContain("context tree setup preview");
+    expect(window.location.pathname).toBe("/");
+    await resetRenderedApp();
+
+    serverChannelStateMock.channel = "prod";
+    const productionRoute = await renderAppAt("/preview/context-tree-setup", false);
+    expect(productionRoute).toContain("workspace page");
+    expect(productionRoute).not.toContain("context tree setup preview");
+    expect(window.location.pathname).toBe("/");
   });
 });

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { lazy, Suspense, useEffect } from "react";
+import { lazy, type ReactNode, Suspense, useEffect } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router";
 import { RouteTracker } from "./analytics.js";
 import { AuthProvider } from "./auth/auth-context.js";
@@ -153,6 +153,15 @@ const SettingsGithubPreviewPage = import.meta.env.DEV
     )
   : null;
 
+// Public fixture preview for the BYO Context Tree handoff. It is compiled into
+// hosted builds so staging can expose it, but the route gate below fails closed
+// on production and unknown channels. It has no auth or backend mutations.
+const ContextTreeSetupPreviewPage = lazy(() =>
+  import("./pages/context-tree-setup-preview.js").then((module) => ({
+    default: module.ContextTreeSetupPreviewPage,
+  })),
+);
+
 // Living design-system reference (companion to DESIGN.md). Unlike the previews
 // above this ships in prod too, so it can be opened on a deployed URL — it has
 // no auth-gated data, only tokens and `components/ui` primitives.
@@ -178,6 +187,16 @@ export function App() {
               {/* Public: the connect-code install popup lands here to auto-close. */}
               <Route path="/onboarding/connected" element={<GithubConnectedPage />} />
               <Route path="/invite/:token" element={<InviteAcceptPage />} />
+              <Route
+                path="/preview/context-tree-setup"
+                element={
+                  <StagingPreviewGate>
+                    <Suspense fallback={null}>
+                      <ContextTreeSetupPreviewPage />
+                    </Suspense>
+                  </StagingPreviewGate>
+                }
+              />
               {ContextPreviewPage ? (
                 <Route
                   path="/preview/context"
@@ -481,6 +500,13 @@ type MobileExperienceState = {
 function AdminRedirect() {
   const location = useLocation();
   return <Navigate to={`/team${location.hash}`} replace />;
+}
+
+function StagingPreviewGate({ children }: { children: ReactNode }) {
+  const { channel, settled } = useServerChannelState();
+  if (!settled) return null;
+  if (!import.meta.env.DEV && channel !== "staging") return <Navigate to="/" replace />;
+  return children;
 }
 
 function LegacyUserSettingsRedirect() {

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -1,13 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { lazy, type ReactNode, Suspense, useEffect } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router";
 import { RouteTracker } from "./analytics.js";
 import { AuthProvider } from "./auth/auth-context.js";
 import { RequireAuth } from "./auth/require-auth.js";
 import { Layout } from "./components/layout.js";
+import { Button } from "./components/ui/button.js";
 import { ToastProvider } from "./components/ui/toast.js";
 import { PulseProvider } from "./hooks/pulse-context.js";
-import { useServerChannelState } from "./hooks/use-server-channel.js";
+import { useContextTreeSetupPreviewBootstrapState, useServerChannelState } from "./hooks/use-server-channel.js";
 import { ProfileTab } from "./pages/agent-detail/profile-tab.js";
 import { PromptTab } from "./pages/agent-detail/prompt-tab.js";
 import { RepositoriesTab } from "./pages/agent-detail/repositories-tab.js";
@@ -187,16 +188,7 @@ export function App() {
               {/* Public: the connect-code install popup lands here to auto-close. */}
               <Route path="/onboarding/connected" element={<GithubConnectedPage />} />
               <Route path="/invite/:token" element={<InviteAcceptPage />} />
-              <Route
-                path="/preview/context-tree-setup"
-                element={
-                  <StagingPreviewGate>
-                    <Suspense fallback={null}>
-                      <ContextTreeSetupPreviewPage />
-                    </Suspense>
-                  </StagingPreviewGate>
-                }
-              />
+              <Route path="/preview/context-tree-setup" element={<ContextTreeSetupPreviewRoute />} />
               {ContextPreviewPage ? (
                 <Route
                   path="/preview/context"
@@ -502,11 +494,33 @@ function AdminRedirect() {
   return <Navigate to={`/team${location.hash}`} replace />;
 }
 
-function StagingPreviewGate({ children }: { children: ReactNode }) {
-  const { channel, settled } = useServerChannelState();
+function ContextTreeSetupPreviewRoute() {
+  const { channel, commandTemplate, settled } = useContextTreeSetupPreviewBootstrapState();
   if (!settled) return null;
   if (!import.meta.env.DEV && channel !== "staging") return <Navigate to="/" replace />;
-  return children;
+  if (!commandTemplate) return <ContextTreeSetupPreviewUnavailable />;
+  return (
+    <Suspense fallback={null}>
+      <ContextTreeSetupPreviewPage bootstrapCommandTemplate={commandTemplate} />
+    </Suspense>
+  );
+}
+
+function ContextTreeSetupPreviewUnavailable() {
+  return (
+    <main className="grid min-h-screen place-items-center bg-background p-6 text-foreground">
+      <section className="w-full max-w-lg rounded-[var(--radius-panel)] border border-border bg-card p-6 text-center sm:p-8">
+        <p className="text-label font-semibold uppercase tracking-wide text-fg-3">Context Tree setup preview</p>
+        <h1 className="mt-2 text-title font-semibold">Preview unavailable</h1>
+        <p className="mx-auto mt-3 max-w-md text-body text-fg-2">
+          This deployment has not published its setup command yet. Reload after the staging update completes.
+        </p>
+        <Button type="button" className="mt-5" onClick={() => window.location.reload()}>
+          Reload preview
+        </Button>
+      </section>
+    </main>
+  );
 }
 
 function LegacyUserSettingsRedirect() {

--- a/packages/web/src/hooks/__tests__/use-server-channel.test.ts
+++ b/packages/web/src/hooks/__tests__/use-server-channel.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { CONNECT_BOOTSTRAP_CODE_PLACEHOLDER } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -8,7 +9,9 @@ import { api } from "../../api/client.js";
 import {
   extractAuthProviderAvailability,
   extractChannel,
+  extractConnectBootstrapCommandTemplate,
   extractGrowthLandingPagesEnabled,
+  useContextTreeSetupPreviewBootstrapState,
   useGrowthLandingPagesEnabled,
   useGrowthLandingPagesState,
   useServerChannelState,
@@ -25,6 +28,7 @@ Object.assign(window, { IS_REACT_ACT_ENVIRONMENT: true });
 
 type ObservedBootstrap = {
   channel: ReturnType<typeof useServerChannelState>;
+  contextTreeSetup: ReturnType<typeof useContextTreeSetupPreviewBootstrapState>;
   growth: ReturnType<typeof useGrowthLandingPagesState>;
   growthEnabled: boolean;
 };
@@ -102,10 +106,42 @@ describe("extractAuthProviderAvailability", () => {
   });
 });
 
+describe("extractConnectBootstrapCommandTemplate", () => {
+  const template = {
+    command: `first-tree-staging login ${CONNECT_BOOTSTRAP_CODE_PLACEHOLDER}`,
+    codePlaceholder: CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+  };
+
+  it("accepts a single server-authored connect-code placeholder", () => {
+    expect(extractConnectBootstrapCommandTemplate({ connectBootstrapCommandTemplate: template })).toEqual(template);
+  });
+
+  it("fails closed for missing, duplicated, or unknown placeholders", () => {
+    expect(extractConnectBootstrapCommandTemplate({})).toBeNull();
+    expect(
+      extractConnectBootstrapCommandTemplate({
+        connectBootstrapCommandTemplate: {
+          ...template,
+          command: `${template.command} ${CONNECT_BOOTSTRAP_CODE_PLACEHOLDER}`,
+        },
+      }),
+    ).toBeNull();
+    expect(
+      extractConnectBootstrapCommandTemplate({
+        connectBootstrapCommandTemplate: { command: template.command, codePlaceholder: "UNKNOWN" },
+      }),
+    ).toBeNull();
+  });
+});
+
 describe("server bootstrap hooks", () => {
   it("reads channel and growth flags from the public bootstrap config", async () => {
     vi.mocked(api.get).mockResolvedValueOnce({
       channel: "staging",
+      connectBootstrapCommandTemplate: {
+        command: `first-tree-staging login ${CONNECT_BOOTSTRAP_CODE_PLACEHOLDER}`,
+        codePlaceholder: CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+      },
       growthLandingPagesEnabled: true,
       authProviders: { google: true, github: true },
     });
@@ -114,6 +150,14 @@ describe("server bootstrap hooks", () => {
 
     expect(api.get).toHaveBeenCalledWith("/bootstrap/config");
     expect(observed.channel).toEqual({ channel: "staging", settled: true });
+    expect(observed.contextTreeSetup).toEqual({
+      channel: "staging",
+      commandTemplate: {
+        command: `first-tree-staging login ${CONNECT_BOOTSTRAP_CODE_PLACEHOLDER}`,
+        codePlaceholder: CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+      },
+      settled: true,
+    });
     expect(observed.growth).toEqual({ enabled: true, settled: true });
     expect(observed.growthEnabled).toBe(true);
   });
@@ -124,6 +168,7 @@ describe("server bootstrap hooks", () => {
     const observed = await renderBootstrapProbe();
 
     expect(observed.channel).toEqual({ channel: null, settled: true });
+    expect(observed.contextTreeSetup).toEqual({ channel: null, commandTemplate: null, settled: true });
     expect(observed.growth).toEqual({ enabled: false, settled: true });
     expect(observed.growthEnabled).toBe(false);
   });
@@ -135,6 +180,7 @@ async function renderBootstrapProbe(): Promise<ObservedBootstrap> {
   function Probe(): null {
     observedRef.current = {
       channel: useServerChannelState(),
+      contextTreeSetup: useContextTreeSetupPreviewBootstrapState(),
       growth: useGrowthLandingPagesState(),
       growthEnabled: useGrowthLandingPagesEnabled(),
     };

--- a/packages/web/src/hooks/use-server-channel.ts
+++ b/packages/web/src/hooks/use-server-channel.ts
@@ -1,10 +1,16 @@
-import { type AuthProviderAvailability, authProviderAvailabilitySchema } from "@first-tree/shared";
+import {
+  type AuthProviderAvailability,
+  authProviderAvailabilitySchema,
+  CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+  type ConnectBootstrapCommandTemplate,
+} from "@first-tree/shared";
 import type { ChannelName } from "@first-tree/shared/channel";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../api/client.js";
 
 type ServerBootstrapConfig = {
   channel: ChannelName | null;
+  connectBootstrapCommandTemplate: ConnectBootstrapCommandTemplate | null;
   growthLandingPagesEnabled: boolean;
   authProviders: AuthProviderAvailability;
 };
@@ -44,9 +50,23 @@ export function extractAuthProviderAvailability(data: unknown): AuthProviderAvai
   return result.success ? result.data : { google: false, github: false };
 }
 
+export function extractConnectBootstrapCommandTemplate(data: unknown): ConnectBootstrapCommandTemplate | null {
+  if (typeof data !== "object" || data === null || !("connectBootstrapCommandTemplate" in data)) return null;
+  const template = data.connectBootstrapCommandTemplate;
+  if (typeof template !== "object" || template === null) return null;
+  if (!("command" in template) || typeof template.command !== "string") return null;
+  if (!("codePlaceholder" in template) || template.codePlaceholder !== CONNECT_BOOTSTRAP_CODE_PLACEHOLDER) return null;
+  if (template.command.split(CONNECT_BOOTSTRAP_CODE_PLACEHOLDER).length !== 2) return null;
+  return {
+    command: template.command,
+    codePlaceholder: CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+  };
+}
+
 function extractServerBootstrapConfig(data: unknown): ServerBootstrapConfig {
   return {
     channel: extractChannel(data),
+    connectBootstrapCommandTemplate: extractConnectBootstrapCommandTemplate(data),
     growthLandingPagesEnabled: extractGrowthLandingPagesEnabled(data),
     authProviders: extractAuthProviderAvailability(data),
   };
@@ -84,6 +104,19 @@ function useServerBootstrapConfig(): { config: ServerBootstrapConfig | null; set
 export function useServerChannelState(): { channel: ChannelName | null; settled: boolean } {
   const { config, settled } = useServerBootstrapConfig();
   return { channel: config?.channel ?? null, settled };
+}
+
+export function useContextTreeSetupPreviewBootstrapState(): {
+  channel: ChannelName | null;
+  commandTemplate: ConnectBootstrapCommandTemplate | null;
+  settled: boolean;
+} {
+  const { config, settled } = useServerBootstrapConfig();
+  return {
+    channel: config?.channel ?? null,
+    commandTemplate: config?.connectBootstrapCommandTemplate ?? null,
+    settled,
+  };
 }
 
 /**

--- a/packages/web/src/pages/__tests__/context-tree-setup-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/context-tree-setup-preview.test.tsx
@@ -209,6 +209,71 @@ describe("Context Tree setup preview handoff", () => {
     );
   });
 
+  it("keeps expiry scoped to each role when only Member regenerates", async () => {
+    const container = await renderPreview("/preview/context-tree-setup?role=admin&code=expired&controls=1");
+    const activeAdmin = container.querySelector('a[aria-current="page"]') as HTMLAnchorElement | null;
+    expect(activeAdmin?.href).toContain("code=expired");
+
+    await act(async () => activeAdmin?.click());
+    await flush();
+    expect(container.querySelector('[data-testid="location-probe"]')?.textContent).toContain("code=expired");
+    expect(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Fixture expired"))
+        ?.disabled,
+    ).toBe(true);
+
+    const memberLink = [...container.querySelectorAll("a")].find((link) => link.textContent === "Member");
+    await act(async () => memberLink?.click());
+    await flush();
+    expect(container.querySelector('[data-context-tree-setup-preview="member"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="location-probe"]')?.textContent).toContain("code=expired");
+    expect(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Fixture expired"))
+        ?.disabled,
+    ).toBe(true);
+
+    await clickButton(container, "Generate new fixture");
+    expect(container.textContent).toContain("FT-PREVIEW-STAGING-1-MEMBER");
+    expect(container.querySelector('[data-testid="location-probe"]')?.textContent).not.toContain("code=expired");
+
+    const adminLink = [...container.querySelectorAll("a")].find((link) => link.textContent === "Admin");
+    await act(async () => adminLink?.click());
+    await flush();
+    expect(container.querySelector('[data-context-tree-setup-preview="admin"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="location-probe"]')?.textContent).toContain("code=expired");
+    expect(container.textContent).toContain("FT-PREVIEW-STAGING-ADMIN");
+    expect(container.textContent).not.toContain("FT-PREVIEW-STAGING-1-ADMIN");
+    expect(
+      [...container.querySelectorAll("button")].find((button) => button.textContent?.includes("Fixture expired"))
+        ?.disabled,
+    ).toBe(true);
+  });
+
+  it("preserves regenerated fixture identity without stealing focus on role return", async () => {
+    const container = await renderPreview("/preview/context-tree-setup?role=admin&code=expired&controls=1");
+
+    await clickButton(container, "Generate new fixture");
+    expect(container.textContent).toContain("FT-PREVIEW-STAGING-1-ADMIN");
+
+    const memberLink = [...container.querySelectorAll("a")].find((link) => link.textContent === "Member");
+    await act(async () => memberLink?.click());
+    await flush();
+    expect(container.querySelector('[data-context-tree-setup-preview="member"]')).not.toBeNull();
+    expect(container.textContent).toContain("FT-PREVIEW-STAGING-MEMBER");
+    expect(container.textContent).not.toContain("FT-PREVIEW-STAGING-1-MEMBER");
+
+    const adminLink = [...container.querySelectorAll("a")].find(
+      (link) => link.textContent === "Admin",
+    ) as HTMLAnchorElement | undefined;
+    adminLink?.focus();
+    await act(async () => adminLink?.click());
+    await flush();
+    expect(container.querySelector('[data-context-tree-setup-preview="admin"]')).not.toBeNull();
+    expect(container.textContent).toContain("FT-PREVIEW-STAGING-1-ADMIN");
+    expect(container.textContent).not.toContain("FT-PREVIEW-STAGING-ADMIN");
+    expect(document.activeElement).toBe(adminLink);
+  });
+
   it("announces clipboard rejection and focuses the opened fallback", async () => {
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,

--- a/packages/web/src/pages/__tests__/context-tree-setup-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/context-tree-setup-preview.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ContextTreeSetupPreviewPage } from "../context-tree-setup-preview.js";
+import {
+  contextTreeSetupPreviewModel,
+  normalizeContextTreeSetupPreviewQuery,
+  setupPreviewBootstrapCommand,
+  setupPreviewCode,
+} from "../context-tree-setup-preview-model.js";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const roots: Root[] = [];
+
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location-probe">{`${location.pathname}${location.search}`}</output>;
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function renderPreview(entry: string): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={[entry]}>
+        <Routes>
+          <Route path="/preview/context-tree-setup" element={<ContextTreeSetupPreviewPage />} />
+        </Routes>
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+  });
+  await flush();
+  return container;
+}
+
+async function clickButton(container: ParentNode, label: string): Promise<HTMLButtonElement> {
+  const button = [...container.querySelectorAll("button")].find((candidate) => candidate.textContent?.includes(label));
+  if (!button) throw new Error(`Missing button: ${label}`);
+  await act(async () => {
+    button.click();
+  });
+  await flush();
+  return button;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await act(async () => root.unmount());
+  }
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("Context Tree setup preview model", () => {
+  it("normalizes role, expiry, and review controls without accepting duplicate state", () => {
+    expect(normalizeContextTreeSetupPreviewQuery("?role=member&code=expired&controls=1")).toMatchObject({
+      role: "member",
+      expired: true,
+      controls: true,
+      changed: false,
+    });
+    expect(
+      normalizeContextTreeSetupPreviewQuery("?role=member&role=admin&code=expired&code=x&controls=2"),
+    ).toMatchObject({
+      role: "admin",
+      expired: false,
+      controls: false,
+      search: "role=admin",
+      changed: true,
+    });
+    expect(normalizeContextTreeSetupPreviewQuery("?role=&code=x&controls=")).toMatchObject({
+      role: "admin",
+      expired: false,
+      controls: false,
+      search: "role=admin",
+      changed: true,
+    });
+  });
+
+  it("uses a strict preview fixture grammar and the exact two-line staging bootstrap", () => {
+    const command = setupPreviewBootstrapCommand(setupPreviewCode("admin"));
+    expect(command.split("\n")).toEqual([
+      "curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh",
+      "~/.local/bin/first-tree-staging login FT-PREVIEW-STAGING-ADMIN",
+    ]);
+    expect(() => setupPreviewBootstrapCommand("FT-X; echo injected")).toThrow(TypeError);
+    expect(() => setupPreviewBootstrapCommand("FT-PREVIEW-STAGING-ADMIN\nwhoami")).toThrow(TypeError);
+  });
+
+  it("keeps Admin and Member prompts inside their authority boundaries", () => {
+    const admin = contextTreeSetupPreviewModel("admin").prompt;
+    const member = contextTreeSetupPreviewModel("member").prompt;
+
+    expect(admin).toContain("set up Context Tree for Gandy's team");
+    const adminSequence = [
+      admin.indexOf("Run tree init to initialize and bind the Context Tree"),
+      admin.indexOf("Install or connect the First Tree GitHub App"),
+      admin.indexOf("grant it only the exact Context Tree repository"),
+      admin.indexOf("Create a reviewer Agent only if automatic Review is enabled"),
+      admin.indexOf("Invite the team"),
+    ];
+    expect(adminSequence.every((position) => position >= 0)).toBe(true);
+    expect(adminSequence).toEqual([...adminSequence].sort((a, b) => a - b));
+    expect(admin).toContain("base bootstrap and ordinary setup must not create a First Tree Agent");
+    expect(member).toContain("Verify an exact read of the Team's shared Context Tree");
+    expect(member).not.toMatch(/tree init|GitHub App|repository grant|reviewer Agent/i);
+    expect(admin).toContain("fixture code does not authenticate");
+    expect(member).toContain("fixture code does not authenticate");
+  });
+});
+
+describe("Context Tree setup preview handoff", () => {
+  it("renders the Admin setup sequence without provider selection", async () => {
+    const container = await renderPreview("/preview/context-tree-setup?role=admin");
+    const text = container.textContent ?? "";
+
+    expect(text).toContain("Gandy's team is ready");
+    expect(text).toContain("initializes and binds the Tree first");
+    expect(text).toContain("install or connect the App and grant the exact Tree repository");
+    expect(text).toContain("Only automatic Review creates a reviewer Agent");
+    expect(text).toContain("The final step is your team invite link");
+    expect(text).not.toMatch(/choose (Claude Code|Codex)|select (Claude Code|Codex)/i);
+    expect(text).toContain("Computer registration and daemon startup are best effort");
+    expect(text).toContain("this bootstrap does not create a First Tree Agent");
+
+    const sequence = [
+      text.indexOf("initializes and binds"),
+      text.indexOf("install or connect the App"),
+      text.indexOf("Only automatic Review"),
+      text.indexOf("team invite link"),
+    ];
+    expect(sequence.every((position) => position >= 0)).toBe(true);
+    expect(sequence).toEqual([...sequence].sort((a, b) => a - b));
+  });
+
+  it("keeps Member setup personal and requires an exact Tree read", async () => {
+    const container = await renderPreview("/preview/context-tree-setup?role=member");
+    const text = container.textContent ?? "";
+
+    expect(text).toContain("You joined Gandy's team");
+    expect(text).toContain("Verify an exact read of the Team's shared Context Tree");
+    expect(text).toContain("This handoff only installs, signs in, and verifies your exact Tree read");
+    expect(text).not.toContain("initializes and binds the Tree first");
+    expect(text).not.toContain("Only automatic Review creates a reviewer Agent");
+    expect(text).not.toContain("team invite link");
+    expect(text).not.toMatch(/tree init|GitHub App|repo(?:sitory)? grant|reviewer Agent/i);
+  });
+
+  it("keeps both terminal fallbacks at exactly two synchronized lines", async () => {
+    for (const role of ["admin", "member"] as const) {
+      const container = await renderPreview(`/preview/context-tree-setup?role=${role}`);
+      await clickButton(container, "Prefer a terminal command?");
+      const command = container.querySelector('[data-testid="terminal-bootstrap-command"]')?.textContent ?? "";
+      const prompt = container.querySelector('[data-testid="setup-prompt"]')?.textContent ?? "";
+
+      expect(command.split("\n")).toHaveLength(2);
+      expect(prompt).toContain(command);
+      expect(command).toContain(`FT-PREVIEW-STAGING-${role.toUpperCase()}`);
+    }
+  });
+
+  it("replaces an expired fixture everywhere, cleans the URL, and restores focus", async () => {
+    const container = await renderPreview("/preview/context-tree-setup?role=admin&code=expired");
+    const oldCode = "FT-PREVIEW-STAGING-ADMIN";
+
+    expect(container.textContent).toContain(oldCode);
+    const copyButton = [...container.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Fixture expired"),
+    );
+    expect(copyButton?.disabled).toBe(true);
+
+    await clickButton(container, "Generate new fixture");
+    expect(document.activeElement?.textContent).toContain("Copy setup prompt");
+    await clickButton(container, "Prefer a terminal command?");
+
+    const newCode = "FT-PREVIEW-STAGING-1-ADMIN";
+    const setupPrompt = container.querySelector('[data-testid="setup-prompt"]')?.textContent ?? "";
+    const agentPrompt = container.querySelector('[data-testid="agent-prompt"]')?.textContent ?? "";
+    const terminal = container.querySelector('[data-testid="terminal-bootstrap-command"]')?.textContent ?? "";
+    expect(setupPrompt).toContain(newCode);
+    expect(agentPrompt).toContain(newCode);
+    expect(terminal).toContain(newCode);
+    expect(container.textContent).not.toContain(oldCode);
+    expect(container.querySelector('[data-testid="location-probe"]')?.textContent).toBe(
+      "/preview/context-tree-setup?role=admin",
+    );
+  });
+
+  it("announces clipboard rejection and focuses the opened fallback", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    const container = await renderPreview("/preview/context-tree-setup?role=member");
+
+    await clickButton(container, "Copy connection prompt");
+
+    expect(container.textContent).toContain("Copy failed. The terminal fallback is open for manual copy.");
+    const fallback = container.querySelector('[data-testid="terminal-bootstrap-command"]');
+    expect(fallback?.textContent?.split("\n")).toHaveLength(2);
+    expect(document.activeElement).toBe(fallback);
+  });
+
+  it("canonicalizes invalid direct links and exposes role controls only on request", async () => {
+    const container = await renderPreview(
+      "/preview/context-tree-setup?role=member&role=admin&code=expired&code=x&controls=2",
+    );
+
+    expect(container.querySelector('[data-context-tree-setup-preview="admin"]')).not.toBeNull();
+    expect(container.querySelector('nav[aria-label="Context Tree setup preview role"]')).toBeNull();
+    expect(container.querySelector('[data-testid="location-probe"]')?.textContent).toBe(
+      "/preview/context-tree-setup?role=admin",
+    );
+
+    const controlled = await renderPreview("/preview/context-tree-setup?role=member&controls=1");
+    expect(controlled.querySelector('nav[aria-label="Context Tree setup preview role"]')).not.toBeNull();
+  });
+});

--- a/packages/web/src/pages/__tests__/context-tree-setup-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/context-tree-setup-preview.test.tsx
@@ -262,9 +262,9 @@ describe("Context Tree setup preview handoff", () => {
     expect(container.textContent).toContain("FT-PREVIEW-STAGING-MEMBER");
     expect(container.textContent).not.toContain("FT-PREVIEW-STAGING-1-MEMBER");
 
-    const adminLink = [...container.querySelectorAll("a")].find(
-      (link) => link.textContent === "Admin",
-    ) as HTMLAnchorElement | undefined;
+    const adminLink = [...container.querySelectorAll("a")].find((link) => link.textContent === "Admin") as
+      | HTMLAnchorElement
+      | undefined;
     adminLink?.focus();
     await act(async () => adminLink?.click());
     await flush();

--- a/packages/web/src/pages/__tests__/context-tree-setup-preview.test.tsx
+++ b/packages/web/src/pages/__tests__/context-tree-setup-preview.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { CONNECT_BOOTSTRAP_CODE_PLACEHOLDER, type ConnectBootstrapCommandTemplate } from "@first-tree/shared";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router";
@@ -15,6 +16,12 @@ import {
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const roots: Root[] = [];
+const bootstrapCommandTemplate: ConnectBootstrapCommandTemplate = {
+  command:
+    "curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh\n" +
+    `~/.local/bin/first-tree-staging login ${CONNECT_BOOTSTRAP_CODE_PLACEHOLDER}`,
+  codePlaceholder: CONNECT_BOOTSTRAP_CODE_PLACEHOLDER,
+};
 
 function LocationProbe() {
   const location = useLocation();
@@ -38,7 +45,10 @@ async function renderPreview(entry: string): Promise<HTMLElement> {
     root.render(
       <MemoryRouter initialEntries={[entry]}>
         <Routes>
-          <Route path="/preview/context-tree-setup" element={<ContextTreeSetupPreviewPage />} />
+          <Route
+            path="/preview/context-tree-setup"
+            element={<ContextTreeSetupPreviewPage bootstrapCommandTemplate={bootstrapCommandTemplate} />}
+          />
         </Routes>
         <LocationProbe />
       </MemoryRouter>,
@@ -101,18 +111,20 @@ describe("Context Tree setup preview model", () => {
   });
 
   it("uses a strict preview fixture grammar and the exact two-line staging bootstrap", () => {
-    const command = setupPreviewBootstrapCommand(setupPreviewCode("admin"));
+    const command = setupPreviewBootstrapCommand(setupPreviewCode("admin"), bootstrapCommandTemplate);
     expect(command.split("\n")).toEqual([
       "curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh",
       "~/.local/bin/first-tree-staging login FT-PREVIEW-STAGING-ADMIN",
     ]);
-    expect(() => setupPreviewBootstrapCommand("FT-X; echo injected")).toThrow(TypeError);
-    expect(() => setupPreviewBootstrapCommand("FT-PREVIEW-STAGING-ADMIN\nwhoami")).toThrow(TypeError);
+    expect(() => setupPreviewBootstrapCommand("FT-X; echo injected", bootstrapCommandTemplate)).toThrow(TypeError);
+    expect(() => setupPreviewBootstrapCommand("FT-PREVIEW-STAGING-ADMIN\nwhoami", bootstrapCommandTemplate)).toThrow(
+      TypeError,
+    );
   });
 
   it("keeps Admin and Member prompts inside their authority boundaries", () => {
-    const admin = contextTreeSetupPreviewModel("admin").prompt;
-    const member = contextTreeSetupPreviewModel("member").prompt;
+    const admin = contextTreeSetupPreviewModel("admin", bootstrapCommandTemplate).prompt;
+    const member = contextTreeSetupPreviewModel("member", bootstrapCommandTemplate).prompt;
 
     expect(admin).toContain("set up Context Tree for Gandy's team");
     const adminSequence = [
@@ -283,9 +295,11 @@ describe("Context Tree setup preview handoff", () => {
 
     await clickButton(container, "Copy connection prompt");
 
-    expect(container.textContent).toContain("Copy failed. The terminal fallback is open for manual copy.");
-    const fallback = container.querySelector('[data-testid="terminal-bootstrap-command"]');
-    expect(fallback?.textContent?.split("\n")).toHaveLength(2);
+    expect(container.textContent).toContain("Copy failed. The full prompt is open below for manual copy.");
+    const fallback = container.querySelector('[data-testid="manual-copy-prompt"]');
+    const primaryPrompt = container.querySelector('[data-testid="setup-prompt"]');
+    expect(fallback?.textContent).toBe(primaryPrompt?.textContent);
+    expect(container.querySelector('[data-testid="terminal-bootstrap-command"]')).toBeNull();
     expect(document.activeElement).toBe(fallback);
   });
 

--- a/packages/web/src/pages/context-tree-setup-preview-model.ts
+++ b/packages/web/src/pages/context-tree-setup-preview-model.ts
@@ -1,8 +1,9 @@
+import { type ConnectBootstrapCommandTemplate, materializeConnectBootstrapCommand } from "@first-tree/shared";
+
 export const CONTEXT_TREE_SETUP_PREVIEW_ROLES = ["admin", "member"] as const;
 
 export type ContextTreeSetupPreviewRole = (typeof CONTEXT_TREE_SETUP_PREVIEW_ROLES)[number];
 
-const INSTALL_COMMAND = "curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh";
 const FIXTURE_CODE_PATTERN = /^FT-PREVIEW-STAGING-(?:(?:ADMIN|MEMBER)|[A-Z0-9]+-(?:ADMIN|MEMBER))$/;
 
 export type ContextTreeSetupPreviewQuery = {
@@ -59,15 +60,19 @@ export function setupPreviewCode(role: ContextTreeSetupPreviewRole, version = 0)
   return `FT-PREVIEW-STAGING-${version.toString(36).toUpperCase()}-${suffix}`;
 }
 
-export function setupPreviewBootstrapCommand(code: string): string {
+export function setupPreviewBootstrapCommand(code: string, template: ConnectBootstrapCommandTemplate): string {
   if (!FIXTURE_CODE_PATTERN.test(code)) {
     throw new TypeError("A valid staging preview fixture code is required");
   }
-  return `${INSTALL_COMMAND}\n~/.local/bin/first-tree-staging login ${code}`;
+  return materializeConnectBootstrapCommand(template, code);
 }
 
-export function setupPreviewPrompt(role: ContextTreeSetupPreviewRole, code: string): string {
-  const command = setupPreviewBootstrapCommand(code);
+export function setupPreviewPrompt(
+  role: ContextTreeSetupPreviewRole,
+  code: string,
+  template: ConnectBootstrapCommandTemplate,
+): string {
+  const command = setupPreviewBootstrapCommand(code, template);
   const fixtureNotice = "Preview note: this fixture code does not authenticate.";
 
   if (role === "admin") {
@@ -101,13 +106,14 @@ Verify an exact read of the Team's shared Context Tree and report the snapshot r
 
 export function contextTreeSetupPreviewModel(
   role: ContextTreeSetupPreviewRole,
+  template: ConnectBootstrapCommandTemplate,
   version = 0,
 ): ContextTreeSetupPreviewModel {
   const code = setupPreviewCode(role, version);
   return {
     code,
-    command: setupPreviewBootstrapCommand(code),
-    prompt: setupPreviewPrompt(role, code),
+    command: setupPreviewBootstrapCommand(code, template),
+    prompt: setupPreviewPrompt(role, code, template),
   };
 }
 

--- a/packages/web/src/pages/context-tree-setup-preview-model.ts
+++ b/packages/web/src/pages/context-tree-setup-preview-model.ts
@@ -1,0 +1,116 @@
+export const CONTEXT_TREE_SETUP_PREVIEW_ROLES = ["admin", "member"] as const;
+
+export type ContextTreeSetupPreviewRole = (typeof CONTEXT_TREE_SETUP_PREVIEW_ROLES)[number];
+
+const INSTALL_COMMAND = "curl -fsSL https://download.first-tree.ai/releases/staging/install.sh | sh";
+const FIXTURE_CODE_PATTERN = /^FT-PREVIEW-STAGING-(?:(?:ADMIN|MEMBER)|[A-Z0-9]+-(?:ADMIN|MEMBER))$/;
+
+export type ContextTreeSetupPreviewQuery = {
+  role: ContextTreeSetupPreviewRole;
+  expired: boolean;
+  controls: boolean;
+  search: string;
+  changed: boolean;
+};
+
+export type ContextTreeSetupPreviewModel = {
+  code: string;
+  command: string;
+  prompt: string;
+};
+
+export function normalizeContextTreeSetupPreviewQuery(search = ""): ContextTreeSetupPreviewQuery {
+  const params = new URLSearchParams(search);
+  const before = params.toString();
+
+  const requestedRoles = params.getAll("role");
+  const hasExplicitRole = params.has("role");
+  const role =
+    requestedRoles.length === 1 && isContextTreeSetupPreviewRole(requestedRoles[0]) ? requestedRoles[0] : "admin";
+  if (hasExplicitRole && (requestedRoles.length !== 1 || requestedRoles[0] !== role)) {
+    params.delete("role");
+    params.set("role", role);
+  }
+
+  const requestedCodes = params.getAll("code");
+  const expired = requestedCodes.length === 1 && requestedCodes[0] === "expired";
+  if (!expired && params.has("code")) params.delete("code");
+
+  const requestedControls = params.getAll("controls");
+  const controls = requestedControls.length === 1 && requestedControls[0] === "1";
+  if (!controls && params.has("controls")) params.delete("controls");
+
+  const normalizedSearch = params.toString();
+  return {
+    role,
+    expired,
+    controls,
+    search: normalizedSearch,
+    changed: normalizedSearch !== before,
+  };
+}
+
+export function setupPreviewCode(role: ContextTreeSetupPreviewRole, version = 0): string {
+  if (!Number.isInteger(version) || version < 0) {
+    throw new TypeError("Fixture version must be a non-negative integer");
+  }
+  const suffix = role.toUpperCase();
+  if (version === 0) return `FT-PREVIEW-STAGING-${suffix}`;
+  return `FT-PREVIEW-STAGING-${version.toString(36).toUpperCase()}-${suffix}`;
+}
+
+export function setupPreviewBootstrapCommand(code: string): string {
+  if (!FIXTURE_CODE_PATTERN.test(code)) {
+    throw new TypeError("A valid staging preview fixture code is required");
+  }
+  return `${INSTALL_COMMAND}\n~/.local/bin/first-tree-staging login ${code}`;
+}
+
+export function setupPreviewPrompt(role: ContextTreeSetupPreviewRole, code: string): string {
+  const command = setupPreviewBootstrapCommand(code);
+  const fixtureNotice = "Preview note: this fixture code does not authenticate.";
+
+  if (role === "admin") {
+    return `Help me set up Context Tree for Gandy's team on First Tree.
+
+Team: team_7F3K
+${fixtureNotice}
+
+First, run this exact staging bootstrap on my computer:
+${command}
+
+Then follow this exact Admin sequence:
+1. Run tree init to initialize and bind the Context Tree.
+2. Install or connect the First Tree GitHub App and grant it only the exact Context Tree repository.
+3. The base bootstrap and ordinary setup must not create a First Tree Agent. Create a reviewer Agent only if automatic Review is enabled.
+4. Invite the team.
+
+Keep the rest of setup in this coding-agent session.`;
+  }
+
+  return `Connect this coding-agent session to Gandy's team on First Tree.
+
+Team: team_7F3K
+${fixtureNotice}
+
+First, run this exact staging bootstrap on my computer:
+${command}
+
+Verify an exact read of the Team's shared Context Tree and report the snapshot read.`;
+}
+
+export function contextTreeSetupPreviewModel(
+  role: ContextTreeSetupPreviewRole,
+  version = 0,
+): ContextTreeSetupPreviewModel {
+  const code = setupPreviewCode(role, version);
+  return {
+    code,
+    command: setupPreviewBootstrapCommand(code),
+    prompt: setupPreviewPrompt(role, code),
+  };
+}
+
+function isContextTreeSetupPreviewRole(value: string | undefined): value is ContextTreeSetupPreviewRole {
+  return value === "admin" || value === "member";
+}

--- a/packages/web/src/pages/context-tree-setup-preview.tsx
+++ b/packages/web/src/pages/context-tree-setup-preview.tsx
@@ -227,7 +227,7 @@ function HandoffPage({
     if (!focusAfterRegenerationRef.current || expired) return;
     copyButtonRef.current?.focus();
     focusAfterRegenerationRef.current = false;
-  }, [expired, version]);
+  }, [expired]);
 
   const regenerate = (): void => {
     setStatusMessage("New preview fixture generated · simulated expiry 9:42");

--- a/packages/web/src/pages/context-tree-setup-preview.tsx
+++ b/packages/web/src/pages/context-tree-setup-preview.tsx
@@ -1,3 +1,4 @@
+import type { ConnectBootstrapCommandTemplate } from "@first-tree/shared";
 import {
   Bot,
   Check,
@@ -46,7 +47,11 @@ const HANDOFF_COPY = {
   },
 } as const;
 
-export function ContextTreeSetupPreviewPage() {
+export function ContextTreeSetupPreviewPage({
+  bootstrapCommandTemplate,
+}: {
+  bootstrapCommandTemplate: ConnectBootstrapCommandTemplate;
+}) {
   const location = useLocation();
   const navigate = useNavigate();
   const query = useMemo(() => normalizeContextTreeSetupPreviewQuery(location.search), [location.search]);
@@ -97,6 +102,7 @@ export function ContextTreeSetupPreviewPage() {
         role={query.role}
         version={fixtureStates[query.role].version}
         expired={fixtureStates[query.role].expired}
+        bootstrapCommandTemplate={bootstrapCommandTemplate}
         onRegenerate={regenerate}
       />
     </div>
@@ -192,36 +198,43 @@ function HandoffPage({
   role,
   version,
   expired,
+  bootstrapCommandTemplate,
   onRegenerate,
 }: {
   role: ContextTreeSetupPreviewRole;
   version: number;
   expired: boolean;
+  bootstrapCommandTemplate: ConnectBootstrapCommandTemplate;
   onRegenerate: () => void;
 }) {
   const copy = HANDOFF_COPY[role];
   const copyButtonRef = useRef<HTMLButtonElement>(null);
   const focusAfterRegenerationRef = useRef(false);
-  const terminalRef = useRef<HTMLPreElement>(null);
+  const manualPromptRef = useRef<HTMLPreElement>(null);
   const { status: copyStatus, copy: copyPrompt, reset: resetCopy } = useCopyFeedback();
   const [showCommand, setShowCommand] = useState(false);
+  const [showManualPrompt, setShowManualPrompt] = useState(false);
   const [showMemberHelp, setShowMemberHelp] = useState(false);
   const [statusMessage, setStatusMessage] = useState("Preview fixture · simulated expiry 9:42");
-  const model = useMemo(() => contextTreeSetupPreviewModel(role, version), [role, version]);
+  const model = useMemo(
+    () => contextTreeSetupPreviewModel(role, bootstrapCommandTemplate, version),
+    [bootstrapCommandTemplate, role, version],
+  );
 
   useEffect(() => {
     if (copyStatus === "copied") {
       setStatusMessage("Preview prompt copied · fixture login will not complete");
+      setShowManualPrompt(false);
     }
     if (copyStatus === "failed") {
-      setStatusMessage("Copy failed. The terminal fallback is open for manual copy.");
-      setShowCommand(true);
+      setStatusMessage("Copy failed. The full prompt is open below for manual copy.");
+      setShowManualPrompt(true);
     }
   }, [copyStatus]);
 
   useEffect(() => {
-    if (copyStatus === "failed" && showCommand) terminalRef.current?.focus();
-  }, [copyStatus, showCommand]);
+    if (copyStatus === "failed" && showManualPrompt) manualPromptRef.current?.focus();
+  }, [copyStatus, showManualPrompt]);
 
   useEffect(() => {
     if (!focusAfterRegenerationRef.current || expired) return;
@@ -231,6 +244,7 @@ function HandoffPage({
 
   const regenerate = (): void => {
     setStatusMessage("New preview fixture generated · simulated expiry 9:42");
+    setShowManualPrompt(false);
     resetCopy();
     focusAfterRegenerationRef.current = true;
     onRegenerate();
@@ -296,6 +310,20 @@ function HandoffPage({
             </span>
           </div>
 
+          {showManualPrompt ? (
+            <div className="mt-4 rounded-[var(--radius-panel)] border border-error/40 bg-bg-sunken p-4 sm:p-5">
+              <p className="mb-3 text-label font-semibold text-foreground">Select and copy the full prompt manually</p>
+              <pre
+                ref={manualPromptRef}
+                data-testid="manual-copy-prompt"
+                tabIndex={-1}
+                className="mono max-h-80 overflow-auto whitespace-pre-wrap text-label text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <code>{model.prompt}</code>
+              </pre>
+            </div>
+          ) : null}
+
           <ul
             className="mt-5 flex list-none flex-wrap gap-x-5 gap-y-2 text-label text-fg-3"
             aria-label="Bootstrap results"
@@ -336,7 +364,6 @@ function HandoffPage({
           </Button>
           {showCommand ? (
             <pre
-              ref={terminalRef}
               id={`${role}-terminal-command`}
               data-testid="terminal-bootstrap-command"
               tabIndex={-1}

--- a/packages/web/src/pages/context-tree-setup-preview.tsx
+++ b/packages/web/src/pages/context-tree-setup-preview.tsx
@@ -50,11 +50,27 @@ export function ContextTreeSetupPreviewPage() {
   const location = useLocation();
   const navigate = useNavigate();
   const query = useMemo(() => normalizeContextTreeSetupPreviewQuery(location.search), [location.search]);
+  const [fixtureStates, setFixtureStates] = useState<
+    Record<ContextTreeSetupPreviewRole, { version: number; expired: boolean }>
+  >(() => ({
+    admin: { version: 0, expired: query.expired },
+    member: { version: 0, expired: query.expired },
+  }));
 
   useEffect(() => {
     if (!query.changed) return;
     void navigate({ pathname: location.pathname, search: query.search }, { replace: true });
   }, [location.pathname, navigate, query.changed, query.search]);
+
+  useEffect(() => {
+    setFixtureStates((current) => {
+      if (current[query.role].expired === query.expired) return current;
+      return {
+        ...current,
+        [query.role]: { ...current[query.role], expired: query.expired },
+      };
+    });
+  }, [query.expired, query.role]);
 
   const clearExpired = (): void => {
     const params = new URLSearchParams(query.search);
@@ -62,15 +78,40 @@ export function ContextTreeSetupPreviewPage() {
     void navigate({ pathname: location.pathname, search: params.toString() }, { replace: true });
   };
 
+  const regenerate = (): void => {
+    setFixtureStates((current) => ({
+      ...current,
+      [query.role]: {
+        version: current[query.role].version + 1,
+        expired: false,
+      },
+    }));
+    clearExpired();
+  };
+
   return (
     <div className="min-h-screen bg-background text-foreground" data-context-tree-setup-preview={query.role}>
-      <PreviewHeader role={query.role} controls={query.controls} />
-      <HandoffPage key={query.role} role={query.role} expired={query.expired} onRegenerate={clearExpired} />
+      <PreviewHeader role={query.role} controls={query.controls} fixtureStates={fixtureStates} />
+      <HandoffPage
+        key={query.role}
+        role={query.role}
+        version={fixtureStates[query.role].version}
+        expired={fixtureStates[query.role].expired}
+        onRegenerate={regenerate}
+      />
     </div>
   );
 }
 
-function PreviewHeader({ role, controls }: { role: ContextTreeSetupPreviewRole; controls: boolean }) {
+function PreviewHeader({
+  role,
+  controls,
+  fixtureStates,
+}: {
+  role: ContextTreeSetupPreviewRole;
+  controls: boolean;
+  fixtureStates: Record<ContextTreeSetupPreviewRole, { version: number; expired: boolean }>;
+}) {
   return (
     <header className="border-b border-border-faint bg-background">
       <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-10">
@@ -91,8 +132,8 @@ function PreviewHeader({ role, controls }: { role: ContextTreeSetupPreviewRole; 
         <div className="flex items-center gap-3">
           {controls ? (
             <nav aria-label="Context Tree setup preview role" className="hidden items-center gap-1 sm:flex">
-              <RoleLink previewRole="admin" activeRole={role} />
-              <RoleLink previewRole="member" activeRole={role} />
+              <RoleLink previewRole="admin" activeRole={role} expired={fixtureStates.admin.expired} />
+              <RoleLink previewRole="member" activeRole={role} expired={fixtureStates.member.expired} />
             </nav>
           ) : null}
           <a href="#preview-help" className="hidden text-body text-fg-2 hover:text-foreground sm:inline">
@@ -112,8 +153,8 @@ function PreviewHeader({ role, controls }: { role: ContextTreeSetupPreviewRole; 
           aria-label="Context Tree setup preview role on narrow screens"
           className="flex items-center justify-center gap-1 border-t border-border-faint px-4 py-2 sm:hidden"
         >
-          <RoleLink previewRole="admin" activeRole={role} />
-          <RoleLink previewRole="member" activeRole={role} />
+          <RoleLink previewRole="admin" activeRole={role} expired={fixtureStates.admin.expired} />
+          <RoleLink previewRole="member" activeRole={role} expired={fixtureStates.member.expired} />
         </nav>
       ) : null}
     </header>
@@ -123,11 +164,14 @@ function PreviewHeader({ role, controls }: { role: ContextTreeSetupPreviewRole; 
 function RoleLink({
   previewRole,
   activeRole,
+  expired,
 }: {
   previewRole: ContextTreeSetupPreviewRole;
   activeRole: ContextTreeSetupPreviewRole;
+  expired: boolean;
 }) {
   const params = new URLSearchParams({ role: previewRole, controls: "1" });
+  if (expired) params.set("code", "expired");
   return (
     <Link
       to={{ pathname: "/preview/context-tree-setup", search: params.toString() }}
@@ -146,18 +190,20 @@ function RoleLink({
 
 function HandoffPage({
   role,
+  version,
   expired,
   onRegenerate,
 }: {
   role: ContextTreeSetupPreviewRole;
+  version: number;
   expired: boolean;
   onRegenerate: () => void;
 }) {
   const copy = HANDOFF_COPY[role];
   const copyButtonRef = useRef<HTMLButtonElement>(null);
+  const focusAfterRegenerationRef = useRef(false);
   const terminalRef = useRef<HTMLPreElement>(null);
   const { status: copyStatus, copy: copyPrompt, reset: resetCopy } = useCopyFeedback();
-  const [version, setVersion] = useState(0);
   const [showCommand, setShowCommand] = useState(false);
   const [showMemberHelp, setShowMemberHelp] = useState(false);
   const [statusMessage, setStatusMessage] = useState("Preview fixture · simulated expiry 9:42");
@@ -178,13 +224,15 @@ function HandoffPage({
   }, [copyStatus, showCommand]);
 
   useEffect(() => {
-    if (version > 0 && !expired) copyButtonRef.current?.focus();
+    if (!focusAfterRegenerationRef.current || expired) return;
+    copyButtonRef.current?.focus();
+    focusAfterRegenerationRef.current = false;
   }, [expired, version]);
 
   const regenerate = (): void => {
-    setVersion((current) => current + 1);
     setStatusMessage("New preview fixture generated · simulated expiry 9:42");
     resetCopy();
+    focusAfterRegenerationRef.current = true;
     onRegenerate();
   };
 

--- a/packages/web/src/pages/context-tree-setup-preview.tsx
+++ b/packages/web/src/pages/context-tree-setup-preview.tsx
@@ -1,0 +1,409 @@
+import {
+  Bot,
+  Check,
+  CheckCircle2,
+  ChevronDown,
+  CircleHelp,
+  Copy,
+  Lock,
+  ShieldCheck,
+  Terminal,
+  Users,
+} from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router";
+import { FirstTreeLogo } from "../components/first-tree-logo.js";
+import { Button } from "../components/ui/button.js";
+import { useCopyFeedback } from "../lib/use-copy-feedback.js";
+import { cn } from "../lib/utils.js";
+import {
+  type ContextTreeSetupPreviewRole,
+  contextTreeSetupPreviewModel,
+  normalizeContextTreeSetupPreviewQuery,
+} from "./context-tree-setup-preview-model.js";
+
+const HANDOFF_COPY = {
+  admin: {
+    status: "Gandy's team is ready",
+    meta: "Created automatically · You are Admin",
+    intro:
+      "Paste this once into Claude Code or Codex. First Tree will detect your environment and guide the rest of setup there.",
+    copyLabel: "Copy setup prompt",
+    detail:
+      "Your coding agent initializes and binds the Tree first, then opens GitHub to install or connect the App and grant the exact Tree repository. Only automatic Review creates a reviewer Agent. The final step is your team invite link.",
+    response:
+      "I detected this environment. I'll initialize the Tree here and ask for browser consent only when needed.",
+  },
+  member: {
+    status: "You joined Gandy's team",
+    meta: "Member · Shared setup is ready",
+    intro:
+      "Paste this once into Claude Code or Codex. First Tree will detect your environment and connect it to your team's shared context.",
+    copyLabel: "Copy connection prompt",
+    detail:
+      "Your coding agent installs the staging First Tree bundle and verifies an exact read of the Team Tree as shared.",
+    response: "First Tree detected this environment. Connecting to Gandy's team and checking an exact Tree read.",
+  },
+} as const;
+
+export function ContextTreeSetupPreviewPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const query = useMemo(() => normalizeContextTreeSetupPreviewQuery(location.search), [location.search]);
+
+  useEffect(() => {
+    if (!query.changed) return;
+    void navigate({ pathname: location.pathname, search: query.search }, { replace: true });
+  }, [location.pathname, navigate, query.changed, query.search]);
+
+  const clearExpired = (): void => {
+    const params = new URLSearchParams(query.search);
+    params.delete("code");
+    void navigate({ pathname: location.pathname, search: params.toString() }, { replace: true });
+  };
+
+  return (
+    <div className="min-h-screen bg-background text-foreground" data-context-tree-setup-preview={query.role}>
+      <PreviewHeader role={query.role} controls={query.controls} />
+      <HandoffPage key={query.role} role={query.role} expired={query.expired} onRegenerate={clearExpired} />
+    </div>
+  );
+}
+
+function PreviewHeader({ role, controls }: { role: ContextTreeSetupPreviewRole; controls: boolean }) {
+  return (
+    <header className="border-b border-border-faint bg-background">
+      <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-10">
+        <div className="flex min-w-0 items-center gap-3 sm:gap-5">
+          <Link to="/" className="flex shrink-0 items-center gap-2 text-foreground" aria-label="First Tree workspace">
+            <FirstTreeLogo className="h-5 w-auto text-brand" />
+            <span className="hidden text-title font-semibold sm:inline">First Tree</span>
+          </Link>
+          <span className="h-7 border-l border-border-faint" aria-hidden="true" />
+          <div className="flex min-w-0 items-center gap-2 text-body font-medium">
+            {role === "member" ? <Users className="h-4 w-4 shrink-0 text-fg-3" aria-hidden="true" /> : null}
+            <span className="truncate">Gandy's team</span>
+          </div>
+          <span className="rounded-[var(--radius-chip)] bg-bg-sunken px-2 py-1 text-eyebrow uppercase text-fg-3">
+            Preview
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          {controls ? (
+            <nav aria-label="Context Tree setup preview role" className="hidden items-center gap-1 sm:flex">
+              <RoleLink previewRole="admin" activeRole={role} />
+              <RoleLink previewRole="member" activeRole={role} />
+            </nav>
+          ) : null}
+          <a href="#preview-help" className="hidden text-body text-fg-2 hover:text-foreground sm:inline">
+            Help
+          </a>
+          <span
+            role="img"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[var(--radius-full)] bg-bg-sunken text-label font-semibold"
+            aria-label={role === "admin" ? "Gandy, Admin preview" : "Jamie, Member preview"}
+          >
+            {role === "admin" ? "GG" : "J"}
+          </span>
+        </div>
+      </div>
+      {controls ? (
+        <nav
+          aria-label="Context Tree setup preview role on narrow screens"
+          className="flex items-center justify-center gap-1 border-t border-border-faint px-4 py-2 sm:hidden"
+        >
+          <RoleLink previewRole="admin" activeRole={role} />
+          <RoleLink previewRole="member" activeRole={role} />
+        </nav>
+      ) : null}
+    </header>
+  );
+}
+
+function RoleLink({
+  previewRole,
+  activeRole,
+}: {
+  previewRole: ContextTreeSetupPreviewRole;
+  activeRole: ContextTreeSetupPreviewRole;
+}) {
+  const params = new URLSearchParams({ role: previewRole, controls: "1" });
+  return (
+    <Link
+      to={{ pathname: "/preview/context-tree-setup", search: params.toString() }}
+      aria-current={previewRole === activeRole ? "page" : undefined}
+      className={cn(
+        "rounded-[var(--radius-input)] px-3 py-2 text-label font-medium",
+        previewRole === activeRole
+          ? "bg-primary text-primary-foreground"
+          : "text-fg-2 hover:bg-bg-hover hover:text-foreground",
+      )}
+    >
+      {previewRole === "admin" ? "Admin" : "Member"}
+    </Link>
+  );
+}
+
+function HandoffPage({
+  role,
+  expired,
+  onRegenerate,
+}: {
+  role: ContextTreeSetupPreviewRole;
+  expired: boolean;
+  onRegenerate: () => void;
+}) {
+  const copy = HANDOFF_COPY[role];
+  const copyButtonRef = useRef<HTMLButtonElement>(null);
+  const terminalRef = useRef<HTMLPreElement>(null);
+  const { status: copyStatus, copy: copyPrompt, reset: resetCopy } = useCopyFeedback();
+  const [version, setVersion] = useState(0);
+  const [showCommand, setShowCommand] = useState(false);
+  const [showMemberHelp, setShowMemberHelp] = useState(false);
+  const [statusMessage, setStatusMessage] = useState("Preview fixture · simulated expiry 9:42");
+  const model = useMemo(() => contextTreeSetupPreviewModel(role, version), [role, version]);
+
+  useEffect(() => {
+    if (copyStatus === "copied") {
+      setStatusMessage("Preview prompt copied · fixture login will not complete");
+    }
+    if (copyStatus === "failed") {
+      setStatusMessage("Copy failed. The terminal fallback is open for manual copy.");
+      setShowCommand(true);
+    }
+  }, [copyStatus]);
+
+  useEffect(() => {
+    if (copyStatus === "failed" && showCommand) terminalRef.current?.focus();
+  }, [copyStatus, showCommand]);
+
+  useEffect(() => {
+    if (version > 0 && !expired) copyButtonRef.current?.focus();
+  }, [expired, version]);
+
+  const regenerate = (): void => {
+    setVersion((current) => current + 1);
+    setStatusMessage("New preview fixture generated · simulated expiry 9:42");
+    resetCopy();
+    onRegenerate();
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 sm:py-10 lg:px-10 lg:py-12">
+      <div className="mb-8 flex flex-wrap items-center gap-x-6 gap-y-2">
+        <div className="flex items-center gap-2 text-success">
+          <CheckCircle2 className="h-5 w-5" aria-hidden="true" />
+          <strong className="text-title">{copy.status}</strong>
+        </div>
+        <span className="text-body text-fg-2">{copy.meta}</span>
+      </div>
+
+      <div className="grid gap-10 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] xl:gap-12">
+        <section className="min-w-0" aria-labelledby="handoff-title">
+          <h1 id="handoff-title" className="text-title font-semibold text-foreground">
+            Continue in your coding agent
+          </h1>
+          <p className="mt-3 max-w-2xl text-body text-fg-2">{copy.intro}</p>
+
+          <div className="mt-5 rounded-[var(--radius-panel)] border border-border bg-bg-sunken p-4 sm:p-5">
+            <p className="mb-3 text-label font-semibold text-error">Preview — fixture codes do not authenticate</p>
+            <pre className="mono overflow-x-auto whitespace-pre-wrap text-label text-foreground">
+              <code data-testid="setup-prompt">{model.prompt}</code>
+            </pre>
+          </div>
+
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <Button
+              ref={copyButtonRef}
+              type="button"
+              variant="cta"
+              size="lg"
+              disabled={expired}
+              onClick={() => void copyPrompt(model.prompt)}
+            >
+              {copyStatus === "copied" ? (
+                <Check className="h-4 w-4" aria-hidden="true" />
+              ) : (
+                <Copy className="h-4 w-4" aria-hidden="true" />
+              )}
+              {expired
+                ? "Fixture expired"
+                : copyStatus === "copied"
+                  ? "Copied"
+                  : copyStatus === "failed"
+                    ? "Copy failed"
+                    : copy.copyLabel}
+            </Button>
+            {expired ? (
+              <Button type="button" variant="default" onClick={regenerate}>
+                Generate new fixture
+              </Button>
+            ) : null}
+            <span
+              className={cn("text-label", expired || copyStatus === "failed" ? "text-error" : "text-fg-3")}
+              role="status"
+              aria-live="polite"
+            >
+              {expired ? "Generate a new fixture to continue preview." : statusMessage}
+            </span>
+          </div>
+
+          <ul
+            className="mt-5 flex list-none flex-wrap gap-x-5 gap-y-2 text-label text-fg-3"
+            aria-label="Bootstrap results"
+          >
+            <li className="inline-flex items-center gap-2">
+              <Check className="h-4 w-4 text-success" aria-hidden="true" />
+              {role === "admin" ? "Installs First Tree locally" : "Installs First Tree and signs you in"}
+            </li>
+            <li className="inline-flex items-center gap-2">
+              <CircleHelp className="h-4 w-4" aria-hidden="true" />
+              Connects this computer when supported
+            </li>
+            <li className="inline-flex items-center gap-2">
+              <CircleHelp className="h-4 w-4" aria-hidden="true" />
+              Starts the daemon when available
+            </li>
+          </ul>
+          <p className="mt-3 max-w-3xl text-label text-fg-3">
+            Computer registration and daemon startup are best effort. If either needs attention, it does not block
+            {role === "admin" ? " Tree setup" : " your Tree access"}; this bootstrap does not create a First Tree Agent.
+          </p>
+
+          <Button
+            type="button"
+            variant="link"
+            disabled={expired}
+            aria-expanded={showCommand}
+            aria-controls={`${role}-terminal-command`}
+            onClick={() => setShowCommand((current) => !current)}
+            className="mt-4 h-auto p-0"
+          >
+            <Terminal className="h-4 w-4" aria-hidden="true" />
+            Prefer a terminal command?
+            <ChevronDown
+              className={cn("h-4 w-4 transition-transform", showCommand && "rotate-180")}
+              aria-hidden="true"
+            />
+          </Button>
+          {showCommand ? (
+            <pre
+              ref={terminalRef}
+              id={`${role}-terminal-command`}
+              data-testid="terminal-bootstrap-command"
+              tabIndex={-1}
+              className="mono mt-3 overflow-x-auto whitespace-pre rounded-[var(--radius-input)] border border-border-faint bg-bg-sunken p-4 text-label text-foreground focus-visible:outline-none focus-visible:border-ring"
+            >
+              <code>{model.command}</code>
+            </pre>
+          ) : null}
+
+          <div id="preview-help" className="mt-7 border-t border-border-faint pt-6">
+            <p className="max-w-3xl text-body text-fg-2">{copy.detail}</p>
+            {role === "admin" ? (
+              <p className="mt-3 flex items-start gap-2 text-label text-fg-3">
+                <CircleHelp className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+                Computer reuse is optional. Only a Local Reviewer Host needs to stay online.
+              </p>
+            ) : (
+              <p className="mt-3 flex items-start gap-2 text-label text-fg-3">
+                <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+                Shared Team setup is already complete. This handoff only installs, signs in, and verifies your exact
+                Tree read.
+              </p>
+            )}
+            {role === "member" ? (
+              <>
+                <Button
+                  type="button"
+                  variant="link"
+                  aria-expanded={showMemberHelp}
+                  aria-controls="member-repository-help"
+                  onClick={() => setShowMemberHelp((current) => !current)}
+                  className="mt-4 h-auto justify-start whitespace-normal p-0 text-left"
+                >
+                  <CircleHelp className="h-4 w-4" aria-hidden="true" />
+                  Can't read the Tree? Ask an admin for repository access.
+                </Button>
+                {showMemberHelp ? (
+                  <p
+                    id="member-repository-help"
+                    className="mt-3 rounded-[var(--radius-input)] border border-border-faint bg-bg-sunken p-3 text-label text-fg-2"
+                  >
+                    Send this screen to a Team admin. They can restore your Context Tree repository access, then you can
+                    paste the same prompt again.
+                  </p>
+                ) : null}
+              </>
+            ) : null}
+            <p className="mt-5 flex items-center gap-2 text-label text-fg-3">
+              <Lock className="h-4 w-4" aria-hidden="true" />
+              Nothing runs until you paste the prompt.
+            </p>
+          </div>
+        </section>
+
+        <CodingAgentPreview role={role} prompt={model.prompt} response={copy.response} />
+      </div>
+    </main>
+  );
+}
+
+function CodingAgentPreview({
+  role,
+  prompt,
+  response,
+}: {
+  role: ContextTreeSetupPreviewRole;
+  prompt: string;
+  response: string;
+}) {
+  return (
+    <aside className="min-w-0 xl:border-l xl:border-border-faint xl:pl-10" aria-label="Coding agent handoff preview">
+      <h2 className="text-subtitle font-semibold text-foreground">Your coding agent</h2>
+      <p className="mt-1 text-body text-fg-2">Claude Code · Codex</p>
+      <div className="surface-raised mt-4 overflow-hidden">
+        <div className="flex items-center gap-2 border-b border-border-faint px-4 py-3" aria-hidden="true">
+          <span className="h-2.5 w-2.5 rounded-[var(--radius-full)] bg-state-error" />
+          <span className="h-2.5 w-2.5 rounded-[var(--radius-full)] bg-state-needs-you" />
+          <span className="h-2.5 w-2.5 rounded-[var(--radius-full)] bg-state-working" />
+        </div>
+        <div className="space-y-5 p-4 sm:p-5">
+          <div className="flex items-center gap-3 border-b border-border-faint pb-4">
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[var(--radius-input)] border border-border bg-bg-sunken">
+              <Bot className="h-4 w-4" aria-hidden="true" />
+            </span>
+            <div>
+              <strong className="text-subtitle">Coding agent</strong>
+              <p className="text-label text-fg-3">How can I help you today?</p>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-3">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-full)] bg-bg-sunken text-caption font-semibold">
+              {role === "admin" ? "GG" : "J"}
+            </span>
+            <div className="min-w-0 flex-1">
+              <strong className="text-label">You</strong>
+              <pre className="mono mt-2 overflow-x-auto whitespace-pre-wrap rounded-[var(--radius-input)] bg-bg-sunken p-3 text-caption text-fg-2">
+                <code data-testid="agent-prompt">{prompt}</code>
+              </pre>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-3">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-input)] bg-brand-bg text-brand">
+              <FirstTreeLogo className="h-4 w-auto" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <strong className="text-label">First Tree</strong>
+              <p className="mt-2 rounded-[var(--radius-input)] bg-success-soft p-3 text-label text-success">
+                {response}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

- add a staging-only `/preview/context-tree-setup` route for Cloud Admin and Member setup handoffs
- keep the preview independent from normal onboarding and fail closed outside Vite development or the hosted staging channel
- model role-safe, non-authenticating fixture flows for exact Tree setup/read, code expiry/regeneration, full-prompt copy recovery, and a separate exact two-line terminal fallback
- source the bootstrap template from the same shared/server-owned command builder used by real connect tokens, including deployment mirror and public-URL overrides

## Product boundaries

- Admin: Tree init/bind → GitHub App install/connect and exact Tree repo grant → reviewer Agent only when automatic Review is enabled → invite the team
- Member: personal install/login and exact Team Tree read only; no Tree init, GitHub App, repo grant, reviewer Agent, or policy controls
- Computer registration and daemon startup are best effort and do not block the base Tree path
- base bootstrap creates no First Tree Agent
- fixture codes are visibly non-authenticating and are never treated as server-issued credentials

## Verification

- Shared tests: 669/669
- Server tests: 2519/2519
- Web tests: 1602/1602
- repository check, package typechecks, Web design-token guard, and full production build
- isolated Docker production artifact using the staging release channel
- Chromium at 390 px for Admin, Member, clipboard rejection/full-prompt recovery, separate two-line terminal disclosure, expired/regenerate, URL cleanup, focus recovery, fixture synchronization, and horizontal overflow
- two independent read-only reviews of each frozen product/successor patch

## Known baseline noise

- the build retains the repository's existing generated-CSS parser and bundle-size warnings
- browser verification observes existing font-preload timing warnings after repeated navigation; there are no console errors

## Screenshots

Implementation screenshots are retained as local QA evidence and intentionally excluded from this source-only PR.
