### PR TITLE
fix(client): start TUI resume transcript tails at EOF with bounded chunked reads

### DIFF
--- a/packages/client/src/__tests__/tui-transcript-tail.test.ts
+++ b/packages/client/src/__tests__/tui-transcript-tail.test.ts
@@ -79,4 +79,60 @@ describe("TranscriptTailer", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ type: "user" });
   });
+
+  it("startAtEnd skips pre-existing history and returns only new entries (resume)", () => {
+    const history = Array.from({ length: 500 }, (_, i) =>
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: `old ${i}` }] } }),
+    ).join("\n");
+    writeFileSync(filePath, `${history}\n`);
+
+    const tailer = new TranscriptTailer(filePath, { startAtEnd: true });
+    expect(tailer.drainEntries()).toEqual([]);
+
+    appendFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "fresh" } })}\n`);
+    const entries = tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "user", message: { content: "fresh" } });
+  });
+
+  it("startAtEnd on a missing file behaves like a fresh tail from offset zero", () => {
+    const tailer = new TranscriptTailer(filePath, { startAtEnd: true });
+    expect(tailer.drainEntries()).toEqual([]);
+
+    writeFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "first" } })}\n`);
+    const entries = tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "user", message: { content: "first" } });
+  });
+
+  it("parses entries larger than a single read chunk", () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    // READ_CHUNK_BYTES is 64 KiB — make one line span several chunks.
+    const big = "x".repeat(256 * 1024);
+    appendFileSync(filePath, `${JSON.stringify({ type: "assistant", message: { content: big } })}\n`);
+    appendFileSync(filePath, `${JSON.stringify({ type: "user", message: { content: "after" } })}\n`);
+
+    const entries = tailer.drainEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({ type: "assistant", message: { content: big } });
+    expect(entries[1]).toMatchObject({ type: "user", message: { content: "after" } });
+  });
+
+  it("reassembles a multi-byte UTF-8 character split across two drains", () => {
+    writeFileSync(filePath, "");
+    const tailer = new TranscriptTailer(filePath);
+
+    const line = Buffer.from(`${JSON.stringify({ type: "user", message: { content: "汉字🎉" } })}\n`, "utf-8");
+    // Split inside the multi-byte sequence of "汉" (well before the newline).
+    const splitAt = line.indexOf(Buffer.from("汉", "utf-8")) + 1;
+    appendFileSync(filePath, line.subarray(0, splitAt));
+    expect(tailer.drainEntries()).toEqual([]);
+
+    appendFileSync(filePath, line.subarray(splitAt));
+    const entries = tailer.drainEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "user", message: { content: "汉字🎉" } });
+  });
 });

--- a/packages/client/src/handlers/claude-code-tui/index.ts
+++ b/packages/client/src/handlers/claude-code-tui/index.ts
@@ -315,7 +315,13 @@ export const createClaudeCodeTuiHandler: HandlerFactory = (config) => {
       throw err;
     }
 
-    transcriptTailer = new TranscriptTailer(transcriptPathFor(cwd, sessionId));
+    // Tail from the file's current end. On resume the transcript already
+    // holds the complete prior history; starting at offset zero would make
+    // the first drain read and parse the whole file just to discard it
+    // (PERF-016). Anything already present is never consumed anyway — each
+    // turn preflushes-and-discards before pasting its prompt. For fresh
+    // sessions the file does not exist yet, so this is offset zero as before.
+    transcriptTailer = new TranscriptTailer(transcriptPathFor(cwd, sessionId), { startAtEnd: true });
     return sessionId;
   }
 

--- a/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
+++ b/packages/client/src/handlers/claude-code-tui/transcript-tail.ts
@@ -45,20 +45,50 @@ export type RawTranscriptEntry = {
 };
 
 /**
+ * Fixed read-chunk size. Bounds the per-`drainEntries` peak allocation: new
+ * data is streamed through one reused buffer of this size instead of a single
+ * allocation proportional to the unread backlog.
+ */
+const READ_CHUNK_BYTES = 64 * 1024;
+
+/** Newline as a byte. Never appears inside a multi-byte UTF-8 sequence. */
+const NEWLINE_BYTE = 0x0a;
+
+/**
  * Tail an append-only JSONL transcript. Each `drainEntries()` returns raw
  * entries appended since the last call. Tolerates the file not yet existing
  * (returns empty), partial lines across reads, and malformed JSON (single
  * bad line is skipped, not fatal).
+ *
+ * Pass `startAtEnd: true` to tail from the file's current end instead of
+ * offset zero — required for resumed sessions, whose transcript already
+ * contains the complete prior history. Reading that history would allocate
+ * and parse the entire file just to discard it (see PERF-016).
  *
  * NOT thread-safe across instances — each session should own one tailer.
  */
 export class TranscriptTailer {
   private readonly path: string;
   private offset = 0;
-  private partial = "";
+  /**
+   * Bytes of a trailing incomplete line carried to the next read, as a list
+   * of buffers so a line spanning many chunks is copied once when it
+   * completes instead of re-concatenated per chunk. Kept as bytes (not a
+   * string) so a multi-byte UTF-8 character split across two reads is
+   * reassembled instead of decoded into replacement characters. Invariant:
+   * never contains a newline byte.
+   */
+  private partialChunks: Buffer[] = [];
 
-  constructor(path: string) {
+  constructor(path: string, options?: { startAtEnd?: boolean }) {
     this.path = path;
+    if (options?.startAtEnd) {
+      try {
+        this.offset = statSync(path).size;
+      } catch {
+        // File not created yet (fresh session) — start from offset zero.
+      }
+    }
   }
 
   /** Read raw JSONL entries appended since the last call. Best-effort. */
@@ -67,29 +97,51 @@ export class TranscriptTailer {
     const stat = statSync(this.path);
     if (stat.size <= this.offset) return [];
 
+    const entries: RawTranscriptEntry[] = [];
     const fd = openSync(this.path, "r");
-    let chunk = "";
     try {
-      const buf = Buffer.allocUnsafe(stat.size - this.offset);
-      const read = readSync(fd, buf, 0, buf.length, this.offset);
-      this.offset += read;
-      chunk = this.partial + buf.subarray(0, read).toString("utf-8");
+      // Stream up to the stat-time size in bounded chunks. Data appended
+      // after the stat is picked up by the next drain.
+      const chunk = Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, stat.size - this.offset));
+      while (this.offset < stat.size) {
+        const toRead = Math.min(chunk.length, stat.size - this.offset);
+        const read = readSync(fd, chunk, 0, toRead, this.offset);
+        if (read <= 0) break; // truncated/raced — retry on the next drain
+        this.offset += read;
+        this.consumeChunk(chunk.subarray(0, read), entries);
+      }
     } finally {
       closeSync(fd);
     }
+    return entries;
+  }
 
