### PR TITLE
fix: make webhook claim a recoverable lease so crashes cannot permanently drop deliveries

### DIFF
--- a/packages/qa/cases/cross-surface/github-webhook-routing-regression.md
+++ b/packages/qa/cases/cross-surface/github-webhook-routing-regression.md
@@ -29,8 +29,12 @@ together without a GitHub-specific post-delivery branch.
   card in the followed chat and, for an explicit target, the expected delegate inbox/session wake. Inspect the delegate's
   assembled turn input and confirm both a current webhook card and a card carried as preceding silent context use
   `[From: GitHub · type=system ...]`, never the representative human carrier.
-- Redeliver the same signed body with the same stable delivery id. Observe a successful deduplicated response and no
-  second card or wake.
+- Redeliver the same signed body with the same stable delivery id. Observe a successful deduplicated response reporting
+  `claimState: "done"` and no second card or wake.
+- Induce one processing failure after the claim (for example, temporarily break audience resolution downstream) and
+  observe the 500 response. Redeliver the same signed body: within the claim TTL a still-held claim answers deduplicated
+  with `claimState: "pending"`; once the claim is released or its TTL (default 300s) has passed, the redelivery must be
+  fully reprocessed — the card lands and the claim finishes `done` — instead of staying deduplicated forever.
 - Deliver an equivalent supported event without `X-GitHub-Delivery`. Confirm it is accepted without creating a
   `processed_events` claim. If the event is repeated, treat repeated side effects as the documented weak-reliability
   baseline rather than an exactly-once promise.
@@ -41,8 +45,9 @@ together without a GitHub-specific post-delivery branch.
 ## Expected Result
 
 `PASS`: signed events resolve through the bound installation, reach the expected chat and wake path, stable delivery ids
-deduplicate the whole request, missing delivery ids do not claim, invalid signatures have no side effects, and optional
-Context Reviewer behavior remains dedicated and claim-covered. Agent-visible webhook attribution is GitHub/system while
+deduplicate the whole request, a failed attempt recovers — redelivering after the claim is released or expired
+reprocesses the event instead of deduplicating it forever — missing delivery ids do not claim, invalid signatures have
+no side effects, and optional Context Reviewer behavior remains dedicated and claim-covered. Agent-visible webhook attribution is GitHub/system while
 the existing participant sender, routing, and wake behavior remains unchanged.
 
 `FAIL`: a reproducible regression in authentication, tenant resolution, followed-chat/card delivery, wake routing,

