### PR TITLE
fix(client): gate Kimi capability on official CLI install

### DIFF
--- a/packages/client/src/__tests__/kimi-binary.test.ts
+++ b/packages/client/src/__tests__/kimi-binary.test.ts
@@ -7,6 +7,7 @@ import {
   formatKimiBinaryMissingMessage,
   isKimiBinaryMissingError,
   KIMI_CLI_PACKAGE,
+  kimiOfficialBinDirs,
 } from "../runtime/kimi-binary.js";
 
 const tempDirs: string[] = [];
@@ -82,6 +83,41 @@ describe("findKimiExecutableOnPath", () => {
         { wellKnownDirs: () => [], loginShellPathDirs: () => [] },
       ),
     ).toBeNull();
+  });
+
+  it("finds kimi in the official installer dir with empty daemon PATH and empty login-shell PATH", () => {
+    const home = makeTempDir("kimi-bin-official-");
+    const officialBin = join(home, ".kimi-code", "bin");
+    mkdirSync(officialBin, { recursive: true });
+    makeExecutable(join(officialBin, "kimi"));
+    expect(kimiOfficialBinDirs(home)).toEqual([officialBin]);
+    expect(
+      findKimiExecutableOnPath(
+        { HOME: home, PATH: "" },
+        // Default wellKnownDirs includes the official installer dir; login-shell
+        // stays empty to model a frozen daemon PATH that never saw the install.
+        { loginShellPathDirs: () => [] },
+      ),
+    ).toBe(join(officialBin, "kimi"));
+  });
+
+  it("finds kimi.exe under %USERPROFILE%\\.kimi-code\\bin on Windows with empty Path", () => {
+    const home = makeTempDir("kimi-bin-win-official-");
+    const officialBin = join(home, ".kimi-code", "bin");
+    mkdirSync(officialBin, { recursive: true });
+    // Windows existence checks use F_OK (not X_OK); a regular file is enough.
+    writeFileSync(join(officialBin, "kimi.exe"), "fake-kimi-exe\n");
+    expect(
+      findKimiExecutableOnPath(
+        { USERPROFILE: home, Path: "" },
+        {
+          platform: "win32",
+          pathDelimiter: ";",
+          // Windows has no login-shell PATH fallback in production either.
+          loginShellPathDirs: () => [],
+        },
+      ),
+    ).toBe(join(officialBin, "kimi.exe"));
   });
 });
 

