### PR TITLE
feat: add Context Reviewer assignment readiness contract

### DIFF
--- a/packages/server/src/__tests__/agent-context-tree-info.test.ts
+++ b/packages/server/src/__tests__/agent-context-tree-info.test.ts
@@ -13,6 +13,57 @@ import { createTestAdmin, seedClient, useTestApp } from "./helpers.js";
 describe("agent context tree info route", () => {
   const getApp = useTestApp();
 
+  it("masks a historical private Reviewer UUID from other Team runtimes", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    const clientId = await seedClient(app, admin.userId, admin.organizationId);
+    const runtimeAgent = await createAgent(app.db, {
+      name: `agent-ct-runtime-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Agent Context Tree Runtime",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+      clientId,
+    });
+    const privateReviewer = await createAgent(app.db, {
+      name: `private-reviewer-${crypto.randomUUID().slice(0, 8)}`,
+      type: "agent",
+      displayName: "Historical Private Reviewer",
+      managerId: admin.memberId,
+      organizationId: admin.organizationId,
+      clientId,
+      visibility: "private",
+    });
+    await app.db.insert(organizationSettings).values({
+      organizationId: admin.organizationId,
+      namespace: "context_tree_features",
+      value: { contextReviewer: { enabled: true, agentUuid: privateReviewer.uuid } },
+      version: 1,
+      updatedBy: admin.userId,
+    });
+
+    await expect(
+      orgSettingsService.getOrgSetting(app.db, admin.organizationId, "context_tree_features"),
+    ).resolves.toEqual({
+      contextReviewer: {
+        enabled: true,
+        agentUuid: null,
+        reviewerAgent: null,
+      },
+    });
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/v1/agent/context-tree/info",
+      headers: { authorization: `Bearer ${admin.accessToken}`, "x-agent-id": runtimeAgent.uuid },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      contextReviewer: { enabled: true, agentUuid: null },
+    });
+    expect(response.body).not.toContain(privateReviewer.uuid);
+  });
+
   it("uses the authenticated agent org, not the caller primary org", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/api-small-routes-extra.test.ts
+++ b/packages/server/src/__tests__/api-small-routes-extra.test.ts
@@ -22,8 +22,8 @@ const routeMocks = {
   assertNoRuntimeSwitchInProgress: vi.fn(),
   getMeDocPreview: vi.fn(),
   getOrganization: vi.fn(),
-  getOrgContextReviewRuntime: vi.fn(),
   getOrgContextTreeBinding: vi.fn(),
+  getTeamSafeOrgContextReviewRuntime: vi.fn(),
   generateConnectToken: vi.fn(),
   ensureMembership: vi.fn(),
   findActiveByToken: vi.fn(),
@@ -117,8 +117,8 @@ function mockRouteDependencies(): void {
     kickoffOnboarding: vi.fn(async () => ({ chatId: "chat_1", sent: null })),
   }));
   vi.doMock("../services/org-settings.js", () => ({
-    getOrgContextReviewRuntime: routeMocks.getOrgContextReviewRuntime,
     getOrgContextTreeBinding: routeMocks.getOrgContextTreeBinding,
+    getTeamSafeOrgContextReviewRuntime: routeMocks.getTeamSafeOrgContextReviewRuntime,
   }));
   vi.doMock("../services/organization.js", () => ({
     getOrganization: routeMocks.getOrganization,
@@ -351,7 +351,7 @@ describe("small API route handlers", () => {
       configService: { getDecrypted: vi.fn().mockResolvedValue({ env: { A: "1" } }) },
       resourcesService: { resolveRuntimeConfig: vi.fn().mockReturnValue({ env: { A: "1" }, resources: [] }) },
     });
-    routeMocks.getOrgContextReviewRuntime
+    routeMocks.getTeamSafeOrgContextReviewRuntime
       .mockResolvedValueOnce({
         provider: "gitlab",
         branch: "main",

--- a/packages/server/src/__tests__/context-reviewer-pr.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-pr.test.ts
@@ -1,10 +1,15 @@
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import { and, desc, eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import postgres from "postgres";
 import { describe, expect, it } from "vitest";
+import { connectDatabase, sslOptions } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { chatMembership } from "../db/schema/chat-membership.js";
 import { chats } from "../db/schema/chats.js";
+import { clients } from "../db/schema/clients.js";
+import { githubAppInstallations } from "../db/schema/github-app-installations.js";
 import { inboxEntries } from "../db/schema/inbox-entries.js";
 import { messages } from "../db/schema/messages.js";
 import { organizationSettings } from "../db/schema/organization-settings.js";
@@ -12,15 +17,15 @@ import { createAgent } from "../services/agent.js";
 import { createChat } from "../services/chat.js";
 import {
   contextReviewerPrTestInternals,
-  handleContextReviewerPrEvent,
-  handleContextReviewerPullRequest,
+  handleContextReviewerPrEvent as handleContextReviewerPrEventService,
+  handleContextReviewerPullRequest as handleContextReviewerPullRequestService,
   normalizeGithubRepo,
   renderContextReviewerPrPrompt,
 } from "../services/context-reviewer-pr.js";
 import { upsertInstallationFromMetadata } from "../services/github-app-installations.js";
 import { createMember } from "../services/member.js";
 import { putOrgSetting } from "../services/org-settings.js";
-import { createAdminContext, useTestApp } from "./helpers.js";
+import { createAdminContext, seedHealthyAgentRuntime, useTestApp } from "./helpers.js";
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
 const HEAD_SHA = "a".repeat(40);
@@ -29,6 +34,27 @@ const { privateKey: TEST_APP_PRIVATE_KEY_PEM } = generateKeyPairSync("rsa", {
   privateKeyEncoding: { type: "pkcs8", format: "pem" },
   publicKeyEncoding: { type: "spki", format: "pem" },
 });
+
+function databaseUrlWithApplicationName(url: string, applicationName: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("application_name", applicationName);
+  return parsed.toString();
+}
+
+async function waitForPostgresLockWait(observer: ReturnType<typeof postgres>, applicationName: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await observer<{ wait_event_type: string | null }[]>`
+      SELECT wait_event_type
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND application_name = ${applicationName}
+    `;
+    if (rows.some((row) => row.wait_event_type === "Lock")) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for PostgreSQL lock: ${applicationName}`);
+}
 
 function pullRequestPayload(overrides: Partial<Record<string, unknown>> = {}) {
   return {
@@ -96,13 +122,18 @@ async function createReviewer(
   admin: Awaited<ReturnType<typeof createAdminContext>>,
   options: { name?: string } = {},
 ) {
-  return createAgent(app.db, {
+  const reviewer = await createAgent(app.db, {
     name: options.name ?? `reviewer-${randomUUID().slice(0, 8)}`,
     type: "agent",
     displayName: "Context Reviewer",
     managerId: admin.memberId,
     clientId: admin.clientId,
   });
+  await seedHealthyAgentRuntime(app, {
+    agentUuid: reviewer.uuid,
+    clientId: admin.clientId,
+  });
+  return reviewer;
 }
 
 async function enableReviewer(app: App, admin: Awaited<ReturnType<typeof createAdminContext>>, reviewerUuid: string) {
@@ -132,11 +163,33 @@ async function seedReviewerInstallation(app: App, organizationId: string): Promi
       accountLogin: "owner",
       accountGithubId: numericId + 1,
       permissions: { metadata: "read", pull_requests: "write" },
-      events: ["pull_request"],
+      events: ["pull_request", "issue_comment", "pull_request_review_comment"],
       suspendedAt: null,
     },
     hubOrganizationId: organizationId,
   });
+}
+
+type TestReviewerPrInput = Omit<Parameters<typeof handleContextReviewerPrEventService>[1], "installationId"> & {
+  installationId?: number;
+};
+
+async function withCurrentInstallation(app: App, input: TestReviewerPrInput) {
+  if (input.installationId !== undefined) return { ...input, installationId: input.installationId };
+  const [installation] = await app.db
+    .select({ installationId: githubAppInstallations.installationId })
+    .from(githubAppInstallations)
+    .where(eq(githubAppInstallations.hubOrganizationId, input.organizationId))
+    .limit(1);
+  return { ...input, installationId: installation?.installationId ?? 0 };
+}
+
+async function handleContextReviewerPrEvent(app: App, input: TestReviewerPrInput) {
+  return handleContextReviewerPrEventService(app, await withCurrentInstallation(app, input));
+}
+
+async function handleContextReviewerPullRequest(app: App, input: TestReviewerPrInput) {
+  return handleContextReviewerPullRequestService(app, await withCurrentInstallation(app, input));
 }
 
 async function seedGithubIdentity(app: App, userId: string, login: string) {
@@ -335,6 +388,26 @@ describe("normalizeGithubRepo", () => {
 
 describe("handleContextReviewerPrEvent", () => {
   const getApp = useTestApp({ githubAppPrivateKeyPem: TEST_APP_PRIVATE_KEY_PEM });
+  const getAppWithoutSlug = useTestApp({
+    githubAppPrivateKeyPem: TEST_APP_PRIVATE_KEY_PEM,
+    omitGithubAppSlug: true,
+  });
+
+  it("fails closed before creating a trusted run when the GitHub App slug is unavailable", async () => {
+    const app = getAppWithoutSlug();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+
+    await expect(
+      handleContextReviewerPrEvent(app, {
+        eventType: "pull_request",
+        payload: pullRequestPayload(),
+        organizationId: admin.organizationId,
+      }),
+    ).resolves.toEqual({ handled: false, reason: "reviewer_runtime_unavailable" });
+    await expect(app.db.select({ id: chats.id }).from(chats)).resolves.toHaveLength(0);
+  });
 
   it("skips when webhook repo is not the bound context repo", async () => {
     const app = getApp();
@@ -808,7 +881,7 @@ describe("handleContextReviewerPrEvent", () => {
     });
   });
 
-  it("does not suppress a delayed opened task after the reviewer manager changes", async () => {
+  it("fails closed after the reviewer manager changes without a matching Computer owner", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
     const reviewer = await createReviewer(app, admin);
@@ -838,22 +911,230 @@ describe("handleContextReviewerPrEvent", () => {
       organizationId: admin.organizationId,
     });
 
-    expect(opened).toMatchObject({ handled: true, reused: true, chatId: synchronized.chatId });
-    if (!opened.handled) throw new Error("expected delayed opened event handled");
+    expect(opened).toEqual({ handled: false, reason: "reviewer_agent_invalid" });
     const runMessages = await app.db
       .select({ id: messages.id, metadata: messages.metadata })
       .from(messages)
       .where(eq(messages.chatId, synchronized.chatId))
       .orderBy(desc(messages.createdAt), desc(messages.id));
-    expect(runMessages).toHaveLength(2);
-    expect(runMessages[0]).toMatchObject({
-      id: opened.messageId,
-      metadata: {
-        triggerEvent: "pull_request.opened",
-        contextReviewReviewerAgentUuid: reviewer.uuid,
-        contextReviewReviewerManagerHumanAgentId: currentManager.agentId,
-      },
+    expect(runMessages).toHaveLength(1);
+  });
+
+  it("fails closed per run while the Computer is offline and recovers without rewriting Reviewer settings", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+    const [settingBefore] = await app.db
+      .select()
+      .from(organizationSettings)
+      .where(
+        and(
+          eq(organizationSettings.organizationId, admin.organizationId),
+          eq(organizationSettings.namespace, "context_tree_features"),
+        ),
+      );
+
+    await app.db.update(clients).set({ status: "disconnected" }).where(eq(clients.id, admin.clientId));
+    await expect(
+      handleContextReviewerPrEvent(app, {
+        eventType: "pull_request",
+        payload: pullRequestPayload(),
+        organizationId: admin.organizationId,
+      }),
+    ).resolves.toEqual({
+      handled: false,
+      reason: "reviewer_runtime_unavailable",
     });
+    await expect(app.db.select({ id: chats.id }).from(chats)).resolves.toHaveLength(0);
+
+    await seedHealthyAgentRuntime(app, {
+      agentUuid: reviewer.uuid,
+      clientId: admin.clientId,
+    });
+    await expect(
+      handleContextReviewerPrEvent(app, {
+        eventType: "pull_request",
+        payload: pullRequestPayload(),
+        organizationId: admin.organizationId,
+      }),
+    ).resolves.toMatchObject({ handled: true, reused: false });
+    const [settingAfter] = await app.db
+      .select()
+      .from(organizationSettings)
+      .where(
+        and(
+          eq(organizationSettings.organizationId, admin.organizationId),
+          eq(organizationSettings.namespace, "context_tree_features"),
+        ),
+      );
+    expect(settingAfter).toEqual(settingBefore);
+  });
+
+  it("rejects a historical enabled landing-campaign trial Agent without creating a trusted run", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+    await app.db
+      .update(agents)
+      .set({ metadata: { landingCampaignTrial: true } })
+      .where(eq(agents.uuid, reviewer.uuid));
+
+    await expect(
+      handleContextReviewerPrEvent(app, {
+        eventType: "pull_request",
+        payload: pullRequestPayload(),
+        organizationId: admin.organizationId,
+      }),
+    ).resolves.toEqual({ handled: false, reason: "reviewer_agent_invalid" });
+    await expect(app.db.select({ id: chats.id }).from(chats)).resolves.toHaveLength(0);
+  });
+
+  it("rechecks disabled settings after routing and writes no trusted run", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+    const [installation] = await app.db
+      .select({ installationId: githubAppInstallations.installationId })
+      .from(githubAppInstallations)
+      .where(eq(githubAppInstallations.hubOrganizationId, admin.organizationId));
+    if (!installation) throw new Error("review installation missing");
+
+    const databaseUrl = process.env.DATABASE_URL ?? "";
+    if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+    const applicationName = `context_review_dispatch_setting_${randomUUID().slice(0, 8)}`;
+    const dispatchDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, applicationName));
+    const dispatchApp = {
+      db: dispatchDb,
+      config: app.config,
+      notifier: app.notifier,
+    } as FastifyInstance;
+    const blocker = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    let blockerCommitted = false;
+    try {
+      await blocker`BEGIN`;
+      await blocker`SELECT id FROM members WHERE id = ${admin.memberId} FOR UPDATE`;
+
+      const handling = handleContextReviewerPrEventService(dispatchApp, {
+        eventType: "pull_request",
+        payload: pullRequestPayload(),
+        organizationId: admin.organizationId,
+        installationId: installation.installationId,
+      });
+      await waitForPostgresLockWait(observer, applicationName);
+
+      // The fence must wait on manager before taking Computer or Agent.
+      await blocker`SELECT id FROM clients WHERE id = ${admin.clientId} FOR UPDATE`;
+      await blocker`SELECT uuid FROM agents WHERE uuid = ${reviewer.uuid} FOR UPDATE`;
+      await putOrgSetting(
+        app.db,
+        admin.organizationId,
+        "context_tree_features",
+        { contextReviewer: { enabled: false, agentUuid: reviewer.uuid } },
+        { updatedBy: admin.userId, memberId: admin.memberId },
+      );
+      await blocker`COMMIT`;
+      blockerCommitted = true;
+
+      await expect(handling).resolves.toEqual({ handled: false, reason: "reviewer_runtime_unavailable" });
+      await expect(app.db.select({ id: chats.id }).from(chats)).resolves.toHaveLength(0);
+      await expect(app.db.select({ id: messages.id }).from(messages)).resolves.toHaveLength(0);
+    } finally {
+      if (!blockerCommitted) await blocker`ROLLBACK`;
+      await dispatchDb.end();
+      await blocker.end();
+      await observer.end();
+    }
+  });
+
+  it("rechecks provider authority after routing and writes no trusted run", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+    const [installation] = await app.db
+      .select({ installationId: githubAppInstallations.installationId })
+      .from(githubAppInstallations)
+      .where(eq(githubAppInstallations.hubOrganizationId, admin.organizationId));
+    if (!installation) throw new Error("review installation missing");
+
+    const databaseUrl = process.env.DATABASE_URL ?? "";
+    if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+    const applicationName = `context_review_dispatch_provider_${randomUUID().slice(0, 8)}`;
+    const dispatchDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, applicationName));
+    const dispatchApp = {
+      db: dispatchDb,
+      config: app.config,
+      notifier: app.notifier,
+    } as FastifyInstance;
+    const blocker = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    let blockerCommitted = false;
+    try {
+      await blocker`BEGIN`;
+      await blocker`SELECT id FROM members WHERE id = ${admin.memberId} FOR UPDATE`;
+
+      const handling = handleContextReviewerPrEventService(dispatchApp, {
+        eventType: "pull_request",
+        payload: pullRequestPayload(),
+        organizationId: admin.organizationId,
+        installationId: installation.installationId,
+      });
+      await waitForPostgresLockWait(observer, applicationName);
+
+      await app.db
+        .update(githubAppInstallations)
+        .set({ permissions: { metadata: "read", pull_requests: "read" } })
+        .where(eq(githubAppInstallations.hubOrganizationId, admin.organizationId));
+      await blocker`COMMIT`;
+      blockerCommitted = true;
+
+      await expect(handling).resolves.toEqual({ handled: false, reason: "reviewer_runtime_unavailable" });
+      await expect(app.db.select({ id: chats.id }).from(chats)).resolves.toHaveLength(0);
+      await expect(app.db.select({ id: messages.id }).from(messages)).resolves.toHaveLength(0);
+    } finally {
+      if (!blockerCommitted) await blocker`ROLLBACK`;
+      await dispatchDb.end();
+      await blocker.end();
+      await observer.end();
+    }
+  });
+
+  it("fails closed before creating a trusted run when current GitHub review authority is revoked", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await enableReviewer(app, admin, reviewer.uuid);
+    const [installation] = await app.db
+      .select({ installationId: githubAppInstallations.installationId })
+      .from(githubAppInstallations)
+      .where(eq(githubAppInstallations.hubOrganizationId, admin.organizationId));
+    if (!installation) throw new Error("review installation missing");
+    await expect(
+      handleContextReviewerPrEvent(app, {
+        eventType: "pull_request",
+        payload: pullRequestPayload(),
+        organizationId: admin.organizationId,
+        installationId: installation.installationId + 1,
+      }),
+    ).resolves.toEqual({ handled: false, reason: "reviewer_runtime_unavailable" });
+
+    await app.db
+      .update(githubAppInstallations)
+      .set({ permissions: { metadata: "read", pull_requests: "read" } })
+      .where(eq(githubAppInstallations.hubOrganizationId, admin.organizationId));
+
+    await expect(
+      handleContextReviewerPrEvent(app, {
+        eventType: "pull_request",
+        payload: pullRequestPayload(),
+        organizationId: admin.organizationId,
+      }),
+    ).resolves.toEqual({ handled: false, reason: "reviewer_runtime_unavailable" });
+    await expect(app.db.select({ id: chats.id }).from(chats)).resolves.toHaveLength(0);
   });
 
   it("reuses the reviewer chat for pull_request.synchronize and notifies the reviewer", async () => {

--- a/packages/server/src/__tests__/context-reviewer-publisher.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-publisher.test.ts
@@ -2,16 +2,17 @@ import { generateKeyPairSync, randomUUID } from "node:crypto";
 import { AGENT_RUNTIME_SESSION_HEADER, AGENT_SELECTOR_HEADER } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { agents } from "../db/schema/agents.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { githubAppInstallations } from "../db/schema/github-app-installations.js";
 import { messages } from "../db/schema/messages.js";
 import { createAgent } from "../services/agent.js";
 import { bindAgentRuntimeSession } from "../services/agent-runtime-session.js";
-import { handleContextReviewerPrEvent } from "../services/context-reviewer-pr.js";
+import { handleContextReviewerPrEvent as handleContextReviewerPrEventService } from "../services/context-reviewer-pr.js";
 import { submitContextReviewOutcome } from "../services/context-reviewer-publisher.js";
 import { upsertInstallationFromMetadata } from "../services/github-app-installations.js";
 import { putOrgSetting } from "../services/org-settings.js";
-import { createAdminContext, useTestApp } from "./helpers.js";
+import { createAdminContext, seedHealthyAgentRuntime, useTestApp } from "./helpers.js";
 
 const { privateKey: privateKeyPem } = generateKeyPairSync("rsa", {
   modulusLength: 2048,
@@ -244,7 +245,41 @@ describe("Context Reviewer App publisher", () => {
       }),
     ).rejects.toMatchObject({ code: "CONTEXT_REVIEW_APP_PERMISSION_REQUIRED" });
   });
+
+  it("revokes publication when the configured Reviewer becomes private mid-run", async () => {
+    const fixture = await createRunFixture(getApp());
+    await fixture.app.db.update(agents).set({ visibility: "private" }).where(eq(agents.uuid, fixture.reviewer.uuid));
+
+    await expect(
+      submitContextReviewOutcome({
+        db: fixture.app.db,
+        chatId: fixture.chatId,
+        runId: fixture.runId,
+        callerAgentUuid: fixture.reviewer.uuid,
+        callerClientId: fixture.admin.clientId,
+        callerRuntimeSessionToken: fixture.runtimeToken,
+        request: { event: "COMMENT", body: "Deferred" },
+        appCredentials: fixture.app.config.oauth?.githubApp,
+        fetcher: successfulGithubFetcher(),
+      }),
+    ).rejects.toMatchObject({ code: "CONTEXT_REVIEW_RUN_FORBIDDEN" });
+  });
 });
+
+async function handleContextReviewerPrEvent(
+  app: ReturnType<ReturnType<typeof useTestApp>>,
+  input: Omit<Parameters<typeof handleContextReviewerPrEventService>[1], "installationId">,
+) {
+  const [installation] = await app.db
+    .select({ installationId: githubAppInstallations.installationId })
+    .from(githubAppInstallations)
+    .where(eq(githubAppInstallations.hubOrganizationId, input.organizationId))
+    .limit(1);
+  return handleContextReviewerPrEventService(app, {
+    ...input,
+    installationId: installation?.installationId ?? 0,
+  });
+}
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -268,6 +303,10 @@ async function createRunFixture(app: ReturnType<ReturnType<typeof useTestApp>>) 
     managerId: admin.memberId,
     clientId: admin.clientId,
   });
