### PR TITLE
feat(cli): read-only doctor check for the service launch path

### DIFF
--- a/apps/cli/src/__tests__/cli-helper-surfaces-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-helper-surfaces-extra.test.ts
@@ -12,6 +12,7 @@ const doctorCoreMocks = vi.hoisted(() => ({
   checkClientConfig: vi.fn(),
   checkNodeVersion: vi.fn(),
   checkServerReachable: vi.fn(),
+  checkServiceLaunchPath: vi.fn(),
   checkWebSocket: vi.fn(),
   ensureFreshAccessToken: vi.fn(),
   reconcileAgentConfigs: vi.fn(),
@@ -76,6 +77,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   doctorCoreMocks.checkAgentConfigs.mockReturnValue({ label: "Agents", ok: true, detail: "local" });
   doctorCoreMocks.checkBackgroundService.mockReturnValue({ label: "Service", ok: true, detail: "running" });
+  doctorCoreMocks.checkServiceLaunchPath.mockReturnValue({ label: "Service launch path", ok: true, detail: "ok" });
   doctorCoreMocks.checkClientConfig.mockReturnValue({ label: "Config", ok: true, detail: "ok" });
   doctorCoreMocks.checkNodeVersion.mockReturnValue({ label: "Node", ok: true, detail: "v24" });
   doctorCoreMocks.checkServerReachable.mockResolvedValue({ label: "Server", ok: true, detail: "ok" });
@@ -155,6 +157,7 @@ describe("doctor checks and agent resolver", () => {
       { label: "Agents", ok: true, detail: "reconciled" },
       { label: "WebSocket", ok: true, detail: "ok" },
       { label: "Service", ok: true, detail: "running" },
+      { label: "Service launch path", ok: true, detail: "ok" },
       { label: "codex", ok: true, detail: "ok — bundled" },
     ]);
     expect(configMocks.resetConfig).toHaveBeenCalled();

--- a/apps/cli/src/__tests__/doctor-core.test.ts
+++ b/apps/cli/src/__tests__/doctor-core.test.ts
@@ -504,4 +504,56 @@ describe("checkServiceLaunchPath", () => {
       detail: expect.stringContaining(target),
     });
   });
+  it("validates every leading absolute token of a node-kind invocation", async () => {
+    const check = await loadCheck();
+    const plistPath = join(home, "service.plist");
+    writeFileSync(plistPath, "<plist></plist>");
+    const node = join(home, "node");
+    writeFileSync(node, "#!/bin/sh\n");
+    const script = join(home, "dist cli.mjs");
+    const wrapperPath = join(home, "wrapper");
+    writeFileSync(wrapperPath, `#!/bin/sh\nexec "${node}" "${script}" daemon start --no-interactive\n`);
+    expect(check({ platform: "darwin", plistPath, wrapperPath })).toMatchObject({
+      ok: false,
+      detail: expect.stringContaining(`launch target missing (${script})`),
+    });
+
+    writeFileSync(script, "// cli\n");
+    expect(check({ platform: "darwin", plistPath, wrapperPath })).toMatchObject({
+      ok: true,
+      detail: expect.stringContaining(script),
+    });
+  });
+
+  it("validates the script token of a node-kind systemd ExecStart", async () => {
+    const check = await loadCheck();
+    const node = join(home, "node");
+    writeFileSync(node, "#!/bin/sh\n");
+    const unitPath = join(home, "unit.service");
+    const script = join(home, "gone.mjs");
+    writeFileSync(unitPath, `[Service]\nExecStart="${node}" ${script} daemon start --no-interactive\n`);
+    expect(check({ platform: "linux", unitPath })).toMatchObject({
+      ok: false,
+      detail: expect.stringContaining(`launch target missing (${script})`),
+    });
+  });
+
+  it("fails as unreadable when a service file is a directory", async () => {
+    const check = await loadCheck();
+    const plistPath = join(home, "service.plist");
+    writeFileSync(plistPath, "<plist></plist>");
+    const wrapperPath = join(home, "wrapper-dir");
+    mkdirSync(wrapperPath, { recursive: true });
+    expect(check({ platform: "darwin", plistPath, wrapperPath })).toMatchObject({
+      ok: false,
+      detail: expect.stringContaining("wrapper unreadable"),
+    });
+
+    const unitPath = join(home, "unit-dir");
+    mkdirSync(unitPath, { recursive: true });
+    expect(check({ platform: "linux", unitPath })).toMatchObject({
+      ok: false,
+      detail: expect.stringContaining("service unit unreadable"),
+    });
+  });
 });

