### PR TITLE
fix: namespace browser stores per user and purge them on logout

### DIFF
--- a/packages/qa/cases/cross-surface/web-logout-storage-purge.md
+++ b/packages/qa/cases/cross-surface/web-logout-storage-purge.md
@@ -1,0 +1,75 @@
+---
+id: web-logout-storage-purge
+description: Validate that signing out of the web app (explicit logout, 401 auto-logout, or OAuth account adoption) leaves no readable chat, image, draft, or account-scoped metadata in browser storage, and that another account on the same profile cannot see the departed account's data.
+areas: [cross-surface]
+surfaces: [web, server]
+---
+
+# Web Logout Storage Purge
+
+## Goal
+
+Confirm that browser-side storage never outlives the account that produced it
+on a shared browser profile: every sign-out path purges the IndexedDB caches
+and account-scoped localStorage, database names are namespaced per account so
+a second account can never open the first account's data, and the
+deliberately-kept preferences survive.
+
+## Operate
+
+Use two disposable accounts (A and B) in one normal, non-incognito browser
+profile. As A: open chats until timelines hydrate from cache, send or view
+images, leave an unsent draft in a composer, and scroll so read positions
+persist. Inspect storage (DevTools Application panel or equivalent) and record
+the pre-logout baseline: database names and `first-tree:*` localStorage keys.
+
+Exercise all three departure paths, re-seeding A's data before each:
+
+1. Explicit logout from the user menu; also smoke the mobile Me screen
+   sign-out.
+2. Automatic logout: invalidate A's session server-side (expire or revoke the
+   refresh token) and let a background request run into a 401.
+3. Account adoption without logout: while A is signed in, complete B's OAuth
+   flow in the same tab so the app adopts B's tokens directly.
+
+After each path, inspect storage again; on path 3 also verify that B's
+freshly-created databases survive the purge of A's. Then work as B in the same
+chats A used. Finally sign back in as A once to confirm caches refill from the
+server. Repeat one explicit logout with a second signed-in tab open on the app.
+
+## Observe
+
+- After explicit and 401 logout: no `first-tree-*` IndexedDB database remains
+  (including the legacy un-namespaced names); `first-tree:chat-drafts:v1`,
+  `first-tree:new-chat-default-agent:*`, and both `first-tree:chat-summary-*`
+  key families are gone; `first-tree:tokens` is gone.
+- Deliberate survivors stay: `first-tree:selectedOrganizationId:<userId>` and
+  pure UI preferences such as `theme` — signing back in as A lands on A's
+  previously selected organization.
+- While A is signed in, database names end in `:u:<A's user id>`; after B
+  signs in they end in B's id, and B's timelines, images, read positions, and
+  composers show none of A's content.
+- On the adoption path, A's databases and account-scoped keys are purged while
+  B's newly-created databases survive.
+- Logout completes promptly (no hang) even with the second tab open; the
+  second tab ends signed out, with storage purged after its next request.
+- The browser console shows no unhandled rejections from cache reads or
+  writes racing the purge at sign-out time.
+- An unsent composer draft is gone after every path — the accepted UX cost of
+  the guarantee, worth confirming rather than assuming.
+
+## Expected Result
+
+`PASS` when every departure path leaves no chat, image, draft, or
+account-metadata residue readable in the profile, B sees none of A's data, the
+listed survivors persist, and re-login refills caches from the server. `FAIL`
+on any readable residue of the departed account, on B seeing A's data, or on
+logout hanging or erroring. `BLOCKED` when two test accounts or server-side
+token revocation are unavailable.
+
+## Evidence
+
+Keep before/after storage inventories per path (database names and
+`first-tree:*` keys with values redacted), the console log around each
+sign-out, and B's view of the chats A had cached. Never retain real tokens,
+message plaintext, or image bytes in the report.

--- a/packages/web/src/api/__tests__/browser-stores.test.ts
+++ b/packages/web/src/api/__tests__/browser-stores.test.ts
@@ -1,6 +1,21 @@
 import "fake-indexeddb/auto";
 import { IDBFactory } from "fake-indexeddb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MessageWithDelivery } from "../chats.js";
+
+// Identity control for the per-account database namespacing (SEC-042); see
+// message-store.test.ts for why the identity is mocked rather than seeded
+// through real tokens in this node-environment suite.
+const identityMock = vi.hoisted(() => ({ userId: "user-1" as string | null }));
+
+vi.mock("../../lib/current-user-id.js", () => ({
+  currentUserIdFromToken: () => identityMock.userId,
+  lastKnownUserId: () => identityMock.userId,
+}));
+
+beforeEach(() => {
+  identityMock.userId = "user-1";
+});
 
 type Callback = () => void;
 
@@ -259,5 +274,102 @@ describe("read-state-store", () => {
     const clearTx = await waitForTransaction(db.transactions, 2);
     clearTx.onabort?.();
     await expect(clear).resolves.toBeUndefined();
+  });
+});
+
+async function listDatabaseNames(): Promise<string[]> {
+  const dbs = await indexedDB.databases();
+  return dbs
+    .map((d) => d.name)
+    .filter((n): n is string => typeof n === "string")
+    .sort();
+}
+
+/** Delete a database, reporting whether the delete had to wait on a blocked
+ *  phase before completing. */
+function deleteDb(name: string): Promise<"success" | "blocked-then-success"> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name);
+    let blocked = false;
+    req.onblocked = () => {
+      blocked = true;
+    };
+    req.onsuccess = () => resolve(blocked ? "blocked-then-success" : "success");
+    req.onerror = () => reject(req.error ?? new Error("delete failed"));
+  });
+}
+
+describe("per-account namespacing (SEC-042)", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  it("image-store writes into a database named for the current account and isolates accounts", async () => {
+    const { getImage, putImage } = await loadImageStore();
+    await putImage({ imageId: "img-1", base64: "abc123", mimeType: "image/png" });
+    expect(await listDatabaseNames()).toEqual(["first-tree-images:u:user-1"]);
+
+    identityMock.userId = "user-2";
+    expect(await getImage("img-1")).toBeNull();
+
+    identityMock.userId = "user-1";
+    expect(await getImage("img-1")).toEqual({ base64: "abc123", mimeType: "image/png" });
+  });
+
+  it("image-store keeps the reject contract for writes while signed out and creates no database", async () => {
+    const { getImage, putImage } = await loadImageStore();
+    identityMock.userId = null;
+
+    await expect(putImage({ imageId: "img-1", base64: "abc123", mimeType: "image/png" })).rejects.toThrow(
+      "Image storage unavailable",
+    );
+    expect(await getImage("img-1")).toBeNull();
+    expect(await listDatabaseNames()).toEqual([]);
+  });
+
+  it("image-store requests deletion of the legacy database on first namespaced open", async () => {
+    const { putImage } = await loadImageStore();
+    const spy = vi.spyOn(indexedDB, "deleteDatabase");
+    await putImage({ imageId: "img-1", base64: "abc123", mimeType: "image/png" });
+    expect(spy.mock.calls.filter(([name]) => name === "first-tree-images")).toHaveLength(1);
+  });
+
+  it("read-state-store writes into the shared per-account chat-cache database and no-ops while signed out", async () => {
+    const { getReadState, setReadState } = await loadReadStateStore();
+    await setReadState("chat-1", "msg-1", "msg-2");
+    expect(await listDatabaseNames()).toEqual(["first-tree-chat-cache:u:user-1"]);
+
+    identityMock.userId = null;
+    await expect(setReadState("chat-2", "msg-3", "msg-4")).resolves.toBeUndefined();
+    expect(await getReadState("chat-1")).toBeNull();
+    expect(await listDatabaseNames()).toEqual(["first-tree-chat-cache:u:user-1"]);
+  });
+
+  it("purge must close BOTH chat-cache connections (message-store and read-state-store) for a delete to complete", async () => {
+    vi.resetModules();
+    globalThis.indexedDB = new IDBFactory();
+    const messageStore = await import("../message-store.js");
+    const readStateStore = await import("../read-state-store.js");
+
+    const message: MessageWithDelivery = {
+      id: "m1",
+      chatId: "chat-1",
+      senderId: "user-1",
+      format: "text",
+      content: { text: "hello" },
+      metadata: {},
+      inReplyTo: null,
+      source: "web",
+      createdAt: new Date(2026, 0, 1).toISOString(),
+    };
+    await messageStore.cacheMessages("chat-1", [message]);
+    await readStateStore.setReadState("chat-1", "m1", "m1");
+
+    // Two modules, one database, one connection each — the purge closes both.
+    messageStore.closeDbForPurge();
+    readStateStore.closeDbForPurge();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await expect(deleteDb("first-tree-chat-cache:u:user-1")).resolves.toBe("success");
   });
 });

--- a/packages/web/src/api/__tests__/browser-stores.test.ts
+++ b/packages/web/src/api/__tests__/browser-stores.test.ts
@@ -373,3 +373,71 @@ describe("per-account namespacing (SEC-042)", () => {
     await expect(deleteDb("first-tree-chat-cache:u:user-1")).resolves.toBe("success");
   });
 });