+  await seedHealthyAgentRuntime(app, {
+    agentUuid: reviewer.uuid,
+    clientId: admin.clientId,
+  });
   const runtimeToken = await bindAgentRuntimeSession(app.db, reviewer.uuid, admin.clientId);
   await upsertInstallationFromMetadata(app.db, {
     installation: {
@@ -276,7 +315,7 @@ async function createRunFixture(app: ReturnType<ReturnType<typeof useTestApp>>) 
       accountLogin: "owner",
       accountGithubId: Math.floor(Math.random() * 1_000_000_000),
       permissions: { metadata: "read", pull_requests: "write" },
-      events: ["pull_request"],
+      events: ["pull_request", "issue_comment", "pull_request_review_comment"],
       suspendedAt: null,
     },
     hubOrganizationId: admin.organizationId,

--- a/packages/server/src/__tests__/context-reviewer-publisher.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-publisher.test.ts
@@ -1,7 +1,9 @@
 import { generateKeyPairSync, randomUUID } from "node:crypto";
 import { AGENT_RUNTIME_SESSION_HEADER, AGENT_SELECTOR_HEADER } from "@first-tree/shared";
 import { eq } from "drizzle-orm";
+import postgres from "postgres";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { connectDatabase, sslOptions } from "../db/connection.js";
 import { agents } from "../db/schema/agents.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { githubAppInstallations } from "../db/schema/github-app-installations.js";
@@ -19,6 +21,27 @@ const { privateKey: privateKeyPem } = generateKeyPairSync("rsa", {
   privateKeyEncoding: { type: "pkcs8", format: "pem" },
   publicKeyEncoding: { type: "spki", format: "pem" },
 });
+
+function databaseUrlWithApplicationName(url: string, applicationName: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("application_name", applicationName);
+  return parsed.toString();
+}
+
+async function waitForPostgresLockWait(observer: ReturnType<typeof postgres>, applicationName: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await observer<{ wait_event_type: string | null }[]>`
+      SELECT wait_event_type
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND application_name = ${applicationName}
+    `;
+    if (rows.some((row) => row.wait_event_type === "Lock")) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for PostgreSQL lock: ${applicationName}`);
+}
 
 describe("Context Reviewer App publisher", () => {
   const getApp = useTestApp({ githubAppPrivateKeyPem: privateKeyPem, runtimeHttpTokenEnforcement: false });
@@ -73,6 +96,49 @@ describe("Context Reviewer App publisher", () => {
       reviewerManagerHumanAgentId: fixture.admin.humanAgentUuid,
       reviewerClientId: fixture.admin.clientId,
     });
+  });
+
+  it("takes manager and Computer locks before the Reviewer Agent row", async () => {
+    const fixture = await createRunFixture(getApp());
+    const databaseUrl = process.env.DATABASE_URL ?? "";
+    if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+
+    const applicationName = `context_review_publish_${randomUUID().slice(0, 8)}`;
+    const publisherDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, applicationName));
+    const blocker = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    let blockerCommitted = false;
+    try {
+      await blocker`BEGIN`;
+      await blocker`SELECT id FROM members WHERE id = ${fixture.admin.memberId} FOR UPDATE`;
+
+      const publishing = submitContextReviewOutcome({
+        db: publisherDb,
+        chatId: fixture.chatId,
+        runId: fixture.runId,
+        callerAgentUuid: fixture.reviewer.uuid,
+        callerClientId: fixture.admin.clientId,
+        callerRuntimeSessionToken: fixture.runtimeToken,
+        request: { event: "COMMENT", body: "Lock order regression" },
+        appCredentials: fixture.app.config.oauth?.githubApp,
+        fetcher: successfulGithubFetcher(),
+      });
+      await waitForPostgresLockWait(observer, applicationName);
+
+      // If publication had already taken the Reviewer Agent lock before
+      // waiting on its manager, this lock would complete a deadlock cycle.
+      await blocker`SELECT id FROM clients WHERE id = ${fixture.admin.clientId} FOR UPDATE`;
+      await blocker`SELECT uuid FROM agents WHERE uuid = ${fixture.reviewer.uuid} FOR UPDATE`;
+      await blocker`COMMIT`;
+      blockerCommitted = true;
+
+      await expect(publishing).resolves.toMatchObject({ action: "COMMENT" });
+    } finally {
+      if (!blockerCommitted) await blocker`ROLLBACK`;
+      await publisherDb.end();
+      await blocker.end();
+      await observer.end();
+    }
   });
 
   it("rejects the wrong reviewer before any GitHub call", async () => {

--- a/packages/server/src/__tests__/context-reviewer-settings.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-settings.test.ts
@@ -603,7 +603,7 @@ describe("Context Reviewer assignment/readiness contract", () => {
     });
   });
 
-  it("keeps GitLab inbound readiness as an enablement prerequisite and recovers without reassignment", async () => {
+  it("requires a processed GitLab System Hook MR before enablement and recovers without reassignment", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
     const reviewer = await createReviewer(app, admin);
@@ -644,12 +644,26 @@ describe("Context Reviewer assignment/readiness contract", () => {
         staleSeconds: 60,
         now: () => observedAt,
       }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      blocker: { code: "gitlab_merge_request_event_not_seen" },
+    });
+    await app.db
+      .update(gitlabConnections)
+      .set({ lastSystemHookMergeRequestInboundAt: observedAt })
+      .where(eq(gitlabConnections.id, connection.connectionId));
+    await expect(
+      putContextReviewerEnablement(app.db, admin.organizationId, true, {
+        updatedBy: admin.userId,
+        staleSeconds: 60,
+        now: () => observedAt,
+      }),
     ).resolves.toMatchObject({
       contextReviewer: { enabled: true, agentUuid: reviewer.uuid },
     });
   });
 
-  it("rechecks GitLab inbound authority after a concurrent bearer-health reset", async () => {
+  it("rechecks GitLab routing verification after a concurrent readiness reset", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
     const reviewer = await createReviewer(app, admin);
@@ -665,7 +679,11 @@ describe("Context Reviewer assignment/readiness contract", () => {
     });
     await app.db
       .update(gitlabConnections)
-      .set({ endpointFirstSeenAt: observedAt, lastValidInboundAt: observedAt })
+      .set({
+        endpointFirstSeenAt: observedAt,
+        lastValidInboundAt: observedAt,
+        lastSystemHookMergeRequestInboundAt: observedAt,
+      })
       .where(eq(gitlabConnections.id, connection.connectionId));
     await putContextReviewerAssignment(app.db, admin.organizationId, reviewer.uuid, {
       updatedBy: admin.userId,
@@ -689,7 +707,7 @@ describe("Context Reviewer assignment/readiness contract", () => {
       await waitForRelease;
       await tx
         .update(gitlabConnections)
-        .set({ endpointFirstSeenAt: null, lastValidInboundAt: null })
+        .set({ lastSystemHookMergeRequestInboundAt: null })
         .where(eq(gitlabConnections.id, connection.connectionId));
     });
     await locked;
@@ -704,7 +722,7 @@ describe("Context Reviewer assignment/readiness contract", () => {
 
     await expect(enabling).rejects.toMatchObject({
       statusCode: 409,
-      blocker: { code: "gitlab_webhook_not_seen" },
+      blocker: { code: "gitlab_merge_request_event_not_seen" },
     });
     await expect(getOrgSetting(app.db, admin.organizationId, "context_tree_features")).resolves.toMatchObject({
       contextReviewer: { enabled: false, agentUuid: reviewer.uuid },

--- a/packages/server/src/__tests__/context-reviewer-settings.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-settings.test.ts
@@ -1,0 +1,759 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import type { FastifyInstance } from "fastify";
+import postgres from "postgres";
+import { describe, expect, it } from "vitest";
+import { connectDatabase, sslOptions } from "../db/connection.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
+import { agents } from "../db/schema/agents.js";
+import { clients } from "../db/schema/clients.js";
+import { gitlabConnections } from "../db/schema/gitlab-connections.js";
+import { members } from "../db/schema/members.js";
+import { organizationSettings } from "../db/schema/organization-settings.js";
+import { serverInstances } from "../db/schema/server-instances.js";
+import { createAgent } from "../services/agent.js";
+import {
+  listContextReviewerCandidates,
+  readContextReviewerAgentReadiness,
+} from "../services/context-reviewer-readiness.js";
+import { putContextReviewerAssignment, putContextReviewerEnablement } from "../services/context-reviewer-settings.js";
+import { upsertInstallationFromMetadata } from "../services/github-app-installations.js";
+import { createGitlabConnection } from "../services/gitlab-connections.js";
+import { getOrgSetting } from "../services/org-settings.js";
+import { getTeamSetupCapabilities } from "../services/setup-capabilities.js";
+import { createAdminContext, createTestAdmin, seedClient, seedHealthyAgentRuntime, useTestApp } from "./helpers.js";
+
+type AdminContext = Awaited<ReturnType<typeof createAdminContext>>;
+
+const observedAt = new Date("2026-07-23T08:00:00.000Z");
+
+function databaseUrlWithApplicationName(url: string, applicationName: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("application_name", applicationName);
+  return parsed.toString();
+}
+
+async function waitForPostgresLockWait(observer: ReturnType<typeof postgres>, applicationName: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const rows = await observer<{ wait_event_type: string | null }[]>`
+      SELECT wait_event_type
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND application_name = ${applicationName}
+    `;
+    if (rows.some((row) => row.wait_event_type === "Lock")) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out waiting for PostgreSQL lock: ${applicationName}`);
+}
+
+async function createReviewer(
+  app: FastifyInstance,
+  admin: AdminContext,
+  options: {
+    clientId?: string | null;
+    displayName?: string;
+    visibility?: "private" | "organization";
+  } = {},
+) {
+  return createAgent(app.db, {
+    name: `reviewer-${randomUUID().slice(0, 8)}`,
+    type: "agent",
+    displayName: options.displayName ?? "Context Reviewer",
+    managerId: admin.memberId,
+    organizationId: admin.organizationId,
+    visibility: options.visibility ?? "organization",
+    ...(options.clientId === null ? {} : { clientId: options.clientId ?? admin.clientId }),
+  });
+}
+
+async function seedContextTreeBinding(
+  app: FastifyInstance,
+  admin: AdminContext,
+  input: { provider: "github" | "gitlab"; repo: string },
+): Promise<void> {
+  await app.db.insert(organizationSettings).values({
+    organizationId: admin.organizationId,
+    namespace: "context_tree",
+    value: {
+      provider: input.provider,
+      repo: input.repo,
+      branch: "main",
+    },
+    version: 1,
+    updatedBy: admin.userId,
+  });
+}
+
+async function seedGithubPrerequisites(app: FastifyInstance, admin: AdminContext): Promise<void> {
+  await seedContextTreeBinding(app, admin, {
+    provider: "github",
+    repo: "https://github.com/acme/context-tree.git",
+  });
+  const installationId = Number.parseInt(randomUUID().replaceAll("-", "").slice(0, 10), 16);
+  await upsertInstallationFromMetadata(app.db, {
+    installation: {
+      id: installationId,
+      accountType: "Organization",
+      accountLogin: "acme",
+      accountGithubId: installationId + 1,
+      permissions: { metadata: "read", pull_requests: "write" },
+      events: ["pull_request", "issue_comment", "pull_request_review_comment"],
+      suspendedAt: null,
+    },
+    hubOrganizationId: admin.organizationId,
+  });
+}
+
+function mutationOptions(
+  app: FastifyInstance,
+  admin: AdminContext,
+  probeGithubReview: () => Promise<"ready" | "permission_required" | "repo_not_covered" | "failed">,
+) {
+  return {
+    updatedBy: admin.userId,
+    staleSeconds: 60,
+    githubAppCredentials: app.config.oauth?.githubApp,
+    probeGithubReview,
+    now: () => observedAt,
+  };
+}
+
+describe("Context Reviewer assignment/readiness contract", () => {
+  const getApp = useTestApp();
+
+  it("lists only structurally eligible organization-visible Agents and keeps offline candidates selectable", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const eligible = await createReviewer(app, admin, { displayName: "Eligible Offline" });
+    const privateAgent = await createReviewer(app, admin, { visibility: "private" });
+    const noComputer = await createReviewer(app, admin, { clientId: null });
+    const retiredClientId = await seedClient(app, admin.userId, admin.organizationId);
+    const retired = await createReviewer(app, admin, { clientId: retiredClientId });
+    const inactive = await createReviewer(app, admin);
+    const disabledRuntime = await createReviewer(app, admin);
+    const inactiveManager = await createAdminContext(app);
+    const unmanaged = await createReviewer(app, inactiveManager);
+    const landingTrial = await createReviewer(app, admin);
+    await app.db.update(clients).set({ retiredAt: observedAt }).where(eq(clients.id, retiredClientId));
+    await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, inactive.uuid));
+    await app.db
+      .update(agents)
+      .set({ runtimeProvider: "claude-code-tui" })
+      .where(eq(agents.uuid, disabledRuntime.uuid));
+    await app.db.update(members).set({ status: "left" }).where(eq(members.id, inactiveManager.memberId));
+    await app.db
+      .update(agents)
+      .set({ metadata: { landingCampaignTrial: true } })
+      .where(eq(agents.uuid, landingTrial.uuid));
+
+    await expect(
+      listContextReviewerCandidates(app.db, {
+        organizationId: admin.organizationId,
+        now: observedAt,
+        staleSeconds: 60,
+      }),
+    ).resolves.toEqual({
+      items: [
+        {
+          uuid: eligible.uuid,
+          name: eligible.name,
+          displayName: "Eligible Offline",
+          visibility: "organization",
+          runtime: {
+            health: "degraded",
+            blockers: [
+              {
+                code: "context_review_agent_runtime_unavailable",
+                resolutionOwner: "admin",
+                actionKind: "open_agent_owner_flow",
+              },
+            ],
+          },
+        },
+      ],
+      blockers: [],
+    });
+
+    for (const [agentUuid, code] of [
+      [privateAgent.uuid, "context_review_agent_private"],
+      [noComputer.uuid, "context_review_agent_no_runtime"],
+      [retired.uuid, "context_review_agent_no_runtime"],
+      [inactive.uuid, "context_review_agent_inactive"],
+      [disabledRuntime.uuid, "context_review_agent_no_runtime"],
+      [unmanaged.uuid, "context_review_agent_manager_inactive"],
+      [landingTrial.uuid, "context_review_agent_missing"],
+    ] as const) {
+      await expect(
+        putContextReviewerAssignment(app.db, admin.organizationId, agentUuid, {
+          updatedBy: admin.userId,
+        }),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        blocker: { code },
+      });
+    }
+
+    await app.db.update(agents).set({ status: "suspended" }).where(eq(agents.uuid, eligible.uuid));
+    await expect(
+      listContextReviewerCandidates(app.db, {
+        organizationId: admin.organizationId,
+        now: observedAt,
+        staleSeconds: 60,
+      }),
+    ).resolves.toEqual({
+      items: [],
+      blockers: [
+        {
+          code: "context_review_no_eligible_agent",
+          resolutionOwner: "admin",
+          actionKind: "open_agent_owner_flow",
+        },
+      ],
+    });
+  });
+
+  it("keeps an assignment visible while the independent Tree binding is unavailable", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await putContextReviewerAssignment(app.db, admin.organizationId, reviewer.uuid, {
+      updatedBy: admin.userId,
+    });
+
+    await expect(
+      getTeamSetupCapabilities(app.db, admin.organizationId, {
+        now: () => observedAt,
+        staleSeconds: 60,
+      }),
+    ).resolves.toMatchObject({
+      contextTree: {
+        binding: { state: "unbound" },
+        automaticReview: {
+          adoption: "unavailable",
+          health: "degraded",
+          reviewerAgent: { uuid: reviewer.uuid, displayName: reviewer.displayName },
+          blockers: [{ code: "context_review_agent_runtime_unavailable" }],
+        },
+      },
+    });
+  });
+
+  it("does not project an invalid historical private selection to Team members", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const privateAgent = await createReviewer(app, admin, { visibility: "private" });
+    await seedGithubPrerequisites(app, admin);
+    await app.db.insert(organizationSettings).values({
+      organizationId: admin.organizationId,
+      namespace: "context_tree_features",
+      value: {
+        contextReviewer: { enabled: true, agentUuid: privateAgent.uuid },
+      },
+      version: 1,
+      updatedBy: admin.userId,
+    });
+
+    await expect(getOrgSetting(app.db, admin.organizationId, "context_tree_features")).resolves.toEqual({
+      contextReviewer: {
+        enabled: true,
+        agentUuid: null,
+        reviewerAgent: null,
+      },
+    });
+    await expect(
+      getTeamSetupCapabilities(app.db, admin.organizationId, {
+        now: () => observedAt,
+        staleSeconds: 60,
+        githubAppCredentials: app.config.oauth?.githubApp,
+        probeGithubReview: async () => "ready",
+      }),
+    ).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          health: "unavailable",
+          reviewerAgent: null,
+          blockers: [{ code: "context_review_agent_private" }],
+        },
+      },
+    });
+  });
+
+  it("classifies connection, presence, heartbeat, and capability drift as recoverable runtime health", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    const staleAt = new Date(observedAt.getTime() - 61_000);
+    const scenarios: Array<{
+      name: string;
+      mutate: () => Promise<unknown>;
+    }> = [
+      {
+        name: "disconnected Computer",
+        mutate: () => app.db.update(clients).set({ status: "disconnected" }).where(eq(clients.id, admin.clientId)),
+      },
+      {
+        name: "paused Computer",
+        mutate: () =>
+          app.db.update(clients).set({ pausedReason: "auth_rejected" }).where(eq(clients.id, admin.clientId)),
+      },
+      {
+        name: "stale Computer heartbeat",
+        mutate: () => app.db.update(clients).set({ lastSeenAt: staleAt }).where(eq(clients.id, admin.clientId)),
+      },
+      {
+        name: "missing Agent presence",
+        mutate: () => app.db.delete(agentPresence).where(eq(agentPresence.agentId, reviewer.uuid)),
+      },
+      {
+        name: "mismatched runtime presence",
+        mutate: () =>
+          app.db.update(agentPresence).set({ runtimeType: "codex" }).where(eq(agentPresence.agentId, reviewer.uuid)),
+      },
+      {
+        name: "unavailable runtime capability",
+        mutate: () =>
+          app.db
+            .update(clients)
+            .set({
+              metadata: {
+                capabilities: {
+                  "claude-code": {
+                    state: "missing",
+                    available: false,
+                    detectedAt: observedAt.toISOString(),
+                  },
+                },
+              },
+            })
+            .where(eq(clients.id, admin.clientId)),
+      },
+      {
+        name: "stale Server heartbeat",
+        mutate: () =>
+          app.db
+            .update(serverInstances)
+            .set({ lastHeartbeat: staleAt })
+            .where(eq(serverInstances.instanceId, `instance-${admin.clientId}`)),
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      await seedHealthyAgentRuntime(app, {
+        agentUuid: reviewer.uuid,
+        clientId: admin.clientId,
+        now: observedAt,
+      });
+      await scenario.mutate();
+      await expect(
+        readContextReviewerAgentReadiness(app.db, {
+          organizationId: admin.organizationId,
+          reviewerAgentUuid: reviewer.uuid,
+          now: observedAt,
+          staleSeconds: 60,
+        }),
+        scenario.name,
+      ).resolves.toMatchObject({
+        structuralBlockers: [],
+        healthBlockers: [{ code: "context_review_agent_runtime_unavailable" }],
+      });
+    }
+
+    await seedHealthyAgentRuntime(app, {
+      agentUuid: reviewer.uuid,
+      clientId: admin.clientId,
+      now: observedAt,
+    });
+    await expect(
+      readContextReviewerAgentReadiness(app.db, {
+        organizationId: admin.organizationId,
+        reviewerAgentUuid: reviewer.uuid,
+        now: observedAt,
+        staleSeconds: 60,
+      }),
+    ).resolves.toMatchObject({
+      structuralBlockers: [],
+      healthBlockers: [],
+    });
+  });
+
+  it("keeps assignment and disable idempotent, preserves selection, and disables on replacement", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const first = await createReviewer(app, admin);
+    const second = await createReviewer(app, admin);
+
+    await putContextReviewerAssignment(app.db, admin.organizationId, first.uuid, {
+      updatedBy: admin.userId,
+    });
+    const readRow = () =>
+      app.db
+        .select({
+          value: organizationSettings.value,
+          version: organizationSettings.version,
+        })
+        .from(organizationSettings)
+        .where(
+          and(
+            eq(organizationSettings.organizationId, admin.organizationId),
+            eq(organizationSettings.namespace, "context_tree_features"),
+          ),
+        )
+        .then((rows) => rows[0]);
+    expect(await readRow()).toMatchObject({
+      value: { contextReviewer: { enabled: false, agentUuid: first.uuid } },
+      version: 1,
+    });
+
+    await putContextReviewerAssignment(app.db, admin.organizationId, first.uuid, {
+      updatedBy: admin.userId,
+    });
+    expect(await readRow()).toMatchObject({ version: 1 });
+
+    await app.db
+      .update(organizationSettings)
+      .set({
+        value: { contextReviewer: { enabled: true, agentUuid: first.uuid } },
+        version: 2,
+      })
+      .where(
+        and(
+          eq(organizationSettings.organizationId, admin.organizationId),
+          eq(organizationSettings.namespace, "context_tree_features"),
+        ),
+      );
+    await putContextReviewerAssignment(app.db, admin.organizationId, second.uuid, {
+      updatedBy: admin.userId,
+    });
+    expect(await readRow()).toMatchObject({
+      value: { contextReviewer: { enabled: false, agentUuid: second.uuid } },
+      version: 3,
+    });
+
+    await putContextReviewerEnablement(app.db, admin.organizationId, false, {
+      updatedBy: admin.userId,
+      staleSeconds: 60,
+    });
+    expect(await readRow()).toMatchObject({
+      value: { contextReviewer: { enabled: false, agentUuid: second.uuid } },
+      version: 3,
+    });
+
+    await putContextReviewerAssignment(app.db, admin.organizationId, null, {
+      updatedBy: admin.userId,
+    });
+    expect(await readRow()).toMatchObject({
+      value: { contextReviewer: { enabled: false, agentUuid: null } },
+      version: 4,
+    });
+    await putContextReviewerAssignment(app.db, admin.organizationId, null, {
+      updatedBy: admin.userId,
+    });
+    expect(await readRow()).toMatchObject({ version: 4 });
+  });
+
+  it("takes manager and Computer locks before the assigned Agent row", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    const databaseUrl = process.env.DATABASE_URL ?? "";
+    if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+
+    const applicationName = `context_review_assignment_${randomUUID().slice(0, 8)}`;
+    const assignmentDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, applicationName));
+    const blocker = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    let blockerCommitted = false;
+    try {
+      await blocker`BEGIN`;
+      await blocker`SELECT id FROM members WHERE id = ${admin.memberId} FOR UPDATE`;
+
+      const assigning = putContextReviewerAssignment(assignmentDb, admin.organizationId, reviewer.uuid, {
+        updatedBy: admin.userId,
+      });
+      await waitForPostgresLockWait(observer, applicationName);
+
+      // If assignment had already taken Agent before waiting on manager,
+      // either of these locks would complete a deadlock cycle.
+      await blocker`SELECT id FROM clients WHERE id = ${admin.clientId} FOR UPDATE`;
+      await blocker`SELECT uuid FROM agents WHERE uuid = ${reviewer.uuid} FOR UPDATE`;
+      await blocker`COMMIT`;
+      blockerCommitted = true;
+
+      await expect(assigning).resolves.toMatchObject({
+        contextReviewer: { enabled: false, agentUuid: reviewer.uuid },
+      });
+    } finally {
+      if (!blockerCommitted) await blocker`ROLLBACK`;
+      await assignmentDb.end();
+      await blocker.end();
+      await observer.end();
+    }
+  });
+
+  it("retains the Tree binding and disabled selection across provider failure, then enables offline and projects degraded health", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await seedGithubPrerequisites(app, admin);
+    await putContextReviewerAssignment(app.db, admin.organizationId, reviewer.uuid, {
+      updatedBy: admin.userId,
+    });
+    const [treeBefore] = await app.db
+      .select()
+      .from(organizationSettings)
+      .where(
+        and(
+          eq(organizationSettings.organizationId, admin.organizationId),
+          eq(organizationSettings.namespace, "context_tree"),
+        ),
+      );
+
+    await expect(
+      putContextReviewerEnablement(
+        app.db,
+        admin.organizationId,
+        true,
+        mutationOptions(app, admin, async () => "repo_not_covered"),
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      blocker: { code: "github_tree_repo_not_covered" },
+    });
+    await expect(getOrgSetting(app.db, admin.organizationId, "context_tree_features")).resolves.toMatchObject({
+      contextReviewer: { enabled: false, agentUuid: reviewer.uuid },
+    });
+    const [treeAfterFailure] = await app.db
+      .select()
+      .from(organizationSettings)
+      .where(
+        and(
+          eq(organizationSettings.organizationId, admin.organizationId),
+          eq(organizationSettings.namespace, "context_tree"),
+        ),
+      );
+    expect(treeAfterFailure).toEqual(treeBefore);
+
+    await expect(
+      putContextReviewerEnablement(
+        app.db,
+        admin.organizationId,
+        true,
+        mutationOptions(app, admin, async () => "ready"),
+      ),
+    ).resolves.toMatchObject({
+      contextReviewer: { enabled: true, agentUuid: reviewer.uuid },
+    });
+    await expect(
+      getTeamSetupCapabilities(app.db, admin.organizationId, {
+        now: () => observedAt,
+        staleSeconds: 60,
+        githubAppCredentials: app.config.oauth?.githubApp,
+        probeGithubReview: async () => "ready",
+      }),
+    ).resolves.toMatchObject({
+      contextTree: {
+        automaticReview: {
+          adoption: "enabled",
+          health: "degraded",
+          reviewerAgent: {
+            uuid: reviewer.uuid,
+            displayName: reviewer.displayName,
+          },
+          blockers: [{ code: "context_review_agent_runtime_unavailable" }],
+        },
+      },
+    });
+
+    await putContextReviewerEnablement(app.db, admin.organizationId, false, {
+      updatedBy: admin.userId,
+      staleSeconds: 60,
+    });
+    await expect(getOrgSetting(app.db, admin.organizationId, "context_tree_features")).resolves.toMatchObject({
+      contextReviewer: { enabled: false, agentUuid: reviewer.uuid },
+    });
+  });
+
+  it("rechecks structural eligibility after the GitHub probe and fails closed on a concurrent privacy change", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await seedGithubPrerequisites(app, admin);
+    await putContextReviewerAssignment(app.db, admin.organizationId, reviewer.uuid, {
+      updatedBy: admin.userId,
+    });
+
+    await expect(
+      putContextReviewerEnablement(
+        app.db,
+        admin.organizationId,
+        true,
+        mutationOptions(app, admin, async () => {
+          await app.db.update(agents).set({ visibility: "private" }).where(eq(agents.uuid, reviewer.uuid));
+          return "ready";
+        }),
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      blocker: { code: "context_review_agent_private" },
+    });
+    await expect(getOrgSetting(app.db, admin.organizationId, "context_tree_features")).resolves.toMatchObject({
+      contextReviewer: { enabled: false, agentUuid: null },
+    });
+  });
+
+  it("keeps GitLab inbound readiness as an enablement prerequisite and recovers without reassignment", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await seedContextTreeBinding(app, admin, {
+      provider: "gitlab",
+      repo: "https://gitlab.internal/acme/context-tree.git",
+    });
+    const connection = await createGitlabConnection(app.db, {
+      organizationId: admin.organizationId,
+      memberId: admin.memberId,
+      displayName: "GitLab",
+      instanceOrigin: "https://gitlab.internal",
+    });
+    await putContextReviewerAssignment(app.db, admin.organizationId, reviewer.uuid, {
+      updatedBy: admin.userId,
+    });
+
+    await expect(
+      putContextReviewerEnablement(app.db, admin.organizationId, true, {
+        updatedBy: admin.userId,
+        staleSeconds: 60,
+        now: () => observedAt,
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      blocker: { code: "gitlab_webhook_not_seen" },
+    });
+    await app.db
+      .update(gitlabConnections)
+      .set({
+        endpointFirstSeenAt: observedAt,
+        lastValidInboundAt: observedAt,
+      })
+      .where(eq(gitlabConnections.id, connection.connectionId));
+    await expect(
+      putContextReviewerEnablement(app.db, admin.organizationId, true, {
+        updatedBy: admin.userId,
+        staleSeconds: 60,
+        now: () => observedAt,
+      }),
+    ).resolves.toMatchObject({
+      contextReviewer: { enabled: true, agentUuid: reviewer.uuid },
+    });
+  });
+
+  it("rechecks GitLab inbound authority after a concurrent bearer-health reset", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await seedContextTreeBinding(app, admin, {
+      provider: "gitlab",
+      repo: "https://gitlab.internal/acme/context-tree.git",
+    });
+    const connection = await createGitlabConnection(app.db, {
+      organizationId: admin.organizationId,
+      memberId: admin.memberId,
+      displayName: "GitLab",
+      instanceOrigin: "https://gitlab.internal",
+    });
+    await app.db
+      .update(gitlabConnections)
+      .set({ endpointFirstSeenAt: observedAt, lastValidInboundAt: observedAt })
+      .where(eq(gitlabConnections.id, connection.connectionId));
+    await putContextReviewerAssignment(app.db, admin.organizationId, reviewer.uuid, {
+      updatedBy: admin.userId,
+    });
+
+    let releaseReset = () => {};
+    const waitForRelease = new Promise<void>((resolve) => {
+      releaseReset = resolve;
+    });
+    let markLocked = () => {};
+    const locked = new Promise<void>((resolve) => {
+      markLocked = resolve;
+    });
+    const reset = app.db.transaction(async (tx) => {
+      await tx
+        .select({ id: gitlabConnections.id })
+        .from(gitlabConnections)
+        .where(eq(gitlabConnections.id, connection.connectionId))
+        .for("update");
+      markLocked();
+      await waitForRelease;
+      await tx
+        .update(gitlabConnections)
+        .set({ endpointFirstSeenAt: null, lastValidInboundAt: null })
+        .where(eq(gitlabConnections.id, connection.connectionId));
+    });
+    await locked;
+    const enabling = putContextReviewerEnablement(app.db, admin.organizationId, true, {
+      updatedBy: admin.userId,
+      staleSeconds: 60,
+      now: () => observedAt,
+    });
+    await Promise.resolve();
+    releaseReset();
+    await reset;
+
+    await expect(enabling).rejects.toMatchObject({
+      statusCode: 409,
+      blocker: { code: "gitlab_webhook_not_seen" },
+    });
+    await expect(getOrgSetting(app.db, admin.organizationId, "context_tree_features")).resolves.toMatchObject({
+      contextReviewer: { enabled: false, agentUuid: reviewer.uuid },
+    });
+  });
+
+  it("exposes the candidate and assignment owner endpoints to Team admins only", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const member = await createTestAdmin(app);
+    await app.db.update(members).set({ role: "member" }).where(eq(members.id, member.memberId));
+    const privateAgent = await createReviewer(app, admin, { visibility: "private" });
+    const baseUrl = `/api/v1/orgs/${admin.organizationId}/context-reviewer`;
+
+    const adminCandidates = await app.inject({
+      method: "GET",
+      url: `${baseUrl}/candidates`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    expect(adminCandidates.statusCode).toBe(200);
+    expect(adminCandidates.json()).toMatchObject({
+      items: [],
+      blockers: [{ code: "context_review_no_eligible_agent" }],
+    });
+
+    const memberCandidates = await app.inject({
+      method: "GET",
+      url: `${baseUrl}/candidates`,
+      headers: { authorization: `Bearer ${member.accessToken}` },
+    });
+    expect(memberCandidates.statusCode).toBe(403);
+
+    const invalidBody = await app.inject({
+      method: "PUT",
+      url: `${baseUrl}/assignment`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { agentUuid: privateAgent.uuid, assignedByMemberId: admin.memberId },
+    });
+    expect(invalidBody.statusCode).toBe(400);
+
+    const privateAssignment = await app.inject({
+      method: "PUT",
+      url: `${baseUrl}/assignment`,
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+      payload: { agentUuid: privateAgent.uuid },
+    });
+    expect(privateAssignment.statusCode).toBe(409);
+    expect(privateAssignment.json()).toMatchObject({
+      code: "context_review_agent_private",
+    });
+  });
+});