--- a/apps/cli/src/__tests__/doctor-core.test.ts
+++ b/apps/cli/src/__tests__/doctor-core.test.ts
@@ -397,3 +397,111 @@ describe("doctor core checks", () => {
     ).toEqual(["claude-code", "zed"]);
   });
 });
+
+describe("checkServiceLaunchPath", () => {
+  async function loadCheck() {
+    const { checkServiceLaunchPath } = await import("../core/doctor.js");
+    return checkServiceLaunchPath;
+  }
+
+  it("reports not applicable on platforms without a validated service chain", async () => {
+    const check = await loadCheck();
+    expect(check({ platform: "win32" })).toMatchObject({
+      label: "Service launch path",
+      ok: true,
+      detail: expect.stringContaining("not applicable"),
+    });
+  });
+
+  it("passes quietly when no service is installed", async () => {
+    const check = await loadCheck();
+    expect(check({ platform: "darwin", plistPath: join(home, "absent.plist") })).toMatchObject({
+      ok: true,
+      detail: expect.stringContaining("not installed"),
+    });
+    expect(check({ platform: "linux", unitPath: join(home, "absent.service") })).toMatchObject({
+      ok: true,
+      detail: expect.stringContaining("not installed"),
+    });
+  });
+
+  it("fails when the plist exists but the wrapper script is gone", async () => {
+    const check = await loadCheck();
+    const plistPath = join(home, "service.plist");
+    writeFileSync(plistPath, "<plist></plist>");
+    expect(check({ platform: "darwin", plistPath, wrapperPath: join(home, "no-wrapper") })).toMatchObject({
+      ok: false,
+      detail: expect.stringContaining("wrapper missing"),
+    });
+  });
+
+  it("fails when the wrapper exec target no longer exists", async () => {
+    const check = await loadCheck();
+    const plistPath = join(home, "service.plist");
+    writeFileSync(plistPath, "<plist></plist>");
+    const wrapperPath = join(home, "wrapper");
+    writeFileSync(wrapperPath, "#!/bin/sh\nexec /missing/node/first-tree daemon start --no-interactive\n");
+    expect(check({ platform: "darwin", plistPath, wrapperPath })).toMatchObject({
+      ok: false,
+      detail: expect.stringContaining("launch target missing (/missing/node/first-tree)"),
+    });
+  });
+
+  it("fails when the wrapper has no parseable exec command", async () => {
+    const check = await loadCheck();
+    const plistPath = join(home, "service.plist");
+    writeFileSync(plistPath, "<plist></plist>");
+    const wrapperPath = join(home, "wrapper");
+    writeFileSync(wrapperPath, "#!/bin/sh\n# hand-edited\n");
+    expect(check({ platform: "darwin", plistPath, wrapperPath })).toMatchObject({
+      ok: false,
+      detail: expect.stringContaining("no parseable exec"),
+    });
+  });
+
+  it("fails when the plist PATH head directory is gone, unescaping XML entities", async () => {
+    const check = await loadCheck();
+    const target = join(home, "node bin");
+    writeFileSync(target, "#!/bin/sh\n");
+    const wrapperPath = join(home, "wrapper");
+    writeFileSync(wrapperPath, `#!/bin/sh\nexec "${target}" daemon start --no-interactive\n`);
+    const plistPath = join(home, "service.plist");
+    writeFileSync(plistPath, `<dict>\n  <key>PATH</key>\n  <string>${home}/a&amp;b:/usr/bin</string>\n</dict>\n`);
+    expect(check({ platform: "darwin", plistPath, wrapperPath })).toMatchObject({
+      ok: false,
+      detail: expect.stringContaining(`service PATH head missing (${home}/a&b)`),
+    });
+  });
+
+  it("passes on a fully healthy launchd chain, including a quoted target with spaces", async () => {
+    const check = await loadCheck();
+    const target = join(home, "node bin");
+    writeFileSync(target, "#!/bin/sh\n");
+    const wrapperPath = join(home, "wrapper");
+    writeFileSync(wrapperPath, `#!/bin/sh\nexec "${target}" daemon start --no-interactive\n`);
+    const plistPath = join(home, "service.plist");
+    writeFileSync(plistPath, `<dict>\n  <key>PATH</key>\n  <string>${home}:/usr/bin</string>\n</dict>\n`);
+    expect(check({ platform: "darwin", plistPath, wrapperPath })).toMatchObject({
+      ok: true,
+      detail: expect.stringContaining(target),
+    });
+  });
+
+  it("validates the systemd ExecStart target on linux", async () => {
+    const check = await loadCheck();
+    const unitPath = join(home, "unit.service");
+    writeFileSync(unitPath, "[Service]\nExecStart=/missing/node cli.mjs daemon start --no-interactive\n");
+    expect(check({ platform: "linux", unitPath })).toMatchObject({
+      ok: false,
+      detail: expect.stringContaining("launch target missing (/missing/node)"),
+    });
+
+    const target = join(home, "node");
+    writeFileSync(target, "#!/bin/sh\n");
+    writeFileSync(unitPath, `[Service]\nExecStart="${target}" daemon start --no-interactive\n`);
+    expect(check({ platform: "linux", unitPath })).toMatchObject({
+      ok: true,
+      detail: expect.stringContaining(target),
+    });
+  });
+});

