### PR TITLE
feat: provision Context Reviewer after Context Tree setup

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1366,8 +1366,12 @@ the setting is still unbound at exactly `expectedUnboundBranch`, the branch read
 during preflight. A competing full binding or branch-only change returns 409
 and is left unchanged. This dedicated endpoint also prevents an older Server
 from interpreting conditional finalization as an ordinary unconditional
-settings write. `--rebind` intentionally bypasses this compare-and-set path and
-uses the generic `PUT /api/v1/orgs/:orgId/settings/context_tree` with only
+settings write. When a new binding commits, the same transaction creates and
+assigns an organization-visible Context Reviewer Agent with a minimal
+`context-tree-review` instruction unless the Team already has a Reviewer
+assigned; an existing assignment is preserved. The new Reviewer starts without
+a Computer binding. `--rebind` intentionally bypasses this compare-and-set path
+and uses the generic `PUT /api/v1/orgs/:orgId/settings/context_tree` with only
 `repo` and `branch` to replace the binding directly. The CLI strictly validates
 the final response before reporting success.
 

--- a/packages/server/src/__tests__/context-tree-initialize.test.ts
+++ b/packages/server/src/__tests__/context-tree-initialize.test.ts
@@ -2,6 +2,7 @@ import { generateKeyPairSync } from "node:crypto";
 import { and, eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { agents } from "../db/schema/agents.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { members } from "../db/schema/members.js";
 import { organizationSettings } from "../db/schema/organization-settings.js";
@@ -148,6 +149,24 @@ owners: [${ACCOUNT_LOGIN}]
 
     const setting = await getOrgContextTreeBinding(app.db, admin.organizationId);
     expect(setting).toEqual({ provider: "github", repo: CLONE_URL, branch: "main" });
+    const features = await getOrgSetting(app.db, admin.organizationId, "context_tree_features");
+    expect(features.contextReviewer).toMatchObject({
+      enabled: true,
+      reviewerAgent: {
+        name: "context-reviewer",
+        displayName: "Context Reviewer",
+      },
+    });
+    const [reviewer] = await app.db
+      .select({ managerId: agents.managerId, visibility: agents.visibility, clientId: agents.clientId })
+      .from(agents)
+      .where(eq(agents.uuid, features.contextReviewer.agentUuid ?? "missing"))
+      .limit(1);
+    expect(reviewer).toEqual({
+      managerId: admin.memberId,
+      visibility: "organization",
+      clientId: null,
+    });
   });
 
   it("does not let initialize overwrite a binding committed after its absent precheck", async () => {

--- a/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
+++ b/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
@@ -613,7 +613,12 @@ describe("org context tree routes with mocked service edges", () => {
       ctx.app.db,
       ctx.scope.organizationId,
       { provider: "github", repo: expectedRepo.cloneUrl, branch: "main" },
-      { expectedUnboundBranch: "main", updatedBy: ctx.scope.userId, gitlabEgressAllowlist: [] },
+      {
+        expectedUnboundBranch: "main",
+        managerId: ctx.scope.memberId,
+        updatedBy: ctx.scope.userId,
+        gitlabEgressAllowlist: [],
+      },
     );
   });
 });

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from "fastify";
 import postgres from "postgres";
 import { describe, expect, it, vi } from "vitest";
 import { connectDatabase, sslOptions } from "../db/connection.js";
+import { agentResourceBindings } from "../db/schema/agent-resource-bindings.js";
 import { agents } from "../db/schema/agents.js";
 import { members } from "../db/schema/members.js";
 import { organizationSettings } from "../db/schema/organization-settings.js";
@@ -12,6 +13,7 @@ import { organizations } from "../db/schema/organizations.js";
 import { users } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
 import { signTokensForUser } from "../services/auth.js";
+import { INITIAL_CONTEXT_REVIEWER_PROMPT } from "../services/context-reviewer-provisioning.js";
 import { upsertInstallationFromMetadata } from "../services/github-app-installations.js";
 import { createGitlabConnection } from "../services/gitlab-connections.js";
 import * as orgSettingsService from "../services/org-settings.js";
@@ -225,7 +227,7 @@ describe("org-settings service", () => {
     });
   });
 
