### PR TITLE
fix: preserve mobile Work filters across chat detail

### DIFF
--- a/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/chat-nav.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import type { MeChatRow } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { MemoryRouter, Route, Routes, useNavigationType } from "react-router";
@@ -12,6 +13,34 @@ const meChatMocks = vi.hoisted(() => ({
   listMeChats: vi.fn(),
   listMeChatSourceCounts: vi.fn(),
 }));
+
+function chatRow(overrides: Partial<MeChatRow> = {}): MeChatRow {
+  return {
+    chatId: overrides.chatId ?? "chat-1",
+    type: overrides.type ?? "group",
+    membershipKind: overrides.membershipKind ?? "participant",
+    createdByMe: overrides.createdByMe ?? false,
+    source: overrides.source ?? "manual",
+    entityType: overrides.entityType ?? null,
+    title: overrides.title ?? "Pinned planning",
+    topic: overrides.topic ?? "Pinned planning",
+    description: overrides.description ?? null,
+    participants: overrides.participants ?? [],
+    participantCount: overrides.participantCount ?? 0,
+    lastMessageAt: overrides.lastMessageAt ?? "2026-07-24T05:00:00.000Z",
+    lastMessagePreview: overrides.lastMessagePreview ?? "Keep the selected quick view after returning.",
+    unreadMentionCount: overrides.unreadMentionCount ?? 0,
+    openRequestCount: overrides.openRequestCount ?? 0,
+    canReply: overrides.canReply ?? true,
+    engagementStatus: overrides.engagementStatus ?? "active",
+    liveActivity: overrides.liveActivity ?? null,
+    failedAgentIds: overrides.failedAgentIds ?? [],
+    busyAgentIds: overrides.busyAgentIds ?? [],
+    chatHasExplicitMentionToMe: overrides.chatHasExplicitMentionToMe ?? false,
+    pinnedAt: overrides.pinnedAt ?? null,
+    activityAt: overrides.activityAt ?? null,
+  };
+}
 
 vi.mock("../../../auth/auth-context.js", () => ({ useAuth: () => authMock.value }));
 vi.mock("../../../api/me-chats.js", () => meChatMocks);
