### PR TITLE
fix(web): restore chat-open scroll landing on mobile

### DIFF
--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -976,7 +976,7 @@ describe("ChatView", () => {
   });
 
   it("lands on the stored bottom-visible anchor on mobile open even when the chat has a summary", async () => {
-    // Regression guard for the #1997 mobile Work surface: a summarized
+    // Regression guard for the PR 1997 mobile Work surface: a summarized
     // chat must still land on the stored bottom-visible anchor (newer
     // messages surface via the pill) instead of jumping to the timeline
     // top to show the in-flow Current state card.
@@ -999,6 +999,112 @@ describe("ChatView", () => {
       () =>
         scrollIntoViewMock.mock.calls.some((args) => (args[0] as ScrollIntoViewOptions | undefined)?.block === "end"),
       "Expected mobile open to land on the stored bottom-visible anchor",
+    );
+
+    await act(async () => root.unmount());
+  });
+
+  it("waits for the persisted read state before committing the chat-open landing", async () => {
+    // PR 2017 review: with cached messages rendering first and the IDB
+    // read-state lookup still in flight, the one-shot landing must NOT
+    // commit the bottom fallback — otherwise a cold open permanently
+    // misses the stored anchor.
+    const { ChatView } = await import("../chat-view.js");
+    let resolveReadState: (
+      value: {
+        chatId: string;
+        bottomVisibleMessageId: string | null;
+        latestKnownMessageId: string | null;
+        updatedAt: number;
+      } | null,
+    ) => void = () => {
+      throw new Error("getReadState was not called");
+    };
+    readStateMocks.getReadState.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveReadState = resolve;
+        }),
+    );
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" narrow presentation="mobile" onShowConversations={vi.fn()} />,
+      (queryClient) => {
+        // Messages stay cached (they render immediately); the read-state
+        // cache is dropped so the query hits the still-pending mock.
+        queryClient.removeQueries({ queryKey: ["chat-read-state", "chat-1"] });
+      },
+      "/",
+    );
+
+    // Messages render while the read state is still pending: no landing
+    // may fire yet (neither the anchor scroll nor the bottom fallback).
+    await waitForText(container, "I found one rollout risk");
+    const scrollIntoViewMock = HTMLElement.prototype.scrollIntoView as unknown as {
+      mock: { calls: unknown[][] };
+    };
+    const scrollToMock = HTMLElement.prototype.scrollTo as unknown as {
+      mock: { calls: unknown[][] };
+    };
+    await flush();
+    await flush();
+    expect(scrollIntoViewMock.mock.calls.length).toBe(0);
+    expect(scrollToMock.mock.calls.some((args) => (args[0] as ScrollToOptions | undefined)?.behavior === "auto")).toBe(
+      false,
+    );
+
+    // Once the persisted row resolves, the landing commits to its anchor.
+    await act(async () => {
+      resolveReadState({
+        chatId: "chat-1",
+        bottomVisibleMessageId: "msg-1",
+        latestKnownMessageId: "msg-1",
+        updatedAt: Date.now(),
+      });
+    });
+    await waitForCondition(
+      () =>
+        scrollIntoViewMock.mock.calls.some((args) => (args[0] as ScrollIntoViewOptions | undefined)?.block === "end"),
+      "Expected the landing to fire once the persisted read state resolved",
+    );
+
+    await act(async () => root.unmount());
+  });
+
+  it("falls back to the timeline bottom when the persisted read state has no row", async () => {
+    const { ChatView } = await import("../chat-view.js");
+    let resolveReadState: (value: null) => void = () => {
+      throw new Error("getReadState was not called");
+    };
+    readStateMocks.getReadState.mockImplementation(
+      () =>
+        new Promise<null>((resolve) => {
+          resolveReadState = resolve;
+        }),
+    );
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" narrow presentation="mobile" onShowConversations={vi.fn()} />,
+      (queryClient) => {
+        queryClient.removeQueries({ queryKey: ["chat-read-state", "chat-1"] });
+      },
+      "/",
+    );
+
+    await waitForText(container, "I found one rollout risk");
+    const scrollToMock = HTMLElement.prototype.scrollTo as unknown as {
+      mock: { calls: unknown[][] };
+    };
+    await flush();
+    expect(scrollToMock.mock.calls.some((args) => (args[0] as ScrollToOptions | undefined)?.behavior === "auto")).toBe(
+      false,
+    );
+
+    // A resolved-but-empty row (first-time visit) still lands at the bottom.
+    await act(async () => {
+      resolveReadState(null);
+    });
+    await waitForCondition(
+      () => scrollToMock.mock.calls.some((args) => (args[0] as ScrollToOptions | undefined)?.behavior === "auto"),
+      "Expected the bottom fallback once the empty read state resolved",
     );
 
     await act(async () => root.unmount());

--- a/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
+++ b/packages/web/src/pages/workspace/center/__tests__/chat-view-dom.test.tsx
@@ -975,6 +975,35 @@ describe("ChatView", () => {
     await act(async () => root.unmount());
   });
 
+  it("lands on the stored bottom-visible anchor on mobile open even when the chat has a summary", async () => {
+    // Regression guard for the #1997 mobile Work surface: a summarized
+    // chat must still land on the stored bottom-visible anchor (newer
+    // messages surface via the pill) instead of jumping to the timeline
+    // top to show the in-flow Current state card.
+    const { ChatView } = await import("../chat-view.js");
+    const summarized = chatDetail({ description: "Status: shipping the mobile Work surface soon." });
+    chatMocks.getChat.mockResolvedValue(summarized);
+    const { container, root } = await renderDom(
+      <ChatView agentId="agent-1" chatId="chat-1" narrow presentation="mobile" onShowConversations={vi.fn()} />,
+      (queryClient) => {
+        seedChat(queryClient, summarized);
+      },
+      "/",
+    );
+
+    await waitForText(container, "Launch planning");
+    const scrollIntoViewMock = HTMLElement.prototype.scrollIntoView as unknown as {
+      mock: { calls: unknown[][] };
+    };
+    await waitForCondition(
+      () =>
+        scrollIntoViewMock.mock.calls.some((args) => (args[0] as ScrollIntoViewOptions | undefined)?.block === "end"),
+      "Expected mobile open to land on the stored bottom-visible anchor",
+    );
+
+    await act(async () => root.unmount());
+  });
+
   it("renders restore and read-only join states", async () => {
     const { ChatView } = await import("../chat-view.js");
     const deleted = chatDetail({ engagementStatus: "deleted", title: "Deleted launch" });

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -2660,7 +2660,7 @@ export function ChatView({
   // where the user's viewport bottom was the last time they left
   // this chat. React Query's cache holds it after first read so a
   // chat re-open does not block on IDB.
-  const { data: readState } = useQuery({
+  const { data: readState, isLoading: readStateLoading } = useQuery({
     queryKey: ["chat-read-state", chatId],
     queryFn: () => getReadState(chatId),
     staleTime: Infinity,
@@ -3044,17 +3044,28 @@ export function ChatView({
   //    at the last message's bottom, leaving in-progress tool_call
   //    workgroups (events that arrived after messages) below the
   //    fold. Added the stable follow-up scroll.
-  //  - yuezengwu manual report → #1997's mobile Work surface landed
+  //  - yuezengwu manual report → PR 1997's mobile Work surface landed
   //    summarized chats at the timeline top (scrollTop = 0) so the
   //    in-flow Current state card was visible on entry. Agent-owned
   //    chats almost always carry a summary, so mobile opens were
   //    stuck at the top of every chat. Reverted to the anchor/bottom
   //    model on all presentations; the card stays reachable by
   //    scrolling up, and its "Updated" badge flags fresh summaries.
+  //  - baixiaohang PR 2017 review → the one-shot guard could commit
+  //    the bottom fallback while the IDB read-state lookup was still
+  //    in flight (cached messages render first, `readState` still
+  //    `undefined`), permanently missing the stored anchor on a cold
+  //    open. Landing now also waits for the read-state query to
+  //    resolve; a resolved-but-empty row still falls through to the
+  //    bottom branch.
   const landedForChatRef = useRef<string | null>(null);
   useLayoutEffect(() => {
     if (itemCount === 0) return;
     if (landedForChatRef.current === chatId) return;
+    // The persisted anchor arrives asynchronously (IndexedDB); do not
+    // commit the one-shot landing until the query has resolved, or the
+    // bottom fallback would win the race on cold opens.
+    if (readStateLoading) return;
     landedForChatRef.current = chatId;
     if (bottomVisibleResolution) {
       // Land the stored anchor at the viewport bottom. Any messages
@@ -3072,6 +3083,7 @@ export function ChatView({
   }, [
     chatId,
     itemCount,
+    readStateLoading,
     bottomVisibleResolution,
     scrollToMessageImmediate,
     scrollToBottomImmediate,

--- a/packages/web/src/pages/workspace/center/chat-view.tsx
+++ b/packages/web/src/pages/workspace/center/chat-view.tsx
@@ -3044,20 +3044,19 @@ export function ChatView({
   //    at the last message's bottom, leaving in-progress tool_call
   //    workgroups (events that arrived after messages) below the
   //    fold. Added the stable follow-up scroll.
+  //  - yuezengwu manual report → #1997's mobile Work surface landed
+  //    summarized chats at the timeline top (scrollTop = 0) so the
+  //    in-flow Current state card was visible on entry. Agent-owned
+  //    chats almost always carry a summary, so mobile opens were
+  //    stuck at the top of every chat. Reverted to the anchor/bottom
+  //    model on all presentations; the card stays reachable by
+  //    scrolling up, and its "Updated" badge flags fresh summaries.
   const landedForChatRef = useRef<string | null>(null);
   useLayoutEffect(() => {
     if (itemCount === 0) return;
     if (landedForChatRef.current === chatId) return;
-    // The Work detail's mobile entry context is the in-flow Current state
-    // card. Wait for the real detail instead of committing the list-cache
-    // stub's empty description, then land the single timeline scroller at the
-    // top when a summary exists so the card is genuinely visible on entry.
-    if (useMobileDetailsSheet && chatDetailFetching) return;
     landedForChatRef.current = chatId;
-    if (useMobileDetailsSheet && (chatDetail?.description?.trim().length ?? 0) > 0) {
-      const container = scrollContainerRef.current;
-      if (container) container.scrollTop = 0;
-    } else if (bottomVisibleResolution) {
+    if (bottomVisibleResolution) {
       // Land the stored anchor at the viewport bottom. Any messages
       // newer than the anchor sit below the fold; the pill will
       // surface them.
@@ -3073,9 +3072,6 @@ export function ChatView({
   }, [
     chatId,
     itemCount,
-    useMobileDetailsSheet,
-    chatDetailFetching,
-    chatDetail?.description,
     bottomVisibleResolution,
     scrollToMessageImmediate,
     scrollToBottomImmediate,


### PR DESCRIPTION
## Problem

On mobile web, opening a chat lands at the very top of the timeline instead of the last-read position / latest message. If new messages arrived, the "↓ N new messages" pill offers a way down; without new messages the user has to scroll manually through the whole timeline.

## Root cause

#1997 (Unify the mobile Work surface) added a branch to the chat-open landing effect in `chat-view.tsx`: when `presentation="mobile"` and the chat detail has a non-empty `description`, the timeline scroller is forced to `scrollTop = 0` so the in-flow Current state card is visible on entry.

Since #1997 also routes every mobile chat through `presentation="mobile"` (`/m/work`), and agent-owned chats almost always carry a summary (`chat update --description`), effectively every mobile chat open landed at the top.

## Fix

Restore the pre-#1997 landing behavior for all presentations (`packages/web/src/pages/workspace/center/chat-view.tsx`):

- stored bottom-visible anchor → land it at the viewport bottom; newer messages surface via the "↓ N new messages" pill
- no anchor (first visit) → land at the timeline bottom

The `MobileCurrentStateCard` itself is unchanged: it still renders in-flow at the top of the timeline with its "Updated" badge, reachable by scrolling up.

## Tests

- New regression test in `chat-view-dom.test.tsx`: a mobile chat **with** a summary still lands on the stored bottom-visible anchor (fails on the pre-fix code, passes after)
- `chat-view-dom.test.tsx` (52) + all `pages/mobile` tests: 129 passed
- `tsc --noEmit` and `biome check` clean

## Review round 1 (request-changes addressed in `adb318d1`)

- **R4 — landing committed before the persisted read state resolved**: the landing effect now also waits for the `["chat-read-state", chatId]` query to resolve before committing the one-shot guard; a resolved-but-empty row keeps the first-visit bottom fallback. Covered by two new tests with messages already rendered and a deferred IDB lookup: stored-anchor resolution lands on the anchor (verified to fail without the fix), and the no-row path lands at the bottom only after resolution.
- **Design-token guard**: `#1997` comment references reworded to `PR 1997` (the guard reads `#` + 4 hex digits as a color literal). `lint:tokens` is clean.
- **ComposeStatusBar note**: not reproduced — full Web suite on this head passes 1738/1738 tests (only `tests/visual-regression.spec.ts` fails collection with "No test suite found", pre-existing and untouched by this PR).
