### PR TITLE
fix: serialize startup migrations across replicas with a held advisory lock

### DIFF
--- a/packages/server/src/__tests__/bootstrap-migration-lock.test.ts
+++ b/packages/server/src/__tests__/bootstrap-migration-lock.test.ts
@@ -1,25 +1,23 @@
 import postgres from "postgres";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { sslOptions } from "../db/connection.js";
 import { runMigrations } from "../db/migrate.js";
 
 /**
  * Pins the `hashtext('drizzle_migrations')` key used by
- * `preflightMigrationLock`. If a future drizzle bump changes the lock key,
- * this test stays green only as long as the preflight constant matches the
- * one we hold here — meaning the preflight and the holder both speak to the
+ * `acquireMigrationLock`. If a future drizzle bump changes the lock key,
+ * this test stays green only as long as the constant matches the one we
+ * hold here — meaning the replica lock and the holder both speak to the
  * same advisory-lock slot.
  *
- * See `packages/server/src/db/migrate.ts` `MIGRATION_LOCK_KEY_SQL` comment
- * for the verification path through drizzle-orm.
+ * Since PERF-027 the lock is held across the whole `migrate()` call, so
+ * these cases cover both the contention timeout and the wait-then-proceed
+ * serialization path. See `packages/server/src/db/migrate.ts`
+ * `MIGRATION_LOCK_KEY_SQL` comment for the verification path through
+ * drizzle-orm.
  */
