### PR TITLE
fix(server): serialize startup migrations across replicas

### DIFF
--- a/packages/server/src/__tests__/bootstrap-migration-lock.test.ts
+++ b/packages/server/src/__tests__/bootstrap-migration-lock.test.ts
@@ -1,53 +1,529 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
 import postgres from "postgres";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { sslOptions } from "../db/connection.js";
 import { runMigrations } from "../db/migrate.js";
 
-/**
- * Pins the `hashtext('drizzle_migrations')` key used by
- * `preflightMigrationLock`. If a future drizzle bump changes the lock key,
- * this test stays green only as long as the preflight constant matches the
- * one we hold here — meaning the preflight and the holder both speak to the
- * same advisory-lock slot.
- *
- * See `packages/server/src/db/migrate.ts` `MIGRATION_LOCK_KEY_SQL` comment
- * for the verification path through drizzle-orm.
- */
-describe("preflightMigrationLock (T10)", () => {
-  const databaseUrl = process.env.DATABASE_URL;
+const REPLICA_A = "ft_migration_replica_a";
+const REPLICA_B = "ft_migration_replica_b";
+const QA_LOCK_CLASS = 1690;
+const FINAL_INSERT_GATE = 1;
+const REPLICA_B_DDL_GATE = 2;
+const SCRATCH_CASE_TIMEOUT_MS = 60_000;
+const SCRATCH_BODY_TIMEOUT_MS = 35_000;
+const SCRATCH_DRAIN_TIMEOUT_MS = 5_000;
 
-  afterEach(() => {
-    // No shared state between cases — each opens / closes its own postgres
-    // client, and the lock is session-scoped so it goes away on .end().
+const journal = JSON.parse(
+  readFileSync(fileURLToPath(new URL("../../drizzle/meta/_journal.json", import.meta.url)), "utf8"),
+) as { entries: Array<{ when: number }> };
+const expectedJournalWhens = journal.entries.map((entry) => entry.when);
+const maybeFinalJournalWhen = expectedJournalWhens.at(-1);
+if (maybeFinalJournalWhen === undefined) throw new Error("migration journal must contain at least one entry");
+const finalJournalWhen: number = maybeFinalJournalWhen;
+
+type Outcome<T> =
+  | { readonly status: "fulfilled"; readonly value: T }
+  | { readonly status: "rejected"; readonly reason: unknown };
+
+type BackendState = {
+  pid: number;
+  state: string;
+  query: string;
+  wait_event_type: string | null;
+  wait_event: string | null;
+  holds_migration_lock: boolean;
+  waits_migration_lock: boolean;
+  waits_final_insert_gate: boolean;
+  waits_replica_b_ddl_gate: boolean;
+};
+
+function track<T>(promise: Promise<T>): Promise<Outcome<T>> {
+  return promise.then(
+    (value) => ({ status: "fulfilled", value }),
+    (reason: unknown) => ({ status: "rejected", reason }),
+  );
+}
+
+function databaseUrlWithApplicationName(url: string, applicationName: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("application_name", applicationName);
+  return parsed.toString();
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readBackendStates(
+  observer: ReturnType<typeof postgres>,
+  applicationName: string,
+): Promise<BackendState[]> {
+  return observer.unsafe<BackendState[]>(
+    `
+      SELECT
+        a.pid,
+        a.state,
+        a.query,
+        a.wait_event_type,
+        a.wait_event,
+        COALESCE(bool_or(
+          l.locktype = 'advisory'
+          AND l.objsubid = 1
+          AND ((l.classid::bigint << 32) | l.objid::bigint)
+              = hashtext('drizzle_migrations')::bigint
+          AND l.granted
+        ), false) AS holds_migration_lock,
+        COALESCE(bool_or(
+          l.locktype = 'advisory'
+          AND l.objsubid = 1
+          AND ((l.classid::bigint << 32) | l.objid::bigint)
+              = hashtext('drizzle_migrations')::bigint
+          AND NOT l.granted
+        ), false) AS waits_migration_lock,
+        COALESCE(bool_or(
+          l.locktype = 'advisory'
+          AND l.classid::bigint = ${QA_LOCK_CLASS}
+          AND l.objid::bigint = ${FINAL_INSERT_GATE}
+          AND l.objsubid = 2
+          AND NOT l.granted
+        ), false) AS waits_final_insert_gate,
+        COALESCE(bool_or(
+          l.locktype = 'advisory'
+          AND l.classid::bigint = ${QA_LOCK_CLASS}
+          AND l.objid::bigint = ${REPLICA_B_DDL_GATE}
+          AND l.objsubid = 2
+          AND NOT l.granted
+        ), false) AS waits_replica_b_ddl_gate
+      FROM pg_stat_activity a
+      LEFT JOIN pg_locks l ON l.pid = a.pid
+      WHERE a.datname = current_database()
+        AND a.application_name = $1
+      GROUP BY a.pid, a.state, a.query, a.wait_event_type, a.wait_event
+    `,
+    [applicationName],
+  );
+}
+
+async function waitForBackendState(
+  observer: ReturnType<typeof postgres>,
+  applicationName: string,
+  predicate: (state: BackendState) => boolean,
+  description: string,
+): Promise<BackendState> {
+  const deadline = performance.now() + 8_000;
+  let lastStates: BackendState[] = [];
+  while (performance.now() < deadline) {
+    lastStates = await readBackendStates(observer, applicationName);
+    const match = lastStates.find(predicate);
+    if (match) return match;
+    await delay(20);
+  }
+  throw new Error(`timed out waiting for ${description}; last state: ${JSON.stringify(lastStates)}`);
+}
+
+async function waitForNoBackend(observer: ReturnType<typeof postgres>, applicationName: string): Promise<void> {
+  const deadline = performance.now() + 5_000;
+  let lastStates: BackendState[] = [];
+  while (performance.now() < deadline) {
+    lastStates = await readBackendStates(observer, applicationName);
+    if (lastStates.length === 0) return;
+    await delay(20);
+  }
+  throw new Error(`backend ${applicationName} remained after termination: ${JSON.stringify(lastStates)}`);
+}
+
+async function readJournalWhens(observer: ReturnType<typeof postgres>): Promise<number[]> {
+  const rows = await observer<Array<{ created_at: string }>>`
+    SELECT created_at::text AS created_at
+    FROM drizzle.__drizzle_migrations
+    ORDER BY created_at
+  `;
+  return rows.map((row) => Number(row.created_at));
+}
+
+async function releaseGate(
+  controller: ReturnType<typeof postgres>,
+  gate: typeof FINAL_INSERT_GATE | typeof REPLICA_B_DDL_GATE,
+): Promise<void> {
+  const rows = await controller<Array<{ unlocked: boolean }>>`
+    SELECT pg_advisory_unlock(${QA_LOCK_CLASS}, ${gate}) AS unlocked
+  `;
+  expect(rows[0]?.unlocked, `controller must hold QA gate ${gate}`).toBe(true);
+}
+
+async function settlesWithin(promises: readonly Promise<unknown>[], timeoutMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<false>((resolve) => {
+    timer = setTimeout(() => resolve(false), timeoutMs);
   });
+  const settled = Promise.allSettled(promises).then(() => true as const);
+  const result = await Promise.race([settled, timeout]);
+  if (timer !== undefined) clearTimeout(timer);
+  return result;
+}
 
-  it("throws migration lock contention when another session holds hashtext('drizzle_migrations')", async () => {
+type ScratchDatabase = {
+  name: string;
+  url: string;
+  admin: ReturnType<typeof postgres>;
+  observer: ReturnType<typeof postgres>;
+  controller: ReturnType<typeof postgres>;
+  tracked: Promise<unknown>[];
+};
+
+async function createScratchDatabase(): Promise<ScratchDatabase> {
+  const baseUrl = process.env.DATABASE_URL;
+  expect(baseUrl, "DATABASE_URL must be set by global setup").toBeTruthy();
+
+  const name = `migration_lock_${process.pid}_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+  if (!/^[a-z0-9_]+$/.test(name)) throw new Error(`unsafe scratch database name: ${name}`);
+
+  const adminUrl = new URL(baseUrl ?? "");
+  adminUrl.pathname = "/postgres";
+  adminUrl.searchParams.delete("application_name");
+  const admin = postgres(adminUrl.toString(), {
+    max: 1,
+    ...sslOptions(adminUrl.toString()),
+    onnotice: () => undefined,
+  });
+  let observer: ReturnType<typeof postgres> | undefined;
+  let controller: ReturnType<typeof postgres> | undefined;
+
+  try {
+    await admin.unsafe(`CREATE DATABASE ${name}`);
+    const scratchUrl = new URL(baseUrl ?? "");
+    scratchUrl.pathname = `/${name}`;
+    scratchUrl.searchParams.delete("application_name");
+    const url = scratchUrl.toString();
+    observer = postgres(url, { max: 1, ...sslOptions(url), onnotice: () => undefined });
+    controller = postgres(url, { max: 1, ...sslOptions(url), onnotice: () => undefined });
+
+    const roles = await observer<Array<{ rolsuper: boolean }>>`
+      SELECT rolsuper FROM pg_roles WHERE rolname = current_user
+    `;
+    if (roles[0]?.rolsuper !== true) {
+      throw new Error("migration serialization regression requires a PostgreSQL superuser for event triggers");
+    }
+
+    await observer.unsafe("CREATE SCHEMA drizzle");
+    await observer.unsafe(`
+      CREATE TABLE drizzle.__drizzle_migrations (
+        id serial PRIMARY KEY,
+        hash text NOT NULL,
+        created_at bigint
+      )
+    `);
+    await observer.unsafe("CREATE SCHEMA qa_migration_lock");
+    await observer.unsafe("CREATE TABLE qa_migration_lock.config (final_when bigint NOT NULL)");
+    await observer`INSERT INTO qa_migration_lock.config (final_when) VALUES (${finalJournalWhen})`;
+    await observer.unsafe(`
+      CREATE FUNCTION qa_migration_lock.gate_final_journal_insert()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $function$
+      BEGIN
+        IF current_setting('application_name', true) = '${REPLICA_A}'
+           AND NEW.created_at = (SELECT final_when FROM qa_migration_lock.config)
+        THEN
+          PERFORM pg_catalog.pg_advisory_lock(${QA_LOCK_CLASS}, ${FINAL_INSERT_GATE});
+          PERFORM pg_catalog.pg_advisory_unlock(${QA_LOCK_CLASS}, ${FINAL_INSERT_GATE});
+        END IF;
+        RETURN NEW;
+      END;
+      $function$
+    `);
+    await observer.unsafe(`
+      CREATE TRIGGER qa_gate_final_journal_insert
+      BEFORE INSERT ON drizzle.__drizzle_migrations
+      FOR EACH ROW
+      EXECUTE FUNCTION qa_migration_lock.gate_final_journal_insert()
+    `);
+    await observer.unsafe(`
+      CREATE FUNCTION qa_migration_lock.gate_replica_b_ddl()
+      RETURNS event_trigger
+      LANGUAGE plpgsql
+      AS $function$
+      BEGIN
+        IF current_setting('application_name', true) = '${REPLICA_B}'
+        THEN
+          PERFORM pg_catalog.pg_advisory_lock(${QA_LOCK_CLASS}, ${REPLICA_B_DDL_GATE});
+          PERFORM pg_catalog.pg_advisory_unlock(${QA_LOCK_CLASS}, ${REPLICA_B_DDL_GATE});
+        END IF;
+      END;
+      $function$
+    `);
+    await observer.unsafe(`
+      CREATE EVENT TRIGGER qa_gate_replica_b_ddl
+      ON ddl_command_start
+      EXECUTE FUNCTION qa_migration_lock.gate_replica_b_ddl()
+    `);
+    await controller.unsafe(`
+      SELECT
+        pg_advisory_lock(${QA_LOCK_CLASS}, ${FINAL_INSERT_GATE}),
+        pg_advisory_lock(${QA_LOCK_CLASS}, ${REPLICA_B_DDL_GATE})
+    `);
+
+    return { name, url, admin, observer, controller, tracked: [] };
+  } catch (error) {
+    await Promise.allSettled([
+      observer?.end({ timeout: 0 }) ?? Promise.resolve(),
+      controller?.end({ timeout: 0 }) ?? Promise.resolve(),
+    ]);
+    await admin.unsafe(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`).catch(() => undefined);
+    await admin.end({ timeout: 0 }).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function cleanupScratchDatabase(scratch: ScratchDatabase): Promise<void> {
+  const cleanupErrors: unknown[] = [];
+  try {
+    await scratch.controller`SELECT pg_advisory_unlock_all()`;
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+
+  let dropped = false;
+  if (!(await settlesWithin(scratch.tracked, SCRATCH_DRAIN_TIMEOUT_MS))) {
+    try {
+      await scratch.admin.unsafe(`DROP DATABASE IF EXISTS ${scratch.name} WITH (FORCE)`);
+      dropped = true;
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    if (!(await settlesWithin(scratch.tracked, SCRATCH_DRAIN_TIMEOUT_MS))) {
+      cleanupErrors.push(new Error("migration promises did not settle after force-dropping the scratch database"));
+    }
+  }
+
+  const connectionCleanup = await Promise.allSettled([
+    scratch.observer.end({ timeout: 0 }),
+    scratch.controller.end({ timeout: 0 }),
+  ]);
+  for (const result of connectionCleanup) {
+    if (result.status === "rejected") cleanupErrors.push(result.reason);
+  }
+
+  if (!dropped) {
+    try {
+      await scratch.admin<Array<{ pg_terminate_backend: boolean }>>`
+        SELECT pg_terminate_backend(pid)
+        FROM pg_stat_activity
+        WHERE datname = ${scratch.name}
+          AND backend_type = 'client backend'
+          AND pid <> pg_backend_pid()
+      `;
+      await scratch.admin.unsafe(`DROP DATABASE IF EXISTS ${scratch.name} WITH (FORCE)`);
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
+
+  if (!(await settlesWithin(scratch.tracked, SCRATCH_DRAIN_TIMEOUT_MS))) {
+    cleanupErrors.push(new Error("migration promises did not settle during scratch database cleanup"));
+  }
+  try {
+    await scratch.admin.end({ timeout: 0 });
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+  if (cleanupErrors.length > 0) throw new AggregateError(cleanupErrors, "scratch database cleanup failed");
+}
+
+async function withScratchDatabase(run: (scratch: ScratchDatabase) => Promise<void>): Promise<void> {
+  const scratch = await createScratchDatabase();
+  const body = track(run(scratch));
+  let hasPrimaryError = false;
+  let primaryError: unknown;
+  if (await settlesWithin([body], SCRATCH_BODY_TIMEOUT_MS)) {
+    const outcome = await body;
+    if (outcome.status === "rejected") {
+      hasPrimaryError = true;
+      primaryError = outcome.reason;
+    }
+  } else {
+    hasPrimaryError = true;
+    primaryError = new Error(`scratch test body did not settle within ${SCRATCH_BODY_TIMEOUT_MS}ms`);
+  }
+
+  const cleanupErrors: unknown[] = [];
+  try {
+    await cleanupScratchDatabase(scratch);
+  } catch (cleanupError) {
+    cleanupErrors.push(cleanupError);
+  }
+  if (!(await settlesWithin([body], 2_000))) {
+    cleanupErrors.push(new Error("scratch test body remained pending after cleanup"));
+  }
+
+  if (hasPrimaryError && cleanupErrors.length > 0) {
+    throw new AggregateError([primaryError, ...cleanupErrors], "test and scratch cleanup both failed");
+  }
+  if (hasPrimaryError) throw primaryError;
+  if (cleanupErrors.length > 0) throw new AggregateError(cleanupErrors, "scratch cleanup failed");
+}
+
+describe("startup migration advisory lock", () => {
+  it("times out a contending session, leaves no waiter, then succeeds after release", async () => {
+    const databaseUrl = process.env.DATABASE_URL;
     expect(databaseUrl, "DATABASE_URL must be set by global setup").toBeTruthy();
     const url = databaseUrl ?? "";
-
-    // Hold the advisory lock from a separate session for the duration of
-    // the test. `pg_advisory_lock` blocks if contested, but we're the only
-    // contender so it returns immediately.
+    const applicationName = `ft_migration_contender_${randomUUID().slice(0, 8)}`;
+    const contenderUrl = databaseUrlWithApplicationName(url, applicationName);
     const holder = postgres(url, { max: 1, ...sslOptions(url) });
+    const observer = postgres(url, { max: 1, ...sslOptions(url) });
+    let holderReleased = false;
     try {
       await holder`SELECT pg_advisory_lock(hashtext('drizzle_migrations'))`;
+      const startedAt = performance.now();
 
-      // Use a tight 2s preflight timeout so the contention path completes
-      // fast. The 30s production default is the right answer for boot, not
-      // for a unit test that just needs to assert the error path.
-      await expect(runMigrations(url, { lockTimeoutMs: 2_000 })).rejects.toThrow(/migration lock contention/);
-    } finally {
-      // Release the lock so subsequent test runs (and other test files in
-      // the same worker process) aren't blocked.
+      await expect(runMigrations(contenderUrl, { lockTimeoutMs: 2_000 })).rejects.toThrow(/migration lock contention/);
+
+      const elapsedMs = performance.now() - startedAt;
+      expect(elapsedMs).toBeGreaterThanOrEqual(1_800);
+      expect(elapsedMs).toBeLessThan(5_000);
+      const sessions = await observer<Array<{ count: number }>>`
+        SELECT count(*)::int AS count
+        FROM pg_stat_activity
+        WHERE datname = current_database() AND application_name = ${applicationName}
+      `;
+      expect(sessions[0]?.count).toBe(0);
+
       await holder`SELECT pg_advisory_unlock(hashtext('drizzle_migrations'))`;
-      await holder.end();
+      holderReleased = true;
+      await expect(runMigrations(contenderUrl, { lockTimeoutMs: 2_000 })).resolves.toBeGreaterThan(0);
+    } finally {
+      if (!holderReleased) {
+        await holder`SELECT pg_advisory_unlock(hashtext('drizzle_migrations'))`.catch(() => undefined);
+      }
+      await Promise.allSettled([holder.end({ timeout: 0 }), observer.end({ timeout: 0 })]);
     }
   });
 
+  it("serializes two real migrations through the final journal commit", {
+    timeout: SCRATCH_CASE_TIMEOUT_MS,
+  }, async () => {
+    await withScratchDatabase(async (scratch) => {
+      const replicaAUrl = databaseUrlWithApplicationName(scratch.url, REPLICA_A);
+      const replicaBUrl = databaseUrlWithApplicationName(scratch.url, REPLICA_B);
+      const replicaA = track(runMigrations(replicaAUrl));
+      scratch.tracked.push(replicaA);
+
+      const stateA = await waitForBackendState(
+        scratch.observer,
+        REPLICA_A,
+        (state) =>
+          state.holds_migration_lock &&
+          state.waits_final_insert_gate &&
+          state.wait_event_type === "Lock" &&
+          state.wait_event === "advisory" &&
+          /insert into "drizzle"\."__drizzle_migrations"/i.test(state.query),
+        "replica A at the final journal insert while holding the migration lock",
+      );
+      expect(await readJournalWhens(scratch.observer)).toEqual([]);
+
+      let replicaBSettled = false;
+      const replicaB = track(runMigrations(replicaBUrl)).then((outcome) => {
+        replicaBSettled = true;
+        return outcome;
+      });
+      scratch.tracked.push(replicaB);
+      await waitForBackendState(
+        scratch.observer,
+        REPLICA_B,
+        (state) => /pg_try_advisory_lock/i.test(state.query),
+        "replica B to attempt the migration lock",
+      );
+
+      await delay(1_250);
+      expect(replicaBSettled).toBe(false);
+      const blockedBStates = await readBackendStates(scratch.observer, REPLICA_B);
+      expect(blockedBStates.some((state) => state.waits_replica_b_ddl_gate)).toBe(false);
+
+      await releaseGate(scratch.controller, FINAL_INSERT_GATE);
+      const stateB = await waitForBackendState(
+        scratch.observer,
+        REPLICA_B,
+        (state) => state.holds_migration_lock && state.waits_replica_b_ddl_gate && /create schema/i.test(state.query),
+        "replica B at its real Drizzle DDL after replica A committed",
+      );
+      expect(stateB.pid).not.toBe(stateA.pid);
+      expect(await readJournalWhens(scratch.observer)).toEqual(expectedJournalWhens);
+
+      await releaseGate(scratch.controller, REPLICA_B_DDL_GATE);
+      const [outcomeA, outcomeB] = await Promise.all([replicaA, replicaB]);
+      expect(outcomeA.status).toBe("fulfilled");
+      expect(outcomeB.status).toBe("fulfilled");
+      if (outcomeA.status === "fulfilled" && outcomeB.status === "fulfilled") {
+        expect(outcomeA.value).toBeGreaterThan(0);
+        expect(outcomeB.value).toBe(outcomeA.value);
+      }
+      expect(await readJournalWhens(scratch.observer)).toEqual(expectedJournalWhens);
+    });
+  });
+
+  it("fails closed on backend loss without reconnecting and allows a later replica to recover", {
+    timeout: SCRATCH_CASE_TIMEOUT_MS,
+  }, async () => {
+    await withScratchDatabase(async (scratch) => {
+      const replicaAUrl = databaseUrlWithApplicationName(scratch.url, REPLICA_A);
+      const replicaBUrl = databaseUrlWithApplicationName(scratch.url, REPLICA_B);
+      const replicaA = track(runMigrations(replicaAUrl));
+      scratch.tracked.push(replicaA);
+
+      const stateA = await waitForBackendState(
+        scratch.observer,
+        REPLICA_A,
+        (state) => state.holds_migration_lock && state.waits_final_insert_gate,
+        "replica A at the final journal gate before backend termination",
+      );
+
+      const replicaB = track(runMigrations(replicaBUrl));
+      scratch.tracked.push(replicaB);
+      const waitingStateB = await waitForBackendState(
+        scratch.observer,
+        REPLICA_B,
+        (state) => /pg_try_advisory_lock/i.test(state.query),
+        "replica B to contend for replica A's migration lock",
+      );
+      expect(
+        (await readBackendStates(scratch.observer, REPLICA_B)).some((state) => state.waits_replica_b_ddl_gate),
+      ).toBe(false);
+
+      const terminated = await scratch.observer<Array<{ terminated: boolean }>>`
+        SELECT pg_terminate_backend(${stateA.pid}) AS terminated
+      `;
+      expect(terminated[0]?.terminated).toBe(true);
+
+      const outcomeA = await replicaA;
+      expect(outcomeA.status).toBe("rejected");
+      await waitForNoBackend(scratch.observer, REPLICA_A);
+      const recoveredStateB = await waitForBackendState(
+        scratch.observer,
+        REPLICA_B,
+        (state) => state.holds_migration_lock && state.waits_replica_b_ddl_gate,
+        "the already-contending replica B to acquire the released session lock",
+      );
+      expect(recoveredStateB.pid).toBe(waitingStateB.pid);
+      await delay(1_250);
+      expect(await readBackendStates(scratch.observer, REPLICA_A)).toEqual([]);
+      expect(await readJournalWhens(scratch.observer)).toEqual([]);
+
+      await releaseGate(scratch.controller, FINAL_INSERT_GATE);
+      await releaseGate(scratch.controller, REPLICA_B_DDL_GATE);
+      const outcomeB = await replicaB;
+      expect(outcomeB.status).toBe("fulfilled");
+      if (outcomeB.status === "fulfilled") expect(outcomeB.value).toBeGreaterThan(0);
+      expect(await readJournalWhens(scratch.observer)).toEqual(expectedJournalWhens);
+    });
+  });
+
   it("succeeds when the advisory lock is free", async () => {
+    const databaseUrl = process.env.DATABASE_URL;
     expect(databaseUrl, "DATABASE_URL must be set by global setup").toBeTruthy();
-    // Sanity case: with no holder, preflight returns fast and migrate runs.
-    const tableCount = await runMigrations(databaseUrl ?? "");
-    expect(tableCount).toBeGreaterThan(0);
+    await expect(runMigrations(databaseUrl ?? "")).resolves.toBeGreaterThan(0);
   });
 });

--- a/packages/server/src/__tests__/bootstrap-migration-lock.test.ts
+++ b/packages/server/src/__tests__/bootstrap-migration-lock.test.ts
@@ -16,9 +16,13 @@ const REPLICA_B_DDL_GATE = 2;
 const SCRATCH_CASE_TIMEOUT_MS = 60_000;
 const SCRATCH_BODY_TIMEOUT_MS = 35_000;
 const SCRATCH_DRAIN_TIMEOUT_MS = 5_000;
-const RECONNECT_BACKOFF_MS = 3_000;
-const RECONNECT_LOCK_TIMEOUT_MS = 2_200;
+const RECONNECT_BACKOFF_MS = 7_000;
+const RECONNECT_LOCK_TIMEOUT_MS = 5_000;
 const RECONNECT_OBSERVATION_MS = RECONNECT_BACKOFF_MS + 500;
+const RECONNECT_SECOND_POLL_WAIT_MS = 1_250;
+const RECONNECT_RETURN_GRACE_MS = 1_000;
+const RECONNECT_DRAIN_TIMEOUT_MS = 5_000;
+const RECONNECT_CASE_TIMEOUT_MS = 45_000;
 
 const journal = JSON.parse(
   readFileSync(fileURLToPath(new URL("../../drizzle/meta/_journal.json", import.meta.url)), "utf8"),
@@ -64,6 +68,8 @@ async function delay(ms: number): Promise<void> {
 type TcpForwardingGate = {
   port: number;
   acceptedConnections(): number;
+  downstreamCloses(): number;
+  waitForDownstreamCloseAfter(count: number, timeoutMs: number): Promise<{ count: number; closedAt: number }>;
   setForwarding(enabled: boolean): void;
   close(): Promise<void>;
 };
@@ -73,12 +79,20 @@ async function createTcpForwardingGate(targetUrl: string): Promise<TcpForwarding
   const targetPort = Number(target.port || "5432");
   let forwarding = true;
   let acceptedConnections = 0;
+  let downstreamCloses = 0;
+  let lastDownstreamClose: { count: number; closedAt: number } | undefined;
+  const downstreamCloseListeners = new Set<(observation: { count: number; closedAt: number }) => void>();
   const sockets = new Set<Socket>();
   const server = createServer((downstream) => {
     acceptedConnections += 1;
     sockets.add(downstream);
     downstream.on("error", () => undefined);
-    downstream.once("close", () => sockets.delete(downstream));
+    downstream.once("close", () => {
+      sockets.delete(downstream);
+      downstreamCloses += 1;
+      lastDownstreamClose = { count: downstreamCloses, closedAt: performance.now() };
+      for (const listener of downstreamCloseListeners) listener(lastDownstreamClose);
+    });
 
     if (!forwarding) {
       downstream.destroy();
@@ -113,6 +127,37 @@ async function createTcpForwardingGate(targetUrl: string): Promise<TcpForwarding
   return {
     port: (address as AddressInfo).port,
     acceptedConnections: () => acceptedConnections,
+    downstreamCloses: () => downstreamCloses,
+    waitForDownstreamCloseAfter(count, timeoutMs) {
+      if (lastDownstreamClose !== undefined && lastDownstreamClose.count > count) {
+        return Promise.resolve(lastDownstreamClose);
+      }
+
+      return new Promise((resolve, reject) => {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const cleanup = (): void => {
+          downstreamCloseListeners.delete(onClose);
+          if (timer !== undefined) clearTimeout(timer);
+        };
+        const onClose = (observation: { count: number; closedAt: number }): void => {
+          if (observation.count <= count) return;
+          cleanup();
+          resolve(observation);
+        };
+
+        downstreamCloseListeners.add(onClose);
+        // Close can race listener registration between the fast-path check
+        // above and this insertion.
+        if (lastDownstreamClose !== undefined && lastDownstreamClose.count > count) {
+          onClose(lastDownstreamClose);
+          return;
+        }
+        timer = setTimeout(() => {
+          cleanup();
+          reject(new Error(`timed out waiting for a downstream close after count ${count}`));
+        }, timeoutMs);
+      });
+    },
     setForwarding(enabled) {
       forwarding = enabled;
       if (enabled) return;
@@ -234,6 +279,20 @@ async function settlesWithin(promises: readonly Promise<unknown>[], timeoutMs: n
     timer = setTimeout(() => resolve(false), timeoutMs);
   });
   const settled = Promise.allSettled(promises).then(() => true as const);
+  const result = await Promise.race([settled, timeout]);
+  if (timer !== undefined) clearTimeout(timer);
+  return result;
+}
+
+async function valueWithin<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<{ readonly kind: "settled"; readonly value: T } | { readonly kind: "timed-out" }> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<{ readonly kind: "timed-out" }>((resolve) => {
+    timer = setTimeout(() => resolve({ kind: "timed-out" }), timeoutMs);
+  });
+  const settled = promise.then((value) => ({ kind: "settled" as const, value }));
   const result = await Promise.race([settled, timeout]);
   if (timer !== undefined) clearTimeout(timer);
   return result;
@@ -477,7 +536,9 @@ describe("startup migration advisory lock", () => {
     }
   });
 
-  it("cancels a queued initial reconnect without creating a backend after returning", { timeout: 30_000 }, async () => {
+  it("cancels a queued initial reconnect without creating a backend after returning", {
+    timeout: RECONNECT_CASE_TIMEOUT_MS,
+  }, async () => {
     const databaseUrl = process.env.DATABASE_URL;
     expect(databaseUrl, "DATABASE_URL must be set by global setup").toBeTruthy();
     const url = databaseUrl ?? "";
@@ -494,6 +555,7 @@ describe("startup migration advisory lock", () => {
     let holderLocked = false;
     let migrationSettled = false;
     let migration: Promise<Outcome<number>> | undefined;
+    let hasPrimaryError = false;
     let primaryError: unknown;
     try {
       await holder`SELECT pg_advisory_lock(hashtext('drizzle_migrations'))`;
@@ -513,21 +575,43 @@ describe("startup migration advisory lock", () => {
         "the first migration lock miss before forcing a reconnect",
       );
       expect(tcpGate.acceptedConnections()).toBeGreaterThan(0);
+      const closesBeforeTermination = tcpGate.downstreamCloses();
       const terminated = await observer<Array<{ terminated: boolean }>>`
           SELECT pg_terminate_backend(${firstBackend.pid}) AS terminated
         `;
       expect(terminated[0]?.terminated).toBe(true);
+      const closeObservation = await tcpGate.waitForDownstreamCloseAfter(closesBeforeTermination, 2_000);
       tcpGate.setForwarding(false);
       await waitForNoBackend(observer, applicationName);
 
-      // The migration loop polls after one second. Keep the endpoint down
-      // until that second query is queued in postgres-js's initial reconnect
-      // state, but restore it only after the acquisition watchdog returns.
-      const untilSecondPollMs = startedAt + 1_250 - performance.now();
-      if (untilSecondPollMs > 0) await delay(untilSecondPollMs);
+      // The first lock miss has completed and the migration-side socket has
+      // observably closed. The acquisition loop sleeps for at most one second
+      // before submitting its next try-lock query, so a full 1.25 seconds from
+      // this close proves that query has entered postgres-js's initial
+      // reconnect state. Keep a separate margin before the watchdog so the
+      // critical setup cannot be inferred merely from a still-pending promise.
+      const watchdogDeadline = startedAt + RECONNECT_LOCK_TIMEOUT_MS;
+      const secondPollSubmittedBy = closeObservation.closedAt + RECONNECT_SECOND_POLL_WAIT_MS;
+      expect(RECONNECT_BACKOFF_MS - RECONNECT_LOCK_TIMEOUT_MS).toBeGreaterThan(RECONNECT_RETURN_GRACE_MS);
+      expect(watchdogDeadline - secondPollSubmittedBy).toBeGreaterThan(RECONNECT_RETURN_GRACE_MS);
+      const acceptedAfterClose = tcpGate.acceptedConnections();
+      while (performance.now() < secondPollSubmittedBy) {
+        await delay(Math.ceil(secondPollSubmittedBy - performance.now()));
+      }
+      expect(performance.now()).toBeGreaterThanOrEqual(secondPollSubmittedBy);
+      expect(watchdogDeadline - performance.now()).toBeGreaterThan(RECONNECT_RETURN_GRACE_MS);
+      expect(tcpGate.acceptedConnections()).toBe(acceptedAfterClose);
       expect(migrationSettled).toBe(false);
 
-      const outcome = await migration;
+      const migrationReturnDeadline = watchdogDeadline + RECONNECT_RETURN_GRACE_MS;
+      const migrationReturnBudget = Math.max(1, migrationReturnDeadline - performance.now());
+      const boundedOutcome = await valueWithin(migration, migrationReturnBudget);
+      if (boundedOutcome.kind === "timed-out") {
+        throw new Error(
+          `migration reconnect regression did not settle by ${RECONNECT_RETURN_GRACE_MS}ms after its watchdog`,
+        );
+      }
+      const outcome = boundedOutcome.value;
       const elapsedMs = performance.now() - startedAt;
       expect(outcome.status).toBe("rejected");
       if (outcome.status === "rejected") {
@@ -544,11 +628,17 @@ describe("startup migration advisory lock", () => {
       expect(tcpGate.acceptedConnections()).toBe(acceptedAtRejection);
       expect(await readBackendStates(observer, applicationName)).toEqual([]);
     } catch (error) {
+      hasPrimaryError = true;
       primaryError = error;
     }
 
     const cleanupErrors: unknown[] = [];
     tcpGate.setForwarding(false);
+    try {
+      await tcpGate.close();
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
     try {
       await observer<Array<{ terminated: boolean }>>`
           SELECT pg_terminate_backend(pid) AS terminated
@@ -565,23 +655,18 @@ describe("startup migration advisory lock", () => {
         cleanupErrors.push(error);
       }
     }
-    if (migration !== undefined && !(await settlesWithin([migration], 5_000))) {
-      cleanupErrors.push(new Error("migration reconnect regression did not settle during cleanup"));
-    }
-    try {
-      await tcpGate.close();
-    } catch (error) {
-      cleanupErrors.push(error);
-    }
     const connectionCleanup = await Promise.allSettled([holder.end({ timeout: 0 }), observer.end({ timeout: 0 })]);
     for (const result of connectionCleanup) {
       if (result.status === "rejected") cleanupErrors.push(result.reason);
     }
+    if (migration !== undefined && !(await settlesWithin([migration], RECONNECT_DRAIN_TIMEOUT_MS))) {
+      cleanupErrors.push(new Error("migration reconnect regression did not settle after forced cleanup"));
+    }
 
-    if (primaryError !== undefined && cleanupErrors.length > 0) {
+    if (hasPrimaryError && cleanupErrors.length > 0) {
       throw new AggregateError([primaryError, ...cleanupErrors], "test and reconnect cleanup both failed");
     }
-    if (primaryError !== undefined) throw primaryError;
+    if (hasPrimaryError) throw primaryError;
     if (cleanupErrors.length > 0) throw new AggregateError(cleanupErrors, "reconnect cleanup failed");
   });
 

--- a/packages/server/src/__tests__/bootstrap-migration-lock.test.ts
+++ b/packages/server/src/__tests__/bootstrap-migration-lock.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { type AddressInfo, createConnection, createServer, type Socket } from "node:net";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
@@ -15,6 +16,9 @@ const REPLICA_B_DDL_GATE = 2;
 const SCRATCH_CASE_TIMEOUT_MS = 60_000;
 const SCRATCH_BODY_TIMEOUT_MS = 35_000;
 const SCRATCH_DRAIN_TIMEOUT_MS = 5_000;
+const RECONNECT_BACKOFF_MS = 3_000;
+const RECONNECT_LOCK_TIMEOUT_MS = 2_200;
+const RECONNECT_OBSERVATION_MS = RECONNECT_BACKOFF_MS + 500;
 
 const journal = JSON.parse(
   readFileSync(fileURLToPath(new URL("../../drizzle/meta/_journal.json", import.meta.url)), "utf8"),
@@ -55,6 +59,76 @@ function databaseUrlWithApplicationName(url: string, applicationName: string): s
 
 async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type TcpForwardingGate = {
+  port: number;
+  acceptedConnections(): number;
+  setForwarding(enabled: boolean): void;
+  close(): Promise<void>;
+};
+
+async function createTcpForwardingGate(targetUrl: string): Promise<TcpForwardingGate> {
+  const target = new URL(targetUrl);
+  const targetPort = Number(target.port || "5432");
+  let forwarding = true;
+  let acceptedConnections = 0;
+  const sockets = new Set<Socket>();
+  const server = createServer((downstream) => {
+    acceptedConnections += 1;
+    sockets.add(downstream);
+    downstream.on("error", () => undefined);
+    downstream.once("close", () => sockets.delete(downstream));
+
+    if (!forwarding) {
+      downstream.destroy();
+      return;
+    }
+
+    const upstream = createConnection({ host: target.hostname, port: targetPort });
+    sockets.add(upstream);
+    upstream.on("error", () => undefined);
+    upstream.once("close", () => {
+      sockets.delete(upstream);
+      downstream.destroy();
+    });
+    downstream.once("close", () => upstream.destroy());
+    downstream.pipe(upstream).pipe(downstream);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error(`TCP forwarding gate did not bind an IP port: ${String(address)}`);
+  }
+
+  return {
+    port: (address as AddressInfo).port,
+    acceptedConnections: () => acceptedConnections,
+    setForwarding(enabled) {
+      forwarding = enabled;
+      if (enabled) return;
+      for (const socket of sockets) socket.destroy();
+      sockets.clear();
+    },
+    async close() {
+      forwarding = false;
+      for (const socket of sockets) socket.destroy();
+      sockets.clear();
+      if (!server.listening) return;
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
 }
 
 async function readBackendStates(
@@ -113,7 +187,7 @@ async function waitForBackendState(
   predicate: (state: BackendState) => boolean,
   description: string,
 ): Promise<BackendState> {
-  const deadline = performance.now() + 8_000;
+  const deadline = performance.now() + 20_000;
   let lastStates: BackendState[] = [];
   while (performance.now() < deadline) {
     lastStates = await readBackendStates(observer, applicationName);
@@ -401,6 +475,114 @@ describe("startup migration advisory lock", () => {
       }
       await Promise.allSettled([holder.end({ timeout: 0 }), observer.end({ timeout: 0 })]);
     }
+  });
+
+  it("cancels a queued initial reconnect without creating a backend after returning", { timeout: 30_000 }, async () => {
+    const databaseUrl = process.env.DATABASE_URL;
+    expect(databaseUrl, "DATABASE_URL must be set by global setup").toBeTruthy();
+    const url = databaseUrl ?? "";
+    const applicationName = `ft_migration_reconnect_${randomUUID().slice(0, 8)}`;
+    const holder = postgres(url, { max: 1, ...sslOptions(url) });
+    const observer = postgres(url, { max: 1, ...sslOptions(url) });
+    const tcpGate = await createTcpForwardingGate(url);
+    const migrationUrl = new URL(url);
+    migrationUrl.hostname = "127.0.0.1";
+    migrationUrl.port = String(tcpGate.port);
+    migrationUrl.searchParams.set("application_name", applicationName);
+    migrationUrl.searchParams.set("backoff", String(RECONNECT_BACKOFF_MS / 1_000));
+
+    let holderLocked = false;
+    let migrationSettled = false;
+    let migration: Promise<Outcome<number>> | undefined;
+    let primaryError: unknown;
+    try {
+      await holder`SELECT pg_advisory_lock(hashtext('drizzle_migrations'))`;
+      holderLocked = true;
+      const startedAt = performance.now();
+      migration = track(runMigrations(migrationUrl.toString(), { lockTimeoutMs: RECONNECT_LOCK_TIMEOUT_MS })).then(
+        (outcome) => {
+          migrationSettled = true;
+          return outcome;
+        },
+      );
+
+      const firstBackend = await waitForBackendState(
+        observer,
+        applicationName,
+        (state) => state.state === "idle" && /pg_try_advisory_lock/i.test(state.query),
+        "the first migration lock miss before forcing a reconnect",
+      );
+      expect(tcpGate.acceptedConnections()).toBeGreaterThan(0);
+      const terminated = await observer<Array<{ terminated: boolean }>>`
+          SELECT pg_terminate_backend(${firstBackend.pid}) AS terminated
+        `;
+      expect(terminated[0]?.terminated).toBe(true);
+      tcpGate.setForwarding(false);
+      await waitForNoBackend(observer, applicationName);
+
+      // The migration loop polls after one second. Keep the endpoint down
+      // until that second query is queued in postgres-js's initial reconnect
+      // state, but restore it only after the acquisition watchdog returns.
+      const untilSecondPollMs = startedAt + 1_250 - performance.now();
+      if (untilSecondPollMs > 0) await delay(untilSecondPollMs);
+      expect(migrationSettled).toBe(false);
+
+      const outcome = await migration;
+      const elapsedMs = performance.now() - startedAt;
+      expect(outcome.status).toBe("rejected");
+      if (outcome.status === "rejected") {
+        expect(outcome.reason).toBeInstanceOf(Error);
+        if (outcome.reason instanceof Error) expect(outcome.reason.message).toMatch(/migration lock contention/);
+      }
+      expect(elapsedMs).toBeGreaterThanOrEqual(RECONNECT_LOCK_TIMEOUT_MS - 300);
+      expect(elapsedMs).toBeLessThan(RECONNECT_LOCK_TIMEOUT_MS + 750);
+      expect(await readBackendStates(observer, applicationName)).toEqual([]);
+
+      const acceptedAtRejection = tcpGate.acceptedConnections();
+      tcpGate.setForwarding(true);
+      await delay(RECONNECT_OBSERVATION_MS);
+      expect(tcpGate.acceptedConnections()).toBe(acceptedAtRejection);
+      expect(await readBackendStates(observer, applicationName)).toEqual([]);
+    } catch (error) {
+      primaryError = error;
+    }
+
+    const cleanupErrors: unknown[] = [];
+    tcpGate.setForwarding(false);
+    try {
+      await observer<Array<{ terminated: boolean }>>`
+          SELECT pg_terminate_backend(pid) AS terminated
+          FROM pg_stat_activity
+          WHERE datname = current_database() AND application_name = ${applicationName}
+        `;
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    if (holderLocked) {
+      try {
+        await holder`SELECT pg_advisory_unlock_all()`;
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
+    if (migration !== undefined && !(await settlesWithin([migration], 5_000))) {
+      cleanupErrors.push(new Error("migration reconnect regression did not settle during cleanup"));
+    }
+    try {
+      await tcpGate.close();
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    const connectionCleanup = await Promise.allSettled([holder.end({ timeout: 0 }), observer.end({ timeout: 0 })]);
+    for (const result of connectionCleanup) {
+      if (result.status === "rejected") cleanupErrors.push(result.reason);
+    }
+
+    if (primaryError !== undefined && cleanupErrors.length > 0) {
+      throw new AggregateError([primaryError, ...cleanupErrors], "test and reconnect cleanup both failed");
+    }
+    if (primaryError !== undefined) throw primaryError;
+    if (cleanupErrors.length > 0) throw new AggregateError(cleanupErrors, "reconnect cleanup failed");
   });
 
   it("serializes two real migrations through the final journal commit", {

--- a/packages/server/src/__tests__/db-migrate-lifecycle.test.ts
+++ b/packages/server/src/__tests__/db-migrate-lifecycle.test.ts
@@ -65,7 +65,7 @@ function makeHarness() {
     sleep: vi.fn(async (ms: number) => {
       nowMs += ms;
     }),
-    armWatchdog: vi.fn((fire: () => void) => {
+    armWatchdog: vi.fn((fire: () => void, _timeoutMs: number) => {
       fireWatchdog = fire;
       return cancelWatchdog;
     }),
@@ -95,11 +95,11 @@ function makeHarness() {
   };
 }
 
-function runHarness(harness: ReturnType<typeof makeHarness>, lockTimeoutMs = 15_000): Promise<number> {
+function runHarness(harness: ReturnType<typeof makeHarness>, lockTimeoutMs?: number): Promise<number> {
   return runMigrationsWithDependencies(
     "postgres://credentials-must-not-be-logged.invalid/database",
     "/valid/migrations",
-    { lockTimeoutMs },
+    lockTimeoutMs === undefined ? {} : { lockTimeoutMs },
     harness.dependencies,
   );
 }
@@ -116,7 +116,8 @@ describe("runMigrations fixed-session lifecycle", () => {
 
     const outcome = await track(runHarness(harness));
 
-    expect(outcome).toEqual({ status: "rejected", reason: primary });
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status === "rejected") expect(outcome.reason).toBe(primary);
     expect(harness.session.unlock).toHaveBeenCalledTimes(1);
     expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
     expect(harness.logger.warn.mock.calls).toEqual([
@@ -143,7 +144,8 @@ describe("runMigrations fixed-session lifecycle", () => {
 
     const outcome = await track(runHarness(harness));
 
-    expect(outcome).toEqual({ status: "rejected", reason: unlockError });
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status === "rejected") expect(outcome.reason).toBe(unlockError);
     expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
   });
 
@@ -154,7 +156,8 @@ describe("runMigrations fixed-session lifecycle", () => {
 
     const outcome = await track(runHarness(harness));
 
-    expect(outcome).toEqual({ status: "rejected", reason: endError });
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status === "rejected") expect(outcome.reason).toBe(endError);
     expect(harness.session.unlock).toHaveBeenCalledTimes(1);
   });
 
@@ -164,7 +167,8 @@ describe("runMigrations fixed-session lifecycle", () => {
 
     const outcome = await track(runHarness(harness));
 
-    expect(outcome).toEqual({ status: "rejected", reason: undefined });
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status === "rejected") expect(outcome.reason).toBeUndefined();
     expect(harness.session.unlock).toHaveBeenCalledTimes(1);
   });
 
@@ -187,6 +191,24 @@ describe("runMigrations fixed-session lifecycle", () => {
     expect(harness.session.unlock).not.toHaveBeenCalled();
     expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
     expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("arms the acquisition watchdog with the default timeout", async () => {
+    const harness = makeHarness();
+
+    await expect(runHarness(harness)).resolves.toBe(7);
+
+    expect(harness.dependencies.armWatchdog).toHaveBeenCalledExactlyOnceWith(expect.any(Function), 15_000);
+    expect(harness.openSession).toHaveBeenCalledWith(expect.objectContaining({ connectTimeoutSeconds: 15 }));
+  });
+
+  it("passes a timeout override to both the watchdog and connection timer", async () => {
+    const harness = makeHarness();
+
+    await expect(runHarness(harness, 1_501)).resolves.toBe(7);
+
+    expect(harness.dependencies.armWatchdog).toHaveBeenCalledExactlyOnceWith(expect.any(Function), 1_501);
+    expect(harness.openSession).toHaveBeenCalledWith(expect.objectContaining({ connectTimeoutSeconds: 2 }));
   });
 
   it("keeps connection loss primary when forced termination also fails", async () => {
@@ -300,7 +322,8 @@ describe("runMigrations fixed-session lifecycle", () => {
     unlock.resolve(true);
     const outcome = await outcomePromise;
 
-    expect(outcome).toEqual({ status: "rejected", reason: primary });
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status === "rejected") expect(outcome.reason).toBe(primary);
     expect(harness.logger.warn).toHaveBeenCalledTimes(1);
     expect(harness.logger.warn).toHaveBeenCalledWith(
       {
@@ -342,7 +365,8 @@ describe("runMigrations fixed-session lifecycle", () => {
 
     const outcome = await track(runHarness(harness));
 
-    expect(outcome).toEqual({ status: "rejected", reason: primary });
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status === "rejected") expect(outcome.reason).toBe(primary);
     expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
     expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
   });
@@ -436,6 +460,16 @@ describe("runMigrations fixed-session lifecycle", () => {
       ],
     ]);
     expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("clamps the connection timer at Node's safe maximum while preserving the watchdog deadline", async () => {
+    const harness = makeHarness();
+    const maximumTimerDelayMs = 2_147_483_647;
+
+    await expect(runHarness(harness, maximumTimerDelayMs)).resolves.toBe(7);
+
+    expect(harness.openSession).toHaveBeenCalledWith(expect.objectContaining({ connectTimeoutSeconds: 2_147_483 }));
+    expect(harness.dependencies.armWatchdog).toHaveBeenCalledExactlyOnceWith(expect.any(Function), maximumTimerDelayMs);
   });
 
   it.each([

--- a/packages/server/src/__tests__/db-migrate-lifecycle.test.ts
+++ b/packages/server/src/__tests__/db-migrate-lifecycle.test.ts
@@ -1,0 +1,455 @@
+import { describe, expect, it, vi } from "vitest";
+import { type RunMigrationsDependencies, runMigrationsWithDependencies } from "../db/migrate.js";
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(reason: unknown): void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason: unknown) => void = () => undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+type Outcome<T> =
+  | { readonly status: "fulfilled"; readonly value: T }
+  | { readonly status: "rejected"; readonly reason: unknown };
+
+function track<T>(promise: Promise<T>): Promise<Outcome<T>> {
+  return promise.then(
+    (value) => ({ status: "fulfilled", value }),
+    (reason: unknown) => ({ status: "rejected", reason }),
+  );
+}
+
+async function waitForCall(mock: ReturnType<typeof vi.fn>): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (mock.mock.calls.length > 0) return;
+    await Promise.resolve();
+  }
+  throw new Error("timed out waiting for mocked operation");
+}
+
+function makeHarness() {
+  let nowMs = 0;
+  let onLockAcquired: (() => void) | undefined;
+  let onClose: ((connectionId: number) => void) | undefined;
+  let fireWatchdog: (() => void) | undefined;
+  const cancelWatchdog = vi.fn();
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+  const session = {
+    tryAcquireLock: vi.fn(async () => true),
+    migrate: vi.fn(async () => undefined),
+    countTables: vi.fn(async () => 7),
+    unlock: vi.fn(async () => true),
+    end: vi.fn(async (_options: { timeout: 0 }) => undefined),
+  };
+  const openSession = vi.fn((input: Parameters<RunMigrationsDependencies["openSession"]>[0]) => {
+    onLockAcquired = input.onLockAcquired;
+    onClose = input.onClose;
+    return session;
+  });
+  const dependencies: RunMigrationsDependencies = {
+    openSession,
+    logger,
+    now: () => nowMs,
+    sleep: vi.fn(async (ms: number) => {
+      nowMs += ms;
+    }),
+    armWatchdog: vi.fn((fire: () => void) => {
+      fireWatchdog = fire;
+      return cancelWatchdog;
+    }),
+  };
+
+  return {
+    dependencies,
+    logger,
+    openSession,
+    session,
+    cancelWatchdog,
+    advanceTime(ms: number) {
+      nowMs += ms;
+    },
+    acquireLock() {
+      if (!onLockAcquired) throw new Error("session has not been opened");
+      onLockAcquired();
+    },
+    close(connectionId = 4242) {
+      if (!onClose) throw new Error("session has not been opened");
+      onClose(connectionId);
+    },
+    fireWatchdog() {
+      if (!fireWatchdog) throw new Error("watchdog has not been armed");
+      fireWatchdog();
+    },
+  };
+}
+
+function runHarness(harness: ReturnType<typeof makeHarness>, lockTimeoutMs = 15_000): Promise<number> {
+  return runMigrationsWithDependencies(
+    "postgres://credentials-must-not-be-logged.invalid/database",
+    "/valid/migrations",
+    { lockTimeoutMs },
+    harness.dependencies,
+  );
+}
+
+describe("runMigrations fixed-session lifecycle", () => {
+  it("preserves the exact migration error when unlock and end both fail", async () => {
+    const harness = makeHarness();
+    const primary = new Error("migration failed");
+    const unlockError = new Error("unlock failed");
+    const endError = new Error("end failed");
+    harness.session.migrate.mockRejectedValueOnce(primary);
+    harness.session.unlock.mockRejectedValueOnce(unlockError);
+    harness.session.end.mockRejectedValueOnce(endError);
+
+    const outcome = await track(runHarness(harness));
+
+    expect(outcome).toEqual({ status: "rejected", reason: primary });
+    expect(harness.session.unlock).toHaveBeenCalledTimes(1);
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+    expect(harness.logger.warn.mock.calls).toEqual([
+      [{ err: unlockError }, "migration cleanup failed after primary error"],
+      [{ err: endError }, "migration cleanup failed after primary error"],
+    ]);
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails a successful migration when advisory unlock returns false", async () => {
+    const harness = makeHarness();
+    harness.session.unlock.mockResolvedValueOnce(false);
+
+    await expect(runHarness(harness)).rejects.toThrow(/unlock was not confirmed/);
+
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails a successful migration with the exact advisory unlock error", async () => {
+    const harness = makeHarness();
+    const unlockError = new Error("unlock query failed");
+    harness.session.unlock.mockRejectedValueOnce(unlockError);
+
+    const outcome = await track(runHarness(harness));
+
+    expect(outcome).toEqual({ status: "rejected", reason: unlockError });
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+  });
+
+  it("fails a successful migration with the exact final close error", async () => {
+    const harness = makeHarness();
+    const endError = new Error("final close failed");
+    harness.session.end.mockRejectedValueOnce(endError);
+
+    const outcome = await track(runHarness(harness));
+
+    expect(outcome).toEqual({ status: "rejected", reason: endError });
+    expect(harness.session.unlock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not treat an undefined cleanup rejection as success", async () => {
+    const harness = makeHarness();
+    harness.session.end.mockRejectedValueOnce(undefined);
+
+    const outcome = await track(runHarness(harness));
+
+    expect(outcome).toEqual({ status: "rejected", reason: undefined });
+    expect(harness.session.unlock).toHaveBeenCalledTimes(1);
+  });
+
+  it("poisons protected work and force-ends once when the backend closes", async () => {
+    const harness = makeHarness();
+    harness.session.migrate.mockImplementationOnce(async () => {
+      harness.close(111);
+    });
+    // Exercise the re-entrancy guard: a driver may synchronously notify close
+    // while force-end is being invoked.
+    harness.session.end.mockImplementationOnce(async () => {
+      harness.close(111);
+    });
+
+    await expect(runHarness(harness)).rejects.toThrow(
+      /migration postgres-js connection 111 closed before advisory lock release was confirmed/,
+    );
+
+    expect(harness.session.countTables).not.toHaveBeenCalled();
+    expect(harness.session.unlock).not.toHaveBeenCalled();
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps connection loss primary when forced termination also fails", async () => {
+    const harness = makeHarness();
+    const endError = new Error("forced end failed");
+    harness.session.migrate.mockImplementationOnce(async () => {
+      harness.close(155);
+    });
+    harness.session.end.mockRejectedValueOnce(endError);
+
+    await expect(runHarness(harness)).rejects.toThrow(
+      /migration postgres-js connection 155 closed before advisory lock release was confirmed/,
+    );
+
+    expect(harness.logger.warn.mock.calls).toEqual([
+      [{ err: endError }, "migration cleanup failed after primary error"],
+    ]);
+  });
+
+  it("poisons a close after the lock result but before the acquire promise resolves", async () => {
+    const harness = makeHarness();
+    harness.session.tryAcquireLock.mockImplementationOnce(async () => {
+      harness.acquireLock();
+      harness.close(166);
+      return true;
+    });
+
+    await expect(runHarness(harness)).rejects.toThrow(
+      /migration postgres-js connection 166 closed before advisory lock release was confirmed/,
+    );
+
+    expect(harness.session.migrate).not.toHaveBeenCalled();
+    expect(harness.session.unlock).not.toHaveBeenCalled();
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("poisons the cleanup gap after count resolves without issuing unlock SQL", async () => {
+    const harness = makeHarness();
+    const count = deferred<number>();
+    harness.session.countTables.mockImplementationOnce(() => count.promise);
+    const outcomePromise = track(runHarness(harness));
+    await waitForCall(harness.session.countTables);
+
+    count.resolve(7);
+    harness.close(222);
+    const outcome = await outcomePromise;
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status === "rejected") {
+      expect(outcome.reason).toEqual(
+        expect.objectContaining({
+          message: "migration postgres-js connection 222 closed before advisory lock release was confirmed",
+        }),
+      );
+    }
+    expect(harness.session.unlock).not.toHaveBeenCalled();
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the session poisoned until an in-flight unlock is confirmed", async () => {
+    const harness = makeHarness();
+    const unlock = deferred<boolean>();
+    harness.session.unlock.mockImplementationOnce(() => unlock.promise);
+    const outcomePromise = track(runHarness(harness));
+    await waitForCall(harness.session.unlock);
+
+    harness.close(333);
+    unlock.resolve(true);
+    const outcome = await outcomePromise;
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status === "rejected") {
+      expect(outcome.reason).toEqual(
+        expect.objectContaining({
+          message: "migration postgres-js connection 333 closed before advisory lock release was confirmed",
+        }),
+      );
+    }
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not poison an intentional bounded close after unlock", async () => {
+    const harness = makeHarness();
+    harness.session.end.mockImplementationOnce(async () => {
+      harness.close(444);
+    });
+
+    await expect(runHarness(harness)).resolves.toBe(7);
+
+    expect(harness.session.unlock).toHaveBeenCalledTimes(1);
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+    expect(harness.logger.info).not.toHaveBeenCalled();
+    expect(harness.logger.warn).not.toHaveBeenCalled();
+    expect(harness.openSession).toHaveBeenCalledWith(expect.objectContaining({ connectTimeoutSeconds: 15 }));
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates connection loss captured again by unlock cleanup", async () => {
+    const harness = makeHarness();
+    const primary = new Error("migration failed first");
+    const unlock = deferred<boolean>();
+    harness.session.migrate.mockRejectedValueOnce(primary);
+    harness.session.unlock.mockImplementationOnce(() => unlock.promise);
+    const outcomePromise = track(runHarness(harness));
+    await waitForCall(harness.session.unlock);
+
+    harness.close(455);
+    unlock.resolve(true);
+    const outcome = await outcomePromise;
+
+    expect(outcome).toEqual({ status: "rejected", reason: primary });
+    expect(harness.logger.warn).toHaveBeenCalledTimes(1);
+    expect(harness.logger.warn).toHaveBeenCalledWith(
+      {
+        err: expect.objectContaining({
+          message: "migration postgres-js connection 455 closed before advisory lock release was confirmed",
+        }),
+      },
+      "migration cleanup failed after primary error",
+    );
+  });
+
+  it("logs one wait and one acquisition without polling spam or credentials", async () => {
+    const harness = makeHarness();
+    harness.session.tryAcquireLock
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    await expect(runHarness(harness)).resolves.toBe(7);
+
+    expect(harness.logger.info.mock.calls).toEqual([
+      [
+        { lockKey: "hashtext('drizzle_migrations')", timeoutMs: 15_000 },
+        "waiting for migration lock held by another session",
+      ],
+      [
+        { lockKey: "hashtext('drizzle_migrations')", waitMs: 2_000, timeoutMs: 15_000 },
+        "acquired migration lock after waiting",
+      ],
+    ]);
+    expect(JSON.stringify(harness.logger.info.mock.calls)).not.toContain("credentials-must-not-be-logged");
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the watchdog and preserves an ordinary acquisition error", async () => {
+    const harness = makeHarness();
+    const primary = new Error("authentication failed");
+    harness.session.tryAcquireLock.mockRejectedValueOnce(primary);
+
+    const outcome = await track(runHarness(harness));
+
+    expect(outcome).toEqual({ status: "rejected", reason: primary });
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("force-ends and drains a pending acquisition at the hard deadline", async () => {
+    const harness = makeHarness();
+    const acquisition = deferred<boolean>();
+    const ended = new Error("connection destroyed");
+    harness.session.tryAcquireLock.mockImplementationOnce(() => acquisition.promise);
+    harness.session.end.mockImplementationOnce(async () => {
+      acquisition.reject(ended);
+    });
+    const outcomePromise = track(runHarness(harness));
+    await waitForCall(harness.session.tryAcquireLock);
+
+    harness.fireWatchdog();
+    const outcome = await outcomePromise;
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status === "rejected") {
+      expect(outcome.reason).toEqual(
+        expect.objectContaining({ message: "migration lock acquisition timed out after 15000ms" }),
+      );
+    }
+    expect(harness.session.migrate).not.toHaveBeenCalled();
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a lock acquired after the hard deadline before migration starts", async () => {
+    const harness = makeHarness();
+    harness.session.tryAcquireLock.mockImplementationOnce(async () => {
+      harness.acquireLock();
+      harness.advanceTime(15_000);
+      return true;
+    });
+
+    await expect(runHarness(harness)).rejects.toThrow(/migration lock acquisition timed out after 15000ms/);
+
+    expect(harness.session.migrate).not.toHaveBeenCalled();
+    expect(harness.session.unlock).not.toHaveBeenCalled();
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains contention diagnostics when a lock miss arrives at the hard deadline", async () => {
+    const harness = makeHarness();
+    harness.session.tryAcquireLock.mockImplementationOnce(async () => {
+      harness.advanceTime(15_000);
+      return false;
+    });
+
+    await expect(runHarness(harness)).rejects.toThrow(/migration lock contention/);
+
+    expect(harness.session.tryAcquireLock).toHaveBeenCalledTimes(1);
+    expect(harness.session.migrate).not.toHaveBeenCalled();
+    expect(harness.logger.info.mock.calls).toEqual([
+      [
+        { lockKey: "hashtext('drizzle_migrations')", timeoutMs: 15_000 },
+        "waiting for migration lock held by another session",
+      ],
+    ]);
+    expect(harness.session.end).toHaveBeenCalledExactlyOnceWith({ timeout: 0 });
+  });
+
+  it("reports contention when the hard deadline fires while sleeping after a miss", async () => {
+    const harness = makeHarness();
+    const sleep = deferred<void>();
+    harness.session.tryAcquireLock.mockResolvedValueOnce(false);
+    harness.dependencies.sleep = vi.fn(async (_ms: number, terminalSignal: Promise<void>) => {
+      await Promise.race([sleep.promise, terminalSignal]);
+    });
+    const outcomePromise = track(runHarness(harness));
+    await waitForCall(harness.dependencies.sleep as ReturnType<typeof vi.fn>);
+
+    harness.fireWatchdog();
+    sleep.resolve();
+    const outcome = await outcomePromise;
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status === "rejected") {
+      expect(outcome.reason).toEqual(
+        expect.objectContaining({ message: expect.stringMatching(/migration lock contention/) }),
+      );
+    }
+    expect(harness.session.tryAcquireLock).toHaveBeenCalledTimes(1);
+    expect(harness.logger.info.mock.calls).toEqual([
+      [
+        { lockKey: "hashtext('drizzle_migrations')", timeoutMs: 15_000 },
+        "waiting for migration lock held by another session",
+      ],
+    ]);
+    expect(harness.cancelWatchdog).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    0,
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    2_147_483_648,
+  ])("rejects invalid lock timeout %s before opening a session", async (lockTimeoutMs) => {
+    const harness = makeHarness();
+
+    await expect(runHarness(harness, lockTimeoutMs)).rejects.toThrow(/finite positive value/);
+
+    expect(harness.openSession).not.toHaveBeenCalled();
+    expect(harness.dependencies.armWatchdog).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -1,10 +1,14 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 import { drizzle } from "drizzle-orm/postgres-js";
-import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { migrate as runDrizzleMigrations } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
+import { createLogger } from "../observability/logger.js";
 import { sslOptions } from "./connection.js";
+
+const log = createLogger("Migrations");
 
 /**
  * Resolve the drizzle migrations directory.
@@ -53,18 +57,16 @@ function validateJournalOrder(migrationsFolder: string): void {
 }
 
 /**
- * Advisory-lock key used by the preflight check.
+ * Advisory-lock key held for the complete Drizzle migration lifecycle.
  *
  * Verified against `drizzle-orm@0.44.7`:
  *   - `node_modules/drizzle-orm/postgres-js/migrator.js` → delegates to
  *     `node_modules/drizzle-orm/pg-core/dialect.js::migrate()`, which
- *     **does NOT acquire any advisory lock** in this version; it only wraps
- *     `INSERT INTO drizzle.__drizzle_migrations` in a transaction.
- *   - So this preflight is **purely defensive**: it surfaces *external*
- *     holders (an operator's `SELECT pg_advisory_lock(...)`, a stale
- *     prior-replica session that exited mid-migration with the lock held,
- *     or a future drizzle release that re-introduces locking) within the
- *     timeout window instead of letting drizzle hang silently.
+ *     **does NOT acquire any advisory lock** in this version; it runs all
+ *     pending migration statements and journal inserts in one transaction.
+ *   - `migrate()` resolves only after that transaction commits. Keeping this
+ *     session-level lock until then serializes journal reads, DDL/backfills,
+ *     the final journal insert, and commit across Server replicas.
  *
  * If you bump `drizzle-orm`, re-read `pg-core/dialect.js::migrate()` and
  * update this key (and `MIGRATION_LOCK_TIMEOUT_MS`) accordingly. The
@@ -72,51 +74,159 @@ function validateJournalOrder(migrationsFolder: string): void {
  * behavior using the same key.
  */
 const MIGRATION_LOCK_KEY_SQL = "hashtext('drizzle_migrations')";
-// Sits inside the 20s `runMigrations` stage budget set in `index.ts`; 15s
-// preflight + ≥5s for the actual drizzle migrate call. If you raise either,
-// raise the other in lockstep (and re-evaluate the Dockerfile HEALTHCHECK
-// `--start-period`).
+// The lock-acquisition watchdog actively terminates its postgres-js client,
+// so a contending replica fails before the non-cancelling 20s bootstrap-stage
+// timeout. Migration execution remains subject to that existing outer timeout,
+// which reports failure but does not cancel the underlying migration promise.
 const DEFAULT_MIGRATION_LOCK_TIMEOUT_MS = 15_000;
 const MIGRATION_LOCK_POLL_INTERVAL_MS = 1_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 export type RunMigrationsOptions = {
-  /** Override the preflight advisory-lock timeout. Default 15s. */
+  /** Override the advisory-lock acquisition timeout. Default 15s. */
   lockTimeoutMs?: number;
 };
 
-/**
- * Probe the advisory-lock key drizzle would use for migrations. If another
- * session holds it, fail with a clear message instead of letting drizzle's
- * `migrate()` hang forever. We don't keep the lock — see the key constant
- * above for the full rationale. See server-bootstrap-resilience-design.md §3 (T10).
- */
-async function preflightMigrationLock(databaseUrl: string, timeoutMs: number): Promise<void> {
-  const ssl = sslOptions(databaseUrl);
-  const client = postgres(databaseUrl, { max: 1, ...ssl });
-  const deadline = Date.now() + timeoutMs;
-  try {
-    while (true) {
-      const rows = (await client.unsafe(
-        `SELECT pg_try_advisory_lock(${MIGRATION_LOCK_KEY_SQL}) AS acquired`,
-      )) as Array<{
-        acquired: boolean;
-      }>;
-      if (rows[0]?.acquired) {
-        await client.unsafe(`SELECT pg_advisory_unlock(${MIGRATION_LOCK_KEY_SQL})`);
-        return;
-      }
-      if (Date.now() >= deadline) {
-        throw new Error(
-          `migration lock contention — another process holds drizzle migration lock (${MIGRATION_LOCK_KEY_SQL}) ` +
-            `after ${timeoutMs}ms`,
-        );
-      }
-      await new Promise((r) => setTimeout(r, MIGRATION_LOCK_POLL_INTERVAL_MS));
-    }
-  } finally {
-    await client.end();
-  }
+type MigrationSession = {
+  tryAcquireLock(): Promise<boolean>;
+  migrate(): Promise<void>;
+  countTables(): Promise<number>;
+  unlock(): Promise<boolean>;
+  end(options: { timeout: 0 }): Promise<void>;
+};
+
+type MigrationLogger = Pick<ReturnType<typeof createLogger>, "info" | "warn">;
+
+export type RunMigrationsDependencies = {
+  openSession(input: {
+    databaseUrl: string;
+    migrationsFolder: string;
+    connectTimeoutSeconds: number;
+    onLockAcquired(): void;
+    onClose(connectionId: number): void;
+  }): MigrationSession;
+  logger: MigrationLogger;
+  now(): number;
+  sleep(ms: number, terminalSignal: Promise<void>): Promise<void>;
+  armWatchdog(fire: () => void, timeoutMs: number): () => void;
+};
+
+type SettledOperation<T> =
+  | { readonly kind: "value"; readonly value: T }
+  | { readonly kind: "error"; readonly error: unknown };
+
+function createDefaultDependencies(): RunMigrationsDependencies {
+  return {
+    openSession({ databaseUrl, migrationsFolder, connectTimeoutSeconds, onLockAcquired, onClose }) {
+      let connectionClosed = false;
+      const client = postgres(databaseUrl, {
+        ...sslOptions(databaseUrl),
+        max: 1,
+        // postgres-js 3.4.8 treats an explicit 0 as disabled. Keep the own
+        // property so URL/PGIDLE_TIMEOUT cannot rotate the sole connection.
+        idle_timeout: 0,
+        max_lifetime: null,
+        connect_timeout: connectTimeoutSeconds,
+        onclose(connectionId) {
+          connectionClosed = true;
+          onClose(connectionId);
+        },
+      });
+
+      type TransactionCallback = (transactionClient: typeof client) => unknown;
+      const migrationClient = new Proxy(client, {
+        get(target, property, receiver) {
+          if (property !== "begin") return Reflect.get(target, property, receiver);
+
+          return async (optionsOrCallback: string | TransactionCallback, maybeCallback?: TransactionCallback) => {
+            const options = typeof optionsOrCallback === "string" ? optionsOrCallback : "";
+            const callback = typeof optionsOrCallback === "function" ? optionsOrCallback : maybeCallback;
+            if (callback === undefined) throw new Error("migration transaction callback is required");
+
+            let began = false;
+            try {
+              const transactionOptions = options.replace(/[^a-z ]/gi, "");
+              await client.unsafe(`BEGIN ${transactionOptions}`);
+              began = true;
+              const result = await callback(client);
+              if (connectionClosed) throw new Error("migration database session closed before commit");
+              await client.unsafe("COMMIT");
+              return result;
+            } catch (error) {
+              if (began && !connectionClosed) {
+                try {
+                  await client.unsafe("ROLLBACK");
+                } catch (rollbackError) {
+                  log.warn({ err: rollbackError }, "migration rollback failed after transaction error");
+                }
+              }
+              throw error;
+            }
+          };
+        },
+      });
+
+      return {
+        async tryAcquireLock() {
+          const rows = await client.unsafe<Array<{ acquired: boolean }>>(
+            `SELECT pg_try_advisory_lock(${MIGRATION_LOCK_KEY_SQL}) AS acquired`,
+          );
+          // A completed query identifies the currently live backend session;
+          // reconnects before lock acquisition are safe because no lock or
+          // migration work existed on the previous session.
+          connectionClosed = false;
+          const acquired = rows[0]?.acquired === true;
+          if (acquired) onLockAcquired();
+          return acquired;
+        },
+        async migrate() {
+          // Drizzle 0.44.7 only needs begin(callback) here. Its default
+          // postgres-js begin() races transaction rollback against onclose;
+          // the proxy keeps identical BEGIN/COMMIT semantics but skips any
+          // post-disconnect ROLLBACK that could run on a replacement session.
+          await runDrizzleMigrations(drizzle(migrationClient), { migrationsFolder });
+        },
+        async countTables() {
+          const rows = await client.unsafe<Array<{ count: number }>>(`
+            SELECT count(*)::int AS count
+            FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+          `);
+          const count = rows[0]?.count;
+          if (typeof count !== "number") {
+            throw new Error("migration table-count query returned no count");
+          }
+          return count;
+        },
+        async unlock() {
+          const rows = await client.unsafe<Array<{ unlocked: boolean }>>(
+            `SELECT pg_advisory_unlock(${MIGRATION_LOCK_KEY_SQL}) AS unlocked`,
+          );
+          return rows[0]?.unlocked === true;
+        },
+        end(options) {
+          return client.end(options);
+        },
+      };
+    },
+    logger: log,
+    now: () => performance.now(),
+    async sleep(ms, terminalSignal) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const delay = new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, ms);
+      });
+      await Promise.race([delay, terminalSignal]);
+      if (timer !== undefined) clearTimeout(timer);
+    },
+    armWatchdog(fire, timeoutMs) {
+      const timer = setTimeout(fire, timeoutMs);
+      return () => clearTimeout(timer);
+    },
+  };
 }
+
+const defaultDependencies = createDefaultDependencies();
 
 /**
  * Run Drizzle database migrations. Returns the count of public tables after
@@ -127,28 +237,275 @@ export async function runMigrations(databaseUrl: string, options: RunMigrationsO
 
   validateJournalOrder(migrationsFolder);
 
-  await preflightMigrationLock(databaseUrl, options.lockTimeoutMs ?? DEFAULT_MIGRATION_LOCK_TIMEOUT_MS);
+  return runMigrationsWithDependencies(databaseUrl, migrationsFolder, options, defaultDependencies);
+}
 
-  const ssl = sslOptions(databaseUrl);
-
-  const client = postgres(databaseUrl, { max: 1, ...ssl });
-  const db = drizzle(client);
-
-  try {
-    await migrate(db, { migrationsFolder });
-  } finally {
-    await client.end();
+/**
+ * Dependency seam for deterministic lifecycle tests. Production callers use
+ * `runMigrations()` above; every operation exposed by the default adapter is
+ * closed over the same one-connection postgres-js client.
+ *
+ * @internal
+ */
+export async function runMigrationsWithDependencies(
+  databaseUrl: string,
+  migrationsFolder: string,
+  options: RunMigrationsOptions,
+  dependencies: RunMigrationsDependencies,
+): Promise<number> {
+  const timeoutMs = options.lockTimeoutMs ?? DEFAULT_MIGRATION_LOCK_TIMEOUT_MS;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_TIMER_DELAY_MS) {
+    throw new Error(`migration lock timeout must be a finite positive value no greater than ${MAX_TIMER_DELAY_MS}ms`);
   }
 
-  const countClient = postgres(databaseUrl, { max: 1, ...ssl });
+  const startedAt = dependencies.now();
+  const deadline = startedAt + timeoutMs;
+  let expectedClose = false;
+  let lockAcquired = false;
+  let unlockConfirmed = false;
+  let sawLockMiss = false;
+  let terminalError: Error | undefined;
+  let connectionLostError: Error | undefined;
+  let forcedEndError: unknown;
+  let forcedEndFailed = false;
+  let forcedEndPromise: Promise<void> | undefined;
+  let resolveTerminalSignal: () => void = () => undefined;
+  let terminalSignalled = false;
+  const terminalSignal = new Promise<void>((resolve) => {
+    resolveTerminalSignal = resolve;
+  });
+
+  let session: MigrationSession;
+
+  const startForcedEnd = (afterCloseCallback = false): Promise<void> => {
+    if (forcedEndPromise !== undefined) return forcedEndPromise;
+
+    let resolveForcedEnd: () => void = () => undefined;
+    // Publish the sticky promise before invoking end(); a test adapter (or a
+    // future driver) may synchronously call onClose from inside end().
+    forcedEndPromise = new Promise<void>((resolve) => {
+      resolveForcedEnd = resolve;
+    });
+    const end = () => {
+      try {
+        void Promise.resolve(session.end({ timeout: 0 })).then(
+          () => resolveForcedEnd(),
+          (error: unknown) => {
+            forcedEndFailed = true;
+            forcedEndError = error;
+            resolveForcedEnd();
+          },
+        );
+      } catch (error) {
+        forcedEndFailed = true;
+        forcedEndError = error;
+        resolveForcedEnd();
+      }
+    };
+    if (afterCloseCallback) {
+      // postgres-js invokes onclose from inside its connection-close
+      // bookkeeping, before processing any queued work that could reconnect.
+      // Calling end() re-entrantly from that hook can race the remainder of
+      // the close path. Publish poison/end state now, then terminate in the
+      // next microtask.
+      queueMicrotask(end);
+    } else {
+      end();
+    }
+    return forcedEndPromise;
+  };
+
+  const poison = (error: Error, afterCloseCallback = false): void => {
+    if (terminalError === undefined) terminalError = error;
+    if (!terminalSignalled) {
+      terminalSignalled = true;
+      resolveTerminalSignal();
+    }
+    void startForcedEnd(afterCloseCallback);
+  };
+
+  session = dependencies.openSession({
+    databaseUrl,
+    migrationsFolder,
+    connectTimeoutSeconds: Math.max(1, Math.ceil(timeoutMs / 1_000)),
+    onLockAcquired() {
+      // Set synchronously inside the session adapter, before its query promise
+      // resolves to this lifecycle. A socket close in that microtask gap must
+      // still poison the lock-owning session.
+      lockAcquired = true;
+    },
+    onClose(connectionId) {
+      if (!expectedClose && lockAcquired && !unlockConfirmed) {
+        connectionLostError ??= new Error(
+          `migration postgres-js connection ${connectionId} closed before advisory lock release was confirmed`,
+        );
+        poison(connectionLostError, true);
+      }
+    },
+  });
+
+  const whileSessionAlive = async <T>(operation: PromiseLike<T>): Promise<T> => {
+    const settled = Promise.resolve(operation).then<SettledOperation<T>, SettledOperation<T>>(
+      (value) => ({ kind: "value", value }),
+      (error: unknown) => ({ kind: "error", error }),
+    );
+    const outcome = await Promise.race([settled, terminalSignal.then(() => ({ kind: "terminal" as const }))]);
+
+    if (outcome.kind === "terminal") {
+      await forcedEndPromise;
+      await settled;
+      throw terminalError ?? new Error("migration database session terminated");
+    }
+    if (outcome.kind === "error") throw outcome.error;
+    if (terminalError !== undefined) {
+      await forcedEndPromise;
+      throw terminalError;
+    }
+    return outcome.value;
+  };
+
+  let acquireWatchdogActive = true;
+  const acquireTimeoutError = (): Error =>
+    sawLockMiss
+      ? new Error(
+          `migration lock contention — another process holds drizzle migration lock (${MIGRATION_LOCK_KEY_SQL}) ` +
+            `after ${timeoutMs}ms`,
+        )
+      : new Error(`migration lock acquisition timed out after ${timeoutMs}ms`);
+  const cancelWatchdog = dependencies.armWatchdog(() => {
+    if (acquireWatchdogActive) poison(acquireTimeoutError());
+  }, timeoutMs);
+  const stopWatchdog = (): void => {
+    if (!acquireWatchdogActive) return;
+    acquireWatchdogActive = false;
+    cancelWatchdog();
+  };
+
+  let tableCount: number | undefined;
+  let hasPrimaryError = false;
+  let primaryError: unknown;
+  const cleanupErrors: unknown[] = [];
+
   try {
-    const result = await countClient`
-      SELECT count(*)::int AS count
-      FROM information_schema.tables
-      WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
-    `;
-    return (result[0] as { count: number }).count;
+    while (true) {
+      const remainingMs = deadline - dependencies.now();
+      if (remainingMs <= 0) {
+        poison(acquireTimeoutError());
+        throw terminalError;
+      }
+
+      const acquired = await whileSessionAlive(session.tryAcquireLock());
+      if (!acquired && !sawLockMiss) {
+        sawLockMiss = true;
+        dependencies.logger.info(
+          { lockKey: MIGRATION_LOCK_KEY_SQL, timeoutMs },
+          "waiting for migration lock held by another session",
+        );
+      }
+      // A query can become ready after the monotonic deadline while its timer
+      // callback is still queued behind I/O. Re-check before cancelling the
+      // watchdog so a late lock acquisition cannot enter migration work. A
+      // false result is recorded first so it retains contention diagnostics.
+      if (dependencies.now() >= deadline) {
+        poison(acquireTimeoutError());
+        throw terminalError;
+      }
+      if (acquired) {
+        lockAcquired = true;
+        stopWatchdog();
+        if (sawLockMiss) {
+          dependencies.logger.info(
+            {
+              lockKey: MIGRATION_LOCK_KEY_SQL,
+              waitMs: Math.round(dependencies.now() - startedAt),
+              timeoutMs,
+            },
+            "acquired migration lock after waiting",
+          );
+        }
+        break;
+      }
+
+      const sleepMs = Math.min(MIGRATION_LOCK_POLL_INTERVAL_MS, deadline - dependencies.now());
+      if (sleepMs <= 0) {
+        poison(acquireTimeoutError());
+        throw terminalError;
+      }
+      await dependencies.sleep(sleepMs, terminalSignal);
+      if (terminalError !== undefined) {
+        await forcedEndPromise;
+        throw terminalError;
+      }
+    }
+
+    await whileSessionAlive(session.migrate());
+    tableCount = await whileSessionAlive(session.countTables());
+  } catch (error) {
+    hasPrimaryError = true;
+    primaryError = error;
   } finally {
-    await countClient.end();
+    stopWatchdog();
+
+    if (lockAcquired && !unlockConfirmed && terminalError === undefined) {
+      try {
+        const unlocked = await whileSessionAlive(session.unlock());
+        if (!unlocked) {
+          cleanupErrors.push(new Error("migration advisory unlock was not confirmed on the lock-owning session"));
+        } else {
+          unlockConfirmed = true;
+        }
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
+
+    if (forcedEndPromise !== undefined) {
+      await forcedEndPromise;
+    } else {
+      // From this point onward no SQL can be issued. Mark the close expected
+      // immediately before the one bounded, deliberate client shutdown.
+      expectedClose = true;
+      try {
+        await session.end({ timeout: 0 });
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
   }
+
+  const secondaryErrors: unknown[] = [];
+  const addSecondaryError = (error: unknown): void => {
+    if (hasPrimaryError && error === primaryError) return;
+    if (!secondaryErrors.some((existing) => Object.is(existing, error))) secondaryErrors.push(error);
+  };
+  if (terminalError !== undefined) addSecondaryError(terminalError);
+  if (forcedEndFailed) addSecondaryError(forcedEndError);
+  for (const error of cleanupErrors) {
+    addSecondaryError(error);
+  }
+
+  if (hasPrimaryError) {
+    for (const error of secondaryErrors) {
+      dependencies.logger.warn({ err: error }, "migration cleanup failed after primary error");
+    }
+    throw primaryError;
+  }
+
+  if (terminalError !== undefined) {
+    for (const error of secondaryErrors) {
+      if (error !== terminalError) dependencies.logger.warn({ err: error }, "migration cleanup also failed");
+    }
+    throw terminalError;
+  }
+
+  if (secondaryErrors.length > 0) {
+    const [error, ...additionalErrors] = secondaryErrors;
+    for (const additionalError of additionalErrors) {
+      dependencies.logger.warn({ err: additionalError }, "additional migration cleanup failure");
+    }
+    throw error;
+  }
+
+  if (tableCount === undefined) throw new Error("migration completed without a table count");
+  return tableCount;
 }

--- a/packages/server/src/db/migrate.ts
+++ b/packages/server/src/db/migrate.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { createConnection, type Socket } from "node:net";
 import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
@@ -115,11 +116,83 @@ type SettledOperation<T> =
   | { readonly kind: "value"; readonly value: T }
   | { readonly kind: "error"; readonly error: unknown };
 
+type PostgresSocketOptions = {
+  host: string[];
+  port: number[];
+  path?: string | false;
+};
+
+type TrackedPostgresSocket = Socket & {
+  host?: string;
+  port?: number;
+};
+
+/**
+ * postgres-js 3.4.8 does not cancel a reconnect timer queued while a query is
+ * in its initial connection state. `end({ timeout: 0 })` can therefore resolve
+ * before that timer creates a replacement socket. This session-private socket
+ * gate preserves normal pre-shutdown retries, but makes socket creation
+ * impossible synchronously once cleanup starts. It destroys sockets that are
+ * still connecting while postgres-js closes established sockets itself.
+ */
+function createMigrationSocketGate(): {
+  connect(options: PostgresSocketOptions): Socket;
+  stop(): void;
+} {
+  let acceptingSockets = true;
+  let nextHostIndex = 0;
+  const rawSockets = new Set<Socket>();
+  const shutdownError = new Error("migration database session is shutting down");
+
+  return {
+    connect(options) {
+      if (!acceptingSockets) throw shutdownError;
+
+      const hosts = options.host;
+      const ports = options.port;
+      const hostIndex = nextHostIndex % Math.max(hosts.length, 1);
+      nextHostIndex += 1;
+      const host = hosts[hostIndex] ?? "localhost";
+      const port = ports[hostIndex % Math.max(ports.length, 1)] ?? 5432;
+      const socket = (
+        options.path ? createConnection(options.path) : createConnection({ host, port })
+      ) as TrackedPostgresSocket;
+      // postgres-js reads these properties when it upgrades a custom socket
+      // to TLS. Its public custom-socket API is documented but missing from
+      // the 3.4.8 Options declaration.
+      socket.host = host;
+      socket.port = port;
+      rawSockets.add(socket);
+      socket.once("close", () => rawSockets.delete(socket));
+
+      if (!acceptingSockets) {
+        socket.destroy();
+        throw shutdownError;
+      }
+      return socket;
+    },
+    stop() {
+      acceptingSockets = false;
+      // postgres-js may have wrapped a connected raw socket in a TLSSocket.
+      // Let client.end() close sockets it already owns; destroying the raw
+      // socket first races the driver's Terminate write. Only sockets still
+      // connecting are outside that reliable shutdown path. Use the Socket's
+      // state instead of a listener-maintained set: direct TLS negotiation
+      // removes the raw socket's listeners before its TCP connect completes.
+      for (const socket of rawSockets) {
+        if (socket.connecting) socket.destroy();
+      }
+      rawSockets.clear();
+    },
+  };
+}
+
 function createDefaultDependencies(): RunMigrationsDependencies {
   return {
     openSession({ databaseUrl, migrationsFolder, connectTimeoutSeconds, onLockAcquired, onClose }) {
       let connectionClosed = false;
-      const client = postgres(databaseUrl, {
+      const socketGate = createMigrationSocketGate();
+      const clientOptions = {
         ...sslOptions(databaseUrl),
         max: 1,
         // postgres-js 3.4.8 treats an explicit 0 as disabled. Keep the own
@@ -127,11 +200,15 @@ function createDefaultDependencies(): RunMigrationsDependencies {
         idle_timeout: 0,
         max_lifetime: null,
         connect_timeout: connectTimeoutSeconds,
+        socket: socketGate.connect,
         onclose(connectionId) {
           connectionClosed = true;
           onClose(connectionId);
         },
-      });
+      } as NonNullable<Parameters<typeof postgres>[1]> & {
+        socket(options: PostgresSocketOptions): Socket;
+      };
+      const client = postgres(databaseUrl, clientOptions);
 
       type TransactionCallback = (transactionClient: typeof client) => unknown;
       const migrationClient = new Proxy(client, {
@@ -205,6 +282,10 @@ function createDefaultDependencies(): RunMigrationsDependencies {
           return rows[0]?.unlocked === true;
         },
         end(options) {
+          // Close the socket-creation gate before asking postgres-js to end.
+          // Any already-queued reconnect callback can still run, but it can no
+          // longer create a socket or backend after this point.
+          socketGate.stop();
           return client.end(options);
         },
       };
@@ -327,7 +408,7 @@ export async function runMigrationsWithDependencies(
   session = dependencies.openSession({
     databaseUrl,
     migrationsFolder,
-    connectTimeoutSeconds: Math.max(1, Math.ceil(timeoutMs / 1_000)),
+    connectTimeoutSeconds: Math.max(1, Math.min(Math.ceil(timeoutMs / 1_000), Math.floor(MAX_TIMER_DELAY_MS / 1_000))),
     onLockAcquired() {
       // Set synchronously inside the session adapter, before its query promise
       // resolves to this lifecycle. A socket close in that microtask gap must


### PR DESCRIPTION
Closes #1690

## Summary

- keep one session-level PostgreSQL advisory lock on one private `max: 1` postgres-js client from the first Drizzle journal operation through the migration transaction's final commit
- fail closed if that lock-owning session closes, force-terminate the client, and never reconnect to migrate, count, or unlock on a replacement backend
- seal a session-private socket factory before shutdown so postgres-js 3.4.8 cannot create a late backend from an already-queued initial/retry reconnect after `end()` resolves
- enforce the existing 15-second acquisition budget as a monotonic hard deadline that actively cancels and drains pending connection/query work; clamp the driver connection timer below Node's maximum safe timer delay
- preserve the original migration error while reporting cleanup failures, and keep wait/acquire logging bounded and credential-free
- add deterministic lifecycle regressions plus real PostgreSQL 17 tests for final-journal serialization, backend loss, contention cleanup, and late reconnect cancellation

## Scope

This changes only Server startup `runMigrations()`. The operator/CI `drizzle-kit migrate` path and bootstrap/health budgets remain unchanged.

## Review and verification

Exact reviewed head: `a815d69bfbb11223f21b382022412b8a979f393c`.

- paired code review — approved with no P0–P2 findings
- focused migration suite — 33/33 passed
- full Server suite — 2,561/2,561 passed
- `pnpm check` — passed (only pre-existing informational findings outside this change)
- `pnpm typecheck` — 10/10 workspace tasks passed
- root `pnpm test` — 11/11 workspace tasks passed at the exact head; First Tree runtime-injected variables were removed from the test process and Turbo was run serially to keep CLI process-safety fixtures isolated
- exact-head GitHub Actions — every applicable check passed, including migrations, lint/typecheck, Server, CLI, Client/Web, portable CLI, aggregate test, and CodeQL; `Validate Skill` was skipped as non-applicable
- exact-head production-image/PostgreSQL 17 targeted smoke — passed: vanilla boot and all four HTTP surfaces; replica B remained outside Drizzle for 4.020s while replica A held the migration lock through final `COMMIT`, then B entered real DDL under its own lock-owning PID and safely no-op'd with the exact ordered 82-row journal unchanged; an external holder produced `migration lock contention` at a 15.010s migration stage, followed by 8.356s with no waiter backend or ungranted lock; the same stopped container then restarted from the same image and became HTTP-ready in 1.354s and Docker-healthy in 5.267s

Full formal First Tree QA is not claimed as `PASS`: this workspace lacks the complete authorized Cloud/provider/daemon product cell. The production-image exercise is scoped to real Server boot/health, PostgreSQL migration serialization, contention timeout, residual-session cleanup, and recovery. Its disposable containers, network, volume, runtime secret, and image tag were all removed after evidence capture.

## Known boundary

The 15-second lock-acquisition watchdog cancels its own database work before the existing 20-second bootstrap-stage timeout. A migration that has already acquired the lock remains subject to the pre-existing non-cancelling outer `Promise.race`; changing migration cancellation after execution begins is outside this issue.
