### PR TITLE
feat(web): promote mobile PWA installation

### DIFF
--- a/packages/qa/cases/cross-surface/mobile-pwa-install-and-auth-handoff.md
+++ b/packages/qa/cases/cross-surface/mobile-pwa-install-and-auth-handoff.md
@@ -1,0 +1,111 @@
+---
+id: mobile-pwa-install-and-auth-handoff
+description: Validate credential-free desktop QR discovery through real iOS and Android home-screen installation, standalone OAuth return, and desktop setup handoff.
+areas: [cross-surface]
+surfaces: [server, web]
+---
+
+# Mobile PWA install and auth handoff
+
+## Goal
+
+Confirm that a desktop user can discover the mobile PWA, scan a public same-origin QR code, install it through the
+platform-supported path, and open the installed app into the existing mobile Work surface. The QR must carry no
+credentials or private context. First use may require the product's existing OAuth flow, while an account that has not
+completed setup must return to desktop rather than starting a second mobile onboarding.
+
+Deterministic web tests own route gating, source allowlisting, install-prompt state, analytics payloads, and component
+rendering. This case owns the live boundaries those tests cannot prove: a camera scan between physical devices, real
+iOS and Android installation behavior, standalone launch, provider OAuth, persisted browser/app state, and the
+incomplete-setup handoff.
+
+## Preconditions
+
+- An HTTPS deployment built from the target ref with the mobile channel enabled, a valid web app manifest, a browser
+  that recognizes the platform's supported install path, and the same configured OAuth providers on desktop and
+  mobile.
+- A desktop browser plus a physical iPhone or iPad running Safari and a physical Android device running Chrome or
+  another supported Chromium browser. Start with the PWA absent and clear disposable site data between independent
+  branches.
+- One disposable account that has completed desktop setup and one disposable account that is authenticated but still
+  requires setup. Do not use production credentials or retain OAuth state, cookies, or tokens as evidence.
+- A QR scanner or device camera. Android native-prompt eligibility is browser-controlled; inability to receive the
+  prompt is a branch to exercise the manual fallback, not permission to simulate installation.
+
+## Operate
+
+Exercise both desktop discovery surfaces: finish Start chat and open its mobile-app promotion, then open **Open on
+mobile** from the user menu. Use keyboard activation as well as a pointer, close the dialog with Escape, and verify
+focus returns to its trigger. Scan each QR code and separately try the copy-link action. Decode each QR locally, retain
+only its redacted payload, and inspect requests made while the QR is rendered.
+
+On iOS, open the scanned page in Safari and follow its Share → Add to Home Screen → Open instructions. On Android,
+exercise the native install action when the browser exposes it, dismiss it once, and confirm the page recovers to a
+usable manual-install path. In a clean state where no native prompt is offered, complete the manual path directly.
+
+Launch each installed app from the home-screen icon. With the completed account signed out on the device, use the
+existing OAuth provider once and follow the return into mobile Work. Close and reopen the installed app to check that a
+valid session is reused. Then repeat the first-launch path with the incomplete account and use both recovery actions:
+copy the desktop setup link, transfer that public URL to a desktop browser and open its `/onboarding` destination, and
+switch to another account.
+
+Also open an install URL with an unknown source value. Interrupt either the install-page or manifest load, and an OAuth
+navigation or callback, with a temporary network failure before retrying; do not try to manipulate the operating
+system's native confirmation sheet. Use a narrow phone viewport and devices with safe-area insets.
+
+Channel gating and analytics remain companion deterministic checks. If an isolated harness already exposes a controlled
+unusable-channel bootstrap response, confirm that a direct install visit recovers to the desktop root; do not mutate a
+valid deployment or simulate a product response merely to make this live branch available.
+
+## Observe
+
+- Start chat remains the primary desktop action; mobile discovery is secondary there and remains available from the
+  user menu. The entry and dialog have readable names, visible keyboard focus, keyboard activation, Escape dismissal,
+  and focus restoration. The Start-chat cards do not overflow a narrow phone-width layout.
+- Every QR and copied URL stays on the current origin and points only to the public mobile install entry with an
+  allowlisted attribution source. It contains no user, Team, workspace, setup, cookie, token, OAuth state, or other
+  credential data, and rendering the QR does not call a third-party QR service.
+- The public page presents truthful platform-specific instructions. iOS requires the operating system's Add to Home
+  Screen action. Android offers a single native install action only when the browser makes it available; a user
+  dismissal or a browser that offers no prompt leaves usable manual instructions.
+- The installed icon launches in standalone display mode and reaches the existing mobile Work surface. An
+  unauthenticated user completes the existing OAuth flow and returns to mobile Work without receiving a credential
+  from the desktop QR or repeating product onboarding. Safe-area content remains reachable, and neither standalone
+  login nor OAuth completion loops back to the install page.
+- A valid mobile session survives an ordinary app close and reopen. An expired or failed session returns to normal
+  OAuth with an actionable retry instead of looping through installation.
+- The incomplete account sees the desktop setup handoff. Its copied link opens the desktop setup path, while switching
+  accounts allows a configured account to continue; the mobile app does not import desktop configuration or expose a
+  parallel setup flow.
+- Unknown attribution is normalized to the bounded direct source and the public install page remains usable; the
+  unknown value does not gain authorization meaning or pass through to telemetry. When a real unusable-channel response
+  is available, it fails closed to the normal desktop entry. After a transient network fault, the product retains a
+  clear retry or manual recovery path and does not enter a product-owned loop. A provider, platform, or environment
+  outage that prevents attribution to the target is `BLOCKED` or `INCONCLUSIVE`, not a target failure.
+
+## Evidence
+
+Keep screenshots or a short recording of both desktop entry points, the decoded same-origin QR paths with any
+deployment hostname redacted, the iOS and Android install branches, the resulting home-screen icon, standalone display
+mode, the final `/m/work` destination after OAuth, and incomplete-setup handoff. Record only a callback's fixed pathname
+if needed; strip its search and hash before capture and never export or record the complete callback URL. Browser
+network logs may establish the absence of a third-party QR request. Record the device, OS, browser, target ref, channel
+state, and whether Android used the native or manual branch.
+
+Use the companion deterministic product results for source normalization, unusable-channel routing, bounded analytics
+keys, privacy-sensitive analytics exclusions, standalone first-open deduplication, and recovery from failed or stale
+Android prompt objects that cannot be reliably manufactured on a physical browser. A non-production live run should
+not be expected to emit production-only analytics.
+
+Never retain cookies, tokens, OAuth authorization codes or state, credentials, private source, user identifiers, Team
+identifiers, or unredacted production analytics.
+
+## Expected behavior and limitations
+
+`PASS` requires a credential-free scan, real installation on both platform families, standalone launch through existing
+OAuth into Work, a durable desktop handoff for incomplete setup, usable manual Android instructions after a dismissal
+or absent prompt, and safe product recovery from a transient network fault. `FAIL` includes credential-bearing QR data,
+an external QR-rendering request, an installation dead end, auth return outside mobile Work, repeated mobile
+onboarding, or a reproducible product-owned recovery loop. `BLOCKED` applies when physical devices, platform install
+support, OAuth, or an eligible deployment are unavailable; `INCONCLUSIVE` applies when an external outage prevents
+attribution. Source inspection or simulated browser events alone cannot upgrade the live journey to `PASS`.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -30,6 +30,7 @@
     "d3-hierarchy": "^3.1.2",
     "dompurify": "^3.4.2",
     "lucide-react": "^0.577.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/packages/web/src/__tests__/app-routes.test.tsx
+++ b/packages/web/src/__tests__/app-routes.test.tsx
@@ -79,6 +79,7 @@ vi.mock("../pages/mobile/shell.js", async () => {
   };
 });
 vi.mock("../pages/mobile/work.js", () => ({ MobileWorkPage: () => <div>mobile work</div> }));
