### PR TITLE
fix: accept GitLab system hooks

### DIFF
--- a/packages/server/src/__tests__/gitlab-identity-fencing.test.ts
+++ b/packages/server/src/__tests__/gitlab-identity-fencing.test.ts
@@ -89,7 +89,7 @@ async function postMr(app: App, bearer: string, reviewers: { username: string }[
   return app.inject({
     method: "POST",
     url: `/api/v1/webhooks/gitlab/${bearer}`,
-    headers: { "content-type": "application/json", "x-gitlab-event": "Merge Request Hook" },
+    headers: { "content-type": "application/json", "x-gitlab-event": "System Hook" },
     payload: JSON.stringify(mrPayload(reviewers)),
   });
 }
@@ -108,7 +108,7 @@ async function holdIngressAfterDurableCard(
     connectionId: fixture.connection.connectionId,
     instanceOrigin: "https://gitlab.internal",
     stableDeliveryId: null,
-    eventHeader: "Merge Request Hook",
+    eventHeader: "System Hook",
     body: mrPayload(reviewers),
   });
   const applied = applyGitlabPersonnelEvidence(normalized, "reviewers");
@@ -172,7 +172,7 @@ describe("GitLab identity authority fencing", () => {
       connectionId: fixture.connection.connectionId,
       instanceOrigin: "https://gitlab.internal",
       stableDeliveryId: null,
-      eventHeader: "Merge Request Hook",
+      eventHeader: "System Hook",
       body: mrPayload([], "Reviewer.One", iid),
     });
     const applied = applyGitlabPersonnelEvidence(normalized, "reviewers");
