### PR TITLE
fix(web): purge plaintext chats, images, and drafts from browser storage on logout (SEC-042)

### DIFF
--- a/packages/web/src/api/__tests__/browser-stores.test.ts
+++ b/packages/web/src/api/__tests__/browser-stores.test.ts
@@ -123,15 +123,28 @@ describe("image-store", () => {
     await expect(getImage("missing")).resolves.toBeNull();
   });
 
+  it("clears every cached image on clearAllImages (logout purge, SEC-042)", async () => {
+    const { clearAllImages, getImage, putImage } = await loadImageStore();
+
+    await putImage({ imageId: "img-1", base64: "abc123", mimeType: "image/png" });
+    await putImage({ imageId: "img-2", base64: "def456", mimeType: "image/jpeg" });
+    await clearAllImages();
+
+    await expect(getImage("img-1")).resolves.toBeNull();
+    await expect(getImage("img-2")).resolves.toBeNull();
+  });
+
   it("rejects writes and returns null when IndexedDB is unavailable", async () => {
     vi.resetModules();
     delete (globalThis as { indexedDB?: unknown }).indexedDB;
-    const { getImage, putImage } = await import("../image-store.js");
+    const { clearAllImages, getImage, putImage } = await import("../image-store.js");
 
     await expect(putImage({ imageId: "img-1", base64: "abc123", mimeType: "image/png" })).rejects.toThrow(
       "Image storage unavailable",
     );
     await expect(getImage("img-1")).resolves.toBeNull();
+    // The purge path must stay silent — logout runs it unconditionally.
+    await expect(clearAllImages()).resolves.toBeUndefined();
   });
 
   it("rejects writes when the database open is blocked", async () => {
@@ -209,13 +222,25 @@ describe("read-state-store", () => {
     await expect(getReadState("chat-1")).resolves.toBeNull();
   });
 
+  it("clears every chat's read state on clearAllReadStates (logout purge, SEC-042)", async () => {
+    const { clearAllReadStates, getReadState, setReadState } = await loadReadStateStore();
+
+    await setReadState("chat-1", "msg-1", "msg-2");
+    await setReadState("chat-2", "msg-3", "msg-4");
+    await clearAllReadStates();
+
+    await expect(getReadState("chat-1")).resolves.toBeNull();
+    await expect(getReadState("chat-2")).resolves.toBeNull();
+  });
+
   it("silently no-ops when IndexedDB is unavailable", async () => {
     vi.resetModules();
     delete (globalThis as { indexedDB?: unknown }).indexedDB;
-    const { clearReadState, getReadState, setReadState } = await import("../read-state-store.js");
+    const { clearAllReadStates, clearReadState, getReadState, setReadState } = await import("../read-state-store.js");
 
     await expect(setReadState("chat-1", "msg-1", "msg-2")).resolves.toBeUndefined();
     await expect(clearReadState("chat-1")).resolves.toBeUndefined();
+    await expect(clearAllReadStates()).resolves.toBeUndefined();
     await expect(getReadState("chat-1")).resolves.toBeNull();
   });
 

--- a/packages/web/src/api/__tests__/message-store.test.ts
+++ b/packages/web/src/api/__tests__/message-store.test.ts
@@ -96,6 +96,34 @@ describe("message-store / cacheMessages", () => {
   });
 });
 
