### PR TITLE
fix(cli): block path traversal in agent remove local-state deletion (SEC-030)

### DIFF
--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -48,6 +48,7 @@ const coreMocks = vi.hoisted(() => ({
   installGlobalLatest: vi.fn(),
   installGlobalSpec: vi.fn(),
   installPortableSpec: vi.fn(),
+  isSafeLocalAgentName: vi.fn(() => true),
   isServiceSupported: vi.fn(),
   listLiveClientRuntimeMarkers: vi.fn(),
   loadCredentials: vi.fn(),

--- a/apps/cli/src/__tests__/agent-prune.test.ts
+++ b/apps/cli/src/__tests__/agent-prune.test.ts
@@ -2,7 +2,13 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { findStaleAliases, formatStaleReason, type PinnedAgent, removeLocalAgent } from "../core/agent-prune.js";
+import {
+  findStaleAliases,
+  formatStaleReason,
+  isSafeLocalAgentName,
+  type PinnedAgent,
+  removeLocalAgent,
+} from "../core/agent-prune.js";
 
 /**
  * Pins the four cases that drove the rewrite:
@@ -192,5 +198,128 @@ describe("findStaleAliases", () => {
     expect(existsSync(join(home, "data", "workspaces", "stale"))).toBe(false);
     expect(existsSync(join(home, "data", "sessions", "stale.json"))).toBe(false);
     rmSync(home, { recursive: true, force: true });
+  });
+});
+
+/**
+ * SEC-030 — `removeLocalAgent` recursively deletes three paths built from a
+ * caller-supplied name. These tests pin the two-layer guard: the canonical
+ * name-schema gate (plus the grandfathered legacy 1–100 form), and realpath
+ * containment right before every deletion.
+ */
+describe("removeLocalAgent containment (SEC-030)", () => {
+  let home = "";
+
+  function seedHome(): void {
+    mkdirSync(join(home, "config", "agents"), { recursive: true });
+    mkdirSync(join(home, "data", "workspaces"), { recursive: true });
+    mkdirSync(join(home, "data", "sessions"), { recursive: true });
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "fthub-remove-home-"));
+    process.env.FIRST_TREE_HOME = home;
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("rejects traversal and non-schema names before touching the filesystem", () => {
+    seedHome();
+    // Victims reachable from the three deletion bases via `../…` names.
+    writeFileSync(join(home, "config", "victim.txt"), "keep");
+    mkdirSync(join(home, "data", "victim-dir"));
+    writeFileSync(join(home, "data", "victim-dir", "keep.txt"), "keep");
+
+    const hostile = [
+      "..",
+      "../victim.txt",
+      "../victim-dir",
+      "../../victim-dir",
+      "a/../../victim-dir",
+      "nested/child",
+      "/tmp/absolute-escape",
+      "",
+      ".",
+      ".hidden",
+      "Uppercase",
+      "-leading-dash",
+      "_leading-underscore",
+      "a".repeat(101),
+    ];
+    for (const name of hostile) {
+      expect(() => removeLocalAgent(name), `name: ${JSON.stringify(name)}`).toThrow(/invalid agent name/);
+    }
+
+    expect(existsSync(join(home, "config", "victim.txt"))).toBe(true);
+    expect(existsSync(join(home, "data", "victim-dir", "keep.txt"))).toBe(true);
+    expect(existsSync(join(home, "config", "agents"))).toBe(true);
+    expect(existsSync(join(home, "data", "workspaces"))).toBe(true);
+    expect(existsSync(join(home, "data", "sessions"))).toBe(true);
+  });
+
+  it("still removes grandfathered names from the previous 1–100 rule", () => {
+    const legacy = "a".repeat(100);
+    seedHome();
+    mkdirSync(join(home, "config", "agents", legacy));
+    mkdirSync(join(home, "data", "workspaces", legacy));
+    writeFileSync(join(home, "data", "sessions", `${legacy}.json`), "{}");
+
+    removeLocalAgent(legacy);
+
+    expect(existsSync(join(home, "config", "agents", legacy))).toBe(false);
+    expect(existsSync(join(home, "data", "workspaces", legacy))).toBe(false);
+    expect(existsSync(join(home, "data", "sessions", `${legacy}.json`))).toBe(false);
+  });
+
+  it("is a no-op when the base dirs do not exist yet", () => {
+    expect(() => removeLocalAgent("ghost")).not.toThrow();
+  });
+
+  it("removes only the symlink when an alias dir points outside the base", (ctx) => {
+    seedHome();
+    const outside = join(home, "outside-target");
+    mkdirSync(outside);
+    writeFileSync(join(outside, "keep.txt"), "keep");
+    try {
+      symlinkSync(outside, join(home, "config", "agents", "linked"));
+      symlinkSync(outside, join(home, "data", "workspaces", "linked"));
+    } catch {
+      ctx.skip("Symlink creation is not supported in this environment.");
+    }
+
+    removeLocalAgent("linked");
+
+    expect(existsSync(join(home, "config", "agents", "linked"))).toBe(false);
+    expect(existsSync(join(home, "data", "workspaces", "linked"))).toBe(false);
+    expect(existsSync(join(outside, "keep.txt"))).toBe(true);
+  });
+});
+
+describe("isSafeLocalAgentName", () => {
+  it("accepts canonical and grandfathered legacy names", () => {
+    for (const name of ["a", "my-agent", "agent_1", "0start", "a".repeat(64), "a".repeat(100)]) {
+      expect(isSafeLocalAgentName(name), name).toBe(true);
+    }
+  });
+
+  it("rejects names that could steer filesystem paths", () => {
+    for (const name of [
+      "..",
+      "../x",
+      "a/b",
+      "a\\b",
+      "/abs",
+      "",
+      ".",
+      ".hidden",
+      "UPPER",
+      "-x",
+      "_x",
+      "a".repeat(101),
+    ]) {
+      expect(isSafeLocalAgentName(name), JSON.stringify(name)).toBe(false);
+    }
   });
 });

--- a/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
+++ b/apps/cli/src/__tests__/cli-command-matrix-extra.test.ts
@@ -40,6 +40,7 @@ const printLineMock = vi.hoisted(() => vi.fn());
 const coreMocks = vi.hoisted(() => ({
   getClientServiceStatus: vi.fn(),
   installClientService: vi.fn(),
+  isSafeLocalAgentName: vi.fn(() => true),
   isServiceSupported: vi.fn(),
   isServiceUnitDriftDetected: vi.fn(),
   loadCredentials: vi.fn(),
@@ -431,6 +432,12 @@ describe("agent admin and local commands", () => {
     await runAgent(["remove", "nova"]);
     expect(coreMocks.removeLocalAgent).toHaveBeenCalledWith("nova");
     await expect(runAgent(["remove", "missing"])).rejects.toMatchObject({ code: 1 });
+
+    // SEC-030: names failing the schema gate exit before any filesystem use.
+    coreMocks.isSafeLocalAgentName.mockReturnValueOnce(false);
+    await expect(runAgent(["remove", "../../escape"])).rejects.toMatchObject({ code: 1 });
+    expect(coreMocks.removeLocalAgent).not.toHaveBeenCalledWith("../../escape");
+    expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("Invalid agent name");
 
     localAgentMocks.createSdk.mockReturnValueOnce({ register: vi.fn(async () => ({ agentId: "agent-1" })) });
     await runAgent(["debug", "register", "--agent", "nova"]);

--- a/apps/cli/src/commands/agent/remove.ts
+++ b/apps/cli/src/commands/agent/remove.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { defaultConfigDir } from "@first-tree/shared/config";
 import type { Command } from "commander";
-import { removeLocalAgent } from "../../core/index.js";
+import { isSafeLocalAgentName, removeLocalAgent } from "../../core/index.js";
 import { print } from "../../core/output.js";
 
 export function registerAgentRemoveCommand(agent: Command): void {
@@ -12,6 +12,13 @@ export function registerAgentRemoveCommand(agent: Command): void {
       "Remove an agent from this client and delete its local runtime data (config dir, workspace, session state)",
     )
     .action((name: string) => {
+      // Gate BEFORE any filesystem use: the name is joined into recursively
+      // deleted paths, so traversal input must never reach existsSync or
+      // removeLocalAgent (SEC-030).
+      if (!isSafeLocalAgentName(name)) {
+        print.line(`  Invalid agent name "${name}". Names are lowercase slugs like "my-agent".\n`);
+        process.exit(1);
+      }
       const agentDir = join(defaultConfigDir(), "agents", name);
       if (!existsSync(agentDir)) {
         print.line(`  Agent "${name}" not found.\n`);

--- a/apps/cli/src/core/agent-prune.ts
+++ b/apps/cli/src/core/agent-prune.ts
@@ -1,5 +1,6 @@
-import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readdirSync, readFileSync, realpathSync, rmSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { AGENT_NAME_REGEX } from "@first-tree/shared";
 import { defaultConfigDir, defaultDataDir } from "@first-tree/shared/config";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
@@ -136,13 +137,66 @@ export function formatStaleReason(reason: StaleAliasReason): string {
 }
 
 /**
+ * Names accepted under the previous 1–100 agent-name rule. Same charset as
+ * `AGENT_NAME_REGEX`, longer length cap: rows created before the tighter
+ * 64-char rule are grandfathered (see `schemas/agent.ts`), and their local
+ * aliases must stay removable.
+ */
+const LEGACY_AGENT_NAME_REGEX = /^[a-z0-9][a-z0-9_-]{0,99}$/;
+
+/**
+ * Whether `name` is safe to use as a local agent alias in filesystem
+ * paths: the canonical agent-name schema, or the grandfathered legacy
+ * form. Anything else (path separators, `..`, absolute paths, hidden
+ * dirs, uppercase, over-length) is rejected so deletion sinks can never
+ * be steered outside First Tree state (SEC-030).
+ */
+export function isSafeLocalAgentName(name: string): boolean {
+  return AGENT_NAME_REGEX.test(name) || LEGACY_AGENT_NAME_REGEX.test(name);
+}
+
+/**
+ * Delete `entryName` strictly as a direct child of `baseDir`.
+ *
+ * Containment is enforced immediately before the deletion: the base dir is
+ * resolved with `realpathSync` (so a relocated/symlinked First Tree home
+ * still works) and the target must resolve to `<realBase>/<entryName>`
+ * exactly — no separators, no `..`, no absolute-path override. If the
+ * entry itself is a symlink only the link inside the base is removed,
+ * never its target: `rmSync` does not follow the final path component.
+ */
+function removeContainedEntry(baseDir: string, entryName: string, opts: { recursive: boolean }): void {
+  let realBase: string;
+  try {
+    realBase = realpathSync(baseDir);
+  } catch (err: unknown) {
+    const isMissing = err instanceof Error && "code" in err && err.code === "ENOENT";
+    if (isMissing) return; // base dir absent → nothing to delete
+    throw err;
+  }
+  const target = resolve(realBase, entryName);
+  if (dirname(target) !== realBase || basename(target) !== entryName) {
+    throw new Error(`refusing to delete outside ${baseDir}: "${entryName}"`);
+  }
+  rmSync(target, { recursive: opts.recursive, force: true });
+}
+
+/**
  * Remove an agent's local footprint: the YAML alias dir, the workspace
  * tree under `data/workspaces/<name>`, and the session-mapping file under
  * `data/sessions/<name>.json`. Mirrors what `agent remove` does, exposed
  * separately so prune and the post-rotation override cleanup can share it.
+ *
+ * Fails closed on names outside the agent-name schema: this function
+ * recursively deletes, so a traversal name (`../…`) must never reach the
+ * filesystem (SEC-030). Callers wanting a friendly error should pre-check
+ * with `isSafeLocalAgentName`.
  */
 export function removeLocalAgent(name: string): void {
-  rmSync(join(defaultConfigDir(), "agents", name), { recursive: true, force: true });
-  rmSync(join(defaultDataDir(), "workspaces", name), { recursive: true, force: true });
-  rmSync(join(defaultDataDir(), "sessions", `${name}.json`), { force: true });
+  if (!isSafeLocalAgentName(name)) {
+    throw new Error(`invalid agent name "${name}" — refusing to delete local state`);
+  }
+  removeContainedEntry(join(defaultConfigDir(), "agents"), name, { recursive: true });
+  removeContainedEntry(join(defaultDataDir(), "workspaces"), name, { recursive: true });
+  removeContainedEntry(join(defaultDataDir(), "sessions"), `${name}.json`, { recursive: false });
 }

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -1,6 +1,6 @@
 // Local agent alias hygiene (stale alias detection + deletion)
 export type { PinnedAgent, StaleAlias, StaleAliasReason } from "./agent-prune.js";
-export { findStaleAliases, formatStaleReason, removeLocalAgent } from "./agent-prune.js";
+export { findStaleAliases, formatStaleReason, isSafeLocalAgentName, removeLocalAgent } from "./agent-prune.js";
 // Bootstrap / credentials
 export {
   AuthRefreshFailedError,


### PR DESCRIPTION
## Summary

Fixes #1636 ([SEC-030][High] `agent remove` permits recursive path traversal).

`removeLocalAgent(name)` (`apps/cli/src/core/agent-prune.ts`) joined a caller-supplied agent name into three recursively deleted paths under `$FIRST_TREE_HOME` with no validation, and `agent remove <name>` passed the raw CLI argument straight in. A name like `../../<dir>` escaped First Tree state and recursively deleted writable files elsewhere.

## Fix (defense in depth at the shared deletion sink)

1. **Canonical name-schema gate** — `isSafeLocalAgentName()` validates against the canonical `AGENT_NAME_REGEX` from `@first-tree/shared` (`packages/shared/src/schemas/agent.ts`), plus the grandfathered legacy form `^[a-z0-9][a-z0-9_-]{0,99}$` so aliases created under the documented old 1–100 rule stay removable. `removeLocalAgent` throws on anything else — fail closed for every caller (`agent remove`, `agent prune`).
2. **Realpath containment immediately before every deletion** — the base dir (`config/agents`, `data/workspaces`, `data/sessions`) is resolved with `realpathSync` (so a relocated/symlinked First Tree home still works) and the target must resolve to exactly `<realBase>/<entry>` (`dirname`/`basename` check). Missing base → nothing to delete; a symlinked alias entry only loses the link, never its target (`rmSync` does not follow the final path component).
3. **Command UX** — `agent remove` pre-validates before any filesystem use and exits 1 with a clean message; `agent prune`'s existing per-alias try/catch reports guard failures inline.

## Behavior changes

- `agent remove '../../x'` (and any non-schema name): clean `Invalid agent name` error, exit 1, no filesystem access — previously it could recursively delete outside First Tree state.
- `agent prune` no longer auto-deletes junk dirs whose names fall outside the agent-name charset (they can't be created by `agent add`; they're now reported per-alias for manual cleanup — fail-closed is the right default for a recursive delete).
- Grandfathered long names (65–100 chars, canonical charset) remain removable.

## Verification

- `pnpm check` (biome) and `pnpm typecheck` pass.
- `apps/cli` vitest: new unit tests for traversal/absolute/separator/hidden/uppercase/over-length rejection with victim files proving nothing outside the bases is touched; grandfathered 100-char removal; missing-base no-op; symlinked alias containment; command-level invalid-name exit path. Full CLI suite: no new failures vs clean `origin/main` (the 19 failures in `client-switch-transaction-extra` / `update-core-helpers-extra` / `detectInstallMode` pre-exist on this machine on a clean checkout — environment-dependent, unrelated).
- `packages/shared` vitest: 670 passed.
- Built-CLI smoke test: `FIRST_TREE_HOME=<tmp> first-tree agent remove '../../victim'` → exit 1, victim dir intact; `agent remove good-agent` → removed as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)