### PR TITLE
Show fuller mobile Work summaries

### DIFF
--- a/packages/web/src/pages/mobile-preview.tsx
+++ b/packages/web/src/pages/mobile-preview.tsx
@@ -209,6 +209,7 @@ function ActionCard({
             WebkitBoxOrient: "vertical",
             overflow: "hidden",
           }}
+          data-line-clamp={2}
         >
           {chat.evidence}
         </p>
@@ -260,11 +261,12 @@ function WorkRow({ chat, onOpen }: { chat: PreviewChat; onOpen: (chat: PreviewCh
                 ? undefined
                 : {
                     display: "-webkit-box",
-                    WebkitLineClamp: 2,
+                    WebkitLineClamp: 3,
                     WebkitBoxOrient: "vertical",
                     overflow: "hidden",
                   }),
             }}
+            data-line-clamp={dynamic ? 1 : 3}
           >
             {chat.summary}
           </p>

--- a/packages/web/src/pages/mobile/__tests__/data.test.ts
+++ b/packages/web/src/pages/mobile/__tests__/data.test.ts
@@ -142,7 +142,7 @@ describe("mobile chat projection", () => {
     expect(mobileChatSignal(explicitMention).attention).toBe(false);
   });
 
-  it("allocates the fixed two-line Work content budget by state", () => {
+  it("allocates Work content by state", () => {
     const summary = "**Current:** staging is green";
     expect(
       mobileCardContent(

--- a/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
@@ -188,17 +188,25 @@ describe("mobile density tiers", () => {
     expect(cards[2]?.textContent).toContain("Team roster polish");
   });
 
-  it("renders standard Work rows with a two-line content budget and no visible overflow actions", async () => {
+  it("gives ordinary summaries three lines while keeping dynamic and action evidence compact", async () => {
     renderWithClient(harness, <MobileWorkPage />, "/m/work");
     await waitForSettled(harness, () => expect(harness.container.textContent).toContain("Release readiness"));
 
-    const listCard = harness.container.querySelector<HTMLElement>('[data-mobile-card="work"]');
-    if (!listCard) throw new Error("Missing Work row");
-    expect(listCard.getAttribute("style")).toContain("min-height: calc(var(--sp-20) + var(--sp-8))");
-    expect(listCard.querySelector("[data-mobile-card-preview]")?.className).toContain("text-mobile-body");
-    expect(listCard.querySelector("[data-mobile-card-preview]")?.className).toContain("truncate");
-    expect(listCard.querySelector("[data-mobile-card-dynamic]")?.textContent).toContain("Working");
-    expect(listCard.querySelector("[data-mobile-card-menu]")).toBeNull();
+    const cards = [...harness.container.querySelectorAll<HTMLElement>("[data-mobile-card]")];
+    const actionCard = cards.find((card) => card.textContent?.includes("Release readiness"));
+    const workingCard = cards.find((card) => card.textContent?.includes("Context docs"));
+    const ordinaryCard = cards.find((card) => card.textContent?.includes("Team roster polish"));
+    if (!actionCard || !workingCard || !ordinaryCard) throw new Error("Missing expected Work cards");
+
+    expect(actionCard.querySelector("[data-mobile-card-preview]")?.getAttribute("data-line-clamp")).toBe("2");
+    expect(workingCard.getAttribute("style")).toContain("min-height: calc(var(--sp-20) + var(--sp-8))");
+    expect(workingCard.querySelector("[data-mobile-card-preview]")?.className).toContain("text-mobile-body");
+    expect(workingCard.querySelector("[data-mobile-card-preview]")?.className).toContain("truncate");
+    expect(workingCard.querySelector("[data-mobile-card-dynamic]")?.textContent).toContain("Working");
+    expect(workingCard.querySelector("[data-mobile-card-preview]")?.getAttribute("data-line-clamp")).toBe("1");
+    expect(ordinaryCard.querySelector("[data-mobile-card-preview]")?.getAttribute("data-line-clamp")).toBe("3");
+    expect(ordinaryCard.querySelector("[data-mobile-card-preview]")?.className).not.toContain("truncate");
+    expect(workingCard.querySelector("[data-mobile-card-menu]")).toBeNull();
     expect(harness.container.querySelector("[data-mobile-swipe-surface]")).toBeNull();
   });
 
@@ -230,6 +238,10 @@ describe("mobile density tiers", () => {
     expect(chips.find((chip) => chip.textContent?.includes("Need you"))?.textContent).toContain("1");
     expect(chips.find((chip) => chip.textContent?.includes("Unread"))?.textContent).toContain("2");
     expect(chips.find((chip) => chip.textContent?.includes("Pinned"))?.textContent).toContain("2");
+    const pinnedCard = [...harness.container.querySelectorAll<HTMLElement>('[data-mobile-card="work"]')].find((card) =>
+      card.textContent?.includes("Pinned quiet work"),
+    );
+    expect(pinnedCard?.querySelector("[data-mobile-card-preview]")?.getAttribute("data-line-clamp")).toBe("3");
   });
 
   it("renders card previews with inline markdown peeled, not as literal markers", async () => {

--- a/packages/web/src/pages/mobile/data.ts
+++ b/packages/web/src/pages/mobile/data.ts
@@ -93,11 +93,11 @@ export function mobileChatPreview(row: MeChatRow): string {
 }
 
 /**
- * Allocate the Work card's fixed two-line content budget.
+ * Allocate Work card content by state.
  *
- * Normal / pinned work spends both lines on the running chat summary. Unread,
- * mention, and working work split the budget into one current-state line and
- * one live-evidence line. Attention cards deliberately replace the summary
+ * Normal / pinned work shows the running chat summary. Unread, mention, and
+ * working work split the compact dynamic budget into one current-state line
+ * and one live-evidence line. Attention cards deliberately replace the summary
  * with the concrete request/failure evidence because that is what the viewer
  * must act on now.
  */

--- a/packages/web/src/pages/mobile/work.tsx
+++ b/packages/web/src/pages/mobile/work.tsx
@@ -407,6 +407,7 @@ function MobileActionCard({
             overflow: "hidden",
           }}
           data-mobile-card-preview
+          data-line-clamp={2}
         >
           {content.primary}
         </p>
@@ -496,12 +497,13 @@ function MobileWorkRow({
                 ? undefined
                 : {
                     display: "-webkit-box",
-                    WebkitLineClamp: 2,
+                    WebkitLineClamp: 3,
                     WebkitBoxOrient: "vertical",
                     overflow: "hidden",
                   }),
             }}
             data-mobile-card-preview
+            data-line-clamp={content.kind === "dynamic" ? 1 : 3}
           >
             {content.primary}
           </p>


### PR DESCRIPTION
## What

- allow ordinary and pinned mobile Work summaries to use up to three lines
- keep unread and working rows at one current-state line plus one dynamic-evidence line
- keep needs-answer and failure action evidence at two lines
- mirror the contract in the deterministic mobile preview and DOM assertions

## Why

Two lines can truncate the status-bearing portion of a Work description on narrow phones. The existing 112 px row floor leaves enough room for a third summary line with minimal density cost, while action and dynamic rows have distinct compact information roles.

## Impact

At 320 px, a three-line summary adds about 7 px only when the content needs it. At 390 px and 430 px, the current fixtures remain at 112 px because their summaries fit in two lines.

## Validation

- focused Web tests: 3 files, 29 tests passed
- full Web suite: 204 files, 1,735 tests passed
- `pnpm check`
- `pnpm typecheck` (including builds, the Web production build, and token guardrails)
- real-browser QA at 320×693, 390×844, and 430×932: no horizontal overflow or console warnings/errors
- root `pnpm test` hit five unrelated skill-eval fixture timeouts under parallel load; the exact three fixture files passed 23/23 when rerun with one worker