+vi.mock("../pages/mobile/install.js", () => ({ MobileInstallPage: () => <div>mobile install</div> }));
 vi.mock("../pages/mobile/team.js", () => ({ MobileTeamPage: () => <div>mobile team</div> }));
 vi.mock("../pages/mobile/me.js", () => ({ MobileMePage: () => <div>mobile me</div> }));
 vi.mock("../pages/settings.js", async () => {
@@ -255,6 +256,9 @@ describe("App routes", () => {
     expect(await renderAppAt("/invite/token-1")).toContain("invite accept");
     await resetRenderedApp();
 
+    expect(await renderAppAt("/m/install?source=start_chat")).toContain("mobile install");
+    await resetRenderedApp();
+
     expect(await renderAppAt("/onboarding")).toContain("onboarding page");
     await resetRenderedApp();
 
@@ -370,6 +374,8 @@ describe("App routes", () => {
     expect(await renderAppAt("/")).not.toContain("workspace page");
     expect(document.body.textContent ?? "").not.toContain("mobile work");
     expect(document.head.querySelector('link[rel="manifest"]')).toBeNull();
+
+    expect(await renderAppAt("/m/install")).not.toContain("mobile install");
   });
 
   it("recovers a settled unusable channel to the desktop root", async () => {
@@ -389,6 +395,11 @@ describe("App routes", () => {
 
     setViewportWidth(390);
     expect(await renderAppAt("/m/chat")).toContain("workspace page");
+    await act(async () => root?.unmount());
+    document.body.innerHTML = "";
+
+    setViewportWidth(390);
+    expect(await renderAppAt("/m/install")).toContain("workspace page");
   });
 
   it("opens mobile routes, phone root, and PWA metadata on staging", async () => {

--- a/packages/web/src/app.tsx
+++ b/packages/web/src/app.tsx
@@ -8,7 +8,8 @@ import { Layout } from "./components/layout.js";
 import { Button } from "./components/ui/button.js";
 import { ToastProvider } from "./components/ui/toast.js";
 import { PulseProvider } from "./hooks/pulse-context.js";
-import { useContextTreeSetupPreviewBootstrapState, useServerChannelState } from "./hooks/use-server-channel.js";
+import { useMobileExperienceState } from "./hooks/use-mobile-experience.js";
+import { useContextTreeSetupPreviewBootstrapState } from "./hooks/use-server-channel.js";
 import { ProfileTab } from "./pages/agent-detail/profile-tab.js";
 import { PromptTab } from "./pages/agent-detail/prompt-tab.js";
 import { RepositoriesTab } from "./pages/agent-detail/repositories-tab.js";
@@ -21,8 +22,10 @@ import { DocPage } from "./pages/docs/doc-page.js";
 import { DocsListPage } from "./pages/docs/docs-list-page.js";
 import { InviteAcceptPage } from "./pages/invite-accept.js";
 import { LoginPage } from "./pages/login.js";
+import { MobileInstallPage } from "./pages/mobile/install.js";
 import { MobileMePage } from "./pages/mobile/me.js";
 import { MobileShell } from "./pages/mobile/shell.js";
+import { MobileStandaloneOpenTracker } from "./pages/mobile/standalone-open-tracker.js";
 import { MobileTeamPage } from "./pages/mobile/team.js";
 import { MobileWorkPage } from "./pages/mobile/work.js";
 import { OAuthCompletePage } from "./pages/oauth-complete.js";
@@ -180,6 +183,7 @@ export function App() {
         <ToastProvider>
           <BrowserRouter>
             <MobileExperienceHead />
+            <MobileStandaloneOpenTracker />
             <RouteTracker />
             <Routes>
               {/* Public routes — no auth required */}
@@ -191,6 +195,7 @@ export function App() {
               {/* Public: the connect-code install popup lands here to auto-close. */}
               <Route path="/onboarding/connected" element={<GithubConnectedPage />} />
               <Route path="/invite/:token" element={<InviteAcceptPage />} />
+              <Route path="/m/install" element={<MobileInstallRoute />} />
               <Route path="/preview/context-tree-setup" element={<ContextTreeSetupPreviewRoute />} />
               {ContextPreviewPage ? (
                 <Route
@@ -496,11 +501,6 @@ export function App() {
   );
 }
 
-type MobileExperienceState = {
-  enabled: boolean;
-  settled: boolean;
-};
-
 function AdminRedirect() {
   const location = useLocation();
   return <Navigate to={`/team${location.hash}`} replace />;
@@ -565,17 +565,6 @@ function shouldOpenMobileRoot(location: ReturnType<typeof useLocation>): boolean
   return window.innerWidth > 0 && window.innerWidth < 768;
 }
 
-function useMobileExperienceState(): MobileExperienceState {
-  const { channel, settled: channelSettled } = useServerChannelState();
-  if (!channelSettled) {
-    return { enabled: false, settled: false };
-  }
-  return {
-    enabled: channel === "dev" || channel === "staging" || channel === "prod",
-    settled: true,
-  };
-}
-
 function MobileExperienceGate() {
   const mobileExperience = useMobileExperienceState();
   if (!mobileExperience.settled) return null;
@@ -586,6 +575,13 @@ function MobileExperienceGate() {
       <MobileShell />
     </PulseProvider>
   );
+}
+
+function MobileInstallRoute() {
+  const mobileExperience = useMobileExperienceState();
+  if (!mobileExperience.settled) return null;
+  if (!mobileExperience.enabled) return <Navigate to="/" replace />;
+  return <MobileInstallPage />;
 }
 
 function MobileExperienceHead() {

--- a/packages/web/src/components/community-channels.tsx
+++ b/packages/web/src/components/community-channels.tsx
@@ -1,5 +1,7 @@
 import { ArrowUpRight } from "lucide-react";
+import { useMobileExperienceState } from "../hooks/use-mobile-experience.js";
 import { DISCORD_INVITE_URL, WECHAT_QR_SRC } from "../lib/community.js";
+import { MobileInstallCard } from "./mobile-install-promotion.js";
 
 /**
  * Discord's official mark (simple-icons path), monochrome via currentColor so
@@ -33,9 +35,20 @@ function DiscordMark({ size }: { size: number }) {
  * SupportMenu so the surfaces stay visually consistent. Design language per
  * DESIGN.md: hairline border, neutral ink, no brand colors.
  */
-export function CommunityChannels() {
+export function CommunityChannels({ includeMobile = false }: { includeMobile?: boolean }) {
+  if (includeMobile) return <CommunityChannelsWithMobile />;
+  return <ChannelGrid showMobile={false} />;
+}
+
+function CommunityChannelsWithMobile() {
+  const mobileExperience = useMobileExperienceState();
+  return <ChannelGrid showMobile={mobileExperience.settled && mobileExperience.enabled} />;
+}
+
+function ChannelGrid({ showMobile }: { showMobile: boolean }) {
   return (
-    <div className="grid grid-cols-2" style={{ gap: "var(--sp-3)" }}>
+    <div className={showMobile ? "grid grid-cols-2 sm:grid-cols-3" : "grid grid-cols-2"} style={{ gap: "var(--sp-3)" }}>
+      {showMobile ? <MobileInstallCard /> : null}
       <ChannelCard
         href={WECHAT_QR_SRC}
         name="WeChat group"
@@ -89,7 +102,7 @@ function ChannelCard({
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="flex flex-col items-center rounded-[var(--radius-panel)] border border-border transition-colors hover:bg-accent/30"
+      className="flex flex-col items-center rounded-[var(--radius-panel)] border border-border transition-colors hover:bg-accent/30 focus-visible:border-ring focus-visible:outline-none"
       style={{ gap: "var(--sp-2)", padding: "var(--sp-3)", textDecoration: "none" }}
     >
       <span className="text-label font-medium" style={{ color: "var(--fg)" }}>

--- a/packages/web/src/components/mobile-install-promotion.tsx
+++ b/packages/web/src/components/mobile-install-promotion.tsx
@@ -1,0 +1,165 @@
+import { Check, Copy, Smartphone } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
+import { type RefObject, useEffect, useState } from "react";
+import { trackEvent } from "../analytics.js";
+import { buildMobileInstallUrl, type MobileInstallSource, type MobilePromotionSource } from "../lib/mobile-install.js";
+import { useCopyFeedback } from "../lib/use-copy-feedback.js";
+import { Button } from "./ui/button.js";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "./ui/dialog.js";
+
+const QR_RENDER_SIZE = 256;
+
+function mobileInstallUrl(source: MobileInstallSource): string {
+  return buildMobileInstallUrl(typeof window === "undefined" ? "" : window.location.origin, source);
+}
+
+export function MobileInstallQr({ source, className }: { source: MobileInstallSource; className?: string }) {
+  const installUrl = mobileInstallUrl(source);
+  return (
+    <span
+      role="img"
+      aria-label="QR code to install First Tree on a phone"
+      className="inline-flex shrink-0 items-center justify-center"
+      style={{
+        padding: "var(--sp-2)",
+        borderRadius: "var(--radius-panel)",
+        background: "var(--qr-bg)",
+      }}
+    >
+      <QRCodeSVG
+        aria-hidden
+        className={className}
+        value={installUrl}
+        size={QR_RENDER_SIZE}
+        level="M"
+        marginSize={2}
+        fgColor="var(--qr-fg)"
+        bgColor="var(--qr-bg)"
+      />
+    </span>
+  );
+}
+
+export function OpenOnMobileDialog({
+  open,
+  onOpenChange,
+  source,
+  trigger,
+  restoreFocusRef,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  source: MobilePromotionSource;
+  trigger?: React.ReactNode;
+  restoreFocusRef?: RefObject<HTMLElement | null>;
+}) {
+  const installUrl = mobileInstallUrl(source);
+  const copyFeedback = useCopyFeedback();
+
+  useEffect(() => {
+    if (!open) return;
+    copyFeedback.reset();
+    trackEvent("mobile_promo_opened", { source });
+  }, [open, source, copyFeedback.reset]);
+
+  const copyLabel =
+    copyFeedback.status === "copied" ? "Copied" : copyFeedback.status === "failed" ? "Copy failed" : "Copy link";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {trigger ? <DialogTrigger asChild>{trigger}</DialogTrigger> : null}
+      <DialogContent
+        className="max-w-md"
+        onCloseAutoFocus={(event) => {
+          if (!restoreFocusRef?.current) return;
+          event.preventDefault();
+          restoreFocusRef.current.focus();
+        }}
+      >
+        <DialogHeader className="items-center text-center sm:text-center">
+          <span
+            aria-hidden
+            className="inline-flex items-center justify-center rounded-[var(--radius-full)]"
+            style={{
+              width: "var(--sp-10)",
+              height: "var(--sp-10)",
+              background: "var(--brand-bg)",
+              color: "var(--brand)",
+              marginBottom: "var(--sp-1)",
+            }}
+          >
+            <Smartphone className="h-5 w-5" />
+          </span>
+          <DialogTitle>Open First Tree on your phone</DialogTitle>
+          <DialogDescription>Scan to install. You’ll sign in once after installation.</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex justify-center" style={{ padding: "var(--sp-2) 0" }}>
+          <MobileInstallQr source={source} className="h-52 w-52" />
+        </div>
+
+        <div
+          className="flex min-w-0 items-center"
+          style={{
+            gap: "var(--sp-2)",
+            padding: "var(--sp-2)",
+            borderRadius: "var(--radius-input)",
+            background: "var(--bg-sunken)",
+          }}
+        >
+          <span className="mono min-w-0 flex-1 truncate text-caption" style={{ color: "var(--fg-3)" }}>
+            {installUrl}
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            onClick={() => void copyFeedback.copy(installUrl)}
+            aria-label={copyLabel}
+          >
+            {copyFeedback.status === "copied" ? (
+              <Check aria-hidden className="h-3 w-3" />
+            ) : (
+              <Copy aria-hidden className="h-3 w-3" />
+            )}
+            {copyLabel}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function MobileInstallCard() {
+  const source = "start_chat";
+  const [open, setOpen] = useState(false);
+
+  return (
+    <OpenOnMobileDialog
+      open={open}
+      onOpenChange={setOpen}
+      source={source}
+      trigger={
+        <button
+          type="button"
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          className="flex flex-col items-center rounded-[var(--radius-panel)] border border-border transition-colors hover:bg-accent/30 focus-visible:border-ring focus-visible:outline-none"
+          style={{
+            gap: "var(--sp-2)",
+            padding: "var(--sp-3)",
+            background: "transparent",
+            color: "var(--fg)",
+            cursor: "pointer",
+          }}
+        >
+          <span className="text-label font-medium">Mobile app</span>
+          <MobileInstallQr source={source} className="h-20 w-20" />
+          <span className="text-caption" style={{ color: "var(--fg-4)" }}>
+            Scan to install
+          </span>
+        </button>
+      }
+    />
+  );
+}

--- a/packages/web/src/components/user-menu.tsx
+++ b/packages/web/src/components/user-menu.tsx
@@ -1,8 +1,10 @@
-import { LogOut, Settings } from "lucide-react";
+import { LogOut, Settings, Smartphone } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { useAuth } from "../auth/auth-context.js";
+import { useMobileExperienceState } from "../hooks/use-mobile-experience.js";
 import { Avatar } from "./avatar.js";
+import { OpenOnMobileDialog } from "./mobile-install-promotion.js";
 
 // Marketing site — where an explicit sign-out lands the browser, so the user
 // leaves the app on the parent brand surface rather than an app route (which
@@ -20,9 +22,12 @@ const PARENT_URL = "https://first-tree.ai";
  */
 export function UserMenu() {
   const { user, logout } = useAuth();
+  const mobileExperience = useMobileExperienceState();
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
+  const [mobileDialogOpen, setMobileDialogOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -48,6 +53,7 @@ export function UserMenu() {
   return (
     <div ref={ref} className="relative" data-testid="user-menu">
       <button
+        ref={triggerRef}
         type="button"
         aria-label={`User menu, ${displayName}`}
         aria-haspopup="menu"
@@ -98,6 +104,23 @@ export function UserMenu() {
               <Settings className="h-3.5 w-3.5" />
               <span>Account settings</span>
             </button>
+            {mobileExperience.settled && mobileExperience.enabled ? (
+              <button
+                type="button"
+                role="menuitem"
+                aria-haspopup="dialog"
+                aria-expanded={mobileDialogOpen}
+                onClick={() => {
+                  setOpen(false);
+                  setMobileDialogOpen(true);
+                }}
+                className="flex w-full items-center gap-2 px-4 py-1.5 text-left text-body hover:bg-accent transition-colors"
+                style={{ color: "var(--fg)" }}
+              >
+                <Smartphone className="h-3.5 w-3.5" />
+                <span>Open on mobile</span>
+              </button>
+            ) : null}
             <button
               type="button"
               role="menuitem"
@@ -118,6 +141,15 @@ export function UserMenu() {
           </div>
         </div>
       )}
+      <OpenOnMobileDialog
+        open={mobileDialogOpen}
+        onOpenChange={(nextOpen) => {
+          setMobileDialogOpen(nextOpen);
+          if (!nextOpen) triggerRef.current?.focus();
+        }}
+        source="user_menu"
+        restoreFocusRef={triggerRef}
+      />
     </div>
   );
 }

--- a/packages/web/src/hooks/use-mobile-experience.ts
+++ b/packages/web/src/hooks/use-mobile-experience.ts
@@ -1,0 +1,22 @@
+import { useServerChannelState } from "./use-server-channel.js";
+
+export type MobileExperienceState = {
+  enabled: boolean;
+  settled: boolean;
+};
+
+/**
+ * One fail-closed capability gate for every mobile surface and promotion.
+ * Older or unreachable servers do not publish the mobile manifest, so they
+ * must not advertise an install path that cannot complete.
+ */
+export function useMobileExperienceState(): MobileExperienceState {
+  const { channel, settled: channelSettled } = useServerChannelState();
+  if (!channelSettled) {
+    return { enabled: false, settled: false };
+  }
+  return {
+    enabled: channel === "dev" || channel === "staging" || channel === "prod",
+    settled: true,
+  };
+}

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -349,6 +349,11 @@
      under .dark and would yield dark-on-color in dark mode. */
   --fg-on-vivid: oklch(0.985 0 0);
 
+  /* QR modules must stay absolute black-on-white in every theme so phone
+     cameras get maximum contrast. These intentionally do not invert in .dark. */
+  --qr-fg: oklch(0 0 0);
+  --qr-bg: oklch(1 0 0);
+
   /* Per-agent avatar palette. Eight perceptually-balanced OkLCH hues
      at matched lightness/chroma so every avatar reads with the same
      visual weight. Consumed via `pickAvatarHue(agentId)` in

--- a/packages/web/src/lib/__tests__/mobile-install.test.ts
+++ b/packages/web/src/lib/__tests__/mobile-install.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { buildMobileInstallUrl, readMobileInstallSource } from "../mobile-install.js";
+
+describe("mobile install links", () => {
+  it("builds an origin-local public URL with analytics source only", () => {
+    expect(buildMobileInstallUrl("https://cloud.first-tree.ai", "start_chat")).toBe(
+      "https://cloud.first-tree.ai/m/install?source=start_chat",
+    );
+    expect(buildMobileInstallUrl("https://self-hosted.example/base", "user_menu")).toBe(
+      "https://self-hosted.example/m/install?source=user_menu",
+    );
+  });
+
+  it("accepts only known attribution values", () => {
+    expect(readMobileInstallSource("start_chat")).toBe("start_chat");
+    expect(readMobileInstallSource("user_menu")).toBe("user_menu");
+    expect(readMobileInstallSource("token-looking-value")).toBe("direct");
+    expect(readMobileInstallSource(null)).toBe("direct");
+  });
+});

--- a/packages/web/src/lib/mobile-install.ts
+++ b/packages/web/src/lib/mobile-install.ts
@@ -1,0 +1,15 @@
+export const MOBILE_INSTALL_SOURCES = ["start_chat", "user_menu", "direct"] as const;
+
+export type MobileInstallSource = (typeof MOBILE_INSTALL_SOURCES)[number];
+export type MobilePromotionSource = Exclude<MobileInstallSource, "direct">;
+
+export function buildMobileInstallUrl(origin: string, source: MobileInstallSource): string {
+  const relative = source === "direct" ? "/m/install" : `/m/install?source=${source}`;
+  const originMatch = /^(https?:\/\/[^/]+)/.exec(origin);
+  return originMatch ? `${originMatch[1]}${relative}` : relative;
+}
+
+export function readMobileInstallSource(value: string | null): MobileInstallSource {
+  if (value === "start_chat" || value === "user_menu") return value;
+  return "direct";
+}

--- a/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
+++ b/packages/web/src/pages/__tests__/web-dom-interactions.test.tsx
@@ -146,6 +146,11 @@ const authMock = vi.hoisted(() => {
   };
 });
 
+const mobileExperienceMock = vi.hoisted(() => ({
+  enabled: true,
+  settled: true,
+}));
+
 vi.mock("../../api/activity.js", () => activityMocks);
 vi.mock("../../api/agent-config.js", () => agentConfigMocks);
 vi.mock("../../api/agents.js", async (importOriginal) => ({
@@ -176,6 +181,9 @@ vi.mock("../../api/client.js", async (importOriginal) => {
 vi.mock("../../auth/auth-context.js", () => ({
   AuthProvider: ({ children }: { children: ReactNode }) => children,
   useAuth: () => authMock.value,
+}));
+vi.mock("../../hooks/use-mobile-experience.js", () => ({
+  useMobileExperienceState: () => mobileExperienceMock,
 }));
 vi.mock("../../lib/use-agent-name-map.js", () => ({
   useAgentNameMap: () => (id: string | null | undefined) => (id ? (AGENT_NAMES[id] ?? id) : "unknown"),
@@ -415,7 +423,7 @@ function createClient(): QueryClient {
 
 async function renderDom(
   element: ReactElement,
-  route = "/",
+  route: string | { pathname: string; state?: unknown } = "/",
   seed?: (queryClient: QueryClient) => void,
 ): Promise<{ container: HTMLElement; root: Root }> {
   const container = document.createElement("div");
@@ -611,6 +619,8 @@ beforeEach(() => {
   setupDom();
   document.body.innerHTML = "";
   vi.clearAllMocks();
+  mobileExperienceMock.enabled = true;
+  mobileExperienceMock.settled = true;
   authMock.value = {
     ...authMock.value,
     role: "admin",
@@ -1316,6 +1326,48 @@ describe("web DOM interaction coverage", () => {
       expect(deepLink.container.textContent).not.toContain("Dev: skip GitHub");
       await unmountRoot(deepLink.root);
 
+      const mobile = await renderDom(
+        <LoginPage />,
+        {
+          pathname: "/login",
+          state: { from: { pathname: "/m/work", search: "", hash: "" } },
+        },
+        undefined,
+      );
+      await waitForText("Sign in to First Tree", mobile.container);
+      expect(mobile.container.textContent).toContain("Use the same Google or GitHub account as on desktop.");
+      expect(mobile.container.textContent).not.toContain("Set up your team");
+      expect(mobile.container.textContent).not.toContain("No repo access yet");
+      const mobileRoot = mobile.container.querySelector(".landing-marketing");
+      expect(mobileRoot?.className).toContain("h-dvh-screen");
+      expect(mobileRoot?.className).toContain("pt-safe-top");
+      expect(mobileRoot?.className).toContain("pb-safe-bottom");
+      expect(
+        mobile.container.querySelector<HTMLAnchorElement>('a[href="/api/v1/auth/github/start?next=%2Fm%2Fwork"]'),
+      ).toBeTruthy();
+      await unmountRoot(mobile.root);
+
+      const originalMatchMedia = window.matchMedia;
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        value: vi.fn().mockReturnValue({ matches: true }),
+      });
+      const installedMobile = await renderDom(
+        <LoginPage />,
+        {
+          pathname: "/login",
+          state: { from: { pathname: "/m/work", search: "", hash: "" } },
+        },
+        undefined,
+      );
+      await waitForText("Sign in to First Tree", installedMobile.container);
+      expect(installedMobile.container.textContent).not.toContain("Back to install");
+      await unmountRoot(installedMobile.root);
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        value: originalMatchMedia,
+      });
+
       authMock.value = { ...authMock.value, isAuthenticated: true };
       const authed = await renderDom(<LoginPage />, "/login", undefined);
       expect(authed.container.textContent).toBe("");
@@ -1508,17 +1560,43 @@ describe("web DOM interaction coverage", () => {
     );
     await waitForText("Join", document.body);
 
-    // The avatar menu is account-only: no team rows, just Sign out.
+    // The avatar menu is account-only: no team rows, with a permanent mobile
+    // handoff alongside account settings and sign-out.
     const account = await renderDom(<UserMenu />);
     await click(account.container.querySelector('button[aria-haspopup="menu"]'));
     expect(account.container.textContent).toContain("Account settings");
+    expect(account.container.textContent).toContain("Open on mobile");
     expect(account.container.textContent).not.toContain("Beta");
     expect(account.container.textContent).not.toContain("Create new team");
+    await click(
+      [...account.container.querySelectorAll("button")].find((button) =>
+        button.textContent?.includes("Open on mobile"),
+      ) ?? null,
+    );
+    await waitForText("Open First Tree on your phone", document.body);
+    expect(document.body.textContent).toContain("You’ll sign in once after installation.");
+    expect(document.body.querySelector('span[role="img"] svg')).not.toBeNull();
+    const mobileDialog = [...document.body.querySelectorAll<HTMLElement>('[role="dialog"]')].find((dialog) =>
+      dialog.textContent?.includes("Open First Tree on your phone"),
+    );
+    await click(
+      [...(mobileDialog?.querySelectorAll("button") ?? [])].find((button) => button.textContent?.includes("Close")) ??
+        null,
+    );
+    expect(document.activeElement).toBe(account.container.querySelector('button[aria-haspopup="menu"]'));
+
+    await click(account.container.querySelector('button[aria-haspopup="menu"]'));
     await click(
       [...account.container.querySelectorAll("button")].find((button) => button.textContent?.includes("Sign out")) ??
         null,
     );
     expect(logout).toHaveBeenCalled();
+
+    mobileExperienceMock.enabled = false;
+    const unavailableAccount = await renderDom(<UserMenu />);
+    await click(unavailableAccount.container.querySelector('button[aria-haspopup="menu"]'));
+    expect(unavailableAccount.container.textContent).not.toContain("Open on mobile");
+
     api.get = originalGet;
   });
 
@@ -2112,6 +2190,17 @@ describe("web DOM interaction coverage", () => {
       treeUrl: "",
     });
     await waitForText("Start working with your agent", adminNoProject.container);
+    expect(adminNoProject.container.textContent).toContain("Stay connected");
+    expect(adminNoProject.container.textContent).toContain("Mobile app");
+    expect(adminNoProject.container.textContent).toContain("Scan to install");
+    expect(adminNoProject.container.textContent).toContain("WeChat group");
+    expect(adminNoProject.container.textContent).toContain("Discord");
+    const communityGrid = [...adminNoProject.container.querySelectorAll(".grid")].find((element) =>
+      element.textContent?.includes("Mobile app"),
+    );
+    expect(communityGrid?.className).toContain("grid-cols-2");
+    expect(communityGrid?.className).toContain("sm:grid-cols-3");
+    expect(communityGrid?.querySelector('span[role="img"] svg')?.getAttribute("class")).toContain("h-20");
     await click(findButton(adminNoProject.container, "Start chat"));
     expect(onboardingEventMocks.startOnboardingChat).toHaveBeenLastCalledWith(
       expect.objectContaining({ agentUuid: "agent-1", topic: "Get started with First Tree" }),

--- a/packages/web/src/pages/login.tsx
+++ b/packages/web/src/pages/login.tsx
@@ -1,11 +1,12 @@
 import { ArrowLeft, Github, Lock, Zap } from "lucide-react";
-import { Navigate, useLocation } from "react-router";
+import { Link, Navigate, useLocation } from "react-router";
 import { beginAuthAttempt } from "../auth/auth-analytics.js";
 import { useAuth } from "../auth/auth-context.js";
 import { readFromPath } from "../auth/redirect-from-state.js";
 import { FirstTreeLogo } from "../components/first-tree-logo.js";
 import { Button } from "../components/ui/button.js";
 import { useAuthProviderAvailabilityState } from "../hooks/use-server-channel.js";
+import { isStandalone } from "./mobile/install-guide-state.js";
 
 // Marketing site (parent brand) — the "Back to home" link points here rather
 // than the in-app landing route. Mirrors the pattern in footer.tsx / layout.tsx.
@@ -37,6 +38,8 @@ export function LoginPage() {
     (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1");
 
   const redirectTo = readFromPath(location.state) ?? "/";
+  const isMobileSignIn = redirectTo.startsWith("/m/");
+  const isStandaloneMobileSignIn = isMobileSignIn && isStandalone();
   // GitHub OAuth is a full-page navigation, so React Router state is
   // dropped on the way out. Pass the deep-link target through the
   // server's `?next=` instead — the server validates it via the same
@@ -66,16 +69,32 @@ export function LoginPage() {
     // `landing-marketing` swaps the local --bg/--fg/--border tokens to the
     // first-tree.ai palette (near-black + cool-light), shared with the parent
     // brand. Scoping it here means the dashboard chrome stays unaffected.
-    <div className="landing-marketing flex min-h-screen flex-col bg-background text-foreground">
-      <header className="px-4 py-3">
-        <a
-          href={PARENT_URL}
-          className="inline-flex items-center gap-1.5 rounded-[var(--radius-input)] px-2 py-1 text-body text-fg-3 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-        >
-          <ArrowLeft className="h-3.5 w-3.5" />
-          Back to home
-        </a>
-      </header>
+    <div
+      className={`landing-marketing flex flex-col overflow-y-auto bg-background text-foreground ${
+        isMobileSignIn ? "h-dvh-screen pt-safe-top pb-safe-bottom" : "min-h-screen"
+      }`}
+    >
+      {isStandaloneMobileSignIn ? null : (
+        <header className="px-4 py-3">
+          {isMobileSignIn ? (
+            <Link
+              to="/m/install"
+              className="inline-flex items-center gap-1.5 rounded-[var(--radius-input)] px-2 py-1 text-body text-fg-3 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            >
+              <ArrowLeft className="h-3.5 w-3.5" />
+              Back to install
+            </Link>
+          ) : (
+            <a
+              href={PARENT_URL}
+              className="inline-flex items-center gap-1.5 rounded-[var(--radius-input)] px-2 py-1 text-body text-fg-3 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            >
+              <ArrowLeft className="h-3.5 w-3.5" />
+              Back to home
+            </a>
+          )}
+        </header>
+      )}
 
       <div className="flex flex-1 items-center justify-center px-4 pb-16">
         <div className="w-full max-w-sm rounded-[var(--radius-panel)] border border-border bg-card p-6 text-card-foreground shadow-[var(--shadow-sm)]">
@@ -83,9 +102,11 @@ export function LoginPage() {
             <div className="mb-2 flex justify-center text-foreground">
               <FirstTreeLogo width={28} height={32} />
             </div>
-            <div className="text-title">First Tree</div>
+            <div className="text-title">{isMobileSignIn ? "Sign in to First Tree" : "First Tree"}</div>
             <p className="text-label text-fg-2" style={{ marginTop: "var(--sp-1)" }}>
-              Set up your team and your first AI agent.
+              {isMobileSignIn
+                ? "Use the same Google or GitHub account as on desktop."
+                : "Set up your team and your first AI agent."}
             </p>
           </div>
 
@@ -118,30 +139,34 @@ export function LoginPage() {
               </>
             )}
 
-            <p className="text-center text-label text-fg-3">
-              <span className="font-medium text-fg-2">
-                {availableProviderLabels.length > 0
-                  ? `Sign in uses your ${availableProviderLabels.join(" or ")} identity.`
-                  : "Sign-in options are managed by this deployment."}
-              </span>{" "}
-              You authorize a repo later, only when an agent needs to work in it.
-            </p>
+            {isMobileSignIn ? null : (
+              <>
+                <p className="text-center text-label text-fg-3">
+                  <span className="font-medium text-fg-2">
+                    {availableProviderLabels.length > 0
+                      ? `Sign in uses your ${availableProviderLabels.join(" or ")} identity.`
+                      : "Sign-in options are managed by this deployment."}
+                  </span>{" "}
+                  You authorize a repo later, only when an agent needs to work in it.
+                </p>
 
-            <div className="flex items-center justify-center gap-4 border-t border-border pt-4 text-caption text-fg-3">
-              <span className="inline-flex items-center gap-1.5">
-                <Lock className="h-3 w-3" />
-                No repo access yet
-              </span>
-              <a
-                href={REPO_URL}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="inline-flex items-center gap-1.5 rounded-[var(--radius-input)] transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-              >
-                <Github className="h-3 w-3" />
-                Open source
-              </a>
-            </div>
+                <div className="flex items-center justify-center gap-4 border-t border-border pt-4 text-caption text-fg-3">
+                  <span className="inline-flex items-center gap-1.5">
+                    <Lock className="h-3 w-3" />
+                    No repo access yet
+                  </span>
+                  <a
+                    href={REPO_URL}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="inline-flex items-center gap-1.5 rounded-[var(--radius-input)] transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+                  >
+                    <Github className="h-3 w-3" />
+                    Open source
+                  </a>
+                </div>
+              </>
+            )}
 
             <p className="text-center text-label text-fg-3">
               By continuing you agree to our{" "}

--- a/packages/web/src/pages/mobile/__tests__/install-guide-hook.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/install-guide-hook.test.tsx
@@ -26,6 +26,15 @@ function fireBeforeInstallPrompt(): ReturnType<typeof vi.fn> {
   return preventDefault;
 }
 
+function fireRejectingBeforeInstallPrompt(): void {
+  const event = new Event("beforeinstallprompt");
+  Object.assign(event, {
+    prompt: () => Promise.reject(new Error("stale prompt")),
+    userChoice: Promise.resolve({ outcome: "accepted", platform: "web" }),
+  });
+  window.dispatchEvent(event);
+}
+
 // Fresh module per test: the capture is a module singleton, so we reset modules
 // and re-import to get a clean deferredPrompt/installed state each time.
 async function renderModeProbe() {
@@ -36,6 +45,19 @@ async function renderModeProbe() {
   }
   harness.render(<ModeProbe />);
   return () => harness.container.querySelector('[data-testid="mode"]')?.getAttribute("data-mode") ?? null;
+}
+
+async function renderInstallProbe(onOutcome: (outcome: string) => void) {
+  const mod = await import("../use-install-guide.js");
+  function InstallProbe() {
+    const { install, mode } = mod.useInstallPrompt();
+    return (
+      <button type="button" data-mode={mode ?? "null"} onClick={() => void install().then(onOutcome)}>
+        install
+      </button>
+    );
+  }
+  harness.render(<InstallProbe />);
 }
 
 beforeEach(() => {
@@ -94,5 +116,21 @@ describe("install prompt capture lifecycle", () => {
     await harness.flush();
 
     expect(readMode()).toBe("null");
+  });
+
+  it("clears a stale native prompt and returns the manual fallback when prompting rejects", async () => {
+    setUserAgent(ANDROID_UA);
+    const onOutcome = vi.fn();
+    await renderInstallProbe(onOutcome);
+
+    act(() => fireRejectingBeforeInstallPrompt());
+    await harness.flush();
+    expect(harness.container.querySelector("button")?.dataset.mode).toBe("native");
+
+    await act(async () => harness.container.querySelector("button")?.click());
+    await harness.flush();
+
+    expect(onOutcome).toHaveBeenCalledWith("unavailable");
+    expect(harness.container.querySelector("button")?.dataset.mode).toBe("android-manual");
   });
 });

--- a/packages/web/src/pages/mobile/__tests__/install-page-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/install-page-dom.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+
+import { act } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
+import { MobileInstallPage } from "../install.js";
+
+const analyticsMocks = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+const installMocks = vi.hoisted(() => ({
+  platform: "ios" as "ios" | "android" | "other",
+  mode: "ios" as "native" | "ios" | "android-manual" | null,
+  install: vi.fn(async () => "accepted" as const),
+}));
+
+vi.mock("../../../analytics.js", () => analyticsMocks);
+vi.mock("../install-guide-state.js", () => ({ isStandalone: () => false }));
+vi.mock("../use-install-guide.js", () => ({
+  useInstallPrompt: () => installMocks,
+}));
+
+describe("MobileInstallPage", () => {
+  let harness: DomHarness;
+
+  beforeEach(() => {
+    harness = createDomHarness();
+    analyticsMocks.trackEvent.mockReset();
+    installMocks.install.mockReset();
+    installMocks.install.mockResolvedValue("accepted");
+    installMocks.platform = "ios";
+    installMocks.mode = "ios";
+  });
+
+  afterEach(() => {
+    harness.cleanup();
+  });
+
+  function render(path: string): void {
+    harness.render(
+      <MemoryRouter initialEntries={[path]}>
+        <MobileInstallPage />
+      </MemoryRouter>,
+    );
+  }
+
+  it("shows the required Safari steps without promising silent installation", async () => {
+    render("/m/install?source=start_chat");
+    await harness.flush();
+
+    expect(harness.container.textContent).toContain("Install First Tree");
+    expect(harness.container.textContent).toContain("Tap Share in Safari");
+    expect(harness.container.textContent).toContain("Choose Add to Home Screen");
+    expect(harness.container.textContent).toContain("Sign in once after installation");
+    expect(harness.container.textContent).not.toContain("automatically");
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("mobile_install_page_opened", {
+      source: "start_chat",
+      platform: "ios",
+    });
+  });
+
+  it("offers one page click into Android's native prompt and records its outcome", async () => {
+    installMocks.platform = "android";
+    installMocks.mode = "native";
+    render("/m/install?source=user_menu");
+    await harness.flush();
+
+    const button = [...harness.container.querySelectorAll("button")].find((item) =>
+      item.textContent?.includes("Install First Tree"),
+    );
+    expect(button).toBeTruthy();
+    await act(async () => button?.click());
+    await harness.flush();
+
+    expect(installMocks.install).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("mobile_install_action", {
+      source: "user_menu",
+      platform: "android",
+      method: "native_prompt",
+      outcome: "accepted",
+    });
+    expect(harness.container.textContent).toContain("First Tree is installed");
+    expect(harness.container.textContent).toContain("Open it from your home screen");
+  });
+
+  it("recovers to Android's manual steps when the native prompt rejects", async () => {
+    installMocks.platform = "android";
+    installMocks.mode = "native";
+    installMocks.install.mockRejectedValueOnce(new Error("stale prompt"));
+    render("/m/install?source=user_menu");
+    await harness.flush();
+
+    const button = [...harness.container.querySelectorAll("button")].find((item) =>
+      item.textContent?.includes("Install First Tree"),
+    );
+    await act(async () => button?.click());
+    await harness.flush();
+
+    expect(harness.container.textContent).toContain("Open your browser menu");
+    expect(harness.container.textContent).toContain("The install prompt is not available yet.");
+    expect(harness.container.textContent).not.toContain("Opening installer");
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("mobile_install_action", {
+      source: "user_menu",
+      platform: "android",
+      method: "native_prompt",
+      outcome: "unavailable",
+    });
+  });
+
+  it("renders a same-origin QR handoff when opened on desktop", async () => {
+    installMocks.platform = "other";
+    installMocks.mode = null;
+    render("/m/install");
+    await harness.flush();
+
+    expect(harness.container.textContent).toContain("Open First Tree on your phone");
+    expect(harness.container.querySelector('span[role="img"] svg')).not.toBeNull();
+    expect(harness.container.textContent).toContain("only this public install link");
+  });
+});

--- a/packages/web/src/pages/mobile/__tests__/shell-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/shell-dom.test.tsx
@@ -28,9 +28,9 @@ const authMock = vi.hoisted(() => {
       currentOrgHasUsableAgent: true,
       currentOrgHasPersonalAgent: true,
       docsEnabled: false,
-      onboardingStep: "completed" as const,
+      onboardingStep: "completed" as "connect" | "create_agent" | "completed" | null,
       onboardingDismissedAt: null,
-      onboardingCompletedAt: "2026-07-01T00:00:00.000Z",
+      onboardingCompletedAt: "2026-07-01T00:00:00.000Z" as string | null,
       dismissOnboarding: vi.fn(async () => undefined),
       restoreOnboarding: vi.fn(async () => undefined),
       markOnboardingCompleted: vi.fn(async () => undefined),
@@ -103,6 +103,9 @@ describe("MobileShell", () => {
 
   beforeEach(() => {
     harness = createDomHarness();
+    authMock.value.onboardingStep = "completed";
+    authMock.value.onboardingCompletedAt = "2026-07-01T00:00:00.000Z";
+    authMock.value.currentOrgHasPersonalAgent = true;
     meChatMocks.listMeChats.mockReset();
     meChatMocks.listMeChats.mockReturnValue(new Promise(() => undefined));
     meChatMocks.listMeChatSourceCounts.mockReset();
@@ -147,6 +150,19 @@ describe("MobileShell", () => {
     expect(shell).not.toBeNull();
     expect((shell as HTMLElement).style.height).toBe("");
     expect(shell?.className).toContain("pt-safe-top");
+  });
+
+  it("hands incomplete setup back to desktop instead of opening complex onboarding on mobile", async () => {
+    authMock.value.onboardingStep = "create_agent";
+    authMock.value.onboardingCompletedAt = null;
+    authMock.value.currentOrgHasPersonalAgent = false;
+    renderShell(harness, "/m/work");
+    await harness.flush();
+
+    expect(harness.container.textContent).toContain("Finish setup on desktop");
+    expect(harness.container.textContent).toContain("Copy desktop setup link");
+    expect(harness.container.textContent).toContain("Use another account");
+    expect(harness.container.textContent).not.toContain("work content");
   });
 
   it("shares one active-list poller and one source-count poller between shell and Work", async () => {

--- a/packages/web/src/pages/mobile/__tests__/standalone-open-tracker.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/standalone-open-tracker.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDomHarness } from "../../../test-utils/dom-harness.js";
+import { MobileStandaloneOpenTracker } from "../standalone-open-tracker.js";
+
+const mocks = vi.hoisted(() => ({
+  standalone: true,
+  trackEvent: vi.fn(),
+}));
+
+vi.mock("../../../analytics.js", () => ({ trackEvent: mocks.trackEvent }));
+vi.mock("../install-guide-state.js", () => ({ isStandalone: () => mocks.standalone }));
+
+describe("MobileStandaloneOpenTracker", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.standalone = true;
+    mocks.trackEvent.mockReset();
+  });
+
+  it("records a standalone first open before auth and deduplicates later mounts", async () => {
+    const first = createDomHarness();
+    first.render(<MobileStandaloneOpenTracker />);
+    await first.flush();
+    expect(mocks.trackEvent).toHaveBeenCalledWith("mobile_standalone_first_open");
+    first.cleanup();
+
+    const second = createDomHarness();
+    second.render(<MobileStandaloneOpenTracker />);
+    await second.flush();
+    expect(mocks.trackEvent).toHaveBeenCalledTimes(1);
+    second.cleanup();
+  });
+
+  it("does not record ordinary browser opens", async () => {
+    mocks.standalone = false;
+    const harness = createDomHarness();
+    harness.render(<MobileStandaloneOpenTracker />);
+    await harness.flush();
+    expect(mocks.trackEvent).not.toHaveBeenCalled();
+    harness.cleanup();
+  });
+});

--- a/packages/web/src/pages/mobile/install.tsx
+++ b/packages/web/src/pages/mobile/install.tsx
@@ -1,0 +1,217 @@
+import { Check, Menu, Monitor, Share, SquarePlus } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Link, Navigate, useSearchParams } from "react-router";
+import { trackEvent } from "../../analytics.js";
+import { MobileInstallQr } from "../../components/mobile-install-promotion.js";
+import { Button } from "../../components/ui/button.js";
+import { readMobileInstallSource } from "../../lib/mobile-install.js";
+import { isStandalone } from "./install-guide-state.js";
+import { type InstallOutcome, useInstallPrompt } from "./use-install-guide.js";
+
+const IOS_STEPS = [
+  { label: "Tap Share in Safari", icon: Share },
+  { label: "Choose Add to Home Screen", icon: SquarePlus },
+  { label: "Open First Tree from your home screen", icon: Check },
+] as const;
+
+const ANDROID_STEPS = [
+  { label: "Open your browser menu", icon: Menu },
+  { label: "Choose Install app or Add to Home screen", icon: SquarePlus },
+  { label: "Open First Tree from your home screen", icon: Check },
+] as const;
+
+export function MobileInstallPage() {
+  const [searchParams] = useSearchParams();
+  const source = readMobileInstallSource(searchParams.get("source"));
+  const { platform, mode, install } = useInstallPrompt();
+  const [installing, setInstalling] = useState(false);
+  const [installOutcome, setInstallOutcome] = useState<InstallOutcome | null>(null);
+  const [nativeUnavailable, setNativeUnavailable] = useState(false);
+  const openedRef = useRef(false);
+
+  useEffect(() => {
+    if (openedRef.current) return;
+    openedRef.current = true;
+    trackEvent("mobile_install_page_opened", { source, platform });
+  }, [platform, source]);
+
+  if (isStandalone()) {
+    return <Navigate to="/m/work" replace />;
+  }
+
+  const onInstall = async (): Promise<void> => {
+    setInstalling(true);
+    try {
+      const outcome = await install();
+      trackEvent("mobile_install_action", { source, platform, method: "native_prompt", outcome });
+      setInstallOutcome(outcome);
+      setNativeUnavailable(outcome === "unavailable");
+    } catch {
+      trackEvent("mobile_install_action", {
+        source,
+        platform,
+        method: "native_prompt",
+        outcome: "unavailable",
+      });
+      setInstallOutcome("unavailable");
+      setNativeUnavailable(true);
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  const isDesktop = platform === "other";
+  const isNativeAndroid = platform === "android" && mode === "native" && !nativeUnavailable;
+  const steps = platform === "ios" ? IOS_STEPS : ANDROID_STEPS;
+
+  return (
+    <main
+      className="min-h-dvh-screen overflow-y-auto"
+      style={{
+        background: "var(--bg)",
+        color: "var(--fg)",
+        padding:
+          "calc(var(--sp-5) + env(safe-area-inset-top)) var(--sp-4) calc(var(--sp-6) + env(safe-area-inset-bottom))",
+      }}
+    >
+      <div className="mx-auto flex w-full max-w-md flex-col" style={{ gap: "var(--sp-6)" }}>
+        <header className="flex flex-col items-center text-center" style={{ gap: "var(--sp-2)" }}>
+          <img
+            src="/icons/first-tree-pwa.svg"
+            width={64}
+            height={64}
+            alt=""
+            style={{ borderRadius: "var(--radius-panel)" }}
+          />
+          <div>
+            <h1 className="text-headline" style={{ margin: 0 }}>
+              {isDesktop ? "Open First Tree on your phone" : "Install First Tree"}
+            </h1>
+            <p className="text-body" style={{ margin: "var(--sp-2) 0 0", color: "var(--fg-3)" }}>
+              {isDesktop
+                ? "Scan this code with your phone camera."
+                : "Keep your agent team one tap away, without the browser chrome."}
+            </p>
+          </div>
+        </header>
+
+        {isDesktop ? (
+          <section className="flex flex-col items-center text-center" style={{ gap: "var(--sp-3)" }}>
+            <MobileInstallQr source={source} className="h-56 w-56" />
+            <p className="text-label" style={{ margin: 0, color: "var(--fg-3)" }}>
+              The code contains only this public install link.
+            </p>
+          </section>
+        ) : (
+          <>
+            {installOutcome === "accepted" ? (
+              <section className="flex flex-col items-center text-center" style={{ gap: "var(--sp-3)" }}>
+                <span
+                  aria-hidden
+                  className="inline-flex items-center justify-center rounded-[var(--radius-full)]"
+                  style={{
+                    width: "var(--sp-10)",
+                    height: "var(--sp-10)",
+                    background: "var(--brand-bg)",
+                    color: "var(--brand)",
+                  }}
+                >
+                  <Check className="h-5 w-5" />
+                </span>
+                <div>
+                  <p className="text-subtitle" style={{ margin: 0 }}>
+                    First Tree is installed
+                  </p>
+                  <p className="text-label" style={{ margin: "var(--sp-1) 0 0", color: "var(--fg-3)" }}>
+                    Open it from your home screen, then sign in once.
+                  </p>
+                </div>
+              </section>
+            ) : isNativeAndroid ? (
+              <Button
+                type="button"
+                variant="cta"
+                size="lg"
+                className="w-full"
+                disabled={installing}
+                onClick={() => void onInstall()}
+              >
+                {installing ? "Opening installer…" : "Install First Tree"}
+              </Button>
+            ) : (
+              <InstallSteps steps={steps} />
+            )}
+
+            {platform === "android" && (mode !== "native" || nativeUnavailable) ? (
+              <p
+                role={nativeUnavailable ? "status" : undefined}
+                className="text-center text-label"
+                style={{ margin: 0, color: "var(--fg-3)" }}
+              >
+                {nativeUnavailable
+                  ? "The install prompt is not available yet. Use the browser menu above."
+                  : "If your browser offers an install prompt, the install button will appear automatically."}
+              </p>
+            ) : null}
+
+            <div
+              className="flex items-start"
+              style={{
+                gap: "var(--sp-3)",
+                paddingTop: "var(--sp-5)",
+                borderTop: "var(--hairline) solid var(--border)",
+              }}
+            >
+              <Monitor aria-hidden className="mt-0.5 h-4 w-4 shrink-0" style={{ color: "var(--fg-3)" }} />
+              <div>
+                <p className="text-subtitle" style={{ margin: 0 }}>
+                  Sign in once after installation
+                </p>
+                <p className="text-label" style={{ margin: "var(--sp-1) 0 0", color: "var(--fg-3)" }}>
+                  Use the same Google or GitHub account as on desktop. No setup is copied through the QR code.
+                </p>
+              </div>
+            </div>
+
+            <Button asChild variant="ghost" className="w-full">
+              <Link to="/m/work">Continue in browser</Link>
+            </Button>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function InstallSteps({ steps }: { steps: ReadonlyArray<{ label: string; icon: typeof Share }> }) {
+  return (
+    <ol className="flex flex-col" style={{ gap: "var(--sp-1)", margin: 0, padding: 0, listStyle: "none" }}>
+      {steps.map((step, index) => (
+        <li
+          key={step.label}
+          className="flex items-center"
+          style={{
+            gap: "var(--sp-3)",
+            padding: "var(--sp-3)",
+            borderBottom: index === steps.length - 1 ? "none" : "var(--hairline) solid var(--border-faint)",
+          }}
+        >
+          <span
+            aria-hidden
+            className="mono inline-flex shrink-0 items-center justify-center rounded-[var(--radius-full)] text-caption"
+            style={{
+              width: "var(--sp-7)",
+              height: "var(--sp-7)",
+              background: "var(--bg-sunken)",
+              color: "var(--fg-3)",
+            }}
+          >
+            {index + 1}
+          </span>
+          <step.icon aria-hidden className="h-4 w-4 shrink-0" style={{ color: "var(--fg-2)" }} />
+          <span className="text-body">{step.label}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/packages/web/src/pages/mobile/setup-handoff.tsx
+++ b/packages/web/src/pages/mobile/setup-handoff.tsx
@@ -1,0 +1,81 @@
+import { Check, Copy, Monitor } from "lucide-react";
+import { useNavigate } from "react-router";
+import { useAuth } from "../../auth/auth-context.js";
+import { Button } from "../../components/ui/button.js";
+import { useCopyFeedback } from "../../lib/use-copy-feedback.js";
+
+function desktopSetupUrl(): string {
+  if (typeof window === "undefined") return "/onboarding";
+  const origin = window.location.origin;
+  if (typeof origin !== "string" || !origin.startsWith("http")) return "/onboarding";
+  return `${origin}/onboarding`;
+}
+
+export function MobileSetupHandoff() {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+  const copyFeedback = useCopyFeedback();
+  const setupUrl = desktopSetupUrl();
+
+  const useAnotherAccount = (): void => {
+    logout();
+    navigate("/login", {
+      replace: true,
+      state: { from: { pathname: "/m/work", search: "", hash: "" } },
+    });
+  };
+
+  return (
+    <main
+      className="grid min-h-dvh-screen place-items-center"
+      style={{
+        background: "var(--bg)",
+        color: "var(--fg)",
+        padding:
+          "calc(var(--sp-6) + env(safe-area-inset-top)) var(--sp-4) calc(var(--sp-6) + env(safe-area-inset-bottom))",
+      }}
+    >
+      <section className="flex w-full max-w-sm flex-col text-center" style={{ gap: "var(--sp-5)" }}>
+        <span
+          aria-hidden
+          className="mx-auto inline-flex items-center justify-center rounded-[var(--radius-full)]"
+          style={{
+            width: "var(--sp-12)",
+            height: "var(--sp-12)",
+            background: "var(--bg-sunken)",
+            color: "var(--fg-2)",
+          }}
+        >
+          <Monitor className="h-5 w-5" />
+        </span>
+
+        <div>
+          <h1 className="text-mobile-title" style={{ margin: 0 }}>
+            Finish setup on desktop
+          </h1>
+          <p className="text-mobile-body" style={{ margin: "var(--sp-2) 0 0", color: "var(--fg-3)" }}>
+            Finish the guided First Tree setup on a computer, then reopen the app here.
+          </p>
+        </div>
+
+        <div className="flex flex-col" style={{ gap: "var(--sp-2)" }}>
+          <Button type="button" onClick={() => void copyFeedback.copy(setupUrl)}>
+            {copyFeedback.status === "copied" ? (
+              <Check aria-hidden className="h-4 w-4" />
+            ) : (
+              <Copy aria-hidden className="h-4 w-4" />
+            )}
+            {copyFeedback.status === "copied"
+              ? "Desktop setup link copied"
+              : copyFeedback.status === "failed"
+                ? "Copy failed"
+                : "Copy desktop setup link"}
+          </Button>
+          <Button type="button" variant="ghost" onClick={useAnotherAccount}>
+            Use another account
+          </Button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/packages/web/src/pages/mobile/shell.tsx
+++ b/packages/web/src/pages/mobile/shell.tsx
@@ -1,5 +1,5 @@
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { Navigate, Outlet, useLocation, useSearchParams } from "react-router";
+import { Outlet, useLocation, useSearchParams } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
 import { TeamSwitchOverlay } from "../../components/team-switch-overlay.js";
 import { useAdminWs } from "../../hooks/use-admin-ws.js";
@@ -7,6 +7,7 @@ import { shouldEnterOnboarding } from "../onboarding/steps.js";
 import { MobileBottomTabs } from "./components.js";
 import { mobileRowsFromList } from "./data.js";
 import { InstallGuideSheet } from "./install-guide-sheet.js";
+import { MobileSetupHandoff } from "./setup-handoff.js";
 import { useInstallGuideAuto } from "./use-install-guide.js";
 import { mobileWorkListQueryOptions, mobileWorkSourceCountsQueryOptions } from "./work-queries.js";
 
@@ -64,7 +65,7 @@ export function MobileShell() {
       onboardingCompletedAt,
     })
   ) {
-    return <Navigate to="/onboarding" replace />;
+    return <MobileSetupHandoff />;
   }
 
   return (

--- a/packages/web/src/pages/mobile/standalone-open-tracker.tsx
+++ b/packages/web/src/pages/mobile/standalone-open-tracker.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { trackEvent } from "../../analytics.js";
+import { isStandalone } from "./install-guide-state.js";
+
+const STORAGE_KEY = "first-tree:mobile-standalone-opened";
+
+/**
+ * Runs before auth routing so a newly installed PWA opening into sign-in is
+ * counted, not only users who make it through OAuth to MobileShell.
+ */
+export function MobileStandaloneOpenTracker() {
+  useEffect(() => {
+    if (!isStandalone()) return;
+    try {
+      if (localStorage.getItem(STORAGE_KEY) === "1") return;
+      localStorage.setItem(STORAGE_KEY, "1");
+    } catch {
+      // Analytics is optional. Storage denial must never block the mobile app.
+    }
+    trackEvent("mobile_standalone_first_open");
+  }, []);
+
+  return null;
+}

--- a/packages/web/src/pages/mobile/use-install-guide.ts
+++ b/packages/web/src/pages/mobile/use-install-guide.ts
@@ -94,11 +94,16 @@ export function useInstallPrompt(): {
   const install = useCallback(async (): Promise<InstallOutcome> => {
     if (!deferredPrompt) return "unavailable";
     const event = deferredPrompt;
-    await event.prompt();
-    const choice = await event.userChoice;
-    deferredPrompt = null;
-    publish();
-    return choice.outcome;
+    try {
+      await event.prompt();
+      const choice = await event.userChoice;
+      return choice.outcome;
+    } catch {
+      return "unavailable";
+    } finally {
+      if (deferredPrompt === event) deferredPrompt = null;
+      publish();
+    }
   }, []);
 
   return { platform, mode, install };

--- a/packages/web/src/pages/onboarding/copy.ts
+++ b/packages/web/src/pages/onboarding/copy.ts
@@ -311,7 +311,7 @@ export const COPY = {
      *  (shared with the top-bar SupportMenu), so only the onboarding-surface
      *  heading is copy here. */
     community: {
-      title: "Join the community",
+      title: "Stay connected",
     },
   },
   /** invitee · join-team confirmation + the one not-ready (blocked-on-admin) state.

--- a/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
+++ b/packages/web/src/pages/onboarding/steps/step-start-chat.tsx
@@ -502,8 +502,8 @@ function StartingState() {
 }
 
 /**
- * "Join the community" — the two channel cards (WeChat / Discord, see
- * CommunityChannels) as a footer under the launch CTA. Rendered only in the
+ * "Stay connected" — the mobile install and community cards as a footer under
+ * the launch CTA. Rendered only in the
  * stable finale bodies (never during loading/starting transitions), separated
  * from the primary action by a hairline so it reads as a footer and can't
  * compete with "Start chat".
@@ -522,7 +522,7 @@ function CommunityBlock() {
       <span className="text-label font-medium" style={{ color: "var(--fg-3)" }}>
         {COPY.startChat.community.title}
       </span>
-      <CommunityChannels />
+      <CommunityChannels includeMobile />
     </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.4)
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -4499,6 +4502,11 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -9497,6 +9505,10 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  qrcode.react@4.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   qs@6.15.2:
     dependencies:


### PR DESCRIPTION
## Summary

- add same-origin QR promotion to the Start chat finale and the desktop user menu
- add a public, channel-gated `/m/install` journey with iOS instructions, Android native-prompt support, and a manual fallback
- keep authentication deliberately simple: install first, then use the existing OAuth flow once and return to `/m/work`
- hand incomplete mobile setup back to desktop instead of duplicating onboarding on the phone
- add low-cardinality funnel events, standalone first-open tracking, safe-area handling, focus restoration, and prompt-failure recovery

The QR code contains only the deployment origin, `/m/install`, and an allowlisted source value. It contains no token, user, Team, or workspace data.

Related to #2006. This MVP intentionally does not add pairing, connect codes, token handoff, backend state, or new credential types.

Mobile scope: allowlisted / handoff

- install and OAuth entry are mobile-native surfaces
- first-agent and computer setup remain a desktop handoff

## Validation

- `pnpm typecheck` — 10/10 monorepo tasks passed, including the production web build
- `pnpm --filter @first-tree/web test` — 207 files, 1,748 tests passed
- changed-file Biome check and `git diff --check` passed
- real-browser validation covered the channel-gated desktop install page and 320px viewport; earlier device emulation covered iOS instructions, Android fallback, mobile OAuth copy, and the user-menu QR dialog
- two independent architecture/security and UX/accessibility reviews completed; all findings were fixed and both re-reviews were clean

The full monorepo test run had one unrelated CLI test timeout under parallel load; that exact test passed immediately when rerun in isolation.

## QA

Formal device QA is warranted before release because this touches the mobile install and OAuth entry journey. This PR
adds the reusable `mobile-pwa-install-and-auth-handoff` case for physical iOS/Android installation, standalone OAuth,
same-origin QR privacy, Android fallback, and incomplete-setup handoff. The formal device run remains human-directed
and was not performed as part of this change.

## Context

The matching authoritative mobile-scope admission is reconciled in
`agent-team-foundation/first-tree-context#730`. Per the repository's code-first Context workflow, that PR remains draft
while this delivery PR is open; after this code merges, its node must be reconciled against the exact merged behavior,
made ready, independently approved, and merged.
