### PR TITLE
feat(server): expose setup capability readiness

### DIFF
--- a/packages/server/src/__tests__/setup-capabilities.test.ts
+++ b/packages/server/src/__tests__/setup-capabilities.test.ts
@@ -24,10 +24,12 @@ const githubAppCredentials = {
   appId: "12345",
   privateKeyPem: githubAppPrivateKey,
   slug: "first-tree-test",
+  webhookSecret: "setup-webhook-secret",
 };
 const githubAppCredentialsWithoutSlug = {
   appId: githubAppCredentials.appId,
   privateKeyPem: githubAppCredentials.privateKeyPem,
+  webhookSecret: githubAppCredentials.webhookSecret,
 };
 
 type Scenario = Awaited<ReturnType<typeof createScenario>>;
@@ -108,7 +110,12 @@ async function seedSetting(
 async function seedGithubInstallation(
   app: FastifyInstance,
   scenario: Scenario,
-  options: { accountLogin?: string; pullRequests?: "read" | "write"; suspended?: boolean } = {},
+  options: {
+    accountLogin?: string;
+    pullRequests?: "read" | "write";
+    suspended?: boolean;
+    events?: string[];
+  } = {},
 ): Promise<void> {
   const installationId = Number.parseInt(randomUUID().replaceAll("-", "").slice(0, 10), 16);
   await app.db.insert(githubAppInstallations).values({
@@ -124,7 +131,7 @@ async function seedGithubInstallation(
       metadata: "read",
       pull_requests: options.pullRequests ?? "write",
     },
-    events: ["pull_request"],
+    events: options.events ?? ["pull_request", "issue_comment", "pull_request_review_comment"],
     suspendedAt: options.suspended ? new Date("2026-07-22T08:00:00.000Z") : null,
   });
 }
@@ -190,6 +197,7 @@ async function seedGithubReview(
     accountLogin?: string;
     pullRequests?: "read" | "write";
     suspended?: boolean;
+    events?: string[];
   } = {},
 ): Promise<void> {
   await seedSetting(app, scenario, "context_tree", {
@@ -207,6 +215,7 @@ async function seedGithubReview(
     accountLogin: options.accountLogin,
     pullRequests: options.pullRequests,
     suspended: options.suspended,
+    events: options.events,
   });
 }
 
@@ -243,9 +252,14 @@ function project(
   scenario: Scenario,
   probeGithubReview?: () => Promise<never | "ready" | "permission_required" | "repo_not_covered" | "failed">,
   options: {
-    githubAppCredentials?: { appId: string; privateKeyPem: string; slug?: string };
+    githubAppCredentials?: {
+      appId: string;
+      privateKeyPem: string;
+      slug?: string;
+      webhookSecret?: string;
+    };
     githubFetch?: typeof fetch;
-  } = {},
+  } = { githubAppCredentials },
 ) {
   return getTeamSetupCapabilities(app.db, scenario.organizationId, {
     now: () => observedAt,
@@ -388,6 +402,41 @@ describe("Team setup capabilities", () => {
     });
     expect(suspendedProbe).not.toHaveBeenCalled();
 
+    const missingApp = await createScenario(app);
+    const missingAppReviewer = await createReviewer(app, missingApp);
+    await seedGithubReview(app, missingApp, { reviewer: missingAppReviewer });
+    const missingAppProbe = vi.fn(async () => "ready" as const);
+    const missingAppProjection = await project(app, missingApp, missingAppProbe, {
+      githubAppCredentials: undefined,
+    });
+    expect(missingAppProjection.repositoryAutomation.providers[0]).toMatchObject({
+      provider: "github",
+      adoption: "enabled",
+      health: "unavailable",
+      blockers: [
+        {
+          code: "github_app_not_configured",
+          resolutionOwner: "operator",
+          actionKind: null,
+        },
+      ],
+    });
+    expect(missingAppProjection).toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          blockers: [
+            {
+              code: "github_app_not_configured",
+              resolutionOwner: "operator",
+              actionKind: null,
+            },
+          ],
+        },
+      },
+    });
+    expect(missingAppProbe).not.toHaveBeenCalled();
+
     const permission = await createScenario(app);
     const permissionReviewer = await createReviewer(app, permission);
     await seedGithubReview(app, permission, { reviewer: permissionReviewer, pullRequests: "read" });
@@ -401,6 +450,69 @@ describe("Team setup capabilities", () => {
       },
     });
     expect(permissionProbe).not.toHaveBeenCalled();
+
+    const missingEvents = await createScenario(app);
+    const missingEventsReviewer = await createReviewer(app, missingEvents);
+    await seedGithubReview(app, missingEvents, { reviewer: missingEventsReviewer, events: [] });
+    const missingEventsProbe = vi.fn(async () => "ready" as const);
+    const missingEventsProjection = await project(app, missingEvents, missingEventsProbe);
+    expect(missingEventsProjection.repositoryAutomation.providers[0]).toMatchObject({
+      provider: "github",
+      adoption: "enabled",
+      health: "unavailable",
+      blockers: [
+        {
+          code: "github_webhook_events_missing",
+          resolutionOwner: "operator",
+          actionKind: null,
+        },
+      ],
+    });
+    expect(missingEventsProjection).toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          blockers: [
+            {
+              code: "github_webhook_events_missing",
+              resolutionOwner: "operator",
+              actionKind: null,
+            },
+          ],
+        },
+      },
+    });
+    expect(missingEventsProbe).not.toHaveBeenCalled();
+
+    const missingCommentEvents = await createScenario(app);
+    const missingCommentEventsReviewer = await createReviewer(app, missingCommentEvents);
+    await seedGithubReview(app, missingCommentEvents, {
+      reviewer: missingCommentEventsReviewer,
+      events: ["pull_request"],
+    });
+    const missingCommentEventsProbe = vi.fn(async () => "ready" as const);
+    const missingCommentEventsProjection = await project(app, missingCommentEvents, missingCommentEventsProbe);
+    expect(missingCommentEventsProjection.repositoryAutomation.providers[0]).toMatchObject({
+      provider: "github",
+      adoption: "enabled",
+      health: "ready",
+      blockers: [],
+    });
+    expect(missingCommentEventsProjection).toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          blockers: [
+            {
+              code: "github_webhook_events_missing",
+              resolutionOwner: "operator",
+              actionKind: null,
+            },
+          ],
+        },
+      },
+    });
+    expect(missingCommentEventsProbe).not.toHaveBeenCalled();
 
     const uncovered = await createScenario(app);
     const uncoveredReviewer = await createReviewer(app, uncovered);

