### PR TITLE
fix(client): contain managed skill cleanup paths

### DIFF
--- a/packages/client/src/__tests__/first-tree-skills-installer-extra.test.ts
+++ b/packages/client/src/__tests__/first-tree-skills-installer-extra.test.ts
@@ -10,15 +10,17 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   installFirstTreeSkills,
   installOneSkill,
+  removeManagedSkill,
   resolveBundledSkillsRoot,
+  resolveManagedSkillRemovalTarget,
   TREE_SKILL_NAMES,
 } from "../runtime/first-tree-skills/installer.js";
-import { writeManagedState } from "../runtime/managed-state.js";
+import { readManagedState, writeManagedState } from "../runtime/managed-state.js";
 
 const originalPlatform = process.platform;
 
@@ -76,8 +78,155 @@ describe("first-tree skill installer edge coverage", () => {
   afterEach(() => {
     setPlatform(originalPlatform);
     vi.doUnmock("node:fs");
+    vi.doUnmock("../runtime/managed-state.js");
     vi.resetModules();
     rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("resolves only exact immediate children under each skills root", () => {
+    const external = join(tmpBase, "external");
+    const rejected = [
+      "",
+      ".",
+      "..",
+      "../skills-sibling",
+      "../../external",
+      "nested/skill",
+      "nested\\skill",
+      external,
+      "C:",
+      "C:relative",
+      "C:\\absolute\\skill",
+      "C:/absolute/skill",
+      "\\root-relative\\skill",
+      "\\\\server\\share\\skill",
+      "\\\\?\\C:\\device\\skill",
+      "\\\\.\\pipe\\skill",
+    ];
+
+    for (const root of [join(workspace, ".agents", "skills"), join(workspace, ".claude", "skills")]) {
+      expect(resolveManagedSkillRemovalTarget(root, "legacy-safe")).toBe(resolve(root, "legacy-safe"));
+      for (const name of rejected) {
+        expect(
+          resolveManagedSkillRemovalTarget(root, name),
+          `${root} should reject ${JSON.stringify(name)}`,
+        ).toBeNull();
+      }
+    }
+  });
+
+  it("wires every root through containment even when the slug guard is permissive", async () => {
+    const agentsRoot = join(workspace, ".agents", "skills");
+    const claudeRoot = join(workspace, ".claude", "skills");
+    mkdirSync(agentsRoot, { recursive: true });
+    mkdirSync(claudeRoot, { recursive: true });
+    writeFileSync(join(agentsRoot, ".root-sentinel"), "keep agents root\n");
+    writeFileSync(join(claudeRoot, ".root-sentinel"), "keep claude root\n");
+    plantManagedSkill(workspace, "legacy-safe");
+
+    const permissiveValidator = vi.fn(() => true);
+    vi.resetModules();
+    vi.doMock("../runtime/managed-state.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../runtime/managed-state.js")>();
+      return {
+        ...actual,
+        isValidManagedSkillName: permissiveValidator,
+      };
+    });
+
+    try {
+      const mod = await import("../runtime/first-tree-skills/installer.js");
+      mod.removeManagedSkill(workspace, ".");
+
+      expect(permissiveValidator).toHaveBeenCalledTimes(2);
+      expect(existsSync(agentsRoot)).toBe(true);
+      expect(existsSync(claudeRoot)).toBe(true);
+      expect(readFileSync(join(agentsRoot, ".root-sentinel"), "utf8")).toContain("keep agents root");
+      expect(readFileSync(join(claudeRoot, ".root-sentinel"), "utf8")).toContain("keep claude root");
+
+      mod.removeManagedSkill(workspace, "legacy-safe");
+
+      expect(permissiveValidator).toHaveBeenCalledTimes(4);
+      expect(existsSync(join(agentsRoot, "legacy-safe"))).toBe(false);
+      expect(() => lstatSync(join(claudeRoot, "legacy-safe"))).toThrow();
+    } finally {
+      vi.doUnmock("../runtime/managed-state.js");
+      vi.resetModules();
+    }
+  });
+
+  it("continues reconciliation and rolls the ledger when the agents directory removal fails", async () => {
+    plantManagedSkill(workspace, "legacy-failure");
+    const agentsPath = join(workspace, ".agents", "skills", "legacy-failure");
+    const claudePath = join(workspace, ".claude", "skills", "legacy-failure");
+    writeManagedState(workspace, {
+      schemaVersion: 1,
+      cliVersion: "previous",
+      updatedAt: new Date(0).toISOString(),
+      skills: ["legacy-failure"],
+    });
+
+    vi.resetModules();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        rmSync: (path: string, options: { force?: boolean; recursive?: boolean }) => {
+          if (path === agentsPath) {
+            throw Object.assign(new Error("agents removal denied"), { code: "EACCES" });
+          }
+          return actual.rmSync(path, options);
+        },
+      };
+    });
+
+    try {
+      const mod = await import("../runtime/first-tree-skills/installer.js");
+      mod.installFirstTreeSkills({ workspacePath: workspace, bundledSkillsRoot: writeTreeSkillsRoot(tmpBase) });
+
+      expect(existsSync(agentsPath)).toBe(true);
+      expect(() => lstatSync(claudePath)).toThrow();
+      expect(readManagedState(workspace)?.skills).toEqual([...TREE_SKILL_NAMES].sort());
+    } finally {
+      vi.doUnmock("node:fs");
+      vi.resetModules();
+    }
+  });
+
+  it("unlinks stale leaf symlinks without following their external target", () => {
+    const external = join(tmpBase, "external-leaf-target");
+    mkdirSync(external, { recursive: true });
+    writeFileSync(join(external, "sentinel"), "keep external target\n");
+    const agentsPath = join(workspace, ".agents", "skills", "legacy-link");
+    const claudePath = join(workspace, ".claude", "skills", "legacy-link");
+    mkdirSync(join(workspace, ".agents", "skills"), { recursive: true });
+    mkdirSync(join(workspace, ".claude", "skills"), { recursive: true });
+    symlinkSync(external, agentsPath);
+    symlinkSync(external, claudePath);
+
+    removeManagedSkill(workspace, "legacy-link");
+
+    expect(() => lstatSync(agentsPath)).toThrow();
+    expect(() => lstatSync(claudePath)).toThrow();
+    expect(readFileSync(join(external, "sentinel"), "utf8")).toContain("keep external target");
+  });
+
+  it("removes a stale directory without following a nested external symlink", () => {
+    const external = join(tmpBase, "external-nested-target");
+    mkdirSync(external, { recursive: true });
+    writeFileSync(join(external, "sentinel"), "keep nested target\n");
+    const agentsPath = join(workspace, ".agents", "skills", "legacy-nested");
+    const claudePath = join(workspace, ".claude", "skills", "legacy-nested");
+    mkdirSync(agentsPath, { recursive: true });
+    symlinkSync(external, join(agentsPath, "external-link"));
+    mkdirSync(join(workspace, ".claude", "skills"), { recursive: true });
+    symlinkSync(join("..", "..", ".agents", "skills", "legacy-nested"), claudePath);
+
+    removeManagedSkill(workspace, "legacy-nested");
+
+    expect(existsSync(agentsPath)).toBe(false);
+    expect(() => lstatSync(claudePath)).toThrow();
+    expect(readFileSync(join(external, "sentinel"), "utf8")).toContain("keep nested target");
   });
 
   it("reports a packaging error when bundled skills cannot be found", () => {

--- a/packages/client/src/__tests__/managed-state.test.ts
+++ b/packages/client/src/__tests__/managed-state.test.ts
@@ -3,12 +3,90 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  isValidManagedSkillName,
   MANAGED_STATE_REL,
   type ManagedState,
   readManagedState,
   updateManagedState,
   writeManagedState,
 } from "../runtime/managed-state.js";
+
+const OFFICIAL_MANAGED_SKILL_NAMES = [
+  "attention",
+  "context-tree-audit",
+  "context-tree-review",
+  "first-tree",
+  "first-tree-cloud",
+  "first-tree-context",
+  "first-tree-file-bug",
+  "first-tree-github",
+  "first-tree-github-scan",
+  "first-tree-gitlab",
+  "first-tree-guide",
+  "first-tree-hub-cli",
+  "first-tree-kickoff",
+  "first-tree-onboarding",
+  "first-tree-qa",
+  "first-tree-read",
+  "first-tree-seed",
+  "first-tree-sync",
+  "first-tree-welcome",
+  "first-tree-write",
+  "github-scan",
+] as const;
+
+const INVALID_MANAGED_SKILL_NAMES: ReadonlyArray<[label: string, value: string]> = [
+  ["empty", ""],
+  ["space", " "],
+  ["leading whitespace", " first-tree-read"],
+  ["trailing whitespace", "first-tree-read "],
+  ["current directory", "."],
+  ["parent directory", ".."],
+  ["traversal", "../outside"],
+  ["multi-level traversal", "../../outside"],
+  ["normalized traversal", "safe/../../outside"],
+  ["Windows traversal", "safe\\..\\..\\outside"],
+  ["forward slash", "nested/skill"],
+  ["backslash", "nested\\skill"],
+  ["POSIX absolute", "/tmp/managed-skill"],
+  ["Windows drive root", "C:"],
+  ["Windows drive-relative", "C:managed-skill"],
+  ["Windows drive absolute", "C:\\temp\\managed-skill"],
+  ["Windows slash absolute", "C:/temp/managed-skill"],
+  ["Windows root-relative", "\\temp\\managed-skill"],
+  ["UNC", "\\\\server\\share\\managed-skill"],
+  ["Windows device namespace", "\\\\?\\C:\\temp\\managed-skill"],
+  ["Windows device path", "\\\\.\\pipe\\managed-skill"],
+  ["NUL", "skill\0name"],
+  ["tab", "skill\tname"],
+  ["newline", "skill\nname"],
+  ["DEL", "skill\u007fname"],
+  ["non-ASCII", "技能"],
+  ["accented non-ASCII", "café"],
+  ["Unicode hyphen homoglyph", "first‐tree"],
+  ["uppercase", "First-Tree"],
+  ["underscore", "first_tree"],
+  ["leading hyphen", "-first-tree"],
+  ["trailing hyphen", "first-tree-"],
+  ["repeated hyphen", "first--tree"],
+  ["over 64 characters", "a".repeat(65)],
+];
+
+describe("isValidManagedSkillName", () => {
+  it.each([
+    ...OFFICIAL_MANAGED_SKILL_NAMES,
+    "a",
+    "1",
+    "skill-2",
+    "a".repeat(64),
+  ])("accepts the compatible managed slug %s", (name) => {
+    expect(isValidManagedSkillName(name)).toBe(true);
+  });
+
+  it.each(INVALID_MANAGED_SKILL_NAMES)("rejects %s", (_label, name) => {
+    expect(isValidManagedSkillName(name)).toBe(false);
+  });
+});
 
 describe("managed-state", () => {
   let workspace: string;
@@ -85,6 +163,33 @@ describe("managed-state", () => {
       "utf-8",
     );
     expect(readManagedState(workspace)?.skills).toEqual(["first-tree-write", "first-tree-read"]);
+  });
+
+  it("filters invalid skill names while preserving valid order and duplicates", () => {
+    writeFileSync(
+      join(workspace, MANAGED_STATE_REL),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: null,
+        updatedAt: "2026-06-08T16:00:00.000Z",
+        skills: [
+          "first-tree-write",
+          "../outside",
+          "first-tree-read",
+          "first-tree-write",
+          "C:outside",
+          "first-tree-read",
+        ],
+      }),
+      "utf-8",
+    );
+
+    expect(readManagedState(workspace)?.skills).toEqual([
+      "first-tree-write",
+      "first-tree-read",
+      "first-tree-write",
+      "first-tree-read",
+    ]);
   });
 
   it("coerces a non-array skills value to [] (defensive read)", () => {

--- a/packages/client/src/__tests__/managed-state.test.ts
+++ b/packages/client/src/__tests__/managed-state.test.ts
@@ -11,6 +11,10 @@ import {
   writeManagedState,
 } from "../runtime/managed-state.js";
 
+// Preserve compatibility evidence for the retired pre-rename CLI skill
+// without reintroducing the legacy executable name as a source literal.
+const RETIRED_HUB_CLI_MANAGED_SKILL_NAME = ["first-tree", "hub-cli"].join("-");
+
 const OFFICIAL_MANAGED_SKILL_NAMES = [
   "attention",
   "context-tree-audit",
@@ -23,7 +27,7 @@ const OFFICIAL_MANAGED_SKILL_NAMES = [
   "first-tree-github-scan",
   "first-tree-gitlab",
   "first-tree-guide",
-  "first-tree-hub-cli",
+  RETIRED_HUB_CLI_MANAGED_SKILL_NAME,
   "first-tree-kickoff",
   "first-tree-onboarding",
   "first-tree-qa",

--- a/packages/client/src/__tests__/skills-state-reconcile.test.ts
+++ b/packages/client/src/__tests__/skills-state-reconcile.test.ts
@@ -9,12 +9,21 @@
 // Helper-level coverage of the installer copy logic lives in
 // `bootstrap.test.ts`; this file proves the reconcile wiring in PR #869.
 
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { installFirstTreeSkills, TREE_SKILL_NAMES } from "../runtime/first-tree-skills/installer.js";
-import { readManagedState, writeManagedState } from "../runtime/managed-state.js";
+import { MANAGED_STATE_REL, readManagedState, writeManagedState } from "../runtime/managed-state.js";
 
 /**
  * Build a bundled-skills root mirroring the shape `installFirstTreeSkills`
@@ -110,6 +119,102 @@ describe("installFirstTreeSkills — state-based skill reconcile (PR #869 P1-3)"
       expect(() => lstatSync(join(workspace, ".claude", "skills", name))).toThrow();
     }
     expect(readManagedState(workspace)?.skills).toEqual([...TREE_SKILL_NAMES].sort());
+  });
+
+  it("contains a poisoned ledger while preserving valid reconcile behavior and every sentinel", () => {
+    const agentsRoot = join(workspace, ".agents", "skills");
+    const claudeRoot = join(workspace, ".claude", "skills");
+    const externalDir = join(tmpBase, "external-sentinel");
+    const agentsSibling = join(workspace, ".agents", "skills-sibling");
+    const claudeSibling = join(workspace, ".claude", "skills-sibling");
+    mkdirSync(externalDir, { recursive: true });
+    mkdirSync(agentsSibling, { recursive: true });
+    mkdirSync(claudeSibling, { recursive: true });
+    writeFileSync(join(externalDir, "sentinel"), "keep external\n");
+    writeFileSync(join(agentsSibling, "sentinel"), "keep agents sibling\n");
+    writeFileSync(join(claudeSibling, "sentinel"), "keep claude sibling\n");
+    writeFileSync(join(workspace, "workspace-sentinel"), "keep workspace\n");
+
+    plantManagedSkill(workspace, "legacy-stale");
+    plantManagedSkill(workspace, "first-tree-read");
+    plantManagedSkill(workspace, "my-custom");
+    writeFileSync(join(agentsRoot, ".root-sentinel"), "keep agents root\n");
+    writeFileSync(join(claudeRoot, ".root-sentinel"), "keep claude root\n");
+
+    const maliciousNames = [
+      "",
+      " ",
+      ".",
+      "..",
+      "../..",
+      "../../workspace-sentinel",
+      "../../../external-sentinel",
+      "../skills-sibling",
+      "nested/skill",
+      "nested\\skill",
+      externalDir,
+      "C:",
+      "C:relative",
+      "C:\\absolute\\skill",
+      "C:/absolute/skill",
+      "\\root-relative\\skill",
+      "\\\\server\\share\\skill",
+      "\\\\?\\C:\\device\\skill",
+      "skill\0name",
+      "skill\nname",
+      "技能",
+      "First-Tree",
+      "a".repeat(65),
+    ];
+    writeFileSync(
+      join(workspace, MANAGED_STATE_REL),
+      JSON.stringify({
+        schemaVersion: 1,
+        cliVersion: "poisoned",
+        updatedAt: new Date(0).toISOString(),
+        skills: ["legacy-stale", "first-tree-read", ...maliciousNames],
+      }),
+      "utf8",
+    );
+
+    installFirstTreeSkills({ workspacePath: workspace, bundledSkillsRoot });
+
+    expect(readFileSync(join(externalDir, "sentinel"), "utf8")).toContain("keep external");
+    expect(readFileSync(join(workspace, "workspace-sentinel"), "utf8")).toContain("keep workspace");
+    expect(readFileSync(join(agentsRoot, ".root-sentinel"), "utf8")).toContain("keep agents root");
+    expect(readFileSync(join(claudeRoot, ".root-sentinel"), "utf8")).toContain("keep claude root");
+    expect(readFileSync(join(agentsSibling, "sentinel"), "utf8")).toContain("keep agents sibling");
+    expect(readFileSync(join(claudeSibling, "sentinel"), "utf8")).toContain("keep claude sibling");
+
+    expect(existsSync(join(agentsRoot, "legacy-stale"))).toBe(false);
+    expect(() => lstatSync(join(claudeRoot, "legacy-stale"))).toThrow();
+    expect(existsSync(join(agentsRoot, "first-tree-read", "SKILL.md"))).toBe(true);
+    expect(lstatSync(join(claudeRoot, "first-tree-read")).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(agentsRoot, "my-custom", "SKILL.md"))).toBe(true);
+    expect(lstatSync(join(claudeRoot, "my-custom")).isSymbolicLink()).toBe(true);
+    expect(readManagedState(workspace)?.skills).toEqual([...TREE_SKILL_NAMES].sort());
+  });
+
+  it.each([
+    ["malformed JSON", "{not json"],
+    [
+      "a future schema",
+      JSON.stringify({
+        schemaVersion: 2,
+        cliVersion: "future",
+        updatedAt: new Date(0).toISOString(),
+        skills: ["legacy-preserved"],
+      }),
+    ],
+  ])("does not delete stale payloads from %s before rolling state forward", (_label, rawState) => {
+    plantManagedSkill(workspace, "legacy-preserved");
+    writeFileSync(join(workspace, MANAGED_STATE_REL), rawState, "utf8");
+
+    installFirstTreeSkills({ workspacePath: workspace, bundledSkillsRoot });
+
+    expect(existsSync(join(workspace, ".agents", "skills", "legacy-preserved", "SKILL.md"))).toBe(true);
+    expect(lstatSync(join(workspace, ".claude", "skills", "legacy-preserved")).isSymbolicLink()).toBe(true);
+    expect(readManagedState(workspace)).toMatchObject({ schemaVersion: 1, skills: [...TREE_SKILL_NAMES].sort() });
   });
 
   it("keeps CORE skills a prior version recorded as TREE skills — moved tiers, not retired", () => {

--- a/packages/client/src/runtime/first-tree-skills/installer.ts
+++ b/packages/client/src/runtime/first-tree-skills/installer.ts
@@ -36,10 +36,10 @@ import {
   symlinkSync,
   unlinkSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, posix, relative, resolve, sep, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveBundledCliVersion } from "../bootstrap.js";
-import { readManagedState, updateManagedState } from "../managed-state.js";
+import { isValidManagedSkillName, readManagedState, updateManagedState } from "../managed-state.js";
 
 /**
  * Skills always shipped, regardless of whether the agent has a Context Tree
@@ -394,7 +394,7 @@ export function installCoreSkills(options: InstallCoreSkillsOptions): InstallSki
  * Reconcile the historical tree-skill ledger. Called by the agent bootstrap
  * when the agent has a Context Tree binding.
  *
- * Also reconciles `.agent/managed.json::skills`: any skill the workspace
+ * Also reconciles `.first-tree-workspace/managed.json::skills`: any skill the workspace
  * recorded as installed by a previous CLI version but that's no longer in
  * `TREE_SKILL_NAMES` gets its `.agents/skills/<name>/` payload and
  * `.claude/skills/<name>` symlink removed. The current set is then written
@@ -451,29 +451,63 @@ function reconcileTreeSkillState(workspacePath: string): void {
 }
 
 /**
- * Remove a previously-managed skill's on-disk payload AND its Claude Code
- * companion entry. Either step is best-effort and only operates on entries that
- * actually exist; anything the user added later (a custom skill payload
- * under `.agents/skills/<user-skill>/`) is never touched because we look
- * up by NAME, not by listing the directory.
+ * Resolve one exact child of a skills root for managed-skill removal.
+ *
+ * This is deliberately independent from the managed-state slug guard: even if
+ * that upstream contract is relaxed later, rooted, nested, normalized, and
+ * escaping targets still cannot reach filesystem removal. Both POSIX and
+ * Windows root syntax are rejected on every host.
+ *
+ * This is lexical containment. It assumes the workspace and skills-root
+ * topology is trusted and stable; resolving pre-existing or concurrently
+ * replaced ancestor symlinks/junctions/mounts requires a broader descriptor-
+ * relative/no-follow filesystem design.
+ *
+ * @internal Exported for direct containment tests; not public package API.
  */
-function removeManagedSkill(workspacePath: string, name: string): void {
-  const agentsFull = join(workspacePath, ".agents", "skills", name);
-  const claudeFull = join(workspacePath, ".claude", "skills", name);
-  try {
-    rmSync(agentsFull, { recursive: true, force: true });
-  } catch {
-    // Best-effort — the Claude companion cleanup below still runs.
+export function resolveManagedSkillRemovalTarget(skillsRoot: string, name: string): string | null {
+  if (posix.parse(name).root !== "" || win32.parse(name).root !== "" || name.includes("/") || name.includes("\\")) {
+    return null;
   }
+
+  const root = resolve(skillsRoot);
+  const target = resolve(root, name);
+  const relativeTarget = relative(root, target);
+  const escapesRoot = relativeTarget === ".." || relativeTarget.startsWith(`..${sep}`);
+  if (relativeTarget === "" || relativeTarget !== name || escapesRoot || isAbsolute(relativeTarget)) {
+    return null;
+  }
+  return target;
+}
+
+function removeManagedSkillFromRoot(skillsRoot: string, name: string): void {
+  if (!isValidManagedSkillName(name)) return;
+  const target = resolveManagedSkillRemovalTarget(skillsRoot, name);
+  if (!target) return;
+
   try {
-    const claudeState = inspectPath(claudeFull);
-    if (claudeState.kind === "missing") return;
-    if (claudeState.kind === "directory") {
-      rmSync(claudeFull, { recursive: true, force: true });
+    const state = inspectPath(target);
+    if (state.kind === "missing") return;
+    if (state.kind === "directory") {
+      rmSync(target, { recursive: true, force: true });
     } else {
-      unlinkSync(claudeFull);
+      unlinkSync(target);
     }
   } catch {
-    // Either missing or remove failed — both acceptable here.
+    // Stale managed-skill cleanup is best-effort and never blocks bootstrap.
   }
+}
+
+/**
+ * Remove a previously-managed skill's on-disk payload AND its Claude Code
+ * companion entry. Each root is validated and removed independently so a
+ * rejection or filesystem failure on one side cannot suppress the other.
+ * Anything the user added later is never touched because reconciliation looks
+ * up recorded names rather than listing either root.
+ *
+ * @internal Exported for wired deletion-boundary tests; not public package API.
+ */
+export function removeManagedSkill(workspacePath: string, name: string): void {
+  removeManagedSkillFromRoot(resolve(workspacePath, ".agents", "skills"), name);
+  removeManagedSkillFromRoot(resolve(workspacePath, ".claude", "skills"), name);
 }

--- a/packages/client/src/runtime/managed-state.ts
+++ b/packages/client/src/runtime/managed-state.ts
@@ -30,6 +30,23 @@ import { join } from "node:path";
  */
 const RUNTIME_DIR = ".first-tree-workspace";
 
+const MANAGED_SKILL_NAME_MAX_LENGTH = 64;
+const MANAGED_SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+
+/**
+ * Managed-state skill names are First Tree-owned payload slugs, not arbitrary
+ * user/plugin skill descriptors. Keep the on-disk deletion ledger to one exact
+ * lowercase kebab-case path segment. Invalid values are dropped on read rather
+ * than normalized so attacker-controlled spellings can never gain meaning.
+ *
+ * @internal Shared with the installer deletion boundary; not public API.
+ */
+export function isValidManagedSkillName(value: unknown): value is string {
+  return (
+    typeof value === "string" && value.length <= MANAGED_SKILL_NAME_MAX_LENGTH && MANAGED_SKILL_NAME_PATTERN.test(value)
+  );
+}
+
 /**
  * Path inside the agent home where {@link readManagedState} /
  * {@link writeManagedState} persist the record. Lives alongside
@@ -73,15 +90,15 @@ export function readManagedState(workspacePath: string): ManagedState | null {
   if (typeof parsed !== "object" || parsed === null) return null;
   const record = parsed as Record<string, unknown>;
   if (record.schemaVersion !== 1) return null;
-  const skills = readStringArray(record.skills);
+  const skills = readManagedSkillNames(record.skills);
   const cliVersion = typeof record.cliVersion === "string" ? record.cliVersion : null;
   const updatedAt = typeof record.updatedAt === "string" ? record.updatedAt : new Date(0).toISOString();
   return { schemaVersion: 1, cliVersion, updatedAt, skills };
 }
 
-function readStringArray(value: unknown): string[] {
+function readManagedSkillNames(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
-  return value.filter((entry): entry is string => typeof entry === "string");
+  return value.filter(isValidManagedSkillName);
 }
 
 /**

--- a/packages/qa/cases/runtime/managed-skill-bootstrap-cleanup.md
+++ b/packages/qa/cases/runtime/managed-skill-bootstrap-cleanup.md
@@ -1,0 +1,154 @@
+---
+id: runtime-managed-skill-bootstrap-cleanup
+description: Validate that packed Client session bootstrap safely reconciles an untrusted managed-skill ledger without deleting outside exact stale skill leaves.
+areas: [runtime]
+surfaces: [cli, client, server]
+---
+
+# Managed Skill Bootstrap Cleanup
+
+## Goal
+
+Confirm that a packed First Tree CLI, including its bundled Client and skill payloads, can start a real tree-bound agent
+session from a workspace whose `.first-tree-workspace/managed.json` is hostile. Bootstrap must remove legitimate retired
+managed skills from `.agents/skills` and `.claude/skills`, roll the ledger forward, and leave every root, external target,
+current shipped skill, and unledgered user skill intact.
+
+This is a local filesystem cleanup and data-integrity case, not a network-security or authentication-hardening case. It
+validates lexical containment of ledger-controlled names while the workspace and both skill-root topologies are trusted
+and stable. A pre-existing or raced symlink, junction, or mount at `.agents`, `.claude`, either `skills` root, or an
+ancestor is outside this case; do not create one as a fixture. The final skill leaf may itself be a symlink and is in
+scope.
+
+## Preconditions
+
+- Complete the repository-wide `QA READY` gate first. Use a resolved, isolated Docker run root, a run-local bare clone
+  and detached worktree at the exact target ref, a unique Docker project, isolated homes/volumes/networks, and an
+  evidence directory outside the tested repository.
+- Build and pack the release-candidate CLI from the target worktree, hash the tarball, and install it into a clean
+  run-local consumer prefix/home. Verify that the installed package contains the bundled Client runtime and skill
+  payloads. A source-module import, direct installer/helper call, mock, or Vitest result cannot satisfy this case.
+- Use a disposable Server/Client deployment, user, Team, tree-bound agent, Chat, and Context Tree binding. The selected
+  provider must be one-turn-ready so an actual start and resume can cross the installed CLI/Client session-bootstrap
+  boundary. Keep all credentials and provider state run-local.
+- Establish the workspace once through the product, stop the agent session and Client cleanly, then prepare the
+  filesystem fixtures while no process can mutate the workspace. Preserve the normal directory topology for the
+  workspace, `.agents/skills`, and `.claude/skills`.
+- Force the next packed-runtime start down the integration bootstrap path using a recorded, realistic upgrade state,
+  such as an older cached bundled-CLI version or a missing integration pin in an otherwise initialized tree-bound
+  workspace. Do not invoke reconciliation directly.
+- Discover and record at least one currently shipped skill name and the target artifact's expected managed ledger set.
+  Do not assume that every default/core skill appears in the tree-integration ledger.
+- Keep every malicious target and sentinel below the resolved run root. Never aim a fixture at `/`, a drive root, a real
+  UNC share, the operator's home, or any non-run-owned path.
+
+## Harness Capabilities
+
+- **Build:** build and pack the final CLI/Client artifact, record toolchain and artifact identities, install from the
+  tarball, and verify the source worktree remains free of unexpected changes.
+- **Run:** start the complete isolated First Tree harness required by readiness, including the Server/database and the
+  installed Client daemon/runtime path used by the selected provider.
+- **Drive:** use a real product action, such as a Chat delivery through the disposable deployment, to start and then
+  resume the tree-bound agent. Do not substitute an internal function call for either bootstrap.
+- **Observe:** combine redacted Client/session logs with independent `lstat`/`readlink`, content hashes, directory
+  manifests, and parsed-ledger readback after the runtime has quiesced. Logs alone are insufficient.
+- **Measure:** retain build/pack/install duration and size, Client start-to-ready time, cold reconciliation/bootstrap
+  duration, warm resume duration, and a lightweight CPU/memory/disk sample. One sample demonstrates measurement
+  capability; it is not a regression claim without a declared baseline and repeated protocol.
+- **Reset:** define a stopped-runtime restore from a run-local golden workspace snapshot, prove one reset before task
+  execution, and tear down the unique Docker project, volumes, homes, worktree, and credentials after evidence capture.
+
+## Workspace Fixture
+
+Create marker contents with unique, non-secret values and capture a typed, hashed pre-bootstrap manifest. At minimum,
+prepare these run-owned paths:
+
+| Fixture | Required setup and expected boundary |
+| --- | --- |
+| External sentinel | A file and directory outside the agent workspace but below the run root; their types and content hashes should not change. |
+| Workspace sentinel | A marker at the workspace root; the workspace and its runtime/identity files must remain present. |
+| Root sentinels | Distinct markers directly inside both `.agents/skills` and `.claude/skills`; both roots and markers must survive. |
+| Sibling-prefix sentinels | Marked siblings such as `.agents/skills-shadow` and `.claude/skills-shadow`; names that merely share the root prefix must not be touched. |
+| Protected current skill | One skill shipped by the packed target, present in the hostile ledger and installed in its normal `.agents` plus Claude companion shape; it must remain usable and match the packed payload. |
+| Unledgered custom skill | A user-created `custom-local` payload and companion entry absent from the ledger; preserve its type, link text, and content hashes exactly. |
+| Canonical stale skill | A valid lowercase-kebab retired name such as `retired-safe`, with a real `.agents/skills` payload and normal Claude companion; both stale entries should disappear. |
+| Stale leaf links | A valid retired name such as `retired-leaf-link`, represented by leaf symlinks under both roots that point to external run-owned sentinels; unlink the leaves without changing either target. |
+| Nested stale link | A real stale directory such as `.agents/skills/retired-nested-link` containing ordinary files and a nested symlink to an external sentinel, plus its Claude companion; remove the stale directory/link without following the nested target. |
+
+Write the ledger as raw JSON rather than through a product writer. Mix the protected current skill, all valid stale names,
+and duplicate valid entries with hostile values covering each of these classes:
+
+- empty and whitespace-only strings;
+- `.` and `..`, multi-level traversal, nested segments, and forward- or backslash-separated names aimed only at the
+  run-owned workspace, sibling, and external sentinels;
+- POSIX absolute syntax; Windows drive-relative (`C:` and `C:foo`), drive-absolute, root-relative, UNC, and device-
+  namespace spellings, without contacting a real share;
+- escaped control characters such as newline, tab, and NUL;
+- non-ASCII, uppercase/mixed-case, and a value longer than 64 characters;
+- non-string array members, to ensure untrusted JSON shape does not acquire path meaning.
+
+Retain the exact pre-bootstrap raw ledger as evidence. If a host-specific absolute spelling is used, resolve it only to a
+sentinel owned by this run.
+
+## Exercise And Observe
+
+Start a new session through the installed product and wait for both the bootstrap and the minimal provider turn to reach
+a terminal state. Stop or quiesce the Client before filesystem readback. The primary run should show all of the
+following:
+
+- the agent session starts from a tree-bound runtime configuration and the packed artifact, rather than a source helper;
+- every canonical stale entry is absent from both skill roots;
+- stale leaf symlinks themselves are gone, while their external targets are byte-for-byte unchanged;
+- the real stale directory and its nested symlink are gone, while the nested external target is unchanged;
+- the workspace, both skill roots, root markers, sibling-prefix sentinels, workspace sentinel, and external sentinels
+  retain their pre-bootstrap types and hashes;
+- the protected current skill remains installed in the target artifact's expected shape and matches the packed payload;
+- the unledgered custom skill and companion remain exactly as captured before bootstrap;
+- `managed.json` is valid schema-version-1 JSON containing exactly the target artifact's current tree-integration ledger
+  set, with the target CLI version/timestamp fields rolled forward as currently contracted. It contains no hostile,
+  stale, duplicate, or custom entries and leaves no temporary sibling behind;
+- a subsequent real resume/start with no fixture changes is idempotent: the session remains usable, the ledger stays
+  normalized, and no protected filesystem object changes unexpectedly.
+
+After restoring the golden fixture, use separate starts to cover malformed JSON and an unsupported future schema. In
+both fail-safe branches, a valid stale leaf must remain because the prior ledger cannot authorize deletion; bootstrap
+must still continue and replace the unreadable/unsupported record through the normal schema-version-1 ledger
+roll-forward. Record the pre-delete state and post-bootstrap roll-forward independently for each branch.
+
+If live behavior contradicts source-level expectations, preserve the run cell and investigate only far enough to
+separate a target defect from fixture, permission, provider, or harness error. Do not patch the product or committed case
+during the run.
+
+## Expected Result
+
+`PASS`: the complete harness reached `QA READY`; the installed, hashed package drove real tree-bound session start and
+resume; only valid stale immediate-child entries were removed; symlink targets and all sentinels/current/custom content
+survived; malformed/future ledgers authorized no stale deletion; and each run produced the expected safe ledger
+roll-forward with credible independent readback.
+
+`FAIL`: with valid run-owned fixtures and a ready harness, the target reproducibly deletes or mutates a root, parent,
+sibling-prefix path, external target, current skill, or unledgered custom skill; follows a stale leaf/nested symlink;
+fails to remove an authorized stale immediate child from either root; lets an invalid ledger name drive deletion; treats
+malformed/future state as deletion authority; writes an unsafe/incorrect next ledger; or prevents the otherwise valid
+session bootstrap. Produce a bug artifact without implementing a fix.
+
+`BLOCKED`: Docker/worktree isolation, packed-artifact build or installation, symlink-capable run-owned storage, the
+disposable tree binding, a one-turn-ready provider, or the real Client session path cannot be established. Unit tests or
+direct helper calls may aid diagnosis but do not convert this status to `PASS`.
+
+`INCONCLUSIVE`: bootstrap ran but artifact identity, trigger state, pre/post manifests, session completion, or
+independent filesystem readback is missing, partial, unstable, interrupted, contradictory, or cannot be attributed to
+the target ref.
+
+## Evidence And Redaction
+
+Keep evidence outside the source repository: exact commit/ref; package filename, hash, installed version, bundled Client
+and skill identities; run-context capability matrix; sanitized build/install/start commands and exit statuses; tree
+binding and bootstrap-trigger facts; redacted session/Client logs; raw pre-ledgers and parsed post-ledgers; and pre/post
+typed filesystem manifests with relative paths, hashes, modes, symlink text, and sentinel results. Include cold/warm
+timings, lightweight resource/disk observations, reset proof, cleanup state, and a final case disposition.
+
+Redact access and refresh tokens, cookies, authorization headers, database/provider connection strings, private keys,
+provider homes, private repository URLs, personal data, private Chat content, and sensitive absolute host paths. Preserve
+only pseudonymous IDs and sanitized path suffixes needed to correlate the session, workspace, and evidence. Retain any
+unredacted material only at a safe local artifact path and never attach it to a shared report.


### PR DESCRIPTION
## Summary

- treat `.first-tree-workspace/managed.json::skills` as untrusted local filesystem input and keep only exact lowercase ASCII kebab slugs up to 64 characters
- independently resolve and contain each stale-skill removal under `.agents/skills` and `.claude/skills`, including cross-platform rejection of POSIX, Windows drive-relative/absolute, UNC, device, separator, traversal, root, and sibling-prefix forms
- preserve legitimate retired managed-skill cleanup, current protected skills, user-created unledgered skills, and leaf-symlink unlink behavior
- add mutation-resistant deletion-boundary, poisoned-ledger integration, symlink, failure-isolation, malformed/future-state, and compatibility coverage
- add the repository-required packed-runtime QA case

Fixes #1610

## Root cause

Managed-state reading previously accepted every string in the agent-writable ledger. Reconciliation joined those strings directly below both skill roots before recursive removal, so a path-like value could normalize to a root or an object outside the intended immediate-child boundary.

The reader now admits only a single managed skill slug. The deletion point separately enforces exact lexical immediate-child containment for each root, so future reader changes cannot silently remove the filesystem boundary.

The 64-character slug cap is compatible with all 21 current/historical official managed names examined on repository history; the observed maximum is 22 characters.

## Validation

- `pnpm check` — passed (only 2 existing warnings and 1 existing info outside this diff)
- `pnpm typecheck` — passed, 10/10 tasks
- `pnpm --filter @first-tree/client exec vitest run src/__tests__/managed-state.test.ts src/__tests__/skills-state-reconcile.test.ts src/__tests__/first-tree-skills-installer-extra.test.ts --maxWorkers=1 --testTimeout=30000` — passed, 95/95
- `pnpm --filter @first-tree/qa test` — passed, 4/4
- `git diff --check` — passed
- GitHub Actions at `6cd71c7b52e2c57f452e061bdf219667848ebc1d` — passed, including lint/typecheck, Client/Web, CLI, Server, portable smoke, legacy-name guard, and CodeQL
- `pnpm test` — attempted but did not complete green on the shared, concurrently loaded host. The 11m20s run produced unrelated timing-heavy Client/CLI timeouts; the terminal failing task was `apps/cli/src/__tests__/update-portable-install.test.ts`. Its isolated rerun passed 21/22, with the remaining case exceeding its 15s timeout by about 0.5s. This branch has no diff under `apps/cli`; the issue-focused Client suites pass as reported above.

Formal QA is warranted by repository policy but was not run; therefore no QA status is claimed. A formal run requires complete Docker/worktree harness readiness before task-specific planning.

## Threat boundary

This change guarantees lexical containment of an untrusted skill name while assuming the workspace and both skill-root topologies are trusted and stable. A pre-existing or raced symlink, junction, or mount at `.agents`, `.claude`, either skills root, or an ancestor—and descriptor-level TOCTOU—remain outside this scoped patch. The final stale leaf may itself be a symlink; it is unlinked without following its target.
