### PR TITLE
fix(cli): retire stranded legacy github-scan launchd runner on upgrade and daemon start

### DIFF
--- a/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/agent-lifecycle-commands-extra.test.ts
@@ -59,6 +59,12 @@ const coreMocks = vi.hoisted(() => ({
   removeLocalAgent: vi.fn(),
   resolveServerUrl: vi.fn(),
   restartClientService: vi.fn(),
+  retireLegacyGithubScanRunner: vi.fn(() => ({
+    checked: true,
+    retiredLabels: [],
+    removedPlists: [],
+    warnings: [],
+  })),
   stopClientService: vi.fn(),
   stopClientRuntimeProcess: vi.fn(),
 }));
@@ -1168,9 +1174,13 @@ describe("logout and upgrade commands", () => {
     coreMocks.detectInstallMode.mockReturnValue("global");
     await expect(runTopLevel(registerUpgradeCommand, ["upgrade"])).rejects.toMatchObject({ code: 1 });
 
+    coreMocks.retireLegacyGithubScanRunner.mockClear();
     await runTopLevel(registerUpgradeCommand, ["upgrade", "--no-restart"]);
     expect(coreMocks.installGlobalSpec).toHaveBeenCalledWith("99.0.0");
     expect(printLineMock.mock.calls.map((call) => String(call[0])).join("")).toContain("first-tree-dev daemon restart");
+    // Issue #995: a successful install retires any stranded legacy
+    // github-scan launchd runner even when the restart is skipped.
+    expect(coreMocks.retireLegacyGithubScanRunner).toHaveBeenCalledTimes(1);
 
     coreMocks.isServiceSupported.mockReturnValueOnce(false);
     await runTopLevel(registerUpgradeCommand, ["upgrade"]);

--- a/apps/cli/src/__tests__/daemon-start-command.test.ts
+++ b/apps/cli/src/__tests__/daemon-start-command.test.ts
@@ -39,6 +39,12 @@ const coreMocks = vi.hoisted(() => ({
   reconcileLocalRuntimeProviders: vi.fn(),
   refreshServerUpdateTarget: vi.fn(),
   resolveClientRuntimeStopReason: vi.fn(),
+  retireLegacyGithubScanRunner: vi.fn(() => ({
+    checked: true,
+    retiredLabels: [],
+    removedPlists: [],
+    warnings: [],
+  })),
   runRuntimeAuthLogin: vi.fn(),
   startClientService: vi.fn(),
   uploadAgentSkills: vi.fn(),

--- a/apps/cli/src/__tests__/install-guidance-surfaces.test.ts
+++ b/apps/cli/src/__tests__/install-guidance-surfaces.test.ts
@@ -45,6 +45,12 @@ vi.mock("../core/index.js", () => ({
   installPortableSpec: vi.fn(),
   isServiceSupported: vi.fn(),
   restartClientService: vi.fn(),
+  retireLegacyGithubScanRunner: vi.fn(() => ({
+    checked: true,
+    retiredLabels: [],
+    removedPlists: [],
+    warnings: [],
+  })),
 }));
 
 vi.mock("../core/update.js", () => ({

--- a/apps/cli/src/__tests__/legacy-github-scan-cleanup.test.ts
+++ b/apps/cli/src/__tests__/legacy-github-scan-cleanup.test.ts
@@ -188,6 +188,33 @@ describe("retireLegacyGithubScanRunner", () => {
     ]);
   });
 
+  it("unions loaded-only and plist-only labels in a single pass", () => {
+    // labelA: loaded in launchd, plist hand-deleted. labelB: plist on disk,
+    // job no longer loaded. Both must be handled in one run.
+    const labelA = `${LEGACY_GITHUB_SCAN_LABEL_PREFIX}gandy.loaded-only`;
+    const labelB = `${LEGACY_GITHUB_SCAN_LABEL_PREFIX}gandy.plist-only`;
+    mkdirSync(legacyDir, { recursive: true });
+    const plistB = join(legacyDir, `${labelB}.plist`);
+    writeFileSync(plistB, "<plist/>");
+
+    spawnSyncMock
+      .mockReturnValueOnce(ok(launchctlList([labelA])))
+      .mockReturnValueOnce(ok()) // bootout labelA
+      .mockReturnValueOnce(fail("Boot-out failed: 113: Could not find specified service")); // bootout labelB
+
+    const result = retireLegacyGithubScanRunner();
+    expect(result.retiredLabels).toEqual([labelA]);
+    expect(result.removedPlists).toEqual([plistB]);
+    expect(result.warnings).toEqual([]);
+    expect(existsSync(plistB)).toBe(false);
+    expect(existsSync(legacyDir)).toBe(false);
+    expect(launchctlCalls()).toEqual([
+      ["launchctl", ["list"]],
+      ["launchctl", ["bootout", `gui/501/${labelA}`]],
+      ["launchctl", ["bootout", `gui/501/${labelB}`]],
+    ]);
+  });
+
   it("retires multiple stranded profiles in deterministic order", () => {
     mkdirSync(legacyDir, { recursive: true });
     const labelA = `${LEGACY_GITHUB_SCAN_LABEL_PREFIX}gandy.alpha`;

--- a/apps/cli/src/__tests__/legacy-github-scan-cleanup.test.ts
+++ b/apps/cli/src/__tests__/legacy-github-scan-cleanup.test.ts
@@ -1,0 +1,216 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  LEGACY_GITHUB_SCAN_LABEL_PREFIX,
+  legacyGithubScanLaunchdDir,
+  retireLegacyGithubScanRunner,
+} from "../core/legacy-github-scan-cleanup.js";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+const userInfoMock = vi.hoisted(() => vi.fn(() => ({ uid: 501, username: "gandy" })));
+const homedirMock = vi.hoisted(() => vi.fn(() => "/Users/gandy"));
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+  execFileSync: execFileSyncMock,
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: homedirMock,
+    userInfo: userInfoMock,
+  };
+});
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+}
+
+const LEGACY_LABEL = `${LEGACY_GITHUB_SCAN_LABEL_PREFIX}gandy.default`;
+
+function ok(stdout = ""): { status: number; stdout: string; stderr: string } {
+  return { status: 0, stdout, stderr: "" };
+}
+
+function fail(stderr: string): { status: number; stdout: string; stderr: string } {
+  return { status: 1, stdout: "", stderr };
+}
+
+/** `launchctl list` output: header + one PID\tStatus\tLabel row per label. */
+function launchctlList(labels: string[]): string {
+  return ["PID\tStatus\tLabel", ...labels.map((label, i) => `${100 + i}\t0\t${label}`)].join("\n");
+}
+
+function launchctlCalls(): Array<[string, string[]]> {
+  return spawnSyncMock.mock.calls.map((call) => [call[0], call[1]]);
+}
+
+let home: string;
+let legacyDir: string;
+
+beforeEach(() => {
+  home = join(tmpdir(), `ft-legacy-scan-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(home, { recursive: true });
+  homedirMock.mockReturnValue(home);
+  userInfoMock.mockReturnValue({ uid: 501, username: "gandy" });
+  spawnSyncMock.mockReset();
+  execFileSyncMock.mockReset();
+  legacyDir = legacyGithubScanLaunchdDir();
+  setPlatform("darwin");
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  setPlatform(originalPlatform);
+});
+
+describe("retireLegacyGithubScanRunner", () => {
+  it("does nothing on platforms without launchd", () => {
+    setPlatform("linux");
+    const result = retireLegacyGithubScanRunner();
+    expect(result).toEqual({ checked: false, retiredLabels: [], removedPlists: [], warnings: [] });
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when nothing is stranded", () => {
+    spawnSyncMock.mockReturnValueOnce(ok(launchctlList(["com.apple.Finder", "first-tree"])));
+    const result = retireLegacyGithubScanRunner();
+    expect(result).toEqual({ checked: true, retiredLabels: [], removedPlists: [], warnings: [] });
+    expect(launchctlCalls()).toEqual([["launchctl", ["list"]]]);
+  });
+
+  it("boots out a stranded runner and removes its plist, leaving foreign files alone", () => {
+    mkdirSync(legacyDir, { recursive: true });
+    const plistPath = join(legacyDir, `${LEGACY_LABEL}.plist`);
+    writeFileSync(plistPath, "<plist/>");
+    const foreignPath = join(legacyDir, "com.other.tool.plist");
+    writeFileSync(foreignPath, "<plist/>");
+
+    spawnSyncMock.mockReturnValueOnce(ok(launchctlList(["com.apple.Finder", LEGACY_LABEL]))).mockReturnValueOnce(ok());
+
+    const result = retireLegacyGithubScanRunner();
+
+    expect(result.retiredLabels).toEqual([LEGACY_LABEL]);
+    expect(result.removedPlists).toEqual([plistPath]);
+    expect(result.warnings).toEqual([]);
+    expect(existsSync(plistPath)).toBe(false);
+    expect(existsSync(foreignPath)).toBe(true);
+    expect(existsSync(legacyDir)).toBe(true); // non-empty dirs are never force-removed
+    expect(launchctlCalls()).toEqual([
+      ["launchctl", ["list"]],
+      ["launchctl", ["bootout", `gui/501/${LEGACY_LABEL}`]],
+    ]);
+  });
+
+  it("removes the legacy launchd dir once it is empty and is idempotent on re-run", () => {
+    mkdirSync(legacyDir, { recursive: true });
+    const plistPath = join(legacyDir, `${LEGACY_LABEL}.plist`);
+    writeFileSync(plistPath, "<plist/>");
+
+    spawnSyncMock.mockReturnValueOnce(ok(launchctlList([LEGACY_LABEL]))).mockReturnValueOnce(ok());
+    const first = retireLegacyGithubScanRunner();
+    expect(first.retiredLabels).toEqual([LEGACY_LABEL]);
+    expect(first.removedPlists).toEqual([plistPath]);
+    expect(existsSync(legacyDir)).toBe(false);
+
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValueOnce(ok(launchctlList([])));
+    const second = retireLegacyGithubScanRunner();
+    expect(second).toEqual({ checked: true, retiredLabels: [], removedPlists: [], warnings: [] });
+    expect(launchctlCalls()).toEqual([["launchctl", ["list"]]]);
+  });
+
+  it("boots out a loaded zombie whose plist was already deleted by hand", () => {
+    spawnSyncMock.mockReturnValueOnce(ok(launchctlList([LEGACY_LABEL]))).mockReturnValueOnce(ok());
+    const result = retireLegacyGithubScanRunner();
+    expect(result.retiredLabels).toEqual([LEGACY_LABEL]);
+    expect(result.removedPlists).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(launchctlCalls()).toEqual([
+      ["launchctl", ["list"]],
+      ["launchctl", ["bootout", `gui/501/${LEGACY_LABEL}`]],
+    ]);
+  });
+
+  it("treats a not-loaded bootout answer as the idempotent case and still removes the plist", () => {
+    mkdirSync(legacyDir, { recursive: true });
+    const plistPath = join(legacyDir, `${LEGACY_LABEL}.plist`);
+    writeFileSync(plistPath, "<plist/>");
+
+    spawnSyncMock
+      .mockReturnValueOnce(ok(launchctlList([])))
+      .mockReturnValueOnce(fail(`Boot-out failed: 113: Could not find specified service`));
+
+    const result = retireLegacyGithubScanRunner();
+    expect(result.retiredLabels).toEqual([]);
+    expect(result.removedPlists).toEqual([plistPath]);
+    expect(result.warnings).toEqual([]);
+    expect(existsSync(plistPath)).toBe(false);
+  });
+
+  it("keeps going past an unexpected bootout failure and surfaces it as a warning", () => {
+    mkdirSync(legacyDir, { recursive: true });
+    const plistPath = join(legacyDir, `${LEGACY_LABEL}.plist`);
+    writeFileSync(plistPath, "<plist/>");
+
+    spawnSyncMock
+      .mockReturnValueOnce(ok(launchctlList([LEGACY_LABEL])))
+      .mockReturnValueOnce(fail("Operation not permitted"));
+
+    const result = retireLegacyGithubScanRunner();
+    expect(result.retiredLabels).toEqual([]);
+    expect(result.removedPlists).toEqual([plistPath]);
+    expect(result.warnings).toEqual([`launchctl bootout gui/501/${LEGACY_LABEL}: Operation not permitted`]);
+    expect(existsSync(plistPath)).toBe(false);
+  });
+
+  it("still sweeps on-disk plists when launchctl list fails", () => {
+    mkdirSync(legacyDir, { recursive: true });
+    const plistPath = join(legacyDir, `${LEGACY_LABEL}.plist`);
+    writeFileSync(plistPath, "<plist/>");
+
+    spawnSyncMock.mockReturnValueOnce(fail("launchctl exploded")).mockReturnValueOnce(ok());
+
+    const result = retireLegacyGithubScanRunner();
+    expect(result.retiredLabels).toEqual([LEGACY_LABEL]);
+    expect(result.removedPlists).toEqual([plistPath]);
+    expect(result.warnings).toEqual(["launchctl list failed: launchctl exploded"]);
+    expect(launchctlCalls()).toEqual([
+      ["launchctl", ["list"]],
+      ["launchctl", ["bootout", `gui/501/${LEGACY_LABEL}`]],
+    ]);
+  });
+
+  it("retires multiple stranded profiles in deterministic order", () => {
+    mkdirSync(legacyDir, { recursive: true });
+    const labelA = `${LEGACY_GITHUB_SCAN_LABEL_PREFIX}gandy.alpha`;
+    const labelB = `${LEGACY_GITHUB_SCAN_LABEL_PREFIX}gandy.beta`;
+    writeFileSync(join(legacyDir, `${labelB}.plist`), "<plist/>");
+    writeFileSync(join(legacyDir, `${labelA}.plist`), "<plist/>");
+
+    spawnSyncMock
+      .mockReturnValueOnce(ok(launchctlList([labelB])))
+      .mockReturnValueOnce(ok())
+      .mockReturnValueOnce(ok());
+
+    const result = retireLegacyGithubScanRunner();
+    expect(result.retiredLabels).toEqual([labelA, labelB]);
+    expect(result.removedPlists.sort()).toEqual([
+      join(legacyDir, `${labelA}.plist`),
+      join(legacyDir, `${labelB}.plist`),
+    ]);
+    expect(existsSync(legacyDir)).toBe(false);
+    expect(launchctlCalls()).toEqual([
+      ["launchctl", ["list"]],
+      ["launchctl", ["bootout", `gui/501/${labelA}`]],
+      ["launchctl", ["bootout", `gui/501/${labelB}`]],
+    ]);
+  });
+});

--- a/apps/cli/src/commands/daemon/start.ts
+++ b/apps/cli/src/commands/daemon/start.ts
@@ -51,6 +51,7 @@ import {
   refreshServerUpdateTarget,
   registerClientRuntimeMarker,
   resolveClientRuntimeStopReason,
+  retireLegacyGithubScanRunner,
   runRuntimeAuthLogin,
   startClientService,
   uploadAgentSkills,
@@ -97,6 +98,24 @@ export function registerDaemonStartCommand(daemon: Command): void {
       const appliedDaemonEnv = loadDaemonEnv();
       if (appliedDaemonEnv.length > 0) {
         writeLine(`  loaded ${appliedDaemonEnv.length} var(s) from daemon.env (${appliedDaemonEnv.join(", ")})\n`);
+      }
+      // Issue #995: a pre-removal `github scan` install left a KeepAlive
+      // launchd job pointing at a dead binary path — a crash-loop that also
+      // squats port 7878. Retire it on every start (idempotent, darwin-only,
+      // never throws) BEFORE the switch-block / credentials gates so even a
+      // logged-out machine self-heals on the first run of the new version.
+      const legacyCleanup = retireLegacyGithubScanRunner();
+      if (legacyCleanup.retiredLabels.length > 0 || legacyCleanup.removedPlists.length > 0) {
+        writeStatus(
+          "•",
+          `retired stranded legacy github-scan launchd runner (${[
+            ...legacyCleanup.retiredLabels.map((label) => `booted out ${label}`),
+            ...legacyCleanup.removedPlists.map((path) => `removed ${path}`),
+          ].join(", ")})`,
+        );
+      }
+      for (const warning of legacyCleanup.warnings) {
+        writeStatus("⚠️", `legacy github-scan cleanup: ${warning}`);
       }
       const switchBlock = getClientSwitchStartupBlock();
       if (switchBlock) {

--- a/apps/cli/src/commands/upgrade.ts
+++ b/apps/cli/src/commands/upgrade.ts
@@ -14,6 +14,7 @@ import {
   installPortableSpec,
   isServiceSupported,
   restartClientService,
+  retireLegacyGithubScanRunner,
 } from "../core/index.js";
 import { getChannelInstallCommand } from "../core/install-guidance.js";
 import { print } from "../core/output.js";
@@ -115,6 +116,23 @@ export function registerUpgradeCommand(program: Command): void {
       }
       const installed = installRes.installedVersion ?? target.version;
       print.line(`  Installed ${installed}.\n`);
+
+      // Issue #995: upgrades used to strand the legacy `github scan` launchd
+      // runner — a KeepAlive job pinned to a now-dead binary path that
+      // crash-loops and squats port 7878. Retire it as part of every upgrade,
+      // before any restart branching, so the cleanup runs even under
+      // `--no-restart` or when no background service is installed.
+      // Idempotent, darwin-only, never throws.
+      const legacyCleanup = retireLegacyGithubScanRunner();
+      for (const label of legacyCleanup.retiredLabels) {
+        print.line(`  Retired stranded legacy github-scan launchd service: ${label}\n`);
+      }
+      for (const path of legacyCleanup.removedPlists) {
+        print.line(`  Removed legacy github-scan plist: ${path}\n`);
+      }
+      for (const warning of legacyCleanup.warnings) {
+        print.line(`  warning: legacy github-scan cleanup: ${warning}\n`);
+      }
 
       // Restart the service so the new binary actually starts handling
       // connections. Skipped under --no-restart so power users can stage

--- a/apps/cli/src/core/index.ts
+++ b/apps/cli/src/core/index.ts
@@ -144,6 +144,14 @@ export type { InstallClaudeResult } from "./install-claude-runtime.js";
 export { installClaudeRuntime } from "./install-claude-runtime.js";
 export type { InstallCodexResult } from "./install-codex-runtime.js";
 export { installCodexRuntime } from "./install-codex-runtime.js";
+// Issue #995 — retires the stranded legacy github-scan launchd runner on
+// upgrade / first daemon start of a new version.
+export type { LegacyGithubScanCleanup } from "./legacy-github-scan-cleanup.js";
+export {
+  LEGACY_GITHUB_SCAN_LABEL_PREFIX,
+  legacyGithubScanLaunchdDir,
+  retireLegacyGithubScanRunner,
+} from "./legacy-github-scan-cleanup.js";
 export {
   type MemberOrganizationProfile,
   type MemberOrganizationResolutionCode,

--- a/apps/cli/src/core/legacy-github-scan-cleanup.ts
+++ b/apps/cli/src/core/legacy-github-scan-cleanup.ts
@@ -33,6 +33,16 @@ import { runCapture, runCaptureOut } from "./supervisor/shared.js";
 export const LEGACY_GITHUB_SCAN_LABEL_PREFIX = "com.first-tree.github-scan.runner.";
 
 /**
+ * "This job is not loaded" answers from `launchctl bootout` — the expected
+ * idempotent case, not an error. Matched both by message ("Could not find
+ * specified service", "No such process") and by the stable launchd error
+ * codes launchctl prints in `Boot-out failed: <code>:` form (3 = ESRCH,
+ * 113 = could-not-find-service), so detection does not hinge on exact
+ * wording.
+ */
+const BOOTOUT_NOT_LOADED_RE = /not find|no such|not loaded|failed: (?:3|113):/i;
+
+/**
  * `~/.first-tree/github-scan/runner/launchd` — matches the retired runner's
  * `resolveRunnerHome()` default. Deliberately based on `homedir()`, not the
  * channel home: the legacy runner predates multi-channel and only ever wrote
@@ -113,7 +123,7 @@ export function retireLegacyGithubScanRunner(): LegacyGithubScanCleanup {
     const bootout = runCapture("launchctl", ["bootout", `${domain}/${label}`], 15_000);
     if (bootout.ok) {
       result.retiredLabels.push(label);
-    } else if (!/not find|no such|not loaded/i.test(bootout.stderr)) {
+    } else if (!BOOTOUT_NOT_LOADED_RE.test(bootout.stderr)) {
       result.warnings.push(
         `launchctl bootout ${domain}/${label}: ${bootout.stderr || `exit ${bootout.code ?? "unknown"}`}`,
       );

--- a/apps/cli/src/core/legacy-github-scan-cleanup.ts
+++ b/apps/cli/src/core/legacy-github-scan-cleanup.ts
@@ -1,0 +1,144 @@
+import { existsSync, readdirSync, rmdirSync, rmSync } from "node:fs";
+import { homedir, userInfo } from "node:os";
+import { join } from "node:path";
+import { runCapture, runCaptureOut } from "./supervisor/shared.js";
+
+/**
+ * One-shot retirement of the legacy GitHub Scan launchd runner (issue #995).
+ *
+ * The retired `github scan` subsystem bootstrapped a per-user launchd job
+ * labelled `com.first-tree.github-scan.runner.<login>.<profile>` whose plist
+ * lived under `~/.first-tree/github-scan/runner/launchd/` (a pre-multi-channel
+ * hardcoded path — NOT `defaultHome()`), with `KeepAlive: true` and an
+ * absolute node/CLI path baked into `ProgramArguments`. When an upgrade
+ * removed the subsystem or relocated the binary, launchd kept restarting the
+ * dead path: a KeepAlive crash-loop that also squatted the legacy default
+ * HTTP port (7878).
+ *
+ * This module detects that stranded state and remediates it:
+ *   1. plists on disk under the legacy launchd dir, and
+ *   2. labels still loaded in the gui domain (covers a zombie whose plist was
+ *      already deleted by hand — the old `stop` never removed plists, but an
+ *      operator may have),
+ * then `launchctl bootout`s each label and deletes its plist.
+ *
+ * The label prefix is exclusively owned by the retired subsystem — no current
+ * channel (`first-tree` / `first-tree-staging` / `first-tree-dev`) or peer
+ * install ever uses it — so booting these labels out can never take down a
+ * live service. The operation is naturally idempotent (nothing found → no-op)
+ * and best-effort: it never throws, so it can never block `upgrade` or
+ * `daemon start`.
+ */
+
+export const LEGACY_GITHUB_SCAN_LABEL_PREFIX = "com.first-tree.github-scan.runner.";
+
+/**
+ * `~/.first-tree/github-scan/runner/launchd` — matches the retired runner's
+ * `resolveRunnerHome()` default. Deliberately based on `homedir()`, not the
+ * channel home: the legacy runner predates multi-channel and only ever wrote
+ * here, so every channel's cleanup must look at the same location.
+ */
+export function legacyGithubScanLaunchdDir(): string {
+  return join(homedir(), ".first-tree", "github-scan", "runner", "launchd");
+}
+
+export type LegacyGithubScanCleanup = {
+  /** False when the platform has no launchd (nothing to check). */
+  checked: boolean;
+  /** Labels successfully booted out of the gui domain. */
+  retiredLabels: string[];
+  /** Plist files removed from the legacy launchd dir. */
+  removedPlists: string[];
+  /** Non-fatal problems encountered (cleanup continues past each). */
+  warnings: string[];
+};
+
+function emptyResult(checked: boolean): LegacyGithubScanCleanup {
+  return { checked, retiredLabels: [], removedPlists: [], warnings: [] };
+}
+
+function legacyPlistFiles(dir: string, warnings: string[]): string[] {
+  if (!existsSync(dir)) return [];
+  try {
+    return readdirSync(dir).filter(
+      (name) => name.startsWith(LEGACY_GITHUB_SCAN_LABEL_PREFIX) && name.endsWith(".plist"),
+    );
+  } catch (err) {
+    warnings.push(`could not read ${dir}: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
+/**
+ * Labels currently loaded in the gui domain that belong to the legacy runner.
+ * `launchctl list` prints one `PID\tStatus\tLabel` row per job; the label is
+ * the last tab-separated column. A failed/timed-out query degrades to "none
+ * found" with a warning — the on-disk plist sweep still runs.
+ */
+function loadedLegacyLabels(warnings: string[]): string[] {
+  const res = runCaptureOut("launchctl", ["list"], 10_000);
+  if (!res.ok) {
+    warnings.push(`launchctl list failed: ${res.stderr || `exit ${res.code ?? "unknown"}`}`);
+    return [];
+  }
+  const labels: string[] = [];
+  for (const line of res.stdout.split(/\r?\n/)) {
+    const label = line.split("\t").at(-1)?.trim();
+    if (label?.startsWith(LEGACY_GITHUB_SCAN_LABEL_PREFIX)) labels.push(label);
+  }
+  return labels;
+}
+
+/**
+ * Detect and retire any stranded legacy github-scan launchd runner.
+ *
+ * Safe to call repeatedly and from any command path; returns a summary the
+ * caller may surface to the operator. Never throws.
+ */
+export function retireLegacyGithubScanRunner(): LegacyGithubScanCleanup {
+  if (process.platform !== "darwin") return emptyResult(false);
+
+  const result = emptyResult(true);
+  const dir = legacyGithubScanLaunchdDir();
+  const plistFiles = legacyPlistFiles(dir, result.warnings);
+
+  const labels = new Set<string>(loadedLegacyLabels(result.warnings));
+  for (const file of plistFiles) labels.add(file.slice(0, -".plist".length));
+  if (labels.size === 0 && plistFiles.length === 0) return result;
+
+  const domain = `gui/${userInfo().uid}`;
+  for (const label of [...labels].sort()) {
+    // Generous timeout: tearing down a live (even crash-looping) job can take
+    // a few seconds. "Not loaded" answers are the expected idempotent case.
+    const bootout = runCapture("launchctl", ["bootout", `${domain}/${label}`], 15_000);
+    if (bootout.ok) {
+      result.retiredLabels.push(label);
+    } else if (!/not find|no such|not loaded/i.test(bootout.stderr)) {
+      result.warnings.push(
+        `launchctl bootout ${domain}/${label}: ${bootout.stderr || `exit ${bootout.code ?? "unknown"}`}`,
+      );
+    }
+  }
+
+  for (const file of plistFiles) {
+    const path = join(dir, file);
+    try {
+      rmSync(path);
+      result.removedPlists.push(path);
+    } catch (err) {
+      result.warnings.push(`could not remove ${path}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // Leave the rest of `~/.first-tree/github-scan/` (config.yaml, logs, repos)
+  // alone — user-owned data is out of scope. Only fold away the now-empty
+  // launchd dir; rmdirSync refuses non-empty dirs, which is exactly what we
+  // want for anything unexpected left inside.
+  try {
+    rmdirSync(dir);
+  } catch {
+    // Missing or non-empty — either way, nothing to do.
+  }
+
+  return result;
+}


### PR DESCRIPTION
Fixes #995 — GoF competition entry (Fable). **Draft by design; submission is signalled via labels (`fire_wip` → `fire_submitted`), not by marking ready.**

## Problem

Installs that ever ran the pre-#775 `github scan` subsystem have a per-user launchd job stranded on disk:

- Label `com.first-tree.github-scan.runner.<login>.<profile>`, plist under `~/.first-tree/github-scan/runner/launchd/` (a pre-multi-channel hardcoded path).
- `KeepAlive: true` with an **absolute** node/CLI path baked into `ProgramArguments`.

When an upgrade removed the subsystem (or relocated the binary), launchd kept restarting the dead path forever: a KeepAlive crash-loop that spams the system log and squats the legacy default HTTP port **7878**. Nothing in the current CLI ever cleaned it up.

## Solution

New core module `apps/cli/src/core/legacy-github-scan-cleanup.ts` exposing `retireLegacyGithubScanRunner()`:

1. **Detect** stranded state from two sources, unioned:
   - plist files matching the legacy label prefix in the legacy launchd dir, and
   - labels still loaded in the gui domain via `launchctl list` (catches a zombie whose plist was already hand-deleted).
2. **Remediate**: `launchctl bootout gui/<uid>/<label>` for each label (a "not loaded / could not find service" answer is the expected idempotent case, not an error), delete the matching plists, then fold away the launchd dir **only if empty** (`rmdirSync` refuses non-empty dirs, so anything unexpected is preserved). The rest of `~/.first-tree/github-scan/` (config, logs, repos) is user data and is left alone.

Properties: **darwin-only**, **idempotent** (nothing found → single `launchctl list` and done), **never throws** (all failures degrade to warnings in the returned summary), and **cannot touch a live service** — the label prefix is exclusively owned by the retired subsystem; no current channel (`first-tree` / `first-tree-staging` / `first-tree-dev`) uses it.

### Hook points

- **`first-tree upgrade`** — after a successful install, *before* any restart branching, so cleanup also runs under `--no-restart` and when no background service is installed. Retired labels / removed plists / warnings are printed.
- **`first-tree daemon start`** — right after daemon.env loading, *before* the switch-block and credentials gates, so even a logged-out machine self-heals on the first run of the new version ("first run" coverage from the issue scope). Covers the supervisor child, foreground mode, and the delegating parent alike.

Deliberately **not** hooked into `installLaunchd()` / `installClientService()`: those paths assert exact `launchctl` call sequences (see `service-install-core.test.ts`) and already have a documented stance that legacy-label cleanup does not belong inside install; command-level hooks keep the blast radius to exactly the two entry points named in the issue.

## Impact / risk

- macOS only; on other platforms the function returns immediately (`checked: false`).
- Worst case on a healthy machine: one extra `launchctl list` (10 s cap) per `upgrade` / `daemon start`.
- Bootout failures never block the command — they surface as warnings and the plist sweep still runs, so the crash-loop stops even when `bootout` is denied.
- No lockfile, config, or migration changes; diff is scoped to `apps/cli`.

## Verification

- New unit tests `apps/cli/src/__tests__/legacy-github-scan-cleanup.test.ts` (10 cases): non-darwin no-op, healthy no-op, bootout+plist removal with foreign files preserved, empty-dir folding + idempotent re-run, plistless zombie, not-loaded-as-success, unexpected bootout failure → warning + sweep continues, `launchctl list` failure → warning + on-disk sweep continues, loaded-only + plist-only label union in one pass, multi-profile deterministic order.
- Existing suites updated only where they fully mock `core/index.js` (mock stub added in 3 test files) plus one new assertion that a successful `upgrade --no-restart` invokes the cleanup.
- Gates run locally in the task worktree:
  - `biome check` clean on all touched files (repo-wide pre-existing diagnostics in `packages/web` / `cron` commands untouched).
  - `tsc --noEmit` for `apps/cli`: no errors in any touched file (one pre-existing, environment-specific pino typing error in `packages/client` reproduces identically on clean `origin/main`).
  - `vitest`: 117 files / 1355 tests pass including all touched suites; the only failing files (`client-switch-transaction-extra`, `update-detect-install-mode`, `core-attention-update-extra`, `tree-init-command-extra`) fail **identically on clean `origin/main`** in this environment (live First Tree daemon on the host + `FIRST_TREE_INSTALL_MODE` set in the agent env), i.e. pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