--- a/packages/server/src/__tests__/setup-capabilities.test.ts
+++ b/packages/server/src/__tests__/setup-capabilities.test.ts
@@ -1,0 +1,857 @@
+import { generateKeyPairSync, randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { agents } from "../db/schema/agents.js";
+import { clients } from "../db/schema/clients.js";
+import { githubAppInstallations } from "../db/schema/github-app-installations.js";
+import { gitlabConnections } from "../db/schema/gitlab-connections.js";
+import { members } from "../db/schema/members.js";
+import { organizationSettings } from "../db/schema/organization-settings.js";
+import { organizations } from "../db/schema/organizations.js";
+import { createAgent } from "../services/agent.js";
+import { getTeamSetupCapabilities } from "../services/setup-capabilities.js";
+import { uuidv7 } from "../uuid.js";
+import { createTestAdmin, useTestApp } from "./helpers.js";
+
+const observedAt = new Date("2026-07-23T08:00:00.000Z");
+const githubAppPrivateKey = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+}).privateKey;
+const githubAppCredentials = {
+  appId: "12345",
+  privateKeyPem: githubAppPrivateKey,
+  slug: "first-tree-test",
+};
+const githubAppCredentialsWithoutSlug = {
+  appId: githubAppCredentials.appId,
+  privateKeyPem: githubAppCredentials.privateKeyPem,
+};
+
+type Scenario = Awaited<ReturnType<typeof createScenario>>;
+
+async function createScenario(app: FastifyInstance, role: "admin" | "member" = "admin") {
+  const identity = await createTestAdmin(app);
+  const organizationId = `org-setup-${randomUUID().slice(0, 8)}`;
+  const memberId = uuidv7();
+  let humanAgentUuid = "";
+
+  await app.db.transaction(async (tx) => {
+    await tx.insert(organizations).values({
+      id: organizationId,
+      name: `setup-${randomUUID().slice(0, 8)}`,
+      displayName: "Setup Contract Team",
+    });
+    const human = await createAgent(tx as unknown as typeof app.db, {
+      name: `setup-human-${randomUUID().slice(0, 8)}`,
+      type: "human",
+      displayName: "Setup Human",
+      managerId: memberId,
+      organizationId,
+      source: "admin-api",
+    });
+    humanAgentUuid = human.uuid;
+    await tx.insert(members).values({
+      id: memberId,
+      userId: identity.userId,
+      organizationId,
+      agentId: human.uuid,
+      role,
+    });
+  });
+
+  return { ...identity, organizationId, memberId, humanAgentUuid };
+}
+
+async function attachMember(app: FastifyInstance, organizationId: string, role: "admin" | "member"): Promise<Scenario> {
+  const identity = await createTestAdmin(app);
+  const memberId = uuidv7();
+  let humanAgentUuid = "";
+  await app.db.transaction(async (tx) => {
+    const human = await createAgent(tx as unknown as typeof app.db, {
+      name: `setup-human-${randomUUID().slice(0, 8)}`,
+      type: "human",
+      displayName: "Setup Human",
+      managerId: memberId,
+      organizationId,
+      source: "admin-api",
+    });
+    humanAgentUuid = human.uuid;
+    await tx.insert(members).values({
+      id: memberId,
+      userId: identity.userId,
+      organizationId,
+      agentId: human.uuid,
+      role,
+    });
+  });
+  return { ...identity, organizationId, memberId, humanAgentUuid };
+}
+
+async function seedSetting(
+  app: FastifyInstance,
+  scenario: Scenario,
+  namespace: "context_tree" | "context_tree_features",
+  value: Record<string, unknown>,
+): Promise<void> {
+  await app.db.insert(organizationSettings).values({
+    organizationId: scenario.organizationId,
+    namespace,
+    value,
+    version: 1,
+    updatedBy: scenario.userId,
+  });
+}
+
+async function seedGithubInstallation(
+  app: FastifyInstance,
+  scenario: Scenario,
+  options: { accountLogin?: string; pullRequests?: "read" | "write"; suspended?: boolean } = {},
+): Promise<void> {
+  const installationId = Number.parseInt(randomUUID().replaceAll("-", "").slice(0, 10), 16);
+  await app.db.insert(githubAppInstallations).values({
+    id: uuidv7(),
+    installationId,
+    accountType: "Organization",
+    accountLogin: options.accountLogin ?? "acme",
+    accountGithubId: installationId + 1,
+    installerGithubId: installationId + 2,
+    requesterGithubId: null,
+    hubOrganizationId: scenario.organizationId,
+    permissions: {
+      metadata: "read",
+      pull_requests: options.pullRequests ?? "write",
+    },
+    events: ["pull_request"],
+    suspendedAt: options.suspended ? new Date("2026-07-22T08:00:00.000Z") : null,
+  });
+}
+
+async function seedGitlabConnection(
+  app: FastifyInstance,
+  scenario: Scenario,
+  options: {
+    origin?: string;
+    firstSeenAt?: Date | null;
+    lastValidInboundAt?: Date | null;
+    lastProcessingFailureAt?: Date | null;
+  } = {},
+): Promise<string> {
+  const id = uuidv7();
+  await app.db.insert(gitlabConnections).values({
+    id,
+    organizationId: scenario.organizationId,
+    displayName: "Setup GitLab",
+    instanceOrigin: options.origin ?? "https://gitlab.internal",
+    tokenHash: `setup-${randomUUID()}`,
+    endpointFirstSeenAt: options.firstSeenAt ?? null,
+    lastValidInboundAt: options.lastValidInboundAt ?? null,
+    lastProcessingFailureAt: options.lastProcessingFailureAt ?? null,
+    createdByMemberId: scenario.memberId,
+    updatedByMemberId: scenario.memberId,
+  });
+  return id;
+}
+
+async function createReviewer(
+  app: FastifyInstance,
+  scenario: Scenario,
+  status: "active" | "suspended" = "active",
+): Promise<{ uuid: string; displayName: string }> {
+  const clientId = `setup-client-${randomUUID().slice(0, 8)}`;
+  await app.db.insert(clients).values({
+    id: clientId,
+    userId: scenario.userId,
+    organizationId: scenario.organizationId,
+    status: "connected",
+  });
+  const reviewer = await createAgent(app.db, {
+    name: `setup-reviewer-${randomUUID().slice(0, 8)}`,
+    type: "agent",
+    displayName: "Context Reviewer",
+    managerId: scenario.memberId,
+    organizationId: scenario.organizationId,
+    clientId,
+  });
+  if (status !== "active") {
+    await app.db.update(agents).set({ status }).where(eq(agents.uuid, reviewer.uuid));
+  }
+  return { uuid: reviewer.uuid, displayName: reviewer.displayName };
+}
+
+async function seedGithubReview(
+  app: FastifyInstance,
+  scenario: Scenario,
+  options: {
+    reviewer?: { uuid: string } | null;
+    enabled?: boolean;
+    accountLogin?: string;
+    pullRequests?: "read" | "write";
+    suspended?: boolean;
+  } = {},
+): Promise<void> {
+  await seedSetting(app, scenario, "context_tree", {
+    provider: "github",
+    repo: "https://github.com/acme/setup-context-tree.git",
+    branch: "main",
+  });
+  await seedSetting(app, scenario, "context_tree_features", {
+    contextReviewer: {
+      enabled: options.enabled ?? true,
+      agentUuid: options.enabled === false ? null : (options.reviewer?.uuid ?? uuidv7()),
+    },
+  });
+  await seedGithubInstallation(app, scenario, {
+    accountLogin: options.accountLogin,
+    pullRequests: options.pullRequests,
+    suspended: options.suspended,
+  });
+}
+
+async function seedGitlabReview(
+  app: FastifyInstance,
+  scenario: Scenario,
+  options: {
+    connectionOrigin?: string;
+    repoOrigin?: string;
+    firstSeenAt?: Date | null;
+    lastValidInboundAt?: Date | null;
+    lastProcessingFailureAt?: Date | null;
+    reviewer: { uuid: string };
+  },
+): Promise<void> {
+  await seedGitlabConnection(app, scenario, {
+    origin: options.connectionOrigin,
+    firstSeenAt: options.firstSeenAt,
+    lastValidInboundAt: options.lastValidInboundAt,
+    lastProcessingFailureAt: options.lastProcessingFailureAt,
+  });
+  await seedSetting(app, scenario, "context_tree", {
+    provider: "gitlab",
+    repo: `${options.repoOrigin ?? "https://gitlab.internal"}/acme/setup-context-tree.git`,
+    branch: "main",
+  });
+  await seedSetting(app, scenario, "context_tree_features", {
+    contextReviewer: { enabled: true, agentUuid: options.reviewer.uuid },
+  });
+}
+
+function project(
+  app: FastifyInstance,
+  scenario: Scenario,
+  probeGithubReview?: () => Promise<never | "ready" | "permission_required" | "repo_not_covered" | "failed">,
+  options: {
+    githubAppCredentials?: { appId: string; privateKeyPem: string; slug?: string };
+    githubFetch?: typeof fetch;
+  } = {},
+) {
+  return getTeamSetupCapabilities(app.db, scenario.organizationId, {
+    now: () => observedAt,
+    ...options,
+    ...(probeGithubReview ? { probeGithubReview } : {}),
+  });
+}
+
+function withoutObservedAt(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutObservedAt);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== "observedAt")
+      .map(([key, nested]) => [key, withoutObservedAt(nested)]),
+  );
+}
+
+describe("Team setup capabilities", () => {
+  const getApp = useTestApp();
+
+  it("keeps untouched optional providers and an unbound Context Tree neutral", async () => {
+    const app = getApp();
+    const scenario = await createScenario(app);
+
+    await expect(project(app, scenario)).resolves.toEqual({
+      organizationId: scenario.organizationId,
+      repositoryAutomation: {
+        providers: [
+          {
+            provider: "github",
+            adoption: "available",
+            health: "not_observed",
+            blockers: [],
+            observedAt: observedAt.toISOString(),
+          },
+          {
+            provider: "gitlab",
+            adoption: "available",
+            health: "not_observed",
+            blockers: [],
+            observedAt: observedAt.toISOString(),
+          },
+        ],
+      },
+      contextTree: {
+        binding: { state: "unbound" },
+        blockers: [],
+        automaticReview: {
+          adoption: "unavailable",
+          health: "not_observed",
+          reviewerAgent: null,
+          blockers: [],
+          observedAt: observedAt.toISOString(),
+        },
+      },
+    });
+  });
+
+  it("fails closed for malformed, unresolved, and provider-mismatched Tree bindings", async () => {
+    const app = getApp();
+    const malformed = await createScenario(app);
+    await seedSetting(app, malformed, "context_tree", { repo: "", branch: "main" });
+    await expect(project(app, malformed)).resolves.toMatchObject({
+      contextTree: {
+        binding: { state: "invalid" },
+        blockers: [{ code: "context_tree_binding_invalid", actionKind: "repair_tree_binding" }],
+      },
+    });
+
+    const unresolved = await createScenario(app);
+    await seedSetting(app, unresolved, "context_tree", {
+      repo: "git@unknown.example:acme/tree.git",
+      branch: "main",
+    });
+    await expect(project(app, unresolved)).resolves.toMatchObject({
+      contextTree: {
+        binding: { state: "invalid" },
+        blockers: [{ code: "context_tree_provider_unresolved", actionKind: "repair_tree_binding" }],
+      },
+    });
+
+    const mismatched = await createScenario(app);
+    await seedSetting(app, mismatched, "context_tree", {
+      provider: "github",
+      repo: "https://gitlab.internal/acme/tree.git",
+      branch: "main",
+    });
+    await expect(project(app, mismatched)).resolves.toMatchObject({
+      contextTree: {
+        binding: { state: "invalid" },
+        blockers: [{ code: "context_tree_provider_unresolved", actionKind: "repair_tree_binding" }],
+      },
+    });
+  });
+
+  it("projects GitHub active, suspended, permission, coverage, and probe-failure states", async () => {
+    const app = getApp();
+
+    const ready = await createScenario(app);
+    const readyReviewer = await createReviewer(app, ready);
+    await seedGithubReview(app, ready, { reviewer: readyReviewer });
+    const readyProjection = await project(app, ready, async () => "ready");
+    expect(readyProjection.repositoryAutomation.providers[0]).toMatchObject({
+      provider: "github",
+      adoption: "enabled",
+      health: "ready",
+      blockers: [],
+    });
+    expect(readyProjection).toMatchObject({
+      contextTree: {
+        binding: { state: "bound", provider: "github" },
+        automaticReview: {
+          adoption: "enabled",
+          health: "ready",
+          reviewerAgent: readyReviewer,
+          blockers: [],
+        },
+      },
+    });
+
+    const suspended = await createScenario(app);
+    const suspendedReviewer = await createReviewer(app, suspended);
+    await seedGithubReview(app, suspended, { reviewer: suspendedReviewer, suspended: true });
+    const suspendedProbe = vi.fn(async () => "ready" as const);
+    const suspendedProjection = await project(app, suspended, suspendedProbe);
+    expect(suspendedProjection.repositoryAutomation.providers[0]).toMatchObject({
+      provider: "github",
+      adoption: "enabled",
+      health: "unavailable",
+      blockers: [{ code: "github_app_suspended" }],
+    });
+    expect(suspendedProjection).toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          blockers: [{ code: "github_app_suspended" }],
+        },
+      },
+    });
+    expect(suspendedProbe).not.toHaveBeenCalled();
+
+    const permission = await createScenario(app);
+    const permissionReviewer = await createReviewer(app, permission);
+    await seedGithubReview(app, permission, { reviewer: permissionReviewer, pullRequests: "read" });
+    const permissionProbe = vi.fn(async () => "ready" as const);
+    await expect(project(app, permission, permissionProbe)).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          blockers: [{ code: "github_pull_requests_permission_required" }],
+        },
+      },
+    });
+    expect(permissionProbe).not.toHaveBeenCalled();
+
+    const uncovered = await createScenario(app);
+    const uncoveredReviewer = await createReviewer(app, uncovered);
+    await seedGithubReview(app, uncovered, { reviewer: uncoveredReviewer });
+    await expect(project(app, uncovered, async () => "repo_not_covered")).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          blockers: [{ code: "github_tree_repo_not_covered" }],
+        },
+      },
+    });
+
+    const failed = await createScenario(app);
+    const failedReviewer = await createReviewer(app, failed);
+    await seedGithubReview(app, failed, { reviewer: failedReviewer });
+    await expect(
+      project(app, failed, async () => {
+        throw new Error("GitHub unavailable");
+      }),
+    ).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "pending_verification",
+          blockers: [{ code: "provider_probe_failed", resolutionOwner: "operator", actionKind: null }],
+        },
+      },
+    });
+  });
+
+  it("uses a bounded exact-repo GitHub token preflight and maps live failures", async () => {
+    const app = getApp();
+    const response = (
+      status: number,
+      permissions: Record<string, "read" | "write" | "admin"> = {
+        metadata: "read",
+        pull_requests: "write",
+      },
+      repositorySelection: "all" | "selected" = "selected",
+    ) =>
+      new Response(
+        JSON.stringify({
+          token: "setup-token",
+          expires_at: "2026-07-23T09:00:00.000Z",
+          permissions,
+          repository_selection: repositorySelection,
+        }),
+        { status, headers: { "content-type": "application/json" } },
+      );
+
+    const ready = await createScenario(app);
+    const readyReviewer = await createReviewer(app, ready);
+    await seedGithubReview(app, ready, { reviewer: readyReviewer });
+    const readyFetch = vi.fn<typeof fetch>(async () => response(201));
+    await expect(
+      project(app, ready, undefined, { githubAppCredentials, githubFetch: readyFetch }),
+    ).resolves.toMatchObject({
+      contextTree: { automaticReview: { health: "ready", blockers: [] } },
+    });
+    expect(readyFetch).toHaveBeenCalledTimes(1);
+    const [, readyRequest] = readyFetch.mock.calls[0] ?? [];
+    expect(readyRequest?.signal).toBeInstanceOf(AbortSignal);
+    expect(JSON.parse(String(readyRequest?.body))).toEqual({
+      repositories: ["setup-context-tree"],
+      permissions: { metadata: "read", pull_requests: "write" },
+    });
+
+    const wrongOwner = await createScenario(app);
+    const wrongOwnerReviewer = await createReviewer(app, wrongOwner);
+    await seedGithubReview(app, wrongOwner, {
+      reviewer: wrongOwnerReviewer,
+      accountLogin: "different-owner",
+    });
+    const wrongOwnerFetch = vi.fn<typeof fetch>(async () => response(201));
+    await expect(
+      project(app, wrongOwner, undefined, { githubAppCredentials, githubFetch: wrongOwnerFetch }),
+    ).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          blockers: [{ code: "github_tree_repo_not_covered" }],
+        },
+      },
+    });
+    expect(wrongOwnerFetch).not.toHaveBeenCalled();
+
+    const missingSlug = await createScenario(app);
+    const missingSlugReviewer = await createReviewer(app, missingSlug);
+    await seedGithubReview(app, missingSlug, { reviewer: missingSlugReviewer });
+    const missingSlugFetch = vi.fn<typeof fetch>(async () => response(201));
+    await expect(
+      project(app, missingSlug, undefined, {
+        githubAppCredentials: githubAppCredentialsWithoutSlug,
+        githubFetch: missingSlugFetch,
+      }),
+    ).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "pending_verification",
+          blockers: [{ code: "provider_probe_failed", resolutionOwner: "operator", actionKind: null }],
+        },
+      },
+    });
+    expect(missingSlugFetch).not.toHaveBeenCalled();
+
+    const permission = await createScenario(app);
+    const permissionReviewer = await createReviewer(app, permission);
+    await seedGithubReview(app, permission, { reviewer: permissionReviewer });
+    const permissionFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(response(403))
+      .mockResolvedValueOnce(response(201, { metadata: "read", pull_requests: "read" }));
+    await expect(
+      project(app, permission, undefined, { githubAppCredentials, githubFetch: permissionFetch }),
+    ).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          blockers: [{ code: "github_pull_requests_permission_required" }],
+        },
+      },
+    });
+    expect(permissionFetch).toHaveBeenCalledTimes(2);
+
+    const uncovered = await createScenario(app);
+    const uncoveredReviewer = await createReviewer(app, uncovered);
+    await seedGithubReview(app, uncovered, { reviewer: uncoveredReviewer });
+    const uncoveredFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(response(422))
+      .mockResolvedValueOnce(response(201))
+      .mockResolvedValueOnce(response(404));
+    await expect(
+      project(app, uncovered, undefined, { githubAppCredentials, githubFetch: uncoveredFetch }),
+    ).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          blockers: [{ code: "github_tree_repo_not_covered" }],
+        },
+      },
+    });
+    expect(uncoveredFetch).toHaveBeenCalledTimes(3);
+    const uncoveredSignals = uncoveredFetch.mock.calls.map(([, request]) => request?.signal);
+    expect(uncoveredSignals.every((signal) => signal === uncoveredSignals[0])).toBe(true);
+
+    const ambiguous = await createScenario(app);
+    const ambiguousReviewer = await createReviewer(app, ambiguous);
+    await seedGithubReview(app, ambiguous, { reviewer: ambiguousReviewer });
+    const ambiguousFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(response(404))
+      .mockResolvedValueOnce(response(201, { metadata: "read", pull_requests: "write" }, "all"));
+    await expect(
+      project(app, ambiguous, undefined, { githubAppCredentials, githubFetch: ambiguousFetch }),
+    ).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "pending_verification",
+          blockers: [{ code: "provider_probe_failed", resolutionOwner: "operator", actionKind: null }],
+        },
+      },
+    });
+
+    const failed = await createScenario(app);
+    const failedReviewer = await createReviewer(app, failed);
+    await seedGithubReview(app, failed, { reviewer: failedReviewer });
+    const failedFetch = vi.fn<typeof fetch>(async () => response(503));
+    await expect(
+      project(app, failed, undefined, { githubAppCredentials, githubFetch: failedFetch }),
+    ).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "pending_verification",
+          blockers: [{ code: "provider_probe_failed", resolutionOwner: "operator", actionKind: null }],
+        },
+      },
+    });
+  });
+
+  it("does not run GitHub live coverage until the App and saved Reviewer are stable", async () => {
+    const app = getApp();
+    const missingInstallation = await createScenario(app);
+    const missingInstallationReviewer = await createReviewer(app, missingInstallation);
+    await seedGithubReview(app, missingInstallation, { reviewer: missingInstallationReviewer });
+    await app.db
+      .delete(githubAppInstallations)
+      .where(eq(githubAppInstallations.hubOrganizationId, missingInstallation.organizationId));
+    const missingInstallationProbe = vi.fn(async () => "ready" as const);
+    await expect(project(app, missingInstallation, missingInstallationProbe)).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          blockers: [{ code: "context_review_provider_prerequisite_missing", actionKind: "connect_github" }],
+        },
+      },
+    });
+    expect(missingInstallationProbe).not.toHaveBeenCalled();
+
+    const missing = await createScenario(app);
+    await seedGithubReview(app, missing);
+    const missingProbe = vi.fn(async () => "ready" as const);
+    await expect(project(app, missing, missingProbe)).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          reviewerAgent: null,
+          blockers: [{ code: "context_review_agent_missing", actionKind: "replace_review_agent" }],
+        },
+      },
+    });
+    expect(missingProbe).not.toHaveBeenCalled();
+
+    const inactive = await createScenario(app);
+    const inactiveReviewer = await createReviewer(app, inactive, "suspended");
+    await seedGithubReview(app, inactive, { reviewer: inactiveReviewer });
+    const inactiveProbe = vi.fn(async () => "ready" as const);
+    await expect(project(app, inactive, inactiveProbe)).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          reviewerAgent: inactiveReviewer,
+          blockers: [{ code: "context_review_agent_inactive", actionKind: "replace_review_agent" }],
+        },
+      },
+    });
+    expect(inactiveProbe).not.toHaveBeenCalled();
+  });
+
+  it("keeps a disabled Reviewer neutral on a valid binding", async () => {
+    const app = getApp();
+    const scenario = await createScenario(app);
+    await seedGithubReview(app, scenario, { enabled: false });
+    const probe = vi.fn(async () => "ready" as const);
+
+    await expect(project(app, scenario, probe)).resolves.toMatchObject({
+      contextTree: {
+        binding: { state: "bound", provider: "github" },
+        automaticReview: {
+          adoption: "disabled",
+          health: "not_observed",
+          reviewerAgent: null,
+          blockers: [],
+        },
+      },
+    });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("projects GitLab pending, ready, degraded, simultaneous-provider, and invalid-connection states", async () => {
+    const app = getApp();
+
+    const pending = await createScenario(app);
+    const pendingReviewer = await createReviewer(app, pending);
+    await seedGitlabReview(app, pending, { reviewer: pendingReviewer });
+    await expect(project(app, pending)).resolves.toMatchObject({
+      repositoryAutomation: {
+        providers: [
+          {},
+          {
+            provider: "gitlab",
+            adoption: "configuring",
+            health: "pending_verification",
+            blockers: [{ code: "gitlab_webhook_not_seen" }],
+          },
+        ],
+      },
+      contextTree: {
+        binding: { state: "bound", provider: "gitlab" },
+        automaticReview: {
+          health: "pending_verification",
+          blockers: [{ code: "gitlab_webhook_not_seen" }],
+        },
+      },
+    });
+
+    const ready = await createScenario(app);
+    const readyReviewer = await createReviewer(app, ready);
+    await seedGitlabReview(app, ready, {
+      reviewer: readyReviewer,
+      firstSeenAt: new Date("2026-07-22T08:00:00.000Z"),
+      lastValidInboundAt: new Date("2026-07-22T09:00:00.000Z"),
+    });
+    await seedGithubInstallation(app, ready);
+    await expect(project(app, ready)).resolves.toMatchObject({
+      repositoryAutomation: {
+        providers: [
+          { provider: "github", adoption: "enabled", health: "ready", blockers: [] },
+          { provider: "gitlab", adoption: "enabled", health: "ready", blockers: [] },
+        ],
+      },
+      contextTree: {
+        automaticReview: { adoption: "enabled", health: "ready", blockers: [] },
+      },
+    });
+
+    const degraded = await createScenario(app);
+    const degradedReviewer = await createReviewer(app, degraded);
+    await seedGitlabReview(app, degraded, {
+      reviewer: degradedReviewer,
+      firstSeenAt: new Date("2026-07-22T08:00:00.000Z"),
+      lastValidInboundAt: new Date("2026-07-22T09:00:00.000Z"),
+      lastProcessingFailureAt: new Date("2026-07-22T10:00:00.000Z"),
+    });
+    await expect(project(app, degraded)).resolves.toMatchObject({
+      repositoryAutomation: {
+        providers: [
+          {},
+          {
+            provider: "gitlab",
+            adoption: "enabled",
+            health: "degraded",
+            blockers: [{ code: "gitlab_processing_failed", resolutionOwner: "admin", actionKind: null }],
+          },
+        ],
+      },
+      contextTree: {
+        automaticReview: {
+          health: "degraded",
+          blockers: [{ code: "gitlab_processing_failed", resolutionOwner: "admin", actionKind: null }],
+        },
+      },
+    });
+
+    const mismatch = await createScenario(app);
+    const mismatchReviewer = await createReviewer(app, mismatch);
+    await seedGitlabReview(app, mismatch, {
+      reviewer: mismatchReviewer,
+      connectionOrigin: "https://gitlab.current",
+      repoOrigin: "https://gitlab.previous",
+      firstSeenAt: new Date("2026-07-22T08:00:00.000Z"),
+      lastValidInboundAt: new Date("2026-07-22T09:00:00.000Z"),
+    });
+    await expect(project(app, mismatch)).resolves.toMatchObject({
+      contextTree: {
+        binding: { state: "bound", provider: "gitlab" },
+        blockers: [],
+        automaticReview: {
+          adoption: "enabled",
+          health: "unavailable",
+          blockers: [
+            {
+              code: "context_tree_connection_mismatch",
+              resolutionOwner: "admin",
+              actionKind: "repair_tree_binding",
+            },
+          ],
+        },
+      },
+    });
+
+    const missingConnection = await createScenario(app);
+    const missingConnectionReviewer = await createReviewer(app, missingConnection);
+    await seedGitlabReview(app, missingConnection, {
+      reviewer: missingConnectionReviewer,
+      firstSeenAt: new Date("2026-07-22T08:00:00.000Z"),
+      lastValidInboundAt: new Date("2026-07-22T09:00:00.000Z"),
+    });
+    await app.db
+      .delete(gitlabConnections)
+      .where(eq(gitlabConnections.organizationId, missingConnection.organizationId));
+    await expect(project(app, missingConnection)).resolves.toMatchObject({
+      repositoryAutomation: {
+        providers: [{}, { provider: "gitlab", adoption: "available", health: "not_observed", blockers: [] }],
+      },
+      contextTree: {
+        binding: { state: "bound", provider: "gitlab" },
+        blockers: [],
+        automaticReview: {
+          adoption: "enabled",
+          health: "unavailable",
+          blockers: [
+            {
+              code: "context_review_provider_prerequisite_missing",
+              resolutionOwner: "admin",
+              actionKind: "connect_gitlab",
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it("enforces active org membership, role-independent shape, and URL-selected multi-org isolation", async () => {
+    const app = getApp();
+    const admin = await createScenario(app, "admin");
+    const member = await attachMember(app, admin.organizationId, "member");
+    const foreign = await createTestAdmin(app);
+    await seedSetting(app, admin, "context_tree", {
+      provider: "github",
+      repo: "https://github.com/acme/private-setup-tree.git",
+      branch: "main",
+    });
+    const url = `/api/v1/orgs/${admin.organizationId}/setup-capabilities`;
+
+    const adminResponse = await app.inject({
+      method: "GET",
+      url,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    const memberResponse = await app.inject({
+      method: "GET",
+      url,
+      headers: { authorization: `Bearer ${member.accessToken}` },
+    });
+    expect(adminResponse.statusCode).toBe(200);
+    expect(memberResponse.statusCode).toBe(200);
+    expect(withoutObservedAt(adminResponse.json())).toEqual(withoutObservedAt(memberResponse.json()));
+
+    await app.db.update(members).set({ role: "admin" }).where(eq(members.id, member.memberId));
+    const promotedResponse = await app.inject({
+      method: "GET",
+      url,
+      headers: { authorization: `Bearer ${member.accessToken}` },
+    });
+    expect(promotedResponse.statusCode).toBe(200);
+    expect(withoutObservedAt(promotedResponse.json())).toEqual(withoutObservedAt(memberResponse.json()));
+
+    const secondOrg = await createScenario(app, "admin");
+    const secondMembership = await attachMember(app, secondOrg.organizationId, "member");
+    await app.db
+      .update(members)
+      .set({ userId: admin.userId, agentId: secondMembership.humanAgentUuid })
+      .where(eq(members.id, secondMembership.memberId));
+    const secondResponse = await app.inject({
+      method: "GET",
+      url: `/api/v1/orgs/${secondOrg.organizationId}/setup-capabilities`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(secondResponse.statusCode).toBe(200);
+    expect(secondResponse.json()).toMatchObject({
+      organizationId: secondOrg.organizationId,
+      contextTree: { binding: { state: "unbound" } },
+    });
+    expect(secondResponse.body).not.toContain("private-setup-tree");
+
+    const foreignResponse = await app.inject({
+      method: "GET",
+      url,
+      headers: { authorization: `Bearer ${foreign.accessToken}` },
+    });
+    expect(foreignResponse.statusCode).toBe(403);
+    expect(foreignResponse.body).not.toContain("private-setup-tree");
+
+    await app.db.update(members).set({ status: "left" }).where(eq(members.id, member.memberId));
+    const inactiveResponse = await app.inject({
+      method: "GET",
+      url,
+      headers: { authorization: `Bearer ${member.accessToken}` },
+    });
+    expect(inactiveResponse.statusCode).toBe(403);
+    expect(inactiveResponse.body).not.toContain("private-setup-tree");
+  });
+});

--- a/packages/server/src/__tests__/setup-capabilities.test.ts
+++ b/packages/server/src/__tests__/setup-capabilities.test.ts
@@ -712,6 +712,26 @@ describe("Team setup capabilities", () => {
     });
     expect(missingInstallationProbe).not.toHaveBeenCalled();
 
+    await expect(
+      project(app, missingInstallation, missingInstallationProbe, {
+        githubAppCredentials: undefined,
+      }),
+    ).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          blockers: [
+            {
+              code: "github_app_not_configured",
+              resolutionOwner: "operator",
+              actionKind: null,
+            },
+          ],
+        },
+      },
+    });
+    expect(missingInstallationProbe).not.toHaveBeenCalled();
+
     const missing = await createScenario(app);
     await seedGithubReview(app, missing);
     const missingProbe = vi.fn(async () => "ready" as const);

--- a/packages/server/src/api/orgs/setup-capabilities.ts
+++ b/packages/server/src/api/orgs/setup-capabilities.ts
@@ -1,0 +1,16 @@
+import { teamSetupCapabilitiesSchema } from "@first-tree/shared";
+import type { FastifyInstance } from "fastify";
+import { requireOrgMembership } from "../../scope/require-org.js";
+import { getTeamSetupCapabilities } from "../../services/setup-capabilities.js";
+
+/** Class B — `/api/v1/orgs/:orgId/setup-capabilities`. */
+export async function orgSetupCapabilitiesRoutes(app: FastifyInstance): Promise<void> {
+  app.get<{ Params: { orgId: string } }>("/", async (request) => {
+    const scope = await requireOrgMembership(request, app.db);
+    return teamSetupCapabilitiesSchema.parse(
+      await getTeamSetupCapabilities(app.db, scope.organizationId, {
+        githubAppCredentials: app.config.oauth?.githubApp,
+      }),
+    );
+  });
+}

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -63,6 +63,7 @@ import { orgOverviewRoutes } from "./api/orgs/overview.js";
 import { orgResourceRoutes } from "./api/orgs/resources.js";
 import { orgSessionRoutes } from "./api/orgs/sessions.js";
 import { orgSettingsRoutes } from "./api/orgs/settings.js";
+import { orgSetupCapabilitiesRoutes } from "./api/orgs/setup-capabilities.js";
 import { orgUsageRoutes } from "./api/orgs/usage.js";
 import { orgWsRoutes } from "./api/orgs/ws.js";
 import { readyzRoutes } from "./api/readyz.js";
@@ -566,6 +567,7 @@ export async function buildApp(config: Config) {
           await scope.register(orgGitlabIdentityLinkRoutes, { prefix: "/gitlab-identity-links" });
           await scope.register(orgContextTreeRoutes, { prefix: "/context-tree" });
           await scope.register(orgContextTreeSnapshotRoutes, { prefix: "/context-tree" });
+          await scope.register(orgSetupCapabilitiesRoutes, { prefix: "/setup-capabilities" });
           await scope.register(orgAttachmentRoutes, { prefix: "/attachments" });
           if (config.docs.enabled) {
             await scope.register(orgDocumentRoutes, { prefix: "/documents" });

--- a/packages/server/src/services/setup-capabilities.ts
+++ b/packages/server/src/services/setup-capabilities.ts
@@ -1,0 +1,337 @@
+import {
+  canonicalGitRepoIdentity,
+  resolveContextTreeProvider,
+  type SetupAutomaticReview,
+  type SetupBlocker,
+  type SetupContextTreeBinding,
+  type SetupRepositoryAutomationProvider,
+  type TeamSetupCapabilities,
+  teamSetupCapabilitiesSchema,
+} from "@first-tree/shared";
+import { and, eq } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { gitlabConnections } from "../db/schema/gitlab-connections.js";
+import {
+  createAppJwt,
+  GithubAppApiError,
+  type GithubAppCredentials,
+  getRepository,
+  mintInstallationToken,
+} from "./github-app.js";
+import { findInstallationByOrg, type InstallationRow } from "./github-app-installations.js";
+import { getOrgContextReviewRuntime } from "./org-settings.js";
+
+type GithubReviewProbeResult = "ready" | "permission_required" | "repo_not_covered" | "failed";
+type GithubReviewCredentials = GithubAppCredentials & { slug?: string };
+const GITHUB_REVIEW_PROBE_TIMEOUT_MS = 5_000;
+
+export type SetupCapabilitiesOptions = {
+  now?: () => Date;
+  githubAppCredentials?: GithubReviewCredentials;
+  githubFetch?: typeof fetch;
+  probeGithubReview?: (installation: InstallationRow, repo: string) => Promise<GithubReviewProbeResult>;
+};
+
+function blocker(
+  code: SetupBlocker["code"],
+  resolutionOwner: SetupBlocker["resolutionOwner"],
+  actionKind: SetupBlocker["actionKind"],
+): SetupBlocker {
+  return { code, resolutionOwner, actionKind };
+}
+
+function gitlabProcessingIsDegraded(connection: typeof gitlabConnections.$inferSelect): boolean {
+  if (!connection.lastProcessingFailureAt) return false;
+  return (
+    !connection.lastValidInboundAt ||
+    connection.lastProcessingFailureAt.getTime() > connection.lastValidInboundAt.getTime()
+  );
+}
+
+async function defaultGithubReviewProbe(
+  installation: InstallationRow,
+  repo: string,
+  credentials: GithubReviewCredentials | undefined,
+  baseFetch: typeof fetch = fetch,
+): Promise<GithubReviewProbeResult> {
+  const signal = AbortSignal.timeout(GITHUB_REVIEW_PROBE_TIMEOUT_MS);
+  const fetcher: typeof fetch = (input, init) =>
+    baseFetch(input, {
+      ...init,
+      signal,
+    });
+  if (!credentials?.slug) return "failed";
+  const identity = canonicalGitRepoIdentity(repo);
+  const parts = identity?.host === "github.com" ? identity.path.split("/") : [];
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return "failed";
+  if (parts[0].toLowerCase() !== installation.accountLogin.toLowerCase()) return "repo_not_covered";
+
+  let appJwt: string;
+  try {
+    appJwt = await createAppJwt(credentials);
+  } catch {
+    return "failed";
+  }
+
+  try {
+    const minted = await mintInstallationToken(appJwt, installation.installationId, {
+      fetcher,
+      repositories: [parts[1]],
+      permissions: { metadata: "read", pull_requests: "write" },
+    });
+    return minted.permissions.pull_requests === "write" ? "ready" : "permission_required";
+  } catch (error) {
+    if (
+      !(error instanceof GithubAppApiError) ||
+      (error.status !== 403 && error.status !== 404 && error.status !== 422)
+    ) {
+      return "failed";
+    }
+  }
+
+  // Scoped-mint 403/404/422 responses are ambiguous. Only a selected-repo
+  // token followed by an exact-repo 404 proves the actionable coverage gap.
+  // Every request shares one abort signal, bounding the whole diagnostic.
+  try {
+    const diagnostic = await mintInstallationToken(appJwt, installation.installationId, { fetcher });
+    if (diagnostic.permissions.pull_requests !== "write") return "permission_required";
+    if (diagnostic.repositorySelection !== "selected") return "failed";
+    try {
+      await getRepository(diagnostic.token, parts[0], parts[1], { fetcher });
+    } catch (error) {
+      if (error instanceof GithubAppApiError && error.status === 404) return "repo_not_covered";
+    }
+    return "failed";
+  } catch {
+    return "failed";
+  }
+}
+
+function projectRepositoryAutomation(
+  installation: InstallationRow | null,
+  gitlabConnection: typeof gitlabConnections.$inferSelect | null,
+  observedAt: string,
+): SetupRepositoryAutomationProvider[] {
+  const github: SetupRepositoryAutomationProvider = !installation
+    ? {
+        provider: "github",
+        adoption: "available",
+        health: "not_observed",
+        blockers: [],
+        observedAt,
+      }
+    : installation.suspendedAt
+      ? {
+          provider: "github",
+          adoption: "enabled",
+          health: "unavailable",
+          blockers: [blocker("github_app_suspended", "admin", "manage_github_installation")],
+          observedAt,
+        }
+      : {
+          provider: "github",
+          adoption: "enabled",
+          health: "ready",
+          blockers: [],
+          observedAt,
+        };
+
+  let gitlab: SetupRepositoryAutomationProvider;
+  if (!gitlabConnection) {
+    gitlab = {
+      provider: "gitlab",
+      adoption: "available",
+      health: "not_observed",
+      blockers: [],
+      observedAt,
+    };
+  } else if (!gitlabConnection.endpointFirstSeenAt) {
+    gitlab = {
+      provider: "gitlab",
+      adoption: "configuring",
+      health: "pending_verification",
+      blockers: [blocker("gitlab_webhook_not_seen", "admin", "configure_gitlab_webhook")],
+      observedAt,
+    };
+  } else if (gitlabProcessingIsDegraded(gitlabConnection)) {
+    gitlab = {
+      provider: "gitlab",
+      adoption: "enabled",
+      health: "degraded",
+      blockers: [blocker("gitlab_processing_failed", "admin", null)],
+      observedAt,
+    };
+  } else {
+    gitlab = {
+      provider: "gitlab",
+      adoption: "enabled",
+      health: "ready",
+      blockers: [],
+      observedAt,
+    };
+  }
+
+  return [github, gitlab];
+}
+
+/**
+ * Project stable Team-scoped setup facts for the permanent Setup surface.
+ *
+ * The projection is deliberately read-only and caller-independent: Admin and
+ * Member receive the same facts. The Web layer decides whether a blocker is
+ * actionable for the current role; this service never persists a synthetic
+ * "setup complete" bit or turns untouched optional providers into debt.
+ */
+export async function getTeamSetupCapabilities(
+  db: Database,
+  organizationId: string,
+  options: SetupCapabilitiesOptions = {},
+): Promise<TeamSetupCapabilities> {
+  const observedAt = (options.now?.() ?? new Date()).toISOString();
+  const [runtime, installation, gitlabRows] = await Promise.all([
+    getOrgContextReviewRuntime(db, organizationId),
+    findInstallationByOrg(db, organizationId),
+    db.select().from(gitlabConnections).where(eq(gitlabConnections.organizationId, organizationId)).limit(1),
+  ]);
+  const gitlabConnection = gitlabRows[0] ?? null;
+
+  const contextTreeBlockers: SetupBlocker[] = [];
+  let binding: SetupContextTreeBinding;
+  if (runtime.bindingState === "unbound") {
+    binding = { state: "unbound" };
+  } else if (runtime.bindingState === "invalid") {
+    binding = { state: "invalid" };
+    contextTreeBlockers.push(blocker("context_tree_binding_invalid", "admin", "repair_tree_binding"));
+  } else {
+    const resolution = resolveContextTreeProvider({
+      repo: runtime.repo,
+      declaredProvider: runtime.provider,
+      gitlabInstanceOrigin: runtime.gitlabConnection?.instanceOrigin,
+    });
+    if (!runtime.repo || !runtime.branch || !resolution.provider || !resolution.declaredProviderMatches) {
+      binding = { state: "invalid" };
+      contextTreeBlockers.push(blocker("context_tree_provider_unresolved", "admin", "repair_tree_binding"));
+    } else {
+      binding = {
+        state: "bound",
+        provider: resolution.provider,
+        repo: runtime.repo,
+        branch: runtime.branch,
+      };
+    }
+  }
+
+  let reviewerAgent: SetupAutomaticReview["reviewerAgent"] = null;
+  let reviewerAgentActive = false;
+  if (runtime.contextReviewer.agentUuid) {
+    const [reviewer] = await db
+      .select({
+        uuid: agents.uuid,
+        displayName: agents.displayName,
+        type: agents.type,
+        status: agents.status,
+      })
+      .from(agents)
+      .where(and(eq(agents.uuid, runtime.contextReviewer.agentUuid), eq(agents.organizationId, organizationId)))
+      .limit(1);
+    if (reviewer?.type === "agent") {
+      reviewerAgent = { uuid: reviewer.uuid, displayName: reviewer.displayName };
+      reviewerAgentActive = reviewer.status === "active";
+    }
+  }
+
+  const reviewBlockers: SetupBlocker[] = [];
+  let reviewHealth: SetupAutomaticReview["health"] = "not_observed";
+  let reviewAdoption: SetupAutomaticReview["adoption"];
+
+  if (binding.state !== "bound") {
+    reviewAdoption = "unavailable";
+  } else if (!runtime.contextReviewer.enabled) {
+    reviewAdoption = "disabled";
+  } else {
+    reviewAdoption = "enabled";
+    reviewHealth = "ready";
+
+    if (!reviewerAgent) {
+      reviewBlockers.push(blocker("context_review_agent_missing", "admin", "replace_review_agent"));
+      reviewHealth = "unavailable";
+    } else if (!reviewerAgentActive) {
+      reviewBlockers.push(blocker("context_review_agent_inactive", "admin", "replace_review_agent"));
+      reviewHealth = "unavailable";
+    }
+
+    if (binding.provider === "github") {
+      if (!installation) {
+        reviewBlockers.push(blocker("context_review_provider_prerequisite_missing", "admin", "connect_github"));
+        reviewHealth = "unavailable";
+      } else if (installation.suspendedAt) {
+        reviewBlockers.push(blocker("github_app_suspended", "admin", "manage_github_installation"));
+        reviewHealth = "unavailable";
+      } else if (installation.permissions.pull_requests !== "write") {
+        reviewBlockers.push(blocker("github_pull_requests_permission_required", "admin", "manage_github_installation"));
+        reviewHealth = "unavailable";
+      } else if (reviewHealth === "ready") {
+        const probe =
+          options.probeGithubReview ??
+          ((candidate: InstallationRow, repo: string) =>
+            defaultGithubReviewProbe(candidate, repo, options.githubAppCredentials, options.githubFetch));
+        let result: GithubReviewProbeResult;
+        try {
+          result = await probe(installation, binding.repo);
+        } catch {
+          result = "failed";
+        }
+        if (result === "permission_required") {
+          reviewBlockers.push(
+            blocker("github_pull_requests_permission_required", "admin", "manage_github_installation"),
+          );
+          reviewHealth = "unavailable";
+        } else if (result === "repo_not_covered") {
+          reviewBlockers.push(blocker("github_tree_repo_not_covered", "admin", "manage_github_installation"));
+          reviewHealth = "unavailable";
+        } else if (result === "failed") {
+          reviewBlockers.push(blocker("provider_probe_failed", "operator", null));
+          if (reviewHealth === "ready") reviewHealth = "pending_verification";
+        }
+      }
+    } else if (
+      !gitlabConnection ||
+      !runtime.providerMatchesRepository ||
+      runtime.gitlabConnection?.id !== gitlabConnection.id
+    ) {
+      reviewBlockers.push(
+        blocker(
+          gitlabConnection ? "context_tree_connection_mismatch" : "context_review_provider_prerequisite_missing",
+          "admin",
+          gitlabConnection ? "repair_tree_binding" : "connect_gitlab",
+        ),
+      );
+      reviewHealth = "unavailable";
+    } else if (!gitlabConnection.endpointFirstSeenAt) {
+      reviewBlockers.push(blocker("gitlab_webhook_not_seen", "admin", "configure_gitlab_webhook"));
+      if (reviewHealth === "ready") reviewHealth = "pending_verification";
+    } else if (gitlabProcessingIsDegraded(gitlabConnection)) {
+      reviewBlockers.push(blocker("gitlab_processing_failed", "admin", null));
+      if (reviewHealth === "ready") reviewHealth = "degraded";
+    }
+  }
+
+  return teamSetupCapabilitiesSchema.parse({
+    organizationId,
+    repositoryAutomation: {
+      providers: projectRepositoryAutomation(installation, gitlabConnection, observedAt),
+    },
+    contextTree: {
+      binding,
+      blockers: contextTreeBlockers,
+      automaticReview: {
+        adoption: reviewAdoption,
+        health: reviewHealth,
+        reviewerAgent,
+        blockers: reviewBlockers,
+        observedAt,
+      },
+    },
+  });
+}

--- a/packages/server/src/services/setup-capabilities.ts
+++ b/packages/server/src/services/setup-capabilities.ts
@@ -298,11 +298,11 @@ export async function getTeamSetupCapabilities(
     }
 
     if (binding.provider === "github") {
-      if (!installation) {
-        reviewBlockers.push(blocker("context_review_provider_prerequisite_missing", "admin", "connect_github"));
-        reviewHealth = "unavailable";
-      } else if (!options.githubAppCredentials?.webhookSecret) {
+      if (!options.githubAppCredentials?.webhookSecret) {
         reviewBlockers.push(blocker("github_app_not_configured", "operator", null));
+        reviewHealth = "unavailable";
+      } else if (!installation) {
+        reviewBlockers.push(blocker("context_review_provider_prerequisite_missing", "admin", "connect_github"));
         reviewHealth = "unavailable";
       } else if (installation.suspendedAt) {
         reviewBlockers.push(blocker("github_app_suspended", "admin", "manage_github_installation"));

--- a/packages/server/src/services/setup-capabilities.ts
+++ b/packages/server/src/services/setup-capabilities.ts
@@ -23,8 +23,19 @@ import { findInstallationByOrg, type InstallationRow } from "./github-app-instal
 import { getOrgContextReviewRuntime } from "./org-settings.js";
 
 type GithubReviewProbeResult = "ready" | "permission_required" | "repo_not_covered" | "failed";
-type GithubReviewCredentials = GithubAppCredentials & { slug?: string };
+type GithubReviewCredentials = GithubAppCredentials & { slug?: string; webhookSecret?: string };
 const GITHUB_REVIEW_PROBE_TIMEOUT_MS = 5_000;
+const GITHUB_REPOSITORY_AUTOMATION_EVENTS: ReadonlySet<string> = new Set([
+  "commit_comment",
+  "discussion",
+  "discussion_comment",
+  "issue_comment",
+  "issues",
+  "pull_request",
+  "pull_request_review",
+  "pull_request_review_comment",
+]);
+const GITHUB_AUTOMATIC_REVIEW_EVENTS = ["pull_request", "issue_comment", "pull_request_review_comment"] as const;
 
 export type SetupCapabilitiesOptions = {
   now?: () => Date;
@@ -47,6 +58,14 @@ function gitlabProcessingIsDegraded(connection: typeof gitlabConnections.$inferS
     !connection.lastValidInboundAt ||
     connection.lastProcessingFailureAt.getTime() > connection.lastValidInboundAt.getTime()
   );
+}
+
+function githubRepositoryAutomationEventsReady(events: string[]): boolean {
+  return events.some((event) => GITHUB_REPOSITORY_AUTOMATION_EVENTS.has(event));
+}
+
+function githubAutomaticReviewEventsReady(events: string[]): boolean {
+  return GITHUB_AUTOMATIC_REVIEW_EVENTS.every((event) => events.includes(event));
 }
 
 async function defaultGithubReviewProbe(
@@ -111,6 +130,7 @@ async function defaultGithubReviewProbe(
 function projectRepositoryAutomation(
   installation: InstallationRow | null,
   gitlabConnection: typeof gitlabConnections.$inferSelect | null,
+  githubWebhookConfigured: boolean,
   observedAt: string,
 ): SetupRepositoryAutomationProvider[] {
   const github: SetupRepositoryAutomationProvider = !installation
@@ -121,21 +141,37 @@ function projectRepositoryAutomation(
         blockers: [],
         observedAt,
       }
-    : installation.suspendedAt
+    : !githubWebhookConfigured
       ? {
           provider: "github",
           adoption: "enabled",
           health: "unavailable",
-          blockers: [blocker("github_app_suspended", "admin", "manage_github_installation")],
+          blockers: [blocker("github_app_not_configured", "operator", null)],
           observedAt,
         }
-      : {
-          provider: "github",
-          adoption: "enabled",
-          health: "ready",
-          blockers: [],
-          observedAt,
-        };
+      : installation.suspendedAt
+        ? {
+            provider: "github",
+            adoption: "enabled",
+            health: "unavailable",
+            blockers: [blocker("github_app_suspended", "admin", "manage_github_installation")],
+            observedAt,
+          }
+        : !githubRepositoryAutomationEventsReady(installation.events)
+          ? {
+              provider: "github",
+              adoption: "enabled",
+              health: "unavailable",
+              blockers: [blocker("github_webhook_events_missing", "operator", null)],
+              observedAt,
+            }
+          : {
+              provider: "github",
+              adoption: "enabled",
+              health: "ready",
+              blockers: [],
+              observedAt,
+            };
 
   let gitlab: SetupRepositoryAutomationProvider;
   if (!gitlabConnection) {
@@ -265,11 +301,17 @@ export async function getTeamSetupCapabilities(
       if (!installation) {
         reviewBlockers.push(blocker("context_review_provider_prerequisite_missing", "admin", "connect_github"));
         reviewHealth = "unavailable";
+      } else if (!options.githubAppCredentials?.webhookSecret) {
+        reviewBlockers.push(blocker("github_app_not_configured", "operator", null));
+        reviewHealth = "unavailable";
       } else if (installation.suspendedAt) {
         reviewBlockers.push(blocker("github_app_suspended", "admin", "manage_github_installation"));
         reviewHealth = "unavailable";
       } else if (installation.permissions.pull_requests !== "write") {
         reviewBlockers.push(blocker("github_pull_requests_permission_required", "admin", "manage_github_installation"));
+        reviewHealth = "unavailable";
+      } else if (!githubAutomaticReviewEventsReady(installation.events)) {
+        reviewBlockers.push(blocker("github_webhook_events_missing", "operator", null));
         reviewHealth = "unavailable";
       } else if (reviewHealth === "ready") {
         const probe =
@@ -320,7 +362,12 @@ export async function getTeamSetupCapabilities(
   return teamSetupCapabilitiesSchema.parse({
     organizationId,
     repositoryAutomation: {
-      providers: projectRepositoryAutomation(installation, gitlabConnection, observedAt),
+      providers: projectRepositoryAutomation(
+        installation,
+        gitlabConnection,
+        Boolean(options.githubAppCredentials?.webhookSecret),
+        observedAt,
+      ),
     },
     contextTree: {
       binding,

--- a/packages/shared/src/__tests__/setup-capabilities.test.ts
+++ b/packages/shared/src/__tests__/setup-capabilities.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  setupActionKindSchema,
+  setupBlockerSchema,
+  setupContextTreeBindingSchema,
+  setupRepositoryAutomationProviderSchema,
+  type TeamSetupCapabilities,
+  teamSetupCapabilitiesSchema,
+} from "../index.js";
+
+const observedAt = "2026-07-23T08:00:00.000Z";
+
+function validCapabilities(): TeamSetupCapabilities {
+  return {
+    organizationId: "org-1",
+    repositoryAutomation: {
+      providers: [
+        {
+          provider: "github",
+          adoption: "enabled",
+          health: "ready",
+          blockers: [],
+          observedAt,
+        },
+        {
+          provider: "gitlab",
+          adoption: "available",
+          health: "not_observed",
+          blockers: [],
+          observedAt,
+        },
+      ],
+    },
+    contextTree: {
+      binding: {
+        state: "bound",
+        provider: "github",
+        repo: "https://github.com/acme/context-tree.git",
+        branch: "main",
+      },
+      blockers: [],
+      automaticReview: {
+        adoption: "enabled",
+        health: "ready",
+        reviewerAgent: {
+          uuid: "01900000-0000-7000-8000-000000000001",
+          displayName: "Context Reviewer",
+        },
+        blockers: [],
+        observedAt,
+      },
+    },
+  };
+}
+
+describe("TeamSetupCapabilities public contract", () => {
+  it("runtime-parses the exported complete contract", () => {
+    const value = validCapabilities();
+
+    expect(teamSetupCapabilitiesSchema.parse(value)).toEqual(value);
+    expect(setupRepositoryAutomationProviderSchema.parse(value.repositoryAutomation.providers[0])).toEqual(
+      value.repositoryAutomation.providers[0],
+    );
+    expect(setupContextTreeBindingSchema.parse(value.contextTree.binding)).toEqual(value.contextTree.binding);
+    expect(setupActionKindSchema.parse("open_tree_setup_chat")).toBe("open_tree_setup_chat");
+  });
+
+  it("fails closed on unknown fields at every public object boundary", () => {
+    const value = validCapabilities();
+
+    expect(teamSetupCapabilitiesSchema.safeParse({ ...value, callerRole: "admin" }).success).toBe(false);
+    expect(
+      setupRepositoryAutomationProviderSchema.safeParse({
+        ...value.repositoryAutomation.providers[0],
+        setupUrl: "/settings/integrations/github",
+      }).success,
+    ).toBe(false);
+    expect(
+      setupBlockerSchema.safeParse({
+        code: "github_app_suspended",
+        resolutionOwner: "admin",
+        actionKind: "manage_github_installation",
+        message: "Reconnect GitHub",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects illegal unions, enum values, timestamps, and provider sets", () => {
+    const value = validCapabilities();
+
+    expect(setupContextTreeBindingSchema.safeParse({ state: "unbound", repo: "secret" }).success).toBe(false);
+    expect(
+      teamSetupCapabilitiesSchema.safeParse({
+        ...value,
+        repositoryAutomation: {
+          providers: [value.repositoryAutomation.providers[0], value.repositoryAutomation.providers[0]],
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      setupRepositoryAutomationProviderSchema.safeParse({
+        ...value.repositoryAutomation.providers[0],
+        health: "unknown",
+      }).success,
+    ).toBe(false);
+    expect(
+      setupRepositoryAutomationProviderSchema.safeParse({
+        ...value.repositoryAutomation.providers[0],
+        observedAt: "yesterday",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/__tests__/setup-capabilities.test.ts
+++ b/packages/shared/src/__tests__/setup-capabilities.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   setupActionKindSchema,
+  setupBlockerCodeSchema,
   setupBlockerSchema,
   setupContextTreeBindingSchema,
   setupRepositoryAutomationProviderSchema,
@@ -63,6 +64,8 @@ describe("TeamSetupCapabilities public contract", () => {
     );
     expect(setupContextTreeBindingSchema.parse(value.contextTree.binding)).toEqual(value.contextTree.binding);
     expect(setupActionKindSchema.parse("open_tree_setup_chat")).toBe("open_tree_setup_chat");
+    expect(setupBlockerCodeSchema.parse("github_app_not_configured")).toBe("github_app_not_configured");
+    expect(setupBlockerCodeSchema.parse("github_webhook_events_missing")).toBe("github_webhook_events_missing");
   });
 
   it("fails closed on unknown fields at every public object boundary", () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1134,6 +1134,28 @@ export {
   sessionReconcileResultSchema,
 } from "./schemas/session-reconcile.js";
 export {
+  type SetupActionKind,
+  type SetupAutomaticReview,
+  type SetupBlocker,
+  type SetupBlockerCode,
+  type SetupCapabilityHealth,
+  type SetupContextTreeBinding,
+  type SetupRepositoryAutomationProvider,
+  type SetupResolutionOwner,
+  type SetupReviewerAgent,
+  setupActionKindSchema,
+  setupAutomaticReviewSchema,
+  setupBlockerCodeSchema,
+  setupBlockerSchema,
+  setupCapabilityHealthSchema,
+  setupContextTreeBindingSchema,
+  setupRepositoryAutomationProviderSchema,
+  setupResolutionOwnerSchema,
+  setupReviewerAgentSchema,
+  type TeamSetupCapabilities,
+  teamSetupCapabilitiesSchema,
+} from "./schemas/setup-capabilities.js";
+export {
   type AgentSkills,
   agentSkillsSchema,
   SKILL_NAME_REGEX,

--- a/packages/shared/src/schemas/setup-capabilities.ts
+++ b/packages/shared/src/schemas/setup-capabilities.ts
@@ -11,7 +11,9 @@ export const setupCapabilityHealthSchema = z.enum([
 
 export const setupBlockerCodeSchema = z.enum([
   "provider_probe_failed",
+  "github_app_not_configured",
   "github_app_suspended",
+  "github_webhook_events_missing",
   "github_pull_requests_permission_required",
   "github_tree_repo_not_covered",
   "gitlab_webhook_not_seen",

--- a/packages/shared/src/schemas/setup-capabilities.ts
+++ b/packages/shared/src/schemas/setup-capabilities.ts
@@ -1,0 +1,126 @@
+import { z } from "zod";
+import { contextTreeBranchSchema, contextTreeProviderSchema, contextTreeRepoSchema } from "./org-settings.js";
+
+export const setupCapabilityHealthSchema = z.enum([
+  "not_observed",
+  "pending_verification",
+  "ready",
+  "degraded",
+  "unavailable",
+]);
+
+export const setupBlockerCodeSchema = z.enum([
+  "provider_probe_failed",
+  "github_app_suspended",
+  "github_pull_requests_permission_required",
+  "github_tree_repo_not_covered",
+  "gitlab_webhook_not_seen",
+  "gitlab_processing_failed",
+  "context_tree_binding_invalid",
+  "context_tree_provider_unresolved",
+  "context_tree_connection_mismatch",
+  "context_review_provider_prerequisite_missing",
+  "context_review_agent_missing",
+  "context_review_agent_inactive",
+]);
+
+export const setupResolutionOwnerSchema = z.enum(["admin", "operator"]);
+
+export const setupActionKindSchema = z.enum([
+  "connect_github",
+  "manage_github_installation",
+  "connect_gitlab",
+  "configure_gitlab_webhook",
+  "repair_tree_binding",
+  "open_tree_setup_chat",
+  "select_review_agent",
+  "replace_review_agent",
+]);
+
+export const setupBlockerSchema = z
+  .object({
+    code: setupBlockerCodeSchema,
+    resolutionOwner: setupResolutionOwnerSchema,
+    actionKind: setupActionKindSchema.nullable(),
+  })
+  .strict();
+
+export const setupRepositoryAutomationProviderSchema = z
+  .object({
+    provider: contextTreeProviderSchema,
+    adoption: z.enum(["available", "configuring", "enabled"]),
+    health: setupCapabilityHealthSchema,
+    blockers: z.array(setupBlockerSchema),
+    observedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const setupContextTreeBindingSchema = z.discriminatedUnion("state", [
+  z.object({ state: z.literal("unbound") }).strict(),
+  z.object({ state: z.literal("invalid") }).strict(),
+  z
+    .object({
+      state: z.literal("bound"),
+      provider: contextTreeProviderSchema,
+      repo: contextTreeRepoSchema,
+      branch: contextTreeBranchSchema,
+    })
+    .strict(),
+]);
+
+export const setupReviewerAgentSchema = z
+  .object({
+    uuid: z.string().min(1),
+    displayName: z.string().min(1),
+  })
+  .strict();
+
+export const setupAutomaticReviewSchema = z
+  .object({
+    adoption: z.enum(["unavailable", "disabled", "enabled"]),
+    health: setupCapabilityHealthSchema,
+    reviewerAgent: setupReviewerAgentSchema.nullable(),
+    blockers: z.array(setupBlockerSchema),
+    observedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const teamSetupCapabilitiesSchema = z
+  .object({
+    organizationId: z.string().min(1),
+    repositoryAutomation: z
+      .object({
+        providers: z
+          .array(setupRepositoryAutomationProviderSchema)
+          .length(2)
+          .superRefine((providers, ctx) => {
+            const providerNames = new Set(providers.map((provider) => provider.provider));
+            if (providerNames.size !== 2 || !providerNames.has("github") || !providerNames.has("gitlab")) {
+              ctx.addIssue({
+                code: "custom",
+                message: "Repository automation must contain exactly one GitHub and one GitLab provider",
+              });
+            }
+          }),
+      })
+      .strict(),
+    contextTree: z
+      .object({
+        binding: setupContextTreeBindingSchema,
+        blockers: z.array(setupBlockerSchema),
+        automaticReview: setupAutomaticReviewSchema,
+      })
+      .strict(),
+  })
+  .strict();
+
+export type SetupCapabilityHealth = z.infer<typeof setupCapabilityHealthSchema>;
+export type SetupBlockerCode = z.infer<typeof setupBlockerCodeSchema>;
+export type SetupResolutionOwner = z.infer<typeof setupResolutionOwnerSchema>;
+export type SetupActionKind = z.infer<typeof setupActionKindSchema>;
+export type SetupBlocker = z.infer<typeof setupBlockerSchema>;
+export type SetupRepositoryAutomationProvider = z.infer<typeof setupRepositoryAutomationProviderSchema>;
+export type SetupContextTreeBinding = z.infer<typeof setupContextTreeBindingSchema>;
+export type SetupReviewerAgent = z.infer<typeof setupReviewerAgentSchema>;
+export type SetupAutomaticReview = z.infer<typeof setupAutomaticReviewSchema>;
+export type TeamSetupCapabilities = z.infer<typeof teamSetupCapabilitiesSchema>;


### PR DESCRIPTION
## Summary

- add a strict shared `TeamSetupCapabilities` Zod contract and public types
- add the Class B `GET /api/v1/orgs/:orgId/setup-capabilities` route
- project Team-scoped GitHub/GitLab repository automation, Context Tree binding, and Automatic Review readiness
- fail closed for invalid bindings and map bounded GitHub exact-repository preflight failures without failing the whole endpoint

## Why

The permanent Setup surface needs one read-only, role-independent Team capability projection. Existing owner endpoints remain responsible for mutations and live rechecks; this change does not persist setup completion, clone a Context Tree snapshot, or introduce caller-specific copy or URLs.

## Impact

Members and admins receive the same stable Team facts after active membership authorization. Optional unconfigured providers remain neutral. The response exposes typed blockers and resolution ownership for the later `/settings/setup` UI.

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter @first-tree/shared test`
- `pnpm --filter @first-tree/server test`
- `pnpm --filter @first-tree/server exec vitest run src/__tests__/setup-capabilities.test.ts`
- two independent final code reviews with no unresolved blockers

The monorepo test run also completed the Web suite and most packages, but one unrelated Client capability-probe test exceeded its existing 5-second timeout; that test passed when rerun in isolation.

## QA risk

Formal QA is warranted because this touches provider, authorization, and multi-org projection paths. Existing matching cases include:

- `packages/qa/cases/cross-surface/github-settings-connection-panel.md`
- `packages/qa/cases/cross-surface/gitlab-webhook-basic-card.md`
- `packages/qa/cases/cross-surface/agent-context-tree-binding-read.md`

No database migration, Settings UI, Merge Gate, kickoff, or Context Tree change is included.
