### PR TITLE
Fix anonymous GitLab snapshots with Git 2.43

### DIFF
--- a/packages/server/src/__tests__/context-tree-snapshot-git-mocked.test.ts
+++ b/packages/server/src/__tests__/context-tree-snapshot-git-mocked.test.ts
@@ -38,6 +38,8 @@ describe("Context Tree snapshot service with mocked git", () => {
   it("materializes public GitLab content anonymously without credential injection", async () => {
     const repo = `https://gitlab.example/public/context-${crypto.randomUUID()}`;
     const head = "a".repeat(40);
+    const previousSslCert = process.env.GIT_SSL_CERT;
+    const previousSslKey = process.env.GIT_SSL_KEY;
     const { execFile, service } = await loadSnapshotServiceWithGit((args) => {
       if (args.includes("clone")) {
         const root = args.at(-1);
@@ -55,6 +57,8 @@ describe("Context Tree snapshot service with mocked git", () => {
     const root = service.contextTreeSnapshotTestInternals.managedContextTreePath(anonymousUrl, "main");
 
     try {
+      process.env.GIT_SSL_CERT = join(tmpdir(), "ambient-client-cert.pem");
+      process.env.GIT_SSL_KEY = join(tmpdir(), "ambient-client-key.pem");
       const resolved = await service.contextTreeSnapshotTestInternals.resolveContextTreeRoot(
         repo,
         null,
@@ -91,6 +95,10 @@ describe("Context Tree snapshot service with mocked git", () => {
       const env = (cloneCall?.[2] as { env?: Record<string, string> } | undefined)?.env ?? {};
       expect(Object.keys(env).some((key) => /gitlab.*token|git_password/iu.test(key))).toBe(false);
       expect(Object.keys(env).some((key) => /^(?:http|https|all|no)_proxy$/iu.test(key))).toBe(false);
+      expect(env.GIT_SSL_CERT).toBeUndefined();
+      expect(env.GIT_SSL_KEY).toBeUndefined();
+      expect(cloneCall?.[1]).not.toContain("http.sslCert=");
+      expect(cloneCall?.[1]).not.toContain("http.sslKey=");
       expect(cloneCall?.[1]).toEqual(
         expect.arrayContaining([
           "-c",
@@ -100,6 +108,10 @@ describe("Context Tree snapshot service with mocked git", () => {
         ]),
       );
     } finally {
+      if (previousSslCert === undefined) delete process.env.GIT_SSL_CERT;
+      else process.env.GIT_SSL_CERT = previousSslCert;
+      if (previousSslKey === undefined) delete process.env.GIT_SSL_KEY;
+      else process.env.GIT_SSL_KEY = previousSslKey;
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/packages/server/src/services/gitlab-anonymous-snapshot.ts
+++ b/packages/server/src/services/gitlab-anonymous-snapshot.ts
@@ -38,14 +38,15 @@ export async function anonymousGitEnv(cacheRoot: string): Promise<NodeJS.Process
 /** Git config for anonymous, address-pinned HTTPS with redirect/auth isolation. */
 export function gitlabAnonymousGitConfig(destination: GitlabPinnedDestination | null | undefined): string[] {
   if (!destination) throw new GitlabEgressPolicyError("origin_not_authorized");
+  // Client certificates are isolated through anonymousGitEnv and the cached
+  // repository config guard. Empty http.sslCert values make some Git/libcurl
+  // builds fail before network access instead of clearing the certificate.
   return [
     "http.followRedirects=false",
     "http.curloptResolve=",
     `http.${destination.origin}/.curloptResolve=${destination.curlResolve}`,
     "http.extraHeader=",
     "http.cookieFile=",
-    "http.sslCert=",
-    "http.sslKey=",
     "http.proxy=",
     "credential.helper=",
   ];


### PR DESCRIPTION
## Summary

- remove empty `http.sslCert` and `http.sslKey` command-line config values from anonymous GitLab snapshot operations because Git 2.43/libcurl can interpret an empty certificate value as a certificate file path and fail before egress
- preserve the anonymous-only boundary through the existing proxy, credential, `GIT_SSL_*`, HOME, global/system config, and cached-repository isolation
- add regression coverage proving ambient client certificate variables are stripped and the incompatible empty Git config values do not return

## Validation

- `pnpm --filter @first-tree/server exec vitest run src/__tests__/context-tree-snapshot-git-mocked.test.ts --maxWorkers=2` (18/18)
- `pnpm check` (passes with existing warnings)
- `pnpm typecheck`
- targeted Biome check and `git diff --check`
- real anonymous `git ls-remote` against the reported Self-Managed GitLab repository: reproduced the X.509 failure with `http.sslCert=` and successfully read `refs/heads/main` after removing the empty client-certificate config

A full Server test run was also attempted. The affected suite passed, while one unrelated cron time assertion failed in `cron-jobs.integration.test.ts` (expected an earlier timestamp and received the next scheduled hour); 244 files and 2,676 tests passed.

## QA

Formal cross-surface QA is warranted because this changes the GitLab provider/auth egress path. The existing `packages/qa/cases/cross-surface/gitlab-context-tree-lifecycle.md` case covers anonymous public Web Context, private/unauthorized degradation, and ambient credential/config isolation. Formal QA was not run automatically.
