### PR TITLE
fix(web): schedule freshness follow-up — visibility catch-up + acceptance regressions

### DIFF
--- a/packages/web/src/pages/workspace/__tests__/schedules-section-dom.test.tsx
+++ b/packages/web/src/pages/workspace/__tests__/schedules-section-dom.test.tsx
@@ -597,7 +597,7 @@ describe("SchedulesSection time freshness", () => {
       expect(document.body.textContent).toContain("in 1 minute");
       const firstRun = renderedOccurrenceInstants();
       expect(firstRun).toHaveLength(5);
-      const oldFirst = firstRun[0]!;
+      const [oldFirst] = firstRun;
       expect(oldFirst).toBeGreaterThan(Date.now());
 
       // Cross the first occurrence without collapsing/reopening the row.
@@ -642,7 +642,7 @@ describe("SchedulesSection time freshness", () => {
       document.dispatchEvent(new Event("visibilitychange"));
       await flushFake(1);
       expect(cronApiMocks.previewChatCronJobs).toHaveBeenCalledTimes(2);
-      const visibleFirst = renderedOccurrenceInstants()[0]!;
+      const [visibleFirst] = renderedOccurrenceInstants();
       expect(visibleFirst).toBeGreaterThan(Date.now());
 
       // Collapsing the row removes the preview observer: no more refetches.

--- a/packages/web/src/pages/workspace/__tests__/schedules-section-dom.test.tsx
+++ b/packages/web/src/pages/workspace/__tests__/schedules-section-dom.test.tsx
@@ -502,7 +502,9 @@ describe("SchedulesSection chat switching", () => {
 
 describe("SchedulesSection time freshness", () => {
   // Fake-timer-aware render/click/flush: the shared helpers wait on a real
-  // setTimeout(0), which never fires once timers are faked.
+  // setTimeout(0), which never fires once timers are faked. The client
+  // mirrors production (app.tsx): window-focus refetch is globally OFF, so
+  // only the section's own clock/interval/visibility policy can refresh.
   async function flushFake(ms: number): Promise<void> {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(ms);
@@ -515,7 +517,9 @@ describe("SchedulesSection time freshness", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
-    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false }, mutations: { retry: false } },
+    });
     await act(async () => {
       root?.render(
         <QueryClientProvider client={queryClient}>
@@ -532,6 +536,35 @@ describe("SchedulesSection time freshness", () => {
       el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
     });
     await flushFake(1);
+  }
+
+  function everyMinuteJob(): CronJob {
+    return makeJob({
+      schedule: "* * * * *",
+      timezone: "UTC",
+      nextRunAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+  }
+
+  /** Server-truth preview: five occurrences, one per minute, all after NOW. */
+  function everyMinutePreview(): CronPreviewResponse {
+    const first = Date.now() + 60_000;
+    return {
+      schedule: "* * * * *",
+      timezone: "UTC",
+      occurrences: [0, 1, 2, 3, 4].map((i) => {
+        const at = new Date(first + i * 60_000).toISOString();
+        return { at, local: at, timezone: "UTC" };
+      }),
+    };
+  }
+
+  function renderedOccurrenceInstants(): number[] {
+    return [...document.querySelectorAll("#schedule-detail-job-1 ol li span")].map((span) => {
+      const raw = span.textContent ?? "";
+      const iso = raw.startsWith("(") && raw.endsWith(")") ? raw.slice(1, -1) : raw;
+      return new Date(iso).getTime();
+    });
   }
 
   it("relative next-run label keeps advancing while a row stays mounted", async () => {
@@ -553,24 +586,79 @@ describe("SchedulesSection time freshness", () => {
     }
   });
 
-  it("expanded preview refetches on the interval so occurrences stay future", async () => {
+  it("expanded preview refetches: label advances, old first occurrence gone, five stay future", async () => {
     vi.useFakeTimers();
     try {
-      cronApiMocks.previewChatCronJobs.mockResolvedValueOnce(previewResponse("2030-01-05T14:00:00.000Z"));
-      await renderFake([makeJob()]);
+      cronApiMocks.previewChatCronJobs.mockImplementation(async () => everyMinutePreview());
+      await renderFake([everyMinuteJob()]);
       await clickFake(document.querySelector("button[aria-expanded]"));
 
       expect(cronApiMocks.previewChatCronJobs).toHaveBeenCalledTimes(1);
-      expect(document.body.textContent).toContain("2030-01-05T14:00:00.000Z");
+      expect(document.body.textContent).toContain("in 1 minute");
+      const firstRun = renderedOccurrenceInstants();
+      expect(firstRun).toHaveLength(5);
+      const oldFirst = firstRun[0]!;
+      expect(oldFirst).toBeGreaterThan(Date.now());
 
-      cronApiMocks.previewChatCronJobs.mockResolvedValueOnce(previewResponse("2030-02-11T14:00:00.000Z"));
-      await flushFake(60_000);
+      // Cross the first occurrence without collapsing/reopening the row.
+      await flushFake(61_000);
 
       expect(cronApiMocks.previewChatCronJobs).toHaveBeenCalledTimes(2);
-      expect(document.body.textContent).toContain("2030-02-11T14:00:00.000Z");
-      // The row never collapsed/reopened to get there.
+      expect(document.body.textContent).toContain("due now");
       expect(document.querySelector("button[aria-expanded]")?.getAttribute("aria-expanded")).toBe("true");
+      const now = Date.now();
+      const after = renderedOccurrenceInstants();
+      expect(after).toHaveLength(5);
+      expect(after).not.toContain(oldFirst);
+      for (const instant of after) {
+        expect(instant).toBeGreaterThan(now);
+      }
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("catches up immediately on visible after a hidden gap, and stops all clocks on collapse/unmount", async () => {
+    vi.useFakeTimers();
+    try {
+      cronApiMocks.previewChatCronJobs.mockImplementation(async () => everyMinutePreview());
+      await renderFake([everyMinuteJob()]);
+      await clickFake(document.querySelector("button[aria-expanded]"));
+      expect(cronApiMocks.previewChatCronJobs).toHaveBeenCalledTimes(1);
+
+      // Hidden transition must not catch up.
+      Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+      document.dispatchEvent(new Event("visibilitychange"));
+      await flushFake(1);
+      expect(cronApiMocks.previewChatCronJobs).toHaveBeenCalledTimes(1);
+
+      // Time passes in the background; interval refetches stay paused.
+      await flushFake(120_000);
+      expect(cronApiMocks.previewChatCronJobs).toHaveBeenCalledTimes(1);
+
+      // Becoming visible triggers the local catch-up immediately — far from
+      // any 60s interval boundary.
+      Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+      document.dispatchEvent(new Event("visibilitychange"));
+      await flushFake(1);
+      expect(cronApiMocks.previewChatCronJobs).toHaveBeenCalledTimes(2);
+      const visibleFirst = renderedOccurrenceInstants()[0]!;
+      expect(visibleFirst).toBeGreaterThan(Date.now());
+
+      // Collapsing the row removes the preview observer: no more refetches.
+      await clickFake(document.querySelector("button[aria-expanded]"));
+      await flushFake(120_000);
+      expect(cronApiMocks.previewChatCronJobs).toHaveBeenCalledTimes(2);
+
+      // Unmount stops every interval (clock, list poll, preview poll).
+      const listCallsBeforeUnmount = cronApiMocks.listChatCronJobs.mock.calls.length;
+      await act(async () => root?.unmount());
+      root = null;
+      await flushFake(120_000);
+      expect(cronApiMocks.previewChatCronJobs).toHaveBeenCalledTimes(2);
+      expect(cronApiMocks.listChatCronJobs.mock.calls.length).toBe(listCallsBeforeUnmount);
+    } finally {
+      Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
       vi.useRealTimers();
     }
   });

--- a/packages/web/src/pages/workspace/conversations/__tests__/row-engagement-menu-dom.test.tsx
+++ b/packages/web/src/pages/workspace/conversations/__tests__/row-engagement-menu-dom.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import type { CronJob } from "@first-tree/shared";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -76,6 +76,19 @@ function activeJob(overrides: Partial<CronJob> = {}): CronJob {
 let root: Root | null = null;
 let queryClient: QueryClient;
 
+const CRON_KEY = ["chat-right-sidebar", "cron-jobs", "chat-1"] as const;
+
+/** Keeps the shared schedule cache ACTIVELY OBSERVED so an invalidation
+ *  triggers a real refetch, exactly like the mounted sidebar section. */
+function CronProbe() {
+  useQuery({ queryKey: CRON_KEY, queryFn: () => cronApiMocks.listChatCronJobs("chat-1") });
+  return null;
+}
+
+function probeJobs(): CronJob[] {
+  return queryClient.getQueryData<{ items: CronJob[] }>(CRON_KEY)?.items ?? [];
+}
+
 async function flush(): Promise<void> {
   await act(async () => {
     await Promise.resolve();
@@ -83,7 +96,7 @@ async function flush(): Promise<void> {
   });
 }
 
-async function renderMenu(status: "active" | "archived"): Promise<void> {
+async function renderMenu(status: "active" | "archived", opts?: { withProbe?: boolean }): Promise<void> {
   const { RowEngagementMenu } = await import("../row-engagement-menu.js");
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -95,6 +108,7 @@ async function renderMenu(status: "active" | "archived"): Promise<void> {
     root?.render(
       <QueryClientProvider client={queryClient}>
         <RowEngagementMenu chatId="chat-1" status={status} hasUnread={false} pinned={false} />
+        {opts?.withProbe ? <CronProbe /> : null}
       </QueryClientProvider>,
     );
   });
@@ -279,15 +293,49 @@ describe("RowEngagementMenu schedule warnings", () => {
     expect(chatApiMocks.patchChatEngagement).toHaveBeenCalledWith("chat-1", "archived");
   });
 
-  it("delete refreshes the chat's schedule projection — the server pause emits no chat:updated", async () => {
-    cronApiMocks.listChatCronJobs.mockResolvedValue({ items: [activeJob()] });
+  it("delete refreshes the shared schedule cache to the server truth: owned paused, others untouched", async () => {
+    const owned = activeJob();
+    const other = activeJob({ id: "job-2", ownerMemberId: "member-other" });
+    cronApiMocks.listChatCronJobs.mockResolvedValue({ items: [owned, other] });
+    await renderMenu("active", { withProbe: true });
+    // The actively-observed cache (as the sidebar sees it) starts with both
+    // owners' jobs active.
+    expect(probeJobs().map((j) => j.state)).toEqual(["active", "active"]);
+
+    await selectMenuItem("Delete");
+    // The Server applies the owner-scoped pause without emitting
+    // chat:updated; the next read after the delete returns the new truth.
+    const pausedOwned: CronJob = {
+      ...owned,
+      state: "paused",
+      stateReason: "owner_chat_deleted",
+      revision: 2,
+      nextRunAt: null,
+    };
+    cronApiMocks.listChatCronJobs.mockResolvedValue({ items: [pausedOwned, other] });
+    await click(buttonByText("Delete chat"));
+
+    expect(chatApiMocks.patchChatEngagement).toHaveBeenCalledWith("chat-1", "deleted");
+    const jobs = probeJobs();
+    const after = jobs.find((j) => j.id === "job-1");
+    expect(after?.state).toBe("paused");
+    expect(after?.stateReason).toBe("owner_chat_deleted");
+    expect(after?.revision).toBe(2);
+    expect(jobs.find((j) => j.id === "job-2")?.state).toBe("active");
+  });
+
+  it("a failed delete leaves the shared schedule cache untouched", async () => {
+    const owned = activeJob();
+    cronApiMocks.listChatCronJobs.mockResolvedValue({ items: [owned] });
     const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries");
-    await renderMenu("active");
+    chatApiMocks.patchChatEngagement.mockRejectedValue(new Error("boom"));
+    await renderMenu("active", { withProbe: true });
     await selectMenuItem("Delete");
     await click(buttonByText("Delete chat"));
 
     expect(chatApiMocks.patchChatEngagement).toHaveBeenCalledWith("chat-1", "deleted");
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["chat-right-sidebar", "cron-jobs", "chat-1"] });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: CRON_KEY });
+    expect(probeJobs().map((j) => j.state)).toEqual(["active"]);
   });
 
   it("archive does not touch the schedule projection (no server-side pause happens)", async () => {

--- a/packages/web/src/pages/workspace/right-sidebar/schedules-section.tsx
+++ b/packages/web/src/pages/workspace/right-sidebar/schedules-section.tsx
@@ -169,6 +169,25 @@ export function SchedulesSection({ chatId, participants }: { chatId: string; par
   const { items, isLoading, isError, retry } = useChatCronJobs(chatId);
   const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
   const now = useNow();
+  const queryClient = useQueryClient();
+
+  // Immediate catch-up after a hidden/backgrounded tab returns. The 60s poll
+  // skips background tabs and global focus refetch is disabled, so without a
+  // local visibility listener an expanded preview could show occurrences from
+  // before the sleep until the next interval fires.
+  useEffect(() => {
+    const catchUp = () => {
+      if (document.visibilityState !== "visible") return;
+      void queryClient.invalidateQueries({ queryKey: cronJobsQueryKey(chatId) });
+      void queryClient.invalidateQueries({ queryKey: ["chat-right-sidebar", "cron-preview", chatId] });
+    };
+    document.addEventListener("visibilitychange", catchUp);
+    window.addEventListener("pageshow", catchUp);
+    return () => {
+      document.removeEventListener("visibilitychange", catchUp);
+      window.removeEventListener("pageshow", catchUp);
+    };
+  }, [queryClient, chatId]);
 
   // First load gets an identifiable lightweight row: rendering nothing could
   // read as "this chat has no schedules" while the answer is still unknown.


### PR DESCRIPTION
## What

Post-merge remediation delta for #1959. The PR was squash-merged (`fd019033`) while GitHub's PR view still advertised head `28db4011…`, so the two newest branch commits did not make the squash. Main is missing:

1. **Visibility catch-up in the Schedules section** (product code): with global focus refetch disabled and background tabs skipping the 60s poll, a hidden→visible return now immediately invalidates the chat's schedule list and expanded previews instead of showing pre-sleep occurrences until the next interval.
2. **Acceptance-strength regressions** (tests only):
   - Delete engagement proves itself in the **shared cache** (actively-observed cron-jobs query refetches to server truth: owned job `paused`/`owner_chat_deleted`/revision bump, other-owner untouched; failed delete leaves cache and invalidation untouched) instead of a spy-only assertion.
   - Preview freshness uses a **dynamic every-minute fixture**: advancing past the first occurrence without collapse/reopen advances the relative label, removes the stale occurrence, keeps exactly five rendered occurrences future, and refetches; collapse removes the preview observer and unmount stops every interval.

Both items were requested in the incremental reacceptance of `28db4011…` and landed on the branch after the merge.

## Scope

Strictly `packages/web/**` (3 files): the section's visibility listener plus the two rewritten/new test files' changes. Cherry-picked verbatim from the merged PR's branch (`0d3fbd05…`, `994d0a50…`). No Backend/API/Tree changes.

## Evidence

- Focused suites on this branch: **41/41 pass** (schedule section + engagement menu).
- Full suite on the pre-merge head containing these exact commits: **197 files / 1661 tests pass**; `pnpm check` clean (no new warnings); typecheck + design-token guard pass; production build pass.
- One intermittent `pages/mobile/card-actions-dom` failure observed in a single full-suite run; isolated and repeated full runs are green (pre-existing cross-file timing flake; no mobile files touched).