--- a/packages/server/src/__tests__/context-reviewer-settings.test.ts
+++ b/packages/server/src/__tests__/context-reviewer-settings.test.ts
@@ -492,6 +492,30 @@ describe("Context Reviewer assignment/readiness contract", () => {
     }
   });
 
+  it("rejects legacy enablement when another request replaced its assigned Agent", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const requested = await createReviewer(app, admin);
+    const replacement = await createReviewer(app, admin);
+    await seedGithubPrerequisites(app, admin);
+    await putContextReviewerAssignment(app.db, admin.organizationId, replacement.uuid, {
+      updatedBy: admin.userId,
+    });
+
+    await expect(
+      putContextReviewerEnablement(app.db, admin.organizationId, true, {
+        ...mutationOptions(app, admin, async () => "ready"),
+        expectedAgentUuid: requested.uuid,
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      blocker: { code: "context_review_state_changed" },
+    });
+    await expect(getOrgSetting(app.db, admin.organizationId, "context_tree_features")).resolves.toMatchObject({
+      contextReviewer: { enabled: false, agentUuid: replacement.uuid },
+    });
+  });
+
   it("retains the Tree binding and disabled selection across provider failure, then enables offline and projects degraded health", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
@@ -661,6 +685,71 @@ describe("Context Reviewer assignment/readiness contract", () => {
     ).resolves.toMatchObject({
       contextReviewer: { enabled: true, agentUuid: reviewer.uuid },
     });
+  });
+
+  it("takes the GitLab connection lock before Reviewer manager, Computer, and Agent locks", async () => {
+    const app = getApp();
+    const admin = await createAdminContext(app);
+    const reviewer = await createReviewer(app, admin);
+    await seedContextTreeBinding(app, admin, {
+      provider: "gitlab",
+      repo: "https://gitlab.internal/acme/context-tree.git",
+    });
+    const connection = await createGitlabConnection(app.db, {
+      organizationId: admin.organizationId,
+      memberId: admin.memberId,
+      displayName: "GitLab",
+      instanceOrigin: "https://gitlab.internal",
+    });
+    await app.db
+      .update(gitlabConnections)
+      .set({
+        endpointFirstSeenAt: observedAt,
+        lastValidInboundAt: observedAt,
+        lastSystemHookMergeRequestInboundAt: observedAt,
+      })
+      .where(eq(gitlabConnections.id, connection.connectionId));
+    await putContextReviewerAssignment(app.db, admin.organizationId, reviewer.uuid, {
+      updatedBy: admin.userId,
+    });
+    const options = {
+      updatedBy: admin.userId,
+      staleSeconds: 60,
+      now: () => observedAt,
+    };
+    await putContextReviewerEnablement(app.db, admin.organizationId, true, options);
+
+    const databaseUrl = process.env.DATABASE_URL ?? "";
+    if (!databaseUrl) throw new Error("DATABASE_URL is required for the concurrency test");
+    const applicationName = `context_review_gitlab_enable_${randomUUID().slice(0, 8)}`;
+    const enablementDb = connectDatabase(databaseUrlWithApplicationName(databaseUrl, applicationName));
+    const blocker = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    const observer = postgres(databaseUrl, { max: 1, ...sslOptions(databaseUrl) });
+    let blockerCommitted = false;
+    try {
+      await blocker`BEGIN`;
+      await blocker`SELECT id FROM gitlab_connections WHERE id = ${connection.connectionId} FOR UPDATE`;
+
+      const enabling = putContextReviewerEnablement(enablementDb, admin.organizationId, true, options);
+      await waitForPostgresLockWait(observer, applicationName);
+
+      // A System Hook holds the connection row before entering Reviewer
+      // dispatch. These locks must not complete a connection ↔ Agent cycle.
+      await blocker`SELECT id FROM members WHERE id = ${admin.memberId} FOR UPDATE`;
+      await blocker`SELECT id FROM clients WHERE id = ${admin.clientId} FOR UPDATE`;
+      await blocker`SELECT uuid FROM agents WHERE uuid = ${reviewer.uuid} FOR UPDATE`;
+      await blocker`COMMIT`;
+      blockerCommitted = true;
+
+      await expect(enabling).resolves.toMatchObject({
+        contextReviewer: { enabled: true, agentUuid: reviewer.uuid },
+      });
+    } finally {
+      if (!blockerCommitted) await blocker`ROLLBACK`;
+      await enablementDb.end();
+      await blocker.end();
+      await observer.end();
+    }
   });
 
   it("rechecks GitLab routing verification after a concurrent readiness reset", async () => {

--- a/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
+++ b/packages/server/src/__tests__/context-tree-routes-mocked.test.ts
@@ -95,6 +95,7 @@ async function setupRoute() {
     gitlabConnection: null,
     contextReviewer: { enabled: false, agentUuid: null },
   });
+  const isOrgContextTreeBindingRuntimeCurrent = vi.fn().mockResolvedValue(true);
   const putInitializedOrgContextTreeBinding = vi
     .fn()
     .mockResolvedValue({ provider: "github", repo: repo.cloneUrl, branch: "main" });
@@ -128,6 +129,7 @@ async function setupRoute() {
     getOrgContextTreeBinding,
     getOrgContextTreeSettingState,
     getOrgContextReviewRuntime,
+    isOrgContextTreeBindingRuntimeCurrent,
     putInitializedOrgContextTreeBinding,
   }));
   vi.doMock("../services/organization.js", () => ({ getOrganization }));
