### PR TITLE
fix(web): prevent native selection on mobile long press

### DIFF
--- a/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
@@ -253,6 +253,9 @@ describe("mobile card behavior", () => {
     expect(card?.querySelector("[data-mobile-card-menu]")).toBeNull();
     expect(harness.container.querySelector("[data-mobile-swipe-surface]")).toBeNull();
     expect(document.body.querySelector('[role="menu"]')).toBeNull();
+    expect(card?.style.userSelect).toBe("none");
+    expect(Reflect.get(card?.style ?? {}, "WebkitUserSelect")).toBe("none");
+    expect(Reflect.get(card?.style ?? {}, "WebkitTouchCallout")).toBe("none");
     expect(card?.querySelector('[aria-haspopup="dialog"]')?.getAttribute("aria-description")).toBe(
       "Long press for chat actions",
     );
@@ -273,15 +276,25 @@ describe("mobile card behavior", () => {
     expect(card?.querySelector("[data-mobile-card-menu]")).toBeNull();
     expect(harness.container.querySelector("[data-mobile-swipe-surface]")).toBeNull();
     expect(card?.getAttribute("aria-haspopup")).toBe("dialog");
+    expect(card?.style.userSelect).toBe("none");
+    expect(Reflect.get(card?.style ?? {}, "WebkitUserSelect")).toBe("none");
+    expect(Reflect.get(card?.style ?? {}, "WebkitTouchCallout")).toBe("none");
+    expect(card?.style.touchAction).toBe("pan-y");
   });
 
   it("opens contextual triage on a Now long press and blocks archive while judgment is unresolved", async () => {
     renderPage(harness, "now");
     await harness.waitFor(() => expect(harness.container.textContent).toContain(row.title));
 
+    const selection = window.getSelection();
+    if (!selection) throw new Error("Missing document selection");
+    const removeAllRanges = vi.spyOn(selection, "removeAllRanges");
+
     await longPress(harness.container.querySelector('[data-mobile-card="feed"] > button'));
 
     expect(currentLocation).toBe("/m/now");
+    expect(removeAllRanges).toHaveBeenCalledOnce();
+    removeAllRanges.mockRestore();
     const actionsSheet = document.body.querySelector("[data-mobile-chat-actions]");
     expect(actionsSheet).not.toBeNull();
     expect(actionsSheet?.getAttribute("aria-label")).toBe(`Actions for ${row.title}`);

--- a/packages/web/src/pages/mobile/now.tsx
+++ b/packages/web/src/pages/mobile/now.tsx
@@ -18,7 +18,7 @@ import {
   mobileRowsFromList,
   sortMobileChats,
 } from "./data.js";
-import { useLongPress } from "./use-long-press.js";
+import { longPressSurfaceStyle, useLongPress } from "./use-long-press.js";
 
 export function MobileNowPage() {
   const { agentId } = useAuth();
@@ -106,6 +106,7 @@ function MobileAttentionCard({
   const accent = mobileAccentColor(signal.tone);
   const cardStyle = {
     ...mobileCardStyle(actionLabel ? "priorityFeed" : "feed"),
+    ...longPressSurfaceStyle,
     textDecoration: "none",
     position: "relative" as const,
     // One pre-attentive priority cue: a left-edge accent in the state hue,

--- a/packages/web/src/pages/mobile/use-long-press.ts
+++ b/packages/web/src/pages/mobile/use-long-press.ts
@@ -14,8 +14,19 @@ type LongPressHandlers = {
   onPointerLeave: () => void;
   onPointerMove: (event: PointerEvent<HTMLElement>) => void;
   onPointerUp: () => void;
-  style: { touchAction: "pan-y"; userSelect: "none"; WebkitTouchCallout: "none" };
+  style: typeof longPressTriggerStyle;
 };
+
+export const longPressSurfaceStyle = {
+  userSelect: "none",
+  WebkitUserSelect: "none",
+  WebkitTouchCallout: "none",
+} as const;
+
+const longPressTriggerStyle = {
+  ...longPressSurfaceStyle,
+  touchAction: "pan-y",
+} as const;
 
 /**
  * Long-press is deliberately an enhancement to the card's normal click:
@@ -43,6 +54,14 @@ export function useLongPress(onLongPress: (trigger: HTMLElement) => void, onClic
     };
   }, [cancel]);
 
+  const openActions = (trigger: HTMLElement) => {
+    // iOS can establish a native text range before dispatching contextmenu.
+    // The card surface prevents new selection; clear any range already started
+    // so the system copy/lookup callout cannot outlive our action sheet.
+    window.getSelection()?.removeAllRanges();
+    onLongPress(trigger);
+  };
+
   return {
     "aria-description": "Long press for chat actions",
     "aria-haspopup": "dialog",
@@ -56,7 +75,7 @@ export function useLongPress(onLongPress: (trigger: HTMLElement) => void, onClic
         timerRef.current = null;
         lastLongPressAtRef.current = Date.now();
         suppressClickRef.current = true;
-        onLongPress(triggerRef.current ?? event.currentTarget);
+        openActions(triggerRef.current ?? event.currentTarget);
       }, LONG_PRESS_MS);
     },
     onPointerMove: (event) => {
@@ -82,14 +101,14 @@ export function useLongPress(onLongPress: (trigger: HTMLElement) => void, onClic
       // Mobile browsers may emit `contextmenu` immediately after our own
       // timer fires. Ignore only that synthetic companion event; a later
       // mouse right-click remains a fresh way to open the sheet.
-      if (Date.now() - lastLongPressAtRef.current > 750) onLongPress(event.currentTarget);
+      if (Date.now() - lastLongPressAtRef.current > 750) openActions(event.currentTarget);
     },
     onKeyDown: (event) => {
       if (event.key !== "ContextMenu" && !(event.key === "F10" && event.shiftKey)) return;
       event.preventDefault();
       cancel();
-      onLongPress(event.currentTarget);
+      openActions(event.currentTarget);
     },
-    style: { touchAction: "pan-y", userSelect: "none", WebkitTouchCallout: "none" },
+    style: longPressTriggerStyle,
   };
 }


### PR DESCRIPTION
## Summary

- apply standard and WebKit text-selection suppression to the actual mobile Now and Chat card surfaces
- clear any native selection that started before opening the custom long-press action sheet
- cover both card variants and selection cleanup with DOM regression assertions

## Product scope

Mobile scope: allowlisted — this fixes the existing Now/Chat long-press triage interaction and adds no new mobile capability.

## Verification

- `pnpm check` (passes; existing repository warnings only)
- `pnpm typecheck`
- `pnpm --filter @first-tree/web test` — 201 files, 1,708 tests passed
- focused mobile card suite — 10 tests passed
- `pnpm test` was also attempted; product tests, including the mobile suite, passed, but the aggregate run was interrupted by four unrelated 5-second timeouts in Context Tree skill-eval fixtures under concurrent load

## Manual acceptance

Please verify on both Android Chrome and iPhone Safari:

- long press opens only the First Tree action sheet, without native selection/copy/lookup UI
- vertical movement or scrolling cancels the pending long press
- completing a long press does not also open the chat
