### PR TITLE
fix(client): retry Codex steer after new input

### DIFF
--- a/packages/client/src/__tests__/codex-app-server-handler.test.ts
+++ b/packages/client/src/__tests__/codex-app-server-handler.test.ts
@@ -1387,6 +1387,9 @@ describe("codex app-server handler", () => {
     await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
     handler.inject(makeMessage("m2", "second"));
     await waitFor(() => fake.requests.some((request) => request.method === "turn/steer"));
+    await flushAsync();
+
+    expect(fake.requests.filter((request) => request.method === "turn/steer")).toHaveLength(1);
 
     completeTurn(fake, "turn-1", "first done");
     await waitFor(() => fake.requests.filter((request) => request.method === "turn/start").length === 2);
@@ -1399,7 +1402,7 @@ describe("codex app-server handler", () => {
     await handler.shutdown();
   });
 
-  it("keeps newer injects behind an older no-custody steer until the next turn", async () => {
+  it("retries the ordered pending batch when input arrives during a no-custody steer", async () => {
     const fake = new FakeAppServerClient();
     fake.deferNextSteer();
     const finished: SessionMessage[][] = [];
@@ -1422,9 +1425,74 @@ describe("codex app-server handler", () => {
     expect(fake.requests.filter((request) => request.method === "turn/steer")).toHaveLength(1);
 
     fake.rejectSteer(activeTurnNotSteerableError());
+    await waitFor(() => fake.requests.filter((request) => request.method === "turn/steer").length === 2);
+
+    const retriedSteer = fake.requests.filter((request) => request.method === "turn/steer")[1];
+    expect(JSON.stringify(retriedSteer?.params)).toContain("second");
+    expect(JSON.stringify(retriedSteer?.params)).toContain("third");
+
+    completeTurn(fake, "turn-1", "all done");
+    await startPromise;
+    await waitFor(() => finished.length === 1);
+
+    expect(fake.requests.filter((request) => request.method === "turn/start")).toHaveLength(1);
+    expect(finished.map((messages) => messages.map((message) => message.id))).toEqual([["m1", "m2", "m3"]]);
+
+    await handler.shutdown();
+  });
+
+  it("retries a rejected pending prefix when a later input arrives", async () => {
+    const fake = new FakeAppServerClient();
+    fake.steerError = activeTurnNotSteerableError();
+    const finished: SessionMessage[][] = [];
+    const handler = makeHandler(fake);
+    const ctx = makeContext({
+      finishTurn: async (messages) => {
+        finished.push(Array.isArray(messages) ? [...messages] : [messages]);
+      },
+    });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    handler.inject(makeMessage("m2", "second"));
+    await waitFor(() => fake.requests.filter((request) => request.method === "turn/steer").length === 1);
     await flushAsync();
 
-    expect(fake.requests.filter((request) => request.method === "turn/steer")).toHaveLength(1);
+    fake.steerError = null;
+    handler.inject(makeMessage("m3", "third"));
+    await waitFor(() => fake.requests.filter((request) => request.method === "turn/steer").length === 2);
+
+    const retriedSteer = fake.requests.filter((request) => request.method === "turn/steer")[1];
+    expect(JSON.stringify(retriedSteer?.params)).toContain("second");
+    expect(JSON.stringify(retriedSteer?.params)).toContain("third");
+
+    completeTurn(fake, "turn-1", "all done");
+    await startPromise;
+
+    expect(finished.map((messages) => messages.map((message) => message.id))).toEqual([["m1", "m2", "m3"]]);
+
+    await handler.shutdown();
+  });
+
+  it("batches repeatedly rejected pending inputs into the next turn", async () => {
+    const fake = new FakeAppServerClient();
+    fake.steerError = activeTurnNotSteerableError();
+    const finished: SessionMessage[][] = [];
+    const handler = makeHandler(fake);
+    const ctx = makeContext({
+      finishTurn: async (messages) => {
+        finished.push(Array.isArray(messages) ? [...messages] : [messages]);
+      },
+    });
+
+    const startPromise = handler.start(makeMessage("m1", "first"), ctx);
+    await waitFor(() => fake.requests.some((request) => request.method === "turn/start"));
+
+    handler.inject(makeMessage("m2", "second"));
+    await waitFor(() => fake.requests.filter((request) => request.method === "turn/steer").length === 1);
+    handler.inject(makeMessage("m3", "third"));
+    await waitFor(() => fake.requests.filter((request) => request.method === "turn/steer").length === 2);
 
     completeTurn(fake, "turn-1", "first done");
     await startPromise;

--- a/packages/client/src/handlers/codex/app-server/index.ts
+++ b/packages/client/src/handlers/codex/app-server/index.ts
@@ -148,7 +148,12 @@ type CurrentTurn = {
   status: "inProgress" | "completed" | "failed" | "interrupted";
   primaryToken: DeliveryToken;
   acceptedMessages: SessionMessage[];
-  appendClosed: boolean;
+  /**
+   * Pending-input generation that Codex definitively refused to steer.
+   * Matching generations wait for the next turn; a newer input changes the
+   * generation and gives the still-ordered pending prefix one fresh attempt.
+   */
+  appendRejectedInputGeneration: number | null;
   inFlightAppend: Promise<void> | null;
   finalAgentText: string;
   completedItemIds: Set<string>;
@@ -212,6 +217,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   let providerRetryFence = false;
   let pendingDrainInProgress = false;
   let pendingDrainScheduled = false;
+  let pendingInputGeneration = 0;
   let shutdownRequested = false;
   let pendingChatContextPrompt: string | null = null;
   let sourceReposForPrompt: PredeclaredSourceRepo[] = [];
@@ -1224,7 +1230,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       status: "inProgress",
       primaryToken: token,
       acceptedMessages: [...messages],
-      appendClosed: false,
+      appendRejectedInputGeneration: null,
       inFlightAppend: null,
       finalAgentText: "",
       completedItemIds: new Set(),
@@ -1525,7 +1531,13 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
 
     const turn = currentTurn;
     if (turn) {
-      if (turn.status !== "inProgress" || turn.appendClosed || turn.inFlightAppend) return;
+      if (
+        turn.status !== "inProgress" ||
+        turn.appendRejectedInputGeneration === pendingInputGeneration ||
+        turn.inFlightAppend
+      ) {
+        return;
+      }
     } else if (startupTurnPending || currentTurnPromise) {
       return;
     }
@@ -1547,7 +1559,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     pendingDrainInProgress = true;
     try {
       const turn = currentTurn;
-      if (turn && turn.status === "inProgress" && !turn.appendClosed) {
+      if (turn && turn.status === "inProgress" && turn.appendRejectedInputGeneration !== pendingInputGeneration) {
         await appendPendingInputsToTurn(turn, sessionCtx);
         return;
       }
@@ -1563,7 +1575,8 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   async function appendPendingInputsToTurn(turn: CurrentTurn, sessionCtx: SessionContext): Promise<void> {
     if (turn.inFlightAppend || pendingInputs.length === 0) return;
     const batch = pendingInputs.slice();
-    const appendPromise = appendBatchToTurn(turn, batch, sessionCtx);
+    const inputGeneration = pendingInputGeneration;
+    const appendPromise = appendBatchToTurn(turn, batch, inputGeneration, sessionCtx);
     const trackedAppend = appendPromise.finally(() => {
       if (turn.inFlightAppend === trackedAppend) turn.inFlightAppend = null;
     });
@@ -1574,6 +1587,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
   async function appendBatchToTurn(
     turn: CurrentTurn,
     batch: readonly QueueEntry[],
+    inputGeneration: number,
     sessionCtx: SessionContext,
   ): Promise<void> {
     const client = appServer;
@@ -1597,7 +1611,9 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
     }
 
     if (currentTurn !== turn || turn.stopRequested || shutdownRequested) return;
-    if (turn.status !== "inProgress" || turn.appendClosed) return;
+    if (turn.status !== "inProgress" || turn.appendRejectedInputGeneration === pendingInputGeneration) {
+      return;
+    }
 
     try {
       await client.request("turn/steer", {
@@ -1612,11 +1628,20 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
         return;
       }
       removePendingPrefix(batch);
+      turn.appendRejectedInputGeneration = null;
       for (const entry of batch) entry.token.processingStarted(entry.message);
       turn.acceptedMessages.push(...batch.map((entry) => entry.message));
     } catch (err) {
       if (shouldFallbackSteerToNextTurn(err)) {
-        turn.appendClosed = true;
+        // The provider definitively did not accept this batch. Block only the
+        // queue generation that was attempted: a later input (including one
+        // that arrived while this request was in flight) re-opens one ordered
+        // steer attempt instead of poisoning the rest of a long-running turn.
+        turn.appendRejectedInputGeneration = inputGeneration;
+        sessionCtx.log(
+          `codex app-server turn/steer rejected without custody; pending generation ${inputGeneration} ` +
+            `will retry after newer input or the next turn: ${err instanceof Error ? err.message : String(err)}`,
+        );
         schedulePendingDrain();
       } else {
         const reason = isCodexAppServerTransientError(err)
@@ -1863,6 +1888,7 @@ export const createCodexAppServerHandler: HandlerFactory = (config: HandlerConfi
       if (!ctx || shutdownRequested) return { kind: "rejected", reason: "no_active_context", retryable: true };
       const deliveryToken = token ?? deliveryTokenFromSessionContext(ctx);
       pendingInputs.push({ message, token: deliveryToken });
+      pendingInputGeneration++;
       schedulePendingDrain();
       return { kind: "owned", mode: "queued" };
     },


### PR DESCRIPTION
## Summary

- replace the turn-wide Codex `appendClosed` latch with a pending-input generation fence
- give the full FIFO pending prefix one fresh `turn/steer` attempt when newer input arrives
- preserve next-turn batching when the active turn remains non-steerable
- log definitive no-custody steer rejections without changing unknown-custody recovery

## Root cause

A single definitive `turn/steer` rejection marked the entire active turn as permanently closed to appends. On a long-running turn, every later human message stayed queued until the turn ended or the operator suspended it, even if Codex became steerable again.

The new generation fence blocks hot retry only for the exact pending-input generation that was rejected. A newer message changes the generation and re-opens one ordered attempt for the complete pending prefix. Inputs are still marked provider-entered only after `turn/steer` succeeds.

## Validation

- `pnpm exec biome check packages/client/src/handlers/codex/app-server/index.ts packages/client/src/__tests__/codex-app-server-handler.test.ts`
- `git diff --check`
- `pnpm --filter @first-tree/client typecheck`
- `pnpm --filter @first-tree/client exec vitest run --passWithNoTests --maxWorkers=2`
  - 153 files passed, 1 skipped
  - 1628 tests passed, 3 skipped

Formal provider-backed QA remains useful for the real Codex compact-state transition; the adjacent `provider-transient-retry-after-visible-output` QA case covers the same steer/drain custody boundary.