@@ -175,6 +177,7 @@ async function setupRoute() {
       getOrgContextTreeBinding,
       getOrgContextTreeSettingState,
       getOrgContextReviewRuntime,
+      isOrgContextTreeBindingRuntimeCurrent,
       putInitializedOrgContextTreeBinding,
       getOrganization,
       preflightContextTreeWriteAuthority,

--- a/packages/server/src/__tests__/context-tree-snapshot-route-mocked.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot-route-mocked.test.ts
@@ -53,7 +53,7 @@ async function setupRoute(input: { orgId: string | null; githubRemote?: boolean;
         }
       : null,
   );
-  const isOrgContextReviewRuntimeCurrent = vi.fn().mockResolvedValue(true);
+  const isOrgContextTreeBindingRuntimeCurrent = vi.fn().mockResolvedValue(true);
   const getContextTreeSnapshot = vi.fn().mockResolvedValue(snapshot);
   const isGithubRemoteBinding = vi.fn().mockReturnValue(input.githubRemote ?? false);
   const findInstallationByOrg = vi.fn().mockResolvedValue({ installationId: 123 });
@@ -88,7 +88,7 @@ async function setupRoute(input: { orgId: string | null; githubRemote?: boolean;
   vi.doMock("../services/org-settings.js", () => ({
     getOrgContextReviewRuntime,
     getOrgContextTreeBinding,
-    isOrgContextReviewRuntimeCurrent,
+    isOrgContextTreeBindingRuntimeCurrent,
     resolveUserPrimaryOrgId,
   }));
   vi.doMock("../services/context-tree-snapshot.js", () => ({
@@ -121,7 +121,7 @@ async function setupRoute(input: { orgId: string | null; githubRemote?: boolean;
       getOrgContextReviewRuntime,
       getContextTreeSnapshot,
       getOrgContextTreeBinding,
-      isOrgContextReviewRuntimeCurrent,
+      isOrgContextTreeBindingRuntimeCurrent,
       isGithubRemoteBinding,
       mintContextTreeInstallationToken,
       resolveContextTreeRecoveryAction,

--- a/packages/server/src/__tests__/github-app-webhook-route.test.ts
+++ b/packages/server/src/__tests__/github-app-webhook-route.test.ts
@@ -15,7 +15,7 @@ import * as githubAudienceService from "../services/github-audience.js";
 import * as githubEntityStateService from "../services/github-entity-state.js";
 import { putOrgSetting } from "../services/org-settings.js";
 import { uuidv7 } from "../uuid.js";
-import { createTestAdmin, useTestApp } from "./helpers.js";
+import { createTestAdmin, seedClient, seedHealthyAgentRuntime, useTestApp } from "./helpers.js";
 
 const APP_WEBHOOK_SECRET = "test-app-webhook-secret";
 const { privateKey: TEST_APP_PRIVATE_KEY_PEM } = generateKeyPairSync("rsa", {
@@ -138,7 +138,7 @@ async function seedInstallation(
     hubOrganizationId: opts.orgId,
     permissions: { contents: "read", pull_requests: "write" },
     events: ["pull_request", "issues"],
-    suspendedAt: opts.suspended ? new Date() : null,
+    suspendedAt: opts.suspended ? new Date(Date.now() - 1_000) : null,
   });
 }
 
@@ -148,6 +148,16 @@ async function configureContextReviewer(app: App, admin: Awaited<ReturnType<type
     memberId: admin.memberId,
     name: `context-reviewer-${randomUUID().slice(0, 6)}`,
   });
+  const clientId = await seedClient(app, admin.userId, admin.organizationId);
+  await app.db.update(agents).set({ clientId, runtimeProvider: "claude-code" }).where(eq(agents.uuid, reviewer));
+  await seedHealthyAgentRuntime(app, {
+    agentUuid: reviewer,
+    clientId,
+  });
+  await app.db
+    .update(githubAppInstallations)
+    .set({ events: ["pull_request", "issue_comment", "pull_request_review_comment", "issues"] })
+    .where(eq(githubAppInstallations.hubOrganizationId, admin.organizationId));
   await putOrgSetting(
     app.db,
     admin.organizationId,

--- a/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
+++ b/packages/server/src/__tests__/gitlab-webhook-stage3.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { agentChatSessions } from "../db/schema/agent-chat-sessions.js";
 import { agents } from "../db/schema/agents.js";
 import { chats } from "../db/schema/chats.js";
+import { clients } from "../db/schema/clients.js";
 import { gitlabConnections } from "../db/schema/gitlab-connections.js";
 import { gitlabEntityChatMappings } from "../db/schema/gitlab-entity-chat-mappings.js";
 import { gitlabIdentityLinks } from "../db/schema/gitlab-identity-links.js";
@@ -34,7 +35,7 @@ import { getCallerEngagement, setChatEngagement } from "../services/me-chat.js";
 import { deleteMember } from "../services/member.js";
 import { deactivateMembership, MEMBER_STATUSES, reactivateMembership } from "../services/membership.js";
 import { putOrgSetting } from "../services/org-settings.js";
-import { createTestAdmin, useTestApp } from "./helpers.js";
+import { createTestAdmin, seedClient, seedHealthyAgentRuntime, useTestApp } from "./helpers.js";
 
 type App = ReturnType<ReturnType<typeof useTestApp>>;
 
@@ -94,13 +95,16 @@ describe("GitLab Stage 3 personnel routing", () => {
 
   async function setupTarget(app: App) {
     const admin = await createTestAdmin(app, { username: `gitlab-stage3-${randomUUID().slice(0, 8)}` });
+    const clientId = await seedClient(app, admin.userId, admin.organizationId);
     const delegate = await createAgent(app.db, {
       name: `review-agent-${randomUUID().slice(0, 8)}`,
       type: "agent",
       displayName: "Review Agent",
       managerId: admin.memberId,
       organizationId: admin.organizationId,
+      clientId,
     });
+    await seedHealthyAgentRuntime(app, { agentUuid: delegate.uuid, clientId });
     await app.db.update(agents).set({ delegateMention: delegate.uuid }).where(eq(agents.uuid, admin.humanAgentUuid));
     const connection = await createGitlabConnection(app.db, {
       organizationId: admin.organizationId,
@@ -114,7 +118,7 @@ describe("GitLab Stage 3 personnel routing", () => {
       membershipId: admin.memberId,
       username: "Reviewer.One",
     });
-    return { admin, delegate, connection, link };
+    return { admin, clientId, delegate, connection, link };
   }
 
   it("dispatches one reserved Context Reviewer run for an old-GitLab MR without personnel routing", async () => {
@@ -201,7 +205,7 @@ describe("GitLab Stage 3 personnel routing", () => {
 
   it("fails closed for wrong repo, disabled or invalid Reviewer, handles draft-to-ready update, and ignores Notes", async () => {
     const app = getApp();
-    const { admin, delegate, connection } = await setupTarget(app);
+    const { admin, clientId, delegate, connection } = await setupTarget(app);
     await putOrgSetting(
       app.db,
       admin.organizationId,
@@ -267,6 +271,19 @@ describe("GitLab Stage 3 personnel routing", () => {
     ).toHaveLength(0);
 
     await app.db.update(agents).set({ status: "active" }).where(eq(agents.uuid, delegate.uuid));
+    await app.db.update(clients).set({ status: "disconnected" }).where(eq(clients.id, clientId));
+    const offline = await postMr(
+      app,
+      connection.bearer,
+      mergeRequestPayload({ projectPath: "Acme/Reviews", iid: 45 }),
+      "offline-context-reviewer",
+    );
+    expect(offline.statusCode).toBe(200);
+    expect(
+      (await app.db.select().from(chats)).filter((chat) => chat.metadata.contextTreeReviewer === true),
+    ).toHaveLength(0);
+    await seedHealthyAgentRuntime(app, { agentUuid: delegate.uuid, clientId });
+
     const draft = await postMr(
       app,
       connection.bearer,

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -6,9 +6,11 @@ import type { FastifyInstance } from "fastify";
 import { afterAll, beforeAll } from "vitest";
 import { buildApp } from "../app.js";
 import type { Config } from "../config.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
 import { agents } from "../db/schema/agents.js";
 import { clients } from "../db/schema/clients.js";
 import { members } from "../db/schema/members.js";
+import { serverInstances } from "../db/schema/server-instances.js";
 import { users } from "../db/schema/users.js";
 import { createAgent } from "../services/agent.js";
 import { signTokensForUser } from "../services/auth.js";
@@ -386,6 +388,71 @@ export async function seedClient(app: FastifyInstance, userId: string, organizat
   const id = `cli-${crypto.randomUUID().slice(0, 8)}`;
   await app.db.insert(clients).values({ id, userId, organizationId, status: "connected" });
   return id;
+}
+
+/** Seed the exact live route and install-only capability facts used by runtime health gates. */
+export async function seedHealthyAgentRuntime(
+  app: FastifyInstance,
+  input: {
+    agentUuid: string;
+    clientId: string;
+    runtimeProvider?: RuntimeProvider;
+    now?: Date;
+  },
+): Promise<void> {
+  const now = input.now ?? new Date();
+  const runtimeProvider = input.runtimeProvider ?? "claude-code";
+  const instanceId = `instance-${input.clientId}`;
+  await app.db
+    .update(clients)
+    .set({
+      status: "connected",
+      instanceId,
+      lastSeenAt: now,
+      retiredAt: null,
+      pausedReason: null,
+      metadata: {
+        capabilities: {
+          [runtimeProvider]: {
+            state: "ok",
+            available: true,
+            detectedAt: now.toISOString(),
+          },
+        },
+      },
+    })
+    .where(eq(clients.id, input.clientId));
+  await app.db
+    .insert(serverInstances)
+    .values({ instanceId, lastHeartbeat: now })
+    .onConflictDoUpdate({
+      target: serverInstances.instanceId,
+      set: { lastHeartbeat: now },
+    });
+  await app.db
+    .insert(agentPresence)
+    .values({
+      agentId: input.agentUuid,
+      status: "online",
+      clientId: input.clientId,
+      instanceId,
+      runtimeType: runtimeProvider,
+      runtimeState: "idle",
+      lastSeenAt: now,
+      runtimeUpdatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: agentPresence.agentId,
+      set: {
+        status: "online",
+        clientId: input.clientId,
+        instanceId,
+        runtimeType: runtimeProvider,
+        runtimeState: "idle",
+        lastSeenAt: now,
+        runtimeUpdatedAt: now,
+      },
+    });
 }
 
 /**

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -822,7 +822,7 @@ describe("org-settings service", () => {
     expect(re).toEqual(out);
   });
 
-  it("context_tree_features clears agentUuid when disabled", async () => {
+  it("context_tree_features preserves the selected reviewer when disabled", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
     const reviewer = await createReviewerAgent(app, {
@@ -846,7 +846,13 @@ describe("org-settings service", () => {
       { updatedBy: admin.userId, memberId: admin.memberId },
     );
 
-    expect(disabled).toEqual({ contextReviewer: { enabled: false, agentUuid: null, reviewerAgent: null } });
+    expect(disabled).toEqual({
+      contextReviewer: {
+        enabled: false,
+        agentUuid: reviewer.uuid,
+        reviewerAgent: { uuid: reviewer.uuid, name: reviewer.name, displayName: reviewer.displayName },
+      },
+    });
   });
 
   it("context_tree_features rejects enabling the Reviewer without a writable GitHub App installation", async () => {
@@ -2371,7 +2377,7 @@ describe("org-settings API (admin gating + masking)", () => {
     expect(get2.json()).toEqual({ repos: [] });
   });
 
-  it("admin can GET and PUT context_tree_features through the generic settings route", async () => {
+  it("admin can persist and preserve a disabled Reviewer selection through the compatibility route", async () => {
     const app = getApp();
     const admin = await createAdminContext(app);
     const reviewer = await createReviewerAgent(app, {
@@ -2393,12 +2399,12 @@ describe("org-settings API (admin gating + masking)", () => {
       method: "PUT",
       url,
       headers: { authorization: `Bearer ${admin.accessToken}` },
-      payload: { contextReviewer: { enabled: true, agentUuid: reviewer.uuid } },
+      payload: { contextReviewer: { enabled: false, agentUuid: reviewer.uuid } },
     });
     expect(put.statusCode).toBe(200);
     expect(put.json()).toEqual({
       contextReviewer: {
-        enabled: true,
+        enabled: false,
         agentUuid: reviewer.uuid,
         reviewerAgent: { uuid: reviewer.uuid, name: reviewer.name, displayName: reviewer.displayName },
       },
@@ -2411,7 +2417,13 @@ describe("org-settings API (admin gating + masking)", () => {
       payload: { contextReviewer: { enabled: false, agentUuid: reviewer.uuid } },
     });
     expect(disabled.statusCode).toBe(200);
-    expect(disabled.json()).toEqual({ contextReviewer: { enabled: false, agentUuid: null, reviewerAgent: null } });
+    expect(disabled.json()).toEqual({
+      contextReviewer: {
+        enabled: false,
+        agentUuid: reviewer.uuid,
+        reviewerAgent: { uuid: reviewer.uuid, name: reviewer.name, displayName: reviewer.displayName },
+      },
+    });
   });
 
   it("member can GET source_repos and context_tree (readPolicy: member) but cannot PUT / DELETE", async () => {

--- a/packages/server/src/__tests__/org-settings.test.ts
+++ b/packages/server/src/__tests__/org-settings.test.ts
@@ -159,6 +159,48 @@ describe("org-settings service", () => {
     }
   });
 
+  it("keeps a GitLab Tree snapshot current when only Reviewer state changes", async () => {
+    const app = getApp();
+    const admin = await createTestAdmin(app);
+    await createGitlabConnection(app.db, {
+      organizationId: admin.organizationId,
+      memberId: admin.memberId,
+      displayName: "GitLab",
+      instanceOrigin: "https://gitlab.internal",
+    });
+    await orgSettingsService.putOrgSetting(
+      app.db,
+      admin.organizationId,
+      "context_tree",
+      {
+        provider: "gitlab",
+        repo: "https://gitlab.internal/acme/context-tree.git",
+        branch: "main",
+      },
+      {
+        updatedBy: admin.userId,
+        memberId: admin.memberId,
+        gitlabEgressAllowlist: [{ origin: "https://gitlab.internal", addressPolicy: { kind: "public" } }],
+      },
+    );
+    const expectedRuntime = await orgSettingsService.getOrgContextReviewRuntime(app.db, admin.organizationId);
+
+    await app.db.insert(organizationSettings).values({
+      organizationId: admin.organizationId,
+      namespace: "context_tree_features",
+      value: { contextReviewer: { enabled: true, agentUuid: uuidv7() } },
+      version: 1,
+      updatedBy: admin.userId,
+    });
+
+    await expect(
+      orgSettingsService.isOrgContextTreeBindingRuntimeCurrent(app.db, admin.organizationId, expectedRuntime),
+    ).resolves.toBe(true);
+    await expect(
+      orgSettingsService.isOrgContextReviewRuntimeCurrent(app.db, admin.organizationId, expectedRuntime),
+    ).resolves.toBe(false);
+  });
+
   it("putOrgSetting stores context_tree and round-trips via getOrgSetting", async () => {
     const app = getApp();
     const admin = await createTestAdmin(app);

--- a/packages/server/src/__tests__/setup-capabilities.test.ts
+++ b/packages/server/src/__tests__/setup-capabilities.test.ts
@@ -13,7 +13,7 @@ import { createAgent } from "../services/agent.js";
 import { projectGitlabConnectionReadiness } from "../services/gitlab-connections.js";
 import { getTeamSetupCapabilities } from "../services/setup-capabilities.js";
 import { uuidv7 } from "../uuid.js";
-import { createTestAdmin, useTestApp } from "./helpers.js";
+import { createTestAdmin, seedHealthyAgentRuntime, useTestApp } from "./helpers.js";
 
 const observedAt = new Date("2026-07-23T08:00:00.000Z");
 const githubAppPrivateKey = generateKeyPairSync("rsa", {
@@ -188,6 +188,11 @@ async function createReviewer(
   if (status !== "active") {
     await app.db.update(agents).set({ status }).where(eq(agents.uuid, reviewer.uuid));
   }
+  await seedHealthyAgentRuntime(app, {
+    agentUuid: reviewer.uuid,
+    clientId,
+    now: observedAt,
+  });
   return { uuid: reviewer.uuid, displayName: reviewer.displayName };
 }
 

--- a/packages/server/src/api/agent/context-tree-info.ts
+++ b/packages/server/src/api/agent/context-tree-info.ts
@@ -1,16 +1,16 @@
 import type { FastifyInstance } from "fastify";
 import { requireAgent } from "../../middleware/require-identity.js";
-import { getOrgContextReviewRuntime } from "../../services/org-settings.js";
+import { getTeamSafeOrgContextReviewRuntime } from "../../services/org-settings.js";
 
 export async function agentContextTreeInfoRoutes(app: FastifyInstance): Promise<void> {
   /**
    * Class D — `/api/v1/agent/context-tree/info`. Returns the Context Tree
-   * binding and Reviewer assignment for the authenticated runtime agent's
-   * organization. The service returns both from one database statement.
+   * binding and Team-safe Reviewer assignment for the authenticated runtime
+   * agent's organization.
    */
   app.get("/context-tree/info", async (request) => {
     const identity = requireAgent(request);
-    const runtime = await getOrgContextReviewRuntime(app.db, identity.organizationId);
+    const runtime = await getTeamSafeOrgContextReviewRuntime(app.db, identity.organizationId);
     return {
       provider: runtime.provider,
       repo: runtime.repo,

--- a/packages/server/src/api/context-tree-snapshot.ts
+++ b/packages/server/src/api/context-tree-snapshot.ts
@@ -19,7 +19,7 @@ import {
 } from "../services/github-app-token.js";
 import {
   getOrgContextReviewRuntime,
-  isOrgContextReviewRuntimeCurrent,
+  isOrgContextTreeBindingRuntimeCurrent,
   resolveUserPrimaryOrgId,
 } from "../services/org-settings.js";
 import { summarizeContextTreeUsage } from "../services/session-event.js";
@@ -60,7 +60,7 @@ export async function contextTreeSnapshotRoutes(app: FastifyInstance): Promise<v
         gitlabEgressAllowlist: app.config.gitlab?.egressAllowlist ?? [],
         gitlabExecutionGuard:
           orgId && reviewRuntime?.provider === "gitlab"
-            ? () => isOrgContextReviewRuntimeCurrent(app.db, orgId, reviewRuntime)
+            ? () => isOrgContextTreeBindingRuntimeCurrent(app.db, orgId, reviewRuntime)
             : undefined,
       }),
     );

--- a/packages/server/src/api/orgs/context-reviewer.ts
+++ b/packages/server/src/api/orgs/context-reviewer.ts
@@ -1,0 +1,48 @@
+import {
+  contextReviewerAssignmentInputSchema,
+  contextReviewerCandidatesOutputSchema,
+  contextReviewerEnablementInputSchema,
+  orgContextTreeFeaturesOutputSchema,
+} from "@first-tree/shared";
+import type { FastifyInstance } from "fastify";
+import { requireOrgAdmin } from "../../scope/require-org.js";
+import { listContextReviewerCandidates } from "../../services/context-reviewer-readiness.js";
+import {
+  putContextReviewerAssignment,
+  putContextReviewerEnablement,
+} from "../../services/context-reviewer-settings.js";
+
+/** Class B — `/api/v1/orgs/:orgId/context-reviewer`. */
+export async function orgContextReviewerRoutes(app: FastifyInstance): Promise<void> {
+  app.get<{ Params: { orgId: string } }>("/candidates", async (request) => {
+    const scope = await requireOrgAdmin(request, app.db);
+    const result = await listContextReviewerCandidates(app.db, {
+      organizationId: scope.organizationId,
+      now: new Date(),
+      staleSeconds: app.config.runtime.presenceCleanupSeconds,
+    });
+    return contextReviewerCandidatesOutputSchema.parse(result);
+  });
+
+  app.put<{ Params: { orgId: string }; Body: unknown }>("/assignment", async (request) => {
+    const scope = await requireOrgAdmin(request, app.db);
+    const input = contextReviewerAssignmentInputSchema.parse(request.body);
+    return orgContextTreeFeaturesOutputSchema.parse(
+      await putContextReviewerAssignment(app.db, scope.organizationId, input.agentUuid, {
+        updatedBy: scope.userId,
+      }),
+    );
+  });
+
+  app.put<{ Params: { orgId: string }; Body: unknown }>("/enablement", async (request) => {
+    const scope = await requireOrgAdmin(request, app.db);
+    const input = contextReviewerEnablementInputSchema.parse(request.body);
+    return orgContextTreeFeaturesOutputSchema.parse(
+      await putContextReviewerEnablement(app.db, scope.organizationId, input.enabled, {
+        updatedBy: scope.userId,
+        staleSeconds: app.config.runtime.presenceCleanupSeconds,
+        githubAppCredentials: app.config.oauth?.githubApp,
+      }),
+    );
+  });
+}

--- a/packages/server/src/api/orgs/context-tree-snapshot.ts
+++ b/packages/server/src/api/orgs/context-tree-snapshot.ts
@@ -16,7 +16,7 @@ import {
   mintContextTreeInstallationToken,
   resolveContextTreeRecoveryAction,
 } from "../../services/github-app-token.js";
-import { getOrgContextReviewRuntime, isOrgContextReviewRuntimeCurrent } from "../../services/org-settings.js";
+import { getOrgContextReviewRuntime, isOrgContextTreeBindingRuntimeCurrent } from "../../services/org-settings.js";
 import { summarizeContextTreeUsage } from "../../services/session-event.js";
 
 const querySchema = z
@@ -54,7 +54,7 @@ export async function orgContextTreeSnapshotRoutes(app: FastifyInstance): Promis
         gitlabEgressAllowlist: app.config.gitlab?.egressAllowlist ?? [],
         gitlabExecutionGuard:
           reviewRuntime.provider === "gitlab"
-            ? () => isOrgContextReviewRuntimeCurrent(app.db, scope.organizationId, reviewRuntime)
+            ? () => isOrgContextTreeBindingRuntimeCurrent(app.db, scope.organizationId, reviewRuntime)
             : undefined,
       }),
     );

--- a/packages/server/src/api/orgs/context-tree.ts
+++ b/packages/server/src/api/orgs/context-tree.ts
@@ -48,7 +48,7 @@ import {
   getOrgContextReviewRuntime,
   getOrgContextTreeBinding,
   getOrgContextTreeSettingState,
-  isOrgContextReviewRuntimeCurrent,
+  isOrgContextTreeBindingRuntimeCurrent,
   putInitializedOrgContextTreeBinding,
 } from "../../services/org-settings.js";
 import { getOrganization } from "../../services/organization.js";
@@ -532,7 +532,7 @@ async function resolveTreeSetupRecoveryMessage(
       gitlabEgressAllowlist: app.config.gitlab?.egressAllowlist ?? [],
       gitlabExecutionGuard:
         reviewRuntime.provider === "gitlab"
-          ? () => isOrgContextReviewRuntimeCurrent(app.db, organizationId, reviewRuntime)
+          ? () => isOrgContextTreeBindingRuntimeCurrent(app.db, organizationId, reviewRuntime)
           : undefined,
     },
   );

--- a/packages/server/src/api/orgs/settings.ts
+++ b/packages/server/src/api/orgs/settings.ts
@@ -7,6 +7,7 @@ import {
 import type { FastifyInstance } from "fastify";
 import { BadRequestError, ConflictError, GoneError } from "../../errors.js";
 import { requireOrgAdmin, requireOrgMembership } from "../../scope/require-org.js";
+import { putLegacyContextReviewerSetting } from "../../services/context-reviewer-settings.js";
 import * as orgSettingsService from "../../services/org-settings.js";
 
 /**
@@ -90,6 +91,13 @@ export async function orgSettingsRoutes(app: FastifyInstance): Promise<void> {
       const namespace = parseNamespace(request.params.namespace);
       if (namespace === "source_repos") {
         throw new GoneError("source_repos is read-only; use Team Resources instead");
+      }
+      if (namespace === "context_tree_features") {
+        return putLegacyContextReviewerSetting(app.db, scope.organizationId, request.body, {
+          updatedBy: scope.userId,
+          staleSeconds: app.config.runtime.presenceCleanupSeconds,
+          githubAppCredentials: app.config.oauth?.githubApp,
+        });
       }
       return orgSettingsService.putOrgSetting(app.db, scope.organizationId, namespace, request.body, {
         memberId: scope.memberId,

--- a/packages/server/src/api/orgs/setup-capabilities.ts
+++ b/packages/server/src/api/orgs/setup-capabilities.ts
@@ -10,6 +10,7 @@ export async function orgSetupCapabilitiesRoutes(app: FastifyInstance): Promise<
     return teamSetupCapabilitiesSchema.parse(
       await getTeamSetupCapabilities(app.db, scope.organizationId, {
         githubAppCredentials: app.config.oauth?.githubApp,
+        staleSeconds: app.config.runtime.presenceCleanupSeconds,
       }),
     );
   });

--- a/packages/server/src/api/webhooks/github-app.ts
+++ b/packages/server/src/api/webhooks/github-app.ts
@@ -282,6 +282,7 @@ export async function githubAppWebhookRoutes(app: FastifyInstance): Promise<void
               eventType,
               payload,
               organizationId,
+              installationId,
             })
           : Promise.resolve({ handled: false, reason: "unsupported_event" } as const),
       resolveAudience: (normalizedEvent) => resolveGithubAudience(app.db, normalizedEvent),

--- a/packages/server/src/api/webhooks/gitlab.ts
+++ b/packages/server/src/api/webhooks/gitlab.ts
@@ -159,6 +159,7 @@ export async function gitlabWebhookRoutes(app: FastifyInstance): Promise<void> {
                   database: tx,
                   normalized,
                   connection: fencedConnection,
+                  staleSeconds: app.config.runtime.presenceCleanupSeconds,
                 });
                 return { endpointSeen: true, contextReviewer };
               },

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -52,6 +52,7 @@ import { orgAgentRoutes } from "./api/orgs/agents.js";
 import { orgAttachmentRoutes } from "./api/orgs/attachments.js";
 import { orgChatRoutes } from "./api/orgs/chats.js";
 import { orgClientRoutes } from "./api/orgs/clients.js";
+import { orgContextReviewerRoutes } from "./api/orgs/context-reviewer.js";
 import { orgContextTreeRoutes } from "./api/orgs/context-tree.js";
 import { orgContextTreeSnapshotRoutes } from "./api/orgs/context-tree-snapshot.js";
 import { orgDocumentRoutes } from "./api/orgs/documents.js";
@@ -571,6 +572,7 @@ export async function buildApp(config: Config) {
           await scope.register(orgGithubAppRoutes, { prefix: "/github-app-installation" });
           await scope.register(orgGitlabConnectionRoutes, { prefix: "/gitlab-connections" });
           await scope.register(orgGitlabIdentityLinkRoutes, { prefix: "/gitlab-identity-links" });
+          await scope.register(orgContextReviewerRoutes, { prefix: "/context-reviewer" });
           await scope.register(orgContextTreeRoutes, { prefix: "/context-tree" });
           await scope.register(orgContextTreeSnapshotRoutes, { prefix: "/context-tree" });
           await scope.register(orgSetupCapabilitiesRoutes, { prefix: "/setup-capabilities" });

--- a/packages/server/src/services/context-reviewer-common.ts
+++ b/packages/server/src/services/context-reviewer-common.ts
@@ -122,12 +122,6 @@ export async function withContextReviewerDispatchAuthority<T>(
     await tx.execute(
       sql`SELECT pg_advisory_xact_lock(hashtext('context_reviewer_dispatch'), hashtext(${reservationKey}))`,
     );
-    await tx
-      .select({ id: chats.id })
-      .from(chats)
-      .where(and(eq(chats.organizationId, input.organizationId), eq(chats.onboardingKickoffKey, reservationKey)))
-      .for("update")
-      .limit(1);
 
     const [snapshot] = await tx
       .select({

--- a/packages/server/src/services/context-reviewer-common.ts
+++ b/packages/server/src/services/context-reviewer-common.ts
@@ -1,16 +1,45 @@
 import { createHash } from "node:crypto";
-import { and, eq, sql } from "drizzle-orm";
+import {
+  AGENT_VISIBILITY,
+  canonicalGitRepoIdentity,
+  isRuntimeProviderEnabled,
+  runtimeProviderSchema,
+} from "@first-tree/shared";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
 import { agents } from "../db/schema/agents.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { chats } from "../db/schema/chats.js";
+import { clients } from "../db/schema/clients.js";
+import { githubAppInstallations } from "../db/schema/github-app-installations.js";
+import { gitlabConnections } from "../db/schema/gitlab-connections.js";
 import { members } from "../db/schema/members.js";
+import { organizationSettings } from "../db/schema/organization-settings.js";
+import { serverInstances } from "../db/schema/server-instances.js";
+import { agentNotLandingCampaignTrialCondition } from "./access-control.js";
+import { readContextReviewerAgentReadiness } from "./context-reviewer-readiness.js";
+import { getOrgContextReviewRuntime } from "./org-settings.js";
+import { githubAutomaticReviewEventsReady } from "./setup-capabilities.js";
 
 export type ContextReviewerAgent = {
   uuid: string;
   managerHumanAgentId: string;
   managerGithubLogin: string | null;
 };
+
+export type ContextReviewerDispatchAuthority =
+  | {
+      provider: "github";
+      installationId: number;
+      repository: string;
+    }
+  | {
+      provider: "gitlab";
+      connectionId: string;
+      instanceOrigin: string;
+      tokenHash: string;
+    };
 
 export function contextReviewerChatReservationKey(organizationId: string, entityKey: string): string {
   const digest = createHash("sha256").update(`${organizationId}\0${entityKey}`).digest("hex");
@@ -24,11 +53,20 @@ export async function loadValidContextReviewerAgent(
   const [agent] = await db
     .select({
       uuid: agents.uuid,
+      visibility: agents.visibility,
+      managerId: agents.managerId,
+      runtimeProvider: agents.runtimeProvider,
+      clientId: clients.id,
+      clientOrganizationId: clients.organizationId,
+      clientUserId: clients.userId,
+      clientRetiredAt: clients.retiredAt,
+      managerUserId: members.userId,
       managerHumanAgentId: members.agentId,
       managerGithubLogin: sql<string | null>`${authIdentities.metadata}->>'login'`,
     })
     .from(agents)
     .innerJoin(members, eq(members.id, agents.managerId))
+    .leftJoin(clients, eq(clients.id, agents.clientId))
     .leftJoin(authIdentities, and(eq(authIdentities.userId, members.userId), eq(authIdentities.provider, "github")))
     .where(
       and(
@@ -36,12 +74,204 @@ export async function loadValidContextReviewerAgent(
         eq(agents.organizationId, input.organizationId),
         eq(agents.type, "agent"),
         eq(agents.status, "active"),
+        agentNotLandingCampaignTrialCondition(),
         eq(members.organizationId, input.organizationId),
         eq(members.status, "active"),
       ),
     )
     .limit(1);
-  return agent ?? null;
+  if (!agent) return null;
+  if (agent.visibility !== AGENT_VISIBILITY.ORGANIZATION) return null;
+  if (
+    !runtimeProviderSchema.safeParse(agent.runtimeProvider).success ||
+    !isRuntimeProviderEnabled(agent.runtimeProvider) ||
+    !agent.clientId ||
+    agent.clientOrganizationId !== input.organizationId ||
+    agent.clientUserId !== agent.managerUserId ||
+    agent.clientRetiredAt !== null
+  ) {
+    return null;
+  }
+  return agent;
+}
+
+/**
+ * Make the last authority decision in the transaction that persists a trusted
+ * Context Review run. The earlier handler reads are cheap routing checks only;
+ * this fence prevents a concurrent disable, reassignment, privacy/lifecycle
+ * change, runtime loss, Tree rebind, or provider revocation from authorizing a
+ * stale run.
+ */
+export async function withContextReviewerDispatchAuthority<T>(
+  db: Database,
+  input: {
+    organizationId: string;
+    reviewerAgentUuid: string;
+    entityKey: string;
+    expectedManagerHumanAgentId?: string;
+    staleSeconds: number;
+    now?: Date;
+    authority: ContextReviewerDispatchAuthority;
+  },
+  callback: (tx: Database, reviewer: ContextReviewerAgent) => Promise<T>,
+): Promise<{ authorized: true; value: T } | { authorized: false }> {
+  return db.transaction(async (rawTx) => {
+    const tx = rawTx as unknown as Database;
+
+    const reservationKey = contextReviewerChatReservationKey(input.organizationId, input.entityKey);
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext('context_reviewer_dispatch'), hashtext(${reservationKey}))`,
+    );
+    await tx
+      .select({ id: chats.id })
+      .from(chats)
+      .where(and(eq(chats.organizationId, input.organizationId), eq(chats.onboardingKickoffKey, reservationKey)))
+      .for("update")
+      .limit(1);
+
+    const [snapshot] = await tx
+      .select({
+        uuid: agents.uuid,
+        managerId: agents.managerId,
+        clientId: agents.clientId,
+      })
+      .from(agents)
+      .where(and(eq(agents.uuid, input.reviewerAgentUuid), agentNotLandingCampaignTrialCondition()))
+      .limit(1);
+    if (!snapshot) return { authorized: false };
+
+    await tx.select({ id: members.id }).from(members).where(eq(members.id, snapshot.managerId)).for("update").limit(1);
+    const [client] = snapshot.clientId
+      ? await tx.select().from(clients).where(eq(clients.id, snapshot.clientId)).for("update").limit(1)
+      : [];
+
+    const [agent] = await tx
+      .select({
+        uuid: agents.uuid,
+        managerId: agents.managerId,
+        clientId: agents.clientId,
+      })
+      .from(agents)
+      .where(and(eq(agents.uuid, input.reviewerAgentUuid), agentNotLandingCampaignTrialCondition()))
+      .for("update")
+      .limit(1);
+    if (!agent || agent.managerId !== snapshot.managerId || agent.clientId !== snapshot.clientId) {
+      return { authorized: false };
+    }
+
+    await tx
+      .select({ agentId: agentPresence.agentId })
+      .from(agentPresence)
+      .where(eq(agentPresence.agentId, agent.uuid))
+      .for("update")
+      .limit(1);
+    if (client?.instanceId) {
+      await tx
+        .select({ instanceId: serverInstances.instanceId })
+        .from(serverInstances)
+        .where(eq(serverInstances.instanceId, client.instanceId))
+        .for("update")
+        .limit(1);
+    }
+
+    if (input.authority.provider === "github") {
+      const [installation] = await tx
+        .select()
+        .from(githubAppInstallations)
+        .where(eq(githubAppInstallations.hubOrganizationId, input.organizationId))
+        .for("update")
+        .limit(1);
+      const repositoryOwner = input.authority.repository.split("/")[0]?.toLowerCase();
+      if (
+        !installation ||
+        installation.installationId !== input.authority.installationId ||
+        installation.suspendedAt !== null ||
+        installation.permissions.pull_requests !== "write" ||
+        !githubAutomaticReviewEventsReady(installation.events) ||
+        !repositoryOwner ||
+        installation.accountLogin.toLowerCase() !== repositoryOwner
+      ) {
+        return { authorized: false };
+      }
+    } else {
+      const [connection] = await tx
+        .select()
+        .from(gitlabConnections)
+        .where(eq(gitlabConnections.id, input.authority.connectionId))
+        .for("update")
+        .limit(1);
+      if (
+        !connection ||
+        connection.organizationId !== input.organizationId ||
+        connection.instanceOrigin !== input.authority.instanceOrigin ||
+        connection.tokenHash !== input.authority.tokenHash
+      ) {
+        return { authorized: false };
+      }
+    }
+
+    const lockedSettings = await tx
+      .select({ namespace: organizationSettings.namespace })
+      .from(organizationSettings)
+      .where(
+        and(
+          eq(organizationSettings.organizationId, input.organizationId),
+          inArray(organizationSettings.namespace, ["context_tree", "context_tree_features"]),
+        ),
+      )
+      .for("update");
+    if (
+      !lockedSettings.some((row) => row.namespace === "context_tree") ||
+      !lockedSettings.some((row) => row.namespace === "context_tree_features")
+    ) {
+      return { authorized: false };
+    }
+
+    const runtime = await getOrgContextReviewRuntime(tx, input.organizationId);
+    if (
+      runtime.bindingState !== "bound" ||
+      !runtime.providerMatchesRepository ||
+      runtime.provider !== input.authority.provider ||
+      !runtime.contextReviewer.enabled ||
+      runtime.contextReviewer.agentUuid !== input.reviewerAgentUuid
+    ) {
+      return { authorized: false };
+    }
+    if (input.authority.provider === "github") {
+      const identity = canonicalGitRepoIdentity(runtime.repo);
+      if (identity?.host !== "github.com" || identity.path !== input.authority.repository.trim().toLowerCase()) {
+        return { authorized: false };
+      }
+    } else if (
+      runtime.gitlabConnection?.id !== input.authority.connectionId ||
+      runtime.gitlabConnection.instanceOrigin !== input.authority.instanceOrigin
+    ) {
+      return { authorized: false };
+    }
+
+    const readiness = await readContextReviewerAgentReadiness(tx, {
+      organizationId: input.organizationId,
+      reviewerAgentUuid: input.reviewerAgentUuid,
+      now: input.now ?? new Date(),
+      staleSeconds: input.staleSeconds,
+    });
+    if (readiness.structuralBlockers.length > 0 || readiness.healthBlockers.length > 0) {
+      return { authorized: false };
+    }
+    const reviewer = await loadValidContextReviewerAgent(tx, {
+      organizationId: input.organizationId,
+      reviewerAgentUuid: input.reviewerAgentUuid,
+    });
+    if (
+      !reviewer ||
+      (input.expectedManagerHumanAgentId !== undefined &&
+        reviewer.managerHumanAgentId !== input.expectedManagerHumanAgentId)
+    ) {
+      return { authorized: false };
+    }
+
+    return { authorized: true, value: await callback(tx, reviewer) };
+  });
 }
 
 export async function findExistingContextReviewerChat(

--- a/packages/server/src/services/context-reviewer-mr.ts
+++ b/packages/server/src/services/context-reviewer-mr.ts
@@ -13,7 +13,9 @@ import {
   contextReviewerChatReservationKey,
   findExistingContextReviewerChat,
   loadValidContextReviewerAgent,
+  withContextReviewerDispatchAuthority,
 } from "./context-reviewer-common.js";
+import { readContextReviewerAgentReadiness } from "./context-reviewer-readiness.js";
 import type { NormalizedGitlabWebhook } from "./gitlab-webhook.js";
 import { type DeferredSendMessagePostCommitEffects, sendMessage } from "./message.js";
 import { getOrgContextReviewRuntime } from "./org-settings.js";
@@ -36,7 +38,8 @@ export type ContextReviewerMrSkipReason =
   | "connection_mismatch"
   | "feature_disabled"
   | "reviewer_agent_missing"
-  | "reviewer_agent_invalid";
+  | "reviewer_agent_invalid"
+  | "reviewer_runtime_unavailable";
 
 export type ContextReviewerMrResult =
   | { handled: false; reason: ContextReviewerMrSkipReason }
@@ -97,7 +100,8 @@ export function isContextReviewerMrCandidate(normalized: NormalizedGitlabWebhook
 export async function handleContextReviewerMrEvent(input: {
   database: Database;
   normalized: NormalizedGitlabWebhook;
-  connection: { id: string; organizationId: string; instanceOrigin: string };
+  connection: { id: string; organizationId: string; instanceOrigin: string; tokenHash: string };
+  staleSeconds?: number;
 }): Promise<ContextReviewerMrResult> {
   if (!isContextReviewerMrCandidate(input.normalized)) {
     return { handled: false, reason: "unsupported_event" };
@@ -132,6 +136,15 @@ export async function handleContextReviewerMrEvent(input: {
     reviewerAgentUuid: runtime.contextReviewer.agentUuid,
   });
   if (!reviewer) return { handled: false, reason: "reviewer_agent_invalid" };
+  const readiness = await readContextReviewerAgentReadiness(input.database, {
+    organizationId: input.connection.organizationId,
+    reviewerAgentUuid: runtime.contextReviewer.agentUuid,
+    now: new Date(),
+    staleSeconds: input.staleSeconds ?? 60,
+  });
+  if (readiness.structuralBlockers.length > 0 || readiness.healthBlockers.length > 0) {
+    return { handled: false, reason: "reviewer_runtime_unavailable" };
+  }
 
   const entityKey = `gitlab:${input.connection.id}:${entity.projectId}:pull_request:${entity.entityIid}`;
   const contextReviewRunId = uuidv7();
@@ -148,137 +161,155 @@ export async function handleContextReviewerMrEvent(input: {
     contextReviewRunId,
   };
   const prompt = await renderContextReviewerMrPrompt(templateInput);
-  const metadata = chatMetadataSchema.parse({
-    source: "gitlab",
-    entityType: "pull_request",
-    entityKey,
-    entityUrl: entity.entityUrl,
-    contextTreeReviewer: true,
-    reviewerAgentUuid: reviewer.uuid,
-  });
-  const messageMetadata = {
-    source: "gitlab",
-    event: event.eventType,
-    action: event.action,
-    triggerEvent: templateInput.triggerEvent,
-    entityType: "pull_request",
-    entityKey,
-    contextTreeReviewer: true,
-    contextReviewRunId,
-    contextReviewRepository: webhookRepo,
-    contextReviewConnectionId: input.connection.id,
-    contextReviewInstanceOrigin: input.connection.instanceOrigin,
-    contextReviewProjectId: entity.projectId,
-    contextReviewMrIid: entity.entityIid,
-    contextReviewEntityUrl: entity.entityUrl,
-    contextReviewOrganizationId: input.connection.organizationId,
-    contextReviewReviewerAgentUuid: reviewer.uuid,
-    contextReviewReviewerManagerHumanAgentId: reviewer.managerHumanAgentId,
-    mentions: [reviewer.uuid],
-    mergeRequestDraft: entity.entityState === "draft",
-  };
-
-  const existingChatId = await findExistingContextReviewerChat(input.database, {
-    organizationId: input.connection.organizationId,
-    entityKey,
-  });
-  if (existingChatId) {
-    await input.database.update(chats).set({ metadata }).where(eq(chats.id, existingChatId));
-    await applyMembershipWrite(
-      input.database,
-      existingChatId,
-      [{ agentId: reviewer.managerHumanAgentId }, { agentId: reviewer.uuid }],
-      { onConflictDoNothing: true, upgradeWatcherToSpeaker: true },
-    );
-    const sent = await sendMessage(
-      input.database,
-      existingChatId,
-      reviewer.managerHumanAgentId,
-      { source: "gitlab", format: "markdown", content: prompt, metadata: messageMetadata },
-      { normalizeMentionsInContent: false, allowContextReviewRun: true, deferPostCommitEffects: true },
-    );
-    if (!sent.deferredPostCommitEffects) {
-      throw new Error("Context Reviewer MR message did not return deferred post-commit effects");
-    }
-    return {
-      handled: true,
-      chatId: existingChatId,
-      messageId: sent.message.id,
-      reused: true,
-      recipients: sent.recipients,
-      deferredPostCommitEffects: sent.deferredPostCommitEffects,
-    };
-  }
-
-  const created = await createChat(input.database, {
-    mode: "task",
-    initiatorAgentId: reviewer.managerHumanAgentId,
-    organizationId: input.connection.organizationId,
-    initialRecipientAgentIds: [reviewer.uuid],
-    contextParticipantAgentIds: [],
-    topic: formatContextReviewTopic({
-      provider: "gitlab",
-      repositoryPath: entity.projectPath,
-      changeNumber: entity.entityIid,
-    }),
-    onboardingKickoffKey: contextReviewerChatReservationKey(input.connection.organizationId, entityKey),
-    initialMessage: {
-      source: "gitlab",
-      format: "markdown",
-      content: prompt,
-      metadata: messageMetadata,
-    },
-    allowContextReviewRun: true,
-    deferPostCommitEffects: true,
-    source: "manual",
-  });
-  await input.database.update(chats).set({ metadata }).where(eq(chats.id, created.chat.id));
-  if (!created.initialMessageCreated) {
-    await applyMembershipWrite(
-      input.database,
-      created.chat.id,
-      [{ agentId: reviewer.managerHumanAgentId }, { agentId: reviewer.uuid }],
-      { onConflictDoNothing: true, upgradeWatcherToSpeaker: true },
-    );
-    const sent = await sendMessage(
-      input.database,
-      created.chat.id,
-      reviewer.managerHumanAgentId,
-      { source: "gitlab", format: "markdown", content: prompt, metadata: messageMetadata },
-      { normalizeMentionsInContent: false, allowContextReviewRun: true, deferPostCommitEffects: true },
-    );
-    if (!sent.deferredPostCommitEffects) {
-      throw new Error("Context Reviewer MR message did not return deferred post-commit effects");
-    }
-    return {
-      handled: true,
-      chatId: created.chat.id,
-      messageId: sent.message.id,
-      reused: true,
-      recipients: sent.recipients,
-      deferredPostCommitEffects: sent.deferredPostCommitEffects,
-    };
-  }
-  log.info(
+  const fenced = await withContextReviewerDispatchAuthority(
+    input.database,
     {
       organizationId: input.connection.organizationId,
-      connectionId: input.connection.id,
+      reviewerAgentUuid: reviewer.uuid,
       entityKey,
-      chatId: created.chat.id,
-      triggerEvent: templateInput.triggerEvent,
+      expectedManagerHumanAgentId: reviewer.managerHumanAgentId,
+      staleSeconds: input.staleSeconds ?? 60,
+      authority: {
+        provider: "gitlab",
+        connectionId: input.connection.id,
+        instanceOrigin: input.connection.instanceOrigin,
+        tokenHash: input.connection.tokenHash,
+      },
     },
-    "context reviewer MR task chat created",
-  );
-  return {
-    handled: true,
-    chatId: created.chat.id,
-    messageId: created.message.id,
-    reused: false,
-    recipients: created.recipients,
-    deferredPostCommitEffects:
-      created.deferredPostCommitEffects ??
-      (() => {
+    async (tx, currentReviewer): Promise<Extract<ContextReviewerMrResult, { handled: true }>> => {
+      const metadata = chatMetadataSchema.parse({
+        source: "gitlab",
+        entityType: "pull_request",
+        entityKey,
+        entityUrl: entity.entityUrl,
+        contextTreeReviewer: true,
+        reviewerAgentUuid: currentReviewer.uuid,
+      });
+      const messageMetadata = {
+        source: "gitlab",
+        event: event.eventType,
+        action: event.action,
+        triggerEvent: templateInput.triggerEvent,
+        entityType: "pull_request",
+        entityKey,
+        contextTreeReviewer: true,
+        contextReviewRunId,
+        contextReviewRepository: webhookRepo,
+        contextReviewConnectionId: input.connection.id,
+        contextReviewInstanceOrigin: input.connection.instanceOrigin,
+        contextReviewProjectId: entity.projectId,
+        contextReviewMrIid: entity.entityIid,
+        contextReviewEntityUrl: entity.entityUrl,
+        contextReviewOrganizationId: input.connection.organizationId,
+        contextReviewReviewerAgentUuid: currentReviewer.uuid,
+        contextReviewReviewerManagerHumanAgentId: currentReviewer.managerHumanAgentId,
+        mentions: [currentReviewer.uuid],
+        mergeRequestDraft: entity.entityState === "draft",
+      };
+
+      const existingChatId = await findExistingContextReviewerChat(tx, {
+        organizationId: input.connection.organizationId,
+        entityKey,
+      });
+      if (existingChatId) {
+        await tx.update(chats).set({ metadata }).where(eq(chats.id, existingChatId));
+        await applyMembershipWrite(
+          tx,
+          existingChatId,
+          [{ agentId: currentReviewer.managerHumanAgentId }, { agentId: currentReviewer.uuid }],
+          { onConflictDoNothing: true, upgradeWatcherToSpeaker: true },
+        );
+        const sent = await sendMessage(
+          tx,
+          existingChatId,
+          currentReviewer.managerHumanAgentId,
+          { source: "gitlab", format: "markdown", content: prompt, metadata: messageMetadata },
+          { normalizeMentionsInContent: false, allowContextReviewRun: true, deferPostCommitEffects: true },
+        );
+        if (!sent.deferredPostCommitEffects) {
+          throw new Error("Context Reviewer MR message did not return deferred post-commit effects");
+        }
+        return {
+          handled: true,
+          chatId: existingChatId,
+          messageId: sent.message.id,
+          reused: true,
+          recipients: sent.recipients,
+          deferredPostCommitEffects: sent.deferredPostCommitEffects,
+        };
+      }
+
+      const created = await createChat(tx, {
+        mode: "task",
+        initiatorAgentId: currentReviewer.managerHumanAgentId,
+        organizationId: input.connection.organizationId,
+        initialRecipientAgentIds: [currentReviewer.uuid],
+        contextParticipantAgentIds: [],
+        topic: formatContextReviewTopic({
+          provider: "gitlab",
+          repositoryPath: entity.projectPath,
+          changeNumber: entity.entityIid,
+        }),
+        onboardingKickoffKey: contextReviewerChatReservationKey(input.connection.organizationId, entityKey),
+        initialMessage: {
+          source: "gitlab",
+          format: "markdown",
+          content: prompt,
+          metadata: messageMetadata,
+        },
+        allowContextReviewRun: true,
+        deferPostCommitEffects: true,
+        source: "manual",
+      });
+      await tx.update(chats).set({ metadata }).where(eq(chats.id, created.chat.id));
+      if (!created.initialMessageCreated) {
+        await applyMembershipWrite(
+          tx,
+          created.chat.id,
+          [{ agentId: currentReviewer.managerHumanAgentId }, { agentId: currentReviewer.uuid }],
+          { onConflictDoNothing: true, upgradeWatcherToSpeaker: true },
+        );
+        const sent = await sendMessage(
+          tx,
+          created.chat.id,
+          currentReviewer.managerHumanAgentId,
+          { source: "gitlab", format: "markdown", content: prompt, metadata: messageMetadata },
+          { normalizeMentionsInContent: false, allowContextReviewRun: true, deferPostCommitEffects: true },
+        );
+        if (!sent.deferredPostCommitEffects) {
+          throw new Error("Context Reviewer MR message did not return deferred post-commit effects");
+        }
+        return {
+          handled: true,
+          chatId: created.chat.id,
+          messageId: sent.message.id,
+          reused: true,
+          recipients: sent.recipients,
+          deferredPostCommitEffects: sent.deferredPostCommitEffects,
+        };
+      }
+      if (!created.deferredPostCommitEffects) {
         throw new Error("Context Reviewer MR chat did not return deferred post-commit effects");
-      })(),
-  };
+      }
+      log.info(
+        {
+          organizationId: input.connection.organizationId,
+          connectionId: input.connection.id,
+          entityKey,
+          chatId: created.chat.id,
+          triggerEvent: templateInput.triggerEvent,
+        },
+        "context reviewer MR task chat created",
+      );
+      return {
+        handled: true,
+        chatId: created.chat.id,
+        messageId: created.message.id,
+        reused: false,
+        recipients: created.recipients,
+        deferredPostCommitEffects: created.deferredPostCommitEffects,
+      };
+    },
+  );
+  return fenced.authorized ? fenced.value : { handled: false, reason: "reviewer_runtime_unavailable" };
 }

--- a/packages/server/src/services/context-reviewer-pr.ts
+++ b/packages/server/src/services/context-reviewer-pr.ts
@@ -17,8 +17,14 @@ import {
   contextReviewerChatReservationKey,
   findExistingContextReviewerChat,
   loadValidContextReviewerAgent,
+  withContextReviewerDispatchAuthority,
 } from "./context-reviewer-common.js";
-import { sendMessage } from "./message.js";
+import { readContextReviewerAgentReadiness } from "./context-reviewer-readiness.js";
+import {
+  type DeferredSendMessagePostCommitEffects,
+  runDeferredSendMessagePostCommitEffects,
+  sendMessage,
+} from "./message.js";
 import { notifyRecipients } from "./notifier.js";
 import { getOrgContextReviewRuntime } from "./org-settings.js";
 import { applyMembershipWrite } from "./participant-mode.js";
@@ -61,6 +67,11 @@ export type ContextReviewerPrResult =
   | { handled: false; reason: ContextReviewerPrSkipReason }
   | { handled: true; chatId: string; messageId: string; reused: boolean; suppressed?: boolean };
 
+type PersistedContextReviewerPrResult = Extract<ContextReviewerPrResult, { handled: true }> & {
+  recipients?: string[];
+  deferredPostCommitEffects?: DeferredSendMessagePostCommitEffects;
+};
+
 export type ContextReviewerPrSkipReason =
   | "unsupported_event"
   | "malformed_payload"
@@ -68,7 +79,8 @@ export type ContextReviewerPrSkipReason =
   | "repo_mismatch"
   | "feature_disabled"
   | "reviewer_agent_missing"
-  | "reviewer_agent_invalid";
+  | "reviewer_agent_invalid"
+  | "reviewer_runtime_unavailable";
 
 type ContextReviewerPrPayloadInput = Omit<
   ContextReviewerPrTemplateInput,
@@ -196,6 +208,7 @@ export async function handleContextReviewerPrEvent(
     eventType: string;
     payload: unknown;
     organizationId: string;
+    installationId: number;
   },
 ): Promise<ContextReviewerPrResult> {
   const action = isRecord(input.payload) ? readString(input.payload.action) : null;
@@ -217,6 +230,7 @@ async function handleContextReviewerPrEventWithInfo(
     eventType: string;
     payload: unknown;
     organizationId: string;
+    installationId: number;
   },
   info: PullRequestPayloadInfo,
 ): Promise<ContextReviewerPrResult> {
@@ -249,6 +263,13 @@ async function handleContextReviewerPrEventWithInfo(
   if (!runtime.contextReviewer.enabled) {
     return { handled: false, reason: "feature_disabled" };
   }
+  if (!app.config.oauth?.githubApp?.slug) {
+    log.warn(
+      { organizationId: input.organizationId },
+      "context reviewer skipped: GitHub App publication identity is not configured",
+    );
+    return { handled: false, reason: "reviewer_runtime_unavailable" };
+  }
   const reviewerAgentUuid = runtime.contextReviewer.agentUuid;
   if (!reviewerAgentUuid) {
     return { handled: false, reason: "reviewer_agent_missing" };
@@ -265,138 +286,213 @@ async function handleContextReviewerPrEventWithInfo(
     );
     return { handled: false, reason: "reviewer_agent_invalid" };
   }
-
-  const existingChatId = await findExistingContextReviewerChat(app.db, {
+  const readiness = await readContextReviewerAgentReadiness(app.db, {
     organizationId: input.organizationId,
-    entityKey: info.entityKey,
+    reviewerAgentUuid,
+    now: new Date(),
+    staleSeconds: app.config.runtime.presenceCleanupSeconds,
   });
-
-  const metadata = chatMetadataSchema.parse({
-    source: "github",
-    entityType: "pull_request",
-    entityKey: info.entityKey,
-    entityUrl: info.htmlUrl,
-    contextTreeReviewer: true,
-    reviewerAgentUuid: reviewer.uuid,
-  });
-  if (existingChatId) {
-    await app.db.update(chats).set({ metadata }).where(eq(chats.id, existingChatId));
-    await applyMembershipWrite(
-      app.db,
-      existingChatId,
-      [{ agentId: reviewer.managerHumanAgentId }, { agentId: reviewer.uuid }],
-      { onConflictDoNothing: true, upgradeWatcherToSpeaker: true },
-    );
-    const suppressedEchoMessageId = await findSuppressibleReviewerEchoMessageId(app.db, {
-      chatId: existingChatId,
-      info,
-      reviewer,
-      appSlug: app.config.oauth?.githubApp?.slug ?? null,
-    });
-    if (suppressedEchoMessageId) {
-      log.info(
-        {
-          organizationId: input.organizationId,
-          entityKey: info.entityKey,
-          chatId: existingChatId,
-          commentAuthorLogin: info.commentAuthorLogin,
-        },
-        "context reviewer echo comment suppressed",
-      );
-      return {
-        handled: true,
-        chatId: existingChatId,
-        messageId: suppressedEchoMessageId,
-        reused: true,
-        suppressed: true,
-      };
-    }
-    const contextReviewRunId = uuidv7();
-    const prompt = await renderContextReviewerPrPrompt(buildTemplateInput(info, reviewer, contextReviewRunId));
-    const { message, recipients } = await sendMessage(
-      app.db,
-      existingChatId,
-      reviewer.managerHumanAgentId,
-      {
-        source: "github",
-        format: "markdown",
-        content: prompt,
-        metadata: contextReviewerMessageMetadata(info, reviewer, contextReviewRunId),
-      },
-      { normalizeMentionsInContent: false, allowContextReviewRun: true },
-    );
-    notifyRecipients(app.notifier, recipients, message.id);
-    log.info(
+  if (readiness.structuralBlockers.length > 0 || readiness.healthBlockers.length > 0) {
+    log.warn(
       {
         organizationId: input.organizationId,
-        entityKey: info.entityKey,
-        chatId: existingChatId,
-        triggerEvent: info.triggerEvent,
-        isDraft: info.isDraft,
+        reviewerAgentUuid,
+        blockers: [...readiness.structuralBlockers, ...readiness.healthBlockers].map((candidate) => candidate.code),
       },
-      "context reviewer task sent to existing chat",
+      "context reviewer skipped: configured reviewer runtime is unavailable",
     );
-    return { handled: true, chatId: existingChatId, messageId: message.id, reused: true };
+    return { handled: false, reason: "reviewer_runtime_unavailable" };
   }
 
   const contextReviewRunId = uuidv7();
   const prompt = await renderContextReviewerPrPrompt(buildTemplateInput(info, reviewer, contextReviewRunId));
-  const created = await createChat(app.db, {
-    mode: "task",
-    initiatorAgentId: reviewer.managerHumanAgentId,
-    organizationId: input.organizationId,
-    initialRecipientAgentIds: [reviewer.uuid],
-    contextParticipantAgentIds: [],
-    topic: formatContextReviewTopic({
-      provider: "github",
-      repositoryPath: info.repoFullName,
-      changeNumber: info.prNumber,
-    }),
-    onboardingKickoffKey: contextReviewerChatReservationKey(input.organizationId, info.entityKey),
-    initialMessage: {
-      source: "github",
-      format: "markdown",
-      content: prompt,
-      metadata: contextReviewerMessageMetadata(info, reviewer, contextReviewRunId),
-    },
-    allowContextReviewRun: true,
-    source: "manual",
-  });
-  await app.db.update(chats).set({ metadata }).where(eq(chats.id, created.chat.id));
-  if (!created.initialMessageCreated) {
-    await applyMembershipWrite(
-      app.db,
-      created.chat.id,
-      [{ agentId: reviewer.managerHumanAgentId }, { agentId: reviewer.uuid }],
-      { onConflictDoNothing: true, upgradeWatcherToSpeaker: true },
-    );
-    const { message, recipients } = await sendMessage(
-      app.db,
-      created.chat.id,
-      reviewer.managerHumanAgentId,
-      {
-        source: "github",
-        format: "markdown",
-        content: prompt,
-        metadata: contextReviewerMessageMetadata(info, reviewer, contextReviewRunId),
-      },
-      { normalizeMentionsInContent: false, allowContextReviewRun: true },
-    );
-    notifyRecipients(app.notifier, recipients, message.id);
-    return { handled: true, chatId: created.chat.id, messageId: message.id, reused: true };
-  }
-  notifyRecipients(app.notifier, created.recipients, created.message.id);
-  log.info(
+  const fenced = await withContextReviewerDispatchAuthority(
+    app.db,
     {
       organizationId: input.organizationId,
+      reviewerAgentUuid,
       entityKey: info.entityKey,
-      chatId: created.chat.id,
-      triggerEvent: info.triggerEvent,
-      isDraft: info.isDraft,
+      expectedManagerHumanAgentId: reviewer.managerHumanAgentId,
+      staleSeconds: app.config.runtime.presenceCleanupSeconds,
+      authority: {
+        provider: "github",
+        installationId: input.installationId,
+        repository: webhookRepo,
+      },
     },
-    "context reviewer task chat created",
+    async (tx, currentReviewer): Promise<PersistedContextReviewerPrResult> => {
+      const metadata = chatMetadataSchema.parse({
+        source: "github",
+        entityType: "pull_request",
+        entityKey: info.entityKey,
+        entityUrl: info.htmlUrl,
+        contextTreeReviewer: true,
+        reviewerAgentUuid: currentReviewer.uuid,
+      });
+      const existingChatId = await findExistingContextReviewerChat(tx, {
+        organizationId: input.organizationId,
+        entityKey: info.entityKey,
+      });
+      if (existingChatId) {
+        await tx.update(chats).set({ metadata }).where(eq(chats.id, existingChatId));
+        await applyMembershipWrite(
+          tx,
+          existingChatId,
+          [{ agentId: currentReviewer.managerHumanAgentId }, { agentId: currentReviewer.uuid }],
+          { onConflictDoNothing: true, upgradeWatcherToSpeaker: true },
+        );
+        const suppressedEchoMessageId = await findSuppressibleReviewerEchoMessageId(tx, {
+          chatId: existingChatId,
+          info,
+          reviewer: currentReviewer,
+          appSlug: app.config.oauth?.githubApp?.slug ?? null,
+        });
+        if (suppressedEchoMessageId) {
+          log.info(
+            {
+              organizationId: input.organizationId,
+              entityKey: info.entityKey,
+              chatId: existingChatId,
+              commentAuthorLogin: info.commentAuthorLogin,
+            },
+            "context reviewer echo comment suppressed",
+          );
+          return {
+            handled: true,
+            chatId: existingChatId,
+            messageId: suppressedEchoMessageId,
+            reused: true,
+            suppressed: true,
+          };
+        }
+        const sent = await sendMessage(
+          tx,
+          existingChatId,
+          currentReviewer.managerHumanAgentId,
+          {
+            source: "github",
+            format: "markdown",
+            content: prompt,
+            metadata: contextReviewerMessageMetadata(info, currentReviewer, contextReviewRunId),
+          },
+          {
+            normalizeMentionsInContent: false,
+            allowContextReviewRun: true,
+            deferPostCommitEffects: true,
+          },
+        );
+        if (!sent.deferredPostCommitEffects) {
+          throw new Error("Context Reviewer PR message did not return deferred post-commit effects");
+        }
+        return {
+          handled: true,
+          chatId: existingChatId,
+          messageId: sent.message.id,
+          reused: true,
+          recipients: sent.recipients,
+          deferredPostCommitEffects: sent.deferredPostCommitEffects,
+        };
+      }
+
+      const created = await createChat(tx, {
+        mode: "task",
+        initiatorAgentId: currentReviewer.managerHumanAgentId,
+        organizationId: input.organizationId,
+        initialRecipientAgentIds: [currentReviewer.uuid],
+        contextParticipantAgentIds: [],
+        topic: formatContextReviewTopic({
+          provider: "github",
+          repositoryPath: info.repoFullName,
+          changeNumber: info.prNumber,
+        }),
+        onboardingKickoffKey: contextReviewerChatReservationKey(input.organizationId, info.entityKey),
+        initialMessage: {
+          source: "github",
+          format: "markdown",
+          content: prompt,
+          metadata: contextReviewerMessageMetadata(info, currentReviewer, contextReviewRunId),
+        },
+        allowContextReviewRun: true,
+        deferPostCommitEffects: true,
+        source: "manual",
+      });
+      await tx.update(chats).set({ metadata }).where(eq(chats.id, created.chat.id));
+      if (!created.initialMessageCreated) {
+        await applyMembershipWrite(
+          tx,
+          created.chat.id,
+          [{ agentId: currentReviewer.managerHumanAgentId }, { agentId: currentReviewer.uuid }],
+          { onConflictDoNothing: true, upgradeWatcherToSpeaker: true },
+        );
+        const sent = await sendMessage(
+          tx,
+          created.chat.id,
+          currentReviewer.managerHumanAgentId,
+          {
+            source: "github",
+            format: "markdown",
+            content: prompt,
+            metadata: contextReviewerMessageMetadata(info, currentReviewer, contextReviewRunId),
+          },
+          {
+            normalizeMentionsInContent: false,
+            allowContextReviewRun: true,
+            deferPostCommitEffects: true,
+          },
+        );
+        if (!sent.deferredPostCommitEffects) {
+          throw new Error("Context Reviewer PR message did not return deferred post-commit effects");
+        }
+        return {
+          handled: true,
+          chatId: created.chat.id,
+          messageId: sent.message.id,
+          reused: true,
+          recipients: sent.recipients,
+          deferredPostCommitEffects: sent.deferredPostCommitEffects,
+        };
+      }
+      if (!created.deferredPostCommitEffects) {
+        throw new Error("Context Reviewer PR chat did not return deferred post-commit effects");
+      }
+      return {
+        handled: true,
+        chatId: created.chat.id,
+        messageId: created.message.id,
+        reused: false,
+        recipients: created.recipients,
+        deferredPostCommitEffects: created.deferredPostCommitEffects,
+      };
+    },
   );
-  return { handled: true, chatId: created.chat.id, messageId: created.message.id, reused: false };
+  if (!fenced.authorized) {
+    log.warn(
+      { organizationId: input.organizationId, reviewerAgentUuid },
+      "context reviewer skipped: authority changed before trusted run write",
+    );
+    return { handled: false, reason: "reviewer_runtime_unavailable" };
+  }
+
+  const persisted = fenced.value;
+  if (persisted.deferredPostCommitEffects) {
+    await runDeferredSendMessagePostCommitEffects(app.db, persisted.deferredPostCommitEffects);
+    notifyRecipients(app.notifier, persisted.recipients ?? [], persisted.messageId);
+  }
+  if (!persisted.suppressed) {
+    log.info(
+      {
+        organizationId: input.organizationId,
+        entityKey: info.entityKey,
+        chatId: persisted.chatId,
+        triggerEvent: info.triggerEvent,
+        isDraft: info.isDraft,
+        reused: persisted.reused,
+      },
+      persisted.reused ? "context reviewer task sent to existing chat" : "context reviewer task chat created",
+    );
+  }
+  const { recipients: _recipients, deferredPostCommitEffects: _effects, ...result } = persisted;
+  return result;
 }
 
 export async function handleContextReviewerPullRequest(
@@ -405,6 +501,7 @@ export async function handleContextReviewerPullRequest(
     eventType: string;
     payload: unknown;
     organizationId: string;
+    installationId: number;
   },
 ): Promise<ContextReviewerPrResult> {
   return handleContextReviewerPrEvent(app, input);

--- a/packages/server/src/services/context-reviewer-publisher.ts
+++ b/packages/server/src/services/context-reviewer-publisher.ts
@@ -79,8 +79,15 @@ export async function submitContextReviewOutcome(input: {
   const request = { ...parsedRequest, body: parsedRequest.body.trimEnd() };
   const inspection = await input.db.transaction(async (tx) => {
     const db = tx as unknown as Database;
+    const runSnapshot = await loadRunFacts(db, input.chatId, input.runId);
+    authorizeRun(runSnapshot, input.callerAgentUuid);
+    const orderingValid = await lockPublisherAuthorityRowsBeforeChat(db, runSnapshot, {
+      callerAgentUuid: input.callerAgentUuid,
+      callerClientId: input.callerClientId,
+    });
     await lockReviewChat(db, input.chatId);
     const run = await loadRunFacts(db, input.chatId, input.runId);
+    assertSameRunAuthority(runSnapshot, run);
     authorizeRun(run, input.callerAgentUuid);
 
     if (run.submission.state === "submitted") {
@@ -91,6 +98,13 @@ export async function submitContextReviewOutcome(input: {
     }
     if (run.submission.state === "failed") {
       throw alreadySubmitted();
+    }
+    if (!orderingValid) {
+      throw new ContextReviewPublisherError(
+        403,
+        "CONTEXT_REVIEW_RUN_FORBIDDEN",
+        "The configured Context Reviewer runtime changed before publication.",
+      );
     }
 
     const current = await assertCurrentAuthority(db, run, {
@@ -157,9 +171,23 @@ export async function submitContextReviewOutcome(input: {
 
   const claim = await input.db.transaction(async (tx) => {
     const db = tx as unknown as Database;
+    const runSnapshot = await loadRunFacts(db, input.chatId, input.runId);
+    authorizeRun(runSnapshot, input.callerAgentUuid);
+    const orderingValid = await lockPublisherAuthorityRowsBeforeChat(db, runSnapshot, {
+      callerAgentUuid: input.callerAgentUuid,
+      callerClientId: input.callerClientId,
+    });
     await lockReviewChat(db, input.chatId);
     const run = await loadRunFacts(db, input.chatId, input.runId);
+    assertSameRunAuthority(runSnapshot, run);
     authorizeRun(run, input.callerAgentUuid);
+    if (!orderingValid) {
+      throw new ContextReviewPublisherError(
+        403,
+        "CONTEXT_REVIEW_RUN_FORBIDDEN",
+        "The configured Context Reviewer runtime changed before publication.",
+      );
+    }
     await assertCurrentAuthority(db, run, {
       callerAgentUuid: input.callerAgentUuid,
       callerClientId: input.callerClientId,
@@ -361,6 +389,60 @@ function authorizeRun(run: RunFacts, callerAgentUuid: string): void {
       "Only the configured reviewer recorded on this run can submit its outcome.",
     );
   }
+}
+
+function assertSameRunAuthority(snapshot: RunFacts, current: RunFacts): void {
+  if (
+    current.messageId !== snapshot.messageId ||
+    current.chatId !== snapshot.chatId ||
+    current.organizationId !== snapshot.organizationId ||
+    current.repository !== snapshot.repository ||
+    current.prNumber !== snapshot.prNumber ||
+    current.reviewerAgentUuid !== snapshot.reviewerAgentUuid ||
+    current.reviewerManagerHumanAgentId !== snapshot.reviewerManagerHumanAgentId
+  ) {
+    throw new ContextReviewPublisherError(
+      403,
+      "CONTEXT_REVIEW_RUN_FORBIDDEN",
+      "Context Reviewer run authority changed before publication.",
+    );
+  }
+}
+
+/**
+ * Match the manager → Computer → Agent order used by assignment and runtime
+ * lifecycle mutations before taking the Chat row. The run is re-read after
+ * the Chat lock, so this unlocked snapshot is used only to choose lock order.
+ */
+async function lockPublisherAuthorityRowsBeforeChat(
+  db: Database,
+  run: RunFacts,
+  input: { callerAgentUuid: string; callerClientId: string },
+): Promise<boolean> {
+  const [organization] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.id, run.organizationId))
+    .for("update")
+    .limit(1);
+  if (!organization) return false;
+
+  const [snapshot] = await db
+    .select({ managerId: agents.managerId, clientId: agents.clientId })
+    .from(agents)
+    .where(eq(agents.uuid, input.callerAgentUuid))
+    .limit(1);
+  if (!snapshot) return false;
+
+  await db.select({ id: members.id }).from(members).where(eq(members.id, snapshot.managerId)).for("update").limit(1);
+  await db.select({ id: clients.id }).from(clients).where(eq(clients.id, input.callerClientId)).for("update").limit(1);
+  const [reviewer] = await db
+    .select({ managerId: agents.managerId, clientId: agents.clientId })
+    .from(agents)
+    .where(eq(agents.uuid, input.callerAgentUuid))
+    .for("update")
+    .limit(1);
+  return reviewer?.managerId === snapshot.managerId && reviewer.clientId === snapshot.clientId;
 }
 
 async function assertCurrentAuthority(

--- a/packages/server/src/services/context-reviewer-publisher.ts
+++ b/packages/server/src/services/context-reviewer-publisher.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+  AGENT_VISIBILITY,
   CONTEXT_REVIEW_RUN_MARKER_PREFIX,
   type ContextReviewEvent,
   type ContextReviewSubmissionState,
@@ -7,6 +8,8 @@ import {
   type ContextReviewSubmitResponse,
   contextReviewSubmissionStateSchema,
   contextReviewSubmitRequestSchema,
+  isRuntimeProviderEnabled,
+  runtimeProviderSchema,
 } from "@first-tree/shared";
 import { and, eq, sql } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
@@ -18,6 +21,7 @@ import { members } from "../db/schema/members.js";
 import { messages } from "../db/schema/messages.js";
 import { organizations } from "../db/schema/organizations.js";
 import { uuidv7 } from "../uuid.js";
+import { agentNotLandingCampaignTrialCondition } from "./access-control.js";
 import { validateAgentRuntimeSession } from "./agent-runtime-session.js";
 import { normalizeGithubRepo } from "./context-reviewer-pr.js";
 import {
@@ -399,26 +403,15 @@ async function assertCurrentAuthority(
   const [owner, repo] = repository.split("/");
   if (!owner || !repo) throw new ContextReviewPublisherError(403, "CONTEXT_REVIEW_RUN_FORBIDDEN", "Invalid repo.");
 
-  const [reviewer] = await db
+  const [reviewerSnapshot] = await db
     .select({
-      uuid: agents.uuid,
-      organizationId: agents.organizationId,
-      type: agents.type,
-      status: agents.status,
-      clientId: agents.clientId,
       managerId: agents.managerId,
+      clientId: agents.clientId,
     })
     .from(agents)
-    .where(eq(agents.uuid, input.callerAgentUuid))
-    .for("update")
+    .where(and(eq(agents.uuid, input.callerAgentUuid), agentNotLandingCampaignTrialCondition()))
     .limit(1);
-  if (
-    !reviewer ||
-    reviewer.organizationId !== run.organizationId ||
-    reviewer.type !== "agent" ||
-    reviewer.status !== "active" ||
-    reviewer.clientId !== input.callerClientId
-  ) {
+  if (!reviewerSnapshot) {
     throw new ContextReviewPublisherError(
       403,
       "CONTEXT_REVIEW_RUN_FORBIDDEN",
@@ -426,6 +419,18 @@ async function assertCurrentAuthority(
     );
   }
 
+  const [manager] = await db
+    .select({
+      id: members.id,
+      organizationId: members.organizationId,
+      userId: members.userId,
+      agentId: members.agentId,
+      status: members.status,
+    })
+    .from(members)
+    .where(eq(members.id, reviewerSnapshot.managerId))
+    .for("update")
+    .limit(1);
   const [client] = await db
     .select({
       id: clients.id,
@@ -437,18 +442,41 @@ async function assertCurrentAuthority(
     .where(eq(clients.id, input.callerClientId))
     .for("update")
     .limit(1);
-  const [manager] = await db
+
+  const [reviewer] = await db
     .select({
-      id: members.id,
-      organizationId: members.organizationId,
-      userId: members.userId,
-      agentId: members.agentId,
-      status: members.status,
+      uuid: agents.uuid,
+      organizationId: agents.organizationId,
+      type: agents.type,
+      status: agents.status,
+      visibility: agents.visibility,
+      runtimeProvider: agents.runtimeProvider,
+      clientId: agents.clientId,
+      managerId: agents.managerId,
     })
-    .from(members)
-    .where(eq(members.id, reviewer.managerId))
+    .from(agents)
+    .where(and(eq(agents.uuid, input.callerAgentUuid), agentNotLandingCampaignTrialCondition()))
     .for("update")
     .limit(1);
+  if (
+    !reviewer ||
+    reviewer.organizationId !== run.organizationId ||
+    reviewer.type !== "agent" ||
+    reviewer.status !== "active" ||
+    reviewer.visibility !== AGENT_VISIBILITY.ORGANIZATION ||
+    !runtimeProviderSchema.safeParse(reviewer.runtimeProvider).success ||
+    !isRuntimeProviderEnabled(reviewer.runtimeProvider) ||
+    reviewer.clientId !== input.callerClientId ||
+    reviewer.clientId !== reviewerSnapshot.clientId ||
+    reviewer.managerId !== reviewerSnapshot.managerId
+  ) {
+    throw new ContextReviewPublisherError(
+      403,
+      "CONTEXT_REVIEW_RUN_FORBIDDEN",
+      "The configured Context Reviewer runtime is no longer active for this run.",
+    );
+  }
+
   if (
     !client ||
     client.organizationId !== run.organizationId ||

--- a/packages/server/src/services/context-reviewer-readiness.ts
+++ b/packages/server/src/services/context-reviewer-readiness.ts
@@ -1,0 +1,256 @@
+import {
+  AGENT_STATUSES,
+  AGENT_TYPES,
+  AGENT_VISIBILITY,
+  type ContextReviewerCandidate,
+  clientCapabilitiesSchema,
+  isRuntimeProviderEnabled,
+  runtimeProviderSchema,
+  type SetupBlocker,
+} from "@first-tree/shared";
+import { and, asc, eq, ne } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agentPresence } from "../db/schema/agent-presence.js";
+import { agents } from "../db/schema/agents.js";
+import { clients } from "../db/schema/clients.js";
+import { members } from "../db/schema/members.js";
+import { serverInstances } from "../db/schema/server-instances.js";
+import { agentNotLandingCampaignTrialCondition } from "./access-control.js";
+
+export type ContextReviewerAgentReadiness = {
+  reviewerAgent: { uuid: string; displayName: string } | null;
+  structuralBlockers: SetupBlocker[];
+  healthBlockers: SetupBlocker[];
+};
+
+function blocker(code: SetupBlocker["code"], actionKind: SetupBlocker["actionKind"]): SetupBlocker {
+  return { code, resolutionOwner: "admin", actionKind };
+}
+
+async function readDynamicRuntimeHealth(
+  db: Database,
+  input: {
+    agentUuid: string;
+    runtimeProvider: string;
+    client: typeof clients.$inferSelect;
+    now: Date;
+    staleSeconds: number;
+  },
+): Promise<SetupBlocker[]> {
+  const [presence] = await db.select().from(agentPresence).where(eq(agentPresence.agentId, input.agentUuid)).limit(1);
+  const staleMs = input.staleSeconds * 1_000;
+  const routeUnavailable =
+    input.client.pausedReason !== null ||
+    input.client.status !== "connected" ||
+    !input.client.instanceId ||
+    input.now.getTime() - input.client.lastSeenAt.getTime() > staleMs ||
+    !presence ||
+    presence.status !== "online" ||
+    presence.clientId !== input.client.id ||
+    presence.instanceId !== input.client.instanceId ||
+    input.now.getTime() - presence.lastSeenAt.getTime() > staleMs ||
+    (presence.runtimeState !== "idle" && presence.runtimeState !== "working");
+  if (routeUnavailable || !input.client.instanceId) {
+    return [blocker("context_review_agent_runtime_unavailable", "open_agent_owner_flow")];
+  }
+
+  const [instance] = await db
+    .select({ lastHeartbeat: serverInstances.lastHeartbeat })
+    .from(serverInstances)
+    .where(eq(serverInstances.instanceId, input.client.instanceId))
+    .limit(1);
+  if (!instance || input.now.getTime() - instance.lastHeartbeat.getTime() > staleMs) {
+    return [blocker("context_review_agent_runtime_unavailable", "open_agent_owner_flow")];
+  }
+
+  const capabilities = clientCapabilitiesSchema.safeParse(input.client.metadata?.capabilities);
+  const capability = capabilities.success ? capabilities.data[input.runtimeProvider] : undefined;
+  if (
+    presence.runtimeType !== input.runtimeProvider ||
+    !capability ||
+    capability.state !== "ok" ||
+    capability.available !== true
+  ) {
+    return [blocker("context_review_agent_runtime_unavailable", "open_agent_owner_flow")];
+  }
+  return [];
+}
+
+/**
+ * Split stable assignment eligibility from transient runtime health.
+ *
+ * Structural blockers prevent assignment/enablement. Dynamic health blockers
+ * never rewrite or disable the setting; capability projection reports them and
+ * webhook dispatch uses them as a fail-closed per-run gate.
+ */
+export async function readContextReviewerAgentReadiness(
+  db: Database,
+  input: {
+    organizationId: string;
+    reviewerAgentUuid: string;
+    now: Date;
+    staleSeconds: number;
+  },
+): Promise<ContextReviewerAgentReadiness> {
+  const [agent] = await db
+    .select({
+      uuid: agents.uuid,
+      organizationId: agents.organizationId,
+      type: agents.type,
+      status: agents.status,
+      displayName: agents.displayName,
+      visibility: agents.visibility,
+      managerOrganizationId: members.organizationId,
+      managerStatus: members.status,
+      managerUserId: members.userId,
+      clientId: agents.clientId,
+      runtimeProvider: agents.runtimeProvider,
+    })
+    .from(agents)
+    .leftJoin(members, eq(members.id, agents.managerId))
+    .where(and(eq(agents.uuid, input.reviewerAgentUuid), agentNotLandingCampaignTrialCondition()))
+    .limit(1);
+
+  if (!agent || agent.organizationId !== input.organizationId || agent.type === AGENT_TYPES.HUMAN) {
+    return {
+      reviewerAgent: null,
+      structuralBlockers: [blocker("context_review_agent_missing", "replace_review_agent")],
+      healthBlockers: [],
+    };
+  }
+
+  const reviewerAgent = { uuid: agent.uuid, displayName: agent.displayName };
+  if (agent.status !== AGENT_STATUSES.ACTIVE) {
+    return {
+      reviewerAgent,
+      structuralBlockers: [blocker("context_review_agent_inactive", "replace_review_agent")],
+      healthBlockers: [],
+    };
+  }
+  if (
+    agent.managerOrganizationId !== input.organizationId ||
+    agent.managerStatus !== "active" ||
+    !agent.managerUserId
+  ) {
+    return {
+      reviewerAgent,
+      structuralBlockers: [blocker("context_review_agent_manager_inactive", "open_agent_owner_flow")],
+      healthBlockers: [],
+    };
+  }
+  if (agent.visibility !== AGENT_VISIBILITY.ORGANIZATION) {
+    return {
+      // Capability projection is member-readable. Never disclose the identity
+      // of an invalid historical private selection as a Team-wide fact.
+      reviewerAgent: null,
+      structuralBlockers: [blocker("context_review_agent_private", "replace_review_agent")],
+      healthBlockers: [],
+    };
+  }
+  if (
+    !agent.clientId ||
+    !runtimeProviderSchema.safeParse(agent.runtimeProvider).success ||
+    !isRuntimeProviderEnabled(agent.runtimeProvider)
+  ) {
+    return {
+      reviewerAgent,
+      structuralBlockers: [blocker("context_review_agent_no_runtime", "open_agent_owner_flow")],
+      healthBlockers: [],
+    };
+  }
+
+  const [client] = await db.select().from(clients).where(eq(clients.id, agent.clientId)).limit(1);
+  if (
+    !client ||
+    client.organizationId !== input.organizationId ||
+    client.userId !== agent.managerUserId ||
+    client.retiredAt !== null
+  ) {
+    return {
+      reviewerAgent,
+      structuralBlockers: [blocker("context_review_agent_no_runtime", "open_agent_owner_flow")],
+      healthBlockers: [],
+    };
+  }
+
+  return {
+    reviewerAgent,
+    structuralBlockers: [],
+    healthBlockers: await readDynamicRuntimeHealth(db, {
+      agentUuid: agent.uuid,
+      runtimeProvider: agent.runtimeProvider,
+      client,
+      now: input.now,
+      staleSeconds: input.staleSeconds,
+    }),
+  };
+}
+
+/** Admin-only list of structurally eligible, organization-visible Reviewers. */
+export async function listContextReviewerCandidates(
+  db: Database,
+  input: {
+    organizationId: string;
+    now: Date;
+    staleSeconds: number;
+  },
+): Promise<{ items: ContextReviewerCandidate[]; blockers: SetupBlocker[] }> {
+  const rows = await db
+    .select({
+      uuid: agents.uuid,
+      name: agents.name,
+      displayName: agents.displayName,
+      visibility: agents.visibility,
+    })
+    .from(agents)
+    .innerJoin(
+      members,
+      and(
+        eq(members.id, agents.managerId),
+        eq(members.organizationId, input.organizationId),
+        eq(members.status, "active"),
+      ),
+    )
+    .where(
+      and(
+        eq(agents.organizationId, input.organizationId),
+        eq(agents.visibility, AGENT_VISIBILITY.ORGANIZATION),
+        eq(agents.status, AGENT_STATUSES.ACTIVE),
+        ne(agents.type, AGENT_TYPES.HUMAN),
+        agentNotLandingCampaignTrialCondition(),
+      ),
+    )
+    .orderBy(asc(agents.createdAt), asc(agents.uuid));
+
+  const candidates = await Promise.all(
+    rows.map(async (row) => ({
+      row,
+      readiness: await readContextReviewerAgentReadiness(db, {
+        organizationId: input.organizationId,
+        reviewerAgentUuid: row.uuid,
+        now: input.now,
+        staleSeconds: input.staleSeconds,
+      }),
+    })),
+  );
+  const items = candidates.flatMap(({ row, readiness }): ContextReviewerCandidate[] =>
+    readiness.structuralBlockers.length > 0
+      ? []
+      : [
+          {
+            uuid: row.uuid,
+            name: row.name,
+            displayName: row.displayName,
+            visibility: AGENT_VISIBILITY.ORGANIZATION,
+            runtime: {
+              health: readiness.healthBlockers.length === 0 ? "ready" : "degraded",
+              blockers: readiness.healthBlockers,
+            },
+          },
+        ],
+  );
+  return {
+    items,
+    blockers: items.length === 0 ? [blocker("context_review_no_eligible_agent", "open_agent_owner_flow")] : [],
+  };
+}

--- a/packages/server/src/services/context-reviewer-settings.ts
+++ b/packages/server/src/services/context-reviewer-settings.ts
@@ -32,6 +32,7 @@ import {
 export type ContextReviewerMutationOptions = {
   updatedBy: string;
   staleSeconds: number;
+  expectedAgentUuid?: string;
   githubAppCredentials?: GithubReviewCredentials;
   githubFetch?: typeof fetch;
   probeGithubReview?: (
@@ -359,6 +360,15 @@ export async function putContextReviewerEnablement(
   if (!expectedRuntime.contextReviewer.agentUuid) {
     fail(blocker("context_review_assignment_required", "select_review_agent"));
   }
+  if (
+    options.expectedAgentUuid !== undefined &&
+    expectedRuntime.contextReviewer.agentUuid !== options.expectedAgentUuid
+  ) {
+    fail(
+      blocker("context_review_state_changed", "manage_review_agent"),
+      "Context Reviewer assignment changed before enablement; retry with current Team state",
+    );
+  }
   const expectedAgentUuid = expectedRuntime.contextReviewer.agentUuid;
   const expectedInstallation = await findInstallationByOrg(db, organizationId);
   await assertReady(db, organizationId, options);
@@ -372,16 +382,16 @@ export async function putContextReviewerEnablement(
         "Context Reviewer state changed during enablement; retry with current Team state",
       );
     }
-    await readAssignableAgentForUpdate(txDb, {
-      organizationId,
-      agentUuid: expectedAgentUuid,
-    });
     if (expectedRuntime.provider === "gitlab") {
       await lockGitlabConnectionForUpdate(txDb, {
         organizationId,
         expectedConnectionId: expectedRuntime.gitlabConnection?.id ?? null,
       });
     }
+    await readAssignableAgentForUpdate(txDb, {
+      organizationId,
+      agentUuid: expectedAgentUuid,
+    });
     const currentInstallationId =
       expectedRuntime.provider === "github" ? await readGithubInstallationIdForUpdate(txDb, organizationId) : null;
     if (expectedRuntime.provider === "github" && currentInstallationId !== expectedInstallation?.installationId) {
@@ -433,5 +443,8 @@ export async function putLegacyContextReviewerSetting(
   if (input.agentUuid) {
     await putContextReviewerAssignment(db, organizationId, input.agentUuid, options);
   }
-  return putContextReviewerEnablement(db, organizationId, input.enabled, options);
+  return putContextReviewerEnablement(db, organizationId, input.enabled, {
+    ...options,
+    expectedAgentUuid: input.enabled && input.agentUuid ? input.agentUuid : undefined,
+  });
 }

--- a/packages/server/src/services/context-reviewer-settings.ts
+++ b/packages/server/src/services/context-reviewer-settings.ts
@@ -1,0 +1,437 @@
+import {
+  AGENT_STATUSES,
+  AGENT_TYPES,
+  AGENT_VISIBILITY,
+  isRuntimeProviderEnabled,
+  ORG_SETTINGS_NAMESPACES,
+  type OrgContextTreeFeaturesOutput,
+  type OrgContextTreeFeaturesStorage,
+  orgContextTreeFeaturesInputSchema,
+  runtimeProviderSchema,
+  type SetupBlocker,
+} from "@first-tree/shared";
+import { and, eq, sql } from "drizzle-orm";
+import type { Database } from "../db/connection.js";
+import { agents } from "../db/schema/agents.js";
+import { clients } from "../db/schema/clients.js";
+import { githubAppInstallations } from "../db/schema/github-app-installations.js";
+import { gitlabConnections } from "../db/schema/gitlab-connections.js";
+import { members } from "../db/schema/members.js";
+import { organizationSettings } from "../db/schema/organization-settings.js";
+import { organizations } from "../db/schema/organizations.js";
+import { ConflictError, NotFoundError } from "../errors.js";
+import { agentNotLandingCampaignTrialCondition } from "./access-control.js";
+import { findInstallationByOrg } from "./github-app-installations.js";
+import { getOrgContextReviewRuntime, getOrgSetting, isOrgContextReviewRuntimeCurrent } from "./org-settings.js";
+import {
+  type GithubReviewCredentials,
+  type GithubReviewProbeResult,
+  getTeamSetupCapabilities,
+} from "./setup-capabilities.js";
+
+export type ContextReviewerMutationOptions = {
+  updatedBy: string;
+  staleSeconds: number;
+  githubAppCredentials?: GithubReviewCredentials;
+  githubFetch?: typeof fetch;
+  probeGithubReview?: (
+    installation: typeof githubAppInstallations.$inferSelect,
+    repo: string,
+  ) => Promise<GithubReviewProbeResult>;
+  now?: () => Date;
+};
+
+export class ContextReviewerReadinessError extends ConflictError {
+  constructor(
+    readonly blocker: SetupBlocker,
+    message = "Context Reviewer is not ready",
+  ) {
+    super(message, { code: blocker.code });
+    this.name = "ContextReviewerReadinessError";
+  }
+}
+
+function blocker(
+  code: SetupBlocker["code"],
+  actionKind: SetupBlocker["actionKind"],
+  resolutionOwner: SetupBlocker["resolutionOwner"] = "admin",
+): SetupBlocker {
+  return { code, resolutionOwner, actionKind };
+}
+
+function fail(blockerValue: SetupBlocker, message?: string): never {
+  throw new ContextReviewerReadinessError(blockerValue, message);
+}
+
+async function lockOrganization(db: Database, organizationId: string): Promise<void> {
+  const [row] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .for("update")
+    .limit(1);
+  if (!row) throw new NotFoundError(`Organization "${organizationId}" not found`);
+}
+
+async function readStorage(db: Database, organizationId: string): Promise<OrgContextTreeFeaturesStorage> {
+  const [row] = await db
+    .select({ value: organizationSettings.value })
+    .from(organizationSettings)
+    .where(
+      and(
+        eq(organizationSettings.organizationId, organizationId),
+        eq(organizationSettings.namespace, "context_tree_features"),
+      ),
+    )
+    .limit(1);
+  return ORG_SETTINGS_NAMESPACES.context_tree_features.storage.parse(row?.value ?? {});
+}
+
+function sameStorage(left: OrgContextTreeFeaturesStorage, right: OrgContextTreeFeaturesStorage): boolean {
+  return (
+    left.contextReviewer.enabled === right.contextReviewer.enabled &&
+    left.contextReviewer.agentUuid === right.contextReviewer.agentUuid
+  );
+}
+
+async function writeStorage(
+  db: Database,
+  organizationId: string,
+  current: OrgContextTreeFeaturesStorage,
+  next: OrgContextTreeFeaturesStorage,
+  updatedBy: string,
+): Promise<void> {
+  const validated = ORG_SETTINGS_NAMESPACES.context_tree_features.storage.parse(next);
+  if (sameStorage(current, validated)) return;
+  await db
+    .insert(organizationSettings)
+    .values({
+      organizationId,
+      namespace: "context_tree_features",
+      value: validated,
+      version: 1,
+      updatedBy,
+      updatedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [organizationSettings.organizationId, organizationSettings.namespace],
+      set: {
+        value: validated,
+        version: sql`${organizationSettings.version} + 1`,
+        updatedBy,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+async function readAssignableAgentForUpdate(
+  db: Database,
+  input: { organizationId: string; agentUuid: string },
+): Promise<{ uuid: string }> {
+  const [snapshot] = await db
+    .select({
+      uuid: agents.uuid,
+      organizationId: agents.organizationId,
+      type: agents.type,
+      managerId: agents.managerId,
+      clientId: agents.clientId,
+    })
+    .from(agents)
+    .where(and(eq(agents.uuid, input.agentUuid), agentNotLandingCampaignTrialCondition()))
+    .limit(1);
+
+  if (!snapshot || snapshot.organizationId !== input.organizationId || snapshot.type === AGENT_TYPES.HUMAN) {
+    fail(blocker("context_review_agent_missing", "replace_review_agent"));
+  }
+
+  const [manager] = await db
+    .select({
+      organizationId: members.organizationId,
+      status: members.status,
+      userId: members.userId,
+    })
+    .from(members)
+    .where(eq(members.id, snapshot.managerId))
+    .for("update")
+    .limit(1);
+
+  const [client] = snapshot.clientId
+    ? await db.select().from(clients).where(eq(clients.id, snapshot.clientId)).for("update").limit(1)
+    : [];
+
+  const [agent] = await db
+    .select({
+      uuid: agents.uuid,
+      organizationId: agents.organizationId,
+      type: agents.type,
+      status: agents.status,
+      visibility: agents.visibility,
+      managerId: agents.managerId,
+      clientId: agents.clientId,
+      runtimeProvider: agents.runtimeProvider,
+    })
+    .from(agents)
+    .where(and(eq(agents.uuid, input.agentUuid), agentNotLandingCampaignTrialCondition()))
+    .for("update")
+    .limit(1);
+  if (!agent || agent.organizationId !== input.organizationId || agent.type === AGENT_TYPES.HUMAN) {
+    fail(blocker("context_review_agent_missing", "replace_review_agent"));
+  }
+  if (agent.managerId !== snapshot.managerId || agent.clientId !== snapshot.clientId) {
+    fail(
+      blocker("context_review_state_changed", "manage_review_agent"),
+      "Reviewer ownership or Computer binding changed; retry with current Team state",
+    );
+  }
+  if (agent.status !== AGENT_STATUSES.ACTIVE) {
+    fail(blocker("context_review_agent_inactive", "replace_review_agent"));
+  }
+  if (manager?.organizationId !== input.organizationId || manager.status !== "active") {
+    fail(blocker("context_review_agent_manager_inactive", "open_agent_owner_flow"));
+  }
+  if (agent.visibility !== AGENT_VISIBILITY.ORGANIZATION) {
+    fail(blocker("context_review_agent_private", "replace_review_agent"));
+  }
+  if (
+    !agent.clientId ||
+    !runtimeProviderSchema.safeParse(agent.runtimeProvider).success ||
+    !isRuntimeProviderEnabled(agent.runtimeProvider)
+  ) {
+    fail(blocker("context_review_agent_no_runtime", "open_agent_owner_flow"));
+  }
+  if (
+    !client ||
+    client.organizationId !== input.organizationId ||
+    client.userId !== manager.userId ||
+    client.retiredAt !== null
+  ) {
+    fail(blocker("context_review_agent_no_runtime", "open_agent_owner_flow"));
+  }
+  return { uuid: agent.uuid };
+}
+
+async function readGithubInstallationIdForUpdate(db: Database, organizationId: string): Promise<number | null> {
+  const [installation] = await db
+    .select({ installationId: githubAppInstallations.installationId })
+    .from(githubAppInstallations)
+    .where(eq(githubAppInstallations.hubOrganizationId, organizationId))
+    .for("update")
+    .limit(1);
+  return installation?.installationId ?? null;
+}
+
+async function lockGitlabConnectionForUpdate(
+  db: Database,
+  input: { organizationId: string; expectedConnectionId: string | null },
+): Promise<void> {
+  const [connection] = await db
+    .select({ id: gitlabConnections.id })
+    .from(gitlabConnections)
+    .where(eq(gitlabConnections.organizationId, input.organizationId))
+    .for("update")
+    .limit(1);
+  if (!connection || connection.id !== input.expectedConnectionId) {
+    fail(
+      blocker("context_review_state_changed", "connect_gitlab"),
+      "GitLab connection changed during enablement; retry with current Team state",
+    );
+  }
+}
+
+export async function putContextReviewerAssignment(
+  db: Database,
+  organizationId: string,
+  agentUuid: string | null,
+  options: Pick<ContextReviewerMutationOptions, "updatedBy">,
+): Promise<OrgContextTreeFeaturesOutput> {
+  await db.transaction(async (tx) => {
+    const txDb = tx as unknown as Database;
+    await lockOrganization(txDb, organizationId);
+    const current = await readStorage(txDb, organizationId);
+
+    if (agentUuid === null) {
+      await writeStorage(
+        txDb,
+        organizationId,
+        current,
+        {
+          contextReviewer: {
+            enabled: false,
+            agentUuid: null,
+          },
+        },
+        options.updatedBy,
+      );
+      return;
+    }
+
+    const agent = await readAssignableAgentForUpdate(txDb, {
+      organizationId,
+      agentUuid,
+    });
+    const sameAgent = current.contextReviewer.agentUuid === agent.uuid;
+    if (sameAgent) return;
+
+    await writeStorage(
+      txDb,
+      organizationId,
+      current,
+      {
+        contextReviewer: {
+          enabled: false,
+          agentUuid: agent.uuid,
+        },
+      },
+      options.updatedBy,
+    );
+  });
+
+  return getOrgSetting(db, organizationId, "context_tree_features");
+}
+
+function firstReadinessBlocker(
+  capabilities: Awaited<ReturnType<typeof getTeamSetupCapabilities>>,
+): SetupBlocker | null {
+  if (capabilities.contextTree.binding.state !== "bound") {
+    return (
+      capabilities.contextTree.blockers[0] ??
+      blocker("context_review_provider_prerequisite_missing", "open_tree_setup_chat")
+    );
+  }
+  return (
+    capabilities.contextTree.automaticReview.blockers.find(
+      (candidate) => candidate.code !== "context_review_agent_runtime_unavailable",
+    ) ?? null
+  );
+}
+
+async function assertReady(
+  db: Database,
+  organizationId: string,
+  options: ContextReviewerMutationOptions,
+): Promise<void> {
+  const capabilities = await getTeamSetupCapabilities(db, organizationId, {
+    now: options.now,
+    staleSeconds: options.staleSeconds,
+    githubAppCredentials: options.githubAppCredentials,
+    githubFetch: options.githubFetch,
+    probeGithubReview: options.probeGithubReview,
+  });
+  const selected = capabilities.contextTree.automaticReview.reviewerAgent;
+  if (!selected) {
+    const runtime = await getOrgContextReviewRuntime(db, organizationId);
+    if (!runtime.contextReviewer.agentUuid) {
+      fail(blocker("context_review_assignment_required", "select_review_agent"));
+    }
+  }
+  const readinessBlocker = firstReadinessBlocker(capabilities);
+  if (readinessBlocker) fail(readinessBlocker);
+}
+
+export async function putContextReviewerEnablement(
+  db: Database,
+  organizationId: string,
+  enabled: boolean,
+  options: ContextReviewerMutationOptions,
+): Promise<OrgContextTreeFeaturesOutput> {
+  if (!enabled) {
+    await db.transaction(async (tx) => {
+      const txDb = tx as unknown as Database;
+      await lockOrganization(txDb, organizationId);
+      const current = await readStorage(txDb, organizationId);
+      await writeStorage(
+        txDb,
+        organizationId,
+        current,
+        {
+          contextReviewer: {
+            ...current.contextReviewer,
+            enabled: false,
+          },
+        },
+        options.updatedBy,
+      );
+    });
+    return getOrgSetting(db, organizationId, "context_tree_features");
+  }
+
+  const expectedRuntime = await getOrgContextReviewRuntime(db, organizationId);
+  if (!expectedRuntime.contextReviewer.agentUuid) {
+    fail(blocker("context_review_assignment_required", "select_review_agent"));
+  }
+  const expectedAgentUuid = expectedRuntime.contextReviewer.agentUuid;
+  const expectedInstallation = await findInstallationByOrg(db, organizationId);
+  await assertReady(db, organizationId, options);
+
+  await db.transaction(async (tx) => {
+    const txDb = tx as unknown as Database;
+    await lockOrganization(txDb, organizationId);
+    if (!(await isOrgContextReviewRuntimeCurrent(txDb, organizationId, expectedRuntime))) {
+      fail(
+        blocker("context_review_state_changed", "manage_review_agent"),
+        "Context Reviewer state changed during enablement; retry with current Team state",
+      );
+    }
+    await readAssignableAgentForUpdate(txDb, {
+      organizationId,
+      agentUuid: expectedAgentUuid,
+    });
+    if (expectedRuntime.provider === "gitlab") {
+      await lockGitlabConnectionForUpdate(txDb, {
+        organizationId,
+        expectedConnectionId: expectedRuntime.gitlabConnection?.id ?? null,
+      });
+    }
+    const currentInstallationId =
+      expectedRuntime.provider === "github" ? await readGithubInstallationIdForUpdate(txDb, organizationId) : null;
+    if (expectedRuntime.provider === "github" && currentInstallationId !== expectedInstallation?.installationId) {
+      fail(
+        blocker("context_review_state_changed", "manage_github_installation"),
+        "GitHub installation changed during enablement; retry with current Team state",
+      );
+    }
+
+    // The exact-repository GitHub probe completed before this short
+    // transaction. Reuse only its successful result after checking that the
+    // selected assignment, binding, and installation identity are unchanged;
+    // every local Agent/runtime/provider fact is queried again here.
+    await assertReady(txDb, organizationId, {
+      ...options,
+      probeGithubReview: expectedRuntime.provider === "github" ? async () => "ready" : options.probeGithubReview,
+    });
+
+    const current = await readStorage(txDb, organizationId);
+    await writeStorage(
+      txDb,
+      organizationId,
+      current,
+      {
+        contextReviewer: {
+          ...current.contextReviewer,
+          enabled: true,
+        },
+      },
+      options.updatedBy,
+    );
+  });
+
+  return getOrgSetting(db, organizationId, "context_tree_features");
+}
+
+/**
+ * Transitional bridge for the existing Repositories toggle. It deliberately
+ * composes the two narrow mutations so a failed enable leaves the selected
+ * Agent persisted and disabled, while Context Tree binding remains untouched.
+ */
+export async function putLegacyContextReviewerSetting(
+  db: Database,
+  organizationId: string,
+  rawInput: unknown,
+  options: ContextReviewerMutationOptions,
+): Promise<OrgContextTreeFeaturesOutput> {
+  const input = orgContextTreeFeaturesInputSchema.parse(rawInput).contextReviewer;
+  if (input.agentUuid) {
+    await putContextReviewerAssignment(db, organizationId, input.agentUuid, options);
+  }
+  return putContextReviewerEnablement(db, organizationId, input.enabled, options);
+}

--- a/packages/server/src/services/context-tree-write-preflight.ts
+++ b/packages/server/src/services/context-tree-write-preflight.ts
@@ -14,6 +14,7 @@ import { agents } from "../db/schema/agents.js";
 import { authIdentities } from "../db/schema/auth-identities.js";
 import { members } from "../db/schema/members.js";
 import { ForbiddenError } from "../errors.js";
+import { loadValidContextReviewerAgent } from "./context-reviewer-common.js";
 import { getOrgContextReviewRuntime } from "./org-settings.js";
 
 type RequesterIdentity = {
@@ -57,24 +58,12 @@ async function readGithubIdentityLogin(db: Database, requester: RequesterIdentit
 
 async function isActiveContextReviewer(
   db: Database,
-  input: { organizationId: string; reviewerAgentUuid: string },
+  input: {
+    organizationId: string;
+    reviewerAgentUuid: string;
+  },
 ): Promise<boolean> {
-  const [reviewer] = await db
-    .select({
-      uuid: agents.uuid,
-      organizationId: agents.organizationId,
-      type: agents.type,
-      status: agents.status,
-    })
-    .from(agents)
-    .where(eq(agents.uuid, input.reviewerAgentUuid))
-    .limit(1);
-  return (
-    reviewer !== undefined &&
-    reviewer.organizationId === input.organizationId &&
-    reviewer.type !== AGENT_TYPES.HUMAN &&
-    reviewer.status === AGENT_STATUSES.ACTIVE
-  );
+  return (await loadValidContextReviewerAgent(db, input)) !== null;
 }
 
 async function requireActiveRequesterMembership(
@@ -199,7 +188,12 @@ export async function preflightContextTreeWriteAuthority(
   }
 
   const reviewerAgentUuid = runtime.contextReviewer.agentUuid;
-  if (!(await isActiveContextReviewer(db, { organizationId: input.organizationId, reviewerAgentUuid }))) {
+  if (
+    !(await isActiveContextReviewer(db, {
+      organizationId: input.organizationId,
+      reviewerAgentUuid,
+    }))
+  ) {
     throw new ContextTreeWritePreflightError(
       "CONTEXT_TREE_WRITE_REVIEWER_UNAVAILABLE",
       409,

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -216,9 +216,11 @@ export async function getOrgContextTreeBinding(db: Database, orgId: string): Pro
 }
 
 /**
- * Read the live Context Tree binding and Reviewer assignment in one database
- * statement. Review mutations use this tuple so they never combine a binding
- * from one settings snapshot with an assignment from another.
+ * Read the live Context Tree binding and raw Reviewer assignment in one
+ * database statement. Server-internal review mutations use this tuple so they
+ * never combine a binding from one settings snapshot with an assignment from
+ * another. Member- or Agent-readable surfaces must use the Team-safe
+ * projection below.
  */
 export async function getOrgContextReviewRuntime(db: Database, orgId: string): Promise<OrgContextReviewRuntime> {
   const rows = await db
@@ -296,6 +298,26 @@ export async function getOrgContextReviewRuntime(db: Database, orgId: string): P
   };
 }
 
+/**
+ * Apply the same Team-safe Reviewer identity projection as `getOrgSetting`.
+ * Invalid historical private, deleted, or foreign selections remain stored
+ * for admin replacement without exposing their opaque UUID to Team runtimes.
+ */
+export async function getTeamSafeOrgContextReviewRuntime(
+  db: Database,
+  orgId: string,
+): Promise<OrgContextReviewRuntime> {
+  const runtime = await getOrgContextReviewRuntime(db, orgId);
+  const reviewerAgent = await resolveContextReviewerAgentSummary(db, orgId, runtime.contextReviewer.agentUuid);
+  return {
+    ...runtime,
+    contextReviewer: {
+      enabled: runtime.contextReviewer.enabled,
+      agentUuid: reviewerAgent?.uuid ?? null,
+    },
+  };
+}
+
 export type OrgContextReviewRuntime = {
   bindingState: "bound" | "unbound" | "invalid";
   provider: ContextTreeProvider | null;
@@ -312,6 +334,38 @@ export type OrgContextReviewRuntime = {
   contextReviewer: { enabled: boolean; agentUuid: string | null };
 };
 
+function isSameOrgContextTreeBindingRuntime(
+  current: OrgContextReviewRuntime,
+  expected: OrgContextReviewRuntime,
+): boolean {
+  return (
+    current.bindingState === expected.bindingState &&
+    current.provider === expected.provider &&
+    current.repo === expected.repo &&
+    current.branch === expected.branch &&
+    current.providerMatchesRepository === expected.providerMatchesRepository &&
+    current.gitlabConnection?.id === expected.gitlabConnection?.id &&
+    current.gitlabConnection?.instanceOrigin === expected.gitlabConnection?.instanceOrigin
+  );
+}
+
+/**
+ * Recheck only the Context Tree binding and provider route used by a snapshot.
+ * Reviewer assignment and enablement are independent and must not invalidate
+ * an in-flight Tree read.
+ */
+export async function isOrgContextTreeBindingRuntimeCurrent(
+  db: Database,
+  orgId: string,
+  expected: OrgContextReviewRuntime,
+): Promise<boolean> {
+  const current = await getOrgContextReviewRuntime(db, orgId);
+  return isSameOrgContextTreeBindingRuntime(current, expected);
+}
+
+/**
+ * Recheck the complete review mutation tuple, including the selected Reviewer.
+ */
 export async function isOrgContextReviewRuntimeCurrent(
   db: Database,
   orgId: string,
@@ -319,15 +373,9 @@ export async function isOrgContextReviewRuntimeCurrent(
 ): Promise<boolean> {
   const current = await getOrgContextReviewRuntime(db, orgId);
   return (
-    current.bindingState === expected.bindingState &&
-    current.provider === expected.provider &&
-    current.repo === expected.repo &&
-    current.branch === expected.branch &&
-    current.providerMatchesRepository === expected.providerMatchesRepository &&
+    isSameOrgContextTreeBindingRuntime(current, expected) &&
     current.contextReviewer.enabled === expected.contextReviewer.enabled &&
-    current.contextReviewer.agentUuid === expected.contextReviewer.agentUuid &&
-    current.gitlabConnection?.id === expected.gitlabConnection?.id &&
-    current.gitlabConnection?.instanceOrigin === expected.gitlabConnection?.instanceOrigin
+    current.contextReviewer.agentUuid === expected.contextReviewer.agentUuid
   );
 }
 

--- a/packages/server/src/services/org-settings.ts
+++ b/packages/server/src/services/org-settings.ts
@@ -1,4 +1,5 @@
 import {
+  AGENT_VISIBILITY,
   type ContextTreeActiveBinding,
   type ContextTreeProvider,
   type ContextTreeSettingState,
@@ -125,11 +126,15 @@ function applyInputDelta<K extends OrgSettingNamespace>(
     return next as OrgSettingStorage<K>;
   }
   if (namespace === "context_tree_features") {
+    const cur = current as OrgSettingStorage<"context_tree_features">;
     const inp = input as OrgSettingInput<"context_tree_features">;
+    const agentUuid = inp.contextReviewer.enabled
+      ? inp.contextReviewer.agentUuid
+      : (inp.contextReviewer.agentUuid ?? cur.contextReviewer.agentUuid);
     const next: OrgSettingStorage<"context_tree_features"> = {
       contextReviewer: {
         enabled: inp.contextReviewer.enabled,
-        agentUuid: inp.contextReviewer.enabled ? inp.contextReviewer.agentUuid : null,
+        agentUuid,
       },
     };
     return next as OrgSettingStorage<K>;
@@ -167,11 +172,15 @@ async function toOutput<K extends OrgSettingNamespace>(
   }
   if (namespace === "context_tree_features") {
     const s = storage as OrgSettingStorage<"context_tree_features">;
+    const reviewerAgent = await resolveContextReviewerAgentSummary(db, orgId, s.contextReviewer.agentUuid);
     const out: OrgSettingOutput<"context_tree_features"> = {
       contextReviewer: {
         enabled: s.contextReviewer.enabled,
-        agentUuid: s.contextReviewer.agentUuid,
-        reviewerAgent: await resolveContextReviewerAgentSummary(db, orgId, s.contextReviewer.agentUuid),
+        // This namespace is member-readable. A private, deleted, or foreign
+        // historical selection stays in storage for replacement, but its
+        // opaque identity is not a Team-wide fact.
+        agentUuid: reviewerAgent?.uuid ?? null,
+        reviewerAgent,
       },
     };
     return out as OrgSettingOutput<K>;
@@ -315,6 +324,8 @@ export async function isOrgContextReviewRuntimeCurrent(
     current.repo === expected.repo &&
     current.branch === expected.branch &&
     current.providerMatchesRepository === expected.providerMatchesRepository &&
+    current.contextReviewer.enabled === expected.contextReviewer.enabled &&
+    current.contextReviewer.agentUuid === expected.contextReviewer.agentUuid &&
     current.gitlabConnection?.id === expected.gitlabConnection?.id &&
     current.gitlabConnection?.instanceOrigin === expected.gitlabConnection?.instanceOrigin
   );
@@ -545,7 +556,14 @@ async function resolveContextReviewerAgentSummary(
       displayName: agents.displayName,
     })
     .from(agents)
-    .where(and(eq(agents.uuid, agentUuid), eq(agents.organizationId, orgId), ne(agents.status, "deleted")))
+    .where(
+      and(
+        eq(agents.uuid, agentUuid),
+        eq(agents.organizationId, orgId),
+        eq(agents.visibility, AGENT_VISIBILITY.ORGANIZATION),
+        ne(agents.status, "deleted"),
+      ),
+    )
     .limit(1);
   return agent ?? null;
 }
@@ -579,7 +597,6 @@ async function assertContextReviewerAgentAllowed(
   if (!agent || agent.organizationId !== orgId || agent.type === "human" || agent.status !== "active") {
     throw new BadRequestError("Context Reviewer agent must be an active non-human agent in this organization");
   }
-
   const runtime = await getOrgContextReviewRuntime(db, orgId);
   if (
     runtime.bindingState !== "bound" ||

--- a/packages/server/src/services/setup-capabilities.ts
+++ b/packages/server/src/services/setup-capabilities.ts
@@ -9,10 +9,10 @@ import {
   type TeamSetupCapabilities,
   teamSetupCapabilitiesSchema,
 } from "@first-tree/shared";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import type { Database } from "../db/connection.js";
-import { agents } from "../db/schema/agents.js";
 import { gitlabConnections } from "../db/schema/gitlab-connections.js";
+import { readContextReviewerAgentReadiness } from "./context-reviewer-readiness.js";
 import {
   createAppJwt,
   GithubAppApiError,
@@ -24,8 +24,8 @@ import { findInstallationByOrg, type InstallationRow } from "./github-app-instal
 import { projectGitlabConnectionReadiness } from "./gitlab-connections.js";
 import { getOrgContextReviewRuntime } from "./org-settings.js";
 
-type GithubReviewProbeResult = "ready" | "permission_required" | "repo_not_covered" | "failed";
-type GithubReviewCredentials = GithubAppCredentials & { slug?: string; webhookSecret?: string };
+export type GithubReviewProbeResult = "ready" | "permission_required" | "repo_not_covered" | "failed";
+export type GithubReviewCredentials = GithubAppCredentials & { slug?: string; webhookSecret?: string };
 const GITHUB_REVIEW_PROBE_TIMEOUT_MS = 5_000;
 const GITHUB_REPOSITORY_AUTOMATION_EVENTS: ReadonlySet<string> = new Set([
   "commit_comment",
@@ -44,6 +44,7 @@ export type SetupCapabilitiesOptions = {
   githubAppCredentials?: GithubReviewCredentials;
   githubFetch?: typeof fetch;
   probeGithubReview?: (installation: InstallationRow, repo: string) => Promise<GithubReviewProbeResult>;
+  staleSeconds?: number;
 };
 
 function blocker(
@@ -58,7 +59,7 @@ function githubRepositoryAutomationEventsReady(events: string[]): boolean {
   return events.some((event) => GITHUB_REPOSITORY_AUTOMATION_EVENTS.has(event));
 }
 
-function githubAutomaticReviewEventsReady(events: string[]): boolean {
+export function githubAutomaticReviewEventsReady(events: string[]): boolean {
   return GITHUB_AUTOMATIC_REVIEW_EVENTS.every((event) => events.includes(event));
 }
 
@@ -227,7 +228,8 @@ export async function getTeamSetupCapabilities(
   organizationId: string,
   options: SetupCapabilitiesOptions = {},
 ): Promise<TeamSetupCapabilities> {
-  const observedAt = (options.now?.() ?? new Date()).toISOString();
+  const now = options.now?.() ?? new Date();
+  const observedAt = now.toISOString();
   const [runtime, installation, gitlabRows] = await Promise.all([
     getOrgContextReviewRuntime(db, organizationId),
     findInstallationByOrg(db, organizationId),
@@ -263,44 +265,33 @@ export async function getTeamSetupCapabilities(
   }
 
   let reviewerAgent: SetupAutomaticReview["reviewerAgent"] = null;
-  let reviewerAgentActive = false;
-  if (runtime.contextReviewer.agentUuid) {
-    const [reviewer] = await db
-      .select({
-        uuid: agents.uuid,
-        displayName: agents.displayName,
-        type: agents.type,
-        status: agents.status,
-      })
-      .from(agents)
-      .where(and(eq(agents.uuid, runtime.contextReviewer.agentUuid), eq(agents.organizationId, organizationId)))
-      .limit(1);
-    if (reviewer?.type === "agent") {
-      reviewerAgent = { uuid: reviewer.uuid, displayName: reviewer.displayName };
-      reviewerAgentActive = reviewer.status === "active";
-    }
-  }
-
+  let reviewerStructurallyEligible = false;
   const reviewBlockers: SetupBlocker[] = [];
   let reviewHealth: SetupAutomaticReview["health"] = "not_observed";
-  let reviewAdoption: SetupAutomaticReview["adoption"];
+  const reviewAdoption: SetupAutomaticReview["adoption"] =
+    binding.state !== "bound" ? "unavailable" : runtime.contextReviewer.enabled ? "enabled" : "disabled";
+
+  if (runtime.contextReviewer.agentUuid) {
+    const agentReadiness = await readContextReviewerAgentReadiness(db, {
+      organizationId,
+      reviewerAgentUuid: runtime.contextReviewer.agentUuid,
+      now,
+      staleSeconds: options.staleSeconds ?? 60,
+    });
+    reviewerAgent = agentReadiness.reviewerAgent;
+    reviewerStructurallyEligible = agentReadiness.structuralBlockers.length === 0;
+    reviewBlockers.push(...agentReadiness.structuralBlockers, ...agentReadiness.healthBlockers);
+    reviewHealth =
+      agentReadiness.structuralBlockers.length > 0
+        ? "unavailable"
+        : agentReadiness.healthBlockers.length > 0
+          ? "degraded"
+          : "ready";
+  }
 
   if (binding.state !== "bound") {
-    reviewAdoption = "unavailable";
-  } else if (!runtime.contextReviewer.enabled) {
-    reviewAdoption = "disabled";
-  } else {
-    reviewAdoption = "enabled";
-    reviewHealth = "ready";
-
-    if (!reviewerAgent) {
-      reviewBlockers.push(blocker("context_review_agent_missing", "admin", "replace_review_agent"));
-      reviewHealth = "unavailable";
-    } else if (!reviewerAgentActive) {
-      reviewBlockers.push(blocker("context_review_agent_inactive", "admin", "replace_review_agent"));
-      reviewHealth = "unavailable";
-    }
-
+    if (reviewHealth === "ready") reviewHealth = "not_observed";
+  } else if (runtime.contextReviewer.agentUuid) {
     if (binding.provider === "github") {
       if (!options.githubAppCredentials?.webhookSecret) {
         reviewBlockers.push(blocker("github_app_not_configured", "operator", null));
@@ -317,7 +308,7 @@ export async function getTeamSetupCapabilities(
       } else if (!githubAutomaticReviewEventsReady(installation.events)) {
         reviewBlockers.push(blocker("github_webhook_events_missing", "operator", null));
         reviewHealth = "unavailable";
-      } else if (reviewHealth === "ready") {
+      } else if (reviewerStructurallyEligible) {
         const probe =
           options.probeGithubReview ??
           ((candidate: InstallationRow, repo: string) =>

--- a/packages/shared/src/__tests__/context-reviewer-settings.test.ts
+++ b/packages/shared/src/__tests__/context-reviewer-settings.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  contextReviewerAssignmentInputSchema,
+  contextReviewerCandidatesOutputSchema,
+  contextReviewerEnablementInputSchema,
+} from "../schemas/context-reviewer-settings.js";
+
+describe("Context Reviewer owner contract", () => {
+  it("keeps assignment and enablement as strict independent inputs", () => {
+    expect(contextReviewerAssignmentInputSchema.parse({ agentUuid: "agent-1" })).toEqual({
+      agentUuid: "agent-1",
+    });
+    expect(contextReviewerAssignmentInputSchema.parse({ agentUuid: null })).toEqual({
+      agentUuid: null,
+    });
+    expect(contextReviewerEnablementInputSchema.parse({ enabled: false })).toEqual({
+      enabled: false,
+    });
+    expect(
+      contextReviewerAssignmentInputSchema.safeParse({
+        agentUuid: "agent-1",
+        assignedByMemberId: "member-1",
+      }).success,
+    ).toBe(false);
+    expect(
+      contextReviewerEnablementInputSchema.safeParse({
+        enabled: true,
+        consent: true,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("projects only Team-safe candidate facts and typed runtime health", () => {
+    expect(
+      contextReviewerCandidatesOutputSchema.parse({
+        items: [
+          {
+            uuid: "agent-1",
+            name: "reviewer",
+            displayName: "Reviewer",
+            visibility: "organization",
+            runtime: {
+              health: "degraded",
+              blockers: [
+                {
+                  code: "context_review_agent_runtime_unavailable",
+                  resolutionOwner: "admin",
+                  actionKind: "open_agent_owner_flow",
+                },
+              ],
+            },
+          },
+        ],
+        blockers: [],
+      }),
+    ).toMatchObject({
+      items: [
+        {
+          uuid: "agent-1",
+          visibility: "organization",
+          runtime: { health: "degraded" },
+        },
+      ],
+    });
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -375,6 +375,18 @@ export {
   contextReviewSubmitResponseSchema,
 } from "./schemas/context-review.js";
 export {
+  type ContextReviewerAssignmentInput,
+  type ContextReviewerCandidate,
+  type ContextReviewerCandidateRuntime,
+  type ContextReviewerCandidatesOutput,
+  type ContextReviewerEnablementInput,
+  contextReviewerAssignmentInputSchema,
+  contextReviewerCandidateRuntimeSchema,
+  contextReviewerCandidateSchema,
+  contextReviewerCandidatesOutputSchema,
+  contextReviewerEnablementInputSchema,
+} from "./schemas/context-reviewer-settings.js";
+export {
   CONTEXT_TREE_CHANGE_TYPES,
   CONTEXT_TREE_EDGE_KINDS,
   CONTEXT_TREE_NODE_KINDS,

--- a/packages/shared/src/schemas/context-reviewer-settings.ts
+++ b/packages/shared/src/schemas/context-reviewer-settings.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { agentVisibilitySchema } from "./agent.js";
+import { setupBlockerSchema, setupCapabilityHealthSchema } from "./setup-capabilities.js";
+
+export const contextReviewerAssignmentInputSchema = z
+  .object({
+    agentUuid: z.string().min(1).nullable(),
+  })
+  .strict();
+
+export const contextReviewerEnablementInputSchema = z
+  .object({
+    enabled: z.boolean(),
+  })
+  .strict();
+
+export const contextReviewerCandidateRuntimeSchema = z
+  .object({
+    health: setupCapabilityHealthSchema,
+    blockers: z.array(setupBlockerSchema),
+  })
+  .strict();
+
+export const contextReviewerCandidateSchema = z
+  .object({
+    uuid: z.string().min(1),
+    name: z.string().nullable(),
+    displayName: z.string().min(1),
+    visibility: agentVisibilitySchema,
+    runtime: contextReviewerCandidateRuntimeSchema,
+  })
+  .strict();
+
+export const contextReviewerCandidatesOutputSchema = z
+  .object({
+    items: z.array(contextReviewerCandidateSchema),
+    blockers: z.array(setupBlockerSchema),
+  })
+  .strict();
+
+export type ContextReviewerAssignmentInput = z.infer<typeof contextReviewerAssignmentInputSchema>;
+export type ContextReviewerEnablementInput = z.infer<typeof contextReviewerEnablementInputSchema>;
+export type ContextReviewerCandidateRuntime = z.infer<typeof contextReviewerCandidateRuntimeSchema>;
+export type ContextReviewerCandidate = z.infer<typeof contextReviewerCandidateSchema>;
+export type ContextReviewerCandidatesOutput = z.infer<typeof contextReviewerCandidatesOutputSchema>;

--- a/packages/shared/src/schemas/setup-capabilities.ts
+++ b/packages/shared/src/schemas/setup-capabilities.ts
@@ -23,8 +23,15 @@ export const setupBlockerCodeSchema = z.enum([
   "context_tree_provider_unresolved",
   "context_tree_connection_mismatch",
   "context_review_provider_prerequisite_missing",
+  "context_review_assignment_required",
+  "context_review_no_eligible_agent",
   "context_review_agent_missing",
   "context_review_agent_inactive",
+  "context_review_agent_manager_inactive",
+  "context_review_agent_private",
+  "context_review_agent_no_runtime",
+  "context_review_agent_runtime_unavailable",
+  "context_review_state_changed",
 ]);
 
 export const setupResolutionOwnerSchema = z.enum(["admin", "operator"]);
@@ -38,6 +45,8 @@ export const setupActionKindSchema = z.enum([
   "open_tree_setup_chat",
   "select_review_agent",
   "replace_review_agent",
+  "open_agent_owner_flow",
+  "manage_review_agent",
 ]);
 
 export const setupBlockerSchema = z

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -169,8 +169,15 @@ const BLOCKER_COPY = {
   context_tree_provider_unresolved: "The Context Tree provider could not be resolved.",
   context_tree_connection_mismatch: "The Context Tree repository does not match the current GitLab connection.",
   context_review_provider_prerequisite_missing: "The repository provider must be connected before review can run.",
+  context_review_assignment_required: "Choose a reviewer before enabling Automatic Review.",
+  context_review_no_eligible_agent: "No eligible organization-visible managed Agent is available.",
   context_review_agent_missing: "The configured reviewer is missing.",
   context_review_agent_inactive: "The configured reviewer is inactive.",
+  context_review_agent_manager_inactive: "The configured reviewer's manager is inactive.",
+  context_review_agent_private: "The configured reviewer is private and cannot run Automatic Review.",
+  context_review_agent_no_runtime: "The configured reviewer does not support Context Review.",
+  context_review_agent_runtime_unavailable: "The configured reviewer's runtime is currently unavailable.",
+  context_review_state_changed: "Reviewer settings changed while this request was in progress.",
 } satisfies Record<SetupBlockerCode, string>;
 
 const ACTION_DESTINATIONS = {
@@ -182,6 +189,8 @@ const ACTION_DESTINATIONS = {
   open_tree_setup_chat: "/context",
   select_review_agent: "/settings/repositories#context-tree",
   replace_review_agent: "/settings/repositories#context-tree",
+  open_agent_owner_flow: "/team",
+  manage_review_agent: "/settings/repositories#context-tree",
 } satisfies Record<SetupActionKind, string>;
 
 const ACTION_LABELS = {
@@ -193,6 +202,8 @@ const ACTION_LABELS = {
   open_tree_setup_chat: "Open setup chat",
   select_review_agent: "Choose reviewer",
   replace_review_agent: "Replace reviewer",
+  open_agent_owner_flow: "Manage agents",
+  manage_review_agent: "Manage reviewer",
 } satisfies Record<SetupActionKind, string>;
 
 function blockerDetail(blockers: SetupBlocker[], isAdmin: boolean): string | undefined {


### PR DESCRIPTION
## Summary

- add admin-only candidate, assignment, and enablement endpoints for Automatic Review
- keep the existing `{ enabled, agentUuid }` storage shape, preserve a selection while disabled, and introduce no migration
- require an existing Team-managed, active, organization-visible Agent with an active manager, a non-retired pinned Computer, and a supported runtime
- project selected-but-disabled and live degraded health through `TeamSetupCapabilities`
- recheck exact Agent, runtime route, Tree binding, and provider authority in the transaction that creates each trusted GitHub/GitLab review run
- map the new typed facts/actions into #1987's existing exhaustive Setup copy/routing tables without adding Reviewer controls

This separates durable assignment from enablement and transient runtime health. Offline or stale Computers remain selected/enabled and recover without a settings rewrite; each run still fails closed. Assignment or enablement failure never mutates or rolls back the independent Context Tree binding.

This supersedes the automatic-provisioning approach proposed in #1977. This PR intentionally selects an existing eligible managed Agent and does not create one.

## Validation

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @first-tree/shared test` — 63 files / 699 tests
- [x] `pnpm --filter @first-tree/server test` — 245 files / 2670 tests
- [x] `pnpm --filter @first-tree/web typecheck`
- [x] `pnpm --filter @first-tree/web test` — 201 files / 1708 tests
- [x] focused assignment/readiness, GitHub/GitLab dispatch, projection, privacy, recovery, concurrency, and idempotency coverage
- [x] `git diff --check`
- [x] two independent review passes; all definite blockers resolved

## Change Surface

- [ ] `apps/cli` public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

Server/shared contract plus an 11-line compatibility mapping in the existing Setup page. No Agent provisioning, visibility mutation, Reviewer consent, Setup query/render/control changes, final Reviewer UI, GitLab System Hook schema/migration, or generic workflow/DAG was added.

## Notes

- package or install behavior changes: none
- docs or tests updated to match: Shared, Server, and merge-state Web contract/regression tests
- follow-up work: the final Setup selector/enable controls stay in a separate Web task
- dependency integrated: based on merged #1988 and reuses its authoritative GitLab System Hook merge-request routing evidence
- Context Tree: paired Draft PR https://github.com/agent-team-foundation/first-tree-context/pull/816; merge this code PR first, then reconcile the Tree PR

