### PR TITLE
feat(web): move owner controls into Setup

### DIFF
--- a/packages/web/src/api/__tests__/context-reviewer-settings.test.ts
+++ b/packages/web/src/api/__tests__/context-reviewer-settings.test.ts
@@ -1,0 +1,70 @@
+import { contextReviewerCandidatesOutputSchema, orgContextTreeFeaturesOutputSchema } from "@first-tree/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../client.js";
+import {
+  getContextReviewerCandidates,
+  putContextReviewerAssignment,
+  putContextReviewerEnablement,
+} from "../context-reviewer-settings.js";
+
+vi.mock("../client.js", () => ({
+  api: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+const candidates = contextReviewerCandidatesOutputSchema.parse({
+  items: [
+    {
+      uuid: "agent-1",
+      name: "reviewer",
+      displayName: "Context Reviewer",
+      visibility: "organization",
+      runtime: { health: "degraded", blockers: [] },
+    },
+  ],
+  blockers: [],
+});
+
+const features = orgContextTreeFeaturesOutputSchema.parse({
+  contextReviewer: {
+    enabled: false,
+    agentUuid: "agent-1",
+    reviewerAgent: {
+      uuid: "agent-1",
+      name: "reviewer",
+      displayName: "Context Reviewer",
+    },
+  },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(api.get).mockResolvedValue(candidates);
+  vi.mocked(api.put).mockResolvedValue(features);
+});
+
+describe("Context Reviewer owner API", () => {
+  it("encodes the Team and parses eligible candidates", async () => {
+    await expect(getContextReviewerCandidates("org/one")).resolves.toEqual(candidates);
+    expect(api.get).toHaveBeenCalledWith("/orgs/org%2Fone/context-reviewer/candidates");
+  });
+
+  it("keeps assignment and enablement as separate writes", async () => {
+    await expect(putContextReviewerAssignment("org/one", "agent-1")).resolves.toEqual(features);
+    await expect(putContextReviewerEnablement("org/one", true)).resolves.toEqual(features);
+
+    expect(api.put).toHaveBeenNthCalledWith(1, "/orgs/org%2Fone/context-reviewer/assignment", {
+      agentUuid: "agent-1",
+    });
+    expect(api.put).toHaveBeenNthCalledWith(2, "/orgs/org%2Fone/context-reviewer/enablement", {
+      enabled: true,
+    });
+  });
+
+  it("rejects malformed Server responses", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({ items: [{ uuid: "private-agent" }], blockers: [] });
+    await expect(getContextReviewerCandidates("org-1")).rejects.toThrow();
+  });
+});

--- a/packages/web/src/api/context-reviewer-settings.ts
+++ b/packages/web/src/api/context-reviewer-settings.ts
@@ -1,0 +1,33 @@
+import {
+  type ContextReviewerCandidatesOutput,
+  contextReviewerCandidatesOutputSchema,
+  type OrgContextTreeFeaturesOutput,
+  orgContextTreeFeaturesOutputSchema,
+} from "@first-tree/shared";
+import { api } from "./client.js";
+
+function path(organizationId: string, operation: string): string {
+  return `/orgs/${encodeURIComponent(organizationId)}/context-reviewer/${operation}`;
+}
+
+export async function getContextReviewerCandidates(organizationId: string): Promise<ContextReviewerCandidatesOutput> {
+  return contextReviewerCandidatesOutputSchema.parse(await api.get<unknown>(path(organizationId, "candidates")));
+}
+
+export async function putContextReviewerAssignment(
+  organizationId: string,
+  agentUuid: string | null,
+): Promise<OrgContextTreeFeaturesOutput> {
+  return orgContextTreeFeaturesOutputSchema.parse(
+    await api.put<unknown>(path(organizationId, "assignment"), { agentUuid }),
+  );
+}
+
+export async function putContextReviewerEnablement(
+  organizationId: string,
+  enabled: boolean,
+): Promise<OrgContextTreeFeaturesOutput> {
+  return orgContextTreeFeaturesOutputSchema.parse(
+    await api.put<unknown>(path(organizationId, "enablement"), { enabled }),
+  );
+}

--- a/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
+++ b/packages/web/src/pages/__tests__/page-ssr-smoke.test.tsx
@@ -960,14 +960,14 @@ describe("page SSR smoke coverage", () => {
     expect(renderPage(<SettingsGithubPage />)).toContain("GitHub");
     const repositories = renderPage(<SettingsRepositoriesPage />, "/settings/repositories");
     expect(repositories).toContain("Code repositories");
-    expect(repositories).toContain("Context Tree");
+    expect(repositories).not.toContain("Context Tree");
     expect(renderPage(<SettingsResourcesPage />)).toContain("Loading");
 
     authMock.value = { ...authMock.value, role: "member" };
     // Settings GitHub, Repositories, and Resources stay visible (read-only)
     // for members.
     expect(renderPage(<SettingsGithubPage />)).toContain("GitHub");
-    expect(renderPage(<SettingsRepositoriesPage />, "/settings/repositories")).toContain("Context Tree");
+    expect(renderPage(<SettingsRepositoriesPage />, "/settings/repositories")).not.toContain("Context Tree");
     expect(renderPage(<SettingsResourcesPage />)).toContain("Loading");
 
     authMock.value = { ...authMock.value, role: null };

--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -235,6 +235,22 @@ describe("extra preview pages", () => {
 
     expect(rendered.container.querySelector('[data-setup-preview="admin-ready"]')).not.toBeNull();
     expect(text(rendered.container)).toContain("Context Tree");
+    const treeRow = rendered.container.querySelector<HTMLElement>('[data-setup-row="context-tree"]');
+    if (!treeRow) throw new Error("Missing Context Tree row");
+    await click(buttonByText(treeRow, "Manage"));
+    expect(treeRow.querySelector('[data-setup-owner-controls="context-tree"]')).not.toBeNull();
+
+    const reviewRow = rendered.container.querySelector<HTMLElement>('[data-setup-row="automatic-review"]');
+    if (!reviewRow) throw new Error("Missing Automatic Review row");
+    await click(buttonByText(reviewRow, "Manage"));
+    expect(reviewRow.querySelector('[data-setup-owner-controls="automatic-review"]')).not.toBeNull();
+    expect(rendered.container.querySelector('[data-setup-owner-controls="context-tree"]')).toBeNull();
+    expect(text(reviewRow)).toContain("Context Reviewer");
+    const enablement = reviewRow.querySelector<HTMLButtonElement>('[role="switch"]');
+    expect(enablement?.getAttribute("aria-checked")).toBe("true");
+    if (!enablement) throw new Error("Missing preview Reviewer enablement switch");
+    await click(enablement);
+    expect(enablement.getAttribute("aria-checked")).toBe("false");
     expect(globalThis.fetch).not.toHaveBeenCalled();
 
     await cleanupRendered(rendered);

--- a/packages/web/src/pages/settings.tsx
+++ b/packages/web/src/pages/settings.tsx
@@ -47,7 +47,7 @@ const COMPUTERS_ITEM: Item = { to: "/settings/computers", label: "Computers" };
 const REPOSITORIES_ITEM: Item = {
   to: "/settings/repositories",
   label: "Repositories",
-  description: "Manage code available to agents and the repository backing your team's Context Tree.",
+  description: "Manage the Team code repositories available to agents.",
 };
 const RESOURCES_ITEM: Item = {
   to: "/settings/resources",

--- a/packages/web/src/pages/settings/__tests__/repositories-page-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/repositories-page-dom.test.tsx
@@ -2,7 +2,7 @@
 
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -11,15 +11,6 @@ const authMock = vi.hoisted(() => ({ role: "admin" as "admin" | "member" | null 
 
 vi.mock("../../../auth/auth-context.js", () => ({
   useAuth: () => ({ role: authMock.role }),
-}));
-
-vi.mock("../../context-tree-settings-panel.js", () => ({
-  ContextTreeSettingsPanel: () => (
-    <section data-testid="context-tree-panel">
-      <h2>Context Tree</h2>
-      <div>Context Tree rows</div>
-    </section>
-  ),
 }));
 
 vi.mock("../resource-sections.js", () => ({
@@ -55,11 +46,19 @@ async function renderPage(path = "/settings/repositories"): Promise<{ container:
   await act(async () => {
     root.render(
       <MemoryRouter initialEntries={[path]}>
-        <SettingsRepositoriesPage />
+        <Routes>
+          <Route path="/settings/repositories" element={<SettingsRepositoriesPage />} />
+          <Route path="/settings/setup" element={<LocationProbe />} />
+        </Routes>
       </MemoryRouter>,
     );
   });
   return { container, root };
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-location={`${location.pathname}${location.hash}`} />;
 }
 
 beforeEach(() => {
@@ -76,7 +75,7 @@ afterEach(() => {
 });
 
 describe("SettingsRepositoriesPage", () => {
-  it("composes the two repository models with only two visible section headings", async () => {
+  it("renders only the Team code repository catalog", async () => {
     const { container, root } = await renderPage();
     const resources = container.querySelector<HTMLElement>('[data-testid="resource-sections"]');
 
@@ -88,28 +87,35 @@ describe("SettingsRepositoriesPage", () => {
     expect(resources?.textContent).toContain("Git credentials on each agent computer");
 
     const headings = [...container.querySelectorAll("h2")].map((heading) => heading.textContent);
-    expect(headings).toEqual(["Code repositories", "Context Tree"]);
+    expect(headings).toEqual(["Code repositories"]);
     expect(container.querySelector("h1")).toBeNull();
-    expect((container.textContent ?? "").indexOf("Code repositories")).toBeLessThan(
-      (container.textContent ?? "").indexOf("Context Tree"),
-    );
+    expect(container.textContent).not.toContain("Context Tree rows");
+    expect(container.textContent).not.toContain("Automatic PR review");
+    expect(container.textContent).not.toContain("Automatic MR review");
     expect(scrollIntoView).not.toHaveBeenCalled();
     await act(async () => root.unmount());
   });
 
-  it.each([
-    ["#code-repositories", "Code repositories"],
-    ["#context-tree", "Context Tree"],
-  ])("positions and focuses %s", async (hash, label) => {
-    const { container, root } = await renderPage(`/settings/repositories${hash}`);
-    const target = container.querySelector<HTMLElement>(hash);
+  it("positions and focuses the code catalog anchor", async () => {
+    const { container, root } = await renderPage("/settings/repositories#code-repositories");
+    const target = container.querySelector<HTMLElement>("#code-repositories");
 
     expect(target?.tagName).toBe("SECTION");
-    expect(target?.getAttribute("aria-label")).toBe(label);
+    expect(target?.getAttribute("aria-label")).toBe("Code repositories");
     expect(target?.tabIndex).toBe(-1);
     expect(scrollIntoView).toHaveBeenCalledOnce();
     expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
     expect(document.activeElement).toBe(target);
+    await act(async () => root.unmount());
+  });
+
+  it("redirects the retired Context Tree anchor to canonical Setup controls", async () => {
+    const { container, root } = await renderPage("/settings/repositories#context-tree");
+
+    expect(container.querySelector("[data-location]")?.getAttribute("data-location")).toBe(
+      "/settings/setup#context-tree",
+    );
+    expect(container.querySelector('[data-testid="resource-sections"]')).toBeNull();
     await act(async () => root.unmount());
   });
 

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -13,7 +13,16 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 const activityMocks = vi.hoisted(() => ({ listClients: vi.fn() }));
 const contextTreeMocks = vi.hoisted(() => ({ getContextTreeSnapshot: vi.fn() }));
 const onboardingEventMocks = vi.hoisted(() => ({ reportOnboardingEvent: vi.fn() }));
+const orgSettingsMocks = vi.hoisted(() => ({
+  getRawContextTreeSetting: vi.fn(),
+  putContextTreeSetting: vi.fn(),
+}));
 const resourceMocks = vi.hoisted(() => ({ listTeamResourcesForOrg: vi.fn() }));
+const reviewerMocks = vi.hoisted(() => ({
+  getContextReviewerCandidates: vi.fn(),
+  putContextReviewerAssignment: vi.fn(),
+  putContextReviewerEnablement: vi.fn(),
+}));
 const setupCapabilityMocks = vi.hoisted(() => ({ getTeamSetupCapabilitiesAt: vi.fn() }));
 const authMock = vi.hoisted(() => ({
   value: {
@@ -32,7 +41,9 @@ const authMock = vi.hoisted(() => ({
 
 vi.mock("../../../api/activity.js", () => activityMocks);
 vi.mock("../../../api/context-tree.js", () => contextTreeMocks);
+vi.mock("../../../api/context-reviewer-settings.js", () => reviewerMocks);
 vi.mock("../../../api/onboarding-events.js", () => onboardingEventMocks);
+vi.mock("../../../api/org-settings.js", () => orgSettingsMocks);
 vi.mock("../../../api/resources.js", () => resourceMocks);
 vi.mock("../../../api/setup-capabilities.js", () => ({
   ...setupCapabilityMocks,
@@ -149,7 +160,7 @@ async function flush(): Promise<void> {
   });
 }
 
-async function renderSettingsSetupPage() {
+async function renderSettingsSetupPage(initialEntry = "/") {
   const host = document.createElement("div");
   document.body.append(host);
   const root = createRoot(host);
@@ -158,7 +169,7 @@ async function renderSettingsSetupPage() {
   });
   await act(async () => {
     root.render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <QueryClientProvider client={queryClient}>
           <SettingsSetupPage />
           <LocationProbe />
@@ -190,10 +201,56 @@ async function waitForRowText(
   throw new Error(`Expected ${key} row to include "${expected}"`);
 }
 
+async function waitForSelector<T extends Element>(host: ParentNode, selector: string, timeoutMs = 3000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const element = host.querySelector<T>(selector);
+    if (element) return element;
+    await flush();
+  }
+  throw new Error(`Expected selector "${selector}"`);
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   activityMocks.listClients.mockResolvedValue([]);
   resourceMocks.listTeamResourcesForOrg.mockResolvedValue([]);
+  orgSettingsMocks.getRawContextTreeSetting.mockResolvedValue({
+    repo: "https://github.com/acme/context-tree.git",
+    branch: "main",
+    provider: "github",
+  });
+  orgSettingsMocks.putContextTreeSetting.mockResolvedValue({
+    repo: "https://github.com/acme/context-tree.git",
+    branch: "release",
+    provider: "github",
+  });
+  reviewerMocks.getContextReviewerCandidates.mockResolvedValue({
+    items: [
+      {
+        uuid: "reviewer-1",
+        name: "context-reviewer",
+        displayName: "Context Reviewer",
+        visibility: "organization",
+        runtime: { health: "ready", blockers: [] },
+      },
+    ],
+    blockers: [],
+  });
+  reviewerMocks.putContextReviewerAssignment.mockResolvedValue({
+    contextReviewer: {
+      enabled: false,
+      agentUuid: "reviewer-1",
+      reviewerAgent: { uuid: "reviewer-1", name: "context-reviewer", displayName: "Context Reviewer" },
+    },
+  });
+  reviewerMocks.putContextReviewerEnablement.mockResolvedValue({
+    contextReviewer: {
+      enabled: true,
+      agentUuid: "reviewer-1",
+      reviewerAgent: { uuid: "reviewer-1", name: "context-reviewer", displayName: "Context Reviewer" },
+    },
+  });
   setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(capabilityFixture());
   contextTreeMocks.getContextTreeSnapshot.mockResolvedValue({
     snapshotStatus: "active",
@@ -278,8 +335,8 @@ describe("Settings Setup overview", () => {
       ["agent", "attention", "circle-alert", "--state-needs-you"],
       ["repositories", "unknown", "circle-question-mark", "--fg-3"],
       ["repository-automation", "pending", "clock-3", "--state-idle"],
-      ["context-tree", "neutral", "circle-alert", "--fg-3"],
-      ["automatic-review", "neutral", "circle-alert", "--fg-3"],
+      ["context-tree", "pending", "clock-3", "--state-idle"],
+      ["automatic-review", "blocked", "circle-alert", "--state-blocked"],
     ] as const;
 
     for (const [key, kind, glyph, token] of expectation) {
@@ -401,7 +458,7 @@ describe("Settings Setup overview", () => {
         },
       }),
       "Degraded",
-      "neutral",
+      "blocked",
     ],
   ] as const)("summarizes %s repository automation coverage", (_name, capabilities, label, kind) => {
     const row = rowFor("repository-automation", facts({ capabilities: { state: "ready", value: capabilities } }));
@@ -471,17 +528,17 @@ describe("Settings Setup overview", () => {
     const adminFacts = facts({ role: "admin", capabilities: { state: "ready", value: capabilities } });
     const memberFacts = facts({ role: "member", capabilities: { state: "ready", value: capabilities } });
 
-    for (const key of ["repository-automation", "automatic-review"] as const) {
-      expect(rowFor(key, adminFacts).action).toEqual({
-        label: "Set up GitLab",
-        to: "/settings/integrations/gitlab",
-      });
-    }
-    expect(rowFor("repository-automation", memberFacts).action).toBeUndefined();
-    expect(rowFor("automatic-review", memberFacts).action).toEqual({
-      label: "View",
-      to: "/settings/repositories#context-tree",
+    expect(rowFor("repository-automation", adminFacts).action).toEqual({
+      label: "Set up GitLab",
+      to: "/settings/integrations/gitlab",
     });
+    expect(rowFor("automatic-review", adminFacts).action).toEqual({
+      label: "Manage",
+      to: "/settings/setup#automatic-review",
+      intent: "open-reviewer-controls",
+    });
+    expect(rowFor("repository-automation", memberFacts).action).toBeUndefined();
+    expect(rowFor("automatic-review", memberFacts).action).toBeUndefined();
   });
 
   it("turns the same Team blocker into admin attention and member read-only explanation", () => {
@@ -509,7 +566,7 @@ describe("Settings Setup overview", () => {
 
     expect(admin.status).toMatchObject({ label: "Needs attention", kind: "attention" });
     expect(admin.action).toEqual({ label: "Manage GitHub", to: "/settings/integrations/github" });
-    expect(member.status).toMatchObject({ label: "Service unavailable", kind: "neutral" });
+    expect(member.status).toMatchObject({ label: "Service unavailable", kind: "blocked" });
     expect(member.status.detail).toContain("Ask an admin");
     expect(member.action).toBeUndefined();
   });
@@ -524,14 +581,14 @@ describe("Settings Setup overview", () => {
     });
     const row = rowFor("repository-automation", facts({ capabilities: { state: "ready", value: shared } }));
 
-    expect(row.status).toMatchObject({ label: "Service unavailable", kind: "neutral" });
+    expect(row.status).toMatchObject({ label: "Service unavailable", kind: "blocked" });
     expect(row.status.detail).toContain("deployment");
     expect(row.action).toBeUndefined();
   });
 
   it.each([
     ["active", "Available", "ready", "Manage"],
-    ["stale", "Available · update delayed", "neutral", "Manage"],
+    ["stale", "Available · update delayed", "pending", "Manage"],
     ["unavailable", "Needs recovery", "attention", "Recover"],
   ] as const)("maps bound Context Tree snapshot %s without equating binding to health", (value, label, kind, action) => {
     const row = rowFor("context-tree", facts({ contextTreeSnapshot: { state: "ready", value } }));
@@ -589,13 +646,21 @@ describe("Settings Setup overview", () => {
     );
 
     expect(unbound.status).toEqual({ label: "Not set up", detail: "Optional", kind: "optional" });
-    expect(unbound.action).toEqual({ label: "Set up", to: "/context" });
+    expect(unbound.action).toEqual({
+      label: "Set up",
+      to: "/settings/setup#context-tree",
+      intent: "open-context-tree-controls",
+    });
     expect(unboundMember.status).toMatchObject({ label: "Not set up", kind: "optional" });
     expect(unboundMember.status.detail).toContain("Ask an admin");
     expect(unboundMember.action).toBeUndefined();
     expect(invalidAdmin.status).toMatchObject({ label: "Needs repair", kind: "attention" });
-    expect(invalidAdmin.action).toEqual({ label: "Repair", to: "/settings/repositories#context-tree" });
-    expect(invalidMember.status).toMatchObject({ label: "Unavailable", kind: "neutral" });
+    expect(invalidAdmin.action).toEqual({
+      label: "Repair",
+      to: "/settings/setup#context-tree",
+      intent: "open-context-tree-controls",
+    });
+    expect(invalidMember.status).toMatchObject({ label: "Unavailable", kind: "blocked" });
     expect(invalidMember.status.detail).toContain("Ask an admin");
     expect(invalidMember.action).toEqual({ label: "View", to: "/context" });
   });
@@ -609,7 +674,7 @@ describe("Settings Setup overview", () => {
       }),
     );
 
-    expect(row.status).toMatchObject({ label: "Unavailable", kind: "neutral" });
+    expect(row.status).toMatchObject({ label: "Unavailable", kind: "blocked" });
     expect(row.status.detail).toContain("Ask an admin to recover");
     expect(row.action).toEqual({ label: "View", to: "/context" });
   });
@@ -618,7 +683,11 @@ describe("Settings Setup overview", () => {
     const row = rowFor("context-tree", facts({ contextTreeSnapshot: { state: "error" } }));
 
     expect(row.status).toMatchObject({ label: "Status unknown", kind: "unknown" });
-    expect(row.action).toEqual({ label: "Manage", to: "/settings/repositories#context-tree" });
+    expect(row.action).toEqual({
+      label: "Manage",
+      to: "/settings/setup#context-tree",
+      intent: "open-context-tree-controls",
+    });
   });
 
   it.each([
@@ -653,7 +722,7 @@ describe("Settings Setup overview", () => {
       }),
       "Verification pending",
       "pending",
-      undefined,
+      "Manage",
     ],
     [
       "degraded",
@@ -672,7 +741,7 @@ describe("Settings Setup overview", () => {
       }),
       "Degraded",
       "attention",
-      "Set up GitLab",
+      "Manage",
     ],
   ] as const)("maps Automatic review %s without making it a Start Chat gate", (_name, capabilities, label, kind, action) => {
     const input = facts({ capabilities: { state: "ready", value: capabilities } });
@@ -705,10 +774,76 @@ describe("Settings Setup overview", () => {
     );
 
     expect(admin.status).toMatchObject({ label: "Needs attention", kind: "attention" });
-    expect(admin.action).toEqual({ label: "Replace reviewer", to: "/settings/repositories#context-tree" });
-    expect(member.status).toMatchObject({ label: "Service unavailable", kind: "neutral" });
+    expect(admin.action).toEqual({
+      label: "Manage",
+      to: "/settings/setup#automatic-review",
+      intent: "open-reviewer-controls",
+    });
+    expect(member.status).toMatchObject({ label: "Service unavailable", kind: "blocked" });
     expect(member.status.detail).toContain("Ask an admin");
-    expect(member.action).toEqual({ label: "View", to: "/settings/repositories#context-tree" });
+    expect(member.action).toBeUndefined();
+  });
+
+  it("shows a retained Reviewer selection while Automatic Review is off", () => {
+    const row = rowFor(
+      "automatic-review",
+      facts({
+        capabilities: {
+          state: "ready",
+          value: capabilityFixture({
+            review: {
+              adoption: "disabled",
+              health: "not_observed",
+              reviewerAgent: { uuid: "reviewer-1", displayName: "Context Reviewer" },
+            },
+          }),
+        },
+      }),
+    );
+
+    expect(row.status).toEqual({
+      label: "Off",
+      detail: "Reviewer · Context Reviewer · Optional",
+      kind: "optional",
+    });
+    expect(row.action).toEqual({
+      label: "Manage",
+      to: "/settings/setup#automatic-review",
+      intent: "open-reviewer-controls",
+    });
+  });
+
+  it("preserves degraded Server facts and inline recovery controls while Automatic Review is off", () => {
+    const row = rowFor(
+      "automatic-review",
+      facts({
+        capabilities: {
+          state: "ready",
+          value: capabilityFixture({
+            review: {
+              adoption: "disabled",
+              health: "degraded",
+              reviewerAgent: { uuid: "reviewer-1", displayName: "Offline Reviewer" },
+              blockers: [
+                {
+                  code: "context_review_agent_runtime_unavailable",
+                  resolutionOwner: "admin",
+                  actionKind: "open_agent_owner_flow",
+                },
+              ],
+            },
+          }),
+        },
+      }),
+    );
+
+    expect(row.status).toMatchObject({ label: "Degraded", kind: "attention" });
+    expect(row.status.detail).toContain("Automatic review remains off");
+    expect(row.action).toEqual({
+      label: "Manage",
+      to: "/settings/setup#automatic-review",
+      intent: "open-reviewer-controls",
+    });
   });
 
   it("uses the Team projection and only asks the snapshot owner endpoint for a bound tree", async () => {
@@ -720,6 +855,264 @@ describe("Settings Setup overview", () => {
     expect(tree.textContent).toContain("acme/context-tree");
     expect(setupCapabilityMocks.getTeamSetupCapabilitiesAt).toHaveBeenCalledWith("org-1");
     expect(contextTreeMocks.getContextTreeSnapshot).toHaveBeenCalledWith("org-1", "7d");
+    await act(async () => view.root.unmount());
+  });
+
+  it("opens Context Tree and Reviewer owner controls only for an Admin", async () => {
+    const view = await renderSettingsSetupPage();
+    const tree = await waitForRowText(view.host, "context-tree", "Available");
+    const treeManage = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Manage",
+    );
+
+    expect(treeManage?.getAttribute("aria-expanded")).toBe("false");
+    await act(async () => treeManage?.click());
+    const treeControls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
+    expect(treeControls.textContent).toContain("acme/context-tree · main branch · github");
+    expect(orgSettingsMocks.getRawContextTreeSetting).toHaveBeenCalledWith("org-1");
+
+    const review = await waitForRowText(view.host, "automatic-review", "On");
+    const reviewManage = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Manage",
+    );
+    await act(async () => reviewManage?.click());
+    const reviewControls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
+    expect(reviewControls.textContent).toContain("Context Reviewer");
+    expect(reviewerMocks.getContextReviewerCandidates).toHaveBeenCalledWith("org-1");
+    expect(view.host.querySelector('[data-setup-owner-controls="context-tree"]')).toBeNull();
+
+    await act(async () => view.root.unmount());
+  });
+
+  it("keeps the binding editor open and reflects the saved Server response immediately", async () => {
+    const view = await renderSettingsSetupPage();
+    const tree = await waitForRowText(view.host, "context-tree", "Available");
+    const manage = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Manage",
+    );
+
+    await act(async () => manage?.click());
+    const controls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
+    const edit = [...controls.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Change repository or branch",
+    );
+    await act(async () => edit?.click());
+    const save = await waitForSelector<HTMLButtonElement>(controls, 'button[aria-label="Save"]');
+    await act(async () => save.click());
+    await flush();
+
+    expect(orgSettingsMocks.putContextTreeSetting).toHaveBeenCalledWith("org-1", {
+      repo: "https://github.com/acme/context-tree.git",
+      branch: "main",
+    });
+    expect(controls.textContent).toContain("release branch");
+    expect(controls.textContent).toContain("Saved");
+    expect(controls.querySelector('button[aria-label="Save"]')).not.toBeNull();
+    await act(async () => view.root.unmount());
+  });
+
+  it.each([
+    ["#context-tree", "context-tree"],
+    ["#automatic-review", "automatic-review"],
+  ] as const)("opens and focuses the canonical owner control for legacy hash %s", async (hash, key) => {
+    const view = await renderSettingsSetupPage(`/settings/setup${hash}`);
+    const row = await waitForSelector<HTMLElement>(view.host, `[data-setup-row="${key}"]`);
+    await waitForSelector(row, `[data-setup-owner-controls="${key}"]`);
+
+    expect(row.id).toBe(key);
+    expect(document.activeElement).toBe(row);
+    await act(async () => view.root.unmount());
+  });
+
+  it("keeps Member Setup read-only without loading owner-only settings", async () => {
+    authMock.value = { ...authMock.value, role: "member" };
+    const view = await renderSettingsSetupPage("/settings/setup#automatic-review");
+    await waitForRowText(view.host, "automatic-review", "On");
+
+    expect(view.host.getAttribute("data-setup-overview")).toBeNull();
+    expect(view.host.querySelector('[data-setup-overview="member"]')).not.toBeNull();
+    expect(view.host.querySelector("[data-setup-owner-controls]")).toBeNull();
+    expect(view.host.querySelector('[role="switch"]')).toBeNull();
+    expect(reviewerMocks.getContextReviewerCandidates).not.toHaveBeenCalled();
+    expect(orgSettingsMocks.getRawContextTreeSetting).not.toHaveBeenCalled();
+    await act(async () => view.root.unmount());
+  });
+
+  it("keeps provider recovery secondary to the initial degraded Reviewer editor", async () => {
+    setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(
+      capabilityFixture({
+        review: {
+          adoption: "disabled",
+          health: "degraded",
+          blockers: [
+            {
+              code: "context_review_agent_runtime_unavailable",
+              resolutionOwner: "admin",
+              actionKind: "open_agent_owner_flow",
+            },
+          ],
+        },
+      }),
+    );
+    const view = await renderSettingsSetupPage();
+    const review = await waitForRowText(view.host, "automatic-review", "Degraded");
+    const manage = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Manage",
+    );
+
+    await act(async () => manage?.click());
+    const controls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
+    expect(controls.querySelector('[role="switch"]')).not.toBeNull();
+    expect([...controls.querySelectorAll("a")].some((link) => link.textContent === "Manage Team Agents")).toBe(true);
+    await act(async () => view.root.unmount());
+  });
+
+  it("enables Automatic Review without rewriting its retained assignment", async () => {
+    setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(
+      capabilityFixture({
+        review: {
+          adoption: "disabled",
+          health: "not_observed",
+          reviewerAgent: { uuid: "reviewer-1", displayName: "Context Reviewer" },
+        },
+      }),
+    );
+    const view = await renderSettingsSetupPage();
+    const review = await waitForRowText(view.host, "automatic-review", "Off");
+    const manage = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Manage",
+    );
+
+    await act(async () => manage?.click());
+    const controls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
+    const enablement = controls.querySelector<HTMLButtonElement>('[role="switch"]');
+    expect(enablement?.getAttribute("aria-checked")).toBe("false");
+    expect(controls.textContent).toContain("selection retained while off");
+
+    await act(async () => enablement?.click());
+    await flush();
+
+    expect(reviewerMocks.putContextReviewerEnablement).toHaveBeenCalledWith("org-1", true);
+    expect(reviewerMocks.putContextReviewerAssignment).not.toHaveBeenCalled();
+    await act(async () => view.root.unmount());
+  });
+
+  it("changes assignment through its split endpoint and keeps an offline candidate selectable", async () => {
+    setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValueOnce(capabilityFixture()).mockResolvedValue(
+      capabilityFixture({
+        review: {
+          adoption: "disabled",
+          health: "degraded",
+          reviewerAgent: { uuid: "reviewer-2", displayName: "Offline Reviewer" },
+        },
+      }),
+    );
+    reviewerMocks.getContextReviewerCandidates.mockResolvedValue({
+      items: [
+        {
+          uuid: "reviewer-1",
+          name: "context-reviewer",
+          displayName: "Context Reviewer",
+          visibility: "organization",
+          runtime: { health: "ready", blockers: [] },
+        },
+        {
+          uuid: "reviewer-2",
+          name: "offline-reviewer",
+          displayName: "Offline Reviewer",
+          visibility: "organization",
+          runtime: {
+            health: "degraded",
+            blockers: [{ code: "context_review_agent_inactive", resolutionOwner: "operator", actionKind: null }],
+          },
+        },
+      ],
+      blockers: [],
+    });
+    reviewerMocks.putContextReviewerAssignment.mockResolvedValue({
+      contextReviewer: {
+        enabled: false,
+        agentUuid: "reviewer-2",
+        reviewerAgent: { uuid: "reviewer-2", name: "offline-reviewer", displayName: "Offline Reviewer" },
+      },
+    });
+    const view = await renderSettingsSetupPage();
+    const review = await waitForRowText(view.host, "automatic-review", "On");
+    const manage = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Manage",
+    );
+
+    await act(async () => manage?.click());
+    const controls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
+    const agentSelect = await waitForSelector<HTMLButtonElement>(controls, '[aria-label="Automatic review Agent"]');
+    await act(async () => agentSelect?.click());
+    await waitForSelector(document.body, '[role="listbox"][aria-label="Automatic review Agent"]');
+    const offlineOption = [...document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')].find((option) =>
+      option.textContent?.includes("Offline Reviewer"),
+    );
+
+    expect(offlineOption?.disabled).toBe(false);
+    expect(offlineOption?.textContent).toContain("Runtime currently unavailable");
+    await act(async () => offlineOption?.click());
+    await flush();
+
+    expect(reviewerMocks.putContextReviewerAssignment).toHaveBeenCalledWith("org-1", "reviewer-2");
+    expect(reviewerMocks.putContextReviewerEnablement).not.toHaveBeenCalled();
+    expect(controls.textContent).toContain("Offline Reviewer");
+    expect(controls.textContent).toContain("selection retained while off");
+    expect(controls.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("false");
+    await act(async () => view.root.unmount());
+  });
+
+  it("keeps an empty eligible-candidate result in Setup without a create escape hatch", async () => {
+    reviewerMocks.getContextReviewerCandidates.mockResolvedValue({ items: [], blockers: [] });
+    setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(
+      capabilityFixture({
+        review: {
+          adoption: "disabled",
+          health: "not_observed",
+          reviewerAgent: null,
+        },
+      }),
+    );
+    const view = await renderSettingsSetupPage();
+    const review = await waitForRowText(view.host, "automatic-review", "Off");
+    const setup = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Set up",
+    );
+
+    await act(async () => setup?.click());
+    const controls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
+    await waitForRowText(view.host, "automatic-review", "No eligible organization-visible managed Agent");
+
+    expect(controls.querySelector('[aria-label="Automatic review Agent"]')).toBeNull();
+    expect(controls.querySelector<HTMLAnchorElement>('a[href="/team"]')?.textContent).toBe("Manage Team Agents");
+    expect(controls.textContent).not.toContain("Create Agent");
+    await act(async () => view.root.unmount());
+  });
+
+  it("allows an Admin to clear the retained Reviewer assignment", async () => {
+    reviewerMocks.putContextReviewerAssignment.mockResolvedValue({
+      contextReviewer: { enabled: false, agentUuid: null, reviewerAgent: null },
+    });
+    const view = await renderSettingsSetupPage();
+    const review = await waitForRowText(view.host, "automatic-review", "On");
+    const manage = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Manage",
+    );
+
+    await act(async () => manage?.click());
+    const controls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
+    const agentSelect = await waitForSelector<HTMLButtonElement>(controls, '[aria-label="Automatic review Agent"]');
+    await act(async () => agentSelect.click());
+    const clearOption = [...document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')].find(
+      (option) => option.textContent === "No Reviewer selected",
+    );
+    await act(async () => clearOption?.click());
+    await flush();
+
+    expect(reviewerMocks.putContextReviewerAssignment).toHaveBeenCalledWith("org-1", null);
+    expect(controls.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("false");
     await act(async () => view.root.unmount());
   });
 
@@ -735,6 +1128,33 @@ describe("Settings Setup overview", () => {
     await waitForRowText(view.host, "context-tree", "Not set up");
 
     expect(contextTreeMocks.getContextTreeSnapshot).not.toHaveBeenCalled();
+    await act(async () => view.root.unmount());
+  });
+
+  it("offers binding repair without a misleading build-chat entry for an invalid Context Tree", async () => {
+    setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(
+      capabilityFixture({
+        binding: { state: "invalid" },
+        contextTreeBlockers: [
+          {
+            code: "context_tree_binding_invalid",
+            resolutionOwner: "admin",
+            actionKind: "repair_tree_binding",
+          },
+        ],
+        review: { adoption: "unavailable", health: "not_observed", reviewerAgent: null },
+      }),
+    );
+    const view = await renderSettingsSetupPage();
+    const tree = await waitForRowText(view.host, "context-tree", "Needs repair");
+    const repair = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Repair",
+    );
+
+    await act(async () => repair?.click());
+    const controls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
+    expect(controls.textContent).toContain("Bind it manually");
+    expect(controls.textContent).not.toContain("Build your Context Tree");
     await act(async () => view.root.unmount());
   });
 

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -336,7 +336,7 @@ describe("Settings Setup overview", () => {
       ["repositories", "unknown", "circle-question-mark", "--fg-3"],
       ["repository-automation", "pending", "clock-3", "--state-idle"],
       ["context-tree", "pending", "clock-3", "--state-idle"],
-      ["automatic-review", "blocked", "circle-alert", "--state-blocked"],
+      ["automatic-review", "neutral", "circle-alert", "--fg-3"],
     ] as const;
 
     for (const [key, kind, glyph, token] of expectation) {
@@ -458,7 +458,7 @@ describe("Settings Setup overview", () => {
         },
       }),
       "Degraded",
-      "blocked",
+      "neutral",
     ],
   ] as const)("summarizes %s repository automation coverage", (_name, capabilities, label, kind) => {
     const row = rowFor("repository-automation", facts({ capabilities: { state: "ready", value: capabilities } }));
@@ -581,7 +581,7 @@ describe("Settings Setup overview", () => {
     });
     const row = rowFor("repository-automation", facts({ capabilities: { state: "ready", value: shared } }));
 
-    expect(row.status).toMatchObject({ label: "Service unavailable", kind: "blocked" });
+    expect(row.status).toMatchObject({ label: "Service unavailable", kind: "neutral" });
     expect(row.status.detail).toContain("deployment");
     expect(row.action).toBeUndefined();
   });
@@ -837,8 +837,9 @@ describe("Settings Setup overview", () => {
       }),
     );
 
-    expect(row.status).toMatchObject({ label: "Degraded", kind: "attention" });
-    expect(row.status.detail).toContain("Automatic review remains off");
+    expect(row.status).toMatchObject({ label: "Off", kind: "optional" });
+    expect(row.status.detail).toContain("Reviewer degraded");
+    expect(row.status.detail).toContain("runtime is currently unavailable");
     expect(row.action).toEqual({
       label: "Manage",
       to: "/settings/setup#automatic-review",
@@ -1026,7 +1027,7 @@ describe("Settings Setup overview", () => {
       }),
     );
     const view = await renderSettingsSetupPage();
-    const review = await waitForRowText(view.host, "automatic-review", "Degraded");
+    const review = await waitForRowText(view.host, "automatic-review", "Off");
     const manage = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
       (button) => button.textContent === "Manage",
     );

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -902,12 +902,83 @@ describe("Settings Setup overview", () => {
     await flush();
 
     expect(orgSettingsMocks.putContextTreeSetting).toHaveBeenCalledWith("org-1", {
+      provider: null,
       repo: "https://github.com/acme/context-tree.git",
       branch: "main",
     });
     expect(controls.textContent).toContain("release branch");
     expect(controls.textContent).toContain("Saved");
     expect(controls.querySelector('button[aria-label="Save"]')).not.toBeNull();
+    await act(async () => view.root.unmount());
+  });
+
+  it.each([
+    [
+      "GitHub to GitLab",
+      "github",
+      "https://github.com/acme/context-tree.git",
+      "https://gitlab.com/acme/context-tree.git",
+      "gitlab",
+    ],
+    [
+      "GitLab to GitHub",
+      "gitlab",
+      "https://gitlab.com/acme/context-tree.git",
+      "https://github.com/acme/context-tree.git",
+      "github",
+    ],
+  ] as const)("clears the stale provider declaration when rebinding %s", async (_name, previousProvider, previousRepo, nextRepo, nextProvider) => {
+    orgSettingsMocks.getRawContextTreeSetting.mockResolvedValue({
+      repo: previousRepo,
+      branch: "main",
+      provider: previousProvider,
+    });
+    orgSettingsMocks.putContextTreeSetting.mockResolvedValue({
+      repo: nextRepo,
+      branch: "main",
+      provider: nextProvider,
+    });
+    setupCapabilityMocks.getTeamSetupCapabilitiesAt.mockResolvedValue(
+      capabilityFixture({
+        binding: {
+          state: "bound",
+          provider: previousProvider,
+          repo: previousRepo,
+          branch: "main",
+        },
+      }),
+    );
+
+    const view = await renderSettingsSetupPage();
+    const tree = await waitForRowText(view.host, "context-tree", "Available");
+    const manage = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Manage",
+    );
+    await act(async () => manage?.click());
+    const controls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
+    const edit = [...controls.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Change repository or branch",
+    );
+    await act(async () => edit?.click());
+    const repoInput = await waitForSelector<HTMLInputElement>(controls, 'input[placeholder*="github.com"]');
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      setter?.call(repoInput, nextRepo);
+      repoInput.dispatchEvent(new InputEvent("input", { bubbles: true, data: nextRepo, inputType: "insertText" }));
+      repoInput.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await flush();
+    const save = await waitForSelector<HTMLButtonElement>(controls, 'button[aria-label="Save"]');
+    await act(async () => save.click());
+    await flush();
+
+    expect(orgSettingsMocks.putContextTreeSetting).toHaveBeenCalledWith("org-1", {
+      provider: null,
+      repo: nextRepo,
+      branch: "main",
+    });
+    expect(controls.textContent).toContain(`main branch · ${nextProvider}`);
+    expect(controls.textContent).toContain("Saved");
     await act(async () => view.root.unmount());
   });
 

--- a/packages/web/src/pages/settings/repositories.tsx
+++ b/packages/web/src/pages/settings/repositories.tsx
@@ -1,41 +1,34 @@
 import { useEffect, useRef } from "react";
-import { useLocation } from "react-router";
+import { Navigate, useLocation } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
-import { ContextTreeSettingsPanel } from "../context-tree-settings-panel.js";
 import { ResourceTypeSections } from "./resource-sections.js";
 
 const CODE_REPOSITORIES_HASH = "#code-repositories";
 const CONTEXT_TREE_HASH = "#context-tree";
 
 /**
- * Settings → Repositories. One provider-neutral home for the repositories
- * available to agents and the separate organization Context Tree binding.
- *
- * The two models deliberately share a page without sharing state: Team repo
- * resources are runtime inputs, while `context_tree` remains the single
- * organization pointer used by Context and agent startup.
+ * Settings → Repositories is the provider-neutral catalog of code available to
+ * agents. Context Tree binding and Automatic Review owner controls live in the
+ * canonical Settings → Setup surface.
  */
 export function SettingsRepositoriesPage() {
   const { role } = useAuth();
   const location = useLocation();
   const codeRepositoriesRef = useRef<HTMLElement>(null);
-  const contextTreeRef = useRef<HTMLElement>(null);
 
   // React Router updates the fragment but not the app shell's persistent
-  // overflow container. Position and focus either section explicitly so old
-  // Context links and Agent Detail exits remain deterministic.
+  // overflow container. Position and focus the code catalog explicitly.
   useEffect(() => {
     if (role === null) return;
-    const target =
-      location.hash === CODE_REPOSITORIES_HASH
-        ? codeRepositoriesRef.current
-        : location.hash === CONTEXT_TREE_HASH
-          ? contextTreeRef.current
-          : null;
+    const target = location.hash === CODE_REPOSITORIES_HASH ? codeRepositoriesRef.current : null;
     if (!target) return;
     target.scrollIntoView({ block: "start" });
     target.focus({ preventScroll: true });
   }, [location.hash, role]);
+
+  if (location.hash === CONTEXT_TREE_HASH) {
+    return <Navigate to="/settings/setup#context-tree" replace />;
+  }
 
   if (role === null) {
     return (
@@ -64,16 +57,6 @@ export function SettingsRepositoriesPage() {
           emptyLabelFor={() => "No code repositories configured yet."}
           compactLimit={3}
         />
-      </section>
-
-      <section
-        ref={contextTreeRef}
-        id={CONTEXT_TREE_HASH.slice(1)}
-        tabIndex={-1}
-        aria-label="Context Tree"
-        style={{ marginTop: "var(--sp-7)", scrollMarginTop: "var(--sp-4)" }}
-      >
-        <ContextTreeSettingsPanel />
       </section>
     </div>
   );

--- a/packages/web/src/pages/settings/setup-context-tree-controls.tsx
+++ b/packages/web/src/pages/settings/setup-context-tree-controls.tsx
@@ -1,0 +1,189 @@
+import type { OrgContextTreeInput, OrgContextTreeOutput, SetupContextTreeBinding } from "@first-tree/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowRight } from "lucide-react";
+import { type FormEvent, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import { getRawContextTreeSetting, putContextTreeSetting } from "../../api/org-settings.js";
+import { setupCapabilitiesQueryKey } from "../../api/setup-capabilities.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { Button } from "../../components/ui/button.js";
+import { SettingsField, SettingsSaveButton } from "../../components/ui/settings-field.js";
+import { ContextTreeBuildEntry } from "../context-tree-build-entry.js";
+
+type ContextTreeAvailability = "active" | "stale" | "unavailable" | "checking" | "unknown" | null;
+
+export function SetupContextTreeControls({
+  binding,
+  availability,
+  loadSetting = getRawContextTreeSetting,
+  saveSetting = putContextTreeSetting,
+  refreshFacts,
+}: {
+  binding: SetupContextTreeBinding;
+  availability: ContextTreeAvailability;
+  loadSetting?: (organizationId: string) => Promise<OrgContextTreeOutput>;
+  saveSetting?: (organizationId: string, input: OrgContextTreeInput) => Promise<OrgContextTreeOutput>;
+  refreshFacts?: (organizationId: string) => Promise<void>;
+}) {
+  const { organizationId, role } = useAuth();
+  const isAdmin = role === "admin";
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = useState(false);
+  const [repo, setRepo] = useState("");
+  const [branch, setBranch] = useState("");
+  const [saved, setSaved] = useState(false);
+  const [savedBinding, setSavedBinding] = useState<OrgContextTreeOutput | null>(null);
+  const savedTimeout = useRef<number | null>(null);
+
+  const settingQuery = useQuery({
+    queryKey: ["org-setting", organizationId, "context_tree", "raw"],
+    queryFn: () => (organizationId ? loadSetting(organizationId) : Promise.reject(new Error("no organization"))),
+    enabled: isAdmin && !!organizationId,
+  });
+
+  useEffect(() => {
+    if (!settingQuery.data) return;
+    setRepo(settingQuery.data.repo ?? "");
+    setBranch(settingQuery.data.branch ?? "main");
+  }, [settingQuery.data]);
+
+  useEffect(
+    () => () => {
+      if (savedTimeout.current !== null) window.clearTimeout(savedTimeout.current);
+    },
+    [],
+  );
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!organizationId) throw new Error("organization not loaded");
+      return saveSetting(organizationId, {
+        repo: repo.trim() || null,
+        branch: branch.trim() || null,
+      });
+    },
+    onSuccess: (next) => {
+      queryClient.setQueryData(["org-setting", organizationId, "context_tree", "raw"], next);
+      setSavedBinding(next);
+      if (refreshFacts && organizationId) {
+        void refreshFacts(organizationId);
+      } else {
+        void queryClient.invalidateQueries({ queryKey: setupCapabilitiesQueryKey(organizationId) });
+        void queryClient.invalidateQueries({ queryKey: ["context-tree-snapshot", organizationId] });
+      }
+      setSaved(true);
+      if (savedTimeout.current !== null) window.clearTimeout(savedTimeout.current);
+      savedTimeout.current = window.setTimeout(() => setSaved(false), 2000);
+    },
+  });
+
+  if (!isAdmin) return null;
+
+  const hasBoundTree = binding.state === "bound";
+  const chatIntent = hasBoundTree ? "recover" : "build";
+  const shouldOfferChat = binding.state === "unbound" || (hasBoundTree && availability === "unavailable");
+  const bindingSummary = savedBinding?.repo
+    ? `${repositoryLabel(savedBinding.repo)} · ${savedBinding.branch ?? "main"} branch · ${
+        savedBinding.provider ?? "provider pending"
+      }`
+    : binding.state === "bound"
+      ? `${repositoryLabel(binding.repo)} · ${binding.branch} branch · ${binding.provider}`
+      : null;
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    mutation.mutate();
+  };
+
+  return (
+    <div
+      data-setup-owner-controls="context-tree"
+      className="flex flex-col"
+      style={{
+        gap: "var(--sp-3)",
+        padding: "var(--sp-4)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-panel)",
+        background: "var(--bg-sunken)",
+      }}
+    >
+      {bindingSummary ? (
+        <div className="flex min-w-0 flex-wrap items-center justify-between" style={{ gap: "var(--sp-3)" }}>
+          <span className="text-label min-w-0" style={{ color: "var(--fg-3)", overflowWrap: "anywhere" }}>
+            {bindingSummary}
+          </span>
+          <Button type="button" variant="link" className="h-auto shrink-0 p-0" onClick={() => navigate("/context")}>
+            <span>Open Context</span>
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </div>
+      ) : null}
+
+      {shouldOfferChat ? <ContextTreeBuildEntry intent={chatIntent} /> : null}
+
+      <div>
+        <Button
+          type="button"
+          variant="link"
+          className="h-auto p-0"
+          style={{ color: "var(--fg-3)" }}
+          onClick={() => setEditing((current) => !current)}
+        >
+          {editing
+            ? "Close binding editor"
+            : hasBoundTree
+              ? "Change repository or branch"
+              : "Already have a tree repo? Bind it manually"}
+        </Button>
+      </div>
+
+      {editing ? (
+        settingQuery.isLoading ? (
+          <div className="text-label" style={{ color: "var(--fg-3)" }}>
+            Loading binding…
+          </div>
+        ) : settingQuery.error ? (
+          <div role="alert" className="text-label" style={{ color: "var(--state-error)" }}>
+            {settingQuery.error instanceof Error ? settingQuery.error.message : "Failed to load Context Tree binding"}
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <SettingsField
+              label="Repo URL"
+              hint="HTTPS or SSH URL of the Context Tree git repository for this team."
+              value={repo}
+              onChange={setRepo}
+              mono
+              placeholder="https://github.com/your-org/first-tree-context"
+            />
+            <SettingsField
+              label="Branch"
+              hint="Branch agents use for new Context Tree tasks."
+              value={branch}
+              onChange={setBranch}
+              mono
+              placeholder="main"
+              saved={saved}
+              rightSlot={<SettingsSaveButton pending={mutation.isPending} disabled={!settingQuery.data} />}
+            />
+            {mutation.error instanceof Error ? (
+              <div role="alert" className="text-label" style={{ color: "var(--state-error)" }}>
+                {mutation.error.message}
+              </div>
+            ) : null}
+          </form>
+        )
+      ) : null}
+    </div>
+  );
+}
+
+function repositoryLabel(repo: string): string {
+  try {
+    const url = new URL(repo);
+    return url.pathname.replace(/^\/|\.git$/g, "") || url.hostname;
+  } catch {
+    return repo.replace(/^git@[^:]+:/, "").replace(/\.git$/, "");
+  }
+}

--- a/packages/web/src/pages/settings/setup-context-tree-controls.tsx
+++ b/packages/web/src/pages/settings/setup-context-tree-controls.tsx
@@ -59,6 +59,7 @@ export function SetupContextTreeControls({
     mutationFn: () => {
       if (!organizationId) throw new Error("organization not loaded");
       return saveSetting(organizationId, {
+        provider: null,
         repo: repo.trim() || null,
         branch: branch.trim() || null,
       });

--- a/packages/web/src/pages/settings/setup-reviewer-controls.tsx
+++ b/packages/web/src/pages/settings/setup-reviewer-controls.tsx
@@ -1,0 +1,236 @@
+import type {
+  ContextReviewerCandidatesOutput,
+  OrgContextTreeFeaturesOutput,
+  SetupActionKind,
+  SetupAutomaticReview,
+} from "@first-tree/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useId, useState } from "react";
+import { Link } from "react-router";
+import {
+  getContextReviewerCandidates,
+  putContextReviewerAssignment,
+  putContextReviewerEnablement,
+} from "../../api/context-reviewer-settings.js";
+import { setupCapabilitiesQueryKey } from "../../api/setup-capabilities.js";
+import { useAuth } from "../../auth/auth-context.js";
+import { Select } from "../../components/ui/select.js";
+import { Switch } from "../../components/ui/switch.js";
+
+export function SetupReviewerControls({
+  review,
+  loadCandidates = getContextReviewerCandidates,
+  assignReviewer = putContextReviewerAssignment,
+  setReviewerEnabled = putContextReviewerEnablement,
+  refreshFacts,
+}: {
+  review: SetupAutomaticReview;
+  loadCandidates?: (organizationId: string) => Promise<ContextReviewerCandidatesOutput>;
+  assignReviewer?: (organizationId: string, agentUuid: string | null) => Promise<OrgContextTreeFeaturesOutput>;
+  setReviewerEnabled?: (organizationId: string, enabled: boolean) => Promise<OrgContextTreeFeaturesOutput>;
+  refreshFacts?: (organizationId: string) => Promise<void>;
+}) {
+  const { organizationId, role } = useAuth();
+  const queryClient = useQueryClient();
+  const switchLabelId = useId();
+  const isAdmin = role === "admin";
+  const projectedAgentUuid = review.reviewerAgent?.uuid ?? null;
+  const projectedEnabled = review.adoption === "enabled";
+  const [selectedAgentUuid, setSelectedAgentUuid] = useState(projectedAgentUuid);
+  const [enabled, setEnabled] = useState(projectedEnabled);
+
+  useEffect(() => {
+    setSelectedAgentUuid(projectedAgentUuid);
+    setEnabled(projectedEnabled);
+  }, [projectedAgentUuid, projectedEnabled]);
+
+  const candidatesQuery = useQuery({
+    queryKey: ["context-reviewer", "candidates", organizationId],
+    queryFn: () =>
+      organizationId ? loadCandidates(organizationId) : Promise.reject(new Error("organization not loaded")),
+    enabled: isAdmin && !!organizationId,
+  });
+
+  const refreshProjectedFacts = async () => {
+    if (organizationId && refreshFacts) {
+      await refreshFacts(organizationId);
+      return;
+    }
+    await queryClient.invalidateQueries({ queryKey: setupCapabilitiesQueryKey(organizationId) });
+  };
+
+  const assignmentMutation = useMutation({
+    mutationFn: (agentUuid: string | null) => {
+      if (!organizationId) throw new Error("organization not loaded");
+      return assignReviewer(organizationId, agentUuid);
+    },
+    onSuccess: async (next) => {
+      setSelectedAgentUuid(next.contextReviewer.agentUuid);
+      setEnabled(next.contextReviewer.enabled);
+      await refreshProjectedFacts();
+    },
+  });
+
+  const enablementMutation = useMutation({
+    mutationFn: (enabled: boolean) => {
+      if (!organizationId) throw new Error("organization not loaded");
+      return setReviewerEnabled(organizationId, enabled);
+    },
+    onSuccess: async (next) => {
+      setEnabled(next.contextReviewer.enabled);
+      await refreshProjectedFacts();
+    },
+  });
+
+  const candidates = candidatesQuery.data?.items ?? [];
+  const selectedCandidate = candidates.find((candidate) => candidate.uuid === selectedAgentUuid) ?? null;
+  const selectedLabel =
+    selectedCandidate?.displayName ??
+    (selectedAgentUuid === projectedAgentUuid ? review.reviewerAgent?.displayName : null) ??
+    null;
+  const saving = assignmentMutation.isPending || enablementMutation.isPending;
+  const options = [
+    {
+      value: "",
+      label: selectedAgentUuid ? "No Reviewer selected" : "Select an eligible managed Agent",
+      disabled: !selectedAgentUuid,
+    },
+    ...candidates.map((candidate) => ({
+      value: candidate.uuid,
+      label: candidate.displayName,
+      hint:
+        candidate.runtime.health === "ready"
+          ? candidate.name || "Runtime ready"
+          : `${candidate.name ? `${candidate.name} · ` : ""}${runtimeLabel(candidate.runtime.health)}`,
+    })),
+  ];
+  const recovery = reviewerRecovery(review);
+
+  if (!isAdmin) return null;
+
+  return (
+    <div
+      data-setup-owner-controls="automatic-review"
+      className="flex flex-col"
+      style={{
+        gap: "var(--sp-3)",
+        padding: "var(--sp-4)",
+        border: "var(--hairline) solid var(--border)",
+        borderRadius: "var(--radius-panel)",
+        background: "var(--bg-sunken)",
+      }}
+    >
+      <div className="flex items-center justify-between" style={{ gap: "var(--sp-3)" }}>
+        <div className="min-w-0">
+          <span id={switchLabelId} className="text-body font-medium" style={{ color: "var(--fg)" }}>
+            Automatic review
+          </span>
+          <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
+            {selectedLabel
+              ? `Reviewer · ${selectedLabel}${enabled ? "" : " · selection retained while off"}`
+              : "Choose an existing eligible Team Agent. Setup never creates one."}
+          </div>
+        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={(next) => enablementMutation.mutate(next)}
+          disabled={saving || (!enabled && !selectedAgentUuid)}
+          aria-labelledby={switchLabelId}
+        />
+      </div>
+
+      {candidatesQuery.isLoading ? (
+        <div className="text-label" style={{ color: "var(--fg-3)" }}>
+          Loading eligible Agents…
+        </div>
+      ) : candidatesQuery.error ? (
+        <div role="alert" className="text-label" style={{ color: "var(--state-error)" }}>
+          {candidatesQuery.error instanceof Error
+            ? candidatesQuery.error.message
+            : "Failed to load eligible Context Review Agents"}
+        </div>
+      ) : candidates.length === 0 ? (
+        <div className="text-label" style={{ color: "var(--fg-3)" }}>
+          No eligible organization-visible managed Agent is available.{" "}
+          <Link to="/team" className="font-medium" style={{ color: "var(--fg-2)" }}>
+            Manage Team Agents
+          </Link>
+          , then retry.
+        </div>
+      ) : (
+        <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+          <span className="text-label font-medium" style={{ color: "var(--fg)" }}>
+            Reviewer Agent
+          </span>
+          <Select
+            aria-label="Automatic review Agent"
+            value={selectedAgentUuid ?? ""}
+            onChange={(agentUuid) => {
+              const next = agentUuid || null;
+              if (next === selectedAgentUuid) return;
+              assignmentMutation.mutate(next);
+            }}
+            disabled={saving}
+            options={options}
+            placeholder="Select an eligible managed Agent"
+            searchable={candidates.length > 6}
+          />
+          <div className="text-caption" style={{ color: "var(--fg-4)" }}>
+            Changing the assignment turns Automatic Review off. Re-enable it separately after reviewing current provider
+            readiness.
+          </div>
+        </div>
+      )}
+
+      {candidatesQuery.data?.blockers.length ? (
+        <div className="text-label" style={{ color: "var(--fg-3)" }}>
+          Candidate availability is limited by current Team Agent ownership or runtime support.
+        </div>
+      ) : null}
+      {recovery ? (
+        <div className="text-label" style={{ color: "var(--fg-3)" }}>
+          Provider or Agent recovery is still required.{" "}
+          <Link to={recovery.to} className="font-medium" style={{ color: "var(--fg-2)" }}>
+            {recovery.label}
+          </Link>
+        </div>
+      ) : null}
+      {assignmentMutation.error instanceof Error || enablementMutation.error instanceof Error ? (
+        <div role="alert" className="text-label" style={{ color: "var(--state-error)" }}>
+          {(assignmentMutation.error ?? enablementMutation.error)?.message}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function reviewerRecovery(review: SetupAutomaticReview): { label: string; to: string } | null {
+  const actionKind = review.blockers.find(
+    (blocker) => blocker.resolutionOwner === "admin" && blocker.actionKind,
+  )?.actionKind;
+  if (!actionKind) return null;
+
+  const recovery: Partial<Record<SetupActionKind, { label: string; to: string }>> = {
+    connect_github: { label: "Connect GitHub", to: "/settings/integrations/github" },
+    manage_github_installation: { label: "Manage GitHub", to: "/settings/integrations/github" },
+    connect_gitlab: { label: "Connect GitLab", to: "/settings/integrations/gitlab" },
+    configure_gitlab_webhook: { label: "Configure GitLab", to: "/settings/integrations/gitlab" },
+    open_agent_owner_flow: { label: "Manage Team Agents", to: "/team" },
+  };
+  return recovery[actionKind] ?? null;
+}
+
+function runtimeLabel(health: SetupAutomaticReview["health"]): string {
+  switch (health) {
+    case "not_observed":
+      return "Runtime not observed";
+    case "pending_verification":
+      return "Runtime verification pending";
+    case "ready":
+      return "Runtime ready";
+    case "degraded":
+      return "Runtime currently unavailable";
+    case "unavailable":
+      return "Runtime unavailable";
+  }
+}

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -52,7 +52,15 @@ type ContextTreeFact = {
   availability: "active" | "stale" | "unavailable" | "checking" | "unknown" | null;
 };
 
-export type SetupStatusKind = "ready" | "optional" | "loading" | "pending" | "attention" | "blocked" | "unknown";
+export type SetupStatusKind =
+  | "ready"
+  | "optional"
+  | "loading"
+  | "pending"
+  | "attention"
+  | "neutral"
+  | "blocked"
+  | "unknown";
 
 export type SetupFacts = {
   role: string | null;
@@ -258,7 +266,9 @@ function providerSummary(providers: SetupRepositoryAutomationProvider[], isAdmin
   const blockers = configured.flatMap((provider) => provider.blockers);
   const issues = blockerDetail(blockers, isAdmin);
   const detail = [providerDetail, issues].filter((item): item is string => Boolean(item)).join(" · ");
-  const adminAttention = isAdmin && hasAdminBlocker(blockers);
+  const hasAdminOwnedBlocker = hasAdminBlocker(blockers);
+  const adminAttention = isAdmin && hasAdminOwnedBlocker;
+  const inactiveKind: SetupStatusKind = adminAttention ? "attention" : hasAdminOwnedBlocker ? "blocked" : "neutral";
 
   if (ready.length === configured.length) {
     return {
@@ -272,12 +282,12 @@ function providerSummary(providers: SetupRepositoryAutomationProvider[], isAdmin
     return { label: "Verification pending", detail, kind: adminAttention ? "attention" : "pending" };
   }
   if (configured.some((provider) => provider.health === "degraded")) {
-    return { label: "Degraded", detail, kind: adminAttention ? "attention" : "blocked" };
+    return { label: "Degraded", detail, kind: inactiveKind };
   }
   return {
     label: hasAdminBlocker(blockers) && isAdmin ? "Needs attention" : "Service unavailable",
     detail,
-    kind: adminAttention ? "attention" : "blocked",
+    kind: inactiveKind,
   };
 }
 
@@ -381,33 +391,41 @@ function reviewStatus(review: SetupAutomaticReview, isAdmin: boolean): SetupRowM
   if (review.adoption === "unavailable") {
     return { label: "Available after Context Tree", kind: "optional" };
   }
-  if (review.adoption === "disabled" && review.health === "not_observed" && review.blockers.length === 0) {
+  if (review.adoption === "disabled") {
     const reviewer = review.reviewerAgent ? `Reviewer · ${review.reviewerAgent.displayName}` : null;
-    return { label: "Off", detail: reviewer ? `${reviewer} · Optional` : "Optional", kind: "optional" };
+    const healthDetail =
+      review.health === "pending_verification"
+        ? "Reviewer verification pending"
+        : review.health === "degraded"
+          ? "Reviewer degraded"
+          : review.health === "unavailable"
+            ? "Reviewer unavailable"
+            : null;
+    const issues = blockerDetail(review.blockers, isAdmin);
+    const detail = [reviewer, healthDetail, issues, "Optional"]
+      .filter((item): item is string => Boolean(item))
+      .join(" · ");
+    return { label: "Off", detail, kind: "optional" };
   }
 
   const reviewer = review.reviewerAgent ? `Reviewer · ${review.reviewerAgent.displayName}` : null;
   const issues = blockerDetail(review.blockers, isAdmin);
-  const disabledDetail = review.adoption === "disabled" ? "Automatic review remains off" : null;
-  const detail =
-    [reviewer, issues, disabledDetail].filter((item): item is string => Boolean(item)).join(" · ") || undefined;
-  if (review.health === "ready") {
-    return review.adoption === "disabled"
-      ? { label: "Off", detail, kind: "optional" }
-      : { label: "On", detail, kind: "ready" };
-  }
-  const adminAttention = isAdmin && hasAdminBlocker(review.blockers);
+  const detail = [reviewer, issues].filter((item): item is string => Boolean(item)).join(" · ") || undefined;
+  if (review.health === "ready") return { label: "On", detail, kind: "ready" };
+  const hasAdminOwnedBlocker = hasAdminBlocker(review.blockers);
+  const adminAttention = isAdmin && hasAdminOwnedBlocker;
+  const inactiveKind: SetupStatusKind = adminAttention ? "attention" : hasAdminOwnedBlocker ? "blocked" : "neutral";
   if (review.health === "pending_verification") {
     return { label: "Verification pending", detail, kind: adminAttention ? "attention" : "pending" };
   }
   if (review.health === "degraded") {
-    return { label: "Degraded", detail, kind: adminAttention ? "attention" : "blocked" };
+    return { label: "Degraded", detail, kind: inactiveKind };
   }
   if (review.health === "unavailable") {
     return {
       label: hasAdminBlocker(review.blockers) && isAdmin ? "Needs attention" : "Service unavailable",
       detail,
-      kind: adminAttention ? "attention" : "blocked",
+      kind: inactiveKind,
     };
   }
   return { label: "Status unknown", detail, kind: "unknown" };
@@ -817,6 +835,7 @@ const SETUP_STATUS_PRESENTATION: Record<SetupStatusKind, { icon: LucideIcon; col
   loading: { icon: LoaderCircle, color: "var(--state-idle)", animate: true },
   pending: { icon: Clock3, color: "var(--state-idle)" },
   attention: { icon: CircleAlert, color: "var(--state-needs-you)" },
+  neutral: { icon: CircleAlert, color: "var(--fg-3)" },
   blocked: { icon: CircleAlert, color: "var(--state-blocked)" },
   unknown: { icon: CircleHelp, color: "var(--fg-3)" },
 };

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -25,7 +25,8 @@ import {
   ShieldCheck,
   Webhook,
 } from "lucide-react";
-import { Link, useNavigate } from "react-router";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router";
 import { listClients } from "../../api/activity.js";
 import { getContextTreeSnapshot } from "../../api/context-tree.js";
 import { reportOnboardingEvent } from "../../api/onboarding-events.js";
@@ -35,6 +36,8 @@ import { useAuth } from "../../auth/auth-context.js";
 import { useWorkspaceViewport } from "../../hooks/use-viewport.js";
 import { cn } from "../../lib/utils.js";
 import { shouldEnterOnboarding } from "../onboarding/steps.js";
+import { SetupContextTreeControls } from "./setup-context-tree-controls.js";
+import { SetupReviewerControls } from "./setup-reviewer-controls.js";
 
 type Fact<T> =
   | { state: "loading" }
@@ -49,15 +52,7 @@ type ContextTreeFact = {
   availability: "active" | "stale" | "unavailable" | "checking" | "unknown" | null;
 };
 
-export type SetupStatusKind =
-  | "ready"
-  | "optional"
-  | "loading"
-  | "pending"
-  | "attention"
-  | "neutral"
-  | "blocked"
-  | "unknown";
+export type SetupStatusKind = "ready" | "optional" | "loading" | "pending" | "attention" | "blocked" | "unknown";
 
 export type SetupFacts = {
   role: string | null;
@@ -94,7 +89,7 @@ export type SetupRowModel = {
   action?: {
     label: string;
     to: string;
-    intent?: "resume-onboarding";
+    intent?: "resume-onboarding" | "open-context-tree-controls" | "open-reviewer-controls";
   };
 };
 
@@ -185,12 +180,12 @@ const ACTION_DESTINATIONS = {
   manage_github_installation: "/settings/integrations/github",
   connect_gitlab: "/settings/integrations/gitlab",
   configure_gitlab_webhook: "/settings/integrations/gitlab",
-  repair_tree_binding: "/settings/repositories#context-tree",
+  repair_tree_binding: "/settings/setup#context-tree",
   open_tree_setup_chat: "/context",
-  select_review_agent: "/settings/repositories#context-tree",
-  replace_review_agent: "/settings/repositories#context-tree",
+  select_review_agent: "/settings/setup#automatic-review",
+  replace_review_agent: "/settings/setup#automatic-review",
   open_agent_owner_flow: "/team",
-  manage_review_agent: "/settings/repositories#context-tree",
+  manage_review_agent: "/settings/setup#automatic-review",
 } satisfies Record<SetupActionKind, string>;
 
 const ACTION_LABELS = {
@@ -263,12 +258,7 @@ function providerSummary(providers: SetupRepositoryAutomationProvider[], isAdmin
   const blockers = configured.flatMap((provider) => provider.blockers);
   const issues = blockerDetail(blockers, isAdmin);
   const detail = [providerDetail, issues].filter((item): item is string => Boolean(item)).join(" · ");
-  const kind: SetupStatusKind =
-    isAdmin && hasAdminBlocker(blockers)
-      ? "attention"
-      : configured.some((provider) => provider.health === "degraded" || provider.health === "unavailable")
-        ? "neutral"
-        : "pending";
+  const adminAttention = isAdmin && hasAdminBlocker(blockers);
 
   if (ready.length === configured.length) {
     return {
@@ -277,17 +267,17 @@ function providerSummary(providers: SetupRepositoryAutomationProvider[], isAdmin
       kind: "ready",
     };
   }
-  if (ready.length > 0) return { label: "Partial coverage", detail, kind };
+  if (ready.length > 0) return { label: "Partial coverage", detail, kind: adminAttention ? "attention" : "pending" };
   if (configured.some((provider) => provider.health === "pending_verification")) {
-    return { label: "Verification pending", detail, kind };
+    return { label: "Verification pending", detail, kind: adminAttention ? "attention" : "pending" };
   }
   if (configured.some((provider) => provider.health === "degraded")) {
-    return { label: "Degraded", detail, kind };
+    return { label: "Degraded", detail, kind: adminAttention ? "attention" : "blocked" };
   }
   return {
     label: hasAdminBlocker(blockers) && isAdmin ? "Needs attention" : "Service unavailable",
     detail,
-    kind,
+    kind: adminAttention ? "attention" : "blocked",
   };
 }
 
@@ -338,7 +328,7 @@ function contextTreeStatus(
       detail:
         blockerDetail(blockers, isAdmin) ??
         (isAdmin ? "The Context Tree binding is invalid." : "Ask an admin to repair the Context Tree binding."),
-      kind: isAdmin ? "attention" : "neutral",
+      kind: isAdmin ? "attention" : "blocked",
     };
   }
 
@@ -350,66 +340,74 @@ function contextTreeStatus(
   const issueDetail = blockerDetail(blockers, isAdmin);
   const detail = [bindingDetail, issueDetail].filter((item): item is string => Boolean(item)).join(" · ");
   if (availability === "active") return { label: "Available", detail, kind: "ready" };
-  if (availability === "stale") return { label: "Available · update delayed", detail, kind: "neutral" };
+  if (availability === "stale") return { label: "Available · update delayed", detail, kind: "pending" };
   if (availability === "unavailable") {
     return isAdmin
       ? { label: "Needs recovery", detail, kind: "attention" }
       : {
           label: "Unavailable",
           detail: issueDetail ? detail : `${bindingDetail} · Ask an admin to recover Context Tree access.`,
-          kind: "neutral",
+          kind: "blocked",
         };
   }
   if (availability === "checking") return { label: "Checking availability", detail, kind: "loading" };
   return { label: "Status unknown", detail, kind: "unknown" };
 }
 
-function contextTreeAction(
-  contextTree: Fact<ContextTreeFact>,
-  blockers: SetupBlocker[],
-  isAdmin: boolean,
-): SetupRowModel["action"] | undefined {
+function contextTreeAction(contextTree: Fact<ContextTreeFact>, isAdmin: boolean): SetupRowModel["action"] | undefined {
   if (contextTree.state !== "ready") return undefined;
   const { binding, availability } = contextTree.value;
   if (binding.state === "unbound") {
-    return isAdmin ? { label: "Set up", to: "/context" } : undefined;
+    return isAdmin
+      ? { label: "Set up", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
+      : undefined;
   }
   if (binding.state === "invalid") {
     return isAdmin
-      ? (actionFromBlockers(blockers, true) ?? { label: "Repair", to: "/settings/repositories#context-tree" })
+      ? { label: "Repair", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
       : { label: "View", to: "/context" };
   }
   if (availability === "unavailable") {
-    return isAdmin ? { label: "Recover", to: "/context" } : { label: "View", to: "/context" };
+    return isAdmin
+      ? { label: "Recover", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
+      : { label: "View", to: "/context" };
   }
-  return isAdmin ? { label: "Manage", to: "/settings/repositories#context-tree" } : { label: "View", to: "/context" };
+  return isAdmin
+    ? { label: "Manage", to: "/settings/setup#context-tree", intent: "open-context-tree-controls" }
+    : { label: "View", to: "/context" };
 }
 
 function reviewStatus(review: SetupAutomaticReview, isAdmin: boolean): SetupRowModel["status"] {
   if (review.adoption === "unavailable") {
     return { label: "Available after Context Tree", kind: "optional" };
   }
-  if (review.adoption === "disabled") {
-    return { label: "Off", detail: "Optional", kind: "optional" };
+  if (review.adoption === "disabled" && review.health === "not_observed" && review.blockers.length === 0) {
+    const reviewer = review.reviewerAgent ? `Reviewer · ${review.reviewerAgent.displayName}` : null;
+    return { label: "Off", detail: reviewer ? `${reviewer} · Optional` : "Optional", kind: "optional" };
   }
 
   const reviewer = review.reviewerAgent ? `Reviewer · ${review.reviewerAgent.displayName}` : null;
   const issues = blockerDetail(review.blockers, isAdmin);
-  const detail = [reviewer, issues].filter((item): item is string => Boolean(item)).join(" · ") || undefined;
-  if (review.health === "ready") return { label: "On", detail, kind: "ready" };
-  const kind: SetupStatusKind =
-    isAdmin && hasAdminBlocker(review.blockers)
-      ? "attention"
-      : review.health === "pending_verification"
-        ? "pending"
-        : "neutral";
-  if (review.health === "pending_verification") return { label: "Verification pending", detail, kind };
-  if (review.health === "degraded") return { label: "Degraded", detail, kind };
+  const disabledDetail = review.adoption === "disabled" ? "Automatic review remains off" : null;
+  const detail =
+    [reviewer, issues, disabledDetail].filter((item): item is string => Boolean(item)).join(" · ") || undefined;
+  if (review.health === "ready") {
+    return review.adoption === "disabled"
+      ? { label: "Off", detail, kind: "optional" }
+      : { label: "On", detail, kind: "ready" };
+  }
+  const adminAttention = isAdmin && hasAdminBlocker(review.blockers);
+  if (review.health === "pending_verification") {
+    return { label: "Verification pending", detail, kind: adminAttention ? "attention" : "pending" };
+  }
+  if (review.health === "degraded") {
+    return { label: "Degraded", detail, kind: adminAttention ? "attention" : "blocked" };
+  }
   if (review.health === "unavailable") {
     return {
       label: hasAdminBlocker(review.blockers) && isAdmin ? "Needs attention" : "Service unavailable",
       detail,
-      kind,
+      kind: adminAttention ? "attention" : "blocked",
     };
   }
   return { label: "Status unknown", detail, kind: "unknown" };
@@ -417,16 +415,13 @@ function reviewStatus(review: SetupAutomaticReview, isAdmin: boolean): SetupRowM
 
 function reviewAction(review: SetupAutomaticReview, isAdmin: boolean): SetupRowModel["action"] | undefined {
   if (review.adoption === "unavailable") return undefined;
-  if (!isAdmin) {
-    return review.adoption === "enabled" ? { label: "View", to: "/settings/repositories#context-tree" } : undefined;
-  }
-  if (review.adoption === "disabled") {
-    return { label: "Set up", to: "/settings/repositories#context-tree" };
-  }
-  const blockerAction = actionFromBlockers(review.blockers, true);
-  if (blockerAction) return blockerAction;
-  if (review.blockers.length > 0) return undefined;
-  return { label: "Manage", to: "/settings/repositories#context-tree" };
+  if (!isAdmin) return undefined;
+
+  return {
+    label: review.adoption === "disabled" && !review.reviewerAgent ? "Set up" : "Manage",
+    to: "/settings/setup#automatic-review",
+    intent: "open-reviewer-controls",
+  };
 }
 
 /**
@@ -574,7 +569,7 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
       description: "Shared decisions and constraints available to agents.",
       icon: GitFork,
       status: contextTreeStatus(contextTree, capabilities?.contextTree.blockers ?? [], isAdmin),
-      action: contextTreeAction(contextTree, capabilities?.contextTree.blockers ?? [], isAdmin),
+      action: contextTreeAction(contextTree, isAdmin),
     },
     {
       key: "automatic-review",
@@ -590,6 +585,13 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
 
 export function SettingsSetupPage() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const [expandedOwnerControl, setExpandedOwnerControl] = useState<{
+    organizationId: string | null;
+    key: SetupRowModel["key"];
+  } | null>(null);
+  const previousOrganizationId = useRef<string | null>(null);
+  const handledOwnerHash = useRef<string | null>(null);
   const {
     role,
     organizationId,
@@ -681,16 +683,101 @@ export function SettingsSetupPage() {
     navigate("/onboarding");
   };
 
-  return <SetupOverview facts={facts} rows={buildSetupRows(facts)} onResumeOnboarding={resumeOnboarding} />;
+  const contextTree = contextTreeFact(capabilities, contextTreeSnapshot);
+  const expandedOwnerControlKey =
+    expandedOwnerControl?.organizationId === organizationId ? expandedOwnerControl.key : null;
+
+  useEffect(() => {
+    if (previousOrganizationId.current !== null && previousOrganizationId.current !== organizationId) {
+      setExpandedOwnerControl(null);
+      handledOwnerHash.current = null;
+    }
+    previousOrganizationId.current = organizationId;
+  }, [organizationId]);
+
+  useEffect(() => {
+    const key =
+      location.hash === "#context-tree"
+        ? "context-tree"
+        : location.hash === "#automatic-review"
+          ? "automatic-review"
+          : null;
+    if (!key || !organizationId || facts.capabilities.state !== "ready") return;
+
+    const hashKey = `${organizationId}:${location.hash}`;
+    if (handledOwnerHash.current === hashKey) return;
+    handledOwnerHash.current = hashKey;
+    if (role === "admin") setExpandedOwnerControl({ organizationId, key });
+  }, [facts.capabilities.state, location.hash, organizationId, role]);
+
+  useEffect(() => {
+    const key =
+      location.hash === "#context-tree"
+        ? "context-tree"
+        : location.hash === "#automatic-review"
+          ? "automatic-review"
+          : null;
+    if (!key || facts.capabilities.state !== "ready") return;
+    if (role === "admin" && expandedOwnerControlKey !== key) return;
+
+    const row = document.getElementById(key);
+    row?.scrollIntoView?.({ block: "start" });
+    row?.focus();
+  }, [expandedOwnerControlKey, facts.capabilities.state, location.hash, role]);
+
+  const ownerControls: Partial<Record<SetupRowModel["key"], ReactNode>> =
+    role !== "admin" || facts.capabilities.state !== "ready"
+      ? {}
+      : {
+          ...(expandedOwnerControlKey === "context-tree" && contextTree.state === "ready"
+            ? {
+                "context-tree": (
+                  <SetupContextTreeControls
+                    key={`context-tree-${organizationId}`}
+                    binding={contextTree.value.binding}
+                    availability={contextTree.value.availability}
+                  />
+                ),
+              }
+            : {}),
+          ...(expandedOwnerControlKey === "automatic-review"
+            ? {
+                "automatic-review": (
+                  <SetupReviewerControls
+                    key={`automatic-review-${organizationId}`}
+                    review={facts.capabilities.value.contextTree.automaticReview}
+                  />
+                ),
+              }
+            : {}),
+        };
+
+  return (
+    <SetupOverview
+      facts={facts}
+      rows={buildSetupRows(facts)}
+      ownerControls={ownerControls}
+      onToggleOwnerControl={(key) => {
+        setExpandedOwnerControl((current) =>
+          current?.organizationId === organizationId && current.key === key ? null : { organizationId, key },
+        );
+      }}
+      onResumeOnboarding={resumeOnboarding}
+    />
+  );
 }
 
 export function SetupOverview({
   facts,
   rows,
+  ownerControls = {},
+  onToggleOwnerControl,
   onResumeOnboarding,
 }: {
   facts: Pick<SetupFacts, "role" | "teamName">;
   rows: SetupRowModel[];
+  ownerControls?: Partial<Record<SetupRowModel["key"], ReactNode>>;
+  onToggleOwnerControl?: (key: SetupRowModel["key"]) => void;
   onResumeOnboarding?: () => Promise<void>;
 }) {
   const viewport = useWorkspaceViewport();
@@ -710,7 +797,14 @@ export function SetupOverview({
 
       <div style={{ borderTop: "var(--hairline) solid var(--border)" }}>
         {rows.map((row) => (
-          <SetupRow key={row.key} row={row} narrow={narrow} onResumeOnboarding={onResumeOnboarding} />
+          <SetupRow
+            key={row.key}
+            row={row}
+            narrow={narrow}
+            ownerControl={ownerControls[row.key]}
+            onToggleOwnerControl={onToggleOwnerControl}
+            onResumeOnboarding={onResumeOnboarding}
+          />
         ))}
       </div>
     </div>
@@ -723,7 +817,6 @@ const SETUP_STATUS_PRESENTATION: Record<SetupStatusKind, { icon: LucideIcon; col
   loading: { icon: LoaderCircle, color: "var(--state-idle)", animate: true },
   pending: { icon: Clock3, color: "var(--state-idle)" },
   attention: { icon: CircleAlert, color: "var(--state-needs-you)" },
-  neutral: { icon: CircleAlert, color: "var(--fg-3)" },
   blocked: { icon: CircleAlert, color: "var(--state-blocked)" },
   unknown: { icon: CircleHelp, color: "var(--fg-3)" },
 };
@@ -743,15 +836,21 @@ function SetupStatusMark({ kind }: { kind: SetupStatusKind }) {
 function SetupRow({
   row,
   narrow,
+  ownerControl,
+  onToggleOwnerControl,
   onResumeOnboarding,
 }: {
   row: SetupRowModel;
   narrow: boolean;
+  ownerControl?: ReactNode;
+  onToggleOwnerControl?: (key: SetupRowModel["key"]) => void;
   onResumeOnboarding?: () => Promise<void>;
 }) {
   const Icon = row.icon;
   return (
     <section
+      id={row.key}
+      tabIndex={-1}
       aria-labelledby={`setup-${row.key}`}
       data-setup-row={row.key}
       data-setup-parent={row.parentKey}
@@ -814,7 +913,23 @@ function SetupRow({
         className={cn("flex", !narrow && "justify-end")}
         style={narrow ? { paddingLeft: "var(--sp-11)" } : undefined}
       >
-        {row.action ? (
+        {(row.action?.intent === "open-context-tree-controls" || row.action?.intent === "open-reviewer-controls") &&
+        onToggleOwnerControl ? (
+          <button
+            type="button"
+            aria-expanded={Boolean(ownerControl)}
+            aria-controls={`setup-${row.key}-owner-controls`}
+            onClick={() => onToggleOwnerControl(row.key)}
+            className={cn(
+              "text-label inline-flex items-center font-medium text-fg-2 transition-colors",
+              "rounded-[var(--radius-input)] hover:bg-bg-hover hover:text-foreground",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
+            )}
+            style={{ minHeight: "var(--sp-8)", padding: "0 var(--sp-2)" }}
+          >
+            {row.action.label}
+          </button>
+        ) : row.action ? (
           <Link
             to={row.action.to}
             onClick={
@@ -840,6 +955,17 @@ function SetupRow({
           </Link>
         ) : null}
       </div>
+      {ownerControl ? (
+        <div
+          id={`setup-${row.key}-owner-controls`}
+          style={{
+            gridColumn: "1 / -1",
+            paddingLeft: narrow || row.parentKey ? "var(--sp-4)" : "var(--sp-11)",
+          }}
+        >
+          {ownerControl}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/packages/web/src/pages/setup-preview.tsx
+++ b/packages/web/src/pages/setup-preview.tsx
@@ -1,11 +1,19 @@
-import type { TeamSetupCapabilities } from "@first-tree/shared";
+import type {
+  ContextReviewerCandidatesOutput,
+  OrgContextTreeFeaturesOutput,
+  OrgContextTreeInput,
+  OrgContextTreeOutput,
+  TeamSetupCapabilities,
+} from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import { setupCapabilitiesQueryKey } from "../api/setup-capabilities.js";
 import { AuthContext } from "../auth/auth-context.js";
 import { cn } from "../lib/utils.js";
 import { buildSetupRows, type SetupFacts, SetupOverview } from "./settings/setup.js";
+import { SetupContextTreeControls } from "./settings/setup-context-tree-controls.js";
+import { SetupReviewerControls } from "./settings/setup-reviewer-controls.js";
 import { SettingsLayout } from "./settings.js";
 
 type PreviewRole = "admin" | "member";
@@ -88,6 +96,85 @@ const MIXED_CAPABILITIES: TeamSetupCapabilities = {
   },
 };
 
+const PREVIEW_REVIEWER_CANDIDATES: ContextReviewerCandidatesOutput = {
+  items: [
+    {
+      uuid: "agent-reviewer",
+      name: "context-reviewer",
+      displayName: "Context Reviewer",
+      visibility: "organization",
+      runtime: { health: "ready", blockers: [] },
+    },
+    {
+      uuid: "agent-offline-reviewer",
+      name: "offline-reviewer",
+      displayName: "Offline Reviewer",
+      visibility: "organization",
+      runtime: {
+        health: "degraded",
+        blockers: [
+          {
+            code: "context_review_agent_inactive",
+            resolutionOwner: "operator",
+            actionKind: null,
+          },
+        ],
+      },
+    },
+  ],
+  blockers: [],
+};
+
+async function previewLoadTreeSetting(): Promise<OrgContextTreeOutput> {
+  return {
+    provider: "github",
+    repo: "https://github.com/agent-team-foundation/first-tree-context",
+    branch: "main",
+  };
+}
+
+async function previewSaveTreeSetting(
+  _organizationId: string,
+  input: OrgContextTreeInput,
+): Promise<OrgContextTreeOutput> {
+  return {
+    provider: "github",
+    repo: input.repo ?? undefined,
+    branch: input.branch ?? undefined,
+  };
+}
+
+async function previewAssignReviewer(
+  _organizationId: string,
+  agentUuid: string | null,
+): Promise<OrgContextTreeFeaturesOutput> {
+  const candidate = PREVIEW_REVIEWER_CANDIDATES.items.find((item) => item.uuid === agentUuid);
+  return {
+    contextReviewer: {
+      enabled: false,
+      agentUuid,
+      reviewerAgent: candidate
+        ? { uuid: candidate.uuid, name: candidate.name, displayName: candidate.displayName }
+        : null,
+    },
+  };
+}
+
+async function previewSetReviewerEnabled(
+  _organizationId: string,
+  enabled: boolean,
+): Promise<OrgContextTreeFeaturesOutput> {
+  return {
+    contextReviewer: {
+      enabled,
+      agentUuid: "agent-reviewer",
+      reviewerAgent: { uuid: "agent-reviewer", name: "context-reviewer", displayName: "Context Reviewer" },
+    },
+  };
+}
+
+async function previewRefresh(): Promise<void> {}
+
 function previewFacts(role: PreviewRole, state: PreviewState): SetupFacts {
   if (state === "mixed") {
     return {
@@ -128,11 +215,14 @@ function previewFacts(role: PreviewRole, state: PreviewState): SetupFacts {
 
 export function SetupPreviewPage() {
   const [searchParams] = useSearchParams();
+  const [expandedOwnerControl, setExpandedOwnerControl] = useState<
+    ReturnType<typeof buildSetupRows>[number]["key"] | null
+  >(null);
   const role: PreviewRole = searchParams.get("role") === "member" ? "member" : "admin";
   const state: PreviewState = searchParams.get("state") === "mixed" ? "mixed" : "ready";
   const facts = previewFacts(role, state);
   const capabilities = state === "mixed" ? MIXED_CAPABILITIES : PREVIEW_CAPABILITIES;
-  const snapshotStatus = state === "mixed" ? "stale" : "active";
+  const snapshotStatus = state === "mixed" ? ("stale" as const) : ("active" as const);
   const queryClient = useMemo(() => {
     const client = new QueryClient({
       defaultOptions: { queries: { staleTime: Number.POSITIVE_INFINITY } },
@@ -141,6 +231,12 @@ export function SetupPreviewPage() {
     client.setQueryData(["context-tree-snapshot", "org-preview", "7d", false], {
       snapshotStatus,
     });
+    client.setQueryData(["org-setting", "org-preview", "context_tree", "raw"], {
+      provider: "github",
+      repo: "https://github.com/agent-team-foundation/first-tree-context",
+      branch: "main",
+    });
+    client.setQueryData(["context-reviewer", "candidates", "org-preview"], PREVIEW_REVIEWER_CANDIDATES);
     return client;
   }, [capabilities, snapshotStatus]);
   const auth = {
@@ -154,13 +250,53 @@ export function SetupPreviewPage() {
     onboardingDismissedAt: facts.onboardingSuppressedAt,
     onboardingCompletedAt: facts.onboardingCompletedAt,
   } as unknown as Parameters<typeof AuthContext.Provider>[0]["value"];
+  const ownerControls =
+    role !== "admin"
+      ? {}
+      : {
+          ...(expandedOwnerControl === "context-tree"
+            ? {
+                "context-tree": (
+                  <SetupContextTreeControls
+                    binding={capabilities.contextTree.binding}
+                    availability={snapshotStatus}
+                    loadSetting={previewLoadTreeSetting}
+                    saveSetting={previewSaveTreeSetting}
+                    refreshFacts={previewRefresh}
+                  />
+                ),
+              }
+            : {}),
+          ...(expandedOwnerControl === "automatic-review"
+            ? {
+                "automatic-review": (
+                  <SetupReviewerControls
+                    review={capabilities.contextTree.automaticReview}
+                    loadCandidates={async () => PREVIEW_REVIEWER_CANDIDATES}
+                    assignReviewer={previewAssignReviewer}
+                    setReviewerEnabled={previewSetReviewerEnabled}
+                    refreshFacts={previewRefresh}
+                  />
+                ),
+              }
+            : {}),
+        };
 
   return (
     <QueryClientProvider client={queryClient}>
       <AuthContext.Provider value={auth}>
         <div style={{ minHeight: "100vh", background: "var(--bg)" }} data-setup-preview={`${role}-${state}`}>
           <SettingsLayout activePathname="/settings/setup">
-            <SetupOverview facts={facts} rows={buildSetupRows(facts)} />
+            <SetupOverview
+              facts={facts}
+              rows={buildSetupRows(facts)}
+              ownerControls={ownerControls}
+              onToggleOwnerControl={
+                role === "admin"
+                  ? (key) => setExpandedOwnerControl((current) => (current === key ? null : key))
+                  : undefined
+              }
+            />
           </SettingsLayout>
           <nav
             aria-label="Setup preview controls"


### PR DESCRIPTION
## Summary

- make Settings → Setup the canonical Admin owner surface for Context Tree build/recovery/manual binding
- add Automatic Review assignment and enablement controls against the split Server contract from #1992
- preserve disabled Reviewer selection, expose Server-canonical degraded/provider facts, and keep runtime-offline candidates selectable
- keep Member Setup fact-equivalent and read-only without owner-only candidate/settings requests
- remove the duplicate Context Tree and Reviewer editors from Settings → Repositories; retain the Team code repository catalog and redirect the legacy `#context-tree` entry to Setup

## Behavior and recovery

- Context Tree uses the existing dedicated setup-chat build/recover flow and existing binding endpoint; Web does not embed Seed/CLI or provider mutation logic
- Automatic Review chooses only existing eligible organization-visible managed Agents and never creates an Agent
- assignment and enablement remain separate writes; assignment turns review off, disabled state retains selection, and dynamic runtime unavailability remains visible without making the candidate unselectable
- provider and Agent recovery links remain secondary to the inline Reviewer editor, so Admin can still disable, reassign, or clear a selection while degraded
- legacy `#context-tree` and `#automatic-review` hashes expand, scroll to, and focus the canonical Setup controls
- Team changes close expanded owner panels; invalid bindings offer repair without a misleading new-tree build action
- manual cross-provider rebinding clears the stale provider declaration so the Server reclassifies the new repository URL
- preview mutations use local adapters and cannot reach production APIs

## Scope

This branch was created from fresh `origin/main` after #1987, #1988, and #1992 merged. The commits contain 12 `packages/web` files only; no Server/shared/provider-owned implementation or disposable combined merge history is included.

## Validation

- exact-head Web full: 202 files / 1,726 tests
- Web typecheck and design-token guardrails
- scoped Biome and `git diff --check`
- exact-head production Docker build: shared, Server, and Web completed
- isolated PostgreSQL/production image smoke: 40 migrated tables; `/healthz`, `/readyz`, `/`, and Setup preview returned 200; restart recovered ready
- all required exact-head GitHub CI and CodeQL checks
- two independent reviews completed; all definite blocker/important findings fixed
- desktop browser development validation: Admin mixed/degraded editor, offline candidate assignment with enablement split, and Member zero owner panels/switches

## External QA boundary

The available environment has no real candidate GitHub App installation, remotely reachable candidate provider callback, disposable authenticated Admin/Member Team, or managed Agent runtime. Therefore authenticated mutation readback and provider-backed fail-closed/recovery dispatch are not claimed as PASS. Mock preview evidence validates deterministic layout and interaction only.
