### PR TITLE
feat(web): refine Setup status semantics

### DIFF
--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -162,6 +162,35 @@ for text sitting on a saturated colored surface (badges, avatars) and does
 > `chat-row-avatar.tsx`. Everywhere else (chips, dots, tints) each state keeps
 > its semantic hue.
 
+### Capability readiness (Setup)
+
+Capability readiness is not agent presence. Setup rows keep the capability
+icon neutral and render a separate Lucide status glyph, so state remains clear
+without relying on color:
+
+| Meaning | Glyph | Token |
+|---------|-------|-------|
+| ready / verified | static `CircleCheck` | `--success` |
+| optional / not configured / off | `CircleMinus` | `--fg-4` |
+| verification pending | static `Clock3` | `--state-idle` |
+| current viewer can resolve it | `CircleAlert` | `--state-needs-you` |
+| degraded / blocked elsewhere | `CircleAlert` | `--state-blocked` |
+| status could not be checked | `CircleHelp` | `--fg-3` |
+
+A transient request may use `LoaderCircle` with a reduced-motion-safe spin;
+long-lived verification never spins. Resolution ownership determines amber
+versus orange: the same Team fact remains visible to every role, while only a
+viewer who can act gets the needs-you treatment and mutation action. Red is
+reserved for a confirmed failed operation or system error, normally in an
+inline callout; a failed status query is neutral unknown, never evidence that
+the capability itself is unavailable.
+
+The visible label and detail are the semantic source; readiness glyphs are
+decorative (`aria-hidden`). Static row readouts do not each get an `aria-live`
+region. Do not reuse agent-centric `StateDot` / `StatusGlyph` for this
+vocabulary, and do not mechanically map backend health enums to color without
+considering adoption, blockers, resolution owner, role, and user impact.
+
 Each state also ships a **soft** companion fill — `--state-working-soft` …
 `--state-offline-soft` (one canonical 14% translucent mix). Use these for
 state-tinted surfaces (chips, wells, `.context-change-breakdown`) instead of

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -12,7 +12,10 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const activityMocks = vi.hoisted(() => ({ listClients: vi.fn() }));
 const contextTreeMocks = vi.hoisted(() => ({ getContextTreeSnapshot: vi.fn() }));
+const githubMocks = vi.hoisted(() => ({ getGithubAppInstallation: vi.fn() }));
+const gitlabMocks = vi.hoisted(() => ({ listGitlabConnectionsAt: vi.fn() }));
 const onboardingEventMocks = vi.hoisted(() => ({ reportOnboardingEvent: vi.fn() }));