-    const parts = chunk.split("\n");
-    this.partial = parts.pop() ?? "";
+  /**
+   * Split a chunk on newline bytes, parse complete lines, carry the rest.
+   * Only the new chunk is searched — the carry holds no newline by invariant.
+   */
+  private consumeChunk(chunk: Buffer, out: RawTranscriptEntry[]): void {
+    const lastNewline = chunk.lastIndexOf(NEWLINE_BYTE);
+    if (lastNewline === -1) {
+      // No line completed in this chunk. Copy — `chunk` views a reused
+      // read buffer that the next iteration overwrites.
+      this.partialChunks.push(Buffer.from(chunk));
+      return;
+    }
 
-    const entries: RawTranscriptEntry[] = [];
-    for (const raw of parts) {
+    const complete =
+      this.partialChunks.length > 0
+        ? Buffer.concat([...this.partialChunks, chunk.subarray(0, lastNewline)])
+        : chunk.subarray(0, lastNewline);
+    this.partialChunks = lastNewline + 1 < chunk.length ? [Buffer.from(chunk.subarray(lastNewline + 1))] : [];
+
+    for (const raw of complete.toString("utf-8").split("\n")) {
       if (!raw.trim()) continue;
       try {
-        entries.push(JSON.parse(raw) as RawTranscriptEntry);
+        out.push(JSON.parse(raw) as RawTranscriptEntry);
       } catch {
         // skip malformed line
       }
     }
-    return entries;
   }
 }


### PR DESCRIPTION
Fixes #1679 ([PERF-016][High] TUI resume synchronously reads and parses the complete transcript).

## Problem

On resume, `startClaude` constructed the `TranscriptTailer` at offset zero against the session's existing full-history JSONL. The first `drainEntries()` — the per-turn preflush — then:

- allocated a single buffer for the **entire** historical file,
- synchronously read it on the shared event loop,
- split and `JSON.parse`d every historical line,
- and discarded all of it.

Large histories block the event loop for the whole read+parse and can OOM the client process shared by all agents. Independently, `drainEntries()` always sized its read buffer to the whole unread region, so even new-data reads were unbounded.

## Fix

1. **Resume tails initialize at EOF.** `TranscriptTailer` accepts `{ startAtEnd: true }`: the constructor stats the file and starts the offset at its current size (missing file → offset zero, i.e. fresh-session behavior). The TUI handler now passes `startAtEnd: true`. This is behavior-preserving: every turn already preflush-discards anything present in the transcript before pasting its prompt, so pre-existing entries were never consumed — we just stop paying to read and parse them.
2. **Bounded streaming chunks for new data.** `drainEntries()` streams through one reused 64 KiB buffer in a loop capped at the stat-time file size, so peak allocation per drain is bounded regardless of backlog. Data appended after the stat is picked up by the next drain.
3. **Byte-level partial-line carry.** Chunking can split a line and even a multi-byte UTF-8 sequence, so the carry is now a list of byte buffers split on the newline byte (`0x0A`, which never occurs inside a multi-byte UTF-8 sequence). A line spanning many chunks is concatenated once when it completes (O(n) total). This also fixes a latent bug where the previous string-based carry corrupted a multi-byte character split across two reads into replacement characters.

## Verification

- `pnpm check` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @first-tree/client test` — 1628 passed; the only failing file (`capability-reprobe.test.ts`, 2 timeouts) reproduces identically on pristine `origin/main` in my environment (node v25 vs supported 22–24), i.e. pre-existing and unrelated to this diff
- New unit tests in `packages/client/src/__tests__/tui-transcript-tail.test.ts`:
  - `startAtEnd` skips pre-existing history and returns only entries appended afterwards (resume case)
  - `startAtEnd` on a not-yet-created file falls back to offset zero (fresh session)
  - an entry larger than a single 64 KiB read chunk parses intact
  - a multi-byte UTF-8 character split across two drains is reassembled correctly
  - all pre-existing tailer tests unchanged and passing

## Scope

Only the TUI transcript tailer and its call site: `packages/client/src/handlers/claude-code-tui/transcript-tail.ts`, `packages/client/src/handlers/claude-code-tui/index.ts`, plus tests. No schema, API, or config changes.
