### PR TITLE
fix: add app-wide browser security headers for Fastify/SPA

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1447,6 +1447,19 @@ The server applies this as one actor-aware global safety cap per minute. It
 keys by agent id, then user id, then request IP for unauthenticated traffic.
 Old per-route rate-limit env vars are no longer read.
 
+**Security headers:**
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `FIRST_TREE_SECURITY_CSP_MODE` | Content-Security-Policy mode for HTML responses: `report-only` sends the full policy as `Content-Security-Policy-Report-Only` plus a small enforced subset (`frame-ancestors` / `object-src` / `base-uri`); `enforce` sends the full policy enforced; `off` sends no CSP header. | `report-only` |
+| `FIRST_TREE_SECURITY_CSP_CONNECT_SRC_EXTRA` | Extra `connect-src` origins (space- or comma-separated) appended to the built-in CSP allowlist — e.g. a regional or self-hosted Sentry ingest domain. | — |
+| `FIRST_TREE_SECURITY_CSP_REPORT_URI` | CSP violation report endpoint (`report-uri` directive), e.g. a Sentry security endpoint. | — |
+| `FIRST_TREE_SECURITY_HSTS_ENABLED` | Send `Strict-Transport-Security: max-age=31536000` on HTTPS responses. Requires `FIRST_TREE_TRUST_PROXY=true` behind a TLS-terminating proxy so the server sees `X-Forwarded-Proto`. Set `false` to stop advertising HSTS. | `true` |
+
+The remaining security headers (`X-Content-Type-Options`, `Referrer-Policy`,
+`X-Frame-Options`, `Permissions-Policy`) are always sent on every response and
+have no toggles.
+
 **Inbox / WS / archive sweeper:**
 
 | Variable | Default |