+describe("message-store / clearAllChatCaches", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+  });
+
+  it("removes every chat's rows (logout purge, SEC-042)", async () => {
+    const { cacheMessages, clearAllChatCaches, getCachedMessages } = await loadStore();
+    await cacheMessages("chat-1", [msg("a", T(1)), msg("b", T(2))]);
+    await cacheMessages("chat-2", [msg("c", T(3), { chatId: "chat-2" })]);
+    await clearAllChatCaches();
+    expect(await getCachedMessages("chat-1")).toEqual([]);
+    expect(await getCachedMessages("chat-2")).toEqual([]);
+  });
+
+  it("is a no-op on an empty cache", async () => {
+    const { clearAllChatCaches, getCachedMessages } = await loadStore();
+    await expect(clearAllChatCaches()).resolves.toBeUndefined();
+    expect(await getCachedMessages("chat-1")).toEqual([]);
+  });
+
+  it("silently no-ops when IndexedDB is unavailable", async () => {
+    vi.resetModules();
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    const { clearAllChatCaches } = await import("../message-store.js");
+    await expect(clearAllChatCaches()).resolves.toBeUndefined();
+  });
+});
+
 describe("message-store / clearChatCache", () => {
   beforeEach(() => {
     globalThis.indexedDB = new IDBFactory();

--- a/packages/web/src/api/image-store.ts
+++ b/packages/web/src/api/image-store.ts
@@ -69,6 +69,26 @@ export async function putImage(params: { imageId: string; base64: string; mimeTy
   });
 }
 
+/**
+ * Remove every cached image. Called on logout so image bytes from the
+ * previous account cannot be recovered from IndexedDB on a shared browser
+ * profile (SEC-042). The authoritative bytes live in the server attachment
+ * store, so the next login re-fetches on demand. Unlike `putImage`, this
+ * resolves silently on unavailability or failure — logout must never be
+ * blocked by best-effort local cleanup.
+ */
+export async function clearAllImages(): Promise<void> {
+  const db = await openDb();
+  if (!db) return;
+  await new Promise<void>((resolve) => {
+    const tx = db.transaction(STORE, "readwrite");
+    tx.objectStore(STORE).clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => resolve();
+    tx.onabort = () => resolve();
+  });
+}
+
 export async function getImage(imageId: string): Promise<{ base64: string; mimeType: string } | null> {
   const db = await openDb();
   if (!db) return null;

--- a/packages/web/src/api/message-store.ts
+++ b/packages/web/src/api/message-store.ts
@@ -144,6 +144,26 @@ export async function cacheMessages(chatId: string, messages: readonly MessageWi
 }
 
 /**
+ * Remove every cached message for every chat. Called on logout so a later
+ * account (or anyone else on the same browser profile) cannot read the
+ * previous user's conversation history out of IndexedDB (SEC-042). The
+ * cache is server-backed, so the next login re-hydrates it on demand.
+ * Resolves silently on IndexedDB unavailability or clear failure —
+ * logout must never be blocked by best-effort local cleanup.
+ */
+export async function clearAllChatCaches(): Promise<void> {
+  const db = await openDb();
+  if (!db) return;
+  await new Promise<void>((resolve) => {
+    const tx = db.transaction(STORE, "readwrite");
+    tx.objectStore(STORE).clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => resolve();
+    tx.onabort = () => resolve();
+  });
+}
+
+/**
  * Remove every cached message for `chatId`. Intended for diagnostic /
  * debug use today (e.g. clearing a corrupt cache); not wired into the
  * UI. Resolves silently on IndexedDB unavailability.

--- a/packages/web/src/api/read-state-store.ts
+++ b/packages/web/src/api/read-state-store.ts
@@ -145,6 +145,25 @@ export async function setReadState(
 }
 
 /**
+ * Remove every chat's scroll-position snapshot. Called on logout so no
+ * chat/message identifiers from the previous account linger in IndexedDB
+ * on a shared browser profile (SEC-042). Resolves silently on IndexedDB
+ * unavailability or clear failure — logout must never be blocked by
+ * best-effort local cleanup.
+ */
+export async function clearAllReadStates(): Promise<void> {
+  const db = await openDb();
+  if (!db) return;
+  await new Promise<void>((resolve) => {
+    const tx = db.transaction(READ_STATE_STORE, "readwrite");
+    tx.objectStore(READ_STATE_STORE).clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => resolve();
+    tx.onabort = () => resolve();
+  });
+}
+
+/**
  * Remove the scroll-position snapshot for `chatId`. Intended for
  * diagnostic / debug use today; the production UI never calls this.
  * Resolves silently on IndexedDB unavailability.

--- a/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
+++ b/packages/web/src/auth/__tests__/auth-context-provider.test.tsx
@@ -19,6 +19,7 @@ const apiMocks = vi.hoisted(() => ({
 
 const loginMock = vi.hoisted(() => vi.fn());
 const onboardingCompletedMock = vi.hoisted(() => vi.fn());
+const purgeLocalUserDataMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
 const flagsMocks = vi.hoisted(() => ({
   clearOnboardingJoinPath: vi.fn(),
   clearOnboardingSessionFlags: vi.fn(),
@@ -45,6 +46,10 @@ vi.mock("../../api/onboarding-events.js", () => ({
 }));
 
 vi.mock("../../utils/onboarding-flags.js", () => flagsMocks);
+
+vi.mock("../../lib/purge-local-data.js", () => ({
+  purgeLocalUserData: purgeLocalUserDataMock,
+}));
 
 let root: Root | null = null;
 let container: HTMLElement | null = null;
@@ -300,6 +305,9 @@ describe("AuthProvider", () => {
     });
     expect(apiMocks.clearStoredTokens).toHaveBeenCalled();
     expect(flagsMocks.clearOnboardingSessionFlags).toHaveBeenCalled();
+    // SEC-042: logout must purge locally persisted user content (cached
+    // messages, read state, images, drafts) — not just tokens + query cache.
+    expect(purgeLocalUserDataMock).toHaveBeenCalled();
     expect(latestAuth?.isAuthenticated).toBe(false);
   });
 

--- a/packages/web/src/auth/auth-context.tsx
+++ b/packages/web/src/auth/auth-context.tsx
@@ -11,6 +11,7 @@ import {
   setStoredTokens,
 } from "../api/client.js";
 import { markOnboardingCompleted as postOnboardingCompleted } from "../api/onboarding-events.js";
+import { purgeLocalUserData } from "../lib/purge-local-data.js";
 import { clearOnboardingJoinPath, clearOnboardingSessionFlags } from "../utils/onboarding-flags.js";
 
 type MeUser = {
@@ -256,6 +257,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // confirmed" / "Step 3 dismissed" / agent uuid / draft from the prior
     // identity.
     clearOnboardingSessionFlags();
+    // Purge locally persisted user content — cached messages + read state
+    // (IndexedDB `first-tree-chat-cache`), image bytes (`first-tree-images`),
+    // and composer drafts (localStorage). Without this, a later account on
+    // the same browser profile could recover the previous user's plaintext
+    // conversations (SEC-042). Fire-and-forget: the purge is best-effort and
+    // never throws, and logout must stay synchronous for the UI.
+    void purgeLocalUserData();
     setIsAuthenticated(false);
     setUser(null);
     setMemberships([]);

--- a/packages/web/src/lib/__tests__/draft-store.test.ts
+++ b/packages/web/src/lib/__tests__/draft-store.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   chatDraftScope,
+  clearAllDrafts,
   clearDraft,
   loadDraft,
   newChatDraftScope,
@@ -71,6 +72,27 @@ describe("clearDraft", () => {
 
   it("is a no-op for an unknown scope", () => {
     expect(() => clearDraft("nope")).not.toThrow();
+  });
+});
+
+describe("clearAllDrafts", () => {
+  it("removes every user's drafts and the backing storage key (logout purge, SEC-042)", () => {
+    saveDraft(chatDraftScope("user-a", "chat-1"), { text: "A's unsent text" });
+    saveDraft(newChatDraftScope("user-a", "org-1"), { text: "A's new chat" });
+    saveDraft(chatDraftScope("user-b", "chat-2"), { text: "B's unsent text" });
+
+    clearAllDrafts();
+
+    expect(loadDraft(chatDraftScope("user-a", "chat-1"))).toBeNull();
+    expect(loadDraft(newChatDraftScope("user-a", "org-1"))).toBeNull();
+    expect(loadDraft(chatDraftScope("user-b", "chat-2"))).toBeNull();
+    // No plaintext blob may survive for devtools inspection either.
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("is a no-op when nothing is stored", () => {
+    expect(() => clearAllDrafts()).not.toThrow();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 });
 

--- a/packages/web/src/lib/__tests__/purge-local-data.test.ts
+++ b/packages/web/src/lib/__tests__/purge-local-data.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+
+import "fake-indexeddb/auto";
+import { IDBFactory } from "fake-indexeddb";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MessageWithDelivery } from "../../api/chats.js";
+
+const DRAFTS_KEY = "first-tree:chat-drafts:v1";
+
+function msg(id: string, chatId: string): MessageWithDelivery {
+  return {
+    id,
+    chatId,
+    senderId: "user-1",
+    format: "text",
+    content: { text: `secret body of ${id}` },
+    metadata: {},
+    inReplyTo: null,
+    source: "web",
+    createdAt: new Date(2026, 0, 1, 0, 0, 1).toISOString(),
+  };
+}
+
+// The store modules cache their DB open across calls (module-scoped
+// `dbPromise`), so give every test a fresh module graph + fresh fake IDB.
+async function loadModules() {
+  vi.resetModules();
+  globalThis.indexedDB = new IDBFactory();
+  const messageStore = await import("../../api/message-store.js");
+  const readStateStore = await import("../../api/read-state-store.js");
+  const imageStore = await import("../../api/image-store.js");
+  const draftStore = await import("../draft-store.js");
+  const { purgeLocalUserData } = await import("../purge-local-data.js");
+  return { messageStore, readStateStore, imageStore, draftStore, purgeLocalUserData };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("purgeLocalUserData (SEC-042)", () => {
+  it("removes cached messages, read state, images, and drafts in one sweep", async () => {
+    const { messageStore, readStateStore, imageStore, draftStore, purgeLocalUserData } = await loadModules();
+
+    // Seed every persistent store with user content, as a real session would.
+    await messageStore.cacheMessages("chat-1", [msg("m1", "chat-1")]);
+    await readStateStore.setReadState("chat-1", "m1", "m1");
+    await imageStore.putImage({ imageId: "img-1", base64: "aGVsbG8=", mimeType: "image/png" });
+    draftStore.saveDraft(draftStore.chatDraftScope("user-1", "chat-1"), { text: "unsent secret" });
+
+    await purgeLocalUserData();
+
+    expect(await messageStore.getCachedMessages("chat-1")).toEqual([]);
+    expect(await readStateStore.getReadState("chat-1")).toBeNull();
+    expect(await imageStore.getImage("img-1")).toBeNull();
+    expect(draftStore.loadDraft(draftStore.chatDraftScope("user-1", "chat-1"))).toBeNull();
+    expect(window.localStorage.getItem(DRAFTS_KEY)).toBeNull();
+  });
+
+  it("resolves without throwing when IndexedDB is unavailable", async () => {
+    vi.resetModules();
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    const { purgeLocalUserData } = await import("../purge-local-data.js");
+
+    await expect(purgeLocalUserData()).resolves.toBeUndefined();
+  });
+
+  it("still purges IndexedDB stores when a draft was never saved", async () => {
+    const { messageStore, purgeLocalUserData } = await loadModules();
+    await messageStore.cacheMessages("chat-1", [msg("m1", "chat-1")]);
+
+    await purgeLocalUserData();
+
+    expect(await messageStore.getCachedMessages("chat-1")).toEqual([]);
+  });
+});

--- a/packages/web/src/lib/draft-store.ts
+++ b/packages/web/src/lib/draft-store.ts
@@ -136,6 +136,24 @@ export function saveDraft(
   writeMap(prune(map));
 }
 
+/**
+ * Remove every stored draft for every user and scope. Called on logout:
+ * drafts are plaintext user content, and logout is the "I'm done on this
+ * browser" signal, so no unsent text may survive it on a shared profile
+ * (SEC-042). All-user removal is intentional — the per-user scope prefix
+ * only prevents cross-account *restore*, not devtools inspection of the
+ * raw `localStorage` value.
+ */
+export function clearAllDrafts(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // localStorage may be unavailable (private mode); nothing was persisted
+    // there in that case, so there is nothing to purge.
+  }
+}
+
 /** Remove any stored draft for `scope` (used on successful send). */
 export function clearDraft(scope: string): void {
   const map = readMap();

--- a/packages/web/src/lib/purge-local-data.ts
+++ b/packages/web/src/lib/purge-local-data.ts
@@ -1,0 +1,41 @@
+/**
+ * Logout-time purge of persistent, user-content-bearing browser storage
+ * (SEC-042).
+ *
+ * `logout()` clears tokens and the React Query cache, but IndexedDB and
+ * `localStorage` outlive it — without this purge, a later account on the
+ * same browser profile (or anyone with devtools access) could recover the
+ * previous user's plaintext messages, image bytes, and unsent drafts.
+ *
+ * Covered stores:
+ *  - IndexedDB `first-tree-chat-cache` / `messages`   (message-store)
+ *  - IndexedDB `first-tree-chat-cache` / `read-state` (read-state-store)
+ *  - IndexedDB `first-tree-images` / `images`         (image-store)
+ *  - localStorage `first-tree:chat-drafts:v1`         (draft-store)
+ *
+ * Intentionally NOT covered:
+ *  - `first-tree:selectedOrganizationId:<userId>` — a per-user org id
+ *    (not content); kept so a returning sign-in lands back in the org the
+ *    user left (see the comment inside `logout()` in auth-context).
+ *  - Benign UI preferences (theme, panel sizes) — no user content.
+ *
+ * Object stores are cleared (`store.clear()`) rather than deleting whole
+ * databases: the store modules hold cached open connections, and
+ * `indexedDB.deleteDatabase` would block until every connection closes.
+ */
+
+import { clearAllImages } from "../api/image-store.js";
+import { clearAllChatCaches } from "../api/message-store.js";
+import { clearAllReadStates } from "../api/read-state-store.js";
+import { clearAllDrafts } from "./draft-store.js";
+
+/**
+ * Best-effort removal of all locally persisted user content. Never throws
+ * and never blocks logout on a slow/broken store — each underlying clear
+ * already resolves silently on failure, and `allSettled` guards against
+ * future clears that reject.
+ */
+export async function purgeLocalUserData(): Promise<void> {
+  clearAllDrafts();
+  await Promise.allSettled([clearAllChatCaches(), clearAllReadStates(), clearAllImages()]);
+}


### PR DESCRIPTION
Closes #1647 ([SEC-042][Medium] Logout leaves plaintext chats, images, and drafts in browser storage)

## Problem

`logout()` in `packages/web/src/auth/auth-context.tsx` clears tokens, the React Query cache, and per-tab onboarding flags — but nothing else. These survive logout on a shared browser profile:

| Store | Location | Content |
| --- | --- | --- |
| IndexedDB `first-tree-chat-cache` / `messages` | `api/message-store.ts` | full plaintext message payloads |
| IndexedDB `first-tree-chat-cache` / `read-state` | `api/read-state-store.ts` | chat/message ids (metadata) |
| IndexedDB `first-tree-images` / `images` | `api/image-store.ts` | base64 image bytes |
| localStorage `first-tree:chat-drafts:v1` | `lib/draft-store.ts` | plaintext unsent drafts |

A later account (or anyone with devtools access to the profile) can recover the previous user's conversation data.

## Approach

The issue offers two directions: per-account/server namespacing, or **purge on logout by default**. This PR implements the purge:

- Namespacing every IDB schema per account/server is a much larger migration with its own risks; drafts are already user-scope-prefixed, and the caches are pure server-backed caches.
- Purging fully closes the "recover after logout" hole and re-hydrates transparently on next login. Read-state and drafts are best-effort conveniences; losing them at logout is the correct security default.

## Changes (all `packages/web`)

- `api/message-store.ts` — new `clearAllChatCaches()` (clears the `messages` object store).
- `api/read-state-store.ts` — new `clearAllReadStates()` (clears the `read-state` object store).
- `api/image-store.ts` — new `clearAllImages()` (clears the `images` object store; silent best-effort like the other purge paths).
- `lib/draft-store.ts` — new `clearAllDrafts()` (removes the single drafts key for all users — the per-user prefix only prevents cross-account *restore*, not raw inspection).
- `lib/purge-local-data.ts` (new) — `purgeLocalUserData()` orchestrator via `Promise.allSettled`; never throws, never blocks logout. Uses `store.clear()` instead of `indexedDB.deleteDatabase()` because the store modules hold cached open connections that would block deletion.
- `auth/auth-context.tsx` — `logout()` fires `void purgeLocalUserData()`; covers both explicit logout and 401-driven `auth:logout`.

Intentionally kept: `first-tree:selectedOrganizationId:<userId>` (per-user org id, not content — existing comment in `logout()` documents why), and benign UI prefs.

## Verification

- `pnpm --filter @first-tree/web test`: 1630 passed; the only 4 failures (`group-rows.test.ts`, `command-palette-dom.test.tsx`) are timezone-sensitive date-bucketing assertions that fail identically on a clean `origin/main` checkout in this environment — unrelated to this change.
- `pnpm check` clean (2 pre-existing CSS warnings), `pnpm --filter @first-tree/web typecheck` clean.
- New/extended tests:
  - `clearAllChatCaches` / `clearAllReadStates` / `clearAllImages` / `clearAllDrafts`: multi-row round-trip clears + silent no-op when IndexedDB/localStorage is unavailable.
  - `lib/__tests__/purge-local-data.test.ts` (new): seeds all four stores and asserts one sweep empties them; resolves without throwing when IndexedDB is missing.
  - `auth-context-provider.test.tsx`: the `auth:logout` path now asserts `purgeLocalUserData` is invoked.

## Residual risk (documented, out of scope)

- An in-flight 5s-poll write-through resolving after the purge could theoretically re-cache a few rows; the window is milliseconds and `queryClient.clear()` stops further polling. Full closure would need an auth-state gate in the write path.
- Data from a session that *never* logs out (browser closed while logged in) remains until the next logout on that profile — that is the namespacing half of the recommendation and a larger follow-up.