-  it("putInitializedOrgContextTreeBinding initializes a branch-only row", async () => {
+  it("putInitializedOrgContextTreeBinding initializes a branch-only row and provisions its Reviewer Agent", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);
     await app.db.insert(organizationSettings).values({
@@ -241,7 +243,7 @@ describe("org-settings service", () => {
         app.db,
         admin.organizationId,
         { repo: "https://github.com/example/initialized.git", branch: "main" },
-        { expectedUnboundBranch: "legacy-branch", updatedBy: admin.userId },
+        { expectedUnboundBranch: "legacy-branch", managerId: admin.memberId, updatedBy: admin.userId },
       ),
     ).resolves.toEqual({ repo: "https://github.com/example/initialized.git", branch: "main" });
 
@@ -258,6 +260,134 @@ describe("org-settings service", () => {
       value: { repo: "https://github.com/example/initialized.git", branch: "main" },
       version: 5,
     });
+
+    const features = await orgSettingsService.getOrgSetting(app.db, admin.organizationId, "context_tree_features");
+    expect(features.contextReviewer).toMatchObject({
+      enabled: true,
+      reviewerAgent: {
+        name: "context-reviewer",
+        displayName: "Context Reviewer",
+      },
+    });
+    const reviewerUuid = features.contextReviewer.agentUuid;
+    expect(reviewerUuid).toBeTruthy();
+    const [reviewer] = await app.db
+      .select({
+        uuid: agents.uuid,
+        organizationId: agents.organizationId,
+        managerId: agents.managerId,
+        type: agents.type,
+        visibility: agents.visibility,
+        clientId: agents.clientId,
+      })
+      .from(agents)
+      .where(eq(agents.uuid, reviewerUuid ?? "missing"))
+      .limit(1);
+    expect(reviewer).toEqual({
+      uuid: reviewerUuid,
+      organizationId: admin.organizationId,
+      managerId: admin.memberId,
+      type: "agent",
+      visibility: "organization",
+      clientId: null,
+    });
+    const [promptBinding] = await app.db
+      .select({
+        type: agentResourceBindings.type,
+        mode: agentResourceBindings.mode,
+        inlinePromptBody: agentResourceBindings.inlinePromptBody,
+      })
+      .from(agentResourceBindings)
+      .where(eq(agentResourceBindings.agentId, reviewerUuid ?? "missing"))
+      .limit(1);
+    expect(promptBinding).toEqual({
+      type: "prompt",
+      mode: "include",
+      inlinePromptBody: INITIAL_CONTEXT_REVIEWER_PROMPT,
+    });
+  });
+
+  it("putInitializedOrgContextTreeBinding preserves an already configured Reviewer Agent", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const existingReviewer = await createReviewerAgent(app, {
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+      name: "existing-context-reviewer",
+    });
+    await app.db.insert(organizationSettings).values({
+      organizationId: admin.organizationId,
+      namespace: "context_tree_features",
+      value: { contextReviewer: { enabled: true, agentUuid: existingReviewer.uuid } },
+      version: 3,
+      updatedBy: admin.userId,
+    });
+    const before = await app.db
+      .select({ uuid: agents.uuid })
+      .from(agents)
+      .where(and(eq(agents.organizationId, admin.organizationId), eq(agents.type, "agent")));
+
+    await expect(
+      orgSettingsService.putInitializedOrgContextTreeBinding(
+        app.db,
+        admin.organizationId,
+        { provider: "github", repo: "https://github.com/example/initialized.git", branch: "main" },
+        { expectedUnboundBranch: "main", managerId: admin.memberId, updatedBy: admin.userId },
+      ),
+    ).resolves.toEqual({
+      provider: "github",
+      repo: "https://github.com/example/initialized.git",
+      branch: "main",
+    });
+
+    const after = await app.db
+      .select({ uuid: agents.uuid })
+      .from(agents)
+      .where(and(eq(agents.organizationId, admin.organizationId), eq(agents.type, "agent")));
+    expect(after).toEqual(before);
+    await expect(
+      orgSettingsService.getOrgSetting(app.db, admin.organizationId, "context_tree_features"),
+    ).resolves.toMatchObject({
+      contextReviewer: {
+        enabled: true,
+        agentUuid: existingReviewer.uuid,
+      },
+    });
+  });
+
+  it("putInitializedOrgContextTreeBinding replaces a suspended configured Reviewer Agent", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const suspendedReviewer = await createReviewerAgent(app, {
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+      name: "suspended-context-reviewer",
+    });
+    await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, suspendedReviewer.uuid));
+    await app.db.insert(organizationSettings).values({
+      organizationId: admin.organizationId,
+      namespace: "context_tree_features",
+      value: { contextReviewer: { enabled: true, agentUuid: suspendedReviewer.uuid } },
+      version: 3,
+      updatedBy: admin.userId,
+    });
+
+    await orgSettingsService.putInitializedOrgContextTreeBinding(
+      app.db,
+      admin.organizationId,
+      { provider: "github", repo: "https://github.com/example/initialized.git", branch: "main" },
+      { expectedUnboundBranch: "main", managerId: admin.memberId, updatedBy: admin.userId },
+    );
+
+    const features = await orgSettingsService.getOrgSetting(app.db, admin.organizationId, "context_tree_features");
+    expect(features.contextReviewer).toMatchObject({
+      enabled: true,
+      reviewerAgent: {
+        name: "context-reviewer",
+        displayName: "Context Reviewer",
+      },
+    });
+    expect(features.contextReviewer.agentUuid).not.toBe(suspendedReviewer.uuid);
   });
 
   it("putInitializedOrgContextTreeBinding preserves a branch changed after preflight", async () => {
@@ -277,7 +407,7 @@ describe("org-settings service", () => {
         app.db,
         admin.organizationId,
         { repo: "https://github.com/example/stale-initializer.git", branch: "main" },
-        { expectedUnboundBranch: "main", updatedBy: admin.userId },
+        { expectedUnboundBranch: "main", managerId: admin.memberId, updatedBy: admin.userId },
       ),
     ).rejects.toThrow("Context Tree setting changed after tree initialization began");
 
@@ -310,7 +440,7 @@ describe("org-settings service", () => {
         app.db,
         admin.organizationId,
         { repo: "https://github.com/example/initialized.git", branch: "main" },
-        { expectedUnboundBranch: "main", updatedBy: admin.userId },
+        { expectedUnboundBranch: "main", managerId: admin.memberId, updatedBy: admin.userId },
       ),
     ).rejects.toThrow("Context Tree setting changed after tree initialization began");
 
@@ -347,7 +477,7 @@ describe("org-settings service", () => {
         app.db,
         admin.organizationId,
         { repo: "https://github.com/example/initialized.git", branch: "main" },
-        { expectedUnboundBranch: "main", updatedBy: admin.userId },
+        { expectedUnboundBranch: "main", managerId: admin.memberId, updatedBy: admin.userId },
       ),
     ).rejects.toThrow("Context Tree setting changed after tree initialization began");
 

--- a/packages/server/src/api/orgs/context-tree.ts
+++ b/packages/server/src/api/orgs/context-tree.ts
@@ -468,6 +468,7 @@ export async function orgContextTreeRoutes(app: FastifyInstance): Promise<void> 
     let setting: ContextTreeActiveBinding;
     try {
       setting = await putInitializedOrgContextTreeBinding(app.db, finalScope.organizationId, initializedBinding.data, {
+        managerId: finalScope.memberId,
         expectedUnboundBranch: existing.branch,
         updatedBy: finalScope.userId,
         gitlabEgressAllowlist: app.config.gitlab?.egressAllowlist ?? [],

--- a/packages/server/src/api/orgs/settings.ts
+++ b/packages/server/src/api/orgs/settings.ts
@@ -50,6 +50,7 @@ export async function orgSettingsRoutes(app: FastifyInstance): Promise<void> {
         scope.organizationId,
         { provider: input.provider, repo: input.repo, branch: input.branch },
         {
+          managerId: scope.memberId,
           updatedBy: scope.userId,
           expectedUnboundBranch: input.expectedUnboundBranch,
           gitlabEgressAllowlist: app.config.gitlab?.egressAllowlist ?? [],

--- a/packages/server/src/services/context-reviewer-provisioning.ts
+++ b/packages/server/src/services/context-reviewer-provisioning.ts
@@ -1,0 +1,226 @@
+import { AGENT_TYPES, AGENT_VISIBILITY, ORG_SETTINGS_NAMESPACES } from "@first-tree/shared";
+import { and, eq, ne, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agentResourceBindings } from "../db/schema/agent-resource-bindings.js";
+import { agents } from "../db/schema/agents.js";
+import { members } from "../db/schema/members.js";
+import { organizationSettings } from "../db/schema/organization-settings.js";
+import { ConflictError } from "../errors.js";
+import { uuidv7 } from "../uuid.js";
+import { createAgent } from "./agent.js";
+
+export const INITIAL_CONTEXT_REVIEWER_PROMPT =
+  "Use $context-tree-review for Context Tree pull request and merge request review work.";
+
+const CONTEXT_REVIEWER_AGENT_NAME = "context-reviewer";
+const CONTEXT_REVIEWER_DISPLAY_NAME = "Context Reviewer";
+
+class InvalidContextReviewerAssignmentError extends Error {}
+
+type EnsureInitializedContextReviewerInput = {
+  organizationId: string;
+  managerId: string;
+  updatedBy: string;
+};
+
+/**
+ * Complete Context Tree initialization with a dedicated Reviewer Agent.
+ *
+ * The caller holds the organization settings mutation lock and runs this
+ * helper in the same transaction as the new Context Tree binding. The feature
+ * assignment is the idempotency key: an existing assignment is preserved, so
+ * retries never create another Reviewer Agent.
+ */
+export async function ensureInitializedContextReviewer(
+  db: Database,
+  input: EnsureInitializedContextReviewerInput,
+): Promise<{ agentUuid: string; created: boolean }> {
+  const [featuresRow] = await db
+    .select({ value: organizationSettings.value })
+    .from(organizationSettings)
+    .where(
+      and(
+        eq(organizationSettings.organizationId, input.organizationId),
+        eq(organizationSettings.namespace, "context_tree_features"),
+      ),
+    )
+    .limit(1);
+  const features = ORG_SETTINGS_NAMESPACES.context_tree_features.storage.parse(featuresRow?.value ?? {});
+  const configuredAgentUuid = features.contextReviewer.agentUuid;
+
+  if (
+    configuredAgentUuid &&
+    (await preserveValidContextReviewerAssignment(db, input.organizationId, configuredAgentUuid))
+  ) {
+    if (!features.contextReviewer.enabled) {
+      await saveContextReviewerAssignment(db, input, configuredAgentUuid);
+    }
+    return { agentUuid: configuredAgentUuid, created: false };
+  }
+
+  const reviewer = await createContextReviewerAgent(db, input);
+  await db.insert(agentResourceBindings).values({
+    id: uuidv7(),
+    organizationId: input.organizationId,
+    agentId: reviewer.uuid,
+    type: "prompt",
+    mode: "include",
+    resourceId: null,
+    replacesResourceId: null,
+    inlinePromptBody: INITIAL_CONTEXT_REVIEWER_PROMPT,
+    repoRef: null,
+    repoLocalPath: null,
+    order: 0,
+    createdBy: input.managerId,
+    updatedBy: input.managerId,
+  });
+  await saveContextReviewerAssignment(db, input, reviewer.uuid);
+  return { agentUuid: reviewer.uuid, created: true };
+}
+
+/**
+ * Validate inside a savepoint so an invalid assignment releases its Agent row
+ * lock before replacement creation takes the new manager's member lock. A
+ * successful savepoint keeps its row lock until the caller's outer transaction
+ * commits, preserving idempotency against concurrent lifecycle writes.
+ */
+async function preserveValidContextReviewerAssignment(
+  db: Database,
+  organizationId: string,
+  agentUuid: string,
+): Promise<boolean> {
+  try {
+    await db.transaction(async (tx) => {
+      const txDb = tx as unknown as Database;
+      if (!(await lockValidContextReviewerAgent(txDb, organizationId, agentUuid))) {
+        throw new InvalidContextReviewerAssignmentError();
+      }
+    });
+    return true;
+  } catch (error) {
+    if (error instanceof InvalidContextReviewerAssignmentError) return false;
+    throw error;
+  }
+}
+
+/**
+ * Lock the Agent before reading its current manager so reassignment, suspension,
+ * and deletion serialize on one stable row. The manager read intentionally
+ * remains non-locking: membership departure takes member → agent locks, so a
+ * reverse lock here could deadlock. A concurrent departure that already owns
+ * the member row is ordered after this transaction when it reaches the locked
+ * Agent; one that commits first is visible through the Agent's current manager.
+ */
+async function lockValidContextReviewerAgent(
+  db: Database,
+  organizationId: string,
+  agentUuid: string,
+): Promise<boolean> {
+  const [agent] = await db
+    .select({
+      managerId: agents.managerId,
+      organizationId: agents.organizationId,
+      status: agents.status,
+      type: agents.type,
+    })
+    .from(agents)
+    .where(eq(agents.uuid, agentUuid))
+    .for("update")
+    .limit(1);
+  if (
+    !agent ||
+    agent.organizationId !== organizationId ||
+    agent.type !== AGENT_TYPES.AGENT ||
+    agent.status !== "active"
+  ) {
+    return false;
+  }
+
+  const [manager] = await db
+    .select({ id: members.id })
+    .from(members)
+    .where(
+      and(eq(members.id, agent.managerId), eq(members.organizationId, organizationId), eq(members.status, "active")),
+    )
+    .limit(1);
+  return Boolean(manager);
+}
+
+async function createContextReviewerAgent(
+  db: Database,
+  input: EnsureInitializedContextReviewerInput,
+): ReturnType<typeof createAgent> {
+  const [existingName] = await db
+    .select({ uuid: agents.uuid })
+    .from(agents)
+    .where(
+      and(
+        eq(agents.organizationId, input.organizationId),
+        eq(agents.name, CONTEXT_REVIEWER_AGENT_NAME),
+        ne(agents.status, "deleted"),
+      ),
+    )
+    .limit(1);
+  const preferredName = existingName ? uniqueContextReviewerName() : CONTEXT_REVIEWER_AGENT_NAME;
+
+  try {
+    return await createAgent(db, {
+      name: preferredName,
+      type: AGENT_TYPES.AGENT,
+      displayName: CONTEXT_REVIEWER_DISPLAY_NAME,
+      organizationId: input.organizationId,
+      managerId: input.managerId,
+      source: "admin-api",
+      visibility: AGENT_VISIBILITY.ORGANIZATION,
+    });
+  } catch (error) {
+    // Agent creation is independent of the organization-settings lock. If a
+    // concurrent user claims the clean slug after the read above, keep tree
+    // initialization convergent with a collision-resistant dedicated slug.
+    if (preferredName === CONTEXT_REVIEWER_AGENT_NAME && error instanceof ConflictError) {
+      return createAgent(db, {
+        name: uniqueContextReviewerName(),
+        type: AGENT_TYPES.AGENT,
+        displayName: CONTEXT_REVIEWER_DISPLAY_NAME,
+        organizationId: input.organizationId,
+        managerId: input.managerId,
+        source: "admin-api",
+        visibility: AGENT_VISIBILITY.ORGANIZATION,
+      });
+    }
+    throw error;
+  }
+}
+
+function uniqueContextReviewerName(): string {
+  return `${CONTEXT_REVIEWER_AGENT_NAME}-${uuidv7().replaceAll("-", "").slice(-10)}`;
+}
+
+async function saveContextReviewerAssignment(
+  db: Database,
+  input: EnsureInitializedContextReviewerInput,
+  agentUuid: string,
+): Promise<void> {
+  const value = ORG_SETTINGS_NAMESPACES.context_tree_features.storage.parse({
+    contextReviewer: { enabled: true, agentUuid },
+  });
+  await db
+    .insert(organizationSettings)
+    .values({
+      organizationId: input.organizationId,
+      namespace: "context_tree_features",
+      value,
+      version: 1,
+      updatedBy: input.updatedBy,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [organizationSettings.organizationId, organizationSettings.namespace],
+      set: {
+        value,
+        version: sql`${organizationSettings.version} + 1`,
+        updatedBy: input.updatedBy,
+        updatedAt: new Date(),
+      },
+    });
+}

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -26,6 +26,7 @@ import { organizationSettings } from "../db/schema/organization-settings.js";
 import { organizations } from "../db/schema/organizations.js";
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError } from "../errors.js";
 import { pickDefaultMembership } from "./auth.js";
+import { ensureInitializedContextReviewer } from "./context-reviewer-provisioning.js";
 import { type GitlabEgressAllowlistEntry, isGitlabOriginAuthorized } from "./gitlab-egress-policy.js";
 
 /**
@@ -468,6 +469,7 @@ export async function putInitializedOrgContextTreeBinding(
   rawInput: unknown,
   options: {
     updatedBy: string;
+    managerId: string;
     expectedUnboundBranch: string;
     gitlabEgressAllowlist?: readonly GitlabEgressAllowlistEntry[];
   },
@@ -528,6 +530,11 @@ export async function putInitializedOrgContextTreeBinding(
     if (!row) {
       throw new ConflictError("Context Tree setting changed after tree initialization began");
     }
+    await ensureInitializedContextReviewer(txDb, {
+      organizationId: orgId,
+      managerId: options.managerId,
+      updatedBy: options.updatedBy,
+    });
     return contextTreeActiveBindingSchema.parse(row.value);
   });
 }


### PR DESCRIPTION
## Summary

- provision a dedicated organization-visible Context Reviewer Agent when Context Tree initialization commits
- attach a minimal prompt that routes Context Tree PR/MR work to `$context-tree-review` and assign the Agent as the Team's Reviewer in the same transaction
- preserve a valid existing Reviewer assignment, replace stale invalid assignments, and keep ordinary Context Tree rebinds unchanged
- document that the provisioned Reviewer starts without a Computer binding

## Testing

- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter @first-tree/server test` (243 files, 2631 tests)
- `pnpm exec vitest run src/__tests__/org-settings.test.ts src/__tests__/context-tree-initialize.test.ts src/__tests__/context-tree-routes-mocked.test.ts` (148 tests)
- two independent code reviews, including transaction/idempotency and product/provider regression passes

Closes #1977