+
+/** Simulate the narrow window where the logout purge (or a versionchange)
+ *  closed the connection after `openDb()` resolved but before the operation
+ *  called `db.transaction()` — per spec that call then throws
+ *  InvalidStateError synchronously. */
+function makeTransactionThrow(request: OpenRequestStub): void {
+  request.result.transaction = () => {
+    throw new DOMException(
+      "An attempt was made to use an object that is not, or is no longer, usable",
+      "InvalidStateError",
+    );
+  };
+}
+
+describe("tolerance of a connection closed mid-operation by the purge (SEC-042)", () => {
+  it("message-store ops resolve silently instead of rejecting", async () => {
+    vi.resetModules();
+    const db = installControllableIndexedDb();
+    makeTransactionThrow(db.request);
+    const { cacheMessages, clearChatCache, getCachedMessages } = await import("../message-store.js");
+
+    const message: MessageWithDelivery = {
+      id: "m1",
+      chatId: "chat-1",
+      senderId: "user-1",
+      format: "text",
+      content: { text: "hello" },
+      metadata: {},
+      inReplyTo: null,
+      source: "web",
+      createdAt: new Date(2026, 0, 1).toISOString(),
+    };
+    const write = cacheMessages("chat-1", [message]);
+    await settleOpen(db.request);
+    await expect(write).resolves.toBeUndefined();
+    await expect(getCachedMessages("chat-1")).resolves.toEqual([]);
+    await expect(clearChatCache("chat-1")).resolves.toBeUndefined();
+  });
+
+  it("read-state ops resolve silently instead of rejecting", async () => {
+    vi.resetModules();
+    const db = installControllableIndexedDb();
+    makeTransactionThrow(db.request);
+    const { clearReadState, getReadState, setReadState } = await import("../read-state-store.js");
+
+    const write = setReadState("chat-1", "m1", "m2");
+    await settleOpen(db.request);
+    await expect(write).resolves.toBeUndefined();
+    await expect(getReadState("chat-1")).resolves.toBeNull();
+    await expect(clearReadState("chat-1")).resolves.toBeUndefined();
+  });
+
+  it("image-store getImage reports a miss while putImage keeps its reject contract", async () => {
+    vi.resetModules();
+    const db = installControllableIndexedDb();
+    makeTransactionThrow(db.request);
+    const { getImage, putImage } = await import("../image-store.js");
+
+    const read = getImage("img-1");
+    await settleOpen(db.request);
+    await expect(read).resolves.toBeNull();
+    // putImage is the one store operation whose contract already includes
+    // rejection; the closed-connection throw surfaces through it unchanged.
+    await expect(putImage({ imageId: "img-1", base64: "abc123", mimeType: "image/png" })).rejects.toThrow(
+      "no longer, usable",
+    );
+  });
+});

--- a/packages/web/src/api/__tests__/message-store.test.ts
+++ b/packages/web/src/api/__tests__/message-store.test.ts
@@ -3,6 +3,22 @@ import { IDBFactory } from "fake-indexeddb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MessageWithDelivery } from "../chats.js";
 
+// The store namespaces its database per account (SEC-042). Tests control the
+// identity through this mock rather than seeding real tokens, because this
+// suite runs in the node environment where localStorage is process-global
+// and would leak identity across tests. The real token → sub decode chain is
+// covered by the purge-local-data and auth-context-provider suites.
+const identityMock = vi.hoisted(() => ({ userId: "user-1" as string | null }));
+
+vi.mock("../../lib/current-user-id.js", () => ({
+  currentUserIdFromToken: () => identityMock.userId,
+  lastKnownUserId: () => identityMock.userId,
+}));
+
+beforeEach(() => {
+  identityMock.userId = "user-1";
+});
+
 function msg(id: string, createdAt: string, overrides: Partial<MessageWithDelivery> = {}): MessageWithDelivery {
   return {
     id,
@@ -114,5 +130,130 @@ describe("message-store / clearChatCache", () => {
     const { clearChatCache, getCachedMessages } = await loadStore();
     await clearChatCache("chat-1");
     expect(await getCachedMessages("chat-1")).toEqual([]);
+  });
+});
+
+async function listDatabaseNames(): Promise<string[]> {
+  const dbs = await indexedDB.databases();
+  return dbs
+    .map((d) => d.name)
+    .filter((n): n is string => typeof n === "string")
+    .sort();
+}
+
+/** Create (and close) a database so it exists on disk without any open
+ *  connection — used to fake a pre-namespacing legacy database. */
+function seedDb(name: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(name, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore("rows");
+    };
+    req.onsuccess = () => {
+      req.result.close();
+      resolve();
+    };
+    req.onerror = () => reject(req.error ?? new Error("seed open failed"));
+  });
+}
+
+/** Delete a database, reporting whether the delete had to wait on a blocked
+ *  phase before completing. */
+function deleteDb(name: string): Promise<"success" | "blocked-then-success"> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name);
+    let blocked = false;
+    req.onblocked = () => {
+      blocked = true;
+    };
+    req.onsuccess = () => resolve(blocked ? "blocked-then-success" : "success");
+    req.onerror = () => reject(req.error ?? new Error("delete failed"));
+  });
+}
+
+describe("message-store / per-account namespacing (SEC-042)", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  it("stores rows in a database named for the current account", async () => {
+    const { cacheMessages } = await loadStore();
+    await cacheMessages("chat-1", [msg("a", T(1))]);
+    expect(await listDatabaseNames()).toEqual(["first-tree-chat-cache:u:user-1"]);
+  });
+
+  it("isolates accounts — after an in-page identity switch the other account's rows are invisible", async () => {
+    const { cacheMessages, getCachedMessages } = await loadStore();
+    await cacheMessages("chat-1", [msg("a", T(1))]);
+
+    identityMock.userId = "user-2";
+    expect(await getCachedMessages("chat-1")).toEqual([]);
+
+    identityMock.userId = "user-1";
+    expect((await getCachedMessages("chat-1")).map((m) => m.id)).toEqual(["a"]);
+  });
+
+  it("does not create any database when signed out — writes no-op, reads return empty", async () => {
+    const { cacheMessages, getCachedMessages } = await loadStore();
+    identityMock.userId = null;
+    await cacheMessages("chat-1", [msg("a", T(1))]);
+    expect(await getCachedMessages("chat-1")).toEqual([]);
+    expect(await listDatabaseNames()).toEqual([]);
+  });
+
+  it("requests deletion of the legacy database once per session on first namespaced open", async () => {
+    const { cacheMessages } = await loadStore();
+    await seedDb("first-tree-chat-cache");
+    const spy = vi.spyOn(indexedDB, "deleteDatabase");
+
+    await cacheMessages("chat-1", [msg("a", T(1))]);
+    expect(spy.mock.calls.filter(([name]) => name === "first-tree-chat-cache")).toHaveLength(1);
+
+    // Second write in the same session must not request it again.
+    await cacheMessages("chat-1", [msg("b", T(2))]);
+    expect(spy.mock.calls.filter(([name]) => name === "first-tree-chat-cache")).toHaveLength(1);
+
+    // The fire-and-forget delete eventually lands: only the namespaced
+    // database remains.
+    for (let i = 0; i < 20 && (await listDatabaseNames()).includes("first-tree-chat-cache"); i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(await listDatabaseNames()).toEqual(["first-tree-chat-cache:u:user-1"]);
+  });
+
+  it("closeDbForPurge closes the connection so a later deleteDatabase completes unblocked", async () => {
+    const { cacheMessages, closeDbForPurge } = await loadStore();
+    await cacheMessages("chat-1", [msg("a", T(1))]);
+
+    closeDbForPurge();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await expect(deleteDb("first-tree-chat-cache:u:user-1")).resolves.toBe("success");
+  });
+
+  it("closes automatically on versionchange when another context deletes the database", async () => {
+    const { cacheMessages } = await loadStore();
+    await cacheMessages("chat-1", [msg("a", T(1))]);
+
+    // No closeDbForPurge: the module still holds its connection, so the
+    // delete below can only complete because the versionchange handler
+    // closes it (the multi-tab purge path).
+    await expect(deleteDb("first-tree-chat-cache:u:user-1")).resolves.toBe("success");
+  });
+
+  it("does not recreate any database when a pending poll write lands after logout", async () => {
+    const { cacheMessages, closeDbForPurge } = await loadStore();
+    await cacheMessages("chat-1", [msg("a", T(1))]);
+
+    // Simulate logout + purge: tokens cleared (identity now null),
+    // connections closed, databases deleted.
+    identityMock.userId = null;
+    closeDbForPurge();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await deleteDb("first-tree-chat-cache:u:user-1");
+
+    // The 5-second poll's write-through resolves late, after the purge.
+    await cacheMessages("chat-1", [msg("b", T(2))]);
+    expect(await listDatabaseNames()).toEqual([]);
   });
 });

--- a/packages/web/src/api/image-store.ts
+++ b/packages/web/src/api/image-store.ts
@@ -7,7 +7,14 @@
  * dead-end like the old IndexedDB-only design.
  */
 
-const DB_NAME = "first-tree-images";
+import { currentUserIdFromToken } from "../lib/current-user-id.js";
+
+// Pre-namespacing database name (SEC-042). Databases are now named per
+// account (`first-tree-images:u:<userId>`) so another account on the same
+// browser profile cannot open this one's cached image bytes. The legacy
+// database is deleted — not migrated — on first namespaced open; see
+// message-store.ts for the rationale.
+const LEGACY_DB_NAME = "first-tree-images";
 const DB_VERSION = 1;
 const STORE = "images";
 
