### PR TITLE
feat: add CLA signing workflow

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -43,6 +43,11 @@ the default branch. Immediately after that pull request merges:
    blocked, the exact ICLA signing comment records the documented fields on
    `cla-signatures`, and the same `CLA` check then succeeds.
 
+Every non-closed workflow run validates the complete ledger after the upstream
+action and any profile enrichment. A queued rerun therefore cannot make the
+required check succeed when an ICLA record is missing either its base evidence
+or the profile fields promised by the agreement.
+
 If adding the required check fails, stop merges until an administrator restores
 the gate. Do not weaken or replace the existing required checks as a workaround.
 

--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,54 @@
+# CLA operations
+
+The `CLA` workflow is a legal and merge-control boundary. Changes to its
+agreement links, signing phrase, signature schema, storage branch, action pin,
+or allowlist require the same review as the workflow itself.
+
+Before activation, the Foundation's legal owner must confirm that the public
+signature fields, branch access, retention policy, and history-tampering
+controls are appropriate. Repository review does not replace that legal and
+records-management decision.
+
+## Initial deployment
+
+The pull request that first adds `.github/workflows/cla.yml` is the only
+bootstrap exception because GitHub loads `pull_request_target` workflows from
+the default branch. Immediately after that pull request merges:
+
+1. Add the `CLA` GitHub Actions job to the existing required checks without
+   replacing the other checks:
+
+   ```bash
+   protection="repos/agent-team-foundation/first-tree/branches/main/protection/required_status_checks"
+   gh api "${protection}" |
+     jq '{
+       strict,
+       checks: (
+         .checks + [{"context": "CLA", "app_id": 15368}] |
+         unique_by([.context, .app_id])
+       )
+     }' |
+     gh api --method PATCH "${protection}" --input -
+   ```
+
+2. Read the protection back and confirm that `CLA` is present:
+
+   ```bash
+   gh api \
+     repos/agent-team-foundation/first-tree/branches/main/protection/required_status_checks \
+     --jq '.checks'
+   ```
+
+3. Open a verification pull request. Confirm that an unsigned human author is
+   blocked, the exact ICLA signing comment records the documented fields on
+   `cla-signatures`, and the same `CLA` check then succeeds.
+
+If adding the required check fails, stop merges until an administrator restores
+the gate. Do not weaken or replace the existing required checks as a workaround.
+
+## Corporate coverage
+
+Only add a GitHub username to the workflow allowlist after the Foundation has
+verified an executed CCLA and confirmed that the username appears in its
+Schedule A. Make allowlist changes through a reviewed pull request; do not edit
+the signature ledger to grant coverage.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -37,9 +37,16 @@ jobs:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://gist.githubusercontent.com/bestony/5a32ba8d5daa68b95adab6a9bba9c1cc/raw/dffb751c6fcb4c0d3b6df087e2353f149ab0e24b/icla.md
           branch: cla-signatures
+          # Add GitHub usernames from a verified CCLA Schedule A here.
           allowlist: "*[bot]"
           custom-notsigned-prcomment: >-