+const orgSettingsMocks = vi.hoisted(() => ({ getContextTreeSetting: vi.fn() }));
 const resourceMocks = vi.hoisted(() => ({ listTeamResourcesForOrg: vi.fn() }));
 const setupCapabilityMocks = vi.hoisted(() => ({ getTeamSetupCapabilitiesAt: vi.fn() }));
 const authMock = vi.hoisted(() => ({
@@ -32,7 +35,13 @@ const authMock = vi.hoisted(() => ({
 
 vi.mock("../../../api/activity.js", () => activityMocks);
 vi.mock("../../../api/context-tree.js", () => contextTreeMocks);
+vi.mock("../../../api/github-app.js", () => githubMocks);
+vi.mock("../../../api/gitlab-connections.js", () => ({
+  ...gitlabMocks,
+  gitlabConnectionsQueryKey: (organizationId: string | null) => ["gitlab-connections", organizationId],
+}));
 vi.mock("../../../api/onboarding-events.js", () => onboardingEventMocks);
+vi.mock("../../../api/org-settings.js", () => orgSettingsMocks);
 vi.mock("../../../api/resources.js", () => resourceMocks);
 vi.mock("../../../api/setup-capabilities.js", () => ({
   ...setupCapabilityMocks,
@@ -116,7 +125,20 @@ function facts(overrides: Partial<SetupFacts> = {}): SetupFacts {
     },
     repositories: { state: "ready", value: 2 },
     capabilities: { state: "ready", value: capabilityFixture() },
+    contextTreeSetting: {
+      state: "ready",
+      value: {
+        provider: "github",
+        repo: "https://github.com/acme/context-tree.git",
+        branch: "main",
+      },
+    },
     contextTreeSnapshot: { state: "ready", value: "active" },
+    github: {
+      state: "ready",
+      value: { accountLogin: "acme", accountType: "Organization" },
+    },
+    gitlab: { state: "ready", value: null },
     ...overrides,
   };
 }
@@ -194,11 +216,20 @@ beforeEach(() => {
   vi.clearAllMocks();
   activityMocks.listClients.mockResolvedValue([]);
   resourceMocks.listTeamResourcesForOrg.mockResolvedValue([]);
+  orgSettingsMocks.getContextTreeSetting.mockResolvedValue({
+    repo: "https://github.com/acme/context-tree.git",
+    branch: "main",
+  });
   setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(capabilityFixture());
   contextTreeMocks.getContextTreeSnapshot.mockResolvedValue({
     snapshotStatus: "active",
     contextStatus: { severity: "ok", label: "Available", detail: null },
   });
+  githubMocks.getGithubAppInstallation.mockResolvedValue({
+    accountLogin: "acme",
+    accountType: "Organization",
+  });
+  gitlabMocks.listGitlabConnectionsAt.mockResolvedValue([]);
   authMock.value = {
     role: "admin",
     organizationId: "org-1",
@@ -218,7 +249,7 @@ afterEach(() => {
 });
 
 describe("Settings Setup overview", () => {
-  it("renders the permanent capability hierarchy without a completion score", async () => {
+  it("renders the approved six-row hierarchy with separate capability and status icons", async () => {
     const view = await renderSetup(facts());
     const titles = [...view.host.querySelectorAll("[data-setup-row] .text-body")].map((node) => node.textContent);
 
@@ -227,19 +258,94 @@ describe("Settings Setup overview", () => {
       "Your computer",
       "Your agent",
       "Code repositories",
-      "Repository automation",
       "Context Tree",
-      "Automatic review",
+      "GitHub / GitLab",
     ]);
-    expect(view.host.querySelector('[data-setup-row="automatic-review"]')?.getAttribute("data-setup-parent")).toBe(
-      "context-tree",
-    );
-    expect(view.host.querySelectorAll('[role="status"][aria-live="polite"]')).toHaveLength(7);
+    expect(view.host.querySelector('[data-setup-row="work-access"] .lucide-message-circle')).not.toBeNull();
+    const readyMarks = view.host.querySelectorAll("[data-setup-status-kind='ready'] .lucide-circle-check");
+    expect(readyMarks).toHaveLength(6);
+    expect([...readyMarks].every((mark) => mark.getAttribute("aria-hidden") === "true")).toBe(true);
+    expect(view.host.querySelectorAll('[role="status"], [aria-live]')).toHaveLength(0);
     expect(view.host.textContent).not.toContain("%");
+    expect(view.host.textContent).not.toContain("Setup complete");
     expect(view.host.textContent).not.toContain("Onboarding completed");
     expect(view.host.querySelector("h1")).toBeNull();
     expect(view.host.querySelector("[data-setup-lead]")?.textContent).toBe("See what's ready and what you can set up.");
     expect(view.host.querySelector("[data-setup-context]")?.textContent).toBe("Acme · Admin");
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("uses form and color together for ready, optional, pending, attention, blocked, and unknown facts", async () => {
+    const mixed = facts({
+      hasPersonalAgent: false,
+      onboardingSuppressedAt: observedAt,
+      onboardingCompletedAt: null,
+      computers: {
+        state: "ready",
+        value: { connected: 0, saved: 0, connectedHostname: null },
+      },
+      repositories: { state: "error" },
+      capabilities: {
+        state: "ready",
+        value: capabilityFixture({
+          github: { adoption: "available", health: "not_observed" },
+          gitlab: {
+            adoption: "configuring",
+            health: "pending_verification",
+            blockers: [
+              {
+                code: "gitlab_webhook_not_seen",
+                resolutionOwner: "admin",
+                actionKind: "configure_gitlab_webhook",
+              },
+            ],
+          },
+          review: {
+            adoption: "enabled",
+            health: "degraded",
+            blockers: [{ code: "provider_probe_failed", resolutionOwner: "operator", actionKind: null }],
+          },
+        }),
+      },
+      github: { state: "ready", value: null },
+      gitlab: {
+        state: "ready",
+        value: { displayName: "Engineering", instanceOrigin: "https://gitlab.acme.test" },
+      },
+    });
+    const view = await renderSetup(mixed);
+    const expectation = [
+      ["work-access", "ready", "circle-check", "--success"],
+      ["computer", "optional", "circle-minus", "--fg-4"],
+      ["agent", "attention", "circle-alert", "--state-needs-you"],
+      ["repositories", "unknown", "circle-question-mark", "--fg-3"],
+      ["context-tree", "blocked", "circle-alert", "--state-blocked"],
+      ["providers", "pending", "clock-3", "--state-idle"],
+    ] as const;
+
+    for (const [key, kind, glyph, token] of expectation) {
+      const status = view.host.querySelector<HTMLElement>(
+        `[data-setup-row="${key}"] [data-setup-status-kind="${kind}"]`,
+      );
+      expect(status?.querySelector(`.lucide-${glyph}`)).not.toBeNull();
+      expect(status?.querySelector("svg")?.getAttribute("style")).toContain(token);
+    }
+    expect(
+      view.host.querySelector('[data-setup-row="providers"] [data-setup-status-kind] svg')?.getAttribute("class"),
+    ).not.toContain("animate-spin");
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("reserves a spinner for transient loading and keeps verification pending static", async () => {
+    const input = facts({ computers: { state: "loading" } });
+    const view = await renderSetup(input);
+    const status = view.host.querySelector('[data-setup-row="computer"] [data-setup-status-kind="loading"]');
+    const icon = status?.querySelector(".lucide-loader-circle");
+
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute("class")).toContain("motion-safe:animate-spin");
 
     await act(async () => view.root.unmount());
   });
@@ -274,12 +380,14 @@ describe("Settings Setup overview", () => {
       detail: "A team agent is available",
     });
     expect(rowFor("work-access", input).action).toEqual({ label: "Start a chat", to: "/" });
+    expect(rowFor("work-access", input).status.kind).toBe("ready");
     expect(rowFor("computer", input).status.detail).toBe("Optional while a team agent is available");
+    expect(rowFor("computer", input).status.kind).toBe("optional");
     expect(rowFor("agent", input).status.detail).toBe("Optional while a team agent is available");
+    expect(rowFor("agent", input).status.kind).toBe("optional");
     expect(view.host.textContent).not.toContain("Action required");
     expect(view.host.textContent).not.toContain("Manage");
     expect(rowFor("context-tree", input).action).toBeUndefined();
-    expect(rowFor("automatic-review", input).status.label).toBe("Available after Context Tree");
 
     await act(async () => view.root.unmount());
   });
@@ -289,20 +397,17 @@ describe("Settings Setup overview", () => {
       github: { adoption: "available", health: "not_observed" },
       gitlab: { adoption: "available", health: "not_observed" },
     });
-    const admin = rowFor("repository-automation", facts({ capabilities: { state: "ready", value: optional } }));
-    const member = rowFor(
-      "repository-automation",
-      facts({ role: "member", capabilities: { state: "ready", value: optional } }),
-    );
+    const admin = rowFor("providers", facts({ capabilities: { state: "ready", value: optional } }));
+    const member = rowFor("providers", facts({ role: "member", capabilities: { state: "ready", value: optional } }));
 
-    expect(admin.status).toEqual({ label: "Not configured", detail: "Optional", tone: "neutral" });
-    expect(admin.action).toEqual({ label: "Set up", to: "/settings/integrations/github" });
+    expect(admin.status).toEqual({ label: "Not connected", detail: "Optional", kind: "optional" });
+    expect(admin.action).toEqual({ label: "Connect", to: "/settings/integrations/github" });
     expect(member.status).toEqual(admin.status);
     expect(member.action).toBeUndefined();
   });
 
   it.each([
-    ["GitHub only", capabilityFixture(), "GitHub ready", "positive"],
+    ["GitHub only", capabilityFixture(), "GitHub · acme", "ready"],
     [
       "GitLab only",
       capabilityFixture({
@@ -310,14 +415,9 @@ describe("Settings Setup overview", () => {
         gitlab: { adoption: "enabled", health: "ready" },
       }),
       "GitLab ready",
-      "positive",
+      "ready",
     ],
-    [
-      "both",
-      capabilityFixture({ gitlab: { adoption: "enabled", health: "ready" } }),
-      "GitHub + GitLab ready",
-      "positive",
-    ],
+    ["both", capabilityFixture({ gitlab: { adoption: "enabled", health: "ready" } }), "GitHub + GitLab", "ready"],
     [
       "partial",
       capabilityFixture({
@@ -334,7 +434,7 @@ describe("Settings Setup overview", () => {
         },
       }),
       "Partial coverage",
-      "attention",
+      "pending",
     ],
     [
       "degraded",
@@ -346,13 +446,21 @@ describe("Settings Setup overview", () => {
         },
       }),
       "Degraded",
-      "neutral",
+      "blocked",
     ],
-  ] as const)("summarizes %s repository automation coverage", (_name, capabilities, label, tone) => {
-    const row = rowFor("repository-automation", facts({ capabilities: { state: "ready", value: capabilities } }));
+  ] as const)("summarizes %s repository automation coverage", (_name, capabilities, label, kind) => {
+    const row = rowFor("providers", facts({ capabilities: { state: "ready", value: capabilities } }));
 
     expect(row.status.label).toBe(label);
-    expect(row.status.tone).toBe(tone);
+    expect(row.status.kind).toBe(kind);
+  });
+
+  it("uses provider identity only as label enrichment, never as readiness evidence", () => {
+    const enriched = rowFor("providers");
+    const identityFailed = rowFor("providers", facts({ github: { state: "error" } }));
+
+    expect(enriched.status).toMatchObject({ label: "GitHub · acme", kind: "ready" });
+    expect(identityFailed.status).toMatchObject({ label: "GitHub ready", kind: "ready" });
   });
 
   it("turns the same Team blocker into admin attention and member read-only explanation", () => {
@@ -369,18 +477,12 @@ describe("Settings Setup overview", () => {
         ],
       },
     });
-    const admin = rowFor(
-      "repository-automation",
-      facts({ role: "admin", capabilities: { state: "ready", value: shared } }),
-    );
-    const member = rowFor(
-      "repository-automation",
-      facts({ role: "member", capabilities: { state: "ready", value: shared } }),
-    );
+    const admin = rowFor("providers", facts({ role: "admin", capabilities: { state: "ready", value: shared } }));
+    const member = rowFor("providers", facts({ role: "member", capabilities: { state: "ready", value: shared } }));
 
-    expect(admin.status).toMatchObject({ label: "Needs attention", tone: "attention" });
+    expect(admin.status).toMatchObject({ label: "Needs attention", kind: "attention" });
     expect(admin.action).toEqual({ label: "Manage GitHub", to: "/settings/integrations/github" });
-    expect(member.status).toMatchObject({ label: "Service unavailable", tone: "neutral" });
+    expect(member.status).toMatchObject({ label: "Service unavailable", kind: "blocked" });
     expect(member.status.detail).toContain("Ask an admin");
     expect(member.action).toBeUndefined();
   });
@@ -393,22 +495,23 @@ describe("Settings Setup overview", () => {
         blockers: [{ code: "github_app_not_configured", resolutionOwner: "operator", actionKind: null }],
       },
     });
-    const row = rowFor("repository-automation", facts({ capabilities: { state: "ready", value: shared } }));
+    const row = rowFor("providers", facts({ capabilities: { state: "ready", value: shared } }));
 
-    expect(row.status).toMatchObject({ label: "Service unavailable", tone: "neutral" });
+    expect(row.status).toMatchObject({ label: "Service unavailable", kind: "blocked" });
     expect(row.status.detail).toContain("deployment");
+    expect(row.status.detail).toContain("No action is needed from you");
     expect(row.action).toBeUndefined();
   });
 
   it.each([
-    ["active", "Available", "positive", "Manage"],
-    ["stale", "Available · update delayed", "neutral", "Manage"],
+    ["active", "Available", "ready", "Manage"],
+    ["stale", "Available · update delayed", "blocked", "Manage"],
     ["unavailable", "Needs recovery", "attention", "Recover"],
-  ] as const)("maps bound Context Tree snapshot %s without equating binding to health", (value, label, tone, action) => {
+  ] as const)("maps bound Context Tree snapshot %s without equating binding to health", (value, label, kind, action) => {
     const row = rowFor("context-tree", facts({ contextTreeSnapshot: { state: "ready", value } }));
 
-    expect(row.status).toMatchObject({ label, tone });
-    expect(row.status.detail).toBe("acme/context-tree · main branch · GitHub");
+    expect(row.status).toMatchObject({ label, kind });
+    expect(row.status.detail).toContain("acme/context-tree · main branch · GitHub");
     expect(row.action?.label).toBe(action);
   });
 
@@ -459,14 +562,14 @@ describe("Settings Setup overview", () => {
       }),
     );
 
-    expect(unbound.status).toEqual({ label: "Not set up", detail: "Optional", tone: "neutral" });
+    expect(unbound.status).toEqual({ label: "Not set up", detail: "Optional", kind: "optional" });
     expect(unbound.action).toEqual({ label: "Set up", to: "/context" });
-    expect(unboundMember.status).toMatchObject({ label: "Not set up", tone: "neutral" });
+    expect(unboundMember.status).toMatchObject({ label: "Not set up", kind: "optional" });
     expect(unboundMember.status.detail).toContain("Ask an admin");
     expect(unboundMember.action).toBeUndefined();
-    expect(invalidAdmin.status).toMatchObject({ label: "Needs repair", tone: "attention" });
+    expect(invalidAdmin.status).toMatchObject({ label: "Needs repair", kind: "attention" });
     expect(invalidAdmin.action).toEqual({ label: "Repair", to: "/settings/repositories#context-tree" });
-    expect(invalidMember.status).toMatchObject({ label: "Unavailable", tone: "neutral" });
+    expect(invalidMember.status).toMatchObject({ label: "Unavailable", kind: "blocked" });
     expect(invalidMember.status.detail).toContain("Ask an admin");
     expect(invalidMember.action).toEqual({ label: "View", to: "/context" });
   });
@@ -480,7 +583,7 @@ describe("Settings Setup overview", () => {
       }),
     );
 
-    expect(row.status).toMatchObject({ label: "Unavailable", tone: "neutral" });
+    expect(row.status).toMatchObject({ label: "Unavailable", kind: "blocked" });
     expect(row.status.detail).toContain("Ask an admin to recover");
     expect(row.action).toEqual({ label: "View", to: "/context" });
   });
@@ -488,31 +591,21 @@ describe("Settings Setup overview", () => {
   it("keeps snapshot lookup failure unknown rather than claiming recovery is needed", () => {
     const row = rowFor("context-tree", facts({ contextTreeSnapshot: { state: "error" } }));
 
-    expect(row.status).toMatchObject({ label: "Status unknown", tone: "neutral" });
+    expect(row.status).toMatchObject({ label: "Status unavailable", kind: "unknown" });
     expect(row.action).toEqual({ label: "Manage", to: "/settings/repositories#context-tree" });
   });
 
   it.each([
     [
-      "unavailable",
-      capabilityFixture({
-        binding: { state: "unbound" },
-        review: { adoption: "unavailable", health: "not_observed", reviewerAgent: null },
-      }),
-      "Available after Context Tree",
-      "neutral",
-      undefined,
-    ],
-    [
       "disabled",
       capabilityFixture({
         review: { adoption: "disabled", health: "not_observed", reviewerAgent: null },
       }),
-      "Off",
-      "neutral",
-      "Set up",
+      "Available",
+      "ready",
+      "Manage",
     ],
-    ["ready", capabilityFixture(), "On", "positive", "Manage"],
+    ["ready", capabilityFixture(), "Available", "ready", "Manage"],
     [
       "pending",
       capabilityFixture({
@@ -522,8 +615,8 @@ describe("Settings Setup overview", () => {
           blockers: [{ code: "provider_probe_failed", resolutionOwner: "operator", actionKind: null }],
         },
       }),
-      "Verification pending",
-      "neutral",
+      "Available · review pending",
+      "pending",
       undefined,
     ],
     [
@@ -535,17 +628,36 @@ describe("Settings Setup overview", () => {
           blockers: [{ code: "gitlab_processing_failed", resolutionOwner: "admin", actionKind: null }],
         },
       }),
-      "Degraded",
+      "Available · review degraded",
       "attention",
       undefined,
     ],
-  ] as const)("maps Automatic review %s without making it a Start Chat gate", (_name, capabilities, label, tone, action) => {
+  ] as const)("keeps Automatic review %s as a qualified Context Tree fact without making it a Start Chat gate", (_name, capabilities, label, kind, action) => {
     const input = facts({ capabilities: { state: "ready", value: capabilities } });
-    const review = rowFor("automatic-review", input);
+    const tree = rowFor("context-tree", input);
 
-    expect(review.status).toMatchObject({ label, tone });
-    expect(review.action?.label).toBe(action);
+    expect(tree.status).toMatchObject({ label, kind });
+    expect(tree.action?.label).toBe(action);
     expect(rowFor("work-access", input).status.label).toBe("Can work now");
+  });
+
+  it("puts degraded review ownership before truncated Context Tree metadata", () => {
+    const capabilities = capabilityFixture({
+      review: {
+        adoption: "enabled",
+        health: "degraded",
+        blockers: [{ code: "gitlab_processing_failed", resolutionOwner: "admin", actionKind: null }],
+      },
+    });
+    const member = rowFor(
+      "context-tree",
+      facts({ role: "member", capabilities: { state: "ready", value: capabilities } }),
+    );
+
+    expect(member.status.detail).toMatch(
+      /^Automatic review degraded · Ask an admin to resolve this: Recent GitLab webhook processing failed\./,
+    );
+    expect(member.status.detail).toContain("acme/context-tree · main branch · GitHub");
   });
 
   it("makes reviewer replacement admin-only while preserving the same Team fact", () => {
@@ -563,32 +675,31 @@ describe("Settings Setup overview", () => {
         ],
       },
     });
-    const admin = rowFor("automatic-review", facts({ role: "admin", capabilities: { state: "ready", value: shared } }));
-    const member = rowFor(
-      "automatic-review",
-      facts({ role: "member", capabilities: { state: "ready", value: shared } }),
-    );
+    const admin = rowFor("context-tree", facts({ role: "admin", capabilities: { state: "ready", value: shared } }));
+    const member = rowFor("context-tree", facts({ role: "member", capabilities: { state: "ready", value: shared } }));
 
-    expect(admin.status).toMatchObject({ label: "Needs attention", tone: "attention" });
+    expect(admin.status).toMatchObject({ label: "Available · review unavailable", kind: "attention" });
     expect(admin.action).toEqual({ label: "Replace reviewer", to: "/settings/repositories#context-tree" });
-    expect(member.status).toMatchObject({ label: "Service unavailable", tone: "neutral" });
+    expect(member.status).toMatchObject({ label: "Available · review unavailable", kind: "blocked" });
     expect(member.status.detail).toContain("Ask an admin");
-    expect(member.action).toEqual({ label: "View", to: "/settings/repositories#context-tree" });
+    expect(member.action).toEqual({ label: "View", to: "/context" });
   });
 
-  it("uses the Team projection and only asks the snapshot owner endpoint for a bound tree", async () => {
+  it("uses Team readiness with identity enrichment and starts the tree snapshot from its owner setting", async () => {
     const view = await renderSettingsSetupPage();
-    const automation = await waitForRowText(view.host, "repository-automation", "GitHub ready");
+    const providers = await waitForRowText(view.host, "providers", "GitHub · acme");
     const tree = await waitForRowText(view.host, "context-tree", "Available");
 
-    expect(automation.textContent).toContain("GitLab not configured");
+    expect(providers.textContent).not.toContain("GitLab not configured");
     expect(tree.textContent).toContain("acme/context-tree");
     expect(setupCapabilityMocks.getTeamSetupCapabilitiesAt).toHaveBeenCalledWith("org-1");
+    expect(githubMocks.getGithubAppInstallation).toHaveBeenCalledWith("org-1");
     expect(contextTreeMocks.getContextTreeSnapshot).toHaveBeenCalledWith("org-1", "7d");
     await act(async () => view.root.unmount());
   });
 
-  it("does not request a tree snapshot when the Team projection says it is unbound", async () => {
+  it("does not request a tree snapshot when the owner setting is unbound", async () => {
+    orgSettingsMocks.getContextTreeSetting.mockResolvedValue({ repo: null, branch: "main" });
     setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(
       capabilityFixture({
         binding: { state: "unbound" },
@@ -627,23 +738,21 @@ describe("Settings Setup overview", () => {
     contextTreeMocks.getContextTreeSnapshot.mockRejectedValue(new Error("snapshot failed"));
 
     const view = await renderSettingsSetupPage();
-    const row = await waitForRowText(view.host, "context-tree", "Status unknown");
+    const row = await waitForRowText(view.host, "context-tree", "Status unavailable");
     expect(row.textContent).not.toContain("Needs recovery");
     await act(async () => view.root.unmount());
   });
 
-  it("fails closed when the capability projection cannot be loaded", async () => {
+  it("keeps primary Tree availability independent when the capability projection cannot be loaded", async () => {
     setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockRejectedValue(new Error("projection failed"));
 
     const view = await renderSettingsSetupPage();
-    const automation = await waitForRowText(view.host, "repository-automation", "Status unknown");
-    const tree = await waitForRowText(view.host, "context-tree", "Status unknown");
-    const review = await waitForRowText(view.host, "automatic-review", "Status unknown");
+    const providers = await waitForRowText(view.host, "providers", "Status unavailable");
+    const tree = await waitForRowText(view.host, "context-tree", "Available · review status unavailable");
 
-    expect(automation.querySelector("a")).toBeNull();
-    expect(tree.querySelector("a")).toBeNull();
-    expect(review.querySelector("a")).toBeNull();
-    expect(contextTreeMocks.getContextTreeSnapshot).not.toHaveBeenCalled();
+    expect(providers.querySelector("a")).toBeNull();
+    expect(tree.textContent).not.toContain("Context Tree unavailable");
+    expect(contextTreeMocks.getContextTreeSnapshot).toHaveBeenCalledWith("org-1", "7d");
     await act(async () => view.root.unmount());
   });
 
@@ -675,15 +784,19 @@ describe("Settings Setup overview", () => {
     );
     authMock.value = {
       ...authMock.value,
+      currentOrgHasPersonalAgent: false,
       onboardingDismissedAt: "2026-07-23T00:00:00.000Z",
       onboardingCompletedAt: null,
       restoreOnboarding,
     };
     const view = await renderSettingsSetupPage();
+    const agent = await waitForRowText(view.host, "agent", "Setup paused");
     const resume = [...view.host.querySelectorAll<HTMLAnchorElement>("a")].find(
       (link) => link.textContent === "Resume setup",
     );
 
+    expect(agent.querySelector("[data-setup-status-kind='attention'] .lucide-circle-alert")).not.toBeNull();
+    expect(agent.textContent).toContain("Resume to create your agent");
     expect(resume).toBeDefined();
     await act(async () => {
       resume?.click();

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -1,19 +1,38 @@
-import type {
-  SetupActionKind,
-  SetupAutomaticReview,
-  SetupBlocker,
-  SetupBlockerCode,
-  SetupCapabilityHealth,
-  SetupContextTreeBinding,
-  SetupRepositoryAutomationProvider,
-  TeamSetupCapabilities,
+import {
+  type ContextTreeProvider,
+  resolveContextTreeProvider,
+  type SetupActionKind,
+  type SetupAutomaticReview,
+  type SetupBlocker,
+  type SetupBlockerCode,
+  type SetupCapabilityHealth,
+  type SetupContextTreeBinding,
+  type SetupRepositoryAutomationProvider,
+  type TeamSetupCapabilities,
 } from "@first-tree/shared";
 import { useQuery } from "@tanstack/react-query";
-import { Bot, CircleCheck, FolderGit2, GitFork, Laptop, type LucideIcon, ShieldCheck, Webhook } from "lucide-react";
+import {
+  Bot,
+  CircleAlert,
+  CircleCheck,
+  CircleHelp,
+  CircleMinus,
+  Clock3,
+  FolderGit2,
+  GitFork,
+  Laptop,
+  LoaderCircle,
+  type LucideIcon,
+  MessageCircle,
+  Webhook,
+} from "lucide-react";
 import { Link, useNavigate } from "react-router";
 import { listClients } from "../../api/activity.js";
 import { getContextTreeSnapshot } from "../../api/context-tree.js";
+import { getGithubAppInstallation } from "../../api/github-app.js";
+import { gitlabConnectionsQueryKey, listGitlabConnectionsAt } from "../../api/gitlab-connections.js";
 import { reportOnboardingEvent } from "../../api/onboarding-events.js";
+import { getContextTreeSetting } from "../../api/org-settings.js";
 import { listTeamResourcesForOrg } from "../../api/resources.js";
 import { getTeamSetupCapabilitiesAt, setupCapabilitiesQueryKey } from "../../api/setup-capabilities.js";
 import { useAuth } from "../../auth/auth-context.js";
@@ -34,6 +53,8 @@ type ContextTreeFact = {
   availability: "active" | "stale" | "unavailable" | "checking" | "unknown" | null;
 };
 
+export type SetupStatusKind = "ready" | "optional" | "loading" | "pending" | "attention" | "blocked" | "unknown";
+
 export type SetupFacts = {
   role: string | null;
   teamName: string | null;
@@ -45,26 +66,25 @@ export type SetupFacts = {
   computers: Fact<{ connected: number; saved: number; connectedHostname: string | null }>;
   repositories: Fact<number>;
   capabilities: Fact<TeamSetupCapabilities>;
+  contextTreeSetting: Fact<{
+    provider?: ContextTreeProvider;
+    repo?: string;
+    branch?: string;
+  }>;
   contextTreeSnapshot: Fact<"active" | "stale" | "unavailable" | null>;
+  github: Fact<{ accountLogin: string; accountType: string } | null>;
+  gitlab: Fact<{ displayName: string; instanceOrigin: string } | null>;
 };
 
 export type SetupRowModel = {
-  key:
-    | "work-access"
-    | "computer"
-    | "agent"
-    | "repositories"
-    | "repository-automation"
-    | "context-tree"
-    | "automatic-review";
+  key: "work-access" | "computer" | "agent" | "repositories" | "context-tree" | "providers";
   title: string;
   description: string;
   icon: LucideIcon;
-  parentKey?: "context-tree";
   status: {
     label: string;
     detail?: string;
-    tone?: "positive" | "neutral" | "attention";
+    kind: SetupStatusKind;
   };
   action?: {
     label: string;
@@ -81,12 +101,35 @@ function queryFact<T>(query: { data: T | undefined; isPending: boolean; isError:
 
 function contextTreeFact(
   capabilities: Fact<TeamSetupCapabilities>,
+  setting: SetupFacts["contextTreeSetting"],
   snapshot: Fact<"active" | "stale" | "unavailable" | null>,
 ): Fact<ContextTreeFact> {
-  if (capabilities.state === "loading") return { state: "loading" };
-  if (capabilities.state === "error") return { state: "error" };
+  let binding: SetupContextTreeBinding;
+  if (capabilities.state === "ready") {
+    binding = capabilities.value.contextTree.binding;
+  } else {
+    if (setting.state === "loading") return { state: "loading" };
+    if (setting.state === "error") return { state: "error" };
+    if (!setting.value.repo) {
+      binding = { state: "unbound" };
+    } else {
+      const provider =
+        setting.value.provider ??
+        resolveContextTreeProvider({
+          repo: setting.value.repo,
+          declaredProvider: setting.value.provider,
+        }).provider;
+      binding = provider
+        ? {
+            state: "bound",
+            provider,
+            repo: setting.value.repo,
+            branch: setting.value.branch ?? "main",
+          }
+        : { state: "invalid" };
+    }
+  }
 
-  const binding = capabilities.value.contextTree.binding;
   if (binding.state !== "bound") {
     return { state: "ready", value: { binding, availability: null } };
   }
@@ -103,11 +146,11 @@ function contextTreeFact(
 }
 
 function pendingStatus(): SetupRowModel["status"] {
-  return { label: "Checking…", tone: "neutral" };
+  return { label: "Checking…", kind: "loading" };
 }
 
 function unknownStatus(): SetupRowModel["status"] {
-  return { label: "Status unknown", detail: "This status could not be loaded.", tone: "neutral" };
+  return { label: "Status unavailable", detail: "We couldn't check this right now.", kind: "unknown" };
 }
 
 function countLabel(count: number, singular: string, plural = `${singular}s`): string {
@@ -122,6 +165,14 @@ function repositoryLabel(repo: string | null): string | undefined {
     return path || url.hostname;
   } catch {
     return repo.replace(/^git@[^:]+:/, "").replace(/\.git$/, "");
+  }
+}
+
+function gitlabOriginLabel(origin: string): string {
+  try {
+    return new URL(origin).hostname;
+  } catch {
+    return origin;
   }
 }
 
@@ -170,11 +221,15 @@ const ACTION_LABELS = {
 } satisfies Record<SetupActionKind, string>;
 
 function blockerDetail(blockers: SetupBlocker[], isAdmin: boolean): string | undefined {
-  const details = blockers.map((item) =>
-    !isAdmin && item.resolutionOwner === "admin"
-      ? `Ask an admin to resolve this: ${BLOCKER_COPY[item.code]}`
-      : BLOCKER_COPY[item.code],
-  );
+  const details = blockers.map((item) => {
+    if (!isAdmin && item.resolutionOwner === "admin") {
+      return `Ask an admin to resolve this: ${BLOCKER_COPY[item.code]}`;
+    }
+    if (item.resolutionOwner === "operator") {
+      return `${BLOCKER_COPY[item.code]} No action is needed from you.`;
+    }
+    return BLOCKER_COPY[item.code];
+  });
   const unique = [...new Set(details)];
   return unique.length > 0 ? unique.join(" · ") : undefined;
 }
@@ -201,6 +256,10 @@ function hasAdminBlocker(blockers: SetupBlocker[]): boolean {
   return blockers.some((item) => item.resolutionOwner === "admin");
 }
 
+function issueKind(blockers: SetupBlocker[], isAdmin: boolean): SetupStatusKind {
+  return isAdmin && hasAdminBlocker(blockers) ? "attention" : "blocked";
+}
+
 function providerHealthLabel(provider: SetupRepositoryAutomationProvider): string {
   if (provider.adoption === "available") return "not configured";
   const labels = {
@@ -213,40 +272,79 @@ function providerHealthLabel(provider: SetupRepositoryAutomationProvider): strin
   return labels[provider.health];
 }
 
-function providerSummary(providers: SetupRepositoryAutomationProvider[], isAdmin: boolean): SetupRowModel["status"] {
+function providerSummary(
+  providers: SetupRepositoryAutomationProvider[],
+  github: SetupFacts["github"],
+  gitlab: SetupFacts["gitlab"],
+  isAdmin: boolean,
+): SetupRowModel["status"] {
   const configured = providers.filter((provider) => provider.adoption !== "available");
   if (configured.length === 0) {
-    return { label: "Not configured", detail: "Optional", tone: "neutral" };
+    return { label: "Not connected", detail: "Optional", kind: "optional" };
   }
 
   const ready = configured.filter((provider) => provider.health === "ready");
-  const providerDetail = providers
+  const providerDetail = configured
     .map((provider) => `${PROVIDER_LABELS[provider.provider]} ${providerHealthLabel(provider)}`)
     .join(" · ");
   const blockers = configured.flatMap((provider) => provider.blockers);
   const issues = blockerDetail(blockers, isAdmin);
   const detail = [providerDetail, issues].filter((item): item is string => Boolean(item)).join(" · ");
-  const tone = isAdmin && hasAdminBlocker(blockers) ? "attention" : "neutral";
 
   if (ready.length === configured.length) {
+    if (ready.length === 1 && ready[0]?.provider === "github" && github.state === "ready" && github.value) {
+      return {
+        label: `GitHub · ${github.value.accountLogin}`,
+        detail: github.value.accountType,
+        kind: "ready",
+      };
+    }
+    if (ready.length === 1 && ready[0]?.provider === "gitlab" && gitlab.state === "ready" && gitlab.value) {
+      return {
+        label: `GitLab · ${gitlab.value.displayName}`,
+        detail: gitlabOriginLabel(gitlab.value.instanceOrigin),
+        kind: "ready",
+      };
+    }
+    const identityDetail =
+      ready.length === 2 && github.state === "ready" && github.value && gitlab.state === "ready" && gitlab.value
+        ? `${github.value.accountLogin} · ${gitlab.value.displayName}`
+        : detail;
     return {
-      label: ready.length === 2 ? "GitHub + GitLab ready" : `${PROVIDER_LABELS[ready[0]?.provider ?? "github"]} ready`,
-      detail,
-      tone: "positive",
+      label: ready.length === 2 ? "GitHub + GitLab" : `${PROVIDER_LABELS[ready[0]?.provider ?? "github"]} ready`,
+      detail: identityDetail,
+      kind: "ready",
     };
   }
-  if (ready.length > 0) return { label: "Partial coverage", detail, tone };
+
+  const hasDegraded = configured.some(
+    (provider) => provider.health === "degraded" || provider.health === "unavailable",
+  );
+  if (hasDegraded) {
+    const hasUnavailable = configured.some((provider) => provider.health === "unavailable");
+    return {
+      label:
+        ready.length > 0
+          ? "Partial coverage"
+          : hasUnavailable
+            ? hasAdminBlocker(blockers) && isAdmin
+              ? "Needs attention"
+              : "Service unavailable"
+            : "Degraded",
+      detail,
+      kind: issueKind(blockers, isAdmin),
+    };
+  }
+
   if (configured.some((provider) => provider.health === "pending_verification")) {
-    return { label: "Verification pending", detail, tone };
+    return {
+      label: ready.length > 0 ? "Partial coverage" : "Waiting for verification",
+      detail,
+      kind: "pending",
+    };
   }
-  if (configured.some((provider) => provider.health === "degraded")) {
-    return { label: "Degraded", detail, tone };
-  }
-  return {
-    label: hasAdminBlocker(blockers) && isAdmin ? "Needs attention" : "Service unavailable",
-    detail,
-    tone,
-  };
+
+  return unknownStatus();
 }
 
 function providerAction(
@@ -269,7 +367,7 @@ function providerAction(
   }
   const first = configured[0];
   return {
-    label: configured.length === 0 ? "Set up" : "Manage",
+    label: configured.length === 0 ? "Connect" : "Manage",
     to: first ? `/settings/integrations/${first.provider}` : "/settings/integrations/github",
   };
 }
@@ -277,6 +375,7 @@ function providerAction(
 function contextTreeStatus(
   contextTree: Fact<ContextTreeFact>,
   blockers: SetupBlocker[],
+  reviewFact: Fact<SetupAutomaticReview>,
   isAdmin: boolean,
 ): SetupRowModel["status"] {
   if (contextTree.state === "loading") return pendingStatus();
@@ -287,7 +386,7 @@ function contextTreeStatus(
     return {
       label: "Not set up",
       detail: isAdmin ? "Optional" : "Optional · Ask an admin to set this up if your team needs it.",
-      tone: "neutral",
+      kind: "optional",
     };
   }
   if (binding.state === "invalid") {
@@ -296,7 +395,7 @@ function contextTreeStatus(
       detail:
         blockerDetail(blockers, isAdmin) ??
         (isAdmin ? "The Context Tree binding is invalid." : "Ask an admin to repair the Context Tree binding."),
-      tone: isAdmin ? "attention" : "neutral",
+      kind: isAdmin ? "attention" : "blocked",
     };
   }
 
@@ -306,25 +405,72 @@ function contextTreeStatus(
     PROVIDER_LABELS[binding.provider],
   ].join(" · ");
   const issueDetail = blockerDetail(blockers, isAdmin);
-  const detail = [bindingDetail, issueDetail].filter((item): item is string => Boolean(item)).join(" · ");
-  if (availability === "active") return { label: "Available", detail, tone: "positive" };
-  if (availability === "stale") return { label: "Available · update delayed", detail, tone: "neutral" };
+  const review = reviewFact.state === "ready" ? reviewFact.value : null;
+  const reviewState = review ? reviewStatus(review, isAdmin) : null;
+  const reviewDetail =
+    review?.adoption === "disabled"
+      ? "Automatic review off · Optional"
+      : review?.adoption === "enabled" && reviewState
+        ? [`Automatic review ${reviewState.label.toLowerCase()}`, reviewState.detail]
+            .filter((item): item is string => Boolean(item))
+            .join(" · ")
+        : null;
+  const prioritizeReview =
+    review?.adoption === "enabled" && reviewState !== null && !["ready", "optional"].includes(reviewState.kind);
+  const detail = (
+    prioritizeReview ? [reviewDetail, issueDetail, bindingDetail] : [bindingDetail, issueDetail, reviewDetail]
+  )
+    .filter((item): item is string => Boolean(item))
+    .join(" · ");
+
+  if (availability === "active") {
+    if (reviewFact.state === "loading") {
+      return { label: "Available · checking review", detail, kind: "loading" };
+    }
+    if (reviewFact.state === "error") {
+      return {
+        label: "Available · review status unavailable",
+        detail: [unknownStatus().detail, detail].filter(Boolean).join(" · "),
+        kind: "unknown",
+      };
+    }
+    if (!review || review.adoption === "unavailable" || review.adoption === "disabled") {
+      return { label: "Available", detail, kind: "ready" };
+    }
+    if (reviewState?.kind === "ready") {
+      return { label: "Available", detail, kind: "ready" };
+    }
+    if (reviewState?.kind === "pending") {
+      return { label: "Available · review pending", detail, kind: "pending" };
+    }
+    if (reviewState?.kind === "attention" || reviewState?.kind === "blocked") {
+      return {
+        label: review.health === "degraded" ? "Available · review degraded" : "Available · review unavailable",
+        detail,
+        kind: reviewState.kind,
+      };
+    }
+    return { label: "Available · review status unavailable", detail, kind: "unknown" };
+  }
+  if (availability === "stale") return { label: "Available · update delayed", detail, kind: "blocked" };
   if (availability === "unavailable") {
     return isAdmin
-      ? { label: "Needs recovery", detail, tone: "attention" }
+      ? { label: "Needs recovery", detail, kind: "attention" }
       : {
           label: "Unavailable",
           detail: issueDetail ? detail : `${bindingDetail} · Ask an admin to recover Context Tree access.`,
-          tone: "neutral",
+          kind: "blocked",
         };
   }
-  if (availability === "checking") return { label: "Checking availability", detail, tone: "neutral" };
-  return { label: "Status unknown", detail, tone: "neutral" };
+  if (availability === "checking") return { label: "Checking availability", detail, kind: "loading" };
+  const unknown = unknownStatus();
+  return { ...unknown, detail: [bindingDetail, unknown.detail].filter(Boolean).join(" · ") };
 }
 
 function contextTreeAction(
   contextTree: Fact<ContextTreeFact>,
   blockers: SetupBlocker[],
+  review: SetupAutomaticReview | null,
   isAdmin: boolean,
 ): SetupRowModel["action"] | undefined {
   if (contextTree.state !== "ready") return undefined;
@@ -340,46 +486,41 @@ function contextTreeAction(
   if (availability === "unavailable") {
     return isAdmin ? { label: "Recover", to: "/context" } : { label: "View", to: "/context" };
   }
+  if (availability === "active" && review?.adoption === "enabled") {
+    const reviewBlockerAction = actionFromBlockers(review.blockers, isAdmin);
+    if (reviewBlockerAction) return reviewBlockerAction;
+    if (review.blockers.length > 0) {
+      return isAdmin ? undefined : { label: "View", to: "/context" };
+    }
+  }
   return isAdmin ? { label: "Manage", to: "/settings/repositories#context-tree" } : { label: "View", to: "/context" };
 }
 
 function reviewStatus(review: SetupAutomaticReview, isAdmin: boolean): SetupRowModel["status"] {
   if (review.adoption === "unavailable") {
-    return { label: "Available after Context Tree", tone: "neutral" };
+    return { label: "Available after Context Tree", kind: "optional" };
   }
   if (review.adoption === "disabled") {
-    return { label: "Off", detail: "Optional", tone: "neutral" };
+    return { label: "Off", detail: "Optional", kind: "optional" };
   }
 
   const reviewer = review.reviewerAgent ? `Reviewer · ${review.reviewerAgent.displayName}` : null;
   const issues = blockerDetail(review.blockers, isAdmin);
-  const detail = [reviewer, issues].filter((item): item is string => Boolean(item)).join(" · ") || undefined;
-  if (review.health === "ready") return { label: "On", detail, tone: "positive" };
-  const tone = isAdmin && hasAdminBlocker(review.blockers) ? "attention" : "neutral";
-  if (review.health === "pending_verification") return { label: "Verification pending", detail, tone };
-  if (review.health === "degraded") return { label: "Degraded", detail, tone };
+  const detail = [issues, reviewer].filter((item): item is string => Boolean(item)).join(" · ") || undefined;
+  if (review.health === "ready") return { label: "On", detail, kind: "ready" };
+  if (review.health === "pending_verification") return { label: "Verification pending", detail, kind: "pending" };
+  if (review.health === "degraded") {
+    return { label: "Degraded", detail, kind: issueKind(review.blockers, isAdmin) };
+  }
   if (review.health === "unavailable") {
     return {
       label: hasAdminBlocker(review.blockers) && isAdmin ? "Needs attention" : "Service unavailable",
       detail,
-      tone,
+      kind: issueKind(review.blockers, isAdmin),
     };
   }
-  return { label: "Status unknown", detail, tone: "neutral" };
-}
-
-function reviewAction(review: SetupAutomaticReview, isAdmin: boolean): SetupRowModel["action"] | undefined {
-  if (review.adoption === "unavailable") return undefined;
-  if (!isAdmin) {
-    return review.adoption === "enabled" ? { label: "View", to: "/settings/repositories#context-tree" } : undefined;
-  }
-  if (review.adoption === "disabled") {
-    return { label: "Set up", to: "/settings/repositories#context-tree" };
-  }
-  const blockerAction = actionFromBlockers(review.blockers, true);
-  if (blockerAction) return blockerAction;
-  if (review.blockers.length > 0) return undefined;
-  return { label: "Manage", to: "/settings/repositories#context-tree" };
+  const unknown = unknownStatus();
+  return { ...unknown, detail: detail ?? unknown.detail };
 }
 
 /**
@@ -403,7 +544,7 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
                 facts.computers.value.connected === 1 && facts.computers.value.connectedHostname
                   ? facts.computers.value.connectedHostname
                   : countLabel(facts.computers.value.connected, "computer"),
-              tone: "positive" as const,
+              kind: "ready" as const,
             }
           : {
               label: "Not connected",
@@ -415,7 +556,7 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
                   : reliesOnTeamAgent
                     ? "Optional while a team agent is available"
                     : "No computer connected",
-              tone: reliesOnTeamAgent ? ("neutral" as const) : ("attention" as const),
+              kind: reliesOnTeamAgent ? ("optional" as const) : ("attention" as const),
             };
 
   const repositoryStatus =
@@ -427,41 +568,41 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
           ? {
               label: `${facts.repositories.value} connected`,
               detail: countLabel(facts.repositories.value, "active repository", "active repositories"),
-              tone: "positive" as const,
+              kind: "ready" as const,
             }
-          : { label: "None connected", detail: "Optional", tone: "neutral" as const };
+          : { label: "None connected", detail: "Optional", kind: "optional" as const };
 
   const capabilities = facts.capabilities.state === "ready" ? facts.capabilities.value : null;
-  const contextTree = contextTreeFact(facts.capabilities, facts.contextTreeSnapshot);
-  const repositoryAutomationStatus =
+  const contextTree = contextTreeFact(facts.capabilities, facts.contextTreeSetting, facts.contextTreeSnapshot);
+  const automaticReview: Fact<SetupAutomaticReview> =
+    facts.capabilities.state === "ready"
+      ? { state: "ready", value: facts.capabilities.value.contextTree.automaticReview }
+      : facts.capabilities.state === "loading"
+        ? { state: "loading" }
+        : { state: "error" };
+  const providerStatus =
     facts.capabilities.state === "loading"
       ? pendingStatus()
       : facts.capabilities.state === "error"
         ? unknownStatus()
-        : providerSummary(facts.capabilities.value.repositoryAutomation.providers, isAdmin);
-  const automaticReviewStatus =
-    facts.capabilities.state === "loading"
-      ? pendingStatus()
-      : facts.capabilities.state === "error"
-        ? unknownStatus()
-        : reviewStatus(facts.capabilities.value.contextTree.automaticReview, isAdmin);
+        : providerSummary(facts.capabilities.value.repositoryAutomation.providers, facts.github, facts.gitlab, isAdmin);
 
   return [
     {
       key: "work-access",
       title: "Work access",
       description: "Whether this team has an agent you can use.",
-      icon: CircleCheck,
+      icon: MessageCircle,
       status: facts.hasUsableAgent
         ? {
             label: "Can work now",
             detail: facts.hasPersonalAgent ? "Your agent is available" : "A team agent is available",
-            tone: "positive",
+            kind: "ready",
           }
         : {
             label: "Agent needed",
             detail: "Set up an agent before starting work",
-            tone: "attention",
+            kind: "attention",
           },
       action: facts.hasUsableAgent
         ? { label: "Start a chat", to: facts.workspaceWillEnterOnboarding ? "/onboarding" : "/" }
@@ -484,12 +625,14 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
       description: "An agent managed by you for personal workflows.",
       icon: Bot,
       status: facts.hasPersonalAgent
-        ? { label: "Available", detail: "Managed by you", tone: "positive" }
-        : {
-            label: "Not set up",
-            detail: facts.hasUsableAgent ? "Optional while a team agent is available" : "No agent managed by you",
-            tone: facts.hasUsableAgent ? "neutral" : "attention",
-          },
+        ? { label: "Available", detail: "Managed by you", kind: "ready" }
+        : resumeSetup
+          ? { label: "Setup paused", detail: "Resume to create your agent", kind: "attention" }
+          : {
+              label: "Not set up",
+              detail: facts.hasUsableAgent ? "Optional while a team agent is available" : "No agent managed by you",
+              kind: facts.hasUsableAgent ? "optional" : "attention",
+            },
       action: resumeSetup
         ? { label: "Resume setup", to: "/onboarding", intent: "resume-onboarding" }
         : facts.hasPersonalAgent
@@ -512,29 +655,25 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
       },
     },
     {
-      key: "repository-automation",
-      title: "Repository automation",
-      description: "GitHub or GitLab connections for events, identity, and webhooks.",
-      icon: Webhook,
-      status: repositoryAutomationStatus,
-      action: capabilities ? providerAction(capabilities.repositoryAutomation.providers, isAdmin) : undefined,
-    },
-    {
       key: "context-tree",
       title: "Context Tree",
       description: "Shared decisions and constraints available to agents.",
       icon: GitFork,
-      status: contextTreeStatus(contextTree, capabilities?.contextTree.blockers ?? [], isAdmin),
-      action: contextTreeAction(contextTree, capabilities?.contextTree.blockers ?? [], isAdmin),
+      status: contextTreeStatus(contextTree, capabilities?.contextTree.blockers ?? [], automaticReview, isAdmin),
+      action: contextTreeAction(
+        contextTree,
+        capabilities?.contextTree.blockers ?? [],
+        capabilities?.contextTree.automaticReview ?? null,
+        isAdmin,
+      ),
     },
     {
-      key: "automatic-review",
-      title: "Automatic review",
-      description: "A managed agent reviews Context Tree pull requests or merge requests.",
-      icon: ShieldCheck,
-      parentKey: "context-tree",
-      status: automaticReviewStatus,
-      action: capabilities ? reviewAction(capabilities.contextTree.automaticReview, isAdmin) : undefined,
+      key: "providers",
+      title: "GitHub / GitLab",
+      description: "A code provider connection for events, identity, and webhooks.",
+      icon: Webhook,
+      status: providerStatus,
+      action: capabilities ? providerAction(capabilities.repositoryAutomation.providers, isAdmin) : undefined,
     },
   ];
 }
@@ -564,30 +703,55 @@ export function SettingsSetupPage() {
       organizationId ? listTeamResourcesForOrg(organizationId) : Promise.reject(new Error("no organization")),
     enabled: !!organizationId,
   });
+  const contextSettingQuery = useQuery({
+    queryKey: ["org-setting", organizationId, "context_tree", "safe"],
+    queryFn: () =>
+      organizationId ? getContextTreeSetting(organizationId) : Promise.reject(new Error("no organization")),
+    enabled: !!organizationId,
+  });
   const capabilitiesQuery = useQuery({
     queryKey: setupCapabilitiesQueryKey(organizationId),
     queryFn: () =>
       organizationId ? getTeamSetupCapabilitiesAt(organizationId) : Promise.reject(new Error("no organization")),
     enabled: !!organizationId,
   });
-  const contextBound = capabilitiesQuery.data?.contextTree.binding.state === "bound";
+  const contextBound = Boolean(contextSettingQuery.data?.repo);
   const contextSnapshotQuery = useQuery({
     queryKey: ["context-tree-snapshot", organizationId, "7d", false],
     queryFn: () =>
       organizationId ? getContextTreeSnapshot(organizationId, "7d") : Promise.reject(new Error("no organization")),
     enabled: !!organizationId && contextBound,
   });
+  const githubQuery = useQuery({
+    queryKey: ["github-app-installation", organizationId],
+    queryFn: () =>
+      organizationId ? getGithubAppInstallation(organizationId) : Promise.reject(new Error("no organization")),
+    enabled: !!organizationId,
+  });
+  const gitlabQuery = useQuery({
+    queryKey: gitlabConnectionsQueryKey(organizationId),
+    queryFn: () =>
+      organizationId ? listGitlabConnectionsAt(organizationId) : Promise.reject(new Error("no organization")),
+    enabled: !!organizationId,
+  });
 
   const computers = queryFact(computersQuery);
   const repositories = queryFact(repositoriesQuery);
+  const contextTreeSetting = queryFact(contextSettingQuery);
   const capabilities = queryFact(capabilitiesQuery);
-  const contextTreeSnapshot: SetupFacts["contextTreeSnapshot"] = !contextBound
-    ? { state: "ready", value: null }
-    : contextSnapshotQuery.isPending
-      ? { state: "loading" }
-      : contextSnapshotQuery.isError || !contextSnapshotQuery.data
-        ? { state: "error" }
-        : { state: "ready", value: contextSnapshotQuery.data.snapshotStatus };
+  const github = queryFact(githubQuery);
+  const gitlab = queryFact(gitlabQuery);
+  const contextTreeSnapshot: SetupFacts["contextTreeSnapshot"] = contextSettingQuery.isPending
+    ? { state: "loading" }
+    : contextSettingQuery.isError
+      ? { state: "error" }
+      : !contextBound
+        ? { state: "ready", value: null }
+        : contextSnapshotQuery.isPending
+          ? { state: "loading" }
+          : contextSnapshotQuery.isError || !contextSnapshotQuery.data
+            ? { state: "error" }
+            : { state: "ready", value: contextSnapshotQuery.data.snapshotStatus };
 
   const facts: SetupFacts = {
     role,
@@ -623,7 +787,32 @@ export function SettingsSetupPage() {
           }
         : repositories,
     capabilities,
+    contextTreeSetting,
     contextTreeSnapshot,
+    github:
+      github.state === "ready"
+        ? {
+            state: "ready",
+            value: github.value
+              ? {
+                  accountLogin: github.value.accountLogin,
+                  accountType: github.value.accountType,
+                }
+              : null,
+          }
+        : github,
+    gitlab:
+      gitlab.state === "ready"
+        ? {
+            state: "ready",
+            value: gitlab.value[0]
+              ? {
+                  displayName: gitlab.value[0].displayName,
+                  instanceOrigin: gitlab.value[0].instanceOrigin,
+                }
+              : null,
+          }
+        : gitlab,
   };
 
   const resumeOnboarding = async () => {
@@ -668,6 +857,28 @@ export function SetupOverview({
   );
 }
 
+const SETUP_STATUS_PRESENTATION: Record<SetupStatusKind, { icon: LucideIcon; color: string; animate?: boolean }> = {
+  ready: { icon: CircleCheck, color: "var(--success)" },
+  optional: { icon: CircleMinus, color: "var(--fg-4)" },
+  loading: { icon: LoaderCircle, color: "var(--state-idle)", animate: true },
+  pending: { icon: Clock3, color: "var(--state-idle)" },
+  attention: { icon: CircleAlert, color: "var(--state-needs-you)" },
+  blocked: { icon: CircleAlert, color: "var(--state-blocked)" },
+  unknown: { icon: CircleHelp, color: "var(--fg-3)" },
+};
+
+function SetupStatusMark({ kind }: { kind: SetupStatusKind }) {
+  const presentation = SETUP_STATUS_PRESENTATION[kind];
+  const StatusIcon = presentation.icon;
+  return (
+    <StatusIcon
+      aria-hidden
+      className={cn("h-4 w-4 shrink-0", presentation.animate && "motion-safe:animate-spin")}
+      style={{ color: presentation.color }}
+    />
+  );
+}
+
 function SetupRow({
   row,
   narrow,
@@ -682,17 +893,12 @@ function SetupRow({
     <section
       aria-labelledby={`setup-${row.key}`}
       data-setup-row={row.key}
-      data-setup-parent={row.parentKey}
       style={{
         display: "grid",
         gridTemplateColumns: narrow ? "minmax(0, 1fr)" : "minmax(0, 1fr) var(--sp-60) var(--sp-35)",
         alignItems: narrow ? "start" : "center",
         gap: narrow ? "var(--sp-3)" : "var(--sp-5)",
-        padding: row.parentKey
-          ? narrow
-            ? "var(--sp-4) 0 var(--sp-4) var(--sp-4)"
-            : "var(--sp-4) 0 var(--sp-4) var(--sp-6)"
-          : "var(--sp-4) 0",
+        padding: "var(--sp-4) 0",
         borderBottom: "var(--hairline) solid var(--border)",
       }}
     >
@@ -720,28 +926,9 @@ function SetupRow({
         </span>
       </div>
 
-      <div
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-        style={narrow ? { paddingLeft: "var(--sp-11)" } : undefined}
-      >
+      <div data-setup-status-kind={row.status.kind} style={narrow ? { paddingLeft: "var(--sp-11)" } : undefined}>
         <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
-          <span
-            aria-hidden
-            style={{
-              width: "var(--sp-2)",
-              height: "var(--sp-2)",
-              flexShrink: 0,
-              borderRadius: "var(--radius-full)",
-              background:
-                row.status.tone === "positive"
-                  ? "var(--color-success)"
-                  : row.status.tone === "attention"
-                    ? "var(--state-needs-you)"
-                    : "var(--border-strong)",
-            }}
-          />
+          <SetupStatusMark kind={row.status.kind} />
           <span className="text-label font-medium" style={{ color: "var(--fg-2)" }}>
             {row.status.label}
           </span>
@@ -750,7 +937,7 @@ function SetupRow({
           <p
             className="text-caption truncate"
             title={row.status.detail}
-            style={{ margin: "var(--sp-0_5) 0 0 var(--sp-4)", color: "var(--fg-4)" }}
+            style={{ margin: "var(--sp-0_5) 0 0 var(--sp-6)", color: "var(--fg-4)" }}
           >
             {row.status.detail}
           </p>

--- a/packages/web/src/pages/setup-preview.tsx
+++ b/packages/web/src/pages/setup-preview.tsx
@@ -9,8 +9,9 @@ import { buildSetupRows, type SetupFacts, SetupOverview } from "./settings/setup
 import { SettingsLayout } from "./settings.js";
 
 type PreviewRole = "admin" | "member";
+type PreviewState = "ready" | "mixed";
 
-const PREVIEW_CAPABILITIES: TeamSetupCapabilities = {
+const READY_CAPABILITIES: TeamSetupCapabilities = {
   organizationId: "org-preview",
   repositoryAutomation: {
     providers: [
@@ -51,8 +52,59 @@ const PREVIEW_CAPABILITIES: TeamSetupCapabilities = {
   },
 };
 
-function previewFacts(role: PreviewRole): SetupFacts {
-  if (role === "member") {
+const MIXED_CAPABILITIES: TeamSetupCapabilities = {
+  ...READY_CAPABILITIES,
+  repositoryAutomation: {
+    providers: [
+      {
+        provider: "github",
+        adoption: "available",
+        health: "not_observed",
+        blockers: [],
+        observedAt: "2026-07-23T00:00:00.000Z",
+      },
+      {
+        provider: "gitlab",
+        adoption: "configuring",
+        health: "pending_verification",
+        blockers: [
+          {
+            code: "gitlab_webhook_not_seen",
+            resolutionOwner: "admin",
+            actionKind: "configure_gitlab_webhook",
+          },
+        ],
+        observedAt: "2026-07-23T00:00:00.000Z",
+      },
+    ],
+  },
+  contextTree: {
+    ...READY_CAPABILITIES.contextTree,
+    automaticReview: {
+      ...READY_CAPABILITIES.contextTree.automaticReview,
+      health: "degraded",
+      blockers: [
+        {
+          code: "gitlab_processing_failed",
+          resolutionOwner: "admin",
+          actionKind: null,
+        },
+      ],
+    },
+  },
+};
+
+const PREVIEW_CONTEXT_SETTING: SetupFacts["contextTreeSetting"] = {
+  state: "ready",
+  value: {
+    provider: "github",
+    repo: "https://github.com/agent-team-foundation/first-tree-context",
+    branch: "main",
+  },
+};
+
+function previewFacts(role: PreviewRole, state: PreviewState): SetupFacts {
+  if (state === "mixed") {
     return {
       role,
       teamName: "Gandy's team",
@@ -65,9 +117,15 @@ function previewFacts(role: PreviewRole): SetupFacts {
         state: "ready",
         value: { connected: 0, saved: 0, connectedHostname: null },
       },
-      repositories: { state: "ready", value: 3 },
-      capabilities: { state: "ready", value: PREVIEW_CAPABILITIES },
+      repositories: { state: "error" },
+      capabilities: { state: "ready", value: MIXED_CAPABILITIES },
+      contextTreeSetting: PREVIEW_CONTEXT_SETTING,
       contextTreeSnapshot: { state: "ready", value: "active" },
+      github: { state: "ready", value: null },
+      gitlab: {
+        state: "ready",
+        value: { displayName: "First Tree", instanceOrigin: "https://gitlab.com" },
+      },
     };
   }
 
@@ -84,22 +142,30 @@ function previewFacts(role: PreviewRole): SetupFacts {
       value: { connected: 1, saved: 1, connectedHostname: "Gandy-MacBook-Pro" },
     },
     repositories: { state: "ready", value: 3 },
-    capabilities: { state: "ready", value: PREVIEW_CAPABILITIES },
+    capabilities: { state: "ready", value: READY_CAPABILITIES },
+    contextTreeSetting: PREVIEW_CONTEXT_SETTING,
     contextTreeSnapshot: { state: "ready", value: "active" },
+    github: {
+      state: "ready",
+      value: { accountLogin: "agent-team-foundation", accountType: "Organization" },
+    },
+    gitlab: { state: "ready", value: null },
   };
 }
 
 export function SetupPreviewPage() {
   const [searchParams] = useSearchParams();
   const role: PreviewRole = searchParams.get("role") === "member" ? "member" : "admin";
-  const facts = previewFacts(role);
+  const state: PreviewState = searchParams.get("state") === "mixed" ? "mixed" : "ready";
+  const facts = previewFacts(role, state);
+  const capabilities = state === "mixed" ? MIXED_CAPABILITIES : READY_CAPABILITIES;
   const queryClient = useMemo(() => {
     const client = new QueryClient({
       defaultOptions: { queries: { staleTime: Number.POSITIVE_INFINITY } },
     });
-    client.setQueryData(setupCapabilitiesQueryKey("org-preview"), PREVIEW_CAPABILITIES);
+    client.setQueryData(setupCapabilitiesQueryKey("org-preview"), capabilities);
     return client;
-  }, []);
+  }, [capabilities]);
   const auth = {
     isAuthenticated: true,
     meLoaded: true,
@@ -115,12 +181,12 @@ export function SetupPreviewPage() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthContext.Provider value={auth}>
-        <div style={{ minHeight: "100vh", background: "var(--bg)" }} data-setup-preview={role}>
+        <div style={{ minHeight: "100vh", background: "var(--bg)" }} data-setup-preview={`${role}-${state}`}>
           <SettingsLayout activePathname="/settings/setup">
             <SetupOverview facts={facts} rows={buildSetupRows(facts)} />
           </SettingsLayout>
           <nav
-            aria-label="Setup preview role"
+            aria-label="Setup preview controls"
             className="fixed flex"
             style={{
               right: "var(--sp-4)",
@@ -133,29 +199,60 @@ export function SetupPreviewPage() {
               boxShadow: "var(--shadow-md)",
             }}
           >
-            {(["admin", "member"] as const).map((candidate) => (
-              <Link
-                key={candidate}
-                to={`/preview/setup?role=${candidate}`}
-                aria-current={role === candidate ? "page" : undefined}
-                className={cn(
-                  "text-label font-medium",
-                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                )}
-                style={{
-                  padding: "var(--sp-1_5) var(--sp-3)",
-                  borderRadius: "var(--radius-input)",
-                  color: role === candidate ? "var(--fg)" : "var(--fg-3)",
-                  background: role === candidate ? "var(--bg-hover)" : "transparent",
-                  textDecoration: "none",
-                }}
-              >
-                {candidate === "admin" ? "Admin" : "Member"}
-              </Link>
-            ))}
+            <PreviewControlGroup
+              label="Role"
+              options={["admin", "member"]}
+              selected={role}
+              href={(candidate) => `/preview/setup?role=${candidate}&state=${state}`}
+            />
+            <PreviewControlGroup
+              label="State"
+              options={["ready", "mixed"]}
+              selected={state}
+              href={(candidate) => `/preview/setup?role=${role}&state=${candidate}`}
+            />
           </nav>
         </div>
       </AuthContext.Provider>
     </QueryClientProvider>
+  );
+}
+
+function PreviewControlGroup<T extends string>({
+  label,
+  options,
+  selected,
+  href,
+}: {
+  label: string;
+  options: readonly T[];
+  selected: T;
+  href: (candidate: T) => string;
+}) {
+  return (
+    <span className="flex" style={{ gap: "var(--sp-1)" }}>
+      <span className="sr-only">{label}</span>
+      {options.map((candidate) => (
+        <Link
+          key={candidate}
+          to={href(candidate)}
+          aria-current={selected === candidate ? "page" : undefined}
+          className={cn(
+            "text-label font-medium",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          )}
+          style={{
+            padding: "var(--sp-1_5) var(--sp-3)",
+            borderRadius: "var(--radius-input)",
+            color: selected === candidate ? "var(--fg)" : "var(--fg-3)",
+            background: selected === candidate ? "var(--bg-hover)" : "transparent",
+            textDecoration: "none",
+            textTransform: "capitalize",
+          }}
+        >
+          {candidate}
+        </Link>
+      ))}
+    </span>
   );
 }


### PR DESCRIPTION
## Summary

- replace ambiguous status dots with a Setup-specific shape-and-color grammar while keeping capability icons neutral
- preserve the approved six-row overview and fold Automatic review into the Context Tree status only when it qualifies that capability
- keep provider readiness authoritative while using GitHub/GitLab identity only to enrich ready labels
- keep all-ready presentation restrained and the Setup tab permanently available

## Product behavior

- `CircleCheck` / green: ready or verified
- `CircleMinus` / gray: optional, off, or not configured
- `LoaderCircle` / motion-safe spin: transient loading only
- `Clock3` / blue: long-lived verification pending
- `CircleAlert` / amber: the current viewer can resolve the issue
- `CircleAlert` / orange: degraded or blocked outside the current viewer
- `CircleHelp` / gray: status could not be checked

The visible label and detail remain the semantic source. Status glyphs are decorative, rows do not create six competing live regions, and failure to query status remains neutral unknown rather than evidence that the capability is unavailable.

Admin and Member continue to see the same Team facts. Actions and ownership copy remain role-aware. For truncated Context Tree details, a non-ready Automatic review explanation is placed before repository metadata so the reason and owner stay visible.

## Dependency

This is a focused stacked follow-up to #1987 and targets `feat/setup-capability-integration`. It changes only:

- `packages/web/DESIGN.md`
- `packages/web/src/pages/settings/setup.tsx`
- `packages/web/src/pages/settings/__tests__/setup-dom.test.tsx`
- `packages/web/src/pages/setup-preview.tsx`

Keep this PR draft until #1987 merges, then change the base to `main` without rewriting history.

## Verification

- focused Setup/routes/API tests: 5 files, 70 tests passed
- full Web source suite: 199 files, 1,700 tests passed
- Web typecheck and design-token lint passed
- repo Biome check passed with only pre-existing warnings
- shared package build and Web production build passed
- real 1440×900 browser checks passed for Admin/Member in both Ready and Mixed states, with six rows and no horizontal overflow

Development previews:

- `/preview/setup?role=admin&state=ready`
- `/preview/setup?role=admin&state=mixed`
- `/preview/setup?role=member&state=ready`
- `/preview/setup?role=member&state=mixed`