@@ -18,34 +25,74 @@ type Stored = {
   createdAt: number;
 };
 
-let dbPromise: Promise<IDBDatabase | null> | null = null;
+// One connection per database name; see message-store.ts for why this is
+// a map rather than a single cached promise.
+const dbPromises = new Map<string, Promise<IDBDatabase | null>>();
+let legacyDeleteRequested = false;
+
+function dbNameForUser(userId: string): string {
+  return `${LEGACY_DB_NAME}:u:${userId}`;
+}
 
 function openDb(): Promise<IDBDatabase | null> {
-  if (dbPromise) return dbPromise;
-  dbPromise = new Promise((resolve) => {
-    if (typeof indexedDB === "undefined") {
-      resolve(null);
-      return;
-    }
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
+  if (typeof indexedDB === "undefined") return Promise.resolve(null);
+  // Per-call identity resolution — anonymous sessions never touch disk;
+  // an in-page account switch transparently lands on the right database.
+  const userId = currentUserIdFromToken();
+  if (userId === null) return Promise.resolve(null);
+  const dbName = dbNameForUser(userId);
+  const existing = dbPromises.get(dbName);
+  if (existing) return existing;
+  const promise = new Promise<IDBDatabase | null>((resolve) => {
+    const req = indexedDB.open(dbName, DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(STORE)) {
         db.createObjectStore(STORE, { keyPath: "imageId" });
       }
     };
-    req.onsuccess = () => resolve(req.result);
+    req.onsuccess = () => {
+      const db = req.result;
+      // Let a purge or another tab's delete/upgrade proceed instead of
+      // staying blocked on this connection.
+      db.onversionchange = () => {
+        db.close();
+        dbPromises.delete(dbName);
+      };
+      if (!legacyDeleteRequested) {
+        legacyDeleteRequested = true;
+        try {
+          indexedDB.deleteDatabase(LEGACY_DB_NAME);
+        } catch {
+          // Best-effort — the logout purge sweeps the legacy name too.
+        }
+      }
+      resolve(db);
+    };
     req.onerror = () => resolve(null);
     req.onblocked = () => resolve(null);
   });
-  return dbPromise;
+  dbPromises.set(dbName, promise);
+  return promise;
+}
+
+/**
+ * Close this module's connections ahead of a purge's `deleteDatabase` so
+ * the delete is not blocked by this tab's own handle.
+ */
+export function closeDbForPurge(): void {
+  for (const promise of dbPromises.values()) {
+    void promise.then((db) => db?.close());
+  }
+  dbPromises.clear();
 }
 
 /**
  * Persist image bytes keyed by imageId. Rejects when IndexedDB is unavailable
- * (incognito, disabled) or the write itself fails (quota, aborted). This is a
- * best-effort cache warm: the bytes also live in the server attachment store,
- * so a rejection is non-fatal — callers should swallow it and let the render
+ * (incognito, disabled, or no signed-in account to namespace the database
+ * under) or the write itself fails (quota, aborted). This is a best-effort
+ * cache warm: the bytes also live in the server attachment store, so a
+ * rejection is non-fatal — callers should swallow it and let the render
  * path re-fetch from the server on the next view.
  */
 export async function putImage(params: { imageId: string; base64: string; mimeType: string }): Promise<void> {

--- a/packages/web/src/api/image-store.ts
+++ b/packages/web/src/api/image-store.ts
@@ -120,7 +120,19 @@ export async function getImage(imageId: string): Promise<{ base64: string; mimeT
   const db = await openDb();
   if (!db) return null;
   return new Promise((resolve) => {
-    const tx = db.transaction(STORE, "readonly");
+    let tx: IDBTransaction;
+    try {
+      tx = db.transaction(STORE, "readonly");
+    } catch {
+      // The logout purge (or a versionchange from another context) closed
+      // this connection between `openDb()` and here, which makes
+      // `transaction()` throw synchronously. The cache is being torn down —
+      // report a miss and let the render path re-fetch from the server.
+      // `putImage` deliberately has no such guard: rejecting is already part
+      // of its contract, and callers swallow the rejection.
+      resolve(null);
+      return;
+    }
     const store = tx.objectStore(STORE);
     const req = store.get(imageId);
     req.onsuccess = () => {

--- a/packages/web/src/api/message-store.ts
+++ b/packages/web/src/api/message-store.ts
@@ -140,6 +140,21 @@ export function closeDbForPurge(): void {
   dbPromises.clear();
 }
 
+// `db.transaction()` throws InvalidStateError synchronously once this
+// connection has been closed — by the logout purge's `closeDbForPurge`, or
+// by a versionchange from another context — in the window between
+// `openDb()` resolving and the transaction starting. The store is being
+// torn down at that point, so operations treat it exactly like the
+// unavailable-database case instead of leaking a rejection into
+// fire-and-forget call sites (`void cacheMessages(...)`).
+function beginTransaction(db: IDBDatabase, mode: IDBTransactionMode): IDBTransaction | null {
+  try {
+    return db.transaction(STORE, mode);
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Read all cached messages for `chatId`, ordered ascending by `createdAt`
  * (oldest first, matching the timeline render order). Returns an empty
@@ -149,7 +164,11 @@ export async function getCachedMessages(chatId: string): Promise<MessageWithDeli
   const db = await openDb();
   if (!db) return [];
   return new Promise((resolve) => {
-    const tx = db.transaction(STORE, "readonly");
+    const tx = beginTransaction(db, "readonly");
+    if (!tx) {
+      resolve([]);
+      return;
+    }
     const store = tx.objectStore(STORE);
     const index = store.index(INDEX_BY_CHAT_CREATED);
     // Range over the composite index from [chatId, ""] to [chatId, "￿"]
@@ -184,7 +203,11 @@ export async function cacheMessages(chatId: string, messages: readonly MessageWi
   const db = await openDb();
   if (!db) return;
   await new Promise<void>((resolve) => {
-    const tx = db.transaction(STORE, "readwrite");
+    const tx = beginTransaction(db, "readwrite");
+    if (!tx) {
+      resolve();
+      return;
+    }
     const store = tx.objectStore(STORE);
     const now = Date.now();
     for (const m of messages) {
@@ -213,7 +236,11 @@ export async function clearChatCache(chatId: string): Promise<void> {
   const db = await openDb();
   if (!db) return;
   await new Promise<void>((resolve) => {
-    const tx = db.transaction(STORE, "readwrite");
+    const tx = beginTransaction(db, "readwrite");
+    if (!tx) {
+      resolve();
+      return;
+    }
     const store = tx.objectStore(STORE);
     const index = store.index(INDEX_BY_CHAT_CREATED);
     const range = IDBKeyRange.bound([chatId, ""], [chatId, "￿"]);

--- a/packages/web/src/api/message-store.ts
+++ b/packages/web/src/api/message-store.ts
@@ -22,9 +22,17 @@
  * issue first-tree-all 119 under parent first-tree-all 118.
  */
 
+import { currentUserIdFromToken } from "../lib/current-user-id.js";
 import type { MessageWithDelivery } from "./chats.js";
 
-const DB_NAME = "first-tree-chat-cache";
+// Pre-namespacing database name (SEC-042). Databases are now named per
+// account (`first-tree-chat-cache:u:<userId>`) so one account can never
+// open another's cache on a shared browser profile. The legacy database is
+// deleted — not migrated — the first time a namespaced open succeeds:
+// legacy rows carry no user attribution, so migrating them could hand a
+// previous account's cached messages to the current one. The logout purge
+// (`lib/purge-local-data.ts`) sweeps it as well.
+const LEGACY_DB_NAME = "first-tree-chat-cache";
 // Schema version is shared with read-state-store.ts (M2). Both modules
 // open the same DB; whichever opens first triggers any pending upgrade.
 // Each module's onupgradeneeded must defensively create-if-not-exists
@@ -49,16 +57,33 @@ type StoredMessage = {
   cachedAt: number;
 };
 
-let dbPromise: Promise<IDBDatabase | null> | null = null;
+// One connection per database name — keyed (rather than a single cached
+// promise) because a logout → login as another account happens without a
+// page reload, so the module must serve different namespaced databases
+// within one page lifetime.
+const dbPromises = new Map<string, Promise<IDBDatabase | null>>();
+// Delete the legacy (pre-namespacing) database at most once per session.
+let legacyDeleteRequested = false;
+
+/** Database name for one account, mirroring the `u:<userId>` scope prefix
+ *  convention the draft store already uses. */
+function dbNameForUser(userId: string): string {
+  return `${LEGACY_DB_NAME}:u:${userId}`;
+}
 
 function openDb(): Promise<IDBDatabase | null> {
-  if (dbPromise) return dbPromise;
-  dbPromise = new Promise((resolve) => {
-    if (typeof indexedDB === "undefined") {
-      resolve(null);
-      return;
-    }
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
+  if (typeof indexedDB === "undefined") return Promise.resolve(null);
+  // Resolve the identity on EVERY call: the same page can serve different
+  // accounts across logout/login, and an anonymous session must not create
+  // (or read) any database at all. All production callers sit behind the
+  // auth gate, so the anonymous branch is defensive.
+  const userId = currentUserIdFromToken();
+  if (userId === null) return Promise.resolve(null);
+  const dbName = dbNameForUser(userId);
+  const existing = dbPromises.get(dbName);
+  if (existing) return existing;
+  const promise = new Promise<IDBDatabase | null>((resolve) => {
+    const req = indexedDB.open(dbName, DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(STORE)) {
@@ -72,11 +97,47 @@ function openDb(): Promise<IDBDatabase | null> {
         db.createObjectStore(READ_STATE_STORE, { keyPath: "chatId" });
       }
     };
-    req.onsuccess = () => resolve(req.result);
+    req.onsuccess = () => {
+      const db = req.result;
+      // Close automatically when another context — another tab, or the
+      // logout purge in this one — wants to delete or upgrade this
+      // database; otherwise its deleteDatabase would stay blocked for as
+      // long as this connection lives.
+      db.onversionchange = () => {
+        db.close();
+        dbPromises.delete(dbName);
+      };
+      if (!legacyDeleteRequested) {
+        legacyDeleteRequested = true;
+        try {
+          // Fire-and-forget: see LEGACY_DB_NAME for why the legacy
+          // database is deleted rather than migrated.
+          indexedDB.deleteDatabase(LEGACY_DB_NAME);
+        } catch {
+          // Best-effort — the logout purge sweeps the legacy name too.
+        }
+      }
+      resolve(db);
+    };
     req.onerror = () => resolve(null);
     req.onblocked = () => resolve(null);
   });
-  return dbPromise;
+  dbPromises.set(dbName, promise);
+  return promise;
+}
+
+/**
+ * Close every connection this module holds so a subsequent
+ * `indexedDB.deleteDatabase` is not blocked by this tab's own handles.
+ * Called by the logout purge before it deletes databases. A connection
+ * still opening settles first and is then closed by the queued callback;
+ * either way the map is cleared so later calls re-open fresh.
+ */
+export function closeDbForPurge(): void {
+  for (const promise of dbPromises.values()) {
+    void promise.then((db) => db?.close());
+  }
+  dbPromises.clear();
 }
 
 /**

--- a/packages/web/src/api/read-state-store.ts
+++ b/packages/web/src/api/read-state-store.ts
@@ -139,6 +139,18 @@ export function closeDbForPurge(): void {
   dbPromises.clear();
 }
 
+// A connection closed by the logout purge (or a versionchange) makes
+// `db.transaction()` throw InvalidStateError synchronously; treat it like
+// the unavailable-database case. See message-store.ts `beginTransaction`
+// for the full rationale.
+function beginTransaction(db: IDBDatabase, mode: IDBTransactionMode): IDBTransaction | null {
+  try {
+    return db.transaction(READ_STATE_STORE, mode);
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Read the scroll-position snapshot for `chatId`. Returns `null` on
  * cache miss, on IndexedDB unavailability, or on any read error —
@@ -148,7 +160,11 @@ export async function getReadState(chatId: string): Promise<ReadState | null> {
   const db = await openDb();
   if (!db) return null;
   return new Promise((resolve) => {
-    const tx = db.transaction(READ_STATE_STORE, "readonly");
+    const tx = beginTransaction(db, "readonly");
+    if (!tx) {
+      resolve(null);
+      return;
+    }
     const store = tx.objectStore(READ_STATE_STORE);
     const req = store.get(chatId);
     req.onsuccess = () => {
@@ -178,7 +194,11 @@ export async function setReadState(
   const db = await openDb();
   if (!db) return;
   await new Promise<void>((resolve) => {
-    const tx = db.transaction(READ_STATE_STORE, "readwrite");
+    const tx = beginTransaction(db, "readwrite");
+    if (!tx) {
+      resolve();
+      return;
+    }
     const store = tx.objectStore(READ_STATE_STORE);
     const entry: ReadState = {
       chatId,
@@ -202,7 +222,11 @@ export async function clearReadState(chatId: string): Promise<void> {
   const db = await openDb();
   if (!db) return;
   await new Promise<void>((resolve) => {
-    const tx = db.transaction(READ_STATE_STORE, "readwrite");
+    const tx = beginTransaction(db, "readwrite");
+    if (!tx) {
+      resolve();
+      return;
+    }
     const store = tx.objectStore(READ_STATE_STORE);
     store.delete(chatId);
     tx.oncomplete = () => resolve();

--- a/packages/web/src/api/read-state-store.ts
+++ b/packages/web/src/api/read-state-store.ts
@@ -29,7 +29,15 @@
  * 120.
  */
 
-const DB_NAME = "first-tree-chat-cache";
+import { currentUserIdFromToken } from "../lib/current-user-id.js";
+
+// Pre-namespacing database name (SEC-042). This module shares one
+// per-account database (`first-tree-chat-cache:u:<userId>`) with
+// message-store.ts but holds its own connection, so the logout purge must
+// close BOTH modules' handles. The legacy database is deleted — not
+// migrated — on first namespaced open; see message-store.ts for the
+// rationale.
+const LEGACY_DB_NAME = "first-tree-chat-cache";
 const DB_VERSION = 2;
 const MESSAGES_STORE = "messages";
 const MESSAGES_INDEX = "by_chat_created";
@@ -63,16 +71,26 @@ export type ReadState = {
   updatedAt: number;
 };
 
-let dbPromise: Promise<IDBDatabase | null> | null = null;
+// One connection per database name; see message-store.ts for why this is
+// a map rather than a single cached promise.
+const dbPromises = new Map<string, Promise<IDBDatabase | null>>();
+let legacyDeleteRequested = false;
+
+function dbNameForUser(userId: string): string {
+  return `${LEGACY_DB_NAME}:u:${userId}`;
+}
 
 function openDb(): Promise<IDBDatabase | null> {
-  if (dbPromise) return dbPromise;
-  dbPromise = new Promise((resolve) => {
-    if (typeof indexedDB === "undefined") {
-      resolve(null);
-      return;
-    }
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
+  if (typeof indexedDB === "undefined") return Promise.resolve(null);
+  // Per-call identity resolution — anonymous sessions never touch disk;
+  // an in-page account switch transparently lands on the right database.
+  const userId = currentUserIdFromToken();
+  if (userId === null) return Promise.resolve(null);
+  const dbName = dbNameForUser(userId);
+  const existing = dbPromises.get(dbName);
+  if (existing) return existing;
+  const promise = new Promise<IDBDatabase | null>((resolve) => {
+    const req = indexedDB.open(dbName, DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(MESSAGES_STORE)) {
@@ -83,11 +101,42 @@ function openDb(): Promise<IDBDatabase | null> {
         db.createObjectStore(READ_STATE_STORE, { keyPath: "chatId" });
       }
     };
-    req.onsuccess = () => resolve(req.result);
+    req.onsuccess = () => {
+      const db = req.result;
+      // Let a purge or another tab's delete/upgrade proceed instead of
+      // staying blocked on this connection.
+      db.onversionchange = () => {
+        db.close();
+        dbPromises.delete(dbName);
+      };
+      if (!legacyDeleteRequested) {
+        legacyDeleteRequested = true;
+        try {
+          // Idempotent with message-store's own legacy delete.
+          indexedDB.deleteDatabase(LEGACY_DB_NAME);
+        } catch {
+          // Best-effort — the logout purge sweeps the legacy name too.
+        }
+      }
+      resolve(db);
+    };
     req.onerror = () => resolve(null);
     req.onblocked = () => resolve(null);
   });
-  return dbPromise;
+  dbPromises.set(dbName, promise);
+  return promise;
+}
+
+/**
+ * Close this module's connections ahead of a purge's `deleteDatabase`.
+ * message-store.ts holds a separate connection to the same database, so
+ * the purge calls both modules' `closeDbForPurge`.
+ */
+export function closeDbForPurge(): void {
+  for (const promise of dbPromises.values()) {
+    void promise.then((db) => db?.close());
+  }
+  dbPromises.clear();
 }
 
 /**

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -19,6 +19,7 @@ const apiMocks = vi.hoisted(() => ({
 
 const loginMock = vi.hoisted(() => vi.fn());
 const onboardingCompletedMock = vi.hoisted(() => vi.fn());
+const purgeMock = vi.hoisted(() => vi.fn());
 const flagsMocks = vi.hoisted(() => ({
   clearOnboardingJoinPath: vi.fn(),
   clearOnboardingSessionFlags: vi.fn(),
@@ -45,6 +46,10 @@ vi.mock("../../api/onboarding-events.js", () => ({
 }));
 
 vi.mock("../../utils/onboarding-flags.js", () => flagsMocks);
+
+vi.mock("../../lib/purge-local-data.js", () => ({
+  purgeLocalUserData: purgeMock,
+}));
 
 let root: Root | null = null;
 let container: HTMLElement | null = null;
@@ -149,6 +154,8 @@ beforeEach(() => {
   root = null;
   container = null;
   vi.clearAllMocks();
+  purgeMock.mockReset();
+  purgeMock.mockResolvedValue(undefined);
   apiMocks.getStoredTokens.mockReturnValue(null);
   apiMocks.apiGet.mockResolvedValue({
     user: { id: "user-1", username: "gandy", displayName: "Gandy", avatarUrl: null },
@@ -397,5 +404,153 @@ describe("AuthProvider", () => {
     });
     expect(latestAuth?.isAuthenticated).toBe(true);
     expect(latestAuth?.meLoaded).toBe(true);
+  });
+});
+
+describe("AuthProvider / logout purge (SEC-042)", () => {
+  it("purges the departing account's local data and resolves only after the purge settles", async () => {
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+    await renderAuth();
+
+    let resolvePurge: (() => void) | null = null;
+    purgeMock.mockReset();
+    purgeMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePurge = resolve;
+        }),
+    );
+
+    let settled = false;
+    let logoutPromise: Promise<void> | undefined;
+    await act(async () => {
+      logoutPromise = latestAuth?.logout().then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+    });
+
+    // The purge receives the id snapshotted BEFORE tokens were cleared, the
+    // synchronous auth teardown has already happened, and logout() is still
+    // awaiting the purge.
+    expect(purgeMock).toHaveBeenCalledWith("user-1");
+    expect(apiMocks.clearStoredTokens).toHaveBeenCalled();
+    expect(latestAuth?.isAuthenticated).toBe(false);
+    expect(settled).toBe(false);
+
+    await act(async () => {
+      resolvePurge?.();
+      await logoutPromise;
+    });
+    expect(settled).toBe(true);
+  });
+
+  it("falls back to the last known user id when tokens were already cleared (401 auto-logout)", async () => {
+    // Mount with user-1's token so the module-level last-known sub is seeded
+    // by the provider's own first-paint decode.
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+    await renderAuth();
+
+    // The real 401 sequence: api/client.ts clears tokens BEFORE dispatching
+    // auth:logout, so by the time logout() runs there is no token to decode.
+    apiMocks.getStoredTokens.mockReturnValue(null);
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("auth:logout"));
+    });
+    await flush();
+
+    expect(purgeMock).toHaveBeenCalledWith("user-1");
+    expect(latestAuth?.isAuthenticated).toBe(false);
+  });
+
+  it("still resets auth state when the purge rejects", async () => {
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+    purgeMock.mockRejectedValue(new Error("purge exploded"));
+    await renderAuth();
+
+    await act(async () => {
+      await latestAuth?.logout();
+    });
+
+    expect(latestAuth?.isAuthenticated).toBe(false);
+    expect(latestAuth?.meLoaded).toBe(false);
+    expect(apiMocks.clearStoredTokens).toHaveBeenCalled();
+  });
+
+  it("purges the previous account when adoptTokens switches subjects", async () => {
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+    // Make the stored-token mocks behave like real storage so the provider
+    // observes the subject change the moment setStoredTokens lands.
+    apiMocks.setStoredTokens.mockImplementation((tokens: { accessToken: string; refreshToken: string }) => {
+      apiMocks.getStoredTokens.mockReturnValue(tokens);
+    });
+    await renderAuth();
+
+    await act(async () => {
+      await latestAuth?.adoptTokens({
+        accessToken: tokenWithPayload({ sub: "user-2" }),
+        refreshToken: "refresh-2",
+      });
+    });
+    await flush();
+
+    expect(purgeMock).toHaveBeenCalledTimes(1);
+    expect(purgeMock).toHaveBeenCalledWith("user-1");
+  });
+
+  it("does not purge when adoptTokens re-adopts the same subject", async () => {
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+    apiMocks.setStoredTokens.mockImplementation((tokens: { accessToken: string; refreshToken: string }) => {
+      apiMocks.getStoredTokens.mockReturnValue(tokens);
+    });
+    await renderAuth();
+
+    await act(async () => {
+      await latestAuth?.adoptTokens({
+        accessToken: tokenWithPayload({ sub: "user-1" }),
+        refreshToken: "refresh-2",
+      });
+    });
+    await flush();
+
+    expect(purgeMock).not.toHaveBeenCalled();
+  });
+
+  it("purges the previous account when login switches subjects", async () => {
+    apiMocks.getStoredTokens.mockReturnValue({
+      accessToken: tokenWithPayload({ sub: "user-1" }),
+      refreshToken: "refresh",
+    });
+    apiMocks.setStoredTokens.mockImplementation((tokens: { accessToken: string; refreshToken: string }) => {
+      apiMocks.getStoredTokens.mockReturnValue(tokens);
+    });
+    loginMock.mockResolvedValue({
+      accessToken: tokenWithPayload({ sub: "user-2" }),
+      refreshToken: "refresh-2",
+    });
+    await renderAuth();
+
+    await act(async () => {
+      await latestAuth?.login("other", "secret");
+    });
+    await flush();
+
+    expect(purgeMock).toHaveBeenCalledTimes(1);
+    expect(purgeMock).toHaveBeenCalledWith("user-1");
   });
 });

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -11,6 +11,8 @@ import {
   setStoredTokens,
 } from "../api/client.js";
 import { markOnboardingCompleted as postOnboardingCompleted } from "../api/onboarding-events.js";
+import { currentUserIdFromToken, lastKnownUserId } from "../lib/current-user-id.js";
+import { purgeLocalUserData } from "../lib/purge-local-data.js";
 import { clearOnboardingJoinPath, clearOnboardingSessionFlags } from "../utils/onboarding-flags.js";
 
 type MeUser = {
@@ -160,7 +162,15 @@ type AuthContextValue = {
   switchingOrg: OrgBrief | null;
   setSwitchingOrg: (org: OrgBrief | null) => void;
   refreshMe: () => Promise<void>;
-  logout: () => void;
+  /**
+   * Clear the session AND purge the departing account's browser-local data
+   * (IndexedDB caches, composer drafts, swept metadata keys — SEC-042).
+   * Resolves once the purge has settled; the purge itself never rejects and
+   * is internally time-boxed, so awaiting cannot hang the caller. Callers
+   * that navigate away with a full page load (user-menu) must await before
+   * navigating so the purge is not cut short.
+   */
+  logout: () => Promise<void>;
 };
 
 // Exported so DEV-only preview pages (e.g. /preview/resources) can render real
@@ -174,23 +184,9 @@ const SELECTED_ORG_KEY = "first-tree:selectedOrganizationId";
 // — so a shared browser never lets one account inherit another's last-used team
 // (two accounts can be members of the same org, so validating "is an active
 // membership" is not enough). The userId comes from the access token's `sub`
-// claim (a plain JWT, no decode lib needed) so the first-paint pre-seed can read
-// the right key before /me resolves.
-function userIdFromToken(): string | null {
-  try {
-    const payload = getStoredTokens()?.accessToken?.split(".")[1];
-    if (!payload) return null;
-    const decoded: unknown = JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
-    if (typeof decoded === "object" && decoded !== null && "sub" in decoded) {
-      const sub = decoded.sub;
-      return typeof sub === "string" ? sub : null;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
+// claim via the shared `currentUserIdFromToken` helper (`lib/current-user-id.ts`,
+// a plain synchronous JWT decode) so the first-paint pre-seed can read the
+// right key before /me resolves.
 function orgStorageKey(userId: string): string {
   return `${SELECTED_ORG_KEY}:${userId}`;
 }
@@ -221,7 +217,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [memberships, setMemberships] = useState<MeMembership[]>([]);
   const [docsEnabled, setDocsEnabled] = useState(false);
   const [selectedOrgId, setSelectedOrgId] = useState<string | null>(() => {
-    const init = readSelectedOrgId(userIdFromToken());
+    const init = readSelectedOrgId(currentUserIdFromToken());
     // Sync the API client's module-level override on first paint so the
     // first wave of requests (made before fetchMe resolves) already carries
     // the correct `?organizationId=` query (codex P1 #2 fix).
@@ -241,7 +237,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // (mounted in the layout) and the switcher (in the header) read one source.
   const [switchingOrg, setSwitchingOrg] = useState<OrgBrief | null>(null);
 
-  const logout = useCallback(() => {
+  const logout = useCallback(async () => {
+    // Snapshot the departing identity BEFORE clearing tokens — the id is
+    // decoded from the stored access token, so it is unreachable afterwards.
+    // The 401 auto-logout path (api/client.ts) clears tokens before it even
+    // dispatches `auth:logout`, so fall back to the module-level last-known
+    // sub for that sequence.
+    const departingUserId = currentUserIdFromToken() ?? lastKnownUserId();
     clearStoredTokens();
     // Keep the persisted last-used org (no writeSelectedOrgId(null) here) so a
     // returning sign-in lands back in the org this user left rather than their
@@ -266,6 +268,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setDocsEnabled(false);
     setMeLoaded(false);
     setSwitchingOrg(null);
+    // Purge the departing account's local data (SEC-042): IndexedDB caches,
+    // composer drafts, and swept metadata keys. The purge never rejects and
+    // is internally time-boxed, so this await cannot hang logout; the extra
+    // catch keeps auth teardown resilient even against a contract regression.
+    await purgeLocalUserData(departingUserId).catch(() => undefined);
   }, [queryClient]);
 
   const fetchMe = useCallback(async () => {
@@ -321,7 +328,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = useCallback(
     async (username: string, password: string) => {
       const tokens = await loginApi(username, password);
+      // An account switch can happen without a logout in between (sign in
+      // as B while A's storage is still warm). Snapshot the old subject
+      // before the new tokens land, then purge the departing account's
+      // local data once the subject provably changed (SEC-042).
+      const previousUserId = currentUserIdFromToken();
       setStoredTokens({ accessToken: tokens.accessToken, refreshToken: tokens.refreshToken });
+      if (previousUserId !== null && previousUserId !== currentUserIdFromToken()) {
+        // Fire-and-forget: this path stays inside the SPA (no full-page
+        // navigation), so the purge completes in the background.
+        void purgeLocalUserData(previousUserId);
+      }
       setIsAuthenticated(true);
       await fetchMe();
     },
@@ -330,7 +347,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const adoptTokens = useCallback(
     async (tokens: { accessToken: string; refreshToken: string }) => {
+      // Same bypass-logout account-switch guard as `login` — this is the
+      // OAuth-completion path, where user B's tokens can replace user A's
+      // without any logout in between.
+      const previousUserId = currentUserIdFromToken();
       setStoredTokens(tokens);
+      if (previousUserId !== null && previousUserId !== currentUserIdFromToken()) {
+        void purgeLocalUserData(previousUserId);
+      }
       setIsAuthenticated(true);
       await fetchMe();
     },
@@ -344,7 +368,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // unauthorized selection just yields a clean 403 from the next call.
       // Persist under the current user's key (token `sub`) so the selection
       // is restored only for this account.
-      writeSelectedOrgId(userIdFromToken(), organizationId);
+      writeSelectedOrgId(currentUserIdFromToken(), organizationId);
       setApiSelectedOrganizationId(organizationId);
       // The org-scoped admin WebSocket is not re-opened by React state changes;
       // signal it to reconnect against the newly selected org so realtime frames
@@ -485,9 +509,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, [isAuthenticated, user, fetchMe]);
 
-  // Listen for auth failure dispatched by the API client
+  // Listen for auth failure dispatched by the API client. Fire-and-forget:
+  // this path stays inside the SPA, so the purge inside logout() completes
+  // without racing a page unload.
   useEffect(() => {
-    const handler = () => logout();
+    const handler = () => {
+      void logout();
+    };
     window.addEventListener("auth:logout", handler);
     return () => window.removeEventListener("auth:logout", handler);
   }, [logout]);

--- a/packages/web/src/components/__tests__/user-menu-dom.test.tsx
+++ b/packages/web/src/components/__tests__/user-menu-dom.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const authMock = vi.hoisted(() => ({
+  value: {
+    user: { id: "user-1", username: "gandy", displayName: "Gandy", avatarUrl: null },
+    logout: vi.fn(),
+  },
+}));
+
+vi.mock("../../auth/auth-context.js", () => ({
+  useAuth: () => authMock.value,
+}));
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+const originalLocation = window.location;
+
+async function renderUserMenu(): Promise<void> {
+  const { UserMenu } = await import("../user-menu.js");
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <MemoryRouter>
+        <UserMenu />
+      </MemoryRouter>,
+    );
+  });
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  authMock.value.logout = vi.fn();
+  // Swap window.location for a plain writable object so the full-page
+  // sign-out navigation is observable without happy-dom actually navigating.
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { href: "http://localhost/workspace" },
+  });
+});
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount());
+  }
+  root = null;
+  container = null;
+  document.body.innerHTML = "";
+  Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+});
+
+describe("UserMenu sign out", () => {
+  it("navigates to the marketing site only after the async logout (purge included) resolves", async () => {
+    let resolveLogout: (() => void) | null = null;
+    authMock.value.logout.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogout = resolve;
+        }),
+    );
+    await renderUserMenu();
+
+    await act(async () => {
+      container?.querySelector<HTMLButtonElement>('button[aria-haspopup="menu"]')?.click();
+    });
+    const signOut =
+      [...(container?.querySelectorAll("button") ?? [])].find((button) => button.textContent?.includes("Sign out")) ??
+      null;
+    expect(signOut).not.toBeNull();
+
+    await act(async () => {
+      signOut?.click();
+      await Promise.resolve();
+    });
+
+    // Ordering contract (SEC-042): while logout — and the local-data purge it
+    // awaits — is still in flight, the full-page navigation that would cut
+    // the purge short must NOT have happened yet.
+    expect(authMock.value.logout).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toBe("http://localhost/workspace");
+
+    await act(async () => {
+      resolveLogout?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(window.location.href).toBe("https://first-tree.ai");
+  });
+});

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -101,9 +101,13 @@ export function UserMenu() {
             <button
               type="button"
               role="menuitem"
-              onClick={() => {
+              onClick={async () => {
                 setOpen(false);
-                logout();
+                // Await the logout — including its local-data purge — before
+                // the full-page navigation below, which would otherwise cut
+                // the in-flight IndexedDB deletes short. logout() is
+                // internally time-boxed, so this cannot hang the click.
+                await logout();
                 // Leave the app on the marketing site rather than an app
                 // route — `logout()` clears local auth state, so staying in
                 // the SPA would just redirect to the login page.

--- a/packages/web/src/lib/__tests__/draft-store.test.ts
+++ b/packages/web/src/lib/__tests__/draft-store.test.ts
@@ -167,3 +167,15 @@ describe("parkFailedDraftIfSwitched", () => {
     expect(loadDraft(chatDraftScope("user-2", "chat-a"))).toBeNull();
   });
 });
+
+describe("scope key format", () => {
+  it("keeps the documented per-user scope shapes (contract the logout purge relies on)", () => {
+    // The logout purge (lib/purge-local-data.ts) deletes the whole drafts
+    // key, and the per-user database namespacing mirrors this `u:<userId>`
+    // prefix convention — lock the exact shapes so neither drifts silently.
+    expect(chatDraftScope("user-1", "chat-9")).toBe("u:user-1:chat:chat-9");
+    expect(chatDraftScope(null, "chat-9")).toBe("u:anon:chat:chat-9");
+    expect(newChatDraftScope("user-1", "org-1", ["agent-a", "agent-b"])).toBe("u:user-1:new:org-1:agent-a,agent-b");
+    expect(newChatDraftScope(null, null)).toBe("u:anon:new:no-org:");
+  });
+});

--- a/packages/web/src/lib/__tests__/purge-local-data.test.ts
+++ b/packages/web/src/lib/__tests__/purge-local-data.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment happy-dom
+
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// This suite exercises the REAL module chain — purge-local-data → the three
+// stores → current-user-id → api/client token storage — with identities
+// seeded through actual stored tokens, so the token → `sub` decode path is
+// covered here (the store suites mock it instead).
+
+function tokenWithPayload(payload: unknown): string {
+  const encoded = btoa(JSON.stringify(payload)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `header.${encoded}.signature`;
+}
+
+function setToken(sub: string): void {
+  localStorage.setItem(
+    "first-tree:tokens",
+    JSON.stringify({ accessToken: tokenWithPayload({ sub }), refreshToken: "refresh" }),
+  );
+}
+
+function createStorage(recordInto?: string[]): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => data.clear(),
+    getItem: (key: string) => data.get(key) ?? null,
+    key: (index: number) => [...data.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      recordInto?.push("localStorage:removeItem");
+      data.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+function installStorage(storage: Storage): void {
+  Object.defineProperty(globalThis, "localStorage", { configurable: true, value: storage });
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
+}
+
+function createThrowingStorage(): Storage {
+  return {
+    get length() {
+      return 0;
+    },
+    clear: () => {
+      throw new Error("storage denied");
+    },
+    getItem: () => {
+      throw new Error("storage denied");
+    },
+    key: () => {
+      throw new Error("storage denied");
+    },
+    removeItem: () => {
+      throw new Error("storage denied");
+    },
+    setItem: () => {
+      throw new Error("storage denied");
+    },
+  };
+}
+
+/** Create (and close) a database so it exists without any open connection. */
+function seedDb(name: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(name, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore("rows");
+    };
+    req.onsuccess = () => {
+      req.result.close();
+      resolve();
+    };
+    req.onerror = () => reject(req.error ?? new Error("seed open failed"));
+  });
+}
+
+async function listDatabaseNames(): Promise<string[]> {
+  const dbs = await indexedDB.databases();
+  return dbs
+    .map((d) => d.name)
+    .filter((n): n is string => typeof n === "string")
+    .sort();
+}
+
+async function loadPurge() {
+  return import("../purge-local-data.js");
+}
+
+type DeleteRequestStub = {
+  onsuccess: (() => void) | null;
+  onerror: (() => void) | null;
+  onblocked: (() => void) | null;
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  globalThis.indexedDB = new IDBFactory();
+  installStorage(createStorage());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("purgeLocalUserData", () => {
+  it("deletes first-party databases and swept keys while preserving the retention list", async () => {
+    await seedDb("first-tree-chat-cache");
+    await seedDb("first-tree-images");
+    await seedDb("first-tree-chat-cache:u:user-a");
+    await seedDb("first-tree-images:u:user-a");
+    localStorage.setItem(
+      "first-tree:chat-drafts:v1",
+      JSON.stringify({ "u:user-a:chat:chat-1": { text: "unsent secret", updatedAt: 1 } }),
+    );
+    localStorage.setItem("first-tree:new-chat-default-agent:user-a:org-1", "agent-1");
+    localStorage.setItem("first-tree:chat-summary-expanded:v1:chat-1", "true");
+    localStorage.setItem("first-tree:chat-summary-dismissed-version:v1:chat-1", "3");
+    localStorage.setItem("first-tree:selectedOrganizationId:user-a", "org-1");
+    localStorage.setItem("theme", "dark");
+    // Explicit logout: tokens already cleared, so no current identity — every
+    // first-party database (all accounts + legacy) goes.
+    const { purgeLocalUserData } = await loadPurge();
+
+    await purgeLocalUserData("user-a");
+
+    expect(await listDatabaseNames()).toEqual([]);
+    expect(localStorage.getItem("first-tree:chat-drafts:v1")).toBeNull();
+    expect(localStorage.getItem("first-tree:new-chat-default-agent:user-a:org-1")).toBeNull();
+    expect(localStorage.getItem("first-tree:chat-summary-expanded:v1:chat-1")).toBeNull();
+    expect(localStorage.getItem("first-tree:chat-summary-dismissed-version:v1:chat-1")).toBeNull();
+    // Retention list: per-user org selection and pure UI preferences survive.
+    expect(localStorage.getItem("first-tree:selectedOrganizationId:user-a")).toBe("org-1");
+    expect(localStorage.getItem("theme")).toBe("dark");
+  });
+
+  it("spares the incoming account's databases on a bypass-logout account switch", async () => {
+    await seedDb("first-tree-chat-cache");
+    await seedDb("first-tree-images");
+    await seedDb("first-tree-chat-cache:u:user-a");
+    await seedDb("first-tree-images:u:user-a");
+    await seedDb("first-tree-chat-cache:u:user-b");
+    await seedDb("first-tree-images:u:user-b");
+    // adoptTokens already stored user-b's tokens before the purge runs.
+    setToken("user-b");
+    const { purgeLocalUserData } = await loadPurge();
+
+    await purgeLocalUserData("user-a");
+
+    expect(await listDatabaseNames()).toEqual(["first-tree-chat-cache:u:user-b", "first-tree-images:u:user-b"]);
+  });
+
+  it("resolves within the time box when database deletes stay blocked", async () => {
+    vi.useFakeTimers();
+    const stub = {
+      databases: async (): Promise<IDBDatabaseInfo[]> => [{ name: "first-tree-chat-cache", version: 2 }],
+      deleteDatabase: (): DeleteRequestStub => ({ onsuccess: null, onerror: null, onblocked: null }),
+    };
+    Object.defineProperty(globalThis, "indexedDB", { configurable: true, value: stub });
+    const { purgeLocalUserData } = await loadPurge();
+
+    let settled = false;
+    const purge = purgeLocalUserData("user-a").then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(10);
+    await purge;
+    expect(settled).toBe(true);
+  });
+
+  it("still resolves and deletes databases when localStorage throws", async () => {
+    await seedDb("first-tree-chat-cache");
+    installStorage(createThrowingStorage());
+    const { purgeLocalUserData } = await loadPurge();
+
+    await expect(purgeLocalUserData("user-a")).resolves.toBeUndefined();
+    expect(await listDatabaseNames()).toEqual([]);
+  });
+
+  it("falls back to the deterministic name list when databases() is unavailable", async () => {
+    const factory = new IDBFactory();
+    globalThis.indexedDB = factory;
+    await seedDb("first-tree-chat-cache");
+    await seedDb("first-tree-chat-cache:u:user-a");
+    await seedDb("first-tree-chat-cache:u:user-c");
+    // Firefox < 126: no indexedDB.databases(). Only open/deleteDatabase exist.
+    const limited = {
+      open: factory.open.bind(factory),
+      deleteDatabase: factory.deleteDatabase.bind(factory),
+    };
+    Object.defineProperty(globalThis, "indexedDB", { configurable: true, value: limited });
+    const { purgeLocalUserData } = await loadPurge();
+
+    await purgeLocalUserData("user-a");
+
+    // Legacy + departing account deleted; an unrelated third account's
+    // database is unreachable without enumeration and survives (its data
+    // stays inaccessible to other accounts via namespacing).
+    const remaining = (await factory.databases()).map((d) => d.name).sort();
+    expect(remaining).toEqual(["first-tree-chat-cache:u:user-c"]);
+  });
+
+  it("sweeps localStorage before issuing any IndexedDB delete", async () => {
+    const order: string[] = [];
+    installStorage(createStorage(order));
+    const stub = {
+      databases: async (): Promise<IDBDatabaseInfo[]> => [{ name: "first-tree-chat-cache", version: 2 }],
+      deleteDatabase: (name: string): DeleteRequestStub => {
+        order.push(`idb:${name}`);
+        const req: DeleteRequestStub = { onsuccess: null, onerror: null, onblocked: null };
+        queueMicrotask(() => req.onsuccess?.());
+        return req;
+      },
+    };
+    Object.defineProperty(globalThis, "indexedDB", { configurable: true, value: stub });
+    const { purgeLocalUserData } = await loadPurge();
+
+    await purgeLocalUserData("user-a");
+
+    const firstStorageSweep = order.indexOf("localStorage:removeItem");
+    const firstDelete = order.findIndex((entry) => entry.startsWith("idb:"));
+    expect(firstStorageSweep).toBeGreaterThanOrEqual(0);
+    expect(firstDelete).toBeGreaterThan(firstStorageSweep);
+  });
+
+  it("resolves when IndexedDB is entirely unavailable", async () => {
+    localStorage.setItem("first-tree:chat-drafts:v1", "{}");
+    delete (globalThis as { indexedDB?: IDBFactory }).indexedDB;
+    const { purgeLocalUserData } = await loadPurge();
+
+    await expect(purgeLocalUserData("user-a")).resolves.toBeUndefined();
+    expect(localStorage.getItem("first-tree:chat-drafts:v1")).toBeNull();
+  });
+});

--- a/packages/web/src/lib/current-user-id.ts
+++ b/packages/web/src/lib/current-user-id.ts
@@ -1,0 +1,58 @@
+/**
+ * Synchronous access to the signed-in user's id, decoded from the stored
+ * access token's JWT `sub` claim (a plain JWT, no decode lib needed).
+ *
+ * Lives outside React so non-React modules — the IndexedDB stores and the
+ * logout purge — can resolve the current account without threading an id
+ * through every call site. Mirrors the module-scope pattern `api/client.ts`
+ * already uses for the selected organization id, and is the shared home of
+ * the decode logic `auth-context.tsx` previously kept private.
+ */
+
+import { getStoredTokens } from "../api/client.js";
+
+/**
+ * The most recent non-null `sub` decoded in this page's lifetime.
+ *
+ * The 401 auto-logout path (`api/client.ts`) clears the stored tokens
+ * BEFORE dispatching `auth:logout`, so by the time `logout()` runs, the
+ * token — and with it the departing user's id — is already gone. This
+ * cache preserves that identity so the purge still targets the right
+ * account's local data.
+ */
+let lastKnownSub: string | null = null;
+
+/**
+ * Decode the current access token's `sub` claim, or `null` when signed out
+ * (no token, malformed token, or unavailable storage). Synchronous — it
+ * reads localStorage directly, so it is correct on first paint before `/me`
+ * resolves. Every successful decode is also recorded for
+ * `lastKnownUserId()`.
+ */
+export function currentUserIdFromToken(): string | null {
+  try {
+    const payload = getStoredTokens()?.accessToken?.split(".")[1];
+    if (!payload) return null;
+    const decoded: unknown = JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
+    if (typeof decoded === "object" && decoded !== null && "sub" in decoded) {
+      const sub = decoded.sub;
+      if (typeof sub === "string") {
+        lastKnownSub = sub;
+        return sub;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The last user id `currentUserIdFromToken()` successfully decoded in this
+ * page's lifetime, or `null` when no token has been seen. Used as the
+ * logout purge's fallback identity for the 401 auto-logout sequence, where
+ * the tokens are cleared before the logout handler runs.
+ */
+export function lastKnownUserId(): string | null {
+  return lastKnownSub;
+}

--- a/packages/web/src/lib/purge-local-data.ts
+++ b/packages/web/src/lib/purge-local-data.ts
@@ -1,0 +1,168 @@
+/**
+ * Best-effort removal of a departing account's browser-local data, run when
+ * that account's session ends: explicit logout, 401 auto-logout, or an
+ * account switch that bypasses logout (`adoptTokens` / `login` with a
+ * different subject). SEC-042: without this sweep, plaintext chat messages,
+ * image bytes, and composer drafts persisted in IndexedDB / localStorage
+ * survive logout and are readable by the next person on the browser.
+ *
+ * Contract: `purgeLocalUserData` NEVER rejects and resolves within
+ * ~`PURGE_TIMEOUT_MS` even when IndexedDB deletes stay blocked — logout
+ * must not hang on storage. Deletes already issued keep running in the
+ * browser's IndexedDB backend after the time box resolves, and any residue
+ * is unreachable through the app anyway thanks to per-account database
+ * namespacing.
+ */
+
+import { closeDbForPurge as closeImageDb } from "../api/image-store.js";
+import { closeDbForPurge as closeMessageDb } from "../api/message-store.js";
+import { closeDbForPurge as closeReadStateDb } from "../api/read-state-store.js";
+import { currentUserIdFromToken } from "./current-user-id.js";
+
+/** Upper bound on how long the purge may keep `logout()` waiting. */
+const PURGE_TIMEOUT_MS = 2000;
+
+/** Prefix shared by every first-party IndexedDB database name — legacy and
+ *  per-account (`…:u:<userId>`) names alike. */
+const IDB_NAME_PREFIX = "first-tree-";
+
+/** Pre-namespacing database names, swept unconditionally. Kept in sync with
+ *  the LEGACY_DB_NAME constants in message-store / read-state-store /
+ *  image-store. */
+const LEGACY_DB_NAMES = ["first-tree-chat-cache", "first-tree-images"] as const;
+
+/** The single localStorage key holding every composer draft (all accounts,
+ *  entries prefixed `u:<userId|anon>` — see `draft-store.ts`). Deleted
+ *  whole: residual entries of OTHER past accounts are the same exposure
+ *  surface, so the sweep is deliberately not scoped to the departing user. */
+const DRAFTS_KEY = "first-tree:chat-drafts:v1";
+
+/** Low-sensitivity chat/agent metadata keys, removed by prefix scan.
+ *  `first-tree:selectedOrganizationId:<userId>` (org UUID only, per-user
+ *  key) and pure UI preference keys are intentionally retained — see the
+ *  retention comment in auth-context's `logout`. */
+const PURGED_KEY_PREFIXES = [
+  "first-tree:new-chat-default-agent:",
+  "first-tree:chat-summary-expanded:v1:",
+  "first-tree:chat-summary-dismissed-version:v1:",
+] as const;
+
+/** Synchronous localStorage sweep. Runs BEFORE the async IndexedDB step so
+ *  it can never be cut short by a navigation or the purge time box. */
+function purgeLocalStorageSync(): void {
+  try {
+    localStorage.removeItem(DRAFTS_KEY);
+  } catch {
+    // Unavailable / denied storage — nothing to purge there, then.
+  }
+  try {
+    const doomed: string[] = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (key !== null && PURGED_KEY_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+        doomed.push(key);
+      }
+    }
+    for (const key of doomed) {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // Same: the sweep is best-effort by contract.
+  }
+}
+
+/** Wrap one `deleteDatabase` call so it always resolves: `blocked` still
+ *  completes once the last open connection closes (the stores'
+ *  `versionchange` handlers close this tab's own), so treat it as issued
+ *  rather than waiting on it. */
+function deleteDatabase(name: string): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      const req = indexedDB.deleteDatabase(name);
+      req.onsuccess = () => resolve();
+      req.onerror = () => resolve();
+      req.onblocked = () => resolve();
+    } catch {
+      resolve();
+    }
+  });
+}
+
+/**
+ * Which databases to delete. Prefers `indexedDB.databases()` enumeration —
+ * it also catches OTHER past accounts' namespaced databases — and falls
+ * back to a deterministic list (legacy names + the departing account's own)
+ * where the API is unavailable (e.g. Firefox < 126).
+ *
+ * Never returns the CURRENT account's databases: on explicit logout the
+ * token is already cleared so nothing is excluded, while on an account
+ * switch (`adoptTokens` / `login`) the new token is already stored and the
+ * new account's warm caches must survive the departing account's purge.
+ */
+async function targetDatabaseNames(departingUserId: string | null): Promise<string[]> {
+  let names: string[] | null = null;
+  if (typeof indexedDB.databases === "function") {
+    try {
+      const all = await indexedDB.databases();
+      names = all
+        .map((info) => info.name)
+        .filter((name): name is string => typeof name === "string" && name.startsWith(IDB_NAME_PREFIX));
+    } catch {
+      names = null;
+    }
+  }
+  if (names === null) {
+    names = [...LEGACY_DB_NAMES];
+    if (departingUserId !== null) {
+      for (const legacy of LEGACY_DB_NAMES) {
+        names.push(`${legacy}:u:${departingUserId}`);
+      }
+    }
+  }
+  const currentUserId = currentUserIdFromToken();
+  if (currentUserId === null) return names;
+  const keepSuffix = `:u:${currentUserId}`;
+  return names.filter((name) => !name.endsWith(keepSuffix));
+}
+
+/**
+ * Purge the departing account's local data: composer drafts and swept
+ * metadata keys (synchronously, first), then every first-party IndexedDB
+ * database except the current account's. `departingUserId` seeds the
+ * fallback delete list when database enumeration is unavailable; pass what
+ * was snapshotted before the tokens were cleared.
+ */
+export async function purgeLocalUserData(departingUserId: string | null): Promise<void> {
+  try {
+    // Close this tab's own connections first so the deletes below are not
+    // blocked by the very app issuing them. message-store and
+    // read-state-store hold separate connections to one shared database —
+    // both must close.
+    closeMessageDb();
+    closeReadStateDb();
+    closeImageDb();
+  } catch {
+    // A close failure only risks a blocked delete, which the time box and
+    // the `onblocked → resolve` wrapper below absorb.
+  }
+
+  purgeLocalStorageSync();
+
+  try {
+    if (typeof indexedDB === "undefined") return;
+    const deletes = (async () => {
+      const names = await targetDatabaseNames(departingUserId);
+      await Promise.allSettled(names.map((name) => deleteDatabase(name)));
+    })();
+    await Promise.race([
+      deletes,
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, PURGE_TIMEOUT_MS);
+      }),
+    ]);
+  } catch {
+    // Purge is strictly best-effort: logout must complete even when
+    // storage APIs misbehave. Residual data stays unreachable through the
+    // app because databases are namespaced per account.
+  }
+}

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -59,7 +59,7 @@ const DEFAULT_AUTH = {
   adoptTokens: async () => undefined,
   selectOrganization: async () => undefined,
   refreshMe: async () => undefined,
-  logout: () => undefined,
+  logout: async () => undefined,
 } as AuthValue;
 
 const JSON_HEADERS = { "Content-Type": "application/json" };

--- a/packages/web/src/pages/mobile/__tests__/me-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/me-dom.test.tsx
@@ -101,7 +101,10 @@ describe("MobileMePage", () => {
 
   beforeEach(() => {
     harness = createDomHarness();
-    authMock.value.logout = vi.fn();
+    // Async to match the real AuthContext contract — logout() now resolves
+    // after the local-data purge (SEC-042). The mobile button passes it
+    // straight to onClick, which tolerates the returned promise.
+    authMock.value.logout = vi.fn(async () => undefined);
   });
 
   it("renders account, team, preference, support, and sign-out controls without admin panels", async () => {


### PR DESCRIPTION
Closes #1647 (audit SEC-042).

## Problem

Logout cleared tokens and React Query state but left the IndexedDB message/image caches and localStorage drafts in place, and none of those stores were scoped per account. On a shared browser profile, the next account (or anyone with access to the profile) could read the previous user's plaintext chats, images, and composer drafts.

## Approach — two independent layers

1. **Per-account namespacing (isolation).** The chat-cache and images databases are now named `first-tree-chat-cache:u:<userId>` / `first-tree-images:u:<userId>` (the same `u:<id>` convention the draft store already uses). Identity is resolved from the JWT `sub` on every open; anonymous sessions never create a database; connections auto-close on `versionchange` so deletes cannot stay blocked. The legacy unnamespaced databases are deleted — not migrated — on first namespaced open: legacy rows carry no user attribution, so migrating them would itself mix accounts.
2. **Purge on session end (removal).** `purgeLocalUserData()` runs on explicit logout, on 401 auto-logout, and on account switches that bypass logout (`login` / `adoptTokens` with a different subject). It never rejects and is time-boxed (~2s) so logout can never hang. The synchronous localStorage sweep (drafts key + low-sensitivity metadata prefixes) runs before the async IndexedDB deletes so it cannot be cut short; database enumeration via `indexedDB.databases()` (deterministic fallback list where unavailable) always spares the incoming account's databases.

Sequencing details worth review attention:

- The departing subject is snapshotted **before** tokens clear; a module-level last-known-sub fallback covers the 401 sequence, which clears tokens before dispatching `auth:logout`.
- `user-menu` now awaits `logout()` before its full-page navigation so the purge is not cut short.
- An operation that already holds a connection when the purge (or a cross-tab `versionchange`) closes it would hit a synchronous `InvalidStateError` from `db.transaction()`; the silent-contract operations treat that like the unavailable-database case, so sign-out cannot leak unhandled rejections from in-flight cache reads/writes into error monitoring.
- `first-tree:selectedOrganizationId:<userId>` (org UUID only, per-user key) and pure UI preference keys are intentionally retained.
- `putImage` keeps its existing reject-on-unavailable contract; only the message/read-state writers are silent no-ops when anonymous.

## Behavior change (intentional)

401 auto-logout now also clears unsent composer drafts. Token expiry on a shared machine is exactly the walk-away scenario this finding is about; splitting behavior by logout cause would leave auto-logout as a leak path.

## Verification

- `pnpm check` and `pnpm typecheck` green.
- `pnpm --filter @first-tree/web test`: **194 files / 1594 tests green**, including 30 new cases — purge contract (blocked deletes, missing `databases()`, storage exceptions, sync-before-async ordering), namespacing + cross-account isolation for all three stores (including the two-connection shared database), closed-connection tolerance for the seven silent-contract store operations, auth sequencing (pre-clear snapshot, 401 fallback identity, `adoptTokens`/`login` switch purge, purge-failure resilience), draft scope-key format regression, and user-menu navigation ordering.

## QA note

This touches the auth / account-switching cross-surface path; per repo guidelines formal QA (shared-profile account switching) is warranted. The matching case is added in this PR: `packages/qa/cases/cross-surface/web-logout-storage-purge.md` (two accounts, three departure paths, storage inventory checks, survivor allowlist).

---

Designed and reviewed with fire-fable-reviewer (design round 1 + M1–M3 revisions absorbed before implementation). Goblet of Fire competition submission — kept as **draft** per competition rules.
