### PR TITLE
perf(server): eliminate N+1 queries in inbox context assembly and bound-agent validation

### DIFF
--- a/packages/server/src/__tests__/inbox-ws-push.test.ts
+++ b/packages/server/src/__tests__/inbox-ws-push.test.ts
@@ -366,6 +366,84 @@ describe("inbox WS data-plane claim helpers", () => {
     expect(afterAck.map((row) => row.status)).toEqual(["acked", "acked"]);
   });
 
+  it("splits per-trigger silent context inside one multi-chat batch claim", async () => {
+    const app = getApp();
+    const uid = crypto.randomUUID().slice(0, 6);
+    const human = await createTestAgent(app, { type: "human", name: `batch-h-${uid}` });
+    const observer = await createTestAgent(app, { type: "agent", name: `batch-obs-${uid}` });
+    const chatA = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [observer.agent.uuid],
+    });
+    const chatB = await createChat(app.db, human.agent.uuid, {
+      type: "group",
+      participantIds: [observer.agent.uuid],
+    });
+
+    // Chat A timeline: silent → trigger one → silent → trigger two, with a
+    // chat B silent + trigger interleaved so one claim spans both chats and
+    // multiple same-chat triggers.
+    await sendMessage(
+      app.db,
+      chatA.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "chatA silent one" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(app.db, chatA.id, human.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "chatA trigger one",
+      metadata: { mentions: [observer.agent.uuid] },
+    });
+    await sendMessage(
+      app.db,
+      chatA.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "chatA silent two" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(
+      app.db,
+      chatB.id,
+      human.agent.uuid,
+      { source: "api", format: "text", content: "chatB silent one" },
+      { allowRecipientlessSend: true },
+    );
+    await sendMessage(app.db, chatA.id, human.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "chatA trigger two",
+      metadata: { mentions: [observer.agent.uuid] },
+    });
+    await sendMessage(app.db, chatB.id, human.agent.uuid, {
+      source: "api",
+      format: "text",
+      content: "chatB trigger",
+      metadata: { mentions: [observer.agent.uuid] },
+    });
+
+    const drained = await inboxService.claimBacklogForPush(app.db, observer.agent.inboxId, 10);
+    expect(drained).toHaveLength(3);
+    const byContent = new Map(drained.map((entry) => [entry.message.content, entry]));
+    expect(byContent.get("chatA trigger one")?.message.precedingMessages.map((p) => p.content)).toEqual([
+      "chatA silent one",
+    ]);
+    expect(byContent.get("chatA trigger two")?.message.precedingMessages.map((p) => p.content)).toEqual([
+      "chatA silent two",
+    ]);
+    expect(byContent.get("chatB trigger")?.message.precedingMessages.map((p) => p.content)).toEqual([
+      "chatB silent one",
+    ]);
+
+    // Bundling is not consumption: every silent row stays pending until the
+    // client ACKs through its notify trigger.
+    const silentA = await loadSilentRows(app, observer.agent.inboxId, chatA.id);
+    const silentB = await loadSilentRows(app, observer.agent.inboxId, chatB.id);
+    expect(silentA.map((row) => row.status)).toEqual(["pending", "pending"]);
+    expect(silentB.map((row) => row.status)).toEqual(["pending"]);
+  });
+
   it("ack-through drains silent rows excluded from preceding context by cap or trigger-relative window", async () => {
     const app = getApp();
     const uid = crypto.randomUUID().slice(0, 6);

--- a/packages/server/src/__tests__/ws-client-branch-fake.test.ts
+++ b/packages/server/src/__tests__/ws-client-branch-fake.test.ts
@@ -326,6 +326,8 @@ describe("Agent client WS branch fakes", () => {
   function activeAgentRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
     return {
       id: "agent_1",
+      // Route revalidation keys its set-based SELECT rows by `uuid`.
+      uuid: "agent_1",
       displayName: "Agent",
       type: "agent",
       organizationId: "org_1",
@@ -537,6 +539,7 @@ describe("Agent client WS branch fakes", () => {
         [activeAgentRow()],
         [
           {
+            uuid: "agent_1",
             clientId: "client_fake1234",
             status: "suspended",
             runtimeProvider: "claude-code",

--- a/packages/server/src/api/agent/ws-client.ts
+++ b/packages/server/src/api/agent/ws-client.ts
@@ -438,34 +438,75 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
         app.log.info({ clientId, agentId, reason }, "dropped stale local agent binding");
       }
 
-      async function ensureAgentStillRoutedHere(agentId: string): Promise<boolean> {
-        if (!isAgentStillRoutedHere(agentId)) return false;
-        const info = boundAgents.get(agentId);
-        if (!info || !clientId) return false;
-        const [row] = await app.db
+      /**
+       * Revalidate local agent routes against the authoritative `agents`
+       * table in one set-based SELECT, so ACK and heartbeat cost stays flat
+       * as the number of bound agents grows (PERF-061); a client has no hard
+       * agent-count cap.
+       *
+       * Returns the subset of `agentIds` still authoritatively routed to this
+       * socket's client. Candidates that no longer match (client reassigned,
+       * agent deleted / suspended, runtime switched) get their local binding
+       * dropped — except the runtime-switch "claimed" grace state, which
+       * stays bound but is reported as not routed so in-flight delivery
+       * pauses until the switch resolves.
+       */
+      async function filterAgentsStillRoutedHere(agentIds: Iterable<string>): Promise<Set<string>> {
+        const stillRouted = new Set<string>();
+        // Snapshot each candidate's bound runtimeProvider before the SELECT:
+        // the comparison contract is "row vs the binding as it was probed".
+        const candidates: Array<{ agentId: string; runtimeProvider: string }> = [];
+        for (const agentId of agentIds) {
+          if (!isAgentStillRoutedHere(agentId)) continue;
+          const info = boundAgents.get(agentId);
+          if (!info || !clientId) continue;
+          candidates.push({ agentId, runtimeProvider: info.runtimeProvider });
+        }
+        if (candidates.length === 0) return stillRouted;
+
+        const rows = await app.db
           .select({
+            uuid: agents.uuid,
             clientId: agents.clientId,
             runtimeProvider: agents.runtimeProvider,
             status: agents.status,
             metadata: agents.metadata,
           })
           .from(agents)
-          .where(eq(agents.uuid, agentId))
-          .limit(1);
-        if (row?.clientId === clientId && row.status === "active" && row.runtimeProvider === info.runtimeProvider) {
-          return true;
+          .where(
+            inArray(
+              agents.uuid,
+              candidates.map((candidate) => candidate.agentId),
+            ),
+          );
+        const rowByAgentId = new Map(rows.map((row) => [row.uuid, row]));
+
+        for (const candidate of candidates) {
+          const row = rowByAgentId.get(candidate.agentId);
+          if (
+            row?.clientId === clientId &&
+            row.status === "active" &&
+            row.runtimeProvider === candidate.runtimeProvider
+          ) {
+            stillRouted.add(candidate.agentId);
+            continue;
+          }
+          const switchClaim = agentRuntimeSwitchService.getRuntimeSwitchClaim(row?.metadata);
+          if (
+            row?.status === "suspended" &&
+            switchClaim?.phase === "claimed" &&
+            switchClaim.oldClientId === clientId &&
+            switchClaim.oldRuntimeProvider === candidate.runtimeProvider
+          ) {
+            continue;
+          }
+          dropLocalAgentBinding(candidate.agentId, "authoritative_route_changed");
         }
-        const switchClaim = agentRuntimeSwitchService.getRuntimeSwitchClaim(row?.metadata);
-        if (
-          row?.status === "suspended" &&
-          switchClaim?.phase === "claimed" &&
-          switchClaim.oldClientId === clientId &&
-          switchClaim.oldRuntimeProvider === info.runtimeProvider
-        ) {
-          return false;
-        }
-        dropLocalAgentBinding(agentId, "authoritative_route_changed");
-        return false;
+        return stillRouted;
+      }
+
+      async function ensureAgentStillRoutedHere(agentId: string): Promise<boolean> {
+        return (await filterAgentsStillRoutedHere([agentId])).has(agentId);
       }
 
       function inboxInFlightCount(agentId: string): number {
@@ -1630,12 +1671,13 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
 
               await chainInboxDelivery("__socket", async () => {
                 try {
-                  const routedBoundAgents = [];
-                  for (const agent of boundAgents.values()) {
-                    if (await ensureAgentStillRoutedHere(agent.agentId)) {
-                      routedBoundAgents.push(agent);
-                    }
-                  }
+                  // One set-based route check for every bound agent; the
+                  // surviving entries keep their inbox-to-agent ownership
+                  // mapping for the owner lookup below.
+                  const routedAgentIds = await filterAgentsStillRoutedHere(boundAgents.keys());
+                  const routedBoundAgents = [...boundAgents.values()].filter((agent) =>
+                    routedAgentIds.has(agent.agentId),
+                  );
                   const ackResult = await inboxService.ackEntryByIdForBoundAgents(
                     app.db,
                     entryId,
@@ -1768,10 +1810,7 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
               });
             } else if (type === "heartbeat") {
               if (clientId && connectionManager.isActiveClientConnection(clientId, socket)) {
-                const routedAgentIds = [];
-                for (const id of boundAgents.keys()) {
-                  if (await ensureAgentStillRoutedHere(id)) routedAgentIds.push(id);
-                }
+                const routedAgentIds = [...(await filterAgentsStillRoutedHere(boundAgents.keys()))];
                 const pausedReason =
                   msg && typeof msg === "object" && "pausedReason" in msg
                     ? ((msg as { pausedReason?: "auth_rejected" | "auth_refresh_failed" | null }).pausedReason ?? null)
@@ -1783,8 +1822,17 @@ export function clientWsRoutes(notifier: Notifier, instanceId: string) {
                   pausedReason,
                 });
                 const repairableAgentIds = new Set(liveness.restoredAgentIds);
-                for (const info of boundAgents.values()) {
-                  if (repairableAgentIds.has(info.agentId) && (await ensureAgentStillRoutedHere(info.agentId))) {
+                // Re-validate restored agents in one batch: the liveness write
+                // above may have raced a route change, so the pre-heartbeat
+                // check cannot be reused here.
+                const repairCandidates = [...boundAgents.values()].filter((info) =>
+                  repairableAgentIds.has(info.agentId),
+                );
+                const repairableRouted = await filterAgentsStillRoutedHere(
+                  repairCandidates.map((info) => info.agentId),
+                );
+                for (const info of repairCandidates) {
+                  if (repairableRouted.has(info.agentId)) {
                     maybeRepairInboxBacklog(info.agentId, info.inboxId);
                   }
                 }

--- a/packages/server/src/services/inbox.ts
+++ b/packages/server/src/services/inbox.ts
@@ -4,7 +4,7 @@ import {
   messageSourceSchema,
   type PrecedingMessage,
 } from "@first-tree/shared";
-import { and, asc, desc, eq, gt, inArray, isNull, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type { Database } from "../db/connection.js";
@@ -29,7 +29,7 @@ export type AckEntryResult =
   | { ok: false; reason: "not_found_or_not_bound" | "non_notify" | "prefix_gap" };
 
 /** Structurally-typed DB so both `Database` and transaction clients work. */
-type TxLike = Pick<PostgresJsDatabase<Record<string, never>>, "select" | "update" | "delete" | "insert">;
+type TxLike = Pick<PostgresJsDatabase<Record<string, never>>, "select" | "update" | "delete" | "insert" | "execute">;
 
 /** Wider DB shape that matches both the concrete `Database` and the
  *  `PgDatabase` widening used by sibling services (e.g. participant-mode).
@@ -454,15 +454,22 @@ export async function claimBacklogForPushFair(
 }
 
 /**
- * Per claimed trigger: SELECT silent (notify=false) pending rows in the same
- * chat that occurred between the previous trigger in this batch (or beginning
- * of time) and this trigger, capped by `PRECEDING_CONTEXT_MAX_ENTRIES` and
- * `PRECEDING_CONTEXT_WINDOW_SECONDS`. Returned messages are oldest-first.
+ * Per claimed trigger: collect silent (notify=false) pending rows in the same
+ * chat that occurred between the previous trigger in this batch (or the
+ * previous notify row on record) and this trigger, capped by
+ * `PRECEDING_CONTEXT_MAX_ENTRIES` and `PRECEDING_CONTEXT_WINDOW_SECONDS`.
+ * Returned messages are oldest-first.
  *
  * This function intentionally does not ACK silent rows. Bundling is not
  * consumption: recovery must be able to reset the notify trigger and rebuild
  * the same trigger-relative context window. Silent rows are drained only when
  * the client ACKs the consumed notify entry.
+ *
+ * The whole batch resolves in two set-based statements regardless of how many
+ * chats/triggers were claimed (PERF-061). The previous shape issued one
+ * previous-notify query per chat plus one context query per trigger, all
+ * sequentially inside the claim transaction, so DB latency and row-lock hold
+ * time grew linearly with drain size.
  */
 async function collectPrecedingContext(
   tx: TxLike,
@@ -479,97 +486,160 @@ async function collectPrecedingContext(
     list.push(t);
     byChat.set(t.chatId, list);
   }
+  if (byChat.size === 0) return result;
 
+  // One spec row per trigger. `lower_bound_id` is the in-batch cursor: the
+  // previous trigger of the same chat in this batch. It is null exactly for
+  // each chat's first trigger, whose cursor instead comes from the DB via the
+  // `prev_notify` lateral below — the latest notify row before it, even if
+  // that trigger was delivered in an earlier unacked batch.
+  const specs: Array<{
+    trigger_id: number;
+    chat_id: string;
+    lower_bound_id: number | null;
+    window_start: string;
+  }> = [];
   for (const [chatId, chatTriggers] of byChat) {
     chatTriggers.sort((a, b) => a.id - b.id);
-
-    const firstTrigger = chatTriggers[0];
-    if (!firstTrigger) continue;
-    const [previousNotify] = await tx
-      .select({ id: inboxEntries.id })
-      .from(inboxEntries)
-      .where(
-        and(
-          eq(inboxEntries.inboxId, inboxId),
-          eq(inboxEntries.chatId, chatId),
-          eq(inboxEntries.notify, true),
-          lt(inboxEntries.id, firstTrigger.id),
-        ),
-      )
-      .orderBy(desc(inboxEntries.id))
-      .limit(1);
-
-    // For each trigger, fetch silent context strictly before it (and after
-    // the previous notify trigger cursor, even if that trigger was delivered
-    // in an earlier unacked batch). Window: 24h before the trigger.
-    //
-    // Order matters: when there are MORE than `PRECEDING_CONTEXT_MAX_ENTRIES`
-    // candidates, we want to keep the rows CLOSEST to the trigger (most
-    // contextually relevant) and drop the oldest. So select DESC + LIMIT,
-    // then reverse in JS to get chronological prompt-ready output. Selecting
-    // ASC + LIMIT would drop the recent rows; ACK-through later drains every
-    // silent row behind the consumed notify cursor, including rows excluded by
-    // this cap, so this delivery must choose the most relevant window now.
-    //
-    // We sort by `messages.createdAt` rather than `inboxEntries.createdAt`
-    // because `addParticipant`'s backfill writes 50 inbox rows in one
-    // `INSERT VALUES (...)` — they all share `statement_timestamp()`. The
-    // message rows themselves have distinct, monotonic timestamps (uuidv7
-    // ids are time-ordered, `messages.created_at` is the authoritative
-    // chronology), so ordering by the joined message timestamp is the only
-    // stable contract the prompt-rendered context can rely on.
-    //
-    // Concurrency: `FOR UPDATE OF inboxEntries SKIP LOCKED` prevents two
-    // parallel polls on the same inbox from bundling the same silent row
-    // twice. Without it, poll A picking trigger T1 and poll B picking T2
-    // (T2 > T1) would both include silent rows < T1 in their preceding
-    // context. With SKIP LOCKED, the second poll skips the rows the first
-    // has reserved.
-    let previousNotifyId: number | null = previousNotify?.id ?? null;
+    let previousTriggerId: number | null = null;
     for (const trigger of chatTriggers) {
-      const windowStart = new Date(trigger.createdAt.getTime() - PRECEDING_CONTEXT_WINDOW_SECONDS * 1000);
-      const rows = await tx
-        .select({
-          messageId: messages.id,
-          senderId: messages.senderId,
-          format: messages.format,
-          content: messages.content,
-          metadata: messages.metadata,
-          source: messages.source,
-          createdAt: messages.createdAt,
-        })
-        .from(inboxEntries)
-        .innerJoin(messages, eq(messages.id, inboxEntries.messageId))
-        .where(
-          and(
-            eq(inboxEntries.inboxId, inboxId),
-            eq(inboxEntries.chatId, chatId),
-            eq(inboxEntries.status, "pending"),
-            eq(inboxEntries.notify, false),
-            lt(inboxEntries.id, trigger.id),
-            previousNotifyId === null ? undefined : gt(inboxEntries.id, previousNotifyId),
-            gt(inboxEntries.createdAt, windowStart),
-          ),
-        )
-        .orderBy(desc(messages.createdAt))
-        .limit(PRECEDING_CONTEXT_MAX_ENTRIES)
-        .for("update", { of: inboxEntries, skipLocked: true });
-
-      // Reverse so the prompt-rendered block reads oldest → newest.
-      const preceding: PrecedingMessage[] = rows
-        .map((r) => ({
-          id: r.messageId,
-          senderId: r.senderId,
-          format: r.format,
-          content: r.content,
-          metadata: (r.metadata ?? {}) as Record<string, unknown>,
-          source: messageSourceSchema.nullable().catch(null).parse(r.source),
-          createdAt: r.createdAt.toISOString(),
-        }))
-        .reverse();
-      result.set(trigger.id, preceding);
-      previousNotifyId = trigger.id;
+      result.set(trigger.id, []);
+      specs.push({
+        trigger_id: trigger.id,
+        chat_id: chatId,
+        lower_bound_id: previousTriggerId,
+        window_start: new Date(trigger.createdAt.getTime() - PRECEDING_CONTEXT_WINDOW_SECONDS * 1000).toISOString(),
+      });
+      previousTriggerId = trigger.id;
     }
+  }
+  const specJson = JSON.stringify(specs);
+
+  // Statement 1 — resolve every trigger's context membership in one pass.
+  //
+  // Order matters inside `ctx`: when there are MORE than
+  // `PRECEDING_CONTEXT_MAX_ENTRIES` candidates, we want to keep the rows
+  // CLOSEST to the trigger (most contextually relevant) and drop the oldest.
+  // So select `m.created_at` DESC + LIMIT per trigger. Selecting ASC + LIMIT
+  // would drop the recent rows; ACK-through later drains every silent row
+  // behind the consumed notify cursor, including rows excluded by this cap,
+  // so this delivery must choose the most relevant window now.
+  //
+  // We rank by `messages.created_at` rather than `inbox_entries.created_at`
+  // because `addParticipant`'s backfill writes 50 inbox rows in one
+  // `INSERT VALUES (...)` — they all share `statement_timestamp()`. The
+  // message rows themselves have distinct, monotonic timestamps (uuidv7
+  // ids are time-ordered, `messages.created_at` is the authoritative
+  // chronology), so ordering by the joined message timestamp is the only
+  // stable contract the prompt-rendered context can rely on.
+  //
+  // Concurrency: `FOR UPDATE OF e SKIP LOCKED` prevents two parallel polls
+  // on the same inbox from bundling the same silent row twice. Without it,
+  // poll A picking trigger T1 and poll B picking T2 (T2 > T1) would both
+  // include silent rows < T1 in their preceding context. With SKIP LOCKED,
+  // the second poll skips the rows the first has reserved. Spec ranges are
+  // disjoint per trigger, so the batch cannot double-bundle within itself.
+  //
+  // `execute()` bypasses the driver's type parsers (every column comes back
+  // as text), so this statement returns only ids — the typed re-read below
+  // keeps jsonb / timestamptz mapping on Drizzle.
+  const contextRows = await tx.execute<{ trigger_id: string; entry_id: string }>(sql`
+    WITH trigger_spec AS (
+      SELECT s.trigger_id, s.chat_id, s.lower_bound_id, s.window_start
+        FROM jsonb_to_recordset(${specJson}::jsonb)
+          AS s(trigger_id bigint, chat_id text, lower_bound_id bigint, window_start timestamptz)
+    ),
+    trigger_bounds AS (
+      SELECT
+        trigger_spec.trigger_id,
+        trigger_spec.chat_id,
+        trigger_spec.window_start,
+        COALESCE(trigger_spec.lower_bound_id, prev_notify.id) AS lower_bound_id
+      FROM trigger_spec
+      LEFT JOIN LATERAL (
+        SELECT e.id
+          FROM inbox_entries e
+         WHERE trigger_spec.lower_bound_id IS NULL
+           AND e.inbox_id = ${inboxId}
+           AND e.chat_id = trigger_spec.chat_id
+           AND e.notify = true
+           AND e.id < trigger_spec.trigger_id
+         ORDER BY e.id DESC
+         LIMIT 1
+      ) prev_notify ON true
+    )
+    SELECT trigger_bounds.trigger_id::text AS trigger_id, ctx.entry_id::text AS entry_id
+      FROM trigger_bounds
+      INNER JOIN LATERAL (
+        SELECT e.id AS entry_id
+          FROM inbox_entries e
+          INNER JOIN messages m ON m.id = e.message_id
+         WHERE e.inbox_id = ${inboxId}
+           AND e.chat_id = trigger_bounds.chat_id
+           AND e.status = 'pending'
+           AND e.notify = false
+           AND e.id < trigger_bounds.trigger_id
+           AND (trigger_bounds.lower_bound_id IS NULL OR e.id > trigger_bounds.lower_bound_id)
+           AND e.created_at > trigger_bounds.window_start
+         ORDER BY m.created_at DESC
+         LIMIT ${PRECEDING_CONTEXT_MAX_ENTRIES}
+           FOR UPDATE OF e SKIP LOCKED
+      ) ctx ON true
+  `);
+
+  const contextIdsByTriggerId = new Map<number, number[]>();
+  const allEntryIds: number[] = [];
+  for (const row of contextRows) {
+    const triggerId = Number(row.trigger_id);
+    const entryId = Number(row.entry_id);
+    if (!Number.isSafeInteger(triggerId) || !Number.isSafeInteger(entryId)) {
+      throw new Error(`Unexpected inbox context ids from batch query: ${row.trigger_id}/${row.entry_id}`);
+    }
+    const list = contextIdsByTriggerId.get(triggerId) ?? [];
+    list.push(entryId);
+    contextIdsByTriggerId.set(triggerId, list);
+    allEntryIds.push(entryId);
+  }
+  if (allEntryIds.length === 0) return result;
+
+  // Statement 2 — typed payload re-read for the locked rows.
+  const payloadRows = await tx
+    .select({
+      entryId: inboxEntries.id,
+      messageId: messages.id,
+      senderId: messages.senderId,
+      format: messages.format,
+      content: messages.content,
+      metadata: messages.metadata,
+      source: messages.source,
+      createdAt: messages.createdAt,
+    })
+    .from(inboxEntries)
+    .innerJoin(messages, eq(messages.id, inboxEntries.messageId))
+    .where(inArray(inboxEntries.id, allEntryIds));
+  const payloadByEntryId = new Map(payloadRows.map((r) => [r.entryId, r]));
+
+  for (const [triggerId, entryIds] of contextIdsByTriggerId) {
+    const rows = entryIds.map((entryId) => {
+      const row = payloadByEntryId.get(entryId);
+      if (!row) throw new Error(`Unexpected: bundled context entry ${entryId} lost its message row`);
+      return row;
+    });
+    // Chronological prompt-ready output, oldest → newest. Entry id breaks
+    // (theoretical) same-timestamp ties by enqueue order.
+    rows.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.entryId - b.entryId);
+    result.set(
+      triggerId,
+      rows.map((r) => ({
+        id: r.messageId,
+        senderId: r.senderId,
+        format: r.format,
+        content: r.content,
+        metadata: (r.metadata ?? {}) as Record<string, unknown>,
+        source: messageSourceSchema.nullable().catch(null).parse(r.source),
+        createdAt: r.createdAt.toISOString(),
+      })),
+    );
   }
 
   return result;


### PR DESCRIPTION
Closes #1724 (PERF-061).

## Problem

Two hot paths issued sequential per-row queries while holding transaction work / socket-serialized sections, so DB latency and lock hold time grew linearly with batch and client size:

- `collectPrecedingContext` (`packages/server/src/services/inbox.ts`): a 50-entry drain issued one previous-notify query per chat plus one silent-context query per trigger, all inside the claim transaction.
- `ws-client.ts`: `inbox:ack` and each `heartbeat` revalidated every bound agent through `ensureAgentStillRoutedHere`, one `SELECT` per agent, twice per heartbeat — and a client has no hard agent-count cap.

## Change

**Inbox context assembly — 2 statements total, regardless of batch size**

1. One raw statement (`jsonb_to_recordset` spec + two laterals) resolves, per claimed trigger: the previous-notify cursor for each chat's first trigger, then the per-trigger silent-context membership with the same `ORDER BY messages.created_at DESC LIMIT cap` selection and `FOR UPDATE OF e SKIP LOCKED` locking the old per-trigger queries used. In-batch cursors (previous trigger of the same chat) are computed in JS and passed in the spec, so the trigger-relative windows stay exactly as before.
2. One typed Drizzle select re-reads the locked rows' message payloads by id. The raw statement returns only `::text` ids because `execute()` bypasses the postgres-js type parsers (jsonb/timestamptz would come back as raw strings).

Preserved semantics: bundling still does not ACK silent rows; cap keeps the rows closest to the trigger; chronological output ordered by `messages.created_at` (entry id as tie-break); `SKIP LOCKED` still prevents two parallel polls from double-bundling; per-trigger ranges are disjoint within the batch.

**Bound-agent route validation — one set-based query per checkpoint**

`ensureAgentStillRoutedHere` is now a thin wrapper over a new `filterAgentsStillRoutedHere(agentIds)`, which validates all candidates with a single `WHERE uuid IN (...)` select and applies the same per-agent decision logic (active/route match → routed; runtime-switch "claimed" grace → not routed but binding retained; anything else → `dropLocalAgentBinding`). The `inbox:ack` handler, the heartbeat route check, and the heartbeat repair re-check each now issue one query for the whole bound set, and the ack path keeps its inbox-to-agent ownership mapping from the surviving `boundAgents` values.

No schema/index changes: the batched statements use the same predicates as the per-row queries they replace (`idx_inbox_chat_silent`, `idx_inbox_pending_notify`, `agents` pk).

## Tests

- New: `splits per-trigger silent context inside one multi-chat batch claim` — one batch claiming two chats with two same-chat triggers, pinning the in-batch cursor split the lateral now computes.
- Updated: `ws-client-branch-fake.test.ts` fake agent rows now carry `uuid`, since the set-based select keys rows by it.
- Existing coverage that pins the preserved behavior passed unchanged: preceding-context bundling/cap/window/cursor tests, chat-scoped recovery redelivery, ack-through drains, heartbeat repair throttle, runtime-switch grace handling.
- `pnpm check`, `pnpm typecheck`, and the full `@first-tree/server` vitest suite pass locally.
