### PR TITLE
fix: keep errored chats in attention while offline

### DIFF
--- a/packages/qa/cases/cross-surface/failed-chat-attention-stability.md
+++ b/packages/qa/cases/cross-surface/failed-chat-attention-stability.md
@@ -1,0 +1,67 @@
+---
+id: failed-chat-attention-stability
+description: Validate that an errored managed-agent chat stays in Needs attention across disconnects and leaves only after recovery.
+areas: [cross-surface]
+surfaces: [client, server, web]
+---
+
+# Failed chat attention stability
+
+## Goal
+
+Confirm the real runtime-to-workspace path keeps a chat in `Needs attention`
+while its caller-managed speaker remains errored, even if that agent disconnects
+and its display status changes between failed and offline. The row should enter
+the group once and leave once after genuine recovery, without repeatedly moving
+between list groups.
+
+The deterministic server test owns the projection rule. This case owns the live
+Client session frames, presence changes, Web refetches, and visible conversation
+rail behavior that the product test cannot prove.
+
+## Preconditions
+
+- Run the candidate server, Web, and Client in an isolated QA cell with a real
+  PostgreSQL database and WebSocket connections.
+- Sign in as the manager of a non-human agent and create a chat where that agent
+  is a speaker.
+- Keep browser network, WebSocket, and a short screen recording available. Do
+  not use an unrelated peer's failed agent because Attention is manager-scoped.
+
+## Operate and observe
+
+- Trigger a real terminal turn or session failure. Confirm the chat moves once
+  into `Needs attention`, its row exposes the failed marker, and the list
+  response includes the agent in `failedAgentIds`.
+- Disconnect the failed agent's Client without retrying or clearing the failed
+  chat session. Observe long enough to cross multiple status frames and at
+  least one conversation-list refetch.
+- Reconnect the Client while leaving the same chat session errored. Repeat the
+  observation window.
+- Perform the supported recovery action and let the session become healthy.
+  Confirm the chat leaves `Needs attention` once and returns to its normal
+  recency or pinned location.
+
+## Evidence
+
+Keep the failure, disconnect, reconnect, and recovery timestamps; the relevant
+WebSocket frames; the corresponding conversation-list responses; and a screen
+recording of the rail. The evidence should show that reachability may change
+the agent's display status to offline while `failedAgentIds` and the chat's
+Attention membership remain stable until recovery.
+
+## Expected result
+
+`PASS` when the errored chat enters Attention once, stays there throughout
+disconnect and reconnect, and leaves once only after recovery, with no repeated
+row movement or visible list flashing.
+
+`FAIL` when disconnecting or reconnecting an otherwise still-errored agent
+removes and re-adds the chat, clears `failedAgentIds`, or repeatedly remounts the
+row.
+
+`BLOCKED` when the isolated runtime cannot produce and retain a real errored
+session or the browser cannot observe the candidate WebSocket/list path.
+
+`INCONCLUSIVE` when the recording or network/status evidence cannot attribute
+the row movement to the candidate build.

--- a/packages/server/src/__tests__/me-chat-priority.test.ts
+++ b/packages/server/src/__tests__/me-chat-priority.test.ts
@@ -193,6 +193,31 @@ describe("listMeChats — server priority projection (PR3)", () => {
     expect(res.priorityRows.attention.find((r) => r.chatId === chatId)?.failedAgentIds).toContain(peer.uuid);
   });
 
