### PR TITLE
fix(client): preserve resume retry message custody

### DIFF
--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -9,6 +9,7 @@ import type {
   SessionEvent,
   SessionState,
 } from "@first-tree/shared";
+import { parseProviderRetryEventMessage } from "@first-tree/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import type { DeliveryDecision, DeliveryRouteOwnership, DeliveryWork } from "../runtime/inbox-delivery-coordinator.js";
@@ -32,7 +33,7 @@ type SessionRecord = {
   lastRetryCategory: string | null;
   lastRetryScope: "session_start" | "session_resume" | null;
   lastRetryRawError: string | null;
-  startMessage: SessionMessage | null;
+  retryHeadMessage: SessionMessage | null;
   retryQueuedMessages: SessionMessage[];
   pendingRuntimeFailureNotice: ProviderRetryEventPayload | null;
   retryFromEvicted: { claudeSessionId: string; lastActivity: number } | null;
@@ -47,12 +48,19 @@ type SessionManagerInternals = {
   inboxDelivery: {
     receive(entry: InboxEntryWithMessage): DeliveryDecision;
     markOwned(work: DeliveryWork): DeliveryRouteOwnership;
+    hasEntry(work: DeliveryWork): boolean;
     markProcessingStarted(chatId: string, messages: SessionMessage | readonly SessionMessage[]): void;
     prepareOperatorSuspend(chatId: string): Promise<void>;
     hasRecoveryDebt(chatId: string): boolean;
+    hasUnsettledWork(chatId: string): boolean;
   };
   _activeCount: number;
-  acquireActiveSlot(chatId: string, message: SessionMessage | null): boolean;
+  acquireActiveSlot(
+    chatId: string,
+    message: SessionMessage | null,
+    deliveryKind?: string,
+    opts?: { queueOnFailure?: boolean },
+  ): boolean;
   routeMessage(chatId: string, message: SessionMessage): Promise<void>;
   resumeSession(entry: SessionRecord, message: SessionMessage | null | undefined): Promise<void>;
   runRetry(chatId: string): Promise<void>;
@@ -262,7 +270,7 @@ function makeSessionRecord(chatId: string, overrides: Partial<SessionRecord> = {
     lastRetryCategory: null,
     lastRetryScope: null,
     lastRetryRawError: null,
-    startMessage: makeMessage(chatId),
+    retryHeadMessage: null,
     retryQueuedMessages: [],
     pendingRuntimeFailureNotice: null,
     retryFromEvicted: null,
@@ -856,7 +864,7 @@ describe("SessionManager edge coverage", () => {
     await sm.shutdown();
   });
 
-  it("covers retry early returns, retry re-queue, empty-message start, resume fallback, and emit failures", async () => {
+  it("covers retry early returns, retry re-queue, start, resume fallback, and emit failures", async () => {
     const events: SessionEvent[] = [];
     const sm = makeManager({
       concurrency: 1,
@@ -875,7 +883,7 @@ describe("SessionManager edge coverage", () => {
       retryAttempt: 1,
       status: "suspended",
       claudeSessionId: "",
-      startMessage: null,
+      retryHeadMessage: makeMessage("chat-retry-queue"),
       lastRetryReason: "rate_limit",
     });
     internals(sm).sessions.set("chat-retry-queue", queued);
@@ -899,6 +907,7 @@ describe("SessionManager edge coverage", () => {
       status: "suspended",
       claudeSessionId: "",
       retryFromEvicted: { claudeSessionId: "evicted-session", lastActivity: 1 },
+      retryHeadMessage: makeMessage("chat-retry-evicted"),
       lastRetryReason: "network_error",
     });
     internals(sm).sessions.set("chat-retry-evicted", fromEvicted);
@@ -927,7 +936,7 @@ describe("SessionManager edge coverage", () => {
     const retrying = makeSessionRecord(chatId, {
       retryAttempt: 1,
       status: "suspended",
-      startMessage: makeMessage(chatId),
+      retryHeadMessage: makeMessage(chatId),
       lastRetryReason: "rate_limit",
     });
     internals(sm).sessions.set(chatId, retrying);
@@ -937,6 +946,176 @@ describe("SessionManager edge coverage", () => {
     expect(recoverChat).toHaveBeenCalledWith(chatId);
     expect(recovered.start).not.toHaveBeenCalled();
     expect(retrying.retryAttempt).toBe(0);
+    await sm.shutdown();
+  });
+
+  it("keeps a message retry head out of the pending queue while a provider slot is busy", async () => {
+    vi.useFakeTimers();
+    const recovered = handler({ resume: vi.fn().mockResolvedValue("resumed-once") });
+    const sm = makeManager({ handlers: [recovered], concurrency: 1 });
+    const i = internals(sm);
+    const chatId = "chat-retry-slot-message";
+    const head = makeMessage(chatId);
+    const retrying = makeSessionRecord(chatId, {
+      retryAttempt: 1,
+      status: "suspended",
+      claudeSessionId: "previous-session",
+      retryHeadMessage: head,
+      lastRetryReason: "network_error",
+    });
+    const blocker = makeSessionRecord("chat-retry-slot-blocker", { status: "active" });
+    i.sessions.set(chatId, retrying);
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const blockerEntry = mockEntry({ id: 901, chatId: blocker.chatId, messageId: "msg-slot-blocker" });
+    const blockerMessage = messageFromEntry(blockerEntry);
+    i.inboxDelivery.receive(blockerEntry);
+    i.inboxDelivery.markOwned({ chatId: blocker.chatId, entryId: blockerEntry.id, messageId: blockerMessage.id });
+    i.inboxDelivery.markProcessingStarted(blocker.chatId, blockerMessage);
+
+    await i.runRetry(chatId);
+
+    expect(recovered.resume).not.toHaveBeenCalled();
+    expect(i.pendingQueue.some((queued) => queued.chatId === chatId)).toBe(false);
+    expect(retrying.retryTimer).not.toBeNull();
+
+    blocker.status = "suspended";
+    i._activeCount = 0;
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(recovered.resume).toHaveBeenCalledTimes(1);
+    expect(recovered.resume).toHaveBeenCalledWith(head, "previous-session", expect.anything(), expect.anything());
+    expect(recovered.inject).not.toHaveBeenCalled();
+    expect(retrying.retryAttempt).toBe(0);
+    expect(retrying.retryTimer).toBeNull();
+
+    await sm.shutdown();
+  });
+
+  it("keeps a control resume retry out of the pending queue while a provider slot is busy", async () => {
+    vi.useFakeTimers();
+    const recovered = handler({ resume: vi.fn().mockResolvedValue("control-resumed-once") });
+    const sm = makeManager({ handlers: [recovered], concurrency: 1 });
+    const i = internals(sm);
+    const chatId = "chat-retry-slot-control";
+    const retrying = makeSessionRecord(chatId, {
+      retryAttempt: 1,
+      status: "suspended",
+      claudeSessionId: "previous-control-session",
+      retryHeadMessage: null,
+      lastRetryReason: "network_error",
+    });
+    const blocker = makeSessionRecord("chat-control-slot-blocker", { status: "active" });
+    i.sessions.set(chatId, retrying);
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const blockerEntry = mockEntry({ id: 902, chatId: blocker.chatId, messageId: "msg-control-blocker" });
+    const blockerMessage = messageFromEntry(blockerEntry);
+    i.inboxDelivery.receive(blockerEntry);
+    i.inboxDelivery.markOwned({ chatId: blocker.chatId, entryId: blockerEntry.id, messageId: blockerMessage.id });
+    i.inboxDelivery.markProcessingStarted(blocker.chatId, blockerMessage);
+
+    await i.runRetry(chatId);
+
+    expect(recovered.resume).not.toHaveBeenCalled();
+    expect(i.pendingQueue.some((queued) => queued.chatId === chatId)).toBe(false);
+    expect(retrying.retryTimer).not.toBeNull();
+
+    blocker.status = "suspended";
+    i._activeCount = 0;
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(recovered.resume).toHaveBeenCalledTimes(1);
+    expect(recovered.resume).toHaveBeenCalledWith(undefined, "previous-control-session", expect.anything());
+    expect(retrying.retryAttempt).toBe(0);
+    expect(retrying.retryTimer).toBeNull();
+
+    await sm.shutdown();
+  });
+
+  it("recovers a retry head whose inbox custody is missing before creating a handler", async () => {
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const blockedHandler = handler();
+    const factory = vi.fn<HandlerFactory>(() => blockedHandler);
+    const events: SessionEvent[] = [];
+    const sm = makeManager({
+      handlerFactory: factory,
+      recoverChat,
+      onSessionEvent: (_chatId, event) => events.push(event),
+    });
+    const chatId = "chat-retry-missing-custody";
+    const retrying = makeSessionRecord(chatId, {
+      retryAttempt: 1,
+      status: "suspended",
+      claudeSessionId: "previous-session",
+      retryHeadMessage: {
+        ...makeMessage(chatId),
+        id: "settled-message",
+        inboxEntryId: 404,
+      },
+      lastRetryReason: "network_error",
+    });
+    internals(sm).sessions.set(chatId, retrying);
+
+    await internals(sm).runRetry(chatId);
+
+    expect(factory).not.toHaveBeenCalled();
+    expect(blockedHandler.start).not.toHaveBeenCalled();
+    expect(blockedHandler.resume).not.toHaveBeenCalled();
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(internals(sm).sessions.has(chatId)).toBe(false);
+    expect(
+      events.some(
+        (event) =>
+          event.kind === "error" &&
+          parseProviderRetryEventMessage(event.payload.message)?.event === "provider_retry_succeeded",
+      ),
+    ).toBe(false);
+
+    await sm.shutdown();
+  });
+
+  it("recovers an unconsumed queued tail after a retry head fails terminally", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const terminal = handler({
+      resume: vi.fn().mockRejectedValue({ name: "ClientUserMismatchError", message: "runtime authorization changed" }),
+    });
+    const sm = makeManager({
+      handlers: [terminal],
+      ackEntry,
+      recoverChat,
+      confirmSessionEvent: vi.fn().mockResolvedValue(undefined),
+    });
+    const i = internals(sm);
+    const chatId = "chat-retry-terminal-tail";
+    const headEntry = mockEntry({ id: 2, chatId, messageId: "msg-terminal-head" });
+    const tailEntry = mockEntry({ id: 3, chatId, messageId: "msg-terminal-tail" });
+    const head = messageFromEntry(headEntry);
+    const tail = messageFromEntry(tailEntry);
+    i.inboxDelivery.receive(headEntry);
+    i.inboxDelivery.receive(tailEntry);
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        retryAttempt: 1,
+        status: "suspended",
+        claudeSessionId: "previous-session",
+        retryHeadMessage: head,
+        retryQueuedMessages: [tail],
+      }),
+    );
+
+    await i.runRetry(chatId);
+
+    expect(ackEntry).toHaveBeenCalledWith(2);
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(i.inboxDelivery.hasEntry({ chatId, entryId: tailEntry.id, messageId: tail.id })).toBe(false);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
+    expect(i.sessions.has(chatId)).toBe(false);
+
     await sm.shutdown();
   });
 
@@ -960,7 +1139,7 @@ describe("SessionManager edge coverage", () => {
       retryAttempt: 1,
       status: "suspended",
       claudeSessionId: "",
-      startMessage: makeMessage("chat-retry-transient"),
+      retryHeadMessage: makeMessage("chat-retry-transient"),
       lastRetryReason: "rate_limit",
     });
     internals(sm).sessions.set("chat-retry-transient", retrying);
@@ -971,7 +1150,7 @@ describe("SessionManager edge coverage", () => {
       retryAttempt: 1,
       status: "suspended",
       claudeSessionId: "",
-      startMessage: makeMessage("chat-retry-permanent"),
+      retryHeadMessage: makeMessage("chat-retry-permanent"),
     });
     internals(sm).sessions.set("chat-retry-permanent", failing);
     await internals(sm).runRetry("chat-retry-permanent");
@@ -1007,7 +1186,7 @@ describe("SessionManager edge coverage", () => {
       retryAttempt: 1,
       status: "suspended",
       claudeSessionId: "",
-      startMessage: makeMessage("chat-rearm"),
+      retryHeadMessage: makeMessage("chat-rearm"),
       lastRetryReason: "rate_limit",
     });
     internals(sm).sessions.set("chat-rearm", retrying);
@@ -1039,7 +1218,7 @@ describe("SessionManager edge coverage", () => {
       retryAttempt: 1,
       status: "suspended",
       claudeSessionId: "previous-session",
-      startMessage: null,
+      retryHeadMessage: null,
       lastRetryReason: "rate_limit",
     });
     internals(sm).sessions.set("chat-retry-success", succeeds);
@@ -1051,7 +1230,7 @@ describe("SessionManager edge coverage", () => {
       status: "suspended",
       claudeSessionId: "previous-session-again",
       retryTimer: existingTimer,
-      startMessage: makeMessage("chat-retry-again"),
+      retryHeadMessage: makeMessage("chat-retry-again"),
       lastRetryReason: "rate_limit",
     });
     internals(sm).sessions.set("chat-retry-again", retriesAgain);
@@ -1071,7 +1250,7 @@ describe("SessionManager edge coverage", () => {
       status: "suspended",
       claudeSessionId: "",
       retryFromEvicted: { claudeSessionId: "evicted-session", lastActivity: 1 },
-      startMessage: makeMessage("chat-retry-from-evicted"),
+      retryHeadMessage: makeMessage("chat-retry-from-evicted"),
       lastRetryReason: "rate_limit",
     });
     internals(sm).sessions.set("chat-retry-from-evicted", retrying);
@@ -1640,6 +1819,7 @@ describe("SessionManager edge coverage", () => {
         retryAttempt: 1,
         status: "suspended",
         claudeSessionId: "previous-retry",
+        retryHeadMessage: makeMessage("chat-retry-resume-lost"),
       }),
     );
     internals(retryResumeManager).markRouteOwned = loseOwnership;
@@ -1655,6 +1835,7 @@ describe("SessionManager edge coverage", () => {
         retryAttempt: 1,
         status: "suspended",
         claudeSessionId: "",
+        retryHeadMessage: makeMessage("chat-retry-start-lost"),
       }),
     );
     internals(retryStartManager).markRouteOwned = loseOwnership;

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -37,7 +37,7 @@ type SessionRecord = {
   retryHeadMessage: SessionMessage | null;
   deferredMessages: SessionMessage[];
   routeTransitionGeneration: number;
-  routeTransition: { generation: number; handler: AgentHandler } | null;
+  routeTransition: { generation: number; handler: AgentHandler; phase: "start" | "resume" } | null;
   pendingRuntimeFailureNotice: ProviderRetryEventPayload | null;
   retryFromEvicted: { claudeSessionId: string; lastActivity: number } | null;
 };
@@ -429,6 +429,11 @@ describe("SessionManager edge coverage", () => {
         status: "suspended",
       };
     }
+    entries["chat-empty-legacy"] = {
+      claudeSessionId: "",
+      lastActivity: new Date(10_000).toISOString(),
+      status: "suspended",
+    };
     writeFileSync(registryPath, JSON.stringify({ version: 1, entries }), "utf-8");
 
     const resumed = handler({ resume: vi.fn().mockResolvedValue("resumed-from-registry") });
@@ -436,6 +441,7 @@ describe("SessionManager edge coverage", () => {
 
     expect(sm.getEvictedChatIds()).not.toContain("chat-0");
     expect(sm.getEvictedChatIds()).toContain("chat-500");
+    expect(sm.getEvictedChatIds()).not.toContain("chat-empty-legacy");
 
     await sm.dispatch(mockEntry({ id: 1, chatId: "chat-500" }));
     expect(resumed.resume).toHaveBeenCalledWith(
@@ -449,6 +455,50 @@ describe("SessionManager edge coverage", () => {
     internals(sm).persistRegistry();
     await sm.shutdown();
 
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does not persist an unresolved fresh start as an empty resume mapping across manager restart", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ft-session-registry-unresolved-start-"));
+    const registryPath = join(dir, "sessions.json");
+    let signalStartStarted: (() => void) | undefined;
+    let resolveStart: (() => void) | undefined;
+    const startStarted = new Promise<void>((resolve) => {
+      signalStartStarted = resolve;
+    });
+    const startGate = new Promise<void>((resolve) => {
+      resolveStart = resolve;
+    });
+    const pendingHandler = handler({
+      start: vi.fn().mockImplementation(async () => {
+        signalStartStarted?.();
+        await startGate;
+        return "stale-session";
+      }),
+    });
+    const first = makeManager({ handlers: [pendingHandler], registryPath });
+    const chatId = "chat-registry-unresolved-start";
+    const entry = mockEntry({ id: 91, chatId, messageId: "msg-registry-unresolved-start" });
+
+    const pendingDispatch = first.dispatch(entry);
+    await startStarted;
+    await first.shutdown();
+
+    const persisted = JSON.parse(readFileSync(registryPath, "utf-8")) as { entries: Record<string, unknown> };
+    expect(persisted.entries).toEqual({});
+
+    resolveStart?.();
+    await pendingDispatch;
+
+    const replacement = handler({ start: vi.fn().mockResolvedValue("replacement-session") });
+    const second = makeManager({ handlers: [replacement], registryPath });
+    await second.dispatch(entry);
+
+    expect(replacement.start).toHaveBeenCalledTimes(1);
+    expect(replacement.resume).not.toHaveBeenCalled();
+    expect(internals(second).sessions.get(chatId)?.claudeSessionId).toBe("replacement-session");
+
+    await second.shutdown();
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -1304,6 +1354,127 @@ describe("SessionManager edge coverage", () => {
     await freshCtx.finishTurn(messageFromEntry(tailEntry), { status: "success", terminal: true });
     expect(ackEntry).toHaveBeenNthCalledWith(1, 2);
     expect(ackEntry).toHaveBeenNthCalledWith(2, 3);
+
+    await sm.shutdown();
+  });
+
+  it("redelivers a canceled unresolved start through a fresh start instead of resume", async () => {
+    let signalStartStarted: (() => void) | undefined;
+    let resolveStart: (() => void) | undefined;
+    const startStarted = new Promise<void>((resolve) => {
+      signalStartStarted = resolve;
+    });
+    const pendingStart = new Promise<void>((resolve) => {
+      resolveStart = resolve;
+    });
+    const oldHandler = handler({
+      start: vi.fn().mockImplementation(async () => {
+        signalStartStarted?.();
+        await pendingStart;
+        return "stale-start-session";
+      }),
+    });
+    let freshCtx: SessionContext | undefined;
+    let freshHead: SessionMessage | undefined;
+    const freshHandler = handler({
+      start: vi.fn().mockImplementation(async (message, ctx) => {
+        freshCtx = ctx;
+        freshHead = message;
+        return "fresh-start-session";
+      }),
+    });
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({
+      handlers: [oldHandler, freshHandler],
+      ackEntry,
+      recoverChat,
+    });
+    const i = internals(sm);
+    const chatId = "chat-suspend-late-success-start";
+    const headEntry = mockEntry({ id: 82, chatId, messageId: "msg-canceled-start-head" });
+    const tailEntry = mockEntry({ id: 83, chatId, messageId: "msg-canceled-start-tail" });
+    const blocker = makeSessionRecord("chat-canceled-start-blocker", { status: "active" });
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const headDispatch = sm.dispatch(headEntry);
+    await startStarted;
+    await sm.dispatch(tailEntry);
+    expect(i.sessions.get(chatId)?.deferredMessages).toHaveLength(1);
+    expect(sm.activeCount).toBe(2);
+
+    await sm.handleCommand(chatId, "session:suspend");
+    await vi.waitFor(() => expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true));
+
+    expect(i.sessions.has(chatId)).toBe(false);
+    expect(sm.activeCount).toBe(1);
+    expect(oldHandler.resume).not.toHaveBeenCalled();
+
+    resolveStart?.();
+    await headDispatch;
+    expect(ackEntry).not.toHaveBeenCalled();
+
+    await sm.handleCommand(chatId, "session:resume");
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+
+    await sm.dispatch(headEntry);
+    await sm.dispatch(tailEntry);
+
+    expect(freshHandler.start).toHaveBeenCalledTimes(1);
+    expect(freshHandler.resume).not.toHaveBeenCalled();
+    expect(freshHead?.id).toBe(headEntry.message.id);
+    expect(freshHandler.inject).toHaveBeenCalledWith(
+      expect.objectContaining({ id: tailEntry.message.id }),
+      expect.anything(),
+    );
+    expect(i.sessions.get(chatId)?.claudeSessionId).toBe("fresh-start-session");
+    expect(sm.activeCount).toBe(2);
+
+    if (!freshCtx || !freshHead) throw new Error("fresh replacement start route was not captured");
+    await freshCtx.finishTurn(freshHead, { status: "success", terminal: true });
+    await freshCtx.finishTurn(messageFromEntry(tailEntry), { status: "success", terminal: true });
+    expect(ackEntry).toHaveBeenNthCalledWith(1, headEntry.id);
+    expect(ackEntry).toHaveBeenNthCalledWith(2, tailEntry.id);
+
+    await sm.shutdown();
+  });
+
+  it("does not create an empty resume mapping when LRU evicts a fresh-start retry window", async () => {
+    const replacement = handler({ start: vi.fn().mockResolvedValue("replacement-after-lru") });
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({
+      handlers: [replacement],
+      recoverChat,
+      maxSessions: 1,
+    });
+    const i = internals(sm);
+    const chatId = "chat-lru-fresh-start-retry";
+    const headEntry = mockEntry({ id: 84, chatId, messageId: "msg-lru-fresh-start-retry" });
+    const head = messageFromEntry(headEntry);
+    i.inboxDelivery.receive(headEntry);
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        status: "suspended",
+        claudeSessionId: "",
+        retryAttempt: 1,
+        retryHeadMessage: head,
+        routeTransition: null,
+      }),
+    );
+
+    i.evictIfNeeded();
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith(chatId));
+
+    expect(i.sessions.has(chatId)).toBe(false);
+    expect(i.evictedMappings.has(chatId)).toBe(false);
+
+    await sm.dispatch(headEntry);
+
+    expect(replacement.start).toHaveBeenCalledTimes(1);
+    expect(replacement.resume).not.toHaveBeenCalled();
+    expect(i.sessions.get(chatId)?.claudeSessionId).toBe("replacement-after-lru");
 
     await sm.shutdown();
   });

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -1406,6 +1406,9 @@ describe("SessionManager edge coverage", () => {
 
     await sm.handleCommand(chatId, "session:suspend");
     await vi.waitFor(() => expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true));
+    const suspension = i.sessions.get(chatId)?.suspending;
+    expect(suspension).not.toBeNull();
+    await suspension;
 
     expect(i.sessions.has(chatId)).toBe(false);
     expect(sm.activeCount).toBe(1);
@@ -1436,6 +1439,87 @@ describe("SessionManager edge coverage", () => {
     await freshCtx.finishTurn(messageFromEntry(tailEntry), { status: "success", terminal: true });
     expect(ackEntry).toHaveBeenNthCalledWith(1, headEntry.id);
     expect(ackEntry).toHaveBeenNthCalledWith(2, tailEntry.id);
+
+    await sm.shutdown();
+  });
+
+  it("keeps canceled fresh-start admission fenced while operator suspend ACK is pending", async () => {
+    let signalStartStarted: (() => void) | undefined;
+    let resolveStart: (() => void) | undefined;
+    const startStarted = new Promise<void>((resolve) => {
+      signalStartStarted = resolve;
+    });
+    const startGate = new Promise<void>((resolve) => {
+      resolveStart = resolve;
+    });
+    let signalAckStarted: (() => void) | undefined;
+    let resolveAck: (() => void) | undefined;
+    const ackStarted = new Promise<void>((resolve) => {
+      signalAckStarted = resolve;
+    });
+    const ackGate = new Promise<void>((resolve) => {
+      resolveAck = resolve;
+    });
+    const oldHandler = handler({
+      start: vi.fn().mockImplementation(async (message, _ctx, token) => {
+        token.processingStarted(message);
+        signalStartStarted?.();
+        await startGate;
+        return "stale-start-session";
+      }),
+    });
+    const replacement = handler({ start: vi.fn().mockResolvedValue("replacement-tail-session") });
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockImplementation(async () => {
+      signalAckStarted?.();
+      await ackGate;
+    });
+    const sm = makeManager({
+      handlers: [oldHandler, replacement],
+      ackEntry,
+    });
+    const i = internals(sm);
+    const chatId = "chat-canceled-start-pending-operator-ack";
+    const headEntry = mockEntry({ id: 85, chatId, messageId: "msg-canceled-start-processing-head" });
+    const tailEntry = mockEntry({ id: 86, chatId, messageId: "msg-canceled-start-during-ack" });
+    const blocker = makeSessionRecord("chat-canceled-start-ack-blocker", { status: "active" });
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const headDispatch = sm.dispatch(headEntry);
+    await startStarted;
+    expect(sm.activeCount).toBe(2);
+
+    await sm.handleCommand(chatId, "session:suspend");
+    await ackStarted;
+    expect(i.sessions.get(chatId)?.suspending).not.toBeNull();
+    expect(sm.activeCount).toBe(1);
+
+    const tailDispatch = sm.dispatch(tailEntry);
+    await Promise.resolve();
+
+    expect(replacement.start).not.toHaveBeenCalled();
+    expect(replacement.resume).not.toHaveBeenCalled();
+    expect(oldHandler.inject).not.toHaveBeenCalled();
+    expect(i.sessions.has(chatId)).toBe(true);
+    expect(sm.activeCount).toBe(1);
+
+    resolveAck?.();
+    await tailDispatch;
+
+    expect(i.sessions.get(chatId)?.claudeSessionId).toBe("replacement-tail-session");
+    expect(replacement.start).toHaveBeenCalledTimes(1);
+    expect(replacement.start).toHaveBeenCalledWith(
+      expect.objectContaining({ id: tailEntry.message.id }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(replacement.resume).not.toHaveBeenCalled();
+    expect(sm.activeCount).toBe(2);
+
+    resolveStart?.();
+    await headDispatch;
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledWith(headEntry.id);
 
     await sm.shutdown();
   });

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -9,7 +9,7 @@ import type {
   SessionEvent,
   SessionState,
 } from "@first-tree/shared";
-import { parseProviderRetryEventMessage } from "@first-tree/shared";
+import { encodeProviderRetryEventMessage, parseProviderRetryEventMessage } from "@first-tree/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentHandler, HandlerFactory, SessionContext, SessionMessage } from "../runtime/handler.js";
 import type { DeliveryDecision, DeliveryRouteOwnership, DeliveryWork } from "../runtime/inbox-delivery-coordinator.js";
@@ -36,7 +36,8 @@ type SessionRecord = {
   lastRetryRawError: string | null;
   retryHeadMessage: SessionMessage | null;
   deferredMessages: SessionMessage[];
-  routeTransitionPending: boolean;
+  routeTransitionGeneration: number;
+  routeTransition: { generation: number; handler: AgentHandler } | null;
   pendingRuntimeFailureNotice: ProviderRetryEventPayload | null;
   retryFromEvicted: { claudeSessionId: string; lastActivity: number } | null;
 };
@@ -55,6 +56,11 @@ type SessionManagerInternals = {
     prepareOperatorSuspend(chatId: string): Promise<void>;
     hasRecoveryDebt(chatId: string): boolean;
     hasUnsettledWork(chatId: string): boolean;
+    snapshot(chatId: string): {
+      entries: Array<{ entryId: number; messageId: string; phase: string }>;
+      recoveryDebt: string;
+      admissionPending: boolean;
+    };
   };
   _activeCount: number;
   acquireActiveSlot(
@@ -64,6 +70,7 @@ type SessionManagerInternals = {
     opts?: { queueOnFailure?: boolean },
   ): boolean;
   routeMessage(chatId: string, message: SessionMessage): Promise<void>;
+  startNewSession(chatId: string, message: SessionMessage, deliveryKind?: string): Promise<void>;
   resumeSession(entry: SessionRecord, message: SessionMessage | null | undefined): Promise<void>;
   runRetry(chatId: string): Promise<void>;
   abortUnownedRoute(entry: SessionRecord, reason: string): void;
@@ -276,7 +283,8 @@ function makeSessionRecord(chatId: string, overrides: Partial<SessionRecord> = {
     lastRetryRawError: null,
     retryHeadMessage: null,
     deferredMessages: [],
-    routeTransitionPending: false,
+    routeTransitionGeneration: 0,
+    routeTransition: null,
     pendingRuntimeFailureNotice: null,
     retryFromEvicted: null,
     ...overrides,
@@ -1082,6 +1090,73 @@ describe("SessionManager edge coverage", () => {
     await sm.shutdown();
   });
 
+  it.each([
+    "normal",
+    "evicted",
+    "retry",
+  ] as const)("fails closed when a messageful %s resume omits its route receipt", async (resumeKind) => {
+    const nullRouteHandler = handler({
+      resume: vi.fn().mockResolvedValue({ sessionId: "unowned-session", route: null }),
+    });
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const retryEvents: string[] = [];
+    const sm = makeManager({
+      handlers: [nullRouteHandler],
+      recoverChat,
+      onSessionEvent: (_chatId, event) => {
+        const parsed = event.kind === "error" ? parseProviderRetryEventMessage(event.payload.message) : null;
+        if (parsed) retryEvents.push(parsed.event);
+      },
+    });
+    const i = internals(sm);
+    const chatId = `chat-null-resume-route-${resumeKind}`;
+    const headEntry = mockEntry({ id: 2, chatId, messageId: `msg-null-route-head-${resumeKind}` });
+    const head = messageFromEntry(headEntry);
+
+    if (resumeKind === "normal") {
+      i.sessions.set(
+        chatId,
+        makeSessionRecord(chatId, {
+          handler: nullRouteHandler,
+          status: "suspended",
+          claudeSessionId: "previous-normal-session",
+        }),
+      );
+      await sm.dispatch(headEntry);
+    } else if (resumeKind === "evicted") {
+      i.evictedMappings.set(chatId, { claudeSessionId: "previous-evicted-session", lastActivity: 1 });
+      i.inboxDelivery.receive(headEntry);
+      await i.startNewSession(chatId, head, "recovery");
+    } else {
+      const tailEntry = mockEntry({ id: 3, chatId, messageId: "msg-null-route-tail-retry" });
+      const tail = messageFromEntry(tailEntry);
+      i.inboxDelivery.receive(headEntry);
+      i.inboxDelivery.receive(tailEntry);
+      i.sessions.set(
+        chatId,
+        makeSessionRecord(chatId, {
+          retryAttempt: 1,
+          retryHeadMessage: head,
+          deferredMessages: [tail],
+          lastRetryReason: "network_error",
+          status: "suspended",
+          claudeSessionId: "previous-retry-session",
+        }),
+      );
+      await i.runRetry(chatId);
+      expect(nullRouteHandler.inject).not.toHaveBeenCalled();
+    }
+
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith(chatId));
+    expect(nullRouteHandler.resume).toHaveBeenCalledTimes(1);
+    expect(i.sessions.has(chatId)).toBe(false);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
+    expect(sm.activeCount).toBe(0);
+    expect(retryEvents).not.toContain("provider_retry_succeeded");
+
+    await sm.shutdown();
+  });
+
   it("recovers an unconsumed queued tail after a retry head fails terminally", async () => {
     const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
@@ -1124,32 +1199,52 @@ describe("SessionManager edge coverage", () => {
     await sm.shutdown();
   });
 
-  it("recovers deferred work when operator suspend races a late terminal resume failure", async () => {
+  it("fences a late resume success after operator suspend and uses a fresh handler for redelivery", async () => {
     let signalResumeStarted: (() => void) | undefined;
-    let rejectResume: ((reason?: unknown) => void) | undefined;
+    let resolveResume: (() => void) | undefined;
     const resumeStarted = new Promise<void>((resolve) => {
       signalResumeStarted = resolve;
     });
-    const pendingResume = new Promise<string>((_resolve, reject) => {
-      rejectResume = reject;
+    const pendingResume = new Promise<void>((resolve) => {
+      resolveResume = resolve;
     });
+    let staleCtx: SessionContext | undefined;
+    let staleHead: SessionMessage | undefined;
     const existingHandler = handler({
-      resume: vi.fn().mockImplementation(() => {
+      resume: vi.fn().mockImplementation(async (message, _sessionId, ctx, token) => {
+        staleCtx = ctx;
+        staleHead = message;
         signalResumeStarted?.();
-        return pendingResume;
+        await pendingResume;
+        ctx.replaceSessionId("stale-session", "late success");
+        if (message) {
+          token?.processingStarted(message);
+          await token?.complete(message, { status: "success", terminal: true });
+          await ctx.finishTurn(message, { status: "success", terminal: true });
+        }
+        return "stale-session";
+      }),
+    });
+    let freshCtx: SessionContext | undefined;
+    let freshHead: SessionMessage | undefined;
+    const freshHandler = handler({
+      resume: vi.fn().mockImplementation(async (message, _sessionId, ctx) => {
+        freshCtx = ctx;
+        freshHead = message;
+        return "fresh-session";
       }),
     });
     const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
     const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
     const sm = makeManager({
+      handlers: [freshHandler],
       ackEntry,
       recoverChat,
-      confirmSessionEvent: vi.fn().mockResolvedValue(undefined),
     });
     const i = internals(sm);
-    const chatId = "chat-suspend-late-terminal-resume";
-    const headEntry = mockEntry({ id: 2, chatId, messageId: "msg-late-terminal-head" });
-    const tailEntry = mockEntry({ id: 3, chatId, messageId: "msg-late-terminal-tail" });
+    const chatId = "chat-suspend-late-success-resume";
+    const headEntry = mockEntry({ id: 2, chatId, messageId: "msg-late-success-head" });
+    const tailEntry = mockEntry({ id: 3, chatId, messageId: "msg-late-success-tail" });
     i.sessions.set(
       chatId,
       makeSessionRecord(chatId, {
@@ -1172,21 +1267,540 @@ describe("SessionManager edge coverage", () => {
     await vi.waitFor(() => expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true));
     expect(sm.activeCount).toBe(1);
 
-    rejectResume?.({ name: "ClientUserMismatchError", message: "runtime authorization changed" });
+    resolveResume?.();
     await headDispatch;
 
-    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(staleCtx).toBeDefined();
+    expect(staleHead?.id).toBe(headEntry.message.id);
+    expect(existingHandler.shutdown).toHaveBeenCalledTimes(2);
+    expect(existingHandler.inject).not.toHaveBeenCalled();
+    expect(i.sessions.get(chatId)?.status).toBe("suspended");
+    expect(i.sessions.get(chatId)?.claudeSessionId).toBe("previous-session");
+    expect(freshHandler.resume).not.toHaveBeenCalled();
+    expect(recoverChat).not.toHaveBeenCalled();
     expect(ackEntry).not.toHaveBeenCalledWith(2);
     expect(ackEntry).not.toHaveBeenCalledWith(3);
-    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
-    expect(i.sessions.has(chatId)).toBe(false);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(true);
     expect(i.sessions.has(blocker.chatId)).toBe(true);
     expect(sm.activeCount).toBe(1);
+
+    await sm.handleCommand(chatId, "session:resume");
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(freshHandler.resume).not.toHaveBeenCalled();
+
+    await sm.dispatch(headEntry);
+    await sm.dispatch(tailEntry);
+
+    expect(freshHandler.resume).toHaveBeenCalledTimes(1);
+    expect(freshHead?.id).toBe(headEntry.message.id);
+    expect(freshHandler.inject).toHaveBeenCalledTimes(1);
+    expect(freshHandler.inject).toHaveBeenCalledWith(
+      expect.objectContaining({ id: tailEntry.message.id }),
+      expect.anything(),
+    );
+    expect(sm.activeCount).toBe(2);
+    if (!freshCtx || !freshHead) throw new Error("fresh recovery route was not captured");
+    await freshCtx.finishTurn(freshHead, { status: "success", terminal: true });
+    await freshCtx.finishTurn(messageFromEntry(tailEntry), { status: "success", terminal: true });
+    expect(ackEntry).toHaveBeenNthCalledWith(1, 2);
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 3);
 
     await sm.shutdown();
   });
 
-  it("does not release a blocker slot twice when suspended resume fails transiently", async () => {
+  it("fences active inject tokens across suspend recovery and same-entry redelivery", async () => {
+    let initialCtx: SessionContext | undefined;
+    let initialHead: SessionMessage | undefined;
+    let staleToken: Parameters<AgentHandler["inject"]>[1];
+    let signalWinningResumeStarted: (() => void) | undefined;
+    let resolveWinningResume: (() => void) | undefined;
+    const winningResumeStarted = new Promise<void>((resolve) => {
+      signalWinningResumeStarted = resolve;
+    });
+    const winningResumeGate = new Promise<void>((resolve) => {
+      resolveWinningResume = resolve;
+    });
+    let winningCtx: SessionContext | undefined;
+    let winningHead: SessionMessage | undefined;
+    const establishedHandler = handler({
+      start: vi.fn().mockImplementation(async (message, ctx) => {
+        initialCtx = ctx;
+        initialHead = message;
+        return "established-token-session";
+      }),
+      inject: vi.fn().mockImplementation((_message, token) => {
+        staleToken = token;
+        return { kind: "owned", mode: "queued" } as const;
+      }),
+      resume: vi.fn().mockImplementation(async (message, _sessionId, ctx) => {
+        winningCtx = ctx;
+        winningHead = message;
+        signalWinningResumeStarted?.();
+        await winningResumeGate;
+        return "winning-token-session";
+      }),
+    });
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({ handlers: [establishedHandler], ackEntry, recoverChat });
+    const i = internals(sm);
+    const chatId = "chat-active-token-fence";
+    const firstEntry = mockEntry({ id: 1, chatId, messageId: "msg-token-first" });
+    const redeliveredEntry = mockEntry({ id: 2, chatId, messageId: "msg-token-redelivered" });
+
+    await sm.dispatch(firstEntry);
+    if (!initialCtx || !initialHead) throw new Error("initial active route was not captured");
+    await initialCtx.finishTurn(initialHead, { status: "success", terminal: true });
+    await sm.dispatch(redeliveredEntry);
+    expect(staleToken).toBeDefined();
+
+    await sm.handleCommand(chatId, "session:suspend");
+    await vi.waitFor(() => expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true));
+    await sm.handleCommand(chatId, "session:resume");
+    expect(recoverChat).toHaveBeenCalledTimes(1);
+
+    const winningDispatch = sm.dispatch(redeliveredEntry);
+    await winningResumeStarted;
+    expect(i.inboxDelivery.snapshot(chatId)).toMatchObject({
+      entries: [{ entryId: 2, messageId: redeliveredEntry.message.id, phase: "open" }],
+      recoveryDebt: "none",
+    });
+
+    const redeliveredMessage = messageFromEntry(redeliveredEntry);
+    staleToken?.processingStarted(redeliveredMessage);
+    await staleToken?.complete(redeliveredMessage, { status: "success", terminal: true });
+    staleToken?.retry(redeliveredMessage, "stale route retry");
+    await staleToken?.terminalRejected(redeliveredMessage, "stale route terminal", {
+      kind: "server_terminal_record",
+      recordId: "stale-record",
+    });
+
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(recoverChat).toHaveBeenCalledTimes(1);
+    expect(i.inboxDelivery.snapshot(chatId)).toMatchObject({
+      entries: [{ entryId: 2, messageId: redeliveredEntry.message.id, phase: "open" }],
+      recoveryDebt: "none",
+    });
+
+    resolveWinningResume?.();
+    await winningDispatch;
+    if (!winningCtx || !winningHead) throw new Error("winning active route was not captured");
+    await winningCtx.finishTurn(winningHead, { status: "success", terminal: true });
+
+    expect(establishedHandler.resume).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenNthCalledWith(1, 1);
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 2);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
+
+    await sm.shutdown();
+  });
+
+  it.each([
+    "rejected",
+    "throw",
+  ] as const)("revokes a failed active inject token before %s recovery and same-entry redelivery", async (failureMode) => {
+    let initialCtx: SessionContext | undefined;
+    let initialHead: SessionMessage | undefined;
+    let staleToken: Parameters<AgentHandler["inject"]>[1];
+    let winningToken: Parameters<AgentHandler["inject"]>[1];
+    let injectCount = 0;
+    const activeHandler = handler({
+      start: vi.fn().mockImplementation(async (message, ctx) => {
+        initialCtx = ctx;
+        initialHead = message;
+        return "active-attempt-session";
+      }),
+      inject: vi.fn().mockImplementation((_message, token) => {
+        injectCount++;
+        if (injectCount === 1) {
+          staleToken = token;
+          if (failureMode === "throw") throw new Error("inject failed after capturing token");
+          return { kind: "rejected", reason: "inject_failed", retryable: true } as const;
+        }
+        winningToken = token;
+        return { kind: "owned", mode: "queued" } as const;
+      }),
+    });
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({ handlers: [activeHandler], ackEntry, recoverChat });
+    const i = internals(sm);
+    const chatId = `chat-active-attempt-${failureMode}`;
+    const firstEntry = mockEntry({ id: 1, chatId, messageId: `msg-attempt-first-${failureMode}` });
+    const redeliveredEntry = mockEntry({ id: 2, chatId, messageId: `msg-attempt-redelivery-${failureMode}` });
+
+    await sm.dispatch(firstEntry);
+    if (!initialCtx || !initialHead) throw new Error("initial route was not captured");
+    await initialCtx.finishTurn(initialHead, { status: "success", terminal: true });
+
+    const failedDispatch = sm.dispatch(redeliveredEntry);
+    if (failureMode === "throw") {
+      await expect(failedDispatch).rejects.toThrow("inject failed after capturing token");
+    } else {
+      await failedDispatch;
+    }
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledTimes(1));
+    expect(staleToken).toBeDefined();
+
+    await sm.dispatch(redeliveredEntry);
+    expect(winningToken).toBeDefined();
+    expect(i.inboxDelivery.snapshot(chatId)).toMatchObject({
+      entries: [{ entryId: 2, messageId: redeliveredEntry.message.id, phase: "owned" }],
+      recoveryDebt: "none",
+    });
+
+    const redeliveredMessage = messageFromEntry(redeliveredEntry);
+    staleToken?.processingStarted(redeliveredMessage);
+    await staleToken?.complete(redeliveredMessage, { status: "success", terminal: true });
+    staleToken?.retry(redeliveredMessage, "stale attempt retry");
+    await staleToken?.terminalRejected(redeliveredMessage, "stale attempt terminal", {
+      kind: "server_terminal_record",
+      recordId: "stale-attempt-record",
+    });
+
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(recoverChat).toHaveBeenCalledTimes(1);
+    expect(i.inboxDelivery.snapshot(chatId)).toMatchObject({
+      entries: [{ entryId: 2, messageId: redeliveredEntry.message.id, phase: "owned" }],
+      recoveryDebt: "none",
+    });
+
+    await winningToken?.complete(redeliveredMessage, { status: "success", terminal: true });
+    expect(ackEntry).toHaveBeenNthCalledWith(1, 1);
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 2);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
+
+    await sm.shutdown();
+  });
+
+  it("does not capture a stale confirmed event into a recovered route", async () => {
+    let oldCtx: SessionContext | undefined;
+    let signalConfirmStarted: (() => void) | undefined;
+    let resolveConfirm: (() => void) | undefined;
+    const confirmStarted = new Promise<void>((resolve) => {
+      signalConfirmStarted = resolve;
+    });
+    const confirmGate = new Promise<void>((resolve) => {
+      resolveConfirm = resolve;
+    });
+    const routedHandler = handler({
+      start: vi.fn().mockImplementation(async (_message, ctx) => {
+        oldCtx = ctx;
+        return "confirmed-event-session";
+      }),
+      resume: vi.fn().mockResolvedValue("confirmed-event-recovered-session"),
+    });
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({
+      handlers: [routedHandler],
+      recoverChat,
+      confirmSessionEvent: vi.fn().mockImplementation(async () => {
+        signalConfirmStarted?.();
+        await confirmGate;
+      }),
+    });
+    const i = internals(sm);
+    const chatId = "chat-stale-confirmed-event";
+    const entry = mockEntry({ id: 80, chatId, messageId: "msg-stale-confirmed-event" });
+    const stalePayload: ProviderRetryEventPayload = {
+      event: "provider_failure_terminal",
+      provider: "claude-code",
+      scope: "provider_turn",
+      category: "credential",
+      reasonCode: "stale_provider_failure",
+      replaySafety: "provider_entered",
+      userSeverity: "error",
+      messagePreview: "stale failure",
+    };
+    const winningPayload: ProviderRetryEventPayload = {
+      ...stalePayload,
+      reasonCode: "winning_provider_failure",
+      messagePreview: "winning failure",
+    };
+
+    await sm.dispatch(entry);
+    if (!oldCtx?.emitEventConfirmed) throw new Error("old confirmed event context was not captured");
+    const staleConfirmation = oldCtx.emitEventConfirmed({
+      kind: "error",
+      payload: { source: "runtime", message: encodeProviderRetryEventMessage(stalePayload) },
+    });
+    await confirmStarted;
+
+    await sm.handleCommand(chatId, "session:suspend");
+    await sm.handleCommand(chatId, "session:resume");
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    await sm.dispatch(entry);
+
+    const winningEntry = i.sessions.get(chatId);
+    if (!winningEntry) throw new Error("winning route was not established");
+    winningEntry.pendingRuntimeFailureNotice = winningPayload;
+
+    resolveConfirm?.();
+    await expect(staleConfirmation).rejects.toThrow("route transition invalidated");
+
+    expect(winningEntry.pendingRuntimeFailureNotice).toBe(winningPayload);
+    expect(i.inboxDelivery.snapshot(chatId)).toMatchObject({
+      entries: [{ entryId: entry.id, messageId: entry.message.id, phase: "owned" }],
+      recoveryDebt: "none",
+    });
+
+    await sm.shutdown();
+  });
+
+  it("does not let a stale notice post clear or settle a recovered delivery", async () => {
+    let oldToken: Parameters<AgentHandler["start"]>[2] | undefined;
+    let winningToken: Parameters<AgentHandler["resume"]>[3] | undefined;
+    let signalNoticeStarted: (() => void) | undefined;
+    let resolveNotice: (() => void) | undefined;
+    const noticeStarted = new Promise<void>((resolve) => {
+      signalNoticeStarted = resolve;
+    });
+    const noticeGate = new Promise<void>((resolve) => {
+      resolveNotice = resolve;
+    });
+    const routedHandler = handler({
+      start: vi.fn().mockImplementation(async (_message, _ctx, token) => {
+        oldToken = token;
+        return "notice-session";
+      }),
+      resume: vi.fn().mockImplementation(async (_message, _sessionId, _ctx, token) => {
+        winningToken = token;
+        return "notice-recovered-session";
+      }),
+    });
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockImplementation(async () => {
+      signalNoticeStarted?.();
+      await noticeGate;
+      return { id: "runtime-notice-message" };
+    });
+    const sm = makeManager({
+      handlers: [routedHandler],
+      ackEntry,
+      recoverChat,
+      sdk: { ...mockSdk(), sendMessage } as unknown as FirstTreeHubSDK,
+    });
+    const i = internals(sm);
+    const chatId = "chat-stale-notice-post";
+    const entry = mockEntry({ id: 81, chatId, messageId: "msg-stale-notice-post" });
+    const message = messageFromEntry(entry);
+    const stalePayload: ProviderRetryEventPayload = {
+      event: "provider_failure_terminal",
+      provider: "claude-code",
+      scope: "provider_turn",
+      category: "credential",
+      reasonCode: "stale_notice",
+      replaySafety: "provider_entered",
+      userSeverity: "error",
+      messagePreview: "stale notice",
+    };
+    const winningPayload: ProviderRetryEventPayload = {
+      ...stalePayload,
+      reasonCode: "winning_notice",
+      messagePreview: "winning notice",
+    };
+
+    await sm.dispatch(entry);
+    const oldEntry = i.sessions.get(chatId);
+    if (!oldEntry || !oldToken) throw new Error("old notice route was not captured");
+    oldEntry.pendingRuntimeFailureNotice = stalePayload;
+    const staleCompletion = oldToken.complete(message, {
+      status: "error",
+      terminal: true,
+      completion: "consumed",
+      reason: "stale provider failure",
+    });
+    await noticeStarted;
+
+    await sm.handleCommand(chatId, "session:suspend");
+    await sm.handleCommand(chatId, "session:resume");
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    await sm.dispatch(entry);
+
+    const winningEntry = i.sessions.get(chatId);
+    if (!winningEntry || !winningToken) throw new Error("winning notice route was not captured");
+    winningEntry.pendingRuntimeFailureNotice = winningPayload;
+    resolveNotice?.();
+    await staleCompletion;
+
+    expect(winningEntry.pendingRuntimeFailureNotice).toBe(winningPayload);
+    expect(ackEntry).not.toHaveBeenCalled();
+    expect(i.inboxDelivery.snapshot(chatId)).toMatchObject({
+      entries: [{ entryId: entry.id, messageId: entry.message.id, phase: "owned" }],
+      recoveryDebt: "none",
+    });
+
+    await winningToken.complete(message, { status: "success", terminal: true });
+    expect(ackEntry).toHaveBeenCalledWith(entry.id);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
+
+    await sm.shutdown();
+  });
+
+  it("runs post-settlement cleanup when a canceled resume materializes resources late", async () => {
+    let signalResumeStarted: (() => void) | undefined;
+    let resolveResume: (() => void) | undefined;
+    const resumeStarted = new Promise<void>((resolve) => {
+      signalResumeStarted = resolve;
+    });
+    const resumeGate = new Promise<void>((resolve) => {
+      resolveResume = resolve;
+    });
+    let providerMaterialized = false;
+    let providerClosed = false;
+    const lateHandler = handler({
+      resume: vi.fn().mockImplementation(async () => {
+        signalResumeStarted?.();
+        await resumeGate;
+        providerMaterialized = true;
+        providerClosed = false;
+        return "late-materialized-session";
+      }),
+      shutdown: vi.fn().mockImplementation(async () => {
+        if (providerMaterialized) providerClosed = true;
+      }),
+    });
+    const sm = makeManager({ recoverChat: vi.fn().mockResolvedValue(undefined) });
+    const i = internals(sm);
+    const chatId = "chat-late-materialized-cleanup";
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        handler: lateHandler,
+        status: "suspended",
+        claudeSessionId: "previous-materialized-session",
+      }),
+    );
+
+    const dispatch = sm.dispatch(mockEntry({ id: 50, chatId, messageId: "msg-late-materialized" }));
+    await resumeStarted;
+    await sm.handleCommand(chatId, "session:suspend");
+    await vi.waitFor(() => expect(lateHandler.shutdown).toHaveBeenCalledTimes(1));
+    expect(providerMaterialized).toBe(false);
+    expect(providerClosed).toBe(false);
+
+    resolveResume?.();
+    await dispatch;
+    await vi.waitFor(() => expect(lateHandler.shutdown).toHaveBeenCalledTimes(2));
+
+    expect(providerMaterialized).toBe(true);
+    expect(providerClosed).toBe(true);
+    expect(i.sessions.get(chatId)?.status).toBe("suspended");
+    expect(sm.activeCount).toBe(0);
+
+    await sm.shutdown();
+  });
+
+  it("lets recovery replace a preempted pending resume before the old handler succeeds", async () => {
+    let signalOldResumeStarted: (() => void) | undefined;
+    let resolveOldResume: (() => void) | undefined;
+    const oldResumeStarted = new Promise<void>((resolve) => {
+      signalOldResumeStarted = resolve;
+    });
+    const oldResumeGate = new Promise<void>((resolve) => {
+      resolveOldResume = resolve;
+    });
+    const oldHandler = handler({
+      resume: vi.fn().mockImplementation(async () => {
+        signalOldResumeStarted?.();
+        await oldResumeGate;
+        return "stale-preempted-session";
+      }),
+    });
+
+    const requesterHandler = handler({ start: vi.fn().mockResolvedValue("requester-session") });
+    let signalFreshResumeStarted: (() => void) | undefined;
+    let resolveFreshResume: (() => void) | undefined;
+    const freshResumeStarted = new Promise<void>((resolve) => {
+      signalFreshResumeStarted = resolve;
+    });
+    const freshResumeGate = new Promise<void>((resolve) => {
+      resolveFreshResume = resolve;
+    });
+    let freshCtx: SessionContext | undefined;
+    let freshHead: SessionMessage | undefined;
+    const freshHandler = handler({
+      resume: vi.fn().mockImplementation(async (message, _sessionId, ctx) => {
+        freshCtx = ctx;
+        freshHead = message;
+        signalFreshResumeStarted?.();
+        await freshResumeGate;
+        return "fresh-preemption-session";
+      }),
+    });
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({
+      handlers: [requesterHandler, freshHandler],
+      ackEntry,
+      recoverChat,
+      concurrency: 2,
+    });
+    const i = internals(sm);
+    const chatId = "chat-preempted-late-success";
+    const headEntry = mockEntry({ id: 20, chatId, messageId: "msg-preempted-head" });
+    const tailEntry = mockEntry({ id: 21, chatId, messageId: "msg-preempted-tail" });
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        handler: oldHandler,
+        status: "suspended",
+        claudeSessionId: "previous-preemption-session",
+      }),
+    );
+    const blocker = makeSessionRecord("chat-preemption-blocker", {
+      status: "active",
+      lastActivity: Date.now() + 10_000,
+    });
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const headDispatch = sm.dispatch(headEntry);
+    await oldResumeStarted;
+    await sm.dispatch(tailEntry);
+    expect(sm.activeCount).toBe(2);
+
+    await sm.dispatch(mockEntry({ id: 30, chatId: "chat-preemption-requester", messageId: "msg-requester" }));
+    await vi.waitFor(() => expect(recoverChat).toHaveBeenCalledWith(chatId));
+    expect(oldHandler.shutdown).toHaveBeenCalledTimes(1);
+    expect(requesterHandler.start).toHaveBeenCalledTimes(1);
+    expect(sm.activeCount).toBe(2);
+
+    const recoveredHeadDispatch = sm.dispatch(headEntry);
+    await freshResumeStarted;
+    await sm.dispatch(tailEntry);
+    expect(i.sessions.get(chatId)?.deferredMessages).toHaveLength(1);
+    expect(requesterHandler.suspend).toHaveBeenCalledTimes(1);
+
+    resolveOldResume?.();
+    await headDispatch;
+    expect(i.sessions.get(chatId)?.claudeSessionId).toBe("previous-preemption-session");
+    expect(oldHandler.inject).not.toHaveBeenCalled();
+
+    resolveFreshResume?.();
+    await recoveredHeadDispatch;
+    await vi.waitFor(() => expect(freshHandler.inject).toHaveBeenCalledTimes(1));
+
+    expect(freshHandler.resume).toHaveBeenCalledTimes(1);
+    expect(freshHead?.id).toBe(headEntry.message.id);
+    expect(freshHandler.inject).toHaveBeenCalledWith(
+      expect.objectContaining({ id: tailEntry.message.id }),
+      expect.anything(),
+    );
+    expect(i.sessions.has(blocker.chatId)).toBe(true);
+    expect(sm.activeCount).toBe(2);
+
+    if (!freshCtx || !freshHead) throw new Error("fresh preemption route was not captured");
+    await freshCtx.finishTurn(freshHead, { status: "success", terminal: true });
+    await freshCtx.finishTurn(messageFromEntry(tailEntry), { status: "success", terminal: true });
+    expect(ackEntry).toHaveBeenNthCalledWith(1, 20);
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 21);
+
+    await sm.shutdown();
+  });
+
+  it("ignores a late transient resume failure after suspend without releasing the blocker slot", async () => {
     let signalResumeStarted: (() => void) | undefined;
     let rejectResume: ((reason?: unknown) => void) | undefined;
     const resumeStarted = new Promise<void>((resolve) => {
@@ -1231,10 +1845,11 @@ describe("SessionManager edge coverage", () => {
     rejectResume?.({ status: 429, message: "provider still limited" });
     await headDispatch;
 
-    expect(i.sessions.get(chatId)?.retryAttempt).toBeGreaterThan(0);
+    expect(i.sessions.get(chatId)?.retryAttempt).toBe(0);
+    expect(i.sessions.get(chatId)?.status).toBe("suspended");
     expect(sm.activeCount).toBe(1);
 
-    await i.runRetry(chatId);
+    await sm.handleCommand(chatId, "session:resume");
 
     expect(recoverChat).toHaveBeenCalledWith(chatId);
     expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
@@ -1242,6 +1857,337 @@ describe("SessionManager edge coverage", () => {
     expect(sm.activeCount).toBe(1);
 
     await sm.shutdown();
+  });
+
+  it("does not report retry success when a suspended retry handler succeeds late", async () => {
+    let signalRetryStarted: (() => void) | undefined;
+    let resolveRetry: (() => void) | undefined;
+    const retryStarted = new Promise<void>((resolve) => {
+      signalRetryStarted = resolve;
+    });
+    const retryGate = new Promise<void>((resolve) => {
+      resolveRetry = resolve;
+    });
+    const retryHandler = handler({
+      resume: vi.fn().mockImplementation(async () => {
+        signalRetryStarted?.();
+        await retryGate;
+        return "stale-retry-session";
+      }),
+    });
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const retryEvents: string[] = [];
+    const sm = makeManager({
+      handlers: [retryHandler],
+      recoverChat,
+      onSessionEvent: (_chatId, event) => {
+        const parsed = event.kind === "error" ? parseProviderRetryEventMessage(event.payload.message) : null;
+        if (parsed) retryEvents.push(parsed.event);
+      },
+    });
+    const i = internals(sm);
+    const chatId = "chat-retry-late-success";
+    const headEntry = mockEntry({ id: 40, chatId, messageId: "msg-retry-late-head" });
+    const tailEntry = mockEntry({ id: 41, chatId, messageId: "msg-retry-late-tail" });
+    const head = messageFromEntry(headEntry);
+    i.inboxDelivery.receive(headEntry);
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        retryAttempt: 1,
+        retryHeadMessage: head,
+        lastRetryReason: "network_error",
+        status: "suspended",
+        claudeSessionId: "previous-retry-session",
+      }),
+    );
+    const blocker = makeSessionRecord("chat-retry-late-success-blocker", { status: "active" });
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const retryPromise = i.runRetry(chatId);
+    await retryStarted;
+    expect(sm.activeCount).toBe(2);
+    await sm.dispatch(tailEntry);
+    expect(i.sessions.get(chatId)?.deferredMessages).toHaveLength(1);
+
+    await sm.handleCommand(chatId, "session:suspend");
+    await vi.waitFor(() => expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true));
+    expect(sm.activeCount).toBe(1);
+
+    resolveRetry?.();
+    await retryPromise;
+
+    expect(retryHandler.shutdown).toHaveBeenCalledTimes(2);
+    expect(retryEvents).toContain("provider_retry_started");
+    expect(retryEvents).not.toContain("provider_retry_succeeded");
+    expect(i.sessions.get(chatId)?.claudeSessionId).toBe("previous-retry-session");
+    expect(i.sessions.get(chatId)?.retryAttempt).toBe(0);
+    expect(i.sessions.get(chatId)?.status).toBe("suspended");
+    expect(i.sessions.has(blocker.chatId)).toBe(true);
+    expect(sm.activeCount).toBe(1);
+
+    await sm.handleCommand(chatId, "session:resume");
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
+
+    await sm.shutdown();
+  });
+
+  it("closes same-chat admission while terminate waits for a slow handler shutdown", async () => {
+    let signalShutdownStarted: (() => void) | undefined;
+    let resolveShutdown: (() => void) | undefined;
+    const shutdownStarted = new Promise<void>((resolve) => {
+      signalShutdownStarted = resolve;
+    });
+    const shutdownGate = new Promise<void>((resolve) => {
+      resolveShutdown = resolve;
+    });
+    const terminatingHandler = handler({
+      shutdown: vi.fn().mockImplementation(async () => {
+        signalShutdownStarted?.();
+        await shutdownGate;
+      }),
+    });
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({ recoverChat });
+    const i = internals(sm);
+    const chatId = "chat-terminate-admission";
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        handler: terminatingHandler,
+        status: "active",
+      }),
+    );
+    const blocker = makeSessionRecord("chat-terminate-admission-blocker", { status: "active" });
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 2;
+
+    const terminate = sm.handleCommand(chatId, "session:terminate");
+    await shutdownStarted;
+    expect(sm.activeCount).toBe(1);
+
+    const lateEntry = mockEntry({ id: 60, chatId, messageId: "msg-during-terminate" });
+    await sm.dispatch(lateEntry);
+
+    expect(terminatingHandler.inject).not.toHaveBeenCalled();
+    expect(terminatingHandler.resume).not.toHaveBeenCalled();
+    expect(sm.activeCount).toBe(1);
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
+
+    resolveShutdown?.();
+    await terminate;
+
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
+    expect(i.sessions.has(chatId)).toBe(false);
+    expect(i.sessions.has(blocker.chatId)).toBe(true);
+    expect(sm.activeCount).toBe(1);
+
+    await sm.shutdown();
+  });
+
+  it("cancels admitted delivery when terminate arrives before SessionEntry creation", async () => {
+    let signalBindingStarted: (() => void) | undefined;
+    let resolveBinding: (() => void) | undefined;
+    const bindingStarted = new Promise<void>((resolve) => {
+      signalBindingStarted = resolve;
+    });
+    const bindingGate = new Promise<void>((resolve) => {
+      resolveBinding = resolve;
+    });
+    const pendingHandler = handler();
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({ handlers: [pendingHandler], recoverChat });
+    const i = internals(sm);
+    const chatId = "chat-terminate-before-session-entry";
+    i.ensureContextTreeBinding = vi.fn().mockImplementation(async () => {
+      signalBindingStarted?.();
+      await bindingGate;
+    });
+
+    const dispatch = sm.dispatch(mockEntry({ id: 70, chatId, messageId: "msg-pending-admission" }));
+    await bindingStarted;
+    expect(i.sessions.has(chatId)).toBe(false);
+    expect(i.inboxDelivery.snapshot(chatId).admissionPending).toBe(true);
+
+    await sm.handleCommand(chatId, "session:terminate");
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(pendingHandler.start).not.toHaveBeenCalled();
+    expect(sm.activeCount).toBe(0);
+
+    resolveBinding?.();
+    await dispatch;
+
+    expect(pendingHandler.start).not.toHaveBeenCalled();
+    expect(i.sessions.has(chatId)).toBe(false);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
+    expect(sm.activeCount).toBe(0);
+
+    await sm.shutdown();
+  });
+
+  it("does not revive a pre-SessionEntry admission after manager shutdown", async () => {
+    let signalBindingStarted: (() => void) | undefined;
+    let resolveBinding: (() => void) | undefined;
+    const bindingStarted = new Promise<void>((resolve) => {
+      signalBindingStarted = resolve;
+    });
+    const bindingGate = new Promise<void>((resolve) => {
+      resolveBinding = resolve;
+    });
+    const pendingHandler = handler();
+    const sm = makeManager({ handlers: [pendingHandler] });
+    const i = internals(sm);
+    const chatId = "chat-manager-shutdown-pending-admission";
+    i.ensureContextTreeBinding = vi.fn().mockImplementation(async () => {
+      signalBindingStarted?.();
+      await bindingGate;
+    });
+
+    const dispatch = sm.dispatch(mockEntry({ id: 71, chatId, messageId: "msg-manager-shutdown-admission" }));
+    await bindingStarted;
+    expect(i.sessions.has(chatId)).toBe(false);
+    expect(i.inboxDelivery.snapshot(chatId).admissionPending).toBe(true);
+
+    await sm.shutdown();
+    resolveBinding?.();
+    await dispatch;
+
+    expect(pendingHandler.start).not.toHaveBeenCalled();
+    expect(i.sessions.has(chatId)).toBe(false);
+    expect(sm.activeCount).toBe(0);
+    expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(true);
+  });
+
+  it("does not enter provider resume after manager shutdown wins a suspension wait", async () => {
+    let releaseSuspending: (() => void) | undefined;
+    const suspending = new Promise<void>((resolve) => {
+      releaseSuspending = resolve;
+    });
+    let signalBlockerShutdown: (() => void) | undefined;
+    let releaseBlockerShutdown: (() => void) | undefined;
+    const blockerShutdownStarted = new Promise<void>((resolve) => {
+      signalBlockerShutdown = resolve;
+    });
+    const blockerShutdownGate = new Promise<void>((resolve) => {
+      releaseBlockerShutdown = resolve;
+    });
+    const replacement = handler();
+    const handlerFactory = vi.fn<HandlerFactory>(() => replacement);
+    const blockerHandler = handler({
+      shutdown: vi.fn().mockImplementation(async () => {
+        signalBlockerShutdown?.();
+        await blockerShutdownGate;
+      }),
+    });
+    const sm = makeManager({ handlerFactory });
+    const i = internals(sm);
+    const chatId = "chat-manager-shutdown-pending-resume";
+    const headEntry = mockEntry({ id: 72, chatId, messageId: "msg-manager-shutdown-resume" });
+    const head = messageFromEntry(headEntry);
+    i.inboxDelivery.receive(headEntry);
+    const target = makeSessionRecord(chatId, {
+      status: "suspended",
+      suspending,
+      claudeSessionId: "previous-session",
+    });
+    i.sessions.set(chatId, target);
+    const blocker = makeSessionRecord("chat-manager-shutdown-pending-resume-blocker", {
+      handler: blockerHandler,
+      status: "active",
+    });
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const resume = i.resumeSession(target, head);
+    const shutdown = sm.shutdown();
+    await blockerShutdownStarted;
+
+    releaseSuspending?.();
+    await resume;
+
+    expect(handlerFactory).not.toHaveBeenCalled();
+    expect(replacement.resume).not.toHaveBeenCalled();
+    expect(sm.activeCount).toBe(1);
+    expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(true);
+
+    releaseBlockerShutdown?.();
+    await shutdown;
+
+    expect(sm.activeCount).toBe(0);
+    expect(i.sessions.size).toBe(0);
+    expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(true);
+  });
+
+  it("does not ACK terminal failure when termination invalidates its pending confirmation", async () => {
+    let signalConfirmStarted: (() => void) | undefined;
+    let resolveConfirm: (() => void) | undefined;
+    const confirmStarted = new Promise<void>((resolve) => {
+      signalConfirmStarted = resolve;
+    });
+    const pendingConfirm = new Promise<void>((resolve) => {
+      resolveConfirm = resolve;
+    });
+    let signalShutdownStarted: (() => void) | undefined;
+    let resolveShutdown: (() => void) | undefined;
+    const shutdownStarted = new Promise<void>((resolve) => {
+      signalShutdownStarted = resolve;
+    });
+    const shutdownGate = new Promise<void>((resolve) => {
+      resolveShutdown = resolve;
+    });
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const targetHandler = handler({
+      resume: vi.fn().mockRejectedValue({ name: "ClientUserMismatchError", message: "wrong client" }),
+      shutdown: vi.fn().mockImplementation(async () => {
+        signalShutdownStarted?.();
+        await shutdownGate;
+      }),
+    });
+    const sm = makeManager({
+      ackEntry,
+      confirmSessionEvent: vi.fn().mockImplementation(() => {
+        signalConfirmStarted?.();
+        return pendingConfirm;
+      }),
+    });
+    const i = internals(sm);
+    const chatId = "chat-terminal-confirm-invalidated";
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        handler: targetHandler,
+        status: "suspended",
+        claudeSessionId: "previous-session",
+      }),
+    );
+
+    const headDispatch = sm.dispatch(mockEntry({ id: 73, chatId, messageId: "msg-terminal-confirm-invalidated" }));
+    await confirmStarted;
+
+    const terminate = sm.handleCommand(chatId, "session:terminate");
+    await shutdownStarted;
+    resolveConfirm?.();
+    await headDispatch;
+
+    expect(ackEntry).not.toHaveBeenCalled();
+    expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(true);
+    expect(i.sessions.has(chatId)).toBe(false);
+
+    resolveShutdown?.();
+    await terminate;
+
+    expect(ackEntry).not.toHaveBeenCalled();
+    expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(true);
+    expect(sm.activeCount).toBe(0);
   });
 
   it("releases an errored transition slot when terminate wins before failure event confirmation", async () => {
@@ -2215,25 +3161,57 @@ describe("SessionManager edge coverage", () => {
     await controlManager.shutdown();
   });
 
-  it("logs retry queued inject failures after a transient retry succeeds", async () => {
+  it.each([
+    "rejected",
+    "throw",
+  ] as const)("stops deferred injection at the first %s result and recovers the untouched suffix", async (failureMode) => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
     const retryHandler = handler({
-      resume: vi.fn().mockResolvedValue("retry-resumed"),
-      inject: vi.fn(() => {
-        throw new Error("queued inject failed");
+      resume: vi.fn().mockImplementation(async (message, _sessionId, _ctx, token) => {
+        if (!message || !token) throw new Error("retry head token was not provided");
+        token.processingStarted(message);
+        await token.complete(message, { status: "success", terminal: true });
+        return "retry-resumed";
+      }),
+      inject: vi.fn((message) => {
+        if (message.id === "msg-deferred-first") {
+          if (failureMode === "throw") throw new Error("provider queue closed");
+          return { kind: "rejected", reason: "provider queue closed", retryable: true } as const;
+        }
+        return { kind: "owned", mode: "queued" } as const;
       }),
     });
-    const sm = makeManager({ handlers: [retryHandler] });
-    const retrying = makeSessionRecord("chat-retry-inject-fail", {
+    const sm = makeManager({ handlers: [retryHandler], ackEntry, recoverChat });
+    const i = internals(sm);
+    const chatId = "chat-retry-inject-prefix";
+    const headEntry = mockEntry({ id: 2, chatId, messageId: "msg-deferred-head" });
+    const firstTailEntry = mockEntry({ id: 3, chatId, messageId: "msg-deferred-first" });
+    const secondTailEntry = mockEntry({ id: 4, chatId, messageId: "msg-deferred-second" });
+    const head = messageFromEntry(headEntry);
+    const firstTail = messageFromEntry(firstTailEntry);
+    const secondTail = messageFromEntry(secondTailEntry);
+    i.inboxDelivery.receive(headEntry);
+    i.inboxDelivery.receive(firstTailEntry);
+    i.inboxDelivery.receive(secondTailEntry);
+    const retrying = makeSessionRecord(chatId, {
       retryAttempt: 1,
       status: "suspended",
       claudeSessionId: "previous-session",
+      retryHeadMessage: head,
+      deferredMessages: [firstTail, secondTail],
     });
-    retrying.deferredMessages.push(makeMessage("chat-retry-inject-fail"));
-    internals(sm).sessions.set("chat-retry-inject-fail", retrying);
+    i.sessions.set(chatId, retrying);
 
-    await internals(sm).runRetry("chat-retry-inject-fail");
+    await i.runRetry(chatId);
 
     expect(retryHandler.inject).toHaveBeenCalledTimes(1);
+    expect(retryHandler.inject).toHaveBeenCalledWith(firstTail, expect.anything());
+    expect(retryHandler.inject).not.toHaveBeenCalledWith(secondTail, expect.anything());
+    expect(ackEntry).toHaveBeenCalledTimes(1);
+    expect(ackEntry).toHaveBeenCalledWith(2);
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
     await sm.shutdown();
   });
 

--- a/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-edge-coverage.test.ts
@@ -24,6 +24,7 @@ type SessionRecord = {
   claudeSessionId: string;
   handler: AgentHandler;
   status: SessionState;
+  activeSlotHeld: boolean;
   lastActivity: number;
   suspending: Promise<void> | null;
   retryAttempt: number;
@@ -34,7 +35,8 @@ type SessionRecord = {
   lastRetryScope: "session_start" | "session_resume" | null;
   lastRetryRawError: string | null;
   retryHeadMessage: SessionMessage | null;
-  retryQueuedMessages: SessionMessage[];
+  deferredMessages: SessionMessage[];
+  routeTransitionPending: boolean;
   pendingRuntimeFailureNotice: ProviderRetryEventPayload | null;
   retryFromEvicted: { claudeSessionId: string; lastActivity: number } | null;
 };
@@ -256,11 +258,13 @@ function messageFromEntry(entry: InboxEntryWithMessage): SessionMessage {
 }
 
 function makeSessionRecord(chatId: string, overrides: Partial<SessionRecord> = {}): SessionRecord {
+  const status = overrides.status ?? "suspended";
   return {
     chatId,
     claudeSessionId: `session-${chatId}`,
     handler: handler(),
-    status: "suspended",
+    status,
+    activeSlotHeld: status === "active",
     lastActivity: Date.now(),
     suspending: null,
     retryAttempt: 0,
@@ -271,7 +275,8 @@ function makeSessionRecord(chatId: string, overrides: Partial<SessionRecord> = {
     lastRetryScope: null,
     lastRetryRawError: null,
     retryHeadMessage: null,
-    retryQueuedMessages: [],
+    deferredMessages: [],
+    routeTransitionPending: false,
     pendingRuntimeFailureNotice: null,
     retryFromEvicted: null,
     ...overrides,
@@ -1104,7 +1109,7 @@ describe("SessionManager edge coverage", () => {
         status: "suspended",
         claudeSessionId: "previous-session",
         retryHeadMessage: head,
-        retryQueuedMessages: [tail],
+        deferredMessages: [tail],
       }),
     );
 
@@ -1116,6 +1121,308 @@ describe("SessionManager edge coverage", () => {
     expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
     expect(i.sessions.has(chatId)).toBe(false);
 
+    await sm.shutdown();
+  });
+
+  it("recovers deferred work when operator suspend races a late terminal resume failure", async () => {
+    let signalResumeStarted: (() => void) | undefined;
+    let rejectResume: ((reason?: unknown) => void) | undefined;
+    const resumeStarted = new Promise<void>((resolve) => {
+      signalResumeStarted = resolve;
+    });
+    const pendingResume = new Promise<string>((_resolve, reject) => {
+      rejectResume = reject;
+    });
+    const existingHandler = handler({
+      resume: vi.fn().mockImplementation(() => {
+        signalResumeStarted?.();
+        return pendingResume;
+      }),
+    });
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({
+      ackEntry,
+      recoverChat,
+      confirmSessionEvent: vi.fn().mockResolvedValue(undefined),
+    });
+    const i = internals(sm);
+    const chatId = "chat-suspend-late-terminal-resume";
+    const headEntry = mockEntry({ id: 2, chatId, messageId: "msg-late-terminal-head" });
+    const tailEntry = mockEntry({ id: 3, chatId, messageId: "msg-late-terminal-tail" });
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        handler: existingHandler,
+        status: "suspended",
+        claudeSessionId: "previous-session",
+      }),
+    );
+    const blocker = makeSessionRecord("chat-suspend-race-blocker", { status: "active" });
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const headDispatch = sm.dispatch(headEntry);
+    await resumeStarted;
+    expect(sm.activeCount).toBe(2);
+    await sm.dispatch(tailEntry);
+    expect(i.sessions.get(chatId)?.deferredMessages).toHaveLength(1);
+
+    await sm.handleCommand(chatId, "session:suspend");
+    await vi.waitFor(() => expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true));
+    expect(sm.activeCount).toBe(1);
+
+    rejectResume?.({ name: "ClientUserMismatchError", message: "runtime authorization changed" });
+    await headDispatch;
+
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(ackEntry).not.toHaveBeenCalledWith(2);
+    expect(ackEntry).not.toHaveBeenCalledWith(3);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
+    expect(i.sessions.has(chatId)).toBe(false);
+    expect(i.sessions.has(blocker.chatId)).toBe(true);
+    expect(sm.activeCount).toBe(1);
+
+    await sm.shutdown();
+  });
+
+  it("does not release a blocker slot twice when suspended resume fails transiently", async () => {
+    let signalResumeStarted: (() => void) | undefined;
+    let rejectResume: ((reason?: unknown) => void) | undefined;
+    const resumeStarted = new Promise<void>((resolve) => {
+      signalResumeStarted = resolve;
+    });
+    const pendingResume = new Promise<string>((_resolve, reject) => {
+      rejectResume = reject;
+    });
+    const existingHandler = handler({
+      resume: vi.fn().mockImplementation(() => {
+        signalResumeStarted?.();
+        return pendingResume;
+      }),
+    });
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({ recoverChat });
+    const i = internals(sm);
+    const chatId = "chat-suspend-late-transient-resume";
+    const headEntry = mockEntry({ id: 2, chatId, messageId: "msg-late-transient-head" });
+    const tailEntry = mockEntry({ id: 3, chatId, messageId: "msg-late-transient-tail" });
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        handler: existingHandler,
+        status: "suspended",
+        claudeSessionId: "previous-session",
+      }),
+    );
+    const blocker = makeSessionRecord("chat-transient-race-blocker", { status: "active" });
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const headDispatch = sm.dispatch(headEntry);
+    await resumeStarted;
+    expect(sm.activeCount).toBe(2);
+    await sm.dispatch(tailEntry);
+
+    await sm.handleCommand(chatId, "session:suspend");
+    await vi.waitFor(() => expect(i.inboxDelivery.hasRecoveryDebt(chatId)).toBe(true));
+    expect(sm.activeCount).toBe(1);
+
+    rejectResume?.({ status: 429, message: "provider still limited" });
+    await headDispatch;
+
+    expect(i.sessions.get(chatId)?.retryAttempt).toBeGreaterThan(0);
+    expect(sm.activeCount).toBe(1);
+
+    await i.runRetry(chatId);
+
+    expect(recoverChat).toHaveBeenCalledWith(chatId);
+    expect(i.inboxDelivery.hasUnsettledWork(chatId)).toBe(false);
+    expect(i.sessions.has(blocker.chatId)).toBe(true);
+    expect(sm.activeCount).toBe(1);
+
+    await sm.shutdown();
+  });
+
+  it("releases an errored transition slot when terminate wins before failure event confirmation", async () => {
+    let signalConfirmStarted: (() => void) | undefined;
+    let resolveConfirm: (() => void) | undefined;
+    const confirmStarted = new Promise<void>((resolve) => {
+      signalConfirmStarted = resolve;
+    });
+    const pendingConfirm = new Promise<void>((resolve) => {
+      resolveConfirm = resolve;
+    });
+    const targetHandler = handler({
+      resume: vi.fn().mockRejectedValue({ name: "ClientUserMismatchError", message: "wrong client" }),
+    });
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    const sm = makeManager({
+      recoverChat,
+      confirmSessionEvent: vi.fn().mockImplementation(() => {
+        signalConfirmStarted?.();
+        return pendingConfirm;
+      }),
+    });
+    const i = internals(sm);
+    const chatId = "chat-terminal-confirm-terminate";
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        handler: targetHandler,
+        status: "suspended",
+        claudeSessionId: "previous-session",
+      }),
+    );
+    const blocker = makeSessionRecord("chat-terminal-confirm-terminate-blocker", { status: "active" });
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const headDispatch = sm.dispatch(mockEntry({ id: 2, chatId, messageId: "msg-terminal-confirm-terminate" }));
+    await confirmStarted;
+
+    expect(i.sessions.get(chatId)?.status).toBe("errored");
+    expect(i.sessions.get(chatId)?.activeSlotHeld).toBe(true);
+    expect(sm.activeCount).toBe(2);
+
+    await sm.handleCommand(chatId, "session:terminate");
+
+    expect(i.sessions.has(chatId)).toBe(false);
+    expect(targetHandler.shutdown).toHaveBeenCalledTimes(1);
+    expect(sm.activeCount).toBe(1);
+
+    resolveConfirm?.();
+    await headDispatch;
+
+    expect(i.sessions.has(blocker.chatId)).toBe(true);
+    expect(sm.activeCount).toBe(1);
+    await sm.shutdown();
+  });
+
+  it("releases an errored transition slot when LRU eviction wins before failure event confirmation", async () => {
+    let signalConfirmStarted: (() => void) | undefined;
+    let resolveConfirm: (() => void) | undefined;
+    const confirmStarted = new Promise<void>((resolve) => {
+      signalConfirmStarted = resolve;
+    });
+    const pendingConfirm = new Promise<void>((resolve) => {
+      resolveConfirm = resolve;
+    });
+    const targetHandler = handler({
+      resume: vi.fn().mockRejectedValue({ name: "ClientUserMismatchError", message: "wrong client" }),
+    });
+    const sm = makeManager({
+      maxSessions: 2,
+      confirmSessionEvent: vi.fn().mockImplementation(() => {
+        signalConfirmStarted?.();
+        return pendingConfirm;
+      }),
+    });
+    const i = internals(sm);
+    const chatId = "chat-terminal-confirm-evict";
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        handler: targetHandler,
+        status: "suspended",
+        claudeSessionId: "previous-session",
+      }),
+    );
+    const blocker = makeSessionRecord("chat-terminal-confirm-evict-blocker", { status: "active" });
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const headDispatch = sm.dispatch(mockEntry({ id: 2, chatId, messageId: "msg-terminal-confirm-evict" }));
+    await confirmStarted;
+
+    expect(i.sessions.get(chatId)?.status).toBe("errored");
+    expect(i.sessions.get(chatId)?.activeSlotHeld).toBe(true);
+    expect(sm.activeCount).toBe(2);
+
+    i.evictIfNeeded();
+
+    expect(i.sessions.has(chatId)).toBe(false);
+    expect(targetHandler.shutdown).toHaveBeenCalledTimes(1);
+    expect(sm.activeCount).toBe(1);
+
+    resolveConfirm?.();
+    await headDispatch;
+
+    expect(i.sessions.has(blocker.chatId)).toBe(true);
+    expect(sm.activeCount).toBe(1);
+    await sm.shutdown();
+  });
+
+  it("blocks retry, tail, and control resume re-entry while terminal retry confirmation is pending", async () => {
+    let signalConfirmStarted: (() => void) | undefined;
+    let resolveConfirm: (() => void) | undefined;
+    const confirmStarted = new Promise<void>((resolve) => {
+      signalConfirmStarted = resolve;
+    });
+    const pendingConfirm = new Promise<void>((resolve) => {
+      resolveConfirm = resolve;
+    });
+    const terminalRetry = handler({
+      resume: vi.fn().mockRejectedValue({ name: "ClientUserMismatchError", message: "wrong client" }),
+    });
+    const replacement = handler({ start: vi.fn().mockResolvedValue("tail-session") });
+    const sm = makeManager({
+      handlers: [terminalRetry, replacement],
+      confirmSessionEvent: vi.fn().mockImplementation(() => {
+        signalConfirmStarted?.();
+        return pendingConfirm;
+      }),
+    });
+    const i = internals(sm);
+    const chatId = "chat-terminal-confirm-admission";
+    const headEntry = mockEntry({ id: 2, chatId, messageId: "msg-terminal-confirm-head" });
+    const tailEntry = mockEntry({ id: 3, chatId, messageId: "msg-terminal-confirm-tail" });
+    const head = messageFromEntry(headEntry);
+    i.inboxDelivery.receive(headEntry);
+    i.sessions.set(
+      chatId,
+      makeSessionRecord(chatId, {
+        retryAttempt: 1,
+        status: "suspended",
+        claudeSessionId: "previous-session",
+        retryHeadMessage: head,
+        lastRetryReason: "network_error",
+      }),
+    );
+    const blocker = makeSessionRecord("chat-terminal-confirm-admission-blocker", { status: "active" });
+    i.sessions.set(blocker.chatId, blocker);
+    i._activeCount = 1;
+
+    const retryPromise = i.runRetry(chatId);
+    await confirmStarted;
+
+    expect(i.sessions.get(chatId)?.status).toBe("errored");
+    expect(i.sessions.get(chatId)?.activeSlotHeld).toBe(true);
+    expect(i.sessions.get(chatId)?.retryAttempt).toBe(0);
+    expect(sm.activeCount).toBe(2);
+
+    await sm.dispatch(tailEntry);
+    await sm.handleCommand(chatId, "session:resume");
+    await i.runRetry(chatId);
+
+    expect(terminalRetry.resume).toHaveBeenCalledTimes(1);
+    expect(replacement.start).not.toHaveBeenCalled();
+    expect(replacement.resume).not.toHaveBeenCalled();
+    expect(i.pendingQueue.some((queued) => queued.message?.id === tailEntry.message.id)).toBe(true);
+    expect(sm.activeCount).toBe(2);
+
+    resolveConfirm?.();
+    await retryPromise;
+    await vi.waitFor(() => expect(replacement.start).toHaveBeenCalledTimes(1));
+
+    expect(replacement.start).toHaveBeenCalledWith(
+      expect.objectContaining({ id: tailEntry.message.id }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(terminalRetry.resume).toHaveBeenCalledTimes(1);
+    expect(i.sessions.has(blocker.chatId)).toBe(true);
+    expect(sm.activeCount).toBe(2);
     await sm.shutdown();
   });
 
@@ -1921,7 +2228,7 @@ describe("SessionManager edge coverage", () => {
       status: "suspended",
       claudeSessionId: "previous-session",
     });
-    retrying.retryQueuedMessages.push(makeMessage("chat-retry-inject-fail"));
+    retrying.deferredMessages.push(makeMessage("chat-retry-inject-fail"));
     internals(sm).sessions.set("chat-retry-inject-fail", retrying);
 
     await internals(sm).runRetry("chat-retry-inject-fail");

--- a/packages/client/src/__tests__/session-manager-retry.test.ts
+++ b/packages/client/src/__tests__/session-manager-retry.test.ts
@@ -67,7 +67,7 @@ class FakeRateLimit extends Error {
   status = 429;
 }
 
-describe("SessionManager: transient retry on session start", () => {
+describe("SessionManager: transient session retry", () => {
   it("keeps the entry alive and schedules a retry on RateLimitError", async () => {
     const handler: AgentHandler = {
       start: vi.fn().mockRejectedValue(new FakeRateLimit("rate limited")),
@@ -329,5 +329,108 @@ describe("SessionManager: transient retry on session start", () => {
     expect(recoverChat).not.toHaveBeenCalled();
 
     await sm.shutdown();
+  });
+
+  it("retries the message that failed resume and drains newer work behind it", async () => {
+    const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+    const recoverChat = vi.fn<(chatId: string) => Promise<void>>().mockResolvedValue(undefined);
+    let initialCtx: SessionContext | undefined;
+    let initialMessage: SessionMessage | undefined;
+    let retryCtx: SessionContext | undefined;
+    let retryMessage: SessionMessage | undefined;
+    const injected: SessionMessage[] = [];
+    const established: AgentHandler = {
+      start: vi.fn(async (message, ctx) => {
+        initialMessage = message;
+        initialCtx = ctx;
+        return "established-session";
+      }),
+      resume: vi.fn().mockRejectedValue(new FakeRateLimit("resume transport failed")),
+      inject: vi.fn(),
+      suspend: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+    const recovered: AgentHandler = {
+      start: vi.fn(),
+      resume: vi.fn(async (message, _sessionId, ctx) => {
+        retryMessage = message;
+        retryCtx = ctx;
+        return "resumed-session";
+      }),
+      inject: vi.fn((message) => {
+        injected.push(message);
+        return { kind: "owned", mode: "queued" } as const;
+      }),
+      suspend: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+    };
+    const sm = makeManager({ handlers: [established, recovered], ackEntry, recoverChat });
+
+    await sm.dispatch(mockEntry({ id: 1, chatId: "chat-resume-head", messageId: "msg-1" }));
+    if (!initialCtx || !initialMessage) throw new Error("initial session was not captured");
+    await initialCtx.finishTurn(initialMessage, { status: "success", terminal: true });
+    await sm.handleCommand("chat-resume-head", "session:suspend");
+
+    await sm.dispatch(mockEntry({ id: 2, chatId: "chat-resume-head", messageId: "msg-2" }));
+    await sm.dispatch(mockEntry({ id: 3, chatId: "chat-resume-head", messageId: "msg-3" }));
+    await vi.waitFor(() => expect(recovered.resume).toHaveBeenCalledTimes(1));
+
+    expect(retryMessage?.id).toBe("msg-2");
+    expect(retryMessage?.inboxEntryId).toBe(2);
+    expect(retryMessage?.id).not.toBe("msg-1");
+    expect(injected.map((message) => message.id)).toEqual(["msg-3"]);
+    if (!retryCtx || !retryMessage || !injected[0]) throw new Error("retry routing was not captured");
+
+    await retryCtx.finishTurn(retryMessage, { status: "success", terminal: true });
+    await retryCtx.finishTurn(injected[0], { status: "success", terminal: true });
+
+    expect(ackEntry).toHaveBeenNthCalledWith(1, 1);
+    expect(ackEntry).toHaveBeenNthCalledWith(2, 2);
+    expect(ackEntry).toHaveBeenNthCalledWith(3, 3);
+    expect(recoverChat).not.toHaveBeenCalled();
+    expect(sm.activeCount).toBe(1);
+
+    await sm.shutdown();
+  });
+
+  it("retries a control resume without replaying the previous user message", async () => {
+    vi.useFakeTimers();
+    try {
+      let initialCtx: SessionContext | undefined;
+      let initialMessage: SessionMessage | undefined;
+      const established: AgentHandler = {
+        start: vi.fn(async (message, ctx) => {
+          initialMessage = message;
+          initialCtx = ctx;
+          return "control-session";
+        }),
+        resume: vi.fn().mockRejectedValue(new FakeRateLimit("control resume transport failed")),
+        inject: vi.fn(),
+        suspend: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      };
+      const recovered: AgentHandler = {
+        start: vi.fn(),
+        resume: vi.fn().mockResolvedValue("control-session-resumed"),
+        inject: vi.fn(),
+        suspend: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      };
+      const sm = makeManager({ handlers: [established, recovered] });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-control-retry", messageId: "old-user-message" }));
+      if (!initialCtx || !initialMessage) throw new Error("initial control session was not captured");
+      await initialCtx.finishTurn(initialMessage, { status: "success", terminal: true });
+      await sm.handleCommand("chat-control-retry", "session:suspend");
+      await sm.handleCommand("chat-control-retry", "session:resume");
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(recovered.resume).toHaveBeenCalledWith(undefined, "control-session", expect.anything());
+      expect(recovered.start).not.toHaveBeenCalled();
+
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/client/src/__tests__/session-manager-retry.test.ts
+++ b/packages/client/src/__tests__/session-manager-retry.test.ts
@@ -393,6 +393,85 @@ describe("SessionManager: transient session retry", () => {
     await sm.shutdown();
   });
 
+  it("moves a tail that arrives during a pending resume onto the retry handler", async () => {
+    vi.useFakeTimers();
+    try {
+      const ackEntry = vi.fn<(entryId: number) => Promise<void>>().mockResolvedValue(undefined);
+      let initialCtx: SessionContext | undefined;
+      let initialMessage: SessionMessage | undefined;
+      let retryCtx: SessionContext | undefined;
+      let retryMessage: SessionMessage | undefined;
+      let rejectResume: ((reason?: unknown) => void) | undefined;
+      let signalResumeStarted: (() => void) | undefined;
+      const resumeStarted = new Promise<void>((resolve) => {
+        signalResumeStarted = resolve;
+      });
+      const pendingResume = new Promise<string>((_resolve, reject) => {
+        rejectResume = reject;
+      });
+      const injected: SessionMessage[] = [];
+      const established: AgentHandler = {
+        start: vi.fn(async (message, ctx) => {
+          initialMessage = message;
+          initialCtx = ctx;
+          return "deferred-resume-session";
+        }),
+        resume: vi.fn(() => {
+          signalResumeStarted?.();
+          return pendingResume;
+        }),
+        inject: vi.fn(),
+        suspend: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      };
+      const recovered: AgentHandler = {
+        start: vi.fn(),
+        resume: vi.fn(async (message, _sessionId, ctx) => {
+          retryMessage = message;
+          retryCtx = ctx;
+          return "deferred-resume-recovered";
+        }),
+        inject: vi.fn((message) => {
+          injected.push(message);
+          return { kind: "owned", mode: "queued" } as const;
+        }),
+        suspend: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      };
+      const sm = makeManager({ handlers: [established, recovered], ackEntry });
+
+      await sm.dispatch(mockEntry({ id: 1, chatId: "chat-pending-resume", messageId: "msg-1" }));
+      if (!initialCtx || !initialMessage) throw new Error("initial deferred session was not captured");
+      await initialCtx.finishTurn(initialMessage, { status: "success", terminal: true });
+      await sm.handleCommand("chat-pending-resume", "session:suspend");
+
+      const headDispatch = sm.dispatch(mockEntry({ id: 2, chatId: "chat-pending-resume", messageId: "msg-2" }));
+      await resumeStarted;
+      await sm.dispatch(mockEntry({ id: 3, chatId: "chat-pending-resume", messageId: "msg-3" }));
+      expect(established.inject).not.toHaveBeenCalled();
+
+      rejectResume?.(new FakeRateLimit("deferred resume transport failed"));
+      await headDispatch;
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(recovered.resume).toHaveBeenCalledTimes(1);
+      expect(retryMessage?.id).toBe("msg-2");
+      expect(injected.map((message) => message.id)).toEqual(["msg-3"]);
+      if (!retryCtx || !retryMessage || !injected[0]) throw new Error("deferred retry routing was not captured");
+
+      await retryCtx.finishTurn(retryMessage, { status: "success", terminal: true });
+      await retryCtx.finishTurn(injected[0], { status: "success", terminal: true });
+
+      expect(ackEntry).toHaveBeenNthCalledWith(1, 1);
+      expect(ackEntry).toHaveBeenNthCalledWith(2, 2);
+      expect(ackEntry).toHaveBeenNthCalledWith(3, 3);
+
+      await sm.shutdown();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("retries a control resume without replaying the previous user message", async () => {
     vi.useFakeTimers();
     try {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -135,9 +135,13 @@ type SessionEntry = {
   retryFromEvicted: { claudeSessionId: string; lastActivity: number } | null;
 };
 
-type RouteTransitionToken = {
+type RouteLeaseToken = {
   generation: number;
   handler: AgentHandler;
+};
+
+type RouteTransitionToken = RouteLeaseToken & {
+  phase: "start" | "resume";
 };
 
 type SessionFailureHandling =
@@ -407,8 +411,15 @@ function jitteredReaffirmDelay(): number {
   return RUNTIME_REAFFIRM_BASE_MS + offset;
 }
 
+function resumableProviderSessionId(...candidates: Array<string | null | undefined>): string | null {
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) return candidate;
+  }
+  return null;
+}
+
 function previousAvailable(entry: SessionEntry): boolean {
-  return Boolean(entry.claudeSessionId) || Boolean(entry.retryFromEvicted?.claudeSessionId);
+  return resumableProviderSessionId(entry.claudeSessionId, entry.retryFromEvicted?.claudeSessionId) !== null;
 }
 
 function normalizeStartReceipt(result: StartResult): {
@@ -1009,9 +1020,13 @@ export class SessionManager {
     return handler;
   }
 
-  private beginRouteTransition(entry: SessionEntry, handler: AgentHandler): RouteTransitionToken {
+  private beginRouteTransition(
+    entry: SessionEntry,
+    handler: AgentHandler,
+    phase: RouteTransitionToken["phase"],
+  ): RouteTransitionToken {
     entry.routeTransitionGeneration++;
-    const transition = { generation: entry.routeTransitionGeneration, handler };
+    const transition = { generation: entry.routeTransitionGeneration, handler, phase };
     entry.routeTransition = transition;
     return transition;
   }
@@ -1020,7 +1035,7 @@ export class SessionManager {
     return entry.routeTransition === transition && this.isRouteLeaseValid(entry, transition);
   }
 
-  private isRouteLeaseValid(entry: SessionEntry, transition: RouteTransitionToken): boolean {
+  private isRouteLeaseValid(entry: SessionEntry, transition: RouteLeaseToken): boolean {
     return (
       !this.shuttingDown &&
       this.sessions.get(entry.chatId) === entry &&
@@ -1190,7 +1205,11 @@ export class SessionManager {
 
     this.invalidateRouteTransition(entry, reason);
     this.clearRetryState(entry);
-    const resumeSessionId = sessionId || entry.claudeSessionId || entry.retryFromEvicted?.claudeSessionId || "";
+    const resumeSessionId = resumableProviderSessionId(
+      sessionId,
+      entry.claudeSessionId,
+      entry.retryFromEvicted?.claudeSessionId,
+    );
     if (resumeSessionId) {
       this.addEvictedMapping(chatId, {
         claudeSessionId: resumeSessionId,
@@ -1517,7 +1536,11 @@ export class SessionManager {
     if (!this.acquireActiveSlot(chatId, message, deliveryKind)) return;
 
     // Check for prior evicted session mapping
-    const evicted = this.evictedMappings.get(chatId);
+    const storedEvicted = this.evictedMappings.get(chatId);
+    const evictedSessionId = resumableProviderSessionId(storedEvicted?.claudeSessionId);
+    const evicted =
+      storedEvicted && evictedSessionId ? { ...storedEvicted, claudeSessionId: evictedSessionId } : undefined;
+    if (storedEvicted && !evicted) this.evictedMappings.delete(chatId);
 
     // Step 6: thread the AgentConfigCache to the handler so it can read the
     // current per-agent runtime config when launching its sub-process.
@@ -1548,7 +1571,7 @@ export class SessionManager {
 
     this.sessions.set(chatId, entry);
     this.claimActiveSlot(entry);
-    const transition = this.beginRouteTransition(entry, handler);
+    const transition = this.beginRouteTransition(entry, handler, evicted ? "resume" : "start");
     const routeLeaseValid = () => this.isRouteLeaseValid(entry, transition);
     const ctx = this.buildSessionContext(chatId, routeLeaseValid);
     if (evicted) this.evictedMappings.delete(chatId);
@@ -1649,7 +1672,7 @@ export class SessionManager {
     const routeHandler = this.handlerForRouteTransition(entry);
     entry.status = "active";
     this.claimActiveSlot(entry);
-    const transition = this.beginRouteTransition(entry, routeHandler);
+    const transition = this.beginRouteTransition(entry, routeHandler, "resume");
     const routeLeaseValid = () => this.isRouteLeaseValid(entry, transition);
     const ctx = this.buildSessionContext(entry.chatId, routeLeaseValid);
     entry.lastActivity = Date.now();
@@ -2051,7 +2074,7 @@ export class SessionManager {
     entry.status = "active";
     this.claimActiveSlot(entry);
     entry.lastActivity = Date.now();
-    const transition = this.beginRouteTransition(entry, newHandler);
+    const transition = this.beginRouteTransition(entry, newHandler, retryRoute.kind);
     const routeLeaseValid = () => this.isRouteLeaseValid(entry, transition);
     const ctx = this.buildSessionContext(chatId, routeLeaseValid);
 
@@ -2353,7 +2376,13 @@ export class SessionManager {
     },
   ): void {
     const canceledTransition = this.invalidateRouteTransition(entry, opts.reason);
+    // A canceled fresh start has never established a provider-neutral resume
+    // handle. Keeping that entry as "suspended" would make redelivery call
+    // resume(undefined/empty-id) instead of starting a replacement route.
+    // Drop only the local SessionEntry; coordinator recovery retains the head.
+    const canceledUnestablishedStart = canceledTransition?.phase === "start";
     if (canceledTransition) entry.deferredMessages = [];
+    if (canceledUnestablishedStart) this.clearRetryState(entry);
     const prepare = opts.operatorResolution
       ? this.inboxDelivery.prepareOperatorSuspend(entry.chatId)
       : opts.ackConsumedPrefix
@@ -2364,6 +2393,10 @@ export class SessionManager {
     // Clear per-session runtime state on suspend
     this.sessionRuntimeStates.delete(entry.chatId);
     this.recomputeRuntimeState();
+    if (canceledUnestablishedStart && this.sessions.get(entry.chatId) === entry) {
+      this.sessions.delete(entry.chatId);
+      this.currentTrigger.delete(entry.chatId);
+    }
     entry.suspending = prepare
       .then(() => {
         if (canceledTransition || this.retiredHandlers.has(entry.handler)) {
@@ -2503,11 +2536,21 @@ export class SessionManager {
 
     if (candidate) {
       this.invalidateRouteTransition(candidate.session, "session_evicted");
-      // Preserve mapping for future recovery
-      this.addEvictedMapping(candidate.key, {
-        claudeSessionId: candidate.session.claudeSessionId,
-        lastActivity: candidate.session.lastActivity,
-      });
+      // Preserve only an adopted, provider-neutral resume handle. Transition
+      // phase is not sufficient: a fresh-start retry/terminal window has no
+      // active start transition but still has no resumable provider session.
+      const resumableSessionId = resumableProviderSessionId(
+        candidate.session.claudeSessionId,
+        candidate.session.retryFromEvicted?.claudeSessionId,
+      );
+      if (resumableSessionId) {
+        this.addEvictedMapping(candidate.key, {
+          claudeSessionId: resumableSessionId,
+          lastActivity: candidate.session.lastActivity,
+        });
+      } else {
+        this.evictedMappings.delete(candidate.key);
+      }
 
       this.config.log.info({ chatId: candidate.key }, "session evicted (max_sessions reached)");
       const activeSlotHeld = candidate.session.activeSlotHeld;
@@ -2602,7 +2645,12 @@ export class SessionManager {
 
   /** Add an evicted mapping, pruning the oldest if over capacity. */
   private addEvictedMapping(chatId: string, mapping: { claudeSessionId: string; lastActivity: number }): void {
-    this.evictedMappings.set(chatId, mapping);
+    const resumableSessionId = resumableProviderSessionId(mapping.claudeSessionId);
+    if (!resumableSessionId) {
+      this.evictedMappings.delete(chatId);
+      return;
+    }
+    this.evictedMappings.set(chatId, { ...mapping, claudeSessionId: resumableSessionId });
     if (this.evictedMappings.size > MAX_EVICTED_MAPPINGS) {
       // Map iteration order is insertion order — first key is the oldest
       const oldest = this.evictedMappings.keys().next().value;
@@ -2931,18 +2979,25 @@ export class SessionManager {
     if (!this.registry) return;
 
     const persisted = this.registry.load();
+    let loadedCount = 0;
     for (const [chatId, data] of persisted) {
       // All persisted sessions become evicted mappings on load.
       // Handlers are allocated lazily when a message arrives (startNewSession
       // checks evictedMappings and calls handler.resume instead of start).
+      const resumableSessionId = resumableProviderSessionId(data.claudeSessionId);
+      if (!resumableSessionId) {
+        this.config.log.warn({ chatId }, "ignoring persisted session mapping without a resumable provider session id");
+        continue;
+      }
       this.addEvictedMapping(chatId, {
-        claudeSessionId: data.claudeSessionId,
+        claudeSessionId: resumableSessionId,
         lastActivity: data.lastActivity,
       });
+      loadedCount++;
     }
 
-    if (persisted.size > 0) {
-      this.config.log.info({ count: persisted.size }, "loaded persisted session mappings");
+    if (loadedCount > 0) {
+      this.config.log.info({ count: loadedCount }, "loaded persisted session mappings");
     }
   }
 
@@ -2951,16 +3006,23 @@ export class SessionManager {
 
     const entries = new Map<string, { claudeSessionId: string; lastActivity: number; status: string }>();
     for (const [chatId, session] of this.sessions) {
+      const resumableSessionId = resumableProviderSessionId(
+        session.claudeSessionId,
+        session.retryFromEvicted?.claudeSessionId,
+      );
+      if (!resumableSessionId) continue;
       entries.set(chatId, {
-        claudeSessionId: session.claudeSessionId,
+        claudeSessionId: resumableSessionId,
         lastActivity: session.lastActivity,
         status: session.status,
       });
     }
     // Include evicted mappings for crash recovery
     for (const [chatId, mapping] of this.evictedMappings) {
+      const resumableSessionId = resumableProviderSessionId(mapping.claudeSessionId);
+      if (!resumableSessionId) continue;
       entries.set(chatId, {
-        claudeSessionId: mapping.claudeSessionId,
+        claudeSessionId: resumableSessionId,
         lastActivity: mapping.lastActivity,
         status: "evicted",
       });

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -68,6 +68,8 @@ type SessionEntry = {
   claudeSessionId: string;
   handler: AgentHandler;
   status: SessionState;
+  /** Whether this entry currently owns one unit of `_activeCount`. */
+  activeSlotHeld: boolean;
   lastActivity: number;
   /** In-flight suspend promise; awaited before resume to avoid race conditions. */
   suspending: Promise<void> | null;
@@ -104,12 +106,15 @@ type SessionEntry = {
    */
   retryHeadMessage: SessionMessage | null;
   /**
-   * Messages that arrived while start/resume is in transient retry. They must
+   * Messages that arrived while a start/resume transition or its transient
+   * retry is pending. They must
    * not replace `retryHeadMessage`: the older accepted inbox entry is still ahead
    * of them in the ACK prefix, so retry consumes the original trigger first and
    * injects these only after the handler is live again.
    */
-  retryQueuedMessages: SessionMessage[];
+  deferredMessages: SessionMessage[];
+  /** True while handler.start / handler.resume has not established its route. */
+  routeTransitionPending: boolean;
   /**
    * Latest terminal, user-actionable provider failure observed on the session
    * event channel. Posting the durable chat notice at the delivery-settlement
@@ -687,7 +692,7 @@ export class SessionManager {
     if (command === "session:suspend") {
       const session = this.sessions.get(chatId);
       if (session) this.clearRetryState(session);
-      if (session?.status === "active") {
+      if (session?.activeSlotHeld) {
         this.config.log.info({ chatId }, "suspend command received");
         this.suspendSession(session, {
           reason: "operator_suspended",
@@ -709,7 +714,13 @@ export class SessionManager {
         return;
       }
       const current = this.sessions.get(chatId);
-      if (current && current.status !== "active") {
+      if (current?.retryAttempt && current.status === "suspended" && !current.activeSlotHeld) {
+        this.triggerImmediateRetry(chatId);
+      } else if (
+        current &&
+        (current.status === "suspended" || current.status === "evicted") &&
+        !current.activeSlotHeld
+      ) {
         this.config.log.info({ chatId }, "resume command received");
         await this.resumeSession(current, undefined, "fresh");
       }
@@ -728,8 +739,9 @@ export class SessionManager {
         clearTimeout(session.retryTimer);
         session.retryTimer = null;
       }
-      if (session?.status === "active") {
-        this._activeCount--;
+      const activeSlotHeld = session?.activeSlotHeld === true;
+      if (session) this.releaseActiveSlot(session);
+      if (activeSlotHeld && session) {
         await session.handler.shutdown().catch(() => {});
       }
 
@@ -797,7 +809,7 @@ export class SessionManager {
     }
 
     const shutdowns = [...this.sessions.values()].map((s) =>
-      s.status === "active" ? s.handler.shutdown(reason) : Promise.resolve(),
+      s.activeSlotHeld ? s.handler.shutdown(reason) : Promise.resolve(),
     );
     await Promise.allSettled(shutdowns);
 
@@ -930,7 +942,21 @@ export class SessionManager {
 
   private clearRetryState(entry: SessionEntry): void {
     this.clearRetryAttemptState(entry);
-    entry.retryQueuedMessages = [];
+    entry.deferredMessages = [];
+    entry.routeTransitionPending = false;
+  }
+
+  private claimActiveSlot(entry: SessionEntry): void {
+    if (entry.activeSlotHeld) return;
+    entry.activeSlotHeld = true;
+    this._activeCount++;
+  }
+
+  private releaseActiveSlot(entry: SessionEntry): boolean {
+    if (!entry.activeSlotHeld) return false;
+    entry.activeSlotHeld = false;
+    this._activeCount = Math.max(0, this._activeCount - 1);
+    return true;
   }
 
   private runtimeProvider(): RuntimeProvider {
@@ -1021,9 +1047,7 @@ export class SessionManager {
         lastActivity: entry.lastActivity,
       });
     }
-    if (entry.status === "active") {
-      this._activeCount = Math.max(0, this._activeCount - 1);
-    }
+    this.releaseActiveSlot(entry);
 
     this.inboxDelivery.prepareEvict(chatId, reason);
     this.sessions.delete(chatId);
@@ -1040,7 +1064,7 @@ export class SessionManager {
     const { chatId } = entry;
     if (this.sessions.get(chatId) !== entry) return;
     this.config.log.warn({ chatId, reason }, "handler route completed after inbox custody was cleared");
-    if (entry.status === "active") this._activeCount = Math.max(0, this._activeCount - 1);
+    this.releaseActiveSlot(entry);
     void entry.handler.shutdown(reason).catch((err) => {
       this.config.log.warn({ chatId, reason, err }, "failed to shut down unowned handler route");
     });
@@ -1168,12 +1192,20 @@ export class SessionManager {
   ): Promise<void> {
     const existing = this.sessions.get(chatId);
 
-    // Transient retry path: keep the original start/resume message at the head
-    // of the provider retry. Newer messages sit later in the inbox ACK prefix,
-    // so they are queued and injected only after retry succeeds.
-    if (existing && existing.retryAttempt > 0) {
-      existing.retryQueuedMessages.push(message);
-      this.triggerImmediateRetry(chatId);
+    // A terminal decision closes route admission before its durable event is
+    // confirmed. New delivery waits for teardown instead of reviving the same
+    // SessionEntry while its original transition still owns the active slot.
+    if (existing?.status === "errored") {
+      this.queueForSlot(chatId, message, deliveryKind, "terminal_teardown_pending");
+      return;
+    }
+
+    // Start/resume transitions and their transient retries keep the original
+    // attempted message at the head. Newer messages sit later in the inbox ACK
+    // prefix, so SessionManager holds them until the winning handler is live.
+    if (existing && (existing.routeTransitionPending || existing.retryAttempt > 0)) {
+      existing.deferredMessages.push(message);
+      if (existing.retryAttempt > 0) this.triggerImmediateRetry(chatId);
       return;
     }
 
@@ -1198,10 +1230,6 @@ export class SessionManager {
         case "suspended":
         case "evicted":
           await this.resumeSession(existing, message, deliveryKind);
-          return;
-
-        case "errored":
-          this.queueForSlot(chatId, message, deliveryKind, "terminal_teardown_pending");
           return;
       }
     }
@@ -1278,6 +1306,7 @@ export class SessionManager {
       claudeSessionId: evicted?.claudeSessionId ?? "",
       handler,
       status: "active",
+      activeSlotHeld: false,
       lastActivity: Date.now(),
       suspending: null,
       retryAttempt: 0,
@@ -1288,13 +1317,14 @@ export class SessionManager {
       lastRetryScope: null,
       lastRetryRawError: null,
       retryHeadMessage: null,
-      retryQueuedMessages: [],
+      deferredMessages: [],
+      routeTransitionPending: true,
       pendingRuntimeFailureNotice: null,
       retryFromEvicted: evicted ?? null,
     };
 
     this.sessions.set(chatId, entry);
-    this._activeCount++;
+    this.claimActiveSlot(entry);
     if (evicted) this.evictedMappings.delete(chatId);
 
     // Report `active` before runtime projection. `session:runtime` frames are
@@ -1327,6 +1357,8 @@ export class SessionManager {
         }
         this.config.log.info({ chatId, sessionId: entry.claudeSessionId }, "session created");
       }
+      entry.routeTransitionPending = false;
+      this.drainDeferredMessages(entry);
       this.persistRegistry();
     } catch (err) {
       if (this.sessions.get(chatId) !== entry) return;
@@ -1367,7 +1399,8 @@ export class SessionManager {
 
     const ctx = this.buildSessionContext(entry.chatId);
     entry.status = "active";
-    this._activeCount++;
+    entry.routeTransitionPending = true;
+    this.claimActiveSlot(entry);
     entry.lastActivity = Date.now();
 
     this.notifySessionState(entry.chatId, "active");
@@ -1397,6 +1430,8 @@ export class SessionManager {
           return;
         }
       }
+      entry.routeTransitionPending = false;
+      this.drainDeferredMessages(entry);
       this.config.log.info({ chatId: entry.chatId, sessionId: entry.claudeSessionId }, "session resumed");
       this.persistRegistry();
     } catch (err) {
@@ -1439,6 +1474,7 @@ export class SessionManager {
     attemptedMessage: SessionMessage | null;
   }): Promise<SessionFailureHandling> {
     const { entry, ctx, err, phase, classification, attemptedMessage } = args;
+    entry.routeTransitionPending = false;
     const errMsg = err instanceof Error ? err.message : String(err);
     const chatId = entry.chatId;
     const provider = this.runtimeProvider();
@@ -1487,7 +1523,7 @@ export class SessionManager {
       // retry_scheduled` event emitted just below is the canonical signal
       // for "we're in the backoff window". Server-side `agent_chat_sessions.
       // state` therefore stays `active` for the entire retry window.
-      this._activeCount--;
+      this.releaseActiveSlot(entry);
       entry.status = "suspended";
       this.sessionRuntimeStates.delete(chatId);
       this.projectSessionRuntime(chatId);
@@ -1542,6 +1578,10 @@ export class SessionManager {
 
     // Stop decision — legacy F2 teardown still owns ACK/recovery, but the
     // visible signal is now the standard provider retry payload.
+    // Close retry admission before awaiting durable event confirmation. The
+    // attempted message is already owned by the caller and deferred custody
+    // remains on the entry for terminal teardown.
+    this.clearRetryAttemptState(entry);
     entry.status = "errored";
     this.notifySessionState(chatId, "errored");
     this.projectSessionRuntime(chatId);
@@ -1596,23 +1636,29 @@ export class SessionManager {
   ): Promise<void> {
     const chatId = entry.chatId;
     if (this.sessions.get(chatId) !== entry) return;
+    const hasDeferredTail = entry.deferredMessages.length > 0;
+    const hasRecoveryDebt = this.inboxDelivery.hasRecoveryDebt(chatId);
     this.clearRetryState(entry);
-    if (handling.terminalEventPersisted && message) {
+    if (handling.terminalEventPersisted && message && !hasRecoveryDebt) {
       await this.completeDeliveryTurn(chatId, message, {
         status: "error",
         terminal: true,
         completion: "consumed",
         reason: `session_failure_terminal:${handling.reasonCode}`,
       });
+      if (hasDeferredTail || this.inboxDelivery.hasRecoveryDebt(chatId)) {
+        await this.inboxDelivery.drainForTerminate(chatId);
+      }
+    } else {
+      await this.inboxDelivery.drainForTerminate(chatId);
     }
-    await this.inboxDelivery.drainForTerminate(chatId);
 
     if (this.sessions.get(chatId) !== entry) return;
     this.sessions.delete(chatId);
     this.sessionRuntimeStates.delete(chatId);
     this.currentTrigger.delete(chatId);
     this.recomputeRuntimeState();
-    this._activeCount = Math.max(0, this._activeCount - 1);
+    this.releaseActiveSlot(entry);
     this.drainPendingQueue();
   }
 
@@ -1625,7 +1671,7 @@ export class SessionManager {
   private async runRetry(chatId: string): Promise<void> {
     const entry = this.sessions.get(chatId);
     if (!entry) return;
-    if (entry.status === "active") return; // racing inject already revived it
+    if (entry.status !== "suspended" || entry.activeSlotHeld || entry.retryAttempt === 0) return;
     if (this.inboxDelivery.hasRecoveryDebt(chatId)) {
       this.clearRetryState(entry);
       await this.inboxDelivery.recoverIfNeeded(chatId, "session_retry:recovery_debt");
@@ -1718,7 +1764,8 @@ export class SessionManager {
     }
 
     entry.status = "active";
-    this._activeCount++;
+    entry.routeTransitionPending = true;
+    this.claimActiveSlot(entry);
     entry.lastActivity = Date.now();
 
     // Fresh handler — the old one may have closed its SDK transport.
@@ -1762,6 +1809,7 @@ export class SessionManager {
       const totalAttempts = entry.retryAttempt;
       const succeededScope = entry.lastRetryScope ?? (previousAvailable(entry) ? "session_resume" : "session_start");
       const succeededClassification = this.retryClassificationForEntry(entry);
+      entry.routeTransitionPending = false;
       this.clearRetryAttemptState(entry);
       this.config.log.info(
         {
@@ -1790,7 +1838,7 @@ export class SessionManager {
       } catch (emitErr) {
         this.config.log.warn({ chatId, emitErr }, "resilience retry_succeeded emit failed");
       }
-      this.drainRetryQueuedMessages(entry);
+      this.drainDeferredMessages(entry);
       this.persistRegistry();
     } catch (err) {
       if (this.sessions.get(chatId) !== entry) return;
@@ -1829,10 +1877,10 @@ export class SessionManager {
     void this.runRetry(chatId);
   }
 
-  private drainRetryQueuedMessages(entry: SessionEntry): void {
-    if (entry.retryQueuedMessages.length === 0) return;
+  private drainDeferredMessages(entry: SessionEntry): void {
+    if (entry.deferredMessages.length === 0) return;
 
-    const queued = entry.retryQueuedMessages.splice(0);
+    const queued = entry.deferredMessages.splice(0);
     for (const message of queued) {
       this.setCurrentTrigger(entry.chatId, message);
       try {
@@ -2007,7 +2055,7 @@ export class SessionManager {
         ? this.inboxDelivery.prepareSuspend(entry.chatId, opts.reason)
         : Promise.resolve(this.inboxDelivery.prepareEvict(entry.chatId, opts.reason));
     entry.status = "suspended";
-    this._activeCount--;
+    this.releaseActiveSlot(entry);
     // Clear per-session runtime state on suspend
     this.sessionRuntimeStates.delete(entry.chatId);
     this.recomputeRuntimeState();
@@ -2150,8 +2198,9 @@ export class SessionManager {
       });
 
       this.config.log.info({ chatId: candidate.key }, "session evicted (max_sessions reached)");
-      if (candidate.session.status === "active") {
-        this._activeCount--;
+      const activeSlotHeld = candidate.session.activeSlotHeld;
+      this.releaseActiveSlot(candidate.session);
+      if (activeSlotHeld) {
         candidate.session.handler.shutdown().catch(() => {});
       }
       // LRU eviction is local memory-management, not operator intent — do

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -2393,10 +2393,6 @@ export class SessionManager {
     // Clear per-session runtime state on suspend
     this.sessionRuntimeStates.delete(entry.chatId);
     this.recomputeRuntimeState();
-    if (canceledUnestablishedStart && this.sessions.get(entry.chatId) === entry) {
-      this.sessions.delete(entry.chatId);
-      this.currentTrigger.delete(entry.chatId);
-    }
     entry.suspending = prepare
       .then(() => {
         if (canceledTransition || this.retiredHandlers.has(entry.handler)) {
@@ -2414,6 +2410,13 @@ export class SessionManager {
       })
       .finally(() => {
         entry.suspending = null;
+        // Keep the unestablished entry addressable until preparation settles:
+        // dispatch() uses its suspending promise as the same-chat admission
+        // fence while operator ACK/recovery decisions are still in flight.
+        if (canceledUnestablishedStart && this.sessions.get(entry.chatId) === entry) {
+          this.sessions.delete(entry.chatId);
+          this.currentTrigger.delete(entry.chatId);
+        }
       });
     this.persistRegistry();
     this.notifySessionState(entry.chatId, "suspended");

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -113,8 +113,10 @@ type SessionEntry = {
    * injects these only after the handler is live again.
    */
   deferredMessages: SessionMessage[];
-  /** True while handler.start / handler.resume has not established its route. */
-  routeTransitionPending: boolean;
+  /** Monotonic fence for start/resume attempts on this entry. */
+  routeTransitionGeneration: number;
+  /** The only start/resume attempt currently allowed to adopt provider state. */
+  routeTransition: RouteTransitionToken | null;
   /**
    * Latest terminal, user-actionable provider failure observed on the session
    * event channel. Posting the durable chat notice at the delivery-settlement
@@ -131,6 +133,11 @@ type SessionEntry = {
    * path (handler.resume) instead of regressing to handler.start.
    */
   retryFromEvicted: { claudeSessionId: string; lastActivity: number } | null;
+};
+
+type RouteTransitionToken = {
+  generation: number;
+  handler: AgentHandler;
 };
 
 type SessionFailureHandling =
@@ -457,8 +464,18 @@ export class SessionManager {
   private readonly currentTrigger = new Map<string, Trigger>();
   private readonly registry: SessionRegistry | null;
   private readonly pendingQueue: PendingMessage[] = [];
+  /** Chats whose terminate command has closed admission but is still draining cleanup. */
+  private readonly terminatingChats = new Set<string>();
+  /** Monotonic fence for delivery work that is still inside the async admission pipeline. */
+  private readonly admissionGenerations = new Map<string, number>();
+  /** One-way lifecycle fence: no provider route may be adopted after manager shutdown begins. */
+  private shuttingDown = false;
   private readonly lastReportedStates = new Map<string, SessionState>();
   private readonly sessionRuntimeStates = new Map<string, RuntimeState>();
+  /** Handlers invalidated while start/resume was unresolved must never be reused. */
+  private readonly retiredHandlers = new WeakSet<AgentHandler>();
+  /** Coalesces concurrent cleanup; a stale settlement may enqueue a later cleanup pass. */
+  private readonly handlerShutdowns = new WeakMap<AgentHandler, Promise<void>>();
   /** Cache of chatId → organizationId, resolved via `getChatDetail`. A chat's
    *  org is immutable, so this is a cheap permanent memo that keeps doc-capture
    *  uploads off the hot path after the first lookup. */
@@ -524,6 +541,11 @@ export class SessionManager {
   async dispatch(entry: InboxEntryWithMessage): Promise<void> {
     const chatId = entry.chatId ?? entry.message.chatId;
     const messageId = entry.message.id;
+    const admissionGeneration = this.admissionGenerations.get(chatId) ?? 0;
+    const admissionValid = () =>
+      !this.shuttingDown &&
+      (this.admissionGenerations.get(chatId) ?? 0) === admissionGeneration &&
+      !this.terminatingChats.has(chatId);
     const suspending = this.sessions.get(chatId)?.suspending;
     if (suspending) await suspending;
     const isRecoveryRedelivery = this.inboxDelivery.takeRecoveryActivationReady(chatId);
@@ -600,6 +622,14 @@ export class SessionManager {
         if (!this.hasHealthyLiveHandler(chatId)) {
           await this.ensureContextTreeBinding();
         }
+
+        if (!admissionValid()) {
+          if (this.inboxDelivery.hasEntry(work)) {
+            this.retryDeliveryTurn(chatId, message, "delivery_admission_invalidated");
+          }
+          return;
+        }
+        if (!this.inboxDelivery.hasEntry(work)) return;
 
         // 5. Route by session state. ACK no longer happens inside route — the
         // entry sits in the coordinator ledger until the handler completes the
@@ -689,8 +719,11 @@ export class SessionManager {
 
   /** Handle a server-issued session command. Terminate drops all local state without reporting back. */
   async handleCommand(chatId: string, command: SessionCommandType): Promise<void> {
+    if (this.terminatingChats.has(chatId)) return;
+
     if (command === "session:suspend") {
       const session = this.sessions.get(chatId);
+      this.invalidateDeliveryAdmission(chatId);
       if (session) this.clearRetryState(session);
       if (session?.activeSlotHeld) {
         this.config.log.info({ chatId }, "suspend command received");
@@ -732,36 +765,45 @@ export class SessionManager {
     if (command === "session:terminate") {
       const session = this.sessions.get(chatId);
       const hadMapping = this.evictedMappings.has(chatId);
-      if (!session && !hadMapping) return;
+      const hasPendingQueue = this.pendingQueue.some((queued) => queued.chatId === chatId);
+      const hasInboxCustody = this.inboxDelivery.hasUnsettledWork(chatId);
+      if (!session && !hadMapping && !hasPendingQueue && !hasInboxCustody) return;
 
+      this.terminatingChats.add(chatId);
+      this.invalidateDeliveryAdmission(chatId);
       this.config.log.info({ chatId }, "terminate command received");
-      if (session?.retryTimer) {
-        clearTimeout(session.retryTimer);
-        session.retryTimer = null;
+      try {
+        if (session?.retryTimer) {
+          clearTimeout(session.retryTimer);
+          session.retryTimer = null;
+        }
+        if (session) this.invalidateRouteTransition(session, "session_terminated");
+        const activeSlotHeld = session?.activeSlotHeld === true;
+        if (session) this.releaseActiveSlot(session);
+        if (activeSlotHeld && session) {
+          await this.shutdownHandler(session.handler, "session_terminated");
+        }
+
+        this.sessions.delete(chatId);
+        this.evictedMappings.delete(chatId);
+        this.sessionRuntimeStates.delete(chatId);
+        this.lastReportedStates.delete(chatId);
+        this.currentTrigger.delete(chatId);
+
+        for (let i = this.pendingQueue.length - 1; i >= 0; i--) {
+          if (this.pendingQueue[i]?.chatId === chatId) this.pendingQueue.splice(i, 1);
+        }
+
+        // Terminate is operator intent: accepted delivery work can be drained,
+        // but coordinator keeps any uncommitted tail as recovery debt.
+        await this.inboxDelivery.drainForTerminate(chatId);
+
+        this.recomputeRuntimeState();
+        this.persistRegistry();
+        this.drainPendingQueue();
+      } finally {
+        this.terminatingChats.delete(chatId);
       }
-      const activeSlotHeld = session?.activeSlotHeld === true;
-      if (session) this.releaseActiveSlot(session);
-      if (activeSlotHeld && session) {
-        await session.handler.shutdown().catch(() => {});
-      }
-
-      this.sessions.delete(chatId);
-      this.evictedMappings.delete(chatId);
-      this.sessionRuntimeStates.delete(chatId);
-      this.lastReportedStates.delete(chatId);
-      this.currentTrigger.delete(chatId);
-
-      for (let i = this.pendingQueue.length - 1; i >= 0; i--) {
-        if (this.pendingQueue[i]?.chatId === chatId) this.pendingQueue.splice(i, 1);
-      }
-
-      // Terminate is operator intent: accepted delivery work can be drained,
-      // but coordinator keeps any uncommitted tail as recovery debt.
-      await this.inboxDelivery.drainForTerminate(chatId);
-
-      this.recomputeRuntimeState();
-      this.persistRegistry();
-      this.drainPendingQueue();
     }
   }
 
@@ -789,6 +831,7 @@ export class SessionManager {
 
   /** Shut down all sessions gracefully. */
   async shutdown(reason?: string, opts: SessionManagerShutdownOptions = {}): Promise<void> {
+    this.shuttingDown = true;
     this.config.subprocessProbe?.stop();
     if (this.idleTimer) {
       clearInterval(this.idleTimer);
@@ -808,9 +851,12 @@ export class SessionManager {
       }
     }
 
-    const shutdowns = [...this.sessions.values()].map((s) =>
-      s.activeSlotHeld ? s.handler.shutdown(reason) : Promise.resolve(),
-    );
+    const shutdowns = [...this.sessions.values()].map((session) => {
+      this.invalidateRouteTransition(session, reason ?? "manager_shutdown");
+      return session.activeSlotHeld
+        ? this.shutdownHandler(session.handler, reason ?? "manager_shutdown")
+        : Promise.resolve();
+    });
     await Promise.allSettled(shutdowns);
 
     const reportSuspendedSessions = opts.reportSuspendedSessions ?? true;
@@ -928,6 +974,10 @@ export class SessionManager {
     return this.inboxDelivery.hasUnsettledWork(chatId);
   }
 
+  private invalidateDeliveryAdmission(chatId: string): void {
+    this.admissionGenerations.set(chatId, (this.admissionGenerations.get(chatId) ?? 0) + 1);
+  }
+
   private clearRetryAttemptState(entry: SessionEntry): void {
     if (entry.retryTimer) clearTimeout(entry.retryTimer);
     entry.retryAttempt = 0;
@@ -943,7 +993,83 @@ export class SessionManager {
   private clearRetryState(entry: SessionEntry): void {
     this.clearRetryAttemptState(entry);
     entry.deferredMessages = [];
-    entry.routeTransitionPending = false;
+  }
+
+  private createHandler(): AgentHandler {
+    const handlerCfg = this.config.agentConfigCache
+      ? { ...this.config.handlerConfig, agentConfigCache: this.config.agentConfigCache }
+      : this.config.handlerConfig;
+    return this.config.handlerFactory(handlerCfg);
+  }
+
+  private handlerForRouteTransition(entry: SessionEntry): AgentHandler {
+    if (!this.retiredHandlers.has(entry.handler)) return entry.handler;
+    const handler = this.createHandler();
+    entry.handler = handler;
+    return handler;
+  }
+
+  private beginRouteTransition(entry: SessionEntry, handler: AgentHandler): RouteTransitionToken {
+    entry.routeTransitionGeneration++;
+    const transition = { generation: entry.routeTransitionGeneration, handler };
+    entry.routeTransition = transition;
+    return transition;
+  }
+
+  private isCurrentRouteTransition(entry: SessionEntry, transition: RouteTransitionToken): boolean {
+    return entry.routeTransition === transition && this.isRouteLeaseValid(entry, transition);
+  }
+
+  private isRouteLeaseValid(entry: SessionEntry, transition: RouteTransitionToken): boolean {
+    return (
+      !this.shuttingDown &&
+      this.sessions.get(entry.chatId) === entry &&
+      entry.routeTransitionGeneration === transition.generation &&
+      entry.handler === transition.handler &&
+      !this.retiredHandlers.has(transition.handler) &&
+      entry.status === "active" &&
+      entry.activeSlotHeld
+    );
+  }
+
+  private completeRouteTransition(entry: SessionEntry, transition: RouteTransitionToken): boolean {
+    if (!this.isCurrentRouteTransition(entry, transition)) return false;
+    entry.routeTransition = null;
+    return true;
+  }
+
+  private shutdownHandler(handler: AgentHandler, reason: string, opts: { afterPrior?: boolean } = {}): Promise<void> {
+    const prior = this.handlerShutdowns.get(handler);
+    if (prior && opts.afterPrior !== true) return prior;
+    const shutdown = (prior ?? Promise.resolve())
+      .then(() => handler.shutdown(reason))
+      .catch((err) => {
+        this.config.log.warn({ reason, err }, "handler shutdown failed");
+      });
+    this.handlerShutdowns.set(handler, shutdown);
+    void shutdown.finally(() => {
+      if (this.handlerShutdowns.get(handler) === shutdown) this.handlerShutdowns.delete(handler);
+    });
+    return shutdown;
+  }
+
+  private retireTransitionHandler(transition: RouteTransitionToken, reason: string): void {
+    this.retiredHandlers.add(transition.handler);
+    void this.shutdownHandler(transition.handler, reason);
+  }
+
+  private invalidateRouteTransition(entry: SessionEntry, reason: string): RouteTransitionToken | null {
+    this.invalidateDeliveryAdmission(entry.chatId);
+    const transition = entry.routeTransition;
+    entry.routeTransitionGeneration++;
+    entry.routeTransition = null;
+    if (transition) this.retireTransitionHandler(transition, reason);
+    return transition;
+  }
+
+  private discardStaleRouteTransition(transition: RouteTransitionToken, reason: string): void {
+    this.retiredHandlers.add(transition.handler);
+    void this.shutdownHandler(transition.handler, reason, { afterPrior: true });
   }
 
   private claimActiveSlot(entry: SessionEntry): void {
@@ -964,14 +1090,29 @@ export class SessionManager {
     return parsed.success ? parsed.data : "claude-code";
   }
 
-  private captureRuntimeFailureNotice(chatId: string, event: SessionEvent): void {
-    if (event.kind !== "error") return;
+  private captureRuntimeFailureNotice(
+    chatId: string,
+    event: SessionEvent,
+    mutationLeaseValid: (() => boolean) | null = null,
+    expectedEntry: SessionEntry | null = null,
+  ): boolean {
+    if (mutationLeaseValid && !mutationLeaseValid()) return false;
+    if (event.kind !== "error") return false;
     const payload = parseProviderRetryEventMessage(event.payload.message);
-    if (!payload || !shouldPostProviderFailureRuntimeNotice(payload)) return;
+    if (!payload || !shouldPostProviderFailureRuntimeNotice(payload)) return false;
 
     const entry = this.sessions.get(chatId);
-    if (!entry) return;
+    if (!entry) return false;
+    if (expectedEntry && entry !== expectedEntry) return false;
+    if (mutationLeaseValid && !mutationLeaseValid()) return false;
     entry.pendingRuntimeFailureNotice = payload;
+    return true;
+  }
+
+  private emitSessionEvent(chatId: string, event: SessionEvent, expectedEntry: SessionEntry | null = null): void {
+    this.config.onSessionEvent?.(chatId, event);
+    const mutationLeaseValid = expectedEntry ? () => this.sessions.get(chatId) === expectedEntry : null;
+    this.captureRuntimeFailureNotice(chatId, event, mutationLeaseValid, expectedEntry);
   }
 
   private clearPendingRuntimeFailureNotice(chatId: string): void {
@@ -1002,16 +1143,24 @@ export class SessionManager {
     }
   }
 
-  private async postPendingRuntimeFailureNotice(chatId: string): Promise<boolean> {
+  private async postPendingRuntimeFailureNotice(
+    chatId: string,
+    mutationLeaseValid: (() => boolean) | null = null,
+  ): Promise<boolean> {
     const entry = this.sessions.get(chatId);
     const payload = entry?.pendingRuntimeFailureNotice;
     if (!entry || !payload) return true;
 
     try {
       await postProviderFailureRuntimeNotice(this.config.sdk, chatId, payload);
-      entry.pendingRuntimeFailureNotice = null;
+      if (mutationLeaseValid && !mutationLeaseValid()) return true;
+      if (this.sessions.get(chatId) === entry && entry.pendingRuntimeFailureNotice === payload) {
+        entry.pendingRuntimeFailureNotice = null;
+      }
       return true;
     } catch (err) {
+      if (mutationLeaseValid && !mutationLeaseValid()) return false;
+      if (this.sessions.get(chatId) !== entry || entry.pendingRuntimeFailureNotice !== payload) return false;
       this.config.log.warn({ chatId, err, reasonCode: payload.reasonCode }, "runtime failure notice delivery failed");
       this.emitRuntimeFailureNoticeDeliveryFailure(chatId, err);
       return false;
@@ -1039,6 +1188,7 @@ export class SessionManager {
     const entry = this.sessions.get(chatId);
     if (!entry) return;
 
+    this.invalidateRouteTransition(entry, reason);
     this.clearRetryState(entry);
     const resumeSessionId = sessionId || entry.claudeSessionId || entry.retryFromEvicted?.claudeSessionId || "";
     if (resumeSessionId) {
@@ -1048,6 +1198,7 @@ export class SessionManager {
       });
     }
     this.releaseActiveSlot(entry);
+    void this.shutdownHandler(entry.handler, reason);
 
     this.inboxDelivery.prepareEvict(chatId, reason);
     this.sessions.delete(chatId);
@@ -1064,10 +1215,9 @@ export class SessionManager {
     const { chatId } = entry;
     if (this.sessions.get(chatId) !== entry) return;
     this.config.log.warn({ chatId, reason }, "handler route completed after inbox custody was cleared");
+    this.invalidateRouteTransition(entry, reason);
     this.releaseActiveSlot(entry);
-    void entry.handler.shutdown(reason).catch((err) => {
-      this.config.log.warn({ chatId, reason, err }, "failed to shut down unowned handler route");
-    });
+    void this.shutdownHandler(entry.handler, reason);
     this.sessions.delete(chatId);
     this.sessionRuntimeStates.delete(chatId);
     this.currentTrigger.delete(chatId);
@@ -1102,7 +1252,9 @@ export class SessionManager {
     chatId: string,
     messages: SessionMessage | readonly SessionMessage[],
     outcome: TurnOutcome,
+    deliveryLeaseValid: (() => boolean) | null = null,
   ): Promise<void> {
+    if (deliveryLeaseValid && !deliveryLeaseValid()) return;
     const retryReason = this.errorCompletionRetryReason(outcome);
     if (retryReason) {
       this.warnRejectedErrorCompletion(chatId, outcome, retryReason);
@@ -1113,20 +1265,27 @@ export class SessionManager {
     if (outcome.status === "success") {
       this.clearPendingRuntimeFailureNotice(chatId);
     } else if (outcome.completion === "consumed") {
-      const noticePosted = await this.postPendingRuntimeFailureNotice(chatId);
+      const noticePosted = await this.postPendingRuntimeFailureNotice(chatId, deliveryLeaseValid);
+      if (deliveryLeaseValid && !deliveryLeaseValid()) return;
       if (!noticePosted) {
         this.retryDeliveryTurn(chatId, messages, "runtime_failure_notice_delivery_failed");
         this.projectSessionRuntime(chatId);
         return;
       }
     }
+    if (deliveryLeaseValid && !deliveryLeaseValid()) return;
     await this.inboxDelivery.finishTurn(chatId, messages, outcome);
     this.projectSessionRuntime(chatId);
   }
 
-  private createDeliveryToken(chatId: string): DeliveryToken {
+  private createDeliveryToken(chatId: string, routeLeaseValid: (() => boolean) | null = null): DeliveryToken {
     let terminalReported = false;
+    const isValid = () => routeLeaseValid?.() ?? true;
     const claimTerminal = (action: string): boolean => {
+      if (!isValid()) {
+        this.config.log.debug({ chatId, action }, "delivery token outcome ignored after route invalidation");
+        return false;
+      }
       if (!terminalReported) {
         terminalReported = true;
         return true;
@@ -1136,13 +1295,13 @@ export class SessionManager {
     };
     return {
       processingStarted: (messages) => {
-        if (terminalReported) return;
+        if (terminalReported || !isValid()) return;
         this.inboxDelivery.markProcessingStarted(chatId, messages);
         this.projectSessionRuntime(chatId);
       },
       complete: async (messages, outcome) => {
         if (!claimTerminal("complete")) return;
-        await this.completeDeliveryTurn(chatId, messages, outcome);
+        await this.completeDeliveryTurn(chatId, messages, outcome, isValid);
       },
       retry: (messages, reason) => {
         if (!claimTerminal("retry")) return;
@@ -1151,7 +1310,8 @@ export class SessionManager {
       },
       terminalRejected: async (messages, reason, evidence) => {
         if (!claimTerminal("terminalRejected")) return;
-        const noticePosted = await this.postPendingRuntimeFailureNotice(chatId);
+        const noticePosted = await this.postPendingRuntimeFailureNotice(chatId, isValid);
+        if (!isValid()) return;
         if (!noticePosted) {
           this.retryDeliveryTurn(chatId, messages, "runtime_failure_notice_delivery_failed");
           this.projectSessionRuntime(chatId);
@@ -1159,6 +1319,23 @@ export class SessionManager {
         }
         await this.inboxDelivery.terminalRejected(chatId, messages, reason, evidence);
         this.projectSessionRuntime(chatId);
+      },
+    };
+  }
+
+  private createDeliveryAttempt(
+    chatId: string,
+    routeLeaseValid: () => boolean,
+  ): {
+    token: DeliveryToken;
+    cancel(): void;
+  } {
+    let active = true;
+    const attemptLeaseValid = () => active && routeLeaseValid();
+    return {
+      token: this.createDeliveryToken(chatId, attemptLeaseValid),
+      cancel: () => {
+        active = false;
       },
     };
   }
@@ -1185,11 +1362,36 @@ export class SessionManager {
     return ownership;
   }
 
+  private adoptResumeReceipt(
+    entry: SessionEntry,
+    message: SessionMessage | null | undefined,
+    receipt: ReturnType<typeof normalizeResumeReceipt>,
+    abortReason: string,
+  ): boolean {
+    if (message) {
+      const ownership = this.markRouteOwned(entry.chatId, message, normalizeRouteReceipt(receipt.route ?? undefined));
+      if (ownership === "lost") {
+        this.abortUnownedRoute(entry, abortReason);
+        return false;
+      }
+    }
+    entry.claudeSessionId = receipt.sessionId;
+    return true;
+  }
+
   private async routeMessage(
     chatId: string,
     message: SessionMessage,
     deliveryKind: SlotDeliveryKind = "fresh",
   ): Promise<void> {
+    if (this.shuttingDown) {
+      this.retryDeliveryTurn(chatId, message, "manager_shutdown");
+      return;
+    }
+    if (this.terminatingChats.has(chatId)) {
+      this.config.log.info({ chatId, messageId: message.id }, "delivery held while session termination is pending");
+      return;
+    }
     const existing = this.sessions.get(chatId);
 
     // A terminal decision closes route admission before its durable event is
@@ -1203,7 +1405,7 @@ export class SessionManager {
     // Start/resume transitions and their transient retries keep the original
     // attempted message at the head. Newer messages sit later in the inbox ACK
     // prefix, so SessionManager holds them until the winning handler is live.
-    if (existing && (existing.routeTransitionPending || existing.retryAttempt > 0)) {
+    if (existing && (existing.routeTransition !== null || existing.retryAttempt > 0)) {
       existing.deferredMessages.push(message);
       if (existing.retryAttempt > 0) this.triggerImmediateRetry(chatId);
       return;
@@ -1211,21 +1413,41 @@ export class SessionManager {
 
     if (existing) {
       switch (existing.status) {
-        case "active":
+        case "active": {
+          const routeLease = {
+            generation: existing.routeTransitionGeneration,
+            handler: existing.handler,
+          };
+          const routeLeaseValid = () => this.isRouteLeaseValid(existing, routeLease);
+          if (!routeLeaseValid()) {
+            this.retryDeliveryTurn(chatId, message, "active_inject_route_invalidated");
+            return;
+          }
           this.setCurrentTrigger(chatId, message);
-          if (
-            this.markRouteOwned(
-              chatId,
-              message,
-              normalizeRouteReceipt(existing.handler.inject(message, this.createDeliveryToken(chatId))),
-            ) === "lost"
-          ) {
+          const attempt = this.createDeliveryAttempt(chatId, routeLeaseValid);
+          let receipt: HandlerRouteReceipt;
+          try {
+            receipt = normalizeRouteReceipt(routeLease.handler.inject(message, attempt.token));
+          } catch (err) {
+            attempt.cancel();
+            throw err;
+          }
+          if (!routeLeaseValid()) {
+            attempt.cancel();
+            this.retryDeliveryTurn(chatId, message, "active_inject_route_invalidated");
+            return;
+          }
+          if (receipt.kind === "rejected") attempt.cancel();
+          const ownership = this.markRouteOwned(chatId, message, receipt);
+          if (ownership !== "owned") attempt.cancel();
+          if (ownership === "lost") {
             return;
           }
           existing.lastActivity = Date.now();
           this.projectSessionRuntime(chatId);
           this.config.log.debug({ chatId }, "message injected");
           return;
+        }
 
         case "suspended":
         case "evicted":
@@ -1283,6 +1505,10 @@ export class SessionManager {
     message: SessionMessage,
     deliveryKind: SlotDeliveryKind,
   ): Promise<void> {
+    if (this.shuttingDown) {
+      this.retryDeliveryTurn(chatId, message, "manager_shutdown");
+      return;
+    }
     // Enforce max_sessions before active-slot preemption so a full pool of
     // working sessions queues instead of first suspending a working victim.
     if (!this.evictIfNeeded(chatId, message, deliveryKind)) return;
@@ -1295,11 +1521,7 @@ export class SessionManager {
 
     // Step 6: thread the AgentConfigCache to the handler so it can read the
     // current per-agent runtime config when launching its sub-process.
-    const handlerCfg = this.config.agentConfigCache
-      ? { ...this.config.handlerConfig, agentConfigCache: this.config.agentConfigCache }
-      : this.config.handlerConfig;
-    const handler = this.config.handlerFactory(handlerCfg);
-    const ctx = this.buildSessionContext(chatId);
+    const handler = this.createHandler();
 
     const entry: SessionEntry = {
       chatId,
@@ -1318,13 +1540,17 @@ export class SessionManager {
       lastRetryRawError: null,
       retryHeadMessage: null,
       deferredMessages: [],
-      routeTransitionPending: true,
+      routeTransitionGeneration: 0,
+      routeTransition: null,
       pendingRuntimeFailureNotice: null,
       retryFromEvicted: evicted ?? null,
     };
 
     this.sessions.set(chatId, entry);
     this.claimActiveSlot(entry);
+    const transition = this.beginRouteTransition(entry, handler);
+    const routeLeaseValid = () => this.isRouteLeaseValid(entry, transition);
+    const ctx = this.buildSessionContext(chatId, routeLeaseValid);
     if (evicted) this.evictedMappings.delete(chatId);
 
     // Report `active` before runtime projection. `session:runtime` frames are
@@ -1334,22 +1560,21 @@ export class SessionManager {
     this.projectSessionRuntime(chatId, { drainPendingOnIdle: false });
     try {
       this.setCurrentTrigger(chatId, message);
-      const token = this.createDeliveryToken(chatId);
+      const token = this.createDeliveryToken(chatId, routeLeaseValid);
       if (evicted) {
         const receipt = normalizeResumeReceipt(await handler.resume(message, evicted.claudeSessionId, ctx, token));
-        if (this.sessions.get(chatId) !== entry) return;
-        entry.claudeSessionId = receipt.sessionId;
-        if (receipt.route) {
-          const ownership = this.markRouteOwned(chatId, message, receipt.route);
-          if (ownership === "lost") {
-            this.abortUnownedRoute(entry, "session_eviction_resume_unowned_delivery");
-            return;
-          }
+        if (!this.isCurrentRouteTransition(entry, transition)) {
+          this.discardStaleRouteTransition(transition, "session_eviction_resume_stale_completion");
+          return;
         }
+        if (!this.adoptResumeReceipt(entry, message, receipt, "session_eviction_resume_unowned_delivery")) return;
         this.config.log.info({ chatId, sessionId: entry.claudeSessionId }, "session resumed from eviction");
       } else {
         const receipt = normalizeStartReceipt(await handler.start(message, ctx, token));
-        if (this.sessions.get(chatId) !== entry) return;
+        if (!this.isCurrentRouteTransition(entry, transition)) {
+          this.discardStaleRouteTransition(transition, "session_start_stale_completion");
+          return;
+        }
         entry.claudeSessionId = receipt.sessionId;
         if (this.markRouteOwned(chatId, message, receipt.route) === "lost") {
           this.abortUnownedRoute(entry, "session_start_unowned_delivery");
@@ -1357,11 +1582,18 @@ export class SessionManager {
         }
         this.config.log.info({ chatId, sessionId: entry.claudeSessionId }, "session created");
       }
-      entry.routeTransitionPending = false;
+      if (!this.completeRouteTransition(entry, transition)) {
+        this.discardStaleRouteTransition(transition, "session_start_stale_adoption");
+        return;
+      }
       this.drainDeferredMessages(entry);
       this.persistRegistry();
     } catch (err) {
-      if (this.sessions.get(chatId) !== entry) return;
+      if (!this.isCurrentRouteTransition(entry, transition)) {
+        this.discardStaleRouteTransition(transition, "session_start_stale_failure");
+        return;
+      }
+      this.invalidateRouteTransition(entry, "session_start_failed");
       const phase: "start" | "resume" = evicted ? "resume" : "start";
       const classification = classifyProviderFailure(err, {
         provider: this.runtimeProvider(),
@@ -1370,7 +1602,6 @@ export class SessionManager {
       });
       const handling = await this.handleSessionFailure({
         entry,
-        ctx,
         err,
         phase,
         classification,
@@ -1386,21 +1617,41 @@ export class SessionManager {
     message: SessionMessage | null | undefined,
     deliveryKind: SlotDeliveryKind = "fresh",
   ): Promise<void> {
+    const stopForManagerShutdown = (reason: string): boolean => {
+      if (!this.shuttingDown) return false;
+      if (message) this.retryDeliveryTurn(entry.chatId, message, reason);
+      return true;
+    };
+    if (stopForManagerShutdown("session_resume:manager_shutdown")) return;
     // Wait for in-flight suspension to complete before resuming
     if (entry.suspending) {
       await entry.suspending;
     }
+    if (stopForManagerShutdown("session_resume:manager_shutdown_after_suspend")) return;
+    if (this.sessions.get(entry.chatId) !== entry) return;
     if (await this.recoverDebtBeforeResume(entry.chatId, "session_resume:recovery_debt")) return;
+    if (stopForManagerShutdown("session_resume:manager_shutdown_after_recovery")) return;
+    if (
+      this.sessions.get(entry.chatId) !== entry ||
+      (entry.status !== "suspended" && entry.status !== "evicted") ||
+      entry.activeSlotHeld ||
+      entry.routeTransition !== null
+    ) {
+      return;
+    }
 
     // Admin-triggered resume has no provider input. It may use idle capacity,
     // but it must not preempt unrelated working turns.
     const slotKind: SlotDeliveryKind = message ? deliveryKind : "control";
     if (!this.acquireActiveSlot(entry.chatId, message ?? null, slotKind)) return;
+    if (stopForManagerShutdown("session_resume:manager_shutdown_after_slot")) return;
 
-    const ctx = this.buildSessionContext(entry.chatId);
+    const routeHandler = this.handlerForRouteTransition(entry);
     entry.status = "active";
-    entry.routeTransitionPending = true;
     this.claimActiveSlot(entry);
+    const transition = this.beginRouteTransition(entry, routeHandler);
+    const routeLeaseValid = () => this.isRouteLeaseValid(entry, transition);
+    const ctx = this.buildSessionContext(entry.chatId, routeLeaseValid);
     entry.lastActivity = Date.now();
 
     this.notifySessionState(entry.chatId, "active");
@@ -1416,26 +1667,29 @@ export class SessionManager {
       // assignment back, a fresh-start fallback would persist the OLD id,
       // and the next suspend→resume cycle would re-trigger the same
       // missing-transcript fallback ad infinitum.
-      const token = message ? this.createDeliveryToken(entry.chatId) : undefined;
+      const token = message ? this.createDeliveryToken(entry.chatId, routeLeaseValid) : undefined;
       const resumeResult = token
-        ? await entry.handler.resume(message ?? undefined, entry.claudeSessionId, ctx, token)
-        : await entry.handler.resume(message ?? undefined, entry.claudeSessionId, ctx);
-      if (this.sessions.get(entry.chatId) !== entry) return;
-      const receipt = normalizeResumeReceipt(resumeResult);
-      entry.claudeSessionId = receipt.sessionId;
-      if (message && receipt.route) {
-        const ownership = this.markRouteOwned(entry.chatId, message, receipt.route);
-        if (ownership === "lost") {
-          this.abortUnownedRoute(entry, "session_resume_unowned_delivery");
-          return;
-        }
+        ? await routeHandler.resume(message ?? undefined, entry.claudeSessionId, ctx, token)
+        : await routeHandler.resume(message ?? undefined, entry.claudeSessionId, ctx);
+      if (!this.isCurrentRouteTransition(entry, transition)) {
+        this.discardStaleRouteTransition(transition, "session_resume_stale_completion");
+        return;
       }
-      entry.routeTransitionPending = false;
+      const receipt = normalizeResumeReceipt(resumeResult);
+      if (!this.adoptResumeReceipt(entry, message, receipt, "session_resume_unowned_delivery")) return;
+      if (!this.completeRouteTransition(entry, transition)) {
+        this.discardStaleRouteTransition(transition, "session_resume_stale_adoption");
+        return;
+      }
       this.drainDeferredMessages(entry);
       this.config.log.info({ chatId: entry.chatId, sessionId: entry.claudeSessionId }, "session resumed");
       this.persistRegistry();
     } catch (err) {
-      if (this.sessions.get(entry.chatId) !== entry) return;
+      if (!this.isCurrentRouteTransition(entry, transition)) {
+        this.discardStaleRouteTransition(transition, "session_resume_stale_failure");
+        return;
+      }
+      this.invalidateRouteTransition(entry, "session_resume_failed");
       const classification = classifyProviderFailure(err, {
         provider: this.runtimeProvider(),
         scope: "session_resume",
@@ -1443,7 +1697,6 @@ export class SessionManager {
       });
       const handling = await this.handleSessionFailure({
         entry,
-        ctx,
         err,
         phase: "resume",
         classification,
@@ -1467,14 +1720,12 @@ export class SessionManager {
    */
   private async handleSessionFailure(args: {
     entry: SessionEntry;
-    ctx: SessionContext;
     err: unknown;
     phase: "start" | "resume";
     classification: ProviderFailureClassification;
     attemptedMessage: SessionMessage | null;
   }): Promise<SessionFailureHandling> {
-    const { entry, ctx, err, phase, classification, attemptedMessage } = args;
-    entry.routeTransitionPending = false;
+    const { entry, err, phase, classification, attemptedMessage } = args;
     const errMsg = err instanceof Error ? err.message : String(err);
     const chatId = entry.chatId;
     const provider = this.runtimeProvider();
@@ -1555,13 +1806,17 @@ export class SessionManager {
           decision,
           messagePreview: errMsg,
         });
-        ctx.emitEvent({
-          kind: "error",
-          payload: {
-            source: "runtime",
-            message: encodeProviderRetryEventMessage(payload),
+        this.emitSessionEvent(
+          chatId,
+          {
+            kind: "error",
+            payload: {
+              source: "runtime",
+              message: encodeProviderRetryEventMessage(payload),
+            },
           },
-        });
+          entry,
+        );
       } catch (emitErr) {
         this.config.log.warn({ chatId, emitErr }, "resilience retry_scheduled emit failed");
       }
@@ -1599,22 +1854,40 @@ export class SessionManager {
       decision,
       messagePreview: preview,
     });
-    const terminalEventPersisted = await this.emitConfirmedSessionEvent(chatId, {
-      kind: "error",
-      payload: {
-        source: "runtime",
-        message: encodeProviderRetryEventMessage(payload),
+    const terminalMutationGeneration = entry.routeTransitionGeneration;
+    const terminalMutationLeaseValid = () =>
+      !this.shuttingDown &&
+      this.sessions.get(chatId) === entry &&
+      entry.routeTransitionGeneration === terminalMutationGeneration &&
+      entry.status === "errored";
+    const terminalEventPersisted = await this.emitConfirmedSessionEvent(
+      chatId,
+      {
+        kind: "error",
+        payload: {
+          source: "runtime",
+          message: encodeProviderRetryEventMessage(payload),
+        },
       },
-    });
+      entry,
+      terminalMutationLeaseValid,
+    );
     return { kind: "terminal", reasonCode: decision.reasonCode, terminalEventPersisted };
   }
 
-  private async emitConfirmedSessionEvent(chatId: string, event: SessionEvent): Promise<boolean> {
+  private async emitConfirmedSessionEvent(
+    chatId: string,
+    event: SessionEvent,
+    expectedEntry: SessionEntry | null = null,
+    mutationLeaseValid: (() => boolean) | null = null,
+  ): Promise<boolean> {
+    const captureLeaseValid = () =>
+      (!expectedEntry || this.sessions.get(chatId) === expectedEntry) && (!mutationLeaseValid || mutationLeaseValid());
     if (this.config.confirmSessionEvent) {
       try {
         await this.config.confirmSessionEvent(chatId, event);
-        this.captureRuntimeFailureNotice(chatId, event);
-        return true;
+        if (!captureLeaseValid()) return false;
+        return this.captureRuntimeFailureNotice(chatId, event, captureLeaseValid, expectedEntry);
       } catch (emitErr) {
         this.config.log.warn({ chatId, emitErr }, "confirmed session event emit failed");
         return false;
@@ -1622,7 +1895,7 @@ export class SessionManager {
     }
     try {
       this.config.onSessionEvent?.(chatId, event);
-      this.captureRuntimeFailureNotice(chatId, event);
+      this.captureRuntimeFailureNotice(chatId, event, captureLeaseValid, expectedEntry);
     } catch (emitErr) {
       this.config.log.warn({ chatId, emitErr }, "session error event emit failed");
     }
@@ -1636,6 +1909,7 @@ export class SessionManager {
   ): Promise<void> {
     const chatId = entry.chatId;
     if (this.sessions.get(chatId) !== entry) return;
+    this.invalidateRouteTransition(entry, "session_terminal_failure");
     const hasDeferredTail = entry.deferredMessages.length > 0;
     const hasRecoveryDebt = this.inboxDelivery.hasRecoveryDebt(chatId);
     this.clearRetryState(entry);
@@ -1669,9 +1943,17 @@ export class SessionManager {
    * had its SDK transport torn down.
    */
   private async runRetry(chatId: string): Promise<void> {
+    if (this.shuttingDown) return;
     const entry = this.sessions.get(chatId);
     if (!entry) return;
-    if (entry.status !== "suspended" || entry.activeSlotHeld || entry.retryAttempt === 0) return;
+    if (
+      entry.status !== "suspended" ||
+      entry.activeSlotHeld ||
+      entry.routeTransition !== null ||
+      entry.retryAttempt === 0
+    ) {
+      return;
+    }
     if (this.inboxDelivery.hasRecoveryDebt(chatId)) {
       this.clearRetryState(entry);
       await this.inboxDelivery.recoverIfNeeded(chatId, "session_retry:recovery_debt");
@@ -1763,43 +2045,41 @@ export class SessionManager {
       return;
     }
 
+    // Fresh handler — the old one may have closed its SDK transport.
+    const newHandler = this.createHandler();
+    entry.handler = newHandler;
     entry.status = "active";
-    entry.routeTransitionPending = true;
     this.claimActiveSlot(entry);
     entry.lastActivity = Date.now();
-
-    // Fresh handler — the old one may have closed its SDK transport.
-    const handlerCfg = this.config.agentConfigCache
-      ? { ...this.config.handlerConfig, agentConfigCache: this.config.agentConfigCache }
-      : this.config.handlerConfig;
-    const newHandler = this.config.handlerFactory(handlerCfg);
-    entry.handler = newHandler;
-    const ctx = this.buildSessionContext(chatId);
+    const transition = this.beginRouteTransition(entry, newHandler);
+    const routeLeaseValid = () => this.isRouteLeaseValid(entry, transition);
+    const ctx = this.buildSessionContext(chatId, routeLeaseValid);
 
     this.notifySessionState(chatId, "active");
     this.projectSessionRuntime(chatId, { drainPendingOnIdle: false });
     try {
       if (retryHeadMessage) this.setCurrentTrigger(chatId, retryHeadMessage);
-      const token = retryHeadMessage ? this.createDeliveryToken(chatId) : undefined;
+      const token = retryHeadMessage ? this.createDeliveryToken(chatId, routeLeaseValid) : undefined;
       if (retryRoute.kind === "resume") {
         const resumeResult = token
           ? await newHandler.resume(retryHeadMessage ?? undefined, retryRoute.previousSessionId, ctx, token)
           : await newHandler.resume(undefined, retryRoute.previousSessionId, ctx);
-        if (this.sessions.get(chatId) !== entry) return;
+        if (!this.isCurrentRouteTransition(entry, transition)) {
+          this.discardStaleRouteTransition(transition, "session_retry_resume_stale_completion");
+          return;
+        }
         const receipt = normalizeResumeReceipt(resumeResult);
-        entry.claudeSessionId = receipt.sessionId;
-        if (retryHeadMessage && receipt.route) {
-          const ownership = this.markRouteOwned(chatId, retryHeadMessage, receipt.route);
-          if (ownership === "lost") {
-            this.abortUnownedRoute(entry, "session_retry_resume_unowned_delivery");
-            return;
-          }
+        if (!this.adoptResumeReceipt(entry, retryHeadMessage, receipt, "session_retry_resume_unowned_delivery")) {
+          return;
         }
       } else {
         const receipt = normalizeStartReceipt(
-          await newHandler.start(retryRoute.message, ctx, this.createDeliveryToken(chatId)),
+          await newHandler.start(retryRoute.message, ctx, this.createDeliveryToken(chatId, routeLeaseValid)),
         );
-        if (this.sessions.get(chatId) !== entry) return;
+        if (!this.isCurrentRouteTransition(entry, transition)) {
+          this.discardStaleRouteTransition(transition, "session_retry_start_stale_completion");
+          return;
+        }
         entry.claudeSessionId = receipt.sessionId;
         if (this.markRouteOwned(chatId, retryRoute.message, receipt.route) === "lost") {
           this.abortUnownedRoute(entry, "session_retry_start_unowned_delivery");
@@ -1809,7 +2089,10 @@ export class SessionManager {
       const totalAttempts = entry.retryAttempt;
       const succeededScope = entry.lastRetryScope ?? (previousAvailable(entry) ? "session_resume" : "session_start");
       const succeededClassification = this.retryClassificationForEntry(entry);
-      entry.routeTransitionPending = false;
+      if (!this.completeRouteTransition(entry, transition)) {
+        this.discardStaleRouteTransition(transition, "session_retry_stale_adoption");
+        return;
+      }
       this.clearRetryAttemptState(entry);
       this.config.log.info(
         {
@@ -1841,7 +2124,11 @@ export class SessionManager {
       this.drainDeferredMessages(entry);
       this.persistRegistry();
     } catch (err) {
-      if (this.sessions.get(chatId) !== entry) return;
+      if (!this.isCurrentRouteTransition(entry, transition)) {
+        this.discardStaleRouteTransition(transition, "session_retry_stale_failure");
+        return;
+      }
+      this.invalidateRouteTransition(entry, "session_retry_failed");
       const phase = retryRoute.kind;
       const classification = classifyProviderFailure(err, {
         provider: this.runtimeProvider(),
@@ -1850,7 +2137,6 @@ export class SessionManager {
       });
       const handling = await this.handleSessionFailure({
         entry,
-        ctx,
         err,
         phase,
         classification,
@@ -1881,22 +2167,39 @@ export class SessionManager {
     if (entry.deferredMessages.length === 0) return;
 
     const queued = entry.deferredMessages.splice(0);
-    for (const message of queued) {
+    const routeLease = {
+      generation: entry.routeTransitionGeneration,
+      handler: entry.handler,
+    };
+    const routeLeaseValid = () => this.isRouteLeaseValid(entry, routeLease);
+    for (let index = 0; index < queued.length; index++) {
+      const message = queued[index];
+      if (!message) continue;
+      if (!routeLeaseValid() || this.inboxDelivery.hasRecoveryDebt(entry.chatId)) {
+        this.retryDeliveryTurn(entry.chatId, queued.slice(index), "deferred_inject_recovery_pending");
+        break;
+      }
       this.setCurrentTrigger(entry.chatId, message);
+      const attempt = this.createDeliveryAttempt(entry.chatId, routeLeaseValid);
       try {
-        if (
-          this.markRouteOwned(
-            entry.chatId,
-            message,
-            normalizeRouteReceipt(entry.handler.inject(message, this.createDeliveryToken(entry.chatId))),
-          ) === "lost"
-        ) {
-          continue;
+        const receipt = normalizeRouteReceipt(routeLease.handler.inject(message, attempt.token));
+        if (!routeLeaseValid()) {
+          attempt.cancel();
+          this.retryDeliveryTurn(entry.chatId, queued.slice(index), "deferred_inject_route_invalidated");
+          break;
+        }
+        if (receipt.kind === "rejected") attempt.cancel();
+        const ownership = this.markRouteOwned(entry.chatId, message, receipt);
+        if (ownership !== "owned") attempt.cancel();
+        if (ownership === "lost") {
+          this.retryDeliveryTurn(entry.chatId, queued.slice(index), "deferred_inject_custody_lost");
+          break;
         }
         entry.lastActivity = Date.now();
       } catch (err) {
+        attempt.cancel();
         this.config.log.warn({ chatId: entry.chatId, messageId: message.id, err }, "retry queued inject failed");
-        this.retryDeliveryTurn(entry.chatId, message, "retry_queued_inject_failed");
+        this.retryDeliveryTurn(entry.chatId, queued.slice(index), "retry_queued_inject_failed");
         break;
       }
     }
@@ -2049,6 +2352,8 @@ export class SessionManager {
       drainQueue: true,
     },
   ): void {
+    const canceledTransition = this.invalidateRouteTransition(entry, opts.reason);
+    if (canceledTransition) entry.deferredMessages = [];
     const prepare = opts.operatorResolution
       ? this.inboxDelivery.prepareOperatorSuspend(entry.chatId)
       : opts.ackConsumedPrefix
@@ -2060,7 +2365,13 @@ export class SessionManager {
     this.sessionRuntimeStates.delete(entry.chatId);
     this.recomputeRuntimeState();
     entry.suspending = prepare
-      .then(() => entry.handler.suspend())
+      .then(() => {
+        if (canceledTransition || this.retiredHandlers.has(entry.handler)) {
+          void this.shutdownHandler(canceledTransition?.handler ?? entry.handler, opts.reason);
+          return;
+        }
+        return entry.handler.suspend(opts.reason);
+      })
       .catch((err) => {
         this.config.log.warn({ chatId: entry.chatId, err }, "suspend preparation error");
       })
@@ -2191,6 +2502,7 @@ export class SessionManager {
     }
 
     if (candidate) {
+      this.invalidateRouteTransition(candidate.session, "session_evicted");
       // Preserve mapping for future recovery
       this.addEvictedMapping(candidate.key, {
         claudeSessionId: candidate.session.claudeSessionId,
@@ -2201,7 +2513,7 @@ export class SessionManager {
       const activeSlotHeld = candidate.session.activeSlotHeld;
       this.releaseActiveSlot(candidate.session);
       if (activeSlotHeld) {
-        candidate.session.handler.shutdown().catch(() => {});
+        void this.shutdownHandler(candidate.session.handler, "session_evicted");
       }
       // LRU eviction is local memory-management, not operator intent — do
       // NOT emit a wire state here. The chat now lives in `evictedMappings`
@@ -2306,7 +2618,7 @@ export class SessionManager {
     this.config.onStateChange(chatId, state);
   }
 
-  private buildSessionContext(chatId: string): SessionContext {
+  private buildSessionContext(chatId: string, routeLeaseValid: (() => boolean) | null = null): SessionContext {
     const sessionLog = this.config.log.child({ chatId });
     const currentSdk = () => this.config.sdk;
     // Runtime-facing string log (handler + result-sink expect a simple
@@ -2394,31 +2706,47 @@ export class SessionManager {
       log,
       chatId,
       recordProviderActivity: () => {
+        if (routeLeaseValid && !routeLeaseValid()) return;
         const entry = this.sessions.get(chatId);
         if (entry && entry.status === "active") {
           entry.lastActivity = Date.now();
         }
       },
       emitEvent: (event) => {
+        if (routeLeaseValid && !routeLeaseValid()) return;
         this.config.onSessionEvent?.(chatId, event);
-        this.captureRuntimeFailureNotice(chatId, event);
+        if (routeLeaseValid && !routeLeaseValid()) return;
+        this.captureRuntimeFailureNotice(chatId, event, routeLeaseValid);
       },
-      emitEventConfirmed: (event) => this.confirmSessionEventOrThrow(chatId, event),
-      forwardResult,
+      emitEventConfirmed: (event) => {
+        if (routeLeaseValid && !routeLeaseValid()) {
+          return Promise.reject(new Error("route transition invalidated"));
+        }
+        return this.confirmSessionEventOrThrow(chatId, event, routeLeaseValid);
+      },
+      forwardResult: (text) => {
+        if (routeLeaseValid && !routeLeaseValid()) return Promise.resolve();
+        return forwardResult(text);
+      },
       markMessagesConsumed: (messages) => {
+        if (routeLeaseValid && !routeLeaseValid()) return;
         this.inboxDelivery.markProcessingStarted(chatId, messages);
       },
       finishTurn: (messages, outcome) => {
-        return this.completeDeliveryTurn(chatId, messages, outcome);
+        if (routeLeaseValid && !routeLeaseValid()) return Promise.resolve();
+        return this.completeDeliveryTurn(chatId, messages, outcome, routeLeaseValid);
       },
       retryTurn: (messages, reason) => {
+        if (routeLeaseValid && !routeLeaseValid()) return;
         this.retryDeliveryTurn(chatId, messages, reason);
         this.projectSessionRuntime(chatId);
       },
       failSessionForRecovery: (reason, sessionId) => {
+        if (routeLeaseValid && !routeLeaseValid()) return;
         this.failSessionForRecovery(chatId, reason, sessionId);
       },
       replaceSessionId: (sessionId, reason) => {
+        if (routeLeaseValid && !routeLeaseValid()) return;
         const entry = this.sessions.get(chatId);
         if (!entry) return;
         const previousSessionId = entry.claudeSessionId;
@@ -2434,13 +2762,23 @@ export class SessionManager {
     };
   }
 
-  private async confirmSessionEventOrThrow(chatId: string, event: SessionEvent): Promise<void> {
+  private async confirmSessionEventOrThrow(
+    chatId: string,
+    event: SessionEvent,
+    mutationLeaseValid: (() => boolean) | null = null,
+  ): Promise<void> {
+    if (mutationLeaseValid && !mutationLeaseValid()) {
+      throw new Error("route transition invalidated");
+    }
     if (!this.config.confirmSessionEvent) {
       this.config.onSessionEvent?.(chatId, event);
       throw new Error("confirmed session event channel unavailable");
     }
     await this.config.confirmSessionEvent(chatId, event);
-    this.captureRuntimeFailureNotice(chatId, event);
+    if (mutationLeaseValid && !mutationLeaseValid()) {
+      throw new Error("route transition invalidated");
+    }
+    this.captureRuntimeFailureNotice(chatId, event, mutationLeaseValid);
   }
 
   private async resolveSelfFence(log: (msg: string) => void, chatId: string): Promise<SelfFence> {

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -97,11 +97,15 @@ type SessionEntry = {
    * nothing actionable). Cleared on a successful start/resume.
    */
   lastRetryRawError: string | null;
-  /** Original message used to bootstrap this session, replayed on retry. */
-  startMessage: SessionMessage | null;
+  /**
+   * Input for the current transient start/resume retry window. This is set at
+   * the failure boundary from the message that actually failed, and cleared
+   * once the retry succeeds or the retry state is torn down.
+   */
+  retryHeadMessage: SessionMessage | null;
   /**
    * Messages that arrived while start/resume is in transient retry. They must
-   * not replace `startMessage`: the older accepted inbox entry is still ahead
+   * not replace `retryHeadMessage`: the older accepted inbox entry is still ahead
    * of them in the ACK prefix, so retry consumes the original trigger first and
    * injects these only after the handler is live again.
    */
@@ -389,10 +393,6 @@ const RUNTIME_REAFFIRM_JITTER_RATIO = 0.2;
 function jitteredReaffirmDelay(): number {
   const offset = (Math.random() * 2 - 1) * RUNTIME_REAFFIRM_BASE_MS * RUNTIME_REAFFIRM_JITTER_RATIO;
   return RUNTIME_REAFFIRM_BASE_MS + offset;
-}
-
-function buildEmptySessionMessage(chatId: string): SessionMessage {
-  return { id: "", chatId, senderId: "", format: "text", content: "", metadata: {} };
 }
 
 function previousAvailable(entry: SessionEntry): boolean {
@@ -916,7 +916,7 @@ export class SessionManager {
     return this.inboxDelivery.hasUnsettledWork(chatId);
   }
 
-  private clearRetryState(entry: SessionEntry): void {
+  private clearRetryAttemptState(entry: SessionEntry): void {
     if (entry.retryTimer) clearTimeout(entry.retryTimer);
     entry.retryAttempt = 0;
     entry.retryNextAt = null;
@@ -925,6 +925,11 @@ export class SessionManager {
     entry.lastRetryCategory = null;
     entry.lastRetryScope = null;
     entry.lastRetryRawError = null;
+    entry.retryHeadMessage = null;
+  }
+
+  private clearRetryState(entry: SessionEntry): void {
+    this.clearRetryAttemptState(entry);
     entry.retryQueuedMessages = [];
   }
 
@@ -1282,7 +1287,7 @@ export class SessionManager {
       lastRetryCategory: null,
       lastRetryScope: null,
       lastRetryRawError: null,
-      startMessage: message,
+      retryHeadMessage: null,
       retryQueuedMessages: [],
       pendingRuntimeFailureNotice: null,
       retryFromEvicted: evicted ?? null,
@@ -1337,6 +1342,7 @@ export class SessionManager {
         err,
         phase,
         classification,
+        attemptedMessage: message,
       });
       if (this.sessions.get(chatId) !== entry) return;
       if (handling.kind === "terminal") await this.teardownTerminalSessionFailure(entry, message, handling);
@@ -1406,6 +1412,7 @@ export class SessionManager {
         err,
         phase: "resume",
         classification,
+        attemptedMessage: message ?? null,
       });
       if (this.sessions.get(entry.chatId) !== entry) return;
       if (handling.kind === "terminal") await this.teardownTerminalSessionFailure(entry, message ?? null, handling);
@@ -1429,8 +1436,9 @@ export class SessionManager {
     err: unknown;
     phase: "start" | "resume";
     classification: ProviderFailureClassification;
+    attemptedMessage: SessionMessage | null;
   }): Promise<SessionFailureHandling> {
-    const { entry, ctx, err, phase, classification } = args;
+    const { entry, ctx, err, phase, classification, attemptedMessage } = args;
     const errMsg = err instanceof Error ? err.message : String(err);
     const chatId = entry.chatId;
     const provider = this.runtimeProvider();
@@ -1449,6 +1457,7 @@ export class SessionManager {
     );
 
     if (decision.action === "retry") {
+      entry.retryHeadMessage = attemptedMessage;
       entry.retryAttempt = decision.attempt;
       entry.lastRetryReason = decision.reasonCode;
       entry.lastRetryCategory = classification.category;
@@ -1587,6 +1596,7 @@ export class SessionManager {
   ): Promise<void> {
     const chatId = entry.chatId;
     if (this.sessions.get(chatId) !== entry) return;
+    this.clearRetryState(entry);
     if (handling.terminalEventPersisted && message) {
       await this.completeDeliveryTurn(chatId, message, {
         status: "error",
@@ -1594,9 +1604,8 @@ export class SessionManager {
         completion: "consumed",
         reason: `session_failure_terminal:${handling.reasonCode}`,
       });
-    } else {
-      await this.inboxDelivery.drainForTerminate(chatId);
     }
+    await this.inboxDelivery.drainForTerminate(chatId);
 
     if (this.sessions.get(chatId) !== entry) return;
     this.sessions.delete(chatId);
@@ -1621,6 +1630,40 @@ export class SessionManager {
       this.clearRetryState(entry);
       await this.inboxDelivery.recoverIfNeeded(chatId, "session_retry:recovery_debt");
       this.projectSessionRuntime(chatId);
+      return;
+    }
+
+    const retryHeadMessage = entry.retryHeadMessage;
+    const previousSessionId = entry.claudeSessionId || entry.retryFromEvicted?.claudeSessionId || "";
+    const retryRoute = previousSessionId
+      ? { kind: "resume" as const, message: retryHeadMessage, previousSessionId }
+      : retryHeadMessage
+        ? { kind: "start" as const, message: retryHeadMessage }
+        : null;
+    if (
+      retryHeadMessage?.inboxEntryId !== undefined &&
+      !this.inboxDelivery.hasEntry({
+        chatId,
+        messageId: retryHeadMessage.id,
+        entryId: retryHeadMessage.inboxEntryId,
+      })
+    ) {
+      this.config.log.warn(
+        {
+          chatId,
+          messageId: retryHeadMessage.id,
+          entryId: retryHeadMessage.inboxEntryId,
+        },
+        "session retry head lost inbox custody; requesting recovery",
+      );
+      this.failSessionForRecovery(chatId, "session_retry_head_custody_missing", previousSessionId);
+      await this.inboxDelivery.recoverIfNeeded(chatId, "session_retry_head_custody_missing");
+      return;
+    }
+    if (!retryRoute) {
+      this.config.log.error({ chatId }, "session start retry has no input; requesting recovery");
+      this.failSessionForRecovery(chatId, "session_retry_head_missing");
+      await this.inboxDelivery.recoverIfNeeded(chatId, "session_retry_head_missing");
       return;
     }
 
@@ -1661,7 +1704,7 @@ export class SessionManager {
     // Enforce concurrency limit before claiming the slot. If we cannot, the
     // entry stays in transient-retry state and a future retry / message will
     // try again.
-    if (!this.acquireActiveSlot(chatId, entry.startMessage ?? buildEmptySessionMessage(chatId), "recovery")) {
+    if (!this.acquireActiveSlot(chatId, retryRoute.message, "recovery", { queueOnFailure: false })) {
       // Couldn't get a slot — re-arm the timer with a short delay.
       const nextDelay = 5_000;
       entry.retryNextAt = Date.now() + nextDelay;
@@ -1689,31 +1732,29 @@ export class SessionManager {
     this.notifySessionState(chatId, "active");
     this.projectSessionRuntime(chatId, { drainPendingOnIdle: false });
     try {
-      const resumeMessage = entry.startMessage ?? null;
-      const previousSessionId = entry.claudeSessionId || entry.retryFromEvicted?.claudeSessionId || "";
-      if (resumeMessage) this.setCurrentTrigger(chatId, resumeMessage);
-      const token = resumeMessage ? this.createDeliveryToken(chatId) : undefined;
-      if (previousSessionId) {
+      if (retryHeadMessage) this.setCurrentTrigger(chatId, retryHeadMessage);
+      const token = retryHeadMessage ? this.createDeliveryToken(chatId) : undefined;
+      if (retryRoute.kind === "resume") {
         const resumeResult = token
-          ? await newHandler.resume(resumeMessage ?? undefined, previousSessionId, ctx, token)
-          : await newHandler.resume(resumeMessage ?? undefined, previousSessionId, ctx);
+          ? await newHandler.resume(retryHeadMessage ?? undefined, retryRoute.previousSessionId, ctx, token)
+          : await newHandler.resume(undefined, retryRoute.previousSessionId, ctx);
         if (this.sessions.get(chatId) !== entry) return;
         const receipt = normalizeResumeReceipt(resumeResult);
         entry.claudeSessionId = receipt.sessionId;
-        if (resumeMessage && receipt.route) {
-          const ownership = this.markRouteOwned(chatId, resumeMessage, receipt.route);
+        if (retryHeadMessage && receipt.route) {
+          const ownership = this.markRouteOwned(chatId, retryHeadMessage, receipt.route);
           if (ownership === "lost") {
             this.abortUnownedRoute(entry, "session_retry_resume_unowned_delivery");
             return;
           }
         }
       } else {
-        // No resume key yet — fall back to fresh start.
-        const message = resumeMessage ?? buildEmptySessionMessage(chatId);
-        const receipt = normalizeStartReceipt(await newHandler.start(message, ctx, this.createDeliveryToken(chatId)));
+        const receipt = normalizeStartReceipt(
+          await newHandler.start(retryRoute.message, ctx, this.createDeliveryToken(chatId)),
+        );
         if (this.sessions.get(chatId) !== entry) return;
         entry.claudeSessionId = receipt.sessionId;
-        if (this.markRouteOwned(chatId, message, receipt.route) === "lost") {
+        if (this.markRouteOwned(chatId, retryRoute.message, receipt.route) === "lost") {
           this.abortUnownedRoute(entry, "session_retry_start_unowned_delivery");
           return;
         }
@@ -1721,12 +1762,7 @@ export class SessionManager {
       const totalAttempts = entry.retryAttempt;
       const succeededScope = entry.lastRetryScope ?? (previousAvailable(entry) ? "session_resume" : "session_start");
       const succeededClassification = this.retryClassificationForEntry(entry);
-      entry.retryAttempt = 0;
-      entry.retryNextAt = null;
-      entry.lastRetryReason = null;
-      entry.lastRetryCategory = null;
-      entry.lastRetryScope = null;
-      entry.lastRetryRawError = null;
+      this.clearRetryAttemptState(entry);
       this.config.log.info(
         {
           chatId,
@@ -1758,7 +1794,7 @@ export class SessionManager {
       this.persistRegistry();
     } catch (err) {
       if (this.sessions.get(chatId) !== entry) return;
-      const phase = previousAvailable(entry) ? "resume" : "start";
+      const phase = retryRoute.kind;
       const classification = classifyProviderFailure(err, {
         provider: this.runtimeProvider(),
         scope: phase === "start" ? "session_start" : "session_resume",
@@ -1770,9 +1806,10 @@ export class SessionManager {
         err,
         phase,
         classification,
+        attemptedMessage: retryHeadMessage,
       });
       if (this.sessions.get(chatId) !== entry) return;
-      if (handling.kind === "terminal") await this.teardownTerminalSessionFailure(entry, entry.startMessage, handling);
+      if (handling.kind === "terminal") await this.teardownTerminalSessionFailure(entry, retryHeadMessage, handling);
     }
   }
 
@@ -1830,7 +1867,9 @@ export class SessionManager {
    *    working session as a last resort and force recovery for its work.
    * 3. Queue recovery/internal traffic instead of displacing working sessions.
    *
-   * Returns true if slot acquired, false if queued. The in-flight entryId
+   * Returns true if a slot is acquired and false if it remains unavailable.
+   * Callers normally enqueue on failure; retry-scoped callers can opt out so
+   * their timer/head state remains the single waiting source. The in-flight entryId
    * is tracked separately in `InboxDeliveryCoordinator` (populated at dispatch),
    * so the queue doesn't carry inbox metadata.
    */
@@ -1838,6 +1877,7 @@ export class SessionManager {
     chatId: string,
     message: SessionMessage | null,
     deliveryKind: SlotDeliveryKind = "fresh",
+    opts: { queueOnFailure?: boolean } = {},
   ): boolean {
     if (this._activeCount < this.config.concurrency) return true;
 
@@ -1897,7 +1937,9 @@ export class SessionManager {
       return true;
     }
 
-    this.queueForSlot(chatId, message, deliveryKind, "concurrency_limit");
+    if (opts.queueOnFailure !== false) {
+      this.queueForSlot(chatId, message, deliveryKind, "concurrency_limit");
+    }
     return false;
   }
 

--- a/packages/qa/cases/runtime/session-resume-transient-retry-custody.md
+++ b/packages/qa/cases/runtime/session-resume-transient-retry-custody.md
@@ -60,6 +60,20 @@ then let that attempt succeed late. There must be no
 attempt, stale session-id adoption, or route revival. Recovery debt and slot
 accounting must remain attributable to the suspend decision.
 
+Repeat cancellation while the chat's first provider `start()` is still
+unresolved and no resumable session id has been adopted. After recovery,
+redeliver the same head and a later tail. The replacement handler must receive
+the head through `start()`, never `resume()`, then accept the tail in order;
+the canceled start must not leave an empty resume mapping or settle either
+delivery.
+
+Evict the same unestablished chat while it is in a non-active fresh-start
+retry/terminal window, and separately restart the SessionManager while its
+first start is unresolved. Neither LRU state nor the persisted registry may
+contain an empty resume mapping. Historical empty mappings must be ignored on
+load, and every recovered delivery must enter the replacement handler through
+`start()`.
+
 After a route is fully active, capture a delivery token from an injected
 message, suspend or preempt the route, recover the chat, and redeliver the
 same inbox entry id. Every late mutation through the old token must be ignored:

--- a/packages/qa/cases/runtime/session-resume-transient-retry-custody.md
+++ b/packages/qa/cases/runtime/session-resume-transient-retry-custody.md
@@ -39,6 +39,92 @@ handler must not receive that tail. After the resume fails, the replacement
 handler must receive message two as its retry head and message three as its
 deferred tail, with the same ordered settlement.
 
+Repeat the pending-resume setup, but suspend the chat before releasing the
+provider boundary and then let the old resume succeed. The old route must not
+be adopted: it must not replace the persisted session id, accept the deferred
+tail, settle inbox work, report retry success, or reclaim an active slot.
+Explicit resume must first request chat-scoped recovery, and recovered entries
+must be accepted exactly once by a fresh handler.
+
+Exercise the same late-success boundary under the configured concurrency
+limit. While the resume is pending, let fresh work in another chat make the
+target yield its slot and start inbox recovery. Redeliver the target head and
+tail while the old provider promise is still unresolved, then release the old
+promise. Only the replacement handler may accept the ordered head and tail,
+and observed live provider routes must never exceed the configured
+concurrency.
+
+During a retry attempt, suspend the chat while provider resume is pending and
+then let that attempt succeed late. There must be no
+`provider_retry_succeeded` event, retry-state clearing on behalf of the stale
+attempt, stale session-id adoption, or route revival. Recovery debt and slot
+accounting must remain attributable to the suspend decision.
+
+After a route is fully active, capture a delivery token from an injected
+message, suspend or preempt the route, recover the chat, and redeliver the
+same inbox entry id. Every late mutation through the old token must be ignored:
+it must not mark the replacement ledger as processing, settle it, request
+another retry, or terminal-reject it. Only the fresh route may settle and ACK
+the redelivery.
+
+Also hold a provider resume before it materializes its provider resource,
+invalidate the route, and allow the first best-effort cleanup to finish. When
+the stale resume later succeeds and creates that resource, a post-settlement
+cleanup pass must close it. Separately, defer an active handler's terminate
+cleanup and deliver another message for the same chat during that wait. Local
+admission must already be closed: the terminating handler must not receive the
+message or run outside its released slot, and terminate recovery must retain
+custody of the new entry.
+
+Repeat terminate while a new chat delivery is still blocked in pre-handler
+configuration or Context Tree resolution, before any local SessionEntry
+exists. Terminate must still cancel that admission and recover the ledger
+entry; releasing the blocked preflight must not start a provider route or
+claim an active slot.
+
+Repeat the same blocked pre-handler admission while shutting down the entire
+SessionManager. Releasing the preflight after shutdown returns must not create
+a handler, session, or active slot; the admitted inbox entry must remain
+recoverable by the next manager lifecycle.
+
+Also begin a messageful resume while the target session is still waiting for
+an earlier suspension or recovery operation. Start manager shutdown and hold it
+open with a second active handler's slow cleanup, then release the resume wait.
+The shutdown tombstone must prevent handler creation, provider resume, and slot
+claiming; the inbox head must remain recoverable for the next manager lifecycle.
+
+For normal resume, eviction resume, and retry resume, inject a messageful
+handler result with a session id but no route receipt. Each path must fail
+closed with `missing_route_receipt`, retain the head for recovery, and avoid
+draining any tail. The retry path must not report
+`provider_retry_succeeded`. A message-less control resume remains the only
+path where a null route receipt is valid.
+
+On an otherwise healthy active route, make `inject()` capture its delivery
+token and then reject or throw before accepting custody. Recover and redeliver
+the same inbox entry id without changing the session generation, then invoke
+every mutation on the old token. The replacement ledger, recovery debt, and
+ACK prefix must remain unchanged until the winning attempt settles.
+
+Hold a confirmed session-event callback across suspend, recovery, and
+redelivery, then let the old callback finish after the winning route has stored
+its own failure notice. The stale callback must not overwrite the winning
+payload. Repeat with the old delivery blocked while posting its runtime failure
+notice: completion of that post must neither clear the winning payload nor
+settle the replacement ledger.
+
+For a terminal resume failure, hold confirmation while terminate or manager
+shutdown invalidates the route and waits on slow handler cleanup. Resolve the
+confirmation before cleanup completes. A callback that can no longer adopt its
+runtime notice must not authorize terminal ACK; the head must stay covered by
+recovery debt.
+
+Finally, queue two later messages behind a retry head and make the handler
+reject or throw on the first tail while it would accept the second. The Runtime
+must stop immediately: the second tail must not reach the provider, the
+already-terminal prefix may ACK, and the rejected tail plus untouched suffix
+must enter chat-scoped recovery without an ACK-prefix inversion.
+
 Also exercise an explicit control resume with no new user message. Inject the
 same transient pre-provider failure and verify the retry calls provider resume
 without a message. It must not synthesize an empty user turn or replay the most
@@ -51,6 +137,7 @@ inbox recovery instead. The recovered delivery may then proceed through the
 normal redelivery path.
 
 Do not report `PASS` unless the exact provider input and inbox entry ids are
-observable alongside ACK order and elapsed time. Report `BLOCKED` or
-`INCONCLUSIVE` when the transient boundary cannot be controlled or inbox
-custody cannot be observed without relying only on unit-test mocks.
+observable alongside ACK order, transition timing, active-slot counts, and
+elapsed time. Report `BLOCKED` or `INCONCLUSIVE` when suspend or concurrency
+yield cannot be interleaved with a controlled late provider success, or when
+inbox custody cannot be observed without relying only on unit-test mocks.

--- a/packages/qa/cases/runtime/session-resume-transient-retry-custody.md
+++ b/packages/qa/cases/runtime/session-resume-transient-retry-custody.md
@@ -33,6 +33,12 @@ fixed head, injects message three only after the handler is live, and settles
 the inbox prefix in the order two then three. No later entry may ACK ahead of
 the retry head.
 
+Repeat with message three arriving while the original resume transition is
+still pending, before the controlled transient failure is released. The old
+handler must not receive that tail. After the resume fails, the replacement
+handler must receive message two as its retry head and message three as its
+deferred tail, with the same ordered settlement.
+
 Also exercise an explicit control resume with no new user message. Inject the
 same transient pre-provider failure and verify the retry calls provider resume
 without a message. It must not synthesize an empty user turn or replay the most

--- a/packages/qa/cases/runtime/session-resume-transient-retry-custody.md
+++ b/packages/qa/cases/runtime/session-resume-transient-retry-custody.md
@@ -1,0 +1,50 @@
+---
+id: session-resume-transient-retry-custody
+description: Session resume retries preserve the current inbox delivery as the retry head and drain later work in order.
+areas: [runtime]
+surfaces: [client, server]
+---
+
+# Session resume transient retry custody
+
+Validate session resume retry behavior with an isolated Client, test agent,
+and scratch chat whose inbox delivery and ACK state are observable. Establish
+a provider session with one notify-worthy message, let its turn finish and its
+inbox entry settle, then suspend the session without terminating its persisted
+provider session id.
+
+Send a second notify-worthy message and inject a controlled transient failure
+before the resumed provider turn accepts that message. A configuration fetch,
+transport handshake, or equivalent pre-provider boundary is suitable when it
+can fail deterministically without changing provider state. The Runtime must
+schedule a bounded session-resume retry and keep the second inbox entry
+unacknowledged during backoff.
+
+Allow the retry to proceed and verify from Client logs, handler/provider input,
+session events, and inbox settlement that it resumes with the second message's
+message id and inbox entry id. It must not replay the first, already-settled
+message. The second delivery should complete and ACK without waiting for the
+idle timeout or producing an `attempt completion ignored for untracked inbox
+entry` warning.
+
+During the retry backoff, send a third notify-worthy message to the same chat.
+It must remain behind the second message: the retry uses message two as its
+fixed head, injects message three only after the handler is live, and settles
+the inbox prefix in the order two then three. No later entry may ACK ahead of
+the retry head.
+
+Also exercise an explicit control resume with no new user message. Inject the
+same transient pre-provider failure and verify the retry calls provider resume
+without a message. It must not synthesize an empty user turn or replay the most
+recent historical message.
+
+If the environment can safely manipulate Client-local custody, remove the
+retry head from the local delivery ledger before the retry attempt. The
+Runtime must not create or call a provider handler and must request chat-scoped
+inbox recovery instead. The recovered delivery may then proceed through the
+normal redelivery path.
+
+Do not report `PASS` unless the exact provider input and inbox entry ids are
+observable alongside ACK order and elapsed time. Report `BLOCKED` or
+`INCONCLUSIVE` when the transient boundary cannot be controlled or inbox
+custody cannot be observed without relying only on unit-test mocks.

--- a/packages/qa/cases/runtime/session-resume-transient-retry-custody.md
+++ b/packages/qa/cases/runtime/session-resume-transient-retry-custody.md
@@ -67,6 +67,13 @@ the head through `start()`, never `resume()`, then accept the tail in order;
 the canceled start must not leave an empty resume mapping or settle either
 delivery.
 
+Before releasing that unresolved start, have it report
+`processingStarted`, then issue operator suspend and hold its terminal-prefix
+ACK open. Deliver a same-chat tail while that ACK is pending. The
+unestablished SessionEntry must remain as an admission fence until suspend
+preparation settles: no replacement start, resume, or inject may enter the
+provider during the ACK window.
+
 Evict the same unestablished chat while it is in a non-active fresh-start
 retry/terminal window, and separately restart the SessionManager while its
 first start is unresolved. Neither LRU state nor the persisted registry may


### PR DESCRIPTION
## Summary

- replace the session-lifetime `startMessage` retry source with a retry-scoped head captured from the exact failed start/resume attempt
- guard inbox-backed retry heads with the existing delivery ledger before creating or invoking a provider handler
- keep control resumes message-free, preserve queued-tail ordering, and recover unconsumed tails after terminal retry failure
- keep retry slot contention out of the generic pending queue so the fixed head cannot be replayed twice
- add deterministic regression coverage and a reusable runtime QA case

This fixes a resume transient failure that replayed an already-settled historical inbox entry while leaving the current delivery idle until the 300-second recovery timeout.

## Validation

- [x] `pnpm check` (passes; reports three pre-existing non-blocking Biome notices)
- [x] `pnpm typecheck`
- [x] `pnpm test` (run as `pnpm exec turbo run test --concurrency=1 -- --maxWorkers=2` to honor the repository's test concurrency limit)
- [x] focused SessionManager tests: 60/60 passed

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: SessionManager retry/edge regression tests and `packages/qa/cases/runtime/session-resume-transient-retry-custody.md`
- risk: runtime/provider/inbox custody and ACK-prefix behavior
- follow-up work: formal QA was not run for this change; release qualification should execute the new QA case