-            Thank you for your contribution. Before it can be accepted, $you must be covered by the [First Tree ICLA v1.0](https://gist.githubusercontent.com/bestony/5a32ba8d5daa68b95adab6a9bba9c1cc/raw/dffb751c6fcb4c0d3b6df087e2353f149ab0e24b/icla.md). Sign individually with the exact comment below. If you contribute for an organization, an authorized signatory can instead complete the [First Tree CCLA v1.0](https://gist.githubusercontent.com/bestony/5a32ba8d5daa68b95adab6a9bba9c1cc/raw/dffb751c6fcb4c0d3b6df087e2353f149ab0e24b/ccla.md) and send it to legal@first-tree.ai for verification.
+            Thank you for your contribution. Before it can be accepted, $you
+            must be covered by the [First Tree ICLA v1.0](https://gist.githubusercontent.com/bestony/5a32ba8d5daa68b95adab6a9bba9c1cc/raw/dffb751c6fcb4c0d3b6df087e2353f149ab0e24b/icla.md).
+            Sign individually with the exact comment below. If you contribute
+            for an organization, an authorized signatory can instead complete
+            the [First Tree CCLA v1.0](https://gist.githubusercontent.com/bestony/5a32ba8d5daa68b95adab6a9bba9c1cc/raw/dffb751c6fcb4c0d3b6df087e2353f149ab0e24b/ccla.md)
+            and send it to legal@first-tree.ai for verification.
           custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
           custom-allsigned-prcomment: All contributors are covered by the First Tree CLA.
           lock-pullrequest-aftermerge: true
+          suggest-recheck: true

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -155,3 +155,45 @@ jobs:
             --input - \
             <<<"${payload}" \
             >/dev/null
+
+      - name: Validate signature record completeness
+        if: >-
+          always() &&
+          steps.commit-range.outcome == 'success' &&
+          (github.event_name != 'pull_request_target' ||
+           github.event.action != 'closed')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          SIGNATURE_BRANCH: cla-signatures
+          SIGNATURE_PATH: signatures/version1/cla.json
+        run: |
+          set -euo pipefail
+
+          ledger_response="$(gh api \
+            "repos/${REPOSITORY}/contents/${SIGNATURE_PATH}?ref=${SIGNATURE_BRANCH}")"
+          ledger="$(jq -r '.content' <<<"${ledger_response}" | base64 --decode)"
+
+          if ! jq -e '
+            if (.signedContributors | type) != "array" then
+              false
+            else
+              all(.signedContributors[];
+                ((.name | type) == "string") and
+                ((.name | length) > 0) and
+                ((.id | type) == "number") and
+                ((.comment_id | type) == "number") and
+                ((.created_at | type) == "string") and
+                ((.created_at | length) > 0) and
+                ((.repoId | type) == "number") and
+                ((.pullRequestNo | type) == "number") and
+                has("full_name") and
+                (.full_name == null or (.full_name | type) == "string") and
+                has("public_email") and
+                (.public_email == null or (.public_email | type) == "string")
+              )
+            end
+          ' <<<"${ledger}" >/dev/null; then
+            echo "::error title=Incomplete CLA signature ledger::Every ICLA record must contain the base signature evidence plus the public profile fields promised by the agreement."
+            exit 1
+          fi

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,8 @@ on:
 
 concurrency:
   group: cla-signatures-${{ github.repository }}
-  cancel-in-progress: false
+  # GitHub supports a FIFO queue here; actionlint v1.7.12 does not yet know it.
+  queue: max
 
 permissions: {}
 
@@ -29,6 +30,32 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Enforce verified commit range
+        id: commit-range
+        if: >-
+          github.event_name != 'pull_request_target' ||
+          github.event.action != 'closed'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          commit_count="$(gh api \
+            "repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
+            --jq '.commits')"
+
+          if [[ ! "${commit_count}" =~ ^[0-9]+$ ]]; then
+            echo "::error title=Unable to verify CLA commit range::GitHub returned an invalid commit count."
+            exit 1
+          fi
+
+          if (( commit_count > 100 )); then
+            echo "::error title=CLA verification limit exceeded::This pull request has ${commit_count} commits, but the pinned CLA action can verify at most 100. Squash or rebase it to 100 commits or fewer."
+            exit 1
+          fi
+
       - name: Verify contributor signatures
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
@@ -50,3 +77,81 @@ jobs:
           custom-allsigned-prcomment: All contributors are covered by the First Tree CLA.
           lock-pullrequest-aftermerge: true
           suggest-recheck: true
+
+      - name: Capture public profile fields in the signature record
+        if: >-
+          always() &&
+          steps.commit-range.outcome == 'success' &&
+          github.event_name == 'issue_comment' &&
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          SIGNATURE_BRANCH: cla-signatures
+          SIGNATURE_PATH: signatures/version1/cla.json
+          SIGNATURE_COMMENT_ID: ${{ github.event.comment.id }}
+          SIGNER_ID: ${{ github.event.comment.user.id }}
+          SIGNER_LOGIN: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${SIGNATURE_COMMENT_ID}" =~ ^[0-9]+$ ]] ||
+             [[ ! "${SIGNER_ID}" =~ ^[0-9]+$ ]]; then
+            echo "::error title=Unable to enrich CLA signature::GitHub returned an invalid signer or comment ID."
+            exit 1
+          fi
+
+          profile="$(gh api "users/${SIGNER_LOGIN}")"
+          profile_name="$(jq -c '.name' <<<"${profile}")"
+          profile_email="$(jq -c '.email' <<<"${profile}")"
+          ledger_response="$(gh api \
+            "repos/${REPOSITORY}/contents/${SIGNATURE_PATH}?ref=${SIGNATURE_BRANCH}")"
+          ledger_sha="$(jq -r '.sha' <<<"${ledger_response}")"
+          ledger="$(jq -r '.content' <<<"${ledger_response}" | base64 --decode)"
+
+          signature_count="$(jq \
+            --argjson signer_id "${SIGNER_ID}" \
+            '[.signedContributors[] | select(.id == $signer_id)] | length' \
+            <<<"${ledger}")"
+
+          if (( signature_count == 0 )); then
+            echo "::error title=Unable to enrich CLA signature::The signer was not found in the signature ledger."
+            exit 1
+          fi
+
+          updated_ledger="$(jq \
+            --argjson comment_id "${SIGNATURE_COMMENT_ID}" \
+            --argjson signer_id "${SIGNER_ID}" \
+            --argjson full_name "${profile_name}" \
+            --argjson public_email "${profile_email}" \
+            '.signedContributors |= map(
+              if .comment_id == $comment_id or
+                 (.id == $signer_id and
+                  ((has("full_name") and has("public_email")) | not))
+              then . + {
+                full_name: $full_name,
+                public_email: $public_email
+              }
+              else .
+              end
+            )' \
+            <<<"${ledger}")"
+
+          if [[ "${updated_ledger}" == "${ledger}" ]]; then
+            exit 0
+          fi
+
+          encoded_ledger="$(printf '%s\n' "${updated_ledger}" | base64 | tr -d '\n')"
+          payload="$(jq -n \
+            --arg message "Record public profile fields for @${SIGNER_LOGIN}" \
+            --arg content "${encoded_ledger}" \
+            --arg sha "${ledger_sha}" \
+            --arg branch "${SIGNATURE_BRANCH}" \
+            '{message: $message, content: $content, sha: $sha, branch: $branch}')"
+
+          gh api \
+            --method PUT \
+            "repos/${REPOSITORY}/contents/${SIGNATURE_PATH}" \
+            --input - \
+            <<<"${payload}" \
+            >/dev/null

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,45 @@
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, reopened, synchronize, closed]
+
+concurrency:
+  group: cla-signatures-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  cla:
+    name: CLA
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      (github.event.action != 'closed' || github.event.pull_request.merged == true) ||
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      (github.event.comment.body == 'recheck' ||
+       github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Verify contributor signatures
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://gist.githubusercontent.com/bestony/5a32ba8d5daa68b95adab6a9bba9c1cc/raw/dffb751c6fcb4c0d3b6df087e2353f149ab0e24b/icla.md
+          branch: cla-signatures
+          allowlist: "*[bot]"
+          custom-notsigned-prcomment: >-
+            Thank you for your contribution. Before it can be accepted, $you must be covered by the [First Tree ICLA v1.0](https://gist.githubusercontent.com/bestony/5a32ba8d5daa68b95adab6a9bba9c1cc/raw/dffb751c6fcb4c0d3b6df087e2353f149ab0e24b/icla.md). Sign individually with the exact comment below. If you contribute for an organization, an authorized signatory can instead complete the [First Tree CCLA v1.0](https://gist.githubusercontent.com/bestony/5a32ba8d5daa68b95adab6a9bba9c1cc/raw/dffb751c6fcb4c0d3b6df087e2353f149ab0e24b/ccla.md) and send it to legal@first-tree.ai for verification.
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: All contributors are covered by the First Tree CLA.
+          lock-pullrequest-aftermerge: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,28 @@ Highlights:
 - If the PR changes the command surface, `docs/cli-reference.md` is
   updated in the same PR.
 
+## Contributor license agreement
+
+Every human commit author on a pull request must be covered by a Contributor
+License Agreement before the change can be merged. Automated bot accounts are
+exempt.
+
+- **Individual contributors:** read the
+  [Individual Contributor License Agreement (ICLA) v1.0](https://gist.githubusercontent.com/bestony/5a32ba8d5daa68b95adab6a9bba9c1cc/raw/dffb751c6fcb4c0d3b6df087e2353f149ab0e24b/icla.md),
+  then post this exact comment on the pull request:
+  `I have read the CLA Document and I hereby sign the CLA`.
+- **Contributors signing for an organization:** have an authorized signatory
+  complete the
+  [Corporate Contributor License Agreement (CCLA) v1.0](https://gist.githubusercontent.com/bestony/5a32ba8d5daa68b95adab6a9bba9c1cc/raw/dffb751c6fcb4c0d3b6df087e2353f149ab0e24b/ccla.md)
+  and email it to `legal@first-tree.ai`. The Foundation must verify the CCLA
+  and the GitHub usernames listed in its Schedule A before those contributors
+  are treated as covered.
+
+The `CLA` workflow records ICLA signature metadata in
+`signatures/version1/cla.json` on the dedicated `cla-signatures` branch. That
+branch is only a signature ledger; source changes continue to go through pull
+requests against `main`.
+
 ## Filing issues
 
 Bugs, feature ideas, and questions are all welcome. Please include:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,11 @@ exempt.
 
 The `CLA` workflow records ICLA signature metadata in
 `signatures/version1/cla.json` on the dedicated `cla-signatures` branch. That
-branch is only a signature ledger; source changes continue to go through pull
-requests against `main`.
+record includes the GitHub username and stable account, comment, repository,
+and pull-request identifiers; the signature timestamp; and the profile name
+and public email exposed by GitHub at signing time. The branch is only a
+signature ledger; source changes continue to go through pull requests against
+`main`.
 
 ## Filing issues
 


### PR DESCRIPTION
## Summary

- add a CLA workflow for pull requests and signature comments
- document individual and corporate contribution paths in `CONTRIBUTING.md`
- store signature metadata on the dedicated `cla-signatures` branch

## Design

- Pins `contributor-assistant/github-action` v2.6.1 to commit `ca4a40a7d1004f18d9960b404b97e5f30a505a08`.
- Pins the supplied ICLA and CCLA v1.0 documents to Gist revision `dffb751c6fcb4c0d3b6df087e2353f149ab0e24b` so an accepted signature always refers to fixed terms.
- Serializes every ledger event with GitHub's FIFO `queue: max`, exempts bot accounts, supports exact comment signing and `recheck`, and locks only merged pull requests.
- Fails closed when a pull request exceeds the pinned action's 100-commit verification range.
- Supplements the action's stable IDs and timestamp with the signer's GitHub profile name and public email so the retained record matches the ICLA.
- Validates the complete ledger schema at the end of every non-closed run, so an already-queued required-check rerun cannot pass after enrichment fails.
- Uses the pre-created unprotected `cla-signatures` branch because `main` is protected and the upstream action must write its JSON ledger directly. Commit [`bb7bd5a`](https://github.com/agent-team-foundation/first-tree/commit/bb7bd5aee082c31e05f023c396f5355322d5dbb5) pre-seeds a schema-valid empty ledger so the action does not fail merely to create the file on its first run.
- Documents the one-time bootstrap exception and the exact post-merge command that appends `CLA` to the existing `main` required checks without replacing them.

The upstream action repository was archived on 2026-03-23. Pinning the full commit SHA prevents tag drift, but the workflow will need a maintained replacement or fork if future GitHub Actions changes break compatibility.

## Validation

- [x] The current SchemaStore GitHub workflow schema validates the complete workflow, including `concurrency.queue`.
- [x] `actionlint` v1.7.12 and ShellCheck pass after suppressing only actionlint's known unsupported `queue` diagnostic ([rhysd/actionlint#657](https://github.com/rhysd/actionlint/issues/657)).
- [x] Sample ledger fixtures verify profile-field enrichment, duplicate-signature behavior, valid empty/enriched ledgers, and rejection of unenriched records.
- [x] The generated branch-protection payload preserves all existing checks and appends `CLA`.
- [x] `git diff --check`
- [x] `pnpm check` (passes with existing warnings outside this diff)
- [x] `pnpm typecheck`
- [ ] `pnpm test` could not complete locally: server tests have no Docker/Testcontainers runtime; the host's Node 26 also exposes existing Web `localStorage`, client, and skill-eval timeout failures. This PR does not touch those paths; Node 22 CI with its PostgreSQL service is the authoritative full run.

## Context Tree

Companion draft PR: https://github.com/agent-team-foundation/first-tree-context/pull/824

It records the durable contributor-licensing policy and must remain draft until this code PR merges.

## Follow-up

- Chinese contributor-guide parity: #2024

## Activation gate

Before merge, the Foundation's legal owner must confirm the public signature
fields, branch access, retention policy, and tamper boundary. After this PR is
merged as the one-time bootstrap exception, a repository administrator must
immediately run the required-check sequence in `.github/CLA.md`; the task is
complete only after `CLA` appears in `main` branch protection and the
unsigned/signed verification PR behaves as documented.
