### PR TITLE
fix: reduce Mobile Work list startup cost

### DIFF
--- a/packages/server/src/__tests__/agent-chat-status.test.ts
+++ b/packages/server/src/__tests__/agent-chat-status.test.ts
@@ -589,6 +589,42 @@ describe("agent-chat-status", () => {
       expect((await resolveAgentChatStatuses(getApp().db, [])).size).toBe(0);
     });
 
+    it("accepts known list speakers and omits detail-only status reasons", async () => {
+      const { app, peer, chatId } = await newChatWithAgent();
+      await bindPresence(peer.agent.uuid, peer.clientId);
+      await setSession(peer.agent.uuid, chatId, "active");
+      await insertEvent(peer.agent.uuid, chatId, 1, "error", {
+        message: encodeProviderRetryEventMessage({
+          event: "provider_retry_scheduled",
+          provider: "codex",
+          scope: "provider_turn",
+          category: "transient_transport",
+          reasonCode: "provider_transient_transport",
+          attempt: 1,
+          maxAttempts: 2,
+          retryMode: "foreground",
+          delayMs: 500,
+          replaySafety: "pre_visible",
+          userSeverity: "info",
+        }),
+      });
+
+      const full = (await resolveAgentChatStatuses(app.db, [chatId])).get(chatId)?.[0];
+      const list = (
+        await resolveAgentChatStatuses(app.db, [chatId], {
+          includeStatusReason: false,
+          nonHumanSpeakersByChat: new Map([[chatId, new Set([peer.agent.uuid])]]),
+        })
+      ).get(chatId)?.[0];
+
+      expect(full?.statusReason?.kind).toBe("retrying");
+      expect(list?.statusReason).toBeUndefined();
+      expect(list?.agentId).toBe(full?.agentId);
+      expect(list?.main).toBe(full?.main);
+      expect(list?.working).toBe(full?.working);
+      expect(list?.errored).toBe(full?.errored);
+    });
+
     it("excludes humans from the union (a human speaker never appears)", async () => {
       const { app, admin, chatId } = await newChatWithAgent();
       const all = (await resolveAgentChatStatuses(app.db, [chatId])).get(chatId) ?? [];

--- a/packages/server/src/__tests__/me-chat-priority.test.ts
+++ b/packages/server/src/__tests__/me-chat-priority.test.ts
@@ -1,6 +1,7 @@
 import { eq, sql } from "drizzle-orm";
 import type { FastifyInstance } from "fastify";
 import { describe, expect, it } from "vitest";
+import type { Database } from "../db/connection.js";
 import { agentPresence } from "../db/schema/agent-presence.js";
 import { chats } from "../db/schema/chats.js";
 import { clients } from "../db/schema/clients.js";
@@ -114,6 +115,43 @@ describe("listMeChats — server priority projection (PR3)", () => {
     if (res.rows.some((r) => r.chatId === chatId)) return "rows";
     return null;
   }
+
+  function countDatabaseQueries(db: Database): { db: Database; getCount: () => number } {
+    let count = 0;
+    const countedMethods = new Set<PropertyKey>(["select", "selectDistinctOn", "execute"]);
+    const countedDb = new Proxy(db, {
+      get(target, property, receiver) {
+        const value = Reflect.get(target, property, receiver);
+        if (typeof value !== "function") return value;
+        if (!countedMethods.has(property)) return value.bind(target);
+        return (...args: unknown[]) => {
+          count += 1;
+          return Reflect.apply(value, target, args);
+        };
+      },
+    });
+    return { db: countedDb, getCount: () => count };
+  }
+
+  it("hydrates overlapping first-page slices within one eight-query budget", async () => {
+    const app = getApp();
+    const owner = await createTestAdmin(app);
+    const peer = await managedAgent(app, owner, "query-budget-peer");
+    const chatId = await chatWith(app, owner, peer.uuid, "query budget");
+    await pinMeChat(app.db, chatId, owner.humanAgentUuid, true);
+    await raiseRequest(app, chatId, peer.uuid, owner.humanAgentUuid);
+
+    const counted = countDatabaseQueries(app.db);
+    const res = await listMeChats(counted.db, owner.humanAgentUuid, owner.memberId, owner.organizationId, {
+      limit: 50,
+      filter: "all",
+      engagement: "all",
+    });
+
+    expect(res.priorityRows.attention.map((row) => row.chatId)).toContain(chatId);
+    expect(res.rows.map((row) => row.chatId)).toContain(chatId);
+    expect(counted.getCount()).toBe(8);
+  });
 
   it("pinned chats surface in priorityRows.pinned (pinned_at DESC); rows stays additive", async () => {
     const app = getApp();

--- a/packages/server/src/services/agent-chat-status.ts
+++ b/packages/server/src/services/agent-chat-status.ts
@@ -388,19 +388,14 @@ const pairKey = (chatId: string, agentId: string) => `${chatId}${ROW_SEP}${agent
 export async function resolveAgentChatStatuses(
   db: Database,
   chatIds: string[],
-  opts?: { withTurnText?: boolean },
+  opts?: {
+    withTurnText?: boolean;
+    includeStatusReason?: boolean;
+    nonHumanSpeakersByChat?: ReadonlyMap<string, ReadonlySet<string>>;
+  },
 ): Promise<Map<string, AgentChatStatus[]>> {
   const out = new Map<string, AgentChatStatus[]>();
   if (chatIds.length === 0) return out;
-
-  // -- Non-human speakers per chat.
-  const speakerRows = await db
-    .select({ chatId: chatMembership.chatId, agentId: chatMembership.agentId })
-    .from(chatMembership)
-    .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
-    .where(
-      and(inArray(chatMembership.chatId, chatIds), eq(chatMembership.accessMode, "speaker"), ne(agents.type, "human")),
-    );
 
   const unionByChat = new Map<string, Set<string>>();
   const addUnion = (chatId: string, agentId: string) => {
@@ -411,7 +406,32 @@ export async function resolveAgentChatStatuses(
     }
     s.add(agentId);
   };
-  for (const r of speakerRows) addUnion(r.chatId, r.agentId);
+
+  // -- Non-human speakers per chat.
+  // The conversation-list hydration has already loaded speaker membership for
+  // its participant chips. Let that caller provide the same canonical set so a
+  // list request does not immediately repeat the membership query. Detail
+  // surfaces omit the map and retain the self-contained resolver path.
+  if (opts?.nonHumanSpeakersByChat) {
+    for (const chatId of chatIds) {
+      for (const agentId of opts.nonHumanSpeakersByChat.get(chatId) ?? []) {
+        addUnion(chatId, agentId);
+      }
+    }
+  } else {
+    const speakerRows = await db
+      .select({ chatId: chatMembership.chatId, agentId: chatMembership.agentId })
+      .from(chatMembership)
+      .innerJoin(agents, eq(chatMembership.agentId, agents.uuid))
+      .where(
+        and(
+          inArray(chatMembership.chatId, chatIds),
+          eq(chatMembership.accessMode, "speaker"),
+          ne(agents.type, "human"),
+        ),
+      );
+    for (const r of speakerRows) addUnion(r.chatId, r.agentId);
+  }
   if (unionByChat.size === 0) return out;
 
   const allAgentIds = [...new Set([...unionByChat.values()].flatMap((s) => [...s]))];
@@ -458,8 +478,15 @@ export async function resolveAgentChatStatuses(
   //    Pure description: 60s drop here means "5-min-old tool_call is not the
   //    current activity description", not "agent is not working" (which is
   //    decided by `computeWorking` above).
-  const activityByChat = await deriveActivities(db, chatIds, opts);
-  const statusReasonByChat = await deriveStatusReasons(db, chatIds);
+  const activityByChat = await deriveActivities(db, chatIds, { withTurnText: opts?.withTurnText });
+  // The list DTO consumes working / errored / activity only. Provider retry
+  // reasons belong to the chat-detail agent-status surface, so list hydration
+  // explicitly skips this LATERAL session-event seek while the default detail
+  // path remains unchanged.
+  const statusReasonByChat =
+    opts?.includeStatusReason === false
+      ? new Map<string, Map<string, AgentStatusReason>>()
+      : await deriveStatusReasons(db, chatIds);
 
   const now = Date.now();
   for (const [chatId, agentSet] of unionByChat) {

--- a/packages/server/src/services/me-chat.ts
+++ b/packages/server/src/services/me-chat.ts
@@ -596,7 +596,11 @@ async function enrichMeChatRows(
 
   // One producer for every per-(agent,chat) status signal (live-dot / failed /
   // busy), shared with `GET /chats/:id/agent-status`.
-  const statusByChat = await resolveAgentChatStatuses(db, chatIds, { withTurnText: false });
+  const statusByChat = await resolveAgentChatStatuses(db, chatIds, {
+    withTurnText: false,
+    includeStatusReason: false,
+    nonHumanSpeakersByChat,
+  });
 
   const liveActivityByChat = new Map<string, LiveActivity>();
   const failedByChat = new Map<string, string[]>();
@@ -790,19 +794,19 @@ export async function listMeChats(
   // stay ADDITIVE: later pages never exclude priority ids, so the ordinary
   // stream is the complete recency list — backward-compatible with a client that
   // ignores `priorityRows`. See docblock.
-  let attention: MeChatRow[] = [];
-  let pinned: MeChatRow[] = [];
+  let attnCandidateRaw: RawMeChatRow[] = [];
+  let pinnedRaw: RawMeChatRow[] = [];
   if (cursor === null) {
     // Attention candidates — the bounded pre-canonical set the enrichment pass
     // resolves (see `selectAttentionCandidateRows` for the superset rationale).
-    const attnCandidateRaw = await selectAttentionCandidateRows(db, {
+    attnCandidateRaw = await selectAttentionCandidateRows(db, {
       humanAgentId,
       organizationId,
       callerMemberId,
       filters,
       orderBy: activityOrder,
     });
-    const pinnedRaw = await selectMeChatRawRows(db, {
+    pinnedRaw = await selectMeChatRawRows(db, {
       humanAgentId,
       organizationId,
       filters,
@@ -810,33 +814,6 @@ export async function listMeChats(
       orderBy: sql`cus.pinned_at DESC, c.id DESC`,
       limit: null,
     });
-
-    // Enrich the priority union once; `failedByChat` splits attention below.
-    const priorityRawUnion = dedupeRawByChatId([...attnCandidateRaw, ...pinnedRaw]);
-    const { rows: priorityRowsFlat, failedByChat } = await enrichMeChatRows(db, priorityRawUnion, {
-      humanAgentId,
-      managedAgentIds,
-    });
-    const priorityRowById = new Map(priorityRowsFlat.map((r) => [r.chatId, r]));
-
-    // Attention = candidates that qualify (failed OR open request), failed-first
-    // then activity DESC. Each candidate slice is already activity DESC from the
-    // query and `filter` preserves order.
-    const attnQualified = attnCandidateRaw.filter((r) => failedByChat.has(r.chat_id) || r.open_request_count > 0);
-    attention = [
-      ...attnQualified.filter((r) => failedByChat.has(r.chat_id)),
-      ...attnQualified.filter((r) => !failedByChat.has(r.chat_id)),
-    ]
-      .map((r) => priorityRowById.get(r.chat_id))
-      .filter((r): r is MeChatRow => r !== undefined);
-    const attentionIds = new Set(attention.map((r) => r.chatId));
-
-    // Pinned excludes anything already surfaced in attention (attention wins),
-    // preserving the `pinned_at` DESC order.
-    pinned = pinnedRaw
-      .filter((r) => !attentionIds.has(r.chat_id))
-      .map((r) => priorityRowById.get(r.chat_id))
-      .filter((r): r is MeChatRow => r !== undefined);
   }
 
   // --- Ordinary page (EVERY page) -----------------------------------------
@@ -859,10 +836,58 @@ export async function listMeChats(
   const last = pageRaw[pageRaw.length - 1];
   const lastActivity = last ? toChatDate(last.activity_at) : null;
   const nextCursor = hasMore && last && lastActivity ? encodeCursor(lastActivity, last.chat_id) : null;
-  const { rows } = await enrichMeChatRows(db, pageRaw, { humanAgentId, managedAgentIds });
 
+  // First page: priority projections and the additive ordinary page overlap in
+  // the common case. Hydrate their de-duplicated union once, then map the same
+  // canonical rows back into each wire slice without changing the additive
+  // response contract. Cursor pages have no priority projection and hydrate
+  // only their ordinary page.
+  if (cursor === null) {
+    // Prefer the ordinary-page copy for overlaps because it comes from the
+    // latest of the three reads and is the canonical additive stream. Priority
+    // ordering still comes from its own raw slices below.
+    const firstPageRawUnion = dedupeRawByChatId([...pageRaw, ...attnCandidateRaw, ...pinnedRaw]);
+    const { rows: firstPageRows, failedByChat } = await enrichMeChatRows(db, firstPageRawUnion, {
+      humanAgentId,
+      managedAgentIds,
+    });
+    const rowById = new Map(firstPageRows.map((row) => [row.chatId, row]));
+
+    // Attention = candidates that qualify (failed OR open request), failed-first
+    // then activity DESC. Each candidate slice is already activity DESC from the
+    // query and `filter` preserves order.
+    const attnQualified = attnCandidateRaw.filter((row) => {
+      const hydrated = rowById.get(row.chat_id);
+      return failedByChat.has(row.chat_id) || (hydrated?.openRequestCount ?? 0) > 0;
+    });
+    const attention = [
+      ...attnQualified.filter((row) => failedByChat.has(row.chat_id)),
+      ...attnQualified.filter((row) => !failedByChat.has(row.chat_id)),
+    ]
+      .map((row) => rowById.get(row.chat_id))
+      .filter((row): row is MeChatRow => row !== undefined);
+    const attentionIds = new Set(attention.map((row) => row.chatId));
+
+    // Pinned excludes anything already surfaced in attention (attention wins),
+    // preserving the `pinned_at` DESC order. Re-check the canonical hydrated
+    // row so an overlap that changed between the priority reads and the later
+    // ordinary-page read never emits a pinned row with `pinnedAt: null`.
+    const pinned = pinnedRaw
+      .filter((row) => !attentionIds.has(row.chat_id))
+      .map((row) => rowById.get(row.chat_id))
+      .filter((row): row is MeChatRow => row?.pinnedAt != null);
+    const rows = pageRaw.map((row) => rowById.get(row.chat_id)).filter((row): row is MeChatRow => row !== undefined);
+
+    return {
+      priorityRows: { attention, pinned },
+      rows,
+      nextCursor,
+    };
+  }
+
+  const { rows } = await enrichMeChatRows(db, pageRaw, { humanAgentId, managedAgentIds });
   return {
-    priorityRows: { attention, pinned },
+    priorityRows: { attention: [], pinned: [] },
     rows,
     nextCursor,
   };

--- a/packages/web/src/components/__tests__/avatar.test.tsx
+++ b/packages/web/src/components/__tests__/avatar.test.tsx
@@ -102,4 +102,23 @@ describe("ChatRowAvatar — group composite uses identicons", () => {
     expect(html).toContain('src="https://example.com/a.png"');
     expect(html).toContain("<svg"); // bob still falls back to an identicon
   });
+
+  it("forwards an explicit lazy policy to uploaded images", () => {
+    const withImages = [
+      participant("self"),
+      participant("alice", { avatarImageUrl: "https://example.com/a.png" }),
+      participant("bob", { avatarImageUrl: "https://example.com/b.png" }),
+    ];
+    const html = renderToStaticMarkup(
+      <ChatRowAvatar
+        title="Team"
+        type="group"
+        participants={withImages}
+        selfAgentId="self"
+        unreadCount={0}
+        imageLoading="lazy"
+      />,
+    );
+    expect(html.match(/loading="lazy"/g) ?? []).toHaveLength(2);
+  });
 });

--- a/packages/web/src/components/chat/chat-row-avatar.tsx
+++ b/packages/web/src/components/chat/chat-row-avatar.tsx
@@ -138,6 +138,7 @@ export function ChatRowAvatar({
   muted = false,
   badge = true,
   statusDot = false,
+  imageLoading,
 }: {
   /** Resolved chat title — used as a fallback initial when no peer exists. */
   title: string;
@@ -174,6 +175,10 @@ export function ChatRowAvatar({
    *  dot. Used by the conversation list (with `badge={false}`) so the avatar
    *  carries the WeChat / iMessage / Telegram corner mark. */
   statusDot?: boolean;
+  /** Optional native image loading policy. Dense mobile lists pass `lazy` so
+   *  uploaded avatars outside the rendered viewport do not compete with the
+   *  first visible cards. Omitted by default to preserve existing surfaces. */
+  imageLoading?: "eager" | "lazy";
 }) {
   const isDirect = type === "direct";
   // Defensive: older server builds may omit `participants` from the me/chats
@@ -206,9 +211,10 @@ export function ChatRowAvatar({
           colorToken={peer?.avatarColorToken ?? null}
           imageUrl={peer?.avatarImageUrl ?? null}
           muted={muted}
+          imageLoading={imageLoading}
         />
       ) : (
-        <CompositeAvatar size={size} peers={peers} muted={muted} />
+        <CompositeAvatar size={size} peers={peers} muted={muted} imageLoading={imageLoading} />
       )}
       {badge && <AttentionBadge failed={failed} unread={unreadCount} />}
       {statusDot && <ListCornerMark failed={failed} needsYou={needsYou} unread={unreadCount > 0} />}
@@ -280,6 +286,7 @@ function SingleAvatar({
   colorToken,
   imageUrl,
   muted = false,
+  imageLoading,
 }: {
   size: number;
   name: string;
@@ -287,6 +294,7 @@ function SingleAvatar({
   colorToken?: string | null;
   imageUrl?: string | null;
   muted?: boolean;
+  imageLoading?: "eager" | "lazy";
 }) {
   if (imageUrl) {
     return (
@@ -295,6 +303,7 @@ function SingleAvatar({
         alt={name}
         width={size}
         height={size}
+        loading={imageLoading}
         style={{ width: size, height: size, borderRadius: "50%", objectFit: "cover", display: "block" }}
       />
     );
@@ -306,10 +315,12 @@ function CompositeAvatar({
   size,
   peers,
   muted = false,
+  imageLoading,
 }: {
   size: number;
   peers: ReadonlyArray<Participant>;
   muted?: boolean;
+  imageLoading?: "eager" | "lazy";
 }) {
   // Layout decision keyed off `pickCompositeShape` (see header docstring):
   //   n2  → vertical bisection
@@ -342,30 +353,30 @@ function CompositeAvatar({
     >
       {shape === "n2" && (
         <>
-          <Seg peer={peers[0]} idx={0} muted={muted} />
-          <Seg peer={peers[1]} idx={1} muted={muted} />
+          <Seg peer={peers[0]} idx={0} muted={muted} imageLoading={imageLoading} />
+          <Seg peer={peers[1]} idx={1} muted={muted} imageLoading={imageLoading} />
         </>
       )}
       {shape === "n3" && (
         <>
-          <Seg peer={peers[0]} idx={0} fullWidth muted={muted} />
-          <Seg peer={peers[1]} idx={1} muted={muted} />
-          <Seg peer={peers[2]} idx={2} muted={muted} />
+          <Seg peer={peers[0]} idx={0} fullWidth muted={muted} imageLoading={imageLoading} />
+          <Seg peer={peers[1]} idx={1} muted={muted} imageLoading={imageLoading} />
+          <Seg peer={peers[2]} idx={2} muted={muted} imageLoading={imageLoading} />
         </>
       )}
       {shape === "n4" && (
         <>
-          <Seg peer={peers[0]} idx={0} muted={muted} />
-          <Seg peer={peers[1]} idx={1} muted={muted} />
-          <Seg peer={peers[2]} idx={2} muted={muted} />
-          <Seg peer={peers[3]} idx={3} muted={muted} />
+          <Seg peer={peers[0]} idx={0} muted={muted} imageLoading={imageLoading} />
+          <Seg peer={peers[1]} idx={1} muted={muted} imageLoading={imageLoading} />
+          <Seg peer={peers[2]} idx={2} muted={muted} imageLoading={imageLoading} />
+          <Seg peer={peers[3]} idx={3} muted={muted} imageLoading={imageLoading} />
         </>
       )}
       {shape === "n5+" && (
         <>
-          <Seg peer={peers[0]} idx={0} muted={muted} />
-          <Seg peer={peers[1]} idx={1} muted={muted} />
-          <Seg peer={peers[2]} idx={2} muted={muted} />
+          <Seg peer={peers[0]} idx={0} muted={muted} imageLoading={imageLoading} />
+          <Seg peer={peers[1]} idx={1} muted={muted} imageLoading={imageLoading} />
+          <Seg peer={peers[2]} idx={2} muted={muted} imageLoading={imageLoading} />
           <SegMore count={n - 3} fontSize={fontSizeMore} />
         </>
       )}
@@ -378,6 +389,7 @@ function Seg({
   idx,
   fullWidth,
   muted = false,
+  imageLoading,
 }: {
   /** The peer in this slot, or `undefined` for a defensive empty cell. */
   peer: Participant | undefined;
@@ -385,6 +397,7 @@ function Seg({
   idx: number;
   fullWidth?: boolean;
   muted?: boolean;
+  imageLoading?: "eager" | "lazy";
 }) {
   const seed = peer?.agentId ?? String(idx);
   const base: CSSProperties = {
@@ -398,7 +411,7 @@ function Seg({
   // deterministic identicon. `slice` cover-crops the square grid into the
   // (often non-square) composite cell without distorting the pixels.
   if (peer?.avatarImageUrl) {
-    return <img src={peer.avatarImageUrl} alt="" style={{ ...base, objectFit: "cover" }} />;
+    return <img src={peer.avatarImageUrl} alt="" loading={imageLoading} style={{ ...base, objectFit: "cover" }} />;
   }
   return (
     <span

--- a/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
@@ -296,7 +296,7 @@ describe("mobile density tiers", () => {
     }
     vi.stubGlobal("IntersectionObserver", TestIntersectionObserver);
 
-    const rows = Array.from({ length: 24 }, (_, index) =>
+    const rows = Array.from({ length: 50 }, (_, index) =>
       chatRow({
         chatId: `progressive-${index}`,
         title: `Progressive ${index}`,
@@ -329,18 +329,38 @@ describe("mobile density tiers", () => {
 
     const list = harness.container.querySelector("[data-mobile-work-list]");
     expect(list?.getAttribute("data-mobile-work-rendered")).toBe("16");
-    expect(list?.getAttribute("data-mobile-work-total")).toBe("24");
+    expect(list?.getAttribute("data-mobile-work-total")).toBe("50");
     expect(harness.container.querySelectorAll("[data-mobile-card]")).toHaveLength(16);
     expect(harness.container.querySelector("img")?.getAttribute("loading")).toBe("lazy");
     expect(activeObserver).not.toBeNull();
+
+    const initialObserver = activeObserver;
+    await act(async () => {
+      activeObserver?.trigger();
+    });
+    await harness.flush();
+
+    expect(harness.container.querySelectorAll("[data-mobile-card]")).toHaveLength(32);
+    expect(list?.getAttribute("data-mobile-work-rendered")).toBe("32");
+    expect(activeObserver).not.toBe(initialObserver);
+
+    const secondObserver = activeObserver;
+    await act(async () => {
+      activeObserver?.trigger();
+    });
+    await harness.flush();
+
+    expect(harness.container.querySelectorAll("[data-mobile-card]")).toHaveLength(48);
+    expect(list?.getAttribute("data-mobile-work-rendered")).toBe("48");
+    expect(activeObserver).not.toBe(secondObserver);
 
     await act(async () => {
       activeObserver?.trigger();
     });
     await harness.flush();
 
-    expect(harness.container.querySelectorAll("[data-mobile-card]")).toHaveLength(24);
-    expect(list?.getAttribute("data-mobile-work-rendered")).toBe("24");
+    expect(harness.container.querySelectorAll("[data-mobile-card]")).toHaveLength(50);
+    expect(list?.getAttribute("data-mobile-work-rendered")).toBe("50");
     expect(harness.container.querySelector("[data-mobile-work-render-sentinel]")).toBeNull();
   });
 

--- a/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
+++ b/packages/web/src/pages/mobile/__tests__/density-dom.test.tsx
@@ -4,7 +4,7 @@ import type { MeChatRow, MeMembership } from "@first-tree/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, type ReactElement } from "react";
 import { MemoryRouter, Route, Routes } from "react-router";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ToastProvider } from "../../../components/ui/toast.js";
 import { createDomHarness, type DomHarness } from "../../../test-utils/dom-harness.js";
 import { MobileWorkPage } from "../work.js";
@@ -170,6 +170,11 @@ describe("mobile density tiers", () => {
     meChatMocks.listMeChatSourceCounts.mockResolvedValue({ counts: {} });
   });
 
+  afterEach(() => {
+    harness.cleanup();
+    vi.unstubAllGlobals();
+  });
+
   it("renders one continuous Work feed in Attention then Pinned then Recency order", async () => {
     renderWithClient(harness, <MobileWorkPage />, "/m/work");
     await waitForSettled(harness, () => expect(harness.container.textContent).toContain("Release readiness"));
@@ -265,5 +270,114 @@ describe("mobile density tiers", () => {
     expect(preview?.textContent).toBe("Task: run the seed (first-tree-seed)");
     expect(preview?.textContent).not.toContain("**");
     expect(preview?.textContent).not.toContain("`");
+  });
+
+  it("mounts the initial row budget, appends the next batch near the sentinel, and lazy-loads avatars", async () => {
+    let activeObserver: TestIntersectionObserver | null = null;
+    class TestIntersectionObserver implements IntersectionObserver {
+      readonly root = null;
+      readonly rootMargin = "50% 0%";
+      readonly thresholds = [0];
+
+      constructor(private readonly callback: IntersectionObserverCallback) {
+        activeObserver = this;
+      }
+
+      disconnect(): void {}
+      observe(): void {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+      unobserve(): void {}
+
+      trigger(): void {
+        this.callback([{ isIntersecting: true } as IntersectionObserverEntry], this);
+      }
+    }
+    vi.stubGlobal("IntersectionObserver", TestIntersectionObserver);
+
+    const rows = Array.from({ length: 24 }, (_, index) =>
+      chatRow({
+        chatId: `progressive-${index}`,
+        title: `Progressive ${index}`,
+        participants: [
+          {
+            agentId: "human-agent-self",
+            displayName: "Gandy",
+            type: "human",
+            avatarColorToken: null,
+            avatarImageUrl: null,
+          },
+          {
+            agentId: `agent-${index}`,
+            displayName: `Agent ${index}`,
+            type: "agent",
+            avatarColorToken: null,
+            avatarImageUrl: `https://example.com/${index}.png`,
+          },
+        ],
+      }),
+    );
+    meChatMocks.listMeChats.mockResolvedValue({
+      rows,
+      priorityRows: { attention: [], pinned: [] },
+      nextCursor: null,
+    });
+
+    renderWithClient(harness, <MobileWorkPage />, "/m/work");
+    await waitForSettled(harness, () => expect(harness.container.textContent).toContain("Progressive 0"));
+
+    const list = harness.container.querySelector("[data-mobile-work-list]");
+    expect(list?.getAttribute("data-mobile-work-rendered")).toBe("16");
+    expect(list?.getAttribute("data-mobile-work-total")).toBe("24");
+    expect(harness.container.querySelectorAll("[data-mobile-card]")).toHaveLength(16);
+    expect(harness.container.querySelector("img")?.getAttribute("loading")).toBe("lazy");
+    expect(activeObserver).not.toBeNull();
+
+    await act(async () => {
+      activeObserver?.trigger();
+    });
+    await harness.flush();
+
+    expect(harness.container.querySelectorAll("[data-mobile-card]")).toHaveLength(24);
+    expect(list?.getAttribute("data-mobile-work-rendered")).toBe("24");
+    expect(harness.container.querySelector("[data-mobile-work-render-sentinel]")).toBeNull();
+  });
+
+  it("keeps explicit network paging available when a local search has no first-page match", async () => {
+    meChatMocks.listMeChats
+      .mockResolvedValueOnce({
+        rows: [chatRow({ chatId: "page-1", title: "First page only" })],
+        priorityRows: { attention: [], pinned: [] },
+        nextCursor: "next-page",
+      })
+      .mockResolvedValueOnce({
+        rows: [chatRow({ chatId: "page-2", title: "Needle on later page" })],
+        priorityRows: { attention: [], pinned: [] },
+        nextCursor: null,
+      });
+
+    renderWithClient(harness, <MobileWorkPage />, "/m/work");
+    await waitForSettled(harness, () => expect(harness.container.textContent).toContain("First page only"));
+
+    const searchToggle = harness.container.querySelector<HTMLButtonElement>('button[aria-label="Search Work"]');
+    await act(async () => searchToggle?.click());
+    const searchInput = harness.container.querySelector<HTMLInputElement>('input[aria-label="Search work"]');
+    if (!searchInput) throw new Error("Missing search input");
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set?.call(searchInput, "Needle");
+      searchInput.dispatchEvent(new InputEvent("input", { bubbles: true, data: "Needle", inputType: "insertText" }));
+    });
+
+    await waitForSettled(harness, () => expect(harness.container.textContent).toContain("No matching work"));
+    expect(harness.container.querySelector("[data-mobile-work-render-sentinel]")).toBeNull();
+    const loadMore = [...harness.container.querySelectorAll<HTMLButtonElement>("button")].find(
+      (button) => button.textContent === "Load more",
+    );
+    expect(loadMore).toBeDefined();
+
+    await act(async () => loadMore?.click());
+    await waitForSettled(harness, () => expect(harness.container.textContent).toContain("Needle on later page"));
+    expect(meChatMocks.listMeChats).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/web/src/pages/mobile/work.tsx
+++ b/packages/web/src/pages/mobile/work.tsx
@@ -1,7 +1,7 @@
 import type { MeChatRow } from "@first-tree/shared";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { AlertCircle, ArrowRight, CircleHelp, Filter, Pin, Plus, Search, X } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 import { useAuth } from "../../auth/auth-context.js";
 import { ChatRowAvatar } from "../../components/chat/chat-row-avatar.js";
@@ -23,6 +23,9 @@ const DEFAULT_FILTERS: MobileWorkFilters = {
   engagement: "active",
   watching: false,
 };
+
+const MOBILE_WORK_INITIAL_RENDER_COUNT = 16;
+const MOBILE_WORK_RENDER_BATCH_SIZE = 16;
 
 export function MobileWorkPage() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -93,6 +96,8 @@ function MobileWorkList({
   const [answeringChatId, setAnsweringChatId] = useState<string | null>(null);
   const [actionsRow, setActionsRow] = useState<MeChatRow | null>(null);
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const [renderedRowCount, setRenderedRowCount] = useState(MOBILE_WORK_INITIAL_RENDER_COUNT);
+  const renderSentinelRef = useRef<HTMLDivElement>(null);
 
   const queryScope = {
     organizationId: organizationId ?? null,
@@ -159,8 +164,31 @@ function MobileWorkList({
     0,
   );
   const narrowed = filters.engagement !== "active" || filters.watching;
+  const renderedRows = orderedRows.slice(0, renderedRowCount);
+  const hasBufferedRows = renderedRows.length < orderedRows.length;
+  const mayLoadNextPage = (quickView === "all" || quickView === "unread") && chatsQuery.hasNextPage;
+
+  useEffect(() => {
+    const target = renderSentinelRef.current;
+    if (!target || !hasBufferedRows) return;
+    if (typeof IntersectionObserver === "undefined") {
+      setRenderedRowCount(orderedRows.length);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        setRenderedRowCount((count) => Math.min(count + MOBILE_WORK_RENDER_BATCH_SIZE, orderedRows.length));
+      },
+      { rootMargin: "50% 0%" },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [hasBufferedRows, orderedRows.length]);
 
   const toggleQuickView = (next: Exclude<MobileWorkQuickView, "all">): void => {
+    setRenderedRowCount(MOBILE_WORK_INITIAL_RENDER_COUNT);
     onQuickViewChange(quickView === next ? "all" : next);
   };
 
@@ -177,7 +205,10 @@ function MobileWorkList({
             aria-expanded={searchOpen}
             onClick={() => {
               setSearchOpen((open) => !open);
-              if (searchOpen) setSearch("");
+              if (searchOpen) {
+                setSearch("");
+                setRenderedRowCount(MOBILE_WORK_INITIAL_RENDER_COUNT);
+              }
             }}
             className="inline-flex h-11 w-11 items-center justify-center rounded-[var(--radius-full)] transition-colors hover:bg-[var(--bg-hover)]"
             style={{ border: 0, background: "transparent", color: "var(--fg)" }}
@@ -199,7 +230,10 @@ function MobileWorkList({
             <input
               type="search"
               value={search}
-              onChange={(event) => setSearch(event.currentTarget.value)}
+              onChange={(event) => {
+                setSearch(event.currentTarget.value);
+                setRenderedRowCount(MOBILE_WORK_INITIAL_RENDER_COUNT);
+              }}
               placeholder="Search work"
               aria-label="Search work"
               className="text-mobile-body h-11 w-full rounded-[var(--radius-input)] border bg-[var(--bg-raised)] px-3 outline-none focus:border-ring"
@@ -273,8 +307,14 @@ function MobileWorkList({
             detail={search.trim() ? "Try another search." : "Change a quick view or filter to see more work."}
           />
         ) : (
-          <div className="flex flex-col" style={{ gap: "var(--sp-2)" }} data-mobile-work-list>
-            {orderedRows.map((row) =>
+          <div
+            className="flex flex-col"
+            style={{ gap: "var(--sp-2)" }}
+            data-mobile-work-list
+            data-mobile-work-rendered={renderedRows.length}
+            data-mobile-work-total={orderedRows.length}
+          >
+            {renderedRows.map((row) =>
               mobileChatSignal(row).attention ? (
                 <MobileActionCard
                   key={row.chatId}
@@ -293,10 +333,18 @@ function MobileWorkList({
                 />
               ),
             )}
+            {hasBufferedRows ? (
+              <div
+                ref={renderSentinelRef}
+                aria-hidden
+                style={{ minHeight: "var(--sp-1)" }}
+                data-mobile-work-render-sentinel
+              />
+            ) : null}
           </div>
         )}
 
-        {(quickView === "all" || quickView === "unread") && chatsQuery.hasNextPage ? (
+        {mayLoadNextPage ? (
           <Button
             type="button"
             variant="outline"
@@ -305,7 +353,7 @@ function MobileWorkList({
             onClick={() => void chatsQuery.fetchNextPage()}
             style={{ marginTop: "var(--sp-4)", alignSelf: "center" }}
           >
-            {chatsQuery.isFetchingNextPage ? "Loading…" : "Load more"}
+            {chatsQuery.isFetchingNextPage ? "Loading…" : chatsQuery.isFetchNextPageError ? "Retry" : "Load more"}
           </Button>
         ) : null}
         {chatsQuery.isFetchNextPageError ? (
@@ -318,7 +366,14 @@ function MobileWorkList({
       {answeringChatId ? <MobileAskSheet chatId={answeringChatId} onClose={() => setAnsweringChatId(null)} /> : null}
       {actionsRow ? <MobileChatActionsSheet row={actionsRow} onClose={() => setActionsRow(null)} /> : null}
       {filtersOpen ? (
-        <MobileWorkFiltersSheet value={filters} onChange={onFiltersChange} onClose={() => setFiltersOpen(false)} />
+        <MobileWorkFiltersSheet
+          value={filters}
+          onChange={(next) => {
+            setRenderedRowCount(MOBILE_WORK_INITIAL_RENDER_COUNT);
+            onFiltersChange(next);
+          }}
+          onClose={() => setFiltersOpen(false)}
+        />
       ) : null}
     </>
   );
@@ -491,6 +546,7 @@ function MobileWorkRow({
           muted
           badge={false}
           statusDot={false}
+          imageLoading="lazy"
         />
         <div className="min-w-0 flex-1">
           <div className="flex items-center" style={{ gap: "var(--sp-2)" }}>

--- a/packages/web/src/pages/mobile/work.tsx
+++ b/packages/web/src/pages/mobile/work.tsx
@@ -176,16 +176,21 @@ function MobileWorkList({
       return;
     }
 
+    // Bind one observer to one rendered batch. React can replace the unkeyed
+    // sentinel when keyed cards are inserted ahead of it, so the rendered-row
+    // dependency deliberately disconnects the old node and observes the
+    // current sentinel after every append.
+    const nextRenderedRowCount = Math.min(renderedRows.length + MOBILE_WORK_RENDER_BATCH_SIZE, orderedRows.length);
     const observer = new IntersectionObserver(
       (entries) => {
         if (!entries.some((entry) => entry.isIntersecting)) return;
-        setRenderedRowCount((count) => Math.min(count + MOBILE_WORK_RENDER_BATCH_SIZE, orderedRows.length));
+        setRenderedRowCount((count) => Math.max(count, nextRenderedRowCount));
       },
       { rootMargin: "50% 0%" },
     );
     observer.observe(target);
     return () => observer.disconnect();
-  }, [hasBufferedRows, orderedRows.length]);
+  }, [hasBufferedRows, orderedRows.length, renderedRows.length]);
 
   const toggleQuickView = (next: Exclude<MobileWorkQuickView, "all">): void => {
     setRenderedRowCount(MOBILE_WORK_INITIAL_RENDER_COUNT);


### PR DESCRIPTION
## Summary

- hydrate the first-page attention, pinned, and ordinary chat slices once while preserving the additive `/me/chats` response contract
- reuse participant speaker membership during list status resolution and skip the detail-only provider retry reason query
- keep Mobile Work card content and chat-summary precedence unchanged, but mount only 16 buffered cards initially and lazy-load uploaded avatars
- retain explicit network pagination so search can recover matches on later pages without automatic over-fetching

## Performance budgets

- a first page with one chat overlapping attention, pinned, and ordinary slices now uses exactly 8 database queries in the deterministic regression fixture
- Mobile Work initially mounts 16 cards, then reveals already-buffered cards in batches near the list boundary

## Validation

- `pnpm check` (passes; repository-existing warnings only)
- full monorepo typecheck: 10/10 tasks passed
- server/web focused typechecks passed
- server focused regression suites: 62 tests passed
- web full unit/DOM suite: 206 files, 1,751 tests passed (the Playwright visual spec is excluded from Vitest collection)
- skill-evals suite: 36 files, 494 tests passed
- server package run: 2,676 tests passed; two unrelated parallel timeout/deadlock cases passed 4/4 when rerun in isolation
- two independent code reviews completed with no blockers

## QA note

A fresh interactive mobile-browser timing could not be recorded because the in-app browser connector timed out. The change therefore adds deterministic database-query and initial-DOM budgets as regression coverage; post-deploy device timing remains useful for confirming the end-to-end production gain.