--- a/apps/cli/src/commands/_shared/doctor-checks.ts
+++ b/apps/cli/src/commands/_shared/doctor-checks.ts
@@ -8,6 +8,7 @@ import {
   checkClientConfig,
   checkNodeVersion,
   checkServerReachable,
+  checkServiceLaunchPath,
   checkWebSocket,
   ensureFreshAccessToken,
   reconcileAgentConfigs,
@@ -70,6 +71,7 @@ export async function runDaemonChecks(): Promise<CheckResult[]> {
     agentCheck,
     await checkWebSocket(),
     checkBackgroundService(),
+    checkServiceLaunchPath(),
     ...(await checkRuntimeProviders()),
   ];
 }

--- a/apps/cli/src/core/doctor.ts
+++ b/apps/cli/src/core/doctor.ts
@@ -14,6 +14,7 @@ import { channelConfig } from "./channel.js";
 import { cliFetch } from "./cli-fetch.js";
 import { blank, print } from "./output.js";
 import { getClientServiceStatus } from "./service-install.js";
+import { launchdPlistPath, launchdWrapperPath, systemdUnitPath } from "./supervisor/index.js";
 
 export type CheckResult = {
   label: string;
@@ -273,6 +274,139 @@ export function checkBackgroundService(): CheckResult {
     ok: false,
     detail: `not installed — re-run \`${channelConfig.binName} login <code>\` to install`,
   };
+}
+
+/**
+ * First shell word of a command string rendered with `shellQuote`: a bare
+ * safe-charset token, or a double-quoted token with `\\` / `\"` escapes.
+ * Both the launchd wrapper `exec` line and the systemd `ExecStart=` value
+ * are rendered that way, so one inverse parser covers both.
+ */
+function firstCommandToken(command: string): string | null {
+  const trimmed = command.trim();
+  if (trimmed === "") return null;
+  if (trimmed.startsWith('"')) {
+    let token = "";
+    for (let i = 1; i < trimmed.length; i += 1) {
+      const ch = trimmed[i];
+      if (ch === "\\" && i + 1 < trimmed.length) {
+        token += trimmed[i + 1];
+        i += 1;
+        continue;
+      }
+      if (ch === '"') return token;
+      token += ch;
+    }
+    return null;
+  }
+  const end = trimmed.search(/\s/);
+  return end === -1 ? trimmed : trimmed.slice(0, end);
+}
+
+function unescapeXml(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+/**
+ * Validate that the installed service's launch chain still points at files
+ * that exist. The service files bake absolute paths resolved at install time
+ * (wrapper `exec` target, plist `PATH` head, unit `ExecStart` binary); a
+ * Node/npm relocation — `nvm uninstall`, switching the default node — leaves
+ * them dangling, and the resulting crash loop cannot self-report because the
+ * process never starts. Doctor is the read-only surface that can: this check
+ * only inspects files and never spawns or mutates anything. Path overrides
+ * exist for tests.
+ */
+export function checkServiceLaunchPath(
+  opts: { platform?: NodeJS.Platform; plistPath?: string; wrapperPath?: string; unitPath?: string } = {},
+): CheckResult {
+  const label = "Service launch path";
+  const platform = opts.platform ?? process.platform;
+  const repair =
+    `re-run \`${channelConfig.binName} login <code>\` ` +
+    `(or \`${channelConfig.binName} daemon ensure-service\`) to re-render the service files`;
+
+  if (platform === "darwin") {
+    const plistPath = opts.plistPath ?? launchdPlistPath();
+    if (!existsSync(plistPath)) {
+      return { label, ok: true, detail: "service not installed — nothing to validate" };
+    }
+    const wrapperPath = opts.wrapperPath ?? launchdWrapperPath();
+    if (!existsSync(wrapperPath)) {
+      return { label, ok: false, detail: `wrapper missing (${wrapperPath}) — ${repair}` };
+    }
+    let wrapperBody: string;
+    try {
+      wrapperBody = readFileSync(wrapperPath, "utf-8");
+    } catch {
+      return { label, ok: false, detail: `wrapper unreadable (${wrapperPath}) — ${repair}` };
+    }
+    const execLine = wrapperBody.split("\n").find((line) => line.startsWith("exec "));
+    const target = execLine === undefined ? null : firstCommandToken(execLine.slice("exec ".length));
+    if (target === null) {
+      return { label, ok: false, detail: `wrapper has no parseable exec command (${wrapperPath}) — ${repair}` };
+    }
+    if (!existsSync(target)) {
+      return {
+        label,
+        ok: false,
+        detail:
+          `launch target missing (${target}) — usually a removed Node install ` + `(e.g. \`nvm uninstall\`); ${repair}`,
+      };
+    }
+    let plistBody: string;
+    try {
+      plistBody = readFileSync(plistPath, "utf-8");
+    } catch {
+      return { label, ok: false, detail: `service plist unreadable (${plistPath}) — ${repair}` };
+    }
+    const pathMatch = plistBody.match(/<key>\s*PATH\s*<\/key>\s*<string>([^<]*)<\/string>/);
+    if (pathMatch !== null) {
+      const pathHead = unescapeXml(pathMatch[1]).split(":")[0];
+      if (pathHead !== "" && !existsSync(pathHead)) {
+        return {
+          label,
+          ok: false,
+          detail: `service PATH head missing (${pathHead}) — the pinned Node directory is gone; ${repair}`,
+        };
+      }
+    }
+    return { label, ok: true, detail: `launch target verified (${target})` };
+  }
+
+  if (platform === "linux") {
+    const unitPath = opts.unitPath ?? systemdUnitPath();
+    if (!existsSync(unitPath)) {
+      return { label, ok: true, detail: "service not installed — nothing to validate" };
+    }
+    let unitBody: string;
+    try {
+      unitBody = readFileSync(unitPath, "utf-8");
+    } catch {
+      return { label, ok: false, detail: `service unit unreadable (${unitPath}) — ${repair}` };
+    }
+    const execLine = unitBody.split("\n").find((line) => line.startsWith("ExecStart="));
+    const target = execLine === undefined ? null : firstCommandToken(execLine.slice("ExecStart=".length));
+    if (target === null) {
+      return { label, ok: false, detail: `unit has no parseable ExecStart (${unitPath}) — ${repair}` };
+    }
+    if (!existsSync(target)) {
+      return {
+        label,
+        ok: false,
+        detail:
+          `launch target missing (${target}) — usually a removed Node install ` + `(e.g. \`nvm uninstall\`); ${repair}`,
+      };
+    }
+    return { label, ok: true, detail: `launch target verified (${target})` };
+  }
+
+  return { label, ok: true, detail: `not applicable on ${platform}` };
 }
 
 export async function checkWebSocket(): Promise<CheckResult> {

--- a/apps/cli/src/core/doctor.ts
+++ b/apps/cli/src/core/doctor.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import type { CapabilityEntry } from "@first-tree/shared";
 import {
   agentConfigSchema,
@@ -277,30 +277,63 @@ export function checkBackgroundService(): CheckResult {
 }
 
 /**
- * First shell word of a command string rendered with `shellQuote`: a bare
- * safe-charset token, or a double-quoted token with `\\` / `\"` escapes.
+ * Shell words of a command string rendered with `shellQuote`: bare
+ * safe-charset tokens, or double-quoted tokens with `\\` / `\"` escapes.
  * Both the launchd wrapper `exec` line and the systemd `ExecStart=` value
- * are rendered that way, so one inverse parser covers both.
+ * are rendered that way, so one inverse parser covers both. An unterminated
+ * quote ends the scan with the tokens collected so far.
  */
-function firstCommandToken(command: string): string | null {
-  const trimmed = command.trim();
-  if (trimmed === "") return null;
-  if (trimmed.startsWith('"')) {
-    let token = "";
-    for (let i = 1; i < trimmed.length; i += 1) {
-      const ch = trimmed[i];
-      if (ch === "\\" && i + 1 < trimmed.length) {
-        token += trimmed[i + 1];
+function commandTokens(command: string): string[] {
+  const tokens: string[] = [];
+  const text = command.trim();
+  let i = 0;
+  while (i < text.length) {
+    while (i < text.length && /\s/.test(text[i])) i += 1;
+    if (i >= text.length) break;
+    if (text[i] === '"') {
+      let token = "";
+      let closed = false;
+      i += 1;
+      while (i < text.length) {
+        const ch = text[i];
+        if (ch === "\\" && i + 1 < text.length) {
+          token += text[i + 1];
+          i += 2;
+          continue;
+        }
+        if (ch === '"') {
+          closed = true;
+          i += 1;
+          break;
+        }
+        token += ch;
         i += 1;
-        continue;
       }
-      if (ch === '"') return token;
-      token += ch;
+      if (!closed) return tokens;
+      tokens.push(token);
+      continue;
     }
-    return null;
+    const start = i;
+    while (i < text.length && !/\s/.test(text[i])) i += 1;
+    tokens.push(text.slice(start, i));
   }
-  const end = trimmed.search(/\s/);
-  return end === -1 ? trimmed : trimmed.slice(0, end);
+  return tokens;
+}
+
+/**
+ * Leading absolute-path tokens of a launch command — the launch binary and,
+ * for node-kind invocations (`node cli.mjs …`), the baked script path. The
+ * first relative token (`daemon`, the CLI subcommand) ends the launch chain.
+ * Every one of these files must exist for the service to start, so a missing
+ * script is as fatal as a missing interpreter (MODULE_NOT_FOUND crash loop).
+ */
+function leadingLaunchPaths(command: string): string[] {
+  const paths: string[] = [];
+  for (const token of commandTokens(command)) {
+    if (!isAbsolute(token)) break;
+    paths.push(token);
+  }
+  return paths;
 }
 
 function unescapeXml(value: string): string {
@@ -315,7 +348,8 @@ function unescapeXml(value: string): string {
 /**
  * Validate that the installed service's launch chain still points at files
  * that exist. The service files bake absolute paths resolved at install time
- * (wrapper `exec` target, plist `PATH` head, unit `ExecStart` binary); a
+ * (the wrapper's / unit's launch binary plus, for node-kind invocations, the
+ * baked script path, and the plist `PATH` head); a
  * Node/npm relocation — `nvm uninstall`, switching the default node — leaves
  * them dangling, and the resulting crash loop cannot self-report because the
  * process never starts. Doctor is the read-only surface that can: this check
@@ -347,16 +381,18 @@ export function checkServiceLaunchPath(
       return { label, ok: false, detail: `wrapper unreadable (${wrapperPath}) — ${repair}` };
     }
     const execLine = wrapperBody.split("\n").find((line) => line.startsWith("exec "));
-    const target = execLine === undefined ? null : firstCommandToken(execLine.slice("exec ".length));
-    if (target === null) {
+    const launchPaths = execLine === undefined ? [] : leadingLaunchPaths(execLine.slice("exec ".length));
+    if (launchPaths.length === 0) {
       return { label, ok: false, detail: `wrapper has no parseable exec command (${wrapperPath}) — ${repair}` };
     }
-    if (!existsSync(target)) {
+    const missingTarget = launchPaths.find((path) => !existsSync(path));
+    if (missingTarget !== undefined) {
       return {
         label,
         ok: false,
         detail:
-          `launch target missing (${target}) — usually a removed Node install ` + `(e.g. \`nvm uninstall\`); ${repair}`,
+          `launch target missing (${missingTarget}) — usually a removed Node install ` +
+          `(e.g. \`nvm uninstall\`); ${repair}`,
       };
     }
     let plistBody: string;
@@ -376,7 +412,7 @@ export function checkServiceLaunchPath(
         };
       }
     }
-    return { label, ok: true, detail: `launch target verified (${target})` };
+    return { label, ok: true, detail: `launch target verified (${launchPaths.join(" ")})` };
   }
 
   if (platform === "linux") {
@@ -391,19 +427,21 @@ export function checkServiceLaunchPath(
       return { label, ok: false, detail: `service unit unreadable (${unitPath}) — ${repair}` };
     }
     const execLine = unitBody.split("\n").find((line) => line.startsWith("ExecStart="));
-    const target = execLine === undefined ? null : firstCommandToken(execLine.slice("ExecStart=".length));
-    if (target === null) {
+    const launchPaths = execLine === undefined ? [] : leadingLaunchPaths(execLine.slice("ExecStart=".length));
+    if (launchPaths.length === 0) {
       return { label, ok: false, detail: `unit has no parseable ExecStart (${unitPath}) — ${repair}` };
     }
-    if (!existsSync(target)) {
+    const missingTarget = launchPaths.find((path) => !existsSync(path));
+    if (missingTarget !== undefined) {
       return {
         label,
         ok: false,
         detail:
-          `launch target missing (${target}) — usually a removed Node install ` + `(e.g. \`nvm uninstall\`); ${repair}`,
+          `launch target missing (${missingTarget}) — usually a removed Node install ` +
+          `(e.g. \`nvm uninstall\`); ${repair}`,
       };
     }
-    return { label, ok: true, detail: `launch target verified (${target})` };
+    return { label, ok: true, detail: `launch target verified (${launchPaths.join(" ")})` };
   }
 
   return { label, ok: true, detail: `not applicable on ${platform}` };

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -124,6 +124,7 @@ export {
   checkClientConfig,
   checkNodeVersion,
   checkServerReachable,
+  checkServiceLaunchPath,
   checkWebSocket,
   printResults,
   reconcileAgentConfigs,

--- a/apps/cli/src/core/supervisor/index.ts
+++ b/apps/cli/src/core/supervisor/index.ts
@@ -16,6 +16,9 @@ import {
 import type { ServiceInfo, ServiceOpResult, ServiceState, SupervisorBackend } from "./types.js";
 import { unsupportedBackend } from "./unsupported.js";
 
+export { launchdPlistPath, launchdWrapperPath } from "./launchd.js";
+export { systemdUnitPath } from "./systemd.js";
+
 function currentBackend(): SupervisorBackend {
   if (process.platform === "darwin") return launchdBackend;
   if (process.platform === "linux") return systemdBackend;

--- a/apps/cli/src/core/supervisor/launchd.ts
+++ b/apps/cli/src/core/supervisor/launchd.ts
@@ -34,7 +34,7 @@ const LAUNCHD_LABEL = channelConfig.launchdLabel;
 // problem (the unit carries a `Description=`), so this is launchd-only.
 const LAUNCHD_DISPLAY_NAME = channelConfig.displayName;
 
-function launchdPlistPath(): string {
+export function launchdPlistPath(): string {
   return join(homedir(), "Library", "LaunchAgents", `${LAUNCHD_LABEL}.plist`);
 }
 
@@ -42,7 +42,7 @@ function launchdPlistPath(): string {
 // shows in the background-items list, so it is the channel display name.
 // Lives under the channel home so it is stable across reinstalls and
 // isolated per channel (parallel installs don't collide).
-function launchdWrapperPath(): string {
+export function launchdWrapperPath(): string {
   return join(defaultHome(), "service", LAUNCHD_DISPLAY_NAME);
 }
 

--- a/apps/cli/src/core/supervisor/systemd.ts
+++ b/apps/cli/src/core/supervisor/systemd.ts
@@ -49,7 +49,7 @@ function rootSystemdUserUnitPath(): string {
   return join(rootHome, ".config", "systemd", "user", SYSTEMD_UNIT);
 }
 
-function systemdUnitPath(scope: SystemdScope = systemdScope()): string {
+export function systemdUnitPath(scope: SystemdScope = systemdScope()): string {
   if (scope === "system") {
     return join(process.env.FIRST_TREE_SYSTEMD_SYSTEM_DIR ?? "/etc/systemd/system", SYSTEMD_UNIT);
   }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -61,6 +61,7 @@ export {
   checkClientConfig,
   checkNodeVersion,
   checkServerReachable,
+  checkServiceLaunchPath,
   checkWebSocket,
   classifyContextTreeUpdateError,
   computeWorkspaceStatus,


### PR DESCRIPTION
Part of #995 (ask 2). Follow-up to #1943, split out per its review so the competition submission stays scoped to the binding acceptance; wrapper *self-healing* is tracked separately in #1949.

## Summary

The installed service's launch chain bakes absolute paths resolved at install time: the launchd wrapper `exec`s a realpath'd CLI invocation, the rendered plist pins `PATH`'s head to the installing Node's directory, and the systemd unit bakes the same invocation into `ExecStart=`. Removing that Node install (`nvm uninstall`, switching the default version) leaves them dangling — the wrapper exits 127 and launchd restarts it every ≥10s forever (launchd has no `StartLimit*` equivalent, unlike the systemd unit which self-stops after 10 failures / 300s) — and every existing recovery path (`refresh-unit` drift repair, `ensure-service`, `login`, `upgrade`) needs a live daemon or an operator command. `daemon doctor` previously reported only "installed but not running" with no root cause.

This PR adds one read-only doctor line, **`Service launch path`** (`checkServiceLaunchPath`):

- **darwin**: plist present → wrapper present → every leading absolute-path token of the wrapper's `exec` command exists (launch binary **and** the baked script of a node-kind invocation) → plist `PATH` head directory exists (XML entities unescaped);
- **linux**: unit present → every leading absolute-path token of `ExecStart=` exists;
- **elsewhere / not installed**: `ok` with "not applicable" / "nothing to validate";
- any broken link fails with the offending absolute path and the repair (`login <code>` or `daemon ensure-service`).

Pure file inspection — no subprocess, no mutation, honoring doctor's read-only contract. The tokenizer is the exact inverse of the `shellQuote` renderer used by both the wrapper and the unit (bare safe-charset tokens, or double-quoted with `\\` / `\"` escapes), so quoted paths with spaces parse correctly; the first relative token (the CLI subcommand) terminates the validated launch chain, keeping bin-kind single-token behavior unchanged.

Mechanical export additions: `launchdPlistPath` / `launchdWrapperPath` / `systemdUnitPath` gain `export` (previously module-private) and are re-exported through `supervisor/index.ts`; `checkServiceLaunchPath` joins the `core/index.ts` + `src/index.ts` public lists per repo convention.

## Tests

11 new cases in `doctor-core.test.ts` (path-injected, no os/platform mocking needed): win32 not-applicable; not-installed on both platforms; wrapper missing; exec target missing; unparseable wrapper; plist `PATH` head missing incl. `&amp;` unescaping; fully healthy chain incl. a quoted target containing a space; node-kind double-token validation on both platforms (missing script → fail, quoted script with a space → ok); unreadable service files (directory-backed, no chmod flakiness); systemd `ExecStart` missing + healthy. `cli-helper-surfaces-extra.test.ts`'s exact `runDaemonChecks` array extended with the new line.

No new `packages/qa/` case: the check is deterministic pure-fs behavior fully covered at the product-test layer (it never touches a live launchd/systemd), per the repo's route-each-check-to-its-layer policy. Happy to add one if review disagrees.

## Validation

- `pnpm check` ✅ (two pre-existing warnings on main, untouched) · `pnpm typecheck` ✅ (10/10)
- Targeted: `doctor-core` + `cli-helper-surfaces-extra` 22/22 ✅
- Full CLI suite at head `ffec18737` (clean env, same invocation as #1943's baseline): **20/20 batches, 1369 tests (1 skipped), 0 failed** — the main-baseline 1358 plus exactly the 11 new cases.

## Note on overlap with #1943

#1943 (competition entry, submitted) adds its own doctor line (`checkLegacyGithubScanRunner`) wired at the same `runDaemonChecks` position and extends the same two test files. The PRs are functionally independent; whichever merges second needs a one-line adjacency resolution in `doctor-checks.ts` / `cli-helper-surfaces-extra.test.ts` / the two index export lists. I'll rebase this one promptly after #1943 lands (or vice versa).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