+  it("keeps an errored chat in attention while its managed speaker is offline", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "offline-failed-peer");
+
+    const chatId = await chatWith(app, owner, peer.uuid);
+    await markFailed(app, peer.uuid, peer.clientId, chatId);
+    await app.db.update(agentPresence).set({ clientId: null }).where(eq(agentPresence.agentId, peer.uuid));
+
+    const offline = await list(app, owner);
+    expect(groupOf(offline, chatId)).toBe("attention");
+    expect(offline.priorityRows.attention.find((r) => r.chatId === chatId)?.failedAgentIds).toContain(peer.uuid);
+
+    await app.db.update(agentPresence).set({ clientId: peer.clientId }).where(eq(agentPresence.agentId, peer.uuid));
+    await app.db.execute(sql`
+      UPDATE agent_chat_sessions
+      SET state = 'active', runtime_state = 'idle', runtime_state_at = NOW(), updated_at = NOW()
+      WHERE agent_id = ${peer.uuid} AND chat_id = ${chatId}
+    `);
+
+    const recovered = await list(app, owner);
+    expect(groupOf(recovered, chatId)).toBe("rows");
+    expect(recovered.rows.find((r) => r.chatId === chatId)?.failedAgentIds).toEqual([]);
+  });
+
   it("a healthy managed speaker (no request, no failure) stays in ordinary rows", async () => {
     const app = getApp();
     const owner = await createTestAdmin(app);

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -618,7 +618,10 @@ async function enrichMeChatRows(
       }
       // failed — speaker-filtered AND narrowed to "mine" (R1): a peer's broken
       // agent in a shared chat no longer pins my row to "Needs attention".
-      if (isSpeaker && s.main === "failed" && isMine) failed.push(s.agentId);
+      // Use the errored axis rather than composite `main`: reachability makes an
+      // errored agent display as offline, but recovery attention must remain
+      // until the per-chat error itself clears.
+      if (isSpeaker && s.errored && isMine) failed.push(s.agentId);
       // busy — speakers with composite `working` (the D-axis truth from
       // `agent_chat_sessions.runtime_state`). NOT narrowed to mine — "someone
       // is working" is informational, not an attention signal.

--- a/packages/shared/src/schemas/me-chat.ts
+++ b/packages/shared/src/schemas/me-chat.ts
@@ -295,15 +295,13 @@ export const meChatRowSchema = z.object({
    */
   liveActivity: liveActivitySchema.nullable(),
   /**
-   * Speakers in this chat whose composite status is `failed` — i.e. reachable
-   * and either their per-(agent,chat) session is `errored` OR their global
-   * runtime is in `error` (the same `errored` input `getChatAgentStatuses`
-   * folds into `failed`; an unreachable agent is `offline`, not `failed`, so
-   * those are excluded). Drives the chat-list "failed" attention signal
-   * (red `!` badge) without opening the chat. Per-chat, derived at query
-   * time (no schema migration). `.default([])` for version skew: an older
-   * server build that predates this field would otherwise blank the row on a
-   * web-ahead deploy.
+   * Speakers in this chat whose per-(agent,chat) status is errored, independent
+   * of reachability. An errored unreachable agent displays as `offline`, but
+   * remains in this set so disconnects do not clear or repeatedly re-add the
+   * chat-list recovery signal (red `!` badge). Per-chat, derived at query time
+   * (no schema migration). `.default([])` for version skew: an older server
+   * build that predates this field would otherwise blank the row on a web-ahead
+   * deploy.
    */
   failedAgentIds: z.array(z.string()).default([]),
   /**


### PR DESCRIPTION
## Summary

- derive `failedAgentIds` from the per-chat `errored` axis instead of the reachability-gated composite display status
- keep an errored managed-agent chat in Attention across disconnect and reconnect, then remove it after genuine recovery
- add a deterministic server regression and a live cross-surface QA case for the visible list-stability path

## Validation

- [x] `pnpm check` (passes with 16 existing warnings and 1 existing info)
- [x] `pnpm typecheck`
- [x] `pnpm --filter @first-tree/server test` (245 files, 2,670 tests)
- [x] `pnpm exec vitest run src/__tests__/me-chat-priority.test.ts` from `packages/server` (16 tests)
- [ ] `pnpm test` (the changed server suite passed, but the monorepo run hit unrelated timeout-only failures in heavy `skill-evals` fixtures under parallel load; 30/32 affected isolated cases passed on retry, with the remaining 2 also timing out)

## Change Surface

- [ ] apps/cli public CLI or help output
- [ ] tree onboarding / binding / inspection behavior
- [ ] shipped or planned skill topology
- [ ] docs or contributor-facing repository metadata
- [ ] CI / packaging / release plumbing

## Notes

- package or install behavior changes: none
- docs or tests updated to match: updated the public schema comment and added server regression coverage plus `failed-chat-attention-stability` live QA coverage
- follow-up work: run the new live QA case against an isolated Client/Server/Web cell before release; no product-code follow-up is expected