@@ -235,7 +235,7 @@ describe("GitLab identity authority fencing", () => {
     const response = await app.inject({
       method: "POST",
       url: `/api/v1/webhooks/gitlab/${fixture.connection.bearer}`,
-      headers: { "content-type": "application/json", "x-gitlab-event": "Merge Request Hook" },
+      headers: { "content-type": "application/json", "x-gitlab-event": "System Hook" },
       payload: JSON.stringify(mrPayload([], "Reviewer.One", iid)),
     });
     expect(response.statusCode).toBe(200);

--- a/packages/server/src/__tests__/gitlab-webhook-normalize.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-normalize.test.ts
@@ -19,6 +19,58 @@ function project() {
 }
 
 describe("GitLab webhook normalization", () => {
+  it("classifies GitLab System Hook merge requests and ignores unrelated instance events", () => {
+    const mr = normalizeGitlabWebhook({
+      ...base,
+      eventHeader: "System Hook",
+      body: {
+        object_kind: "merge_request",
+        project: project(),
+        user: { username: "alice" },
+        reviewers: [],
+        object_attributes: {
+          iid: 7,
+          action: "open",
+          title: "System Hook MR",
+          url: "https://gitlab.internal/Acme/API/-/merge_requests/7",
+        },
+      },
+    });
+    expect(mr.event).toMatchObject({
+      eventType: "merge_request",
+      kind: "opened",
+      entity: { type: "pull_request", key: "99:pull_request:7" },
+    });
+
+    const repositoryUpdate = normalizeGitlabWebhook({
+      ...base,
+      eventHeader: "System Hook",
+      body: { event_name: "repository_update", project_id: 99 },
+    });
+    expect(repositoryUpdate).toMatchObject({
+      observation: null,
+      event: null,
+      entityIdentity: null,
+    });
+  });
+
+  it("rejects missing or contradictory GitLab System Hook discriminators", () => {
+    expect(() =>
+      normalizeGitlabWebhook({
+        ...base,
+        eventHeader: "System Hook",
+        body: {},
+      }),
+    ).toThrow("requires event_name or object_kind=merge_request");
+    expect(() =>
+      normalizeGitlabWebhook({
+        ...base,
+        eventHeader: "System Hook",
+        body: { event_name: "repository_update", object_kind: "merge_request" },
+      }),
+    ).toThrow("event_name does not match object_kind");
+  });
+
   it("normalizes merge request, issue, and note payloads without exposing raw provider fields", () => {
     const mr = normalizeGitlabWebhook({
       ...base,

--- a/packages/server/src/__tests__/gitlab-webhook-stage2a.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-stage2a.test.ts
@@ -39,6 +39,7 @@ function issuePayload(iid = 42, input: { projectId?: number; projectPath?: strin
   const projectId = input.projectId ?? 501;
   const projectPath = input.projectPath ?? "Acme/API";
   return {
+    event_name: "issue",
     object_kind: "issue",
     project: {
       id: projectId,
@@ -74,7 +75,7 @@ async function postWebhook(
     url: `/api/v1/webhooks/gitlab/${bearer}`,
     headers: {
       "content-type": "application/json",
-      "x-gitlab-event": options.event ?? "Issue Hook",
+      "x-gitlab-event": options.event ?? "System Hook",
       ...(options.stableId ? { "idempotency-key": options.stableId } : {}),
       ...(options.webhookId ? { "webhook-id": options.webhookId } : {}),
       ...(options.webhookUuid ? { "x-gitlab-webhook-uuid": options.webhookUuid } : {}),
@@ -123,7 +124,7 @@ describe("GitLab Stage 2A backend", () => {
     expect(await findActiveGitlabEndpoint(app.db, first.bearer)).toBeNull();
     expect(await findActiveGitlabEndpoint(app.db, regenerated.bearer)).not.toBeNull();
     expect((await getGitlabConnectionSummary(app.db, first.connectionId)).endpointSeen).toBe(false);
-    const test = await postWebhook(app, regenerated.bearer, { object_kind: "test" }, { event: "Test Hook" });
+    const test = await postWebhook(app, regenerated.bearer, { event_name: "test" });
     expect(test.statusCode).toBe(200);
     expect((await getGitlabConnectionSummary(app.db, first.connectionId)).endpointSeen).toBe(true);
 
@@ -402,12 +403,12 @@ describe("GitLab Stage 2A backend", () => {
         state,
       },
     });
-    expect(
-      (await postWebhook(app, first.bearer, mrPayload("open", "opened"), { event: "Merge Request Hook" })).json(),
-    ).toMatchObject({ outcome: "delivered" });
-    expect(
-      (await postWebhook(app, first.bearer, mrPayload("merge", "merged"), { event: "Merge Request Hook" })).json(),
-    ).toMatchObject({ outcome: "provider_only" });
+    expect((await postWebhook(app, first.bearer, mrPayload("open", "opened"))).json()).toMatchObject({
+      outcome: "delivered",
+    });
+    expect((await postWebhook(app, first.bearer, mrPayload("merge", "merged"))).json()).toMatchObject({
+      outcome: "provider_only",
+    });
     expect(
       await app.db
         .select()
@@ -433,7 +434,7 @@ describe("GitLab Stage 2A backend", () => {
         url: "https://gitlab.internal/Acme/API/-/merge_requests/52",
       },
     };
-    expect((await postWebhook(app, first.bearer, note, { event: "Note Hook" })).statusCode).toBe(200);
+    expect((await postWebhook(app, first.bearer, note, { event: "Note Hook" })).statusCode).toBe(400);
     const [mapping] = await app.db
       .select()
       .from(gitlabEntityChatMappings)
@@ -455,14 +456,43 @@ describe("GitLab Stage 2A backend", () => {
   it("applies content/body guards while accepting valid unsupported events as no-ops", async () => {
     const app = getApp();
     const first = await connection(app);
-    const unsupported = await postWebhook(app, first.bearer, { object_kind: "push" }, { event: "Push Hook" });
+    const repositoryUpdate = await postWebhook(app, first.bearer, {
+      event_name: "repository_update",
+      project_id: 5,
+      project: {
+        id: 5,
+        path_with_namespace: "Acme/Context",
+        web_url: "https://gitlab.internal/Acme/Context",
+      },
+      changes: [
+        {
+          before: "0".repeat(40),
+          after: "1".repeat(40),
+          ref: "refs/heads/main",
+        },
+      ],
+    });
+    expect(repositoryUpdate.statusCode).toBe(200);
+    expect(repositoryUpdate.json()).toMatchObject({ outcome: "provider_only" });
+    expect((await getGitlabConnectionSummary(app.db, first.connectionId)).endpointSeen).toBe(true);
+
+    const unsupported = await postWebhook(app, first.bearer, { event_name: "push" });
     expect(unsupported.statusCode).toBe(200);
     expect(unsupported.json()).toMatchObject({ outcome: "provider_only" });
+
+    const projectHook = await postWebhook(
+      app,
+      first.bearer,
+      { object_kind: "merge_request" },
+      { event: "Merge Request Hook" },
+    );
+    expect(projectHook.statusCode).toBe(400);
+    expect(projectHook.json()).toMatchObject({ error: expect.stringContaining("/admin/hooks") });
 
     const wrongType = await app.inject({
       method: "POST",
       url: `/api/v1/webhooks/gitlab/${first.bearer}`,
-      headers: { "content-type": "text/plain", "x-gitlab-event": "Issue Hook" },
+      headers: { "content-type": "text/plain", "x-gitlab-event": "System Hook" },
       payload: JSON.stringify(issuePayload()),
     });
     expect(wrongType.statusCode).toBeGreaterThanOrEqual(400);
@@ -958,39 +988,35 @@ describe("GitLab Stage 2A backend", () => {
     const malformed = await app.inject({
       method: "POST",
       url: `/api/v1/webhooks/gitlab/${malformedConnection.bearer}`,
-      headers: { "content-type": "application/json", "x-gitlab-event": "Issue Hook" },
+      headers: { "content-type": "application/json", "x-gitlab-event": "System Hook" },
       payload: '{"object_kind":',
     });
     expect(malformed.statusCode).toBe(400);
 
     const limited = await connection(app, { isolatedOrg: true });
     for (let index = 0; index < 119; index += 1) {
-      const response = await postWebhook(app, limited.bearer, { object_kind: "test" }, { event: "Test Hook" });
+      const response = await postWebhook(app, limited.bearer, { event_name: "test" });
       expect(response.statusCode).toBe(200);
     }
     const missingEventHeader = await app.inject({
       method: "POST",
       url: `/api/v1/webhooks/gitlab/${limited.bearer}`,
       headers: { "content-type": "application/json" },
-      payload: JSON.stringify({ object_kind: "test" }),
+      payload: JSON.stringify({ event_name: "test" }),
     });
     expect(missingEventHeader.statusCode).toBe(400);
-    expect((await postWebhook(app, limited.bearer, { object_kind: "test" }, { event: "Test Hook" })).statusCode).toBe(
-      429,
-    );
+    expect((await postWebhook(app, limited.bearer, { event_name: "test" })).statusCode).toBe(429);
     const rateLimitedBeforeJsonParsing = await app.inject({
       method: "POST",
       url: `/api/v1/webhooks/gitlab/${limited.bearer}`,
-      headers: { "content-type": "application/json", "x-gitlab-event": "Issue Hook" },
+      headers: { "content-type": "application/json", "x-gitlab-event": "System Hook" },
       payload: '{"object_kind":',
     });
     expect(rateLimitedBeforeJsonParsing.statusCode).toBe(429);
     expect((await getGitlabConnectionSummary(app.db, limited.connectionId)).health.lastProcessingFailureCode).toBe(
       "missing_or_invalid_event_header",
     );
-    expect(
-      (await postWebhook(app, malformedConnection.bearer, { object_kind: "test" }, { event: "Test Hook" })).statusCode,
-    ).toBe(200);
+    expect((await postWebhook(app, malformedConnection.bearer, { event_name: "test" })).statusCode).toBe(200);
 
     const unknownSourceIp = "203.0.113.77";
     for (let index = 0; index < 119; index += 1) {
@@ -1021,9 +1047,8 @@ describe("GitLab Stage 2A backend", () => {
         await postWebhook(
           app,
           malformedConnection.bearer,
-          { object_kind: "test" },
+          { event_name: "test" },
           {
-            event: "Test Hook",
             remoteAddress: unknownSourceIp,
           },
         )

--- a/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
@@ -81,7 +81,7 @@ async function postMr(app: App, bearer: string, body: object, stableId?: string,
     url: `/api/v1/webhooks/gitlab/${bearer}`,
     headers: {
       "content-type": "application/json",
-      "x-gitlab-event": "Merge Request Hook",
+      "x-gitlab-event": "System Hook",
       "user-agent": userAgent,
       ...(stableId ? { "idempotency-key": stableId } : {}),
     },
@@ -146,7 +146,21 @@ describe("GitLab Stage 3 personnel routing", () => {
     );
 
     const payload = mergeRequestPayload({ projectPath: "Acme/Reviews" });
-    const first = await postMr(app, connection.bearer, payload, "context-review-old-gitlab", "GitLab/14.10.5");
+    const rejectedProjectHook = await app.inject({
+      method: "POST",
+      url: `/api/v1/webhooks/gitlab/${connection.bearer}`,
+      headers: {
+        "content-type": "application/json",
+        "x-gitlab-event": "Merge Request Hook",
+      },
+      payload: JSON.stringify(payload),
+    });
+    expect(rejectedProjectHook.statusCode).toBe(400);
+    expect(
+      (await app.db.select().from(chats)).filter((chat) => chat.metadata.contextTreeReviewer === true),
+    ).toHaveLength(0);
+
+    const first = await postMr(app, connection.bearer, payload, "context-review-old-gitlab", "GitLab/11.11.3");
     expect(first.statusCode).toBe(200);
 
     const reviewerChats = await app.db.select().from(chats).where(eq(chats.organizationId, admin.organizationId));
@@ -346,7 +360,7 @@ describe("GitLab Stage 3 personnel routing", () => {
         },
       }),
     });
-    expect(note.statusCode).toBe(200);
+    expect(note.statusCode).toBe(400);
     expect(
       reviewerChat ? await app.db.select().from(messages).where(eq(messages.chatId, reviewerChat.id)) : [],
     ).toHaveLength(3);
@@ -406,7 +420,7 @@ describe("GitLab Stage 3 personnel routing", () => {
         connectionId: "connection-1",
         instanceOrigin: "https://gitlab.internal",
         stableDeliveryId: null,
-        eventHeader: "Merge Request Hook",
+        eventHeader: "System Hook",
         body,
       });
 

--- a/packages/server/src/api/webhooks/gitlab.ts
+++ b/packages/server/src/api/webhooks/gitlab.ts
@@ -70,6 +70,18 @@ export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
           failureMarked.add(request);
           throw new BadRequestError("X-Gitlab-Event is required");
         }
+        if (eventHeader !== "System Hook") {
+          await markGitlabProcessingFailure(
+            app.db,
+            endpoint.connection.id,
+            endpoint.connection.tokenHash,
+            "unsupported_hook_type",
+          );
+          failureMarked.add(request);
+          throw new BadRequestError(
+            "Only GitLab System Hooks are supported; configure this webhook URL under GitLab /admin/hooks",
+          );
+        }
         eventHeaderByRequest.set(request, eventHeader);
         return payload;
       },

--- a/packages/server/src/services/gitlab-webhook.ts
+++ b/packages/server/src/services/gitlab-webhook.ts
@@ -296,15 +296,30 @@ export function normalizeGitlabWebhook(input: {
   body: unknown;
 }): NormalizedGitlabWebhook {
   const payload = object(input.body, "GitLab webhook body");
-  const objectKind = requiredString(payload.object_kind, "object_kind");
   const expectedKind: Record<string, string> = {
     "Merge Request Hook": "merge_request",
     "Issue Hook": "issue",
     "Note Hook": "note",
     "Test Hook": "test",
   };
-  const expected = expectedKind[input.eventHeader];
-  if (expected && objectKind !== expected) throw new BadRequestError("X-Gitlab-Event does not match object_kind");
+  let expected: string | undefined;
+  if (input.eventHeader === "System Hook") {
+    const eventName = payload.event_name === undefined ? undefined : requiredString(payload.event_name, "event_name");
+    const objectKind =
+      payload.object_kind === undefined ? undefined : requiredString(payload.object_kind, "object_kind");
+    if (eventName && objectKind && eventName !== objectKind) {
+      throw new BadRequestError("GitLab System Hook event_name does not match object_kind");
+    }
+    const discriminator = objectKind === "merge_request" ? objectKind : eventName;
+    if (!discriminator) {
+      throw new BadRequestError("GitLab System Hook requires event_name or object_kind=merge_request");
+    }
+    expected = ["merge_request", "issue", "note", "test"].includes(discriminator) ? discriminator : undefined;
+  } else {
+    const objectKind = requiredString(payload.object_kind, "object_kind");
+    expected = expectedKind[input.eventHeader];
+    if (expected && objectKind !== expected) throw new BadRequestError("X-Gitlab-Event does not match object_kind");
+  }
   const ingress: ScmIngressContext = {
     provider: "gitlab",
     source: { organizationId: input.organizationId, externalId: input.connectionId },


### PR DESCRIPTION
## Summary

- accept GitLab instance-wide `System Hook` deliveries at the public GitLab webhook endpoint
- normalize GitLab 11.11 merge request System Hooks through the existing Context Reviewer dispatcher
- treat `repository_update` and other unrelated System Hook events as provider-only health no-ops
- reject Project Hook headers with actionable `/admin/hooks` guidance

## Scope

This is the minimal Server-only ingress fix. It adds no database migration, provider API call, credential, polling, replay system, new dispatcher, skill-eval change, or UI/documentation expansion.

## Validation

- `pnpm exec vitest run src/__tests__/gitlab-webhook-normalize.test.ts src/__tests__/gitlab-webhook-stage2a.test.ts src/__tests__/gitlab-webhook-stage3.test.ts --maxWorkers=2` — 59 passed
- `pnpm --filter @first-tree/server typecheck`
- targeted Biome checks for the five changed files
- `git diff --check`

A repository-wide local test run and skill-evals were intentionally not run; remote CI provides the broader matrix after PR creation.