### PR TITLE
feat(web): unify Context Tree review settings

### DIFF
--- a/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
+++ b/packages/web/src/pages/__tests__/preview-pages-extra.test.tsx
@@ -238,19 +238,19 @@ describe("extra preview pages", () => {
     const treeRow = rendered.container.querySelector<HTMLElement>('[data-setup-row="context-tree"]');
     if (!treeRow) throw new Error("Missing Context Tree row");
     await click(buttonByText(treeRow, "Manage"));
-    expect(treeRow.querySelector('[data-setup-owner-controls="context-tree"]')).not.toBeNull();
-
-    const reviewRow = rendered.container.querySelector<HTMLElement>('[data-setup-row="automatic-review"]');
-    if (!reviewRow) throw new Error("Missing Automatic Review row");
-    await click(buttonByText(reviewRow, "Manage"));
-    expect(reviewRow.querySelector('[data-setup-owner-controls="automatic-review"]')).not.toBeNull();
-    expect(rendered.container.querySelector('[data-setup-owner-controls="context-tree"]')).toBeNull();
-    expect(text(reviewRow)).toContain("Context Reviewer");
-    const enablement = reviewRow.querySelector<HTMLButtonElement>('[role="switch"]');
+    const treeControls = treeRow.querySelector<HTMLElement>('[data-setup-owner-controls="context-tree"]');
+    expect(treeControls).not.toBeNull();
+    const reviewerControls = treeControls?.querySelector<HTMLElement>('[data-setup-owner-controls="automatic-review"]');
+    expect(reviewerControls).not.toBeNull();
+    expect(rendered.container.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
+    expect(text(reviewerControls ?? treeRow)).toContain("Context Reviewer");
+    const enablement = reviewerControls?.querySelector<HTMLButtonElement>('[role="switch"]');
     expect(enablement?.getAttribute("aria-checked")).toBe("true");
     if (!enablement) throw new Error("Missing preview Reviewer enablement switch");
     await click(enablement);
     expect(enablement.getAttribute("aria-checked")).toBe("false");
+    await click(buttonByText(treeRow, "Manage"));
+    expect(treeRow.querySelector('[data-setup-owner-controls="context-tree"]')).toBeNull();
     expect(globalThis.fetch).not.toHaveBeenCalled();
 
     await cleanupRendered(rendered);

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -731,7 +731,7 @@ describe("Settings Setup overview", () => {
       }),
       "Review degraded",
       "attention",
-      "acme/context-tree · Context Tree available",
+      "Recent GitLab webhook processing failed. · acme/context-tree · Context Tree available",
     ],
     [
       "pending verification",
@@ -744,7 +744,21 @@ describe("Settings Setup overview", () => {
       }),
       "Review verification pending",
       "pending",
-      "acme/context-tree · Context Tree available",
+      "First Tree could not verify provider readiness. · acme/context-tree · Context Tree available",
+    ],
+    [
+      "disabled with an actionless Reviewer diagnostic",
+      capabilityFixture({
+        review: {
+          adoption: "disabled",
+          health: "degraded",
+          reviewerAgent: { uuid: "reviewer-1", displayName: "Context Reviewer" },
+          blockers: [{ code: "provider_probe_failed", resolutionOwner: "operator", actionKind: null }],
+        },
+      }),
+      "Available",
+      "ready",
+      "Review off · Reviewer degraded · First Tree could not verify provider readiness. · acme/context-tree",
     ],
   ] as const)("summarizes Automatic review %s in the Context Tree row", (_name, capabilities, label, kind, detail) => {
     const input = facts({ capabilities: { state: "ready", value: capabilities } });
@@ -774,9 +788,11 @@ describe("Settings Setup overview", () => {
     const member = rowFor("context-tree", facts({ role: "member", capabilities: { state: "ready", value: shared } }));
 
     expect(admin.status).toMatchObject({ label: "Review needs attention", kind: "attention" });
+    expect(admin.status.detail).toContain("The configured reviewer is missing.");
     expect(admin.status.detail).toContain("Context Tree available");
     expect(admin.action?.label).toBe("Manage");
     expect(member.status).toMatchObject({ label: "Review service unavailable", kind: "blocked" });
+    expect(member.status.detail).toContain("Ask an admin to resolve this: The configured reviewer is missing.");
     expect(member.status.detail).toContain("Context Tree available");
     expect(member.action).toEqual({ label: "View", to: "/context" });
   });

--- a/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
+++ b/packages/web/src/pages/settings/__tests__/setup-dom.test.tsx
@@ -211,6 +211,20 @@ async function waitForSelector<T extends Element>(host: ParentNode, selector: st
   throw new Error(`Expected selector "${selector}"`);
 }
 
+async function openContextTreeControls(view: Awaited<ReturnType<typeof renderSettingsSetupPage>>) {
+  const tree = await waitForRowText(view.host, "context-tree", "Available");
+  const manage = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
+    (button) => button.textContent === "Manage",
+  );
+  await act(async () => manage?.click());
+  const controls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
+  const reviewerControls = await waitForSelector<HTMLElement>(
+    controls,
+    '[data-setup-owner-controls="automatic-review"]',
+  );
+  return { tree, manage, controls, reviewerControls };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   activityMocks.listClients.mockResolvedValue([]);
@@ -286,14 +300,11 @@ describe("Settings Setup overview", () => {
       "Code repositories",
       "Repository automation",
       "Context Tree",
-      "Automatic review",
     ]);
-    expect(view.host.querySelector('[data-setup-row="automatic-review"]')?.getAttribute("data-setup-parent")).toBe(
-      "context-tree",
-    );
+    expect(view.host.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
     expect(view.host.querySelector('[data-setup-row="work-access"] .lucide-message-circle')).not.toBeNull();
     const readyMarks = view.host.querySelectorAll("[data-setup-status-kind='ready'] .lucide-circle-check");
-    expect(readyMarks).toHaveLength(7);
+    expect(readyMarks).toHaveLength(6);
     expect([...readyMarks].every((mark) => mark.getAttribute("aria-hidden") === "true")).toBe(true);
     expect(view.host.querySelectorAll('[role="status"], [aria-live]')).toHaveLength(0);
     expect(view.host.textContent).not.toContain("%");
@@ -335,8 +346,7 @@ describe("Settings Setup overview", () => {
       ["agent", "attention", "circle-alert", "--state-needs-you"],
       ["repositories", "unknown", "circle-question-mark", "--fg-3"],
       ["repository-automation", "pending", "clock-3", "--state-idle"],
-      ["context-tree", "pending", "clock-3", "--state-idle"],
-      ["automatic-review", "neutral", "circle-alert", "--fg-3"],
+      ["context-tree", "neutral", "circle-alert", "--fg-3"],
     ] as const;
 
     for (const [key, kind, glyph, token] of expectation) {
@@ -396,7 +406,7 @@ describe("Settings Setup overview", () => {
     expect(view.host.textContent).not.toContain("Action required");
     expect(view.host.textContent).not.toContain("Manage");
     expect(rowFor("context-tree", input).action).toBeUndefined();
-    expect(rowFor("automatic-review", input).status.label).toBe("Available after Context Tree");
+    expect(view.host.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
 
     await act(async () => view.root.unmount());
   });
@@ -532,13 +542,12 @@ describe("Settings Setup overview", () => {
       label: "Set up GitLab",
       to: "/settings/integrations/gitlab",
     });
-    expect(rowFor("automatic-review", adminFacts).action).toEqual({
-      label: "Manage",
-      to: "/settings/setup#automatic-review",
-      intent: "open-reviewer-controls",
+    expect(rowFor("context-tree", adminFacts).status).toMatchObject({
+      label: "Review degraded",
+      kind: "attention",
     });
     expect(rowFor("repository-automation", memberFacts).action).toBeUndefined();
-    expect(rowFor("automatic-review", memberFacts).action).toBeUndefined();
+    expect(rowFor("context-tree", memberFacts).action).toEqual({ label: "View", to: "/context" });
   });
 
   it("turns the same Team blocker into admin attention and member read-only explanation", () => {
@@ -587,14 +596,14 @@ describe("Settings Setup overview", () => {
   });
 
   it.each([
-    ["active", "Available", "ready", "Manage"],
-    ["stale", "Available · update delayed", "pending", "Manage"],
-    ["unavailable", "Needs recovery", "attention", "Recover"],
-  ] as const)("maps bound Context Tree snapshot %s without equating binding to health", (value, label, kind, action) => {
+    ["active", "Available", "ready", "Manage", "acme/context-tree · Review on"],
+    ["stale", "Available · update delayed", "pending", "Manage", "acme/context-tree · Review on"],
+    ["unavailable", "Needs recovery", "attention", "Recover", "acme/context-tree · main branch · GitHub"],
+  ] as const)("maps bound Context Tree snapshot %s without equating binding to health", (value, label, kind, action, detail) => {
     const row = rowFor("context-tree", facts({ contextTreeSnapshot: { state: "ready", value } }));
 
     expect(row.status).toMatchObject({ label, kind });
-    expect(row.status.detail).toBe("acme/context-tree · main branch · GitHub");
+    expect(row.status.detail).toBe(detail);
     expect(row.action?.label).toBe(action);
   });
 
@@ -691,38 +700,19 @@ describe("Settings Setup overview", () => {
   });
 
   it.each([
+    ["enabled", capabilityFixture(), "Available", "ready", "acme/context-tree · Review on"],
     [
-      "unavailable",
-      capabilityFixture({
-        binding: { state: "unbound" },
-        review: { adoption: "unavailable", health: "not_observed", reviewerAgent: null },
-      }),
-      "Available after Context Tree",
-      "optional",
-      undefined,
-    ],
-    [
-      "disabled",
-      capabilityFixture({
-        review: { adoption: "disabled", health: "not_observed", reviewerAgent: null },
-      }),
-      "Off",
-      "optional",
-      "Set up",
-    ],
-    ["ready", capabilityFixture(), "On", "ready", "Manage"],
-    [
-      "pending",
+      "disabled with a retained Reviewer",
       capabilityFixture({
         review: {
-          adoption: "enabled",
-          health: "pending_verification",
-          blockers: [{ code: "provider_probe_failed", resolutionOwner: "operator", actionKind: null }],
+          adoption: "disabled",
+          health: "not_observed",
+          reviewerAgent: { uuid: "reviewer-1", displayName: "Context Reviewer" },
         },
       }),
-      "Verification pending",
-      "pending",
-      "Manage",
+      "Available",
+      "ready",
+      "acme/context-tree · Review off",
     ],
     [
       "degraded",
@@ -739,20 +729,33 @@ describe("Settings Setup overview", () => {
           ],
         },
       }),
-      "Degraded",
+      "Review degraded",
       "attention",
-      "Manage",
+      "acme/context-tree · Context Tree available",
     ],
-  ] as const)("maps Automatic review %s without making it a Start Chat gate", (_name, capabilities, label, kind, action) => {
+    [
+      "pending verification",
+      capabilityFixture({
+        review: {
+          adoption: "enabled",
+          health: "pending_verification",
+          blockers: [{ code: "provider_probe_failed", resolutionOwner: "operator", actionKind: null }],
+        },
+      }),
+      "Review verification pending",
+      "pending",
+      "acme/context-tree · Context Tree available",
+    ],
+  ] as const)("summarizes Automatic review %s in the Context Tree row", (_name, capabilities, label, kind, detail) => {
     const input = facts({ capabilities: { state: "ready", value: capabilities } });
-    const review = rowFor("automatic-review", input);
+    const contextTree = rowFor("context-tree", input);
 
-    expect(review.status).toMatchObject({ label, kind });
-    expect(review.action?.label).toBe(action);
+    expect(contextTree.status).toMatchObject({ label, kind, detail });
+    expect(contextTree.action?.label).toBe("Manage");
     expect(rowFor("work-access", input).status.label).toBe("Can work now");
   });
 
-  it("makes reviewer replacement admin-only while preserving the same Team fact", () => {
+  it("keeps reviewer replacement admin-only while preserving the same Team fact", () => {
     const shared = capabilityFixture({
       review: {
         adoption: "enabled",
@@ -767,84 +770,15 @@ describe("Settings Setup overview", () => {
         ],
       },
     });
-    const admin = rowFor("automatic-review", facts({ role: "admin", capabilities: { state: "ready", value: shared } }));
-    const member = rowFor(
-      "automatic-review",
-      facts({ role: "member", capabilities: { state: "ready", value: shared } }),
-    );
+    const admin = rowFor("context-tree", facts({ role: "admin", capabilities: { state: "ready", value: shared } }));
+    const member = rowFor("context-tree", facts({ role: "member", capabilities: { state: "ready", value: shared } }));
 
-    expect(admin.status).toMatchObject({ label: "Needs attention", kind: "attention" });
-    expect(admin.action).toEqual({
-      label: "Manage",
-      to: "/settings/setup#automatic-review",
-      intent: "open-reviewer-controls",
-    });
-    expect(member.status).toMatchObject({ label: "Service unavailable", kind: "blocked" });
-    expect(member.status.detail).toContain("Ask an admin");
-    expect(member.action).toBeUndefined();
-  });
-
-  it("shows a retained Reviewer selection while Automatic Review is off", () => {
-    const row = rowFor(
-      "automatic-review",
-      facts({
-        capabilities: {
-          state: "ready",
-          value: capabilityFixture({
-            review: {
-              adoption: "disabled",
-              health: "not_observed",
-              reviewerAgent: { uuid: "reviewer-1", displayName: "Context Reviewer" },
-            },
-          }),
-        },
-      }),
-    );
-
-    expect(row.status).toEqual({
-      label: "Off",
-      detail: "Reviewer · Context Reviewer · Optional",
-      kind: "optional",
-    });
-    expect(row.action).toEqual({
-      label: "Manage",
-      to: "/settings/setup#automatic-review",
-      intent: "open-reviewer-controls",
-    });
-  });
-
-  it("preserves degraded Server facts and inline recovery controls while Automatic Review is off", () => {
-    const row = rowFor(
-      "automatic-review",
-      facts({
-        capabilities: {
-          state: "ready",
-          value: capabilityFixture({
-            review: {
-              adoption: "disabled",
-              health: "degraded",
-              reviewerAgent: { uuid: "reviewer-1", displayName: "Offline Reviewer" },
-              blockers: [
-                {
-                  code: "context_review_agent_runtime_unavailable",
-                  resolutionOwner: "admin",
-                  actionKind: "open_agent_owner_flow",
-                },
-              ],
-            },
-          }),
-        },
-      }),
-    );
-
-    expect(row.status).toMatchObject({ label: "Off", kind: "optional" });
-    expect(row.status.detail).toContain("Reviewer degraded");
-    expect(row.status.detail).toContain("runtime is currently unavailable");
-    expect(row.action).toEqual({
-      label: "Manage",
-      to: "/settings/setup#automatic-review",
-      intent: "open-reviewer-controls",
-    });
+    expect(admin.status).toMatchObject({ label: "Review needs attention", kind: "attention" });
+    expect(admin.status.detail).toContain("Context Tree available");
+    expect(admin.action?.label).toBe("Manage");
+    expect(member.status).toMatchObject({ label: "Review service unavailable", kind: "blocked" });
+    expect(member.status.detail).toContain("Context Tree available");
+    expect(member.action).toEqual({ label: "View", to: "/context" });
   });
 
   it("uses the Team projection and only asks the snapshot owner endpoint for a bound tree", async () => {
@@ -862,24 +796,22 @@ describe("Settings Setup overview", () => {
   it("opens Context Tree and Reviewer owner controls only for an Admin", async () => {
     const view = await renderSettingsSetupPage();
     const tree = await waitForRowText(view.host, "context-tree", "Available");
-    const treeManage = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
+    const manage = [...tree.querySelectorAll<HTMLButtonElement>("button")].find(
       (button) => button.textContent === "Manage",
     );
 
-    expect(treeManage?.getAttribute("aria-expanded")).toBe("false");
-    await act(async () => treeManage?.click());
-    const treeControls = await waitForSelector<HTMLElement>(tree, '[data-setup-owner-controls="context-tree"]');
-    expect(treeControls.textContent).toContain("acme/context-tree · main branch · github");
+    expect(manage?.getAttribute("aria-expanded")).toBe("false");
+    const { controls, reviewerControls } = await openContextTreeControls(view);
+    expect(manage?.getAttribute("aria-expanded")).toBe("true");
+    expect(controls.textContent).toContain("acme/context-tree · main branch · github");
     expect(orgSettingsMocks.getRawContextTreeSetting).toHaveBeenCalledWith("org-1");
-
-    const review = await waitForRowText(view.host, "automatic-review", "On");
-    const reviewManage = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Manage",
-    );
-    await act(async () => reviewManage?.click());
-    const reviewControls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
-    expect(reviewControls.textContent).toContain("Context Reviewer");
+    await waitForSelector(reviewerControls, '[aria-label="Automatic review Agent"]');
+    expect(reviewerControls.textContent).toContain("Context Reviewer");
+    expect(reviewerControls.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("true");
     expect(reviewerMocks.getContextReviewerCandidates).toHaveBeenCalledWith("org-1");
+
+    await act(async () => manage?.click());
+    expect(manage?.getAttribute("aria-expanded")).toBe("false");
     expect(view.host.querySelector('[data-setup-owner-controls="context-tree"]')).toBeNull();
 
     await act(async () => view.root.unmount());
@@ -985,11 +917,12 @@ describe("Settings Setup overview", () => {
 
   it.each([
     ["#context-tree", "context-tree"],
-    ["#automatic-review", "automatic-review"],
+    ["#automatic-review", "context-tree"],
   ] as const)("opens and focuses the canonical owner control for legacy hash %s", async (hash, key) => {
     const view = await renderSettingsSetupPage(`/settings/setup${hash}`);
     const row = await waitForSelector<HTMLElement>(view.host, `[data-setup-row="${key}"]`);
     await waitForSelector(row, `[data-setup-owner-controls="${key}"]`);
+    await waitForSelector(row, '[data-setup-owner-controls="automatic-review"]');
 
     expect(row.id).toBe(key);
     expect(document.activeElement).toBe(row);
@@ -999,7 +932,7 @@ describe("Settings Setup overview", () => {
   it("keeps Member Setup read-only without loading owner-only settings", async () => {
     authMock.value = { ...authMock.value, role: "member" };
     const view = await renderSettingsSetupPage("/settings/setup#automatic-review");
-    await waitForRowText(view.host, "automatic-review", "On");
+    await waitForRowText(view.host, "context-tree", "Review on");
 
     expect(view.host.getAttribute("data-setup-overview")).toBeNull();
     expect(view.host.querySelector('[data-setup-overview="member"]')).not.toBeNull();
@@ -1027,15 +960,11 @@ describe("Settings Setup overview", () => {
       }),
     );
     const view = await renderSettingsSetupPage();
-    const review = await waitForRowText(view.host, "automatic-review", "Off");
-    const manage = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Manage",
+    const { reviewerControls } = await openContextTreeControls(view);
+    expect(reviewerControls.querySelector('[role="switch"]')).not.toBeNull();
+    expect([...reviewerControls.querySelectorAll("a")].some((link) => link.textContent === "Manage Team Agents")).toBe(
+      true,
     );
-
-    await act(async () => manage?.click());
-    const controls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
-    expect(controls.querySelector('[role="switch"]')).not.toBeNull();
-    expect([...controls.querySelectorAll("a")].some((link) => link.textContent === "Manage Team Agents")).toBe(true);
     await act(async () => view.root.unmount());
   });
 
@@ -1050,16 +979,11 @@ describe("Settings Setup overview", () => {
       }),
     );
     const view = await renderSettingsSetupPage();
-    const review = await waitForRowText(view.host, "automatic-review", "Off");
-    const manage = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Manage",
-    );
-
-    await act(async () => manage?.click());
-    const controls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
-    const enablement = controls.querySelector<HTMLButtonElement>('[role="switch"]');
+    const { reviewerControls } = await openContextTreeControls(view);
+    const enablement = reviewerControls.querySelector<HTMLButtonElement>('[role="switch"]');
     expect(enablement?.getAttribute("aria-checked")).toBe("false");
-    expect(controls.textContent).toContain("selection retained while off");
+    await waitForSelector(reviewerControls, '[aria-label="Automatic review Agent"]');
+    expect(reviewerControls.textContent).toContain("Reviewer selection retained while Automatic review is off");
 
     await act(async () => enablement?.click());
     await flush();
@@ -1109,14 +1033,11 @@ describe("Settings Setup overview", () => {
       },
     });
     const view = await renderSettingsSetupPage();
-    const review = await waitForRowText(view.host, "automatic-review", "On");
-    const manage = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Manage",
+    const { reviewerControls } = await openContextTreeControls(view);
+    const agentSelect = await waitForSelector<HTMLButtonElement>(
+      reviewerControls,
+      '[aria-label="Automatic review Agent"]',
     );
-
-    await act(async () => manage?.click());
-    const controls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
-    const agentSelect = await waitForSelector<HTMLButtonElement>(controls, '[aria-label="Automatic review Agent"]');
     await act(async () => agentSelect?.click());
     await waitForSelector(document.body, '[role="listbox"][aria-label="Automatic review Agent"]');
     const offlineOption = [...document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')].find((option) =>
@@ -1130,9 +1051,9 @@ describe("Settings Setup overview", () => {
 
     expect(reviewerMocks.putContextReviewerAssignment).toHaveBeenCalledWith("org-1", "reviewer-2");
     expect(reviewerMocks.putContextReviewerEnablement).not.toHaveBeenCalled();
-    expect(controls.textContent).toContain("Offline Reviewer");
-    expect(controls.textContent).toContain("selection retained while off");
-    expect(controls.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("false");
+    expect(reviewerControls.textContent).toContain("Offline Reviewer");
+    expect(reviewerControls.textContent).toContain("Reviewer selection retained while Automatic review is off");
+    expect(reviewerControls.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("false");
     await act(async () => view.root.unmount());
   });
 
@@ -1148,18 +1069,27 @@ describe("Settings Setup overview", () => {
       }),
     );
     const view = await renderSettingsSetupPage();
-    const review = await waitForRowText(view.host, "automatic-review", "Off");
-    const setup = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Set up",
+    const { reviewerControls } = await openContextTreeControls(view);
+    await waitForSelector<HTMLAnchorElement>(reviewerControls, 'a[href="/team"]');
+
+    expect(reviewerControls.querySelector('[aria-label="Automatic review Agent"]')).toBeNull();
+    expect(reviewerControls.querySelector<HTMLAnchorElement>('a[href="/team"]')?.textContent).toBe(
+      "Manage Team Agents",
     );
+    expect(reviewerControls.textContent).toContain("No eligible organization-visible managed Agent");
+    expect(reviewerControls.textContent).not.toContain("Create Agent");
+    await act(async () => view.root.unmount());
+  });
 
-    await act(async () => setup?.click());
-    const controls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
-    await waitForRowText(view.host, "automatic-review", "No eligible organization-visible managed Agent");
+  it("keeps the projected Reviewer visible when eligible candidates fail to load", async () => {
+    reviewerMocks.getContextReviewerCandidates.mockRejectedValue(new Error("candidate lookup failed"));
+    const view = await renderSettingsSetupPage();
+    const { reviewerControls } = await openContextTreeControls(view);
+    await waitForSelector(reviewerControls, '[role="alert"]');
 
-    expect(controls.querySelector('[aria-label="Automatic review Agent"]')).toBeNull();
-    expect(controls.querySelector<HTMLAnchorElement>('a[href="/team"]')?.textContent).toBe("Manage Team Agents");
-    expect(controls.textContent).not.toContain("Create Agent");
+    expect(reviewerControls.textContent).toContain("Reviewer · Context Reviewer");
+    expect(reviewerControls.textContent).toContain("candidate lookup failed");
+    expect(reviewerControls.querySelector('[aria-label="Automatic review Agent"]')).toBeNull();
     await act(async () => view.root.unmount());
   });
 
@@ -1168,14 +1098,11 @@ describe("Settings Setup overview", () => {
       contextReviewer: { enabled: false, agentUuid: null, reviewerAgent: null },
     });
     const view = await renderSettingsSetupPage();
-    const review = await waitForRowText(view.host, "automatic-review", "On");
-    const manage = [...review.querySelectorAll<HTMLButtonElement>("button")].find(
-      (button) => button.textContent === "Manage",
+    const { reviewerControls } = await openContextTreeControls(view);
+    const agentSelect = await waitForSelector<HTMLButtonElement>(
+      reviewerControls,
+      '[aria-label="Automatic review Agent"]',
     );
-
-    await act(async () => manage?.click());
-    const controls = await waitForSelector<HTMLElement>(review, '[data-setup-owner-controls="automatic-review"]');
-    const agentSelect = await waitForSelector<HTMLButtonElement>(controls, '[aria-label="Automatic review Agent"]');
     await act(async () => agentSelect.click());
     const clearOption = [...document.body.querySelectorAll<HTMLButtonElement>('[role="option"]')].find(
       (option) => option.textContent === "No Reviewer selected",
@@ -1184,7 +1111,7 @@ describe("Settings Setup overview", () => {
     await flush();
 
     expect(reviewerMocks.putContextReviewerAssignment).toHaveBeenCalledWith("org-1", null);
-    expect(controls.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("false");
+    expect(reviewerControls.querySelector('[role="switch"]')?.getAttribute("aria-checked")).toBe("false");
     await act(async () => view.root.unmount());
   });
 
@@ -1265,11 +1192,10 @@ describe("Settings Setup overview", () => {
     const view = await renderSettingsSetupPage();
     const automation = await waitForRowText(view.host, "repository-automation", "Status unavailable");
     const tree = await waitForRowText(view.host, "context-tree", "Status unavailable");
-    const review = await waitForRowText(view.host, "automatic-review", "Status unavailable");
 
     expect(automation.querySelector("a")).toBeNull();
     expect(tree.querySelector("a")).toBeNull();
-    expect(review.querySelector("a")).toBeNull();
+    expect(view.host.querySelector('[data-setup-row="automatic-review"]')).toBeNull();
     expect(contextTreeMocks.getContextTreeSnapshot).not.toHaveBeenCalled();
     await act(async () => view.root.unmount());
   });

--- a/packages/web/src/pages/settings/setup-context-tree-controls.tsx
+++ b/packages/web/src/pages/settings/setup-context-tree-controls.tsx
@@ -1,7 +1,7 @@
 import type { OrgContextTreeInput, OrgContextTreeOutput, SetupContextTreeBinding } from "@first-tree/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight } from "lucide-react";
-import { type FormEvent, useEffect, useRef, useState } from "react";
+import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { getRawContextTreeSetting, putContextTreeSetting } from "../../api/org-settings.js";
 import { setupCapabilitiesQueryKey } from "../../api/setup-capabilities.js";
@@ -18,12 +18,14 @@ export function SetupContextTreeControls({
   loadSetting = getRawContextTreeSetting,
   saveSetting = putContextTreeSetting,
   refreshFacts,
+  children,
 }: {
   binding: SetupContextTreeBinding;
   availability: ContextTreeAvailability;
   loadSetting?: (organizationId: string) => Promise<OrgContextTreeOutput>;
   saveSetting?: (organizationId: string, input: OrgContextTreeInput) => Promise<OrgContextTreeOutput>;
   refreshFacts?: (organizationId: string) => Promise<void>;
+  children?: ReactNode;
 }) {
   const { organizationId, role } = useAuth();
   const isAdmin = role === "admin";
@@ -175,6 +177,17 @@ export function SetupContextTreeControls({
             ) : null}
           </form>
         )
+      ) : null}
+
+      {children ? (
+        <div
+          style={{
+            paddingTop: "var(--sp-4)",
+            borderTop: "var(--hairline) solid var(--border-faint)",
+          }}
+        >
+          {children}
+        </div>
       ) : null}
     </div>
   );

--- a/packages/web/src/pages/settings/setup-reviewer-controls.tsx
+++ b/packages/web/src/pages/settings/setup-reviewer-controls.tsx
@@ -19,12 +19,14 @@ import { Switch } from "../../components/ui/switch.js";
 
 export function SetupReviewerControls({
   review,
+  embedded = false,
   loadCandidates = getContextReviewerCandidates,
   assignReviewer = putContextReviewerAssignment,
   setReviewerEnabled = putContextReviewerEnablement,
   refreshFacts,
 }: {
   review: SetupAutomaticReview;
+  embedded?: boolean;
   loadCandidates?: (organizationId: string) => Promise<ContextReviewerCandidatesOutput>;
   assignReviewer?: (organizationId: string, agentUuid: string | null) => Promise<OrgContextTreeFeaturesOutput>;
   setReviewerEnabled?: (organizationId: string, enabled: boolean) => Promise<OrgContextTreeFeaturesOutput>;
@@ -112,13 +114,17 @@ export function SetupReviewerControls({
     <div
       data-setup-owner-controls="automatic-review"
       className="flex flex-col"
-      style={{
-        gap: "var(--sp-3)",
-        padding: "var(--sp-4)",
-        border: "var(--hairline) solid var(--border)",
-        borderRadius: "var(--radius-panel)",
-        background: "var(--bg-sunken)",
-      }}
+      style={
+        embedded
+          ? { gap: "var(--sp-3)" }
+          : {
+              gap: "var(--sp-3)",
+              padding: "var(--sp-4)",
+              border: "var(--hairline) solid var(--border)",
+              borderRadius: "var(--radius-panel)",
+              background: "var(--bg-sunken)",
+            }
+      }
     >
       <div className="flex items-center justify-between" style={{ gap: "var(--sp-3)" }}>
         <div className="min-w-0">
@@ -126,9 +132,13 @@ export function SetupReviewerControls({
             Automatic review
           </span>
           <div className="text-label" style={{ marginTop: "var(--sp-0_5)", color: "var(--fg-3)" }}>
-            {selectedLabel
+            {selectedLabel && !selectedCandidate
               ? `Reviewer · ${selectedLabel}${enabled ? "" : " · selection retained while off"}`
-              : "Choose an existing eligible Team Agent. Setup never creates one."}
+              : selectedLabel
+                ? enabled
+                  ? "Reviews Context Tree pull requests and merge requests."
+                  : "Reviewer selection retained while Automatic review is off."
+                : "Choose an existing eligible Team Agent. Setup never creates one."}
           </div>
         </div>
         <Switch

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -11,6 +11,8 @@ import type {
 import { useQuery } from "@tanstack/react-query";
 import {
   Bot,
+  ChevronDown,
+  ChevronUp,
   CircleAlert,
   CircleCheck,
   CircleHelp,
@@ -22,7 +24,6 @@ import {
   LoaderCircle,
   type LucideIcon,
   MessageCircle,
-  ShieldCheck,
   Webhook,
 } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
@@ -77,18 +78,10 @@ export type SetupFacts = {
 };
 
 export type SetupRowModel = {
-  key:
-    | "work-access"
-    | "computer"
-    | "agent"
-    | "repositories"
-    | "repository-automation"
-    | "context-tree"
-    | "automatic-review";
+  key: "work-access" | "computer" | "agent" | "repositories" | "repository-automation" | "context-tree";
   title: string;
   description: string;
   icon: LucideIcon;
-  parentKey?: "context-tree";
   status: {
     label: string;
     detail?: string;
@@ -97,7 +90,7 @@ export type SetupRowModel = {
   action?: {
     label: string;
     to: string;
-    intent?: "resume-onboarding" | "open-context-tree-controls" | "open-reviewer-controls";
+    intent?: "resume-onboarding" | "open-context-tree-controls";
   };
 };
 
@@ -190,10 +183,10 @@ const ACTION_DESTINATIONS = {
   configure_gitlab_webhook: "/settings/integrations/gitlab",
   repair_tree_binding: "/settings/setup#context-tree",
   open_tree_setup_chat: "/context",
-  select_review_agent: "/settings/setup#automatic-review",
-  replace_review_agent: "/settings/setup#automatic-review",
+  select_review_agent: "/settings/setup#context-tree",
+  replace_review_agent: "/settings/setup#context-tree",
   open_agent_owner_flow: "/team",
-  manage_review_agent: "/settings/setup#automatic-review",
+  manage_review_agent: "/settings/setup#context-tree",
 } satisfies Record<SetupActionKind, string>;
 
 const ACTION_LABELS = {
@@ -431,14 +424,38 @@ function reviewStatus(review: SetupAutomaticReview, isAdmin: boolean): SetupRowM
   return { label: "Status unknown", detail, kind: "unknown" };
 }
 
-function reviewAction(review: SetupAutomaticReview, isAdmin: boolean): SetupRowModel["action"] | undefined {
-  if (review.adoption === "unavailable") return undefined;
-  if (!isAdmin) return undefined;
+function combineContextTreeAndReviewStatus(
+  contextStatus: SetupRowModel["status"],
+  automaticReviewStatus: SetupRowModel["status"],
+): SetupRowModel["status"] {
+  if (
+    !["ready", "pending"].includes(contextStatus.kind) ||
+    automaticReviewStatus.label === "Available after Context Tree"
+  ) {
+    return contextStatus;
+  }
+
+  const repository = contextStatus.detail?.split(" · ")[0];
+  const reviewSummary =
+    automaticReviewStatus.label === "On"
+      ? "Review on"
+      : automaticReviewStatus.label === "Off"
+        ? "Review off"
+        : `Review ${automaticReviewStatus.label.toLowerCase()}`;
+
+  if (!["On", "Off"].includes(automaticReviewStatus.label)) {
+    return {
+      label: reviewSummary,
+      detail: [repository, `Context Tree ${contextStatus.label.toLowerCase()}`]
+        .filter((item): item is string => Boolean(item))
+        .join(" · "),
+      kind: automaticReviewStatus.kind,
+    };
+  }
 
   return {
-    label: review.adoption === "disabled" && !review.reviewerAgent ? "Set up" : "Manage",
-    to: "/settings/setup#automatic-review",
-    intent: "open-reviewer-controls",
+    ...contextStatus,
+    detail: [repository, reviewSummary].filter((item): item is string => Boolean(item)).join(" · "),
   };
 }
 
@@ -586,17 +603,11 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
       title: "Context Tree",
       description: "Shared decisions and constraints available to agents.",
       icon: GitFork,
-      status: contextTreeStatus(contextTree, capabilities?.contextTree.blockers ?? [], isAdmin),
+      status: combineContextTreeAndReviewStatus(
+        contextTreeStatus(contextTree, capabilities?.contextTree.blockers ?? [], isAdmin),
+        automaticReviewStatus,
+      ),
       action: contextTreeAction(contextTree, isAdmin),
-    },
-    {
-      key: "automatic-review",
-      title: "Automatic review",
-      description: "A managed agent reviews Context Tree pull requests or merge requests.",
-      icon: ShieldCheck,
-      parentKey: "context-tree",
-      status: automaticReviewStatus,
-      action: capabilities ? reviewAction(capabilities.contextTree.automaticReview, isAdmin) : undefined,
     },
   ];
 }
@@ -714,12 +725,7 @@ export function SettingsSetupPage() {
   }, [organizationId]);
 
   useEffect(() => {
-    const key =
-      location.hash === "#context-tree"
-        ? "context-tree"
-        : location.hash === "#automatic-review"
-          ? "automatic-review"
-          : null;
+    const key = location.hash === "#context-tree" || location.hash === "#automatic-review" ? "context-tree" : null;
     if (!key || !organizationId || facts.capabilities.state !== "ready") return;
 
     const hashKey = `${organizationId}:${location.hash}`;
@@ -729,12 +735,7 @@ export function SettingsSetupPage() {
   }, [facts.capabilities.state, location.hash, organizationId, role]);
 
   useEffect(() => {
-    const key =
-      location.hash === "#context-tree"
-        ? "context-tree"
-        : location.hash === "#automatic-review"
-          ? "automatic-review"
-          : null;
+    const key = location.hash === "#context-tree" || location.hash === "#automatic-review" ? "context-tree" : null;
     if (!key || facts.capabilities.state !== "ready") return;
     if (role === "admin" && expandedOwnerControlKey !== key) return;
 
@@ -754,17 +755,15 @@ export function SettingsSetupPage() {
                     key={`context-tree-${organizationId}`}
                     binding={contextTree.value.binding}
                     availability={contextTree.value.availability}
-                  />
-                ),
-              }
-            : {}),
-          ...(expandedOwnerControlKey === "automatic-review"
-            ? {
-                "automatic-review": (
-                  <SetupReviewerControls
-                    key={`automatic-review-${organizationId}`}
-                    review={facts.capabilities.value.contextTree.automaticReview}
-                  />
+                  >
+                    {facts.capabilities.value.contextTree.automaticReview.adoption !== "unavailable" ? (
+                      <SetupReviewerControls
+                        key={`automatic-review-${organizationId}`}
+                        review={facts.capabilities.value.contextTree.automaticReview}
+                        embedded
+                      />
+                    ) : null}
+                  </SetupContextTreeControls>
                 ),
               }
             : {}),
@@ -872,17 +871,12 @@ function SetupRow({
       tabIndex={-1}
       aria-labelledby={`setup-${row.key}`}
       data-setup-row={row.key}
-      data-setup-parent={row.parentKey}
       style={{
         display: "grid",
         gridTemplateColumns: narrow ? "minmax(0, 1fr)" : "minmax(0, 1fr) var(--sp-60) var(--sp-35)",
         alignItems: narrow ? "start" : "center",
         gap: narrow ? "var(--sp-3)" : "var(--sp-5)",
-        padding: row.parentKey
-          ? narrow
-            ? "var(--sp-4) 0 var(--sp-4) var(--sp-4)"
-            : "var(--sp-4) 0 var(--sp-4) var(--sp-6)"
-          : "var(--sp-4) 0",
+        padding: "var(--sp-4) 0",
         borderBottom: "var(--hairline) solid var(--border)",
       }}
     >
@@ -932,8 +926,7 @@ function SetupRow({
         className={cn("flex", !narrow && "justify-end")}
         style={narrow ? { paddingLeft: "var(--sp-11)" } : undefined}
       >
-        {(row.action?.intent === "open-context-tree-controls" || row.action?.intent === "open-reviewer-controls") &&
-        onToggleOwnerControl ? (
+        {row.action?.intent === "open-context-tree-controls" && onToggleOwnerControl ? (
           <button
             type="button"
             aria-expanded={Boolean(ownerControl)}
@@ -944,9 +937,14 @@ function SetupRow({
               "rounded-[var(--radius-input)] hover:bg-bg-hover hover:text-foreground",
               "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
             )}
-            style={{ minHeight: "var(--sp-8)", padding: "0 var(--sp-2)" }}
+            style={{ minHeight: "var(--sp-8)", gap: "var(--sp-1)", padding: "0 var(--sp-2)" }}
           >
             {row.action.label}
+            {ownerControl ? (
+              <ChevronUp className="h-4 w-4" aria-hidden />
+            ) : (
+              <ChevronDown className="h-4 w-4" aria-hidden />
+            )}
           </button>
         ) : row.action ? (
           <Link
@@ -979,7 +977,7 @@ function SetupRow({
           id={`setup-${row.key}-owner-controls`}
           style={{
             gridColumn: "1 / -1",
-            paddingLeft: narrow || row.parentKey ? "var(--sp-4)" : "var(--sp-11)",
+            paddingLeft: narrow ? "var(--sp-4)" : "var(--sp-11)",
           }}
         >
           {ownerControl}

--- a/packages/web/src/pages/settings/setup.tsx
+++ b/packages/web/src/pages/settings/setup.tsx
@@ -380,24 +380,29 @@ function contextTreeAction(contextTree: Fact<ContextTreeFact>, isAdmin: boolean)
     : { label: "View", to: "/context" };
 }
 
+function reviewDiagnosticDetail(review: SetupAutomaticReview, isAdmin: boolean): string | undefined {
+  const healthDetail =
+    review.adoption === "disabled"
+      ? review.health === "pending_verification"
+        ? "Reviewer verification pending"
+        : review.health === "degraded"
+          ? "Reviewer degraded"
+          : review.health === "unavailable"
+            ? "Reviewer unavailable"
+            : null
+      : null;
+  const issues = blockerDetail(review.blockers, isAdmin);
+  return [healthDetail, issues].filter((item): item is string => Boolean(item)).join(" · ") || undefined;
+}
+
 function reviewStatus(review: SetupAutomaticReview, isAdmin: boolean): SetupRowModel["status"] {
   if (review.adoption === "unavailable") {
     return { label: "Available after Context Tree", kind: "optional" };
   }
   if (review.adoption === "disabled") {
     const reviewer = review.reviewerAgent ? `Reviewer · ${review.reviewerAgent.displayName}` : null;
-    const healthDetail =
-      review.health === "pending_verification"
-        ? "Reviewer verification pending"
-        : review.health === "degraded"
-          ? "Reviewer degraded"
-          : review.health === "unavailable"
-            ? "Reviewer unavailable"
-            : null;
-    const issues = blockerDetail(review.blockers, isAdmin);
-    const detail = [reviewer, healthDetail, issues, "Optional"]
-      .filter((item): item is string => Boolean(item))
-      .join(" · ");
+    const diagnostic = reviewDiagnosticDetail(review, isAdmin);
+    const detail = [reviewer, diagnostic, "Optional"].filter((item): item is string => Boolean(item)).join(" · ");
     return { label: "Off", detail, kind: "optional" };
   }
 
@@ -427,6 +432,7 @@ function reviewStatus(review: SetupAutomaticReview, isAdmin: boolean): SetupRowM
 function combineContextTreeAndReviewStatus(
   contextStatus: SetupRowModel["status"],
   automaticReviewStatus: SetupRowModel["status"],
+  automaticReviewDiagnostic: string | undefined,
 ): SetupRowModel["status"] {
   if (
     !["ready", "pending"].includes(contextStatus.kind) ||
@@ -446,7 +452,7 @@ function combineContextTreeAndReviewStatus(
   if (!["On", "Off"].includes(automaticReviewStatus.label)) {
     return {
       label: reviewSummary,
-      detail: [repository, `Context Tree ${contextStatus.label.toLowerCase()}`]
+      detail: [automaticReviewDiagnostic, repository, `Context Tree ${contextStatus.label.toLowerCase()}`]
         .filter((item): item is string => Boolean(item))
         .join(" · "),
       kind: automaticReviewStatus.kind,
@@ -455,7 +461,11 @@ function combineContextTreeAndReviewStatus(
 
   return {
     ...contextStatus,
-    detail: [repository, reviewSummary].filter((item): item is string => Boolean(item)).join(" · "),
+    detail: automaticReviewDiagnostic
+      ? [reviewSummary, automaticReviewDiagnostic, repository]
+          .filter((item): item is string => Boolean(item))
+          .join(" · ")
+      : [repository, reviewSummary].filter((item): item is string => Boolean(item)).join(" · "),
   };
 }
 
@@ -606,6 +616,7 @@ export function buildSetupRows(facts: SetupFacts): SetupRowModel[] {
       status: combineContextTreeAndReviewStatus(
         contextTreeStatus(contextTree, capabilities?.contextTree.blockers ?? [], isAdmin),
         automaticReviewStatus,
+        capabilities ? reviewDiagnosticDetail(capabilities.contextTree.automaticReview, isAdmin) : undefined,
       ),
       action: contextTreeAction(contextTree, isAdmin),
     },

--- a/packages/web/src/pages/setup-preview.tsx
+++ b/packages/web/src/pages/setup-preview.tsx
@@ -263,20 +263,18 @@ export function SetupPreviewPage() {
                     loadSetting={previewLoadTreeSetting}
                     saveSetting={previewSaveTreeSetting}
                     refreshFacts={previewRefresh}
-                  />
-                ),
-              }
-            : {}),
-          ...(expandedOwnerControl === "automatic-review"
-            ? {
-                "automatic-review": (
-                  <SetupReviewerControls
-                    review={capabilities.contextTree.automaticReview}
-                    loadCandidates={async () => PREVIEW_REVIEWER_CANDIDATES}
-                    assignReviewer={previewAssignReviewer}
-                    setReviewerEnabled={previewSetReviewerEnabled}
-                    refreshFacts={previewRefresh}
-                  />
+                  >
+                    {capabilities.contextTree.automaticReview.adoption !== "unavailable" ? (
+                      <SetupReviewerControls
+                        review={capabilities.contextTree.automaticReview}
+                        embedded
+                        loadCandidates={async () => PREVIEW_REVIEWER_CANDIDATES}
+                        assignReviewer={previewAssignReviewer}
+                        setReviewerEnabled={previewSetReviewerEnabled}
+                        refreshFacts={previewRefresh}
+                      />
+                    ) : null}
+                  </SetupContextTreeControls>
                 ),
               }
             : {}),


### PR DESCRIPTION
## Summary

- remove the standalone Automatic review Setup row and its shield icon
- embed Automatic review enablement and Reviewer assignment inside the Context Tree management panel
- summarize Review on/off in the collapsed Context Tree row and promote degraded, pending, unavailable, or unknown Review states to the primary row status
- preserve the legacy `#automatic-review` deep link by opening and focusing the unified Context Tree controls
- keep loading, error, empty-candidate, recovery, and retained-Reviewer states visible
- update the seeded Setup preview and DOM coverage for the unified interaction

## Verification

- `pnpm --filter @first-tree/web typecheck`
- `pnpm --filter @first-tree/web build`
- `pnpm --filter @first-tree/web exec vitest run src/pages/settings/__tests__/setup-dom.test.tsx src/pages/__tests__/preview-pages-extra.test.tsx` (59 tests)
- Playwright verification of collapsed/expanded, enablement toggle, ready/degraded states, and 900px responsive layout
- two independent code/UI/accessibility reviews, followed by clean re-review after fixes

## Design

The implementation reuses the existing Setup grid, tokenized spacing, hairlines, panel radius, Switch, Select, and Link/Button treatments. Context Tree remains the single Setup entry and immediate-save semantics are unchanged.
