### PR TITLE
Stabilize Context Review chat topics

### DIFF
--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -503,6 +503,7 @@ describe("handleContextReviewerPrEvent", () => {
     if (!result.handled) throw new Error("expected handled result");
 
     const [chat] = await app.db.select().from(chats).where(eq(chats.id, result.chatId)).limit(1);
+    expect(chat?.topic).toBe("Context Review · context-tree#123");
     expect(chat?.metadata).toMatchObject({
       source: "github",
       entityType: "pull_request",
@@ -603,6 +604,35 @@ describe("handleContextReviewerPrEvent", () => {
     expect(followUp?.content).not.toContain("gh pr review");
     const chatRows = await app.db.select({ id: chats.id }).from(chats);
     expect(chatRows).toHaveLength(1);
+  });
+
+  it("does not rename a reused reviewer chat with a legacy topic", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+
+    const first = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload(),
+      organizationId: admin.organizationId,
+    });
+    if (!first.handled) throw new Error("expected handled result");
+
+    const legacyTopic = "Context Review PR #123: Clarify agent routing context";
+    await app.db.update(chats).set({ topic: legacyTopic }).where(eq(chats.id, first.chatId));
+
+    const second = await handleContextReviewerPrEvent(app, {
+      eventType: "pull_request",
+      payload: pullRequestPayload({
+        pull_request: { ...pullRequestPayload().pull_request, title: "Renamed upstream title" },
+      }),
+      organizationId: admin.organizationId,
+    });
+
+    expect(second).toMatchObject({ handled: true, chatId: first.chatId, reused: true });
+    const [chat] = await app.db.select({ topic: chats.topic }).from(chats).where(eq(chats.id, first.chatId)).limit(1);
+    expect(chat?.topic).toBe(legacyTopic);
   });
 
   it("does not reuse caller-spoofable reviewer chat metadata", async () => {

--- a/packages/server/src/__tests__/scm-entity-chat-topic.test.ts
+++ b/packages/server/src/__tests__/scm-entity-chat-topic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatContextReviewTopic,
   formatGitlabEntityTopic,
   formatScmAutoTopic,
   refreshGitlabEntityTopic,
@@ -11,6 +12,23 @@ describe("SCM automatic topics", () => {
     expect(formatScmAutoTopic("PR repo#7", "Ship it")).toBe("PR repo#7: Ship it");
     expect(formatScmAutoTopic("Issue repo#8", null)).toBe("Issue repo#8");
     expect(refreshScmAutoTopic("manual", "New", [{ matches: "PR repo#7", nextHead: "PR repo#7" }])).toBeNull();
+  });
+
+  it("renders stable Context Review topics with provider-native references", () => {
+    expect(
+      formatContextReviewTopic({
+        provider: "github",
+        repositoryPath: "agent-team-foundation/first-tree-context",
+        changeNumber: 789,
+      }),
+    ).toBe("Context Review · first-tree-context#789");
+    expect(
+      formatContextReviewTopic({
+        provider: "gitlab",
+        repositoryPath: "platform/context/first-tree-context",
+        changeNumber: 42,
+      }),
+    ).toBe("Context Review · first-tree-context!42");
   });
 
   it("renders all GitLab automatic topic variants", () => {

--- a/packages/server/src/services/context-reviewer-pr.ts
+++ b/packages/server/src/services/context-reviewer-pr.ts
@@ -20,6 +20,7 @@ import { sendMessage } from "./message.js";
 import { notifyRecipients } from "./notifier.js";
 import { getOrgContextTreeBinding, getOrgSetting } from "./org-settings.js";
 import { applyMembershipWrite } from "./participant-mode.js";
+import { formatContextReviewTopic } from "./scm-entity-chat-topic.js";
 
 const log = createLogger("ContextReviewerPr");
 const require = createRequire(import.meta.url);
@@ -340,7 +341,11 @@ async function handleContextReviewerPrEventWithInfo(
     organizationId: input.organizationId,
     initialRecipientAgentIds: [reviewer.uuid],
     contextParticipantAgentIds: [],
-    topic: `Context Review PR #${info.prNumber}: ${info.title}`,
+    topic: formatContextReviewTopic({
+      provider: "github",
+      repositoryPath: info.repoFullName,
+      changeNumber: info.prNumber,
+    }),
     onboardingKickoffKey: contextReviewerChatReservationKey(input.organizationId, info.entityKey),
     initialMessage: {
       source: "github",

--- a/packages/server/src/services/scm-entity-chat-topic.ts
+++ b/packages/server/src/services/scm-entity-chat-topic.ts
@@ -33,12 +33,25 @@ export type GitlabTopicEntity = {
   title: string | null;
 };
 
-function gitlabProjectSegment(projectPath: string): string {
-  return projectPath.split("/").filter(Boolean).at(-1) ?? projectPath;
+export type ContextReviewTopicEntity = {
+  provider: "github" | "gitlab";
+  repositoryPath: string;
+  /** GitHub PR number or project-scoped GitLab MR IID. */
+  changeNumber: number;
+};
+
+function repositorySegment(repositoryPath: string): string {
+  return repositoryPath.split("/").filter(Boolean).at(-1) ?? repositoryPath;
+}
+
+export function formatContextReviewTopic(entity: ContextReviewTopicEntity): string {
+  const repository = repositorySegment(entity.repositoryPath);
+  const referencePrefix = entity.provider === "github" ? "#" : "!";
+  return `Context Review · ${repository}${referencePrefix}${entity.changeNumber}`;
 }
 
 export function formatGitlabEntityTopic(entity: GitlabTopicEntity, reviewFirstTouch = false): string {
-  const project = gitlabProjectSegment(entity.projectPath);
+  const project = repositorySegment(entity.projectPath);
   const head =
     entity.entityType === "pull_request"
       ? `${reviewFirstTouch ? "MR Review" : "MR"} ${project}!${entity.entityIid}`
@@ -47,7 +60,7 @@ export function formatGitlabEntityTopic(entity: GitlabTopicEntity, reviewFirstTo
 }
 
 export function refreshGitlabEntityTopic(storedTopic: string, entity: GitlabTopicEntity): string | null {
-  const project = gitlabProjectSegment(entity.projectPath);
+  const project = repositorySegment(entity.projectPath);
   const iid = String(entity.entityIid);
   if (entity.entityType === "pull_request") {
     return refreshScmAutoTopic(storedTopic, entity.title, [


### PR DESCRIPTION
## Summary

- generate stable topics for newly created Context Reviewer chats: `Context Review · <repo>#<PR number>`
- preserve existing Reviewer chat topics on reuse, with no migration or lazy rename
- codify the provider-neutral formatter contract for a future GitLab MR reviewer: `Context Review · <repo>!<MR IID>`
- keep GitHub source metadata and existing GitHub/GitLab automatic entity topics unchanged

## Tests

- `pnpm check` (passes with pre-existing repository warnings)
- `pnpm typecheck`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/scm-entity-chat-topic.test.ts src/__tests__/context-reviewer-pr.test.ts` (47 passed)
- `pnpm --filter @first-tree/server test` (2,533 passed)

The monorepo-wide `pnpm test` was also attempted. Its parallel run was not clean because unrelated Web and skill-evals tests timed out under machine load; the affected Server package subsequently passed its complete test suite in isolation.