@@ -72,5 +101,57 @@ describe("MobileWorkPage back navigation", () => {
     // clearChat must REPLACE the detail with the list (not PUSH), so the
     // browser Back button / swipe cannot reopen the chat detail just exited.
     expect(lastNavType).toBe("REPLACE");
+  });
+
+  it("preserves the selected quick view after opening a chat and returning", async () => {
+    const pinned = chatRow({ pinnedAt: "2026-07-24T05:30:00.000Z" });
+    meChatMocks.listMeChats.mockResolvedValue({
+      priorityRows: { attention: [], pinned: [pinned] },
+      rows: [pinned],
+      nextCursor: null,
+    });
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    harness.render(
+      <MemoryRouter initialEntries={["/m/work"]}>
+        <QueryClientProvider client={queryClient}>
+          <Routes>
+            <Route path="/m/work" element={<MobileWorkPage />} />
+          </Routes>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+
+    await harness.waitFor(() => expect(harness.container.textContent).toContain("Pinned planning"));
+    const pinnedQuickView = [...harness.container.querySelectorAll<HTMLButtonElement>("button")].find((button) =>
+      button.textContent?.includes("Pinned"),
+    );
+    expect(pinnedQuickView).not.toBeNull();
+
+    await act(async () => {
+      pinnedQuickView?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await harness.flush();
+    expect(pinnedQuickView?.getAttribute("aria-pressed")).toBe("true");
+
+    const chatCard = harness.container.querySelector<HTMLButtonElement>('[data-mobile-card="work"]');
+    await act(async () => {
+      chatCard?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await harness.flush();
+    expect(harness.container.querySelector('button[aria-label="back"]')).not.toBeNull();
+
+    await act(async () => {
+      harness.container
+        .querySelector<HTMLButtonElement>('button[aria-label="back"]')
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await harness.flush();
+
+    const restoredPinnedQuickView = [...harness.container.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent?.includes("Pinned"),
+    );
+    expect(restoredPinnedQuickView?.getAttribute("aria-pressed")).toBe("true");
+    expect(harness.container.textContent).toContain("Pinned planning");
   });
 });

--- a/packages/web/src/pages/mobile/work.tsx
+++ b/packages/web/src/pages/mobile/work.tsx
@@ -26,6 +26,8 @@ const DEFAULT_FILTERS: MobileWorkFilters = {
 
 export function MobileWorkPage() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const [quickView, setQuickView] = useState<MobileWorkQuickView>("all");
+  const [filters, setFilters] = useState<MobileWorkFilters>(DEFAULT_FILTERS);
   const selectedChatId = searchParams.get("c");
 
   const selectChat = useCallback(
@@ -59,17 +61,33 @@ export function MobileWorkPage() {
           />
         </div>
       ) : (
-        <MobileWorkList onSelectChat={selectChat} />
+        <MobileWorkList
+          onSelectChat={selectChat}
+          quickView={quickView}
+          onQuickViewChange={setQuickView}
+          filters={filters}
+          onFiltersChange={setFilters}
+        />
       )}
       <DocPreviewDrawer />
     </>
   );
 }
 
-function MobileWorkList({ onSelectChat }: { onSelectChat: (chatId: string) => void }) {
+function MobileWorkList({
+  onSelectChat,
+  quickView,
+  onQuickViewChange,
+  filters,
+  onFiltersChange,
+}: {
+  onSelectChat: (chatId: string) => void;
+  quickView: MobileWorkQuickView;
+  onQuickViewChange: (quickView: MobileWorkQuickView) => void;
+  filters: MobileWorkFilters;
+  onFiltersChange: (filters: MobileWorkFilters) => void;
+}) {
   const { agentId, organizationId } = useAuth();
-  const [quickView, setQuickView] = useState<MobileWorkQuickView>("all");
-  const [filters, setFilters] = useState<MobileWorkFilters>(DEFAULT_FILTERS);
   const [searchOpen, setSearchOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [answeringChatId, setAnsweringChatId] = useState<string | null>(null);
@@ -143,7 +161,7 @@ function MobileWorkList({ onSelectChat }: { onSelectChat: (chatId: string) => vo
   const narrowed = filters.engagement !== "active" || filters.watching;
 
   const toggleQuickView = (next: Exclude<MobileWorkQuickView, "all">): void => {
-    setQuickView((current) => (current === next ? "all" : next));
+    onQuickViewChange(quickView === next ? "all" : next);
   };
 
   return (
@@ -300,7 +318,7 @@ function MobileWorkList({ onSelectChat }: { onSelectChat: (chatId: string) => vo
       {answeringChatId ? <MobileAskSheet chatId={answeringChatId} onClose={() => setAnsweringChatId(null)} /> : null}
       {actionsRow ? <MobileChatActionsSheet row={actionsRow} onClose={() => setActionsRow(null)} /> : null}
       {filtersOpen ? (
-        <MobileWorkFiltersSheet value={filters} onChange={setFilters} onClose={() => setFiltersOpen(false)} />
+        <MobileWorkFiltersSheet value={filters} onChange={onFiltersChange} onClose={() => setFiltersOpen(false)} />
       ) : null}
     </>
   );


### PR DESCRIPTION
## Summary

- keep the mobile Work quick-view and filter state mounted while chat detail replaces the list
- restore the selected `Need you`, `Unread`, or `Pinned` view when returning from detail
- add a regression test for `Pinned → open chat → back → Pinned remains selected`

## Product scope

Mobile scope: allowlisted — this preserves existing Work navigation state and adds no new mobile capability.

Card swipe actions are intentionally out of scope.

## Verification

- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter @first-tree/web test` — 204 files / 1,736 tests passed
- `pnpm --filter @first-tree/web exec vitest run src/pages/mobile/__tests__/chat-nav.test.tsx` — 2/2 passed
- two independent code reviews completed with no blocking findings
