### PR TITLE
fix(kimi-code): pass KIMI_CODE_HOME to harness for config/credential resolution

### DIFF
--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -592,9 +592,9 @@ describe("Kimi homeDir lifecycle", () => {
     const secondSession = new FakeSession("s-2", [successfulTurn("s-2")]);
     let factoryCalls = 0;
     const homes: (string | undefined)[] = [];
-    let closeResolver: (() => void) | null = null;
+    let resolveClose: (() => void) | undefined;
     const closePromise = new Promise<void>((resolve) => {
-      closeResolver = resolve;
+      resolveClose = resolve;
     });
     const payload = {
       kind: "kimi-code" as const,
@@ -637,7 +637,7 @@ describe("Kimi homeDir lifecycle", () => {
     expect(factoryCalls).toBe(1);
     expect(homes).toEqual(["/old/kimi"]);
 
-    if (closeResolver) closeResolver();
+    if (resolveClose) resolveClose();
     await resumePromise;
 
     expect(factoryCalls).toBe(2);

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -437,6 +437,199 @@ describe("Kimi Code handler", () => {
   });
 });
 
+describe("Kimi homeDir lifecycle", () => {
+  it("normalizes trimmed KIMI_CODE_HOME and forwards it as harness homeDir", async () => {
+    const harnessOptions: Array<Record<string, unknown>> = [];
+    const payload = {
+      kind: "kimi-code" as const,
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [],
+      env: [{ key: "KIMI_CODE_HOME", value: "  /custom/kimi  " }],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const handler = createKimiCodeHandler({
+      workspaceRoot,
+      runtimeProvider: "kimi-code",
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      kimiKaosFactory: async () => ({ withCwd: vi.fn().mockReturnThis(), withEnv: vi.fn().mockReturnThis() }),
+      kimiHarnessFactory: (options) => {
+        harnessOptions.push(options as Record<string, unknown>);
+        return {
+          createSession: async () => new FakeSession("s1", [successfulTurn("s1")]),
+          resumeSession: async () => new FakeSession("s1", [successfulTurn("s1")]),
+          close: async () => {},
+        };
+      },
+    });
+
+    await handler.start(message("m1", "hi"), makeContext([]), makeToken());
+
+    expect(harnessOptions).toHaveLength(1);
+    expect(harnessOptions[0].homeDir).toBe("/custom/kimi");
+  });
+
+  it("omits homeDir when KIMI_CODE_HOME is empty or whitespace-only", async () => {
+    const harnessOptions: Array<Record<string, unknown>> = [];
+    const payload = {
+      kind: "kimi-code" as const,
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [],
+      env: [{ key: "KIMI_CODE_HOME", value: "   " }],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const handler = createKimiCodeHandler({
+      workspaceRoot,
+      runtimeProvider: "kimi-code",
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      kimiKaosFactory: async () => ({ withCwd: vi.fn().mockReturnThis(), withEnv: vi.fn().mockReturnThis() }),
+      kimiHarnessFactory: (options) => {
+        harnessOptions.push(options as Record<string, unknown>);
+        return {
+          createSession: async () => new FakeSession("s1", [successfulTurn("s1")]),
+          resumeSession: async () => new FakeSession("s1", [successfulTurn("s1")]),
+          close: async () => {},
+        };
+      },
+    });
+
+    await handler.start(message("m1", "hi"), makeContext([]), makeToken());
+
+    expect(harnessOptions).toHaveLength(1);
+    expect(harnessOptions[0]).not.toHaveProperty("homeDir");
+  });
+
+  it("reuses the same harness after suspend when effective home is unchanged", async () => {
+    const session = new FakeSession("shared-session", [successfulTurn("shared-session")]);
+    let factoryCalls = 0;
+    const closeFn = vi.fn().mockResolvedValue(undefined);
+    const payload = {
+      kind: "kimi-code" as const,
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [],
+      env: [{ key: "KIMI_CODE_HOME", value: "/custom/kimi" }],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const handler = createKimiCodeHandler({
+      workspaceRoot,
+      runtimeProvider: "kimi-code",
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      kimiKaosFactory: async () => ({ withCwd: vi.fn().mockReturnThis(), withEnv: vi.fn().mockReturnThis() }),
+      kimiHarnessFactory: () => {
+        factoryCalls++;
+        return {
+          createSession: async () => session,
+          resumeSession: async () => session,
+          close: closeFn,
+        };
+      },
+    });
+
+    await handler.start(message("m1", "hi"), makeContext([]), makeToken());
+    expect(factoryCalls).toBe(1);
+    expect(closeFn).not.toHaveBeenCalled();
+
+    await handler.suspend("test");
+    expect(closeFn).not.toHaveBeenCalled();
+
+    await handler.resume(message("m2", "resume"), "shared-session", makeContext([]), makeToken());
+    expect(factoryCalls).toBe(1);
+    expect(closeFn).not.toHaveBeenCalled();
+  });
+
+  it("reuses the default harness across resume when KIMI_CODE_HOME is unset", async () => {
+    const session = new FakeSession("default-session", [successfulTurn("default-session")]);
+    let factoryCalls = 0;
+    const closeFn = vi.fn().mockResolvedValue(undefined);
+    const payload = {
+      kind: "kimi-code" as const,
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [],
+      env: [],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const handler = createKimiCodeHandler({
+      workspaceRoot,
+      runtimeProvider: "kimi-code",
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      kimiKaosFactory: async () => ({ withCwd: vi.fn().mockReturnThis(), withEnv: vi.fn().mockReturnThis() }),
+      kimiHarnessFactory: () => {
+        factoryCalls++;
+        return {
+          createSession: async () => session,
+          resumeSession: async () => session,
+          close: closeFn,
+        };
+      },
+    });
+
+    await handler.start(message("m1", "hi"), makeContext([]), makeToken());
+    expect(factoryCalls).toBe(1);
+
+    await handler.suspend("test");
+    expect(closeFn).not.toHaveBeenCalled();
+
+    await handler.resume(message("m2", "resume"), "default-session", makeContext([]), makeToken());
+    expect(factoryCalls).toBe(1);
+    expect(closeFn).not.toHaveBeenCalled();
+  });
+
+  it("closes old harness before creating a replacement when home changes across suspend/resume", async () => {
+    let factoryCalls = 0;
+    const homes: (string | undefined)[] = [];
+    const closeFn = vi.fn().mockResolvedValue(undefined);
+    const payload = {
+      kind: "kimi-code" as const,
+      prompt: { append: "" },
+      model: "",
+      mcpServers: [],
+      env: [{ key: "KIMI_CODE_HOME", value: "/old/kimi" }],
+      gitRepos: [],
+      resourceSkills: [],
+    };
+    const handler = createKimiCodeHandler({
+      workspaceRoot,
+      runtimeProvider: "kimi-code",
+      agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
+      kimiKaosFactory: async () => ({ withCwd: vi.fn().mockReturnThis(), withEnv: vi.fn().mockReturnThis() }),
+      kimiHarnessFactory: (options) => {
+        factoryCalls++;
+        homes.push(options.homeDir);
+        const id = `s-${factoryCalls}`;
+        return {
+          createSession: async () => new FakeSession(id, [successfulTurn(id)]),
+          resumeSession: async () => new FakeSession(id, [successfulTurn(id)]),
+          close: closeFn,
+        };
+      },
+    });
+
+    await handler.start(message("m1", "hi"), makeContext([]), makeToken());
+    const startSessionId = "s-1";
+    expect(factoryCalls).toBe(1);
+    expect(homes).toEqual(["/old/kimi"]);
+    expect(closeFn).not.toHaveBeenCalled();
+
+    // Simulate operator correcting KIMI_CODE_HOME after a credential/config failure.
+    payload.env = [{ key: "KIMI_CODE_HOME", value: "/new/kimi" }];
+
+    await handler.suspend("test");
+    expect(closeFn).not.toHaveBeenCalled();
+
+    await handler.resume(message("m2", "resume"), startSessionId, makeContext([]), makeToken());
+    expect(factoryCalls).toBe(2);
+    expect(homes).toEqual(["/old/kimi", "/new/kimi"]);
+    expect(closeFn).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("Kimi provider helpers", () => {
   it("only treats reads and proven read-only Bash commands as replay safe", () => {
     expect(kimiToolIsReadOnly("Read", { path: "NODE.md" })).toBe(true);

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -440,7 +440,7 @@ describe("Kimi Code handler", () => {
 
 describe("Kimi homeDir lifecycle", () => {
   it("normalizes trimmed KIMI_CODE_HOME and forwards it as harness homeDir", async () => {
-    const harnessOptions: Array<Record<string, unknown>> = [];
+    const harnessOptions: KimiHarnessOptions[] = [];
     const payload = {
       kind: "kimi-code" as const,
       prompt: { append: "" },
@@ -472,7 +472,7 @@ describe("Kimi homeDir lifecycle", () => {
   });
 
   it.each(["", "   "])("omits homeDir when KIMI_CODE_HOME is %j", async (rawValue) => {
-    const harnessOptions: Array<Record<string, unknown>> = [];
+    const harnessOptions: KimiHarnessOptions[] = [];
     const payload = {
       kind: "kimi-code" as const,
       prompt: { append: "" },
@@ -488,7 +488,7 @@ describe("Kimi homeDir lifecycle", () => {
       agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
       kimiKaosFactory: async () => ({ withCwd: vi.fn().mockReturnThis(), withEnv: vi.fn().mockReturnThis() }),
       kimiHarnessFactory: (options: KimiHarnessOptions) => {
-        harnessOptions.push(options as Record<string, unknown>);
+        harnessOptions.push(options);
         return {
           createSession: async () => new FakeSession("s1", [successfulTurn("s1")]),
           resumeSession: async () => new FakeSession("s1", [successfulTurn("s1")]),

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type {
   CreateSessionOptions,
   Event as KimiEvent,
+  KimiHarnessOptions,
   ResumeSessionInput,
   SessionUsage,
 } from "@botiverse/kimi-code-sdk";
@@ -454,8 +455,8 @@ describe("Kimi homeDir lifecycle", () => {
       runtimeProvider: "kimi-code",
       agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
       kimiKaosFactory: async () => ({ withCwd: vi.fn().mockReturnThis(), withEnv: vi.fn().mockReturnThis() }),
-      kimiHarnessFactory: (options) => {
-        harnessOptions.push(options as Record<string, unknown>);
+      kimiHarnessFactory: (options: KimiHarnessOptions) => {
+        harnessOptions.push(options);
         return {
           createSession: async () => new FakeSession("s1", [successfulTurn("s1")]),
           resumeSession: async () => new FakeSession("s1", [successfulTurn("s1")]),
@@ -467,7 +468,7 @@ describe("Kimi homeDir lifecycle", () => {
     await handler.start(message("m1", "hi"), makeContext([]), makeToken());
 
     expect(harnessOptions).toHaveLength(1);
-    expect(harnessOptions[0].homeDir).toBe("/custom/kimi");
+    expect(harnessOptions.at(0)?.homeDir).toBe("/custom/kimi");
   });
 
   it.each(["", "   "])("omits homeDir when KIMI_CODE_HOME is %j", async (rawValue) => {
@@ -486,7 +487,7 @@ describe("Kimi homeDir lifecycle", () => {
       runtimeProvider: "kimi-code",
       agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
       kimiKaosFactory: async () => ({ withCwd: vi.fn().mockReturnThis(), withEnv: vi.fn().mockReturnThis() }),
-      kimiHarnessFactory: (options) => {
+      kimiHarnessFactory: (options: KimiHarnessOptions) => {
         harnessOptions.push(options as Record<string, unknown>);
         return {
           createSession: async () => new FakeSession("s1", [successfulTurn("s1")]),
@@ -610,7 +611,7 @@ describe("Kimi homeDir lifecycle", () => {
       runtimeProvider: "kimi-code",
       agentConfigCache: { refresh: async () => ({ payload }), get: () => ({ payload }) },
       kimiKaosFactory: async () => ({ withCwd: vi.fn().mockReturnThis(), withEnv: vi.fn().mockReturnThis() }),
-      kimiHarnessFactory: (options) => {
+      kimiHarnessFactory: (options: KimiHarnessOptions) => {
         factoryCalls++;
         homes.push(options.homeDir);
         return {

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -470,14 +470,14 @@ describe("Kimi homeDir lifecycle", () => {
     expect(harnessOptions[0].homeDir).toBe("/custom/kimi");
   });
 
-  it("omits homeDir when KIMI_CODE_HOME is empty or whitespace-only", async () => {
+  it.each(["", "   "])("omits homeDir when KIMI_CODE_HOME is %j", async (rawValue) => {
     const harnessOptions: Array<Record<string, unknown>> = [];
     const payload = {
       kind: "kimi-code" as const,
       prompt: { append: "" },
       model: "",
       mcpServers: [],
-      env: [{ key: "KIMI_CODE_HOME", value: "   " }],
+      env: [{ key: "KIMI_CODE_HOME", value: rawValue }],
       gitRepos: [],
       resourceSkills: [],
     };

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -616,7 +616,12 @@ describe("Kimi homeDir lifecycle", () => {
         return {
           createSession: async () => (factoryCalls === 1 ? firstSession : secondSession),
           resumeSession: async () => (factoryCalls === 2 ? secondSession : firstSession),
-          close: factoryCalls === 1 ? async () => { await closePromise; } : async () => {},
+          close:
+            factoryCalls === 1
+              ? async () => {
+                  await closePromise;
+                }
+              : async () => {},
         };
       },
     });

--- a/packages/client/src/__tests__/kimi-code-handler.test.ts
+++ b/packages/client/src/__tests__/kimi-code-handler.test.ts
@@ -503,7 +503,10 @@ describe("Kimi homeDir lifecycle", () => {
   });
 
   it("reuses the same harness after suspend when effective home is unchanged", async () => {
-    const session = new FakeSession("shared-session", [successfulTurn("shared-session")]);
+    const session = new FakeSession("shared-session", [
+      successfulTurn("shared-session"),
+      successfulTurn("shared-session"),
+    ]);
     let factoryCalls = 0;
     const closeFn = vi.fn().mockResolvedValue(undefined);
     const payload = {
@@ -543,7 +546,10 @@ describe("Kimi homeDir lifecycle", () => {
   });
 
   it("reuses the default harness across resume when KIMI_CODE_HOME is unset", async () => {
-    const session = new FakeSession("default-session", [successfulTurn("default-session")]);
+    const session = new FakeSession("default-session", [
+      successfulTurn("default-session"),
+      successfulTurn("default-session"),
+    ]);
     let factoryCalls = 0;
     const closeFn = vi.fn().mockResolvedValue(undefined);
     const payload = {
@@ -582,9 +588,14 @@ describe("Kimi homeDir lifecycle", () => {
   });
 
   it("closes old harness before creating a replacement when home changes across suspend/resume", async () => {
+    const firstSession = new FakeSession("s-1", [successfulTurn("s-1")]);
+    const secondSession = new FakeSession("s-2", [successfulTurn("s-2")]);
     let factoryCalls = 0;
     const homes: (string | undefined)[] = [];
-    const closeFn = vi.fn().mockResolvedValue(undefined);
+    let closeResolver: (() => void) | null = null;
+    const closePromise = new Promise<void>((resolve) => {
+      closeResolver = resolve;
+    });
     const payload = {
       kind: "kimi-code" as const,
       prompt: { append: "" },
@@ -602,31 +613,35 @@ describe("Kimi homeDir lifecycle", () => {
       kimiHarnessFactory: (options) => {
         factoryCalls++;
         homes.push(options.homeDir);
-        const id = `s-${factoryCalls}`;
         return {
-          createSession: async () => new FakeSession(id, [successfulTurn(id)]),
-          resumeSession: async () => new FakeSession(id, [successfulTurn(id)]),
-          close: closeFn,
+          createSession: async () => (factoryCalls === 1 ? firstSession : secondSession),
+          resumeSession: async () => (factoryCalls === 2 ? secondSession : firstSession),
+          close: factoryCalls === 1 ? async () => { await closePromise; } : async () => {},
         };
       },
     });
 
     await handler.start(message("m1", "hi"), makeContext([]), makeToken());
-    const startSessionId = "s-1";
     expect(factoryCalls).toBe(1);
     expect(homes).toEqual(["/old/kimi"]);
-    expect(closeFn).not.toHaveBeenCalled();
 
     // Simulate operator correcting KIMI_CODE_HOME after a credential/config failure.
     payload.env = [{ key: "KIMI_CODE_HOME", value: "/new/kimi" }];
 
     await handler.suspend("test");
-    expect(closeFn).not.toHaveBeenCalled();
 
-    await handler.resume(message("m2", "resume"), startSessionId, makeContext([]), makeToken());
+    // Kick off resume; the second harness factory must not fire before
+    // the first harness's close promise resolves.
+    const resumePromise = handler.resume(message("m2", "resume"), "s-1", makeContext([]), makeToken());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(factoryCalls).toBe(1);
+    expect(homes).toEqual(["/old/kimi"]);
+
+    if (closeResolver) closeResolver();
+    await resumePromise;
+
     expect(factoryCalls).toBe(2);
     expect(homes).toEqual(["/old/kimi", "/new/kimi"]);
-    expect(closeFn).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -170,7 +170,7 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
   let cwd: string | null = null;
   let ctx: SessionContext | null = null;
   let harness: KimiHarnessLike | null = null;
-  let harnessHomeDir: string | null = null;
+  let harnessEffectiveHome: string | null = null;
   let session: Session | null = null;
   let sessionId: string | null = null;
   let activePayload: AgentRuntimeConfigPayload | null = null;
@@ -675,19 +675,22 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     };
   }
 
-  function ensureHarness(homeDir?: string): KimiHarnessLike {
-    const options: KimiHarnessOptions = {
-      identity: { userAgentProduct: "first-tree", version: KIMI_IDENTITY_VERSION },
-      uiMode: "first-tree",
-    };
-    if (homeDir !== undefined) {
-      options.homeDir = homeDir;
+  async function ensureHarness(homeDir?: string): Promise<KimiHarnessLike> {
+    const effectiveHome = homeDir ?? null;
+    if (harness && harnessEffectiveHome !== effectiveHome) {
+      await closeHarness();
     }
-    if (harness && harnessHomeDir !== homeDir) {
-      void closeHarness();
+    if (!harness) {
+      const options: KimiHarnessOptions = {
+        identity: { userAgentProduct: "first-tree", version: KIMI_IDENTITY_VERSION },
+        uiMode: "first-tree",
+      };
+      if (homeDir !== undefined) {
+        options.homeDir = homeDir;
+      }
+      harness = harnessFactory(options);
     }
-    harness ??= harnessFactory(options);
-    harnessHomeDir = homeDir ?? null;
+    harnessEffectiveHome = effectiveHome;
     return harness;
   }
 
@@ -740,10 +743,10 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         roleAdditional: prepared.roleAdditional,
         ...(prepared.payload.model ? { model: prepared.payload.model } : {}),
       };
-      kimiHomeDir = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value.trim() ?? null;
-      if (kimiHomeDir !== null && kimiHomeDir.length === 0) kimiHomeDir = null;
+      const kimiHome = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value.trim() ?? null;
+      const effectiveHomeDir = kimiHome !== null && kimiHome.length === 0 ? null : kimiHome;
       try {
-        session = await ensureHarness(kimiHomeDir ?? undefined).createSession(options);
+        session = await ensureHarness(effectiveHomeDir ?? undefined).createSession(options);
         sessionId = session.id;
         sessionActive = true;
         initialTurnPreparing = true;
@@ -769,10 +772,10 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         additionalDirs: prepared.additionalDirs,
         roleAdditional: prepared.roleAdditional,
       };
-      kimiHomeDir = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value.trim() ?? null;
-      if (kimiHomeDir !== null && kimiHomeDir.length === 0) kimiHomeDir = null;
+      const kimiHome = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value.trim() ?? null;
+      const effectiveHomeDir = kimiHome !== null && kimiHome.length === 0 ? null : kimiHome;
       try {
-        session = await ensureHarness(kimiHomeDir ?? undefined).resumeSession(input);
+        session = await ensureHarness(effectiveHomeDir ?? undefined).resumeSession(input);
         sessionId = session.id;
         await session.setPermission("yolo");
         if (prepared.payload.model) await session.setModel(prepared.payload.model);

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -684,10 +684,8 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
       const options: KimiHarnessOptions = {
         identity: { userAgentProduct: "first-tree", version: KIMI_IDENTITY_VERSION },
         uiMode: "first-tree",
+        ...(homeDir !== undefined ? { homeDir } : {}),
       };
-      if (homeDir !== undefined) {
-        options.homeDir = homeDir;
-      }
       harness = harnessFactory(options);
     }
     harnessEffectiveHome = effectiveHome;

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -170,6 +170,7 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
   let cwd: string | null = null;
   let ctx: SessionContext | null = null;
   let harness: KimiHarnessLike | null = null;
+  let kimiHomeDir: string | null = null;
   let session: Session | null = null;
   let sessionId: string | null = null;
   let activePayload: AgentRuntimeConfigPayload | null = null;
@@ -674,11 +675,15 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     };
   }
 
-  function ensureHarness(): KimiHarnessLike {
-    harness ??= harnessFactory({
+  function ensureHarness(homeDir?: string): KimiHarnessLike {
+    const options: KimiHarnessOptions = {
       identity: { userAgentProduct: "first-tree", version: KIMI_IDENTITY_VERSION },
       uiMode: "first-tree",
-    });
+    };
+    if (homeDir !== undefined) {
+      options.homeDir = homeDir;
+    }
+    harness ??= harnessFactory(options);
     return harness;
   }
 
@@ -731,8 +736,9 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         roleAdditional: prepared.roleAdditional,
         ...(prepared.payload.model ? { model: prepared.payload.model } : {}),
       };
+      kimiHomeDir = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value ?? null;
       try {
-        session = await ensureHarness().createSession(options);
+        session = await ensureHarness(kimiHomeDir ?? undefined).createSession(options);
         sessionId = session.id;
         sessionActive = true;
         initialTurnPreparing = true;
@@ -758,8 +764,9 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         additionalDirs: prepared.additionalDirs,
         roleAdditional: prepared.roleAdditional,
       };
+      kimiHomeDir = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value ?? null;
       try {
-        session = await ensureHarness().resumeSession(input);
+        session = await ensureHarness(kimiHomeDir ?? undefined).resumeSession(input);
         sessionId = session.id;
         await session.setPermission("yolo");
         if (prepared.payload.model) await session.setModel(prepared.payload.model);

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -746,7 +746,8 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
       const kimiHome = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value.trim() ?? null;
       const effectiveHomeDir = kimiHome !== null && kimiHome.length === 0 ? null : kimiHome;
       try {
-        session = await ensureHarness(effectiveHomeDir ?? undefined).createSession(options);
+        const activeHarness = await ensureHarness(effectiveHomeDir ?? undefined);
+        session = await activeHarness.createSession(options);
         sessionId = session.id;
         sessionActive = true;
         initialTurnPreparing = true;
@@ -775,7 +776,8 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
       const kimiHome = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value.trim() ?? null;
       const effectiveHomeDir = kimiHome !== null && kimiHome.length === 0 ? null : kimiHome;
       try {
-        session = await ensureHarness(effectiveHomeDir ?? undefined).resumeSession(input);
+        const activeHarness = await ensureHarness(effectiveHomeDir ?? undefined);
+        session = await activeHarness.resumeSession(input);
         sessionId = session.id;
         await session.setPermission("yolo");
         if (prepared.payload.model) await session.setModel(prepared.payload.model);

--- a/packages/client/src/handlers/kimi-code.ts
+++ b/packages/client/src/handlers/kimi-code.ts
@@ -170,7 +170,7 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
   let cwd: string | null = null;
   let ctx: SessionContext | null = null;
   let harness: KimiHarnessLike | null = null;
-  let kimiHomeDir: string | null = null;
+  let harnessHomeDir: string | null = null;
   let session: Session | null = null;
   let sessionId: string | null = null;
   let activePayload: AgentRuntimeConfigPayload | null = null;
@@ -683,7 +683,11 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
     if (homeDir !== undefined) {
       options.homeDir = homeDir;
     }
+    if (harness && harnessHomeDir !== homeDir) {
+      void closeHarness();
+    }
     harness ??= harnessFactory(options);
+    harnessHomeDir = homeDir ?? null;
     return harness;
   }
 
@@ -736,7 +740,8 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         roleAdditional: prepared.roleAdditional,
         ...(prepared.payload.model ? { model: prepared.payload.model } : {}),
       };
-      kimiHomeDir = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value ?? null;
+      kimiHomeDir = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value.trim() ?? null;
+      if (kimiHomeDir !== null && kimiHomeDir.length === 0) kimiHomeDir = null;
       try {
         session = await ensureHarness(kimiHomeDir ?? undefined).createSession(options);
         sessionId = session.id;
@@ -764,7 +769,8 @@ export const createKimiCodeHandler: HandlerFactory = (config) => {
         additionalDirs: prepared.additionalDirs,
         roleAdditional: prepared.roleAdditional,
       };
-      kimiHomeDir = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value ?? null;
+      kimiHomeDir = prepared.payload.env.find((entry) => entry.key === "KIMI_CODE_HOME")?.value.trim() ?? null;
+      if (kimiHomeDir !== null && kimiHomeDir.length === 0) kimiHomeDir = null;
       try {
         session = await ensureHarness(kimiHomeDir ?? undefined).resumeSession(input);
         sessionId = session.id;


### PR DESCRIPTION
## Summary

Pass the agent-configured \`KIMI_CODE_HOME\` as the Kimi harness \`homeDir\` in both \`start()\` and \`resume()\`. When unset, behavior is unchanged (falls through to \`~/.kimi-code\`).

## Fix (per review — all rounds addressed)

### Production code (\`packages/client/src/handlers/kimi-code.ts\`)

1. **Harness lifecycle — \`resume()\` no longer reuses a stale harness**
   \`suspend()\` closes the session but not the harness. \`ensureHarness()\` tracks \`harnessEffectiveHome\`; when the effective home dir changes (canonicalized as \`homeDir ?? null\`), the old harness is \`await\`ed closed before a new one is constructed.

2. **\`KIMI_CODE_HOME\` normalization matches \`resolveKimiConfigPath()\` semantics**
   The env value is \`.trim()\`-ed and empty/whitespace-only strings are treated as unset, falling back to the SDK default instead of becoming a literal bogus directory.

3. **Async \`ensureHarness()\` call sites corrected**
   \`start()\` and \`resume()\` now \`await ensureHarness(...)\` first, then call \`createSession\` / \`resumeSession\` on the resolved harness.

### Regression tests (\`packages/client/src/__tests__/kimi-code-handler.test.ts\`)

Five focused product tests covering the lifecycle invariants:

- **Trimmed \`KIMI_CODE_HOME\` passthrough** — verifies the harness factory receives the trimmed value as \`homeDir\`.
- **Empty / whitespace-only fallback** — parameterized over \`["", "   "]\`; confirms \`homeDir\` is omitted so the SDK uses its default.
- **Unchanged custom home reuse** — \`suspend()\` + \`resume()\` with the same \`KIMI_CODE_HOME\` reuses the same harness factory instance (factory called once, \`close\` never called).
- **Unchanged default home reuse** — same invariant when \`KIMI_CODE_HOME\` is entirely unset.
- **Home change teardown-before-rebuild** — uses a deferred close promise: asserts the second factory call has not fired while close is unresolved, resolves the gate, then confirms the replacement was constructed with the new home only after teardown completed.

## Root Cause Detail

\`createKimiHarness()\` constructs \`SDKRpcClient\`, which creates \`KimiAuthFacade\` from the resolved \`homeDir\` and \`configPath\`, then passes \`options.resolveOAuthTokenProvider ?? this.auth.resolveOAuthTokenProvider\` into \`KimiCore\`. First Tree was not passing \`homeDir\` to the harness factory, so the SDK defaulted to \`~/.kimi-code\` and could not locate either \`config.toml\` or the host-local OAuth credential store at the operator-configured root. Passing the agent-configured \`KIMI_CODE_HOME\` as \`homeDir\` fixes both: model discovery and the SDK-owned \`KimiAuthFacade\` now resolve against the same intended root.

When used with the API-key workaround (direct \`api_key\` in \`config.toml\`), this fix is sufficient. If OAuth login is still required after this home-dir fix, treat it as a separately evidenced defect rather than a missing callback or upstream SDK gap.

Closes #1973