### PR TITLE
release: bump apps/cli to v0.5.17

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-tree-dev",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "type": "module",
   "description": "First Tree — unified CLI for Context Tree onboarding, agent management, and team messaging. (Source-tree dev build; CI rewrites `name` and `bin` for prod / staging publishes — see docs/local-dev-isolation.md.)",
   "keywords": [


### PR DESCRIPTION
## Summary

- bump `apps/cli/package.json` from `0.5.16` to stable version `0.5.17`
- keep the source package identity as `first-tree-dev`; CI will perform the production package rewrite
- leave the lockfile, binary names, build metadata, and release tags unchanged

## Draft GitHub Release

**Title:** `v0.5.17 — Unified Work, scheduled jobs, and guided Setup`

## Highlights

- Mobile now has one unified Work surface for attention, unread, pinned, active, archived, and watched conversations, with fuller summaries and inline current state.
- Scheduled jobs are now first-class: agents can create and manage recurring work through the CLI, while Desktop shows schedule status, upcoming runs, and owner lifecycle controls.
- Settings → Setup now centralizes Team readiness and owner actions for repository automation, Context Tree, and Automatic Review, including guided GitLab System Hook setup with real merge-request routing verification.
- Context Tree workflows now support GitLab repositories, while review flows gain repair-first handling, stronger final-tree checks, and exact decision-influence receipts.
- The composer now exposes a focused live activity inspector so users can understand active agent work and jump to its timeline evidence.

## Notable fixes

- New human input can retry Codex steering after an earlier append rejection instead of waiting for a long-running turn to finish.
- Failed managed-agent chats remain in Attention while offline and through reconnects until they genuinely recover.
- Mobile selection, sent mention rendering, GitLab entity links, and Context Review topic/merge behavior are more reliable.

## Validation

- `pnpm check` — passed with repository-existing warnings/info only
- `pnpm typecheck` — passed, 10/10 tasks
- `git diff --check` — passed
- `pnpm test` — full parallel run exited non-zero on load-sensitive 5-second timeouts in five skill-eval cases and one Client capability probe; no failure touched the release diff
- isolated single-worker rerun of the affected skill-eval files — passed, 26/26 tests
- isolated single-worker rerun of `capability-probes.test.ts` — passed, 51/51 tests
- latest pre-bump `main` CI, Docker, CodeQL, and staging npm Publish — passed at `9483165e3`

## Post-merge

1. Wait for the release bump merge commit's `main` CI, Docker, and staging publish runs.
2. Confirm version `0.5.17`, tag `v0.5.17`, target commit SHA, release title, and release body with the maintainer.
3. Create the GitHub Release/tag from the exact merge commit.
4. Verify the tag-triggered production npm publish, portable artifacts, Docker image, public npm coordinates, and GitHub Release.
