### PR TITLE
feat(web): refine Setup status icons

### DIFF
--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -167,6 +167,35 @@ Each state also ships a **soft** companion fill — `--state-working-soft` …
 state-tinted surfaces (chips, wells, `.context-change-breakdown`) instead of
 hand-rolling `color-mix(... var(--state-*) ..., transparent)` at the call site.
 
+### Capability readiness (Setup)
+
+Capability readiness is not agent presence. Setup rows keep the capability
+icon neutral and render a separate Lucide status glyph, so state remains clear
+without relying on color:
+
+| Meaning | Glyph | Token |
+|---------|-------|-------|
+| ready / verified | static `CircleCheck` | `--success` |
+| optional / not configured / off | `CircleMinus` | `--fg-4` |
+| verification pending | static `Clock3` | `--state-idle` |
+| current viewer can resolve it | `CircleAlert` | `--state-needs-you` |
+| degraded / blocked elsewhere | `CircleAlert` | `--state-blocked` |
+| status could not be checked | `CircleHelp` | `--fg-3` |
+
+A transient request may use `LoaderCircle` with a reduced-motion-safe spin;
+long-lived verification never spins. Use amber only when explicit ownership
+or personal scope establishes that the current viewer can resolve the issue;
+role or a generic Manage link alone is not enough. Red is reserved for a
+confirmed failed operation or system error, normally in an inline callout; a
+failed status query is neutral unknown, never evidence that the capability
+itself is unavailable.
+
+The visible label and detail are the semantic source; readiness glyphs are
+decorative (`aria-hidden`). Static row readouts do not each get an `aria-live`
+region. Do not reuse agent-centric `StateDot` / `StatusGlyph` for this
+vocabulary, and do not mechanically map backend health enums to color without
+considering adoption, blockers, resolution owner, role, and user impact.
+
 ### Feedback / severity
 A named set, aliased to shared base hues (one value per color):
 `--success` (green, = brand hue) · `--warning` (orange, = `--state-blocked`; the caution/blocked hue) · `--danger` (red).

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -187,9 +187,9 @@ afterEach(() => {
 });
 
 describe("Settings Setup overview", () => {
-  it("renders the six approved facts in order without completion or resource rows", async () => {
+  it("renders the six approved facts with separate capability and status icons", async () => {
     const view = await renderSetup(facts());
-    const titles = [...view.host.querySelectorAll("section > div:first-child .text-body")].map(
+    const titles = [...view.host.querySelectorAll("[data-setup-row] > div:first-child .text-body")].map(
       (node) => node.textContent,
     );
 
@@ -213,6 +213,80 @@ describe("Settings Setup overview", () => {
     expect(view.host.textContent).not.toContain("Your access and configuration");
     expect(view.host.textContent).not.toContain("finish setup");
     expect(view.host.textContent).not.toContain("complete setup");
+    expect(view.host.querySelector('[data-setup-row="work-access"] .lucide-message-circle')).not.toBeNull();
+    const readyMarks = view.host.querySelectorAll("[data-setup-status-kind='ready'] .lucide-circle-check");
+    expect(readyMarks).toHaveLength(6);
+    expect([...readyMarks].every((mark) => mark.getAttribute("aria-hidden") === "true")).toBe(true);
+    expect(view.host.querySelectorAll('[role="status"], [aria-live]')).toHaveLength(0);
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("uses form and color together for ready, optional, attention, unknown, blocked, and pending facts", async () => {
+    const view = await renderSetup(
+      facts({
+        hasPersonalAgent: false,
+        onboardingSuppressedAt: "2026-07-23T00:00:00.000Z",
+        onboardingCompletedAt: null,
+        computers: {
+          state: "ready",
+          value: { connected: 0, saved: 0, connectedHostname: null },
+        },
+        repositories: { state: "error" },
+        contextTree: {
+          state: "ready",
+          value: {
+            bound: true,
+            repo: "https://github.com/acme/context-tree.git",
+            branch: "main",
+            availability: "stale",
+          },
+        },
+        github: { state: "ready", value: null },
+        gitlab: {
+          state: "ready",
+          value: {
+            displayName: "Engineering",
+            instanceOrigin: "https://gitlab.acme.test",
+            endpointSeen: false,
+            health: {
+              lastValidInboundAt: null,
+              lastProcessingFailureAt: null,
+            },
+          },
+        },
+      }),
+    );
+    const expectation = [
+      ["work-access", "ready", "circle-check", "--success"],
+      ["computer", "optional", "circle-minus", "--fg-4"],
+      ["agent", "attention", "circle-alert", "--state-needs-you"],
+      ["repositories", "unknown", "circle-question-mark", "--fg-3"],
+      ["context-tree", "blocked", "circle-alert", "--state-blocked"],
+      ["providers", "pending", "clock-3", "--state-idle"],
+    ] as const;
+
+    for (const [key, kind, glyph, token] of expectation) {
+      const status = view.host.querySelector<HTMLElement>(
+        `[data-setup-row="${key}"] [data-setup-status-kind="${kind}"]`,
+      );
+      expect(status?.querySelector(`.lucide-${glyph}`)).not.toBeNull();
+      expect(status?.querySelector("svg")?.getAttribute("style")).toContain(token);
+    }
+    expect(
+      view.host.querySelector('[data-setup-row="providers"] [data-setup-status-kind] svg')?.getAttribute("class"),
+    ).not.toContain("animate-spin");
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("reserves a reduced-motion-safe spinner for transient loading", async () => {
+    const view = await renderSetup(facts({ computers: { state: "loading" } }));
+    const status = view.host.querySelector('[data-setup-row="computer"] [data-setup-status-kind="loading"]');
+    const icon = status?.querySelector(".lucide-loader-circle");
+
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute("class")).toContain("motion-safe:animate-spin");
 
     await act(async () => view.root.unmount());
   });
@@ -256,7 +330,7 @@ describe("Settings Setup overview", () => {
     expect(actionByTitle.get("GitHub / GitLab")).toBeUndefined();
     expect(view.host.textContent).not.toContain("Manage");
     expect(view.host.querySelector("button[disabled]")).toBeNull();
-    expect(view.host.querySelectorAll('[role="status"][aria-live="polite"]')).toHaveLength(6);
+    expect(view.host.querySelectorAll('[role="status"], [aria-live]')).toHaveLength(0);
 
     await act(async () => view.root.unmount());
   });
@@ -282,6 +356,7 @@ describe("Settings Setup overview", () => {
   it("keeps a Resume setup path for suppressed onboarding that is not complete", () => {
     const rows = buildSetupRows(
       facts({
+        hasPersonalAgent: false,
         onboardingSuppressedAt: "2026-07-23T00:00:00.000Z",
         onboardingCompletedAt: null,
       }),
@@ -291,6 +366,11 @@ describe("Settings Setup overview", () => {
       label: "Resume setup",
       to: "/onboarding",
       intent: "resume-onboarding",
+    });
+    expect(rows.find((row) => row.key === "agent")?.status).toEqual({
+      label: "Setup paused",
+      detail: "Resume to create your agent",
+      kind: "attention",
     });
   });
 
@@ -350,7 +430,7 @@ describe("Settings Setup overview", () => {
     const row = buildSetupRows(input).find((candidate) => candidate.key === "context-tree");
 
     expect(row?.status.label).toBe("Bound · unavailable");
-    expect(row?.status.positive).not.toBe(true);
+    expect(row?.status.kind).toBe("blocked");
     expect(row?.status.detail).toBe("acme/context-tree · main branch");
   });
 
@@ -363,7 +443,7 @@ describe("Settings Setup overview", () => {
     );
     const providers = rows.find((row) => row.key === "providers");
 
-    expect(providers?.status).toEqual({ label: "Not connected", detail: "Optional" });
+    expect(providers?.status).toEqual({ label: "Not connected", detail: "Optional", kind: "optional" });
     expect(providers?.action).toEqual({ label: "Connect", to: "/settings/integrations" });
   });
 
@@ -413,6 +493,7 @@ describe("Settings Setup overview", () => {
           state: "ready",
           value: { accountLogin: "acme", accountType: "Organization", suspended: true },
         },
+        gitlab: waitingGitlab,
       }),
     ).find((row) => row.key === "providers");
     const githubOnlySuspended = buildSetupRows(
@@ -428,22 +509,22 @@ describe("Settings Setup overview", () => {
     expect(gitlabOnly?.status).toMatchObject({
       label: "GitLab · Engineering",
       detail: "Waiting for inbound webhook",
-      positive: false,
+      kind: "pending",
     });
     expect(combinedGitlabDegraded?.status).toMatchObject({
       label: "GitHub + GitLab",
       detail: "GitHub connected · GitLab waiting for inbound webhook",
-      positive: false,
+      kind: "pending",
     });
     expect(combinedGithubDegraded?.status).toMatchObject({
       label: "GitHub + GitLab",
-      detail: "GitHub suspended · GitLab connected",
-      positive: false,
+      detail: "GitHub suspended · GitLab waiting for inbound webhook",
+      kind: "blocked",
     });
     expect(githubOnlySuspended?.status).toMatchObject({
       label: "GitHub · acme",
       detail: "Connection suspended",
-      positive: false,
+      kind: "blocked",
     });
   });
 
@@ -466,7 +547,7 @@ describe("Settings Setup overview", () => {
       }),
     ).find((row) => row.key === "providers");
 
-    expect(providers?.status.positive).toBe(false);
+    expect(providers?.status.kind).toBe("blocked");
     expect(providers?.status.detail).toBe("Processing issue");
   });
 
@@ -485,8 +566,13 @@ describe("Settings Setup overview", () => {
     ).find((row) => row.key === "providers");
 
     expect(loading?.status.label).toBe("Checking…");
+    expect(loading?.status.kind).toBe("loading");
     expect(loading?.action).toBeUndefined();
-    expect(failed?.status.label).toBe("Unavailable");
+    expect(failed?.status).toEqual({
+      label: "Status unavailable",
+      detail: "We couldn't check this right now.",
+      kind: "unknown",
+    });
     expect(failed?.action).toBeUndefined();
   });
 
@@ -537,8 +623,8 @@ describe("Settings Setup overview", () => {
     contextTreeMocks.getContextTreeSnapshot.mockRejectedValue(new Error("snapshot failed"));
 
     const view = await renderSettingsSetupPage();
-    const row = await waitForRowText(view.host, "Context Tree", "This status could not be loaded.");
-    expect(row.textContent).toContain("Unavailable");
+    const row = await waitForRowText(view.host, "Context Tree", "We couldn't check this right now.");
+    expect(row.textContent).toContain("Status unavailable");
     expect(row.textContent).not.toContain("Bound · unavailable");
     await act(async () => view.root.unmount());
   });

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -1,5 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
-import { Bot, CircleCheck, FolderGit2, GitFork, Laptop, type LucideIcon, Webhook } from "lucide-react";
+import {
+  Bot,
+  CircleAlert,
+  CircleCheck,
+  CircleHelp,
+  CircleMinus,
+  Clock3,
+  FolderGit2,
+  GitFork,
+  Laptop,
+  LoaderCircle,
+  type LucideIcon,
+  MessageCircle,
+  Webhook,
+} from "lucide-react";
 import { Link, useNavigate } from "react-router";
 import { listClients } from "../../api/activity.js";
 import { getContextTreeSnapshot } from "../../api/context-tree.js";
@@ -27,6 +41,8 @@ type ContextTreeFact = {
   branch: string | null;
   availability: "active" | "stale" | "unavailable" | "checking";
 };
+
+export type SetupStatusKind = "ready" | "optional" | "loading" | "pending" | "attention" | "blocked" | "unknown";
 
 export type SetupFacts = {
   role: string | null;
@@ -59,7 +75,7 @@ export type SetupRowModel = {
   status: {
     label: string;
     detail?: string;
-    positive?: boolean;
+    kind: SetupStatusKind;
   };
   action?: {
     label: string;
@@ -103,12 +119,12 @@ function contextTreeFact(
   return { state: "error" };
 }
 
-function pendingStatus(): SetupRowModel["status"] {
-  return { label: "Checking…" };
+function loadingStatus(): SetupRowModel["status"] {
+  return { label: "Checking…", kind: "loading" };
 }
 
-function unavailableStatus(): SetupRowModel["status"] {
-  return { label: "Unavailable", detail: "This status could not be loaded." };
+function unknownStatus(): SetupRowModel["status"] {
+  return { label: "Status unavailable", detail: "We couldn't check this right now.", kind: "unknown" };
 }
 
 function countLabel(count: number, singular: string, plural = `${singular}s`): string {
@@ -136,12 +152,16 @@ function gitlabOriginLabel(origin: string): string {
 
 function gitlabConnectionIssue(
   gitlab: NonNullable<Extract<SetupFacts["gitlab"], { state: "ready" }>["value"]>,
-): string | null {
+): "processing" | "pending" | null {
   // A valid inbound clears the failure fields server-side, so any remaining
   // failure is current and takes precedence over first-inbound readiness.
-  if (gitlab.health.lastProcessingFailureAt) return "Processing issue";
-  if (!gitlab.endpointSeen) return "Waiting for inbound webhook";
+  if (gitlab.health.lastProcessingFailureAt) return "processing";
+  if (!gitlab.endpointSeen) return "pending";
   return null;
+}
+
+function gitlabIssueLabel(issue: NonNullable<ReturnType<typeof gitlabConnectionIssue>>): string {
+  return issue === "processing" ? "Processing issue" : "Waiting for inbound webhook";
 }
 
 /**
@@ -155,9 +175,9 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
 
   const computerStatus =
     facts.computers.state === "loading"
-      ? pendingStatus()
+      ? loadingStatus()
       : facts.computers.state === "error"
-        ? unavailableStatus()
+        ? unknownStatus()
         : facts.computers.value.connected > 0
           ? {
               label: `${facts.computers.value.connected} connected`,
@@ -165,7 +185,7 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
                 facts.computers.value.connected === 1 && facts.computers.value.connectedHostname
                   ? facts.computers.value.connectedHostname
                   : countLabel(facts.computers.value.connected, "computer"),
-              positive: true,
+              kind: "ready" as const,
             }
           : {
               label: "Not connected",
@@ -177,28 +197,29 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
                   : reliesOnTeamAgent
                     ? "Optional while a team agent is available"
                     : "No computer connected",
+              kind: reliesOnTeamAgent ? ("optional" as const) : ("attention" as const),
             };
 
   const repositoryStatus =
     facts.repositories.state === "loading"
-      ? pendingStatus()
+      ? loadingStatus()
       : facts.repositories.state === "error"
-        ? unavailableStatus()
+        ? unknownStatus()
         : facts.repositories.value > 0
           ? {
               label: `${facts.repositories.value} connected`,
               detail: countLabel(facts.repositories.value, "active repository", "active repositories"),
-              positive: true,
+              kind: "ready" as const,
             }
-          : { label: "None connected", detail: "Optional" };
+          : { label: "None connected", detail: "Optional", kind: "optional" as const };
 
   const contextStatus =
     facts.contextTree.state === "loading"
-      ? pendingStatus()
+      ? loadingStatus()
       : facts.contextTree.state === "error"
-        ? unavailableStatus()
+        ? unknownStatus()
         : !facts.contextTree.value.bound
-          ? { label: "Not set up", detail: "Optional" }
+          ? { label: "Not set up", detail: "Optional", kind: "optional" as const }
           : {
               label:
                 facts.contextTree.value.availability === "active"
@@ -214,12 +235,19 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
               ]
                 .filter(Boolean)
                 .join(" · "),
-              positive: facts.contextTree.value.availability === "active",
+              kind:
+                facts.contextTree.value.availability === "active"
+                  ? ("ready" as const)
+                  : facts.contextTree.value.availability === "checking"
+                    ? ("loading" as const)
+                    : ("blocked" as const),
             };
 
   const github = facts.github.state === "ready" ? facts.github.value : null;
   const gitlab = facts.gitlab.state === "ready" ? facts.gitlab.value : null;
   const gitlabIssue = gitlab ? gitlabConnectionIssue(gitlab) : null;
+  const providerIssueKind: SetupStatusKind =
+    github?.suspended || gitlabIssue === "processing" ? "blocked" : gitlabIssue === "pending" ? "pending" : "ready";
   const providerStatus: SetupRowModel["status"] =
     github && gitlab
       ? {
@@ -227,28 +255,28 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
           detail:
             github.suspended || gitlabIssue
               ? `${github.suspended ? "GitHub suspended" : "GitHub connected"} · ${
-                  gitlabIssue ? `GitLab ${gitlabIssue.toLowerCase()}` : "GitLab connected"
+                  gitlabIssue ? `GitLab ${gitlabIssueLabel(gitlabIssue).toLowerCase()}` : "GitLab connected"
                 }`
               : `${github.accountLogin} · ${gitlab.displayName}`,
-          positive: !github.suspended && gitlabIssue === null,
+          kind: providerIssueKind,
         }
       : github
         ? {
             label: `GitHub · ${github.accountLogin}`,
             detail: github.suspended ? "Connection suspended" : github.accountType,
-            positive: !github.suspended,
+            kind: github.suspended ? "blocked" : "ready",
           }
         : gitlab
           ? {
               label: `GitLab · ${gitlab.displayName}`,
-              detail: gitlabIssue ?? gitlabOriginLabel(gitlab.instanceOrigin),
-              positive: gitlabIssue === null,
+              detail: gitlabIssue ? gitlabIssueLabel(gitlabIssue) : gitlabOriginLabel(gitlab.instanceOrigin),
+              kind: providerIssueKind,
             }
           : facts.github.state === "loading" || facts.gitlab.state === "loading"
-            ? pendingStatus()
+            ? loadingStatus()
             : facts.github.state === "error" || facts.gitlab.state === "error"
-              ? unavailableStatus()
-              : { label: "Not connected", detail: "Optional" };
+              ? unknownStatus()
+              : { label: "Not connected", detail: "Optional", kind: "optional" };
   const hasProvider = !!github || !!gitlab;
   const providersKnownAbsent =
     facts.github.state === "ready" &&
@@ -266,14 +294,14 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
       key: "work-access",
       title: "Work access",
       description: "Whether this team has an agent you can use.",
-      icon: CircleCheck,
+      icon: MessageCircle,
       status: facts.hasUsableAgent
         ? {
             label: "Can work now",
             detail: facts.hasPersonalAgent ? "Your agent is available" : "A team agent is available",
-            positive: true,
+            kind: "ready",
           }
-        : { label: "Agent needed", detail: "Set up an agent before starting work" },
+        : { label: "Agent needed", detail: "Set up an agent before starting work", kind: "attention" },
       action: facts.hasUsableAgent
         ? { label: "Start a chat", to: facts.workspaceWillEnterOnboarding ? "/onboarding" : "/" }
         : { label: "Set up", to: "/onboarding" },
@@ -295,11 +323,14 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
       description: "An agent managed by you for personal workflows.",
       icon: Bot,
       status: facts.hasPersonalAgent
-        ? { label: "Available", detail: "Managed by you", positive: true }
-        : {
-            label: "Not set up",
-            detail: facts.hasUsableAgent ? "Optional while a team agent is available" : "No agent managed by you",
-          },
+        ? { label: "Available", detail: "Managed by you", kind: "ready" }
+        : resumeSetup
+          ? { label: "Setup paused", detail: "Resume to create your agent", kind: "attention" }
+          : {
+              label: "Not set up",
+              detail: facts.hasUsableAgent ? "Optional while a team agent is available" : "No agent managed by you",
+              kind: facts.hasUsableAgent ? "optional" : "attention",
+            },
       action: resumeSetup
         ? { label: "Resume setup", to: "/onboarding", intent: "resume-onboarding" }
         : facts.hasPersonalAgent
@@ -524,6 +555,28 @@ export function SetupOverview({
   );
 }
 
+const SETUP_STATUS_PRESENTATION: Record<SetupStatusKind, { icon: LucideIcon; color: string; animate?: boolean }> = {
+  ready: { icon: CircleCheck, color: "var(--success)" },
+  optional: { icon: CircleMinus, color: "var(--fg-4)" },
+  loading: { icon: LoaderCircle, color: "var(--state-idle)", animate: true },
+  pending: { icon: Clock3, color: "var(--state-idle)" },
+  attention: { icon: CircleAlert, color: "var(--state-needs-you)" },
+  blocked: { icon: CircleAlert, color: "var(--state-blocked)" },
+  unknown: { icon: CircleHelp, color: "var(--fg-3)" },
+};
+
+function SetupStatusMark({ kind }: { kind: SetupStatusKind }) {
+  const presentation = SETUP_STATUS_PRESENTATION[kind];
+  const StatusIcon = presentation.icon;
+  return (
+    <StatusIcon
+      aria-hidden
+      className={cn("h-4 w-4 shrink-0", presentation.animate && "motion-safe:animate-spin")}
+      style={{ color: presentation.color }}
+    />
+  );
+}
+
 function SetupRow({
   row,
   narrow,
@@ -537,6 +590,7 @@ function SetupRow({
   return (
     <section
       aria-labelledby={`setup-${row.key}`}
+      data-setup-row={row.key}
       style={{
         display: "grid",
         gridTemplateColumns: narrow ? "minmax(0, 1fr)" : "minmax(0, 1fr) var(--sp-60) var(--sp-35)",
@@ -570,23 +624,9 @@ function SetupRow({
         </span>
       </div>
 
-      <div
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-        style={narrow ? { paddingLeft: "var(--sp-11)" } : undefined}
-      >
+      <div data-setup-status-kind={row.status.kind} style={narrow ? { paddingLeft: "var(--sp-11)" } : undefined}>
         <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>
-          <span
-            aria-hidden
-            style={{
-              width: "var(--sp-2)",
-              height: "var(--sp-2)",
-              flexShrink: 0,
-              borderRadius: "var(--radius-full)",
-              background: row.status.positive ? "var(--color-success)" : "var(--border-strong)",
-            }}
-          />
+          <SetupStatusMark kind={row.status.kind} />
           <span className="text-label font-medium" style={{ color: "var(--fg-2)" }}>
             {row.status.label}
           </span>
@@ -595,7 +635,7 @@ function SetupRow({
           <p
             className="text-caption truncate"
             title={row.status.detail}
-            style={{ margin: "var(--sp-0_5) 0 0 var(--sp-4)", color: "var(--fg-4)" }}
+            style={{ margin: "var(--sp-0_5) 0 0 var(--sp-6)", color: "var(--fg-4)" }}
           >
             {row.status.detail}
           </p>

--- a/packages/web/src/pages/setup-preview.tsx
+++ b/packages/web/src/pages/setup-preview.tsx
@@ -5,9 +5,10 @@ import { buildSetupRows, type SetupFacts, SetupOverview } from "./settings/setup
 import { SettingsLayout } from "./settings.js";
 
 type PreviewRole = "admin" | "member";
+type PreviewState = "ready" | "mixed";
 
-function previewFacts(role: PreviewRole): SetupFacts {
-  if (role === "member") {
+function previewFacts(role: PreviewRole, state: PreviewState): SetupFacts {
+  if (state === "mixed") {
     return {
       role,
       teamName: "Gandy's team",
@@ -20,25 +21,29 @@ function previewFacts(role: PreviewRole): SetupFacts {
         state: "ready",
         value: { connected: 0, saved: 0, connectedHostname: null },
       },
-      repositories: { state: "ready", value: 3 },
+      repositories: { state: "error" },
       contextTree: {
         state: "ready",
         value: {
           bound: true,
           repo: "https://github.com/agent-team-foundation/first-tree-context",
           branch: "main",
-          availability: "active",
+          availability: "stale",
         },
       },
-      github: {
+      github: { state: "ready", value: null },
+      gitlab: {
         state: "ready",
         value: {
-          accountLogin: "agent-team-foundation",
-          accountType: "Organization",
-          suspended: false,
+          displayName: "First Tree",
+          instanceOrigin: "https://gitlab.com",
+          endpointSeen: false,
+          health: {
+            lastValidInboundAt: null,
+            lastProcessingFailureAt: null,
+          },
         },
       },
-      gitlab: { state: "ready", value: null },
     };
   }
 
@@ -79,7 +84,8 @@ function previewFacts(role: PreviewRole): SetupFacts {
 export function SetupPreviewPage() {
   const [searchParams] = useSearchParams();
   const role: PreviewRole = searchParams.get("role") === "member" ? "member" : "admin";
-  const facts = previewFacts(role);
+  const state: PreviewState = searchParams.get("state") === "mixed" ? "mixed" : "ready";
+  const facts = previewFacts(role, state);
   const auth = {
     isAuthenticated: true,
     meLoaded: true,
@@ -92,12 +98,12 @@ export function SetupPreviewPage() {
 
   return (
     <AuthContext.Provider value={auth}>
-      <div style={{ minHeight: "100vh", background: "var(--bg)" }} data-setup-preview={role}>
+      <div style={{ minHeight: "100vh", background: "var(--bg)" }} data-setup-preview={`${role}-${state}`}>
         <SettingsLayout activePathname="/settings/setup">
           <SetupOverview facts={facts} rows={buildSetupRows(facts)} />
         </SettingsLayout>
         <nav
-          aria-label="Setup preview role"
+          aria-label="Setup preview controls"
           className="fixed flex"
           style={{
             right: "var(--sp-4)",
@@ -110,28 +116,59 @@ export function SetupPreviewPage() {
             boxShadow: "var(--shadow-md)",
           }}
         >
-          {(["admin", "member"] as const).map((candidate) => (
-            <Link
-              key={candidate}
-              to={`/preview/setup?role=${candidate}`}
-              aria-current={role === candidate ? "page" : undefined}
-              className={cn(
-                "text-label font-medium",
-                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-              )}
-              style={{
-                padding: "var(--sp-1_5) var(--sp-3)",
-                borderRadius: "var(--radius-input)",
-                color: role === candidate ? "var(--fg)" : "var(--fg-3)",
-                background: role === candidate ? "var(--bg-hover)" : "transparent",
-                textDecoration: "none",
-              }}
-            >
-              {candidate === "admin" ? "Admin" : "Member"}
-            </Link>
-          ))}
+          <PreviewControlGroup
+            label="Role"
+            options={["admin", "member"]}
+            selected={role}
+            href={(candidate) => `/preview/setup?role=${candidate}&state=${state}`}
+          />
+          <PreviewControlGroup
+            label="State"
+            options={["ready", "mixed"]}
+            selected={state}
+            href={(candidate) => `/preview/setup?role=${role}&state=${candidate}`}
+          />
         </nav>
       </div>
     </AuthContext.Provider>
+  );
+}
+
+function PreviewControlGroup<T extends string>({
+  label,
+  options,
+  selected,
+  href,
+}: {
+  label: string;
+  options: readonly T[];
+  selected: T;
+  href: (candidate: T) => string;
+}) {
+  return (
+    <span className="flex" style={{ gap: "var(--sp-1)" }}>
+      <span className="sr-only">{label}</span>
+      {options.map((candidate) => (
+        <Link
+          key={candidate}
+          to={href(candidate)}
+          aria-current={selected === candidate ? "page" : undefined}
+          className={cn(
+            "text-label font-medium",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          )}
+          style={{
+            padding: "var(--sp-1_5) var(--sp-3)",
+            borderRadius: "var(--radius-input)",
+            color: selected === candidate ? "var(--fg)" : "var(--fg-3)",
+            background: selected === candidate ? "var(--bg-hover)" : "transparent",
+            textDecoration: "none",
+            textTransform: "capitalize",
+          }}
+        >
+          {candidate}
+        </Link>
+      ))}
+    </span>
   );
 }


### PR DESCRIPTION
## Summary

- replace ambiguous status dots in the permanent Settings → Setup overview with a dedicated shape-and-color readiness grammar
- keep the six capability icons neutral and separate from their status glyphs
- distinguish ready, optional, transient loading, verification pending, viewer-actionable, blocked/degraded, and unknown states
- keep the Setup tab permanently visible when every row is ready; do not add a completion hero

## Product behavior

- green `CircleCheck`: ready / verified
- gray `CircleMinus`: optional / off / not configured
- blue `LoaderCircle`: transient loading only, with reduced-motion-safe animation
- blue static `Clock3`: long-lived verification pending
- amber `CircleAlert`: the current viewer can explicitly resolve the issue
- orange `CircleAlert`: confirmed blocked or degraded state without reliable viewer ownership
- gray `CircleHelp`: status could not be checked

Visible labels and details remain the semantic source. Status glyphs are decorative, and the six static rows no longer create competing `aria-live` regions. A query failure remains neutral unknown instead of being presented as a capability failure.

## Scope

This PR is based directly on current `main`, which already contains #1972. It changes only:

- `packages/web/DESIGN.md`
- `packages/web/src/pages/settings/setup.tsx`
- `packages/web/src/pages/settings/__tests__/setup-dom.test.tsx`
- `packages/web/src/pages/setup-preview.tsx`

It does not include the capability API, navigation attention, Automatic Review projection, or any other work from #1987. It supersedes the incorrectly stacked #1989.

## Verification

- focused Setup/routes/Settings tests: 3 files, 46 tests passed
- full Web suite: 198 files, 1,676 tests passed
- Web typecheck and design-token lint passed
- root Biome check passed with pre-existing warnings only
- shared build and Web production build passed
- real browser checks passed for Admin/Member × Ready/Mixed: six rows, expected role actions, no completion hero, no horizontal overflow, and no row-level live regions
- independent final review found and verified a severity-precedence fix: confirmed provider degradation now outranks pending verification

Development previews:

- `/preview/setup?role=admin&state=ready`
- `/preview/setup?role=admin&state=mixed`
- `/preview/setup?role=member&state=ready`
- `/preview/setup?role=member&state=mixed`