-describe("preflightMigrationLock (T10)", () => {
+describe("migration advisory lock (T10)", () => {
   const databaseUrl = process.env.DATABASE_URL;
-
-  afterEach(() => {
-    // No shared state between cases — each opens / closes its own postgres
-    // client, and the lock is session-scoped so it goes away on .end().
-  });
 
   it("throws migration lock contention when another session holds hashtext('drizzle_migrations')", async () => {
     expect(databaseUrl, "DATABASE_URL must be set by global setup").toBeTruthy();
@@ -32,8 +30,8 @@ describe("preflightMigrationLock (T10)", () => {
     try {
       await holder`SELECT pg_advisory_lock(hashtext('drizzle_migrations'))`;
 
-      // Use a tight 2s preflight timeout so the contention path completes
-      // fast. The 30s production default is the right answer for boot, not
+      // Use a tight 2s lock-wait timeout so the contention path completes
+      // fast. The 15s production default is the right answer for boot, not
       // for a unit test that just needs to assert the error path.
       await expect(runMigrations(url, { lockTimeoutMs: 2_000 })).rejects.toThrow(/migration lock contention/);
     } finally {
@@ -44,9 +42,50 @@ describe("preflightMigrationLock (T10)", () => {
     }
   });
 
+  it("waits for a held lock and migrates after the holder releases (replica serialization)", async () => {
+    expect(databaseUrl, "DATABASE_URL must be set by global setup").toBeTruthy();
+    const url = databaseUrl ?? "";
+
+    // Simulate the rollout race: another replica (holder) owns the lock
+    // while this replica boots. runMigrations must wait — not error, not
+    // proceed lock-free — and once the holder releases, the journal has
+    // advanced so its own migrate is a cheap no-op.
+    const holder = postgres(url, { max: 1, ...sslOptions(url) });
+    try {
+      await holder`SELECT pg_advisory_lock(hashtext('drizzle_migrations'))`;
+
+      let settled = false;
+      const pending = runMigrations(url, { lockTimeoutMs: 10_000 }).then(
+        (tableCount) => {
+          settled = true;
+          return tableCount;
+        },
+        (error: unknown) => {
+          settled = true;
+          throw error;
+        },
+      );
+
+      // 2s >> the 1s poll interval, so a working wait path cannot have
+      // settled yet; a broken (lock-free) path settles within milliseconds.
+      await new Promise((r) => setTimeout(r, 2_000));
+      expect(settled, "runMigrations must keep waiting while another session holds the lock").toBe(false);
+
+      await holder`SELECT pg_advisory_unlock(hashtext('drizzle_migrations'))`;
+
+      const tableCount = await pending;
+      expect(tableCount).toBeGreaterThan(0);
+    } finally {
+      // No-op if the test already unlocked (pg_advisory_unlock just returns
+      // false); keeps the worker unblocked on assertion failures.
+      await holder`SELECT pg_advisory_unlock(hashtext('drizzle_migrations'))`;
+      await holder.end();
+    }
+  });
+
   it("succeeds when the advisory lock is free", async () => {
     expect(databaseUrl, "DATABASE_URL must be set by global setup").toBeTruthy();
-    // Sanity case: with no holder, preflight returns fast and migrate runs.
+    // Sanity case: with no holder, the lock is acquired fast and migrate runs.
     const tableCount = await runMigrations(databaseUrl ?? "");
     expect(tableCount).toBeGreaterThan(0);
   });

--- a/packages/server/src/bootstrap-server.ts
+++ b/packages/server/src/bootstrap-server.ts
@@ -87,13 +87,15 @@ export async function startServer(deps: ServerBootstrapDeps = {}): Promise<void>
   // failed}` logs emitted by `runStage`, which are sufficient for boot
   // analysis without dragging a context onto every downstream span.
 
-  // Run Drizzle migrations before the app comes up. Idempotent under
-  // multi-replica startup (Drizzle journal table); cold-start cost is a few
-  // hundred ms when there's nothing new to apply. The 20s budget matches
-  // the Dockerfile HEALTHCHECK start-period so a migration that truly
-  // exceeds it fails the boot fast rather than letting docker judge
-  // unhealthy mid-migration. If a future migration is known to run longer,
-  // raise both this and the HEALTHCHECK start-period together.
+  // Run Drizzle migrations before the app comes up. Serialized across
+  // replicas by a session-level advisory lock held for the whole migrate
+  // (see db/migrate.ts): non-owner replicas wait, and once they acquire the
+  // lock the journal has advanced, so their migrate is a no-op. The 20s
+  // budget matches the Dockerfile HEALTHCHECK start-period so a migration
+  // (including the lock wait) that truly exceeds it fails the boot fast
+  // rather than letting docker judge unhealthy mid-migration. If a future
+  // migration is known to run longer, raise both this and the HEALTHCHECK
+  // start-period together.
   const tableCount = await runStage(
     "runMigrations",
     () => (deps.runMigrations ?? runMigrations)(serverConfig.database.url),

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -4,7 +4,10 @@ import { fileURLToPath } from "node:url";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
+import { createLogger } from "../observability/index.js";
 import { sslOptions } from "./connection.js";
+
+const log = createLogger("Migrations");
 
 /**
  * Resolve the drizzle migrations directory.
@@ -53,18 +56,23 @@ function validateJournalOrder(migrationsFolder: string): void {
 }
 
 /**
- * Advisory-lock key used by the preflight check.
+ * Advisory-lock key serializing startup migrations across replicas (T10).
  *
  * Verified against `drizzle-orm@0.44.7`:
  *   - `node_modules/drizzle-orm/postgres-js/migrator.js` → delegates to
  *     `node_modules/drizzle-orm/pg-core/dialect.js::migrate()`, which
  *     **does NOT acquire any advisory lock** in this version; it only wraps
  *     `INSERT INTO drizzle.__drizzle_migrations` in a transaction.
- *   - So this preflight is **purely defensive**: it surfaces *external*
- *     holders (an operator's `SELECT pg_advisory_lock(...)`, a stale
- *     prior-replica session that exited mid-migration with the lock held,
- *     or a future drizzle release that re-introduces locking) within the
- *     timeout window instead of letting drizzle hang silently.
+ *   - The journal table makes migrations idempotent but NOT serialized:
+ *     without this lock, two replicas starting together both execute
+ *     DDL/backfills concurrently (duplicate-object errors, duplicated data
+ *     work, failed rollout replicas — PERF-027).
+ *
+ * The lock is acquired on the same dedicated connection that then runs
+ * `migrate()`, and is held from acquisition through the final statement so
+ * the lock window covers the full operation. Non-owner replicas poll until
+ * the owner releases; once they acquire it, the journal has already
+ * advanced and their `migrate()` is a no-op.
  *
  * If you bump `drizzle-orm`, re-read `pg-core/dialect.js::migrate()` and
  * update this key (and `MIGRATION_LOCK_TIMEOUT_MS`) accordingly. The
@@ -72,49 +80,49 @@ function validateJournalOrder(migrationsFolder: string): void {
  * behavior using the same key.
  */
 const MIGRATION_LOCK_KEY_SQL = "hashtext('drizzle_migrations')";
-// Sits inside the 20s `runMigrations` stage budget set in `index.ts`; 15s
-// preflight + ≥5s for the actual drizzle migrate call. If you raise either,
-// raise the other in lockstep (and re-evaluate the Dockerfile HEALTHCHECK
-// `--start-period`).
+// Sits inside the 20s `runMigrations` stage budget set in `bootstrap-server.ts`;
+// 15s lock wait + ≥5s for the actual drizzle migrate call. A waiting replica
+// can block for the holder's whole migrate, so if a future migration is known
+// to run longer, raise this budget, the stage budget, and the Dockerfile
+// HEALTHCHECK `--start-period` in lockstep.
 const DEFAULT_MIGRATION_LOCK_TIMEOUT_MS = 15_000;
 const MIGRATION_LOCK_POLL_INTERVAL_MS = 1_000;
 
 export type RunMigrationsOptions = {
-  /** Override the preflight advisory-lock timeout. Default 15s. */
+  /** Override the advisory-lock wait timeout. Default 15s. */
   lockTimeoutMs?: number;
 };
 
 /**
- * Probe the advisory-lock key drizzle would use for migrations. If another
- * session holds it, fail with a clear message instead of letting drizzle's
- * `migrate()` hang forever. We don't keep the lock — see the key constant
- * above for the full rationale. See server-bootstrap-resilience-design.md §3 (T10).
+ * Acquire the migration advisory lock on `client`, polling once per second
+ * until `timeoutMs` elapses. Throws a clear contention error on timeout; on
+ * success the caller owns the lock and MUST release it (see `runMigrations`).
+ * The lock is session-scoped, so it is also released automatically if the
+ * connection drops — a crashed replica never leaves an orphan lock behind.
  */
-async function preflightMigrationLock(databaseUrl: string, timeoutMs: number): Promise<void> {
-  const ssl = sslOptions(databaseUrl);
-  const client = postgres(databaseUrl, { max: 1, ...ssl });
+async function acquireMigrationLock(client: postgres.Sql, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
-  try {
-    while (true) {
-      const rows = (await client.unsafe(
-        `SELECT pg_try_advisory_lock(${MIGRATION_LOCK_KEY_SQL}) AS acquired`,
-      )) as Array<{
-        acquired: boolean;
-      }>;
-      if (rows[0]?.acquired) {
-        await client.unsafe(`SELECT pg_advisory_unlock(${MIGRATION_LOCK_KEY_SQL})`);
-        return;
-      }
-      if (Date.now() >= deadline) {
-        throw new Error(
-          `migration lock contention — another process holds drizzle migration lock (${MIGRATION_LOCK_KEY_SQL}) ` +
-            `after ${timeoutMs}ms`,
-        );
-      }
-      await new Promise((r) => setTimeout(r, MIGRATION_LOCK_POLL_INTERVAL_MS));
+  let loggedWait = false;
+  while (true) {
+    const rows = (await client.unsafe(`SELECT pg_try_advisory_lock(${MIGRATION_LOCK_KEY_SQL}) AS acquired`)) as Array<{
+      acquired: boolean;
+    }>;
+    if (rows[0]?.acquired) {
+      return;
     }
-  } finally {
-    await client.end();
+    if (!loggedWait) {
+      // A replica blocked here would otherwise sit silent until the timeout
+      // crash — log once so operators can see who it is waiting on.
+      log.info({ lockKey: MIGRATION_LOCK_KEY_SQL }, "waiting for migration lock held by another session");
+      loggedWait = true;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `migration lock contention — another process holds drizzle migration lock (${MIGRATION_LOCK_KEY_SQL}) ` +
+          `after ${timeoutMs}ms`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, MIGRATION_LOCK_POLL_INTERVAL_MS));
   }
 }
 
@@ -123,32 +131,41 @@ async function preflightMigrationLock(databaseUrl: string, timeoutMs: number): P
  * migration, used as a rough indicator that the schema landed.
  */
 export async function runMigrations(databaseUrl: string, options: RunMigrationsOptions = {}): Promise<number> {
+  // Validation must stay before any postgres client is created — the edge
+  // tests assert no connection is opened for validation failures.
   const migrationsFolder = resolveMigrationsFolder();
 
   validateJournalOrder(migrationsFolder);
 
-  await preflightMigrationLock(databaseUrl, options.lockTimeoutMs ?? DEFAULT_MIGRATION_LOCK_TIMEOUT_MS);
-
   const ssl = sslOptions(databaseUrl);
-
+  // max: 1 keeps the advisory lock and migrate() on one session, so the lock
+  // covers the full migration (see the MIGRATION_LOCK_KEY_SQL comment above).
   const client = postgres(databaseUrl, { max: 1, ...ssl });
-  const db = drizzle(client);
-
+  let lockAcquired = false;
   try {
+    await acquireMigrationLock(client, options.lockTimeoutMs ?? DEFAULT_MIGRATION_LOCK_TIMEOUT_MS);
+    lockAcquired = true;
+
+    const db = drizzle(client);
     await migrate(db, { migrationsFolder });
-  } finally {
-    await client.end();
-  }
 
-  const countClient = postgres(databaseUrl, { max: 1, ...ssl });
-  try {
-    const result = await countClient`
+    const result = await client`
       SELECT count(*)::int AS count
       FROM information_schema.tables
       WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
     `;
     return (result[0] as { count: number }).count;
   } finally {
-    await countClient.end();
+    if (lockAcquired) {
+      try {
+        await client.unsafe(`SELECT pg_advisory_unlock(${MIGRATION_LOCK_KEY_SQL})`);
+      } catch (unlockError) {
+        // Best-effort release: if the connection died mid-migration the
+        // server has already dropped the session lock. Never mask the
+        // original migrate error with an unlock failure.
+        log.warn({ err: unlockError }, "failed to release migration advisory lock explicitly");
+      }
+    }
+    await client.end();
   }
 }


### PR DESCRIPTION
## Summary

Fixes #1690 (PERF-027, High): startup migrations were not serialized across replicas.

`runMigrations` previously probed the advisory lock in a preflight step and **released it before** the actual Drizzle `migrate()` ran. Every replica in a rolling deploy could then pass the preflight and execute DDL/backfills concurrently with no lock covering the operation — duplicate-object errors, duplicated data work, and failed rollout replicas.

The advisory lock (`hashtext('drizzle_migrations')`, unchanged) is now acquired on the same dedicated `max: 1` connection that runs `migrate()`, and is held from acquisition through the final statement. Non-owner replicas poll once per second until the owner releases; by the time they acquire it, the journal has advanced and their `migrate()` is a no-op. The lock is session-scoped, so a crashed or killed replica never leaves an orphan lock.

## Why hold a session-level lock across the whole migrate

- Verified against `drizzle-orm@0.44.7`: `pg-core/dialect.js::migrate()` acquires **no advisory lock at all**; it only wraps the journal insert in a transaction. The journal table makes migrations idempotent but **not serialized**, so the lock must come from us.
- Acquiring and running on one connection guarantees the lock window covers the full operation with no gap between "preflight" and execution.

## Waiter semantics (why this is safe for rollouts)

A non-owner replica waits at most `lockTimeoutMs` (15s default, unchanged) — inside the 20s `runMigrations` stage budget, which matches the Dockerfile `HEALTHCHECK --start-period=20s`. On timeout it fails with the same `migration lock contention` error as before; the orchestrator restarts it, and the next attempt passes quickly because the journal has already advanced. This fail-fast behavior is identical in shape to the previous preflight timeout; only the lock window changed. A first-wait `log.info` ("waiting for migration lock held by another session") was added so a blocked replica is no longer silent until the crash.

The `drizzle-kit migrate` (`db:migrate`) path is intentionally untouched: it is operator/CI-triggered, not a multi-replica boot race, and outside the issue's scope.

## Test plan

`packages/server/src/__tests__/bootstrap-migration-lock.test.ts` (testcontainers Postgres):

- **Kept:** contention timeout — external holder owns the lock, `runMigrations({ lockTimeoutMs: 2_000 })` rejects with `migration lock contention`.
- **New (acceptance for this fix):** replica serialization — holder owns the lock; `runMigrations` is started with a 10s budget and asserted to still be waiting after 2s; once the holder releases, it resolves with `tableCount > 0` (journal already advanced, migrate is a no-op).
- **Kept:** success path with a free lock.

`db-migrate-edge.test.ts` unchanged and still green: folder/journal validation still runs before any postgres client is constructed.

## QA

Touches the boot/migration path. Matches existing case `packages/qa/cases/cross-surface/release-boot-health.md` (PASS criteria unaffected — no case edit needed); **formal QA warranted** per repo testing policy. Optional variant worth running: boot 2 server replicas simultaneously against one Postgres and observe one waiting on the lock, then booting clean.

## Verification

- `pnpm check` ✅
- `pnpm typecheck` ✅
- `pnpm --filter @first-tree/server test` ✅ (incl. the new serialization case)

---

🤖 Goblet of Fire competition entry — stays **draft** by design.
