### PR TITLE
fix(client): validate managed skill names before reconcile deletion

### DIFF
--- a/packages/client/src/__tests__/first-tree-skills-installer-extra.test.ts
+++ b/packages/client/src/__tests__/first-tree-skills-installer-extra.test.ts
@@ -10,12 +10,13 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   installFirstTreeSkills,
   installOneSkill,
   resolveBundledSkillsRoot,
+  resolveWithinSkillsRoot,
   TREE_SKILL_NAMES,
 } from "../runtime/first-tree-skills/installer.js";
 import { writeManagedState } from "../runtime/managed-state.js";
@@ -204,5 +205,23 @@ describe("first-tree skill installer edge coverage", () => {
     expect(mod.installOneSkill(workspace, skillLayout(bundledRoot))).toBe("installed");
 
     expect(existsSync(join(workspace, ".claude", "skills", "first-tree-write", ".sentinel"))).toBe(true);
+  });
+});
+
+describe("resolveWithinSkillsRoot", () => {
+  it("returns the resolved target for a name inside the root", () => {
+    expect(resolveWithinSkillsRoot(join("tmp", "skills-root"), "first-tree-write")).toBe(
+      resolve("tmp", "skills-root", "first-tree-write"),
+    );
+  });
+
+  it("refuses targets equal to the root or escaping it (#1610)", () => {
+    const root = join("tmp", "skills-root");
+    expect(resolveWithinSkillsRoot(root, ".")).toBeNull();
+    expect(resolveWithinSkillsRoot(root, "")).toBeNull();
+    expect(resolveWithinSkillsRoot(root, "..")).toBeNull();
+    expect(resolveWithinSkillsRoot(root, "../sibling")).toBeNull();
+    expect(resolveWithinSkillsRoot(root, "../../outside")).toBeNull();
+    expect(resolveWithinSkillsRoot(root, "/abs/path")).toBeNull();
   });
 });

--- a/packages/client/src/__tests__/managed-state.test.ts
+++ b/packages/client/src/__tests__/managed-state.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  isManagedSkillName,
   MANAGED_STATE_REL,
   type ManagedState,
   readManagedState,
@@ -180,5 +181,48 @@ describe("managed-state", () => {
 
     const agentDir = join(workspace, ".first-tree-workspace");
     expect(readdirSync(agentDir).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
+  });
+
+  it("isManagedSkillName accepts current and historical skill slugs", () => {
+    for (const name of ["first-tree-write", "context-tree-review", "first-tree-gitlab", "a", "0", "x".repeat(63)]) {
+      expect(isManagedSkillName(name)).toBe(true);
+    }
+  });
+
+  it("isManagedSkillName rejects path-like and malformed names (#1610)", () => {
+    for (const name of [
+      "..",
+      "../..",
+      "../../etc",
+      "/etc/passwd",
+      "a/b",
+      "a\\b",
+      "C:\\temp",
+      "",
+      "has space",
+      "line\nbreak",
+      "nul\u0000byte",
+      "Foo",
+      "under_score",
+      "dot.name",
+      "-leading-dash",
+      "x".repeat(64),
+    ]) {
+      expect(isManagedSkillName(name)).toBe(false);
+    }
+  });
+
+  it("drops invalid skill names on read — the state file is untrusted input (#1610)", () => {
+    writeFileSync(
+      join(workspace, MANAGED_STATE_REL),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: null,
+        updatedAt: "2026-06-08T16:00:00.000Z",
+        skills: ["first-tree-write", "../../outside", "/etc/passwd", "..", "", "has space", "Foo"],
+      }),
+      "utf-8",
+    );
+    expect(readManagedState(workspace)?.skills).toEqual(["first-tree-write"]);
   });
 });

