### PR TITLE
Fix images in tracked requests

### DIFF
--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -24,6 +24,10 @@ const docCaptureMock = vi.hoisted(() => ({
   captureOutboundDocs: vi.fn(),
 }));
 
+const imageCaptureMock = vi.hoisted(() => ({
+  captureOutboundImages: vi.fn(),
+}));
+
 const ioMocks = vi.hoisted(() => ({
   readStdin: vi.fn(),
 }));
@@ -46,6 +50,10 @@ vi.mock("../core/cli-fetch.js", () => ({ cliFetch: cliFetchMock }));
 vi.mock("../commands/_shared/resolve-agent.js", () => ({ resolveAgent: resolveAgentMock }));
 vi.mock("../commands/_shared/local-agent.js", () => localAgentMocks);
 vi.mock("../core/doc-capture.js", () => docCaptureMock);
+vi.mock("../core/image-capture.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../core/image-capture.js")>()),
+  captureOutboundImages: imageCaptureMock.captureOutboundImages,
+}));
 vi.mock("../commands/chat/_shared/io.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../commands/chat/_shared/io.js")>()),
   readStdin: ioMocks.readStdin,
@@ -86,6 +94,10 @@ beforeEach(() => {
   bootstrapMocks.resolveServerUrl.mockReturnValue("https://hub.example");
   resolveAgentMock.mockResolvedValue({ uuid: "agent-1", name: "nova", displayName: "Nova" });
   docCaptureMock.captureOutboundDocs.mockImplementation(async (content: string) => ({ content }));
+  imageCaptureMock.captureOutboundImages.mockImplementation(async (content: string) => ({
+    caption: content,
+    imageRefs: [],
+  }));
   ioMocks.readStdin.mockResolvedValue("stdin message");
   localAgentMocks.createSdk.mockReturnValue({
     agentId: "agent-self",
@@ -247,6 +259,37 @@ describe("chat command behavior", () => {
         format: "request",
         content: "What's the rollback window?",
         metadata: expect.objectContaining({ request: {} }),
+      }),
+    );
+  });
+
+  it("chat ask preserves request semantics when image capture returns refs", async () => {
+    const sdk = localAgentMocks.createSdk();
+    const imageRef = {
+      imageId: "11111111-1111-4111-8111-111111111111",
+      mimeType: "image/png",
+      filename: "decision.png",
+      size: 42,
+    };
+    imageCaptureMock.captureOutboundImages.mockResolvedValueOnce({
+      caption: "Which layout should ship?",
+      imageRefs: [imageRef],
+    });
+
+    await runChat(["ask", "nova", "Which layout should ship?\n\n![layout](output/decision.png)"]);
+
+    expect(imageCaptureMock.captureOutboundImages).toHaveBeenCalledWith(
+      "Which layout should ship?\n\n![layout](output/decision.png)",
+      expect.objectContaining({ chatId: "chat-env" }),
+    );
+    expect(sdk.sendMessage).toHaveBeenLastCalledWith(
+      "chat-env",
+      expect.objectContaining({
+        format: "request",
+        content: {
+          caption: "Which layout should ship?",
+          attachments: [imageRef],
+        },
       }),
     );
   });

--- a/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
+++ b/apps/cli/src/__tests__/chat-attention-commands-extra.test.ts
@@ -280,18 +280,102 @@ describe("chat command behavior", () => {
 
     expect(imageCaptureMock.captureOutboundImages).toHaveBeenCalledWith(
       "Which layout should ship?\n\n![layout](output/decision.png)",
-      expect.objectContaining({ chatId: "chat-env" }),
+      expect.objectContaining({ chatId: "chat-env", maxAttachments: 10 }),
     );
     expect(sdk.sendMessage).toHaveBeenLastCalledWith(
       "chat-env",
       expect.objectContaining({
         format: "request",
-        content: {
-          caption: "Which layout should ship?",
-          attachments: [imageRef],
-        },
+        content: "Which layout should ship?",
+        metadata: expect.objectContaining({
+          attachments: [
+            {
+              attachmentId: imageRef.imageId,
+              kind: "image",
+              mimeType: "image/png",
+              filename: "decision.png",
+              size: 42,
+            },
+          ],
+        }),
       }),
     );
+  });
+
+  it("chat ask shares one attachment budget across caller refs, documents, and images", async () => {
+    const sdk = localAgentMocks.createSdk();
+    const existingRef = {
+      attachmentId: "21111111-1111-4111-8111-111111111111",
+      kind: "file",
+      mimeType: "text/plain",
+      filename: "existing.txt",
+      size: 8,
+    };
+    const documentRef = {
+      attachmentId: "31111111-1111-4111-8111-111111111111",
+      kind: "document",
+      mimeType: "text/markdown",
+      filename: "plan.md",
+      size: 16,
+    };
+    const imageRef = {
+      imageId: "41111111-1111-4111-8111-111111111111",
+      mimeType: "image/png",
+      filename: "decision.png",
+      size: 42,
+    };
+    const body = "Which layout should ship?\n\nsee plan.md\n\n![layout](decision.png)";
+    const docCapturedBody =
+      "Which layout should ship?\n\nsee [plan.md](attachment:31111111-1111-4111-8111-111111111111)\n\n![layout](decision.png)";
+    docCaptureMock.captureOutboundDocs.mockResolvedValueOnce({
+      content: docCapturedBody,
+      attachments: [documentRef],
+    });
+    imageCaptureMock.captureOutboundImages.mockResolvedValueOnce({
+      caption: "Which layout should ship?",
+      imageRefs: [imageRef],
+    });
+
+    await runChat(["ask", "nova", body, "--metadata", JSON.stringify({ attachments: [existingRef] })]);
+
+    expect(docCaptureMock.captureOutboundDocs).toHaveBeenCalledWith(
+      body,
+      expect.objectContaining({ chatId: "chat-env", maxAttachments: 9 }),
+    );
+    expect(imageCaptureMock.captureOutboundImages).toHaveBeenCalledWith(
+      docCapturedBody,
+      expect.objectContaining({ chatId: "chat-env", maxAttachments: 8 }),
+    );
+    expect(sdk.sendMessage).toHaveBeenLastCalledWith(
+      "chat-env",
+      expect.objectContaining({
+        format: "request",
+        content: "Which layout should ship?",
+        metadata: expect.objectContaining({
+          attachments: [
+            existingRef,
+            documentRef,
+            {
+              attachmentId: imageRef.imageId,
+              kind: "image",
+              mimeType: "image/png",
+              filename: "decision.png",
+              size: 42,
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("chat ask rejects malformed caller attachment metadata before capture", async () => {
+    await expect(
+      runChat(["ask", "nova", "Which layout?", "--metadata", JSON.stringify({ attachments: [{ bad: true }] })]),
+    ).rejects.toMatchObject({ code: "INVALID_METADATA", exitCode: 2 });
+
+    expect(docCaptureMock.captureOutboundDocs).not.toHaveBeenCalled();
+    expect(imageCaptureMock.captureOutboundImages).not.toHaveBeenCalled();
+    expect(localAgentMocks.createSdk).not.toHaveBeenCalled();
   });
 
   it("chat ask --multi-select records multiSelect alongside options", async () => {

--- a/apps/cli/src/__tests__/image-capture.test.ts
+++ b/apps/cli/src/__tests__/image-capture.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { FirstTreeHubSDK } from "@first-tree/client";
 import { type ImageRefContent, imageBatchRefContentSchema, isImageBatchRefContent } from "@first-tree/shared";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { captureOutboundImages, toOutboundImageMessage } from "../core/image-capture.js";
+import { captureOutboundImages, toGenericImageAttachmentRefs, toOutboundImageMessage } from "../core/image-capture.js";
 
 /**
  * `chat send` image capture: the picture sibling of doc capture. Driven by the
@@ -140,14 +140,26 @@ describe("toOutboundImageMessage (format/content conversion)", () => {
     expect(out.content).toMatchObject({ caption: "看图", attachments: [ref] });
   });
 
-  it("keeps a tracked request as request while attaching the captured image batch", () => {
+  it("does not put a captured image batch into request content", () => {
     const out = toOutboundImageMessage("request", "Choose the rollout?", {
       caption: "Choose the rollout?",
       imageRefs: [ref],
     });
     expect(out.format).toBe("request");
-    expect(out.content).toEqual({ caption: "Choose the rollout?", attachments: [ref] });
-    expect(isImageBatchRefContent(out.content)).toBe(true);
+    expect(out.content).toBe("Choose the rollout?");
+  });
+
+  it("adapts captured image refs into generic metadata attachments", () => {
+    expect(toGenericImageAttachmentRefs([ref])).toEqual([
+      {
+        attachmentId: ref.imageId,
+        kind: "image",
+        mimeType: "image/png",
+        filename: "shot.png",
+        size: 8,
+      },
+    ]);
+    expect(toGenericImageAttachmentRefs([{ ...ref, size: undefined }])).toEqual([]);
   });
 
   it("omits the caption key for an image-only send (empty caption)", () => {

--- a/apps/cli/src/__tests__/image-capture.test.ts
+++ b/apps/cli/src/__tests__/image-capture.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { FirstTreeHubSDK } from "@first-tree/client";
@@ -45,6 +45,9 @@ describe("captureOutboundImages (chat send image capture)", () => {
   beforeAll(async () => {
     base = await mkdtemp(join(tmpdir(), "cli-img-capture-"));
     await writeFile(join(base, "shot.png"), PNG);
+    const repoBase = join(base, "source-repos", "first-tree");
+    await mkdir(repoBase, { recursive: true });
+    await writeFile(join(repoBase, "shot.png"), Buffer.concat([PNG, Buffer.from("repo-copy")]));
   });
 
   afterAll(async () => {
@@ -80,6 +83,22 @@ describe("captureOutboundImages (chat send image capture)", () => {
     );
     expect(out.imageRefs).toHaveLength(1);
     expect(out.imageRefs[0]).toMatchObject({ mimeType: "image/png", filename: "shot.png" });
+    expect(out.caption).toBe("看图：");
+  });
+
+  it("resolves relative images from the agent workspace even when documents use a repo base", async () => {
+    const { sdk } = stubSdk();
+    const out = await captureOutboundImages(
+      "看图：\n\n![shot](shot.png)",
+      { sdk, chatId: CHAT_ID },
+      {
+        FIRST_TREE_DOC_AGENT_HOME: base,
+        FIRST_TREE_DOC_BASE: join(base, "source-repos", "first-tree"),
+        FIRST_TREE_DOC_REPO_LOCAL_PATH: "source-repos/first-tree",
+      },
+    );
+    expect(out.imageRefs).toHaveLength(1);
+    expect(out.imageRefs[0]).toMatchObject({ filename: "shot.png", size: PNG.byteLength });
     expect(out.caption).toBe("看图：");
   });
 
@@ -119,6 +138,16 @@ describe("toOutboundImageMessage (format/content conversion)", () => {
     expect(out.format).toBe("file");
     expect(isImageBatchRefContent(out.content)).toBe(true);
     expect(out.content).toMatchObject({ caption: "看图", attachments: [ref] });
+  });
+
+  it("keeps a tracked request as request while attaching the captured image batch", () => {
+    const out = toOutboundImageMessage("request", "Choose the rollout?", {
+      caption: "Choose the rollout?",
+      imageRefs: [ref],
+    });
+    expect(out.format).toBe("request");
+    expect(out.content).toEqual({ caption: "Choose the rollout?", attachments: [ref] });
+    expect(isImageBatchRefContent(out.content)).toBe(true);
   });
 
   it("omits the caption key for an image-only send (empty caption)", () => {

--- a/apps/cli/src/commands/chat/ask.ts
+++ b/apps/cli/src/commands/chat/ask.ts
@@ -3,6 +3,7 @@ import type { Command } from "commander";
 import { fail, success } from "../../cli/output.js";
 import { channelConfig } from "../../core/channel.js";
 import { captureOutboundDocs } from "../../core/doc-capture.js";
+import { captureOutboundImages, toOutboundImageMessage } from "../../core/image-capture.js";
 import { print } from "../../core/output.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
 import { guardInlineShellResidue, looksLikeEscapedNewlineBody, readMessageBody, readStdin } from "./_shared/io.js";
@@ -141,6 +142,8 @@ export function registerChatAskCommand(chat: Command): void {
         const sdk = createSdk(options.agent);
 
         const captured = await captureOutboundDocs(content ?? "", { sdk, chatId });
+        const capturedImages = await captureOutboundImages(captured.content, { sdk, chatId });
+        const { content: outboundContent } = toOutboundImageMessage(format, captured.content, capturedImages);
         const cliBodyOrigin =
           options.messageFile !== undefined
             ? CLI_BODY_ORIGINS.MESSAGE_FILE
@@ -164,7 +167,7 @@ export function registerChatAskCommand(chat: Command): void {
         // under another message (no `inReplyTo`).
         const result = await sdk.sendMessage(chatId, {
           format,
-          content: captured.content,
+          content: outboundContent,
           metadata: outboundMetadata,
           source: "cli",
           ...(target ? { receiverNames: [target] } : {}),

--- a/apps/cli/src/commands/chat/ask.ts
+++ b/apps/cli/src/commands/chat/ask.ts
@@ -1,9 +1,16 @@
-import { CLI_BODY_ORIGIN_METADATA_KEY, CLI_BODY_ORIGINS, type MessageFormat } from "@first-tree/shared";
+import {
+  type AttachmentRef,
+  attachmentRefSchema,
+  CLI_BODY_ORIGIN_METADATA_KEY,
+  CLI_BODY_ORIGINS,
+  MAX_MESSAGE_ATTACHMENT_REFS,
+  type MessageFormat,
+} from "@first-tree/shared";
 import type { Command } from "commander";
 import { fail, success } from "../../cli/output.js";
 import { channelConfig } from "../../core/channel.js";
 import { captureOutboundDocs } from "../../core/doc-capture.js";
-import { captureOutboundImages, toOutboundImageMessage } from "../../core/image-capture.js";
+import { captureOutboundImages, toGenericImageAttachmentRefs } from "../../core/image-capture.js";
 import { print } from "../../core/output.js";
 import { createSdk, handleSdkError } from "../_shared/local-agent.js";
 import { guardInlineShellResidue, looksLikeEscapedNewlineBody, readMessageBody, readStdin } from "./_shared/io.js";
@@ -16,6 +23,33 @@ interface AskOptions {
   options?: string;
   multiSelect?: boolean;
   messageFile?: string;
+}
+
+/**
+ * Write-side reader for caller-supplied attachment metadata. Render paths are
+ * intentionally tolerant of malformed history, but a new send must fail
+ * closed instead of silently dropping bad entries while merging captures.
+ */
+function readOutboundAttachmentRefs(metadata: Record<string, unknown> | undefined): AttachmentRef[] {
+  const raw = metadata?.attachments;
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) {
+    fail("INVALID_METADATA", "metadata.attachments must be an array of attachment references.", 2);
+  }
+  if (raw.length > MAX_MESSAGE_ATTACHMENT_REFS) {
+    fail(
+      "INVALID_METADATA",
+      `metadata.attachments exceeds the per-message limit of ${MAX_MESSAGE_ATTACHMENT_REFS}.`,
+      2,
+    );
+  }
+  return raw.map((entry, index) => {
+    const parsed = attachmentRefSchema.safeParse(entry);
+    if (!parsed.success) {
+      fail("INVALID_METADATA", `metadata.attachments[${index}] is not a valid attachment reference.`, 2);
+    }
+    return parsed.data;
+  });
 }
 
 export function registerChatAskCommand(chat: Command): void {
@@ -138,12 +172,28 @@ export function registerChatAskCommand(chat: Command): void {
         }
         const format: MessageFormat = "request";
         metadata = buildRequestMetadata(metadata, options);
+        const existingAttachments = readOutboundAttachmentRefs(metadata);
 
         const sdk = createSdk(options.agent);
 
-        const captured = await captureOutboundDocs(content ?? "", { sdk, chatId });
-        const capturedImages = await captureOutboundImages(captured.content, { sdk, chatId });
-        const { content: outboundContent } = toOutboundImageMessage(format, captured.content, capturedImages);
+        const captured = await captureOutboundDocs(content ?? "", {
+          sdk,
+          chatId,
+          maxAttachments: MAX_MESSAGE_ATTACHMENT_REFS - existingAttachments.length,
+        });
+        const documentAttachments = captured.attachments ?? [];
+        const imageCapacity = Math.max(
+          0,
+          MAX_MESSAGE_ATTACHMENT_REFS - existingAttachments.length - documentAttachments.length,
+        );
+        const capturedImages = await captureOutboundImages(captured.content, {
+          sdk,
+          chatId,
+          maxAttachments: imageCapacity,
+        });
+        const imageAttachments = toGenericImageAttachmentRefs(capturedImages.imageRefs);
+        const outboundAttachments = [...existingAttachments, ...documentAttachments, ...imageAttachments];
+        const outboundContent = imageAttachments.length > 0 ? capturedImages.caption : captured.content;
         const cliBodyOrigin =
           options.messageFile !== undefined
             ? CLI_BODY_ORIGINS.MESSAGE_FILE
@@ -155,10 +205,10 @@ export function registerChatAskCommand(chat: Command): void {
             ? { ...(metadata ?? {}), [CLI_BODY_ORIGIN_METADATA_KEY]: cliBodyOrigin }
             : metadata;
         const outboundMetadata =
-          captured.attachments || captured.documentContext
+          outboundAttachments.length > 0 || captured.documentContext
             ? {
                 ...(metadataWithBodyOrigin ?? {}),
-                ...(captured.attachments ? { attachments: captured.attachments } : {}),
+                ...(outboundAttachments.length > 0 ? { attachments: outboundAttachments } : {}),
                 ...(captured.documentContext ? { documentContext: captured.documentContext } : {}),
               }
             : metadataWithBodyOrigin;

--- a/apps/cli/src/core/capture-context.ts
+++ b/apps/cli/src/core/capture-context.ts
@@ -31,3 +31,16 @@ export function resolveSelfFenceFromEnv(env: NodeJS.ProcessEnv): SelfFence | nul
   const legacyBase = env.FIRST_TREE_DOC_BASE;
   return legacyBase ? { agentHome: legacyBase } : null;
 }
+
+/**
+ * Image embeds are authored directly in an agent turn, so their relative paths
+ * are workspace-relative. Keep the document capture's optional repo base out
+ * of this fence: generated screenshots commonly live beside `source-repos/`,
+ * and an agent-managed source repository may be bare.
+ */
+export function resolveImageFenceFromEnv(env: NodeJS.ProcessEnv): SelfFence | null {
+  const agentHome = env.FIRST_TREE_DOC_AGENT_HOME;
+  if (agentHome) return { agentHome };
+  const legacyBase = env.FIRST_TREE_DOC_BASE;
+  return legacyBase ? { agentHome: legacyBase } : null;
+}

--- a/apps/cli/src/core/doc-capture.ts
+++ b/apps/cli/src/core/doc-capture.ts
@@ -27,7 +27,7 @@ import { resolveChatOrgId, resolveSelfFenceFromEnv } from "./capture-context.js"
  */
 export async function captureOutboundDocs(
   content: string,
-  ctx: { sdk: FirstTreeHubSDK; chatId?: string },
+  ctx: { sdk: FirstTreeHubSDK; chatId?: string; maxAttachments?: number },
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<{ content: string; attachments?: AttachmentRef[]; documentContext?: unknown }> {
   const self = resolveSelfFenceFromEnv(env);
@@ -45,7 +45,11 @@ export async function captureOutboundDocs(
     const { refs, rewrittenText, failedMentions } = await buildMessageDocumentSnapshots(
       content,
       self,
-      { uploader: ctx.sdk, orgId },
+      {
+        uploader: ctx.sdk,
+        orgId,
+        ...(ctx.maxAttachments !== undefined ? { maxAttachments: ctx.maxAttachments } : {}),
+      },
       fence,
     );
     const result: { content: string; attachments?: AttachmentRef[]; documentContext?: unknown } = {

--- a/apps/cli/src/core/image-capture.ts
+++ b/apps/cli/src/core/image-capture.ts
@@ -1,6 +1,6 @@
 import { buildMessageImageSnapshots, type FirstTreeHubSDK } from "@first-tree/client";
 import type { ImageRefContent, MessageFormat } from "@first-tree/shared";
-import { resolveChatOrgId, resolveSelfFenceFromEnv } from "./capture-context.js";
+import { resolveChatOrgId, resolveImageFenceFromEnv } from "./capture-context.js";
 
 /**
  * Capture the workspace images an outbound `chat send` body references, the
@@ -20,7 +20,7 @@ export async function captureOutboundImages(
   ctx: { sdk: FirstTreeHubSDK; chatId?: string },
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<{ caption: string; imageRefs: ImageRefContent[] }> {
-  const self = resolveSelfFenceFromEnv(env);
+  const self = resolveImageFenceFromEnv(env);
   if (!self || !ctx.chatId) return { caption: content, imageRefs: [] };
 
   try {
@@ -35,22 +35,21 @@ export async function captureOutboundImages(
 
 /**
  * Decide the outbound `format` + `content` given the doc-captured body and the
- * image-capture result. When any image captured (and the base format is an
- * image-eligible text/markdown), the send becomes a human-identical
- * `imageBatchRefContent` file message: caption = the image-stripped body
- * (omitted when empty), attachments = the refs. `card`/`request`/`reference`
- * bodies and image-free sends pass through unchanged. Pure + synchronous so the
- * conversion is unit-tested without a live send.
+ * image-capture result. Text/markdown sends become a human-identical
+ * `imageBatchRefContent` file message. A tracked request keeps
+ * `format: "request"` while reusing that same image-batch content shape, so
+ * its open-question semantics survive. Card/reference bodies and image-free
+ * sends pass through unchanged.
  */
 export function toOutboundImageMessage(
   baseFormat: MessageFormat,
   docContent: string,
   captured: { caption: string; imageRefs: ImageRefContent[] },
 ): { format: MessageFormat; content: unknown } {
-  const eligible = baseFormat === "text" || baseFormat === "markdown";
+  const eligible = baseFormat === "text" || baseFormat === "markdown" || baseFormat === "request";
   if (!eligible || captured.imageRefs.length === 0) return { format: baseFormat, content: docContent };
   return {
-    format: "file",
+    format: baseFormat === "request" ? "request" : "file",
     content: {
       ...(captured.caption.trim() ? { caption: captured.caption } : {}),
       attachments: captured.imageRefs,

--- a/apps/cli/src/core/image-capture.ts
+++ b/apps/cli/src/core/image-capture.ts
@@ -1,14 +1,15 @@
 import { buildMessageImageSnapshots, type FirstTreeHubSDK } from "@first-tree/client";
-import type { ImageRefContent, MessageFormat } from "@first-tree/shared";
+import type { AttachmentRef, ImageRefContent, MessageFormat } from "@first-tree/shared";
 import { resolveChatOrgId, resolveImageFenceFromEnv } from "./capture-context.js";
 
 /**
  * Capture the workspace images an outbound `chat send` body references, the
  * picture sibling of `captureOutboundDocs`. An agent that writes a markdown
  * image `![alt](path)` pointing at a local image inside its own workspace gets
- * the bytes uploaded to the org attachment store; the caller then sends the
- * message as a `format: "file"` image batch (caption = the image-stripped body,
- * attachments = these refs) so web renders it exactly like a human image send.
+ * the bytes uploaded to the org attachment store; the caller then chooses the
+ * persisted reference shape. Ordinary sends use a `format: "file"` image batch,
+ * while tracked asks adapt the refs into generic metadata attachments and keep
+ * the request content textual.
  *
  * Like doc capture, this resolves the send-side fence from the runtime-injected
  * env and the upload org from the target chat, so it is a pure pass-through
@@ -17,7 +18,7 @@ import { resolveChatOrgId, resolveImageFenceFromEnv } from "./capture-context.js
  */
 export async function captureOutboundImages(
   content: string,
-  ctx: { sdk: FirstTreeHubSDK; chatId?: string },
+  ctx: { sdk: FirstTreeHubSDK; chatId?: string; maxAttachments?: number },
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<{ caption: string; imageRefs: ImageRefContent[] }> {
   const self = resolveImageFenceFromEnv(env);
@@ -26,7 +27,11 @@ export async function captureOutboundImages(
   try {
     const orgId = await resolveChatOrgId(ctx.sdk, ctx.chatId);
     if (!orgId) return { caption: content, imageRefs: [] };
-    const { imageRefs, strippedText } = await buildMessageImageSnapshots(content, self, { uploader: ctx.sdk, orgId });
+    const { imageRefs, strippedText } = await buildMessageImageSnapshots(content, self, {
+      uploader: ctx.sdk,
+      orgId,
+      ...(ctx.maxAttachments !== undefined ? { maxAttachments: ctx.maxAttachments } : {}),
+    });
     return { caption: strippedText, imageRefs };
   } catch {
     return { caption: content, imageRefs: [] };
@@ -36,23 +41,44 @@ export async function captureOutboundImages(
 /**
  * Decide the outbound `format` + `content` given the doc-captured body and the
  * image-capture result. Text/markdown sends become a human-identical
- * `imageBatchRefContent` file message. A tracked request keeps
- * `format: "request"` while reusing that same image-batch content shape, so
- * its open-question semantics survive. Card/reference bodies and image-free
- * sends pass through unchanged.
+ * `imageBatchRefContent` file message. Requests keep their textual body and
+ * attach images through generic metadata in `chat ask`; card/reference bodies
+ * and image-free sends pass through unchanged.
  */
 export function toOutboundImageMessage(
   baseFormat: MessageFormat,
   docContent: string,
   captured: { caption: string; imageRefs: ImageRefContent[] },
 ): { format: MessageFormat; content: unknown } {
-  const eligible = baseFormat === "text" || baseFormat === "markdown" || baseFormat === "request";
+  const eligible = baseFormat === "text" || baseFormat === "markdown";
   if (!eligible || captured.imageRefs.length === 0) return { format: baseFormat, content: docContent };
   return {
-    format: baseFormat === "request" ? "request" : "file",
+    format: "file",
     content: {
       ...(captured.caption.trim() ? { caption: captured.caption } : {}),
       attachments: captured.imageRefs,
     },
   };
+}
+
+/**
+ * Adapt freshly uploaded legacy image refs into the generic metadata ref used
+ * by tracked requests. Capture always supplies `size`; an incomplete ref is
+ * dropped so the server never receives metadata that cannot pass blob
+ * integrity validation.
+ */
+export function toGenericImageAttachmentRefs(imageRefs: readonly ImageRefContent[]): AttachmentRef[] {
+  return imageRefs.flatMap((ref) =>
+    ref.size === undefined
+      ? []
+      : [
+          {
+            attachmentId: ref.imageId,
+            kind: "image" as const,
+            mimeType: ref.mimeType,
+            filename: ref.filename,
+            size: ref.size,
+          },
+        ],
+  );
 }

--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -436,7 +436,7 @@ describe("formatInboundContent", () => {
     expect(out).not.toContain('{"caption"');
   });
 
-  it("renders a tracked request image batch for the agent instead of a JSON dump", async () => {
+  it("renders generic request image attachments without changing the textual body", async () => {
     const sdk = mkSdk(async () => participants);
     const cache = createParticipantCache(sdk, "chat-1", () => {});
     const msg: SessionMessage = {
@@ -444,23 +444,25 @@ describe("formatInboundContent", () => {
       chatId: "chat-1",
       senderId: "agent-a",
       format: "request",
-      content: {
-        caption: "Which layout should ship?",
+      content: "Which layout should ship?",
+      metadata: {
+        request: {},
         attachments: [
           {
-            imageId: "9c2ce4e7-3f0d-4f53-9c0c-1c93e7d51a92",
+            attachmentId: "9c2ce4e7-3f0d-4f53-9c0c-1c93e7d51a92",
+            kind: "image",
             mimeType: "image/png",
             filename: "decision.png",
+            size: 42,
           },
         ],
       },
-      metadata: { request: {} },
     };
     const out = await formatInboundContent(msg, cache);
     expect(out).toContain("Which layout should ship?");
     expect(out).toContain("An image was shared");
     expect(out).toContain("decision.png");
-    expect(out).not.toContain('{"caption"');
+    expect(out).not.toContain('{"attachments"');
   });
 
   it("does not reinterpret a batch-shaped card as an image message", async () => {
@@ -601,7 +603,7 @@ describe("formatInboundContent", () => {
     expect(out).not.toContain("file was shared");
   });
 
-  it("does not render image metadata attachments as document files", async () => {
+  it("renders image metadata attachments through the image path, not as document files", async () => {
     const sdk = mkSdk(async () => participants);
     const cache = createParticipantCache(sdk, "chat-1", () => {});
     const msg: SessionMessage = {
@@ -625,8 +627,9 @@ describe("formatInboundContent", () => {
 
     const out = await formatInboundContent(msg, cache);
 
-    expect(out).toBe("[From: alice · type=agent]\n\nImage metadata only.");
-    expect(out).not.toContain("chart.png");
+    expect(out).toContain("[From: alice · type=agent]\n\nImage metadata only.");
+    expect(out).toContain("An image was shared in this chat");
+    expect(out).toContain('Image "chart.png" not available on this device');
     expect(out).not.toContain("file was shared");
   });
 

--- a/packages/client/src/__tests__/agent-io.test.ts
+++ b/packages/client/src/__tests__/agent-io.test.ts
@@ -436,6 +436,59 @@ describe("formatInboundContent", () => {
     expect(out).not.toContain('{"caption"');
   });
 
+  it("renders a tracked request image batch for the agent instead of a JSON dump", async () => {
+    const sdk = mkSdk(async () => participants);
+    const cache = createParticipantCache(sdk, "chat-1", () => {});
+    const msg: SessionMessage = {
+      id: "m1",
+      chatId: "chat-1",
+      senderId: "agent-a",
+      format: "request",
+      content: {
+        caption: "Which layout should ship?",
+        attachments: [
+          {
+            imageId: "9c2ce4e7-3f0d-4f53-9c0c-1c93e7d51a92",
+            mimeType: "image/png",
+            filename: "decision.png",
+          },
+        ],
+      },
+      metadata: { request: {} },
+    };
+    const out = await formatInboundContent(msg, cache);
+    expect(out).toContain("Which layout should ship?");
+    expect(out).toContain("An image was shared");
+    expect(out).toContain("decision.png");
+    expect(out).not.toContain('{"caption"');
+  });
+
+  it("does not reinterpret a batch-shaped card as an image message", async () => {
+    const sdk = mkSdk(async () => participants);
+    const cache = createParticipantCache(sdk, "chat-1", () => {});
+    const content = {
+      caption: "card payload",
+      attachments: [
+        {
+          imageId: "9c2ce4e7-3f0d-4f53-9c0c-1c93e7d51a92",
+          mimeType: "image/png",
+          filename: "not-an-image-message.png",
+        },
+      ],
+    };
+    const msg: SessionMessage = {
+      id: "m1",
+      chatId: "chat-1",
+      senderId: "agent-a",
+      format: "card",
+      content,
+      metadata: null,
+    };
+    const out = await formatInboundContent(msg, cache);
+    expect(out).toContain(JSON.stringify(content));
+    expect(out).not.toContain("An image was shared");
+  });
+
   it("renders a single image ref (pre-batch shape) as filename + placeholder", async () => {
     const sdk = mkSdk(async () => participants);
     const cache = createParticipantCache(sdk, "chat-1", () => {});

--- a/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
+++ b/packages/client/src/__tests__/claude-code-inject-startup-race.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatInboundContent } from "../runtime/agent-io.js";
 import type { ChatContext } from "../runtime/chat-context.js";
 import type { SessionContext, SessionMessage } from "../runtime/handler.js";
 import { mockCtxPlumbing } from "./test-helpers.js";
@@ -206,9 +207,14 @@ describe("claude-code handler startup inject queue", () => {
   it("materializes legacy inline images and describes unavailable image batches", async () => {
     const completedCounts: Array<number | undefined> = [];
     const handler = createClaudeCodeHandler({ workspaceRoot });
-    const ctx = makeContext((count) => {
-      completedCounts.push(count);
-    });
+    const ctx = makeContext(
+      (count) => {
+        completedCounts.push(count);
+      },
+      {
+        formatInboundContent: async (message) => formatInboundContent(message, { get: async () => [] }),
+      },
+    );
     state.resolveChatContext?.({
       chatId: "chat-claude-startup-race",
       title: "startup race",
@@ -230,34 +236,55 @@ describe("claude-code handler startup inject queue", () => {
       ctx,
     );
 
-    handler.inject(
-      makeFileMessage("batch-images", {
-        caption: "Compare these screenshots",
-        attachments: [
-          {
-            imageId: "00000000-0000-4000-8000-000000000001",
-            mimeType: "image/png",
-            filename: "one.png",
-            size: 12,
-          },
-          {
-            imageId: "00000000-0000-4000-8000-000000000002",
-            mimeType: "image/jpeg",
-            filename: "two.jpg",
-            size: 34,
-          },
-        ],
-      }),
-    );
+    const batchMessage = makeFileMessage("batch-images", {
+      caption: "Compare these screenshots",
+      attachments: [
+        {
+          imageId: "00000000-0000-4000-8000-000000000001",
+          mimeType: "image/png",
+          filename: "one.png",
+          size: 12,
+        },
+        {
+          imageId: "00000000-0000-4000-8000-000000000002",
+          mimeType: "image/jpeg",
+          filename: "two.jpg",
+          size: 34,
+        },
+      ],
+    });
+    batchMessage.precedingMessages = [
+      {
+        id: "earlier-request",
+        senderId: "agent-2",
+        format: "request",
+        content: "Which earlier layout should ship?",
+        metadata: {
+          request: {},
+          attachments: [
+            {
+              attachmentId: "00000000-0000-4000-8000-000000000003",
+              kind: "image",
+              mimeType: "image/png",
+              filename: "decision.png",
+              size: 56,
+            },
+          ],
+        },
+        createdAt: "2026-07-24T00:00:00.000Z",
+      },
+    ];
+    handler.inject(batchMessage);
 
     await waitFor(() => state.observedInputs.length === 2);
     expect(state.observedInputs[0]).toContain("Filename: legacy.png");
     expect(state.observedInputs[0]).toContain(join("first-tree", "images", "unknown"));
     expect(state.observedInputs[0]).toContain(".png");
     expect(state.observedInputs[1]).toContain("Compare these screenshots");
-    expect(state.observedInputs[1]).toContain(
-      "2 images were shared in this chat. Please use the Read tool to read each one",
-    );
+    expect(state.observedInputs[1]).toContain("[Earlier in chat — context you missed]");
+    expect(state.observedInputs[1]).toContain("Which earlier layout should ship?");
+    expect(state.observedInputs[1]).toContain('[Image "decision.png" not available on this device]');
+    expect(state.observedInputs[1]).toContain("2 images were shared in this chat");
     expect(state.observedInputs[1]).toContain('[Image "one.png" not available on this device]');
     expect(state.observedInputs[1]).toContain('[Image "two.jpg" not available on this device]');
     expect(completedCounts).toEqual([undefined, undefined]);

--- a/packages/client/src/__tests__/doc-snapshots.test.ts
+++ b/packages/client/src/__tests__/doc-snapshots.test.ts
@@ -162,6 +162,21 @@ describe("buildMessageDocumentSnapshots — capture + attachment-link rewrite", 
     expect(failedMentions).toEqual([]);
   });
 
+  it("honors a smaller caller-specific share of the attachment budget", async () => {
+    const names = ["caller-budget-1.md", "caller-budget-2.md", "caller-budget-3.md"];
+    await Promise.all(names.map((name) => writeFile(join(root, name), `# ${name}\n`, "utf8")));
+
+    const { refs, skipped } = await buildMessageDocumentSnapshots(
+      names.map((name) => `[${name}](${name})`).join(" "),
+      root,
+      { ...opts(uploader), maxAttachments: 1 },
+    );
+
+    expect(refs).toHaveLength(1);
+    expect(skipped).toBe(2);
+    expect(uploads).toHaveLength(1);
+  });
+
   it("reports an existing .md directory as missing", async () => {
     await mkdir(join(root, "folder.md"), { recursive: true });
 

--- a/packages/client/src/__tests__/image-snapshots.test.ts
+++ b/packages/client/src/__tests__/image-snapshots.test.ts
@@ -321,6 +321,18 @@ describe("buildMessageImageSnapshots — batch cap", () => {
     expect(res.strippedText).not.toContain("![");
   });
 
+  it("honors a smaller caller cap for generic message attachments", async () => {
+    const { uploader, uploads } = stubUploader();
+    const res = await buildMessageImageSnapshots("![a](p0.png) ![b](p1.png)", root, {
+      ...opts(uploader),
+      maxAttachments: 1,
+    });
+    expect(res.imageRefs.map((ref) => ref.filename)).toEqual(["p0.png"]);
+    expect(uploads).toHaveLength(1);
+    expect(res.skipped).toBe(1);
+    expect(res.strippedText).not.toContain("![");
+  });
+
   it("does not let unsupported targets consume the cap budget (cap is over supported images)", async () => {
     const { uploader } = stubUploader();
     const txts = Array.from({ length: 20 }, (_, i) => `![n${i}](notes${i}.txt)`).join(" ");

--- a/packages/client/src/__tests__/session-manager-more-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-more-coverage.test.ts
@@ -630,7 +630,7 @@ describe("SessionManager additional delivery token and payload coverage", () => 
     await sm.shutdown();
   });
 
-  it("downloads request image batches before routing them to the agent", async () => {
+  it("downloads generic request image attachments before routing them to the agent", async () => {
     const home = mkdtempSync(join(tmpdir(), "session-manager-request-images-"));
     vi.stubEnv("FIRST_TREE_HOME", home);
     try {
@@ -651,18 +651,19 @@ describe("SessionManager additional delivery token and payload coverage", () => 
         message: {
           ...base.message,
           format: "request",
-          content: {
-            caption: "Which layout should ship?",
+          content: "Which layout should ship?",
+          metadata: {
+            request: {},
             attachments: [
               {
-                imageId,
+                attachmentId: imageId,
+                kind: "image",
                 mimeType: "image/png",
                 filename: "decision.png",
                 size: 11,
               },
             ],
           },
-          metadata: { request: {} },
         },
       };
 

--- a/packages/client/src/__tests__/session-manager-more-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-more-coverage.test.ts
@@ -21,6 +21,7 @@ import type {
   SessionContext,
   SessionMessage,
 } from "../runtime/handler.js";
+import { findImagePath } from "../runtime/image-store.js";
 import { InboxDeliveryCoordinator } from "../runtime/inbox-delivery-coordinator.js";
 import type { SubprocessProbe } from "../runtime/process-tree-probe.js";
 import { SessionManager, type SessionManagerShutdownOptions } from "../runtime/session-manager.js";
@@ -626,6 +627,87 @@ describe("SessionManager additional delivery token and payload coverage", () => 
     expect(capturedMessage?.format).toBe("file");
     expect(capturedMessage?.content).toEqual({ attachments: [{ imageId: "image-without-mime-type" }] });
 
+    await sm.shutdown();
+  });
+
+  it("downloads request image batches before routing them to the agent", async () => {
+    const home = mkdtempSync(join(tmpdir(), "session-manager-request-images-"));
+    vi.stubEnv("FIRST_TREE_HOME", home);
+    try {
+      const fetchAttachment = vi.fn().mockResolvedValue({ bytes: Buffer.from("image bytes") });
+      const sdk = mockSdk({ fetchAttachment });
+      let capturedMessage: SessionMessage | undefined;
+      const handler = createMockHandler({
+        start: vi.fn(async (message) => {
+          capturedMessage = message;
+          return "session-id-mock";
+        }),
+      });
+      const sm = createSessionManager({ handler, sdk });
+      const imageId = "11111111-1111-4111-8111-111111111111";
+      const base = mockEntry({ id: 405, chatId: "chat-request-image", messageId: "msg-request-image" });
+      const requestEntry: InboxEntryWithMessage = {
+        ...base,
+        message: {
+          ...base.message,
+          format: "request",
+          content: {
+            caption: "Which layout should ship?",
+            attachments: [
+              {
+                imageId,
+                mimeType: "image/png",
+                filename: "decision.png",
+                size: 11,
+              },
+            ],
+          },
+          metadata: { request: {} },
+        },
+      };
+
+      await sm.dispatch(requestEntry);
+
+      expect(fetchAttachment).toHaveBeenCalledWith({ id: imageId });
+      expect(findImagePath("chat-request-image", imageId, "image/png")).not.toBeNull();
+      expect(capturedMessage?.format).toBe("request");
+      expect(capturedMessage?.content).toEqual(requestEntry.message.content);
+
+      await sm.shutdown();
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("does not download batch-shaped content from non-image message formats", async () => {
+    const fetchAttachment = vi.fn().mockResolvedValue({ bytes: Buffer.from("image bytes") });
+    const sdk = mockSdk({ fetchAttachment });
+    const handler = createMockHandler();
+    const sm = createSessionManager({ handler, sdk });
+    const base = mockEntry({ id: 406, chatId: "chat-card-batch", messageId: "msg-card-batch" });
+    const cardEntry: InboxEntryWithMessage = {
+      ...base,
+      message: {
+        ...base.message,
+        format: "card",
+        content: {
+          caption: "card payload",
+          attachments: [
+            {
+              imageId: "11111111-1111-4111-8111-111111111111",
+              mimeType: "image/png",
+              filename: "not-an-image-message.png",
+            },
+          ],
+        },
+      },
+    };
+
+    await sm.dispatch(cardEntry);
+
+    expect(fetchAttachment).not.toHaveBeenCalled();
+    expect(handler.start).toHaveBeenCalledTimes(1);
     await sm.shutdown();
   });
 

--- a/packages/client/src/__tests__/session-manager-more-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-more-coverage.test.ts
@@ -701,44 +701,71 @@ describe("SessionManager additional delivery token and payload coverage", () => 
     }
   });
 
-  it("bounds preceding-context image fetches and prioritizes the newest refs", async () => {
+  it("bounds preceding request-image fetches without consuming the budget for non-request images", async () => {
     const home = mkdtempSync(join(tmpdir(), "session-manager-bounded-images-"));
     vi.stubEnv("FIRST_TREE_HOME", home);
     try {
       const fetchAttachment = vi.fn().mockResolvedValue({ bytes: Buffer.from("image bytes") });
       const sdk = mockSdk({ fetchAttachment });
-      const handler = createMockHandler();
+      let renderedContent = "";
+      const handler = createMockHandler({
+        start: vi.fn(async (message, ctx) => {
+          renderedContent = await ctx.formatInboundContent(message);
+          return "session-id-mock";
+        }),
+      });
       const sm = createSessionManager({ handler, sdk });
       const base = mockEntry({ id: 408, chatId: "chat-bounded-images", messageId: "msg-bounded-images" });
       const imageIds = Array.from(
         { length: 12 },
         (_, index) => `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
       );
+      const nonRequestImageId = "99999999-9999-4999-8999-999999999999";
       const entry: InboxEntryWithMessage = {
         ...base,
         message: {
           ...base.message,
           format: "text",
           content: "@agent-1 review the recent context",
-          precedingMessages: imageIds.map((attachmentId, index) => ({
-            id: `preceding-${index}`,
-            senderId: "agent-2",
-            format: "request",
-            content: `Decision ${index}`,
-            metadata: {
-              request: {},
-              attachments: [
-                {
-                  attachmentId,
-                  kind: "image",
-                  mimeType: "image/png",
-                  filename: `decision-${index}.png`,
-                  size: 11,
-                },
-              ],
+          precedingMessages: [
+            ...imageIds.map((attachmentId, index) => ({
+              id: `preceding-${index}`,
+              senderId: "agent-2",
+              format: "request" as const,
+              content: `Decision ${index}`,
+              metadata: {
+                request: {},
+                attachments: [
+                  {
+                    attachmentId,
+                    kind: "image",
+                    mimeType: "image/png",
+                    filename: `decision-${index}.png`,
+                    size: 11,
+                  },
+                ],
+              },
+              createdAt: new Date(Date.UTC(2026, 6, 24, 0, 0, index)).toISOString(),
+            })),
+            {
+              id: "newer-non-request-image",
+              senderId: "agent-2",
+              format: "text",
+              content: "An unrelated image",
+              metadata: {
+                attachments: [
+                  {
+                    attachmentId: nonRequestImageId,
+                    kind: "image",
+                    mimeType: "image/png",
+                    filename: "unrelated.png",
+                    size: 11,
+                  },
+                ],
+              },
+              createdAt: "2026-07-24T00:01:00.000Z",
             },
-            createdAt: new Date(Date.UTC(2026, 6, 24, 0, 0, index)).toISOString(),
-          })),
+          ],
         },
       };
 
@@ -747,6 +774,9 @@ describe("SessionManager additional delivery token and payload coverage", () => 
       expect(fetchAttachment).toHaveBeenCalledTimes(10);
       const fetchedIds = fetchAttachment.mock.calls.map(([arg]) => (arg as { id: string }).id);
       expect(fetchedIds).toEqual(imageIds.slice(2).reverse());
+      expect(fetchedIds).not.toContain(nonRequestImageId);
+      expect(renderedContent).toContain("An unrelated image");
+      expect(renderedContent).not.toContain("Filename: unrelated.png");
 
       await sm.shutdown();
     } finally {

--- a/packages/client/src/__tests__/session-manager-more-coverage.test.ts
+++ b/packages/client/src/__tests__/session-manager-more-coverage.test.ts
@@ -630,16 +630,21 @@ describe("SessionManager additional delivery token and payload coverage", () => 
     await sm.shutdown();
   });
 
-  it("downloads generic request image attachments before routing them to the agent", async () => {
+  it("downloads and renders request images from production-reachable preceding context", async () => {
     const home = mkdtempSync(join(tmpdir(), "session-manager-request-images-"));
     vi.stubEnv("FIRST_TREE_HOME", home);
     try {
       const fetchAttachment = vi.fn().mockResolvedValue({ bytes: Buffer.from("image bytes") });
-      const sdk = mockSdk({ fetchAttachment });
+      const sdk = mockSdk({
+        fetchAttachment,
+        listChatParticipants: vi.fn().mockResolvedValue([]),
+      });
       let capturedMessage: SessionMessage | undefined;
+      let renderedContent = "";
       const handler = createMockHandler({
-        start: vi.fn(async (message) => {
+        start: vi.fn(async (message, ctx) => {
           capturedMessage = message;
+          renderedContent = await ctx.formatInboundContent(message);
           return "session-id-mock";
         }),
       });
@@ -650,29 +655,98 @@ describe("SessionManager additional delivery token and payload coverage", () => 
         ...base,
         message: {
           ...base.message,
-          format: "request",
-          content: "Which layout should ship?",
-          metadata: {
-            request: {},
-            attachments: [
-              {
-                attachmentId: imageId,
-                kind: "image",
-                mimeType: "image/png",
-                filename: "decision.png",
-                size: 11,
+          format: "text",
+          content: "@agent-1 please review the earlier decision",
+          metadata: {},
+          precedingMessages: [
+            {
+              id: "request-for-human",
+              senderId: "agent-2",
+              format: "request",
+              content: "Which layout should ship?",
+              metadata: {
+                request: {},
+                attachments: [
+                  {
+                    attachmentId: imageId,
+                    kind: "image",
+                    mimeType: "image/png",
+                    filename: "decision.png",
+                    size: 11,
+                  },
+                ],
               },
-            ],
-          },
+              createdAt: "2026-07-24T00:00:00.000Z",
+            },
+          ],
         },
       };
 
       await sm.dispatch(requestEntry);
 
       expect(fetchAttachment).toHaveBeenCalledWith({ id: imageId });
-      expect(findImagePath("chat-request-image", imageId, "image/png")).not.toBeNull();
-      expect(capturedMessage?.format).toBe("request");
+      const path = findImagePath("chat-request-image", imageId, "image/png");
+      expect(path).not.toBeNull();
+      expect(capturedMessage?.format).toBe("text");
       expect(capturedMessage?.content).toEqual(requestEntry.message.content);
+      expect(renderedContent).toContain("[Earlier in chat — context you missed]");
+      expect(renderedContent).toContain("Which layout should ship?");
+      expect(renderedContent).toContain("Filename: decision.png");
+      expect(renderedContent).toContain(`Path: ${path}`);
+
+      await sm.shutdown();
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("bounds preceding-context image fetches and prioritizes the newest refs", async () => {
+    const home = mkdtempSync(join(tmpdir(), "session-manager-bounded-images-"));
+    vi.stubEnv("FIRST_TREE_HOME", home);
+    try {
+      const fetchAttachment = vi.fn().mockResolvedValue({ bytes: Buffer.from("image bytes") });
+      const sdk = mockSdk({ fetchAttachment });
+      const handler = createMockHandler();
+      const sm = createSessionManager({ handler, sdk });
+      const base = mockEntry({ id: 408, chatId: "chat-bounded-images", messageId: "msg-bounded-images" });
+      const imageIds = Array.from(
+        { length: 12 },
+        (_, index) => `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+      );
+      const entry: InboxEntryWithMessage = {
+        ...base,
+        message: {
+          ...base.message,
+          format: "text",
+          content: "@agent-1 review the recent context",
+          precedingMessages: imageIds.map((attachmentId, index) => ({
+            id: `preceding-${index}`,
+            senderId: "agent-2",
+            format: "request",
+            content: `Decision ${index}`,
+            metadata: {
+              request: {},
+              attachments: [
+                {
+                  attachmentId,
+                  kind: "image",
+                  mimeType: "image/png",
+                  filename: `decision-${index}.png`,
+                  size: 11,
+                },
+              ],
+            },
+            createdAt: new Date(Date.UTC(2026, 6, 24, 0, 0, index)).toISOString(),
+          })),
+        },
+      };
+
+      await sm.dispatch(entry);
+
+      expect(fetchAttachment).toHaveBeenCalledTimes(10);
+      const fetchedIds = fetchAttachment.mock.calls.map(([arg]) => (arg as { id: string }).id);
+      expect(fetchedIds).toEqual(imageIds.slice(2).reverse());
 
       await sm.shutdown();
     } finally {
@@ -686,7 +760,7 @@ describe("SessionManager additional delivery token and payload coverage", () => 
     const sdk = mockSdk({ fetchAttachment });
     const handler = createMockHandler();
     const sm = createSessionManager({ handler, sdk });
-    const base = mockEntry({ id: 406, chatId: "chat-card-batch", messageId: "msg-card-batch" });
+    const base = mockEntry({ id: 409, chatId: "chat-card-batch", messageId: "msg-card-batch" });
     const cardEntry: InboxEntryWithMessage = {
       ...base,
       message: {

--- a/packages/client/src/handlers/claude-code.ts
+++ b/packages/client/src/handlers/claude-code.ts
@@ -1003,29 +1003,19 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
     sessionCtx: SessionContext,
     sessionId: string,
   ): Promise<SDKUserMessage> {
-    // Image messages — two supported shapes:
-    //   1. imageRef: `{imageId, mimeType, filename, size}` — new path. Bytes
-    //      live on local disk, fetched from the `attachments` store on delivery
-    //      (see SessionManager.ensureImagesLocal).
-    //   2. legacy inline: `{data, mimeType, filename, size}` — pre-refactor
-    //      messages still pending at rollout time. Decode once and drop the
-    //      temp path into the prompt.
-    //
-    // Either way we direct the model at a real file path because Claude Code's
-    // native Read tool loads images as multimodal content blocks — the SDK
-    // does not reliably forward `{ type: "image" }` blocks to the underlying
-    // model.
     if (message.format === "file") {
-      // Build the full attribution header (name · type · sent) once up front so
-      // both branches emit the same `[From: …]` header as the default text path.
-      const header = await sessionCtx.formatFromHeader(message);
-      const prefix = header ? `${header}\n\n` : "";
+      // Preserve the specialized current-image prompt while routing it through
+      // the shared formatter, which is responsible for the supported generic
+      // request images in precedingMessages. Clear current metadata because
+      // batch documents are appended explicitly below.
+      const formatFileText = async (text: string): Promise<string> =>
+        sessionCtx.formatInboundContent({
+          ...message,
+          format: "text",
+          content: text,
+          metadata: null,
+        });
 
-      // Batched send (caption + N images in one message). Resolve every
-      // imageId to a local path the Read tool can open; missing-byte cases
-      // surface a per-attachment "not available on this device" placeholder
-      // so the session keeps moving and a partial-delivery doesn't strand
-      // the whole turn.
       if (isImageBatchRefContent(message.content)) {
         const caption = message.content.caption?.trim() ?? "";
         const lines: string[] = [];
@@ -1037,20 +1027,17 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
         );
         for (const att of message.content.attachments) {
           const imagePath = findImagePath(message.chatId, att.imageId, att.mimeType);
-          if (imagePath) {
-            lines.push(`\nFilename: ${att.filename}\nPath: ${imagePath}`);
-          } else {
-            lines.push(`\n[Image "${att.filename}" not available on this device]`);
-          }
+          lines.push(
+            imagePath
+              ? `\nFilename: ${att.filename}\nPath: ${imagePath}`
+              : `\n[Image "${att.filename}" not available on this device]`,
+          );
         }
-        // A mixed send (images + documents) also carries document/file refs in
-        // metadata.attachments — append their on-disk paths so the agent sees
-        // both. Null when the message has no documents (the common image case).
         const docNote = renderDocumentAttachmentsForLLM(message);
         if (docNote) lines.push(`\n${docNote}`);
         return {
           type: "user",
-          message: { role: "user", content: `${prefix}${lines.join("\n")}` },
+          message: { role: "user", content: await formatFileText(lines.join("\n")) },
           parent_tool_use_id: null,
           session_id: sessionId,
         };
@@ -1059,28 +1046,22 @@ export const createClaudeCodeHandler: HandlerFactory = (config) => {
       if (isImageRefContent(message.content)) {
         const { imageId, mimeType, filename } = message.content;
         const imagePath = findImagePath(message.chatId, imageId, mimeType);
-        if (imagePath) {
-          const text = `${prefix}An image was shared in this chat. Please use the Read tool to read it, then respond based on what you see.\n\nFilename: ${filename}\nPath: ${imagePath}`;
-          return {
-            type: "user",
-            message: { role: "user", content: text },
-            parent_tool_use_id: null,
-            session_id: sessionId,
-          };
-        }
-        // Bytes never reached this client (the attachments fetch failed or
-        // the ref points at a deleted/expired attachment). Treat as the
-        // "not available on this device" case so the session keeps moving.
-        const fallbackText = `[Image "${filename}" not available on this device]`;
+        const text = imagePath
+          ? `An image was shared in this chat. Please use the Read tool to read it, then respond based on what you see.\n\nFilename: ${filename}\nPath: ${imagePath}`
+          : `[Image "${filename}" not available on this device]`;
         return {
           type: "user",
-          message: { role: "user", content: `${prefix}${fallbackText}` },
+          message: { role: "user", content: await formatFileText(text) },
           parent_tool_use_id: null,
           session_id: sessionId,
         };
       }
 
       if (isLegacyImageFileContent(message.content)) {
+        // Preserve the pre-refactor inline-image path unchanged; historical
+        // inline payload behavior is explicitly outside this PR's scope.
+        const header = await sessionCtx.formatFromHeader(message);
+        const prefix = header ? `${header}\n\n` : "";
         const { filename } = message.content;
         try {
           const imagePath = await writeLegacyImageToTempFile(message.content, message.chatId);

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -370,7 +370,7 @@ export function renderDocumentAttachmentsForLLM(message: SessionMessage): string
 }
 
 /** Render generic image attachments as local paths for the receiving agent. */
-export function renderImageAttachmentsForLLM(message: SessionMessage): string | null {
+export function renderImageAttachmentsForLLM(message: Pick<SessionMessage, "chatId" | "metadata">): string | null {
   const refs = imageAttachmentRefsFromMetadata(message.metadata ?? undefined);
   if (refs.length === 0) return null;
   const lines: string[] = [
@@ -434,7 +434,12 @@ export async function formatInboundContent(message: SessionMessage, participants
     const ps = await participants.get();
     const lines: string[] = ["[Earlier in chat — context you missed]"];
     for (const p of preceding) {
-      const text = typeof p.content === "string" ? p.content : JSON.stringify(p.content);
+      let text = typeof p.content === "string" ? p.content : JSON.stringify(p.content);
+      const imageNote = renderImageAttachmentsForLLM({
+        chatId: message.chatId,
+        metadata: p.metadata,
+      });
+      if (imageNote) text = `${text}\n\n${imageNote}`;
       lines.push(`${formatMessageFromHeaderLine(p, ps)} ${text}`);
     }
     lines.push("", "[Now — message that woke you]");

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -320,20 +320,23 @@ export async function buildFromHeader(message: SessionMessage, participants: Par
  * read as user input. Most formats are already strings; non-string
  * payloads are stringified so the resumed turn still sees readable text.
  *
- * `format: "file"` image messages (single-ref or batched caption + N refs)
- * get a human-readable rendering — caption text plus the on-disk path of
- * each image so a shell-capable LLM (codex CLI, claude-code) can read it,
- * or a "[Image … not available on this device]" placeholder when the bytes
- * never arrived on this client. Without this, codex / future handlers that
- * delegate to `formatInboundContent` would see the raw `{caption,
- * attachments}` JSON.
+ * Image messages (single file ref, or the batch shape shared by file messages
+ * and tracked requests) get a human-readable rendering — caption text plus the
+ * on-disk path of each image so a shell-capable LLM (codex CLI, claude-code)
+ * can read it, or a "[Image … not available on this device]" placeholder when
+ * the bytes never arrived on this client. Without this, codex / future
+ * handlers that delegate to `formatInboundContent` would see the raw
+ * `{caption, attachments}` JSON.
  */
 function renderForLLM(message: SessionMessage): string {
   let base: string;
   if (typeof message.content === "string") {
     base = message.content;
-  } else if (message.format === "file") {
-    base = renderFileMessageForLLM(message) ?? JSON.stringify(message.content);
+  } else if (
+    ((message.format === "file" || message.format === "request") && isImageBatchRefContent(message.content)) ||
+    message.format === "file"
+  ) {
+    base = renderImageMessageForLLM(message) ?? JSON.stringify(message.content);
   } else {
     base = JSON.stringify(message.content);
   }
@@ -370,7 +373,7 @@ export function renderDocumentAttachmentsForLLM(message: SessionMessage): string
 
 /** Return a text rendering for a file message's content, or null when the
  * shape isn't a known image variant — caller falls back to JSON. */
-function renderFileMessageForLLM(message: SessionMessage): string | null {
+function renderImageMessageForLLM(message: SessionMessage): string | null {
   const content = message.content;
 
   // Batch shape: caption + N image refs.

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -435,10 +435,13 @@ export async function formatInboundContent(message: SessionMessage, participants
     const lines: string[] = ["[Earlier in chat — context you missed]"];
     for (const p of preceding) {
       let text = typeof p.content === "string" ? p.content : JSON.stringify(p.content);
-      const imageNote = renderImageAttachmentsForLLM({
-        chatId: message.chatId,
-        metadata: p.metadata,
-      });
+      const imageNote =
+        p.format === "request"
+          ? renderImageAttachmentsForLLM({
+              chatId: message.chatId,
+              metadata: p.metadata,
+            })
+          : null;
       if (imageNote) text = `${text}\n\n${imageNote}`;
       lines.push(`${formatMessageFromHeaderLine(p, ps)} ${text}`);
     }

--- a/packages/client/src/runtime/agent-io.ts
+++ b/packages/client/src/runtime/agent-io.ts
@@ -5,6 +5,7 @@ import {
   type ChatParticipantDetail,
   extractCaption,
   type ImageRefContent,
+  imageAttachmentRefsFromMetadata,
   isImageBatchRefContent,
   isImageRefContent,
   resolveTrustedSystemSender,
@@ -320,26 +321,22 @@ export async function buildFromHeader(message: SessionMessage, participants: Par
  * read as user input. Most formats are already strings; non-string
  * payloads are stringified so the resumed turn still sees readable text.
  *
- * Image messages (single file ref, or the batch shape shared by file messages
- * and tracked requests) get a human-readable rendering — caption text plus the
- * on-disk path of each image so a shell-capable LLM (codex CLI, claude-code)
- * can read it, or a "[Image … not available on this device]" placeholder when
- * the bytes never arrived on this client. Without this, codex / future
- * handlers that delegate to `formatInboundContent` would see the raw
- * `{caption, attachments}` JSON.
+ * `format: "file"` image messages (single-ref or batched caption + N refs)
+ * get a human-readable rendering. Generic image attachments on a textual
+ * request are appended through the same path-based note without changing the
+ * request body shape.
  */
 function renderForLLM(message: SessionMessage): string {
   let base: string;
   if (typeof message.content === "string") {
     base = message.content;
-  } else if (
-    ((message.format === "file" || message.format === "request") && isImageBatchRefContent(message.content)) ||
-    message.format === "file"
-  ) {
-    base = renderImageMessageForLLM(message) ?? JSON.stringify(message.content);
+  } else if (message.format === "file") {
+    base = renderFileMessageForLLM(message) ?? JSON.stringify(message.content);
   } else {
     base = JSON.stringify(message.content);
   }
+  const imageNote = renderImageAttachmentsForLLM(message);
+  if (imageNote) base = base.length > 0 ? `${base}\n\n${imageNote}` : imageNote;
   // Document/file attachments ride metadata.attachments on any format — append
   // their on-disk paths so a shell-capable agent can open them.
   const docNote = renderDocumentAttachmentsForLLM(message);
@@ -351,8 +348,9 @@ function renderForLLM(message: SessionMessage): string {
 /**
  * A text note listing the on-disk paths of any document/file attachments on
  * this message (`metadata.attachments`, non-image), so a shell-capable agent
- * can open them. Returns null when there are none. Images are handled
- * separately — they ride `content`.
+ * can open them. Returns null when there are none. Generic image refs are
+ * handled separately by `renderImageAttachmentsForLLM`; legacy image messages
+ * remain content-backed.
  */
 export function renderDocumentAttachmentsForLLM(message: SessionMessage): string | null {
   const refs = attachmentRefsFromMetadata(message.metadata ?? undefined).filter((ref) => ref.kind !== "image");
@@ -371,9 +369,27 @@ export function renderDocumentAttachmentsForLLM(message: SessionMessage): string
   return lines.join("\n");
 }
 
+/** Render generic image attachments as local paths for the receiving agent. */
+export function renderImageAttachmentsForLLM(message: SessionMessage): string | null {
+  const refs = imageAttachmentRefsFromMetadata(message.metadata ?? undefined);
+  if (refs.length === 0) return null;
+  const lines: string[] = [
+    refs.length === 1
+      ? "An image was shared in this chat. Use the Read tool / shell to open it before responding."
+      : `${refs.length} images were shared in this chat. Use the Read tool / shell to open each before responding.`,
+  ];
+  for (const ref of refs) {
+    const path = findImagePath(message.chatId, ref.attachmentId, ref.mimeType);
+    lines.push(
+      path ? `\nFilename: ${ref.filename}\nPath: ${path}` : `\n[Image "${ref.filename}" not available on this device]`,
+    );
+  }
+  return lines.join("\n");
+}
+
 /** Return a text rendering for a file message's content, or null when the
  * shape isn't a known image variant — caller falls back to JSON. */
-function renderImageMessageForLLM(message: SessionMessage): string | null {
+function renderFileMessageForLLM(message: SessionMessage): string | null {
   const content = message.content;
 
   // Batch shape: caption + N image refs.

--- a/packages/client/src/runtime/doc-snapshots.ts
+++ b/packages/client/src/runtime/doc-snapshots.ts
@@ -115,6 +115,8 @@ type ResolvedOccurrence = DocPathOccurrence & {
 export type BuildDocAttachmentsOptions = {
   uploader: AttachmentUploader;
   orgId: string;
+  /** Caller-specific share of the per-message attachment budget. */
+  maxAttachments?: number;
 };
 
 export async function buildMessageDocumentSnapshots(
@@ -147,6 +149,11 @@ export async function buildMessageDocumentSnapshots(
   if (!roots) return { ...empty, skipped: occurrences.length };
 
   const workspacesRootReal = fence ? await safeRealpath(fence.workspacesRoot) : null;
+  const requestedLimit = opts.maxAttachments;
+  const attachmentLimit =
+    requestedLimit === undefined || !Number.isFinite(requestedLimit)
+      ? MAX_MESSAGE_ATTACHMENT_REFS
+      : Math.min(MAX_MESSAGE_ATTACHMENT_REFS, Math.max(0, Math.trunc(requestedLimit)));
 
   // Pass 1 — resolve every occurrence to a readable file + canonical source
   // path, or attach a failure reason. Same provenance fence as before.
@@ -185,7 +192,7 @@ export async function buildMessageDocumentSnapshots(
     if (attempted.has(sourcePath)) continue;
     attempted.add(sourcePath);
 
-    if (refsByPath.size + uploadTasks.length >= MAX_MESSAGE_ATTACHMENT_REFS) {
+    if (refsByPath.size + uploadTasks.length >= attachmentLimit) {
       occ.failReason = "budget-exceeded";
       skipped += 1;
       continue;

--- a/packages/client/src/runtime/image-snapshots.ts
+++ b/packages/client/src/runtime/image-snapshots.ts
@@ -18,14 +18,14 @@ import {
 /**
  * Outbound image capture — the picture sibling of `doc-snapshots.ts`.
  *
- * When an agent's `chat send` body contains a markdown image `![alt](path)` or
- * `![alt](<path>)` whose target is a local image file inside the sender's own
- * workspace fence, we upload the bytes to the org attachment store and hand
- * the caller an `ImageRefContent` (the exact shape a human image send
- * produces). The caller then converts the message to a `format: "file"` batch:
- * caption = the body with the captured image spans stripped, `attachments` =
- * these refs. Web then renders it identically to a human image send (caption on
- * top, thumbnails below) — zero web/server change.
+ * When an agent's `chat send` or `chat ask` body contains a markdown image
+ * `![alt](path)` or `![alt](<path>)` whose target is a local image file inside
+ * the sender's own workspace fence, we upload the bytes to the org attachment
+ * store and hand the caller an `ImageRefContent` (the exact shape a human image
+ * send produces). The caller carries these refs in the shared batch shape:
+ * ordinary sends use `format: "file"`; tracked asks retain `format: "request"`.
+ * In both cases the caption is the body with captured image spans stripped and
+ * `attachments` contains these refs.
  *
  * Scope (see the paired design note): we deliberately capture ONLY markdown
  * image syntax (an explicit "show this picture" intent, unlike a bare filename
@@ -65,8 +65,8 @@ export type BuildImageAttachmentsOptions = {
 };
 
 export type BuildMessageImageSnapshotsResult = {
-  /** Image refs to carry as the `format: "file"` batch `attachments` (empty ⇒
-   *  caller sends the message unchanged). Order follows first appearance. */
+  /** Image refs to carry as batch `attachments` (empty ⇒ caller sends the
+   *  message unchanged). Order follows first appearance. */
   imageRefs: ImageRefContent[];
   /** `text` with every captured image span removed and the leftover blank
    *  lines collapsed — becomes the batch `caption`. */

--- a/packages/client/src/runtime/image-snapshots.ts
+++ b/packages/client/src/runtime/image-snapshots.ts
@@ -22,10 +22,10 @@ import {
  * `![alt](path)` or `![alt](<path>)` whose target is a local image file inside
  * the sender's own workspace fence, we upload the bytes to the org attachment
  * store and hand the caller an `ImageRefContent` (the exact shape a human image
- * send produces). The caller carries these refs in the shared batch shape:
- * ordinary sends use `format: "file"`; tracked asks retain `format: "request"`.
- * In both cases the caption is the body with captured image spans stripped and
- * `attachments` contains these refs.
+ * send produces). Ordinary sends carry these refs in the legacy
+ * `format: "file"` batch shape; tracked asks adapt the uploaded ids into
+ * generic `metadata.attachments` refs while keeping the request body textual.
+ * In both cases the caption is the body with captured image spans stripped.
  *
  * Scope (see the paired design note): we deliberately capture ONLY markdown
  * image syntax (an explicit "show this picture" intent, unlike a bare filename
@@ -62,14 +62,17 @@ type ImageOccurrence = {
 export type BuildImageAttachmentsOptions = {
   uploader: AttachmentUploader;
   orgId: string;
+  /** Caller-specific cap. Defaults to the legacy image-batch limit. */
+  maxAttachments?: number;
 };
 
 export type BuildMessageImageSnapshotsResult = {
-  /** Image refs to carry as batch `attachments` (empty ⇒ caller sends the
-   *  message unchanged). Order follows first appearance. */
+  /** Uploaded image refs for the caller to persist in its format-appropriate
+   *  reference shape (empty ⇒ caller sends the message unchanged). Order
+   *  follows first appearance. */
   imageRefs: ImageRefContent[];
   /** `text` with every captured image span removed and the leftover blank
-   *  lines collapsed — becomes the batch `caption`. */
+   *  lines collapsed — becomes the visible textual body/caption. */
   strippedText: string;
   /** Count of image mentions that resolved in-fence but could not be captured
    *  (unreadable / too large / upload failed / over the batch cap). */
@@ -107,7 +110,12 @@ export async function buildMessageImageSnapshots(
     seenPath.add(occ.writtenPath);
     distinctPaths.push({ path: occ.writtenPath, mime: occ.mime });
   }
-  const inCapPaths = distinctPaths.slice(0, MAX_BATCH_ATTACHMENTS);
+  const requestedLimit = opts.maxAttachments;
+  const attachmentLimit =
+    requestedLimit === undefined || !Number.isFinite(requestedLimit)
+      ? MAX_BATCH_ATTACHMENTS
+      : Math.min(MAX_BATCH_ATTACHMENTS, Math.max(0, Math.trunc(requestedLimit)));
+  const inCapPaths = distinctPaths.slice(0, attachmentLimit);
   let skipped = distinctPaths.length - inCapPaths.length;
 
   // Pass 1 — resolve each in-cap distinct path to a readable in-fence file
@@ -144,11 +152,11 @@ export async function buildMessageImageSnapshots(
   }
 
   // Pass 3 — collect the refs (first-appearance order, de-duped by file) and
-  // strip the caption. Because at least one image captured, the message flips
-  // to a `file` batch whose caption is this text — so EVERY local-path image
-  // candidate span is stripped, not just the captured ones: a captured mention
-  // became an attachment, and an uncaptured or over-cap one would otherwise be
-  // left as a `![alt](local/path)` that renders broken in the caption.
+  // strip the visible text. Because at least one image captured, the caller
+  // persists the uploaded refs separately from this text — so EVERY local-path
+  // image candidate span is stripped, not just the captured ones: a captured
+  // mention became an attachment, and an uncaptured or over-cap one would
+  // otherwise be left as a `![alt](local/path)` that renders broken.
   // (Candidates already exclude web-URL images and code-block samples, which
   // stay.)
   const seenFile = new Set<string>();

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -14,6 +14,7 @@ import {
   attachmentRefsFromMetadata,
   deriveRepoLocalPath,
   encodeProviderRetryEventMessage,
+  imageAttachmentRefsFromMetadata,
   isImageBatchRefContent,
   isImageRefContent,
   parseProviderRetryEventMessage,
@@ -622,20 +623,25 @@ export class SessionManager {
 
   /**
    * Resolve every inbound image reference to a file on local disk, fetching
-   * missing bytes from the `attachments` store. The batch shape is shared by
-   * regular file messages and tracked requests; the legacy single-ref shape
-   * remains file-only. Fetches run in parallel and never throw — the renderer
-   * degrades to a placeholder for any ref that didn't land.
+   * missing bytes from the attachment store. Legacy file-message refs and
+   * generic metadata refs share the same local image cache. Fetches run in
+   * parallel and never throw — the renderer degrades to a placeholder for any
+   * ref that did not land.
    */
   private async ensureImagesLocal(message: SessionMessage): Promise<void> {
-    // Images: refs in `content`. Written under the images dir and handed to the
-    // model as a path to Read.
-    const imageRefs =
-      (message.format === "file" || message.format === "request") && isImageBatchRefContent(message.content)
+    const legacyImageRefs =
+      message.format === "file" && isImageBatchRefContent(message.content)
         ? message.content.attachments
         : message.format === "file" && isImageRefContent(message.content)
           ? [message.content]
           : [];
+    const genericImageRefs = imageAttachmentRefsFromMetadata(message.metadata ?? undefined).map((ref) => ({
+      imageId: ref.attachmentId,
+      mimeType: ref.mimeType,
+      filename: ref.filename,
+      size: ref.size,
+    }));
+    const imageRefs = [...legacyImageRefs, ...genericImageRefs];
     await Promise.all(
       imageRefs.map(async (ref) => {
         if (findImagePath(message.chatId, ref.imageId, ref.mimeType)) return;

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -17,6 +17,7 @@ import {
   imageAttachmentRefsFromMetadata,
   isImageBatchRefContent,
   isImageRefContent,
+  MAX_MESSAGE_ATTACHMENT_REFS,
   parseProviderRetryEventMessage,
   runtimeProviderSchema,
   SOURCE_REPOS_DIRNAME,
@@ -365,6 +366,7 @@ type SessionManagerConfig = {
  */
 /** Maximum number of evicted session mappings to retain for resume recovery. */
 const MAX_EVICTED_MAPPINGS = 500;
+const MAX_EAGER_IMAGE_FETCHES_PER_DELIVERY = MAX_MESSAGE_ATTACHMENT_REFS;
 
 /**
  * Minimum spacing between lazy Context-Tree re-resolutions for a slot that is
@@ -577,11 +579,10 @@ export class SessionManager {
         // we assume server already decided we should handle it — this avoids a
         // double-guard that drifted between server / client in early M1.
 
-        // 4b. Pull any referenced image bytes to local disk before the handler
-        // renders. Bytes live in the server's `attachments` object store (uploaded
-        // by the sender); each client fetches once and caches under the chat's
-        // images dir. Best-effort — a failed fetch leaves the handler to surface a
-        // "not available on this device" placeholder for that ref.
+        // 4b. Preserve current-message image materialization, then pull only
+        // generic request images from silent preceding context. The added
+        // history work is best-effort and bounded; anything not fetched still
+        // renders with a filename and an unavailable placeholder.
         await this.ensureImagesLocal(message);
 
         // 4c. Lazily resolve a tree-LESS Context Tree binding before routing this
@@ -622,11 +623,10 @@ export class SessionManager {
   }
 
   /**
-   * Resolve every inbound image reference to a file on local disk, fetching
-   * missing bytes from the attachment store. Legacy file-message refs and
-   * generic metadata refs share the same local image cache. Fetches run in
-   * parallel and never throw — the renderer degrades to a placeholder for any
-   * ref that did not land.
+   * Resolve current-message image refs exactly as before, then materialize only
+   * the generic request-image refs from silent preceding context. Historical
+   * refs are considered newest-first under a separate 10-fetch budget;
+   * duplicates and cached refs consume no budget.
    */
   private async ensureImagesLocal(message: SessionMessage): Promise<void> {
     const legacyImageRefs =
@@ -642,6 +642,24 @@ export class SessionManager {
       size: ref.size,
     }));
     const imageRefs = [...legacyImageRefs, ...genericImageRefs];
+    const seenImageIds = new Set(imageRefs.map((ref) => ref.imageId));
+    let precedingFetches = 0;
+    for (const source of (message.precedingMessages ?? []).slice().reverse()) {
+      for (const ref of imageAttachmentRefsFromMetadata(source.metadata ?? undefined)) {
+        if (seenImageIds.has(ref.attachmentId)) continue;
+        seenImageIds.add(ref.attachmentId);
+        if (findImagePath(message.chatId, ref.attachmentId, ref.mimeType)) continue;
+        if (precedingFetches === MAX_EAGER_IMAGE_FETCHES_PER_DELIVERY) break;
+        imageRefs.push({
+          imageId: ref.attachmentId,
+          mimeType: ref.mimeType,
+          filename: ref.filename,
+          size: ref.size,
+        });
+        precedingFetches += 1;
+      }
+      if (precedingFetches === MAX_EAGER_IMAGE_FETCHES_PER_DELIVERY) break;
+    }
     await Promise.all(
       imageRefs.map(async (ref) => {
         if (findImagePath(message.chatId, ref.imageId, ref.mimeType)) return;

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -645,6 +645,7 @@ export class SessionManager {
     const seenImageIds = new Set(imageRefs.map((ref) => ref.imageId));
     let precedingFetches = 0;
     for (const source of (message.precedingMessages ?? []).slice().reverse()) {
+      if (source.format !== "request") continue;
       for (const ref of imageAttachmentRefsFromMetadata(source.metadata ?? undefined)) {
         if (seenImageIds.has(ref.attachmentId)) continue;
         seenImageIds.add(ref.attachmentId);

--- a/packages/client/src/runtime/session-manager.ts
+++ b/packages/client/src/runtime/session-manager.ts
@@ -621,17 +621,17 @@ export class SessionManager {
   }
 
   /**
-   * Resolve every image reference on an inbound `format: "file"` message to a
-   * file on local disk, fetching missing bytes from the `attachments` store.
-   * Single-ref and batch-ref shapes are both handled; non-image file content
-   * is ignored. Fetches run in parallel and never throw — the renderer
+   * Resolve every inbound image reference to a file on local disk, fetching
+   * missing bytes from the `attachments` store. The batch shape is shared by
+   * regular file messages and tracked requests; the legacy single-ref shape
+   * remains file-only. Fetches run in parallel and never throw — the renderer
    * degrades to a placeholder for any ref that didn't land.
    */
   private async ensureImagesLocal(message: SessionMessage): Promise<void> {
-    // Images: refs in `content` on a `format: "file"` message. Written under
-    // the images dir and handed to the model as a path to Read.
+    // Images: refs in `content`. Written under the images dir and handed to the
+    // model as a path to Read.
     const imageRefs =
-      message.format === "file" && isImageBatchRefContent(message.content)
+      (message.format === "file" || message.format === "request") && isImageBatchRefContent(message.content)
         ? message.content.attachments
         : message.format === "file" && isImageRefContent(message.content)
           ? [message.content]

--- a/packages/server/src/__tests__/agent-send-mention-injection.test.ts
+++ b/packages/server/src/__tests__/agent-send-mention-injection.test.ts
@@ -410,39 +410,6 @@ describe("mention enforcement + content normalisation", () => {
       expect(result.message.content).toEqual(card);
     });
 
-    it("prepends missing target mentions to a request image-batch caption", async () => {
-      const app = getApp();
-      const uid = crypto.randomUUID().slice(0, 6);
-      const sender = await createTestAgent(app, { name: `mt-request-s-${uid}` });
-      const { agent: human } = await createTestAgent(app, { name: `mt-request-h-${uid}`, type: "human" });
-      const chat = await createChat(app.db, sender.agent.uuid, {
-        type: "group",
-        participantIds: [human.uuid],
-      });
-      const content = {
-        caption: "Choose a layout",
-        attachments: [
-          {
-            imageId: crypto.randomUUID(),
-            mimeType: "image/png",
-            filename: "decision.png",
-            size: 42,
-          },
-        ],
-      };
-      const result = await sendMessage(
-        app.db,
-        chat.id,
-        sender.agent.uuid,
-        { source: "api", format: "request", content, metadata: { mentions: [human.uuid], request: {} } },
-        { normalizeMentionsInContent: true },
-      );
-      expect(result.message.content).toEqual({
-        ...content,
-        caption: `@${human.name} Choose a layout`,
-      });
-    });
-
     it("does NOT mutate content when the flag is off", async () => {
       const app = getApp();
       const uid = crypto.randomUUID().slice(0, 6);

--- a/packages/server/src/__tests__/agent-send-mention-injection.test.ts
+++ b/packages/server/src/__tests__/agent-send-mention-injection.test.ts
@@ -410,6 +410,39 @@ describe("mention enforcement + content normalisation", () => {
       expect(result.message.content).toEqual(card);
     });
 
+    it("prepends missing target mentions to a request image-batch caption", async () => {
+      const app = getApp();
+      const uid = crypto.randomUUID().slice(0, 6);
+      const sender = await createTestAgent(app, { name: `mt-request-s-${uid}` });
+      const { agent: human } = await createTestAgent(app, { name: `mt-request-h-${uid}`, type: "human" });
+      const chat = await createChat(app.db, sender.agent.uuid, {
+        type: "group",
+        participantIds: [human.uuid],
+      });
+      const content = {
+        caption: "Choose a layout",
+        attachments: [
+          {
+            imageId: crypto.randomUUID(),
+            mimeType: "image/png",
+            filename: "decision.png",
+            size: 42,
+          },
+        ],
+      };
+      const result = await sendMessage(
+        app.db,
+        chat.id,
+        sender.agent.uuid,
+        { source: "api", format: "request", content, metadata: { mentions: [human.uuid], request: {} } },
+        { normalizeMentionsInContent: true },
+      );
+      expect(result.message.content).toEqual({
+        ...content,
+        caption: `@${human.name} Choose a layout`,
+      });
+    });
+
     it("does NOT mutate content when the flag is off", async () => {
       const app = getApp();
       const uid = crypto.randomUUID().slice(0, 6);

--- a/packages/server/src/__tests__/doc-snapshots.test.ts
+++ b/packages/server/src/__tests__/doc-snapshots.test.ts
@@ -121,6 +121,38 @@ describe("validateMessageAttachmentRefs", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("accepts a supported generic image ref whose mime + size match the stored row", async () => {
+    await expect(
+      validateMessageAttachmentRefs(readerWith({ mimeType: "image/png", sizeBytes: 12 }), {
+        attachments: [
+          baseRef({
+            kind: "image",
+            mimeType: "image/png",
+            filename: "decision.png",
+            sha256: undefined,
+            source: undefined,
+          }),
+        ],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a generic image ref whose MIME is unsupported by image consumers", async () => {
+    await expect(
+      validateMessageAttachmentRefs(readerWith({ mimeType: "image/svg+xml", sizeBytes: 12 }), {
+        attachments: [
+          baseRef({
+            kind: "image",
+            mimeType: "image/svg+xml",
+            filename: "decision.svg",
+            sha256: undefined,
+            source: undefined,
+          }),
+        ],
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
   it("rejects a ref pointing at a non-existent attachment", async () => {
     await expect(validateMessageAttachmentRefs(readerWith(null), { attachments: [baseRef()] })).rejects.toThrow(
       BadRequestError,

--- a/packages/server/src/__tests__/message-empty-body-validation.test.ts
+++ b/packages/server/src/__tests__/message-empty-body-validation.test.ts
@@ -84,7 +84,7 @@ describe("sendMessage — empty / placeholder body is rejected fail-closed", () 
     );
   });
 
-  it("accepts a request image batch when its caption carries the question", async () => {
+  it("rejects a request image batch because the question body stays textual", async () => {
     await expect(
       sendMessage(
         stubDb,
@@ -102,10 +102,10 @@ describe("sendMessage — empty / placeholder body is rejected fail-closed", () 
           ],
         }),
       ),
-    ).rejects.not.toThrow(BadRequestError);
+    ).rejects.toThrow(BadRequestError);
   });
 
-  it("rejects a request image batch without a meaningful caption", async () => {
+  it("rejects request image batches regardless of caption shape", async () => {
     const attachment = {
       imageId: "11111111-1111-4111-8111-111111111111",
       mimeType: "image/png",
@@ -118,6 +118,12 @@ describe("sendMessage — empty / placeholder body is rejected fail-closed", () 
     await expect(
       sendMessage(stubDb, "chat-1", "sender-1", message("request", { caption: "TODO", attachments: [attachment] })),
     ).rejects.toThrow(BadRequestError);
+  });
+
+  it("accepts a textual request body with generic attachment metadata", async () => {
+    await expect(
+      sendMessage(stubDb, "chat-1", "sender-1", messageWithAttachment("request", "Which layout should ship?")),
+    ).rejects.not.toThrow(BadRequestError);
   });
 
   it("does NOT reject a body that merely contains the word placeholder", async () => {

--- a/packages/server/src/__tests__/message-empty-body-validation.test.ts
+++ b/packages/server/src/__tests__/message-empty-body-validation.test.ts
@@ -84,6 +84,42 @@ describe("sendMessage — empty / placeholder body is rejected fail-closed", () 
     );
   });
 
+  it("accepts a request image batch when its caption carries the question", async () => {
+    await expect(
+      sendMessage(
+        stubDb,
+        "chat-1",
+        "sender-1",
+        message("request", {
+          caption: "Which layout should ship?",
+          attachments: [
+            {
+              imageId: "11111111-1111-4111-8111-111111111111",
+              mimeType: "image/png",
+              filename: "decision.png",
+              size: 42,
+            },
+          ],
+        }),
+      ),
+    ).rejects.not.toThrow(BadRequestError);
+  });
+
+  it("rejects a request image batch without a meaningful caption", async () => {
+    const attachment = {
+      imageId: "11111111-1111-4111-8111-111111111111",
+      mimeType: "image/png",
+      filename: "decision.png",
+      size: 42,
+    };
+    await expect(
+      sendMessage(stubDb, "chat-1", "sender-1", message("request", { attachments: [attachment] })),
+    ).rejects.toThrow(BadRequestError);
+    await expect(
+      sendMessage(stubDb, "chat-1", "sender-1", message("request", { caption: "TODO", attachments: [attachment] })),
+    ).rejects.toThrow(BadRequestError);
+  });
+
   it("does NOT reject a body that merely contains the word placeholder", async () => {
     // A real body that mentions the sentinel must pass the content guard (it
     // then proceeds past validation and fails on the stub DB, which is NOT a

--- a/packages/server/src/__tests__/open-question.test.ts
+++ b/packages/server/src/__tests__/open-question.test.ts
@@ -786,6 +786,21 @@ describe("open-question (format=request) + open_request_count", () => {
     await expect(
       editMessage(app.db, chat.id, question.id, asker.agent.uuid, { content: "PLACEHOLDER" }),
     ).rejects.toThrow(BadRequestError);
+    await expect(
+      editMessage(app.db, chat.id, question.id, asker.agent.uuid, {
+        content: {
+          caption: "ratio?",
+          attachments: [
+            {
+              imageId: "11111111-1111-4111-8111-111111111111",
+              mimeType: "image/png",
+              filename: "ratio.png",
+              size: 42,
+            },
+          ],
+        },
+      }),
+    ).rejects.toThrow(BadRequestError);
   });
 });
 

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -7,6 +7,7 @@ import {
   extractCaption,
   imageBatchRefContentSchema,
   imageRefContentSchema,
+  isImageBatchRefContent,
   MAX_BATCH_ATTACHMENTS,
   MESSAGE_FORMATS,
   MESSAGE_SOURCES,
@@ -196,10 +197,24 @@ function validateMessageContent(
     validateFileContent(data.content);
     return;
   }
+  if (data.format === "request") {
+    if (typeof data.content === "string") {
+      validateTextBody(data.content, true);
+      return;
+    }
+    const parsed = imageBatchRefContentSchema.safeParse(data.content);
+    if (!parsed.success) {
+      throw new BadRequestError(
+        "Invalid request message content: expected a non-empty text body or an image batch with a non-empty caption.",
+      );
+    }
+    validateTextBody(parsed.data.caption ?? "", true);
+    return;
+  }
   // Non-string content (card / reference object shapes) is out of scope here;
   // only string-bearing bodies are guarded against empty / placeholder sends.
   if (typeof data.content === "string") {
-    validateTextBody(data.content, data.format === "request", opts?.hasAttachmentRefs === true);
+    validateTextBody(data.content, false, opts?.hasAttachmentRefs === true);
   }
 }
 
@@ -414,9 +429,7 @@ export function preflightMessageSendIntent(input: {
   // placeholder body after `maybeUnwrapDoubleEncoded`. `effectiveContent` is
   // what gets normalized and persisted, so guard it here too — before mention
   // normalization can salvage an empty body into a bare "@name".
-  if (typeof effectiveContent === "string") {
-    validateTextBody(effectiveContent, data.format === "request", hasAttachmentRefs);
-  }
+  validateMessageContent({ format: data.format, content: effectiveContent }, { hasAttachmentRefs });
 
   const incomingMeta = stripUntrustedMetadataKeys(rawIncomingMeta, options);
   validateDocumentContext(incomingMeta);
@@ -560,8 +573,14 @@ export function preflightMessageSendIntent(input: {
   }
 
   let outboundContent = effectiveContent;
-  if (options.normalizeMentionsInContent && typeof outboundContent === "string") {
-    const present = new Set(scanMentionTokens(outboundContent));
+  const outboundText =
+    typeof outboundContent === "string"
+      ? outboundContent
+      : data.format === "request" && isImageBatchRefContent(outboundContent)
+        ? extractCaption(outboundContent)
+        : null;
+  if (options.normalizeMentionsInContent && outboundText !== null) {
+    const present = new Set(scanMentionTokens(outboundText));
     const missingNames: string[] = [];
     for (const id of mergedMentions) {
       if (id === senderId) continue;
@@ -572,7 +591,12 @@ export function preflightMessageSendIntent(input: {
     }
     if (missingNames.length > 0) {
       const prefix = missingNames.map((n) => `@${n}`).join(" ");
-      outboundContent = outboundContent.length > 0 ? `${prefix} ${outboundContent}` : prefix;
+      const normalizedText = outboundText.length > 0 ? `${prefix} ${outboundText}` : prefix;
+      if (typeof outboundContent === "string") {
+        outboundContent = normalizedText;
+      } else if (isImageBatchRefContent(outboundContent)) {
+        outboundContent = { ...outboundContent, caption: normalizedText };
+      }
     }
   }
 

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -7,7 +7,6 @@ import {
   extractCaption,
   imageBatchRefContentSchema,
   imageRefContentSchema,
-  isImageBatchRefContent,
   MAX_BATCH_ATTACHMENTS,
   MESSAGE_FORMATS,
   MESSAGE_SOURCES,
@@ -198,17 +197,10 @@ function validateMessageContent(
     return;
   }
   if (data.format === "request") {
-    if (typeof data.content === "string") {
-      validateTextBody(data.content, true);
-      return;
+    if (typeof data.content !== "string") {
+      throw new BadRequestError("Invalid request message content: expected a non-empty text question.");
     }
-    const parsed = imageBatchRefContentSchema.safeParse(data.content);
-    if (!parsed.success) {
-      throw new BadRequestError(
-        "Invalid request message content: expected a non-empty text body or an image batch with a non-empty caption.",
-      );
-    }
-    validateTextBody(parsed.data.caption ?? "", true);
+    validateTextBody(data.content, true);
     return;
   }
   // Non-string content (card / reference object shapes) is out of scope here;
@@ -573,14 +565,8 @@ export function preflightMessageSendIntent(input: {
   }
 
   let outboundContent = effectiveContent;
-  const outboundText =
-    typeof outboundContent === "string"
-      ? outboundContent
-      : data.format === "request" && isImageBatchRefContent(outboundContent)
-        ? extractCaption(outboundContent)
-        : null;
-  if (options.normalizeMentionsInContent && outboundText !== null) {
-    const present = new Set(scanMentionTokens(outboundText));
+  if (options.normalizeMentionsInContent && typeof outboundContent === "string") {
+    const present = new Set(scanMentionTokens(outboundContent));
     const missingNames: string[] = [];
     for (const id of mergedMentions) {
       if (id === senderId) continue;
@@ -591,12 +577,7 @@ export function preflightMessageSendIntent(input: {
     }
     if (missingNames.length > 0) {
       const prefix = missingNames.map((n) => `@${n}`).join(" ");
-      const normalizedText = outboundText.length > 0 ? `${prefix} ${outboundText}` : prefix;
-      if (typeof outboundContent === "string") {
-        outboundContent = normalizedText;
-      } else if (isImageBatchRefContent(outboundContent)) {
-        outboundContent = { ...outboundContent, caption: normalizedText };
-      }
+      outboundContent = outboundContent.length > 0 ? `${prefix} ${outboundContent}` : prefix;
     }
   }
 

--- a/packages/shared/src/__tests__/attachment-ref.test.ts
+++ b/packages/shared/src/__tests__/attachment-ref.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { attachmentRefsFromMetadata, isAttachmentRef } from "../schemas/attachment-ref.js";
+import {
+  attachmentRefSchema,
+  attachmentRefsFromMetadata,
+  imageAttachmentRefsFromMetadata,
+  isAttachmentRef,
+} from "../schemas/attachment-ref.js";
 
 const baseAttachment = {
   attachmentId: "123e4567-e89b-12d3-a456-426614174000",
@@ -21,6 +26,8 @@ describe("attachment refs", () => {
       isAttachmentRef({
         ...baseAttachment,
         kind: "image",
+        mimeType: "image/png",
+        filename: "decision.png",
         sha256: undefined,
         source: undefined,
       }),
@@ -34,6 +41,8 @@ describe("attachment refs", () => {
       { ...baseAttachment, attachmentId: "not-a-uuid" },
       { ...baseAttachment, kind: "video" },
       { ...baseAttachment, mimeType: "" },
+      { ...baseAttachment, kind: "image", mimeType: "image/svg+xml" },
+      { ...baseAttachment, kind: "image", mimeType: "application/pdf" },
       { ...baseAttachment, filename: "" },
       { ...baseAttachment, size: 1.5 },
       { ...baseAttachment, size: -1 },
@@ -44,6 +53,9 @@ describe("attachment refs", () => {
     ]) {
       expect(isAttachmentRef(value)).toBe(false);
     }
+    expect(attachmentRefSchema.safeParse({ ...baseAttachment, kind: "image", mimeType: "image/svg+xml" }).success).toBe(
+      false,
+    );
   });
 
   it("extracts only valid attachment refs from metadata", () => {
@@ -61,5 +73,24 @@ describe("attachment refs", () => {
       { ...baseAttachment, filename: "valid.md" },
       { ...baseAttachment, kind: "file", filename: "archive.zip", size: 0 },
     ]);
+  });
+
+  it("extracts only renderable generic image refs", () => {
+    const image = {
+      ...baseAttachment,
+      attachmentId: "223e4567-e89b-42d3-a456-426614174001",
+      kind: "image",
+      mimeType: "image/png",
+      filename: "decision.png",
+    } as const;
+    expect(
+      imageAttachmentRefsFromMetadata({
+        attachments: [
+          image,
+          { ...image, attachmentId: "323e4567-e89b-42d3-a456-426614174002", mimeType: "application/pdf" },
+          { ...baseAttachment, filename: "notes.md" },
+        ],
+      }),
+    ).toEqual([image]);
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -210,6 +210,8 @@ export {
   attachmentKindSchema,
   attachmentRefSchema,
   attachmentRefsFromMetadata,
+  type ImageAttachmentRef,
+  imageAttachmentRefsFromMetadata,
   isAttachmentRef,
   MAX_MESSAGE_ATTACHMENT_REFS,
 } from "./schemas/attachment-ref.js";

--- a/packages/shared/src/schemas/attachment-ref.ts
+++ b/packages/shared/src/schemas/attachment-ref.ts
@@ -1,12 +1,16 @@
 import { z } from "zod";
+import { SUPPORTED_IMAGE_MIMES, type SupportedImageMime } from "./image-payload.js";
+
+const SUPPORTED_IMAGE_MIME_SET = new Set<string>(SUPPORTED_IMAGE_MIMES);
 
 /**
  * Attachment kinds carried by an {@link AttachmentRef}. `kind` is derived from
  * the mime type at capture time and stored explicitly so render/delivery code
  * can branch without re-sniffing the mime on every read:
- *  - `image`    — a picture (rendered inline / lightbox). NOTE: images today
- *                 still travel as `imageRefContent` in `messages.content`; this
- *                 kind exists for the future convergence onto the generic ref.
+ *  - `image`    — a picture (rendered inline / lightbox). New tracked-request
+ *                 images use this generic ref; ordinary and historical image
+ *                 messages retain `imageRefContent` in `messages.content`
+ *                 until a separately scoped migration.
  *  - `document` — a text document previewed in the doc drawer (markdown today).
  *  - `file`     — any other blob; rendered as a download card.
  */
@@ -15,10 +19,10 @@ export const attachmentKindSchema = z.enum(ATTACHMENT_KINDS);
 export type AttachmentKind = z.infer<typeof attachmentKindSchema>;
 
 /**
- * Generic "this message references a stored blob" model — the single shape
- * every consumer (image / document / arbitrary file) hangs off, mounted at
- * `messages.metadata.attachments[]`. Mirrors the live image-ref convergence
- * onto the `attachments` blob substrate: the sender uploads bytes to
+ * Generic "this message references a stored blob" model, mounted at
+ * `messages.metadata.attachments[]`. Documents/files and new tracked-request
+ * images use it; legacy image-message content remains readable during the
+ * transition. The sender uploads bytes to
  * `POST /orgs/:orgId/attachments`, then sends a message carrying only this
  * reference. Every reader fetches the bytes on demand from
  * `GET /attachments/:attachmentId` — bytes never travel inside the message.
@@ -30,31 +34,45 @@ export type AttachmentKind = z.infer<typeof attachmentKindSchema>;
  * cross-navigation) and `sourcePath` is a forward hook for "show latest" that
  * is written but not consumed this phase.
  */
-export const attachmentRefSchema = z.object({
-  attachmentId: z.string().uuid(),
-  kind: attachmentKindSchema,
-  mimeType: z.string().min(1),
-  filename: z.string().min(1),
-  size: z.number().int().nonnegative(),
-  sha256: z
-    .string()
-    .regex(/^[0-9a-f]{64}$/, "sha256 must be 64 lowercase hex chars")
-    .optional(),
-  // SECURITY: `source.path` (and `sourcePath`) is UNTRUSTED, DISPLAY-ONLY
-  // metadata. A ref's bytes are self-supplied by the sender and downloads are
-  // capability-based (valid session + unguessable attachmentId), so a malicious
-  // runtime can fabricate bytes and pair them with an arbitrary `source.path`.
-  // The server cannot meaningfully validate a free-form display string, so it
-  // does not — this is display-spoofing only, NOT access escalation. NEVER use
-  // `source.path` for authorization, routing, or filesystem access.
-  source: z
-    .object({
-      path: z.string(),
-      sourcePath: z.string().optional(),
-    })
-    .optional(),
-});
+export const attachmentRefSchema = z
+  .object({
+    attachmentId: z.string().uuid(),
+    kind: attachmentKindSchema,
+    mimeType: z.string().min(1),
+    filename: z.string().min(1),
+    size: z.number().int().nonnegative(),
+    sha256: z
+      .string()
+      .regex(/^[0-9a-f]{64}$/, "sha256 must be 64 lowercase hex chars")
+      .optional(),
+    // SECURITY: `source.path` (and `sourcePath`) is UNTRUSTED, DISPLAY-ONLY
+    // metadata. A ref's bytes are self-supplied by the sender and downloads are
+    // capability-based (valid session + unguessable attachmentId), so a malicious
+    // runtime can fabricate bytes and pair them with an arbitrary `source.path`.
+    // The server cannot meaningfully validate a free-form display string, so it
+    // does not — this is display-spoofing only, NOT access escalation. NEVER use
+    // `source.path` for authorization, routing, or filesystem access.
+    source: z
+      .object({
+        path: z.string(),
+        sourcePath: z.string().optional(),
+      })
+      .optional(),
+  })
+  .superRefine((ref, ctx) => {
+    if (ref.kind === "image" && !SUPPORTED_IMAGE_MIME_SET.has(ref.mimeType)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["mimeType"],
+        message: "image attachments must use a supported image MIME type",
+      });
+    }
+  });
 export type AttachmentRef = z.infer<typeof attachmentRefSchema>;
+export type ImageAttachmentRef = AttachmentRef & {
+  kind: "image";
+  mimeType: SupportedImageMime;
+};
 
 /**
  * Hard cap on attachment refs a single message may carry. Bounds the
@@ -89,6 +107,7 @@ export function isAttachmentRef(value: unknown): value is AttachmentRef {
   if (typeof v.attachmentId !== "string" || !UUID_RE.test(v.attachmentId)) return false;
   if (typeof v.kind !== "string" || !ATTACHMENT_KINDS_SET.has(v.kind)) return false;
   if (typeof v.mimeType !== "string" || v.mimeType.length === 0) return false;
+  if (v.kind === "image" && !SUPPORTED_IMAGE_MIME_SET.has(v.mimeType)) return false;
   if (typeof v.filename !== "string" || v.filename.length === 0) return false;
   if (typeof v.size !== "number" || !Number.isInteger(v.size) || v.size < 0) return false;
   if (v.sha256 !== undefined && (typeof v.sha256 !== "string" || !SHA256_RE.test(v.sha256))) return false;
@@ -115,4 +134,15 @@ export function attachmentRefsFromMetadata(metadata: Record<string, unknown> | u
     if (isAttachmentRef(entry)) out.push(entry);
   }
   return out;
+}
+
+/**
+ * Read generic image attachments from message metadata. The generic ref schema
+ * and its hand-rolled reader both enforce the MIME set supported by renderers
+ * and the local image store.
+ */
+export function imageAttachmentRefsFromMetadata(metadata: Record<string, unknown> | undefined): ImageAttachmentRef[] {
+  return attachmentRefsFromMetadata(metadata).filter(
+    (ref): ref is ImageAttachmentRef => ref.kind === "image" && SUPPORTED_IMAGE_MIME_SET.has(ref.mimeType),
+  );
 }

--- a/packages/web/src/api/chats.ts
+++ b/packages/web/src/api/chats.ts
@@ -176,10 +176,11 @@ export type ImageBatchRefContent = {
  *   the send. Without this, the message arrives with no addressees and is
  *   rejected before the text reaches anyone (issue 387).
  * - `attachments` carries generic {@link AttachmentRef}s (documents / files
- *   uploaded in the composer) in `message.metadata.attachments[]`. Images stay
- *   in `content` as `ImageRefContent`; a mixed send (images + documents) rides
- *   one `format: "file"` message carrying both. The server validates each ref
- *   against its stored blob (`validateMessageAttachmentRefs`).
+ *   uploaded in the composer) in `message.metadata.attachments[]`. Ordinary
+ *   composer image sends stay in `content` as `ImageRefContent`; tracked
+ *   requests may carry generic image refs in metadata while keeping their
+ *   question body textual. The server validates each generic ref against its
+ *   stored blob (`validateMessageAttachmentRefs`).
  */
 export type SendFileMessageMetadata = { mentions?: string[]; attachments?: AttachmentRef[] };
 

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -31,7 +31,7 @@
  * the ONLY way to resolve a question: the target human answers here, in the web
  * UI; an agent can only ask, never answer or close.
  */
-import type { AskOption, AskRequest, AttachmentKind, MentionParticipant } from "@first-tree/shared";
+import type { AskOption, AskRequest, AttachmentKind, ImageRefContent, MentionParticipant } from "@first-tree/shared";
 import { COMPOSER_ACCEPT_ATTRIBUTE, extractMentions } from "@first-tree/shared";
 import { AtSign, Paperclip, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -46,6 +46,7 @@ import {
 import { MentionHighlightOverlay } from "../mention-highlight-overlay.js";
 import { FileChip } from "../ui/file-chip.js";
 import { Markdown, type MarkdownProps } from "../ui/markdown.js";
+import { ImageRefGallery } from "./image-ref-gallery.js";
 import { allRequiredAnswered, buildResolveAnswer } from "./request-state.js";
 
 /**
@@ -108,6 +109,7 @@ function useKeyboardInset(): number {
 
 export function AskTakeover({
   body,
+  images = [],
   payload,
   askerName,
   sending = false,
@@ -129,6 +131,8 @@ export function AskTakeover({
   mobile?: boolean;
   /** The ask itself — the request message's markdown body. */
   body: string;
+  /** Images attached to the ask, shown beneath the body in the same scroller. */
+  images?: readonly ImageRefContent[];
   payload: AskRequest;
   askerName?: string;
   sending?: boolean;
@@ -634,6 +638,7 @@ export function AskTakeover({
             }}
           >
             <Markdown components={markdownComponents}>{body}</Markdown>
+            <ImageRefGallery images={images} hasLeadingContent={body.trim().length > 0} />
           </div>
 
           {/* Answer surface — options + Other (or a single free-text box),

--- a/packages/web/src/components/chat/ask-takeover.tsx
+++ b/packages/web/src/components/chat/ask-takeover.tsx
@@ -31,7 +31,7 @@
  * the ONLY way to resolve a question: the target human answers here, in the web
  * UI; an agent can only ask, never answer or close.
  */
-import type { AskOption, AskRequest, AttachmentKind, ImageRefContent, MentionParticipant } from "@first-tree/shared";
+import type { AskOption, AskRequest, AttachmentKind, MentionParticipant } from "@first-tree/shared";
 import { COMPOSER_ACCEPT_ATTRIBUTE, extractMentions } from "@first-tree/shared";
 import { AtSign, Paperclip, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -46,7 +46,7 @@ import {
 import { MentionHighlightOverlay } from "../mention-highlight-overlay.js";
 import { FileChip } from "../ui/file-chip.js";
 import { Markdown, type MarkdownProps } from "../ui/markdown.js";
-import { ImageRefGallery } from "./image-ref-gallery.js";
+import { ImageRefGallery, type ReferencedImage } from "./image-ref-gallery.js";
 import { allRequiredAnswered, buildResolveAnswer } from "./request-state.js";
 
 /**
@@ -132,7 +132,7 @@ export function AskTakeover({
   /** The ask itself — the request message's markdown body. */
   body: string;
   /** Images attached to the ask, shown beneath the body in the same scroller. */
-  images?: readonly ImageRefContent[];
+  images?: readonly ReferencedImage[];
   payload: AskRequest;
   askerName?: string;
   sending?: boolean;

--- a/packages/web/src/components/chat/image-ref-gallery.tsx
+++ b/packages/web/src/components/chat/image-ref-gallery.tsx
@@ -1,0 +1,105 @@
+import type { CSSProperties } from "react";
+import { useState } from "react";
+import { useImageSrc } from "../../lib/use-image-src.js";
+import { ImageLightbox, type LightboxImage } from "../ui/image-lightbox.js";
+
+const STANDALONE_IMG_STYLE = {
+  maxWidth: "min(25rem, 100%)",
+  maxHeight: 360,
+  borderRadius: "var(--radius-panel)",
+  cursor: "zoom-in",
+  display: "block",
+} satisfies CSSProperties;
+
+const GALLERY_IMG_STYLE = {
+  height: 172,
+  width: "auto",
+  maxWidth: "min(28.75rem, 100%)",
+  objectFit: "cover",
+  borderRadius: "var(--radius-panel)",
+  cursor: "zoom-in",
+  display: "block",
+} satisfies CSSProperties;
+
+function ImageFromRef({
+  content,
+  variant,
+  onOpen,
+}: {
+  content: ReferencedImage;
+  variant: "standalone" | "gallery";
+  onOpen: () => void;
+}) {
+  const state = useImageSrc(content.imageId);
+
+  if (state.kind === "hit") {
+    return (
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={`Open image ${content.filename}`}
+        className="block border-none bg-transparent p-0"
+        style={{ marginTop: variant === "standalone" ? 4 : 0, maxWidth: "100%", minWidth: 0 }}
+      >
+        <img
+          src={state.src}
+          alt={content.filename}
+          style={variant === "standalone" ? STANDALONE_IMG_STYLE : GALLERY_IMG_STYLE}
+        />
+      </button>
+    );
+  }
+  if (state.kind === "miss") {
+    return (
+      <span className="text-label" style={{ color: "var(--fg-3)", fontStyle: "italic" }}>
+        [Image "{content.filename}" failed to load]
+      </span>
+    );
+  }
+  return (
+    <span className="text-label" style={{ color: "var(--fg-4)" }}>
+      …
+    </span>
+  );
+}
+
+type ReferencedImage = {
+  imageId: string;
+  filename: string;
+};
+
+/**
+ * Shared referenced-image presentation for timeline messages and tracked
+ * request takeovers. A single ref uses the larger standalone treatment; a
+ * batch uses the existing equal-height gallery and one shared lightbox.
+ */
+export function ImageRefGallery({
+  images,
+  hasLeadingContent = false,
+}: {
+  images: readonly ReferencedImage[];
+  hasLeadingContent?: boolean;
+}) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const lightboxImages: LightboxImage[] = images.map((image) => ({
+    imageId: image.imageId,
+    filename: image.filename,
+  }));
+  const only = images.length === 1 ? images[0] : undefined;
+
+  if (images.length === 0) return null;
+  return (
+    <>
+      {only ? (
+        <ImageFromRef content={only} variant="standalone" onOpen={() => setOpenIndex(0)} />
+      ) : (
+        <div className="flex flex-wrap items-start" style={{ gap: 6, marginTop: hasLeadingContent ? 2 : 0 }}>
+          {images.map((image, index) => (
+            <ImageFromRef key={image.imageId} content={image} variant="gallery" onOpen={() => setOpenIndex(index)} />
+          ))}
+        </div>
+      )}
+      <ImageLightbox images={lightboxImages} index={openIndex} onIndexChange={setOpenIndex} />
+    </>
+  );
+}

--- a/packages/web/src/components/chat/image-ref-gallery.tsx
+++ b/packages/web/src/components/chat/image-ref-gallery.tsx
@@ -63,7 +63,7 @@ function ImageFromRef({
   );
 }
 
-type ReferencedImage = {
+export type ReferencedImage = {
   imageId: string;
   filename: string;
 };

--- a/packages/web/src/components/ui/image-lightbox.tsx
+++ b/packages/web/src/components/ui/image-lightbox.tsx
@@ -73,7 +73,7 @@ export function ImageLightbox({ images, index, onIndexChange }: ImageLightboxPro
   return (
     <DialogPrimitive.Root open={open} onOpenChange={(next) => !next && close()}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="fixed inset-0 z-[60] bg-overlay-scrim data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[80] bg-overlay-scrim data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <DialogPrimitive.Content
           aria-describedby={undefined}
           onKeyDown={(e) => {
@@ -81,7 +81,7 @@ export function ImageLightbox({ images, index, onIndexChange }: ImageLightboxPro
             if (e.key === "ArrowLeft") step(-1);
             if (e.key === "ArrowRight") step(1);
           }}
-          className="fixed inset-0 z-[60] flex items-center justify-center focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+          className="fixed inset-0 z-[80] flex items-center justify-center focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
           // Click on the empty backdrop (not the image or a control) closes.
           onClick={(e) => {
             if (e.target === e.currentTarget) close();

--- a/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
@@ -31,6 +31,9 @@ vi.mock("../../../auth/auth-context.js", () => ({
 }));
 vi.mock("../../../api/me-chats.js", () => meChatMocks);
 vi.mock("../../../api/chats.js", () => chatMocks);
+vi.mock("../../../lib/use-image-src.js", () => ({
+  useImageSrc: () => ({ kind: "hit", src: "data:image/png;base64,aW1hZ2U=" }),
+}));
 vi.mock("../../../api/gitlab-connections.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../api/gitlab-connections.js")>()),
   listGitlabConnectionsAt: gitlabMocks.listGitlabConnectionsAt,
@@ -82,7 +85,17 @@ const request: Message = {
   chatId: row.chatId,
   senderId: "agent-1",
   format: "request",
-  content: "## Release decision\n\nThe staging evidence is green. Which rollout should we use?",
+  content: {
+    caption: "## Release decision\n\nThe staging evidence is green. Which rollout should we use?",
+    attachments: [
+      {
+        imageId: "11111111-1111-4111-8111-111111111111",
+        mimeType: "image/png",
+        filename: "release-evidence.png",
+        size: 42,
+      },
+    ],
+  },
   metadata: {
     mentions: ["human-agent-self"],
     request: {
@@ -435,6 +448,14 @@ describe("mobile card behavior", () => {
     );
     expect(currentLocation).toBe("/m/work");
     expect(document.body.textContent).toContain("Which rollout should we use?");
+    const imageButton = document.body.querySelector('button[aria-label="Open image release-evidence.png"]');
+    expect(imageButton).not.toBeNull();
+
+    await click(imageButton);
+    const lightbox = document.body.querySelector('[role="dialog"][class*="z-[80]"]');
+    expect(lightbox?.querySelector('img[alt="release-evidence.png"]')).not.toBeNull();
+    await click(lightbox?.querySelector('button[aria-label="Close"]') ?? null);
+    await harness.waitFor(() => expect(document.body.querySelector('[role="dialog"][class*="z-[80]"]')).toBeNull());
 
     await click(
       [...document.body.querySelectorAll('button[role="radio"]')].find((item) =>

--- a/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/card-actions-dom.test.tsx
@@ -85,17 +85,7 @@ const request: Message = {
   chatId: row.chatId,
   senderId: "agent-1",
   format: "request",
-  content: {
-    caption: "## Release decision\n\nThe staging evidence is green. Which rollout should we use?",
-    attachments: [
-      {
-        imageId: "11111111-1111-4111-8111-111111111111",
-        mimeType: "image/png",
-        filename: "release-evidence.png",
-        size: 42,
-      },
-    ],
-  },
+  content: "## Release decision\n\nThe staging evidence is green. Which rollout should we use?",
   metadata: {
     mentions: ["human-agent-self"],
     request: {
@@ -105,6 +95,15 @@ const request: Message = {
         { label: "Hold", description: "Keep the release on staging." },
       ],
     },
+    attachments: [
+      {
+        attachmentId: "11111111-1111-4111-8111-111111111111",
+        kind: "image",
+        mimeType: "image/png",
+        filename: "release-evidence.png",
+        size: 42,
+      },
+    ],
   },
   inReplyTo: null,
   source: "web",

--- a/packages/web/src/pages/mobile/ask-sheet.tsx
+++ b/packages/web/src/pages/mobile/ask-sheet.tsx
@@ -1,3 +1,4 @@
+import { extractCaption, isImageBatchRefContent } from "@first-tree/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -78,7 +79,8 @@ export function MobileAskSheet({ chatId, onClose }: { chatId: string; onClose: (
       <div className="fixed inset-0" style={{ zIndex: 70 }} data-mobile-ask-sheet>
         <AskTakeover
           key={request.id}
-          body={typeof request.content === "string" ? request.content : ""}
+          body={typeof request.content === "string" ? request.content : extractCaption(request.content)}
+          images={isImageBatchRefContent(request.content) ? request.content.attachments : []}
           payload={payload}
           askerName={askerName}
           sending={sending}

--- a/packages/web/src/pages/mobile/ask-sheet.tsx
+++ b/packages/web/src/pages/mobile/ask-sheet.tsx
@@ -1,4 +1,4 @@
-import { extractCaption, isImageBatchRefContent } from "@first-tree/shared";
+import { imageAttachmentRefsFromMetadata } from "@first-tree/shared";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -79,8 +79,11 @@ export function MobileAskSheet({ chatId, onClose }: { chatId: string; onClose: (
       <div className="fixed inset-0" style={{ zIndex: 70 }} data-mobile-ask-sheet>
         <AskTakeover
           key={request.id}
-          body={typeof request.content === "string" ? request.content : extractCaption(request.content)}
-          images={isImageBatchRefContent(request.content) ? request.content.attachments : []}
+          body={typeof request.content === "string" ? request.content : ""}
+          images={imageAttachmentRefsFromMetadata(request.metadata).map((ref) => ({
+            imageId: ref.attachmentId,
+            filename: ref.filename,
+          }))}
           payload={payload}
           askerName={askerName}
           sending={sending}

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1896,17 +1896,7 @@ describe("ChatView", () => {
       id: "req-render",
       senderId: "agent-1",
       format: "request",
-      content: {
-        caption: "Lifecycle **body** stays memoized.",
-        attachments: [
-          {
-            imageId: "11111111-1111-4111-8111-111111111111",
-            mimeType: "image/png",
-            filename: "lifecycle.png",
-            size: 42,
-          },
-        ],
-      },
+      content: "Lifecycle **body** stays memoized.",
       metadata: {
         mentions: ["human-agent-self"],
         request: {
@@ -1915,6 +1905,22 @@ describe("ChatView", () => {
             { label: "Hold", description: "wait" },
           ],
         },
+        attachments: [
+          {
+            attachmentId: "11111111-1111-4111-8111-111111111111",
+            kind: "image",
+            mimeType: "image/png",
+            filename: "lifecycle.png",
+            size: 42,
+          },
+          {
+            attachmentId: "11111111-1111-4111-8111-111111111112",
+            kind: "image",
+            mimeType: "image/jpeg",
+            filename: "lifecycle-alt.jpg",
+            size: 84,
+          },
+        ],
       },
       source: "api",
       createdAt: "2026-05-28T12:00:00.000Z",
@@ -1944,6 +1950,12 @@ describe("ChatView", () => {
       () => container.querySelector('button[aria-label="Open image lifecycle.png"]') !== null,
       "request image thumbnail did not render",
     );
+    const requestRow = container.querySelector('[data-message-id="req-render"]');
+    expect(
+      [...(requestRow?.querySelectorAll('button[aria-label^="Open image "]') ?? [])].map((button) =>
+        button.getAttribute("aria-label"),
+      ),
+    ).toEqual(["Open image lifecycle.png", "Open image lifecycle-alt.jpg"]);
     expect(container.textContent).not.toContain("RESOLVED");
     await flush();
     markdownMocks.render.mockClear();
@@ -2760,17 +2772,7 @@ describe("ChatView", () => {
       id: "req-gitlab-link",
       senderId: "agent-1",
       format: "request",
-      content: {
-        caption: [canonical, `[Review the MR](${canonical})`].join("\n\n"),
-        attachments: [
-          {
-            imageId: "22222222-2222-4222-8222-222222222222",
-            mimeType: "image/png",
-            filename: "evidence.png",
-            size: 42,
-          },
-        ],
-      },
+      content: [canonical, `[Review the MR](${canonical})`].join("\n\n"),
       metadata: {
         mentions: ["human-agent-self"],
         request: {
@@ -2779,6 +2781,15 @@ describe("ChatView", () => {
             { label: "Hold", description: "wait" },
           ],
         },
+        attachments: [
+          {
+            attachmentId: "22222222-2222-4222-8222-222222222222",
+            kind: "image",
+            mimeType: "image/png",
+            filename: "evidence.png",
+            size: 42,
+          },
+        ],
       },
       source: "api",
       createdAt: "2026-05-28T11:59:00.000Z",

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -1896,7 +1896,17 @@ describe("ChatView", () => {
       id: "req-render",
       senderId: "agent-1",
       format: "request",
-      content: "Lifecycle **body** stays memoized.",
+      content: {
+        caption: "Lifecycle **body** stays memoized.",
+        attachments: [
+          {
+            imageId: "11111111-1111-4111-8111-111111111111",
+            mimeType: "image/png",
+            filename: "lifecycle.png",
+            size: 42,
+          },
+        ],
+      },
       metadata: {
         mentions: ["human-agent-self"],
         request: {
@@ -1930,6 +1940,10 @@ describe("ChatView", () => {
     // `format="request"`. Viewer agent-1 is not the target, so there is no
     // answer overlay either.
     await waitForText(container, "Lifecycle");
+    await waitForCondition(
+      () => container.querySelector('button[aria-label="Open image lifecycle.png"]') !== null,
+      "request image thumbnail did not render",
+    );
     expect(container.textContent).not.toContain("RESOLVED");
     await flush();
     markdownMocks.render.mockClear();
@@ -2746,7 +2760,17 @@ describe("ChatView", () => {
       id: "req-gitlab-link",
       senderId: "agent-1",
       format: "request",
-      content: [canonical, `[Review the MR](${canonical})`].join("\n\n"),
+      content: {
+        caption: [canonical, `[Review the MR](${canonical})`].join("\n\n"),
+        attachments: [
+          {
+            imageId: "22222222-2222-4222-8222-222222222222",
+            mimeType: "image/png",
+            filename: "evidence.png",
+            size: 42,
+          },
+        ],
+      },
       metadata: {
         mentions: ["human-agent-self"],
         request: {
@@ -2778,6 +2802,7 @@ describe("ChatView", () => {
     expect(compact?.getAttribute("href")).toBe(canonical);
     expect(compact?.title).toBe(canonical);
     expect(anchors.find((anchor) => anchor.textContent === "Review the MR")?.getAttribute("href")).toBe(canonical);
+    expect(dialog?.querySelector('button[aria-label="Open image evidence.png"]')).not.toBeNull();
 
     await act(async () => root.unmount());
   });

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -9,8 +9,8 @@ import {
   chatMetadataSchema,
   type DocSnapshotFailReason,
   documentContextSchema,
-  extractCaption,
   extractMentions,
+  imageAttachmentRefsFromMetadata,
   isImageBatchRefContent,
   isImageRefContent,
   isLandingCampaignTrialChatLocked,
@@ -597,6 +597,14 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
     }
     return map;
   }, [msg.metadata]);
+  const metadataImages = useMemo(
+    () =>
+      imageAttachmentRefsFromMetadata(msg.metadata).map((ref) => ({
+        imageId: ref.attachmentId,
+        filename: ref.filename,
+      })),
+    [msg.metadata],
+  );
   // Attachment refs to render as download chips: everything in
   // `metadata.attachments` that is NOT already surfaced as an inline
   // `[display](attachment:<id>)` link in the body (the agent doc-capture
@@ -612,7 +620,9 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
         : isImageBatchRefContent(msg.content)
           ? (msg.content.caption ?? "")
           : "";
-    return attachmentRefsFromMetadata(msg.metadata).filter((ref) => !body.includes(`attachment:${ref.attachmentId}`));
+    return attachmentRefsFromMetadata(msg.metadata).filter(
+      (ref) => ref.kind !== "image" && !body.includes(`attachment:${ref.attachmentId}`),
+    );
   }, [msg.metadata, msg.content]);
   const failedDocMentions = useMemo(() => failedDocMentionsFromMetadata(msg.metadata), [msg.metadata]);
   // Resolve a visible label only when this token's persisted mention ID still
@@ -782,7 +792,7 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
         marginTop: 2,
       }}
     >
-      {(msg.format === "file" || msg.format === "request") && isImageBatchRefContent(msg.content) ? (
+      {msg.format === "file" && isImageBatchRefContent(msg.content) ? (
         <ImageBatchFromRef
           content={msg.content}
           markdownComponents={markdownComponents}
@@ -817,6 +827,10 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
           {JSON.stringify(msg.content, null, 2)}
         </pre>
       )}
+      <ImageRefGallery
+        images={metadataImages}
+        hasLeadingContent={typeof msg.content === "string" && msg.content.trim().length > 0}
+      />
       {chipAttachmentRefs.length > 0 && (
         <div className="flex flex-col items-start" style={{ gap: 6, marginTop: 6 }}>
           {chipAttachmentRefs.map((ref) => (
@@ -3529,10 +3543,11 @@ export function ChatView({
             <div style={{ position: "absolute", top: 52, left: 0, right: 0, bottom: 0, zIndex: 30 }}>
               <AskTakeover
                 key={dockRequest.id}
-                body={
-                  typeof dockRequest.content === "string" ? dockRequest.content : extractCaption(dockRequest.content)
-                }
-                images={isImageBatchRefContent(dockRequest.content) ? dockRequest.content.attachments : []}
+                body={typeof dockRequest.content === "string" ? dockRequest.content : ""}
+                images={imageAttachmentRefsFromMetadata(dockRequest.metadata).map((ref) => ({
+                  imageId: ref.attachmentId,
+                  filename: ref.filename,
+                }))}
                 payload={dockPayload}
                 askerName={chatScopedAgentName(dockRequest.senderId)}
                 sending={askBusy}

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -9,6 +9,7 @@ import {
   chatMetadataSchema,
   type DocSnapshotFailReason,
   documentContextSchema,
+  extractCaption,
   extractMentions,
   isImageBatchRefContent,
   isImageRefContent,
@@ -104,6 +105,7 @@ import {
   isGitlabEventCardContent,
   isTrustedGitlabDispatcherMessage,
 } from "../../../components/chat/gitlab-event-card.js";
+import { ImageRefGallery } from "../../../components/chat/image-ref-gallery.js";
 import {
   findBlockingRequest,
   findThreadableRequestId,
@@ -151,7 +153,6 @@ import { useAgentIdentityMap, useAgentNameMap } from "../../../lib/use-agent-nam
 import { useAutoResizeTextarea } from "../../../lib/use-autoresize-textarea.js";
 import { useChatDraftText } from "../../../lib/use-chat-draft-text.js";
 import { useClientMap } from "../../../lib/use-client-map.js";
-import { useImageSrc } from "../../../lib/use-image-src.js";
 import { useOrgAgents } from "../../../lib/use-org-agents.js";
 import { usePendingAttachments } from "../../../lib/use-pending-attachments.js";
 import { cn } from "../../../lib/utils.js";
@@ -781,7 +782,7 @@ const MessageBody = memo(function MessageBody({ msg, myAgentId, mentionParticipa
         marginTop: 2,
       }}
     >
-      {msg.format === "file" && isImageBatchRefContent(msg.content) ? (
+      {(msg.format === "file" || msg.format === "request") && isImageBatchRefContent(msg.content) ? (
         <ImageBatchFromRef
           content={msg.content}
           markdownComponents={markdownComponents}
@@ -1100,16 +1101,10 @@ function isInlineImageContent(content: unknown): content is FileMessageContent {
  *
  * - `standalone` (a single-image message): shown at its natural aspect within
  *   a width AND height cap, so a tall image no longer runs the full column.
- * - `gallery` (a multi-image batch): aligned to one common row height so mixed
- *   aspect ratios read as one tidy row — the fix for the old `flex` default
- *   `align-items: stretch`, which stretched every sibling to the tallest one.
- *
  * The width caps are `min(<desktop cap>, 100%)` so they never exceed the
  * (narrow, on mobile) message column — an inline `maxWidth` would otherwise
  * override the responsive `img { max-width: 100% }` preflight and overflow the
- * shared mobile chat surface. Neither variant upscales past the source; both
- * open the lightbox on click. The wrapping button carries `minWidth: 0` so a
- * gallery flex item can shrink below its intrinsic width on a narrow column.
+ * shared mobile chat surface.
  */
 const STANDALONE_IMG_STYLE = {
   maxWidth: "min(25rem, 100%)",
@@ -1118,81 +1113,8 @@ const STANDALONE_IMG_STYLE = {
   cursor: "zoom-in",
   display: "block",
 } satisfies CSSProperties;
-const GALLERY_IMG_STYLE = {
-  height: 172,
-  width: "auto",
-  maxWidth: "min(28.75rem, 100%)",
-  objectFit: "cover",
-  borderRadius: "var(--radius-panel)",
-  cursor: "zoom-in",
-  display: "block",
-} satisfies CSSProperties;
-
-/**
- * Clickable thumbnail for an image referenced by `{imageId}`. Bytes resolve
- * via {@link useImageSrc} (IndexedDB cache first, then the org attachment
- * store, warming the cache) — the sender's own sends and any already-rendered
- * thumbnail keep it warm, so the click-through to the lightbox is instant. A
- * failed fetch (deleted attachment / network) falls through to a placeholder.
- * The owning wrapper (standalone or batch) holds the lightbox and is notified
- * via `onOpen`.
- */
-function ImageFromRef({
-  content,
-  variant,
-  onOpen,
-}: {
-  content: ImageRefContent;
-  variant: "standalone" | "gallery";
-  onOpen: () => void;
-}) {
-  const state = useImageSrc(content.imageId);
-
-  if (state.kind === "hit") {
-    return (
-      <button
-        type="button"
-        onClick={onOpen}
-        aria-label={`Open image ${content.filename}`}
-        className="block border-none bg-transparent p-0"
-        // `minWidth: 0` lets a gallery flex item shrink below the image's
-        // intrinsic width on a narrow column instead of overflowing.
-        style={{ marginTop: variant === "standalone" ? 4 : 0, maxWidth: "100%", minWidth: 0 }}
-      >
-        <img
-          src={state.src}
-          alt={content.filename}
-          style={variant === "standalone" ? STANDALONE_IMG_STYLE : GALLERY_IMG_STYLE}
-        />
-      </button>
-    );
-  }
-  if (state.kind === "miss") {
-    return (
-      <span className="text-label" style={{ color: "var(--fg-3)", fontStyle: "italic" }}>
-        [Image "{content.filename}" failed to load]
-      </span>
-    );
-  }
-  return (
-    <span className="text-label" style={{ color: "var(--fg-4)" }}>
-      …
-    </span>
-  );
-}
-
-/**
- * A single-image `{imageId}` message: the thumbnail plus its own lightbox.
- */
 function StandaloneImageRef({ content }: { content: ImageRefContent }) {
-  const [openIndex, setOpenIndex] = useState<number | null>(null);
-  const images: LightboxImage[] = [{ imageId: content.imageId, filename: content.filename }];
-  return (
-    <>
-      <ImageFromRef content={content} variant="standalone" onOpen={() => setOpenIndex(0)} />
-      <ImageLightbox images={images} index={openIndex} onIndexChange={setOpenIndex} />
-    </>
-  );
+  return <ImageRefGallery images={[content]} />;
 }
 
 /**
@@ -1236,14 +1158,6 @@ function ImageBatchFromRef({
   rehypePlugins: MarkdownProps["rehypePlugins"];
 }) {
   const caption = content.caption?.trim() ?? "";
-  const [openIndex, setOpenIndex] = useState<number | null>(null);
-  const images: LightboxImage[] = content.attachments.map((att) => ({
-    imageId: att.imageId,
-    filename: att.filename,
-  }));
-  // A batch of one (the composer sends even a single image this way) reads as a
-  // single image, not a lone gallery tile: show it at the larger standalone size.
-  const only = content.attachments.length === 1 ? content.attachments[0] : undefined;
   return (
     <div className="flex flex-col" style={{ gap: 4 }}>
       {caption.length > 0 ? (
@@ -1251,16 +1165,7 @@ function ImageBatchFromRef({
           {caption}
         </Markdown>
       ) : null}
-      {only ? (
-        <ImageFromRef content={only} variant="standalone" onOpen={() => setOpenIndex(0)} />
-      ) : (
-        <div className="flex flex-wrap items-start" style={{ gap: 6, marginTop: caption.length > 0 ? 2 : 0 }}>
-          {content.attachments.map((att, i) => (
-            <ImageFromRef key={att.imageId} content={att} variant="gallery" onOpen={() => setOpenIndex(i)} />
-          ))}
-        </div>
-      )}
-      <ImageLightbox images={images} index={openIndex} onIndexChange={setOpenIndex} />
+      <ImageRefGallery images={content.attachments} hasLeadingContent={caption.length > 0} />
     </div>
   );
 }
@@ -3624,7 +3529,10 @@ export function ChatView({
             <div style={{ position: "absolute", top: 52, left: 0, right: 0, bottom: 0, zIndex: 30 }}>
               <AskTakeover
                 key={dockRequest.id}
-                body={typeof dockRequest.content === "string" ? dockRequest.content : ""}
+                body={
+                  typeof dockRequest.content === "string" ? dockRequest.content : extractCaption(dockRequest.content)
+                }
+                images={isImageBatchRefContent(dockRequest.content) ? dockRequest.content.attachments : []}
                 payload={dockPayload}
                 askerName={chatScopedAgentName(dockRequest.senderId)}
                 sending={askBusy}


### PR DESCRIPTION
## Summary

- keep tracked-request content as plain text
- upload request images and carry them as generic message attachment references
- render those references in the timeline, desktop takeover, and Mobile Work answer sheet
- materialize request images when agents receive the request through the production `precedingMessages` path, bounded to 10 missing unique images per delivery
- enforce one shared 10-attachment budget across caller references, documents, and captured images
- reject malformed references and unsupported image MIME types before persistence

## Architecture boundary

This deliberately does not add an object-shaped request body, change the request lifecycle, migrate ordinary image messages, add storage infrastructure, or change attachment authorization. Existing ordinary and historical image messages keep their legacy `format: "file"` representation. The added agent-runtime work handles only generic request-image references in preceding context; legacy historical images, documents/files in preceding context, and old inline-image behavior remain unchanged.

## Validation

- `pnpm check`
- `pnpm typecheck`
- 1,735 Web tests
- 279 focused Shared, Client, CLI, and Server tests
- two independent focused code reviews with no blocker or important findings remaining
- real PostgreSQL + Server + Web browser QA on desktop and Mobile Work, including image preview and an actual resolving reply; zero browser console errors

## Companion Context Tree PR

- https://github.com/agent-team-foundation/first-tree-context/pull/821