--- a/packages/server/src/__tests__/attachments-route.test.ts
+++ b/packages/server/src/__tests__/attachments-route.test.ts
@@ -57,6 +57,9 @@ describe("attachments route — upload + capability download", () => {
     expect(download.headers["content-type"]).toBe("image/png");
     expect(download.headers["content-length"]).toBe(String(bytes.byteLength));
     expect(download.headers["x-content-type-options"]).toBe("nosniff");
+    // Stamped by the global security-headers onSend hook — proves the hook
+    // covers DB-backed API routes, not just static/SPA responses.
+    expect(download.headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
     expect(download.headers["cache-control"]).toBe("private, max-age=31536000, immutable");
     expect(download.headers.etag).toBe(`"${body.id}"`);
     expect(download.headers["content-disposition"]).toBe('inline; filename="kitten.png"');

--- a/packages/server/src/__tests__/security-headers.test.ts
+++ b/packages/server/src/__tests__/security-headers.test.ts
@@ -1,0 +1,323 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import type { OutgoingHttpHeaders } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildApp } from "../app.js";
+import type { Config } from "../config.js";
+import { buildCsp, isHtmlContentType } from "../middleware/security-headers.js";
+
+/**
+ * App-wide browser security headers (issue #1541).
+ *
+ * The onSend hook registered in `buildApp` must stamp the unconditional
+ * header set on EVERY response class (static HTML, SPA fallback, assets,
+ * API JSON, 404s, health checks), attach the CSP to `text/html` responses
+ * only, and send HSTS only for https requests on a trusted proxy.
+ *
+ * Uses the same temp-webroot + `buildApp` + `inject` skeleton as
+ * `build-app-validation.test.ts` — no seeded DB rows needed; the vitest
+ * globalSetup Postgres is enough for `buildApp` to boot.
+ */
+const baseConfig: Config = {
+  channel: "dev",
+  growth: {
+    landingPagesEnabled: false,
+    landingCampaignMaxAgentTurns: 1,
+    landingCampaignMaxEstimatedTokens: 120_000,
+    landingCampaignMaxTrialsPerUserPer24Hours: 5,
+  },
+  docs: { enabled: false },
+  database: { url: process.env.DATABASE_URL ?? "", provider: "external" },
+  server: { port: 0, host: "127.0.0.1", publicUrl: undefined },
+  workspace: { root: "/tmp/first-tree-test-workspaces" },
+  secrets: {
+    jwtSecret: "test-jwt-secret-key-for-vitest",
+    encryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  },
+  auth: { accessTokenExpiry: "30m", refreshTokenExpiry: "30d", connectTokenExpiry: "10m" },
+  trustProxy: false,
+  connectBootstrap: {
+    portableDownloadBaseUrl: "https://download.first-tree.ai/releases",
+  },
+  observability: { logging: { level: "error", format: "json", bridgeToSpanLevel: "off" } },
+  runtime: {
+    agentHttpTokenEnforcement: false,
+    runtimeSwitchFaultInjection: false,
+    pollingIntervalSeconds: 5,
+    presenceCleanupSeconds: 60,
+    archiveSweepIntervalSeconds: 0,
+    archiveMappedIdleSeconds: 60 * 60,
+    notificationWebhookUrl: undefined,
+  },
+  update: {
+    commandVersion: "test.version",
+    pollIntervalMinutes: 1440,
+    registryUrl: "https://localhost.invalid",
+  },
+  instanceId: "test-instance",
+};
+
+/** Exact enforced subset delivered alongside the report-only policy. */
+const ENFORCED_SUBSET = "frame-ancestors 'none'; object-src 'none'; base-uri 'self'";
+
+/** The unconditional header set, asserted verbatim (full-string equality). */
+function expectUnconditionalHeaders(headers: OutgoingHttpHeaders): void {
+  expect(headers["x-content-type-options"]).toBe("nosniff");
+  expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+  expect(headers["x-frame-options"]).toBe("DENY");
+  expect(headers["permissions-policy"]).toBe("camera=(), microphone=(), geolocation=()");
+}
+
+function expectNoCspHeaders(headers: OutgoingHttpHeaders): void {
+  expect(headers["content-security-policy"]).toBeUndefined();
+  expect(headers["content-security-policy-report-only"]).toBeUndefined();
+}
+
+describe("security headers — app-wide onSend hook", () => {
+  let webRoot: string;
+
+  beforeAll(async () => {
+    webRoot = await mkdtemp(join(tmpdir(), "first-tree-sec-headers-"));
+    await writeFile(join(webRoot, "index.html"), "<!doctype html><html><body>App shell</body></html>", "utf8");
+    await mkdir(join(webRoot, "assets"), { recursive: true });
+    await writeFile(join(webRoot, "assets", "app.js"), "console.log('asset');\n", "utf8");
+  });
+
+  afterAll(async () => {
+    await rm(webRoot, { recursive: true, force: true });
+  });
+
+  describe("default mode — report-only CSP, no security config block", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildApp({ ...baseConfig, webDistPath: webRoot });
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it("stamps the header set and split CSP on the directly served index.html", async () => {
+      const res = await app.inject({ method: "GET", url: "/" });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["content-type"]).toContain("text/html");
+      expectUnconditionalHeaders(res.headers);
+      // Enforced header carries EXACTLY the zero-risk subset while the full
+      // policy rides report-only (frame-ancestors is spec-ignored in RO).
+      expect(res.headers["content-security-policy"]).toBe(ENFORCED_SUBSET);
+      expect(res.headers["content-security-policy-report-only"]).toBe(
+        buildCsp({ cspMode: "report-only", hstsEnabled: true }),
+      );
+    });
+
+    it("stamps the same headers on the SPA fallback response", async () => {
+      const res = await app.inject({ method: "GET", url: "/workspace/deep-link" });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toContain("App shell");
+      expectUnconditionalHeaders(res.headers);
+      expect(res.headers["content-security-policy"]).toBe(ENFORCED_SUBSET);
+      expect(res.headers["content-security-policy-report-only"]).toBeDefined();
+    });
+
+    it("applies the header set WITHOUT CSP to static assets", async () => {
+      const res = await app.inject({ method: "GET", url: "/assets/app.js" });
+      expect(res.statusCode).toBe(200);
+      expectUnconditionalHeaders(res.headers);
+      expectNoCspHeaders(res.headers);
+    });
+
+    it("applies the header set WITHOUT CSP to API 404 JSON", async () => {
+      const res = await app.inject({ method: "GET", url: "/api/missing" });
+      expect(res.statusCode).toBe(404);
+      expect(res.headers["content-type"]).toContain("application/json");
+      expectUnconditionalHeaders(res.headers);
+      expectNoCspHeaders(res.headers);
+    });
+
+    it("applies the header set WITHOUT CSP to a 200 API route (/healthz)", async () => {
+      const res = await app.inject({ method: "GET", url: "/healthz" });
+      expect(res.statusCode).toBe(200);
+      expectUnconditionalHeaders(res.headers);
+      expectNoCspHeaders(res.headers);
+    });
+
+    it("never sends HSTS when trustProxy=false, even for a spoofed x-forwarded-proto", async () => {
+      // trustProxy=false means request.protocol ignores XFP — a client-forged
+      // header must not conjure HSTS onto a plain-HTTP deployment.
+      const spoofed = await app.inject({
+        method: "GET",
+        url: "/",
+        headers: { "x-forwarded-proto": "https" },
+      });
+      expect(spoofed.headers["strict-transport-security"]).toBeUndefined();
+
+      const plain = await app.inject({ method: "GET", url: "/" });
+      expect(plain.headers["strict-transport-security"]).toBeUndefined();
+    });
+  });
+
+  describe("enforce mode — trusted proxy, connect-src extras, report-uri", () => {
+    let app: FastifyInstance;
+    const security = {
+      cspMode: "enforce" as const,
+      cspConnectSrcExtra: "https://extra.example",
+      cspReportUri: "https://report.example/csp",
+      hstsEnabled: true,
+    };
+
+    beforeAll(async () => {
+      app = await buildApp({ ...baseConfig, webDistPath: webRoot, trustProxy: true, security });
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it("sends the full policy enforced, with no report-only header", async () => {
+      const res = await app.inject({ method: "GET", url: "/" });
+      expect(res.statusCode).toBe(200);
+      expectUnconditionalHeaders(res.headers);
+      const csp = res.headers["content-security-policy"];
+      expect(csp).toBe(buildCsp(security));
+      expect(res.headers["content-security-policy-report-only"]).toBeUndefined();
+      // Config plumbing: the operator-provided extra origin and report
+      // endpoint must land in the wire policy.
+      expect(csp).toContain("https://extra.example");
+      expect(csp).toContain("report-uri https://report.example/csp");
+    });
+
+    it("sends HSTS exactly for https (x-forwarded-proto behind trustProxy)", async () => {
+      const https = await app.inject({
+        method: "GET",
+        url: "/",
+        headers: { "x-forwarded-proto": "https" },
+      });
+      expect(https.headers["strict-transport-security"]).toBe("max-age=31536000");
+
+      const http = await app.inject({ method: "GET", url: "/" });
+      expect(http.headers["strict-transport-security"]).toBeUndefined();
+    });
+  });
+
+  describe("off mode — CSP escape hatch, HSTS disabled", () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      app = await buildApp({
+        ...baseConfig,
+        webDistPath: webRoot,
+        trustProxy: true,
+        security: { cspMode: "off", cspConnectSrcExtra: undefined, cspReportUri: undefined, hstsEnabled: false },
+      });
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it("sends no CSP headers on HTML but keeps the unconditional set", async () => {
+      const res = await app.inject({ method: "GET", url: "/" });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["content-type"]).toContain("text/html");
+      expectUnconditionalHeaders(res.headers);
+      expectNoCspHeaders(res.headers);
+    });
+
+    it("sends no HSTS on https when hstsEnabled=false", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/",
+        headers: { "x-forwarded-proto": "https" },
+      });
+      expect(res.headers["strict-transport-security"]).toBeUndefined();
+    });
+  });
+});
+
+describe("buildCsp", () => {
+  const defaults = { cspMode: "report-only" as const, hstsEnabled: true };
+
+  function directive(csp: string, name: string): string {
+    const match = csp.split("; ").find((d) => d.startsWith(`${name} `));
+    expect(match, `directive ${name} present`).toBeDefined();
+    return match ?? "";
+  }
+
+  it("emits the evidence-driven minimal policy", () => {
+    const csp = buildCsp(defaults);
+    expect(csp).toContain("default-src 'self'");
+    expect(directive(csp, "img-src")).toBe("img-src 'self' data: blob: https:");
+    expect(directive(csp, "style-src")).toBe("style-src 'self' 'unsafe-inline'");
+    expect(directive(csp, "font-src")).toBe("font-src 'self'");
+    expect(csp).toContain("manifest-src 'self'");
+    expect(csp).toContain("frame-src 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).not.toContain("'unsafe-eval'");
+    expect(csp).not.toContain("report-uri");
+  });
+
+  it("keeps script-src free of 'unsafe-inline' and redundant hosts", () => {
+    const scriptSrc = directive(buildCsp(defaults), "script-src");
+    expect(scriptSrc).toBe("script-src 'self' https://*.googletagmanager.com https://*.clarity.ms");
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+    // `https://*.clarity.ms` already matches www.clarity.ms — the explicit
+    // host would be redundant.
+    expect(scriptSrc).not.toContain("https://www.clarity.ms");
+  });
+
+  it("allowlists analytics + Sentry ingest in connect-src", () => {
+    const connectSrc = directive(buildCsp(defaults), "connect-src");
+    expect(connectSrc).toContain("'self'");
+    expect(connectSrc).toContain("https://*.google-analytics.com");
+    expect(connectSrc).toContain("https://*.analytics.google.com");
+    expect(connectSrc).toContain("https://*.googletagmanager.com");
+    expect(connectSrc).toContain("https://*.clarity.ms");
+    expect(connectSrc).toContain("https://c.bing.com");
+    expect(connectSrc).toContain("https://*.ingest.sentry.io");
+    expect(connectSrc).toContain("https://*.ingest.us.sentry.io");
+  });
+
+  it("normalizes connect-src extras: commas, whitespace, semicolons, newlines", () => {
+    const csp = buildCsp({
+      ...defaults,
+      cspConnectSrcExtra: "  https://a.example;,\n https://b.example ",
+    });
+    const connectSrc = directive(csp, "connect-src");
+    expect(connectSrc.endsWith("https://a.example https://b.example")).toBe(true);
+    // Directive-injection guard: no newline and no stray semicolon survives.
+    expect(csp).not.toContain("\n");
+    expect(csp).not.toContain(";;");
+  });
+
+  it("appends a sanitized report-uri as the final directive", () => {
+    const csp = buildCsp({ ...defaults, cspReportUri: " https://r.example/csp;\n" });
+    expect(csp.endsWith("; report-uri https://r.example/csp")).toBe(true);
+  });
+
+  it("drops a report-uri that is empty after sanitizing", () => {
+    const csp = buildCsp({ ...defaults, cspReportUri: " ;\n " });
+    expect(csp).not.toContain("report-uri");
+  });
+});
+
+describe("isHtmlContentType", () => {
+  it("accepts text/html with parameters and any casing", () => {
+    expect(isHtmlContentType("text/html")).toBe(true);
+    expect(isHtmlContentType("text/html; charset=utf-8")).toBe(true);
+    expect(isHtmlContentType("TEXT/HTML; Charset=UTF-8")).toBe(true);
+  });
+
+  it("rejects non-HTML, unset, and non-string header values", () => {
+    expect(isHtmlContentType("application/json; charset=utf-8")).toBe(false);
+    expect(isHtmlContentType("text/plain")).toBe(false);
+    expect(isHtmlContentType(undefined)).toBe(false);
+    expect(isHtmlContentType(["text/html"])).toBe(false);
+    expect(isHtmlContentType(42)).toBe(false);
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -76,6 +76,7 @@ import type { Config } from "./config.js";
 import { connectDatabase, sslOptions } from "./db/connection.js";
 import { AppError } from "./errors.js";
 import { agentSelectorHook } from "./middleware/agent-selector.js";
+import { createSecurityHeadersOnSendHook, type SecurityHeadersOptions } from "./middleware/security-headers.js";
 import { userAuthHook } from "./middleware/user-auth.js";
 import {
   applyLoggerConfig,
@@ -391,6 +392,30 @@ export async function buildApp(config: Config) {
   // and only fires on `statusCode >= 400`. Registered globally so any route
   // that flips the flag participates without extra wiring.
   app.addHook("onSend", bodyCaptureOnSendHook);
+
+  // App-wide browser security headers (issue #1541). Registered HERE — before
+  // any route registration — because Fastify routes snapshot the hook chain
+  // at registration time; only from this point does the hook cover the API
+  // routes, static assets, the SPA fallback and 404 / error responses alike.
+  // Header semantics, CSP allowlist rationale, and rollout modes live in
+  // middleware/security-headers.ts.
+  const securityHeadersOptions: SecurityHeadersOptions = {
+    cspMode: config.security?.cspMode ?? "report-only",
+    cspConnectSrcExtra: config.security?.cspConnectSrcExtra,
+    cspReportUri: config.security?.cspReportUri,
+    hstsEnabled: config.security?.hstsEnabled ?? true,
+  };
+  app.addHook("onSend", createSecurityHeadersOnSendHook(securityHeadersOptions));
+  // Surface the active mode on every boot (same spirit as the trustProxy
+  // warning above) so an operator can tell from the log alone whether CSP is
+  // still report-only, already enforcing, or switched off.
+  app.log.info(
+    {
+      cspMode: securityHeadersOptions.cspMode,
+      hstsEnabled: securityHeadersOptions.hstsEnabled,
+    },
+    "Security headers active",
+  );
 
   // Auth hooks
   const userAuth = userAuthHook(db, config.secrets.jwtSecret);

--- a/packages/server/src/middleware/security-headers.ts
+++ b/packages/server/src/middleware/security-headers.ts
@@ -1,0 +1,208 @@
+import type { DoneFuncWithErrOrRes, FastifyReply, FastifyRequest, onSendHookHandler } from "fastify";
+
+/**
+ * App-wide browser security headers (issue #1541 / SEC-041).
+ *
+ * The server is the only thing that ever answers browser requests in a
+ * deployment (TLS terminates at the edge, but no edge layer sets headers —
+ * there is no _headers / nginx / Caddy config in this repo), so the Fastify
+ * layer owns the full response-header security surface:
+ *
+ *   - A fixed set of headers on EVERY response (API JSON, static assets,
+ *     SPA HTML, 404 / error bodies, health checks).
+ *   - A Content-Security-Policy on `text/html` responses only — the SPA
+ *     shell served directly or via the SPA fallback, plus any other HTML
+ *     the server may emit (e.g. an `inline` HTML attachment).
+ *   - Strict-Transport-Security only when the request actually arrived over
+ *     https (behind the TLS-terminating proxy this requires the existing
+ *     FIRST_TREE_TRUST_PROXY=true so `request.protocol` reflects
+ *     X-Forwarded-Proto; plain-HTTP local dev never sees the header).
+ */
+export type SecurityHeadersOptions = {
+  /**
+   * CSP delivery mode for HTML responses:
+   *   - `report-only` (default): send the full policy as
+   *     Content-Security-Policy-Report-Only plus a small zero-risk enforced
+   *     subset. The spec ignores `frame-ancestors` in a report-only header,
+   *     so the anti-embedding requirement can only ship enforced — that is
+   *     why the two headers are split rather than sending RO alone.
+   *   - `enforce`: send the full policy as Content-Security-Policy.
+   *   - `off`: send no CSP header at all (emergency escape hatch; the
+   *     unconditional headers below are unaffected).
+   */
+  cspMode: "report-only" | "enforce" | "off";
+  /**
+   * Extra `connect-src` origins appended to the built-in allowlist,
+   * space- or comma-separated — e.g. a regional / self-hosted Sentry
+   * ingest domain not covered by the defaults.
+   */
+  cspConnectSrcExtra?: string;
+  /** CSP violation report endpoint (`report-uri` directive). */
+  cspReportUri?: string;
+  /** Send Strict-Transport-Security on https responses. */
+  hstsEnabled: boolean;
+};
+
+/**
+ * Zero-risk subset enforced while the full policy is still report-only:
+ * nothing in the app is ever framed, uses plugins, or rewrites its base URL,
+ * and `frame-ancestors` MUST be enforced to mean anything (see
+ * `SecurityHeadersOptions.cspMode`).
+ */
+const REPORT_ONLY_ENFORCED_SUBSET = "frame-ancestors 'none'; object-src 'none'; base-uri 'self'";
+
+/** One year, in seconds. No `includeSubDomains` / `preload`: the cloud host
+ * has no subdomains to protect, while a self-hosted operator experimenting
+ * with TLS on a shared parent domain would be locked out of plain-HTTP
+ * siblings — the blast radius is not worth the zero marginal win. */
+const HSTS_VALUE = "max-age=31536000";
+
+/**
+ * Build the full Content-Security-Policy string.
+ *
+ * Exported separately so tests can assert on the policy without booting an
+ * app. The allowlist is evidence-driven (see issue #1541):
+ *   - `script-src`: self (Vite emits only same-origin external scripts; the
+ *     former inline bootstrap now lives in `/init.js`) + the GA4 / Clarity
+ *     loader hosts. `https://*.clarity.ms` covers `www.clarity.ms`.
+ *   - `style-src 'unsafe-inline'`: React `style={{…}}` attributes are used
+ *     throughout the app (Radix / cmdk included); style attributes require
+ *     it.
+ *   - `img-src data: blob: https:`: chat images render as `data:` URLs,
+ *     upload previews use `URL.createObjectURL`, human avatars and
+ *     user-authored markdown reference arbitrary https images.
+ *   - `connect-src`: same-origin API/WS (`'self'` matches same-host ws/wss
+ *     per CSP3) + GA4 / Clarity collection + Sentry ingest domains, plus
+ *     the operator-provided extras.
+ *   - Everything is same-origin or denied otherwise; the app never frames
+ *     other content and must never be framed (`frame-ancestors 'none'`).
+ */
+export function buildCsp(options: SecurityHeadersOptions): string {
+  const connectSrc = [
+    "'self'",
+    "https://*.google-analytics.com",
+    "https://*.analytics.google.com",
+    "https://*.googletagmanager.com",
+    "https://*.clarity.ms",
+    "https://c.bing.com",
+    "https://*.ingest.sentry.io",
+    "https://*.ingest.us.sentry.io",
+    ...normalizeSourceList(options.cspConnectSrcExtra),
+  ];
+  const directives = [
+    "default-src 'self'",
+    "script-src 'self' https://*.googletagmanager.com https://*.clarity.ms",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self'",
+    `connect-src ${connectSrc.join(" ")}`,
+    "manifest-src 'self'",
+    "frame-src 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ];
+  const reportUri = normalizeReportUri(options.cspReportUri);
+  if (reportUri) {
+    directives.push(`report-uri ${reportUri}`);
+  }
+  return directives.join("; ");
+}
+
+/**
+ * `true` when a response `content-type` header value is HTML. Exported for
+ * unit tests. Handles the header being unset (e.g. a hijacked reply) and
+ * uppercase spellings; a string[] value (multi-value header) never happens
+ * for content-type, so it deliberately fails the check.
+ */
+export function isHtmlContentType(contentType: unknown): boolean {
+  return typeof contentType === "string" && contentType.toLowerCase().startsWith("text/html");
+}
+
+/**
+ * Global `onSend` hook applying the security headers described above.
+ *
+ * Must be registered before route registration (next to
+ * `bodyCaptureOnSendHook` in `buildApp`) — Fastify routes snapshot the hook
+ * chain at registration time, so only hooks added earlier cover the API
+ * routes, the static handler and the SPA fallback.
+ *
+ * Overwrite semantics: existing same-named headers are overwritten
+ * UNCONDITIONALLY. Today the only overlap is the attachment route's
+ * identical `X-Content-Type-Options: nosniff` (idempotent); if a route ever
+ * needs a differing value, switch this hook to set-if-absent explicitly
+ * rather than relying on registration order.
+ *
+ * Deliberately a CALLBACK hook, not an async one: the body is pure
+ * synchronous header writes, and every async onSend hook adds a microtask
+ * gap between `reply.send()` and the response head being written. A handler
+ * that calls `reply.send()` without returning the reply (fire-and-forget)
+ * can then race the head write and die with ERR_HTTP_HEADERS_SENT — adding
+ * a second async hook next to `bodyCaptureOnSendHook` reproducibly did so.
+ * The callback form adds zero async gap.
+ */
+export function createSecurityHeadersOnSendHook(options: SecurityHeadersOptions): onSendHookHandler {
+  // The header values are request-independent — compute them once.
+  const csp = buildCsp(options);
+
+  return function securityHeadersOnSendHook(
+    request: FastifyRequest,
+    reply: FastifyReply,
+    payload: unknown,
+    done: DoneFuncWithErrOrRes,
+  ): void {
+    reply.header("X-Content-Type-Options", "nosniff");
+    // Matches the modern-browser default → zero behavior change, but makes
+    // the guarantee explicit for sensitive paths like `/invite/:token`.
+    reply.header("Referrer-Policy", "strict-origin-when-cross-origin");
+    // Legacy-browser complement of `frame-ancestors 'none'`.
+    reply.header("X-Frame-Options", "DENY");
+    // Minimal deny-list: these device APIs are unused. `clipboard-write` is
+    // deliberately NOT restricted (copy buttons use navigator.clipboard).
+    reply.header("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+
+    // `request.protocol` is only "https" when TLS terminated here (never in
+    // this deployment) or when trustProxy makes X-Forwarded-Proto
+    // authoritative — so a spoofed XFP header without trustProxy can not
+    // conjure HSTS onto a plain-HTTP deployment.
+    if (options.hstsEnabled && request.protocol === "https") {
+      reply.header("Strict-Transport-Security", HSTS_VALUE);
+    }
+
+    if (options.cspMode !== "off" && isHtmlContentType(reply.getHeader("content-type"))) {
+      if (options.cspMode === "enforce") {
+        reply.header("Content-Security-Policy", csp);
+      } else {
+        reply.header("Content-Security-Policy", REPORT_ONLY_ENFORCED_SUBSET);
+        reply.header("Content-Security-Policy-Report-Only", csp);
+      }
+    }
+
+    done(null, payload);
+  };
+}
+
+/**
+ * Split an operator-provided source list on whitespace / commas, dropping
+ * `;` and newlines first so a mis-quoted env value cannot smuggle extra CSP
+ * directives into the policy.
+ */
+function normalizeSourceList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .replace(/[;\r\n]/g, " ")
+    .split(/[\s,]+/)
+    .filter((source) => source.length > 0);
+}
+
+/**
+ * Trim the report URI and strip `;`, whitespace and newlines — same
+ * directive-injection guard as `normalizeSourceList`. A URL containing any
+ * of these was invalid for `report-uri` anyway.
+ */
+function normalizeReportUri(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const cleaned = raw.replace(/[;\s]/g, "");
+  return cleaned.length > 0 ? cleaned : undefined;
+}

--- a/packages/shared/src/config/server-config.ts
+++ b/packages/shared/src/config/server-config.ts
@@ -297,6 +297,45 @@ export const serverConfigSchema = defineConfig({
     /** Actor-aware global safety cap. High enough to avoid normal-use 429s. */
     max: field(z.number().default(3000), { env: "FIRST_TREE_RATE_LIMIT_MAX" }),
   }),
+  security: optional({
+    /**
+     * Content-Security-Policy mode for HTML responses (the SPA shell).
+     * `report-only` (default) delivers the full policy as
+     * `Content-Security-Policy-Report-Only` plus a small always-enforced
+     * subset (`frame-ancestors` / `object-src` / `base-uri` — the spec
+     * ignores `frame-ancestors` in a report-only header, so anti-embedding
+     * only works enforced). `enforce` delivers the full policy as
+     * `Content-Security-Policy`. `off` sends no CSP header — an emergency
+     * escape hatch that leaves the other security headers untouched.
+     */
+    cspMode: field(z.enum(["report-only", "enforce", "off"]).default("report-only"), {
+      env: "FIRST_TREE_SECURITY_CSP_MODE",
+    }),
+    /**
+     * Extra `connect-src` origins appended to the built-in CSP allowlist,
+     * space- or comma-separated. Needed when a deployment reports to a
+     * Sentry region not covered by the defaults (`*.ingest.sentry.io`,
+     * `*.ingest.us.sentry.io`) or talks to another cross-origin endpoint.
+     */
+    cspConnectSrcExtra: field(z.string().optional(), {
+      env: "FIRST_TREE_SECURITY_CSP_CONNECT_SRC_EXTRA",
+    }),
+    /**
+     * CSP violation report endpoint (`report-uri` directive) — e.g. a
+     * Sentry security endpoint derived from the web DSN. Reports fire for
+     * report-only AND enforced policies, which is what makes the
+     * report-only rollout phase observable beyond browser consoles.
+     */
+    cspReportUri: field(z.string().url().optional(), { env: "FIRST_TREE_SECURITY_CSP_REPORT_URI" }),
+    /**
+     * Send `Strict-Transport-Security` on https responses. TLS terminates
+     * at the edge, so production needs the existing FIRST_TREE_TRUST_PROXY=true
+     * for `request.protocol` to reflect `X-Forwarded-Proto`; plain-HTTP
+     * traffic (local dev, container healthcheck) never receives the header.
+     * Set false as an escape hatch for a host that must return to HTTP.
+     */
+    hstsEnabled: field(z.boolean().default(true), { env: "FIRST_TREE_SECURITY_HSTS_ENABLED" }),
+  }),
   ws: optional({
     /**
      * Maximum payload size (bytes) for a single WebSocket frame on the

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -9,72 +9,14 @@
     <link rel="preload" href="/fonts/jetbrains-mono-latin.woff2" as="font" type="font/woff2" crossorigin />
     <title>First Tree</title>
     <!--
-      Google Analytics 4 — same property (G-BHG918MZ02) as first-tree.ai, with
-      cross-domain linking so a visitor who goes marketing-site -> cloud is
-      stitched into one user (that's what makes "click_app -> signup"
-      attributable per repo/campaign). send_page_view is off: this is a
-      react-router SPA, so RouteTracker (src/analytics.tsx) reports page_view on
-      every route change — leaving it on would double-count the first screen.
-
-      PRODUCTION ONLY: the Docker build produces one web dist for every channel,
-      so we gate here on hostname. Without this, dev (127.0.0.1) and staging
-      (dev.cloud.first-tree.ai) would load gtag and write into the shared
-      production property, polluting the attribution dataset. gtag is neither
-      fetched nor configured off the production host. analytics.tsx applies the
-      same host gate before sending, as defense in depth.
+      Theme, GA4 and Clarity bootstrap. Lives in an external same-origin file
+      (public/init.js) rather than inline <script> blocks so the
+      Content-Security-Policy can enforce script-src without 'unsafe-inline'
+      (issue 1541) — a guard test fails on any inline script added here.
+      Classic blocking script: it still runs before first paint (no theme
+      flash), exactly like the inline blocks it replaces.
     -->
-    <script>
-      (() => {
-        if (window.location.hostname !== "cloud.first-tree.ai") return;
-        window.dataLayer = window.dataLayer || [];
-        // Keep the official gtag queue shape. gtag.js consumes the function's
-        // Arguments object; pushing the rest-parameter Array leaves commands
-        // queued without producing GA collect requests in production.
-        window.gtag = function gtag() {
-          // biome-ignore lint/complexity/noArguments: the official gtag.js queue contract uses Arguments.
-          window.dataLayer.push(arguments);
-        };
-        const tag = document.createElement("script");
-        tag.async = true;
-        tag.src = "https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02";
-        document.head.appendChild(tag);
-        window.gtag("js", new Date());
-        window.gtag("config", "G-BHG918MZ02", {
-          send_page_view: false,
-          linker: { domains: ["first-tree.ai", "cloud.first-tree.ai"] },
-        });
-      })();
-    </script>
-    <!--
-      Microsoft Clarity — session insights for the production Web Console.
-      Like GA4, this is hostname-gated because the Docker build ships one dist
-      across channels; staging/local must not write into the production project.
-      The React app root is masked below so customer/workspace text is not
-      uploaded in Clarity recordings by default.
-    -->
-    <script>
-      (() => {
-        if (window.location.hostname !== "cloud.first-tree.ai") return;
-        window.clarity =
-          window.clarity ||
-          ((...args) => {
-            const queue = window.clarity.q || [];
-            window.clarity.q = queue;
-            queue.push(args);
-          });
-        const tag = document.createElement("script");
-        tag.async = true;
-        tag.src = "https://www.clarity.ms/tag/xj2f9syfng";
-        document.head.appendChild(tag);
-      })();
-    </script>
-    <script>
-      (() => {
-        const t = localStorage.getItem("theme");
-        const m = window.matchMedia("(prefers-color-scheme: dark)").matches;
-        if (t === "dark" || (!t && m)) document.documentElement.classList.add("dark");
-      })();
-    </script>
+    <script src="/init.js"></script>
   </head>
   <body>
     <div id="root" data-clarity-mask="true"></div>

--- a/packages/web/public/init.js
+++ b/packages/web/public/init.js
@@ -1,0 +1,76 @@
+/*
+  index.html bootstrap — theme, GA4 and Microsoft Clarity.
+
+  These used to be three inline <script> blocks in index.html. They live in
+  this external same-origin file so the Content-Security-Policy can enforce
+  `script-src` without 'unsafe-inline' (issue 1541). Vite copies public/
+  assets through verbatim, so dev and build serve the identical file.
+
+  Order matters: the theme snippet runs first — this file is loaded as a
+  classic blocking script in <head>, so the `dark` class lands on <html>
+  before first paint and the page cannot flash the wrong theme.
+*/
+
+(() => {
+  const t = localStorage.getItem("theme");
+  const m = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  if (t === "dark" || (!t && m)) document.documentElement.classList.add("dark");
+})();
+
+/*
+  Google Analytics 4 — same property (G-BHG918MZ02) as first-tree.ai, with
+  cross-domain linking so a visitor who goes marketing-site -> cloud is
+  stitched into one user (that's what makes "click_app -> signup"
+  attributable per repo/campaign). send_page_view is off: this is a
+  react-router SPA, so RouteTracker (src/analytics.tsx) reports page_view on
+  every route change — leaving it on would double-count the first screen.
+
+  PRODUCTION ONLY: the Docker build produces one web dist for every channel,
+  so we gate here on hostname. Without this, dev (127.0.0.1) and staging
+  (dev.cloud.first-tree.ai) would load gtag and write into the shared
+  production property, polluting the attribution dataset. gtag is neither
+  fetched nor configured off the production host. analytics.tsx applies the
+  same host gate before sending, as defense in depth.
+*/
+(() => {
+  if (window.location.hostname !== "cloud.first-tree.ai") return;
+  window.dataLayer = window.dataLayer || [];
+  // Keep the official gtag queue shape. gtag.js consumes the function's
+  // Arguments object; pushing the rest-parameter Array leaves commands
+  // queued without producing GA collect requests in production.
+  window.gtag = function gtag() {
+    // biome-ignore lint/complexity/noArguments: the official gtag.js queue contract uses Arguments.
+    window.dataLayer.push(arguments);
+  };
+  const tag = document.createElement("script");
+  tag.async = true;
+  tag.src = "https://www.googletagmanager.com/gtag/js?id=G-BHG918MZ02";
+  document.head.appendChild(tag);
+  window.gtag("js", new Date());
+  window.gtag("config", "G-BHG918MZ02", {
+    send_page_view: false,
+    linker: { domains: ["first-tree.ai", "cloud.first-tree.ai"] },
+  });
+})();
+
+/*
+  Microsoft Clarity — session insights for the production Web Console.
+  Like GA4, this is hostname-gated because the Docker build ships one dist
+  across channels; staging/local must not write into the production project.
+  The React app root is masked in index.html (data-clarity-mask) so
+  customer/workspace text is not uploaded in Clarity recordings by default.
+*/
+(() => {
+  if (window.location.hostname !== "cloud.first-tree.ai") return;
+  window.clarity =
+    window.clarity ||
+    ((...args) => {
+      const queue = window.clarity.q || [];
+      window.clarity.q = queue;
+      queue.push(args);
+    });
+  const tag = document.createElement("script");
+  tag.async = true;
+  tag.src = "https://www.clarity.ms/tag/xj2f9syfng";
+  document.head.appendChild(tag);
+})();

--- a/packages/web/src/__tests__/analytics.test.ts
+++ b/packages/web/src/__tests__/analytics.test.ts
@@ -2,12 +2,14 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { sanitizePath } from "../analytics.js";
 
-const indexHtml = readFileSync(new URL("../../index.html", import.meta.url), "utf8");
+// The gtag bootstrap lives in public/init.js — external rather than inline
+// so the CSP can enforce script-src without 'unsafe-inline' (issue 1541).
+const initJs = readFileSync(new URL("../../public/init.js", import.meta.url), "utf8");
 
 describe("production gtag bootstrap", () => {
   it("queues the official Arguments object so gtag.js processes commands", () => {
-    expect(indexHtml).toContain("window.dataLayer.push(arguments)");
-    expect(indexHtml).not.toContain("window.dataLayer.push(args)");
+    expect(initJs).toContain("window.dataLayer.push(arguments)");
+    expect(initJs).not.toContain("window.dataLayer.push(args)");
   });
 });
 

--- a/packages/web/tests/index-html-no-inline-scripts.test.ts
+++ b/packages/web/tests/index-html-no-inline-scripts.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * CSP guard (issue 1541): the server delivers `script-src` WITHOUT
+ * 'unsafe-inline', so any inline `<script>` in index.html would be silently
+ * dead in production once the CSP is enforced. The former inline bootstrap
+ * (theme / GA4 / Clarity) lives in `public/init.js`; this test fails the
+ * build the moment someone adds a new inline script or drops the external
+ * bootstrap, instead of the regression surfacing as a broken page.
+ */
+const indexHtml = readFileSync(fileURLToPath(new URL("../index.html", import.meta.url)), "utf8");
+const initJs = readFileSync(fileURLToPath(new URL("../public/init.js", import.meta.url)), "utf8");
+// Browsers ignore markup inside comments, so the guard should too — the
+// prose comment above the bootstrap tag legitimately mentions "<script>".
+const markup = indexHtml.replace(/<!--[\s\S]*?-->/g, "");
+
+describe("index.html CSP guard", () => {
+  it("has only external <script> tags (every script tag carries src=)", () => {
+    const scriptTags = markup.match(/<script\b[^>]*>/gi) ?? [];
+    expect(scriptTags.length).toBeGreaterThan(0);
+    for (const tag of scriptTags) {
+      expect(tag, `inline script is incompatible with the enforced CSP: ${tag}`).toMatch(/\bsrc\s*=/);
+    }
+  });
+
+  it("loads the /init.js bootstrap", () => {
+    expect(markup).toContain('<script src="/init.js"></script>');
+  });
+
+  it("carries no meta CSP — the policy is owned by the server response headers", () => {
+    // A <meta http-equiv="Content-Security-Policy"> would fork the policy
+    // definition; frame-ancestors and report-uri are not even valid there.
+    expect(markup.toLowerCase()).not.toContain("http-equiv");
+  });
+});
+
+describe("public/init.js bootstrap", () => {
+  it("runs theme initialization before the analytics loaders (FOUC guard)", () => {
+    const themeIndex = initJs.indexOf('localStorage.getItem("theme")');
+    const gtagIndex = initJs.indexOf("googletagmanager.com");
+    const clarityIndex = initJs.indexOf("clarity.ms");
+    expect(themeIndex).toBeGreaterThan(-1);
+    expect(gtagIndex).toBeGreaterThan(-1);
+    expect(clarityIndex).toBeGreaterThan(-1);
+    expect(themeIndex).toBeLessThan(gtagIndex);
+    expect(gtagIndex).toBeLessThan(clarityIndex);
+  });
+
+  it("keeps the production hostname gate on both analytics loaders", () => {
+    const gates = initJs.match(/window\.location\.hostname !== "cloud\.first-tree\.ai"/g) ?? [];
+    expect(gates).toHaveLength(2);
+  });
+});

--- a/packages/web/tests/index-html-no-inline-scripts.test.ts
+++ b/packages/web/tests/index-html-no-inline-scripts.test.ts
@@ -1,4 +1,6 @@
+// @vitest-environment happy-dom
 import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
@@ -10,29 +12,37 @@ import { describe, expect, it } from "vitest";
  * build the moment someone adds a new inline script or drops the external
  * bootstrap, instead of the regression surfacing as a broken page.
  */
-const indexHtml = readFileSync(fileURLToPath(new URL("../index.html", import.meta.url)), "utf8");
-const initJs = readFileSync(fileURLToPath(new URL("../public/init.js", import.meta.url)), "utf8");
-// Browsers ignore markup inside comments, so the guard should too — the
-// prose comment above the bootstrap tag legitimately mentions "<script>".
-const markup = indexHtml.replace(/<!--[\s\S]*?-->/g, "");
+// happy-dom shadows the global URL, so resolve paths without `new URL(...)`:
+// `import.meta.url` stays a file:// string that fileURLToPath handles directly.
+const webRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const indexHtml = readFileSync(join(webRoot, "index.html"), "utf8");
+const initJs = readFileSync(join(webRoot, "public", "init.js"), "utf8");
+// Parse the markup instead of regex-scanning it so commented-out markup is
+// ignored exactly the way a browser ignores it (the prose comment above the
+// bootstrap tag legitimately mentions "<script>"). DOMParser documents are
+// inert: nothing from index.html executes here.
+const doc = new DOMParser().parseFromString(indexHtml, "text/html");
 
 describe("index.html CSP guard", () => {
   it("has only external <script> tags (every script tag carries src=)", () => {
-    const scriptTags = markup.match(/<script\b[^>]*>/gi) ?? [];
-    expect(scriptTags.length).toBeGreaterThan(0);
-    for (const tag of scriptTags) {
-      expect(tag, `inline script is incompatible with the enforced CSP: ${tag}`).toMatch(/\bsrc\s*=/);
+    const scripts = Array.from(doc.querySelectorAll("script"));
+    expect(scripts.length).toBeGreaterThan(0);
+    for (const script of scripts) {
+      expect(
+        script.hasAttribute("src"),
+        `inline script is incompatible with the enforced CSP: ${script.outerHTML}`,
+      ).toBe(true);
     }
   });
 
   it("loads the /init.js bootstrap", () => {
-    expect(markup).toContain('<script src="/init.js"></script>');
+    expect(doc.querySelector('script[src="/init.js"]')).not.toBeNull();
   });
 
   it("carries no meta CSP — the policy is owned by the server response headers", () => {
     // A <meta http-equiv="Content-Security-Policy"> would fork the policy
     // definition; frame-ancestors and report-uri are not even valid there.
-    expect(markup.toLowerCase()).not.toContain("http-equiv");
+    expect(doc.querySelector("meta[http-equiv]")).toBeNull();
   });
 });
 


### PR DESCRIPTION
Fixes #1541 (and the SEC-041 audit addendum on it).

## Problem

The Fastify server serves both the API and the SPA, and nothing in the repo — app code, Dockerfile, or any edge config — sets browser security headers. No CSP, no frame protection, no HSTS, no global `nosniff` (only the attachments route set one locally), while `index.html` ran three inline scripts (GA4, Clarity, theme init) with full origin authority.

## Approach

One `onSend` hook (`packages/server/src/middleware/security-headers.ts`), registered alongside the existing global body-capture hook **before any route or static registration**, so it covers API JSON, static assets, the SPA shell (direct and fallback), 404/error bodies, and health checks:

- **On every response** — `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `X-Frame-Options: DENY`, `Permissions-Policy: camera=(), microphone=(), geolocation=()` (clipboard deliberately not restricted — the app uses it), and `Strict-Transport-Security: max-age=31536000` only when the request arrived over https (`FIRST_TREE_TRUST_PROXY=true` in proxied deployments; plain-HTTP dev never sees it; no `includeSubDomains`/`preload` by design — self-hosted operators on shared parent domains would be the blast radius).
- **On `text/html` responses only** — CSP, staged:
  - enforced immediately (all modes except `off`): `frame-ancestors 'none'; object-src 'none'; base-uri 'self'` — the anti-embedding requirement can only ship enforced because the spec ignores `frame-ancestors` in report-only headers;
  - the full least-privilege policy (script/img/connect/style/font/manifest/form-action) ships as **Content-Security-Policy-Report-Only** by default (`FIRST_TREE_SECURITY_CSP_MODE=report-only`), with `FIRST_TREE_SECURITY_CSP_REPORT_URI` for violation collection, flipping to `enforce` after an observation cycle. `off` is the emergency escape hatch.
  - A side benefit: HTML attachments served `inline` now also carry the CSP, constraining the stored-HTML-attachment XSS surface.
- **Inline scripts externalized** to `packages/web/public/init.js` (theme init first to keep the no-FOUC guarantee, GA4/Clarity order and production hostname gates preserved verbatim), so `script-src` needs no `'unsafe-inline'`. A web-side guard test keeps `index.html` inline-free.

Config lives in the shared server config (`security` block, four `FIRST_TREE_SECURITY_*` envs, documented in `docs/cli-reference.md`); boot logs one line with the active `cspMode`/`hstsEnabled`.

`@fastify/helmet` was evaluated and not used: the two load-bearing behaviors here are conditional (CSP by content type, HSTS by request protocol), which helmet does not express natively, and its COOP default would break the GitHub-App install popup flow — a fully hand-rolled ~small hook is simpler to test than helmet-plus-overrides.

## Implementation note reviewers should know

The hook is written in Fastify's callback (`done`) style, not async: adding a second **async** `onSend` hook exposed a latent race with a fire-and-forget `reply.status(204).send()` in an existing route handler (unhandled `ERR_HTTP_HEADERS_SENT`), reproduced minimally and sidestepped by not adding a microtask window. The pre-existing pattern deserves its own sweep — follow-up issue suggested rather than folded into this PR.

## Verification

- `pnpm check` / `pnpm typecheck` green.
- New `security-headers.test.ts`: **18/18** — exact-value assertions for every unconditional header, CSP scope (HTML yes; `/assets`, API 404, `/healthz` no), report-only vs enforce vs off, connect-src extension and report-uri normalization (directive-injection resistant), HSTS positive/negative including the trust-boundary case (`trustProxy: false` + forged `X-Forwarded-Proto` sends nothing), content-type edge cases.
- Full server package: **239 files / 2581 tests green**. Web package: **193 files / 1569 tests green** (includes the new index.html guard test). `pnpm --filter @first-tree/web build` verified: dist HTML has no inline script; `init.js` passes through byte-identical.
- Rollout runbook (in-repo docs + this PR): keep `report-only` for one release cycle with reports pointed at a Sentry security endpoint, staging first, then flip the default to `enforce`.

---

Designed and reviewed with fire-fable-reviewer (design round 1 absorbed: external avatar evidence for `img-src https:`, HTML-attachment surface, cache semantics, report collection as a hard requirement). Goblet of Fire competition submission — kept as **draft** per competition rules.