--- a/packages/client/src/__tests__/skills-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/skills-state-reconcile.test.ts
@@ -9,12 +9,21 @@
 // Helper-level coverage of the installer copy logic lives in
 // `bootstrap.test.ts`; this file proves the reconcile wiring in PR #869.
 
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { installFirstTreeSkills, TREE_SKILL_NAMES } from "../runtime/first-tree-skills/installer.js";
-import { readManagedState, writeManagedState } from "../runtime/managed-state.js";
+import { MANAGED_STATE_REL, readManagedState, writeManagedState } from "../runtime/managed-state.js";
 
 /**
  * Build a bundled-skills root mirroring the shape `installFirstTreeSkills`
@@ -160,5 +169,47 @@ describe("installFirstTreeSkills — state-based skill reconcile (PR #869 P1-3)"
     for (const name of TREE_SKILL_NAMES) {
       expect(existsSync(join(workspace, ".agents", "skills", name, "SKILL.md"))).toBe(true);
     }
+  });
+
+  it("never deletes outside the skills roots for hostile names in prev state (#1610)", () => {
+    // Sentinel OUTSIDE the workspace, reachable only through a traversal
+    // name: `join(workspace, ".agents/skills", "../../../outside-payload")`
+    // would normalize to `<tmpBase>/outside-payload` without validation.
+    const outsidePayload = join(tmpBase, "outside-payload");
+    mkdirSync(outsidePayload, { recursive: true });
+    writeFileSync(join(outsidePayload, "sentinel.txt"), "do not delete");
+
+    // A legitimate stale skill the reconcile must still remove.
+    plantManagedSkill(workspace, "legacy-foo");
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "test",
+      updatedAt: new Date(0).toISOString(),
+      skills: [
+        ...TREE_SKILL_NAMES,
+        "legacy-foo",
+        "../../../outside-payload",
+        "../..", // resolves to the workspace root itself
+        "..", // resolves to `.agents/` / `.claude/`
+        ".", // the skills root itself
+        "",
+        "/etc",
+      ],
+    });
+
+    installFirstTreeSkills({ workspacePath: workspace, bundledSkillsRoot });
+
+    // Traversal targets outside the skills roots are untouched …
+    expect(readFileSync(join(outsidePayload, "sentinel.txt"), "utf-8")).toBe("do not delete");
+    // … the workspace itself survived "../.." …
+    expect(existsSync(join(workspace, MANAGED_STATE_REL))).toBe(true);
+    // … the skills roots survived ".." and "." …
+    expect(existsSync(join(workspace, ".agents", "skills"))).toBe(true);
+    expect(existsSync(join(workspace, ".claude", "skills"))).toBe(true);
+    // … and the legitimate stale skill was still removed.
+    expect(existsSync(join(workspace, ".agents", "skills", "legacy-foo"))).toBe(false);
+    expect(() => lstatSync(join(workspace, ".claude", "skills", "legacy-foo"))).toThrow();
+    // State rolls forward to the current bundle set as usual.
+    expect(readManagedState(workspace)?.skills).toEqual([...TREE_SKILL_NAMES].sort());
   });
 });

--- a/packages/client/src/runtime/first-tree-skills/installer.ts
+++ b/packages/client/src/runtime/first-tree-skills/installer.ts
@@ -36,10 +36,10 @@ import {
   symlinkSync,
   unlinkSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveBundledCliVersion } from "../bootstrap.js";
-import { readManagedState, updateManagedState } from "../managed-state.js";
+import { isManagedSkillName, readManagedState, updateManagedState } from "../managed-state.js";
 
 /**
  * Skills always shipped, regardless of whether the agent has a Context Tree
@@ -456,15 +456,24 @@ function reconcileTreeSkillState(workspacePath: string): void {
  * actually exist; anything the user added later (a custom skill payload
  * under `.agents/skills/<user-skill>/`) is never touched because we look
  * up by NAME, not by listing the directory.
+ *
+ * The name comes from the agent-writable managed-state file, i.e. untrusted
+ * input (#1610): anything that is not a strict skill slug is skipped, and
+ * each delete target must resolve strictly inside its skills root before a
+ * recursive remove runs.
  */
 function removeManagedSkill(workspacePath: string, name: string): void {
-  const agentsFull = join(workspacePath, ".agents", "skills", name);
-  const claudeFull = join(workspacePath, ".claude", "skills", name);
-  try {
-    rmSync(agentsFull, { recursive: true, force: true });
-  } catch {
-    // Best-effort — the Claude companion cleanup below still runs.
+  if (!isManagedSkillName(name)) return;
+  const agentsFull = resolveWithinSkillsRoot(join(workspacePath, ".agents", "skills"), name);
+  if (agentsFull !== null) {
+    try {
+      rmSync(agentsFull, { recursive: true, force: true });
+    } catch {
+      // Best-effort — the Claude companion cleanup below still runs.
+    }
   }
+  const claudeFull = resolveWithinSkillsRoot(join(workspacePath, ".claude", "skills"), name);
+  if (claudeFull === null) return;
   try {
     const claudeState = inspectPath(claudeFull);
     if (claudeState.kind === "missing") return;
@@ -476,4 +485,24 @@ function removeManagedSkill(workspacePath: string, name: string): void {
   } catch {
     // Either missing or remove failed — both acceptable here.
   }
+}
+
+/**
+ * Resolve `name` inside a skills root (`<workspace>/.agents/skills` or
+ * `<workspace>/.claude/skills`) and verify the result stays strictly inside
+ * that root; returns `null` when it does not. Defense in depth behind
+ * `isManagedSkillName`: even if the slug schema were ever loosened, a
+ * resolved path equal to the root or escaping it is refused instead of
+ * reaching a recursive delete. Mirrors the containment idiom in
+ * `runtime/git-local-path.ts`.
+ *
+ * @internal Exported for unit tests.
+ */
+export function resolveWithinSkillsRoot(skillsRoot: string, name: string): string | null {
+  const root = resolve(skillsRoot);
+  const target = resolve(root, name);
+  const relativeTarget = relative(root, target);
+  const escapesRoot = relativeTarget === ".." || relativeTarget.startsWith(`..${sep}`);
+  if (!relativeTarget || escapesRoot || isAbsolute(relativeTarget)) return null;
+  return target;
 }

--- a/packages/client/src/runtime/managed-state.ts
+++ b/packages/client/src/runtime/managed-state.ts
@@ -14,6 +14,11 @@
 // (names in `current` and not in `prev`) is handled by the existing
 // installer (`installFirstTreeSkills`), which already (re)materialises
 // everything it expects to be present.
+//
+// Trust: this file lives inside the agent workspace and is agent-writable,
+// so every read treats it as untrusted input — `skills` entries are checked
+// against {@link isManagedSkillName} before they can reach any filesystem
+// operation (#1610).
 
 import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
@@ -39,6 +44,28 @@ const RUNTIME_DIR = ".first-tree-workspace";
 export const MANAGED_STATE_REL = join(RUNTIME_DIR, "managed.json");
 
 /**
+ * Strict slug schema for a managed skill name: a single lowercase
+ * kebab-case path segment (max 63 chars). Matches the slug convention used
+ * across the repo (e.g. `packages/shared/src/schemas/organization.ts`) and
+ * covers every current and historical First Tree skill name. Anything else
+ * — absolute paths, `..` segments, path separators, control characters,
+ * drive letters — is rejected, so an accepted name can never escape its
+ * parent directory when joined into a path.
+ */
+const MANAGED_SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+/**
+ * Whether `name` is a valid managed skill slug. The managed-state file is
+ * agent-writable and therefore untrusted input (#1610): every name read
+ * from it must pass this check before reaching a filesystem operation.
+ * Rejection is fail-safe — an unrecognised name is simply never
+ * auto-removed and stays on disk.
+ */
+export function isManagedSkillName(name: string): boolean {
+  return MANAGED_SKILL_NAME_PATTERN.test(name);
+}
+
+/**
  * Schema-versioned record of the resources the CLI currently manages in a
  * workspace. `schemaVersion` is checked on read; anything else makes the
  * read return null (treated as "first run", no deletions performed).
@@ -60,6 +87,11 @@ export type ManagedState = {
  * unreadable, malformed JSON, or written by a future schema this code
  * doesn't understand — callers treat null as "first run on this workspace"
  * and perform no deletions.
+ *
+ * The file is agent-writable, so its content is untrusted input (#1610):
+ * `skills` entries that are not valid skill slugs ({@link isManagedSkillName})
+ * are dropped on read, keeping path-traversal names away from the reconcile
+ * deletion path.
  */
 export function readManagedState(workspacePath: string): ManagedState | null {
   const path = join(workspacePath, MANAGED_STATE_REL);
@@ -73,7 +105,7 @@ export function readManagedState(workspacePath: string): ManagedState | null {
   if (typeof parsed !== "object" || parsed === null) return null;
   const record = parsed as Record<string, unknown>;
   if (record.schemaVersion !== 1) return null;
-  const skills = readStringArray(record.skills);
+  const skills = readStringArray(record.skills).filter(isManagedSkillName);
   const cliVersion = typeof record.cliVersion === "string" ? record.cliVersion : null;
   const updatedAt = typeof record.updatedAt === "string" ? record.updatedAt : new Date(0).toISOString();
   return { schemaVersion: 1, cliVersion, updatedAt, skills };


### PR DESCRIPTION
## Summary

- Fix SEC-004 / #1610: skill names read from the agent-writable `.first-tree-workspace/managed.json` were joined into delete targets and passed to recursive `rmSync` with no validation. A `"../"` name escaped the workspace and could recursively delete arbitrary writable directories (`"../.."` resolves to the workspace root itself); the reconcile runs automatically at every agent session start.
- Two-layer fix, per the issue's recommended direction:
  1. **Strict slug schema at the data boundary** (`managed-state.ts`): new `isManagedSkillName` (`/^[a-z0-9][a-z0-9-]{0,62}$/`, matching the repo's existing slug convention and every current/historical First Tree skill name). `readManagedState` now drops non-conforming `skills` entries on read — the managed-state file is treated as untrusted input. Rejection is fail-safe: an unrecognized name is simply never auto-removed and stays on disk.
  2. **Resolve + containment at the deletion point** (`installer.ts`): `removeManagedSkill` skips non-slug names and routes each target through new `resolveWithinSkillsRoot`, which refuses any resolved path equal to or escaping its skills root (same containment idiom as `runtime/git-local-path.ts`) — defense in depth even if the slug schema is ever loosened.
- Behavior change: hostile/invalid ledger entries no longer trigger deletion; legitimate stale-skill cleanup is unchanged (all pre-existing reconcile tests pass unmodified). No schema change (`schemaVersion` stays 1); the reconcile rewrites the ledger on every run, so files self-heal.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- Note on root `pnpm test`: the turbo-parallel full run failed twice on this machine with environmental flakes (failure point drifted between web jsdom focus, skill-evals fixture timeout, and a server worker exiting without summary). Every package passes standalone (`@first-tree/client` 1632, `@first-tree/server` 2532, `@first-tree/skill-evals` 469, the web file 26/26), GitHub CI is fully green, and the failing packages have no dependency path to this diff (`web`/`skill-evals` depend only on `@first-tree/shared`; `server` declares `@first-tree/client` but never imports the touched modules). Judged not introduced by this change.
- New test coverage:
  - `managed-state.test.ts` — slug accept/reject matrix (traversal, absolute paths, separators, control characters, drive letters, whitespace, case, length cap) and read-side filtering of hostile entries.
  - `skills-state-reconcile.test.ts` — end-to-end: prev state containing `"../../../outside-payload"`, `"../.."`, `".."`, `"."`, `""`, `"/etc"` deletes nothing outside the skills roots (outside sentinel file, workspace root, and both skills roots all verified intact), while a legitimate stale skill is still removed and state rolls forward.
  - `first-tree-skills-installer-extra.test.ts` — `resolveWithinSkillsRoot` containment unit tests.

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: `@first-tree/client` skill reconcile now validates managed skill names before deletion; invalid ledger entries are ignored (left on disk) rather than removed.
- docs or tests updated to match: tests listed above; no doc changes (no contract change beyond the security fix).
- follow-up work: none.
- QA flag (per CLAUDE.md): the reconcile path runs on the agent bootstrap/runtime surface. The change is deterministic input validation fully covered by the product tests above, and `packages/qa/cases/README.md` directs stable automatable checks to the product test suite — so no formal QA case was added. Flagging the judgment for maintainer review.
- Threat-model scope: `fs.rm`/`rmSync` uses lstat semantics and does not follow symlinks, and planting in-workspace symlinks already requires filesystem write access; realpath/ancestor-symlink checks are therefore out of scope for this data-validation fix.

Fixes #1610
