### PR TITLE
fix: correct invite action hierarchy

### DIFF
--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -1585,6 +1585,10 @@ describe("web DOM interaction coverage", () => {
     expect(panel.container.querySelector<HTMLInputElement>("input")?.value).toBe(
       "https://first-tree.example/invite/token-1",
     );
+    const inviteActions = [...panel.container.querySelectorAll("button")];
+    expect(inviteActions.map((button) => button.textContent)).toEqual(["Rotate", "Copy"]);
+    expect(inviteActions[0]?.classList.contains("border")).toBe(true);
+    expect(inviteActions[1]?.classList.contains("bg-primary")).toBe(true);
     await click(
       [...panel.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Copy")) ?? null,
     );

--- a/packages/web/src/pages/invite-link-panel.tsx
+++ b/packages/web/src/pages/invite-link-panel.tsx
@@ -88,14 +88,14 @@ export function InviteLinkPanel() {
               className="flex-1 rounded-[var(--radius-panel)] border bg-muted px-2 py-1 text-label font-mono"
               value={invite.inviteUrl}
             />
-            <Button size="sm" variant="outline" onClick={() => void copy(invite.inviteUrl)}>
-              {copied ? "Copied!" : "Copy"}
-            </Button>
             {isAdmin && (
-              <Button size="sm" onClick={rotate} disabled={busy}>
+              <Button size="sm" variant="outline" onClick={rotate} disabled={busy}>
                 {busy ? "Rotating…" : "Rotate"}
               </Button>
             )}
+            <Button size="sm" onClick={() => void copy(invite.inviteUrl)}>
+              {copied ? "Copied!" : "Copy"}
+            </Button>
           </div>
           <p className="text-label text-muted-foreground">
             Created {new Date(invite.createdAt).toLocaleString()}


### PR DESCRIPTION
## Summary

- make Copy the rightmost primary action in the invite dialog
- move Rotate to the left and use the outline treatment for its destructive lifecycle role
- add DOM regression coverage for action order and visual variants

## Verification

- `pnpm --dir packages/web exec vitest run src/pages/__tests__/web-dom-interactions.test.tsx --reporter=dot`
- `pnpm --filter @first-tree/web typecheck`
- `pnpm exec biome check packages/web/src/pages/invite-link-panel.tsx packages/web/src/pages/__tests__/web-dom-interactions.test.tsx`
- `pnpm check`
- `pnpm typecheck`
- browser QA in light and dark themes, including Copy → Copied! feedback