--- a/packages/client/src/__tests__/kimi-binary.test.ts
+++ b/packages/client/src/__tests__/kimi-binary.test.ts
@@ -1,0 +1,101 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  findKimiExecutableOnPath,
+  formatKimiBinaryMissingMessage,
+  isKimiBinaryMissingError,
+  KIMI_CLI_PACKAGE,
+} from "../runtime/kimi-binary.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeExecutable(path: string): void {
+  writeFileSync(path, "#!/bin/sh\necho kimi-fake\n", { mode: 0o755 });
+  chmodSync(path, 0o755);
+}
+
+describe("findKimiExecutableOnPath", () => {
+  it("returns null when PATH and fallback dirs are empty", () => {
+    expect(
+      findKimiExecutableOnPath(
+        { HOME: makeTempDir("kimi-bin-empty-"), PATH: "" },
+        { wellKnownDirs: () => [], loginShellPathDirs: () => [] },
+      ),
+    ).toBeNull();
+  });
+
+  it("finds kimi on the daemon PATH", () => {
+    const binDir = makeTempDir("kimi-bin-path-");
+    makeExecutable(join(binDir, "kimi"));
+    expect(
+      findKimiExecutableOnPath(
+        { HOME: makeTempDir("kimi-bin-home-"), PATH: binDir },
+        { wellKnownDirs: () => [], loginShellPathDirs: () => [] },
+      ),
+    ).toBe(join(binDir, "kimi"));
+  });
+
+  it("falls back to well-known install dirs when PATH misses", () => {
+    const wellKnown = join(makeTempDir("kimi-bin-well-"), "local-bin");
+    mkdirSync(wellKnown);
+    makeExecutable(join(wellKnown, "kimi"));
+    expect(
+      findKimiExecutableOnPath(
+        { HOME: makeTempDir("kimi-bin-home-"), PATH: "" },
+        { wellKnownDirs: () => [wellKnown], loginShellPathDirs: () => [] },
+      ),
+    ).toBe(join(wellKnown, "kimi"));
+  });
+
+  it("falls back to login-shell PATH dirs last", () => {
+    const loginBin = makeTempDir("kimi-bin-login-");
+    makeExecutable(join(loginBin, "kimi"));
+    expect(
+      findKimiExecutableOnPath(
+        { HOME: makeTempDir("kimi-bin-home-"), PATH: "" },
+        { wellKnownDirs: () => [], loginShellPathDirs: () => [loginBin] },
+      ),
+    ).toBe(join(loginBin, "kimi"));
+  });
+
+  it("ignores a non-executable kimi file on PATH", () => {
+    const binDir = makeTempDir("kimi-bin-nonexec-");
+    writeFileSync(join(binDir, "kimi"), "not executable\n", { mode: 0o644 });
+    expect(
+      findKimiExecutableOnPath(
+        { HOME: makeTempDir("kimi-bin-home-"), PATH: binDir },
+        { wellKnownDirs: () => [], loginShellPathDirs: () => [] },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("kimi binary missing helpers", () => {
+  it("formatKimiBinaryMissingMessage names the official package and /login", () => {
+    const message = formatKimiBinaryMissingMessage("not found");
+    expect(message).toContain(KIMI_CLI_PACKAGE);
+    expect(message).toContain("`kimi`");
+    expect(message).toContain("`/login`");
+    expect(message).toContain("Original error: not found");
+  });
+
+  it("isKimiBinaryMissingError matches formatted missing copy", () => {
+    expect(isKimiBinaryMissingError(formatKimiBinaryMissingMessage("x"))).toBe(true);
+    expect(isKimiBinaryMissingError("unrelated")).toBe(false);
+  });
+});

--- a/packages/client/src/__tests__/kimi-code-capability.test.ts
+++ b/packages/client/src/__tests__/kimi-code-capability.test.ts
@@ -1,15 +1,96 @@
-import { describe, expect, it } from "vitest";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { KIMI_CODE_SDK_VERSION, probeKimiCodeCapability } from "../runtime/capabilities/kimi-code.js";
+import { findKimiExecutableOnPath } from "../runtime/kimi-binary.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeExecutable(path: string): void {
+  writeFileSync(path, "#!/bin/sh\necho kimi-fake\n", { mode: 0o755 });
+  chmodSync(path, 0o755);
+}
 
 describe("probeKimiCodeCapability", () => {
-  it("reports the exact bundled SDK without launching or checking auth", async () => {
-    expect(await probeKimiCodeCapability()).toMatchObject({
+  it("reports missing when no kimi CLI resolves (isolated HOME/PATH)", async () => {
+    const emptyHome = makeTempDir("kimi-cap-empty-home-");
+    const entry = await probeKimiCodeCapability({
+      env: { HOME: emptyHome, PATH: "" },
+      findOnPath: (env) =>
+        findKimiExecutableOnPath(env, {
+          wellKnownDirs: () => [],
+          loginShellPathDirs: () => [],
+        }),
+    });
+    expect(entry).toMatchObject({
+      state: "missing",
+      available: false,
+    });
+    expect(entry.error).toMatch(/Official Kimi CLI is missing/i);
+    expect(entry.runtimeSource).toBeUndefined();
+  });
+
+  it("reports ok when an official kimi executable is resolvable", async () => {
+    const binDir = makeTempDir("kimi-cap-bin-");
+    const kimiPath = join(binDir, "kimi");
+    makeExecutable(kimiPath);
+
+    const entry = await probeKimiCodeCapability({
+      env: { HOME: makeTempDir("kimi-cap-home-"), PATH: binDir },
+      findOnPath: (env) =>
+        findKimiExecutableOnPath(env, {
+          wellKnownDirs: () => [],
+          loginShellPathDirs: () => [],
+        }),
+    });
+    expect(entry).toMatchObject({
       state: "ok",
       available: true,
       sdkVersion: KIMI_CODE_SDK_VERSION,
       runtimeSource: "bundled",
       runtimePath: null,
     });
+  });
+
+  it("does not report ok merely because the bundled SDK is present", async () => {
+    // The bundled SDK package remains a client dependency; capability must still
+    // require a real host `kimi` CLI. Injecting a finder that always misses
+    // proves the probe no longer hard-codes installed:true from the SDK alone.
     expect(KIMI_CODE_SDK_VERSION).toBe("0.26.0-botiverse.2");
+    const entry = await probeKimiCodeCapability({
+      findOnPath: () => null,
+    });
+    expect(entry).toMatchObject({
+      state: "missing",
+      available: false,
+    });
+    expect(entry.sdkVersion).toBeUndefined();
+  });
+
+  it("findOnPath injectable seam drives ok without touching the real host PATH", async () => {
+    const findOnPath = vi.fn(() => "/opt/fake/kimi");
+    const entry = await probeKimiCodeCapability({ findOnPath });
+    expect(findOnPath).toHaveBeenCalledOnce();
+    expect(entry).toMatchObject({
+      state: "ok",
+      available: true,
+      sdkVersion: KIMI_CODE_SDK_VERSION,
+      runtimeSource: "bundled",
+      runtimePath: null,
+    });
   });
 });

--- a/packages/client/src/runtime/capabilities/kimi-code.ts
+++ b/packages/client/src/runtime/capabilities/kimi-code.ts
@@ -1,18 +1,51 @@
 import type { CapabilityEntry } from "@first-tree/shared";
-import { runDetect } from "./detect.js";
+import {
+  findKimiExecutableOnPath,
+  formatKimiBinaryMissingMessage,
+} from "../kimi-binary.js";
+import { type DetectOutcome, runDetect } from "./detect.js";
 
 /** Exact SDK build bundled with the client and used by the runtime handler. */
 export const KIMI_CODE_SDK_VERSION = "0.26.0-botiverse.2";
 
+/** Injectable seams — production callers pass nothing. */
+export type KimiCodeProbeDeps = {
+  findOnPath?: (env?: Record<string, string | undefined>) => string | null;
+  env?: NodeJS.ProcessEnv;
+};
+
 /**
- * Install-only Kimi capability. The SDK is a declared client dependency, so
- * detection does not launch Kimi, touch credentials, or make a network call.
+ * Install-only Kimi capability.
+ *
+ * Product contract: Computer availability tracks the official `kimi` CLI so
+ * the operator can complete provider-owned `/login` and credential recovery on
+ * this host. The bundled `@botiverse/kimi-code-sdk` remains the execution
+ * engine and must not by itself make the capability `ok`.
+ *
+ * Detection is existence-only: no Kimi launch, no credential read, no network.
+ * When the CLI is present, the entry still reports `runtimeSource: "bundled"`
+ * and `runtimePath: null` because the CLI is the setup artifact, not the
+ * spawn target for agent turns.
  */
-export async function probeKimiCodeCapability(): Promise<CapabilityEntry> {
-  return runDetect(async () => ({
-    installed: true,
-    version: KIMI_CODE_SDK_VERSION,
-    runtimeSource: "bundled",
-    runtimePath: null,
-  }));
+export async function probeKimiCodeCapability(deps: KimiCodeProbeDeps = {}): Promise<CapabilityEntry> {
+  const env = deps.env ?? process.env;
+  const findOnPath = deps.findOnPath ?? findKimiExecutableOnPath;
+
+  return runDetect(async (): Promise<DetectOutcome> => {
+    const pathBinary = findOnPath(env);
+    if (pathBinary) {
+      return {
+        installed: true,
+        version: KIMI_CODE_SDK_VERSION,
+        runtimeSource: "bundled",
+        runtimePath: null,
+      };
+    }
+    return {
+      installed: false,
+      error: formatKimiBinaryMissingMessage(
+        "no kimi binary resolved on PATH, well-known install dirs, or login-shell PATH",
+      ),
+    };
+  });
 }

--- a/packages/client/src/runtime/capabilities/kimi-code.ts
+++ b/packages/client/src/runtime/capabilities/kimi-code.ts
@@ -1,8 +1,5 @@
 import type { CapabilityEntry } from "@first-tree/shared";
-import {
-  findKimiExecutableOnPath,
-  formatKimiBinaryMissingMessage,
-} from "../kimi-binary.js";
+import { findKimiExecutableOnPath, formatKimiBinaryMissingMessage } from "../kimi-binary.js";
 import { type DetectOutcome, runDetect } from "./detect.js";
 
 /** Exact SDK build bundled with the client and used by the runtime handler. */

--- a/packages/client/src/runtime/kimi-binary.ts
+++ b/packages/client/src/runtime/kimi-binary.ts
@@ -1,0 +1,128 @@
+import { accessSync, constants, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { delimiter, isAbsolute, join, resolve } from "node:path";
+import { wellKnownBinDirs } from "./install-locations.js";
+import { getLoginShellPathDirs } from "./login-shell-path.js";
+
+/**
+ * Official Kimi Code CLI binary resolution for Computer capability detection.
+ *
+ * First Tree executes Kimi through the bundled `@botiverse/kimi-code-sdk`; the
+ * official `kimi` CLI is the required local setup/recovery artifact so the
+ * operator can run `/login` on this host. Discovery is existence-only — never
+ * launches the binary and never reads credentials.
+ */
+
+/** Package name surfaced in missing-binary copy and setup UI. */
+export const KIMI_CLI_PACKAGE = "@moonshot-ai/kimi-code";
+
+const KIMI_BINARY_MISSING_PATTERNS: readonly RegExp[] = [
+  /kimi (?:code )?cli is missing/i,
+  /official `?kimi`? cli/i,
+  /kimi.*not (?:found|installed)/i,
+];
+
+export function isKimiBinaryMissingError(input: unknown): boolean {
+  const text = errorSearchText(input);
+  return KIMI_BINARY_MISSING_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function formatKimiBinaryMissingMessage(input: unknown): string {
+  const original = errorText(input).trim();
+  const suffix = original ? ` Original error: ${original}` : "";
+  return (
+    "Official Kimi CLI is missing on this machine. " +
+    "First Tree runs Kimi through its bundled SDK, but Computer availability requires the official `kimi` CLI so you can complete provider-owned login and recovery locally. " +
+    `Install it with \`npm install -g ${KIMI_CLI_PACKAGE}\`, then run \`kimi\` and enter \`/login\`.` +
+    suffix
+  );
+}
+
+/** Injectable seams so probe tests stay hermetic (no real shell spawn / no host install dirs). */
+export type FindKimiExecutableDeps = {
+  /** Returns the user's interactive-login-shell PATH dirs; defaults to the memoized probe. */
+  loginShellPathDirs?: () => string[];
+  /** Returns the curated well-known bin dirs; defaults to the real host list. */
+  wellKnownDirs?: () => string[];
+  platform?: NodeJS.Platform;
+  pathDelimiter?: string;
+};
+
+/**
+ * Resolve the official `kimi` CLI on this host. Existence-only — never launches
+ * the binary and never reads `~/.kimi-code`.
+ *
+ * Directory order mirrors the other external providers — daemon PATH → curated
+ * well-known install dirs (npm global / Homebrew / volta / …) → login-shell
+ * PATH (may spawn a shell, so consulted last). This covers the common case
+ * where launchd/systemd freezes a PATH that omits the operator's interactive
+ * install location.
+ */
+export function findKimiExecutableOnPath(
+  env: Record<string, string | undefined> = process.env,
+  deps: FindKimiExecutableDeps = {},
+): string | null {
+  const platform = deps.platform ?? process.platform;
+  const pathDelimiter = deps.pathDelimiter ?? (platform === "win32" ? ";" : delimiter);
+  const loginShellPathDirs = deps.loginShellPathDirs ?? getLoginShellPathDirs;
+  const home = env.HOME && env.HOME.length > 0 ? env.HOME : homedir();
+  const wellKnownDirs = deps.wellKnownDirs ?? (() => wellKnownBinDirs(home));
+  const names = kimiExecutableNames(platform);
+  const seen = new Set<string>();
+
+  const search = (dirs: readonly string[]): string | null => {
+    for (const dir of dirs) {
+      if (!dir) continue;
+      const base = isAbsolute(dir) ? dir : resolve(dir);
+      if (seen.has(base)) continue;
+      seen.add(base);
+      for (const name of names) {
+        const candidate = join(base, name);
+        if (isExecutableFile(candidate, platform)) return candidate;
+      }
+    }
+    return null;
+  };
+
+  const pathValue = readPathValue(env, platform);
+  const fromDaemon = search(pathValue ? pathValue.split(pathDelimiter) : []);
+  if (fromDaemon) return fromDaemon;
+  const fromWellKnown = search(wellKnownDirs());
+  if (fromWellKnown) return fromWellKnown;
+  return search(loginShellPathDirs());
+}
+
+function kimiExecutableNames(platform: NodeJS.Platform): string[] {
+  return platform === "win32" ? ["kimi.exe", "kimi.cmd", "kimi"] : ["kimi"];
+}
+
+function readPathValue(env: Record<string, string | undefined>, platform = process.platform): string | undefined {
+  if (platform !== "win32") return env.PATH;
+  const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === "path");
+  return key ? env[key] : undefined;
+}
+
+function isExecutableFile(filePath: string, platform: NodeJS.Platform): boolean {
+  try {
+    if (!statSync(filePath).isFile()) return false;
+    accessSync(filePath, platform === "win32" ? constants.F_OK : constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function errorText(input: unknown): string {
+  if (input instanceof Error) return input.message;
+  if (typeof input === "string") return input;
+  if (input && typeof input === "object") {
+    const maybe = input as { message?: unknown };
+    if (typeof maybe.message === "string") return maybe.message;
+  }
+  return String(input);
+}
+
+function errorSearchText(input: unknown): string {
+  if (input instanceof Error) return `${input.name} ${input.message}`;
+  return errorText(input);
+}

--- a/packages/client/src/runtime/kimi-binary.ts
+++ b/packages/client/src/runtime/kimi-binary.ts
@@ -38,11 +38,22 @@ export function formatKimiBinaryMissingMessage(input: unknown): string {
   );
 }
 
+/**
+ * Official installer's default binary directory (`$HOME/.kimi-code/bin` /
+ * `%USERPROFILE%\.kimi-code\bin`). The macOS/Linux `install.sh` and Windows
+ * `install.ps1` scripts place `kimi` here and append the dir to the user's
+ * shell PATH — which a long-lived daemon service PATH does not see until
+ * restart, and which Windows never recovers via login-shell PATH probing.
+ */
+export function kimiOfficialBinDirs(home: string): string[] {
+  return [join(home, ".kimi-code", "bin")];
+}
+
 /** Injectable seams so probe tests stay hermetic (no real shell spawn / no host install dirs). */
 export type FindKimiExecutableDeps = {
   /** Returns the user's interactive-login-shell PATH dirs; defaults to the memoized probe. */
   loginShellPathDirs?: () => string[];
-  /** Returns the curated well-known bin dirs; defaults to the real host list. */
+  /** Returns the curated well-known bin dirs; defaults to official + shared host list. */
   wellKnownDirs?: () => string[];
   platform?: NodeJS.Platform;
   pathDelimiter?: string;
@@ -50,13 +61,14 @@ export type FindKimiExecutableDeps = {
 
 /**
  * Resolve the official `kimi` CLI on this host. Existence-only — never launches
- * the binary and never reads `~/.kimi-code`.
+ * the binary and never reads credential files under `~/.kimi-code`.
  *
- * Directory order mirrors the other external providers — daemon PATH → curated
- * well-known install dirs (npm global / Homebrew / volta / …) → login-shell
- * PATH (may spawn a shell, so consulted last). This covers the common case
- * where launchd/systemd freezes a PATH that omits the operator's interactive
- * install location.
+ * Directory order: daemon PATH → curated well-known install dirs (official
+ * `$HOME/.kimi-code/bin` first, then npm global / Homebrew / volta / …) →
+ * login-shell PATH (may spawn a shell, so consulted last; always empty on
+ * Windows). This covers the common case where launchd/systemd freezes a PATH
+ * that omits the operator's interactive install location, including a fresh
+ * official-script install that has not yet restarted the daemon.
  */
 export function findKimiExecutableOnPath(
   env: Record<string, string | undefined> = process.env,
@@ -65,8 +77,8 @@ export function findKimiExecutableOnPath(
   const platform = deps.platform ?? process.platform;
   const pathDelimiter = deps.pathDelimiter ?? (platform === "win32" ? ";" : delimiter);
   const loginShellPathDirs = deps.loginShellPathDirs ?? getLoginShellPathDirs;
-  const home = env.HOME && env.HOME.length > 0 ? env.HOME : homedir();
-  const wellKnownDirs = deps.wellKnownDirs ?? (() => wellKnownBinDirs(home));
+  const home = resolveHome(env, platform);
+  const wellKnownDirs = deps.wellKnownDirs ?? (() => [...kimiOfficialBinDirs(home), ...wellKnownBinDirs(home)]);
   const names = kimiExecutableNames(platform);
   const seen = new Set<string>();
 
@@ -90,6 +102,12 @@ export function findKimiExecutableOnPath(
   const fromWellKnown = search(wellKnownDirs());
   if (fromWellKnown) return fromWellKnown;
   return search(loginShellPathDirs());
+}
+
+function resolveHome(env: Record<string, string | undefined>, platform: NodeJS.Platform): string {
+  if (env.HOME && env.HOME.length > 0) return env.HOME;
+  if (platform === "win32" && env.USERPROFILE && env.USERPROFILE.length > 0) return env.USERPROFILE;
+  return homedir();
 }
 
 function kimiExecutableNames(platform: NodeJS.Platform): string[] {

--- a/packages/qa/cases/runtime/kimi-code-provider.md
+++ b/packages/qa/cases/runtime/kimi-code-provider.md
@@ -28,9 +28,10 @@ classification, or Context Tree Kimi-tool derivation changes.
 
 ## Checklist
 
-- Capability: the connected client advertises `kimi-code` as `ok`, `runtimeSource: bundled`, version
-  `0.26.0-botiverse.2`, and no runtime path. Re-probing must not launch a Kimi turn, check auth, or make a provider
-  request.
+- Capability: with the official `kimi` CLI installed on the host, the connected client advertises `kimi-code` as `ok`,
+  `runtimeSource: bundled`, version `0.26.0-botiverse.2`, and no runtime path. Without that CLI the capability must be
+  `missing` even though the bundled SDK is present. Re-probing must not launch a Kimi turn, check auth, or make a
+  provider request.
 - Provider selection: Web and CLI can create a Kimi Code agent only on a client advertising the capability. The agent
   config defaults to an empty model and has no reasoning-effort field.
 - Auth boundary: with the host logged out, a real turn classifies `auth.login_required` or `provider.auth_error` as a

--- a/packages/web/src/pages/clients/__tests__/kimi-code-provider-surfaces.test.tsx
+++ b/packages/web/src/pages/clients/__tests__/kimi-code-provider-surfaces.test.tsx
@@ -39,7 +39,8 @@ describe("Kimi Code provider surfaces", () => {
     expect(providerSupportsInProductAuth("kimi-code")).toBe(false);
     expect(buildInstallCommand("kimi-code")).toContain("@moonshot-ai/kimi-code");
     expect(buildInstallCommand("kimi-code")).toContain("/login");
-    expect(providerInstallHint("kimi-code", "darwin")).toContain("bundled with First Tree");
+    expect(providerInstallHint("kimi-code", "darwin")).toContain("official Kimi CLI");
+    expect(providerInstallHint("kimi-code", "darwin")).toContain("bundled Kimi SDK");
   });
 
   it("exposes DEFAULT + Custom with a local-Kimi default hint on the custom entry", async () => {

--- a/packages/web/src/pages/clients/cards/shared/providers.ts
+++ b/packages/web/src/pages/clients/cards/shared/providers.ts
@@ -215,7 +215,7 @@ export function providerInstallHint(
     return `Run \`${CURSOR_INSTALL_COMMAND}\` on this ${device} (official Cursor installer).`;
   }
   if (provider === "kimi-code") {
-    return `Kimi's engine is bundled with First Tree. For login recovery, install \`@moonshot-ai/kimi-code\` on this ${device}, run \`kimi\`, then \`/login\`.`;
+    return `Install the official Kimi CLI with \`npm install -g @moonshot-ai/kimi-code\` on this ${device}, run \`kimi\`, then \`/login\`. First Tree still executes through its bundled Kimi SDK.`;
   }
   return `Install the OpenAI Codex CLI on this ${device}.`;
 }


### PR DESCRIPTION
## Summary
- Kimi Computer capability now probes for a real host `kimi` CLI (daemon PATH → well-known install dirs including official `$HOME/.kimi-code/bin` → login-shell PATH), matching other provider binary discovery.
- Missing CLI → `state=missing` / `available=false`. Present CLI → `state=ok` / `available=true`, still with `runtimeSource: bundled` because `@botiverse/kimi-code-sdk` remains the execution engine.
- Detection stays existence-only (no launch, no credential read). Web install hint and the Kimi QA case checklist are aligned with this contract.

Cross-links Context Tree decision: https://github.com/agent-team-foundation/first-tree-context/pull/822

## Test plan
- [x] `pnpm exec vitest run src/__tests__/kimi-code-capability.test.ts src/__tests__/kimi-binary.test.ts` (packages/client) — 13 passed
- [x] `pnpm typecheck` (packages/client)
- [x] Full `pnpm test` in packages/client — 1652 passed
- [x] Full `pnpm test` in packages/web — 1738 passed (includes kimi provider surface copy)
- [x] Independent QA by yzw-codex on head `c1dbcea90af77901db1fe9d9a171a6963f5841fa` — change-scoped PASS (see [QA comment](https://github.com/agent-team-foundation/first-tree/pull/2018#issuecomment-5081855611)); formal first-tree-qa remains BLOCKED for full product matrix