--- a/packages/server/drizzle/0082_processed_events_claim_lease.sql
+++ b/packages/server/drizzle/0082_processed_events_claim_lease.sql
@@ -1,0 +1,25 @@
+-- Webhook claim lease for `processed_events` (issue #317).
+--
+-- Turns the at-most-once dedupe marker into a recoverable pending/done
+-- lease: deliveries are claimed `pending` with an expiry before processing
+-- and flipped to `done` after their side effects landed. A redelivery of an
+-- expired `pending` claim takes it over instead of being deduped, so a crash
+-- between claim and completion no longer loses the event permanently.
+--
+-- Custom migration (0046/0053 precedent): `processed_events` predates
+-- drizzle-kit management — it was created by 0003 and is deliberately not
+-- exported from `src/db/schema/index.ts`, so it is absent from the drizzle
+-- snapshots and `drizzle-kit generate` cannot diff column changes for it.
+--
+-- Backward compatible by construction: no backfill — the `done` default
+-- makes every pre-existing row equivalent to "fully processed", preserving
+-- the permanent-dedupe semantics for historical deliveries. Old replicas
+-- that still insert only (event_id, platform) during a rolling deploy also
+-- hit the default and record a terminal `done` row, which is correct.
+ALTER TABLE "processed_events" ADD COLUMN "status" text DEFAULT 'done' NOT NULL;--> statement-breakpoint
+ALTER TABLE "processed_events" ADD COLUMN "expires_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "processed_events" ADD COLUMN "claim_token" text;--> statement-breakpoint
+-- Pending rows are near-zero in steady state (only live or crashed claims),
+-- so this partial index stays tiny; it serves the hygiene sweep and ops
+-- queries over stuck claims.
+CREATE INDEX "idx_processed_events_pending" ON "processed_events" USING btree ("expires_at") WHERE "processed_events"."status" = 'pending';

--- a/packages/server/drizzle/LATEST
+++ b/packages/server/drizzle/LATEST
@@ -1,1 +1,1 @@
-0081_dizzy_tyrannus
+0082_processed_events_claim_lease

--- a/packages/server/drizzle/meta/0082_snapshot.json
+++ b/packages/server/drizzle/meta/0082_snapshot.json
@@ -1,0 +1,5582 @@
+{
+  "id": "e9d7b30c-d289-464c-a52b-c60fa7935be6",
+  "prevId": "ed77360a-1de2-4ce5-9f63-dd2d28edbdaf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_chat_sessions": {
+      "name": "agent_chat_sessions",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "runtime_state_at": {
+          "name": "runtime_state_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_chat_sessions_chat_agent": {
+          "name": "idx_agent_chat_sessions_chat_agent",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_chat_sessions_agent_id_agents_uuid_fk": {
+          "name": "agent_chat_sessions_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_chat_sessions",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_chat_sessions_chat_id_chats_id_fk": {
+          "name": "agent_chat_sessions_chat_id_chats_id_fk",
+          "tableFrom": "agent_chat_sessions",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_chat_sessions_agent_id_chat_id_pk": {
+          "name": "agent_chat_sessions_agent_id_chat_id_pk",
+          "columns": [
+            "agent_id",
+            "chat_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_configs": {
+      "name": "agent_configs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_presence": {
+      "name": "agent_presence",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_type": {
+          "name": "runtime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_state": {
+          "name": "runtime_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_sessions": {
+          "name": "active_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_sessions": {
+          "name": "total_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_updated_at": {
+          "name": "runtime_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_presence_agent_id_agents_uuid_fk": {
+          "name": "agent_presence_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_presence",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_presence_client_id_clients_id_fk": {
+          "name": "agent_presence_client_id_clients_id_fk",
+          "tableFrom": "agent_presence",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "tableTo": "clients",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_resource_bindings": {
+      "name": "agent_resource_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaces_resource_id": {
+          "name": "replaces_resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_prompt_body": {
+          "name": "inline_prompt_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_ref": {
+          "name": "repo_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_local_path": {
+          "name": "repo_local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_resource_bindings_agent": {
+          "name": "idx_agent_resource_bindings_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agent_resource_bindings_resource": {
+          "name": "idx_agent_resource_bindings_resource",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agent_resource_bindings_replaces": {
+          "name": "idx_agent_resource_bindings_replaces",
+          "columns": [
+            {
+              "expression": "replaces_resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_resource_bindings_organization_id_organizations_id_fk": {
+          "name": "agent_resource_bindings_organization_id_organizations_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_resource_bindings_agent_id_agents_uuid_fk": {
+          "name": "agent_resource_bindings_agent_id_agents_uuid_fk",
+          "tableFrom": "agent_resource_bindings",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_resource_bindings_resource_id_resources_id_fk": {
+          "name": "agent_resource_bindings_resource_id_resources_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "tableTo": "resources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_resource_bindings_replaces_resource_id_resources_id_fk": {
+          "name": "agent_resource_bindings_replaces_resource_id_resources_id_fk",
+          "tableFrom": "agent_resource_bindings",
+          "columnsFrom": [
+            "replaces_resource_id"
+          ],
+          "tableTo": "resources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_mention": {
+          "name": "delegate_mention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'claude-code'"
+        },
+        "avatar_color_token": {
+          "name": "avatar_color_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_data": {
+          "name": "avatar_image_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_mime": {
+          "name": "avatar_image_mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_image_updated_at": {
+          "name": "avatar_image_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_org": {
+          "name": "idx_agents_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agents_manager": {
+          "name": "idx_agents_manager",
+          "columns": [
+            {
+              "expression": "manager_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agents_visibility_org": {
+          "name": "idx_agents_visibility_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agents_client": {
+          "name": "idx_agents_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agents_organization_id_organizations_id_fk": {
+          "name": "agents_organization_id_organizations_id_fk",
+          "tableFrom": "agents",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "agents_client_id_clients_id_fk": {
+          "name": "agents_client_id_clients_id_fk",
+          "tableFrom": "agents",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "tableTo": "clients",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_inbox_id_unique": {
+          "name": "agents_inbox_id_unique",
+          "columns": [
+            "inbox_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "uq_agents_org_name": {
+          "name": "uq_agents_org_name",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachments": {
+      "name": "attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "attachments_uploaded_by_idx": {
+          "name": "attachments_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "attachments_created_at_idx": {
+          "name": "attachments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attentions": {
+      "name": "attentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "origin_agent_id": {
+          "name": "origin_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_chat_id": {
+          "name": "origin_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_human_id": {
+          "name": "target_human_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "requires_response": {
+          "name": "requires_response",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_by": {
+          "name": "responded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_reason": {
+          "name": "cancelled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_attentions_target_open": {
+          "name": "idx_attentions_target_open",
+          "columns": [
+            {
+              "expression": "target_human_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_attentions_chat_open": {
+          "name": "idx_attentions_chat_open",
+          "columns": [
+            {
+              "expression": "origin_chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_attentions_origin": {
+          "name": "idx_attentions_origin",
+          "columns": [
+            {
+              "expression": "origin_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_identities": {
+      "name": "auth_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_payload": {
+          "name": "credential_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_auth_identities_user": {
+          "name": "idx_auth_identities_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_auth_identities_email": {
+          "name": "idx_auth_identities_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "auth_identities_user_id_users_id_fk": {
+          "name": "auth_identities_user_id_users_id_fk",
+          "tableFrom": "auth_identities",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_auth_identities_provider_identifier": {
+          "name": "uq_auth_identities_provider_identifier",
+          "columns": [
+            "provider",
+            "identifier"
+          ],
+          "nullsNotDistinct": false
+        },
+        "uq_auth_identities_user_provider": {
+          "name": "uq_auth_identities_user_provider",
+          "columns": [
+            "user_id",
+            "provider"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_membership": {
+      "name": "chat_membership",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "access_mode": {
+          "name": "access_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_membership_agent": {
+          "name": "idx_membership_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_membership_chat_role": {
+          "name": "idx_membership_chat_role",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "access_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_membership_chat_id_agent_id_pk": {
+          "name": "chat_membership_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_user_state": {
+      "name": "chat_user_state",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unread_mention_count": {
+          "name": "unread_mention_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "open_request_count": {
+          "name": "open_request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_status": {
+          "name": "engagement_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_state_agent": {
+          "name": "idx_user_state_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_user_state_unread": {
+          "name": "idx_user_state_unread",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "unread_mention_count > 0",
+          "concurrently": false
+        },
+        "idx_user_state_open_req": {
+          "name": "idx_user_state_open_req",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "open_request_count > 0",
+          "concurrently": false
+        },
+        "idx_user_state_pinned": {
+          "name": "idx_user_state_pinned",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "pinned_at IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_user_state_chat_id_agent_id_pk": {
+          "name": "chat_user_state_chat_id_agent_id_pk",
+          "columns": [
+            "chat_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_updated_at": {
+          "name": "description_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_policy": {
+          "name": "lifecycle_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'persistent'"
+        },
+        "parent_chat_id": {
+          "name": "parent_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_kickoff_key": {
+          "name": "onboarding_kickoff_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message_preview": {
+          "name": "last_message_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chats_org_last_message": {
+          "name": "idx_chats_org_last_message",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"last_message_at\" desc",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_chats_org_activity": {
+          "name": "idx_chats_org_activity",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"activity_at\" desc",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_chats_onboarding_kickoff_key": {
+          "name": "uq_chats_onboarding_kickoff_key",
+          "columns": [
+            {
+              "expression": "onboarding_kickoff_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "chats_organization_id_organizations_id_fk": {
+          "name": "chats_organization_id_organizations_id_fk",
+          "tableFrom": "chats",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disconnected'"
+        },
+        "sdk_version": {
+          "name": "sdk_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_user": {
+          "name": "idx_clients_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_clients_org": {
+          "name": "idx_clients_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "clients_user_id_users_id_fk": {
+          "name": "clients_user_id_users_id_fk",
+          "tableFrom": "clients",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "clients_organization_id_organizations_id_fk": {
+          "name": "clients_organization_id_organizations_id_fk",
+          "tableFrom": "clients",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connect_codes": {
+      "name": "connect_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connect_codes_user": {
+          "name": "idx_connect_codes_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_connect_codes_expires_at": {
+          "name": "idx_connect_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "connect_codes_user_id_users_id_fk": {
+          "name": "connect_codes_user_id_users_id_fk",
+          "tableFrom": "connect_codes",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connect_codes_code_hash_unique": {
+          "name": "connect_codes_code_hash_unique",
+          "columns": [
+            "code_hash"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context_tree_io_events": {
+      "name": "context_tree_io_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_session_event_id": {
+          "name": "source_session_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_index": {
+          "name": "source_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "runtime_provider": {
+          "name": "runtime_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_repo_url": {
+          "name": "tree_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_branch": {
+          "name": "tree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_context_tree_io_source": {
+          "name": "uq_context_tree_io_source",
+          "columns": [
+            {
+              "expression": "source_session_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_context_tree_io_org_recent": {
+          "name": "idx_context_tree_io_org_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_context_tree_io_org_action_recent": {
+          "name": "idx_context_tree_io_org_action_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_context_tree_io_org_agent_recent": {
+          "name": "idx_context_tree_io_org_agent_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_context_tree_io_org_target_recent": {
+          "name": "idx_context_tree_io_org_target_recent",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "context_tree_io_events_organization_id_organizations_id_fk": {
+          "name": "context_tree_io_events_organization_id_organizations_id_fk",
+          "tableFrom": "context_tree_io_events",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "context_tree_io_events_agent_id_agents_uuid_fk": {
+          "name": "context_tree_io_events_agent_id_agents_uuid_fk",
+          "tableFrom": "context_tree_io_events",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "context_tree_io_events_chat_id_chats_id_fk": {
+          "name": "context_tree_io_events_chat_id_chats_id_fk",
+          "tableFrom": "context_tree_io_events",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_context_tree_io_action": {
+          "name": "ck_context_tree_io_action",
+          "value": "\"context_tree_io_events\".\"action\" IN ('read', 'write')"
+        },
+        "ck_context_tree_io_target_kind": {
+          "name": "ck_context_tree_io_target_kind",
+          "value": "\"context_tree_io_events\".\"target_kind\" IN ('file', 'directory', 'repo')"
+        },
+        "ck_context_tree_io_target_path_nonempty": {
+          "name": "ck_context_tree_io_target_path_nonempty",
+          "value": "\"context_tree_io_events\".\"target_path\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.doc_comments": {
+      "name": "doc_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_comments_document_status_idx": {
+          "name": "doc_comments_document_status_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "doc_comments_parent_idx": {
+          "name": "doc_comments_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "doc_comments_document_id_doc_documents_id_fk": {
+          "name": "doc_comments_document_id_doc_documents_id_fk",
+          "tableFrom": "doc_comments",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "tableTo": "doc_documents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "doc_comments_parent_id_doc_comments_id_fk": {
+          "name": "doc_comments_parent_id_doc_comments_id_fk",
+          "tableFrom": "doc_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "tableTo": "doc_comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_documents": {
+      "name": "doc_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_kind": {
+          "name": "created_by_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_name": {
+          "name": "created_by_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_documents_org_slug_unique": {
+          "name": "doc_documents_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "doc_documents_org_updated_idx": {
+          "name": "doc_documents_org_updated_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "doc_documents_organization_id_organizations_id_fk": {
+          "name": "doc_documents_organization_id_organizations_id_fk",
+          "tableFrom": "doc_documents",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.doc_versions": {
+      "name": "doc_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "doc_versions_document_number_unique": {
+          "name": "doc_versions_document_number_unique",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "doc_versions_document_id_doc_documents_id_fk": {
+          "name": "doc_versions_document_id_doc_documents_id_fk",
+          "tableFrom": "doc_versions",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "tableTo": "doc_documents",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_app_installations": {
+      "name": "github_app_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_github_id": {
+          "name": "account_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installer_github_id": {
+          "name": "installer_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester_github_id": {
+          "name": "requester_github_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hub_organization_id": {
+          "name": "hub_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_github_app_installations_installation_id": {
+          "name": "uq_github_app_installations_installation_id",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_github_app_installations_hub_org": {
+          "name": "uq_github_app_installations_hub_org",
+          "columns": [
+            {
+              "expression": "hub_organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_github_app_installations_account": {
+          "name": "idx_github_app_installations_account",
+          "columns": [
+            {
+              "expression": "account_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_github_app_installations_installer": {
+          "name": "idx_github_app_installations_installer",
+          "columns": [
+            {
+              "expression": "installer_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_github_app_installations_requester": {
+          "name": "idx_github_app_installations_requester",
+          "columns": [
+            {
+              "expression": "requester_github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_hub_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_hub_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "columnsFrom": [
+            "hub_organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_github_app_installations_account_type": {
+          "name": "ck_github_app_installations_account_type",
+          "value": "\"github_app_installations\".\"account_type\" IN ('User', 'Organization')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_entity_chat_mappings": {
+      "name": "github_entity_chat_mappings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "human_agent_id": {
+          "name": "human_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_agent_id": {
+          "name": "delegate_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_key": {
+          "name": "entity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_at": {
+          "name": "bound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "bound_via": {
+          "name": "bound_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_state": {
+          "name": "entity_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "entity_state_updated_at": {
+          "name": "entity_state_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_github_entity_chat_mappings_chat": {
+          "name": "idx_github_entity_chat_mappings_chat",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_github_entity_chat_mappings_chat_state": {
+          "name": "idx_github_entity_chat_mappings_chat_state",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "github_entity_chat_mappings_organization_id_organizations_id_fk": {
+          "name": "github_entity_chat_mappings_organization_id_organizations_id_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "github_entity_chat_mappings_human_agent_id_agents_uuid_fk": {
+          "name": "github_entity_chat_mappings_human_agent_id_agents_uuid_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "columnsFrom": [
+            "human_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "github_entity_chat_mappings_delegate_agent_id_agents_uuid_fk": {
+          "name": "github_entity_chat_mappings_delegate_agent_id_agents_uuid_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "columnsFrom": [
+            "delegate_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "github_entity_chat_mappings_chat_id_chats_id_fk": {
+          "name": "github_entity_chat_mappings_chat_id_chats_id_fk",
+          "tableFrom": "github_entity_chat_mappings",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "github_entity_chat_mappings_organization_id_human_agent_id_delegate_agent_id_entity_type_entity_key_pk": {
+          "name": "github_entity_chat_mappings_organization_id_human_agent_id_delegate_agent_id_entity_type_entity_key_pk",
+          "columns": [
+            "organization_id",
+            "human_agent_id",
+            "delegate_agent_id",
+            "entity_type",
+            "entity_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gitlab_connections": {
+      "name": "gitlab_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instance_origin": {
+          "name": "instance_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_first_seen_at": {
+          "name": "endpoint_first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_valid_inbound_at": {
+          "name": "last_valid_inbound_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processing_failure_at": {
+          "name": "last_processing_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processing_failure_code": {
+          "name": "last_processing_failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stable_delivery_observed_at": {
+          "name": "stable_delivery_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_observed_version": {
+          "name": "last_observed_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_mode": {
+          "name": "reviewer_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "last_reviewer_schema_anomaly_at": {
+          "name": "last_reviewer_schema_anomaly_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reviewer_schema_anomaly_code": {
+          "name": "last_reviewer_schema_anomaly_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_member_id": {
+          "name": "created_by_member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_member_id": {
+          "name": "updated_by_member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_gitlab_connections_org": {
+          "name": "uq_gitlab_connections_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_gitlab_connections_token_hash": {
+          "name": "uq_gitlab_connections_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "gitlab_connections_organization_id_organizations_id_fk": {
+          "name": "gitlab_connections_organization_id_organizations_id_fk",
+          "tableFrom": "gitlab_connections",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_connections_created_by_member_id_members_id_fk": {
+          "name": "gitlab_connections_created_by_member_id_members_id_fk",
+          "tableFrom": "gitlab_connections",
+          "columnsFrom": [
+            "created_by_member_id"
+          ],
+          "tableTo": "members",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "gitlab_connections_updated_by_member_id_members_id_fk": {
+          "name": "gitlab_connections_updated_by_member_id_members_id_fk",
+          "tableFrom": "gitlab_connections",
+          "columnsFrom": [
+            "updated_by_member_id"
+          ],
+          "tableTo": "members",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_gitlab_connections_reviewer_mode": {
+          "name": "ck_gitlab_connections_reviewer_mode",
+          "value": "\"gitlab_connections\".\"reviewer_mode\" IN ('unknown', 'assignee', 'reviewers')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gitlab_entity_chat_mappings": {
+      "name": "gitlab_entity_chat_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declared_by_agent_id": {
+          "name": "declared_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_via": {
+          "name": "bound_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'agent_declared'"
+        },
+        "identity_link_id": {
+          "name": "identity_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "human_agent_id": {
+          "name": "human_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delegate_agent_id": {
+          "name": "delegate_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attention_mode": {
+          "name": "attention_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy_route_only'"
+        },
+        "attention_backfill_version": {
+          "name": "attention_backfill_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_iid": {
+          "name": "entity_iid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_path": {
+          "name": "project_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_path_normalized": {
+          "name": "project_path_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_url": {
+          "name": "entity_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_state": {
+          "name": "entity_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_gitlab_entity_pending_pair": {
+          "name": "uq_gitlab_entity_pending_pair",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "human_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delegate_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_path_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "uq_gitlab_entity_observed_pair": {
+          "name": "uq_gitlab_entity_observed_pair",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "human_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delegate_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "uq_gitlab_entity_pending_legacy_chat": {
+          "name": "uq_gitlab_entity_pending_legacy_chat",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_path_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NULL",
+          "concurrently": false
+        },
+        "uq_gitlab_entity_observed_legacy_chat": {
+          "name": "uq_gitlab_entity_observed_legacy_chat",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NULL",
+          "concurrently": false
+        },
+        "uq_gitlab_entity_identity_target": {
+          "name": "uq_gitlab_entity_identity_target",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identity_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"active\" AND \"gitlab_entity_chat_mappings\".\"bound_via\" = 'identity_target'",
+          "concurrently": false
+        },
+        "idx_gitlab_entity_observed_lookup": {
+          "name": "idx_gitlab_entity_observed_lookup",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_gitlab_entity_pending_lookup": {
+          "name": "idx_gitlab_entity_pending_lookup",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_path_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_iid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"gitlab_entity_chat_mappings\".\"project_id\" IS NULL",
+          "concurrently": false
+        },
+        "idx_gitlab_entity_chat": {
+          "name": "idx_gitlab_entity_chat",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "gitlab_entity_chat_mappings_organization_id_organizations_id_fk": {
+          "name": "gitlab_entity_chat_mappings_organization_id_organizations_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_connection_id_gitlab_connections_id_fk": {
+          "name": "gitlab_entity_chat_mappings_connection_id_gitlab_connections_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "tableTo": "gitlab_connections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_chat_id_chats_id_fk": {
+          "name": "gitlab_entity_chat_mappings_chat_id_chats_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_declared_by_agent_id_agents_uuid_fk": {
+          "name": "gitlab_entity_chat_mappings_declared_by_agent_id_agents_uuid_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "declared_by_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_identity_link_id_gitlab_identity_links_id_fk": {
+          "name": "gitlab_entity_chat_mappings_identity_link_id_gitlab_identity_links_id_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "identity_link_id"
+          ],
+          "tableTo": "gitlab_identity_links",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_human_agent_id_agents_uuid_fk": {
+          "name": "gitlab_entity_chat_mappings_human_agent_id_agents_uuid_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "human_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_entity_chat_mappings_delegate_agent_id_agents_uuid_fk": {
+          "name": "gitlab_entity_chat_mappings_delegate_agent_id_agents_uuid_fk",
+          "tableFrom": "gitlab_entity_chat_mappings",
+          "columnsFrom": [
+            "delegate_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_gitlab_entity_type": {
+          "name": "ck_gitlab_entity_type",
+          "value": "\"gitlab_entity_chat_mappings\".\"entity_type\" IN ('issue', 'pull_request')"
+        },
+        "ck_gitlab_entity_bound_via": {
+          "name": "ck_gitlab_entity_bound_via",
+          "value": "\"gitlab_entity_chat_mappings\".\"bound_via\" IN ('agent_declared', 'human_declared', 'identity_target')"
+        },
+        "ck_gitlab_entity_identity_owner": {
+          "name": "ck_gitlab_entity_identity_owner",
+          "value": "\"gitlab_entity_chat_mappings\".\"bound_via\" <> 'identity_target' OR (\"gitlab_entity_chat_mappings\".\"identity_link_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"project_id\" IS NOT NULL)"
+        },
+        "ck_gitlab_entity_attention_pair": {
+          "name": "ck_gitlab_entity_attention_pair",
+          "value": "(\"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NULL) OR (\"gitlab_entity_chat_mappings\".\"human_agent_id\" IS NOT NULL AND \"gitlab_entity_chat_mappings\".\"delegate_agent_id\" IS NOT NULL)"
+        },
+        "ck_gitlab_entity_attention_mode": {
+          "name": "ck_gitlab_entity_attention_mode",
+          "value": "\"gitlab_entity_chat_mappings\".\"attention_mode\" IN ('paired', 'legacy_route_only')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gitlab_identity_links": {
+      "name": "gitlab_identity_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_id": {
+          "name": "membership_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_username": {
+          "name": "display_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_username": {
+          "name": "normalized_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_gitlab_identity_connection_membership": {
+          "name": "uq_gitlab_identity_connection_membership",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_gitlab_identity_connection_username": {
+          "name": "uq_gitlab_identity_connection_username",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_gitlab_identity_org_state": {
+          "name": "idx_gitlab_identity_org_state",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_gitlab_identity_membership_state": {
+          "name": "idx_gitlab_identity_membership_state",
+          "columns": [
+            {
+              "expression": "membership_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "gitlab_identity_links_organization_id_organizations_id_fk": {
+          "name": "gitlab_identity_links_organization_id_organizations_id_fk",
+          "tableFrom": "gitlab_identity_links",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "gitlab_identity_links_membership_id_members_id_fk": {
+          "name": "gitlab_identity_links_membership_id_members_id_fk",
+          "tableFrom": "gitlab_identity_links",
+          "columnsFrom": [
+            "membership_id"
+          ],
+          "tableTo": "members",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "gitlab_identity_links_connection_id_gitlab_connections_id_fk": {
+          "name": "gitlab_identity_links_connection_id_gitlab_connections_id_fk",
+          "tableFrom": "gitlab_identity_links",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "tableTo": "gitlab_connections",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_gitlab_identity_state": {
+          "name": "ck_gitlab_identity_state",
+          "value": "\"gitlab_identity_links\".\"state\" IN ('active', 'suspended')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inbox_entries": {
+      "name": "inbox_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_id": {
+          "name": "inbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notify": {
+          "name": "notify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbox_pending": {
+          "name": "idx_inbox_pending",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_inbox_pending_notify": {
+          "name": "idx_inbox_pending_notify",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "status = 'pending' AND notify = true",
+          "concurrently": false
+        },
+        "idx_inbox_chat_silent": {
+          "name": "idx_inbox_chat_silent",
+          "columns": [
+            {
+              "expression": "inbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notify",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_inbox_entries_message_status": {
+          "name": "idx_inbox_entries_message_status",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "inbox_entries_message_id_messages_id_fk": {
+          "name": "inbox_entries_message_id_messages_id_fk",
+          "tableFrom": "inbox_entries",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "tableTo": "messages",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_inbox_delivery": {
+          "name": "uq_inbox_delivery",
+          "columns": [
+            "inbox_id",
+            "message_id",
+            "chat_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_inbox_entries_status": {
+          "name": "ck_inbox_entries_status",
+          "value": "\"inbox_entries\".\"status\" IN ('pending', 'delivered', 'acked')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitation_redemptions": {
+      "name": "invitation_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invitation_redemptions_invitation": {
+          "name": "idx_invitation_redemptions_invitation",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_invitation_redemptions_user": {
+          "name": "idx_invitation_redemptions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_redemptions_invitation_id_invitations_id_fk": {
+          "name": "invitation_redemptions_invitation_id_invitations_id_fk",
+          "tableFrom": "invitation_redemptions",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "tableTo": "invitations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "invitation_redemptions_user_id_users_id_fk": {
+          "name": "invitation_redemptions_user_id_users_id_fk",
+          "tableFrom": "invitation_redemptions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitations_token": {
+          "name": "idx_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_invitations_org": {
+          "name": "idx_invitations_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "invitations_created_by_users_id_fk": {
+          "name": "invitations_created_by_users_id_fk",
+          "tableFrom": "invitations",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_suppressed_at": {
+          "name": "onboarding_suppressed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_suppressed_reason": {
+          "name": "onboarding_suppressed_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_members_user": {
+          "name": "idx_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_members_org": {
+          "name": "idx_members_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "members_agent_id_agents_uuid_fk": {
+          "name": "members_agent_id_agents_uuid_fk",
+          "tableFrom": "members",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_agent_id_unique": {
+          "name": "members_agent_id_unique",
+          "columns": [
+            "agent_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "uq_members_user_org": {
+          "name": "uq_members_user_org",
+          "columns": [
+            "user_id",
+            "organization_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_members_completed_implies_suppressed": {
+          "name": "ck_members_completed_implies_suppressed",
+          "value": "\"members\".\"onboarding_completed_at\" IS NULL OR \"members\".\"onboarding_suppressed_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reply_to_inbox": {
+          "name": "reply_to_inbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_chat": {
+          "name": "reply_to_chat",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_messages_chat_time": {
+          "name": "idx_messages_chat_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_messages_in_reply_to": {
+          "name": "idx_messages_in_reply_to",
+          "columns": [
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_messages_chat_source_time": {
+          "name": "idx_messages_chat_source_time",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_messages_mentions": {
+          "name": "idx_messages_mentions",
+          "columns": [
+            {
+              "expression": "((\"metadata\" -> 'mentions')) jsonb_path_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_id_chats_id_fk": {
+          "name": "messages_chat_id_chats_id_fk",
+          "tableFrom": "messages",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "tableTo": "chats",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notifications_org_created": {
+          "name": "idx_notifications_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_notifications_agent": {
+          "name": "idx_notifications_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_notifications_org_read": {
+          "name": "idx_notifications_org_read",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_notifications_org_dedup_unread": {
+          "name": "uq_notifications_org_dedup_unread",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "read = false AND dedup_key IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_settings": {
+      "name": "organization_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_settings_namespace": {
+          "name": "idx_org_settings_namespace",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_settings_organization_id_organizations_id_fk": {
+          "name": "organization_settings_organization_id_organizations_id_fk",
+          "tableFrom": "organization_settings",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "organization_settings_updated_by_users_id_fk": {
+          "name": "organization_settings_updated_by_users_id_fk",
+          "tableFrom": "organization_settings",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {
+        "organization_settings_organization_id_namespace_pk": {
+          "name": "organization_settings_organization_id_namespace_pk",
+          "columns": [
+            "organization_id",
+            "namespace"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_agents": {
+          "name": "max_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_messages_per_minute": {
+          "name": "max_messages_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_name_unique": {
+          "name": "organizations_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_questions": {
+      "name": "pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pending_questions_agent_status": {
+          "name": "idx_pending_questions_agent_status",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_pending_questions_chat_status": {
+          "name": "idx_pending_questions_chat_status",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_agent_id": {
+          "name": "owner_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_canonical_key": {
+          "name": "repo_canonical_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_enabled": {
+          "name": "default_enabled",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_resources_org_type_scope": {
+          "name": "idx_resources_org_type_scope",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_resources_owner_agent": {
+          "name": "idx_resources_owner_agent",
+          "columns": [
+            {
+              "expression": "owner_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_resources_repo_key": {
+          "name": "idx_resources_repo_key",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_resources_team_repo_canonical_active": {
+          "name": "uq_resources_team_repo_canonical_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"resources\".\"type\" = 'repo' AND \"resources\".\"scope\" = 'team' AND \"resources\".\"status\" IN ('active', 'stale') AND \"resources\".\"repo_canonical_key\" IS NOT NULL",
+          "concurrently": false
+        },
+        "uq_resources_agent_repo_canonical_active": {
+          "name": "uq_resources_agent_repo_canonical_active",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_canonical_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"resources\".\"type\" = 'repo' AND \"resources\".\"scope\" = 'agent' AND \"resources\".\"status\" IN ('active', 'stale') AND \"resources\".\"repo_canonical_key\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "resources_organization_id_organizations_id_fk": {
+          "name": "resources_organization_id_organizations_id_fk",
+          "tableFrom": "resources",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organizations",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "resources_owner_agent_id_agents_uuid_fk": {
+          "name": "resources_owner_agent_id_agents_uuid_fk",
+          "tableFrom": "resources",
+          "columnsFrom": [
+            "owner_agent_id"
+          ],
+          "tableTo": "agents",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_instances": {
+      "name": "server_instances",
+      "schema": "",
+      "columns": {
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_heartbeat": {
+          "name": "last_heartbeat",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_events": {
+      "name": "session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_session_events_chat_seq": {
+          "name": "uq_session_events_chat_seq",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_session_events_chat_created": {
+          "name": "idx_session_events_chat_created",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_session_events_context_tree_usage_recent": {
+          "name": "idx_session_events_context_tree_usage_recent",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"session_events\".\"kind\" = 'context_tree_usage'",
+          "concurrently": false
+        },
+        "idx_session_events_context_tree_io_agent_recent": {
+          "name": "idx_session_events_context_tree_io_agent_recent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"session_events\".\"kind\" IN ('context_tree_usage', 'tool_call')",
+          "concurrently": false
+        },
+        "idx_session_events_token_usage_agent_recent": {
+          "name": "idx_session_events_token_usage_agent_recent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"session_events\".\"kind\" = 'token_usage'",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1784284070652,
       "tag": "0081_dizzy_tyrannus",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1784713986252,
+      "tag": "0082_processed_events_claim_lease",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/__tests__/background-tasks-extra.test.ts
+++ b/packages/server/src/__tests__/background-tasks-extra.test.ts
@@ -15,12 +15,14 @@ const serviceMocks = {
   notifyAgentEvent: vi.fn(),
   pruneStaleSilentEntries: vi.fn(),
   sweepChatArchive: vi.fn(),
+  sweepExpiredWebhookClaims: vi.fn(),
 };
 
 const mockedModules = [
   "../observability/index.js",
   "../services/chat-archive.js",
   "../services/client.js",
+  "../services/event-dedup.js",
   "../services/inbox.js",
   "../services/notification.js",
   "../services/presence.js",
@@ -36,6 +38,9 @@ function mockBackgroundTaskDependencies(): void {
   vi.doMock("../services/client.js", () => ({
     cleanupStaleClients: serviceMocks.cleanupStaleClients,
   }));
+  vi.doMock("../services/event-dedup.js", () => ({
+    sweepExpiredWebhookClaims: serviceMocks.sweepExpiredWebhookClaims,
+  }));
   vi.doMock("../services/inbox.js", () => ({
     pruneStaleSilentEntries: serviceMocks.pruneStaleSilentEntries,
   }));
@@ -49,13 +54,17 @@ function mockBackgroundTaskDependencies(): void {
   }));
 }
 
-function makeApp(archiveSweepIntervalSeconds = 30): FastifyInstance {
+function makeApp(
+  archiveSweepIntervalSeconds = 30,
+  webhookClaimSweepIntervalSeconds = archiveSweepIntervalSeconds,
+): FastifyInstance {
   return {
     config: {
       runtime: {
         archiveMappedIdleSeconds: 3_600,
         archiveSweepIntervalSeconds,
         presenceCleanupSeconds: 60,
+        webhookClaimSweepIntervalSeconds,
       },
     },
     db: { name: "db" },
@@ -74,6 +83,7 @@ beforeEach(() => {
   serviceMocks.notifyAgentEvent.mockResolvedValue(undefined);
   serviceMocks.pruneStaleSilentEntries.mockResolvedValue({ ackedDeleted: 0, stalePendingDeleted: 0 });
   serviceMocks.sweepChatArchive.mockResolvedValue({ mappedRowsArchived: 0, unmappedRowsArchived: 0 });
+  serviceMocks.sweepExpiredWebhookClaims.mockResolvedValue(0);
 });
 
 afterEach(() => {
@@ -90,6 +100,7 @@ describe("createBackgroundTasks", () => {
     serviceMocks.pruneStaleSilentEntries.mockResolvedValue({ ackedDeleted: 2, stalePendingDeleted: 1 });
     serviceMocks.markStaleAgents.mockResolvedValue(["agent_1", "agent_2"]);
     serviceMocks.sweepChatArchive.mockResolvedValue({ mappedRowsArchived: 1, unmappedRowsArchived: 1 });
+    serviceMocks.sweepExpiredWebhookClaims.mockResolvedValue(2);
     const app = makeApp(30);
     const tasks = createBackgroundTasks(app, "srv_1");
 
@@ -116,6 +127,8 @@ describe("createBackgroundTasks", () => {
       { mappedRowsArchived: 1, unmappedRowsArchived: 1 },
       "chat auto-archive sweep flipped rows to archived",
     );
+    expect(serviceMocks.sweepExpiredWebhookClaims).toHaveBeenCalledWith(app.db);
+    expect(loggerMocks.info).toHaveBeenCalledWith({ swept: 2 }, "webhook claim sweep deleted stale pending claims");
 
     tasks.stop();
     expect(vi.getTimerCount()).toBe(0);
@@ -136,6 +149,7 @@ describe("createBackgroundTasks", () => {
     await vi.advanceTimersByTimeAsync(60_000);
 
     expect(serviceMocks.sweepChatArchive).not.toHaveBeenCalled();
+    expect(serviceMocks.sweepExpiredWebhookClaims).not.toHaveBeenCalled();
     expect(loggerMocks.error).toHaveBeenCalledWith({ err: expect.any(Error) }, "failed initial heartbeat");
     expect(loggerMocks.error).toHaveBeenCalledWith({ err: expect.any(Error) }, "failed to prune silent inbox rows");
     expect(loggerMocks.error).toHaveBeenCalledWith(

--- a/packages/server/src/__tests__/bootstrap.test.ts
+++ b/packages/server/src/__tests__/bootstrap.test.ts
@@ -59,6 +59,8 @@ const baseServerConfig: ServerConfig = {
     presenceCleanupSeconds: 60,
     archiveSweepIntervalSeconds: 0,
     archiveMappedIdleSeconds: 60 * 60,
+    webhookClaimTtlSeconds: 300,
+    webhookClaimSweepIntervalSeconds: 0,
     notificationWebhookUrl: undefined,
   },
   update: {

--- a/packages/server/src/__tests__/build-app-validation.test.ts
+++ b/packages/server/src/__tests__/build-app-validation.test.ts
@@ -44,6 +44,8 @@ const baseConfig: Config = {
     presenceCleanupSeconds: 60,
     archiveSweepIntervalSeconds: 0,
     archiveMappedIdleSeconds: 60 * 60,
+    webhookClaimTtlSeconds: 300,
+    webhookClaimSweepIntervalSeconds: 0,
     notificationWebhookUrl: undefined,
   },
   update: {

--- a/packages/server/src/__tests__/event-dedup.test.ts
+++ b/packages/server/src/__tests__/event-dedup.test.ts
@@ -1,36 +1,179 @@
+import { and, eq, sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import { processedEvents } from "../db/schema/processed-events.js";
 import * as eventDedup from "../services/event-dedup.js";
 import { useTestApp } from "./helpers.js";
 
-describe("Event deduplication", () => {
+const TTL_SECONDS = 300;
+
+describe("Event deduplication (claim lease)", () => {
   const getApp = useTestApp();
 
-  it("claims an event the first time", async () => {
+  type App = ReturnType<typeof getApp>;
+
+  async function getRow(app: App, eventId: string, platform = "github") {
+    const [row] = await app.db
+      .select()
+      .from(processedEvents)
+      .where(and(eq(processedEvents.eventId, eventId), eq(processedEvents.platform, platform)));
+    return row;
+  }
+
+  /** Rewind a pending claim's expiry into the past — the test-time stand-in
+   * for "the TTL elapsed" (or "the claiming process crashed long ago"). */
+  async function expireClaim(app: App, eventId: string, platform = "github") {
+    await app.db
+      .update(processedEvents)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(and(eq(processedEvents.eventId, eventId), eq(processedEvents.platform, platform)));
+  }
+
+  it("claims an event the first time and returns the owning token", async () => {
     const app = getApp();
-    const claimed = await eventDedup.claimEvent(app.db, "evt_unique_1", "github");
-    expect(claimed).toBe(true);
+    const token = await eventDedup.claimEvent(app.db, "evt_first_1", "github", TTL_SECONDS);
+    expect(token).toEqual(expect.any(String));
+
+    const row = await getRow(app, "evt_first_1");
+    expect(row).toMatchObject({ status: "pending", claimToken: token });
+    expect(row?.expiresAt?.getTime()).toBeGreaterThan(Date.now());
   });
 
-  it("rejects a duplicate event", async () => {
+  it("returns null for a duplicate while the pending claim is unexpired", async () => {
     const app = getApp();
-    await eventDedup.claimEvent(app.db, "evt_dup_1", "github");
-    const duplicate = await eventDedup.claimEvent(app.db, "evt_dup_1", "github");
-    expect(duplicate).toBe(false);
+    await eventDedup.claimEvent(app.db, "evt_dup_1", "github", TTL_SECONDS);
+    const duplicate = await eventDedup.claimEvent(app.db, "evt_dup_1", "github", TTL_SECONDS);
+    expect(duplicate).toBeNull();
+  });
+
+  it("returns null forever once the event is done", async () => {
+    const app = getApp();
+    const token = await eventDedup.claimEvent(app.db, "evt_done_1", "github", TTL_SECONDS);
+    if (token === null) throw new Error("expected initial claim to win");
+    expect(await eventDedup.completeEvent(app.db, "evt_done_1", "github", token)).toBe(true);
+    expect(await eventDedup.claimEvent(app.db, "evt_done_1", "github", TTL_SECONDS)).toBeNull();
+  });
+
+  it("treats rows predating the lease columns as done (legacy dedupe markers)", async () => {
+    const app = getApp();
+    // Simulate a row written by pre-lease code: only (event_id, platform),
+    // every lease column filled by its column default.
+    await app.db.execute(sql`INSERT INTO processed_events (event_id, platform) VALUES ('evt_legacy_1', 'github')`);
+
+    expect(await eventDedup.claimEvent(app.db, "evt_legacy_1", "github", TTL_SECONDS)).toBeNull();
+    const row = await getRow(app, "evt_legacy_1");
+    expect(row).toMatchObject({ status: "done", expiresAt: null, claimToken: null });
+  });
+
+  it("takes over an expired pending claim with a fresh token", async () => {
+    const app = getApp();
+    const firstToken = await eventDedup.claimEvent(app.db, "evt_takeover_1", "github", TTL_SECONDS);
+    if (firstToken === null) throw new Error("expected initial claim to win");
+    await expireClaim(app, "evt_takeover_1");
+
+    const secondToken = await eventDedup.claimEvent(app.db, "evt_takeover_1", "github", TTL_SECONDS);
+    expect(secondToken).toEqual(expect.any(String));
+    expect(secondToken).not.toBe(firstToken);
+
+    const row = await getRow(app, "evt_takeover_1");
+    expect(row).toMatchObject({ status: "pending", claimToken: secondToken });
+    expect(row?.expiresAt?.getTime()).toBeGreaterThan(Date.now());
   });
 
   it("allows same event_id on different platforms", async () => {
     const app = getApp();
-    const r1 = await eventDedup.claimEvent(app.db, "evt_cross_1", "github");
-    const r2 = await eventDedup.claimEvent(app.db, "evt_cross_1", "other");
-    expect(r1).toBe(true);
-    expect(r2).toBe(true);
+    const r1 = await eventDedup.claimEvent(app.db, "evt_cross_1", "github", TTL_SECONDS);
+    const r2 = await eventDedup.claimEvent(app.db, "evt_cross_1", "other", TTL_SECONDS);
+    expect(r1).toEqual(expect.any(String));
+    expect(r2).toEqual(expect.any(String));
   });
 
-  it("unclaimEvent allows a re-claim", async () => {
+  it("completeEvent with the owning token marks the row done and clears the lease", async () => {
     const app = getApp();
-    await eventDedup.claimEvent(app.db, "evt_unclaim_1", "github");
-    await eventDedup.unclaimEvent(app.db, "evt_unclaim_1", "github");
-    const reclaimed = await eventDedup.claimEvent(app.db, "evt_unclaim_1", "github");
-    expect(reclaimed).toBe(true);
+    const token = await eventDedup.claimEvent(app.db, "evt_complete_1", "github", TTL_SECONDS);
+    if (token === null) throw new Error("expected initial claim to win");
+
+    expect(await eventDedup.completeEvent(app.db, "evt_complete_1", "github", token)).toBe(true);
+    const row = await getRow(app, "evt_complete_1");
+    expect(row).toMatchObject({ status: "done", expiresAt: null, claimToken: null });
+  });
+
+  it("completeEvent with a stale token returns false and leaves the row alone", async () => {
+    const app = getApp();
+    const firstToken = await eventDedup.claimEvent(app.db, "evt_stale_complete_1", "github", TTL_SECONDS);
+    if (firstToken === null) throw new Error("expected initial claim to win");
+    await expireClaim(app, "evt_stale_complete_1");
+    const takeoverToken = await eventDedup.claimEvent(app.db, "evt_stale_complete_1", "github", TTL_SECONDS);
+    if (takeoverToken === null) throw new Error("expected takeover claim to win");
+
+    // The original (slow, superseded) attempt tries to complete late.
+    expect(await eventDedup.completeEvent(app.db, "evt_stale_complete_1", "github", firstToken)).toBe(false);
+    const row = await getRow(app, "evt_stale_complete_1");
+    expect(row).toMatchObject({ status: "pending", claimToken: takeoverToken });
+  });
+
+  it("releaseClaimedEvent makes the claim immediately reclaimable", async () => {
+    const app = getApp();
+    const token = await eventDedup.claimEvent(app.db, "evt_release_1", "github", TTL_SECONDS);
+    if (token === null) throw new Error("expected initial claim to win");
+
+    await eventDedup.releaseClaimedEvent(app.db, "evt_release_1", "github", token);
+    const row = await getRow(app, "evt_release_1");
+    expect(row?.status).toBe("pending");
+
+    const reclaimed = await eventDedup.claimEvent(app.db, "evt_release_1", "github", TTL_SECONDS);
+    expect(reclaimed).toEqual(expect.any(String));
+    expect(reclaimed).not.toBe(token);
+  });
+
+  it("a late release with a stale token does not disturb the takeover's active claim", async () => {
+    const app = getApp();
+    const firstToken = await eventDedup.claimEvent(app.db, "evt_stale_release_1", "github", TTL_SECONDS);
+    if (firstToken === null) throw new Error("expected initial claim to win");
+    await expireClaim(app, "evt_stale_release_1");
+    const takeoverToken = await eventDedup.claimEvent(app.db, "evt_stale_release_1", "github", TTL_SECONDS);
+    if (takeoverToken === null) throw new Error("expected takeover claim to win");
+
+    await eventDedup.releaseClaimedEvent(app.db, "evt_stale_release_1", "github", firstToken);
+
+    const row = await getRow(app, "evt_stale_release_1");
+    expect(row).toMatchObject({ status: "pending", claimToken: takeoverToken });
+    expect(row?.expiresAt?.getTime()).toBeGreaterThan(Date.now());
+    // The takeover's claim still shields the delivery from another claim.
+    expect(await eventDedup.claimEvent(app.db, "evt_stale_release_1", "github", TTL_SECONDS)).toBeNull();
+  });
+
+  it("exactly one of two concurrent claims wins an expired pending takeover", async () => {
+    const app = getApp();
+    const initial = await eventDedup.claimEvent(app.db, "evt_race_1", "github", TTL_SECONDS);
+    if (initial === null) throw new Error("expected initial claim to win");
+    await expireClaim(app, "evt_race_1");
+
+    const [a, b] = await Promise.all([
+      eventDedup.claimEvent(app.db, "evt_race_1", "github", TTL_SECONDS),
+      eventDedup.claimEvent(app.db, "evt_race_1", "github", TTL_SECONDS),
+    ]);
+
+    const winners = [a, b].filter((token) => token !== null);
+    expect(winners).toHaveLength(1);
+    const row = await getRow(app, "evt_race_1");
+    expect(row).toMatchObject({ status: "pending", claimToken: winners[0] });
+  });
+
+  it("readClaimState reports pending with expiry, done without, and null for missing rows", async () => {
+    const app = getApp();
+    const token = await eventDedup.claimEvent(app.db, "evt_read_1", "github", TTL_SECONDS);
+    if (token === null) throw new Error("expected initial claim to win");
+
+    const pending = await eventDedup.readClaimState(app.db, "evt_read_1", "github");
+    expect(pending?.state).toBe("pending");
+    expect(pending?.expiresAt?.getTime()).toBeGreaterThan(Date.now());
+
+    await eventDedup.completeEvent(app.db, "evt_read_1", "github", token);
+    expect(await eventDedup.readClaimState(app.db, "evt_read_1", "github")).toEqual({
+      state: "done",
+      expiresAt: null,
+    });
+
+    expect(await eventDedup.readClaimState(app.db, "evt_read_missing", "github")).toBeNull();
   });
 });

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -11,6 +11,7 @@ import { githubEntityChatMappings } from "../db/schema/github-entity-chat-mappin
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
+import { processedEvents } from "../db/schema/processed-events.js";
 import { users } from "../db/schema/users.js";
 import * as eventDedupService from "../services/event-dedup.js";
 import * as githubAudienceService from "../services/github-audience.js";
@@ -774,43 +775,102 @@ describe("POST /webhooks/github-app", () => {
     }
   });
 
-  it("unclaims a delivery when downstream handling fails and logs unclaim failures", async () => {
+  it("recovers a delivery whose handling and release both failed once the claim TTL elapses", async () => {
+    // End-to-end regression for the issue #317 headline scenario: audience
+    // resolution fails AND the release fails (leak path 2), so the pending
+    // claim survives with its original TTL. Before the claim lease this row
+    // was permanent and every redelivery was deduped — the event was lost.
     const app = getApp();
     const admin = await createTestAdmin(app);
     const installationId = 100017;
     const deliveryId = randomUUID();
     await seedInstallation(app, { installationId, orgId: admin.organizationId });
+
+    // A followed chat so the recovered redelivery has a visible card to land.
+    const delegate = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `dlg-${randomUUID().slice(0, 6)}`,
+    });
+    const human = await seedAgent(app, {
+      orgId: admin.organizationId,
+      memberId: admin.memberId,
+      name: `human-${randomUUID().slice(0, 6)}`,
+      delegateMention: delegate,
+      type: "human",
+    });
+    const chatId = `chat_${randomUUID()}`;
+    await app.db.insert(chats).values({ id: chatId, organizationId: admin.organizationId, type: "direct" });
+    await app.db.insert(githubEntityChatMappings).values({
+      organizationId: admin.organizationId,
+      humanAgentId: human,
+      delegateAgentId: delegate,
+      entityType: "issue",
+      entityKey: "owner/repo#913",
+      chatId,
+      boundVia: "direct",
+    });
+
+    const payload = {
+      action: "opened",
+      issue: {
+        number: 913,
+        title: "Issue",
+        html_url: "https://github.com/owner/repo/issues/913",
+        body: "",
+      },
+      repository: { full_name: "owner/repo" },
+      sender: { login: "author", type: "User" },
+      installation: { id: installationId },
+    };
+
     const audienceSpy = vi
       .spyOn(githubAudienceService, "resolveGithubAudience")
       .mockRejectedValueOnce(new Error("audience down"));
-    const unclaimSpy = vi.spyOn(eventDedupService, "unclaimEvent").mockRejectedValueOnce(new Error("unclaim down"));
+    const releaseSpy = vi
+      .spyOn(eventDedupService, "releaseClaimedEvent")
+      .mockRejectedValueOnce(new Error("release down"));
 
     try {
-      const res = await postWebhook(
-        app,
-        "issues",
-        {
-          action: "opened",
-          issue: {
-            number: 913,
-            title: "Issue",
-            html_url: "https://github.com/owner/repo/issues/913",
-            body: "",
-          },
-          repository: { full_name: "owner/repo" },
-          sender: { login: "author", type: "User" },
-          installation: { id: installationId },
-        },
-        { deliveryId },
-      );
+      const res = await postWebhook(app, "issues", payload, { deliveryId });
 
       expect(res.statusCode).toBe(500);
       expect(audienceSpy).toHaveBeenCalled();
-      expect(unclaimSpy).toHaveBeenCalledWith(app.db, deliveryId, "github");
+      expect(releaseSpy).toHaveBeenCalledWith(app.db, deliveryId, "github", expect.any(String));
     } finally {
       audienceSpy.mockRestore();
-      unclaimSpy.mockRestore();
+      releaseSpy.mockRestore();
     }
+
+    const stuck = await app.db
+      .select()
+      .from(processedEvents)
+      .where(and(eq(processedEvents.eventId, deliveryId), eq(processedEvents.platform, "github")));
+    expect(stuck[0]).toMatchObject({ status: "pending" });
+
+    // Inside the TTL the claim still shields the delivery: deduped, with
+    // claimState telling the operator to redeliver after the TTL.
+    const shielded = await postWebhook(app, "issues", payload, { deliveryId });
+    expect(shielded.statusCode).toBe(200);
+    expect(shielded.json()).toMatchObject({ ok: true, deduped: true, claimState: "pending" });
+
+    // TTL elapses (rewound in the DB), the operator redelivers: the claim is
+    // taken over inline and the event is fully processed this time.
+    await app.db
+      .update(processedEvents)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(and(eq(processedEvents.eventId, deliveryId), eq(processedEvents.platform, "github")));
+
+    const recovered = await postWebhook(app, "issues", payload, { deliveryId });
+    expect(recovered.statusCode).toBe(200);
+    expect(recovered.json()).toMatchObject({ ok: true, delivered: 1 });
+    const cards = await app.db.select().from(messages).where(eq(messages.chatId, chatId));
+    expect(cards).toHaveLength(1);
+    const finished = await app.db
+      .select()
+      .from(processedEvents)
+      .where(and(eq(processedEvents.eventId, deliveryId), eq(processedEvents.platform, "github")));
+    expect(finished[0]).toMatchObject({ status: "done", expiresAt: null, claimToken: null });
   });
 
   it("Bug 1 — pull_request.synchronize delivers to subscribed chat (was silenced before)", async () => {
@@ -2036,7 +2096,12 @@ describe("POST /webhooks/github-app", () => {
     expect(first.statusCode).toBe(200);
     const second = await postWebhook(app, "issues", payload, { deliveryId });
     expect(second.statusCode).toBe(200);
-    expect(second.json().deduped).toBe(true);
+    expect(second.json()).toMatchObject({ deduped: true, claimState: "done" });
+    const rows = await app.db
+      .select()
+      .from(processedEvents)
+      .where(and(eq(processedEvents.eventId, deliveryId), eq(processedEvents.platform, "github")));
+    expect(rows[0]).toMatchObject({ status: "done" });
   });
 
   it("duplicate context reviewer delivery is deduped and does not send another task", async () => {
@@ -2053,7 +2118,7 @@ describe("POST /webhooks/github-app", () => {
 
     expect(first.statusCode).toBe(200);
     expect(second.statusCode).toBe(200);
-    expect(second.json().deduped).toBe(true);
+    expect(second.json()).toMatchObject({ deduped: true, claimState: "done" });
     const messageRows = await app.db.select({ id: messages.id }).from(messages);
     expect(messageRows).toHaveLength(1);
   });

--- a/packages/server/src/__tests__/gitlab-webhook-stage2a.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-stage2a.test.ts
@@ -29,6 +29,7 @@ import {
   observeGitlabEntityAndResolveFollowers,
   removeGitlabEntityFollow,
 } from "../services/gitlab-entity-follow.js";
+import * as gitlabWebhookService from "../services/gitlab-webhook.js";
 import { createOrganization } from "../services/organization.js";
 import * as scmCardDelivery from "../services/scm-card-delivery.js";
 import { createTestAdmin, createTestAgent, useTestApp } from "./helpers.js";
@@ -450,6 +451,63 @@ describe("GitLab Stage 2A backend", () => {
     expect(response.statusCode).toBe(400);
     const after = await app.db.select().from(processedEvents).where(eq(processedEvents.platform, "gitlab"));
     expect(after).toHaveLength(before.length);
+  });
+
+  it("rolls back the claim with the fence when processing fails inside it, and a redelivery reprocesses", async () => {
+    // The GitLab path runs the whole claim state machine inside the ingress
+    // fence transaction: a handler failure rolls the pending claim INSERT
+    // back with everything else (zero residue), so the same delivery id can
+    // simply be redelivered — the transactional equivalent of the GitHub
+    // path's expire-and-take-over recovery.
+    const app = getApp();
+    const first = await connection(app);
+    const chatId = `chat_${randomUUID()}`;
+    await app.db
+      .insert(chats)
+      .values({ id: chatId, organizationId: first.admin.organizationId, type: "group", metadata: {} });
+    await app.db.insert(chatMembership).values({
+      chatId,
+      agentId: first.admin.humanAgentUuid,
+      role: "owner",
+      accessMode: "speaker",
+    });
+    await declareGitlabEntityFollow(app.db, {
+      organizationId: first.admin.organizationId,
+      connectionId: first.connectionId,
+      chatId,
+      declaredByAgentId: first.admin.humanAgentUuid,
+      humanAgentId: first.admin.humanAgentUuid,
+      delegateAgentId: first.admin.humanAgentUuid,
+      entityUrl: "https://gitlab.internal/Acme/API/-/issues/42",
+    });
+    const stableId = `fence-rollback-${randomUUID()}`;
+    const claimRows = async () => {
+      const rows = await app.db.select().from(processedEvents).where(eq(processedEvents.platform, "gitlab"));
+      return rows.filter((row) => row.eventId.startsWith(first.connectionId));
+    };
+
+    const audienceSpy = vi
+      .spyOn(gitlabWebhookService, "resolveGitlabAudience")
+      .mockRejectedValueOnce(new Error("audience down inside fence"));
+    try {
+      const failed = await postWebhook(app, first.bearer, issuePayload(), { stableId });
+      expect(failed.statusCode).toBe(500);
+      expect(audienceSpy).toHaveBeenCalledOnce();
+    } finally {
+      audienceSpy.mockRestore();
+    }
+    expect(await claimRows()).toHaveLength(0);
+
+    const redelivered = await postWebhook(app, first.bearer, issuePayload(), { stableId });
+    expect(redelivered.statusCode).toBe(200);
+    expect(redelivered.json()).toMatchObject({ ok: true, outcome: "delivered" });
+    const cards = await app.db
+      .select()
+      .from(messages)
+      .where(and(eq(messages.chatId, chatId), eq(messages.source, "gitlab")));
+    expect(cards).toHaveLength(1);
+    const [claimRow] = await claimRows();
+    expect(claimRow).toMatchObject({ status: "done", expiresAt: null, claimToken: null });
   });
 
   it("applies content/body guards while accepting valid unsupported events as no-ops", async () => {

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -197,6 +197,10 @@ export async function createTestApp(opts: CreateTestAppOptions = {}): Promise<Fa
       // timer would only add nondeterminism.
       archiveSweepIntervalSeconds: 0,
       archiveMappedIdleSeconds: 60 * 60,
+      webhookClaimTtlSeconds: 300,
+      // Same rationale as archiveSweepIntervalSeconds: suites that exercise
+      // the webhook-claim sweeper call `sweepExpiredWebhookClaims` directly.
+      webhookClaimSweepIntervalSeconds: 0,
       notificationWebhookUrl: undefined,
     },
     update: {

--- a/packages/server/src/__tests__/scm-webhook-processing.test.ts
+++ b/packages/server/src/__tests__/scm-webhook-processing.test.ts
@@ -1,7 +1,12 @@
 import type { NormalizedScmEvent, ScmIngressContext } from "@first-tree/shared";
+import { and, eq } from "drizzle-orm";
 import { describe, expect, it, vi } from "vitest";
+import { processedEvents } from "../db/schema/processed-events.js";
+import * as eventDedupService from "../services/event-dedup.js";
 import { processScmWebhookDelivery } from "../services/scm-webhook-processing.js";
 import { useTestApp } from "./helpers.js";
+
+const TTL_SECONDS = 300;
 
 function makeIngress(stableDeliveryId: string | null): ScmIngressContext {
   return {
@@ -35,7 +40,26 @@ function makeEvent(ingress: ScmIngressContext): NormalizedScmEvent {
 describe("processScmWebhookDelivery", () => {
   const getApp = useTestApp();
 
-  it("claims a stable delivery once and skips the duplicate before provider work", async () => {
+  type App = ReturnType<typeof getApp>;
+
+  async function getClaimRow(app: App, deliveryId: string) {
+    const [row] = await app.db
+      .select()
+      .from(processedEvents)
+      .where(and(eq(processedEvents.eventId, deliveryId), eq(processedEvents.platform, "github")));
+    return row;
+  }
+
+  /** Rewind a pending claim's expiry into the past — the test-time stand-in
+   * for "the claim TTL elapsed since the attempt died". */
+  async function expireClaim(app: App, deliveryId: string) {
+    await app.db
+      .update(processedEvents)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(and(eq(processedEvents.eventId, deliveryId), eq(processedEvents.platform, "github")));
+  }
+
+  it("claims a stable delivery once, finishes it done, and skips the duplicate before provider work", async () => {
     const app = getApp();
     const ingress = makeIngress("delivery-stable");
     const event = makeEvent(ingress);
@@ -46,6 +70,7 @@ describe("processScmWebhookDelivery", () => {
     const first = await processScmWebhookDelivery({
       db: app.db,
       ingress,
+      claimTtlSeconds: TTL_SECONDS,
       observation: null,
       event,
       applyObservation: async () => undefined,
@@ -56,6 +81,7 @@ describe("processScmWebhookDelivery", () => {
     const duplicate = await processScmWebhookDelivery({
       db: app.db,
       ingress,
+      claimTtlSeconds: TTL_SECONDS,
       observation: null,
       event,
       applyObservation: async () => undefined,
@@ -69,9 +95,14 @@ describe("processScmWebhookDelivery", () => {
       deliveryStats: { delivered: 1, failed: 0 },
       providerResult: "provider-result",
     });
-    expect(duplicate).toEqual({ outcome: "duplicate" });
+    expect(duplicate).toEqual({ outcome: "duplicate", claimState: "done" });
     expect(runProviderWork).toHaveBeenCalledOnce();
     expect(deliver).toHaveBeenCalledOnce();
+    expect(await getClaimRow(app, "delivery-stable")).toMatchObject({
+      status: "done",
+      expiresAt: null,
+      claimToken: null,
+    });
   });
 
   it("does not claim without a stable delivery id, so repeated requests repeat side effects", async () => {
@@ -82,6 +113,7 @@ describe("processScmWebhookDelivery", () => {
     const input = {
       db: app.db,
       ingress,
+      claimTtlSeconds: TTL_SECONDS,
       observation: null,
       event,
       applyObservation: async () => undefined,
@@ -105,6 +137,7 @@ describe("processScmWebhookDelivery", () => {
     const result = await processScmWebhookDelivery({
       db: app.db,
       ingress,
+      claimTtlSeconds: TTL_SECONDS,
       observation: {
         entity: {
           type: "pull_request",
@@ -128,6 +161,26 @@ describe("processScmWebhookDelivery", () => {
     expect(deliver).not.toHaveBeenCalled();
   });
 
+  it("marks a provider_only stable delivery done", async () => {
+    const app = getApp();
+    const ingress = makeIngress("delivery-provider-only");
+
+    const result = await processScmWebhookDelivery({
+      db: app.db,
+      ingress,
+      claimTtlSeconds: TTL_SECONDS,
+      observation: null,
+      event: null,
+      applyObservation: async () => undefined,
+      runProviderWork: async () => "provider-result",
+      resolveAudience: async () => ({ targets: [], actorHumanId: null }),
+      deliver: async () => ({ delivered: 0 }),
+    });
+
+    expect(result).toEqual({ outcome: "provider_only", providerResult: "provider-result" });
+    expect(await getClaimRow(app, "delivery-provider-only")).toMatchObject({ status: "done" });
+  });
+
   it("does not suppress semantic delivery when projection refresh fails", async () => {
     const app = getApp();
     const ingress = makeIngress(null);
@@ -138,6 +191,7 @@ describe("processScmWebhookDelivery", () => {
       processScmWebhookDelivery({
         db: app.db,
         ingress,
+        claimTtlSeconds: TTL_SECONDS,
         observation: {
           entity: event.entity,
           state: "open",
@@ -155,7 +209,7 @@ describe("processScmWebhookDelivery", () => {
     expect(deliver).toHaveBeenCalledOnce();
   });
 
-  it("best-effort unclaims a stable delivery after an uncaught top-level failure", async () => {
+  it("releases a stable delivery after an uncaught failure so a redelivery reprocesses immediately", async () => {
     const app = getApp();
     const ingress = makeIngress("delivery-retryable");
     const event = makeEvent(ingress);
@@ -164,6 +218,7 @@ describe("processScmWebhookDelivery", () => {
       processScmWebhookDelivery({
         db: app.db,
         ingress,
+        claimTtlSeconds: TTL_SECONDS,
         observation: null,
         event,
         applyObservation: async () => undefined,
@@ -175,9 +230,16 @@ describe("processScmWebhookDelivery", () => {
       }),
     ).rejects.toThrow("audience unavailable");
 
+    // Release fast-expires the pending row instead of deleting it, so the
+    // next redelivery takes the claim over inline.
+    const released = await getClaimRow(app, "delivery-retryable");
+    expect(released?.status).toBe("pending");
+    expect(released?.expiresAt?.getTime()).toBeLessThanOrEqual(Date.now());
+
     const retried = await processScmWebhookDelivery({
       db: app.db,
       ingress,
+      claimTtlSeconds: TTL_SECONDS,
       observation: null,
       event,
       applyObservation: async () => undefined,
@@ -186,6 +248,176 @@ describe("processScmWebhookDelivery", () => {
       deliver: async () => ({ delivered: 1 }),
     });
     expect(retried.outcome).toBe("delivered");
+    expect(await getClaimRow(app, "delivery-retryable")).toMatchObject({ status: "done" });
+  });
+
+  it("returns duplicate with claimState pending while an unexpired claim shields a crashed attempt", async () => {
+    // Crash equivalent A: the previous attempt committed its claim and died
+    // mid-processing; its TTL has not elapsed yet, so a redelivery inside
+    // the protection window is deduped (this also shields live handlers).
+    const app = getApp();
+    const ingress = makeIngress("delivery-crash-window");
+    const event = makeEvent(ingress);
+    const preClaim = await eventDedupService.claimEvent(app.db, "delivery-crash-window", "github", TTL_SECONDS);
+    expect(preClaim).not.toBeNull();
+    const runProviderWork = vi.fn(async () => null);
+
+    const result = await processScmWebhookDelivery({
+      db: app.db,
+      ingress,
+      claimTtlSeconds: TTL_SECONDS,
+      observation: null,
+      event,
+      applyObservation: async () => undefined,
+      runProviderWork,
+      resolveAudience: async () => ({ targets: ["target-1"], actorHumanId: null }),
+      deliver: async () => ({ delivered: 1 }),
+    });
+
+    expect(result).toEqual({ outcome: "duplicate", claimState: "pending" });
+    expect(runProviderWork).not.toHaveBeenCalled();
+  });
+
+  it("takes over an expired pending claim and fully reprocesses the delivery", async () => {
+    // Crash equivalent B (the issue's core scenario): the previous attempt
+    // claimed and died; after the TTL a redelivery must take the claim over
+    // and run the whole pipeline exactly once instead of losing the event.
+    const app = getApp();
+    const ingress = makeIngress("delivery-crash-recovery");
+    const event = makeEvent(ingress);
+    const preClaim = await eventDedupService.claimEvent(app.db, "delivery-crash-recovery", "github", TTL_SECONDS);
+    expect(preClaim).not.toBeNull();
+    await expireClaim(app, "delivery-crash-recovery");
+    const runProviderWork = vi.fn(async () => "provider-result");
+    const deliver = vi.fn(async () => ({ delivered: 1, failed: 0 }));
+
+    const result = await processScmWebhookDelivery({
+      db: app.db,
+      ingress,
+      claimTtlSeconds: TTL_SECONDS,
+      observation: null,
+      event,
+      applyObservation: async () => undefined,
+      runProviderWork,
+      resolveAudience: async () => ({ targets: ["target-1"], actorHumanId: null }),
+      deliver,
+    });
+
+    expect(result).toMatchObject({ outcome: "delivered" });
+    expect(runProviderWork).toHaveBeenCalledOnce();
+    expect(deliver).toHaveBeenCalledOnce();
+    expect(await getClaimRow(app, "delivery-crash-recovery")).toMatchObject({
+      status: "done",
+      expiresAt: null,
+      claimToken: null,
+    });
+  });
+
+  it("stays recoverable when the release itself fails (leak path 2)", async () => {
+    const app = getApp();
+    const ingress = makeIngress("delivery-release-down");
+    const event = makeEvent(ingress);
+    const releaseSpy = vi
+      .spyOn(eventDedupService, "releaseClaimedEvent")
+      .mockRejectedValueOnce(new Error("release down"));
+
+    try {
+      await expect(
+        processScmWebhookDelivery({
+          db: app.db,
+          ingress,
+          claimTtlSeconds: TTL_SECONDS,
+          observation: null,
+          event,
+          applyObservation: async () => undefined,
+          runProviderWork: async () => null,
+          resolveAudience: async () => {
+            throw new Error("audience unavailable");
+          },
+          deliver: async () => ({ delivered: 0 }),
+        }),
+      ).rejects.toThrow("audience unavailable");
+      expect(releaseSpy).toHaveBeenCalledOnce();
+    } finally {
+      releaseSpy.mockRestore();
+    }
+
+    // The claim row survived the failed release with its original TTL…
+    const stuck = await getClaimRow(app, "delivery-release-down");
+    expect(stuck?.status).toBe("pending");
+    expect(stuck?.expiresAt?.getTime()).toBeGreaterThan(Date.now());
+
+    // …so once the TTL elapses, a redelivery recovers the event (before
+    // this fix the row was permanent and the delivery was lost forever).
+    await expireClaim(app, "delivery-release-down");
+    const retried = await processScmWebhookDelivery({
+      db: app.db,
+      ingress,
+      claimTtlSeconds: TTL_SECONDS,
+      observation: null,
+      event,
+      applyObservation: async () => undefined,
+      runProviderWork: async () => null,
+      resolveAudience: async () => ({ targets: ["target-1"], actorHumanId: null }),
+      deliver: async () => ({ delivered: 1 }),
+    });
+    expect(retried.outcome).toBe("delivered");
+    expect(await getClaimRow(app, "delivery-release-down")).toMatchObject({ status: "done" });
+  });
+
+  it("returns the success outcome when completeEvent fails, leaving the row pending", async () => {
+    const app = getApp();
+    const ingress = makeIngress("delivery-complete-down");
+    const event = makeEvent(ingress);
+    const completeSpy = vi.spyOn(eventDedupService, "completeEvent").mockRejectedValueOnce(new Error("complete down"));
+
+    try {
+      const result = await processScmWebhookDelivery({
+        db: app.db,
+        ingress,
+        claimTtlSeconds: TTL_SECONDS,
+        observation: null,
+        event,
+        applyObservation: async () => undefined,
+        runProviderWork: async () => null,
+        resolveAudience: async () => ({ targets: ["target-1"], actorHumanId: null }),
+        deliver: async () => ({ delivered: 1, failed: 0 }),
+      });
+
+      // Side effects landed; failing the request would provoke a redelivery
+      // and a guaranteed duplicate, so the outcome stays a success.
+      expect(result).toMatchObject({ outcome: "delivered" });
+      expect(completeSpy).toHaveBeenCalledOnce();
+    } finally {
+      completeSpy.mockRestore();
+    }
+    expect((await getClaimRow(app, "delivery-complete-down"))?.status).toBe("pending");
+  });
+
+  it("processes exactly one of two concurrent deliveries with the same id", async () => {
+    const app = getApp();
+    const ingress = makeIngress("delivery-concurrent");
+    const event = makeEvent(ingress);
+    const runProviderWork = vi.fn(async () => null);
+    const deliver = vi.fn(async () => ({ delivered: 1, failed: 0 }));
+    const input = {
+      db: app.db,
+      ingress,
+      claimTtlSeconds: TTL_SECONDS,
+      observation: null,
+      event,
+      applyObservation: async () => undefined,
+      runProviderWork,
+      resolveAudience: async () => ({ targets: ["target-1"], actorHumanId: null }),
+      deliver,
+    };
+
+    const [a, b] = await Promise.all([processScmWebhookDelivery(input), processScmWebhookDelivery(input)]);
+
+    const outcomes = [a.outcome, b.outcome].sort();
+    expect(outcomes).toEqual(["delivered", "duplicate"]);
+    expect(runProviderWork).toHaveBeenCalledOnce();
+    expect(deliver).toHaveBeenCalledOnce();
   });
 
   it("keeps the whole-request claim when provider delivery isolates a per-chat failure", async () => {
@@ -195,6 +427,7 @@ describe("processScmWebhookDelivery", () => {
     const input = {
       db: app.db,
       ingress,
+      claimTtlSeconds: TTL_SECONDS,
       observation: null,
       event,
       applyObservation: async () => undefined,
@@ -207,7 +440,7 @@ describe("processScmWebhookDelivery", () => {
     const duplicate = await processScmWebhookDelivery(input);
 
     expect(first).toMatchObject({ outcome: "delivered", deliveryStats: { delivered: 1, failed: 1 } });
-    expect(duplicate).toEqual({ outcome: "duplicate" });
+    expect(duplicate).toEqual({ outcome: "duplicate", claimState: "done" });
   });
 
   it("rejects a normalized event whose provider-neutral ingress facts drift", async () => {
@@ -219,6 +452,7 @@ describe("processScmWebhookDelivery", () => {
       processScmWebhookDelivery({
         db: app.db,
         ingress,
+        claimTtlSeconds: TTL_SECONDS,
         observation: null,
         event,
         applyObservation: async () => undefined,
@@ -227,5 +461,38 @@ describe("processScmWebhookDelivery", () => {
         deliver: async () => ({ delivered: 0 }),
       }),
     ).rejects.toThrow("normalized SCM event does not match its ingress context");
+  });
+
+  it("sweepExpiredWebhookClaims deletes only pending rows expired past the grace period", async () => {
+    const app = getApp();
+
+    // Pending, expired far beyond the 24h grace — the only sweep target.
+    const staleToken = await eventDedupService.claimEvent(app.db, "sweep-stale", "github", TTL_SECONDS);
+    expect(staleToken).not.toBeNull();
+    await app.db
+      .update(processedEvents)
+      .set({ expiresAt: new Date(Date.now() - 25 * 60 * 60 * 1000) })
+      .where(and(eq(processedEvents.eventId, "sweep-stale"), eq(processedEvents.platform, "github")));
+
+    // Pending, expired but still inside the grace period.
+    const recentToken = await eventDedupService.claimEvent(app.db, "sweep-recent", "github", TTL_SECONDS);
+    expect(recentToken).not.toBeNull();
+    await expireClaim(app, "sweep-recent");
+
+    // Fresh pending claim.
+    expect(await eventDedupService.claimEvent(app.db, "sweep-fresh", "github", TTL_SECONDS)).not.toBeNull();
+
+    // Done row — never swept.
+    const doneToken = await eventDedupService.claimEvent(app.db, "sweep-done", "github", TTL_SECONDS);
+    if (doneToken === null) throw new Error("expected claim to win");
+    await eventDedupService.completeEvent(app.db, "sweep-done", "github", doneToken);
+
+    const swept = await eventDedupService.sweepExpiredWebhookClaims(app.db);
+
+    expect(swept).toBe(1);
+    expect(await getClaimRow(app, "sweep-stale")).toBeUndefined();
+    expect(await getClaimRow(app, "sweep-recent")).toMatchObject({ status: "pending" });
+    expect(await getClaimRow(app, "sweep-fresh")).toMatchObject({ status: "pending" });
+    expect(await getClaimRow(app, "sweep-done")).toMatchObject({ status: "done" });
   });
 });

--- a/packages/server/src/api/webhooks/github-app.ts
+++ b/packages/server/src/api/webhooks/github-app.ts
@@ -157,8 +157,10 @@ async function handleInstallationLifecycle(app: FastifyInstance, eventType: stri
  *      the normalize pipeline (these events shouldn't fan out as cards)
  *   4. other events → installation.id → hub_organization_id reverse-lookup,
  *      then GitHub normalize → provider-neutral SCM processing seam →
- *      GitHub audience/delivery adapters. The seam best-effort unclaims on
- *      uncaught handler failure so GitHub's retry has a chance to clear.
+ *      GitHub audience/delivery adapters. The seam claims each delivery as a
+ *      pending lease and marks it done on success; on failure (including a
+ *      crash mid-processing) the claim expires, so redelivering the same id
+ *      after the TTL reprocesses the event instead of being deduped.
  *
  * Routes return 200 for "ignored" cases (no installation context, not
  * bound, suspended, duplicate delivery) so GitHub doesn't accumulate
@@ -256,6 +258,7 @@ export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void
     const result = await processScmWebhookDelivery({
       db: app.db,
       ingress,
+      claimTtlSeconds: app.config.runtime.webhookClaimTtlSeconds,
       observation: normalized.observation,
       event: normalized.event,
       applyObservation: async (current) => {
@@ -295,7 +298,16 @@ export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void
 
     switch (result.outcome) {
       case "duplicate":
-        return reply.status(200).send({ ok: true, event: eventType, deduped: true });
+        // claimState tells a redelivering operator whether to retry again:
+        // `pending` = an attempt owns the claim until its TTL expires
+        // (redeliver after that), `done` = processed for good. Additive so
+        // existing consumers of the response shape are unaffected.
+        return reply.status(200).send({
+          ok: true,
+          event: eventType,
+          deduped: true,
+          ...(result.claimState ? { claimState: result.claimState } : {}),
+        });
       case "provider_only":
         log.debug({ eventType, action: rawAction }, "Stage 1 returned null");
         return reply

--- a/packages/server/src/api/webhooks/gitlab.ts
+++ b/packages/server/src/api/webhooks/gitlab.ts
@@ -114,6 +114,7 @@ export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
             const processed = await processScmWebhookDelivery({
               db: tx,
               ingress: normalized.ingress,
+              claimTtlSeconds: app.config.runtime.webhookClaimTtlSeconds,
               observation: normalized.observation,
               event: applied.event,
               applyObservation: async () => {

--- a/packages/server/src/db/schema/processed-events.ts
+++ b/packages/server/src/db/schema/processed-events.ts
@@ -1,9 +1,23 @@
-import { pgTable, serial, text, timestamp, unique } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { index, pgTable, serial, text, timestamp, unique } from "drizzle-orm/pg-core";
 
 /**
- * Webhook event deduplication. External webhook sources (e.g. GitHub) can
- * deliver the same event multiple times; we use INSERT ... ON CONFLICT DO
- * NOTHING to ensure single processing.
+ * Webhook event deduplication with a claim lease. External webhook sources
+ * (e.g. GitHub) can deliver the same event multiple times. Each delivery is
+ * claimed as `pending` with an expiry before processing and marked `done`
+ * after its side effects landed. A redelivery of an expired `pending` claim
+ * (crashed or wedged attempt) takes the claim over instead of being deduped,
+ * so a crash between claim and completion no longer loses the event; `done`
+ * rows dedupe forever. `claim_token` scopes complete/release to the attempt
+ * that actually holds the claim. Rows predating the lease columns carry the
+ * `done` default: they were recorded by code that only inserted after-the-fact
+ * dedupe markers, and they keep deduping forever.
+ *
+ * NOTE: this table predates drizzle-kit management — it was created by
+ * migration 0003 and is deliberately not exported from `./index.ts`, so it
+ * is absent from the drizzle snapshots. Schema changes here need a custom
+ * migration (`drizzle-kit generate --custom`, see 0082 / the 0046 and 0053
+ * precedents); a plain `db:generate` cannot diff this table.
  */
 export const processedEvents = pgTable(
   "processed_events",
@@ -12,6 +26,14 @@ export const processedEvents = pgTable(
     eventId: text("event_id").notNull(),
     platform: text("platform").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    status: text("status").$type<"pending" | "done">().notNull().default("done"),
+    /** Set while `pending`; NULL once `done`. */
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
+    /** Owning attempt (UUID v7) while `pending`; NULL once `done`. */
+    claimToken: text("claim_token"),
   },
-  (table) => [unique("uq_processed_event").on(table.eventId, table.platform)],
+  (table) => [
+    unique("uq_processed_event").on(table.eventId, table.platform),
+    index("idx_processed_events_pending").on(table.expiresAt).where(sql`status = 'pending'`),
+  ],
 );

--- a/packages/server/src/services/background-tasks.ts
+++ b/packages/server/src/services/background-tasks.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { createLogger } from "../observability/index.js";
 import * as chatArchiveService from "./chat-archive.js";
 import * as clientService from "./client.js";
+import * as eventDedupService from "./event-dedup.js";
 import * as inboxService from "./inbox.js";
 import * as notificationService from "./notification.js";
 import * as presenceService from "./presence.js";
@@ -17,6 +18,7 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
   let inboxTimer: ReturnType<typeof setInterval> | null = null;
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let archiveSweepTimer: ReturnType<typeof setInterval> | null = null;
+  let webhookClaimSweepTimer: ReturnType<typeof setInterval> | null = null;
 
   return {
     start() {
@@ -83,6 +85,27 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
         }, archiveSweepSeconds * 1000);
       }
 
+      // Webhook claim hygiene sweep — cadence comes from runtime config so
+      // ops (and tests) can tune or zero-disable it. Recovery of crashed
+      // webhook attempts never depends on this sweep — expired pending
+      // claims are taken over inline by the next redelivery — it only
+      // deletes long-expired pending rows nobody redelivered. See
+      // services/event-dedup.ts for the claim state machine and the
+      // deletion grace period.
+      const webhookClaimSweepSeconds = app.config.runtime.webhookClaimSweepIntervalSeconds;
+      if (webhookClaimSweepSeconds > 0) {
+        webhookClaimSweepTimer = setInterval(async () => {
+          try {
+            const swept = await eventDedupService.sweepExpiredWebhookClaims(app.db);
+            if (swept > 0) {
+              log.info({ swept }, "webhook claim sweep deleted stale pending claims");
+            }
+          } catch (err) {
+            log.error({ err }, "webhook claim sweep failed");
+          }
+        }, webhookClaimSweepSeconds * 1000);
+      }
+
       // Initial heartbeat
       presenceService.heartbeatInstance(app.db, instanceId).catch((err) => {
         log.error({ err }, "failed initial heartbeat");
@@ -101,6 +124,10 @@ export function createBackgroundTasks(app: FastifyInstance, instanceId: string):
       if (archiveSweepTimer) {
         clearInterval(archiveSweepTimer);
         archiveSweepTimer = null;
+      }
+      if (webhookClaimSweepTimer) {
+        clearInterval(webhookClaimSweepTimer);
+        webhookClaimSweepTimer = null;
       }
     },
   };

--- a/packages/server/src/services/event-dedup.ts
+++ b/packages/server/src/services/event-dedup.ts
@@ -1,23 +1,133 @@
 import { sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
+import { uuidv7 } from "../uuid.js";
 
-// ── Event deduplication ─────────────────────────────────────────────
+// ── Event deduplication (claim lease) ───────────────────────────────
+//
+// State machine per (event_id, platform):
+//
+//   (no row) --claim--> pending(expires_at, claim_token) --complete--> done
+//
+// * claim on an existing `done` row, or on a `pending` row that has not
+//   expired yet, is a duplicate (returns null).
+// * claim on an EXPIRED `pending` row takes the claim over in the same
+//   single statement (the previous attempt crashed or wedged), so a
+//   redelivery after the TTL reprocesses the event instead of losing it.
+// * release flips the current attempt's pending row to already-expired so
+//   the next redelivery can take over immediately; the claim token keeps a
+//   slow handler's late release/complete from touching a newer attempt.
+//
+// Every transition is one atomic statement on the unique key, so any number
+// of replicas can race a delivery and exactly one wins.
+
+export type WebhookClaimState = "pending" | "done";
+
+/** Grace period the hygiene sweep leaves expired pending claims in place.
+ * Correctness never depends on the sweep — expired pending rows are taken
+ * over inline by the next redelivery — so the only job here is to stop
+ * never-redelivered rows from accumulating forever. 24h keeps the row (and
+ * its `pending` diagnosis) visible for a full ops day before deletion. */
+const WEBHOOK_CLAIM_SWEEP_GRACE_SECONDS = 24 * 60 * 60;
 
 /**
- * Attempt to claim an event for processing.
- * Returns true if this is the first time the event is seen, false if duplicate.
+ * Attempt to claim an event delivery for processing.
+ * Returns the claim token when this attempt owns the event (fresh claim or
+ * takeover of an expired pending claim), or null on duplicate (`done`, or
+ * `pending` still inside its TTL).
  */
-export async function claimEvent(db: Database, eventId: string, platform: string): Promise<boolean> {
+export async function claimEvent(
+  db: Database,
+  eventId: string,
+  platform: string,
+  ttlSeconds: number,
+): Promise<string | null> {
+  const token = uuidv7();
   const result = await db.execute<{ event_id: string }>(
-    sql`INSERT INTO processed_events (event_id, platform) VALUES (${eventId}, ${platform}) ON CONFLICT DO NOTHING RETURNING event_id`,
+    sql`INSERT INTO processed_events (event_id, platform, status, expires_at, claim_token)
+        VALUES (${eventId}, ${platform}, 'pending', now() + make_interval(secs => ${ttlSeconds}), ${token})
+        ON CONFLICT (event_id, platform) DO UPDATE
+          SET status = 'pending', expires_at = now() + make_interval(secs => ${ttlSeconds}), claim_token = ${token}
+          WHERE processed_events.status = 'pending' AND processed_events.expires_at < now()
+        RETURNING event_id`,
+  );
+  return result.length > 0 ? token : null;
+}
+
+/**
+ * Mark a claimed delivery as processed. Returns false when this attempt no
+ * longer holds the claim (it expired and a redelivery took it over), in
+ * which case the row is left alone.
+ */
+export async function completeEvent(
+  db: Database,
+  eventId: string,
+  platform: string,
+  claimToken: string,
+): Promise<boolean> {
+  const result = await db.execute<{ event_id: string }>(
+    sql`UPDATE processed_events
+        SET status = 'done', expires_at = NULL, claim_token = NULL
+        WHERE event_id = ${eventId} AND platform = ${platform}
+          AND status = 'pending' AND claim_token = ${claimToken}
+        RETURNING event_id`,
   );
   return result.length > 0;
 }
 
 /**
- * Remove a claimed event so it can be retried on next delivery.
- * Called when processing fails after claimEvent() succeeded.
+ * Release this attempt's claim after a processing failure so the next
+ * redelivery can take over immediately. Expiring the row (instead of
+ * deleting it) keeps the token guard: a takeover happening concurrently is
+ * untouched, and if this release itself fails the TTL still recovers.
  */
-export async function unclaimEvent(db: Database, eventId: string, platform: string): Promise<void> {
-  await db.execute(sql`DELETE FROM processed_events WHERE event_id = ${eventId} AND platform = ${platform}`);
+export async function releaseClaimedEvent(
+  db: Database,
+  eventId: string,
+  platform: string,
+  claimToken: string,
+): Promise<void> {
+  await db.execute(
+    sql`UPDATE processed_events
+        SET expires_at = now()
+        WHERE event_id = ${eventId} AND platform = ${platform}
+          AND status = 'pending' AND claim_token = ${claimToken}`,
+  );
+}
+
+/**
+ * Read the current claim state of a delivery, for duplicate diagnostics
+ * (a `pending` duplicate means "an attempt owns this until expires_at" —
+ * redeliver after that; `done` means processed for good). Returns null when
+ * no row exists (e.g. the row was hygiene-swept since the claim attempt).
+ */
+export async function readClaimState(
+  db: Database,
+  eventId: string,
+  platform: string,
+): Promise<{ state: WebhookClaimState; expiresAt: Date | null } | null> {
+  const result = await db.execute<{ status: WebhookClaimState; expires_at: string | Date | null }>(
+    sql`SELECT status, expires_at FROM processed_events
+        WHERE event_id = ${eventId} AND platform = ${platform}`,
+  );
+  const row = result[0];
+  if (!row) return null;
+  return {
+    state: row.status,
+    expiresAt: row.expires_at === null ? null : new Date(row.expires_at),
+  };
+}
+
+/**
+ * Hygiene sweep: delete pending claims that expired more than the grace
+ * period ago and were never redelivered. Idempotent and safe under multiple
+ * replicas. Returns the number of rows deleted.
+ */
+export async function sweepExpiredWebhookClaims(db: Database): Promise<number> {
+  const result = await db.execute<{ event_id: string }>(
+    sql`DELETE FROM processed_events
+        WHERE status = 'pending'
+          AND expires_at < now() - make_interval(secs => ${WEBHOOK_CLAIM_SWEEP_GRACE_SECONDS})
+        RETURNING event_id`,
+  );
+  return result.length;
 }

--- a/packages/server/src/services/github-app-installations.ts
+++ b/packages/server/src/services/github-app-installations.ts
@@ -316,7 +316,10 @@ export async function markInstallationUnsuspended(
  * The original race the grace was meant to solve doesn't actually exist:
  * GitHub mints a fresh `installation.id` per install, so a delayed
  * `deleted` for id N cannot wipe a fresh re-install (which has id M ≠ N).
- * Same-id replays are handled by the `processed_events` dedup table.
+ * Same-id replays are not deduped — installation lifecycle events branch
+ * off before the `processed_events` claim pipeline (see
+ * githubAppWebhookRoutes) — but the lifecycle handlers absorb them
+ * idempotently (upsert/update semantics).
  *
  * The remaining "stale `created` after `deleted` resurrects the row" risk
  * is a pre-existing hole in `upsertInstallationFromMetadata` (not

--- a/packages/server/src/services/github-delivery.ts
+++ b/packages/server/src/services/github-delivery.ts
@@ -26,10 +26,11 @@ export type DeliveryStats = {
   newChats: number;
   /**
    * Number of chats whose delivery threw and was caught by the per-chat
-   * guard. These chats did NOT receive a card; the webhook has already been
-   * claimed in `processed_events`, so GitHub will not retry. Surfaced in the
-   * response + metric so a regression in single-chat reliability becomes
-   * observable instead of silent.
+   * guard. These chats did NOT receive a card; the delivery's claim in
+   * `processed_events` will still be marked done, so a GitHub redelivery is
+   * deduped rather than retrying them. Surfaced in the response + metric so
+   * a regression in single-chat reliability becomes observable instead of
+   * silent.
    */
   failed: number;
 };
@@ -214,9 +215,10 @@ export async function deliverGithubEvent(
     } catch (err) {
       stats.failed += 1;
       // Per-chat failures are isolated so one bad chat doesn't poison the rest,
-      // but the webhook is already claimed in `processed_events` — GitHub will
-      // not retry. Emit a structured metric line so a regression in single-chat
-      // reliability is observable instead of silently swallowed. See #507.
+      // but the delivery's claim in `processed_events` will still be marked
+      // done — a GitHub redelivery is deduped, not retried. Emit a structured
+      // metric line so a regression in single-chat reliability is observable
+      // instead of silently swallowed. See #507.
       log.error(
         {
           err,

--- a/packages/server/src/services/scm-webhook-processing.ts
+++ b/packages/server/src/services/scm-webhook-processing.ts
@@ -1,7 +1,13 @@
 import type { NormalizedScmEvent, ScmEntityObservation, ScmIngressContext } from "@first-tree/shared";
 import type { Database } from "../db/connection.js";
 import { createLogger } from "../observability/index.js";
-import { claimEvent, unclaimEvent } from "./event-dedup.js";
+import {
+  claimEvent,
+  completeEvent,
+  readClaimState,
+  releaseClaimedEvent,
+  type WebhookClaimState,
+} from "./event-dedup.js";
 
 const log = createLogger("ScmWebhookProcessing");
 
@@ -11,7 +17,16 @@ export type ScmAudienceResolution<TTarget> = {
 };
 
 export type ScmProcessingResult<TDeliveryStats, TProviderResult> =
-  | { outcome: "duplicate" }
+  | {
+      outcome: "duplicate";
+      /**
+       * Claim state behind the dedupe: `pending` means an attempt owns the
+       * delivery until its TTL expires (redeliver after that to take over),
+       * `done` means it was fully processed. Null in the rare case the row
+       * disappeared between the claim attempt and the diagnostic read.
+       */
+      claimState: WebhookClaimState | null;
+    }
   | { outcome: "provider_only"; providerResult: TProviderResult }
   | {
       outcome: "audience_empty";
@@ -23,6 +38,9 @@ export type ScmProcessingResult<TDeliveryStats, TProviderResult> =
 type ProcessScmWebhookDeliveryInput<TTarget, TDeliveryStats, TProviderResult> = {
   db: Database;
   ingress: ScmIngressContext;
+  /** Claim lease TTL: how long a pending claim shields the delivery from
+   * duplicates before a redelivery may take it over. */
+  claimTtlSeconds: number;
   observation: ScmEntityObservation | null;
   event: NormalizedScmEvent | null;
   applyObservation: (observation: ScmEntityObservation) => Promise<void>;
@@ -38,10 +56,16 @@ type ProcessScmWebhookDeliveryInput<TTarget, TDeliveryStats, TProviderResult> = 
  * Narrow provider-neutral SCM processing seam.
  *
  * The ingress adapter authenticates and normalizes first. This kernel owns
- * only the existing optional whole-request claim, provider work covered by
- * that claim, audience orchestration, and best-effort unclaim on an uncaught
- * top-level failure. Provider payloads, stores, mapping rules, card shapes,
- * and per-chat failure guards remain behind the supplied callbacks.
+ * only the optional whole-request claim lease (claimed `pending` up front,
+ * marked `done` on success, released to expired on an uncaught top-level
+ * failure — with expired pending claims taken over by a later redelivery),
+ * provider work covered by that claim, and audience orchestration. Provider
+ * payloads, stores, mapping rules, card shapes, and per-chat failure guards
+ * remain behind the supplied callbacks.
+ *
+ * Deliveries without a stable id skip the claim entirely, and symmetrically
+ * skip complete/release: those calls run only while this attempt actually
+ * holds the claim token.
  */
 export async function processScmWebhookDelivery<TTarget, TDeliveryStats, TProviderResult>(
   input: ProcessScmWebhookDeliveryInput<TTarget, TDeliveryStats, TProviderResult>,
@@ -49,13 +73,54 @@ export async function processScmWebhookDelivery<TTarget, TDeliveryStats, TProvid
   assertEventMatchesIngress(input.ingress, input.event);
 
   const deliveryId = input.ingress.stableDeliveryId;
+  let claimToken: string | null = null;
   if (deliveryId) {
-    const claimed = await claimEvent(input.db, deliveryId, input.ingress.provider);
-    if (!claimed) {
-      log.info({ provider: input.ingress.provider, deliveryId }, "duplicate SCM webhook delivery, skipping");
-      return { outcome: "duplicate" };
+    claimToken = await claimEvent(input.db, deliveryId, input.ingress.provider, input.claimTtlSeconds);
+    if (claimToken === null) {
+      const claim = await readClaimState(input.db, deliveryId, input.ingress.provider);
+      log.info(
+        {
+          provider: input.ingress.provider,
+          deliveryId,
+          claimState: claim?.state ?? null,
+          ...(claim?.state === "pending" ? { claimExpiresAt: claim.expiresAt } : {}),
+        },
+        "duplicate SCM webhook delivery, skipping",
+      );
+      return { outcome: "duplicate", claimState: claim?.state ?? null };
     }
   }
+
+  const markDone = async (): Promise<void> => {
+    if (!deliveryId || claimToken === null) return;
+    try {
+      const completed = await completeEvent(input.db, deliveryId, input.ingress.provider, claimToken);
+      if (!completed) {
+        // The claim expired mid-handler and a redelivery took it over. The
+        // side effects of this attempt already landed; the takeover attempt
+        // duplicates them (bounded, at-least-once by design), so there is
+        // nothing to roll back — just make the overlap observable.
+        log.warn(
+          { provider: input.ingress.provider, deliveryId },
+          "webhook claim was taken over before completion; redelivery may duplicate side effects",
+        );
+      }
+    } catch (err) {
+      // Side effects are durably committed, so failing the request here
+      // would make GitHub redeliver and duplicate them after the TTL. Keep
+      // the success response and ring a bell instead: the row stays pending
+      // until a redelivery takes it over or the hygiene sweep removes it.
+      log.error(
+        {
+          err,
+          metric: "webhook_claim_complete_failed_total",
+          provider: input.ingress.provider,
+          deliveryId,
+        },
+        "failed to mark processed webhook delivery done",
+      );
+    }
+  };
 
   try {
     const providerResult = await input.runProviderWork();
@@ -76,7 +141,10 @@ export async function processScmWebhookDelivery<TTarget, TDeliveryStats, TProvid
         );
       });
     }
-    if (!input.event) return { outcome: "provider_only", providerResult };
+    if (!input.event) {
+      await markDone();
+      return { outcome: "provider_only", providerResult };
+    }
 
     const audience = await input.resolveAudience(input.event);
     if (audience.targets.length === 0) {
@@ -93,17 +161,21 @@ export async function processScmWebhookDelivery<TTarget, TDeliveryStats, TProvid
         },
         "SCM webhook audience empty, skipping",
       );
+      await markDone();
       return { outcome: "audience_empty", reason, providerResult };
     }
 
     const deliveryStats = await input.deliver(input.event, audience);
+    await markDone();
     return { outcome: "delivered", deliveryStats, providerResult };
   } catch (err) {
-    if (deliveryId) {
-      await unclaimEvent(input.db, deliveryId, input.ingress.provider).catch((unclaimErr) => {
+    if (deliveryId && claimToken !== null) {
+      await releaseClaimedEvent(input.db, deliveryId, input.ingress.provider, claimToken).catch((releaseErr) => {
+        // Release is best-effort: if it fails the claim simply stays pending
+        // until its TTL expires, after which a redelivery takes it over.
         log.error(
-          { err: unclaimErr, provider: input.ingress.provider, deliveryId },
-          "failed to unclaim SCM webhook delivery after handler error",
+          { err: releaseErr, provider: input.ingress.provider, deliveryId },
+          "failed to release claimed SCM webhook delivery after handler error",
         );
       });
     }

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -489,6 +489,30 @@ export const serverConfigSchema = defineConfig({
       },
     ),
     /**
+     * Webhook claim lease TTL. An inbound SCM delivery is claimed `pending`
+     * for this long before processing; within the TTL a redelivery of the
+     * same id is deduped (shields live handlers and replica races), after it
+     * a redelivery takes the claim over and reprocesses (recovers deliveries
+     * whose attempt crashed between claim and completion). Deliberately
+     * positive-only: with no TTL the claim degrades back to an at-most-once
+     * marker and a crash mid-processing silently loses the event. Default
+     * 300s is orders of magnitude above real handler time (DB-bound,
+     * seconds) while keeping operator redelivery recovery within minutes.
+     */
+    webhookClaimTtlSeconds: field(z.coerce.number().int().positive().default(300), {
+      env: "FIRST_TREE_WEBHOOK_CLAIM_TTL_SECONDS",
+    }),
+    /**
+     * Webhook claim hygiene-sweep cadence. Set to 0 to disable the sweeper
+     * (useful in tests). Recovery never depends on the sweep — expired
+     * pending claims are taken over inline by the next redelivery — it only
+     * deletes long-expired pending rows nobody redelivered, so the default
+     * hourly tick is plenty.
+     */
+    webhookClaimSweepIntervalSeconds: field(z.coerce.number().int().nonnegative().default(3600), {
+      env: "FIRST_TREE_WEBHOOK_CLAIM_SWEEP_INTERVAL_SECONDS",
+    }),
+    /**
      * Optional outbound webhook URL — if set, every notification is
      * fire-and-forget POSTed here in JSON. Replaces the prior DB-backed
      * `notification_webhook_url` config row.


### PR DESCRIPTION
Fixes #317.

## Problem

The webhook dedupe guard claimed a delivery by inserting into `processed_events` **before** doing the work, on an autocommit connection. If the process died between the claim and the side effects (deploy mid-request, OOM, DB drop), the row stayed committed while nothing had happened — and GitHub's redelivery of the same `x-github-delivery` GUID was answered with `deduped: 200`. The event was lost permanently. A failed `unclaimEvent` after a handler error leaked the same way.

## Approach: turn the claim into a recoverable lease

`processed_events` becomes a per-delivery state machine — `pending(expires_at, claim_token) → done` — where every transition is a single atomic statement on the unique key:

- **Claim** inserts `pending` with a TTL (config `FIRST_TREE_WEBHOOK_CLAIM_TTL_SECONDS`, default 300s) and a fresh claim token. A redelivery that finds an **expired** pending row **takes it over in the same `INSERT … ON CONFLICT DO UPDATE … WHERE expired` statement** — recovery is inline in the redelivery request, not dependent on any sweeper. `done` rows and live pending rows still dedupe.
- **Complete** flips to `done` only while this attempt's token still holds the claim; a lost race (takeover after a wedged attempt) is logged, never overwritten.
- **Release** (handler error) fast-expires the row instead of deleting it, keeping the token guard so a slow handler's late release cannot hurt a newer attempt; if the release itself fails, the TTL still recovers the event.
- **Hygiene sweep** (independent interval, config `FIRST_TREE_WEBHOOK_CLAIM_SWEEP_INTERVAL_SECONDS`, default 3600s, `0` disables) deletes pending rows expired for >24h. Correctness never depends on it.
- **Duplicate responses now carry `claimState: "pending" | "done"`** (additive field) with structured logs. Runbook: a redelivery answered with `claimState: "pending"` means an attempt may still be in flight — wait out the TTL (default 5 min) and redeliver once more.

Trade-off, made explicit: the crash window moves from silent at-most-once (lost forever) to at-least-once (bounded, user-visible duplication of cards/prompts in the rare crash+redelivery overlap). Entity projections and chat mappings are idempotent; for the context-review path the residual duplication is one extra review prompt — since #1916 that flow keeps chat-level idempotency (existing-chat reuse + chat reservation key) but has no per-delivery prompt dedupe. This matches the repo's own delivery doctrine ("Delivery is at-least-once; Client deduplicates").

## Scope notes

- The legacy per-org webhook route named in the issue no longer exists (superseded by the GitHub App route).
- The GitLab path runs the same seam **inside** `withGitlabIngressFence`'s transaction, so its claim and side effects already commit or roll back atomically — unaffected, and now pinned by a regression test (handler failure inside the fence leaves no row; redelivery reprocesses).

## Migration

`drizzle/0082_processed_events_claim_lease.sql` — pure `ADD COLUMN ×3` + partial index on pending rows. Generated via `drizzle-kit generate --custom` (0046/0053 precedent): `processed_events` predates drizzle-kit management (created by migration 0003, deliberately absent from the snapshots), so a schema diff cannot see it; the header comment documents this. No backfill: `status` defaults to `'done'`, so every pre-existing row keeps its permanent-dedupe meaning, and old replicas inserting only `(event_id, platform)` during a rolling deploy record a terminal `done` row — correct.

## Verification

- `pnpm check` / `pnpm typecheck` green; `node scripts/check-migrations.mjs` green.
- Affected suites: **94/94** (event-dedup 12 — incl. concurrent-takeover single winner and legacy-row default simulation; seam 14 — incl. crash equivalents for both leak paths, complete-failure, concurrent same-GUID single processing, sweep bounds; GitHub e2e 47 — incl. the issue's headline scenario end-to-end: fail → pending → in-TTL redeliver answered `claimState:"pending"` → post-TTL redeliver processes fully with `done` terminal-state assertions; GitLab stage2a 21 — incl. the rollback-leaves-no-row regression).
- Full server package: **238 files / 2579 tests green**. Full repo `pnpm test`: 11/11 turbo tasks green.
- QA asset updated: `packages/qa/cases/cross-surface/github-webhook-routing-regression.md` now covers post-failure redelivery recovery. This is a webhook/cross-surface path — formal QA is warranted per repo guidelines.

## Follow-ups (out of scope here, as agreed in design review)

- Paired **draft** Context Tree PR updating the recorded reliability-boundary decision for SCM webhook routing (this PR flips that recorded semantic); to be reconciled and marked ready after this PR merges. Link will follow in a comment.
- `done`-row retention/GC (separate issue — changes permanent dedupe into windowed dedupe).
- Per-delivery dedupe for the context-review prompt. #1916 (restore GitHub App review flow) landed after this PR's base and reshaped that path, so the follow-up must be re-scoped against the merged structure first.

---

Designed and reviewed with fire-fable-reviewer (design v1.1: R1–R6 revisions absorbed and confirmed before implementation). Goblet of Fire competition submission — kept as **draft** per competition rules.

